### PR TITLE
perf: remove cubic interpolation and scipy dependency

### DIFF
--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a6be58b70923dfd23c667d2b98a5bef2e4b1550afffecc35bb200574a3a7edb9
-size 586731
+oid sha256:d6c3f6cb92bbb222237eea02e78fea0457100ebe856a0390a604df8ad38ec651
+size 581388

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ dependencies = [
     "prettytable>=3.16.0",
     "pydantic~=2.11.4",
     "pyyaml>=6.0",
-    "scipy>=1.13.1",
     "uvicorn>=0.34.2",
     "bokeh",
     "nvidia-ml-py",

--- a/tests/sdk/database/test_interpolation.py
+++ b/tests/sdk/database/test_interpolation.py
@@ -143,16 +143,8 @@ class TestInterpolationMethods:
                     data[x][y][z] = x * 0.1 + y * 0.2 + z * 0.3
 
         # Test bilinear method
-        result_bilinear = comprehensive_perf_db._interp_2d_1d(15, 35, 55, data, method="bilinear")
-        assert result_bilinear > 0
-
-        # Test cubic method (if scipy is available)
-        result_cubic = comprehensive_perf_db._interp_2d_1d(15, 35, 55, data, method="cubic")
-        assert result_cubic > 0
-
-        # Invalid method should raise error
-        with pytest.raises(NotImplementedError):
-            comprehensive_perf_db._interp_2d_1d(15, 35, 55, data, method="invalid")
+        result = comprehensive_perf_db._interp_2d_1d(15, 35, 55, data)
+        assert result > 0
 
     def test_interp_3d(self, comprehensive_perf_db):
         """Test general 3D interpolation dispatcher."""
@@ -166,9 +158,9 @@ class TestInterpolationMethods:
         result_linear = comprehensive_perf_db._interp_3d(15, 35, 55, data, "linear")
         assert result_linear > 0
 
-        # Test fallback to 2D-1D
-        result_bilinear = comprehensive_perf_db._interp_3d(15, 35, 55, data, "bilinear")
-        assert result_bilinear > 0
+        # Test default 2D-1D bilinear interpolation
+        result = comprehensive_perf_db._interp_3d(15, 35, 55, data)
+        assert result > 0
 
 
 class TestExtrapolateDataGrid:

--- a/tests/sdk/database/test_perf_database_coverage.md
+++ b/tests/sdk/database/test_perf_database_coverage.md
@@ -91,7 +91,7 @@ Tests for interpolation helper methods:
   - `_interp_1d()` - linear interpolation
   - `_bilinear_interpolation()` - 2D interpolation
   - `_interp_3d_linear()` - 3D linear interpolation
-  - `_interp_2d_1d()` - bilinear/cubic methods
+  - `_interp_2d_1d()` - bilinear interpolation
   - `_interp_3d()` - dispatcher method
 - **TestExtrapolateDataGrid**:
   - Basic extrapolation functionality


### PR DESCRIPTION
#### Overview:

This change removes all usage of cubic interpolation via `scipy.griddata` in favor of only using bilinear interpolation.

In my local testing, this speeds up `aiconfigurator cli default --model DEEPSEEK_V3 --total_gpus 32 --system h200_sxm` from `63.3s` --> `38.7s` (39% faster)

#### Details:

`scipy.interpolate.griddata` with cubic interpolation is called ~119K times in the above example, and is around 10x slower than bilinear interpolation. This is intended for irregular scattered data, which seems unnecessary for regular grid data.

Reasons why cubic interpolation is probably not required:
- We currently interpolate on 2x2 grids (4 points), but cubic interpolation usually only provides a meaningful accuracy difference for larger grids
- The logic in [`_extrapolate_data_grid`](https://github.com/ai-dynamo/aiconfigurator/blob/main/src/aiconfigurator/sdk/perf_database.py#L1664) already performs a sqrt transformation with linear interpolation, and so applying cubic interpolation on linearly-extrapolated points shouldn't provide any additional benefit

Empirical analysis:

1. `aiconfigurator cli default --model DEEPSEEK_V3 --total_gpus 32 --system h200_sxm --moe_backend WIDEEP`

Before this change:
```
agg Top Configurations: (Sorted by tokens/s/gpu)
+------+--------------+---------------+---------+-------------+-------------------+----------+--------------+-------------+------------------+----+
| Rank | tokens/s/gpu | tokens/s/user |   TTFT  | concurrency | total_gpus (used) | replicas | gpus/replica | gpus/worker |     parallel     | bs |
+------+--------------+---------------+---------+-------------+-------------------+----------+--------------+-------------+------------------+----+
|  1   |    228.22    |     42.40     | 1970.70 | 192 (=48x4) |    32 (32=4x8)    |    4     |      8       |  8 (=1x1x8) | tp1pp1dp8etp1ep8 | 6  |
|  2   |    220.40    |     40.84     | 1993.31 | 192 (=48x4) |    32 (32=4x8)    |    4     |      8       |  8 (=1x1x8) | tp1pp1dp8etp2ep4 | 6  |
|  3   |    174.48    |     36.04     |  917.40 | 160 (=40x4) |    32 (32=4x8)    |    4     |      8       |  8 (=8x1x1) | tp8pp1dp1etp1ep8 | 40 |
|  4   |    164.42    |     33.97     |  975.59 | 160 (=40x4) |    32 (32=4x8)    |    4     |      8       |  8 (=8x1x1) | tp8pp1dp1etp2ep4 | 40 |
|  5   |    144.92    |     37.75     | 1030.73 | 128 (=32x4) |    32 (32=4x8)    |    4     |      8       |  8 (=8x1x1) | tp8pp1dp1etp4ep2 | 32 |
+------+--------------+---------------+---------+-------------+-------------------+----------+--------------+-------------+------------------+----+

disagg Top Configurations: (Sorted by tokens/s/gpu)
+------+--------------+---------------+---------+--------------+-------------------+----------+---------------+------------+----------------+------------------+-------+------------+----------------+------------------+-------+
| Rank | tokens/s/gpu | tokens/s/user |   TTFT  | concurrency  | total_gpus (used) | replicas |  gpus/replica | (p)workers | (p)gpus/worker |   (p)parallel    | (p)bs | (d)workers | (d)gpus/worker |   (d)parallel    | (d)bs |
+------+--------------+---------------+---------+--------------+-------------------+----------+---------------+------------+----------------+------------------+-------+------------+----------------+------------------+-------+
|  1   |    403.59    |     33.71     | 1809.04 | 416 (=208x2) |    32 (32=2x16)   |    2     | 16 (=1x8+1x8) |     1      |   8 (=1x1x8)   | tp1pp1dp8etp1ep8 |   1   |     1      |   8 (=1x1x8)   | tp1pp1dp8etp1ep8 |   26  |
|  2   |    338.50    |     33.41     | 1809.04 | 352 (=176x2) |    32 (32=2x16)   |    2     | 16 (=1x8+1x8) |     1      |   8 (=1x1x8)   | tp1pp1dp8etp1ep8 |   1   |     1      |   8 (=1x1x8)   | tp1pp1dp8etp2ep4 |   22  |
|  3   |    221.32    |     33.72     | 1809.04 | 228 (=228x1) |    32 (32=1x32)   |    1     | 32 (=1x8+3x8) |     1      |   8 (=1x1x8)   | tp1pp1dp8etp1ep8 |   1   |     3      |   8 (=8x1x1)   | tp8pp1dp1etp1ep8 |   76  |
|  4   |    215.11    |     33.37     | 1809.04 | 224 (=224x1) |    32 (24=1x24)   |    1     | 24 (=1x8+2x8) |     1      |   8 (=1x1x8)   | tp1pp1dp8etp1ep8 |   1   |     2      |   8 (=1x1x8)   | tp1pp1dp8etp4ep2 |   14  |
|  5   |    199.84    |     34.05     | 1809.04 | 204 (=204x1) |    32 (32=1x32)   |    1     | 32 (=1x8+3x8) |     1      |   8 (=1x1x8)   | tp1pp1dp8etp1ep8 |   1   |     3      |   8 (=8x1x1)   | tp8pp1dp1etp2ep4 |   68  |
+------+--------------+---------------+---------+--------------+-------------------+----------+---------------+------------+----------------+------------------+-------+------------+----------------+------------------+-------+
********************************************************************************
2025-11-18 18:49:03,817 - aiconfigurator.cli.main - INFO - All experiments completed in 63.10 seconds
```

After this change:
```
agg Top Configurations: (Sorted by tokens/s/gpu)
+------+--------------+---------------+---------+-------------+-------------------+----------+--------------+-------------+------------------+----+
| Rank | tokens/s/gpu | tokens/s/user |   TTFT  | concurrency | total_gpus (used) | replicas | gpus/replica | gpus/worker |     parallel     | bs |
+------+--------------+---------------+---------+-------------+-------------------+----------+--------------+-------------+------------------+----+
|  1   |    228.25    |     42.40     | 1969.51 | 192 (=48x4) |    32 (32=4x8)    |    4     |      8       |  8 (=1x1x8) | tp1pp1dp8etp1ep8 | 6  |
|  2   |    220.43    |     40.84     | 1992.12 | 192 (=48x4) |    32 (32=4x8)    |    4     |      8       |  8 (=1x1x8) | tp1pp1dp8etp2ep4 | 6  |
|  3   |    174.50    |     36.05     |  917.01 | 160 (=40x4) |    32 (32=4x8)    |    4     |      8       |  8 (=8x1x1) | tp8pp1dp1etp1ep8 | 40 |
|  4   |    164.44    |     33.97     |  975.20 | 160 (=40x4) |    32 (32=4x8)    |    4     |      8       |  8 (=8x1x1) | tp8pp1dp1etp2ep4 | 40 |
|  5   |    144.93    |     37.76     | 1030.37 | 128 (=32x4) |    32 (32=4x8)    |    4     |      8       |  8 (=8x1x1) | tp8pp1dp1etp4ep2 | 32 |
+------+--------------+---------------+---------+-------------+-------------------+----------+--------------+-------------+------------------+----+

disagg Top Configurations: (Sorted by tokens/s/gpu)
+------+--------------+---------------+---------+--------------+-------------------+----------+---------------+------------+----------------+------------------+-------+------------+----------------+------------------+-------+
| Rank | tokens/s/gpu | tokens/s/user |   TTFT  | concurrency  | total_gpus (used) | replicas |  gpus/replica | (p)workers | (p)gpus/worker |   (p)parallel    | (p)bs | (d)workers | (d)gpus/worker |   (d)parallel    | (d)bs |
+------+--------------+---------------+---------+--------------+-------------------+----------+---------------+------------+----------------+------------------+-------+------------+----------------+------------------+-------+
|  1   |    403.59    |     33.71     | 1807.95 | 416 (=208x2) |    32 (32=2x16)   |    2     | 16 (=1x8+1x8) |     1      |   8 (=1x1x8)   | tp1pp1dp8etp1ep8 |   1   |     1      |   8 (=1x1x8)   | tp1pp1dp8etp1ep8 |   26  |
|  2   |    338.50    |     33.41     | 1807.95 | 352 (=176x2) |    32 (32=2x16)   |    2     | 16 (=1x8+1x8) |     1      |   8 (=1x1x8)   | tp1pp1dp8etp1ep8 |   1   |     1      |   8 (=1x1x8)   | tp1pp1dp8etp2ep4 |   22  |
|  3   |    221.32    |     33.73     | 1807.95 | 228 (=228x1) |    32 (32=1x32)   |    1     | 32 (=1x8+3x8) |     1      |   8 (=1x1x8)   | tp1pp1dp8etp1ep8 |   1   |     3      |   8 (=8x1x1)   | tp8pp1dp1etp1ep8 |   76  |
|  4   |    215.11    |     33.37     | 1807.95 | 224 (=224x1) |    32 (24=1x24)   |    1     | 24 (=1x8+2x8) |     1      |   8 (=1x1x8)   | tp1pp1dp8etp1ep8 |   1   |     2      |   8 (=1x1x8)   | tp1pp1dp8etp4ep2 |   14  |
|  5   |    199.84    |     34.05     | 1807.95 | 204 (=204x1) |    32 (32=1x32)   |    1     | 32 (=1x8+3x8) |     1      |   8 (=1x1x8)   | tp1pp1dp8etp1ep8 |   1   |     3      |   8 (=8x1x1)   | tp8pp1dp1etp2ep4 |   68  |
+------+--------------+---------------+---------+--------------+-------------------+----------+---------------+------------+----------------+------------------+-------+------------+----------------+------------------+-------+
********************************************************************************
2025-11-18 18:48:07,087 - aiconfigurator.cli.main - INFO - All experiments completed in 39.80 seconds
```

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Total Runtime | 63.10s | 39.80s | -37% (23.3s saved) |
| AGG tokens/s/gpu | 228.22 | 228.25 | +0.01% |
| AGG TTFT | 1970.70ms | 1969.51ms | -0.06% |
| DISAGG tokens/s/gpu | 403.59 | 403.59 | 0.00% |
| DISAGG TTFT | 1809.04ms | 1807.95ms | -0.06% |

2. `aiconfigurator cli default --model QWEN3_32B --total_gpus 64 --system a100_sxm`

Before this change:

```
agg Top Configurations: (Sorted by tokens/s/gpu)
+------+--------------+---------------+---------+--------------+-------------------+----------+--------------+-------------+----------+----+
| Rank | tokens/s/gpu | tokens/s/user |   TTFT  | concurrency  | total_gpus (used) | replicas | gpus/replica | gpus/worker | parallel | bs |
+------+--------------+---------------+---------+--------------+-------------------+----------+--------------+-------------+----------+----+
|  1   |    253.21    |     33.76     | 1795.76 | 512 (=32x16) |    64 (64=16x4)   |    16    |      4       |  4 (=4x1x1) |  tp4pp1  | 32 |
|  2   |    241.64    |     36.00     | 1346.60 | 448 (=56x8)  |    64 (64=8x8)    |    8     |      8       |  8 (=8x1x1) |  tp8pp1  | 56 |
|  3   |    112.48    |     34.06     | 1329.32 | 224 (=7x32)  |    64 (64=32x2)   |    32    |      2       |  2 (=2x1x1) |  tp2pp1  | 7  |
+------+--------------+---------------+---------+--------------+-------------------+----------+--------------+-------------+----------+----+

disagg Top Configurations: (Sorted by tokens/s/gpu)
+------+--------------+---------------+---------+--------------+-------------------+----------+----------------+------------+----------------+-------------+-------+------------+----------------+-------------+-------+
| Rank | tokens/s/gpu | tokens/s/user |   TTFT  | concurrency  | total_gpus (used) | replicas |  gpus/replica  | (p)workers | (p)gpus/worker | (p)parallel | (p)bs | (d)workers | (d)gpus/worker | (d)parallel | (d)bs |
+------+--------------+---------------+---------+--------------+-------------------+----------+----------------+------------+----------------+-------------+-------+------------+----------------+-------------+-------+
|  1   |    318.54    |     34.73     | 2224.62 | 648 (=648x1) |    64 (64=1x64)   |    1     | 64 (=28x1+9x4) |     28     |    1 (=1x1)    |    tp1pp1   |   1   |     9      |    4 (=4x1)    |    tp4pp1   |   72  |
|  2   |    182.02    |     34.09     | 2224.62 | 384 (=192x2) |    64 (48=2x24)   |    2     | 24 (=8x1+2x8)  |     8      |    1 (=1x1)    |    tp1pp1   |   1   |     2      |    8 (=8x1)    |    tp8pp1   |   96  |
|  3   |    86.25     |     33.35     | 2224.62 | 180 (=90x2)  |    64 (48=2x24)   |    2     | 24 (=4x1+10x2) |     4      |    1 (=1x1)    |    tp1pp1   |   1   |     10     |    2 (=2x1)    |    tp2pp1   |   9   |
+------+--------------+---------------+---------+--------------+-------------------+----------+----------------+------------+----------------+-------------+-------+------------+----------------+-------------+-------+
********************************************************************************
2025-11-18 18:59:04,491 - aiconfigurator.cli.main - INFO - All experiments completed in 15.06 seconds
```

After this change:

```
agg Top Configurations: (Sorted by tokens/s/gpu)
+------+--------------+---------------+---------+--------------+-------------------+----------+--------------+-------------+----------+----+
| Rank | tokens/s/gpu | tokens/s/user |   TTFT  | concurrency  | total_gpus (used) | replicas | gpus/replica | gpus/worker | parallel | bs |
+------+--------------+---------------+---------+--------------+-------------------+----------+--------------+-------------+----------+----+
|  1   |    253.61    |     33.82     | 1793.39 | 512 (=32x16) |    64 (64=16x4)   |    16    |      4       |  4 (=4x1x1) |  tp4pp1  | 32 |
|  2   |    241.69    |     36.00     | 1345.11 | 448 (=56x8)  |    64 (64=8x8)    |    8     |      8       |  8 (=8x1x1) |  tp8pp1  | 56 |
|  3   |    112.57    |     34.08     | 1326.57 | 224 (=7x32)  |    64 (64=32x2)   |    32    |      2       |  2 (=2x1x1) |  tp2pp1  | 7  |
+------+--------------+---------------+---------+--------------+-------------------+----------+--------------+-------------+----------+----+

disagg Top Configurations: (Sorted by tokens/s/gpu)
+------+--------------+---------------+---------+--------------+-------------------+----------+----------------+------------+----------------+-------------+-------+------------+----------------+-------------+-------+
| Rank | tokens/s/gpu | tokens/s/user |   TTFT  | concurrency  | total_gpus (used) | replicas |  gpus/replica  | (p)workers | (p)gpus/worker | (p)parallel | (p)bs | (d)workers | (d)gpus/worker | (d)parallel | (d)bs |
+------+--------------+---------------+---------+--------------+-------------------+----------+----------------+------------+----------------+-------------+-------+------------+----------------+-------------+-------+
|  1   |    319.33    |     34.76     | 2219.88 | 648 (=648x1) |    64 (64=1x64)   |    1     | 64 (=28x1+9x4) |     28     |    1 (=1x1)    |    tp1pp1   |   1   |     9      |    4 (=4x1)    |    tp4pp1   |   72  |
|  2   |    182.48    |     34.04     | 2219.88 | 384 (=192x2) |    64 (48=2x24)   |    2     | 24 (=8x1+2x8)  |     8      |    1 (=1x1)    |    tp1pp1   |   1   |     2      |    8 (=8x1)    |    tp8pp1   |   96  |
|  3   |    86.54     |     33.37     | 2219.88 | 180 (=90x2)  |    64 (48=2x24)   |    2     | 24 (=4x1+10x2) |     4      |    1 (=1x1)    |    tp1pp1   |   1   |     10     |    2 (=2x1)    |    tp2pp1   |   9   |
+------+--------------+---------------+---------+--------------+-------------------+----------+----------------+------------+----------------+-------------+-------+------------+----------------+-------------+-------+
********************************************************************************
2025-11-18 18:59:34,792 - aiconfigurator.cli.main - INFO - All experiments completed in 9.67 seconds
```

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Total Runtime | 15.06s | 9.67s | -36% (5.4s saved) |
| AGG tokens/s/gpu | 253.21 | 253.61 | +0.16% |
| AGG TTFT | 1795.76ms | 1793.39ms | -0.13% |
| DISAGG tokens/s/gpu | 318.54 | 319.33 | +0.25% |
| DISAGG TTFT | 2224.62ms | 2219.88ms | -0.21% |

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
