### PR TITLE
feat: delete 0.20.0 database and add new data from 1.2.0rc5 (H100 & H200)

### DIFF
--- a/src/aiconfigurator/systems/data/h100_sxm/trtllm/0.20.0/context_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/trtllm/0.20.0/context_attention_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:20f3f6bcfb2920ff53d93586bc549308903f25dc9d90f8354a704cfd2a6d128b
-size 1380196

--- a/src/aiconfigurator/systems/data/h100_sxm/trtllm/0.20.0/context_mla_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/trtllm/0.20.0/context_mla_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:543ebde12855ddaee25db9244f230c4d806efcb3fed72276667e0ca50b5e1e8f
-size 113205

--- a/src/aiconfigurator/systems/data/h100_sxm/trtllm/0.20.0/custom_allreduce_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/trtllm/0.20.0/custom_allreduce_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7c4b9d710d0b67b039c5faa6e22cc7ffbd9fe637b71f4776608422a06d380fc3
-size 6399

--- a/src/aiconfigurator/systems/data/h100_sxm/trtllm/0.20.0/gemm_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/trtllm/0.20.0/gemm_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b2b9ea5df8cb3fbe0f3e21777c0d406cd2169fb03455f79b658481cd1d94574a
-size 2419408

--- a/src/aiconfigurator/systems/data/h100_sxm/trtllm/0.20.0/generation_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/trtllm/0.20.0/generation_attention_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:926dde635d1b264883ee5733d8781e15b37bfe0d44215b89ccc519e803f14f72
-size 1001936

--- a/src/aiconfigurator/systems/data/h100_sxm/trtllm/0.20.0/generation_mla_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/trtllm/0.20.0/generation_mla_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6b6f9ae3587458a95a4facaeda8bbbc3bba55b869f63b77ece431cad62d0ed10
-size 244849

--- a/src/aiconfigurator/systems/data/h100_sxm/trtllm/0.20.0/mla_bmm_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/trtllm/0.20.0/mla_bmm_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c45bf200d9b764f702a650f8830c9fedb4c081c6893e77fb4eef7e879d27845f
-size 69314

--- a/src/aiconfigurator/systems/data/h100_sxm/trtllm/0.20.0/moe_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/trtllm/0.20.0/moe_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50f60f36e409a9168298937a58dd76dbea27d654a398cf26c529975c75303952
-size 2373245

--- a/src/aiconfigurator/systems/data/h100_sxm/trtllm/1.2.0rc5/context_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/trtllm/1.2.0rc5/context_attention_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39890428da2c8b9d55992829a0d401d2e80bdf51d343c3715a5796c6c74504f9
+size 5625203

--- a/src/aiconfigurator/systems/data/h100_sxm/trtllm/1.2.0rc5/context_mla_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/trtllm/1.2.0rc5/context_mla_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:881b5c05cb9d689385d10571cd4787a9e8e2688b60d76f493c4d86deaaaa71df
+size 147252

--- a/src/aiconfigurator/systems/data/h100_sxm/trtllm/1.2.0rc5/custom_allreduce_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/trtllm/1.2.0rc5/custom_allreduce_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:452649c88fbe86e1e29459837e1ed4c320ecbbce186919244adf2fbd1df0cd06
+size 7038

--- a/src/aiconfigurator/systems/data/h100_sxm/trtllm/1.2.0rc5/gemm_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/trtllm/1.2.0rc5/gemm_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7fbeb21cfc0660edd6792f82380bf27bb1dabc1c0042c1ecae8907fd401f60d4
+size 6691814

--- a/src/aiconfigurator/systems/data/h100_sxm/trtllm/1.2.0rc5/generation_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/trtllm/1.2.0rc5/generation_attention_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:638a343fba69d5f7454a862a51601703a891e28b6ccc39aff918921e41852366
+size 3744987

--- a/src/aiconfigurator/systems/data/h100_sxm/trtllm/1.2.0rc5/generation_mla_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/trtllm/1.2.0rc5/generation_mla_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:095890ed12f9441ffad610a2349a0b467321760b42c6f62bae98b0dd30083215
+size 317040

--- a/src/aiconfigurator/systems/data/h100_sxm/trtllm/1.2.0rc5/mla_bmm_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/trtllm/1.2.0rc5/mla_bmm_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e23fdd69a99fa34bc4577f448a4c3bf425050e5e95970fc8af78b6d617d9cb52
+size 77822

