### PR TITLE
feat: add new performance data for SGLang 0.5.6.post2

### DIFF
--- a/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.6.post2/context_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.6.post2/context_attention_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2c1abcc493b6502dee77e2fec242ee87adff299b151db458d8652b805a9d476
+size 1970124

--- a/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.6.post2/context_mla_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.6.post2/context_mla_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f64bec4e40b79b1ac4739bd9aec095d74885787a161348258fe7b3c9add864f
+size 283338

--- a/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.6.post2/custom_allreduce_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.6.post2/custom_allreduce_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:452649c88fbe86e1e29459837e1ed4c320ecbbce186919244adf2fbd1df0cd06
+size 7038

--- a/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.6.post2/gemm_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.6.post2/gemm_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4406c6b9b8254954d187ae445cfba3e4db9921a93cdba83a9b0dc25be2272c01
+size 3318316

--- a/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.6.post2/generation_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.6.post2/generation_attention_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:891531641e9a48ca8f608a45d1d63f695a543a63bb27a9dcc83185d944cbb97a
+size 1341897

--- a/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.6.post2/generation_mla_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.6.post2/generation_mla_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67b733733879bcc7eacd60b5db99288a292340363612226e8cb89794978d148d
+size 558129

--- a/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.6.post2/mla_bmm_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.6.post2/mla_bmm_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9fd63064345e5572fdf12c44efc33185c3eb37213dd3a95ccb6a79a55da4af65
+size 80287

--- a/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.6.post2/moe_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.6.post2/moe_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f231a7d6bf645e46a91c71f002c1ac9bcdf99b483a5cebd0a344646ddfaf3669
+size 588746

--- a/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.6.post2/wideep_context_mla_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.6.post2/wideep_context_mla_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe6c46c1a24fc4f5cfafdbc0330e7248063a02b18f7e03d6f5259d27212bd01a
+size 94077

--- a/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.6.post2/wideep_context_mlp_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.6.post2/wideep_context_mlp_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:771b9892f14bc5c12115e12193e633940d91816a32dab844621eb3e9e8796d16
+size 1916

--- a/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.6.post2/wideep_context_moe_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.6.post2/wideep_context_moe_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29575125bf04c615cb8aec23effb5e60a719a6447ef3e1795cad189135e2c71c
+size 56744

--- a/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.6.post2/wideep_deepep_ll_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.6.post2/wideep_deepep_ll_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8478eb53164c994480a2da47608e7f3e2dfd8ca24414102f59093035f85a67fd
+size 7400

--- a/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.6.post2/wideep_deepep_normal_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.6.post2/wideep_deepep_normal_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c75dfd072a4c13e690cf7239deb1a69ec466c2d2f407a11cf917970518cc1761
+size 37830

--- a/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.6.post2/wideep_generation_mla_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.6.post2/wideep_generation_mla_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2df9c6d732390f1b5576e192adc2b4aa78dc7a05eda44ae504fc521f63390e08
+size 115611

--- a/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.6.post2/wideep_generation_mlp_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.6.post2/wideep_generation_mlp_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35016709ff249f3f7e2d65282204ef333b48624d57d5900d5183b39f03704eb6
+size 1918

--- a/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.6.post2/wideep_generation_moe_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.6.post2/wideep_generation_moe_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:13909d67846b5f54425487ddd6912442b61b8da0c17bba6fec4fe2b6d7e9904f
+size 51350


### PR DESCRIPTION
#### Overview:

- Add new performance data for SGLang 0.5.6.post2
- Collectors are working on Hopper, but this PR will only cover H100's data
- Reused previously collected wideep_deepep_ll_perf.txt and wideep_deepep_normal_perf.txt
- All other data are freshly collected
