### PR TITLE
chore: Minor speedups

### DIFF
--- a/src/aiconfigurator/sdk/backends/trtllm_backend.py
+++ b/src/aiconfigurator/sdk/backends/trtllm_backend.py
@@ -233,6 +233,7 @@ class TRTLLMBackend(BaseBackend):
         ctx_tokens_list.sort()
         
         results_df = pd.DataFrame(columns=common.ColumnsIFB)
+        df_list = []
         capped_b = []
         for b in b_list:
             for ctx_tokens in ctx_tokens_list:
@@ -256,10 +257,10 @@ class TRTLLMBackend(BaseBackend):
                 if summary.check_oom():
                     break # larger ctx tokens will cause oom
                 if summary.get_summary_df().loc[0,'tpot'] <= tpot and summary.get_summary_df().loc[0,'ttft'] <= ttft:
-                    if len(results_df) == 0:
-                        results_df = summary.get_summary_df()
-                    else:
-                        results_df = pd.concat([results_df, summary.get_summary_df()], axis=0, ignore_index=True)
+                    df_list.append(summary.get_summary_df())
+
+        if df_list:
+            results_df = pd.concat(df_list, axis=0, ignore_index=True)
 
         sorted_results_df = results_df.sort_values(by='seq/s', ascending=False).round(3)
         if top_k > 0:

--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -743,9 +743,11 @@ class PerfDatabase(object):
         y0,y1 = y
         if (x0 - x1) * (y0 - y1) < 0 and (value - x0) * (value - x1) > 0:
             y1 = y0
-        model = np.polyfit(x, [y0,y1], 1)
-        
-        return self._validate(np.polyval(model, value))
+
+        if y0 == y1:
+            return y0
+
+        return y0 + (y1 - y0) / (x1 - x0) * (value - x0)
 
     def set_default_sol_mode(self, mode:common.SOLMode) -> None:
         """


### PR DESCRIPTION
Small rewrites of slow code. Runtime for the following command went from 

Old time: 127s
New time: 79s (38% faster)
```
aiconfigurator cli --model QWEN3_32B --total_gpus 32 --system h200_sxm --tpot 10
```

Database loading is much faster now. To load `system='h200_sxm', backend='trtllm', version='0.20.0'`, the time went from 18s to 1s.

Summary of changes:
- In `_1d_interp()`, replace slow calls to `np.polyfit` and `np.polyval` with a simple algebra formula
- In results Dataframe construction, only perform `pd.concat` on the final list of dataframes to concat rather than doing a `pd.concat` for every new result