### PR TITLE
fix: trigger review assignment on pull_request_target

### DIFF
--- a/.github/workflows/random-review-assignment.yml
+++ b/.github/workflows/random-review-assignment.yml
@@ -1,7 +1,7 @@
 name: Random Review Assignment
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, ready_for_review]
 
 permissions:


### PR DESCRIPTION
#### Overview:

- Trigger the review assignment action on pull_request_target to avoid failure when PR is coming from a fork
