### PR TITLE
fix: include --max-model-len and --max-num-batched-tokens in vllm run.sh

### DIFF
--- a/src/aiconfigurator/generator/config/backend_templates/vllm/cli_args.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/vllm/cli_args.j2
@@ -6,6 +6,7 @@
 {%- if vllm['kv-cache-dtype'] is defined -%}{%- set _ = args.append('--kv-cache-dtype ' ~ vllm['kv-cache-dtype']) -%}{%- endif -%}
 {%- if vllm['max-model-len'] is defined -%}{%- set _ = args.append('--max-model-len ' ~ vllm['max-model-len']) -%}{%- endif -%}
 {%- if vllm['max-num-seqs'] is defined -%}{%- set _ = args.append('--max-num-seqs ' ~ vllm['max-num-seqs']) -%}{%- endif -%}
+{%- if vllm['max-num-batched-tokens'] is defined -%}{%- set _ = args.append('--max-num-batched-tokens ' ~ vllm['max-num-batched-tokens']) -%}{%- endif -%}
 {%- if vllm['skip-tokenizer-init'] -%}{%- set _ = args.append('--skip-tokenizer-init') -%}{%- endif -%}
 {%- if vllm['trust-remote-code'] -%}{%- set _ = args.append('--trust-remote-code') -%}{%- endif -%}
 {%- if vllm['enforce-eager'] -%}{%- set _ = args.append('--enforce-eager') -%}{%- endif -%}

--- a/src/aiconfigurator/generator/rule_plugin/vllm.rule
+++ b/src/aiconfigurator/generator/rule_plugin/vllm.rule
@@ -7,6 +7,7 @@ agg_prefill_decode gpus_per_worker = (tensor_parallel_size or 1) * (pipeline_par
 prefill max_num_tokens = (SlaConfig.isl or 0) + 1500
 decode max_num_tokens = max_batch_size
 agg max_num_tokens = (max_batch_size or 0) + (SlaConfig.isl or 0) + 1500
+agg max_seq_len = (SlaConfig.isl or 0) + (SlaConfig.osl or 0) + 1500
 
 when (ModelConfig.prefix or 0) > 0:
     disable_prefix_cache = false


### PR DESCRIPTION
#### Overview:

The original `run.sh` generated for vllm agg mode doesn't include `--max-model-len` and `--max-num-batched-tokens`, which leads to OOM when launching the inference server.

#### Details:
OOM caused by missing `--max-num-batched-tokens`
```
No available memory for the cache blocks. Try increasing `gpu_memory_utilization` when initializing the engine.
```
OOM caused by missing `--max-model-len` 
```
ValueError: To serve at least one request with the models's max seq len (40960), (3.67 GiB KV cache is needed, which is larger than the available KV cache memory (1.46 GiB). Based on the available memory, the estimated maximum model length is 16320. Try increasing `gpu_memory_utilization` or decreasing `max_model_len` when initializing the engine.
```
