### PR TITLE
fix: make SOL_FULL mode return a tuple like before

### DIFF
--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -2601,8 +2601,7 @@ class PerfDatabase:
             return PerformanceResult(get_sol(m, n, k, quant_mode)[0], energy=0.0)
         elif database_mode == common.DatabaseMode.SOL_FULL:
             sol_result = get_sol(m, n, k, quant_mode)
-            # SOL_FULL returns tuple - use first element as latency
-            return PerformanceResult(sol_result[0], energy=0.0)
+            return tuple(PerformanceResult(x, energy=0.0) for x in sol_result)
         elif database_mode == common.DatabaseMode.EMPIRICAL:
             return PerformanceResult(get_empirical(m, n, k, quant_mode), energy=0.0)
         else:
@@ -2721,7 +2720,7 @@ class PerfDatabase:
             return PerformanceResult(sol_latency, energy=0.0)
         elif database_mode == common.DatabaseMode.SOL_FULL:
             sol_result = get_sol(b, s, prefix, n, n_kv, head_size, window_size, kvcache_quant_mode, fmha_quant_mode)
-            return PerformanceResult(sol_result[0], energy=0.0)
+            return tuple(PerformanceResult(x, energy=0.0) for x in sol_result)
         elif database_mode == common.DatabaseMode.EMPIRICAL:
             emp_latency = get_empirical(
                 b,
@@ -2865,7 +2864,7 @@ class PerfDatabase:
             return PerformanceResult(sol_latency, energy=0.0)
         elif database_mode == common.DatabaseMode.SOL_FULL:
             sol_result = get_sol(b, s, n, n_kv, head_size, window_size, kvcache_quant_mode)
-            return PerformanceResult(sol_result[0], energy=0.0)
+            return tuple(PerformanceResult(x, energy=0.0) for x in sol_result)
         elif database_mode == common.DatabaseMode.EMPIRICAL:
             emp_latency = get_empirical(b, s, n, n_kv, head_size, window_size, kvcache_quant_mode)
             return PerformanceResult(emp_latency, energy=0.0)
@@ -2970,7 +2969,7 @@ class PerfDatabase:
             return PerformanceResult(sol_latency, energy=0.0)
         elif database_mode == common.DatabaseMode.SOL_FULL:
             sol_result = get_sol(b, s, prefix, num_heads, kvcache_quant_mode, fmha_quant_mode)
-            return PerformanceResult(sol_result[0], energy=0.0)
+            return tuple(PerformanceResult(x, energy=0.0) for x in sol_result)
         elif database_mode == common.DatabaseMode.EMPIRICAL:
             emp_latency = get_empirical(b, s, prefix, num_heads, kvcache_quant_mode, fmha_quant_mode)
             return PerformanceResult(emp_latency, energy=0.0)
@@ -3063,7 +3062,7 @@ class PerfDatabase:
             return PerformanceResult(sol_latency, energy=0.0)
         elif database_mode == common.DatabaseMode.SOL_FULL:
             sol_result = get_sol(b, s, num_heads, kvcache_quant_mode)
-            return PerformanceResult(sol_result[0], energy=0.0)
+            return tuple(PerformanceResult(x, energy=0.0) for x in sol_result)
         elif database_mode == common.DatabaseMode.EMPIRICAL:
             emp_latency = get_empirical(b, s, num_heads, kvcache_quant_mode)
             return PerformanceResult(emp_latency, energy=0.0)
@@ -3190,7 +3189,8 @@ class PerfDatabase:
         if database_mode == common.DatabaseMode.SOL:
             return get_sol(b, s, tp_size, kvcache_quant_mode, fmha_quant_mode)[0]
         elif database_mode == common.DatabaseMode.SOL_FULL:
-            return get_sol(b, s, tp_size, kvcache_quant_mode, fmha_quant_mode)
+            sol_result = get_sol(b, s, tp_size, kvcache_quant_mode, fmha_quant_mode)
+            return tuple(PerformanceResult(x, energy=0.0) for x in sol_result)
         elif database_mode == common.DatabaseMode.EMPIRICAL:
             return get_empirical(b, s, tp_size, kvcache_quant_mode, fmha_quant_mode)
         else:
@@ -3319,7 +3319,8 @@ class PerfDatabase:
         if database_mode == common.DatabaseMode.SOL:
             return get_sol(b, s, prefix, tp_size, kvcache_quant_mode, fmha_quant_mode)[0]
         elif database_mode == common.DatabaseMode.SOL_FULL:
-            return get_sol(b, s, prefix, tp_size, kvcache_quant_mode, fmha_quant_mode)
+            sol_result = get_sol(b, s, prefix, tp_size, kvcache_quant_mode, fmha_quant_mode)
+            return tuple(PerformanceResult(x, energy=0.0) for x in sol_result)
         elif database_mode == common.DatabaseMode.EMPIRICAL:
             return get_empirical(b, s, prefix, tp_size, kvcache_quant_mode, fmha_quant_mode)
         else:
@@ -3412,7 +3413,7 @@ class PerfDatabase:
             return PerformanceResult(sol_latency, energy=0.0)
         elif database_mode == common.DatabaseMode.SOL_FULL:
             sol_result = get_sol(quant_mode, tp_size, size)
-            return PerformanceResult(sol_result[0], energy=0.0)
+            return tuple(PerformanceResult(x, energy=0.0) for x in sol_result)
         elif database_mode == common.DatabaseMode.EMPIRICAL:
             emp_latency = get_empirical(quant_mode, tp_size, size)
             return PerformanceResult(emp_latency, energy=0.0)
@@ -3534,7 +3535,7 @@ class PerfDatabase:
             return PerformanceResult(get_sol(dtype, num_gpus, operation, message_size)[0], energy=0.0)
         elif database_mode == common.DatabaseMode.SOL_FULL:
             sol_result = get_sol(dtype, num_gpus, operation, message_size)
-            return PerformanceResult(sol_result[0], energy=0.0)
+            return tuple(PerformanceResult(x, energy=0.0) for x in sol_result)
         elif database_mode == common.DatabaseMode.EMPIRICAL:
             return PerformanceResult(get_empirical(dtype, num_gpus, operation, message_size), energy=0.0)
         else:
@@ -3724,7 +3725,7 @@ class PerfDatabase:
                 quant_mode,
                 workload_distribution,
             )
