### PR TITLE
fix: correct backend templates path in package data configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ aiconfigurator = "aiconfigurator.main:main"
 
 [tool.setuptools.package-data]
 "aiconfigurator.cli" = ["*.yaml", "exps/*.yaml"]
-"aiconfigurator.generator" = ["config/**/*.yaml", "config/mappings/backend_templates/**/*.j2", "rule_plugin/*.rule"]
+"aiconfigurator.generator" = ["config/**/*.yaml", "config/backend_templates/**/*.j2", "rule_plugin/*.rule"]
 "aiconfigurator" = ["systems/*.yaml", "systems/**/*.txt", "model_configs/*.json"]
 "aiconfigurator.webapp.components.profiling" = ["styles.css", "js/*.js"]
 


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
Fixed an incorrect path in the `aiconfigurator.generator` package data configuration in `pyproject.toml`.

#### Details:

<!-- Describe the changes made in this PR. -->
- Corrected path from `config/mappings/backend_templates/**/*.j2` to `config/backend_templates/**/*.j2`
- Removed the erroneous `mappings/` intermediate directory level to align with the actual directory structure

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
