### PR TITLE
fix: Use nixl as default disagg transfer backend for sglang 0.5.6.post2 and allow user to set disagg transfer backend in cli

### DIFF
--- a/src/aiconfigurator/generator/aggregators.py
+++ b/src/aiconfigurator/generator/aggregators.py
@@ -51,6 +51,10 @@ def collect_generator_params(
     is_kv = bool(enable_router)
     router_mode = "kv" if is_kv else ""
     mode_tag = "agg" if mode_value == "agg" else "disagg"
+    if backend_key == "sglang" and mode_tag == "disagg":
+        for params in (prefill_params, decode_params):
+            if params.get("kv_transfer_backend") is None:
+                params["kv_transfer_backend"] = "nixl"
     name_prefix = k8s.get("name_prefix") or "dynamo"
     name = f"{name_prefix}-{mode_tag}{('-router' if is_kv else '')}"
     use_engine_cm = k8s.get("k8s_engine_mode", "inline") == "configmap"

--- a/src/aiconfigurator/generator/config/backend_templates/sglang/cli_args.0.5.6.post2.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/sglang/cli_args.0.5.6.post2.j2
@@ -19,4 +19,5 @@
 {%- if sglang['speculative-num-steps'] is defined -%}{%- set _ = args.append('--speculative-num-steps "' ~ sglang['speculative-num-steps'] ~ '"') -%}{%- endif -%}
 {%- if sglang['disable-cuda-graph-padding'] -%}{%- set _ = args.append('--disable-cuda-graph-padding') -%}{%- endif -%}
 {%- if sglang['cuda-graph-max-bs'] is defined -%}{%- set _ = args.append('--cuda-graph-max-bs "' ~ sglang['cuda-graph-max-bs'] ~ '"') -%}{%- endif -%}
+{%- if sglang['disaggregation-transfer-backend'] is defined -%}{%- set _ = args.append('--disaggregation-transfer-backend "' ~ sglang['disaggregation-transfer-backend'] ~ '"') -%}{%- endif -%}
 {{ args | join(' ') }}


### PR DESCRIPTION
#### Overview:

1. By default the generator will now set disaggregation-transfer-backend for sglang 0.5.6.post2 as nixl
2. Also user can now set disaggregation-transfer-backend manually using --generator-set Workers.prefill.kv_transfer_backend and --generator-set Workers.decode.kv_transfer_backend when using aiconfigurator cli default
