### PR TITLE
chore: minor docs update and CI fix for Ruff linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,6 @@ jobs:
 
       - name: Check Linting
         run: ruff check .
-        continue-on-error: true
 
       - name: Check Formatting
         run: ruff format --check .

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -55,6 +55,10 @@ This installs:
 - All runtime dependencies
 - Development tools: `ruff`, `pre-commit`, `pytest` and related plugins
 
+### Optional: Install Ruff Extension
+
+If you are using VS Code or one of its forks (e.g. Cursor), you can install the [Ruff extension](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff) which will highlight linting issues in your editor. You can also configure your editor to auto-apply formatting when saving files using the instructions [here](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff#:~:text=Taken%20together%2C%20you%20can%20configure%20Ruff%20to%20format%2C%20fix%2C%20and%20organize%20imports%20on%2Dsave%20via%20the%20following%20settings.json%3A).
+
 ## Development Workflow
 
 ### Code Style and Linting


### PR DESCRIPTION
#### Overview:

Adds a section about installing the Ruff VS Code extension to the docs. Also, removes the `continue-on-error` flag in the lint CI which would allow the job to pass even if linting fails.