### PR TITLE
feat: make perf db and task config more error proof. add l40s sglang custom all reduce data

### DIFF
--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -23,6 +23,10 @@ databases_cache = defaultdict(lambda: defaultdict(lambda: defaultdict()))
 logger = logging.getLogger(__name__)
 
 
+class PerfDataNotAvailableError(RuntimeError):
+    """Raised when required performance data is missing or unsupported for a requested mode."""
+
+
 def get_system_config_path():
     """
     Get the system config path
@@ -1836,49 +1840,64 @@ class PerfDatabase:
         """
         Update the support matrix
         """
+
+        def _enum_key_names(data: dict | None) -> list[str]:
+            """
+            Safely extract Enum key names from a mapping.
+
+            Many perf tables are optional and loaders return None when data files
+            are missing. Treat missing/empty tables as supporting no modes.
+            """
+            if not data:
+                return []
+            names: list[str] = []
+            for key in data:
+                names.append(key.name if hasattr(key, "name") else str(key))
+            return names
+
         # For sglang backend, context_mla_data and generation_mla_data have kernel_source as first
         # level
         # We need to collect quant_modes from the nested structure
         if self.backend == "sglang":
             wideep_context_mla_modes = set()
-            for kernel_source in self._wideep_context_mla_data:
-                for quant_mode in self._wideep_context_mla_data[kernel_source]:
+            for kernel_source in self._wideep_context_mla_data or {}:
+                for quant_mode in (self._wideep_context_mla_data or {})[kernel_source]:
                     wideep_context_mla_modes.add(quant_mode.name)
 
             wideep_generation_mla_modes = set()
-            for kernel_source in self._wideep_generation_mla_data:
-                for kv_cache_dtype in self._wideep_generation_mla_data[kernel_source]:
+            for kernel_source in self._wideep_generation_mla_data or {}:
+                for kv_cache_dtype in (self._wideep_generation_mla_data or {})[kernel_source]:
                     wideep_generation_mla_modes.add(kv_cache_dtype.name)
 
             self.supported_quant_mode = {
-                "gemm": [key.name for key in self._moe_data],
-                "context_attention": [key.name for key in self._context_attention_data],
-                "generation_attention": [key.name for key in self._generation_attention_data],
-                "context_mla": [key.name for key in self._context_mla_data],
-                "generation_mla": [key.name for key in self._generation_mla_data],
-                "mla_bmm": [key.name for key in self._mla_bmm_data],
-                "nccl": [key.name for key in self._nccl_data],
-                "moe": [key.name for key in self._moe_data],
+                "gemm": _enum_key_names(getattr(self, "_gemm_data", None)),
+                "context_attention": _enum_key_names(getattr(self, "_context_attention_data", None)),
+                "generation_attention": _enum_key_names(getattr(self, "_generation_attention_data", None)),
+                "context_mla": _enum_key_names(getattr(self, "_context_mla_data", None)),
+                "generation_mla": _enum_key_names(getattr(self, "_generation_mla_data", None)),
+                "mla_bmm": _enum_key_names(getattr(self, "_mla_bmm_data", None)),
+                "nccl": _enum_key_names(getattr(self, "_nccl_data", None)),
+                "moe": _enum_key_names(getattr(self, "_moe_data", None)),
                 "wideep_context_mla": list(wideep_context_mla_modes),
                 "wideep_generation_mla": list(wideep_generation_mla_modes),
             }
         elif self.backend == "trtllm":
             self.supported_quant_mode = {
-                "gemm": [key.name for key in self._gemm_data],
-                "context_attention": [key.name for key in self._context_attention_data],
-                "generation_attention": [key.name for key in self._generation_attention_data],
-                "context_mla": [key.name for key in self._context_mla_data],
-                "generation_mla": [key.name for key in self._generation_mla_data],
-                "mla_bmm": [key.name for key in self._mla_bmm_data],
-                "nccl": [key.name for key in self._nccl_data],
-                "moe": [key.name for key in self._moe_data],
+                "gemm": _enum_key_names(getattr(self, "_gemm_data", None)),
+                "context_attention": _enum_key_names(getattr(self, "_context_attention_data", None)),
+                "generation_attention": _enum_key_names(getattr(self, "_generation_attention_data", None)),
+                "context_mla": _enum_key_names(getattr(self, "_context_mla_data", None)),
+                "generation_mla": _enum_key_names(getattr(self, "_generation_mla_data", None)),
+                "mla_bmm": _enum_key_names(getattr(self, "_mla_bmm_data", None)),
+                "nccl": _enum_key_names(getattr(self, "_nccl_data", None)),
+                "moe": _enum_key_names(getattr(self, "_moe_data", None)),
             }
         elif self.backend == "vllm":  # TODO: add support for moe and deepseek
             self.supported_quant_mode = {
-                "gemm": [key.name for key in self._gemm_data],
-                "context_attention": [key.name for key in self._context_attention_data],
-                "generation_attention": [key.name for key in self._generation_attention_data],
-                "nccl": [key.name for key in self._nccl_data],
+                "gemm": _enum_key_names(getattr(self, "_gemm_data", None)),
+                "context_attention": _enum_key_names(getattr(self, "_context_attention_data", None)),
+                "generation_attention": _enum_key_names(getattr(self, "_generation_attention_data", None)),
+                "nccl": _enum_key_names(getattr(self, "_nccl_data", None)),
                 "context_mla": [],
                 "generation_mla": [],
                 "mla_bmm": [],
@@ -2123,8 +2142,13 @@ class PerfDatabase:
         """
         Find the nearest 1d point
         """
-        assert values is not None and len(values) >= 2, "values is None or len(values) < 2"
+        if values is None or len(values) == 0:
+            raise PerfDataNotAvailableError("No data points available for interpolation (values is None or empty).")
         sorted_values = sorted(values)
+
+        # Degenerate grid: only one point available. Treat as constant.
+        if len(sorted_values) == 1:
+            return sorted_values[0], sorted_values[0]
 
         if x < sorted_values[0]:
             if inner_only:
@@ -2316,6 +2340,15 @@ class PerfDatabase:
         y1, y2 = y_list
         # Calculate the weights for the corners
         Q11, Q12, Q21, Q22 = data[x1][y1], data[x1][y2], data[x2][y1], data[x2][y2]  # noqa: N806
+
+        # Handle degenerate rectangles (can happen when a dimension has only one grid point).
+        if x1 == x2 and y1 == y2:
+            return Q11
+        if x1 == x2:
+            return self._interp_1d([y1, y2], [Q11, Q12], y)
+        if y1 == y2:
+            return self._interp_1d([x1, x2], [Q11, Q21], x)
+
         f_x1_y1 = Q11 * (x2 - x) * (y2 - y)
         f_x1_y2 = Q12 * (x2 - x) * (y - y1)
         f_x2_y1 = Q21 * (x - x1) * (y2 - y)
@@ -2373,6 +2406,10 @@ class PerfDatabase:
         """
         x0, x1 = x
         y0, y1 = y
