### PR TITLE
chore: mark SLA service dependencies as optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,12 +41,9 @@ license-files = ["LICENSE"]
 requires-python = ">=3.9"
 
 dependencies = [
-    "uv",
-    "fastapi>=0.115.12",
     "jinja2>=3.1.0",
     "matplotlib>=3.9.4",
     "numpy~=1.26.4",
-    "orjson>=3.10.16",
     "pandas>=2.2.3",
     "plotext>=5.3.2",
     "plotly>=6.0.1",
@@ -54,7 +51,6 @@ dependencies = [
     "pyyaml>=6.0",
     "scipy>=1.13.1",
     "tqdm>=4.0.0",
-    "uvicorn>=0.34.2",
     "bokeh",
     "nvidia-ml-py",
     "munch>=4.0.0"
@@ -62,6 +58,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "uv",
     "ruff==0.14.1",
     "pre-commit==4.3.0",
     "pytest>=8.3.5",
@@ -75,6 +72,11 @@ dev = [
 ]
 webapp = [
     "gradio==5.47.1"
+]
+service = [
+    "fastapi>=0.115.12",
+    "orjson>=3.10.16",
+    "uvicorn>=0.34.2"
 ]
 
 [project.urls]

--- a/tools/simple_sdk_demo/sla_service/sla_service.md
+++ b/tools/simple_sdk_demo/sla_service/sla_service.md
@@ -3,15 +3,29 @@ SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All 
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# clone the repo
-git clone the repo
+# Web Service
 
-# install aiconfigurator follow readme including the required dependency
+This example demonstrates how to use the aiconfigurator SDK to build a simple SLA service.
 
-# launch the container
-python3 tools/sla_service/sla_service.py --server_name 0.0.0.0 --server_port 7860
+NOTE: this script is not actively maintained and may contain bugs.
 
-# access the service
+# Install aiconfigurator with extra dependencies
+
+Install aiconfigurator with some extra packages that are needed for the service:
+
+```bash
+pip install aiconfigurator[service]
+```
+
+# Launch the Web Service
+
+```bash
+python3 tools/simple_sdk_demo/sla_service/sla_service.py --server_name 0.0.0.0 --server_port 7860
+```
+
+# Access the Service
+
+Estimate performance:
 ```
 curl -X 'POST' \
   'http://127.0.0.1:7860/sla' \
@@ -29,7 +43,8 @@ curl -X 'POST' \
     "kvcache_quant": "fp8"
   }'
 ```
-get supported models
+
+Get a list of the supported models:
 ```
 curl -X 'GET' \
   'http://127.0.0.1:7860/sla/supported_models' \


### PR DESCRIPTION
#### Overview:

Mark dependencies used only in the SLA service example to an optional dependency group. This includes `fastapi`, `orjson`, and `uvicorn`.

Also marks `uv` as a dev dependency.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
