### PR TITLE
fix: cache_transceiver_config.backend should default to DEFAULT

### DIFF
--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.yaml.j2
@@ -33,7 +33,7 @@ kv_cache_config:
   enable_block_reuse: {{ kv_cache_config.enable_block_reuse | default(false) }}
 
 cache_transceiver_config:
-  backend: {{ cache_transceiver_config.backend | default('default') }}
+  backend: {{ cache_transceiver_config.backend | default('DEFAULT') }}
   max_tokens_in_buffer: {{ k8s.max_tokens_in_buffer | default(1024) }}
 
 cuda_graph_config:


### PR DESCRIPTION
#### Overview:

Latest TRTLLM uses DEFAULT.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
