### PR TITLE
fix: support small ISL

### DIFF
--- a/src/aiconfigurator/sdk/backends/sglang_backend.py
+++ b/src/aiconfigurator/sdk/backends/sglang_backend.py
@@ -16,10 +16,6 @@ from aiconfigurator.sdk.perf_database import PerfDatabase
 
 logger = logging.getLogger(__name__)
 
-MAX_NORMAL_CTX_TOKENS = 8192
-MAX_CTX_TOKENS_MULTIPLE_OF_ISL = 2
-MAX_CTX_TOKENS_SEARCH_STEPS = 8  # for ctx stride large for faster sweeping
-
 
 class SGLANGBackend(BaseBackend):
     """
@@ -308,14 +304,6 @@ class SGLANGBackend(BaseBackend):
         ctx_stride = kwargs.get("ctx_stride", 512)
         enable_chunked_prefill = kwargs.get("enable_chunked_prefill", False)
 
-        max_ctx_tokens = max(MAX_NORMAL_CTX_TOKENS, isl * MAX_CTX_TOKENS_MULTIPLE_OF_ISL)
-        # if ctx tokens is already larger than 2048, we need to increase ctx_stride for faster
-        # sweeping
-        ctx_stride_large = max(
-            1024,
-            ctx_stride,
-            max_ctx_tokens // MAX_CTX_TOKENS_SEARCH_STEPS,
-        )
         # when b is larger than 1024, the result is not good as the data collection is not enough
         # to cover this.
         b_list_default = (
@@ -328,15 +316,6 @@ class SGLANGBackend(BaseBackend):
             + [1024]
         )
 
-        if not enable_chunked_prefill:
-            logger.debug(
-                f"enable_chunked_prefill is off, override ctx_stride: from {ctx_stride} to {isl}, "
-                f"ctx_stride_large: from {ctx_stride_large} to "
-                f"{np.ceil(ctx_stride_large / isl) * isl}"
-            )
-            ctx_stride = isl
-            ctx_stride_large = np.ceil(ctx_stride_large / isl) * isl
-
         # sweep for batch_size and ctx_tokens
         # ctx_tokens will have a step of ctx_stride. When it's larger than 8192, we will increase
         # the step to ctx_stride_large.
@@ -346,22 +325,7 @@ class SGLANGBackend(BaseBackend):
         # during the loop, as b, ctx_tokens and system memory are monotonic, we can break the
         # inner loop when the system is oom.
         b_list = [b for b in b_list_default if b <= max_batch_size]
-        # prepare ctx_tokens_list
-        ctx_tokens_list = []
-        ctx_tokens = 0
-        while True:
-            ctx_tokens = (
-                (ctx_tokens + ctx_stride) if ctx_tokens < MAX_NORMAL_CTX_TOKENS else (ctx_tokens + ctx_stride_large)
-            )
-            if ctx_tokens > max_ctx_tokens:
-                break
-            ctx_tokens_list.append(ctx_tokens)
-        # add those just match the multiple of isl
-        for i in range(1, MAX_CTX_TOKENS_MULTIPLE_OF_ISL + 1):
-            ctx_tokens = isl * i
-            if ctx_tokens not in ctx_tokens_list:
-                ctx_tokens_list.append(ctx_tokens)
-        ctx_tokens_list.sort()
+        ctx_tokens_list = self._get_ctx_tokens_list_for_agg_sweep(isl, ctx_stride, enable_chunked_prefill)
 
         results_df = pd.DataFrame(columns=common.ColumnsAgg)
         results_dict_list = []

--- a/src/aiconfigurator/sdk/backends/trtllm_backend.py
+++ b/src/aiconfigurator/sdk/backends/trtllm_backend.py
@@ -17,11 +17,6 @@ from aiconfigurator.sdk.perf_database import PerfDatabase
 logger = logging.getLogger(__name__)
 
 
-MAX_NORMAL_CTX_TOKENS = 8192
-MAX_CTX_TOKENS_MULTIPLE_OF_ISL = 2
-MAX_CTX_TOKENS_SEARCH_STEPS = 8  # for ctx stride large for faster sweeping
-
-
 class TRTLLMBackend(BaseBackend):
     """
     TRTLLM backend.
@@ -311,14 +306,6 @@ class TRTLLMBackend(BaseBackend):
         ctx_stride = kwargs.get("ctx_stride", 512)
         enable_chunked_prefill = kwargs.get("enable_chunked_prefill", False)
 
-        max_ctx_tokens = max(MAX_NORMAL_CTX_TOKENS, isl * MAX_CTX_TOKENS_MULTIPLE_OF_ISL)
-        # if ctx tokens is already larger than 2048, we need to increase ctx_stride for faster
-        # sweeping
-        ctx_stride_large = max(
-            1024,
-            ctx_stride,
-            max_ctx_tokens // MAX_CTX_TOKENS_SEARCH_STEPS,
-        )
         # when b is larger than 1024, the result is not good as the data collection is not enough
         # to cover this.
         b_list_default = (
@@ -331,15 +318,6 @@ class TRTLLMBackend(BaseBackend):
             + [1024]
         )
 