-            return PerformanceResult(sol_result[0], energy=0.0)
+            return tuple(PerformanceResult(x, energy=0.0) for x in sol_result)
         elif database_mode == common.DatabaseMode.EMPIRICAL:
             emp_latency = get_empirical(
                 num_tokens,
@@ -3927,7 +3928,7 @@ class PerfDatabase:
             return PerformanceResult(sol_latency, energy=0.0)
         elif database_mode == common.DatabaseMode.SOL_FULL:
             sol_result = get_sol(num_tokens, num_heads, quant_mode, if_pre)
-            return PerformanceResult(sol_result[0], energy=0.0)
+            return tuple(PerformanceResult(x, energy=0.0) for x in sol_result)
         elif database_mode == common.DatabaseMode.EMPIRICAL:
             emp_latency = get_empirical(num_tokens, num_heads, quant_mode, if_pre)
             return PerformanceResult(emp_latency, energy=0.0)
@@ -4005,7 +4006,7 @@ class PerfDatabase:
             return PerformanceResult(get_sol(mem_bytes)[0], energy=0.0)
         elif database_mode == common.DatabaseMode.SOL_FULL:
             sol_result = get_sol(mem_bytes)
-            return PerformanceResult(sol_result[0], energy=0.0)
+            return tuple(PerformanceResult(x, energy=0.0) for x in sol_result)
         elif database_mode == common.DatabaseMode.EMPIRICAL:
             return PerformanceResult(get_empirical(mem_bytes), energy=0.0)
         else:
@@ -4048,7 +4049,7 @@ class PerfDatabase:
             return PerformanceResult(get_sol(message_bytes)[0], energy=0.0)
         elif database_mode == common.DatabaseMode.SOL_FULL:
             sol_result = get_sol(message_bytes)
-            return PerformanceResult(sol_result[0], energy=0.0)
+            return tuple(PerformanceResult(x, energy=0.0) for x in sol_result)
         elif database_mode == common.DatabaseMode.EMPIRICAL:
             return PerformanceResult(get_empirical(message_bytes), energy=0.0)
         else:
@@ -4104,7 +4105,8 @@ class PerfDatabase:
         if database_mode == common.DatabaseMode.SOL:
             return get_sol(num_tokens, hidden_size, intermediate_size, quant_mode)[0]
         elif database_mode == common.DatabaseMode.SOL_FULL:
-            return get_sol(num_tokens, hidden_size, intermediate_size, quant_mode)
+            sol_result = get_sol(num_tokens, hidden_size, intermediate_size, quant_mode)
+            return tuple(PerformanceResult(x, energy=0.0) for x in sol_result)
         elif database_mode == common.DatabaseMode.EMPIRICAL:
             return get_empirical(num_tokens, hidden_size, intermediate_size, quant_mode)
         else:
@@ -4162,7 +4164,7 @@ class PerfDatabase:
             return PerformanceResult(get_sol(num_tokens, topk, num_experts)[0], energy=0.0)
         elif database_mode == common.DatabaseMode.SOL_FULL:
             sol_result = get_sol(num_tokens, topk, num_experts)
-            return PerformanceResult(sol_result[0], energy=0.0)
+            return tuple(PerformanceResult(x, energy=0.0) for x in sol_result)
         elif database_mode == common.DatabaseMode.EMPIRICAL:
             return PerformanceResult(get_empirical(num_tokens, topk, num_experts), energy=0.0)
         else:
@@ -4202,7 +4204,7 @@ class PerfDatabase:
             return PerformanceResult(get_sol(num_tokens, num_experts, topk, hidden_size)[0], energy=0.0)
         elif database_mode == common.DatabaseMode.SOL_FULL:
             sol_result = get_sol(num_tokens, num_experts, topk, hidden_size)
-            return PerformanceResult(sol_result[0], energy=0.0)
+            return tuple(PerformanceResult(x, energy=0.0) for x in sol_result)
         elif database_mode == common.DatabaseMode.EMPIRICAL:
             return PerformanceResult(get_empirical(num_tokens, num_experts, topk, hidden_size), energy=0.0)
         else:

--- a/tests/sdk/database/test_attention.py
+++ b/tests/sdk/database/test_attention.py
@@ -37,7 +37,7 @@ class TestContextAttention:
         assert math.isclose(result, expected, rel_tol=1e-6)
 
     def test_query_context_attention_sol_full_mode(self, comprehensive_perf_db):
-        """Test SOL_FULL mode returns PerformanceResult (acts as float)."""
+        """Test SOL_FULL mode returns complete tuple."""
         b, full_s, prefix, n, n_kv = 1, 32, 0, 8, 4
         s = full_s - prefix
         kv_cache_quant_mode = common.KVCacheQuantMode.float16
@@ -47,11 +47,16 @@ class TestContextAttention:
             b, s, prefix, n, n_kv, kv_cache_quant_mode, fmha_quant_mode, database_mode=common.DatabaseMode.SOL_FULL
         )
 
