### PR TITLE
fix: enable simple_sdk_demo/main.py to test wideep deepseek

### DIFF
--- a/tools/simple_sdk_demo/cli/main.py
+++ b/tools/simple_sdk_demo/cli/main.py
@@ -111,6 +111,18 @@ def parse(args):
         default=64,
         help="Agg: ctx_stride, mimicking num_tokens_per_block param in TRT-LLM, defaulted as 64",
     )
+    parser.add_argument(
+        "--enable_wideep",
+        action="store_true",
+        help="Enable WideEP DeepSeek modeling (only effective when --backend sglang and model is DeepSeek).",
+    )
+    parser.add_argument(
+        "--moe_backend",
+        type=str,
+        default="deepep_moe",
+        choices=["deepep_moe", "none"],
+        help="moe backend",
+    )
     args = parser.parse_args(args=args)
 
     return args
@@ -130,6 +142,8 @@ def main(args):
         workload_distribution=args.workload_distribution,
         attention_dp_size=args.attention_dp_size,
         overwrite_num_layers=args.overwrite_num_layers,
+        enable_wideep=args.enable_wideep,
+        moe_backend=args.moe_backend,
     )
     runtime_config = config.RuntimeConfig(
         batch_size=args.batch_size,


### PR DESCRIPTION
The previous simple_sdk_demo/main.py didn't support sglang wideep deepseek, I added two arguments to fix that.