### PR TITLE
fix: update generator doc and allow graceful exit of cli when lacking database data

### DIFF
--- a/docs/generator_overview.md
+++ b/docs/generator_overview.md
@@ -57,7 +57,7 @@ You can use the generator in three ways: AIConfigurator CLI, webapp, or standalo
   ```
   aiconfigurator cli default \
     --backend sglang \
-    --backend_version 0.5.1.post1 \
+    --backend_version 0.5.6.post2 \
     --model QWEN3_32B \
     --system h200_sxm \
     --total_gpus 8 \

--- a/docs/generator_overview.md
+++ b/docs/generator_overview.md
@@ -93,7 +93,7 @@ You can use the generator in three ways: AIConfigurator CLI, webapp, or standalo
             "mode": "disagg",
             "enable_router": True,
             "k8s_namespace": "dynamo",
-            "k8s_image": "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0",
+            "k8s_image": "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.0",
             "k8s_engine_mode": "configmap",
             "k8s_model_cache": "pvc:model-cache-7b",
         },
@@ -105,9 +105,9 @@ You can use the generator in three ways: AIConfigurator CLI, webapp, or standalo
     }
 
     params = generate_config_from_input_dict(input_params, backend="trtllm")
-    artifacts = generate_backend_artifacts(params, backend="trtllm", output_dir="./results/sample", backend_version="1.2.0rc3")
+    artifacts = generate_backend_artifacts(params, backend="trtllm", output_dir="./results/sample", backend_version="1.2.0rc5")
     ```
