### PR TITLE
fix(generator): use logarithmic cuda graph sizes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ license-files = ["LICENSE"]
 requires-python = ">=3.9"
 
 dependencies = [
+    "asteval>=1.0.5",
     "jinja2>=3.1.0",
     "matplotlib>=3.9.4",
     "numpy~=1.26.4",

--- a/src/aiconfigurator/generator/rule_plugin/sglang.rule
+++ b/src/aiconfigurator/generator/rule_plugin/sglang.rule
@@ -4,7 +4,7 @@ agg_decode max_batch_size = (max_batch_size if max_batch_size else 128)
 agg_prefill_decode max_prefill_tokens = SlaConfig.isl + 1500
 agg enable_mixed_chunk = true
 
-agg_prefill_decode cuda_graph_batch_sizes = ((range(1, max_batch_size + 1) | list) if max_batch_size else [])
+agg_prefill_decode cuda_graph_batch_sizes = ([x for x in [1,2,4,8,16,32,64,128,256,512,1024] if x < max_batch_size] + [max_batch_size] if max_batch_size else [])
 
 # GPUs per worker follow the same TP/PP/DP product that SGLang expects
 agg_prefill_decode gpus_per_worker = (tensor_parallel_size or 1) * (pipeline_parallel_size or 1) * (data_parallel_size or 1)

--- a/src/aiconfigurator/generator/rule_plugin/trtllm.rule
+++ b/src/aiconfigurator/generator/rule_plugin/trtllm.rule
@@ -9,7 +9,7 @@ prefill max_num_tokens = SlaConfig.isl + 1500
 decode max_num_tokens = max_batch_size
 agg max_num_tokens = max_batch_size + SlaConfig.isl + 1500
 
-agg_prefill_decode cuda_graph_batch_sizes = ((range(1, max_batch_size + 1) | list) if max_batch_size else [])
+agg_prefill_decode cuda_graph_batch_sizes = ([x for x in [1,2,4,8,16,32,64,128,256,512,1024] if x < max_batch_size] + [max_batch_size] if max_batch_size else [])
 
 # Enforce TensorRT-LLM MoE parallelism: moe_tp × moe_ep = tp
 when ModelConfig.is_moe and (moe_tensor_parallel_size and moe_expert_parallel_size):

--- a/src/aiconfigurator/generator/rule_plugin/vllm.rule
+++ b/src/aiconfigurator/generator/rule_plugin/vllm.rule
@@ -10,6 +10,8 @@ decode max_num_tokens = max_batch_size
 agg max_num_tokens = (max_batch_size or 0) + (SlaConfig.isl or 0) + 1500
 agg max_seq_len = (SlaConfig.isl or 0) + (SlaConfig.osl or 0) + 1500
 
+agg_prefill_decode cuda_graph_batch_sizes = ([x for x in [1,2,4,8,16,32,64,128,256,512,1024] if x < max_batch_size] + [max_batch_size] if max_batch_size else [])
+
 when (ModelConfig.prefix or 0) > 0:
     disable_prefix_cache = false
     DynConfig.enable_router = true


### PR DESCRIPTION
#### Overview:
Set `cuda_graph_batch_sizes` to a logarithmic series of graphs than capturing all graph sizes with step 1. 

#### Details:

- Refactored the `_eval` function in the rule engine to support a wider range of python expressions (e.g. list comprehension) for better flexibility. Instead of using jinja's expression compiler, use `asteval` to evaluate the rules in Python.
  - Why: The jinja expression compiler supports very limited python expression and doesn't support the use case of creating a logarithmic series. Without this change, we must define the series in all `extra_engine_args*.yaml.j2`.
  ```
    >>> env = Environment()
    >>> expr = env.compile_expression("[x * 2 for x in numbers]")
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/home/simonec/virtual_envs/venv_aic/lib/python3.12/site-packages/jinja2/environment.py", line 812, in compile_expression
        self.handle_exception(source=source)
      File "/home/simonec/virtual_envs/venv_aic/lib/python3.12/site-packages/jinja2/environment.py", line 942, in handle_exception
        raise rewrite_traceback_stack(source=source)
      File "<unknown>", line 1, in template
    jinja2.exceptions.TemplateSyntaxError: expected token ',', got 'for'
  ```
  - Intention: All computation logic should be centralized in `.rule` files instead of scattering in jinja templates, ensuring consistency and maintainability.
- Set `cuda_graph_batch_sizes` to a logarithmic series of graphs than capturing all graph sizes with step 1. This saves excessive resource consumption at runtime.
  - Ref: https://forums.developer.nvidia.com/t/best-practices-for-optimizing-pytorch-models-with-cuda-graphs/351177

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
