### PR TITLE
feat: add new data for SGLang 0.5.6.post2 on h200

### DIFF
--- a/src/aiconfigurator/systems/data/h200_sxm/sglang/0.5.6.post2/context_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/sglang/0.5.6.post2/context_attention_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6c1423b0d5d90d52bc40376801c9b6840fbf94a66a72117e1ebeca5b164bd84
+size 3690106

--- a/src/aiconfigurator/systems/data/h200_sxm/sglang/0.5.6.post2/context_mla_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/sglang/0.5.6.post2/context_mla_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e964fa2fe8e6b056adf2c2aad16462b4da432a0b967ac13764dafe48b26706ac
+size 527586

--- a/src/aiconfigurator/systems/data/h200_sxm/sglang/0.5.6.post2/custom_allreduce_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/sglang/0.5.6.post2/custom_allreduce_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe5a03103666e01dec1306b8d0fe7ef9358d05edb8f279de7aab65d2e669dd93
+size 6123

--- a/src/aiconfigurator/systems/data/h200_sxm/sglang/0.5.6.post2/gemm_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/sglang/0.5.6.post2/gemm_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4b4dbc5bddd93b0ae693fa136040cc750ed477dc09c87f5e0313db74a481816
+size 9216529

--- a/src/aiconfigurator/systems/data/h200_sxm/sglang/0.5.6.post2/generation_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/sglang/0.5.6.post2/generation_attention_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9896c2eff3cd84c4eeaf43ee041fb581680572a8580e448e23eb0cdcbf4043a5
+size 2520660

--- a/src/aiconfigurator/systems/data/h200_sxm/sglang/0.5.6.post2/generation_mla_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/sglang/0.5.6.post2/generation_mla_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec002bcd8a2e7c1b61a6b487123aa9374c5d11c4f16f997dee0088b2183a3798
+size 1041841

--- a/src/aiconfigurator/systems/data/h200_sxm/sglang/0.5.6.post2/mla_bmm_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/sglang/0.5.6.post2/mla_bmm_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ce74f2e996de8b422dea458960647061ac541e1d653acdec390bf7f759a715f
+size 147045

--- a/src/aiconfigurator/systems/data/h200_sxm/sglang/0.5.6.post2/moe_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/sglang/0.5.6.post2/moe_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:04aa63c488e47a118408157b4c29f9fe64fb21ea4141801ef841d35f244f606d
+size 1107797

--- a/src/aiconfigurator/systems/data/h200_sxm/sglang/0.5.6.post2/wideep_context_mla_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/sglang/0.5.6.post2/wideep_context_mla_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba3bec1b23ef1b8a0d10ee4b774002c2d64627108a39f579d22fd109c1048b4d
+size 92130

--- a/src/aiconfigurator/systems/data/h200_sxm/sglang/0.5.6.post2/wideep_context_mlp_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/sglang/0.5.6.post2/wideep_context_mlp_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74f1a7338a1318aeb0ec97a5d612f96c7948820b33abad9421e7b77f1ecb13d1
+size 1813

--- a/src/aiconfigurator/systems/data/h200_sxm/sglang/0.5.6.post2/wideep_context_moe_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/sglang/0.5.6.post2/wideep_context_moe_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d35e207edbd03438b0d0b36dff8988dcc1ee0c3bd80034e1e2431d2f2c1ac5c5
+size 61824

--- a/src/aiconfigurator/systems/data/h200_sxm/sglang/0.5.6.post2/wideep_deepep_ll_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/sglang/0.5.6.post2/wideep_deepep_ll_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:859c4f859eb4153ff0d0217a8dc9be1aad22808ea0886580c8df21c2c0f4742e
+size 7400

--- a/src/aiconfigurator/systems/data/h200_sxm/sglang/0.5.6.post2/wideep_deepep_normal_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/sglang/0.5.6.post2/wideep_deepep_normal_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3706dcfce563a497d142e0defd15df5b4fc9ee485241a95c0254af8dddee9da
+size 37830

--- a/src/aiconfigurator/systems/data/h200_sxm/sglang/0.5.6.post2/wideep_generation_mla_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/sglang/0.5.6.post2/wideep_generation_mla_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a775af661b67b6c8b774eb3f8a506e4d064161dc27feaa35d75e1ae4634d36de
+size 101975

--- a/src/aiconfigurator/systems/data/h200_sxm/sglang/0.5.6.post2/wideep_generation_mlp_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/sglang/0.5.6.post2/wideep_generation_mlp_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5894ab726ce57e4129a1c52548f47a32cf5867bc0dc34baa1790b16dbb18b04
+size 1812

--- a/src/aiconfigurator/systems/data/h200_sxm/sglang/0.5.6.post2/wideep_generation_moe_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/sglang/0.5.6.post2/wideep_generation_moe_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69cd8d19c838a1c624aafe4009aaa25d90bb3e9832b7dcf2bc2de92ff6e7d26b
+size 49052


### PR DESCRIPTION
- Reused previously collected wideep_deepep_ll_perf.txt, wideep_deepep_normal_perf.txt, and custom_allreduce_perf.txt from h200sxm/sglang/0.5.1.post1