### PR TITLE
fix: moe data with power law; sol calc for gen attn

### DIFF
--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -824,7 +824,7 @@ class PerfDatabase(object):
             Get the sol time, sol math and sol mem
             """
             # only consider fp16 mmha
-            ops = 2 * b * n * 128 * 2 # 2 for fma, 2 for q*k^t+*v
+            ops = 2 * b * n * 128 * 2 * s # 2 for fma, 2 for q*k^t+*v
             # kvcache load bytes will depend on kvcache quant. while input q and output might be in fp16.
             mem_bytes = b * (n*128*2 + 2*n_kv*(s-1)*128*kvcache_quant_mode.value.memory + n*128*2)
             

--- a/src/aiconfigurator/systems/data/h100_sxm/trtllm/1.0.0rc3/moe_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/trtllm/1.0.0rc3/moe_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d317903b9af6c5f369d368a13adb3a1aa1bbe903a3e494fead8c76d9e0d7efe1
-size 2416447
+oid sha256:7892aa2a5e5ca0507f85b4720c7f7f1b305bd839bef6e50eb15e82799798b960
+size 4557674

--- a/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.0.0rc3/moe_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.0.0rc3/moe_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b58cd6c3cf96305ded5e011e733320930f606fff2c1e3e64cd297123ddd5a903
-size 2208660
+oid sha256:9e2a274c47f6e55d76c53ae8c9a6bffaa7ebb50f7243e74dfa4d49b57b58f62c
+size 4206900


### PR DESCRIPTION
#### Overview:

1. fix sol calc for gen attn
2. fix moe data for power law. esp, for w4a8 with autotune.

#### Details:

1. fix sol calc for gen attn
2. fix moe data for power law. esp, for w4a8 with autotune.

#### Where should the reviewer start?

two new moe data; sol calc in gen attn. missing s.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

NA
