### PR TITLE
feat: Add k8s_hf_home option

### DIFF
--- a/docs/dynamo_deployment_guide.md
+++ b/docs/dynamo_deployment_guide.md
@@ -480,6 +480,7 @@ Use `--generator-set K8sConfig.<field>=value` (or place the same keys inside `--
 
 * `K8sConfig.k8s_engine_mode={inline|configmap}` - engine config delivery. **inline** by default.
 * `K8sConfig.k8s_model_cache=<claimName>` - optional model cache PVC mount (mounted at `/workspace/model_cache`). Leave it unset or empty to disable the mount. Specify the PVC name when you want pods to reuse an existing model cache; otherwise, if you directly set something like `--generator-set ServiceConfig.model_path=Qwen/Qwen3-32B-FP8`, the model is downloaded from Hugging Face and no PVC is required.
+* `K8sConfig.k8s_hf_home=<path>` - optional path for the `HF_HOME` environment variable in worker pods. When `k8s_model_cache` is configured but `k8s_hf_home` is not explicitly set, it automatically defaults to `/workspace/model_cache` to ensure HuggingFace libraries use the persistent volume. Set this to a custom path if you have a different volume mount structure.
 * `K8sConfig.k8s_namespace=<ns>` - target namespace. Default **dynamo**.
 * `K8sConfig.k8s_image=<image>` - runtime image. Default **nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0**.
 * `K8sConfig.k8s_image_pull_secret=<secret>` - optional pull secret name.

--- a/src/aiconfigurator/generator/aggregators.py
+++ b/src/aiconfigurator/generator/aggregators.py
@@ -54,6 +54,16 @@ def collect_generator_params(
     use_engine_cm = k8s.get("k8s_engine_mode", "inline") == "configmap"
     _mc_raw = k8s.get("k8s_model_cache")
     k8s_model_cache = _mc_raw.strip() if isinstance(_mc_raw, str) else ""
+
+    _hf_home_raw = k8s.get("k8s_hf_home")
+    k8s_hf_home = _hf_home_raw.strip() if isinstance(_hf_home_raw, str) else ""
+
+    # If model cache PVC mount is configured but HF_HOME is not set,
+    # set it to /workspace/model_cache, which is where the PVC is mounted.
+    # Note: k8s_model_cache is the PVC name, not the mount path.
+    if k8s_model_cache and not k8s_hf_home:
+        k8s_hf_home = "/workspace/model_cache"
+
     workers_dict = {
         "prefill_workers": int(prefill_workers),
         "decode_workers": int(decode_workers),
@@ -83,6 +93,7 @@ def collect_generator_params(
             "k8s_engine_mode": k8s.get("k8s_engine_mode"),
             "use_engine_cm": use_engine_cm,
             "k8s_model_cache": k8s_model_cache,
+            "k8s_hf_home": k8s_hf_home,
             "prefill_engine_args": "/workspace/engine_configs/prefill_config.yaml",
             "decode_engine_args": "/workspace/engine_configs/decode_config.yaml",
             "agg_engine_args": "/workspace/engine_configs/agg_config.yaml",

--- a/src/aiconfigurator/generator/config/backend_templates/sglang/k8s_deploy.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/sglang/k8s_deploy.yaml.j2
@@ -8,6 +8,11 @@
 {%- macro render_worker(component_name, role, replicas, gpu, cli_args) -%}
 {{ "    " ~ component_name ~ ":" }}
       envFromSecret: hf-token-secret
+      {% if K8sConfig.k8s_hf_home %}
+      envs:
+        - name: HF_HOME
+          value: {{ K8sConfig.k8s_hf_home }}
+      {% endif %}
       componentType: worker
       {% if role %}
       subComponentType: {{ role }}
@@ -64,6 +69,7 @@ metadata:
 spec:
   services:
     Frontend:
+      envFromSecret: hf-token-secret
       componentType: frontend
       replicas: {{ frontend_replicas | default(1) }}
       extraPodSpec:     
@@ -74,10 +80,16 @@ spec:
         mainContainer:
           image: {{ K8sConfig.k8s_image }}
           imagePullPolicy: IfNotPresent
-      {% if enable_router %}
+      {% if enable_router or K8sConfig.k8s_hf_home %}
       envs:
+        {% if enable_router %}
         - name: DYN_ROUTER_MODE
           value: kv
+        {% endif %}
+        {% if K8sConfig.k8s_hf_home %}
+        - name: HF_HOME
+          value: {{ K8sConfig.k8s_hf_home }}
+        {% endif %}
       {% endif %}
 
     {% if DynConfig.mode | default('disagg') == 'agg' %}

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/k8s_deploy.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/k8s_deploy.yaml.j2
@@ -73,6 +73,11 @@ readinessProbe:
 {%- macro render_worker(component_name, sub_component_type, replicas, gpu, engine_path, inline_payload, disagg_mode=None, publish_metrics=False) -%}
 {{ "    " ~ component_name ~ ":" }}
       envFromSecret: hf-token-secret
+      {% if K8sConfig.k8s_hf_home %}
+      envs:
+        - name: HF_HOME
+          value: {{ K8sConfig.k8s_hf_home }}
+      {% endif %}
       componentType: worker
       {% if sub_component_type %}
       subComponentType: {{ sub_component_type }}
@@ -146,6 +151,7 @@ metadata:
 spec:
   services:
     Frontend:
+      envFromSecret: hf-token-secret
       componentType: frontend
       replicas: {{ frontend_replicas }}
       extraPodSpec:
@@ -167,10 +173,16 @@ spec:
             - name: model-cache
               mountPath: {{ k8s_model_cache_mount }}
           {% endif %}
-      {% if enable_router %}
+      {% if enable_router or K8sConfig.k8s_hf_home %}
       envs:
+        {% if enable_router %}
         - name: DYN_ROUTER_MODE
           value: kv
+        {% endif %}
+        {% if K8sConfig.k8s_hf_home %}
+        - name: HF_HOME
+          value: {{ K8sConfig.k8s_hf_home }}
+        {% endif %}
       {% endif %}
 
     {% if DynConfig.mode | default('disagg') == 'agg' %}

--- a/src/aiconfigurator/generator/config/backend_templates/vllm/k8s_deploy.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/vllm/k8s_deploy.yaml.j2
@@ -13,6 +13,11 @@
     {%- set parsed_args = cli_args_list | default([]) -%}
 {{ "    " ~ component_name ~ ":" }}
       envFromSecret: hf-token-secret
+      {% if K8sConfig.k8s_hf_home %}
+      envs:
+        - name: HF_HOME
+          value: {{ K8sConfig.k8s_hf_home }}
+      {% endif %}
       componentType: worker
       {% if role %}
       subComponentType: {{ role }}
@@ -66,6 +71,12 @@ metadata:
 spec:
   services:
     Frontend:
+      envFromSecret: hf-token-secret
+      {% if K8sConfig.k8s_hf_home %}
+      envs:
+        - name: HF_HOME
+          value: {{ K8sConfig.k8s_hf_home }}
+      {% endif %}
       componentType: frontend
       replicas: {{ frontend_replicas | default(1) }}
       extraPodSpec:

--- a/src/aiconfigurator/generator/config/deployment_config.yaml
+++ b/src/aiconfigurator/generator/config/deployment_config.yaml
@@ -74,6 +74,9 @@ inputs:
   - key: K8sConfig.k8s_model_cache
     required: false
     default: ""
+  - key: K8sConfig.k8s_hf_home
+    required: false
+    default: ""
 
   # Worker config
   - key: WorkerConfig.prefill_workers

--- a/src/aiconfigurator/generator/rendering/engine.py
+++ b/src/aiconfigurator/generator/rendering/engine.py
@@ -438,6 +438,7 @@ def prepare_template_context(param_values: dict[str, Any], backend: str) -> dict
     context["working_dir"] = k8s_config.get("working_dir")
     context["k8s_engine_mode"] = k8s_config.get("k8s_engine_mode")
     context["k8s_model_cache"] = k8s_config.get("k8s_model_cache")
+    context["k8s_hf_home"] = k8s_config.get("k8s_hf_home")
 
     # Extract DynConfig for mode/router decisions
     dyn_config = param_values.get("DynConfig", {})

--- a/tests/unit/generator/test_aggregators.py
+++ b/tests/unit/generator/test_aggregators.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for generator aggregators module."""
+
+import pytest
+
+from aiconfigurator.generator.aggregators import collect_generator_params
+
+
+@pytest.mark.unit
+class TestK8sHfHomeDefaulting:
+    """Test k8s_hf_home auto-defaulting behavior."""
+
+    @pytest.mark.parametrize(
+        "k8s_model_cache,k8s_hf_home,expected_hf_home",
+        [
+            # Auto-default: model cache set, hf_home not set
+            ("model-cache-pvc", None, "/workspace/model_cache"),
+            # Explicit value: should not be overridden
+            ("model-cache-pvc", "/custom/path", "/custom/path"),
+            # No model cache: hf_home should remain empty
+            (None, None, ""),
+            # hf_home set without model cache: independent configuration
+            (None, "/custom/hf/home", "/custom/hf/home"),
+            # Empty string hf_home: treated as unset, triggers auto-default
+            ("model-cache-pvc", "", "/workspace/model_cache"),
+        ],
+    )
+    def test_k8s_hf_home_behavior(self, k8s_model_cache, k8s_hf_home, expected_hf_home):
+        """Test various k8s_hf_home and k8s_model_cache combinations."""
+        service = {"model_path": "test/model", "served_model_name": "test-model"}
+        k8s = {"k8s_namespace": "dynamo"}
+
+        if k8s_model_cache is not None:
+            k8s["k8s_model_cache"] = k8s_model_cache
+        if k8s_hf_home is not None:
+            k8s["k8s_hf_home"] = k8s_hf_home
+
+        result = collect_generator_params(service=service, k8s=k8s, backend="trtllm")
+
+        assert result["K8sConfig"]["k8s_hf_home"] == expected_hf_home
+
+    @pytest.mark.parametrize("backend", ["trtllm", "vllm", "sglang"])
+    def test_k8s_hf_home_consistent_across_backends(self, backend):
+        """k8s_hf_home defaulting should work consistently across all backends."""
+        service = {"model_path": "test/model", "served_model_name": "test-model"}
+        k8s = {"k8s_model_cache": "model-cache-pvc", "k8s_namespace": "dynamo"}
+
+        result = collect_generator_params(service=service, k8s=k8s, backend=backend)
+
+        assert result["K8sConfig"]["k8s_hf_home"] == "/workspace/model_cache"


### PR DESCRIPTION
#### Overview:

If `k8s_model_cache` is specified while generating the a dynamo k8s deployment config, set the `HF_HOME` environment variable to the path where the model cache is mounted, so that HF actually makes use of the mounted directory for caching HF downloads.

Also add a new option, `--generator-set K8sConfig.k8s_hf_home=/path/to/hf/home`, to override the HF_HOME variable, which could be useful if the HF_HOME dir isn't at the root of the mounted path.