### PR TITLE
feat: support agg for vllm

### DIFF
--- a/src/aiconfigurator/sdk/backends/vllm_backend.py
+++ b/src/aiconfigurator/sdk/backends/vllm_backend.py
@@ -1,6 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
+from collections import defaultdict
+
+import numpy as np
+import pandas as pd
 
 from aiconfigurator.sdk import common
 from aiconfigurator.sdk.backends.base_backend import BaseBackend
@@ -8,6 +13,12 @@ from aiconfigurator.sdk.config import RuntimeConfig
 from aiconfigurator.sdk.inference_summary import InferenceSummary
 from aiconfigurator.sdk.models import BaseModel
 from aiconfigurator.sdk.perf_database import PerfDatabase
+
+logger = logging.getLogger(__name__)
+
+MAX_NORMAL_CTX_TOKENS = 8192
+MAX_CTX_TOKENS_MULTIPLE_OF_ISL = 2
+MAX_CTX_TOKENS_SEARCH_STEPS = 8  # for ctx stride large for faster sweeping
 
 
 class VLLMBackend(BaseBackend):
@@ -19,17 +30,377 @@ class VLLMBackend(BaseBackend):
         self,
     ):
         super().__init__()
+        self._agg_cache = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict())))
         self.name = common.BackendName.vllm
 
     def run_agg(
         self, model: BaseModel, database: PerfDatabase, runtime_config: RuntimeConfig, **kwargs
     ) -> InferenceSummary:
-        pass
+        """
+        Run the agg inference for VLLM backend.
+        """
+        isl = runtime_config.isl
+        osl = runtime_config.osl
+        b = runtime_config.batch_size
+        ctx_tokens = kwargs.get("ctx_tokens")
+        assert ctx_tokens is not None, "ctx_tokens is required"
+        balance_score = isl * b / ctx_tokens / osl
+
+        try:
+            summary = self._agg_cache[isl][osl][b][ctx_tokens]
+        except KeyError:
+            # we would like to calculate num_mix_steps and num_genonly_steps based on
+            # isl, osl, b, ctx_tokens within osl steps, need to finish all the ctx tokens
+            steps_to_finish_ctx = np.ceil(isl * b / ctx_tokens)
+            num_mix_steps = num_genonly_steps = 0
+            num_mix_steps_for_tpot_calc = 0  # this is a correction for tpot calc only.
+            if b > 1:
+                if steps_to_finish_ctx >= osl:
+                    num_mix_steps = steps_to_finish_ctx
+                    num_mix_ctx_tokens = ctx_tokens
+                    num_mix_gen_tokens = max(1, b // (steps_to_finish_ctx / osl))
+                    num_genonly_steps = 0
+                    num_genonly_tokens = 0
+                    num_mix_steps_for_tpot_calc = num_mix_steps
+                else:
+                    # 3-step is an empirical correction for pipelining requests where new requests
+                    # cannot be enqueued immediately after last request's exit
+                    num_mix_steps = steps_to_finish_ctx
+                    num_mix_ctx_tokens = ctx_tokens
+                    num_mix_gen_tokens = b - np.ceil(ctx_tokens / isl)  # the error check is outside
+                    assert num_mix_gen_tokens >= 1, (
+                        f"num_mix_gen_tokens: {num_mix_gen_tokens}, b: {b}, ctx_tokens: {ctx_tokens}, isl: {isl}"
+                    )
+                    num_genonly_steps = osl - num_mix_steps
+                    num_genonly_tokens = b
+                    num_mix_steps_for_tpot_calc = max(1, num_mix_steps - 3)
+            elif b == 1:
+                # special case for b=1
+                num_mix_steps = 1
+                num_mix_ctx_tokens = ctx_tokens
+                num_mix_gen_tokens = 0
+                num_genonly_steps = osl - 1
+                num_genonly_tokens = 1
+                num_mix_steps_for_tpot_calc = 0
+
+            def _get_mix_step_latency(
+                model: BaseModel,
+                database: PerfDatabase,
+                ctx_tokens: int,
+                gen_tokens: int,
+                isl: int,
+                osl: int,
+            ) -> float:
+                num_tokens = ctx_tokens + gen_tokens
+                summary = self.run_static(
+                    model,
+                    database,
+                    RuntimeConfig(batch_size=1, beam_width=1, isl=num_tokens, osl=1),
+                    mode="static_ctx",
+                )
+                latency_dict = summary.get_context_latency_dict()
+                non_attention_latency = 0.0
+                # TODO, fix for DS. DS has different ops for attn in ctx and gen.
+                for layer_name, latency in latency_dict.items():
+                    if layer_name != "context_attention":
+                        non_attention_latency += latency
+
+                # second pass to get ctx attn, split full isl over
+                # num_steps(=np.ceil(isl/ctx_tokens)), average the ctx attn latency
+                num_tokens = isl
+                summary = self.run_static(
+                    model,
+                    database,
+                    RuntimeConfig(batch_size=1, beam_width=1, isl=num_tokens, osl=1),
+                    mode="static_ctx",
+                )
+                latency_dict = summary.get_context_latency_dict()
+                ctx_attention_latency = latency_dict["context_attention"] / (np.ceil(isl / ctx_tokens))
+
+                # third pass to get generation attn. use isl+osl//2 for avg generation attn latency.
+                if gen_tokens > 0:
+                    num_tokens = gen_tokens
+                    summary = self.run_static(
+                        model,
+                        database,
+                        RuntimeConfig(batch_size=num_tokens, beam_width=1, isl=isl + osl // 2, osl=2),
+                        mode="static_gen",
+                    )
+                    latency_dict = summary.get_generation_latency_dict()
+                    gen_attention_latency = latency_dict["generation_attention"]
+                else:
+                    gen_attention_latency = 0.0
+
+                return non_attention_latency + ctx_attention_latency + gen_attention_latency
+
+            def _get_genonly_step_latency(
+                model: BaseModel, database: PerfDatabase, gen_tokens: int, isl: int, osl: int
+            ) -> float:
+                if gen_tokens <= 0:
+                    return 0.0
+                num_tokens = gen_tokens
+                summary = self.run_static(
+                    model,
+                    database,
+                    RuntimeConfig(batch_size=num_tokens, beam_width=1, isl=isl + osl // 2, osl=2),
+                    mode="static_gen",
+                )
+                latency_dict = summary.get_generation_latency_dict()
+                genonly_step_latency = 0.0
+                for layer_name, latency in latency_dict.items():
+                    genonly_step_latency += latency
+
+                return genonly_step_latency
+
+            mix_step_latency = _get_mix_step_latency(model, database, num_mix_ctx_tokens, num_mix_gen_tokens, isl, osl)
+            genonly_step_latency = _get_genonly_step_latency(model, database, num_genonly_tokens, isl, osl)
+
+            ttft = mix_step_latency * np.ceil(isl / ctx_tokens)
+            # correction for ttft in vllm agg mode, assume we have requests 10x of concurrency
+            # (batch size here) to mitigate the impact of first round latency
+            # assume we need to increase x of requests when concurrency gets larger.
+            # thus capped to 4 to make it reasonable.
+            correction_factor = min(2 + (steps_to_finish_ctx - 3) / 2 / 10, 4)
+            ttft *= correction_factor
+            logger.debug(
+                f"ttft correction factor: {2 + (steps_to_finish_ctx - 3) / 2 / 10} capped to "
+                f"{correction_factor} when b: {b}, ctx_tokens: {ctx_tokens} isl {isl}"
+            )
+
+            tpot = (mix_step_latency * num_mix_steps_for_tpot_calc + genonly_step_latency * num_genonly_steps) / (
+                num_mix_steps_for_tpot_calc + num_genonly_steps
+            )
+            output_throughput = (
+                1000 / (num_mix_steps * mix_step_latency + num_genonly_steps * genonly_step_latency) * b * (osl - 1)
+            )
+            logger.debug(
+                f"ctx_tokens: {ctx_tokens}, b: {b}, osl: {osl}, isl: {isl}, "
+                f"num_mix_steps: {num_mix_steps}, num_genonly_steps: {num_genonly_steps}, "
+                f"num_mix_ctx_tokens: {num_mix_ctx_tokens}, "
+                f"num_mix_gen_tokens: {num_mix_gen_tokens}, "
+                f"num_genonly_tokens: {num_genonly_tokens}"
+            )
+            logger.debug(f"mix_step_latency: {mix_step_latency}, genonly_step_latency: {genonly_step_latency}")
+            logger.debug(f"ttft: {ttft}, tpot: {tpot}, output_throughput: {output_throughput}")
+
+            num_ctx_requests = np.ceil(ctx_tokens / isl)
+            num_gen_requests = b - num_ctx_requests
+            if b == 1:
+                num_ctx_requests = 1
+                num_gen_requests = 1
+
+            # correct output_throughput and concurrency for attention dp (global batch)
+            scale_factor = model.config.pp_size * model.config.attention_dp_size
+            output_throughput = output_throughput * scale_factor
+            concurrency = b * scale_factor
+
+            request_rate = output_throughput / (osl - 1)
+            if b > 1:
+                # will not be corrected by balance score when it's larger than 1.0
+                # in order to indicate what's happening
+                num_tokens = num_gen_requests + ctx_tokens
+            else:
+                num_tokens = ctx_tokens
+            memory = self._get_memory_usage(model, database, b, 1, isl, osl, num_tokens)
+            tp = model.config.tp_size
+            pp = model.config.pp_size
+            dp = model.config.attention_dp_size
+            moe_tp = model.config.moe_tp_size
+            moe_ep = model.config.moe_ep_size
+            tokens_s_gpu = output_throughput / pp / tp / dp
+            tokens_s_user = 1000 / tpot
+            seq_s = request_rate
+            seq_s_gpu = seq_s / pp / tp / dp
+            tokens_s = output_throughput
+            num_total_gpus = tp * pp * dp
+            parallel = f"tp{tp}pp{pp}dp{dp}etp{moe_tp}ep{moe_ep}"
+            gemm = model.config.gemm_quant_mode.name
+            kvcache = model.config.kvcache_quant_mode.name
+            fmha = model.config.fmha_quant_mode.name
+            moe = model.config.moe_quant_mode.name
+            comm = model.config.comm_quant_mode.name
+            mem = memory["total"]
+
+            result = pd.DataFrame(
+                columns=common.ColumnsAgg,
+                data=[
+                    [
+                        model.model_name,
+                        isl,
+                        osl,
+                        concurrency,
+                        request_rate,
+                        b,
+                        b * model.config.attention_dp_size,
+                        ttft,
+                        tpot,
+                        seq_s,
+                        seq_s_gpu,
+                        tokens_s,
+                        tokens_s_gpu,
+                        tokens_s_user,
+                        num_total_gpus,
+                        tp,
+                        pp,
+                        dp,
+                        moe_tp,
+                        moe_ep,
+                        parallel,
+                        gemm,
+                        kvcache,
+                        fmha,
+                        moe,
+                        comm,
+                        mem,
+                        balance_score,
+                        num_ctx_requests,
+                        num_gen_requests,
+                        num_tokens,
+                        ctx_tokens,
+                        num_gen_requests,
+                        database.backend,
+                        database.version,
+                        database.system,
+                    ]
+                ],
+            ).round(3)
+            summary = InferenceSummary(RuntimeConfig(isl=isl, osl=osl))
+            summary.set_memory_and_check_oom(memory, database.system_spec["gpu"]["mem_capacity"])
+            summary.set_summary_df(result)
+
+            # caching
+            self._agg_cache[isl][osl][b][ctx_tokens] = summary
+
+        return summary
 
     def find_best_agg_result_under_constraints(
         self, model: BaseModel, database: PerfDatabase, runtime_config: RuntimeConfig, **kwargs
     ) -> InferenceSummary:
-        pass
+        """
+        Find the best agg result under constraints for VLLM backend.
+
+        Args:
+            model: the model to be tested
+            database: the database to be tested
+            runtime_config: the runtime configuration
+            top_k: the number of best results to return
+            max_batch_size: the maximum batch size to test
+            ctx_stride: the stride of ctx tokens to test, it will impact the time to run the test.
+            enable_chunked_prefill: whether to enable chunked prefill, it will impact the time to
+                run the test while have little impact on the result. Default off.
+
+        Returns:
+            A summary of the best agg result under constraints.
+        """
+        isl = runtime_config.isl
+        osl = runtime_config.osl
+        ttft = runtime_config.ttft
+        tpot = runtime_config.tpot
+
+        top_k = kwargs.get("top_k", 1)
+        max_batch_size = kwargs.get("max_batch_size", 512)
+        ctx_stride = kwargs.get("ctx_stride", 512)
+        enable_chunked_prefill = kwargs.get("enable_chunked_prefill", False)
+
+        max_ctx_tokens = max(MAX_NORMAL_CTX_TOKENS, isl * MAX_CTX_TOKENS_MULTIPLE_OF_ISL)
+        # if ctx tokens is already larger than 2048, we need to increase ctx_stride for faster
+        # sweeping
+        ctx_stride_large = max(
+            1024,
+            ctx_stride,
+            max_ctx_tokens // MAX_CTX_TOKENS_SEARCH_STEPS,
+        )
+        # when b is larger than 1024, the result is not good as the data collection is not enough
+        # to cover this.
+        b_list_default = (
+            list(range(1, 16, 1))
+            + list(range(16, 32, 4))
+            + list(range(32, 64, 8))
+            + list(range(64, 256, 16))
+            + list(range(256, 512, 32))
+            + list(range(512, 1024, 256))
+            + [1024]
+        )
+
+        if not enable_chunked_prefill:
+            logger.debug(
+                f"enable_chunked_prefill is off, override ctx_stride: from {ctx_stride} to {isl}, "
+                f"ctx_stride_large: from {ctx_stride_large} to "
+                f"{np.ceil(ctx_stride_large / isl) * isl}"
+            )
+            ctx_stride = isl
+            ctx_stride_large = np.ceil(ctx_stride_large / isl) * isl
+
+        # sweep for batch_size and ctx_tokens
+        # ctx_tokens will have a step of ctx_stride. When it's larger than 8192, we will increase
+        # the step to ctx_stride_large.
+        # outer_loop is over batch_size dimention, from 1 to max_batch_size
+        # inner_loop is over ctx_tokens dimention, from 0 to max_ctx_tokens where it's
+        # max(8192, 4*isl).
+        # during the loop, as b, ctx_tokens and system memory are monotonic, we can break the
+        # inner loop when the system is oom.
+        b_list = [b for b in b_list_default if b <= max_batch_size]
+        # prepare ctx_tokens_list
+        ctx_tokens_list = []
+        ctx_tokens = 0
+        while True:
+            ctx_tokens = (
+                (ctx_tokens + ctx_stride) if ctx_tokens < MAX_NORMAL_CTX_TOKENS else (ctx_tokens + ctx_stride_large)
+            )
+            if ctx_tokens > max_ctx_tokens:
+                break
+            ctx_tokens_list.append(ctx_tokens)
+        # add those just match the multiple of isl
+        for i in range(1, MAX_CTX_TOKENS_MULTIPLE_OF_ISL + 1):
+            ctx_tokens = isl * i
+            if ctx_tokens not in ctx_tokens_list:
+                ctx_tokens_list.append(ctx_tokens)
+        ctx_tokens_list.sort()
+
+        results_df = pd.DataFrame(columns=common.ColumnsAgg)
+        df_list = []
+        capped_b = []
+        for b in b_list:
+            for ctx_tokens in ctx_tokens_list:
+                if b - np.ceil(ctx_tokens / isl) < 0:  # allow b==1
+                    break
+
+                if b > 1 and (
+                    b - np.ceil(ctx_tokens / isl) < 1
+                ):  # general case, to ensure there's at least one gen req
+                    break
+
+                # filter out repeated records for balance score correction
+                balance_score = isl * b / ctx_tokens / osl
+                if balance_score > 1:
+                    gen_tokens = b // balance_score
+                    if gen_tokens > 1 and gen_tokens in capped_b:
+                        continue
+                    else:
+                        capped_b.append(gen_tokens)
+
+                summary = self.run_agg(
+                    model=model,
+                    database=database,
+                    runtime_config=RuntimeConfig(batch_size=b, isl=isl, osl=osl),
+                    ctx_tokens=ctx_tokens,
+                )
+
+                if summary.check_oom():
+                    break  # larger ctx tokens will cause oom
+                if summary.get_summary_df().loc[0, "tpot"] <= tpot and summary.get_summary_df().loc[0, "ttft"] <= ttft:
+                    df_list.append(summary.get_summary_df())
+
+        if df_list:
+            results_df = pd.concat(df_list, axis=0, ignore_index=True)
+
+        sorted_results_df = results_df.sort_values(by="seq/s", ascending=False).round(3)
+        if top_k > 0:
+            sorted_results_df = sorted_results_df.head(top_k)
+
+        summary = InferenceSummary(runtime_config)
+        summary.set_summary_df(sorted_results_df)
+        return summary
 
     def _get_memory_usage(
         self,


### PR DESCRIPTION
Example:
```
(aic_venv) jasonzho@NV-25010035:~/repo/repo3/aiconfigurator$ aiconfigurator cli default --model QWEN3_32B --total_gpus 32 --system h100_sxm --backend vllm
INFO 2025-11-05 14:25:52,578 main.py:349] Loading Dynamo AIConfigurator version: 0.3.0
INFO 2025-11-05 14:25:52,583 perf_database.py:180] loading system='h100_sxm', backend='vllm', version='0.11.0'
INFO 2025-11-05 14:25:52,881 task.py:674] Task agg_QWEN3_32B_h100_sxm_vllm_0.11.0_4000_1000_1000.0_20.0: Runtime config: DefaultMunch(<class 'munch.DefaultMunch'>, {'isl': 4000, 'osl': 1000, 'ttft': 1000.0, 'tpot': 20.0})
INFO 2025-11-05 14:25:52,881 task.py:675] Task agg_QWEN3_32B_h100_sxm_vllm_0.11.0_4000_1000_1000.0_20.0: Worker config: DefaultMunch(<class 'munch.DefaultMunch'>, {'system_name': 'h100_sxm', 'backend_name': 'vllm', 'backend_version': '0.11.0', 'num_gpu_per_worker': [1, 2, 4, 8], 'tp_list': [1, 2, 4, 8], 'pp_list': [1], 'dp_list': [1], 'moe_tp_list': [1], 'moe_ep_list': [1], 'gemm_quant_mode': <GEMMQuantMode.fp8: QuantMapping(memory=1, compute=2, name='fp8')>, 'moe_quant_mode': <MoEQuantMode.fp8: QuantMapping(memory=1, compute=2, name='fp8')>, 'kvcache_quant_mode': <KVCacheQuantMode.fp8: QuantMapping(memory=1, compute=0, name='fp8')>, 'fmha_quant_mode': <FMHAQuantMode.float16: QuantMapping(memory=0, compute=1, name='float16')>, 'comm_quant_mode': <CommQuantMode.half: QuantMapping(memory=2, compute=0, name='half')>})
INFO 2025-11-05 14:25:52,890 task.py:679] Task disagg_QWEN3_32B_h100_sxm_h100_sxm_vllm_0.11.0_4000_1000_1000.0_20.0: Runtime config: DefaultMunch(<class 'munch.DefaultMunch'>, {'isl': 4000, 'osl': 1000, 'ttft': 1000.0, 'tpot': 20.0})
INFO 2025-11-05 14:25:52,890 task.py:680] Task disagg_QWEN3_32B_h100_sxm_h100_sxm_vllm_0.11.0_4000_1000_1000.0_20.0: Prefill worker config: DefaultMunch(<class 'munch.DefaultMunch'>, {'system_name': 'h100_sxm', 'backend_name': 'vllm', 'backend_version': '0.11.0', 'num_gpu_per_worker': [1, 2, 4, 8], 'tp_list': [1, 2, 4, 8], 'pp_list': [1], 'dp_list': [1], 'moe_tp_list': [1], 'moe_ep_list': [1], 'gemm_quant_mode': <GEMMQuantMode.fp8: QuantMapping(memory=1, compute=2, name='fp8')>, 'moe_quant_mode': <MoEQuantMode.fp8: QuantMapping(memory=1, compute=2, name='fp8')>, 'kvcache_quant_mode': <KVCacheQuantMode.fp8: QuantMapping(memory=1, compute=0, name='fp8')>, 'fmha_quant_mode': <FMHAQuantMode.float16: QuantMapping(memory=0, compute=1, name='float16')>, 'comm_quant_mode': <CommQuantMode.half: QuantMapping(memory=2, compute=0, name='half')>})
INFO 2025-11-05 14:25:52,891 task.py:685] Task disagg_QWEN3_32B_h100_sxm_h100_sxm_vllm_0.11.0_4000_1000_1000.0_20.0: Decode worker config: DefaultMunch(<class 'munch.DefaultMunch'>, {'system_name': 'h100_sxm', 'backend_name': 'vllm', 'backend_version': '0.11.0', 'num_gpu_per_worker': [1, 2, 4, 8], 'tp_list': [1, 2, 4, 8], 'pp_list': [1], 'dp_list': [1], 'moe_tp_list': [1], 'moe_ep_list': [1], 'gemm_quant_mode': <GEMMQuantMode.fp8: QuantMapping(memory=1, compute=2, name='fp8')>, 'moe_quant_mode': <MoEQuantMode.fp8: QuantMapping(memory=1, compute=2, name='fp8')>, 'kvcache_quant_mode': <KVCacheQuantMode.fp8: QuantMapping(memory=1, compute=0, name='fp8')>, 'fmha_quant_mode': <FMHAQuantMode.float16: QuantMapping(memory=0, compute=1, name='float16')>, 'comm_quant_mode': <CommQuantMode.half: QuantMapping(memory=2, compute=0, name='half')>})
INFO 2025-11-05 14:25:52,891 task.py:690] Task disagg_QWEN3_32B_h100_sxm_h100_sxm_vllm_0.11.0_4000_1000_1000.0_20.0: Replica config: DefaultMunch(<class 'munch.DefaultMunch'>, {'num_gpu_per_replica': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128], 'max_gpu_per_replica': 32, 'max_prefill_worker': 32, 'max_decode_worker': 32})
INFO 2025-11-05 14:25:52,891 task.py:691] Task disagg_QWEN3_32B_h100_sxm_h100_sxm_vllm_0.11.0_4000_1000_1000.0_20.0: Advanced tuning config: DefaultMunch(<class 'munch.DefaultMunch'>, {'prefill_latency_correction_scale': 1.1, 'decode_latency_correction_scale': 1.08, 'prefill_max_batch_size': 1, 'decode_max_batch_size': 512})
INFO 2025-11-05 14:25:52,891 main.py:286] Starting experiment: disagg
INFO 2025-11-05 14:25:52,891 main.py:287] Task config: {
  "disagg_QWEN3_32B_h100_sxm_h100_sxm_vllm_0.11.0_4000_1000_1000.0_20.0": {
    "mode": "patch",
    "serving_mode": "disagg",
    "model_name": "QWEN3_32B",
    "total_gpus": 32,
    "system_name": "h100_sxm",
    "decode_system_name": "h100_sxm",
    "backend_name": "vllm",
    "backend_version": "0.11.0",
    "isl": 4000,
    "osl": 1000,
    "ttft": 1000.0,
    "tpot": 20.0,
    "profiles": [],
    "config": {
      "nextn": 0,
      "nextn_accept_rates": [
        0.85,
        0,
        0,
        0,
        0
      ],
      "prefill_worker_config": {
        "system_name": "h100_sxm",
        "backend_name": "vllm",
        "backend_version": "0.11.0",
        "num_gpu_per_worker": [
          1,
          2,
          4,
          8
        ],
        "tp_list": [
          1,
          2,
          4,
          8
        ],
        "pp_list": [
          1
        ],
        "dp_list": [
          1
        ],
        "moe_tp_list": [
          1
        ],
        "moe_ep_list": [
          1
        ],
        "gemm_quant_mode": "fp8",
        "moe_quant_mode": "fp8",
        "kvcache_quant_mode": "fp8",
        "fmha_quant_mode": "float16",
        "comm_quant_mode": "half"
      },
      "decode_worker_config": {
        "system_name": "h100_sxm",
        "backend_name": "vllm",
        "backend_version": "0.11.0",
        "num_gpu_per_worker": [
          1,
          2,
          4,
          8
        ],
        "tp_list": [
          1,
          2,
          4,
          8
        ],
        "pp_list": [
          1
        ],
        "dp_list": [
          1
        ],
        "moe_tp_list": [
          1
        ],
        "moe_ep_list": [
          1
        ],
        "gemm_quant_mode": "fp8",
        "moe_quant_mode": "fp8",
        "kvcache_quant_mode": "fp8",
        "fmha_quant_mode": "float16",
        "comm_quant_mode": "half"
      },
      "replica_config": {
        "num_gpu_per_replica": [
          1,
          2,
          4,
          8,
          16,
          24,
          32,
          40,
          48,
          56,
          64,
          72,
          80,
          88,
          96,
          104,
          112,
          120,
          128
        ],
        "max_gpu_per_replica": 32,
        "max_prefill_worker": 32,
        "max_decode_worker": 32
      },
      "advanced_tuning_config": {
        "prefill_latency_correction_scale": 1.1,
        "decode_latency_correction_scale": 1.08,
        "prefill_max_batch_size": 1,
        "decode_max_batch_size": 512
      }
    }
  }
}
INFO 2025-11-05 14:25:52,891 task.py:1022] Starting Pareto Analysis for disagg_QWEN3_32B_h100_sxm_h100_sxm_vllm_0.11.0_4000_1000_1000.0_20.0 in disagg mode...
INFO 2025-11-05 14:25:52,891 task.py:881] Task disagg_QWEN3_32B_h100_sxm_h100_sxm_vllm_0.11.0_4000_1000_1000.0_20.0: Setting up runtime config
INFO 2025-11-05 14:25:52,891 task.py:889] Task disagg_QWEN3_32B_h100_sxm_h100_sxm_vllm_0.11.0_4000_1000_1000.0_20.0: Setting up prefill database
INFO 2025-11-05 14:25:52,960 task.py:906] Task disagg_QWEN3_32B_h100_sxm_h100_sxm_vllm_0.11.0_4000_1000_1000.0_20.0: Setting up prefill model config
INFO 2025-11-05 14:25:52,960 task.py:917] Task disagg_QWEN3_32B_h100_sxm_h100_sxm_vllm_0.11.0_4000_1000_1000.0_20.0: Enumerating prefill parallel config
INFO 2025-11-05 14:25:52,960 pareto_analysis.py:75] Enumerated parallel config: tp=1, pp=1, dp=1, moe_tp=1, moe_ep=1
INFO 2025-11-05 14:25:52,960 pareto_analysis.py:75] Enumerated parallel config: tp=2, pp=1, dp=1, moe_tp=1, moe_ep=1
INFO 2025-11-05 14:25:52,960 pareto_analysis.py:75] Enumerated parallel config: tp=4, pp=1, dp=1, moe_tp=1, moe_ep=1
INFO 2025-11-05 14:25:52,960 pareto_analysis.py:75] Enumerated parallel config: tp=8, pp=1, dp=1, moe_tp=1, moe_ep=1
INFO 2025-11-05 14:25:52,960 task.py:940] Task disagg_QWEN3_32B_h100_sxm_h100_sxm_vllm_0.11.0_4000_1000_1000.0_20.0: Setting up decode database
INFO 2025-11-05 14:25:53,027 task.py:957] Task disagg_QWEN3_32B_h100_sxm_h100_sxm_vllm_0.11.0_4000_1000_1000.0_20.0: Setting up decode model config
INFO 2025-11-05 14:25:53,027 task.py:968] Task disagg_QWEN3_32B_h100_sxm_h100_sxm_vllm_0.11.0_4000_1000_1000.0_20.0: Enumerating decode parallel config
INFO 2025-11-05 14:25:53,027 pareto_analysis.py:75] Enumerated parallel config: tp=1, pp=1, dp=1, moe_tp=1, moe_ep=1
INFO 2025-11-05 14:25:53,027 pareto_analysis.py:75] Enumerated parallel config: tp=2, pp=1, dp=1, moe_tp=1, moe_ep=1
INFO 2025-11-05 14:25:53,027 pareto_analysis.py:75] Enumerated parallel config: tp=4, pp=1, dp=1, moe_tp=1, moe_ep=1
INFO 2025-11-05 14:25:53,027 pareto_analysis.py:75] Enumerated parallel config: tp=8, pp=1, dp=1, moe_tp=1, moe_ep=1
INFO 2025-11-05 14:25:53,028 task.py:991] Task disagg_QWEN3_32B_h100_sxm_h100_sxm_vllm_0.11.0_4000_1000_1000.0_20.0: Running disagg pareto
INFO 2025-11-05 14:26:11,289 main.py:293] Experiment disagg completed with 21 results.
INFO 2025-11-05 14:26:11,289 main.py:286] Starting experiment: agg
INFO 2025-11-05 14:26:11,289 main.py:287] Task config: {
  "agg_QWEN3_32B_h100_sxm_vllm_0.11.0_4000_1000_1000.0_20.0": {
    "mode": "patch",
    "serving_mode": "agg",
    "model_name": "QWEN3_32B",
    "total_gpus": 32,
    "system_name": "h100_sxm",
    "backend_name": "vllm",
    "backend_version": "0.11.0",
    "isl": 4000,
    "osl": 1000,
    "ttft": 1000.0,
    "tpot": 20.0,
    "profiles": [],
    "config": {
      "nextn": 0,
      "nextn_accept_rates": [
        0.85,
        0,
        0,
        0,
        0
      ],
      "worker_config": {
        "system_name": "h100_sxm",
        "backend_name": "vllm",
        "backend_version": "0.11.0",
        "num_gpu_per_worker": [
          1,
          2,
          4,
          8
        ],
        "tp_list": [
          1,
          2,
          4,
          8
        ],
        "pp_list": [
          1
        ],
        "dp_list": [
          1
        ],
        "moe_tp_list": [
          1
        ],
        "moe_ep_list": [
          1
        ],
        "gemm_quant_mode": "fp8",
        "moe_quant_mode": "fp8",
        "kvcache_quant_mode": "fp8",
        "fmha_quant_mode": "float16",
        "comm_quant_mode": "half"
      }
    }
  }
}
INFO 2025-11-05 14:26:11,289 task.py:1022] Starting Pareto Analysis for agg_QWEN3_32B_h100_sxm_vllm_0.11.0_4000_1000_1000.0_20.0 in agg mode...
INFO 2025-11-05 14:26:11,289 task.py:808] Task agg_QWEN3_32B_h100_sxm_vllm_0.11.0_4000_1000_1000.0_20.0: Setting up runtime config
INFO 2025-11-05 14:26:11,289 task.py:815] Task agg_QWEN3_32B_h100_sxm_vllm_0.11.0_4000_1000_1000.0_20.0: Setting up database
INFO 2025-11-05 14:26:11,349 task.py:832] Task agg_QWEN3_32B_h100_sxm_vllm_0.11.0_4000_1000_1000.0_20.0: Setting up model config
INFO 2025-11-05 14:26:11,349 task.py:842] Task agg_QWEN3_32B_h100_sxm_vllm_0.11.0_4000_1000_1000.0_20.0: Enumerating parallel config
INFO 2025-11-05 14:26:11,349 pareto_analysis.py:75] Enumerated parallel config: tp=1, pp=1, dp=1, moe_tp=1, moe_ep=1
INFO 2025-11-05 14:26:11,349 pareto_analysis.py:75] Enumerated parallel config: tp=2, pp=1, dp=1, moe_tp=1, moe_ep=1
INFO 2025-11-05 14:26:11,349 pareto_analysis.py:75] Enumerated parallel config: tp=4, pp=1, dp=1, moe_tp=1, moe_ep=1
INFO 2025-11-05 14:26:11,349 pareto_analysis.py:75] Enumerated parallel config: tp=8, pp=1, dp=1, moe_tp=1, moe_ep=1
INFO 2025-11-05 14:26:11,349 task.py:864] Task agg_QWEN3_32B_h100_sxm_vllm_0.11.0_4000_1000_1000.0_20.0: Running agg pareto
INFO 2025-11-05 14:26:14,319 main.py:293] Experiment agg completed with 40 results.
INFO 2025-11-05 14:26:14,333 report_and_save.py:296] 
********************************************************************************
*                     Dynamo aiconfigurator Final Results                      *
********************************************************************************
  ----------------------------------------------------------------------------
  Input Configuration & SLA Target:
    Model: QWEN3_32B (is_moe: False)
    Total GPUs: 32
    Best Experiment Chosen: disagg at 1100.84 tokens/s/gpu (disagg 1.08x better)
  ----------------------------------------------------------------------------
  Overall Best Configuration:
    - Best Throughput: 1100.84 tokens/s/gpu
    - User Throughput: 50.33 tokens/s/user
    - TTFT: 514.76ms
    - TPOT: 19.87ms
  ----------------------------------------------------------------------------
  Pareto Frontier:
               QWEN3_32B Pareto Frontier: tokens/s/gpu vs tokens/s/user         
      ┌────────────────────────────────────────────────────────────────────────┐
1750.0┤ •• disagg                                                              │
      │ ff agg                                                                 │
      │ xx disagg best                                                         │
      │                                                                        │
1458.3┤        f                                                               │
      │         ff                                                             │
      │           ff•                                                          │
      │             ffff                                                       │
1166.7┤               ••ff                                                     │
      │                 •x•••                                                  │
      │                   f  •••                                               │
      │                    ffff •                                              │
 875.0┤                        f •••••                                         │
      │                         f    •                                         │
      │                          ff  •                                         │
      │                           f  •                                         │
 583.3┤                            fff                                         │
      │                              •f••                                      │
      │                                ff•                                     │
      │                                  ffffff                                │
 291.7┤                                     •••fffff                           │
      │                                        •    fff                        │
      │                                        ••••••  ffffffffff              │
      │                                              •••••••     fff           │
   0.0┤                                                             f          │
      └┬─────────────────┬─────────────────┬────────────────┬─────────────────┬┘
       0                50                100              150              200 
tokens/s/gpu                         tokens/s/user                              

  ----------------------------------------------------------------------------
  Deployment Details:
    (p) stands for prefill, (d) stands for decode, bs stands for batch size, a replica stands for the smallest scalable unit xPyD of the disagg system
    Some math: total gpus used = replicas * gpus/replica
               gpus/replica = (p)gpus/worker * (p)workers + (d)gpus/worker * (d)workers; for Agg, gpus/replica = gpus/worker
               gpus/worker = tp * pp * dp = etp * ep * pp for MoE models; tp * pp for dense models (underlined numbers are the actual values in math)

disagg Top Configurations: (Sorted by tokens/s/gpu)
+------+--------------+---------------+--------+--------------+-------------------+----------+----------------+------------+----------------+-------------+-------+------------+----------------+-------------+-------+
| Rank | tokens/s/gpu | tokens/s/user |  TTFT  | concurrency  | total_gpus (used) | replicas |  gpus/replica  | (p)workers | (p)gpus/worker | (p)parallel | (p)bs | (d)workers | (d)gpus/worker | (d)parallel | (d)bs |
+------+--------------+---------------+--------+--------------+-------------------+----------+----------------+------------+----------------+-------------+-------+------------+----------------+-------------+-------+
|  1   |   1100.84    |     50.33     | 514.76 | 760 (=380x2) |    32 (32=2x16)   |    2     | 16 (=6x1+5x2)  |     6      |    1 (=1x1)    |    tp1pp1   |   1   |     5      |    2 (=2x1)    |    tp2pp1   |   76  |
|  2   |   1076.26    |     58.44     | 514.76 | 640 (=640x1) |    32 (32=1x32)   |    1     | 32 (=12x1+5x4) |     12     |    1 (=1x1)    |    tp1pp1   |   1   |     5      |    4 (=4x1)    |    tp4pp1   |  128  |
|  3   |    786.83    |     72.91     | 514.76 | 384 (=384x1) |    32 (32=1x32)   |    1     | 32 (=8x1+3x8)  |     8      |    1 (=1x1)    |    tp1pp1   |   1   |     3      |    8 (=8x1)    |    tp8pp1   |  128  |
|  4   |    687.84    |     53.11     | 514.76 | 450 (=450x1) |    32 (32=1x32)   |    1     | 32 (=7x1+25x1) |     7      |    1 (=1x1)    |    tp1pp1   |   1   |     25     |    1 (=1x1)    |    tp1pp1   |   18  |
+------+--------------+---------------+--------+--------------+-------------------+----------+----------------+------------+----------------+-------------+-------+------------+----------------+-------------+-------+

agg Top Configurations: (Sorted by tokens/s/gpu)
+------+--------------+---------------+--------+--------------+-------------------+----------+--------------+-------------+----------+-----+
| Rank | tokens/s/gpu | tokens/s/user |  TTFT  | concurrency  | total_gpus (used) | replicas | gpus/replica | gpus/worker | parallel |  bs |
+------+--------------+---------------+--------+--------------+-------------------+----------+--------------+-------------+----------+-----+
|  1   |   1022.63    |     53.45     | 839.35 | 640 (=40x16) |    32 (32=16x2)   |    16    |      2       |  2 (=2x1x1) |  tp2pp1  |  40 |
|  2   |   1005.02    |     51.65     | 738.94 | 640 (=80x8)  |    32 (32=8x4)    |    8     |      4       |  4 (=4x1x1) |  tp4pp1  |  80 |
|  3   |    773.63    |     50.19     | 703.32 | 512 (=16x32) |    32 (32=32x1)   |    32    |      1       |  1 (=1x1x1) |  tp1pp1  |  16 |
|  4   |    721.21    |     52.50     | 535.64 | 448 (=112x4) |    32 (32=4x8)    |    4     |      8       |  8 (=8x1x1) |  tp8pp1  | 112 |
+------+--------------+---------------+--------+--------------+-------------------+----------+--------------+-------------+----------+-----+
********************************************************************************
INFO 2025-11-05 14:26:14,333 main.py:338] All experiments completed in 21.44 seconds
```