+
+        # Degenerate grid: treat as constant.
+        if x0 == x1:
+            return y0
 
         # Check if values are dicts (new format) or floats (legacy)
         if isinstance(y0, dict) and isinstance(y1, dict):
@@ -2484,6 +2521,20 @@ class PerfDatabase:
         else:
             # SILICON or HYBRID mode - use database
             try:
+                if self._gemm_data is None:
+                    msg = (
+                        "GEMM perf table is missing for "
+                        f"system='{self.system}', backend='{self.backend}', version='{self.version}'."
+                    )
+                    raise PerfDataNotAvailableError(msg)
+                if quant_mode not in self._gemm_data:
+                    supported = sorted([k.name for k in self._gemm_data])
+                    raise PerfDataNotAvailableError(
+                        "GEMM perf data not available for requested quant mode. "
+                        f"system='{self.system}', backend='{self.backend}', version='{self.version}', "
+                        f"quant_mode='{quant_mode.name}'. "
+                        f"Supported gemm modes: {supported}"
+                    )
                 result = self._interp_3d(m, n, k, self._gemm_data[quant_mode], "cubic")
                 # Result is dict: {"latency": ..., "power": ..., "energy": ...}
                 return PerformanceResult(result["latency"], energy=result.get("energy", 0.0))
@@ -2612,6 +2663,12 @@ class PerfDatabase:
             return PerformanceResult(emp_latency, energy=0.0)
         else:
             try:
+                if self._context_attention_data is None:
+                    raise PerfDataNotAvailableError(
+                        f"Context attention perf table is missing for system='{self.system}', "
+                        f"backend='{self.backend}', version='{self.version}'. "
+                        "Please use HYBRID or EMPIRICAL database mode, or provide the data file."
+                    )
                 full_s = s + prefix
                 prefix_correction = (full_s * full_s - prefix * prefix) / (full_s * full_s)
                 # In self._context_attention_data, we use n_kv = 0 to mean n_kv == n.
@@ -2623,7 +2680,7 @@ class PerfDatabase:
                 latency = result["latency"] * prefix_correction
                 energy = result.get("energy", 0.0) * prefix_correction
                 return PerformanceResult(latency, energy=energy)
-            except:
+            except Exception as e:
                 if database_mode == common.DatabaseMode.HYBRID:
                     logger.debug(
                         f"Failed to query context attention data for {b=}, {s=}, {prefix=}, {n=}, {n_kv=}, "
@@ -2642,11 +2699,19 @@ class PerfDatabase:
                     )
                     return PerformanceResult(latency, energy=0.0)
                 else:
-                    logger.exception(
-                        f"Failed to query context attention data for {b=}, {s=}, {prefix=}, {n=}, "
-                        f"{n_kv=}, {head_size=}, {window_size=}, {kvcache_quant_mode=}, {fmha_quant_mode=}. "
-                        "Please consider Hybrid mode."
-                    )
+                    # Missing perf data is expected for some system/backend/mode combinations.
+                    # Avoid spamming full tracebacks during Pareto enumeration.
+                    if isinstance(e, PerfDataNotAvailableError):
+                        logger.debug(
+                            f"Missing context attention perf data for {b=}, {s=}, {prefix=}, {n=}, {n_kv=}, "
+                            f"{head_size=}, {window_size=}, {kvcache_quant_mode=}, {fmha_quant_mode=}"
+                        )
+                    else:
+                        logger.exception(
+                            f"Failed to query context attention data for {b=}, {s=}, {prefix=}, {n=}, "
+                            f"{n_kv=}, {head_size=}, {window_size=}, {kvcache_quant_mode=}, {fmha_quant_mode=}. "
+                            "Please consider Hybrid mode."
+                        )
                     raise
 
     @functools.lru_cache(maxsize=32768)
@@ -2745,6 +2810,12 @@ class PerfDatabase:
             return PerformanceResult(emp_latency, energy=0.0)
         else:
             try:
+                if self._generation_attention_data is None:
+                    raise PerfDataNotAvailableError(
+                        f"Generation attention perf table is missing for system='{self.system}', "
+                        f"backend='{self.backend}', version='{self.version}'. "
+                        "Please use HYBRID or EMPIRICAL database mode, or provide the data file."
+                    )
                 # In self._generation_attention_data, we use n_kv = 0 to mean n_kv == n.
                 if n_kv == n:
                     n_kv = 0
@@ -2849,6 +2920,12 @@ class PerfDatabase:
             return PerformanceResult(emp_latency, energy=0.0)
         else:
             try:
+                if self._context_mla_data is None:
+                    raise PerfDataNotAvailableError(
+                        f"Context MLA perf table is missing for system='{self.system}', "
+                        f"backend='{self.backend}', version='{self.version}'. "
+                        "Please use HYBRID or EMPIRICAL database mode, or provide the data file."
+                    )
                 full_s = s + prefix
                 prefix_correction = (full_s * full_s - prefix * prefix) / (full_s * full_s)
                 mla_dict = self._context_mla_data[fmha_quant_mode][kvcache_quant_mode]
@@ -2941,6 +3018,12 @@ class PerfDatabase:
             return PerformanceResult(emp_latency, energy=0.0)
         else:
             try:
