### PR TITLE
perf: optimize num_gpu lookup in match_workers

### DIFF
--- a/src/aiconfigurator/sdk/inference_session.py
+++ b/src/aiconfigurator/sdk/inference_session.py
@@ -422,10 +422,12 @@ class DisaggInferenceSession:
             """
             prefill_opt_num_worker, decode_opt_num_worker = -1, -1
             throughput_per_gpu_max = 0
+            # minor perf optimization: convert num_gpu_list to a set to speed up lookup
+            num_gpu_set = set(num_gpu_list) if num_gpu_list is not None else None
             for decode_num_worker in decode_num_worker_list:
                 for prefill_num_worker in prefill_num_worker_list:
                     num_gpu = prefill_gpus * prefill_num_worker + decode_gpus * decode_num_worker
-                    if num_gpu_list is not None and num_gpu not in num_gpu_list:
+                    if num_gpu_set is not None and num_gpu not in num_gpu_set:
                         continue
 
                     prefill_throughput_corrected = (


### PR DESCRIPTION
#### Overview:

Optimizes the implementation of `_match_workers` using a set for `num_gpu` lookup.

#### Details:

In my local testing, this speeds up `aiconfigurator cli default --model DEEPSEEK_V3 --total_gpus 32 --system h200_sxm` from `63.3s` --> `61.4s`

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
