### PR TITLE
fix: use model_family for checkings instead of model_name

### DIFF
--- a/src/aiconfigurator/sdk/backends/sglang_backend.py
+++ b/src/aiconfigurator/sdk/backends/sglang_backend.py
@@ -467,19 +467,19 @@ class SGLANGBackend(BaseBackend):
         # ==== SGLANG backend specific memory calculations ====
         # SGLANG typically has higher activation memory due to Python overhead
         # and dynamic execution patterns
-        if "GPT" in model.model_name:
+        if model.model_family == "GPT":
             c_dict = {1: 13, 2: 8, 4: 6.5, 8: 6.5}
             activations = 2 * num_tokens * h * c_dict[min(model.config.tp_size, 8)]
             activations = max(activations, 90 * 1024 * 1024)  # Higher minimum for SGLANG
-        elif "LLAMA" in model.model_name:
+        elif model.model_family == "LLAMA":
             c_dict = {1: 14, 2: 8.5, 4: 6.5, 8: 6.5}
             activations = 2 * num_tokens * h * c_dict[min(model.config.tp_size, 8)]
             activations = max(activations, 90 * 1024 * 1024)  # Higher minimum for SGLANG
-        elif "MOE" in model.model_name:
+        elif model.model_family == "MOE":
             c_dict = {1: 28, 2: 17, 4: 13, 8: 13}
             activations = 2 * num_tokens * h * c_dict[min(model.config.tp_size, 8)]
             activations = max(activations, 90 * 1024 * 1024)  # Higher minimum for SGLANG
-        elif "DEEPSEEK" in model.model_name:
+        elif model.model_family == "DEEPSEEK":
             c_dict = {1: 28, 2: 17, 4: 13, 8: 13}
             activations = 2 * num_tokens * h * c_dict[min(model.config.tp_size, 8)]
             activations += (
@@ -505,7 +505,7 @@ class SGLANGBackend(BaseBackend):
         activations += sglang_overhead
 
         # ==== KV Cache calculation - SGLANG specific ====
-        if "DEEPSEEK" in model.model_name:
+        if model.model_family == "DEEPSEEK":
             kvcache_per_token = model._num_layers * 576
         else:
             num_kv_heads_per_gpu = (model._num_kv_heads + model.config.tp_size - 1) // model.config.tp_size

--- a/src/aiconfigurator/sdk/task.py
+++ b/src/aiconfigurator/sdk/task.py
@@ -169,7 +169,7 @@ class TaskConfigFactory:
 
     @staticmethod
     def _base_common_layer(ctx: TaskContext) -> dict:
-        nextn = 1 if ctx.model_name in ["DEEPSEEK_V3", "KIMI_K2"] else 0
+        nextn = 1 if ctx.model_family == "DEEPSEEK" else 0
         return {
             "serving_mode": ctx.serving_mode,
             "model_name": ctx.model_name,
@@ -439,6 +439,7 @@ class TaskConfigFactory:
         cls._apply_quant_modes(
             target_cfg=worker_config,
             model_name=ctx.model_name,
+            model_family=ctx.model_family,
             system=worker_config.system_name,
             backend=worker_config.backend_name,
             version=worker_config.backend_version,
@@ -468,6 +469,7 @@ class TaskConfigFactory:
         cls._apply_quant_modes(
             target_cfg=prefill_cfg,
             model_name=ctx.model_name,
+            model_family=ctx.model_family,
             system=prefill_cfg.system_name,
             backend=prefill_cfg.backend_name,
             version=prefill_cfg.backend_version,
@@ -477,6 +479,7 @@ class TaskConfigFactory:
         cls._apply_quant_modes(
             target_cfg=decode_cfg,
             model_name=ctx.model_name,
+            model_family=ctx.model_family,
             system=decode_cfg.system_name,
             backend=decode_cfg.backend_name,
             version=decode_cfg.backend_version,
@@ -487,6 +490,7 @@ class TaskConfigFactory:
     def _apply_quant_modes(
         target_cfg: DefaultMunch,
         model_name: str,
+        model_family: str,
         system: str,
         backend: str,
         version: str,
@@ -508,6 +512,7 @@ class TaskConfigFactory:
         database = get_database(system=system, backend=backend, version=version)
         defaults = TaskConfigFactory._get_quant_mode(
             model_name=model_name,
+            model_family=model_family,
             backend=backend,
             database=database,
             use_specific_quant_mode=preferred_mode,
@@ -521,13 +526,14 @@ class TaskConfigFactory:
     @staticmethod
     def _get_quant_mode(
         model_name: str,
+        model_family: str,
         backend: str,
         database: PerfDatabase,
         use_specific_quant_mode: str | None = None,
     ) -> tuple[str, str, str, str, str]:
         gemm_quant_mode = "fp8_block"
         kvcache_quant_mode = "fp8"
-        fmha_quant_mode = "float16" if model_name in ["DEEPSEEK_V3", "KIMI_K2"] else "fp8"
+        fmha_quant_mode = "float16" if model_family == "DEEPSEEK" else "fp8"
         comm_quant_mode = "half"
 
         sm_version = database.system_spec["gpu"]["sm_version"]
@@ -556,14 +562,10 @@ class TaskConfigFactory:
             kvcache_quant_mode = "float16"
             fmha_quant_mode = "float16"
 
-        if model_name in ["DEEPSEEK_V3", "KIMI_K2"]:
+        if model_family == "DEEPSEEK":
             fmha_quant_mode = "float16"
 
-        if (
-            any(keyword in model_name for keyword in ["MOE_Mixtral", "QWEN2", "LLAMA"])
-            and sm_version < 100
-            and sm_version >= 89
-        ):
+        if model_family in ["MOE", "LLAMA"] and sm_version < 100 and sm_version >= 89:
             gemm_quant_mode = fp8_gemm_quant
             moe_quant_mode = fp8_gemm_quant
 


### PR DESCRIPTION
#### Overview:

This command was broken:
```
aiconfigurator cli default --hf_id deepseek-ai/DeepSeek-V3 --total_gpus 16 --system gb200_sxm --isl 4000 --osl 500 --ttft 3000 --tpot 100 --save_dir ds_v
```

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
