### PR TITLE
fix: handle sglang l40s missing data gracefully

### DIFF
--- a/src/aiconfigurator/sdk/task.py
+++ b/src/aiconfigurator/sdk/task.py
@@ -563,10 +563,13 @@ class TaskConfigFactory:
         if backend == "vllm":
             # TODO: collect fp8_block quant mode data for vllm
             fp8_gemm_quant = "fp8"
+            fp8_moe_quant = "fp8"
             fp8_fhma_quant = "float16"
         else:
             # fp8_block GEMM requires SM90+ (TMA). On SM89 (e.g., L40S) we use fp8 instead.
             fp8_gemm_quant = "fp8_block" if sm_version >= 90 else "fp8"
+            # MOE fp8_block uses a different kernel path that works on SM89+.
+            fp8_moe_quant = "fp8_block" if sm_version >= 89 else "fp8"
             # FP8 attention is effectively SM90+ only; on SM89 prefer float16/bf16.
             fp8_fhma_quant = "fp8" if sm_version >= 90 else "float16"
 
@@ -577,7 +580,7 @@ class TaskConfigFactory:
             fmha_quant_mode = fp8_fhma_quant
         elif sm_version >= 89:
             gemm_quant_mode = _pick([fp8_gemm_quant, "fp8", "float16"], supported_gemm, fp8_gemm_quant)
-            moe_quant_mode = _pick([fp8_gemm_quant, "float16"], supported_moe, fp8_gemm_quant)
+            moe_quant_mode = _pick([fp8_moe_quant, "fp8", "float16"], supported_moe, fp8_moe_quant)
             fmha_quant_mode = fp8_fhma_quant
             kvcache_quant_mode = "fp8"
         else:
@@ -591,7 +594,7 @@ class TaskConfigFactory:
 
         if model_family in ["MOE", "LLAMA"] and sm_version < 100 and sm_version >= 89:
             gemm_quant_mode = fp8_gemm_quant
-            moe_quant_mode = _pick([fp8_gemm_quant, "float16"], supported_moe, fp8_gemm_quant)
+            moe_quant_mode = _pick([fp8_moe_quant, "fp8", "float16"], supported_moe, fp8_moe_quant)
 
         if model_path in ["GPT_OSS_120B", "GPT_OSS_20B"]:
             moe_quant_mode = "w4a16_mxfp4"


### PR DESCRIPTION
#### Overview:

fix: handle sglang l40s missing data gracefully

#### Details:

