### PR TITLE
chore: Update h100 vllm custom allreduce

### DIFF
--- a/src/aiconfigurator/systems/data/h100_sxm/custom_allreduce_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/custom_allreduce_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:689584cd8c435f8b507775e299b0bc70ac62e17cf732d90d1b80f85edcf00993
+size 14543


### PR DESCRIPTION
#### Overview:
Updates h100 vllm custom_allreduce perf data using the vllm backend in the collect_custom_allreduce script. The old data was copied from TRTLLM.

Sanity check:
Not sure why some values are over 100%. The existing H200 custom_allreduce also has those values over 100%.
<img width="1084" height="225" alt="Screenshot 2025-12-03 at 4 42 53 PM" src="https://github.com/user-attachments/assets/5a49ff17-aabe-4cd9-b16f-e3cfc5acd597" />
