### PR TITLE
fix: relax pydantic requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "plotext>=5.3.2",
     "plotly>=6.0.1",
     "prettytable>=3.16.0",
-    "pydantic~=2.11.4",
+    "pydantic>=2.11.4,<2.13", # vllm depends on pydantic>=2.12.0
     "pyyaml>=6.0",
     "scipy>=1.13.1",
     "tqdm>=4.0.0",


### PR DESCRIPTION
#### Overview:

This PR should fix:
```
Because ai-dynamo-runtime==0.7.0+f49d6873e depends on pydantic>=2.10.6,<=2.11.7 and vllm==0.11.1 depends on pydantic>=2.12.0, we can conclude that ai-dynamo-runtime==0.7.0+f49d6873e and
      vllm==0.11.1 are incompatible.
```
#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