Previous error:
```
(aic_venv) jasonzho@NV-25010035:~/repo/repo6/aiconfigurator$ aiconfigurator cli default --model Qwen/Qwen3-32B --total_gpus 8 --system l40s --backend sglang
2026-01-27 10:39:22,682 - aiconfigurator.main - WARNING - Gradio not installed, you can install it with pip3 install .[webapp]
2026-01-27 10:39:22,689 - aiconfigurator.cli.main - INFO - Loading Dynamo AIConfigurator version: 0.6.0
2026-01-27 10:39:22,690 - aiconfigurator.sdk.utils - INFO - Model architecture: architecture=Qwen3ForCausalLM, layers=64, n=64, n_kv=8, d=128, hidden_size=5120, inter_size=25600, vocab=151936, context=40960, topk=0, num_experts=0, moe_inter_size=0, extra_params=None
2026-01-27 10:39:22,698 - aiconfigurator.sdk.perf_database - INFO - loading system='l40s', backend='sglang', version='0.5.5.post3'
2026-01-27 10:39:22,811 - aiconfigurator.sdk.perf_database - WARNING - Context mla data file /home/jasonzho/repo/repo6/aiconfigurator/src/aiconfigurator/systems/data/l40s/sglang/0.5.5.post3/context_mla_perf.txt not found.
2026-01-27 10:39:22,812 - aiconfigurator.sdk.perf_database - WARNING - Generation mla data file /home/jasonzho/repo/repo6/aiconfigurator/src/aiconfigurator/systems/data/l40s/sglang/0.5.5.post3/generation_mla_perf.txt not found.
2026-01-27 10:39:22,815 - aiconfigurator.sdk.perf_database - WARNING - Context MoE data file /home/jasonzho/repo/repo6/aiconfigurator/src/aiconfigurator/systems/data/l40s/sglang/0.5.5.post3/wideep_context_moe_perf.txt not found.
2026-01-27 10:39:22,815 - aiconfigurator.sdk.perf_database - WARNING - Generation MoE data file /home/jasonzho/repo/repo6/aiconfigurator/src/aiconfigurator/systems/data/l40s/sglang/0.5.5.post3/wideep_generation_moe_perf.txt not found.
2026-01-27 10:39:22,815 - aiconfigurator.sdk.perf_database - WARNING - SGLang wideep context mla data file /home/jasonzho/repo/repo6/aiconfigurator/src/aiconfigurator/systems/data/l40s/sglang/0.5.5.post3/wideep_context_mla_perf.txt not found.
2026-01-27 10:39:22,815 - aiconfigurator.sdk.perf_database - WARNING - SGLang wideep generation mla data file /home/jasonzho/repo/repo6/aiconfigurator/src/aiconfigurator/systems/data/l40s/sglang/0.5.5.post3/wideep_generation_mla_perf.txt not found.
2026-01-27 10:39:22,815 - aiconfigurator.sdk.perf_database - WARNING - SGLang wideep deepep normal operation data file /home/jasonzho/repo/repo6/aiconfigurator/src/aiconfigurator/systems/data/l40s/sglang/0.5.5.post3/wideep_deepep_normal_perf.txt not found.
2026-01-27 10:39:22,815 - aiconfigurator.sdk.perf_database - WARNING - SGLang wideep deepep LL operation data file /home/jasonzho/repo/repo6/aiconfigurator/src/aiconfigurator/systems/data/l40s/sglang/0.5.5.post3/wideep_deepep_ll_perf.txt not found.
2026-01-27 10:39:23,301 - aiconfigurator.sdk.task - INFO - Task agg_Qwen/Qwen3-32B_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Runtime config: DefaultMunch(<class 'munch.DefaultMunch'>, {'isl': 4000, 'osl': 1000, 'prefix': 0, 'ttft': 2000.0, 'tpot': 30.0, 'request_latency': None})
2026-01-27 10:39:23,301 - aiconfigurator.sdk.task - INFO - Task agg_Qwen/Qwen3-32B_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Worker config: DefaultMunch(<class 'munch.DefaultMunch'>, {'system_name': 'l40s', 'backend_name': 'sglang', 'backend_version': '0.5.5.post3', 'num_gpu_per_worker': [1, 2, 4, 8], 'tp_list': [1, 2, 4, 8], 'pp_list': [1], 'dp_list': [1], 'moe_tp_list': [1], 'moe_ep_list': [1], 'gemm_quant_mode': <GEMMQuantMode.fp8: QuantMapping(memory=1, compute=2, name='fp8')>, 'moe_quant_mode': <MoEQuantMode.fp8: QuantMapping(memory=1, compute=2, name='fp8')>, 'kvcache_quant_mode': <KVCacheQuantMode.float16: QuantMapping(memory=2, compute=0, name='float16')>, 'fmha_quant_mode': <FMHAQuantMode.float16: QuantMapping(memory=2, compute=1, name='float16')>, 'comm_quant_mode': <CommQuantMode.half: QuantMapping(memory=2, compute=0, name='half')>})
Traceback (most recent call last):
  File "/home/jasonzho/repo/repo6/aic_venv/bin/aiconfigurator", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/jasonzho/repo/repo6/aiconfigurator/src/aiconfigurator/main.py", line 87, in main
    handler(extras)
  File "/home/jasonzho/repo/repo6/aiconfigurator/src/aiconfigurator/main.py", line 44, in _run_cli
    cli_main(cli_args)
  File "/home/jasonzho/repo/repo6/aiconfigurator/src/aiconfigurator/cli/main.py", line 605, in main
    task_configs = _build_default_task_configs(args)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jasonzho/repo/repo6/aiconfigurator/src/aiconfigurator/cli/main.py", line 266, in _build_default_task_configs
    agg_task = TaskConfig(serving_mode="agg", **common_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jasonzho/repo/repo6/aiconfigurator/src/aiconfigurator/sdk/task.py", line 857, in __init__
    self.validate()
  File "/home/jasonzho/repo/repo6/aiconfigurator/src/aiconfigurator/sdk/task.py", line 930, in validate
    _validate_worker_config(self.config.worker_config, validate_context=True, validate_generation=True)
  File "/home/jasonzho/repo/repo6/aiconfigurator/src/aiconfigurator/sdk/task.py", line 920, in _validate_worker_config
    _supported_or_raise("moe", moe_mode)
  File "/home/jasonzho/repo/repo6/aiconfigurator/src/aiconfigurator/sdk/task.py", line 883, in _supported_or_raise
    raise ValueError(
ValueError: Unsupported moe quant mode 'fp8' for system='l40s', backend='sglang', version='0.5.5.post3'. Supported moe modes: ['float16', 'fp8_block']
```

