### PR TITLE
docs: Update SGLang version to 0.5.6.post2

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,8 +318,8 @@ To go through the process, refer to the [guidance](collector/README.md) under th
 
 | System | Framework(Version) | Status |
 |--------|-------------------|--------|
-| h100_sxm | TRTLLM(0.20.0, 1.0.0rc3), SGLang(0.5.5.post2, 0.5.5.post3), vLLM(0.11.0) | ✅ |
-| h200_sxm | TRTLLM(0.20.0, 1.0.0rc3), SGLang(0.5.5.post2, 0.5.5.post3), vLLM(0.11.0) | ✅ |
+| h100_sxm | TRTLLM(0.20.0, 1.0.0rc3), SGLang(0.5.6.post2), vLLM(0.11.0) | ✅ |
+| h200_sxm | TRTLLM(0.20.0, 1.0.0rc3), SGLang(0.5.6.post2), vLLM(0.11.0) | ✅ |
 | b200_sxm | TRTLLM(1.0.0rc6) | ✅ |
 | gb200_sxm | TRTLLM(1.0.0rc6) | ✅ |
 | a100_sxm | TRTLLM(1.0.0) | ✅ |

--- a/collector/README.md
+++ b/collector/README.md
@@ -149,7 +149,7 @@ how many files are needed accordingly.
 SGLang requires a **hybrid collection approach**:
 
 ### 1. Run unified collectors (GEMM, MLA, MoE, Normal Attention)
-Suggest to start from lmsysorg docker image. Say, for 0.5.5.post3, we can use lmsysorg/sglang:v0.5.5.post3-cu126
+Suggest to start from lmsysorg docker image. Say, for 0.5.6.post2, we can use lmsysorg/sglang:v0.5.6.post2-cu126
 ```bash
 python3 collect.py --backend sglang
 ```
@@ -212,4 +212,4 @@ of the GPU system and kernel optimization.
 aiconfigurator 0.1.0
 trtllm: 0.20.0, 1.0.0rc3 on Hopper GPUs
 vllm: NA
-sglang: 0.5.5.post2, 0.5.5.post3 on Hopper GPUs
+sglang: 0.5.6.post2 on Hopper GPUs

--- a/collector/sglang/README.md
+++ b/collector/sglang/README.md
@@ -20,9 +20,9 @@ The collected performance data can be used for performance modeling, scheduling 
 
 ## Requirements
 
-- SGLang framework: v0.5.0rc0 
+- SGLang framework: v0.5.6.post2
 ```bash
-docker run -itd --shm-size 32g --gpus all --ipc=host --network=host --name sglang lmsysorg/sglang:v0.5.0rc0-cu126
+docker run -itd --shm-size 32g --gpus all --ipc=host --network=host --name sglang lmsysorg/sglang:v0.5.6.post2-cu126
 ```
 - DeepSeek model config (or use dummy weights)
 


### PR DESCRIPTION
## [Docs] Update SGLang version to 0.5.6.post2

### Summary
Update documentation to reflect the current supported SGLang version (0.5.6.post2).

### Changes
- Update SGLang version from `0.5.5.post2/0.5.5.post3` to `0.5.6.post2` in:
  - `README.md` - System Data Support Matrix
  - `collector/README.md` - Docker image example and Support Matrix
  - `collector/sglang/README.md` - Requirements section

### Files Changed
| File | Change |
|------|--------|
| `README.md` | h100_sxm/h200_sxm SGLang version |
| `collector/README.md` | Docker example + Support Matrix |
| `collector/sglang/README.md` | Requirements + Docker command |

### Verification
- ✅ Data directory `h200_sxm/sglang/0.5.6.post2/` exists with full wideep data
- ✅ Data directory `b200_sxm/sglang/0.5.6.post2/` exists
- ✅ `support_matrix.csv` already uses 0.5.6.post2