+                if self._generation_mla_data is None:
+                    raise PerfDataNotAvailableError(
+                        f"Generation MLA perf table is missing for system='{self.system}', "
+                        f"backend='{self.backend}', version='{self.version}'. "
+                        "Please use HYBRID or EMPIRICAL database mode, or provide the data file."
+                    )
                 mla_dict = self._generation_mla_data[kvcache_quant_mode]
                 result = self._interp_3d(num_heads, b, s, mla_dict, "bilinear")
                 latency = result["latency"]
@@ -3068,6 +3151,12 @@ class PerfDatabase:
             return PerformanceResult(get_empirical(b, s, tp_size, kvcache_quant_mode, fmha_quant_mode), energy=0.0)
         else:
             try:
+                if self._wideep_generation_mla_data is None:
+                    raise PerfDataNotAvailableError(
+                        f"WiDeep generation MLA perf table is missing for system='{self.system}', "
+                        f"backend='{self.backend}', version='{self.version}'. "
+                        "Please use HYBRID or EMPIRICAL database mode, or provide the data file."
+                    )
                 if attention_backend is None:
                     attention_backend = "flashinfer"
                 if attention_backend == "flashinfer":
@@ -3203,6 +3292,12 @@ class PerfDatabase:
             )
         else:
             try:
+                if self._wideep_context_mla_data is None:
+                    raise PerfDataNotAvailableError(
+                        f"WiDeep context MLA perf table is missing for system='{self.system}', "
+                        f"backend='{self.backend}', version='{self.version}'. "
+                        "Please use HYBRID or EMPIRICAL database mode, or provide the data file."
+                    )
                 if attention_backend is None:
                     attention_backend = "flashinfer"
                 if attention_backend == "flashinfer":
@@ -3303,6 +3398,13 @@ class PerfDatabase:
                 if self.system_spec["node"]["num_gpus_per_node"] == 72 and tp_size > 4:
                     # on GB200, we only have custom all reduce for up to tp4.
                     return self.query_nccl(quant_mode, tp_size, "all_reduce", size)
+
+                if self._custom_allreduce_data is None:
+                    raise PerfDataNotAvailableError(
+                        f"Custom allreduce perf table is missing for system='{self.system}', "
+                        f"backend='{self.backend}', version='{self.version}'. "
+                        "Please use HYBRID or EMPIRICAL database mode, or provide the data file."
+                    )
 
                 comm_dict = self._custom_allreduce_data[quant_mode][min(tp_size, 8)][
                     "AUTO"
@@ -3420,6 +3522,13 @@ class PerfDatabase:
             try:
                 if num_gpus == 1:
                     return PerformanceResult(0.0, energy=0.0)
+
+                if self._nccl_data is None:
+                    raise PerfDataNotAvailableError(
+                        f"NCCL perf table is missing for system='{self.system}', "
+                        f"backend='{self.backend}', version='{self.version}'. "
+                        "Please use HYBRID or EMPIRICAL database mode, or provide the data file."
+                    )
 
                 max_num_gpus = max(self._nccl_data[dtype][operation].keys())
                 nccl_dict = self._nccl_data[dtype][operation][min(num_gpus, max_num_gpus)]
@@ -3628,6 +3737,13 @@ class PerfDatabase:
                     else:
                         moe_data = self._moe_data
 
+                    if moe_data is None:
+                        raise PerfDataNotAvailableError(
+                            f"MoE perf table is missing for system='{self.system}', "
+                            f"backend='{self.backend}', version='{self.version}', moe_backend='{moe_backend}'. "
+                            "Please use HYBRID or EMPIRICAL database mode, or provide the data file."
+                        )
+
                     used_workload_distribution = (
                         workload_distribution if workload_distribution in moe_data[quant_mode] else "uniform"
                     )
@@ -3652,6 +3768,12 @@ class PerfDatabase:
                         energy = 0.0
                     return PerformanceResult(lat, energy=energy)
                 elif self.backend == common.BackendName.trtllm.value:
+                    if self._moe_data is None and self._moe_low_latency_data is None:
+                        raise PerfDataNotAvailableError(
+                            f"MoE perf table is missing for system='{self.system}', "
+                            f"backend='{self.backend}', version='{self.version}'. "
+                            "Please use HYBRID or EMPIRICAL database mode, or provide the data file."
+                        )
                     # aligned with trtllm, kernel source selection.
                     if num_tokens <= 128 and self._moe_low_latency_data and quant_mode == common.MoEQuantMode.nvfp4:
                         try:
@@ -3703,6 +3825,12 @@ class PerfDatabase:
                         energy = 0.0
                     return PerformanceResult(lat, energy=energy)
                 elif self.backend == common.BackendName.vllm.value:
+                    if self._moe_data is None:
+                        raise PerfDataNotAvailableError(
+                            f"MoE perf table is missing for system='{self.system}', "
+                            f"backend='{self.backend}', version='{self.version}'. "
+                            "Please use HYBRID or EMPIRICAL database mode, or provide the data file."
+                        )
                     used_workload_distribution = (
                         workload_distribution if workload_distribution in self._moe_data[quant_mode] else "uniform"
                     )
@@ -3814,6 +3942,12 @@ class PerfDatabase:
             return PerformanceResult(emp_latency, energy=0.0)
         else:
             try:
+                if self._mla_bmm_data is None:
+                    raise PerfDataNotAvailableError(
+                        f"MLA BMM perf table is missing for system='{self.system}', "
+                        f"backend='{self.backend}', version='{self.version}'. "
+                        "Please use HYBRID or EMPIRICAL database mode, or provide the data file."
+                    )
                 if quant_mode not in self._mla_bmm_data:
                     quant_mode = common.GEMMQuantMode.float16
                 mla_bmm_dict = self._mla_bmm_data[quant_mode]["mla_gen_pre" if if_pre else "mla_gen_post"][num_heads]

--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -2142,13 +2142,8 @@ class PerfDatabase:
         """
         Find the nearest 1d point
         """
-        if values is None or len(values) == 0:
-            raise PerfDataNotAvailableError("No data points available for interpolation (values is None or empty).")
+        assert values is not None and len(values) >= 2, "values is None or len(values) < 2"
         sorted_values = sorted(values)
-
-        # Degenerate grid: only one point available. Treat as constant.
-        if len(sorted_values) == 1:
-            return sorted_values[0], sorted_values[0]
 
         if x < sorted_values[0]:
             if inner_only:
@@ -2341,14 +2336,6 @@ class PerfDatabase:
         # Calculate the weights for the corners
         Q11, Q12, Q21, Q22 = data[x1][y1], data[x1][y2], data[x2][y1], data[x2][y2]  # noqa: N806
 
-        # Handle degenerate rectangles (can happen when a dimension has only one grid point).
-        if x1 == x2 and y1 == y2:
-            return Q11
-        if x1 == x2:
-            return self._interp_1d([y1, y2], [Q11, Q12], y)
-        if y1 == y2:
-            return self._interp_1d([x1, x2], [Q11, Q21], x)
-
         f_x1_y1 = Q11 * (x2 - x) * (y2 - y)
         f_x1_y2 = Q12 * (x2 - x) * (y - y1)
         f_x2_y1 = Q21 * (x - x1) * (y2 - y)
@@ -2406,10 +2393,6 @@ class PerfDatabase:
         """
         x0, x1 = x
         y0, y1 = y
-
-        # Degenerate grid: treat as constant.
-        if x0 == x1:
-            return y0
 
         # Check if values are dicts (new format) or floats (legacy)
         if isinstance(y0, dict) and isinstance(y1, dict):

--- a/src/aiconfigurator/systems/data/l40s/sglang/0.5.5.post3/custom_allreduce_perf.txt
+++ b/src/aiconfigurator/systems/data/l40s/sglang/0.5.5.post3/custom_allreduce_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e38b547232fc1cd0389fb25493e577a4808c7cfa74aa26c03361e7085b2c9f71
+size 5554

--- a/tests/sdk/database/test_interpolation.py
+++ b/tests/sdk/database/test_interpolation.py
@@ -46,10 +46,8 @@ class TestInterpolationMethods:
 
     def test_nearest_1d_point_helper_errors(self, comprehensive_perf_db):
         """Test error cases for _nearest_1d_point_helper."""
-        from aiconfigurator.sdk.perf_database import PerfDataNotAvailableError
-
-        # Empty list raises PerfDataNotAvailableError
-        with pytest.raises(PerfDataNotAvailableError):
+        # Empty list
+        with pytest.raises(AssertionError):
             comprehensive_perf_db._nearest_1d_point_helper(10, [], inner_only=True)
 
         # Single value list

--- a/tests/sdk/database/test_interpolation.py
+++ b/tests/sdk/database/test_interpolation.py
@@ -46,13 +46,16 @@ class TestInterpolationMethods:
 
     def test_nearest_1d_point_helper_errors(self, comprehensive_perf_db):
         """Test error cases for _nearest_1d_point_helper."""
-        # Empty list
-        with pytest.raises(AssertionError):
+        from aiconfigurator.sdk.perf_database import PerfDataNotAvailableError
+
+        # Empty list raises PerfDataNotAvailableError
+        with pytest.raises(PerfDataNotAvailableError):
             comprehensive_perf_db._nearest_1d_point_helper(10, [], inner_only=True)
 
-        # Single value list
-        with pytest.raises(AssertionError):
-            comprehensive_perf_db._nearest_1d_point_helper(10, [5], inner_only=True)
+        # Single value list now returns the same point twice (for constant interpolation)
+        left, right = comprehensive_perf_db._nearest_1d_point_helper(10, [5], inner_only=False)
+        assert left == 5
+        assert right == 5
 
         # Value out of range with inner_only=True
         with pytest.raises(ValueError):

--- a/tests/sdk/database/test_interpolation.py
+++ b/tests/sdk/database/test_interpolation.py
@@ -52,10 +52,9 @@ class TestInterpolationMethods:
         with pytest.raises(PerfDataNotAvailableError):
             comprehensive_perf_db._nearest_1d_point_helper(10, [], inner_only=True)
 
-        # Single value list now returns the same point twice (for constant interpolation)
-        left, right = comprehensive_perf_db._nearest_1d_point_helper(10, [5], inner_only=False)
-        assert left == 5
-        assert right == 5
+        # Single value list
+        with pytest.raises(AssertionError):
+            comprehensive_perf_db._nearest_1d_point_helper(10, [5], inner_only=True)
 
         # Value out of range with inner_only=True
         with pytest.raises(ValueError):

--- a/tests/sdk/test_quant_mode_selection.py
+++ b/tests/sdk/test_quant_mode_selection.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import pytest
+
+from aiconfigurator.sdk.perf_database import get_database
+from aiconfigurator.sdk.task import TaskConfig, TaskConfigFactory
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SYSTEMS_DIR = str(REPO_ROOT / "src" / "aiconfigurator" / "systems")
+
+
+@pytest.mark.parametrize("model_name", ["QWEN3_32B"])
+def test_l40s_sglang_default_gemm_quant_does_not_use_fp8_block(model_name: str) -> None:
+    db = get_database(system="l40s", backend="sglang", version="0.5.5.post3", systems_dir=SYSTEMS_DIR)
+    assert db is not None, "Expected l40s/sglang/0.5.5.post3 database to load in test environment"
+
+    gemm, moe, kvcache, fmha, comm = TaskConfigFactory._get_quant_mode(
+        model_name=model_name, backend="sglang", database=db, use_specific_quant_mode=None
+    )
+    assert gemm != "fp8_block"
+    assert gemm in {"fp8", "float16", "int8_wo"}
+
+
+def test_l40s_sglang_forced_fp8_block_gemm_fails_fast_with_actionable_error() -> None:
+    with pytest.raises(ValueError) as excinfo:
+        TaskConfig(
+            serving_mode="agg",
+            model_name="QWEN3_32B",
+            system_name="l40s",
+            backend_name="sglang",
+            backend_version="0.5.5.post3",
+            total_gpus=8,
+            yaml_config={
+                "mode": "patch",
+                "config": {"worker_config": {"gemm_quant_mode": "fp8_block"}},
+            },
+        )
+
+    msg = str(excinfo.value)
+    assert "Unsupported gemm quant mode" in msg
+    assert "Supported gemm modes" in msg


### PR DESCRIPTION
#### Overview:

1. Make perf db and task config more error proof. Currently too many hard-to-read errors.
2. Add l40s sglang custom all reduce data. Copied from l40s trtllm btw, since custom all reduce collector doesn't support sglang.

#### Details:

Now this case passed:

(aic_venv) jasonzho@NV-25010035:~/repo/aiconfigurator$ aiconfigurator cli default --model QWEN3_32B --total_gpus 8 --system l40s --backend sglang 
2025-12-17 16:45:08,832 - aiconfigurator.cli.main - INFO - Loading Dynamo AIConfigurator version: 0.5.0
2025-12-17 16:45:08,838 - aiconfigurator.sdk.perf_database - INFO - loading system='l40s', backend='sglang', version='0.5.5.post3'
2025-12-17 16:45:09,012 - aiconfigurator.sdk.perf_database - WARNING - Context mla data file /home/jasonzho/repo/aiconfigurator/src/aiconfigurator/systems/data/l40s/sglang/0.5.5.post3/context_mla_perf.txt not found.
2025-12-17 16:45:09,012 - aiconfigurator.sdk.perf_database - WARNING - Generation mla data file /home/jasonzho/repo/aiconfigurator/src/aiconfigurator/systems/data/l40s/sglang/0.5.5.post3/generation_mla_perf.txt not found.
2025-12-17 16:45:09,015 - aiconfigurator.sdk.perf_database - WARNING - Context MoE data file /home/jasonzho/repo/aiconfigurator/src/aiconfigurator/systems/data/l40s/sglang/0.5.5.post3/wideep_context_moe_perf.txt not found.
2025-12-17 16:45:09,015 - aiconfigurator.sdk.perf_database - WARNING - Generation MoE data file /home/jasonzho/repo/aiconfigurator/src/aiconfigurator/systems/data/l40s/sglang/0.5.5.post3/wideep_generation_moe_perf.txt not found.
2025-12-17 16:45:09,015 - aiconfigurator.sdk.perf_database - WARNING - SGLang wideep context mla data file /home/jasonzho/repo/aiconfigurator/src/aiconfigurator/systems/data/l40s/sglang/0.5.5.post3/wideep_context_mla_perf.txt not found.
2025-12-17 16:45:09,015 - aiconfigurator.sdk.perf_database - WARNING - SGLang wideep generation mla data file /home/jasonzho/repo/aiconfigurator/src/aiconfigurator/systems/data/l40s/sglang/0.5.5.post3/wideep_generation_mla_perf.txt not found.
2025-12-17 16:45:09,015 - aiconfigurator.sdk.perf_database - WARNING - SGLang wideep deepep normal operation data file /home/jasonzho/repo/aiconfigurator/src/aiconfigurator/systems/data/l40s/sglang/0.5.5.post3/wideep_deepep_normal_perf.txt not found.
2025-12-17 16:45:09,015 - aiconfigurator.sdk.perf_database - WARNING - SGLang wideep deepep LL operation data file /home/jasonzho/repo/aiconfigurator/src/aiconfigurator/systems/data/l40s/sglang/0.5.5.post3/wideep_deepep_ll_perf.txt not found.
2025-12-17 16:45:09,547 - aiconfigurator.sdk.task - INFO - Task agg_QWEN3_32B_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Runtime config: DefaultMunch(<class 'munch.DefaultMunch'>, {'isl': 4000, 'osl': 1000, 'prefix': 0, 'ttft': 2000.0, 'tpot': 30.0, 'request_latency': None})
2025-12-17 16:45:09,547 - aiconfigurator.sdk.task - INFO - Task agg_QWEN3_32B_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Worker config: DefaultMunch(<class 'munch.DefaultMunch'>, {'system_name': 'l40s', 'backend_name': 'sglang', 'backend_version': '0.5.5.post3', 'num_gpu_per_worker': [1, 2, 4, 8], 'tp_list': [1, 2, 4, 8], 'pp_list': [1], 'dp_list': [1], 'moe_tp_list': [1], 'moe_ep_list': [1], 'gemm_quant_mode': <GEMMQuantMode.fp8: QuantMapping(memory=1, compute=2, name='fp8')>, 'moe_quant_mode': <MoEQuantMode.float16: QuantMapping(memory=2, compute=1, name='float16')>, 'kvcache_quant_mode': <KVCacheQuantMode.float16: QuantMapping(memory=2, compute=0, name='float16')>, 'fmha_quant_mode': <FMHAQuantMode.float16: QuantMapping(memory=0, compute=1, name='float16')>, 'comm_quant_mode': <CommQuantMode.half: QuantMapping(memory=2, compute=0, name='half')>})
2025-12-17 16:45:09,558 - aiconfigurator.sdk.task - INFO - Task disagg_QWEN3_32B_l40s_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Runtime config: DefaultMunch(<class 'munch.DefaultMunch'>, {'isl': 4000, 'osl': 1000, 'prefix': 0, 'ttft': 2000.0, 'tpot': 30.0, 'request_latency': None})
2025-12-17 16:45:09,558 - aiconfigurator.sdk.task - INFO - Task disagg_QWEN3_32B_l40s_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Prefill worker config: DefaultMunch(<class 'munch.DefaultMunch'>, {'system_name': 'l40s', 'backend_name': 'sglang', 'backend_version': '0.5.5.post3', 'num_gpu_per_worker': [1, 2, 4, 8], 'tp_list': [1, 2, 4, 8], 'pp_list': [1], 'dp_list': [1], 'moe_tp_list': [1], 'moe_ep_list': [1], 'gemm_quant_mode': <GEMMQuantMode.fp8: QuantMapping(memory=1, compute=2, name='fp8')>, 'moe_quant_mode': <MoEQuantMode.float16: QuantMapping(memory=2, compute=1, name='float16')>, 'kvcache_quant_mode': <KVCacheQuantMode.float16: QuantMapping(memory=2, compute=0, name='float16')>, 'fmha_quant_mode': <FMHAQuantMode.float16: QuantMapping(memory=0, compute=1, name='float16')>, 'comm_quant_mode': <CommQuantMode.half: QuantMapping(memory=2, compute=0, name='half')>})
2025-12-17 16:45:09,558 - aiconfigurator.sdk.task - INFO - Task disagg_QWEN3_32B_l40s_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Decode worker config: DefaultMunch(<class 'munch.DefaultMunch'>, {'system_name': 'l40s', 'backend_name': 'sglang', 'backend_version': '0.5.5.post3', 'num_gpu_per_worker': [1, 2, 4, 8], 'tp_list': [1, 2, 4, 8], 'pp_list': [1], 'dp_list': [1], 'moe_tp_list': [1], 'moe_ep_list': [1], 'gemm_quant_mode': <GEMMQuantMode.fp8: QuantMapping(memory=1, compute=2, name='fp8')>, 'moe_quant_mode': <MoEQuantMode.float16: QuantMapping(memory=2, compute=1, name='float16')>, 'kvcache_quant_mode': <KVCacheQuantMode.float16: QuantMapping(memory=2, compute=0, name='float16')>, 'fmha_quant_mode': <FMHAQuantMode.float16: QuantMapping(memory=0, compute=1, name='float16')>, 'comm_quant_mode': <CommQuantMode.half: QuantMapping(memory=2, compute=0, name='half')>})
2025-12-17 16:45:09,558 - aiconfigurator.sdk.task - INFO - Task disagg_QWEN3_32B_l40s_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Replica config: DefaultMunch(<class 'munch.DefaultMunch'>, {'num_gpu_per_replica': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128], 'max_gpu_per_replica': 8, 'max_prefill_worker': 32, 'max_decode_worker': 32})
2025-12-17 16:45:09,558 - aiconfigurator.sdk.task - INFO - Task disagg_QWEN3_32B_l40s_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Advanced tuning config: DefaultMunch(<class 'munch.DefaultMunch'>, {'prefill_latency_correction_scale': 1.1, 'decode_latency_correction_scale': 1.08, 'prefill_max_batch_size': 1, 'decode_max_batch_size': 512})
2025-12-17 16:45:09,558 - aiconfigurator.cli.main - INFO - Starting experiment: agg
2025-12-17 16:45:09,558 - aiconfigurator.cli.main - INFO - Task config: {
  "agg_QWEN3_32B_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0": {
    "mode": "patch",
    "serving_mode": "agg",
    "model_name": "QWEN3_32B",
    "total_gpus": 8,
    "system_name": "l40s",
    "backend_name": "sglang",
    "backend_version": "0.5.5.post3",
    "isl": 4000,
    "osl": 1000,
    "prefix": 0,
    "ttft": 2000.0,
    "tpot": 30.0,
    "enable_wideep": false,
    "moe_backend": null,
    "attention_backend": "flashinfer",
    "profiles": [],
    "config": {
      "nextn": 0,
      "nextn_accept_rates": [
        0.85,
        0,
        0,
        0,
        0
      ],
      "worker_config": {
        "system_name": "l40s",
        "backend_name": "sglang",
        "backend_version": "0.5.5.post3",
        "num_gpu_per_worker": [
          1,
          2,
          4,
          8
        ],
        "tp_list": [
          1,
          2,
          4,
          8
        ],
        "pp_list": [
          1
        ],
        "dp_list": [
          1
        ],
        "moe_tp_list": [
          1
        ],
        "moe_ep_list": [
          1
        ],
        "gemm_quant_mode": "fp8",
        "moe_quant_mode": "float16",
        "kvcache_quant_mode": "float16",
        "fmha_quant_mode": "float16",
        "comm_quant_mode": "half"
      }
    }
  }
}
2025-12-17 16:45:09,558 - aiconfigurator.sdk.task - INFO - Starting Pareto Analysis for agg_QWEN3_32B_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0 in agg mode...
2025-12-17 16:45:09,558 - aiconfigurator.sdk.task - INFO - Task agg_QWEN3_32B_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Setting up runtime config
2025-12-17 16:45:09,558 - aiconfigurator.sdk.task - INFO - Task agg_QWEN3_32B_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Setting up database
2025-12-17 16:45:09,789 - aiconfigurator.sdk.task - INFO - Task agg_QWEN3_32B_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Using database mode: SILICON
2025-12-17 16:45:09,789 - aiconfigurator.sdk.task - INFO - Task agg_QWEN3_32B_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Setting up model config
2025-12-17 16:45:09,789 - aiconfigurator.sdk.task - INFO - Task agg_QWEN3_32B_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Enumerating parallel config
2025-12-17 16:45:09,789 - aiconfigurator.sdk.utils - INFO - Enumerated parallel config: tp=1, pp=1, dp=1, moe_tp=1, moe_ep=1
2025-12-17 16:45:09,789 - aiconfigurator.sdk.utils - INFO - Enumerated parallel config: tp=2, pp=1, dp=1, moe_tp=1, moe_ep=1
2025-12-17 16:45:09,789 - aiconfigurator.sdk.utils - INFO - Enumerated parallel config: tp=4, pp=1, dp=1, moe_tp=1, moe_ep=1
2025-12-17 16:45:09,789 - aiconfigurator.sdk.utils - INFO - Enumerated parallel config: tp=8, pp=1, dp=1, moe_tp=1, moe_ep=1
2025-12-17 16:45:09,789 - aiconfigurator.sdk.task - INFO - Task agg_QWEN3_32B_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Running agg pareto
2025-12-17 16:45:11,586 - aiconfigurator.cli.main - INFO - Experiment agg completed with 22 results.
2025-12-17 16:45:11,586 - aiconfigurator.cli.main - INFO - Starting experiment: disagg
2025-12-17 16:45:11,586 - aiconfigurator.cli.main - INFO - Task config: {
  "disagg_QWEN3_32B_l40s_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0": {
    "mode": "patch",
    "serving_mode": "disagg",
    "model_name": "QWEN3_32B",
    "total_gpus": 8,
    "system_name": "l40s",
    "decode_system_name": "l40s",
    "backend_name": "sglang",
    "backend_version": "0.5.5.post3",
    "isl": 4000,
    "osl": 1000,
    "prefix": 0,
    "ttft": 2000.0,
    "tpot": 30.0,
    "enable_wideep": false,
    "moe_backend": null,
    "attention_backend": "flashinfer",
    "profiles": [],
    "config": {
      "nextn": 0,
      "nextn_accept_rates": [
        0.85,
        0,
        0,
        0,
        0
      ],
      "prefill_worker_config": {
        "system_name": "l40s",
        "backend_name": "sglang",
        "backend_version": "0.5.5.post3",
        "num_gpu_per_worker": [
          1,
          2,
          4,
          8
        ],
        "tp_list": [
          1,
          2,
          4,
          8
        ],
        "pp_list": [
          1
        ],
        "dp_list": [
          1
        ],
        "moe_tp_list": [
          1
        ],
        "moe_ep_list": [
          1
        ],
        "gemm_quant_mode": "fp8",
        "moe_quant_mode": "float16",
        "kvcache_quant_mode": "float16",
        "fmha_quant_mode": "float16",
        "comm_quant_mode": "half"
      },
      "decode_worker_config": {
        "system_name": "l40s",
        "backend_name": "sglang",
        "backend_version": "0.5.5.post3",
        "num_gpu_per_worker": [
          1,
          2,
          4,
          8
        ],
        "tp_list": [
          1,
          2,
          4,
          8
        ],
        "pp_list": [
          1
        ],
        "dp_list": [
          1
        ],
        "moe_tp_list": [
          1
        ],
        "moe_ep_list": [
          1
        ],
        "gemm_quant_mode": "fp8",
        "moe_quant_mode": "float16",
        "kvcache_quant_mode": "float16",
        "fmha_quant_mode": "float16",
        "comm_quant_mode": "half"
      },
      "replica_config": {
        "num_gpu_per_replica": [
          1,
          2,
          4,
          8,
          16,
          24,
          32,
          40,
          48,
          56,
          64,
          72,
          80,
          88,
          96,
          104,
          112,
          120,
          128
        ],
        "max_gpu_per_replica": 8,
        "max_prefill_worker": 32,
        "max_decode_worker": 32
      },
      "advanced_tuning_config": {
        "prefill_latency_correction_scale": 1.1,
        "decode_latency_correction_scale": 1.08,
        "prefill_max_batch_size": 1,
        "decode_max_batch_size": 512
      }
    }
  }
}
2025-12-17 16:45:11,586 - aiconfigurator.sdk.task - INFO - Starting Pareto Analysis for disagg_QWEN3_32B_l40s_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0 in disagg mode...
2025-12-17 16:45:11,586 - aiconfigurator.sdk.task - INFO - Task disagg_QWEN3_32B_l40s_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Setting up runtime config
2025-12-17 16:45:11,586 - aiconfigurator.sdk.task - INFO - Task disagg_QWEN3_32B_l40s_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Setting up prefill database
2025-12-17 16:45:11,816 - aiconfigurator.sdk.task - INFO - Task disagg_QWEN3_32B_l40s_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Using prefill database mode: SILICON
2025-12-17 16:45:11,816 - aiconfigurator.sdk.task - INFO - Task disagg_QWEN3_32B_l40s_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Setting up prefill model config
2025-12-17 16:45:11,816 - aiconfigurator.sdk.task - INFO - Task disagg_QWEN3_32B_l40s_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Enumerating prefill parallel config
2025-12-17 16:45:11,816 - aiconfigurator.sdk.utils - INFO - Enumerated parallel config: tp=1, pp=1, dp=1, moe_tp=1, moe_ep=1
2025-12-17 16:45:11,816 - aiconfigurator.sdk.utils - INFO - Enumerated parallel config: tp=2, pp=1, dp=1, moe_tp=1, moe_ep=1
2025-12-17 16:45:11,816 - aiconfigurator.sdk.utils - INFO - Enumerated parallel config: tp=4, pp=1, dp=1, moe_tp=1, moe_ep=1
2025-12-17 16:45:11,816 - aiconfigurator.sdk.utils - INFO - Enumerated parallel config: tp=8, pp=1, dp=1, moe_tp=1, moe_ep=1
2025-12-17 16:45:11,816 - aiconfigurator.sdk.task - INFO - Task disagg_QWEN3_32B_l40s_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Setting up decode database
2025-12-17 16:45:12,040 - aiconfigurator.sdk.task - INFO - Task disagg_QWEN3_32B_l40s_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Using decode database mode: SILICON
2025-12-17 16:45:12,040 - aiconfigurator.sdk.task - INFO - Task disagg_QWEN3_32B_l40s_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Setting up decode model config
2025-12-17 16:45:12,041 - aiconfigurator.sdk.task - INFO - Task disagg_QWEN3_32B_l40s_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Enumerating decode parallel config
2025-12-17 16:45:12,041 - aiconfigurator.sdk.utils - INFO - Enumerated parallel config: tp=1, pp=1, dp=1, moe_tp=1, moe_ep=1
2025-12-17 16:45:12,041 - aiconfigurator.sdk.utils - INFO - Enumerated parallel config: tp=2, pp=1, dp=1, moe_tp=1, moe_ep=1
2025-12-17 16:45:12,041 - aiconfigurator.sdk.utils - INFO - Enumerated parallel config: tp=4, pp=1, dp=1, moe_tp=1, moe_ep=1
2025-12-17 16:45:12,041 - aiconfigurator.sdk.utils - INFO - Enumerated parallel config: tp=8, pp=1, dp=1, moe_tp=1, moe_ep=1
2025-12-17 16:45:12,041 - aiconfigurator.sdk.task - INFO - Task disagg_QWEN3_32B_l40s_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Running disagg pareto
2025-12-17 16:45:12,558 - aiconfigurator.sdk.inference_session - WARNING - No decode worker candidates found for tpot 1ms.
2025-12-17 16:45:12,559 - aiconfigurator.sdk.inference_session - WARNING - No decode worker candidates found for tpot 2ms.
2025-12-17 16:45:12,560 - aiconfigurator.sdk.inference_session - WARNING - No decode worker candidates found for tpot 3ms.
2025-12-17 16:45:12,561 - aiconfigurator.sdk.inference_session - WARNING - No decode worker candidates found for tpot 4ms.
2025-12-17 16:45:12,562 - aiconfigurator.sdk.inference_session - WARNING - No decode worker candidates found for tpot 5ms.
2025-12-17 16:45:12,562 - aiconfigurator.sdk.inference_session - WARNING - No decode worker candidates found for tpot 6ms.
2025-12-17 16:45:12,563 - aiconfigurator.sdk.inference_session - WARNING - No decode worker candidates found for tpot 7ms.
2025-12-17 16:45:12,564 - aiconfigurator.sdk.inference_session - WARNING - No decode worker candidates found for tpot 8ms.
2025-12-17 16:45:12,565 - aiconfigurator.sdk.inference_session - WARNING - No decode worker candidates found for tpot 9ms.
2025-12-17 16:45:12,566 - aiconfigurator.sdk.inference_session - WARNING - No decode worker candidates found for tpot 10ms.
2025-12-17 16:45:12,567 - aiconfigurator.sdk.inference_session - WARNING - No decode worker candidates found for tpot 11ms.
2025-12-17 16:45:12,568 - aiconfigurator.sdk.inference_session - WARNING - No decode worker candidates found for tpot 12ms.
2025-12-17 16:45:12,904 - aiconfigurator.cli.main - INFO - Experiment disagg completed with 33 results.
2025-12-17 16:45:12,917 - aiconfigurator.cli.report_and_save - INFO - 
********************************************************************************
*                     Dynamo aiconfigurator Final Results                      *
********************************************************************************
  ----------------------------------------------------------------------------
  Input Configuration & SLA Target:
    Model: QWEN3_32B (is_moe: False)
    Total GPUs: 8
    Best Experiment Chosen: agg at 95.14 tokens/s/gpu (disagg 0.74x better)
  ----------------------------------------------------------------------------
  Overall Best Configuration:
    - Best Throughput: 761.14 tokens/s
    - Per-GPU Throughput: 95.14 tokens/s/gpu
    - Per-User Throughput: 33.94 tokens/s/user
    - TTFT: 1521.57ms
    - TPOT: 29.47ms
    - Request Latency: 30957.62ms
  ----------------------------------------------------------------------------
  Pareto Frontier:
          QWEN3_32B Pareto Frontier: tokens/s/gpu_cluster vs tokens/s/user      
     ┌─────────────────────────────────────────────────────────────────────────┐
250.0┤ •• agg                                                                  │
     │ ff disagg                                                               │
     │ xx agg best                                                             │
     │                                                                         │
208.3┤                                                                         │
     │              f                                                          │
     │              f                                                          │
     │               f                                                         │
166.7┤                ff                                                       │
     │                  f                                                      │
     │                   f••                                                   │
     │                   f  ••                                                 │
125.0┤                    f   •••                                              │
     │                     fff   ••                                            │
     │                        fff  •                                           │
     │                          f   •x                                         │
 83.3┤                          f     •                                        │
     │                           ffff  ••                                      │
     │                               ffffff                                    │
     │                                   • ffff                                │
 41.7┤                                   •     fffffffff                       │
     │                                    •             fffff                  │
     │                                     ••                ff                │
     │                                                         ff              │
  0.0┤                                                                         │
     └┬─────────────────┬─────────────────┬─────────────────┬─────────────────┬┘
      0                20                40                60                80 
tokens/s/gpu_cluster                tokens/s/user                               

  ----------------------------------------------------------------------------
  Deployment Details:
    (p) stands for prefill, (d) stands for decode, bs stands for batch size, a replica stands for the smallest scalable unit xPyD of the disagg system
    Some math: total gpus used = replicas * gpus/replica
               gpus/replica = (p)gpus/worker * (p)workers + (d)gpus/worker * (d)workers; for Agg, gpus/replica = gpus/worker
               gpus/worker = tp * pp * dp = etp * ep * pp for MoE models; tp * pp for dense models (underlined numbers are the actual values in math)

agg Top Configurations: (Sorted by tokens/s/gpu)
+------+--------------+---------------+---------+-----------------+-------------+-------------------+----------+--------------+-------------+----------+----+
| Rank | tokens/s/gpu | tokens/s/user |   TTFT  | request_latency | concurrency | total_gpus (used) | replicas | gpus/replica | gpus/worker | parallel | bs |
+------+--------------+---------------+---------+-----------------+-------------+-------------------+----------+--------------+-------------+----------+----+
|  1   |    95.14     |     33.94     | 1521.57 |     30957.62    |  24 (=6x4)  |     8 (8=4x2)     |    4     |      2       |  2 (=2x1x1) |  tp2pp1  | 6  |
+------+--------------+---------------+---------+-----------------+-------------+-------------------+----------+--------------+-------------+----------+----+

disagg Top Configurations: (Sorted by tokens/s/gpu)
+------+--------------+---------------+---------+-----------------+-------------+-------------------+----------+--------------+------------+----------------+-------------+-------+------------+----------------+-------------+-------+
| Rank | tokens/s/gpu | tokens/s/user |   TTFT  | request_latency | concurrency | total_gpus (used) | replicas | gpus/replica | (p)workers | (p)gpus/worker | (p)parallel | (p)bs | (d)workers | (d)gpus/worker | (d)parallel | (d)bs |
+------+--------------+---------------+---------+-----------------+-------------+-------------------+----------+--------------+------------+----------------+-------------+-------+------------+----------------+-------------+-------+
|  1   |    70.03     |     33.79     | 1713.78 |     31275.19    |  18 (=18x1) |     8 (8=1x8)     |    1     | 8 (=2x1+3x2) |     2      |    1 (=1x1)    |    tp1pp1   |   1   |     3      |    2 (=2x1)    |    tp2pp1   |   6   |
|  2   |    66.12     |     35.93     | 1713.78 |     29517.95    |  16 (=16x1) |     8 (8=1x8)     |    1     | 8 (=4x1+1x4) |     4      |    1 (=1x1)    |    tp1pp1   |   1   |     1      |    4 (=4x1)    |    tp4pp1   |   16  |
+------+--------------+---------------+---------+-----------------+-------------+-------------------+----------+--------------+------------+----------------+-------------+-------+------------+----------------+-------------+-------+
********************************************************************************
2025-12-17 16:45:12,917 - aiconfigurator.cli.main - INFO - All experiments completed in 3.36 seconds

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
