### PR TITLE
docs: add nccl-test path to avoid No such file or directory: 'all_gather_perf'

### DIFF
--- a/collector/README.md
+++ b/collector/README.md
@@ -41,6 +41,7 @@ Prepare a clean env with the target framework and nccl lib installed.
 
 # Collect comm data
 ```bash
+export PATH=$PATH:${NCCL_TEST_BIN_PATH}/
 collect_comm.sh #all_reduce data will be collected using default trtllm backend
 collect_comm.sh --all_reduce_backend vllm #all_reduce data will be collected using vllm backend
 ```


### PR DESCRIPTION
Directly run the collect script will fail due to nccl-test binary will not always be installed in default BIN PATH.
mostly people git clone from https://github.com/NVIDIA/nccl-tests



```
bash ./collect_comm.sh --all_reduce_backend vllm
Running benchmarks with all_reduce_backend: vllm
Power monitoring: DISABLED
================================================
Traceback (most recent call last):
  File "/home/ubuntu/aiconfigurator/collector/collect_nccl.py", line 142, in <module>
    nccl_benchmark(args.dtype, args.nccl_op, args.range, args.num_gpus, args.measure_power)
  File "/home/ubuntu/aiconfigurator/collector/collect_nccl.py", line 74, in nccl_benchmark
    result = subprocess.run(cmd_args, capture_output=True, text=True)
  File "/usr/lib/python3.10/subprocess.py", line 503, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/usr/lib/python3.10/subprocess.py", line 971, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.10/subprocess.py", line 1863, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'all_gather_perf'
Traceback (most recent call last):
  File "/home/ubuntu/aiconfigurator/collector/collect_nccl.py", line 142, in <module>
    nccl_benchmark(args.dtype, args.nccl_op, args.range, args.num_gpus, args.measure_power)
  File "/home/ubuntu/aiconfigurator/collector/collect_nccl.py", line 74, in nccl_benchmark
    result = subprocess.run(cmd_args, capture_output=True, text=True)
  File "/usr/lib/python3.10/subprocess.py", line 503, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/usr/lib/python3.10/subprocess.py", line 971, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.10/subprocess.py", line 1863, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'all_gather_perf'
^C
```