### PR TITLE
feat: sglang wideep tp attention modeling

### DIFF
--- a/src/aiconfigurator/sdk/models.py
+++ b/src/aiconfigurator/sdk/models.py
@@ -1323,7 +1323,7 @@ class WideEPDeepSeekModel(BaseModel):
                     h,
                     self._moe_inter_size,
                     moe_quant_mode,
-                    tp_attn_size=tp_size,
+                    tp_size=tp_size,
                 )
             ]
         )

--- a/src/aiconfigurator/sdk/operations.py
+++ b/src/aiconfigurator/sdk/operations.py
@@ -747,11 +747,11 @@ class WideEPMLP(Operation):
         self._quant_mode = quant_mode
         self._weights = (3 * self._hidden_size * self._intermediate_size) * quant_mode.value.memory
         self.is_context = kwargs.get("is_context", True)  # Default to context mode
-        self.tp_attn_size = kwargs.get("tp_attn_size", 1)
+        self.tp_size = kwargs.get("tp_size", 1)
 
     def query(self, database: PerfDatabase, **kwargs):
         x = kwargs.get("x")  # num_tokens
-        x /= self.tp_attn_size
+        x /= self.tp_size
         overwrite_quant_mode = kwargs.get("quant_mode")
         quant_mode = self._quant_mode if overwrite_quant_mode is None else overwrite_quant_mode
 


### PR DESCRIPTION
In wide for sglang, when TP attention is enabled in the prefill phase, it affects the input to the shared experts as num_tokens/tp_size, and introduces two additional NCCL operators to handle the TP attention outputs(all gather and reduce scatter). Here, the modeling and MLP logic for WideEP DeepSeek has been modified accordingly.