### PR TITLE
ci: Add test for validate_database.ipynb

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,8 @@ dev = [
     "pytest-mock>=3.14.0",
     "pytest-split>=0.10.0",
     "pytest-timeout>=2.3.1",
-    "pytest-xdist==3.8.0"
+    "pytest-xdist==3.8.0",
+    "import-ipynb==0.2",
 ]
 webapp = [
     "gradio==5.47.1"

--- a/tests/e2e/tools/test_sanity_check.py
+++ b/tests/e2e/tools/test_sanity_check.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+import pytest
+
+pytestmark = [pytest.mark.e2e, pytest.mark.build]
+
+
+@pytest.fixture
+def set_cwd_to_sanity_check_dir():
+    old_cwd = os.getcwd()
+    os.chdir(
+        os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__),
+                "../../../tools/sanity_check",
+            )
+        )
+    )
+    yield
+    os.chdir(old_cwd)
+
+
+def test_validate_database(set_cwd_to_sanity_check_dir):
+    """
+    Test that validate_database.ipynb runs successfully.
+    """
+
+    # Disable interactive backend for matplotlib
+    os.environ["MPLBACKEND"] = "agg"
+
+    # Import validate_database.ipynb jupyter notebook.
+    # This will cause all the cells to run and any errors will be raised.
+    import import_ipynb  # noqa: F401
+    import validate_database  # noqa: F401

--- a/tools/sanity_check/validate_database.ipynb
+++ b/tools/sanity_check/validate_database.ipynb
@@ -17,7 +17,7 @@
     "from aiconfigurator.sdk.common import DatabaseMode\n",
     "\n",
     "system = \"h200_sxm\"\n",
-    "database = get_database(system=system, backend=\"trtllm\", version=\"1.2.0rc2\")\n"
+    "database = get_database(system=system, backend=\"trtllm\", version=\"1.2.0rc5\")\n"
    ]
   },
   {


### PR DESCRIPTION
#### Overview:

This PR adds a test that runs the `validate_database.ipynb` jupyter notebook to make sure it runs without errors. Previously, the notebook was not tested in CI, so sometimes it would break or use removed data.