--- a/src/aiconfigurator/systems/data/h100_sxm/trtllm/1.2.0rc5/moe_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/trtllm/1.2.0rc5/moe_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eab21128646b81f562fef834c0578a2ad25e458591bd2148c9a8ff496d016a59
+size 6902948

--- a/src/aiconfigurator/systems/data/h200_sxm/trtllm/0.20.0/context_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/trtllm/0.20.0/context_attention_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e60585fdd351aa1a3a89135d6ea3268bf3504aed86e5db51a3f2f5cd15090ec0
-size 1249431

--- a/src/aiconfigurator/systems/data/h200_sxm/trtllm/0.20.0/context_mla_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/trtllm/0.20.0/context_mla_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dbcf191145a1489e501b0ca3d48dbd56616f1316762cf98580bc89329ccf9e1a
-size 101075

--- a/src/aiconfigurator/systems/data/h200_sxm/trtllm/0.20.0/custom_allreduce_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/trtllm/0.20.0/custom_allreduce_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0f3a8525d9accc33bf6978735df13ea0397ee7b7126568d8d3c0046562465171
-size 5988

--- a/src/aiconfigurator/systems/data/h200_sxm/trtllm/0.20.0/gemm_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/trtllm/0.20.0/gemm_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8585da6554bbb345bcd9c590ca0de0e71fed29acb48aa0d17c79352b4ddaf379
-size 2446015

--- a/src/aiconfigurator/systems/data/h200_sxm/trtllm/0.20.0/generation_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/trtllm/0.20.0/generation_attention_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:01d9bd32f8838512be4b0b3fe42d0a4467b74158e8164b0ec075aa9a8f9f5185
-size 911843

--- a/src/aiconfigurator/systems/data/h200_sxm/trtllm/0.20.0/generation_mla_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/trtllm/0.20.0/generation_mla_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8c0cfd174033c6ec7a176b89f9820469bc1c1296972c8e2cefb75fb5b30d4e39
-size 219537

--- a/src/aiconfigurator/systems/data/h200_sxm/trtllm/0.20.0/mla_bmm_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/trtllm/0.20.0/mla_bmm_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0e4c0ac8334d4a12b7e59ce367e6b3fcbf3969bc8a48a161dbb1f64016f02af2
-size 60843

--- a/src/aiconfigurator/systems/data/h200_sxm/trtllm/0.20.0/moe_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/trtllm/0.20.0/moe_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c9650a88c627d55ce23d6fda076bdcc2cedf78d088eb7a3287bc103f190ef1cc
-size 2165710

--- a/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.2.0rc5/context_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.2.0rc5/context_attention_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34835a143faa767d57b93f1f7f6e7555010a5bca2924c22f6a6d51c4f8dc24a1
+size 5158665

--- a/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.2.0rc5/context_mla_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.2.0rc5/context_mla_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43c2061374f69ccd0de8f2c0719eb52dcba398fc13147c006b9f05a35d88ad69
+size 133377

--- a/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.2.0rc5/custom_allreduce_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.2.0rc5/custom_allreduce_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f07ad68a252c88cf504b9ae250a87ca2f7a814e13ea0facd5cfc128fa8b649a2
+size 6343

--- a/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.2.0rc5/gemm_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.2.0rc5/gemm_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81eb1eeab4f9c4609da284ebef23d993f23557a3ea184d42d49dfbbf74a1f94d
+size 6155450

--- a/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.2.0rc5/generation_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.2.0rc5/generation_attention_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9797ac8d2855434cafbdcb8346cb521cf9ffe255d2ac463b566c10b91ab09d5
+size 3447987

--- a/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.2.0rc5/generation_mla_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.2.0rc5/generation_mla_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:62d25b09120de25ca8af7e5fe2058d7cea055ff51c403520ba442cf933395bc7
+size 288152

--- a/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.2.0rc5/mla_bmm_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.2.0rc5/mla_bmm_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e5a7866dc34e5c71c7122b40b64ef1e8ae94b79b1d04fb1541d58b162aca9dd
+size 69341

--- a/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.2.0rc5/moe_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.2.0rc5/moe_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44461ce25106f1281300a940296119e483348d0e7ddb017c9930370413f872f5
+size 6333991


### PR DESCRIPTION
#### Overview:

- Delete outdated performance data (TensorRT-LLM 0.20.0)
- Add new performance data from TensorRT-LLM 1.2.0rc5

