### PR TITLE
ci: dco bot not required for ai-dynamo members with gpg signing

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,2 @@
+require:
+  members: false


### PR DESCRIPTION
#### Overview:

Configuration file setup ahead of enabling the DCO bot. This will allow any member of the ai-dynamo organization the ability to use GPG-signed commits in lieu of a `--signoff` flag when making a commit.