-  - Command line: `python -m aiconfigurator.generator.main render-artifacts --backend trtllm --version 1.2.0rc3 --config sample_input.yaml --output ./results`
+  - Command line: `python -m aiconfigurator.generator.main render-artifacts --backend trtllm --version 1.2.0rc5 --config sample_input.yaml --output ./results`
     ```
     # Sample sample_input.yaml
     
@@ -118,7 +118,7 @@ You can use the generator in three ways: AIConfigurator CLI, webapp, or standalo
       port: 8000
     K8sConfig:
       k8s_namespace: dynamo
-      k8s_image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.1
+      k8s_image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.0
     WorkerConfig:
       prefill_workers: 1
       decode_workers: 1

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -16,7 +16,7 @@ import yaml
 from aiconfigurator import __version__
 from aiconfigurator.cli.report_and_save import log_final_summary, save_results
 from aiconfigurator.generator.api import add_generator_override_arguments, generator_cli_helper
-from aiconfigurator.sdk import common
+from aiconfigurator.sdk import common, perf_database
 from aiconfigurator.sdk.pareto_analysis import (
     get_best_configs_under_request_latency_constraint,
     get_best_configs_under_tpot_constraint,
@@ -139,8 +139,48 @@ def configure_parser(parser):
     _add_experiments_mode_arguments(experiments_parser)
 
 
+def _get_backend_data_path(system_name: str, backend_name: str, backend_version: str) -> str | None:
+    systems_dir = perf_database.get_system_config_path()
+    system_yaml = os.path.join(systems_dir, f"{system_name}.yaml")
+    if not os.path.exists(system_yaml):
+        return None
+    with open(system_yaml, encoding="utf-8") as fh:
+        system_spec = yaml.safe_load(fh) or {}
+    data_dir = system_spec.get("data_dir")
+    if not data_dir:
+        return None
+    return os.path.join(systems_dir, data_dir, backend_name, backend_version)
+
+
+def _ensure_backend_version_available(system_name: str, backend_name: str, backend_version: str) -> None:
+    supported = perf_database.get_supported_databases()
+    versions = supported.get(system_name, {}).get(backend_name, [])
+    if backend_version in versions:
+        return
+
+    logger.error(
+        "No perf database for system=%s backend=%s version=%s.",
+        system_name,
+        backend_name,
+        backend_version,
+    )
+    data_path = _get_backend_data_path(system_name, backend_name, backend_version)
+    if data_path:
+        logger.error("Searched: %s", data_path)
+    if versions:
+        logger.error("Available versions: %s", ", ".join(versions))
+    else:
+        logger.error("Available versions: none")
+    logger.error("Fix: remove --backend_version to use the latest, or provide one of the available versions.")
+    raise SystemExit(1)
+
+
 def _build_default_task_configs(args) -> dict[str, TaskConfig]:
     decode_system = args.decode_system or args.system
+    if args.backend_version:
+        _ensure_backend_version_available(args.system, args.backend, args.backend_version)
+        if decode_system != args.system:
+            _ensure_backend_version_available(decode_system, args.backend, args.backend_version)
     common_kwargs: dict[str, Any] = {
         "model_name": args.model or args.hf_id,
         "system_name": args.system,
@@ -282,6 +322,9 @@ def _build_experiment_task_configs(args) -> dict[str, TaskConfig]:
         }
 
         if backend_version is not None:
+            _ensure_backend_version_available(system_name, backend_name, backend_version)
+            if serving_mode == "disagg" and inferred_decode_system and inferred_decode_system != system_name:
+                _ensure_backend_version_available(inferred_decode_system, backend_name, backend_version)
             task_kwargs["backend_version"] = backend_version
 
         if serving_mode == "disagg":

--- a/src/aiconfigurator/sdk/common.py
+++ b/src/aiconfigurator/sdk/common.py
@@ -168,8 +168,6 @@ SupportedSystems = {
     "gb200_sxm",
     "a100_sxm",
     "l40s",
-    "gh200_all2all",
-    "gh200_deepep",
 }
 
 """

--- a/src/aiconfigurator/sdk/common.py
+++ b/src/aiconfigurator/sdk/common.py
@@ -161,7 +161,16 @@ CachedHFModels = {
 """
 Supported systems (GPU types)
 """
-SupportedSystems = {"h100_sxm", "h200_sxm", "b200_sxm", "gb200_sxm", "a100_sxm", "l40s"}
+SupportedSystems = {
+    "h100_sxm",
+    "h200_sxm",
+    "b200_sxm",
+    "gb200_sxm",
+    "a100_sxm",
+    "l40s",
+    "gh200_all2all",
+    "gh200_deepep",
+}
 
 """
 Model family for model definition

--- a/src/aiconfigurator/sdk/task.py
+++ b/src/aiconfigurator/sdk/task.py
@@ -18,6 +18,7 @@ from aiconfigurator.sdk.models import check_is_moe, get_model_family
 from aiconfigurator.sdk.pareto_analysis import get_pareto_front
 from aiconfigurator.sdk.perf_database import (
     PerfDatabase,
+    PerfDataNotAvailableError,
     get_database,
     get_latest_database_version,
 )
@@ -510,6 +511,10 @@ class TaskConfigFactory:
             return
 
         database = get_database(system=system, backend=backend, version=version)
+        if database is None:
+            raise PerfDataNotAvailableError(
+                f"Missing perf database for system={system} backend={backend} version={version}."
+            )
         defaults = TaskConfigFactory._get_quant_mode(
             model_name=model_name,
             model_family=model_family,


### PR DESCRIPTION

#### Overview:

1. Updated the generator doc to use SGLang 0.5.6.post2 and latest dynamo container
2. Implemented graceful exit of cli program when the user specified backend_version is not supported

#### Details:

<!-- Describe the changes made in this PR. -->
**Now if you specify an unsupported backend version**
aiconfigurator cli default \
  --backend sglang \
  --backend_version 0.5.1.post1 \
  --model QWEN3_32B \
  --system h200_sxm \
  --total_gpus 8 \
  --isl 5000 --osl 1000 --ttft 2000 --tpot 50 \
  --generator-set ServiceConfig.model_path=Qwen/Qwen3-32B-FP8 \
  --generator-set ServiceConfig.served_model_name=Qwen/Qwen3-32B-FP8 \
  --generator-set K8sConfig.k8s_engine_mode=inline \
  --generator-set K8sConfig.k8s_namespace=ets-dynamo \
  --save_dir ./results

**We will output following messaages and suggest fixes to the user**
2026-01-23 09:40:23,747 - aiconfigurator.cli.main - INFO - Loading Dynamo AIConfigurator version: 0.6.0
2026-01-23 09:40:23,833 - aiconfigurator.cli.main - ERROR - No perf database for system=h200_sxm backend=sglang version=0.5.1.post1.
2026-01-23 09:40:23,835 - aiconfigurator.cli.main - ERROR - Searched: /workspace/aiconfigurator/src/aiconfigurator/systems/data/h200_sxm/sglang/0.5.1.post1
2026-01-23 09:40:23,836 - aiconfigurator.cli.main - ERROR - Available versions: 0.5.6.post2
2026-01-23 09:40:23,836 - aiconfigurator.cli.main - ERROR - Fix: remove --backend_version to use the latest, or provide one of the available versions.

