### PR TITLE
fix: vllm/sglang k8s template missing k8s_model_cache param

### DIFF
--- a/src/aiconfigurator/generator/config/backend_templates/sglang/k8s_deploy.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/sglang/k8s_deploy.yaml.j2
@@ -1,5 +1,9 @@
 {%- set enable_router = DynConfig.enable_router | default(false) -%}
 {%- set runtime_working_dir = working_dir or '/workspace/components/backends/sglang' -%}
+{%- set model_cache_input = K8sConfig.k8s_model_cache | default('', true) | trim -%}
+{%- set k8s_use_model_cache = (model_cache_input != '') -%}
+{%- set k8s_model_cache_pvc = (model_cache_input if k8s_use_model_cache else 'model-cache') -%}
+{%- set k8s_model_cache_mount = '/workspace/model_cache' -%}
 
 {%- macro render_worker(component_name, role, replicas, gpu, cli_args) -%}
 {{ "    " ~ component_name ~ ":" }}
@@ -54,6 +58,12 @@ spec:
       componentType: frontend
       replicas: {{ frontend_replicas | default(1) }}
       extraPodSpec:
+        {% if k8s_use_model_cache %}
+        volumes:
+          - name: model-cache
+            persistentVolumeClaim:
+              claimName: {{ k8s_model_cache_pvc }}
+        {% endif %}      
         {% if K8sConfig.k8s_image_pull_secret %}
         imagePullSecrets:
           - name: {{ K8sConfig.k8s_image_pull_secret }}
@@ -61,6 +71,11 @@ spec:
         mainContainer:
           image: {{ K8sConfig.k8s_image }}
           imagePullPolicy: IfNotPresent
+          {% if k8s_use_model_cache %}
+          volumeMounts:
+            - name: model-cache
+              mountPath: {{ k8s_model_cache_mount }}
+          {% endif %}
       {% if enable_router %}
       envs:
         - name: DYN_ROUTER_MODE

--- a/src/aiconfigurator/generator/config/backend_templates/vllm/k8s_deploy.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/vllm/k8s_deploy.yaml.j2
@@ -4,6 +4,10 @@
 {%- else -%}
 {%- set runtime_working_dir = _default_vllm_workdir -%}
 {%- endif -%}
+{%- set model_cache_input = K8sConfig.k8s_model_cache | default('', true) | trim -%}
+{%- set k8s_use_model_cache = (model_cache_input != '') -%}
+{%- set k8s_model_cache_pvc = (model_cache_input if k8s_use_model_cache else 'model-cache') -%}
+{%- set k8s_model_cache_mount = '/workspace/model_cache' -%}
 
 {%- macro render_worker(component_name, role, replicas, gpu, cli_args_list) -%}
     {%- set parsed_args = cli_args_list | default([]) -%}
@@ -19,6 +23,12 @@
         limits:
           gpu: "{{ gpu }}"
       extraPodSpec:
+        {% if k8s_use_model_cache %}
+        volumes:
+          - name: model-cache
+            persistentVolumeClaim:
+              claimName: {{ k8s_model_cache_pvc }}
+        {% endif %}      
         {% if K8sConfig.k8s_image_pull_secret %}
         imagePullSecrets:
           - name: {{ K8sConfig.k8s_image_pull_secret }}
@@ -27,6 +37,11 @@
           image: {{ K8sConfig.k8s_image }}
           workingDir: {{ runtime_working_dir }}
           imagePullPolicy: IfNotPresent
+          {% if k8s_use_model_cache %}
+          volumeMounts:
+            - name: model-cache
+              mountPath: {{ k8s_model_cache_mount }}
+          {% endif %}
           command:
             - python3
             - -m


### PR DESCRIPTION
#### Overview:

Fixed the bug that the k8s_model_cache parameter is not rendered into k8s_deploy.yaml.

A potential improvement would be adding an additional `--generator-set K8sConfig.k8s_model_cache_mount_path=...` flag to allow custom mount paths. Right now we hardcoded it to `/workspace/model_cache`. But let's address in a separate PR.

