### PR TITLE
fix: cache_transceiver_config default to DEFAULT

### DIFF
--- a/src/aiconfigurator/generator/templates/trtllm/extra_engine_args.yaml.j2
+++ b/src/aiconfigurator/generator/templates/trtllm/extra_engine_args.yaml.j2
@@ -26,7 +26,7 @@ kv_cache_config:
   dtype: {{ kv_cache_dtype | default('auto') }}
 
 cache_transceiver_config:
-  backend: {{ dynamo_config.cache_transceiver_backend | default('default') }} # dynamo_config.cache_transceiver_backend The communication backend type to use for the cache transceiver (default, ucx, nixl, mpi)
+  backend: {{ dynamo_config.cache_transceiver_backend | default('DEFAULT') }} # dynamo_config.cache_transceiver_backend The communication backend type to use for the cache transceiver (default, ucx, nixl, mpi)
   max_tokens_in_buffer: {{dynamo_config.max_tokens_in_buffer | default(1024)}} # dynamo_config.max_tokens_in_buffer The max number of tokens the transfer buffer can fit
 
 cuda_graph_config:


### PR DESCRIPTION
#### Overview:

bug report in discord:
the aiconfigurator generates an incorrect cache_transceiver_config.backend – it should be DEFAULT not default
```
pydantic_core._pydantic_core.ValidationError: 1 validation error for TorchLlmArgs
cache_transceiver_config.backend
  Input should be 'DEFAULT', 'UCX', 'NIXL' or 'MPI' [type=literal_error, input_value='default', input_type=str]
    For further information visit https://errors.pydantic.dev/2.10/v/literal_error 
```

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
