### PR TITLE
fix: gracefully unsupport agg for sglang/vllm

### DIFF
--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -118,13 +118,24 @@ def _build_default_task_configs(args) -> dict[str, TaskConfig]:
         "tpot": args.tpot,
     }
 
-    agg_task = TaskConfig(serving_mode="agg", **common_kwargs)
+    task_configs: dict[str, TaskConfig] = {}
+
+    # Validate backend compatibility with aggregated serving mode
+    if args.backend in [common.BackendName.sglang.value, common.BackendName.vllm.value]:
+        logger.warning(
+            "Backend '%s' is not supported with serving_mode 'agg'. Only 'disagg' mode will be configured.",
+            args.backend,
+        )
+    else:
+        agg_task = TaskConfig(serving_mode="agg", **common_kwargs)
+        task_configs["agg"] = agg_task
 
     disagg_kwargs = dict(common_kwargs)
     disagg_kwargs["decode_system_name"] = decode_system
     disagg_task = TaskConfig(serving_mode="disagg", **disagg_kwargs)
+    task_configs["disagg"] = disagg_task
 
-    return {"disagg": disagg_task, "agg": agg_task}
+    return task_configs
 
 
 _EXPERIMENT_RESERVED_KEYS = {
@@ -223,6 +234,16 @@ def _build_experiment_task_configs(args) -> dict[str, TaskConfig]:
         else:
             backend_name = exp_config.get("backend_name") or common.BackendName.trtllm.value
             backend_version = exp_config.get("backend_version")
+
+        # Validate backend compatibility with serving mode
+        if serving_mode == "agg" and backend_name in [common.BackendName.sglang.value, common.BackendName.vllm.value]:
+            logger.error(
+                "Experiment '%s': serving_mode 'agg' is not supported with backend '%s'. "
+                "Please either use serving_mode 'disagg' or switch to backend 'trtllm'.",
+                exp_name,
+                backend_name,
+            )
+            raise SystemExit(1)
 
         total_gpus = exp_config.get("total_gpus")
         if total_gpus is None:


### PR DESCRIPTION
#### Overview:

Example:
```
((aic_venv) ) ➜  aiconfigurator git:(main) ✗ aiconfigurator cli exp --yaml_path ./src/aiconfigurator/cli/exps/deepseek_disagg_sglang.yaml

INFO 2025-10-28 05:56:42,955 main.py:371] Loading Dynamo AIConfigurator version: 0.3.0
ERROR 2025-10-28 05:56:42,961 main.py:241] Experiment 'exp_disagg_full': serving_mode 'agg' is not supported with backend 'sglang'. Please either use serving_mode 'disagg' or switch to backend 'trtllm'.
```

```
((aic_venv) ) ➜  aiconfigurator git:(main) ✗ aiconfigurator cli default --model QWEN3_32B --total_gpus 32 --system h200_sxm --backend sglang

INFO 2025-10-28 05:57:43,033 main.py:371] Loading Dynamo AIConfigurator version: 0.3.0
WARNING 2025-10-28 05:57:43,033 main.py:125] Backend 'sglang' is not supported with serving_mode 'agg'. Only 'disagg' mode will be configured.
INFO 2025-10-28 05:57:43,076 perf_database.py:180] loading system='h200_sxm', backend='sglang', version='0.5.0'
```

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
