### PR TITLE
feat: add hf_token support in AIC generated config

### DIFF
--- a/src/aiconfigurator/generator/config/backend_templates/sglang/run.sh.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/sglang/run.sh.j2
@@ -3,6 +3,7 @@ set -e
 trap 'echo "Cleaning up..."; kill 0 2>/dev/null || true' EXIT INT TERM
 
 export MODEL_PATH=${MODEL_PATH:-"{{ service.model_path }}"}
+export HF_TOKEN=${HF_TOKEN:-"{{ service.hf_token }}"}
 export SERVED_MODEL_NAME=${SERVED_MODEL_NAME:-"{{ service.served_model_name }}"}
 export HEAD_NODE_IP=${HEAD_NODE_IP:-"{{ service.head_node_ip }}"}
 export ETCD_ENDPOINTS="${HEAD_NODE_IP}:2379"

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/run.sh.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/run.sh.j2
@@ -3,6 +3,7 @@ set -e
 trap 'echo "Cleaning up..."; kill 0 2>/dev/null || true' EXIT INT TERM
 
 export MODEL_PATH=${MODEL_PATH:-"{{ service.model_path }}"}
+export HF_TOKEN=${HF_TOKEN:-"{{ service.hf_token }}"}
 export SERVED_MODEL_NAME=${SERVED_MODEL_NAME:-"{{ service.served_model_name }}"}
 export HEAD_NODE_IP=${HEAD_NODE_IP:-"{{ service.head_node_ip }}"}
 export ETCD_ENDPOINTS="${HEAD_NODE_IP}:2379"

--- a/src/aiconfigurator/generator/config/backend_templates/vllm/run.sh.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/vllm/run.sh.j2
@@ -3,6 +3,7 @@ set -e
 trap 'echo "Cleaning up..."; kill 0 2>/dev/null || true' EXIT INT TERM
 
 export MODEL=${MODEL:-"{{ service.model_path }}"}
+export HF_TOKEN=${HF_TOKEN:-"{{ service.hf_token }}"}
 python3 -m dynamo.frontend --http-port "{{ service.port }}" &
 
 {% if k8s.mode == 'agg' %}

--- a/src/aiconfigurator/generator/config/deployment_config.yaml
+++ b/src/aiconfigurator/generator/config/deployment_config.yaml
@@ -15,6 +15,9 @@ inputs:
   - key: ServiceConfig.model_path
     required: true
     default: ""
+  - key: ServiceConfig.hf_token
+    required: false
+    default: ""
   - key: ServiceConfig.served_model_name
     required: true
     default: ""


### PR DESCRIPTION
#### Overview:

Allow users to do this:

```
aiconfigurator cli default \
  --hf_id meta-llama/Llama-3.1-8B-Instruct \
  --total_gpus 4 \
  --system gb200_sxm \
  --save_dir llama3_1_8b \
  --generator-set ServiceConfig.hf_token="hf_xxx"
```

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
