### PR TITLE
fix: use Union instead of | operator for lower python version compatibility

### DIFF
--- a/src/aiconfigurator/sdk/config.py
+++ b/src/aiconfigurator/sdk/config.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from dataclasses import dataclass
+from typing import Union
 
 from aiconfigurator.sdk import common
 
@@ -45,5 +46,5 @@ class RuntimeConfig:
     osl: int = None
     prefix: int = 0  # prefix len of isl
     ttft: float = None
-    tpot: float | list = None
+    tpot: Union[float, list] = None
     request_latency: float = None  # it works together with ttft. 1. <= req_lat 2. <= req_lat and <= ttft


### PR DESCRIPTION
#### Overview:
Fixes Python 3.9 compatibility issue by replacing Python 3.10+ union operator syntax with `Union` from `typing` module.

#### Details:
- Replaced `float | list` with `Union[float, list]` in `RuntimeConfig.tpot` field
- Added `from typing import Union` import

#### Where should the reviewer start?
- Review `src/aiconfigurator/sdk/config.py`


#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #157
