### PR TITLE
fix: fp8 block gemm collector

### DIFF
--- a/collector/vllm/collect_gemm.py
+++ b/collector/vllm/collect_gemm.py
@@ -18,7 +18,7 @@ from vllm.version import __version__ as vllm_version
 
 from helper import benchmark_with_power, get_sm_version, log_perf
 
-compatible_versions = ["0.11.0"]
+compatible_versions = ["0.11.0", "0.12.0"]
 
 FP8_BLOCK_SHAPE = (128, 128)
 


### PR DESCRIPTION
current vllm fp8 block gemm (using deepgemm) is broken. it's required by ds/qwen
verified with 0.11.0 and 0.12.0