-        if not enable_chunked_prefill:
-            logger.debug(
-                f"enable_chunked_prefill is off, override ctx_stride: from {ctx_stride} to {isl}, "
-                f"ctx_stride_large: from {ctx_stride_large} to "
-                f"{np.ceil(ctx_stride_large / isl) * isl}"
-            )
-            ctx_stride = isl
-            ctx_stride_large = np.ceil(ctx_stride_large / isl) * isl
-
         # sweep for batch_size and ctx_tokens
         # ctx_tokens will have a step of ctx_stride. When it's larger than 8192, we will increase
         # the step to ctx_stride_large.
@@ -349,22 +327,7 @@ class TRTLLMBackend(BaseBackend):
         # during the loop, as b, ctx_tokens and system memory are monotonic, we can break the
         # inner loop when the system is oom.
         b_list = [b for b in b_list_default if b <= max_batch_size]
-        # prepare ctx_tokens_list
-        ctx_tokens_list = []
-        ctx_tokens = 0
-        while True:
-            ctx_tokens = (
-                (ctx_tokens + ctx_stride) if ctx_tokens < MAX_NORMAL_CTX_TOKENS else (ctx_tokens + ctx_stride_large)
-            )
-            if ctx_tokens > max_ctx_tokens:
-                break
-            ctx_tokens_list.append(ctx_tokens)
-        # add those just match the multiple of isl
-        for i in range(1, MAX_CTX_TOKENS_MULTIPLE_OF_ISL + 1):
-            ctx_tokens = isl * i
-            if ctx_tokens not in ctx_tokens_list:
-                ctx_tokens_list.append(ctx_tokens)
-        ctx_tokens_list.sort()
+        ctx_tokens_list = self._get_ctx_tokens_list_for_agg_sweep(isl, ctx_stride, enable_chunked_prefill)
 
         results_df = pd.DataFrame(columns=common.ColumnsAgg)
         results_dict_list = []

--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -1225,9 +1225,11 @@ class PerfDatabase:
                                 ]  # n
                                 # currently, support max seq to 1M. Because all the system is linear for
                                 # now. it will be difficult to do square interpolation. Use more points
-                                # to do the approximation
+                                # to do the approximation.
+                                # Note: start from 1 to make sure any small ISL can be interpolated,
+                                # even if the ISL is smaller than what exists in the collected data.
                                 target_y_list = (
-                                    [16, 32, 64, 128, 256, 512, 1024, 2048]
+                                    [1, 16, 32, 64, 128, 256, 512, 1024, 2048]
                                     + [4096 + i * 2048 for i in range(14)]
                                     + [32768 + 16384 * i for i in range(6)]
                                     + [131072 + 32768 * i for i in range(12)]

--- a/tests/sdk/database/test_attention.py
+++ b/tests/sdk/database/test_attention.py
@@ -86,6 +86,21 @@ class TestContextAttention:
         ][b]
         assert math.isclose(result, expected, rel_tol=1e-6)
 
+    def test_query_context_attention_non_sol_mode_small_s(self, comprehensive_perf_db):
+        """
+        Test that query context attention works even when s is smaller than what exists
+        in the collected data.
+        """
+        # Testing s = 1, but in comprehensive_perf_db, smallest s is 16.
+        b, s, prefix, n, n_kv = 2, 1, 0, 16, 4
+        kv_cache_quant_mode = common.KVCacheQuantMode.float16
+        fmha_quant_mode = common.FMHAQuantMode.float16
+
+        result = comprehensive_perf_db.query_context_attention(
+            b, s, prefix, n, n_kv, kv_cache_quant_mode, fmha_quant_mode, sol_mode=common.SOLMode.NON_SOL
+        )
+        assert result > 0
+
     def test_query_context_attention_assertion_error(self, comprehensive_perf_db):
         """Test that n_kv > n raises assertion error."""
         with pytest.raises(AssertionError):


### PR DESCRIPTION
#### Overview:

Fixes an error when `--isl` < 16:
```
File "/home/hongkuanz/Projects/dynamo/.venv/lib/python3.12/site-packages/aiconfigurator/sdk/perf_database.py", line 1134, in _nearest_1d_point_helper
    raise ValueError(f"x is less than the smallest value in the list. {x=}, {sorted_values=}")
ValueError: x is less than the smallest value in the list. x=9, sorted_values=[16, 32, 64, 128, 256, 512, 1024, 1536, 2048, 3072, 4096, 6144, 8192, 10240, 12288, 14336, 16384, 18432, 20480, 22528, 24576, 26624, 28672, 30720, 32768, 49152, 65536, 81920, 98304, 114688, 131072, 163840, 196608, 229376, 262144, 294912, 327680, 360448, 393216, 425984, 458752, 491520, 524288, 589824, 655360, 720896, 786432, 851968, 917504, 983040, 1048576]
```

## Fix overview:
When loading the database, extrapolate existing context_attention values down to a minimum of s=1 instead of s=16.

## Misc
I also had to make minor changes to the ctx_tokens sweep list when sweeping for the optimal agg config. Previously, the stride was set to `isl`, so when `isl` was very small, the agg sweep took forever. I increased the stride length in these cases, and refactored the code so it is shared between `vllm_backend`, `sglang_backend`, and `trtllm_backend`.