### PR TITLE
chore: Add H200 SXM vllm moe_perf

### DIFF
--- a/src/aiconfigurator/systems/data/h200_sxm/vllm/0.11.0/moe_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/vllm/0.11.0/moe_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:797ae07944639273ff0f6b6cd81765d56efa042efbe3f6e8f53230fbb495dd18
+size 1049191


### PR DESCRIPTION
Sanity check:
Looks similar to the vllm h100_sxm sanity check.

<img width="1131" height="903" alt="Screenshot 2025-12-03 at 4 08 58 PM" src="https://github.com/user-attachments/assets/65640f6b-8549-4d91-8df1-92d8bc6c0720" />