+        assert isinstance(result, tuple)
+        assert len(result) == 3
+        assert result[0] == max(result[1], result[2])
+
         # Should return PerformanceResult that acts as float
-        assert isinstance(result, float)  # PerformanceResult is a float subclass
-        assert float(result) > 0  # Latency should be positive
-        assert hasattr(result, "energy")  # Should have energy attribute
-        assert result.energy == 0.0  # SOL mode has no energy data
+        for x in result:
+            assert isinstance(x, float)  # PerformanceResult is a float subclass
+            assert float(x) > 0  # Latency should be positive
+            assert hasattr(x, "energy")  # Should have energy attribute
+            assert x.energy == 0.0  # SOL mode has no energy data
 
     def test_query_context_attention_non_database_mode_mha(self, comprehensive_perf_db):
         """Test SILICON mode with MHA (n_kv == n)."""
@@ -139,7 +144,7 @@ class TestGenerationAttention:
         assert math.isclose(result, expected, rel_tol=1e-6)
 
     def test_query_generation_attention_sol_full_mode(self, comprehensive_perf_db):
-        """Test SOL_FULL mode returns PerformanceResult (acts as float)."""
+        """Test SOL_FULL mode returns complete tuple."""
         b, s, n, n_kv = 2, 64, 16, 4
         kv_cache_quant_mode = common.KVCacheQuantMode.fp8
 
@@ -147,11 +152,16 @@ class TestGenerationAttention:
             b, s, n, n_kv, kv_cache_quant_mode, database_mode=common.DatabaseMode.SOL_FULL
         )
 
+        assert isinstance(result, tuple)
+        assert len(result) == 3
+        assert result[0] == max(result[1], result[2])
+
         # Should return PerformanceResult that acts as float
-        assert isinstance(result, float)  # PerformanceResult is a float subclass
-        assert float(result) > 0  # Latency should be positive
-        assert hasattr(result, "energy")  # Should have energy attribute
-        assert result.energy == 0.0  # SOL mode has no energy data
+        for x in result:
+            assert isinstance(x, float)  # PerformanceResult is a float subclass
+            assert float(x) > 0  # Latency should be positive
+            assert hasattr(x, "energy")  # Should have energy attribute
+            assert x.energy == 0.0  # SOL mode has no energy data
 
     def test_query_generation_attention_non_database_mode(self, comprehensive_perf_db):
         """Test SILICON mode with interpolation."""
@@ -290,16 +300,21 @@ class TestGenerationMLA:
         assert math.isclose(result, expected, rel_tol=1e-6)
 
     def test_query_generation_mla_sol_full_mode(self, comprehensive_perf_db):
