### PR TITLE
feat(collector): auto-download DeepSeek-V3 config from HuggingFace

### DIFF
--- a/collector/sglang/collect_wideep_attn.py
+++ b/collector/sglang/collect_wideep_attn.py
@@ -31,7 +31,52 @@ except ModuleNotFoundError:
     sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     from helper import benchmark_with_power, log_perf
 
-DEEPSEEK_MODEL_PATH = os.environ.get("DEEPSEEK_MODEL_PATH", "/deepseek-v3")
+
+def _get_deepseek_model_path():
+    """Get DeepSeek model path, downloading config files from HuggingFace if needed.
+
+    If DEEPSEEK_MODEL_PATH is set, use that path.
+    Otherwise, download only the necessary config files from HuggingFace.
+    This allows running the collector without downloading the full model weights.
+    """
+    env_path = os.environ.get("DEEPSEEK_MODEL_PATH")
+    if env_path:
+        return env_path
+
+    # Download config files from HuggingFace (no model weights needed)
+    try:
+        from huggingface_hub import hf_hub_download
+
+        repo_id = "deepseek-ai/DeepSeek-V3"
+        config_files = [
+            "config.json",
+            "configuration_deepseek.py",
+            "tokenizer_config.json",
+            "tokenizer.json",
+        ]
+
+        snapshot_dir = None
+        for filename in config_files:
+            try:
+                path = hf_hub_download(repo_id=repo_id, filename=filename)
+                if snapshot_dir is None:
+                    snapshot_dir = os.path.dirname(path)
+            except Exception as e:
+                print(f"Warning: Failed to download {filename}: {e}")
+
+        if snapshot_dir:
+            print(f"Using DeepSeek-V3 config from HuggingFace cache: {snapshot_dir}")
+            return snapshot_dir
+    except ImportError:
+        print("Warning: huggingface_hub not installed, cannot auto-download config")
+    except Exception as e:
+        print(f"Warning: Failed to download DeepSeek-V3 config: {e}")
+
+    # Fallback to default path
+    return "/deepseek-v3"
+
+
+DEEPSEEK_MODEL_PATH = _get_deepseek_model_path()
 
 
 def cleanup_distributed():
@@ -651,7 +696,7 @@ run_mla("{attention_backend}", {head_num}, {is_prefill}, {gpu_id}, None)
     )
 
     try:
-        stdout, _ = proc.communicate(timeout=300)
+        stdout, _ = proc.communicate(timeout=1800)  # 30 min for DeepGEMM JIT compile
         if stdout:
             print(stdout.decode("utf-8", errors="replace"))
     except subprocess.TimeoutExpired:


### PR DESCRIPTION
## Summary

Auto-download DeepSeek-V3 config files from HuggingFace when `DEEPSEEK_MODEL_PATH` is not set, enabling the wideep collector to run without local model weights.

## Changes

### 1. Auto-download Config Files
Added `_get_deepseek_model_path()` function that:
- Uses `DEEPSEEK_MODEL_PATH` environment variable if set
- Otherwise, automatically downloads only the necessary config files from HuggingFace:
  - `config.json`
  - `configuration_deepseek.py`
  - `tokenizer_config.json`
  - `tokenizer.json`

This works because the collector uses `load_format=dummy` (no real weights needed).

### 2. Increased Subprocess Timeout
Changed timeout from 300s to 1800s (30 minutes) to accommodate DeepGEMM JIT compilation on first run.

## Motivation

Previously, running the wideep collector required:
1. Downloading the full DeepSeek-V3 model (~600GB)
2. Setting `DEEPSEEK_MODEL_PATH` manually

Now users can run the collector immediately without any setup - config files (~50KB total) are downloaded automatically.

## Testing

Verified on H20 GPU with SGLang 0.5.6.post2:
# Without setting DEEPSEEK_MODEL_PATH
python collect.py --backend sglang --ops wideep_mla_contextOutput: