### PR TITLE
fix: align generator run script with dynamo 0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ results/QWEN3_32B_isl4000_osl1000_ttft1000_tpot20_904495
 └── pareto_frontier.png
 ```
 
-Use `--generator-config path/to/file.yaml` to load a YAML payload with `ServiceConfig`, `K8sConfig`, and `Workers.*` sections, or specify inline overrides with `--generator-set KEY=VALUE` (repeatable). Examples:
+Use `--generator-config path/to/file.yaml` to load a YAML payload with `ServiceConfig`, `K8sConfig`, `DynConfig`, `WorkerConfig`, and `Workers.<role>` sections, or specify inline overrides with `--generator-set KEY=VALUE` (repeatable). Examples:
 
 - `--generator-set ServiceConfig.model_path=Qwen/Qwen3-32B-FP8`
 - `--generator-set K8sConfig.k8s_namespace=dynamo \`

--- a/docs/cli_user_guide.md
+++ b/docs/cli_user_guide.md
@@ -156,7 +156,7 @@ By default, we output top3 configs we have found. You can get the configs and sc
 
 `--save_dir DIR` allows you to specify more information such as generating the config for a different version of the backend, say estimating the performance using trtllm 1.0.0rc3 but generate config for 1.0.0rc6. This is allowed and feasible. By passing `--generated_config_version 1.0.0rc6` can give you the right result.
 
-Use `--generator-config path/to/file.yaml` to provide ServiceConfig/K8sConfig/Workers sections, or add inline overrides via `--generator-set KEY=VALUE`. Examples:
+Use `--generator-config path/to/file.yaml` to provide ServiceConfig/K8sConfig/DynConfig/WorkerConfig/Workers.<role> sections, or add inline overrides via `--generator-set KEY=VALUE`. Examples:
 
 - `--generator-set ServiceConfig.model_path=Qwen/Qwen3-32B-FP8`
 - `--generator-set K8sConfig.k8s_namespace=dynamo \`

--- a/docs/dynamo_deployment_guide.md
+++ b/docs/dynamo_deployment_guide.md
@@ -132,7 +132,7 @@ aiconfigurator cli default \
   --head_node_ip x.x.x.x
 ````
 
-To customize parameters per worker type, override the `Workers.<role>` keys with `--generator-set`. For example:
+To customize parameters per worker type, override the `Workers.<role>` keys with `--generator-set`. To set worker counts, use `WorkerConfig.*` (e.g., `WorkerConfig.prefill_workers=2`). For example:
 
 Run `aiconfigurator cli default --generator-help` to print information that is sourced directly from `src/aiconfigurator/generator/config/deployment_config.yaml` and `backend_config_mapping.yaml`. 
 

--- a/src/aiconfigurator/eval/pipeline.py
+++ b/src/aiconfigurator/eval/pipeline.py
@@ -539,7 +539,7 @@ class Pipeline:
             with config_path.open() as f:
                 config = yaml.safe_load(f) or {}
 
-            workers = config.get("workers", {}).get("agg_workers", 1)
+            workers = config.get("WorkerConfig", {}).get("agg_workers", 1)
             LOG.info(f"Extracted agg worker count: {workers}")
             return int(workers)
 

--- a/src/aiconfigurator/generator/aggregators.py
+++ b/src/aiconfigurator/generator/aggregators.py
@@ -48,11 +48,9 @@ def collect_generator_params(
 
     mode_value = dyn_cfg.get("mode") or "disagg"
     enable_router = coerce_bool(dyn_cfg.get("enable_router"))
-    is_kv = bool(enable_router)
-    router_mode = "kv" if is_kv else ""
     mode_tag = "agg" if mode_value == "agg" else "disagg"
     name_prefix = k8s.get("name_prefix") or "dynamo"
-    name = f"{name_prefix}-{mode_tag}{('-router' if is_kv else '')}"
+    name = f"{name_prefix}-{mode_tag}{('-router' if enable_router else '')}"
     use_engine_cm = k8s.get("k8s_engine_mode", "inline") == "configmap"
     _mc_raw = k8s.get("k8s_model_cache")
     k8s_model_cache = _mc_raw.strip() if isinstance(_mc_raw, str) else ""
@@ -79,10 +77,6 @@ def collect_generator_params(
     k8s_payload.update(
         {
             "name_prefix": name_prefix,
-            "mode": mode_value,
-            "router_mode": router_mode,
-            "is_kv": is_kv,
-            "enable_router": is_kv,
             "name": name,
             "k8s_namespace": k8s.get("k8s_namespace"),
             "k8s_image": k8s.get("k8s_image"),
@@ -96,16 +90,17 @@ def collect_generator_params(
         }
     )
     return {
-        "service": service_payload,
-        "k8s": k8s_payload,
-        "workers": workers_dict,
-        "num_gpus_per_node": int(num_gpus_per_node),
+        "ServiceConfig": service_payload,
+        "K8sConfig": k8s_payload,
+        "DynConfig": dict(dyn_cfg),
+        "WorkerConfig": workers_dict,
+        "SlaConfig": sla or {},
+        "NodeConfig": {"num_gpus_per_node": int(num_gpus_per_node)},
         "params": {
             "prefill": prefill_params,
             "decode": decode_params,
             "agg": agg_params,
         },
-        "sla": sla or {},
     }
 
 
@@ -175,9 +170,9 @@ def generate_config_from_input_dict(
             group = parts[0]
             rest = parts[1:]
             if group == "ServiceConfig":
-                dest = ".".join(["service"] + rest)
+                dest = ".".join(["ServiceConfig"] + rest)
             elif group == "K8sConfig":
-                dest = ".".join(["k8s"] + rest)
+                dest = ".".join(["K8sConfig"] + rest)
             elif group == "Workers":
                 if len(rest) >= 2:
                     role = rest[0]
@@ -185,26 +180,26 @@ def generate_config_from_input_dict(
                 else:
                     dest = None
             elif group in {"WorkerCounts", "WorkerConfig"}:
-                dest = ".".join(["workers"] + rest)
+                dest = ".".join(["WorkerConfig"] + rest)
             elif group == "SlaConfig":
-                dest = ".".join(["sla"] + rest)
+                dest = ".".join(["SlaConfig"] + rest)
             elif group == "ModelConfig":
-                dest = ".".join(["service"] + rest)
+                dest = ".".join(["ModelConfig"] + rest)
             elif group == "DynConfig":
-                dest = ".".join(["dyn_config"] + rest)
+                dest = ".".join(["DynConfig"] + rest)
             elif group == "NodeConfig":
-                dest = ".".join(["node_config"] + rest)
+                dest = ".".join(["NodeConfig"] + rest)
             else:
                 dest = None
             if dest:
                 _set_by_path(target, dest, val)
-    target.setdefault("service", {})
-    target.setdefault("k8s", {})
-    target.setdefault("workers", {})
+    target.setdefault("ServiceConfig", {})
+    target.setdefault("K8sConfig", {})
+    target.setdefault("WorkerConfig", {})
     target.setdefault("params", {})
-    target.setdefault("sla", {})
-    target.setdefault("dyn_config", {})
-    target.setdefault("node_config", {})
+    target.setdefault("SlaConfig", {})
+    target.setdefault("DynConfig", {})
+    target.setdefault("NodeConfig", {})
     try:
         default_mapping = os.path.join(os.path.dirname(__file__), "config", "backend_config_mapping.yaml")
         allowed_keys = set(get_param_keys(default_mapping))
@@ -218,17 +213,20 @@ def generate_config_from_input_dict(
             if filtered:
                 for k, v in filtered.items():
                     _set_by_path(target, f"params.{role}.{k}", v)
-    return collect_generator_params(
-        service=target.get("service", {}),
-        k8s=target.get("k8s", {}),
+    params = collect_generator_params(
+        service=target.get("ServiceConfig", {}),
+        k8s=target.get("K8sConfig", {}),
         prefill_params=target.get("params", {}).get("prefill"),
         decode_params=target.get("params", {}).get("decode"),
         agg_params=target.get("params", {}).get("agg"),
-        prefill_workers=int(target.get("workers", {}).get("prefill_workers", 1)),
-        decode_workers=int(target.get("workers", {}).get("decode_workers", 1)),
-        agg_workers=int(target.get("workers", {}).get("agg_workers", 1)),
-        num_gpus_per_node=int(target.get("node_config", {}).get("num_gpus_per_node", 8)),
-        sla=target.get("sla", {}),
-        dyn_config=target.get("dyn_config", {}),
+        prefill_workers=int(target.get("WorkerConfig", {}).get("prefill_workers", 1)),
+        decode_workers=int(target.get("WorkerConfig", {}).get("decode_workers", 1)),
+        agg_workers=int(target.get("WorkerConfig", {}).get("agg_workers", 1)),
+        num_gpus_per_node=int(target.get("NodeConfig", {}).get("num_gpus_per_node", 8)),
+        sla=target.get("SlaConfig", {}),
+        dyn_config=target.get("DynConfig", {}),
         backend=backend_key,
     )
+    if target.get("ModelConfig"):
+        params["ModelConfig"] = target.get("ModelConfig", {})
+    return params

--- a/src/aiconfigurator/generator/config/backend_templates/sglang/k8s_deploy.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/sglang/k8s_deploy.yaml.j2
@@ -1,6 +1,4 @@
-{%- set router_mode = k8s.router_mode | default('') -%}
-{%- set enable_router = k8s.enable_router | default(router_mode == 'kv') -%}
-{%- set is_kv = enable_router -%}
+{%- set enable_router = DynConfig.enable_router | default(false) -%}
 {%- set runtime_working_dir = working_dir or '/workspace/components/backends/sglang' -%}
 
 {%- macro render_worker(component_name, role, replicas, gpu, cli_args) -%}
@@ -16,12 +14,12 @@
         limits:
           gpu: "{{ gpu }}"
       extraPodSpec:
-        {% if k8s.k8s_image_pull_secret %}
+        {% if K8sConfig.k8s_image_pull_secret %}
         imagePullSecrets:
-          - name: {{ k8s.k8s_image_pull_secret }}
+          - name: {{ K8sConfig.k8s_image_pull_secret }}
         {% endif %}
         mainContainer:
-          image: {{ k8s.k8s_image }}
+          image: {{ K8sConfig.k8s_image }}
           workingDir: {{ runtime_working_dir }}
           imagePullPolicy: IfNotPresent
           command: ["/bin/bash","-c"]
@@ -29,11 +27,11 @@
             - |
               set -euo pipefail
               args=(
-                --model-path "{{ service.model_path }}"
-                --served-model-name "{{ service.served_model_name }}"
+                --model-path "{{ ServiceConfig.model_path }}"
+                --served-model-name "{{ ServiceConfig.served_model_name }}"
                 {{ cli_args }}
               )
-              {% if k8s.mode != 'agg' %}
+              {% if DynConfig.mode | default('disagg') != 'agg' %}
               args+=(--host "0.0.0.0")
               {% endif %}
               {% if role == 'prefill' %}
@@ -48,7 +46,7 @@ apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:
   name: {{ name }}
-  namespace: {{ k8s.k8s_namespace }}
+  namespace: {{ K8sConfig.k8s_namespace }}
 spec:
   services:
     Frontend:
@@ -56,20 +54,20 @@ spec:
       componentType: frontend
       replicas: {{ frontend_replicas | default(1) }}
       extraPodSpec:
-        {% if k8s.k8s_image_pull_secret %}
+        {% if K8sConfig.k8s_image_pull_secret %}
         imagePullSecrets:
-          - name: {{ k8s.k8s_image_pull_secret }}
+          - name: {{ K8sConfig.k8s_image_pull_secret }}
         {% endif %}
         mainContainer:
-          image: {{ k8s.k8s_image }}
+          image: {{ K8sConfig.k8s_image }}
           imagePullPolicy: IfNotPresent
-      {% if is_kv %}
+      {% if enable_router %}
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
       {% endif %}
 
-    {% if k8s.mode == 'agg' %}
+    {% if DynConfig.mode | default('disagg') == 'agg' %}
 {{ render_worker(
     "SGLangWorker",
     None,

--- a/src/aiconfigurator/generator/config/backend_templates/sglang/run.sh.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/sglang/run.sh.j2
@@ -2,10 +2,10 @@
 set -e
 trap 'echo "Cleaning up..."; kill 0 2>/dev/null || true' EXIT INT TERM
 
-export MODEL_PATH=${MODEL_PATH:-"{{ service.model_path }}"}
-export HF_TOKEN=${HF_TOKEN:-"{{ service.hf_token }}"}
-export SERVED_MODEL_NAME=${SERVED_MODEL_NAME:-"{{ service.served_model_name }}"}
-export HEAD_NODE_IP=${HEAD_NODE_IP:-"{{ service.head_node_ip }}"}
+export MODEL_PATH=${MODEL_PATH:-"{{ ServiceConfig.model_path }}"}
+export HF_TOKEN=${HF_TOKEN:-"{{ ServiceConfig.hf_token }}"}
+export SERVED_MODEL_NAME=${SERVED_MODEL_NAME:-"{{ ServiceConfig.served_model_name }}"}
+export HEAD_NODE_IP=${HEAD_NODE_IP:-"{{ ServiceConfig.head_node_ip }}"}
 export ETCD_ENDPOINTS="${HEAD_NODE_IP}:2379"
 export NATS_SERVER="nats://${HEAD_NODE_IP}:4222"
 
@@ -16,10 +16,10 @@ DECODE_WORKERS={{ decode_workers | default(0) | int }}
 PREFILL_SYSTEM_PORT_BASE=${PREFILL_SYSTEM_PORT_BASE:-8082}
 DECODE_SYSTEM_PORT_BASE=${DECODE_SYSTEM_PORT_BASE:-$((PREFILL_SYSTEM_PORT_BASE + PREFILL_WORKERS))}
 
-{% set mode = k8s.mode %}
-{% if service.include_frontend %}
+{% set mode = DynConfig.mode | default('disagg') %}
+{% if ServiceConfig.include_frontend %}
 OTEL_SERVICE_NAME=dynamo-frontend \
-python3 -m dynamo.frontend --http-port "{{ service.port }}" 2>&1 | sed "s/^/[Frontend] /" &
+python3 -m dynamo.frontend --http-port "{{ ServiceConfig.port }}" 2>&1 | sed "s/^/[Frontend] /" &
 {% endif %}
 
 {% if mode == 'agg' %}

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.yaml.j2
@@ -34,7 +34,7 @@ kv_cache_config:
 
 cache_transceiver_config:
   backend: {{ cache_transceiver_config.backend | default('DEFAULT') }}
-  max_tokens_in_buffer: {{ k8s.max_tokens_in_buffer | default(1024) }}
+  max_tokens_in_buffer: {{ K8sConfig.max_tokens_in_buffer | default(1024) }}
 
 cuda_graph_config:
   enable_padding: {{ cuda_graph_config.enable_padding | default(false) }}
@@ -43,7 +43,7 @@ cuda_graph_config:
                     {{- s }}{{ ',' if not loop.last else '' }} {%- endfor %}]
 
 disable_overlap_scheduler: {{ disable_overlap_scheduler | default(true) }}
-print_iter_log: {{ service.print_iter_log | default(false) }}
+print_iter_log: {{ ServiceConfig.print_iter_log | default(false) }}
 
 {% if speculative_config.decoding_type is defined %}  # speculative decoding
 speculative_config:

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/k8s_deploy.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/k8s_deploy.yaml.j2
@@ -1,9 +1,7 @@
-{%- set router_mode = k8s.router_mode | default('') -%}
-{%- set enable_router = k8s.enable_router | default(router_mode == 'kv') -%}
-{%- set is_kv = enable_router -%}
-{%- set k8s_engine_mode = k8s.k8s_engine_mode -%}
+{%- set enable_router = DynConfig.enable_router | default(false) -%}
+{%- set k8s_engine_mode = K8sConfig.k8s_engine_mode -%}
 {%- set use_engine_cm = (k8s_engine_mode == 'configmap') -%}
-{%- set model_cache_input = k8s.k8s_model_cache | default('', true) | trim -%}
+{%- set model_cache_input = K8sConfig.k8s_model_cache | default('', true) | trim -%}
 {%- set k8s_use_model_cache = (model_cache_input != '') -%}
 {%- set k8s_model_cache_pvc = (model_cache_input if k8s_use_model_cache else 'model-cache') -%}
 {%- set k8s_model_cache_mount = '/workspace/model_cache' -%}
@@ -86,12 +84,12 @@ readinessProbe:
           gpu: "{{ gpu }}"
       extraPodSpec:
 {{ render_volumes() | indent(8, True) }}
-        {% if k8s.k8s_image_pull_secret %}
+        {% if K8sConfig.k8s_image_pull_secret %}
         imagePullSecrets:
-          - name: {{ k8s.k8s_image_pull_secret }}
+          - name: {{ K8sConfig.k8s_image_pull_secret }}
         {% endif %}
         mainContainer:
-          image: {{ k8s.k8s_image }}
+          image: {{ K8sConfig.k8s_image }}
           workingDir: {{ runtime_working_dir }}
           imagePullPolicy: IfNotPresent
 {{ render_volume_mounts() | indent(10, True) }}
@@ -106,8 +104,8 @@ readinessProbe:
               YAML
               {% endif %}
               args=(
-                --model-path "{{ service.model_path }}"
-                --served-model-name "{{ service.served_model_name }}"
+                --model-path "{{ ServiceConfig.model_path }}"
+                --served-model-name "{{ ServiceConfig.served_model_name }}"
                 --extra-engine-args "{{ engine_path }}"
               )
               {% if disagg_mode %}
@@ -129,7 +127,7 @@ kind: ConfigMap
 metadata:
   name: {{ engine_cm_name }}
 data:
-  {% if k8s.mode == 'agg' %}
+  {% if DynConfig.mode | default('disagg') == 'agg' %}
   {{ agg_engine_key }}: |
 {{ (agg_engine_args_inline | default('', true) | trim | indent(4, true)) }}
   {% else %}
@@ -145,7 +143,7 @@ apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:
   name: {{ name }}
-  namespace: {{ k8s.k8s_namespace }}
+  namespace: {{ K8sConfig.k8s_namespace }}
 spec:
   services:
     Frontend:
@@ -159,25 +157,25 @@ spec:
             persistentVolumeClaim:
               claimName: {{ k8s_model_cache_pvc }}
         {% endif %}
-        {% if k8s.k8s_image_pull_secret %}
+        {% if K8sConfig.k8s_image_pull_secret %}
         imagePullSecrets:
-          - name: {{ k8s.k8s_image_pull_secret }}
+          - name: {{ K8sConfig.k8s_image_pull_secret }}
         {% endif %}
         mainContainer:
-          image: {{ k8s.k8s_image }}
+          image: {{ K8sConfig.k8s_image }}
           imagePullPolicy: IfNotPresent
           {% if k8s_use_model_cache %}
           volumeMounts:
             - name: model-cache
               mountPath: {{ k8s_model_cache_mount }}
           {% endif %}
-      {% if is_kv %}
+      {% if enable_router %}
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
       {% endif %}
 
-    {% if k8s.mode == 'agg' %}
+    {% if DynConfig.mode | default('disagg') == 'agg' %}
 {{ render_worker(
     "TRTLLMWorker",
     None,
@@ -186,7 +184,7 @@ spec:
     agg_engine_args,
     agg_engine_args_inline,
     None,
-    is_kv
+    enable_router
 ) }}
     {% else %}
 {{ render_worker(
@@ -197,7 +195,7 @@ spec:
     prefill_engine_args,
     prefill_engine_args_inline,
     "prefill",
-    is_kv
+    enable_router
 ) }}
 {{ render_worker(
     "TRTLLMDecodeWorker",
@@ -207,7 +205,7 @@ spec:
     decode_engine_args,
     decode_engine_args_inline,
     "decode",
-    is_kv
+    enable_router
 ) }}
     {% endif %}
 {{ '\n' }}

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/run.sh.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/run.sh.j2
@@ -2,20 +2,20 @@
 set -e
 trap 'echo "Cleaning up..."; kill 0 2>/dev/null || true' EXIT INT TERM
 
-export MODEL_PATH=${MODEL_PATH:-"{{ service.model_path }}"}
-export HF_TOKEN=${HF_TOKEN:-"{{ service.hf_token }}"}
-export SERVED_MODEL_NAME=${SERVED_MODEL_NAME:-"{{ service.served_model_name }}"}
-export HEAD_NODE_IP=${HEAD_NODE_IP:-"{{ service.head_node_ip }}"}
+export MODEL_PATH=${MODEL_PATH:-"{{ ServiceConfig.model_path }}"}
+export HF_TOKEN=${HF_TOKEN:-"{{ ServiceConfig.hf_token }}"}
+export SERVED_MODEL_NAME=${SERVED_MODEL_NAME:-"{{ ServiceConfig.served_model_name }}"}
+export HEAD_NODE_IP=${HEAD_NODE_IP:-"{{ ServiceConfig.head_node_ip }}"}
 export ETCD_ENDPOINTS="${HEAD_NODE_IP}:2379"
 export NATS_SERVER="nats://${HEAD_NODE_IP}:4222"
 
-{% set enable_router = k8s.enable_router %}
+{% set enable_router = DynConfig.enable_router | default(false) %}
 
-{% if service.include_frontend %}
-python3 -m dynamo.frontend {% if enable_router %}--router-mode kv {% endif %}--http-port "{{ service.port }}" 2>&1 | sed "s/^/[Frontend] /" &
+{% if ServiceConfig.include_frontend %}
+python3 -m dynamo.frontend {% if enable_router %}--router-mode kv {% endif %}--http-port "{{ ServiceConfig.port }}" 2>&1 | sed "s/^/[Frontend] /" &
 {% endif %}
 
-{% if k8s.mode == "agg" %}
+{% if DynConfig.mode | default('disagg') == "agg" %}
 AGG_GPU={{ agg_gpu }}
 AGG_WORKERS={{ agg_workers }}
 AGG_GPU_OFFSET={{ agg_gpu_offset | default(0) }}

--- a/src/aiconfigurator/generator/config/backend_templates/vllm/k8s_deploy.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/vllm/k8s_deploy.yaml.j2
@@ -19,12 +19,12 @@
         limits:
           gpu: "{{ gpu }}"
       extraPodSpec:
-        {% if k8s.k8s_image_pull_secret %}
+        {% if K8sConfig.k8s_image_pull_secret %}
         imagePullSecrets:
-          - name: {{ k8s.k8s_image_pull_secret }}
+          - name: {{ K8sConfig.k8s_image_pull_secret }}
         {% endif %}
         mainContainer:
-          image: {{ k8s.k8s_image }}
+          image: {{ K8sConfig.k8s_image }}
           workingDir: {{ runtime_working_dir }}
           imagePullPolicy: IfNotPresent
           command:
@@ -33,7 +33,7 @@
             - dynamo.vllm
           args:
             - --model
-            - "{{ service.model_path }}"
+            - "{{ ServiceConfig.model_path }}"
             {% for arg in parsed_args %}
             - {{ arg | tojson }}
             {% endfor %}
@@ -48,7 +48,7 @@ apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:
   name: {{ name }}
-  namespace: {{ k8s.k8s_namespace }}
+  namespace: {{ K8sConfig.k8s_namespace }}
 spec:
   services:
     Frontend:
@@ -56,15 +56,15 @@ spec:
       componentType: frontend
       replicas: {{ frontend_replicas | default(1) }}
       extraPodSpec:
-        {% if k8s.k8s_image_pull_secret %}
+        {% if K8sConfig.k8s_image_pull_secret %}
         imagePullSecrets:
-          - name: {{ k8s.k8s_image_pull_secret }}
+          - name: {{ K8sConfig.k8s_image_pull_secret }}
         {% endif %}
         mainContainer:
-          image: {{ k8s.k8s_image }}
+          image: {{ K8sConfig.k8s_image }}
           imagePullPolicy: IfNotPresent
 
-    {% if k8s.mode == 'agg' %}
+    {% if DynConfig.mode | default('disagg') == 'agg' %}
 {{ render_worker(
     "VllmDecodeWorker",
     "decode",

--- a/src/aiconfigurator/generator/config/backend_templates/vllm/run.sh.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/vllm/run.sh.j2
@@ -2,50 +2,84 @@
 set -e
 trap 'echo "Cleaning up..."; kill 0 2>/dev/null || true' EXIT INT TERM
 
-export MODEL=${MODEL:-"{{ service.model_path }}"}
-export HF_TOKEN=${HF_TOKEN:-"{{ service.hf_token }}"}
-python3 -m dynamo.frontend --http-port "{{ service.port }}" 2>&1 | sed "s/^/[Frontend] /" &
+{% set enable_router = DynConfig.enable_router | default(false) %}
+{% if enable_router %}
+export PYTHONHASHSEED=0
+{% endif %}
+export MODEL=${MODEL:-"{{ ServiceConfig.model_path }}"}
+export HF_TOKEN=${HF_TOKEN:-"{{ ServiceConfig.hf_token }}"}
+python3 -m dynamo.frontend {% if enable_router %}--router-mode kv --router-reset-states {% endif %}--http-port "{{ ServiceConfig.port }}" 2>&1 | sed "s/^/[Frontend] /" &
 
-{% if k8s.mode == 'agg' %}
+{% if DynConfig.mode | default('disagg') == 'agg' %}
 AGG_GPU={{ agg_gpu }}
 AGG_WORKERS={{ agg_workers }}
 AGG_GPU_OFFSET={{ agg_gpu_offset | default(0) }}
+AGG_SYSTEM_PORT_BASE=${AGG_SYSTEM_PORT_BASE:-${DYN_SYSTEM_PORT1:-8081}}
+AGG_EVENT_PORT_BASE=${AGG_EVENT_PORT_BASE:-${DYN_VLLM_KV_EVENT_PORT:-{{ ServiceConfig.dyn_vllm_kv_event_port }}}}
+AGG_SIDE_CHANNEL_PORT_BASE=${AGG_SIDE_CHANNEL_PORT_BASE:-${VLLM_NIXL_SIDE_CHANNEL_PORT:-{{ ServiceConfig.vllm_nixl_side_channel_port }}}}
 for ((w=0; w<AGG_WORKERS; w++)); do
   BASE=$(( AGG_GPU_OFFSET + w * AGG_GPU ))
   GPU_LIST=$(seq -s, $BASE $((BASE+AGG_GPU-1)))
-  ( CUDA_VISIBLE_DEVICES=$GPU_LIST python3 -m dynamo.vllm \
+  SYSTEM_PORT=$(( AGG_SYSTEM_PORT_BASE + w ))
+  if [[ $w -eq 1 && -n "${DYN_SYSTEM_PORT2:-}" ]]; then
+    SYSTEM_PORT=$DYN_SYSTEM_PORT2
+  fi
+  EVENT_PORT=$(( AGG_EVENT_PORT_BASE + w ))
+  SIDE_CHANNEL_PORT=$(( AGG_SIDE_CHANNEL_PORT_BASE + w ))
+  ( DYN_SYSTEM_PORT=$SYSTEM_PORT \
+    DYN_VLLM_KV_EVENT_PORT=$EVENT_PORT \
+    VLLM_NIXL_SIDE_CHANNEL_PORT=$SIDE_CHANNEL_PORT \
+    CUDA_VISIBLE_DEVICES=$GPU_LIST python3 -m dynamo.vllm \
     --model "$MODEL" \
+    {% if enable_router %}--kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${EVENT_PORT}\",\"enable_kv_cache_events\":true}" {% endif %}\
     {{ agg_cli_args }} 2>&1 | sed "s/^/[Worker $w] /" ) &
 done
 wait
 {% else %}
+PREFILL_WORKERS={{ prefill_workers }}
+DECODE_WORKERS={{ decode_workers }}
+DECODE_SYSTEM_PORT_BASE=${DECODE_SYSTEM_PORT_BASE:-${DYN_SYSTEM_PORT1:-8081}}
+PREFILL_SYSTEM_PORT_BASE=${PREFILL_SYSTEM_PORT_BASE:-${DYN_SYSTEM_PORT2:-$((DECODE_SYSTEM_PORT_BASE + DECODE_WORKERS))}}
+PREFILL_EVENT_PORT_BASE=${PREFILL_EVENT_PORT_BASE:-${DYN_VLLM_KV_EVENT_PORT:-{{ ServiceConfig.dyn_vllm_kv_event_port }}}}
+PREFILL_SIDE_CHANNEL_PORT_BASE=${PREFILL_SIDE_CHANNEL_PORT_BASE:-${VLLM_NIXL_SIDE_CHANNEL_PORT:-{{ ServiceConfig.vllm_nixl_side_channel_port }}}}
+DECODE_EVENT_PORT_BASE=${DECODE_EVENT_PORT_BASE:-$((PREFILL_EVENT_PORT_BASE + PREFILL_WORKERS))}
+DECODE_SIDE_CHANNEL_PORT_BASE=${DECODE_SIDE_CHANNEL_PORT_BASE:-$((PREFILL_SIDE_CHANNEL_PORT_BASE + PREFILL_WORKERS))}
+
 {% if prefill_workers|int > 0 %}
 PREFILL_GPU={{ prefill_gpu }}
-PREFILL_WORKERS={{ prefill_workers }}
-PREFILL_EVENT_PORT={{ service.dyn_vllm_kv_event_port }}
-PREFILL_SIDE_CHANNEL_PORT={{ service.vllm_nixl_side_channel_port }}
 for ((w=0; w<PREFILL_WORKERS; w++)); do
   BASE=$(( w * PREFILL_GPU ))
   GPU_LIST=$(seq -s, $BASE $((BASE+PREFILL_GPU-1)))
-  ( DYN_VLLM_KV_EVENT_PORT=$PREFILL_EVENT_PORT \
-  VLLM_NIXL_SIDE_CHANNEL_PORT=$PREFILL_SIDE_CHANNEL_PORT \
+  SYSTEM_PORT=$(( PREFILL_SYSTEM_PORT_BASE + w ))
+  EVENT_PORT=$(( PREFILL_EVENT_PORT_BASE + w ))
+  SIDE_CHANNEL_PORT=$(( PREFILL_SIDE_CHANNEL_PORT_BASE + w ))
+  ( DYN_SYSTEM_PORT=$SYSTEM_PORT \
+  DYN_VLLM_KV_EVENT_PORT=$EVENT_PORT \
+  VLLM_NIXL_SIDE_CHANNEL_PORT=$SIDE_CHANNEL_PORT \
   CUDA_VISIBLE_DEVICES=$GPU_LIST \
     python3 -m dynamo.vllm \
       --model "$MODEL" \
+      {% if enable_router %}--kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${EVENT_PORT}\",\"enable_kv_cache_events\":true}" {% endif %}\
       {{ prefill_cli_args }} --is-prefill-worker 2>&1 | sed "s/^/[Prefill $w] /" ) &
 done
 {% endif %}
 
 {% if decode_workers|int > 0 %}
 DECODE_GPU={{ decode_gpu }}
-DECODE_WORKERS={{ decode_workers }}
 DECODE_GPU_OFFSET={{ decode_gpu_offset | default(0) }}
 for ((w=0; w<DECODE_WORKERS; w++)); do
   BASE=$(( DECODE_GPU_OFFSET + w * DECODE_GPU ))
   GPU_LIST=$(seq -s, $BASE $((BASE+DECODE_GPU-1)))
-  ( CUDA_VISIBLE_DEVICES=$GPU_LIST \
+  SYSTEM_PORT=$(( DECODE_SYSTEM_PORT_BASE + w ))
+  EVENT_PORT=$(( DECODE_EVENT_PORT_BASE + w ))
+  SIDE_CHANNEL_PORT=$(( DECODE_SIDE_CHANNEL_PORT_BASE + w ))
+  ( DYN_SYSTEM_PORT=$SYSTEM_PORT \
+  DYN_VLLM_KV_EVENT_PORT=$EVENT_PORT \
+  VLLM_NIXL_SIDE_CHANNEL_PORT=$SIDE_CHANNEL_PORT \
+  CUDA_VISIBLE_DEVICES=$GPU_LIST \
     python3 -m dynamo.vllm \
       --model "$MODEL" \
+      {% if enable_router %}--kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${EVENT_PORT}\",\"enable_kv_cache_events\":true}" {% endif %}\
       {{ decode_cli_args }} --is-decode-worker 2>&1 | sed "s/^/[Decode $w] /" ) &
 done
 {% endif %}

--- a/src/aiconfigurator/generator/main.py
+++ b/src/aiconfigurator/generator/main.py
@@ -116,10 +116,12 @@ def _resolve_roles(requested: str, params: dict[str, Any], logger: logging.Logge
 
 def _build_worker_context(params: dict[str, Any], role: str) -> dict[str, Any]:
     ctx: dict[str, Any] = {}
-    ctx.update(params.get("service") or {})
-    ctx.update(params.get("k8s") or {})
-    ctx.update(params.get("workers") or {})
-    ctx.update(params.get("sla") or {})
+    ctx.update(params.get("ServiceConfig") or {})
+    ctx.update(params.get("K8sConfig") or {})
+    ctx.update(params.get("WorkerConfig") or {})
+    ctx.update(params.get("SlaConfig") or {})
+    ctx.update(params.get("DynConfig") or {})
+    ctx.update(params.get("NodeConfig") or {})
     ctx.update(params.get("params", {}).get(role, {}) or {})
     ctx["role"] = role
     return ctx

--- a/src/aiconfigurator/generator/rendering/engine.py
+++ b/src/aiconfigurator/generator/rendering/engine.py
@@ -67,9 +67,9 @@ def render_backend_templates(
     }
     wd = backend_dirs.get(backend)
     if wd:
-        # k8s.working_dir used in k8s_deploy templates, also expose top-level
-        context.setdefault("k8s", {})
-        context["k8s"]["working_dir"] = wd
+        # K8sConfig.working_dir used in k8s_deploy templates, also expose top-level
+        context.setdefault("K8sConfig", {})
+        context["K8sConfig"]["working_dir"] = wd
         context["working_dir"] = wd
 
     # Determine generation mode by params presence
@@ -198,7 +198,7 @@ def render_backend_templates(
             logger.warning(f"Failed to render engine template {engine_template_file.name}: {e}")
 
     # Inject inline engine args content into context for k8s template
-    # These are used when k8s.k8s_engine_mode == 'inline'
+    # These are used when K8sConfig.k8s_engine_mode == 'inline'
     context["prefill_engine_args_inline"] = rendered_templates.get("extra_engine_args_prefill.yaml", "")
     context["decode_engine_args_inline"] = rendered_templates.get("extra_engine_args_decode.yaml", "")
     context["agg_engine_args_inline"] = rendered_templates.get("extra_engine_args_agg.yaml", "")
@@ -268,13 +268,14 @@ def render_backend_templates(
             tmpl = env.get_template("run.sh.j2")
 
             # Determine mode
-            mode = context.get("k8s", {}).get("mode", "disagg")
+            mode = context.get("DynConfig", {}).get("mode", "disagg")
 
             if mode == "agg":
                 # Use GPU counts injected earlier from rule outputs
                 agg_gpu = int(context.get("agg_gpu", 1))
                 agg_workers = int(context.get("agg_workers", 1))
-                num_gpus_per_node = int(context.get("num_gpus_per_node", 8))
+                node_cfg = context.get("NodeConfig", {})
+                num_gpus_per_node = int(node_cfg.get("num_gpus_per_node", 8))
 
                 # Simple greedy allocation
                 def _allocate_agg_nodes(workers: int, gpu: int, gpu_per_node: int):
@@ -295,10 +296,10 @@ def render_backend_templates(
 
                 for idx, cnt in enumerate(plan):
                     node_ctx = dict(context)
-                    # Ensure nested service dict exists and set include_frontend
-                    svc = dict(node_ctx.get("service", {}))
+                    # Ensure nested ServiceConfig dict exists and set include_frontend
+                    svc = dict(node_ctx.get("ServiceConfig", {}))
                     svc["include_frontend"] = idx == 0
-                    node_ctx["service"] = svc
+                    node_ctx["ServiceConfig"] = svc
                     node_ctx["agg_gpu"] = agg_gpu
                     node_ctx["agg_workers"] = int(cnt["workers"])
                     node_ctx["agg_gpu_offset"] = 0
@@ -311,7 +312,8 @@ def render_backend_templates(
 
                 prefill_workers = int(context.get("prefill_workers", 1))
                 decode_workers = int(context.get("decode_workers", 1))
-                num_gpus_per_node = int(context.get("num_gpus_per_node", 8))
+                node_cfg = context.get("NodeConfig", {})
+                num_gpus_per_node = int(node_cfg.get("num_gpus_per_node", 8))
 
                 # Simple greedy allocation
                 def _allocate_disagg_nodes(p_worker: int, p_gpu: int, d_worker: int, d_gpu: int, gpu_per_node: int):
@@ -384,9 +386,9 @@ def render_backend_templates(
 
                 for idx, cnt in enumerate(plan):
                     node_ctx = dict(context)
-                    svc = dict(node_ctx.get("service", {}))
+                    svc = dict(node_ctx.get("ServiceConfig", {}))
                     svc["include_frontend"] = idx == 0
-                    node_ctx["service"] = svc
+                    node_ctx["ServiceConfig"] = svc
                     node_ctx["prefill_gpu"] = prefill_gpu
                     node_ctx["decode_gpu"] = decode_gpu
                     node_ctx["prefill_workers"] = int(cnt.get("p_worker", 0))
@@ -417,41 +419,39 @@ def prepare_template_context(param_values: dict[str, Any], backend: str) -> dict
     context = {}
 
     # Extract ModelConfig (is_moe, nextn, etc.)
-    context["num_gpus_per_node"] = param_values.get("num_gpus_per_node", 8)
     model_config = param_values.get("ModelConfig", {})
     if model_config.get("is_moe"):
         context["is_moe"] = model_config["is_moe"]
 
     # Extract unified service configuration
-    service_config = param_values.get("service", {})
+    service_config = param_values.get("ServiceConfig", {})
     context["model_name"] = service_config.get("model_name") or service_config.get("served_model_name", "")
     context["model_path"] = service_config.get("model_path")
     context["served_model_name"] = service_config.get("served_model_name")
-    context["service"] = dict(service_config)
+    context["ServiceConfig"] = dict(service_config)
 
     # Extract K8s configuration
-    k8s_config = param_values.get("k8s", {})
+    k8s_config = param_values.get("K8sConfig", {})
     context["name_prefix"] = k8s_config.get("name_prefix")
-    context["mode"] = k8s_config.get("mode")
     context["k8s_namespace"] = k8s_config.get("k8s_namespace")
     context["k8s_image"] = k8s_config.get("k8s_image")
     context["k8s_image_pull_secret"] = k8s_config.get("k8s_image_pull_secret")
     context["working_dir"] = k8s_config.get("working_dir")
     context["k8s_engine_mode"] = k8s_config.get("k8s_engine_mode")
     context["k8s_model_cache"] = k8s_config.get("k8s_model_cache")
-    enable_router = bool(k8s_config.get("enable_router"))
-    context["router_mode"] = "kv" if enable_router else ""
-    context["is_kv"] = enable_router
-    context["enable_router"] = enable_router
-    name_suffix = "agg" if context["mode"] == "agg" else "disagg"
+
+    # Extract DynConfig for mode/router decisions
+    dyn_config = param_values.get("DynConfig", {})
+    if isinstance(dyn_config, dict):
+        context["DynConfig"] = dyn_config
+    mode_value = dyn_config.get("mode") if isinstance(dyn_config, dict) else None
+    mode_value = mode_value or "disagg"
+    enable_router = bool(dyn_config.get("enable_router")) if isinstance(dyn_config, dict) else False
+    name_suffix = "agg" if mode_value == "agg" else "disagg"
     router_suffix = "-router" if enable_router else ""
     full_name = f"{context['name_prefix']}-{name_suffix}{router_suffix}"
     context["name"] = k8s_config.get("name") or full_name
-    k8s_copy = dict(k8s_config)
-    k8s_copy["router_mode"] = context["router_mode"]
-    k8s_copy["is_kv"] = enable_router
-    k8s_copy["enable_router"] = enable_router
-    context["k8s"] = k8s_copy
+    context["K8sConfig"] = dict(k8s_config)
 
     # Runtime is part of service
     context["head_node_ip"] = service_config.get("head_node_ip")
@@ -465,7 +465,7 @@ def prepare_template_context(param_values: dict[str, Any], backend: str) -> dict
     context["agg_params"] = worker_params.get("agg", {})
 
     # Extract worker counts
-    workers = param_values.get("workers", {})
+    workers = param_values.get("WorkerConfig", {})
     context["prefill_workers"] = workers.get("prefill_workers", 1)
     context["decode_workers"] = workers.get("decode_workers", 1)
     context["agg_workers"] = workers.get("agg_workers", 1)
@@ -478,6 +478,10 @@ def prepare_template_context(param_values: dict[str, Any], backend: str) -> dict
 
     fr = 1 if (context.get("include_frontend") is True) else 0
     context["frontend_replicas"] = fr
+
+    node_config = param_values.get("NodeConfig", {})
+    if isinstance(node_config, dict):
+        context["NodeConfig"] = dict(node_config)
 
     # Load backend_config_mapping.yaml to understand parameter mappings
     mapping_data = load_yaml_mapping(_BACKEND_MAPPING_FILE)

--- a/src/aiconfigurator/generator/rule_plugin/sglang.rule
+++ b/src/aiconfigurator/generator/rule_plugin/sglang.rule
@@ -13,6 +13,7 @@ agg_prefill_decode kv_cache_dtype = ("fp8_e4m3" if kv_cache_dtype == "fp8" else 
 
 when (ModelConfig.prefix or 0) > 0:
     disable_prefix_cache = false
+    DynConfig.enable_router = true
 
 when (ModelConfig.nextn or 0) > 0:
     speculative_decoding_type = "NEXTN"

--- a/src/aiconfigurator/generator/rule_plugin/trtllm.rule
+++ b/src/aiconfigurator/generator/rule_plugin/trtllm.rule
@@ -22,6 +22,8 @@ agg_prefill_decode enable_attention_dp = ((data_parallel_size or 1) > 1) and Mod
 
 when (ModelConfig.prefix or 0) > 0:
     agg_prefill_decode disable_prefix_cache = false
+    DynConfig.enable_router = true
+
 
 # Speculative decoding
 when (ModelConfig.nextn or 0) > 0:

--- a/src/aiconfigurator/generator/rule_plugin/vllm.rule
+++ b/src/aiconfigurator/generator/rule_plugin/vllm.rule
@@ -12,6 +12,7 @@ agg max_seq_len = (SlaConfig.isl or 0) + (SlaConfig.osl or 0) + 1500
 
 when (ModelConfig.prefix or 0) > 0:
     disable_prefix_cache = false
+    DynConfig.enable_router = true
 
 when (ModelConfig.nextn or 0) > 0:
     speculative_decoding_type = "mtp"


### PR DESCRIPTION
#### Overview:

Align generator run script with dynamo 0.8.0, solve port conflict issue when enable kv router.

1. align the variable name prefix with https://github.com/ai-dynamo/aiconfigurator/blob/main/src/aiconfigurator/generator/config/deployment_config.yaml, for example, k8s.xxx -> K8sConfig.xxx
2. Try to cover the various scenarios inside https://github.com/ai-dynamo/dynamo/tree/main/examples/backends/vllm/launch (not include multimodal, lmcache and single gpu)
3. Resolve the port conflict issue in vllm run script when launch with multiple workers
