### PR TITLE
docs: add git lfs pull step before install from source code to download full data files

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ apt-get install git-lfs  # (Linux)
 
 # 2. Clone the repo
 git clone https://github.com/ai-dynamo/aiconfigurator.git
+git lfs pull
 
 # 3. Create and activate a virtual environment
 python3 -m venv myenv && source myenv/bin/activate # (requires Python 3.9 or later)


### PR DESCRIPTION


#### Overview:

The data files (e.g., gemm_perf.txt, ~4.8MB) are stored in Git LFS. Without running `git lfs pull`, aiconfigurator attempts to parse LFS pointer text instead of actual CSV data, causing the database to fail loading.

```bash
aiconfigurator cli default --model QWEN3_32B --total_gpus 32 --system h200_sxm
INFO 2025-10-17 23:16:58,328 main.py:323] Loading Dynamo AIConfigurator version: 0.3.0
INFO 2025-10-17 23:16:58,333 perf_database.py:166] loading system='h200_sxm', backend='trtllm', version='1.0.0rc3'
ERROR 2025-10-17 23:16:58,335 perf_database.py:175] failed to load system='h200_sxm', backend='trtllm', version='1.0.0rc3': 'gemm_dtype'
Traceback (most recent call last):
  File "/Users/sevenc/code/nvidia/aiconfigurator/myenv/bin/aiconfigurator", line 7, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/sevenc/code/nvidia/aiconfigurator/myenv/lib/python3.12/site-packages/aiconfigurator/main.py", line 62, in main
    handler(extras)
  File "/Users/sevenc/code/nvidia/aiconfigurator/myenv/lib/python3.12/site-packages/aiconfigurator/main.py", line 17, in _run_cli
    cli_main(cli_args)
  File "/Users/sevenc/code/nvidia/aiconfigurator/myenv/lib/python3.12/site-packages/aiconfigurator/cli/main.py", line 326, in main
    task_configs = _build_default_task_configs(args)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sevenc/code/nvidia/aiconfigurator/myenv/lib/python3.12/site-packages/aiconfigurator/cli/main.py", line 95, in _build_default_task_configs
    agg_task = TaskConfig(serving_mode="agg", **common_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sevenc/code/nvidia/aiconfigurator/myenv/lib/python3.12/site-packages/aiconfigurator/sdk/task.py", line 628, in __init__
    self.config, applied_layers = TaskConfigFactory.create(ctx)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sevenc/code/nvidia/aiconfigurator/myenv/lib/python3.12/site-packages/aiconfigurator/sdk/task.py", line 148, in create
    cls._finalize_agg(config, ctx)
  File "/Users/sevenc/code/nvidia/aiconfigurator/myenv/lib/python3.12/site-packages/aiconfigurator/sdk/task.py", line 332, in _finalize_agg
    cls._apply_quant_modes(
  File "/Users/sevenc/code/nvidia/aiconfigurator/myenv/lib/python3.12/site-packages/aiconfigurator/sdk/task.py", line 406, in _apply_quant_modes
    defaults = TaskConfigFactory._get_quant_mode(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sevenc/code/nvidia/aiconfigurator/myenv/lib/python3.12/site-packages/aiconfigurator/sdk/task.py", line 429, in _get_quant_mode
    sm_version = database.system_spec["gpu"]["sm_version"]
                 ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'system_spec'
```

#### Details:

This PR add explicit instruction in README to run `git lfs pull` before `pip install .` to ensure all large data files are downloaded before installation.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