-        """Test SOL_FULL mode returns PerformanceResult (acts as float)."""
+        """Test SOL_FULL mode returns (sol_time, 0, sol_time)."""
         result = comprehensive_perf_db.query_generation_mla(
             1, 32, 32, common.KVCacheQuantMode.float16, database_mode=common.DatabaseMode.SOL_FULL
         )
 
+        assert isinstance(result, tuple)
+        assert len(result) == 3
+        assert result[0] == max(result[1], result[2])
+
         # Should return PerformanceResult that acts as float
-        assert isinstance(result, float)  # PerformanceResult is a float subclass
-        assert float(result) > 0  # Latency should be positive
-        assert hasattr(result, "energy")  # Should have energy attribute
-        assert result.energy == 0.0  # SOL mode has no energy data
+        for x in result:
+            assert isinstance(x, float)  # PerformanceResult is a float subclass
+            assert float(x) > 0  # Latency should be positive
+            assert hasattr(x, "energy")  # Should have energy attribute
+            assert x.energy == 0.0  # SOL mode has no energy data
 
 
 def test_default_database_mode(comprehensive_perf_db):

--- a/tests/sdk/database/test_base_queries.py
+++ b/tests/sdk/database/test_base_queries.py
@@ -70,7 +70,7 @@ def test_query_custom_allreduce_database_mode_calculation(perf_db):
 
 def test_query_custom_allreduce_sol_full_returns_full_tuple(perf_db):
     """
-    When database_mode == SOL_FULL, query_custom_allreduce returns PerformanceResult (acts as float).
+    When database_mode == SOL_FULL, query_custom_allreduce returns the full tuple (time, 0, 0) from get_sol.
     The latency value should match the calculated SOL time.
     """
     size = 1024
@@ -81,11 +81,16 @@ def test_query_custom_allreduce_sol_full_returns_full_tuple(perf_db):
     # The get_sol function calculates: sol_time = 2 * size * 2 / tp_size * (tp_size - 1) / p2p_bw * 1000
     expected_sol_time = (2 * size * 2 / tp_size * (tp_size - 1) / perf_db.system_spec["node"]["inter_node_bw"]) * 1000
 
-    # Should return PerformanceResult that acts as float
-    assert isinstance(result, float)  # PerformanceResult is a float subclass
-    assert math.isclose(float(result), expected_sol_time)
-    assert hasattr(result, "energy")  # Should have energy attribute
-    assert result.energy == 0.0  # SOL mode has no energy data
+    assert isinstance(result, tuple) and len(result) == 3
+    for i in range(3):
+        x = result[i]
+        expected = expected_sol_time if i == 0 else 0
+
+        # Should return PerformanceResult that acts as float
+        assert isinstance(x, float)  # PerformanceResult is a float subclass
+        assert math.isclose(float(x), expected)
+        assert hasattr(x, "energy")  # Should have energy attribute
+        assert x.energy == 0.0  # SOL mode has no energy data
 
 
 def test_query_custom_allreduce_non_database_mode_uses_custom_latency(perf_db):

--- a/tests/sdk/database/test_moe_mla.py
+++ b/tests/sdk/database/test_moe_mla.py
@@ -51,7 +51,7 @@ class TestMoE:
         assert math.isclose(result, expected, rel_tol=1e-6)
 
     def test_query_moe_sol_full_mode(self, comprehensive_perf_db):
-        """Test SOL_FULL mode returns PerformanceResult (acts as float)."""
+        """Test SOL_FULL mode returns complete tuple."""
         result = comprehensive_perf_db.query_moe(
             8,
             1024,
@@ -65,11 +65,16 @@ class TestMoE:
             database_mode=common.DatabaseMode.SOL_FULL,
         )
 
+        assert isinstance(result, tuple)
+        assert len(result) == 3
+        assert result[0] == max(result[1], result[2])
+
         # Should return PerformanceResult that acts as float
-        assert isinstance(result, float)  # PerformanceResult is a float subclass
-        assert float(result) > 0  # Latency should be positive
-        assert hasattr(result, "energy")  # Should have energy attribute
-        assert result.energy == 0.0  # SOL mode has no energy data
+        for x in result:
+            assert isinstance(x, float)  # PerformanceResult is a float subclass
+            assert float(x) > 0  # Latency should be positive
+            assert hasattr(x, "energy")  # Should have energy attribute
+            assert x.energy == 0.0  # SOL mode has no energy data
 
     def test_query_moe_non_database_mode(self, comprehensive_perf_db):
         """Test SILICON mode with data lookup."""