Looking at this error, the issue is that the default moe_quant_mode is being set to fp8, but for the l40s system with sglang backend, only float16 and fp8_block are supported.

1. On line 573-575, for SM89 (L40S), _pick() is correctly used to select an moe_quant_mode from the supported set
2. But on lines 587-589, there's an override for MOE and LLAMA model families that directly sets moe_quant_mode = fp8_gemm_quant without checking if it's supported

Since Qwen3-32B has architecture Qwen3ForCausalLM which maps to the LLAMA family, lines 587-589 bypass the support check and set moe_quant_mode to "fp8" directly, even though L40S/sglang only supports ['float16', 'fp8_block'] for MoE.

The fix is to use _pick() on line 589 to respect the supported modes.

After fix:
```
(aic_venv) jasonzho@NV-25010035:~/repo/repo6/aiconfigurator$ aiconfigurator cli default --model Qwen/Qwen3-32B --total_gpus 8 --system l40s --backend sglang
2026-01-27 10:45:53,370 - aiconfigurator.main - WARNING - Gradio not installed, you can install it with pip3 install .[webapp]
2026-01-27 10:45:53,376 - aiconfigurator.cli.main - INFO - Loading Dynamo AIConfigurator version: 0.6.0
2026-01-27 10:45:53,377 - aiconfigurator.sdk.utils - INFO - Model architecture: architecture=Qwen3ForCausalLM, layers=64, n=64, n_kv=8, d=128, hidden_size=5120, inter_size=25600, vocab=151936, context=40960, topk=0, num_experts=0, moe_inter_size=0, extra_params=None
2026-01-27 10:45:53,384 - aiconfigurator.sdk.perf_database - INFO - loading system='l40s', backend='sglang', version='0.5.5.post3'
2026-01-27 10:45:53,490 - aiconfigurator.sdk.perf_database - WARNING - Context mla data file /home/jasonzho/repo/repo6/aiconfigurator/src/aiconfigurator/systems/data/l40s/sglang/0.5.5.post3/context_mla_perf.txt not found.
2026-01-27 10:45:53,490 - aiconfigurator.sdk.perf_database - WARNING - Generation mla data file /home/jasonzho/repo/repo6/aiconfigurator/src/aiconfigurator/systems/data/l40s/sglang/0.5.5.post3/generation_mla_perf.txt not found.
2026-01-27 10:45:53,494 - aiconfigurator.sdk.perf_database - WARNING - Context MoE data file /home/jasonzho/repo/repo6/aiconfigurator/src/aiconfigurator/systems/data/l40s/sglang/0.5.5.post3/wideep_context_moe_perf.txt not found.
2026-01-27 10:45:53,494 - aiconfigurator.sdk.perf_database - WARNING - Generation MoE data file /home/jasonzho/repo/repo6/aiconfigurator/src/aiconfigurator/systems/data/l40s/sglang/0.5.5.post3/wideep_generation_moe_perf.txt not found.
2026-01-27 10:45:53,494 - aiconfigurator.sdk.perf_database - WARNING - SGLang wideep context mla data file /home/jasonzho/repo/repo6/aiconfigurator/src/aiconfigurator/systems/data/l40s/sglang/0.5.5.post3/wideep_context_mla_perf.txt not found.
2026-01-27 10:45:53,494 - aiconfigurator.sdk.perf_database - WARNING - SGLang wideep generation mla data file /home/jasonzho/repo/repo6/aiconfigurator/src/aiconfigurator/systems/data/l40s/sglang/0.5.5.post3/wideep_generation_mla_perf.txt not found.
2026-01-27 10:45:53,494 - aiconfigurator.sdk.perf_database - WARNING - SGLang wideep deepep normal operation data file /home/jasonzho/repo/repo6/aiconfigurator/src/aiconfigurator/systems/data/l40s/sglang/0.5.5.post3/wideep_deepep_normal_perf.txt not found.
2026-01-27 10:45:53,494 - aiconfigurator.sdk.perf_database - WARNING - SGLang wideep deepep LL operation data file /home/jasonzho/repo/repo6/aiconfigurator/src/aiconfigurator/systems/data/l40s/sglang/0.5.5.post3/wideep_deepep_ll_perf.txt not found.
2026-01-27 10:45:53,976 - aiconfigurator.sdk.task - INFO - Task agg_Qwen/Qwen3-32B_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Runtime config: DefaultMunch(<class 'munch.DefaultMunch'>, {'isl': 4000, 'osl': 1000, 'prefix': 0, 'ttft': 2000.0, 'tpot': 30.0, 'request_latency': None})
2026-01-27 10:45:53,976 - aiconfigurator.sdk.task - INFO - Task agg_Qwen/Qwen3-32B_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Worker config: DefaultMunch(<class 'munch.DefaultMunch'>, {'system_name': 'l40s', 'backend_name': 'sglang', 'backend_version': '0.5.5.post3', 'num_gpu_per_worker': [1, 2, 4, 8], 'tp_list': [1, 2, 4, 8], 'pp_list': [1], 'dp_list': [1], 'moe_tp_list': [1], 'moe_ep_list': [1], 'gemm_quant_mode': <GEMMQuantMode.fp8: QuantMapping(memory=1, compute=2, name='fp8')>, 'moe_quant_mode': <MoEQuantMode.float16: QuantMapping(memory=2, compute=1, name='float16')>, 'kvcache_quant_mode': <KVCacheQuantMode.float16: QuantMapping(memory=2, compute=0, name='float16')>, 'fmha_quant_mode': <FMHAQuantMode.float16: QuantMapping(memory=2, compute=1, name='float16')>, 'comm_quant_mode': <CommQuantMode.half: QuantMapping(memory=2, compute=0, name='half')>})
2026-01-27 10:45:53,986 - aiconfigurator.sdk.task - INFO - Task disagg_Qwen/Qwen3-32B_l40s_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Runtime config: DefaultMunch(<class 'munch.DefaultMunch'>, {'isl': 4000, 'osl': 1000, 'prefix': 0, 'ttft': 2000.0, 'tpot': 30.0, 'request_latency': None})
2026-01-27 10:45:53,986 - aiconfigurator.sdk.task - INFO - Task disagg_Qwen/Qwen3-32B_l40s_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Prefill worker config: DefaultMunch(<class 'munch.DefaultMunch'>, {'system_name': 'l40s', 'backend_name': 'sglang', 'backend_version': '0.5.5.post3', 'num_gpu_per_worker': [1, 2, 4, 8], 'tp_list': [1, 2, 4, 8], 'pp_list': [1], 'dp_list': [1], 'moe_tp_list': [1], 'moe_ep_list': [1], 'gemm_quant_mode': <GEMMQuantMode.fp8: QuantMapping(memory=1, compute=2, name='fp8')>, 'moe_quant_mode': <MoEQuantMode.float16: QuantMapping(memory=2, compute=1, name='float16')>, 'kvcache_quant_mode': <KVCacheQuantMode.float16: QuantMapping(memory=2, compute=0, name='float16')>, 'fmha_quant_mode': <FMHAQuantMode.float16: QuantMapping(memory=2, compute=1, name='float16')>, 'comm_quant_mode': <CommQuantMode.half: QuantMapping(memory=2, compute=0, name='half')>})
2026-01-27 10:45:53,986 - aiconfigurator.sdk.task - INFO - Task disagg_Qwen/Qwen3-32B_l40s_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Decode worker config: DefaultMunch(<class 'munch.DefaultMunch'>, {'system_name': 'l40s', 'backend_name': 'sglang', 'backend_version': '0.5.5.post3', 'num_gpu_per_worker': [1, 2, 4, 8], 'tp_list': [1, 2, 4, 8], 'pp_list': [1], 'dp_list': [1], 'moe_tp_list': [1], 'moe_ep_list': [1], 'gemm_quant_mode': <GEMMQuantMode.fp8: QuantMapping(memory=1, compute=2, name='fp8')>, 'moe_quant_mode': <MoEQuantMode.float16: QuantMapping(memory=2, compute=1, name='float16')>, 'kvcache_quant_mode': <KVCacheQuantMode.float16: QuantMapping(memory=2, compute=0, name='float16')>, 'fmha_quant_mode': <FMHAQuantMode.float16: QuantMapping(memory=2, compute=1, name='float16')>, 'comm_quant_mode': <CommQuantMode.half: QuantMapping(memory=2, compute=0, name='half')>})
2026-01-27 10:45:53,986 - aiconfigurator.sdk.task - INFO - Task disagg_Qwen/Qwen3-32B_l40s_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Replica config: DefaultMunch(<class 'munch.DefaultMunch'>, {'num_gpu_per_replica': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128], 'max_gpu_per_replica': 8, 'max_prefill_worker': 32, 'max_decode_worker': 32})
2026-01-27 10:45:53,986 - aiconfigurator.sdk.task - INFO - Task disagg_Qwen/Qwen3-32B_l40s_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Advanced tuning config: DefaultMunch(<class 'munch.DefaultMunch'>, {'prefill_latency_correction_scale': 1.1, 'decode_latency_correction_scale': 1.08, 'prefill_max_batch_size': 1, 'decode_max_batch_size': 512})
2026-01-27 10:45:53,986 - aiconfigurator.cli.main - INFO - Starting experiment: agg
2026-01-27 10:45:53,987 - aiconfigurator.cli.main - INFO - Task config: {
  "agg_Qwen/Qwen3-32B_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0": {
    "mode": "patch",
    "serving_mode": "agg",
    "model_path": "Qwen/Qwen3-32B",
    "total_gpus": 8,
    "system_name": "l40s",
    "backend_name": "sglang",
    "backend_version": "0.5.5.post3",
    "isl": 4000,
    "osl": 1000,
    "prefix": 0,
    "ttft": 2000.0,
    "tpot": 30.0,
    "enable_wideep": false,
    "moe_backend": null,
    "attention_backend": "flashinfer",
    "profiles": [],
    "config": {
      "nextn": 0,
      "nextn_accept_rates": [
        0.85,
        0,
        0,
        0,
        0
      ],
      "worker_config": {
        "system_name": "l40s",
        "backend_name": "sglang",
        "backend_version": "0.5.5.post3",
        "num_gpu_per_worker": [
          1,
          2,
          4,
          8
        ],
        "tp_list": [
          1,
          2,
          4,
          8
        ],
        "pp_list": [
          1
        ],
        "dp_list": [
          1
        ],
        "moe_tp_list": [
          1
        ],
        "moe_ep_list": [
          1
        ],
        "gemm_quant_mode": "fp8",
        "moe_quant_mode": "float16",
        "kvcache_quant_mode": "float16",
        "fmha_quant_mode": "float16",
        "comm_quant_mode": "half"
      }
    }
  }
}
2026-01-27 10:45:53,987 - aiconfigurator.sdk.task - INFO - Starting Pareto Analysis for agg_Qwen/Qwen3-32B_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0 in agg mode...
2026-01-27 10:45:53,987 - aiconfigurator.sdk.task - INFO - Task agg_Qwen/Qwen3-32B_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Setting up runtime config
2026-01-27 10:45:53,987 - aiconfigurator.sdk.task - INFO - Task agg_Qwen/Qwen3-32B_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Setting up database
2026-01-27 10:45:54,261 - aiconfigurator.sdk.task - INFO - Task agg_Qwen/Qwen3-32B_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Using database mode: SILICON
2026-01-27 10:45:54,261 - aiconfigurator.sdk.task - INFO - Task agg_Qwen/Qwen3-32B_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Setting up model config
2026-01-27 10:45:54,261 - aiconfigurator.sdk.task - INFO - Task agg_Qwen/Qwen3-32B_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Enumerating parallel config
2026-01-27 10:45:54,261 - aiconfigurator.sdk.utils - INFO - Enumerated parallel config: tp=1, pp=1, dp=1, moe_tp=1, moe_ep=1
2026-01-27 10:45:54,261 - aiconfigurator.sdk.utils - INFO - Enumerated parallel config: tp=2, pp=1, dp=1, moe_tp=1, moe_ep=1
2026-01-27 10:45:54,261 - aiconfigurator.sdk.utils - INFO - Enumerated parallel config: tp=4, pp=1, dp=1, moe_tp=1, moe_ep=1
2026-01-27 10:45:54,261 - aiconfigurator.sdk.utils - INFO - Enumerated parallel config: tp=8, pp=1, dp=1, moe_tp=1, moe_ep=1
2026-01-27 10:45:54,261 - aiconfigurator.sdk.task - INFO - Task agg_Qwen/Qwen3-32B_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Running agg pareto
2026-01-27 10:45:55,943 - aiconfigurator.cli.main - INFO - Experiment agg completed with 22 results.
2026-01-27 10:45:55,943 - aiconfigurator.cli.main - INFO - Starting experiment: disagg
2026-01-27 10:45:55,943 - aiconfigurator.cli.main - INFO - Task config: {
  "disagg_Qwen/Qwen3-32B_l40s_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0": {
    "mode": "patch",
    "serving_mode": "disagg",
    "model_path": "Qwen/Qwen3-32B",
    "total_gpus": 8,
    "system_name": "l40s",
    "decode_system_name": "l40s",
    "backend_name": "sglang",
    "backend_version": "0.5.5.post3",
    "isl": 4000,
    "osl": 1000,
    "prefix": 0,
    "ttft": 2000.0,
    "tpot": 30.0,
    "enable_wideep": false,
    "moe_backend": null,
    "attention_backend": "flashinfer",
    "profiles": [],
    "config": {
      "nextn": 0,
      "nextn_accept_rates": [
        0.85,
        0,
        0,
        0,
        0
      ],
      "prefill_worker_config": {
        "system_name": "l40s",
        "backend_name": "sglang",
        "backend_version": "0.5.5.post3",
        "num_gpu_per_worker": [
          1,
          2,
          4,
          8
        ],
        "tp_list": [
          1,
          2,
          4,
          8
        ],
        "pp_list": [
          1
        ],
        "dp_list": [
          1
        ],
        "moe_tp_list": [
          1
        ],
        "moe_ep_list": [
          1
        ],
        "gemm_quant_mode": "fp8",
        "moe_quant_mode": "float16",
        "kvcache_quant_mode": "float16",
        "fmha_quant_mode": "float16",
        "comm_quant_mode": "half"
      },
      "decode_worker_config": {
        "system_name": "l40s",
        "backend_name": "sglang",
        "backend_version": "0.5.5.post3",
        "num_gpu_per_worker": [
          1,
          2,
          4,
          8
        ],
        "tp_list": [
          1,
          2,
          4,
          8
        ],
        "pp_list": [
          1
        ],
        "dp_list": [
          1
        ],
        "moe_tp_list": [
          1
        ],
        "moe_ep_list": [
          1
        ],
        "gemm_quant_mode": "fp8",
        "moe_quant_mode": "float16",
        "kvcache_quant_mode": "float16",
        "fmha_quant_mode": "float16",
        "comm_quant_mode": "half"
      },
      "replica_config": {
        "num_gpu_per_replica": [
          1,
          2,
          4,
          8,
          16,
          24,
          32,
          40,
          48,
          56,
          64,
          72,
          80,
          88,
          96,
          104,
          112,
          120,
          128
        ],
        "max_gpu_per_replica": 8,
        "max_prefill_worker": 32,
        "max_decode_worker": 32
      },
      "advanced_tuning_config": {
        "prefill_latency_correction_scale": 1.1,
        "decode_latency_correction_scale": 1.08,
        "prefill_max_batch_size": 1,
        "decode_max_batch_size": 512
      }
    }
  }
}
2026-01-27 10:45:55,943 - aiconfigurator.sdk.task - INFO - Starting Pareto Analysis for disagg_Qwen/Qwen3-32B_l40s_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0 in disagg mode...
2026-01-27 10:45:55,943 - aiconfigurator.sdk.task - INFO - Task disagg_Qwen/Qwen3-32B_l40s_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Setting up runtime config
2026-01-27 10:45:55,943 - aiconfigurator.sdk.task - INFO - Task disagg_Qwen/Qwen3-32B_l40s_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Setting up prefill database
2026-01-27 10:45:56,195 - aiconfigurator.sdk.task - INFO - Task disagg_Qwen/Qwen3-32B_l40s_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Using prefill database mode: SILICON
2026-01-27 10:45:56,195 - aiconfigurator.sdk.task - INFO - Task disagg_Qwen/Qwen3-32B_l40s_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Setting up prefill model config
2026-01-27 10:45:56,195 - aiconfigurator.sdk.task - INFO - Task disagg_Qwen/Qwen3-32B_l40s_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Enumerating prefill parallel config
2026-01-27 10:45:56,195 - aiconfigurator.sdk.utils - INFO - Enumerated parallel config: tp=1, pp=1, dp=1, moe_tp=1, moe_ep=1
2026-01-27 10:45:56,195 - aiconfigurator.sdk.utils - INFO - Enumerated parallel config: tp=2, pp=1, dp=1, moe_tp=1, moe_ep=1
2026-01-27 10:45:56,195 - aiconfigurator.sdk.utils - INFO - Enumerated parallel config: tp=4, pp=1, dp=1, moe_tp=1, moe_ep=1
2026-01-27 10:45:56,195 - aiconfigurator.sdk.utils - INFO - Enumerated parallel config: tp=8, pp=1, dp=1, moe_tp=1, moe_ep=1
2026-01-27 10:45:56,195 - aiconfigurator.sdk.task - INFO - Task disagg_Qwen/Qwen3-32B_l40s_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Setting up decode database
2026-01-27 10:45:56,471 - aiconfigurator.sdk.task - INFO - Task disagg_Qwen/Qwen3-32B_l40s_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Using decode database mode: SILICON
2026-01-27 10:45:56,471 - aiconfigurator.sdk.task - INFO - Task disagg_Qwen/Qwen3-32B_l40s_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Setting up decode model config
2026-01-27 10:45:56,471 - aiconfigurator.sdk.task - INFO - Task disagg_Qwen/Qwen3-32B_l40s_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Enumerating decode parallel config
2026-01-27 10:45:56,472 - aiconfigurator.sdk.utils - INFO - Enumerated parallel config: tp=1, pp=1, dp=1, moe_tp=1, moe_ep=1
2026-01-27 10:45:56,472 - aiconfigurator.sdk.utils - INFO - Enumerated parallel config: tp=2, pp=1, dp=1, moe_tp=1, moe_ep=1
2026-01-27 10:45:56,472 - aiconfigurator.sdk.utils - INFO - Enumerated parallel config: tp=4, pp=1, dp=1, moe_tp=1, moe_ep=1
2026-01-27 10:45:56,472 - aiconfigurator.sdk.utils - INFO - Enumerated parallel config: tp=8, pp=1, dp=1, moe_tp=1, moe_ep=1
2026-01-27 10:45:56,472 - aiconfigurator.sdk.task - INFO - Task disagg_Qwen/Qwen3-32B_l40s_l40s_sglang_0.5.5.post3_4000_1000_0_2000.0_30.0: Running disagg pareto
2026-01-27 10:45:57,018 - aiconfigurator.sdk.inference_session - WARNING - No decode worker candidates found for tpot 1ms.
2026-01-27 10:45:57,020 - aiconfigurator.sdk.inference_session - WARNING - No decode worker candidates found for tpot 2ms.
2026-01-27 10:45:57,021 - aiconfigurator.sdk.inference_session - WARNING - No decode worker candidates found for tpot 3ms.
2026-01-27 10:45:57,022 - aiconfigurator.sdk.inference_session - WARNING - No decode worker candidates found for tpot 4ms.
2026-01-27 10:45:57,023 - aiconfigurator.sdk.inference_session - WARNING - No decode worker candidates found for tpot 5ms.
2026-01-27 10:45:57,023 - aiconfigurator.sdk.inference_session - WARNING - No decode worker candidates found for tpot 6ms.
2026-01-27 10:45:57,024 - aiconfigurator.sdk.inference_session - WARNING - No decode worker candidates found for tpot 7ms.
2026-01-27 10:45:57,026 - aiconfigurator.sdk.inference_session - WARNING - No decode worker candidates found for tpot 8ms.
2026-01-27 10:45:57,027 - aiconfigurator.sdk.inference_session - WARNING - No decode worker candidates found for tpot 9ms.
2026-01-27 10:45:57,028 - aiconfigurator.sdk.inference_session - WARNING - No decode worker candidates found for tpot 10ms.
2026-01-27 10:45:57,029 - aiconfigurator.sdk.inference_session - WARNING - No decode worker candidates found for tpot 11ms.
2026-01-27 10:45:57,030 - aiconfigurator.sdk.inference_session - WARNING - No decode worker candidates found for tpot 12ms.
2026-01-27 10:45:57,430 - aiconfigurator.cli.main - INFO - Experiment disagg completed with 33 results.
2026-01-27 10:45:57,449 - aiconfigurator.cli.report_and_save - INFO - 
********************************************************************************
*                     Dynamo aiconfigurator Final Results                      *
********************************************************************************
  ----------------------------------------------------------------------------
  Input Configuration & SLA Target:
    Model: Qwen/Qwen3-32B (is_moe: False)
    Total GPUs: 8
    Best Experiment Chosen: agg at 95.14 tokens/s/gpu (disagg 0.74x better)
  ----------------------------------------------------------------------------
  Overall Best Configuration:
    - Best Throughput: 761.14 tokens/s
    - Per-GPU Throughput: 95.14 tokens/s/gpu
    - Per-User Throughput: 33.94 tokens/s/user
    - TTFT: 1521.57ms
    - TPOT: 29.47ms
    - Request Latency: 30957.62ms
  ----------------------------------------------------------------------------
  Pareto Frontier:
        Qwen/Qwen3-32B Pareto Frontier: tokens/s/gpu_cluster vs tokens/s/user   
     ┌─────────────────────────────────────────────────────────────────────────┐
250.0┤ •• agg                                                                  │
     │ ff disagg                                                               │
208.3┤ xx agg best  f                                                          │
166.7┤               fff                                                       │
     │                  ff•••                                                  │
125.0┤                    ffff•••••                                            │
     │                        fff  ••x                                         │
 83.3┤                           ffffff••                                      │
 41.7┤                                 fffffffffffffffff                       │
     │                                    •••           fffffffff              │
  0.0┤                                                                         │
     └┬─────────────────┬─────────────────┬─────────────────┬─────────────────┬┘
      0                20                40                60                80 
tokens/s/gpu_cluster                tokens/s/user                               

  ----------------------------------------------------------------------------
  Deployment Details:
    (p) stands for prefill, (d) stands for decode, bs stands for batch size, a replica stands for the smallest scalable unit xPyD of the disagg system
    Some math: total gpus used = replicas * gpus/replica
               gpus/replica = (p)gpus/worker * (p)workers + (d)gpus/worker * (d)workers; for Agg, gpus/replica = gpus/worker
               gpus/worker = tp * pp * dp = etp * ep * pp for MoE models; tp * pp for dense models (underlined numbers are the actual values in math)

agg Top Configurations: (Sorted by tokens/s/gpu)
+------+--------------+---------------+---------+-----------------+-------------+-------------------+----------+--------------+-------------+----------+----+
| Rank | tokens/s/gpu | tokens/s/user |   TTFT  | request_latency | concurrency | total_gpus (used) | replicas | gpus/replica | gpus/worker | parallel | bs |
+------+--------------+---------------+---------+-----------------+-------------+-------------------+----------+--------------+-------------+----------+----+
|  1   |    95.14     |     33.94     | 1521.57 |     30957.62    |  24 (=6x4)  |     8 (8=4x2)     |    4     |      2       |  2 (=2x1x1) |  tp2pp1  | 6  |
+------+--------------+---------------+---------+-----------------+-------------+-------------------+----------+--------------+-------------+----------+----+

disagg Top Configurations: (Sorted by tokens/s/gpu)
+------+--------------+---------------+---------+-----------------+-------------+-------------------+----------+--------------+------------+----------------+-------------+-------+------------+----------------+-------------+-------+
| Rank | tokens/s/gpu | tokens/s/user |   TTFT  | request_latency | concurrency | total_gpus (used) | replicas | gpus/replica | (p)workers | (p)gpus/worker | (p)parallel | (p)bs | (d)workers | (d)gpus/worker | (d)parallel | (d)bs |
+------+--------------+---------------+---------+-----------------+-------------+-------------------+----------+--------------+------------+----------------+-------------+-------+------------+----------------+-------------+-------+
|  1   |    70.03     |     33.79     | 1713.78 |     31275.19    |  18 (=18x1) |     8 (8=1x8)     |    1     | 8 (=2x1+3x2) |     2      |    1 (=1x1)    |    tp1pp1   |   1   |     3      |    2 (=2x1)    |    tp2pp1   |   6   |
|  2   |    66.12     |     35.93     | 1713.78 |     29517.95    |  16 (=16x1) |     8 (8=1x8)     |    1     | 8 (=4x1+1x4) |     4      |    1 (=1x1)    |    tp1pp1   |   1   |     1      |    4 (=4x1)    |    tp4pp1   |   16  |
+------+--------------+---------------+---------+-----------------+-------------+-------------------+----------+--------------+------------+----------------+-------------+-------+------------+----------------+-------------+-------+
********************************************************************************
2026-01-27 10:45:57,449 - aiconfigurator.cli.main - INFO - All experiments completed in 3.46 seconds
```

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
