### PR TITLE
fix: moe args and workload distribution fallback

### DIFF
--- a/src/aiconfigurator/sdk/operations.py
+++ b/src/aiconfigurator/sdk/operations.py
@@ -230,6 +230,8 @@ class MoE(Operation):
             moe_ep_size=self._moe_ep_size,
             quant_mode=quant_mode,
             workload_distribution=self._workload_distribution,
+            is_context=self._is_context,
+            moe_backend=self._moe_backend,
         )
 
         return PerformanceResult(float(result) * self._scale_factor, energy=result.energy * self._scale_factor)

--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -3750,9 +3750,12 @@ class PerfDatabase:
                     else:
                         moe_data = self._moe_data
 
-                    moe_dict = moe_data[quant_mode][workload_distribution][topk][num_experts][hidden_size][inter_size][
-                        moe_tp_size
-                    ][moe_ep_size]
+                    used_workload_distribution = (
+                        workload_distribution if workload_distribution in moe_data[quant_mode] else "uniform"
+                    )
+                    moe_dict = moe_data[quant_mode][used_workload_distribution][topk][num_experts][hidden_size][
+                        inter_size
+                    ][moe_tp_size][moe_ep_size]
                     num_left, num_right = self._nearest_1d_point_helper(
                         num_tokens,
                         list(moe_dict.keys()),
@@ -3774,37 +3777,35 @@ class PerfDatabase:
                     # aligned with trtllm, kernel source selection.
                     if num_tokens <= 128 and self._moe_low_latency_data and quant_mode == common.MoEQuantMode.nvfp4:
                         try:
-                            if workload_distribution in self._moe_low_latency_data[quant_mode]:
-                                moe_dict = self._moe_low_latency_data[quant_mode][workload_distribution][topk][
-                                    num_experts
-                                ][hidden_size][inter_size][moe_tp_size][moe_ep_size]
-                            else:
-                                moe_dict = self._moe_low_latency_data[quant_mode]["uniform"][topk][num_experts][
-                                    hidden_size
-                                ][inter_size][moe_tp_size][moe_ep_size]
+                            used_workload_distribution = (
+                                workload_distribution
+                                if workload_distribution in self._moe_low_latency_data[quant_mode]
+                                else "uniform"
+                            )
+                            moe_dict = self._moe_low_latency_data[quant_mode][used_workload_distribution][topk][
+                                num_experts
+                            ][hidden_size][inter_size][moe_tp_size][moe_ep_size]
                             logger.debug(
                                 f"trying to find low latency data for moe {quant_mode} "
                                 f"{workload_distribution} {topk} {num_experts} {hidden_size} "
                                 f"{inter_size} {moe_tp_size} {moe_ep_size} but failed."
                             )
                         except:
-                            if workload_distribution in self._moe_data[quant_mode]:
-                                moe_dict = self._moe_data[quant_mode][workload_distribution][topk][num_experts][
-                                    hidden_size
-                                ][inter_size][moe_tp_size][moe_ep_size]
-                            else:
-                                moe_dict = self._moe_data[quant_mode]["uniform"][topk][num_experts][hidden_size][
-                                    inter_size
-                                ][moe_tp_size][moe_ep_size]
-                    else:
-                        if workload_distribution in self._moe_data[quant_mode]:
-                            moe_dict = self._moe_data[quant_mode][workload_distribution][topk][num_experts][
+                            used_workload_distribution = (
+                                workload_distribution
+                                if workload_distribution in self._moe_data[quant_mode]
+                                else "uniform"
+                            )
+                            moe_dict = self._moe_data[quant_mode][used_workload_distribution][topk][num_experts][
                                 hidden_size
                             ][inter_size][moe_tp_size][moe_ep_size]
-                        else:
-                            moe_dict = self._moe_data[quant_mode]["uniform"][topk][num_experts][hidden_size][
-                                inter_size
-                            ][moe_tp_size][moe_ep_size]
+                    else:
+                        used_workload_distribution = (
+                            workload_distribution if workload_distribution in self._moe_data[quant_mode] else "uniform"
+                        )
+                        moe_dict = self._moe_data[quant_mode][used_workload_distribution][topk][num_experts][
+                            hidden_size
+                        ][inter_size][moe_tp_size][moe_ep_size]
 
                     num_left, num_right = self._nearest_1d_point_helper(
                         num_tokens,
@@ -3824,7 +3825,10 @@ class PerfDatabase:
                         energy = 0.0
                     return PerformanceResult(lat, energy=energy)
                 elif self.backend == common.BackendName.vllm.value:
-                    moe_dict = self._moe_data[quant_mode][workload_distribution][topk][num_experts][hidden_size][
+                    used_workload_distribution = (
+                        workload_distribution if workload_distribution in self._moe_data[quant_mode] else "uniform"
+                    )
+                    moe_dict = self._moe_data[quant_mode][used_workload_distribution][topk][num_experts][hidden_size][
                         inter_size
                     ][moe_tp_size][moe_ep_size]
                     num_left, num_right = self._nearest_1d_point_helper(


### PR DESCRIPTION
1.Args are not passed in ops.query() for moe wideep.
2.needs to fallback workload_distribution to uniform to make data compatible for wideep moe
