### PR TITLE
fix: use ttft to filter prefill candidates

### DIFF
--- a/src/aiconfigurator/sdk/inference_session.py
+++ b/src/aiconfigurator/sdk/inference_session.py
@@ -567,9 +567,9 @@ class DisaggInferenceSession:
             correction_factor = 1.8  # let's make it simple for now.
             prefill_candidates = prefill_summary_df.assign(ttft=prefill_summary_df["ttft"] * correction_factor)
 
-            prefill_candidates = prefill_candidates[prefill_candidates["context_latency"] < ttft]
+            prefill_candidates = prefill_candidates[prefill_candidates["ttft"] < ttft]
             if len(prefill_candidates) == 0:
-                logger.debug(f"No prefill worker candidates found for ttft {ttft}ms.")
+                logger.warning(f"No prefill worker candidates found for ttft {ttft}ms.")
                 return None
             prefill_candidates = (
                 prefill_candidates.sort_values(by=["seq/s/gpu", "global_bs"], ascending=[False, True])
@@ -582,7 +582,7 @@ class DisaggInferenceSession:
                 & (decode_summary_df["tpot"] > tpot * DECODE_FILTER_RATIO_MIN)
             ].copy()
             if len(decode_candidates) == 0:
-                logger.debug(f"No decode worker candidates found for tpot {tpot}ms.")
+                logger.warning(f"No decode worker candidates found for tpot {tpot}ms.")
                 return None
 
             all_category_results: list[dict] = []


### PR DESCRIPTION
use ttft to filter out prefill candidates rather than context_latency
