### PR TITLE
fix: Recollect h100 vllm custom_allreduce

### DIFF
--- a/src/aiconfigurator/systems/data/h100_sxm/vllm/0.11.0/custom_allreduce_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/vllm/0.11.0/custom_allreduce_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:689584cd8c435f8b507775e299b0bc70ac62e17cf732d90d1b80f85edcf00993
-size 14543
+oid sha256:83fb9d60ecf0c0b2da6c1311b613cb74fd4814ddbe4379d5c40d8da37ecd0e8d
+size 15444


### PR DESCRIPTION
#### Overview:

Old data had bad sanity check:

<img width="1015" height="216" alt="Screenshot 2025-12-09 at 10 13 31 PM" src="https://github.com/user-attachments/assets/02c955f4-add5-4d80-84fe-4c00ac3d34c7" />


New data is much better:
<img width="1016" height="217" alt="Screenshot 2025-12-09 at 10 14 36 PM" src="https://github.com/user-attachments/assets/f0017f79-20be-457e-af41-2a71d771408c" />

