### PR TITLE
fix: cuda_graph_config optimized with less batch_sizes and enable_padding to True

### DIFF
--- a/src/aiconfigurator/generator/rule_plugin/sglang.rule
+++ b/src/aiconfigurator/generator/rule_plugin/sglang.rule
@@ -4,7 +4,8 @@ agg_decode max_batch_size = (max_batch_size if max_batch_size else 128)
 agg_prefill_decode max_prefill_tokens = SlaConfig.isl + 1500
 
 
-agg_prefill_decode cuda_graph_batch_sizes = ((range(1, max_batch_size + 1) | list) if max_batch_size else [])
+agg_prefill_decode cuda_graph_enable_padding = true
+agg_prefill_decode cuda_graph_batch_sizes = ((([1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768] | select('le', max_batch_size) | list) + ([max_batch_size] if max_batch_size not in [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768] else [])) if max_batch_size else [])
 
 # GPUs per worker follow the same TP/PP/DP product that SGLang expects
 agg_prefill_decode gpus_per_worker = (tensor_parallel_size or 1) * (pipeline_parallel_size or 1) * (data_parallel_size or 1)

--- a/src/aiconfigurator/generator/rule_plugin/trtllm.rule
+++ b/src/aiconfigurator/generator/rule_plugin/trtllm.rule
@@ -9,7 +9,8 @@ prefill max_num_tokens = SlaConfig.isl + 1500
 decode max_num_tokens = max_batch_size
 agg max_num_tokens = max_batch_size + SlaConfig.isl + 1500
 
-agg_prefill_decode cuda_graph_batch_sizes = ((range(1, max_batch_size + 1) | list) if max_batch_size else [])
+agg_prefill_decode cuda_graph_enable_padding = true
+agg_prefill_decode cuda_graph_batch_sizes = ((([1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768] | select('le', max_batch_size) | list) + ([max_batch_size] if max_batch_size not in [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768] else [])) if max_batch_size else [])
 
 # GPUs per worker (fallback to 1 if any dimension missing)
 agg_prefill_decode gpus_per_worker = (tensor_parallel_size or 1) * (pipeline_parallel_size or 1) * (data_parallel_size or 1)


### PR DESCRIPTION
#### Overview:

Decode warmup step takes too long with too many batch sizes. It will also crash the deployment due to memory limit.
Reduce the batch_sizes to exponential and enable_padding for intermittent batch sizes.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