@@ -204,16 +209,21 @@ class TestMLABMM:
         assert math.isclose(result, expected, rel_tol=1e-6)
 
     def test_query_mla_bmm_sol_full_mode(self, comprehensive_perf_db):
-        """Test SOL_FULL mode returns PerformanceResult (acts as float)."""
+        """Test SOL_FULL mode returns complete tuple."""
         result = comprehensive_perf_db.query_mla_bmm(
             8, 4, common.GEMMQuantMode.float16, True, database_mode=common.DatabaseMode.SOL_FULL
         )
 
+        assert isinstance(result, tuple)
+        assert len(result) == 3
+        assert result[0] == max(result[1], result[2])
+
         # Should return PerformanceResult that acts as float
-        assert isinstance(result, float)  # PerformanceResult is a float subclass
-        assert float(result) > 0  # Latency should be positive
-        assert hasattr(result, "energy")  # Should have energy attribute
-        assert result.energy == 0.0  # SOL mode has no energy data
+        for x in result:
+            assert isinstance(x, float)  # PerformanceResult is a float subclass
+            assert float(x) > 0  # Latency should be positive
+            assert hasattr(x, "energy")  # Should have energy attribute
+            assert x.energy == 0.0  # SOL mode has no energy data
 
     def test_query_mla_bmm_non_database_mode_pre(self, comprehensive_perf_db):
         """Test SILICON mode for pre operation."""
@@ -276,16 +286,22 @@ class TestMemoryOperations:
         assert math.isclose(result, expected, rel_tol=1e-6)
 
     def test_query_mem_op_sol_full_mode(self, comprehensive_perf_db):
-        """Test SOL_FULL mode returns PerformanceResult (acts as float)."""
+        """Test SOL_FULL mode returns (sol_time, 0, sol_time)."""
         mem_bytes = 500_000
 
         result = comprehensive_perf_db.query_mem_op(mem_bytes, database_mode=common.DatabaseMode.SOL_FULL)
 
+        assert isinstance(result, tuple)
+        assert len(result) == 3
+        assert result[1] == 0  # No compute component
+        assert result[0] == result[2]  # sol_time == sol_mem
+        assert result[0] > 0  # Latency should be positive
+
         # Should return PerformanceResult that acts as float
-        assert isinstance(result, float)  # PerformanceResult is a float subclass
-        assert float(result) > 0  # Latency should be positive
-        assert hasattr(result, "energy")  # Should have energy attribute
-        assert result.energy == 0.0  # SOL mode has no energy data
+        for x in result:
+            assert isinstance(x, float)  # PerformanceResult is a float subclass
+            assert hasattr(x, "energy")  # Should have energy attribute
+            assert x.energy == 0.0  # SOL mode has no energy data
 
     def test_query_mem_op_non_database_mode(self, comprehensive_perf_db):
         """Test SILICON mode with empirical scaling."""
@@ -331,16 +347,22 @@ class TestP2P:
         assert math.isclose(result, expected, rel_tol=1e-6)
 
     def test_query_p2p_sol_full_mode(self, comprehensive_perf_db):
-        """Test SOL_FULL mode returns PerformanceResult (acts as float)."""
+        """Test SOL_FULL mode returns (sol_time, 0, sol_time)."""
         message_bytes = 500_000
 
         result = comprehensive_perf_db.query_p2p(message_bytes, database_mode=common.DatabaseMode.SOL_FULL)
 
+        assert isinstance(result, tuple)
+        assert len(result) == 3
+        assert result[1] == 0  # No compute component
+        assert result[0] == result[2]  # sol_time == sol_mem
+        assert float(result[0]) > 0  # Latency should be positive
+
         # Should return PerformanceResult that acts as float
-        assert isinstance(result, float)  # PerformanceResult is a float subclass
-        assert float(result) > 0  # Latency should be positive
-        assert hasattr(result, "energy")  # Should have energy attribute
-        assert result.energy == 0.0  # SOL mode has no energy data
+        for x in result:
+            assert isinstance(x, float)  # PerformanceResult is a float subclass
+            assert hasattr(x, "energy")  # Should have energy attribute
+            assert x.energy == 0.0  # SOL mode has no energy data
 
     def test_query_p2p_non_database_mode(self, comprehensive_perf_db):
         """Test SILICON mode with P2P latency."""


### PR DESCRIPTION
#### Overview:

Recent MR changed SOL_MODE to just return a single number instead of a tuple of (sol_total, sol_math, sol_mem). This broke the code in the `validate_database.ipynb` validation notebook. This PR reverts the change and makes SOL_MODE return a tuple as before (using the new `PerformanceResult` class).
