### PR TITLE
feat: add "any" backend mode and heterogeneous backend support

### DIFF
--- a/docs/cli_user_guide.md
+++ b/docs/cli_user_guide.md
@@ -261,7 +261,7 @@ results/Qwen_Qwen3-32B_h200_sxm_trtllm_isl4000_osl1000_ttft1000_tpot20_904495
 │   ...
 └── pareto_frontier.png
 ```
-By default, we output top3 configs we have found. You can get the configs and scripts to deploy under each experiment's folder. `agg_config.yaml` and `node_0_run.sh` are the files you need to deploy with Dynamo. If you want to deploy using k8s, you can leverage `k8s_deploy.yaml`. Refer to [deployment guide](dynamo_deployment_guide.md) for info about deployment.
+By default, we output top 5 configs we have found. You can get the configs and scripts to deploy under each experiment's folder. `agg_config.yaml` and `node_0_run.sh` are the files you need to deploy with Dynamo. If you want to deploy using k8s, you can leverage `k8s_deploy.yaml`. Refer to [deployment guide](dynamo_deployment_guide.md) for info about deployment.
 
 `--save_dir DIR` allows you to specify more information such as generating the config for a different version of the backend, say estimating the performance using trtllm 1.0.0rc3 but generate config for 1.0.0rc6. This is allowed and feasible. By passing `--generated_config_version 1.0.0rc6` can give you the right result.
 

--- a/src/aiconfigurator/cli/__init__.py
+++ b/src/aiconfigurator/cli/__init__.py
@@ -7,7 +7,7 @@ CLI module for aiconfigurator.
 Provides both command-line interface and programmatic Python API.
 
 Python API usage:
-    from aiconfigurator.cli import cli_default, cli_exp, cli_generate
+    from aiconfigurator.cli import cli_default, cli_exp, cli_generate, cli_support
 
     # cli_default: Run agg vs disagg comparison
     result = cli_default(
@@ -28,6 +28,12 @@ Python API usage:
         system="h200_sxm",
         backend="trtllm",
         output_dir="./output",
+    )
+
+    # cli_support: Check model/hardware support
+    agg_ok, disagg_ok = cli_support(
+        model_path="Qwen/Qwen3-32B",
+        system="h200_sxm",
     )
 """
 

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -98,9 +98,12 @@ class CLIResult:
 def _execute_and_wrap_result(
     task_configs: dict[str, TaskConfig],
     mode: str,
+    top_n: int = 5,
 ) -> CLIResult:
     """Execute task configs using main.py's function and wrap result in CLIResult."""
-    chosen_exp, best_configs, pareto_fronts, best_throughputs = _execute_task_configs_internal(task_configs, mode)
+    chosen_exp, best_configs, pareto_fronts, best_throughputs = _execute_task_configs_internal(
+        task_configs, mode, top_n=top_n
+    )
 
     return CLIResult(
         chosen_exp=chosen_exp,
@@ -127,6 +130,7 @@ def cli_default(
     tpot: float = 30.0,
     request_latency: float | None = None,
     prefix: int = 0,
+    top_n: int = 5,
     save_dir: str | None = None,
 ) -> CLIResult:
     """
@@ -151,6 +155,7 @@ def cli_default(
         request_latency: Optional end-to-end request latency target (ms).
             Enables request-latency optimization mode.
         prefix: Prefix cache length. Default is 0.
+        top_n: Number of top configurations to return for each mode (agg/disagg). Default is 5.
         save_dir: Directory to save results. If None, results are not saved to disk.
 
     Returns:
@@ -184,7 +189,7 @@ def cli_default(
         prefix=prefix,
     )
 
-    result = _execute_and_wrap_result(task_configs, mode="default")
+    result = _execute_and_wrap_result(task_configs, mode="default", top_n=top_n)
 
     if save_dir:
         # Create a mock args object for save_results compatibility
@@ -203,6 +208,7 @@ def cli_default(
         mock_args.ttft = ttft
         mock_args.tpot = tpot
         mock_args.request_latency = request_latency
+        mock_args.top_n = top_n
         mock_args.generated_config_version = None
 
         save_results(
@@ -221,6 +227,7 @@ def cli_exp(
     *,
     yaml_path: str | None = None,
     config: dict[str, dict] | None = None,
+    top_n: int = 5,
     save_dir: str | None = None,
 ) -> CLIResult:
     """
@@ -235,6 +242,7 @@ def cli_exp(
         yaml_path: Path to a YAML file containing experiment definitions.
         config: Dict containing experiment definitions (alternative to yaml_path).
             Keys are experiment names, values are experiment configs.
+        top_n: Number of top configurations to return for each experiment. Default is 5.
         save_dir: Directory to save results. If None, results are not saved to disk.
 
     Returns:
@@ -300,7 +308,7 @@ def cli_exp(
     if not task_configs:
         raise ValueError("No valid experiments found in configuration.")
 
-    result = _execute_and_wrap_result(task_configs, mode="exp")
+    result = _execute_and_wrap_result(task_configs, mode="exp", top_n=top_n)
 
     if save_dir:
         # Create a mock args object for save_results compatibility
@@ -311,6 +319,7 @@ def cli_exp(
         mock_args.save_dir = save_dir
         mock_args.mode = "exp"
         mock_args.yaml_path = yaml_path
+        mock_args.top_n = top_n
         mock_args.generated_config_version = None
 
         save_results(

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -101,7 +101,7 @@ def _execute_and_wrap_result(
     top_n: int = 5,
 ) -> CLIResult:
     """Execute task configs using main.py's function and wrap result in CLIResult."""
-    chosen_exp, best_configs, pareto_fronts, best_throughputs = _execute_task_configs_internal(
+    chosen_exp, best_configs, pareto_fronts, best_throughputs, task_configs = _execute_task_configs_internal(
         task_configs, mode, top_n=top_n
     )
 
@@ -120,9 +120,13 @@ def cli_default(
     total_gpus: int,
     system: str,
     *,
-    decode_system: str | None = None,
     backend: str = "trtllm",
     backend_version: str | None = None,
+    backend_deploy_version: str | None = None,
+    decode_system: str | None = None,
+    decode_backend: str | None = None,
+    decode_backend_version: str | None = None,
+    decode_backend_deploy_version: str | None = None,
     database_mode: str = "SILICON",
     isl: int = 4000,
     osl: int = 1000,
@@ -143,9 +147,14 @@ def cli_default(
         model_path: HuggingFace model path (e.g., 'Qwen/Qwen3-32B') or local path.
         total_gpus: Total number of GPUs for deployment.
         system: System name (GPU type), e.g., 'h200_sxm', 'b200_sxm'.
-        decode_system: System name for disagg decode workers. Defaults to `system`.
         backend: Backend name ('trtllm', 'sglang', 'vllm'). Default is 'trtllm'.
-        backend_version: Backend database version. Default is latest.
+        backend_version: Backend database version for performance estimation. Default is latest.
+        backend_deploy_version: Backend version for deployment artifact generation.
+            If None, falls back to backend_version.
+        decode_system: System name for disagg decode workers. Defaults to `system`.
+        decode_backend: For disagg mode, backend for decode workers.
+        decode_backend_version: For disagg mode, backend version for decode workers.
+        decode_backend_deploy_version: For disagg mode, deploy version for decode workers.
         database_mode: Database mode for performance estimation
             ('SILICON', 'HYBRID', 'EMPIRICAL', 'SOL'). Default is 'SILICON'.
         isl: Input sequence length. Default is 4000.
@@ -177,9 +186,13 @@ def cli_default(
         model_path=model_path,
         total_gpus=total_gpus,
         system=system,
-        decode_system=decode_system,
         backend=backend,
         backend_version=backend_version,
+        backend_deploy_version=backend_deploy_version,
+        decode_system=decode_system,
+        decode_backend=decode_backend,
+        decode_backend_version=decode_backend_version,
+        decode_backend_deploy_version=decode_backend_deploy_version,
         database_mode=database_mode,
         isl=isl,
         osl=osl,
@@ -209,7 +222,6 @@ def cli_default(
         mock_args.tpot = tpot
         mock_args.request_latency = request_latency
         mock_args.top_n = top_n
-        mock_args.generated_config_version = None
 
         save_results(
             args=mock_args,
@@ -217,7 +229,6 @@ def cli_default(
             pareto_fronts=result.pareto_fronts,
             task_configs=result.task_configs,
             save_dir=save_dir,
-            generated_backend_version=None,
         )
 
     return result
@@ -320,7 +331,6 @@ def cli_exp(
         mock_args.mode = "exp"
         mock_args.yaml_path = yaml_path
         mock_args.top_n = top_n
-        mock_args.generated_config_version = None
 
         save_results(
             args=mock_args,
@@ -328,7 +338,6 @@ def cli_exp(
             pareto_fronts=result.pareto_fronts,
             task_configs=result.task_configs,
             save_dir=save_dir,
-            generated_backend_version=None,
         )
 
     return result

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -122,11 +122,11 @@ def cli_default(
     *,
     backend: str = "trtllm",
     backend_version: str | None = None,
-    backend_deploy_version: str | None = None,
+    generated_config_version: str | None = None,
     decode_system: str | None = None,
     decode_backend: str | None = None,
     decode_backend_version: str | None = None,
-    decode_backend_deploy_version: str | None = None,
+    generated_decode_config_version: str | None = None,
     database_mode: str = "SILICON",
     isl: int = 4000,
     osl: int = 1000,
@@ -149,12 +149,12 @@ def cli_default(
         system: System name (GPU type), e.g., 'h200_sxm', 'b200_sxm'.
         backend: Backend name ('trtllm', 'sglang', 'vllm'). Default is 'trtllm'.
         backend_version: Backend database version for performance estimation. Default is latest.
-        backend_deploy_version: Backend version for deployment artifact generation.
+        generated_config_version: Backend version for deployment artifact generation.
             If None, falls back to backend_version.
         decode_system: System name for disagg decode workers. Defaults to `system`.
         decode_backend: For disagg mode, backend for decode workers.
         decode_backend_version: For disagg mode, backend version for decode workers.
-        decode_backend_deploy_version: For disagg mode, deploy version for decode workers.
+        generated_decode_config_version: For disagg mode, deploy version for decode workers.
         database_mode: Database mode for performance estimation
             ('SILICON', 'HYBRID', 'EMPIRICAL', 'SOL'). Default is 'SILICON'.
         isl: Input sequence length. Default is 4000.
@@ -188,11 +188,11 @@ def cli_default(
         system=system,
         backend=backend,
         backend_version=backend_version,
-        backend_deploy_version=backend_deploy_version,
+        generated_config_version=generated_config_version,
         decode_system=decode_system,
         decode_backend=decode_backend,
         decode_backend_version=decode_backend_version,
-        decode_backend_deploy_version=decode_backend_deploy_version,
+        generated_decode_config_version=generated_decode_config_version,
         database_mode=database_mode,
         isl=isl,
         osl=osl,

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -36,6 +36,13 @@ def _build_common_cli_parser() -> argparse.ArgumentParser:
     common_parser = argparse.ArgumentParser(add_help=False)
     common_parser.add_argument("--save_dir", type=str, default=None, help="Directory to save the results.")
     common_parser.add_argument("--debug", action="store_true", help="Enable debug mode.")
+    common_parser.add_argument(
+        "--top_n",
+        type=int,
+        default=5,
+        help="Number of top configurations to output for each experiment (in exp mode) "
+        "or for each mode (agg/disagg) in default mode. Default: 5.",
+    )
     add_generator_override_arguments(common_parser)
     return common_parser
 
@@ -518,6 +525,7 @@ def build_experiment_task_configs(
 def _execute_task_configs(
     task_configs: dict[str, TaskConfig],
     mode: str,
+    top_n: int = 5,
 ) -> tuple[str, dict[str, pd.DataFrame], dict[str, pd.DataFrame], dict[str, float]]:
     """Execute the task configs and return the chosen experiment, best configs, results, and best
     throughputs."""
@@ -584,7 +592,7 @@ def _execute_task_configs(
                 total_gpus=total_gpus,
                 pareto_df=pareto_df,
                 target_request_latency=target_request_latency,
-                top_n=5,
+                top_n=top_n,
                 group_by=group_by_key,
             )
         else:
@@ -592,7 +600,7 @@ def _execute_task_configs(
                 total_gpus=total_gpus,
                 pareto_df=pareto_df,
                 target_tpot=target_tpot,
-                top_n=5,
+                top_n=top_n,
                 group_by=group_by_key,
             )
         best_configs[name] = best_config_df
@@ -613,6 +621,7 @@ def _execute_task_configs(
         task_configs=task_configs,  # for info in summary
         mode=mode,
         pareto_x_axis=pareto_x_axis,
+        top_n=top_n,
     )
 
     end_time = time.time()
@@ -740,6 +749,7 @@ def main(args):
     )
 
     logger.info(f"Loading Dynamo AIConfigurator version: {__version__}")
+    logger.info(f"Number of top configurations to output: {args.top_n} (change with --top_n)")
 
     # Handle generate mode separately (no sweeping)
     if args.mode == "generate":
@@ -782,6 +792,7 @@ def main(args):
     chosen_exp, best_configs, pareto_fronts, best_throughputs = _execute_task_configs(
         task_configs,
         args.mode,
+        top_n=args.top_n,
     )
 
     if args.save_dir:

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -308,6 +308,7 @@ def _ensure_backend_version_available(system_name: str, backend_name: str, backe
 def validate_backend_versions(
     system: str,
     backend_name: str,
+    decode_system: str,
     decode_backend_name: str,
     backend_version: str | None,
     decode_backend_version: str | None,
@@ -318,7 +319,7 @@ def validate_backend_versions(
             _ensure_backend_version_available(system, backend, backend_version)
     else:
         _ensure_backend_version_available(system, backend_name, backend_version)
-        _ensure_backend_version_available(system, decode_backend_name, decode_backend_version)
+        _ensure_backend_version_available(decode_system, decode_backend_name, decode_backend_version)
 
 
 def build_default_task_configs(
@@ -374,7 +375,9 @@ def build_default_task_configs(
     decode_backend_version = decode_backend_version or backend_version
     generated_decode_config_version = generated_decode_config_version or generated_config_version
 
-    validate_backend_versions(system, backend, decode_system, backend_version, decode_backend_version, backend == "any")
+    validate_backend_versions(
+        system, backend, decode_system, decode_backend, backend_version, decode_backend_version, backend == "any"
+    )
 
     task_configs: dict[str, TaskConfig] = {}
 

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -40,9 +40,8 @@ def _build_common_cli_parser() -> argparse.ArgumentParser:
         "--top_n",
         type=int,
         default=5,
-        metavar="5",
         help="Number of top configurations to output for each experiment (in exp mode) "
-        "or for each mode (agg/disagg) in default mode. Default: 5.",
+        "or for each mode (agg/disagg) in default mode (default: %(default)s).",
     )
     add_generator_override_arguments(common_parser)
     return common_parser
@@ -98,13 +97,15 @@ def _add_default_mode_arguments(parser):
         choices=[backend.value for backend in common.BackendName],
         type=str,
         default=common.BackendName.trtllm.value,
-        help="Backend name. 'any' will check all 3 backends and find best performance.",
+        help="Name of the backend (default: %(default)s). "
+        "Use 'any' to search best configurations for all backends (with heterogeneous P/D in disagg mode).",
     )
     parser.add_argument(
         "--backend_version",
         type=str,
         default=None,
-        help="Backend database version. Default is latest",
+        help="Backend version used for workers in agg mode and prefill workers in disagg mode "
+        "(default: latest available version).",
     )
     parser.add_argument(
         "--decode_system",
@@ -123,28 +124,28 @@ def _add_default_mode_arguments(parser):
         "--decode_backend_version",
         type=str,
         default=None,
-        help="Backend database version for disagg decode workers. Defaults to --backend_version if omitted.",
+        help="Backend version for disagg decode workers. Defaults to --backend_version if omitted.",
     )
     parser.add_argument(
         "--database_mode",
         choices=[mode.name for mode in common.DatabaseMode if mode != common.DatabaseMode.SOL_FULL],
         type=str,
         default=common.DatabaseMode.SILICON.name,
-        help="Database mode for performance estimation. Options: SILICON (default, uses silicon data), "
+        help="Database mode for performance estimation. Options: SILICON (uses silicon data), "
         "HYBRID (uses silicon data when available, otherwise SOL+empirical factor), "
-        "EMPIRICAL (SOL+empirical factor), SOL (provide SOL time only).",
+        "EMPIRICAL (SOL+empirical factor), SOL (provide SOL time only) (default: %(default)s).",
     )
-    parser.add_argument("--isl", type=int, default=4000, help="Input sequence length.")
-    parser.add_argument("--osl", type=int, default=1000, help="Output sequence length.")
-    parser.add_argument("--ttft", type=float, default=2000.0, help="Time to first token in ms.")
-    parser.add_argument("--tpot", type=float, default=30.0, help="Time per output token in ms.")
+    parser.add_argument("--isl", type=int, default=4000, help="Input sequence length (default: %(default)s).")
+    parser.add_argument("--osl", type=int, default=1000, help="Output sequence length (default: %(default)s).")
+    parser.add_argument("--ttft", type=float, default=2000.0, help="Time to first token in ms (default: %(default)s).")
+    parser.add_argument("--tpot", type=float, default=30.0, help="Time per output token in ms (default: %(default)s).")
     parser.add_argument(
         "--request_latency",
         type=float,
         default=None,
         help="Optional end-to-end request latency target (ms). Enables request-latency optimization mode.",
     )
-    parser.add_argument("--prefix", type=int, default=0, help="Prefix cache length. Default to 0.")
+    parser.add_argument("--prefix", type=int, default=0, help="Prefix cache length (default: %(default)s).")
 
 
 def _add_experiments_mode_arguments(parser):
@@ -163,7 +164,7 @@ def _add_generate_mode_arguments(parser):
         type=_validate_model_path,
         required=True,
         help="Model path: HuggingFace model path (e.g., 'Qwen/Qwen3-32B') or "
-        "local path to directory containing config.json.",
+        "local path to a directory containing config.json.",
     )
     parser.add_argument(
         "--total_gpus",
@@ -183,7 +184,7 @@ def _add_generate_mode_arguments(parser):
         choices=[backend.value for backend in common.BackendName],
         type=str,
         default=common.BackendName.trtllm.value,
-        help="Backend name (default: trtllm).",
+        help="Backend name (default: %(default)s).",
     )
 
 
@@ -208,7 +209,7 @@ def _add_support_mode_arguments(parser):
         choices=[backend.value for backend in common.BackendName],
         type=str,
         default="trtllm",
-        help="Backend name to filter by. Defaults to 'trtllm'.",
+        help="Backend name to filter by (default: %(default)s).",
     )
     parser.add_argument(
         "--backend_version",

--- a/src/aiconfigurator/cli/report_and_save.py
+++ b/src/aiconfigurator/cli/report_and_save.py
@@ -662,7 +662,7 @@ def _save_experiment_results(
     exp_task_config = task_configs[exp_name]
 
     # Get the deploy version from task config (falls back to backend_version if not set)
-    deploy_version = getattr(exp_task_config, "backend_deploy_version", None) or exp_task_config.backend_version
+    deploy_version = getattr(exp_task_config, "generated_config_version", None) or exp_task_config.backend_version
 
     # 1. Save best config dataframe
     best_config_df = best_configs.get(exp_name)  # top n configs
@@ -681,7 +681,7 @@ def _save_experiment_results(
     if not is_any_backend_mode:
         if deploy_version != exp_task_config.backend_version:
             logger.info(
-                "Experiment '%s': Using backend_deploy_version=%s for artifact generation "
+                "Experiment '%s': Using generated_config_version=%s for artifact generation "
                 "(backend_version=%s used for estimation)",
                 exp_name,
                 deploy_version,

--- a/src/aiconfigurator/cli/report_and_save.py
+++ b/src/aiconfigurator/cli/report_and_save.py
@@ -244,6 +244,7 @@ def log_final_summary(
     task_configs: dict[str, TaskConfig],
     mode: str,
     pareto_x_axis: dict[str, str] | None = None,
+    top_n: int = 5,
 ):
     """Log final summary of configuration results"""
 
@@ -356,7 +357,7 @@ def log_final_summary(
             config_df,
             total_gpus,
             exp_task_config.runtime_config.tpot,
-            5,
+            top_n,
             exp_task_config.is_moe,
             exp_task_config.runtime_config.request_latency,
             show_power,

--- a/src/aiconfigurator/generator/api.py
+++ b/src/aiconfigurator/generator/api.py
@@ -364,19 +364,19 @@ def add_generator_override_arguments(parser: argparse.ArgumentParser) -> None:
         help="Print generator schema help (deploy, backend, or all) and exit.",
     )
     grp.add_argument(
-        "--backend_deploy_version",
+        "--generated_config_version",
         type=str,
         default=None,
         help="Backend version for deployment artifact generation (e.g. 1.1.0rc5). "
         "If not specified, falls back to --backend_version.",
     )
     grp.add_argument(
-        "--decode_backend_deploy_version",
+        "--generated_decode_config_version",
         type=str,
         default=None,
         help=(
             "Backend version for disagg decode worker deployment artifacts. "
-            "Defaults to --backend_deploy_version if omitted."
+            "Defaults to --generated_config_version if omitted."
         ),
     )
 

--- a/src/aiconfigurator/generator/api.py
+++ b/src/aiconfigurator/generator/api.py
@@ -367,15 +367,16 @@ def add_generator_override_arguments(parser: argparse.ArgumentParser) -> None:
         "--generated_config_version",
         type=str,
         default=None,
-        help="Backend version for deployment artifact generation (e.g. 1.1.0rc5). "
-        "If not specified, falls back to --backend_version.",
+        help="Backend version for workers in agg mode and prefill workers in disagg mode "
+        "for deployment artifact generation (e.g. 1.1.0rc5). "
+        "Defaults to --backend_version if omitted.",
     )
     grp.add_argument(
         "--generated_decode_config_version",
         type=str,
         default=None,
         help=(
-            "Backend version for disagg decode worker deployment artifacts. "
+            "Backend version for disagg decode workers in deployment artifact generation. "
             "Defaults to --generated_config_version if omitted."
         ),
     )

--- a/src/aiconfigurator/generator/main.py
+++ b/src/aiconfigurator/generator/main.py
@@ -84,12 +84,17 @@ def main(argv: Optional[list[str]] = None):
 
     cmd = args.cmd
     if cmd == "render-artifacts":
+        # Resolve roles to build backends/versions mapping
+        roles = _resolve_roles("all", generator_params, logger)
+        role_backends = dict.fromkeys(roles, backend)
+        role_versions = dict.fromkeys(roles, args.version) if args.version else None
+
         artifacts = generate_backend_artifacts(
-            generator_params,
-            backend,
+            params=generator_params,
+            role_backends=role_backends,
+            role_versions=role_versions,
             templates_dir=args.templates_dir,
             output_dir=args.output,
-            backend_version=args.version,
         )
         print(json.dumps(artifacts, ensure_ascii=False, indent=2))
         return

--- a/src/aiconfigurator/generator/rendering/engine.py
+++ b/src/aiconfigurator/generator/rendering/engine.py
@@ -1,13 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-Configuration mappings for AI generator.
-
-This module provides the mapping engine for converting parameters
-to backend-specific configurations using YAML mapping files and Jinja2 templates.
-"""
-
 import logging
 import os
 import shlex
@@ -17,67 +10,122 @@ from typing import Any, Optional
 import yaml
 from jinja2 import Environment, FileSystemLoader, Undefined
 
-from .rule_engine import apply_rule_plugins
+from aiconfigurator.generator.rendering.rule_engine import apply_rule_plugins
 
-_JINJA_ENV = Environment(trim_blocks=True, lstrip_blocks=True)
-_TEMPLATE_ENV_CACHE: dict[str, Environment] = {}
 logger = logging.getLogger(__name__)
-_YAML_CACHE: dict[str, Any] = {}
-_PARAM_KEYS_CACHE: dict[str, list[str]] = {}
+
 _BASE_DIR = Path(__file__).resolve().parent
 _CONFIG_DIR = (_BASE_DIR.parent / "config").resolve()
 _TEMPLATE_ROOT = _CONFIG_DIR / "backend_templates"
-_BACKEND_MAPPING_FILE = str((_CONFIG_DIR / "backend_config_mapping.yaml").resolve())
+_BACKEND_MAPPING_FILE = _CONFIG_DIR / "backend_config_mapping.yaml"
+
+_TEMPLATE_ENV_CACHE: dict[str, Environment] = {}
+_JINJA_ENV = Environment()
+_YAML_CACHE: dict[str, dict[str, Any]] = {}
 
 
 def render_backend_templates(
     param_values: dict[str, Any],
-    backend: str,
+    role_backends: dict[str, str],
+    role_versions: Optional[dict[str, str]] = None,
     templates_dir: Optional[str] = None,
-    version: Optional[str] = None,
 ) -> dict[str, str]:
     """
-    Render templates for a specific backend with version-specific template selection.
+    Render templates based on role-specific backends and versions.
 
     Args:
-        param_values: Dictionary of parameter values to use in template rendering
-        backend: Backend name (e.g., 'trtllm', 'vllm', 'sglang')
-        templates_dir: Directory containing backend-specific template directories
-        version: Version string (e.g., '1.1.0rc5'). If None, uses default templates
+        param_values: Dictionary of parameter values
+        role_backends: Mapping of role (prefill/decode/agg) to backend name
+        role_versions: Optional mapping of role to version string
+        templates_dir: Optional override for the base templates directory.
+                      If None, derived from the primary backend (decode or agg).
 
     Returns:
         Dictionary mapping template names to rendered content
     """
+    role_versions = role_versions or {}
+
+    # Determine the primary backend to use for the base deployment templates (K8s/Slurm)
+    # We prefer 'decode' for disagg as it's the more constrained side, or 'agg' for single-node.
+    primary_backend = role_backends.get("decode") or role_backends.get("agg") or role_backends.get("prefill")
+    if not primary_backend:
+        raise ValueError("role_backends must contain at least one backend (agg, decode, or prefill)")
+
+    primary_version = role_versions.get("decode") or role_versions.get("agg") or role_versions.get("prefill")
+
+    # Check if we have heterogeneous backends (different backends for different roles)
+    unique_backends = set(role_backends.values())
+    is_heterogeneous = len(unique_backends) > 1
+
     if templates_dir is None:
-        templates_dir = str(_TEMPLATE_ROOT / backend)
+        if is_heterogeneous:
+            # Use the 'any' template directory for heterogeneous deployments
+            templates_dir = str(_TEMPLATE_ROOT / "any")
+        else:
+            templates_dir = str(_TEMPLATE_ROOT / primary_backend)
 
     if not os.path.exists(templates_dir):
         raise FileNotFoundError(f"Templates directory not found: {templates_dir}")
 
     # Set up Jinja2 environment with FileSystemLoader
-    # Support multiple search paths for template inclusion:
-    # 1. Backend-specific directory (e.g., backend_templates/sglang/)
+    # Use multiple search paths to enable cross-directory imports:
+    # 1. Primary templates directory (backend-specific or 'any')
     # 2. _common/ for shared base templates
     # 3. _workers/ for backend-specific worker macros
+    # 4. Template root for relative imports like '_workers/sglang.j2'
     env = _TEMPLATE_ENV_CACHE.get(templates_dir)
     if env is None:
         search_paths = [
             templates_dir,
             str(_TEMPLATE_ROOT / "_common"),
             str(_TEMPLATE_ROOT / "_workers"),
+            str(_TEMPLATE_ROOT),
         ]
-        env = Environment(loader=FileSystemLoader(search_paths), trim_blocks=True, lstrip_blocks=True)
+        env = Environment(
+            loader=FileSystemLoader(search_paths),
+            trim_blocks=True,
+            lstrip_blocks=True,
+        )
         _TEMPLATE_ENV_CACHE[templates_dir] = env
 
-    param_values = apply_rule_plugins(dict(param_values), backend)
-    context = prepare_template_context(param_values, backend)
+    param_values = apply_rule_plugins(dict(param_values), primary_backend)
+    context = prepare_template_context(param_values, primary_backend)
+
+    # Inject role information into context
+    for role, rb in role_backends.items():
+        context[f"{role}_backend"] = rb
+    for role, rv in role_versions.items():
+        context[f"{role}_backend_version"] = rv
+
+    # Inject role-specific K8s images for heterogeneous deployments
+    if is_heterogeneous and "K8sConfig" in context:
+        for role, rb in role_backends.items():
+            rv = role_versions.get(role, "0.8.0")  # Default version if not specified
+            # Determine the appropriate image for this backend
+            backend_image_map = {
+                "trtllm": f"nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:{rv}",
+                "sglang": f"nvcr.io/nvidia/ai-dynamo/sglang-runtime:{rv}",
+                "vllm": f"nvcr.io/nvidia/ai-dynamo/vllm-runtime:{rv}",
+            }
+            role_image = backend_image_map.get(rb)
+            if role_image:
+                context[f"{role}_k8s_image"] = role_image
+                # Also add to K8sConfig dict for generator_config.yaml output
+                if "K8sConfig" in param_values:
+                    param_values["K8sConfig"][f"{role}_k8s_image"] = role_image
+
+    # Also set top-level backend for backward compatibility in templates
+    context["backend"] = primary_backend
+    if primary_version:
+        context["backend_version"] = primary_version
+
     # Assign backend-specific working_dir (removes need for input-driven path)
     backend_dirs = {
         "trtllm": "/workspace/components/backends/trtllm",
         "sglang": "/workspace/components/backends/sglang",
         "vllm": "/workspace/components/backends/vllm",
     }
-    wd = backend_dirs.get(backend)
+    wd = backend_dirs.get(primary_backend)
     if wd:
         # K8sConfig.working_dir used in k8s_deploy templates, also expose top-level
         context.setdefault("K8sConfig", {})
@@ -105,99 +153,61 @@ def render_backend_templates(
     # Find template files
     template_path = Path(templates_dir)
 
-    # Resolve engine template (version-specific preferred). Some backends (e.g., vllm, sglang)
-    # do not ship engine configs at all, so only warn when such templates actually exist.
-    engine_template_file = None
-    engine_template_candidates = list(template_path.glob("extra_engine_args*.yaml.j2"))
-    has_engine_templates = bool(engine_template_candidates)
-    if version and has_engine_templates:
-        candidates = [p for p in engine_template_candidates if p.name == f"extra_engine_args.{version}.yaml.j2"]
-        if candidates:
-            engine_template_file = candidates[0]
-        else:
-            logger.warning(f"No version-specific engine template for {version}, using default")
-    if engine_template_file is None and has_engine_templates:
-        default_candidates = [p for p in engine_template_candidates if p.name == "extra_engine_args.yaml.j2"]
-        if default_candidates:
-            engine_template_file = default_candidates[0]
-        # If no engine args template exists (e.g., sglang/vllm), proceed without it
+    def resolve_template(
+        target_backend: str, target_version: Optional[str], pattern: str
+    ) -> tuple[Optional[Path], Any]:
+        """Resolve a template file and its environment for a specific backend and version."""
+        target_dir = str(_TEMPLATE_ROOT / target_backend)
+        target_env = _TEMPLATE_ENV_CACHE.get(target_dir)
+        if target_env is None:
+            if not os.path.exists(target_dir):
+                return None, None
+            target_env = Environment(loader=FileSystemLoader(target_dir), trim_blocks=True, lstrip_blocks=True)
+            _TEMPLATE_ENV_CACHE[target_dir] = target_env
 
-    # Render engine templates per worker plan with worker-specific context
-    mapping_data = load_yaml_mapping(_BACKEND_MAPPING_FILE)
+        tp = Path(target_dir)
+        if "extra_engine_args" in pattern:
+            base_name = "extra_engine_args"
+            ext = ".yaml.j2"
+        elif "cli_args" in pattern:
+            base_name = "cli_args"
+            ext = ".j2"
+        else:
+            exact = tp / pattern
+            return (exact, target_env) if exact.exists() else (None, None)
+
+        if target_version:
+            v_match = tp / f"{base_name}.{target_version}{ext}"
+            if v_match.exists():
+                return v_match, target_env
+
+        default = tp / f"{base_name}{ext}"
+        return (default, target_env) if default.exists() else (None, None)
+
+    # Render engine and CLI templates per worker plan with worker-specific context
+    mapping_data_cache = {}
+
+    def get_mapping_data(target_backend: str):
+        if target_backend not in mapping_data_cache:
+            mapping_data_cache[target_backend] = load_yaml_mapping(_BACKEND_MAPPING_FILE)
+        return mapping_data_cache[target_backend]
+
     param_keys = get_param_keys(_BACKEND_MAPPING_FILE)
 
-    def make_worker_context(
-        base_ctx: dict[str, Any],
-        worker: str,
-        worker_param_keys: list[str],
-        mapping_def: dict[str, Any],
-    ) -> dict[str, Any]:
-        wc = dict(base_ctx)
+    for worker in worker_plan:
+        w_backend = role_backends.get(worker, primary_backend)
+        w_version = role_versions.get(worker, primary_version)
 
-        def _remove_key_and_nested(key: str) -> None:
-            if key in wc:
-                wc.pop(key, None)
-            if "." in key:
-                parts = key.split(".")
-                cursor = wc
-                for p in parts[:-1]:
-                    node = cursor.get(p)
-                    if not isinstance(node, dict):
-                        return
-                    cursor = node
-                if isinstance(cursor, dict):
-                    cursor.pop(parts[-1], None)
+        w_mapping_data = get_mapping_data(w_backend)
 
-        for k in worker_param_keys:
-            wk = f"{worker}_{k}"
-            if wk in base_ctx:
-                wc[k] = base_ctx[wk]
-            else:
-                _remove_key_and_nested(k)
+        # 1. Resolve and render engine template for this worker
+        engine_pattern = "extra_engine_args*.yaml.j2"
+        w_engine_tmpl_file, w_env = resolve_template(w_backend, w_version, engine_pattern)
 
-        # Promote worker-scoped dotted backend keys into nested dicts
-        prefix = f"{worker}_"
-        for bk, val in list(base_ctx.items()):
-            if bk.startswith(prefix):
-                name = bk[len(prefix) :]
-                if "." in name:
-                    parts = name.split(".")
-                    cursor = wc
-                    for p in parts[:-1]:
-                        if p not in cursor or not isinstance(cursor[p], dict):
-                            cursor[p] = {}
-                        cursor = cursor[p]
-                    cursor[parts[-1]] = val
-
-        # Build backend dict with worker-scoped keys (including hyphenated names)
-        backend_keys = []
-        for entry in mapping_def.get("parameters", []):
-            m = entry.get(backend)
-            if isinstance(m, str):
-                backend_keys.append(m)
-            elif isinstance(m, dict):
-                dest = m.get("key")
-                if dest:
-                    backend_keys.append(dest)
-        wc.setdefault(backend, {})
-        for bk, val in list(base_ctx.items()):
-            if bk.startswith(prefix):
-                name = bk[len(prefix) :]
-                if name in backend_keys and "." not in name:
-                    wc[backend][name] = val
-        for bk in backend_keys:
-            wk = f"{worker}_{bk}"
-            if wk in base_ctx:
-                wc[bk] = base_ctx[wk]
-            else:
-                _remove_key_and_nested(bk)
-        return wc
-
-    if engine_template_file is not None:
-        try:
-            eng_tmpl = env.get_template(engine_template_file.name)
-            for worker in worker_plan:
-                wc = make_worker_context(context, worker, param_keys, mapping_data)
+        if w_engine_tmpl_file:
+            try:
+                eng_tmpl = w_env.get_template(w_engine_tmpl_file.name)
+                wc = make_worker_context(context, worker, param_keys, w_mapping_data, w_backend)
                 rendered = eng_tmpl.render(**wc)
                 if worker == "agg":
                     out_name = "extra_engine_args_agg.yaml"
@@ -206,38 +216,24 @@ def render_backend_templates(
                 else:
                     out_name = "extra_engine_args_decode.yaml"
                 rendered_templates[out_name] = rendered
-        except Exception as e:
-            logger.warning(f"Failed to render engine template {engine_template_file.name}: {e}")
+            except Exception as e:
+                logger.warning(f"Failed to render engine template {w_engine_tmpl_file.name} for {worker}: {e}")
 
-    # Inject inline engine args content into context for k8s template
-    # These are used when K8sConfig.k8s_engine_mode == 'inline'
-    context["prefill_engine_args_inline"] = rendered_templates.get("extra_engine_args_prefill.yaml", "")
-    context["decode_engine_args_inline"] = rendered_templates.get("extra_engine_args_decode.yaml", "")
-    context["agg_engine_args_inline"] = rendered_templates.get("extra_engine_args_agg.yaml", "")
+        # 2. Resolve and render CLI args template for this worker
+        cli_pattern = "cli_args*.j2"
+        w_cli_tmpl_file, w_env = resolve_template(w_backend, w_version, cli_pattern)
 
-    # Resolve CLI args template (version-specific preferred)
-    cli_template_file = None
-    cli_template_candidates = list(template_path.glob("cli_args*.j2"))
-    if version and cli_template_candidates:
-        candidates = [p for p in cli_template_candidates if p.name == f"cli_args.{version}.j2"]
-        if candidates:
-            cli_template_file = candidates[0]
-    if cli_template_file is None:
-        default_candidates = [p for p in cli_template_candidates if p.name == "cli_args.j2"]
-        if default_candidates:
-            cli_template_file = default_candidates[0]
-
-    # Compute CLI args per worker using template if present, else mapping fallback
-    for worker in worker_plan:
-        wc = make_worker_context(context, worker, param_keys, mapping_data)
-        if cli_template_file is not None:
+        wc = make_worker_context(context, worker, param_keys, w_mapping_data, w_backend)
+        cli = ""
+        if w_cli_tmpl_file:
             try:
-                cli_tmpl = env.get_template(cli_template_file.name)
+                cli_tmpl = w_env.get_template(w_cli_tmpl_file.name)
                 cli = cli_tmpl.render(**wc).strip()
             except Exception:
-                cli = _format_cli_args(backend, wc)
+                cli = _format_cli_args(w_backend, wc)
         else:
-            cli = _format_cli_args(backend, wc)
+            cli = _format_cli_args(w_backend, wc)
+
         cli_list = shlex.split(cli) if cli else []
         if worker == "prefill":
             context["prefill_cli_args"] = cli
@@ -252,15 +248,11 @@ def render_backend_templates(
             context["agg_cli_args_list"] = cli_list
             rendered_templates["cli_args_agg"] = cli
 
-    # Compute GPU counts per worker using rule outputs (minimal fallback)
-    pv_params = param_values.get("params", {})
-    prefill_gpu = int(pv_params.get("prefill", {}).get("gpus_per_worker") or 1)
-    decode_gpu = int(pv_params.get("decode", {}).get("gpus_per_worker") or 1)
-    agg_gpu = int(pv_params.get("agg", {}).get("gpus_per_worker") or 1)
-
-    context["prefill_gpu"] = prefill_gpu
-    context["decode_gpu"] = decode_gpu
-    context["agg_gpu"] = agg_gpu
+    # Inject inline engine args content into context for k8s template
+    # These are used when K8sConfig.k8s_engine_mode == 'inline'
+    context["prefill_engine_args_inline"] = rendered_templates.get("extra_engine_args_prefill.yaml", "")
+    context["decode_engine_args_inline"] = rendered_templates.get("extra_engine_args_decode.yaml", "")
+    context["agg_engine_args_inline"] = rendered_templates.get("extra_engine_args_agg.yaml", "")
 
     # Render auxiliary templates (k8s deploy and run script)
     # k8s deploy: single file
@@ -330,67 +322,29 @@ def render_backend_templates(
                 # Simple greedy allocation
                 def _allocate_disagg_nodes(p_worker: int, p_gpu: int, d_worker: int, d_gpu: int, gpu_per_node: int):
                     nodes = []
-
-                    # Interleave allocation to balance prefill and decode workers across nodes
-                    # We try to keep p_worker/d_worker ratio consistent across nodes
-                    if p_worker > 0 and d_worker > 0:
-                        import math
-
-                        gcd = math.gcd(p_worker, d_worker)
-                        p_unit = p_worker // gcd
-                        d_unit = d_worker // gcd
-
-                        p_rem, d_rem = p_worker, d_worker
-                        while p_rem > 0 or d_rem > 0:
-                            # Allocate p_unit prefill
-                            for _ in range(min(p_unit, p_rem)):
-                                placed = False
-                                for n in nodes:
-                                    if n["used"] + p_gpu <= gpu_per_node:
-                                        n["p_worker"] += 1
-                                        n["used"] += p_gpu
-                                        placed = True
-                                        break
-                                if not placed:
-                                    nodes.append({"p_worker": 1, "d_worker": 0, "used": p_gpu})
-                                p_rem -= 1
-
-                            # Allocate d_unit decode
-                            for _ in range(min(d_unit, d_rem)):
-                                placed = False
-                                for n in nodes:
-                                    if n["used"] + d_gpu <= gpu_per_node:
-                                        n["d_worker"] += 1
-                                        n["used"] += d_gpu
-                                        placed = True
-                                        break
-                                if not placed:
-                                    nodes.append({"p_worker": 0, "d_worker": 1, "used": d_gpu})
-                                d_rem -= 1
-                    else:
-                        # Fallback for simple cases where one type is missing
-                        for _ in range(p_worker):
-                            placed = False
-                            for n in nodes:
-                                if n["used"] + p_gpu <= gpu_per_node:
-                                    n["p_worker"] += 1
-                                    n["used"] += p_gpu
-                                    placed = True
-                                    break
-                            if not placed:
-                                nodes.append({"p_worker": 1, "d_worker": 0, "used": p_gpu})
-                        for _ in range(d_worker):
-                            placed = False
-                            for n in nodes:
-                                if n["used"] + d_gpu <= gpu_per_node:
-                                    n["d_worker"] += 1
-                                    n["used"] += d_gpu
-                                    placed = True
-                                    break
-                            if not placed:
-                                nodes.append({"p_worker": 0, "d_worker": 1, "used": d_gpu})
-
-                    return [{"p_worker": n.get("p_worker", 0), "d_worker": n.get("d_worker", 0)} for n in nodes]
+                    # Place prefill workers
+                    for _ in range(p_worker):
+                        placed = False
+                        for n in nodes:
+                            if n["used"] + p_gpu <= gpu_per_node:
+                                n["p_workers"] += 1
+                                n["used"] += p_gpu
+                                placed = True
+                                break
+                        if not placed:
+                            nodes.append({"p_workers": 1, "d_workers": 0, "used": p_gpu})
+                    # Place decode workers
+                    for _ in range(d_worker):
+                        placed = False
+                        for n in nodes:
+                            if n["used"] + d_gpu <= gpu_per_node:
+                                n["d_workers"] += 1
+                                n["used"] += d_gpu
+                                placed = True
+                                break
+                        if not placed:
+                            nodes.append({"p_workers": 0, "d_workers": 1, "used": d_gpu})
+                    return nodes
 
                 plan = _allocate_disagg_nodes(
                     prefill_workers, prefill_gpu, decode_workers, decode_gpu, num_gpus_per_node
@@ -398,20 +352,93 @@ def render_backend_templates(
 
                 for idx, cnt in enumerate(plan):
                     node_ctx = dict(context)
+                    # Ensure nested ServiceConfig dict exists and set include_frontend
                     svc = dict(node_ctx.get("ServiceConfig", {}))
                     svc["include_frontend"] = idx == 0
                     node_ctx["ServiceConfig"] = svc
                     node_ctx["prefill_gpu"] = prefill_gpu
                     node_ctx["decode_gpu"] = decode_gpu
-                    node_ctx["prefill_workers"] = int(cnt.get("p_worker", 0))
-                    node_ctx["decode_workers"] = int(cnt.get("d_worker", 0))
-                    node_ctx["decode_gpu_offset"] = int(cnt.get("p_worker", 0)) * prefill_gpu
+                    node_ctx["prefill_workers"] = int(cnt["p_workers"])
+                    node_ctx["decode_workers"] = int(cnt["d_workers"])
+                    # Use a fixed offset for simplicity; actual multi-process placement might vary
+                    node_ctx["decode_gpu_offset"] = int(cnt["p_workers"]) * prefill_gpu
                     rendered = tmpl.render(**node_ctx)
                     rendered_templates[f"run_{idx}.sh"] = rendered
         except Exception as e:
             logger.warning(f"Failed to render template run.sh.j2: {e}")
 
     return rendered_templates
+
+
+def make_worker_context(
+    base_ctx: dict[str, Any],
+    worker: str,
+    worker_param_keys: list[str],
+    mapping_def: dict[str, Any],
+    target_backend: Optional[str] = None,
+) -> dict[str, Any]:
+    wc = dict(base_ctx)
+    # Use primary backend from context if target_backend not provided
+    target_backend = target_backend or base_ctx.get("backend")
+
+    def _remove_key_and_nested(key: str) -> None:
+        if key in wc:
+            wc.pop(key, None)
+        if "." in key:
+            parts = key.split(".")
+            cursor = wc
+            for p in parts[:-1]:
+                node = cursor.get(p)
+                if not isinstance(node, dict):
+                    return
+                cursor = node
+            if isinstance(cursor, dict):
+                cursor.pop(parts[-1], None)
+
+    for k in worker_param_keys:
+        wk = f"{worker}_{k}"
+        if wk in base_ctx:
+            wc[k] = base_ctx[wk]
+        else:
+            _remove_key_and_nested(k)
+
+    # Promote worker-scoped dotted backend keys into nested dicts
+    prefix = f"{worker}_"
+    for bk, val in list(base_ctx.items()):
+        if bk.startswith(prefix):
+            name = bk[len(prefix) :]
+            if "." in name:
+                parts = name.split(".")
+                cursor = wc
+                for p in parts[:-1]:
+                    if p not in cursor or not isinstance(cursor[p], dict):
+                        cursor[p] = {}
+                    cursor = cursor[p]
+                cursor[parts[-1]] = val
+
+    # Build backend dict with worker-scoped keys (including hyphenated names)
+    backend_keys = []
+    for entry in mapping_def.get("parameters", []):
+        m = entry.get(target_backend)
+        if isinstance(m, str):
+            backend_keys.append(m)
+        elif isinstance(m, dict):
+            dest = m.get("key")
+            if dest:
+                backend_keys.append(dest)
+    wc.setdefault(target_backend, {})
+    for bk, val in list(base_ctx.items()):
+        if bk.startswith(prefix):
+            name = bk[len(prefix) :]
+            if name in backend_keys and "." not in name:
+                wc[target_backend][name] = val
+    for bk in backend_keys:
+        wk = f"{worker}_{bk}"
+        if wk in base_ctx:
+            wc[bk] = base_ctx[wk]
+        else:
+            _remove_key_and_nested(bk)
+    return wc
 
 
 def prepare_template_context(param_values: dict[str, Any], backend: str) -> dict[str, Any]:
@@ -451,6 +478,13 @@ def prepare_template_context(param_values: dict[str, Any], backend: str) -> dict
     context["k8s_engine_mode"] = k8s_config.get("k8s_engine_mode")
     context["k8s_model_cache"] = k8s_config.get("k8s_model_cache")
     context["k8s_hf_home"] = k8s_config.get("k8s_hf_home")
+    # Extract role-specific K8s images if present (for heterogeneous deployments)
+    if "prefill_k8s_image" in k8s_config:
+        context["prefill_k8s_image"] = k8s_config["prefill_k8s_image"]
+    if "decode_k8s_image" in k8s_config:
+        context["decode_k8s_image"] = k8s_config["decode_k8s_image"]
+    if "agg_k8s_image" in k8s_config:
+        context["agg_k8s_image"] = k8s_config["agg_k8s_image"]
 
     # Extract DynConfig for mode/router decisions
     dyn_config = param_values.get("DynConfig", {})
@@ -461,7 +495,7 @@ def prepare_template_context(param_values: dict[str, Any], backend: str) -> dict
     enable_router = bool(dyn_config.get("enable_router")) if isinstance(dyn_config, dict) else False
     name_suffix = "agg" if mode_value == "agg" else "disagg"
     router_suffix = "-router" if enable_router else ""
-    full_name = f"{context['name_prefix']}-{name_suffix}{router_suffix}"
+    full_name = f"{context.get('name_prefix', 'dynamo')}-{name_suffix}{router_suffix}"
     context["name"] = k8s_config.get("name") or full_name
     context["K8sConfig"] = dict(k8s_config)
 
@@ -515,51 +549,49 @@ def prepare_template_context(param_values: dict[str, Any], backend: str) -> dict
                 "pipeline_parallel_size": "pp",
                 "data_parallel_size": "dp",
                 "max_batch_size": "max_batch_size",
-                "max_num_tokens": "max_num_tokens",
-                "max_seq_len": "max_seq_len",
-                "kv_cache_dtype": "kv_cache_dtype",
-                "tokens_per_block": "tokens_per_block",
-                "enable_chunked_prefill": "enable_chunked_prefill",
-                "cuda_graph_enable_padding": "cuda_graph_enable_padding",
-                "disable_prefix_cache": "disable_prefix_cache",
+                "gemm_quant_mode": "gemm_quant",
+                "moe_quant_mode": "moe_quant",
+                "kvcache_quant_mode": "kv_cache_quant",
+                "fmha_quant_mode": "fmha_quant",
+                "comm_quant_mode": "comm_quant",
             }
-
             if param_key in template_var_mapping:
                 param_to_template_var[param_key] = template_var_mapping[param_key]
 
-    # Apply parameter mapping for each worker type
+    # Map worker parameters to their specific context keys
     for worker_type in ["prefill", "decode", "agg"]:
         worker_config = worker_params.get(worker_type, {})
-
         for param_key, value in worker_config.items():
-            # Always expose param_key variables
-            context[param_key] = value
-            context[f"{worker_type}_{param_key}"] = value
             if param_key in param_to_backend:
-                backend_mapping = param_to_backend[param_key]
-
-                # Handle different types of backend mappings
-                if isinstance(backend_mapping, str):
-                    # Simple string mapping (e.g., "tensor_parallel_size" -> "tensor_parallel_size")
-                    context[backend_mapping] = value
-                    # Also add with worker prefix for disambiguation
-                    context[f"{worker_type}_{backend_mapping}"] = value
-
-                    # Map to template variable if available
-                    if param_key in param_to_template_var:
-                        template_var = param_to_template_var[param_key]
-                        context[template_var] = value
-                        context[f"{worker_type}_{template_var}"] = value
-
-                elif isinstance(backend_mapping, dict):
-                    # Complex mapping with key and value expressions
-                    dest_key = backend_mapping.get("key")
-                    value_expr = backend_mapping.get("value")
-
-                    if dest_key:
-                        # Evaluate the value expression if provided
+                dest_key = param_to_backend[param_key]
+                if isinstance(dest_key, dict):
+                    # Complex mapping with nested dictionary
+                    dest_path = dest_key.get("key")
+                    value_expr = dest_key.get("value")
+                    if dest_path:
                         if value_expr:
-                            # Create a simple context for evaluation
+                            # Evaluate Jinja2-style expression
+                            eval_context = {param_key: value}
+                            evaluated_value = evaluate_expression(value_expr, eval_context)
+                            _set_by_path(context, f"{worker_type}_{dest_path}", evaluated_value)
+                            _set_by_path(context, dest_path, evaluated_value)
+                        else:
+                            _set_by_path(context, f"{worker_type}_{dest_path}", value)
+                            _set_by_path(context, dest_path, value)
+                elif isinstance(dest_key, str):
+                    # Simple key mapping
+                    if "." in dest_key:
+                        _set_by_path(context, f"{worker_type}_{dest_key}", value)
+                        _set_by_path(context, dest_key, value)
+                    else:
+                        # For top-level keys, also check expression mapping if exists in mapping_data
+                        # This part handles expressions defined as strings in the mapping file
+                        entry = next(
+                            (e for e in mapping_data.get("parameters", []) if e.get("param_key") == param_key), None
+                        )
+                        mapping_def = entry.get(backend) if entry else None
+                        if isinstance(mapping_def, dict) and mapping_def.get("value"):
+                            value_expr = mapping_def["value"]
                             eval_context = {param_key: value}
                             evaluated_value = evaluate_expression(value_expr, eval_context)
                             context[dest_key] = evaluated_value
@@ -661,158 +693,119 @@ def load_yaml_mapping(yaml_path: str) -> dict[str, Any]:
     return data
 
 
-def render_parameters(
-    param_values: dict[str, Any],
-    yaml_path: Optional[str] = None,
-) -> dict[str, dict[str, dict[str, Any]]]:
-    """
-    Render parameter mappings to concrete key/value dicts per framework.
-
-    Behavior:
-    - String shorthand (e.g. vllm: some-flag) includes only when the input value is not None.
-    - Dict form retention is controlled solely by presence of "default":
-      { "key": <dest_key>, "value": <jinja_expr>, ["default": <jinja_expr>] }
-      * If value evaluates to None and default is present, include dest_key
-        with the evaluated default (which may be None).
-      * If value evaluates to a non-None value, include it.
-      * If value is None and no default is present, omit.
-      * Inline form {dest_key: <jinja_expr>} behaves like shorthand (omit when None).
-
-    Args:
-        param_values: Dictionary of parameter values
-        yaml_path: Optional path to YAML mapping file
-
-    Returns:
-        Nested dictionary structure: {param_key: {framework: {key: value}}}
-    """
-    yaml_file = _BACKEND_MAPPING_FILE if yaml_path is None else str(yaml_path)
-    data = load_yaml_mapping(yaml_file)
-
-    out: dict[str, dict[str, dict[str, Any]]] = {}
-    parameters = data.get("parameters", [])
-
-    for entry in parameters:
-        param_key = entry.get("param_key")
-        if not param_key:
-            continue
-
-        # Determine frameworks dynamically from entry keys
-        framework_keys = [k for k in entry if k not in ("param_key",)]
-        result: dict[str, dict[str, Any]] = {}
-        for fw in framework_keys:
-            mapping = entry.get(fw)
-
-            # Missing or null -> skip
-            if mapping is None:
-                continue
-
-            # Empty object -> skip
-            if isinstance(mapping, dict) and len(mapping) == 0:
-                continue
-
-            # String shorthand: interpret as key name, value := param_values[param_key]
-            if isinstance(mapping, str):
-                v = param_values.get(param_key)
-                if v is not None:
-                    result.setdefault(fw, {})[mapping] = v
-                continue
-
-            # Dict with explicit key/value and optional default-only retention
-            if isinstance(mapping, dict) and "key" in mapping and "value" in mapping:
-                k = mapping.get("key")
-                v_expr = mapping.get("value")
-                default_expr = mapping.get("default")
-
-                v = evaluate_expression(v_expr, param_values)
-                has_default = "default" in mapping
-                if v is None and has_default:
-                    # Presence of default implies retention, even if evaluated default is None
-                    v_default = evaluate_expression(default_expr, param_values)
-                    result.setdefault(fw, {})[k] = v_default
-                elif v is not None:
-                    result.setdefault(fw, {})[k] = v
-                # else: omit when None and no default present
-                continue
-
-            # Dict as {key: expr} mapping (fallback)
-            if isinstance(mapping, dict):
-                rendered: dict[str, Any] = {}
-                for k, v_expr in mapping.items():
-                    v = evaluate_expression(v_expr, param_values)
-                    if v is not None:
-                        rendered[k] = v
-                if rendered:
-                    result[fw] = rendered
-                continue
-
-            # Otherwise, unsupported type -> skip
-            continue
-
-        # Only record this param_key if any backend has values
-        if result:
-            out[param_key] = result
-
-    return out
-
-
-def render_backend_parameters(
-    param_values: dict[str, Any],
-    backend: str,
-    yaml_path: Optional[str] = None,
-) -> dict[str, dict[str, Any]]:
-    """
-    Render parameter mappings only for a specific backend.
-
-    Args:
-        param_values: Dictionary of parameter values
-        backend: Target backend name
-        yaml_path: Optional path to YAML mapping file
-
-    Returns:
-        Dictionary structure: {param_key: {backend_key: value}} (pruned for None)
-    """
-    all_rendered = render_parameters(param_values, yaml_path=yaml_path)
-    out: dict[str, dict[str, Any]] = {}
-    for param_key, fw_map in all_rendered.items():
-        backend_dict = fw_map.get(backend)
-        if not backend_dict:
-            continue
-        out[param_key] = backend_dict
-    return out
-
-
 def get_param_keys(yaml_path: str) -> list[str]:
     """
-    Get parameter keys from YAML mapping file.
+    Get list of all supported parameter keys from mapping file.
 
     Args:
-        yaml_path: Path to YAML mapping file
+        yaml_path: Path to mapping YAML file
 
     Returns:
         List of parameter keys
     """
-    path = os.path.abspath(str(yaml_path))
-    cached = _PARAM_KEYS_CACHE.get(path)
-    if cached is not None:
-        return cached
-    data = load_yaml_mapping(path)
-    keys = [e["param_key"] for e in data.get("parameters", []) if e.get("param_key")]
-    _PARAM_KEYS_CACHE[path] = keys
-    return keys
+    data = load_yaml_mapping(yaml_path)
+    return [entry.get("param_key") for entry in data.get("parameters", []) if entry.get("param_key")]
 
 
-def _format_cli_args(backend: str, worker_ctx: dict[str, Any]) -> str:
-    rendered = render_backend_parameters(worker_ctx, backend, yaml_path=_BACKEND_MAPPING_FILE)
-    parts: list[str] = []
-    for _pk, kv in rendered.items():
-        for flag, val in kv.items():
-            if isinstance(val, bool):
-                if val:
-                    parts.append(f"--{flag}")
-                continue
-            if isinstance(val, (list, tuple)):
-                v = ",".join(str(x) for x in val)
-                parts.append(f'--{flag} "{v}"')
-                continue
-            parts.append(f'--{flag} "{val}"')
-    return " ".join(parts)
+def _format_cli_args(backend: str, context: dict[str, Any]) -> str:
+    """
+    Fallback CLI arg formatter when template is missing.
+    Uses backend_config_mapping.yaml to determine keys.
+    """
+    mapping_data = load_yaml_mapping(_BACKEND_MAPPING_FILE)
+    args = []
+    for entry in mapping_data.get("parameters", []):
+        param_key = entry.get("param_key")
+        backend_mapping = entry.get(backend)
+        if not backend_mapping:
+            continue
+
+        # Get key name from mapping
+        if isinstance(backend_mapping, str):
+            arg_name = backend_mapping
+        elif isinstance(backend_mapping, dict):
+            arg_name = backend_mapping.get("key")
+        else:
+            continue
+
+        if not arg_name or "." in arg_name:
+            continue
+
+        # Check context for value (prioritize role-scoped)
+        val = context.get(param_key)
+        if val is None or val is False:
+            continue
+
+        # Format based on value type
+        if val is True:
+            args.append(f"--{arg_name.replace('_', '-')}")
+        else:
+            args.append(f"--{arg_name.replace('_', '-')} {val}")
+
+    return " ".join(args)
+
+
+def _set_by_path(dst: dict[str, Any], path: str, value: Any) -> None:
+    """Set value in nested dict using dot notation path."""
+    parts = path.split(".")
+    cur = dst
+    for p in parts[:-1]:
+        if p not in cur or not isinstance(cur[p], dict):
+            cur[p] = {}
+        cur = cur[p]
+    cur[parts[-1]] = value
+
+
+def render_backend_parameters(
+    params: dict[str, Any], backend: str, yaml_path: Optional[str] = None
+) -> dict[str, dict[str, Any]]:
+    """
+    Transform unified parameters into backend-specific configuration for all roles.
+
+    Args:
+        params: Unified parameters dictionary
+        backend: Target backend name
+        yaml_path: Optional path to mapping YAML file
+
+    Returns:
+        Dictionary mapping roles to backend-specific configurations
+    """
+    if yaml_path is None:
+        yaml_path = str(_BACKEND_MAPPING_FILE)
+    mapping_data = load_yaml_mapping(yaml_path)
+    param_keys = get_param_keys(yaml_path)
+
+    context = prepare_template_context(params, backend)
+    rendered = {}
+
+    # Available roles
+    for role in ["prefill", "decode", "agg"]:
+        if params.get("params", {}).get(role):
+            wc = make_worker_context(context, role, param_keys, mapping_data, backend)
+            # Backend-specific keys are collected into a nested dict named after the backend
+            rendered[role] = wc.get(backend, {})
+
+    return rendered
+
+
+def render_parameters(params: dict[str, Any], backend: str, yaml_path: Optional[str] = None) -> dict[str, Any]:
+    """
+    Transform unified parameters into a single backend-specific configuration dict.
+    If multiple roles exist, returns the aggregate or prefill one.
+
+    Args:
+        params: Unified parameters dictionary
+        backend: Target backend name
+        yaml_path: Optional path to mapping YAML file
+
+    Returns:
+        Backend-specific configuration dictionary
+    """
+    rendered = render_backend_parameters(params, backend, yaml_path)
+    if "agg" in rendered:
+        return rendered["agg"]
+    if "prefill" in rendered:
+        return rendered["prefill"]
+    if "decode" in rendered:
+        return rendered["decode"]
+    return {}

--- a/src/aiconfigurator/sdk/backends/factory.py
+++ b/src/aiconfigurator/sdk/backends/factory.py
@@ -13,15 +13,24 @@ def get_backend(backend_name: str) -> BaseBackend:
     Get the backend class by the backend name.
 
     Raises:
-        ValueError: If the backend name is not found.
+        ValueError: If the backend name is not found or if 'any' is passed
+            (which should be expanded before reaching this point).
     """
+    backend_enum = common.BackendName[backend_name]
+
+    if backend_enum == common.BackendName.any:
+        raise ValueError(
+            "Cannot instantiate 'any' backend directly. "
+            "It should be expanded into concrete backends (trtllm/sglang/vllm) before reaching here."
+        )
+
     backend_map = {
         common.BackendName.trtllm: TRTLLMBackend,
         common.BackendName.sglang: SGLANGBackend,
         common.BackendName.vllm: VLLMBackend,
     }
 
-    backend_class = backend_map.get(common.BackendName[backend_name])
+    backend_class = backend_map.get(backend_enum)
     if backend_class is None:
         raise ValueError(f"Unknown backend: {backend_name}")
 

--- a/src/aiconfigurator/sdk/common.py
+++ b/src/aiconfigurator/sdk/common.py
@@ -499,6 +499,17 @@ class BackendName(Enum):
     trtllm = "trtllm"
     sglang = "sglang"
     vllm = "vllm"
+    any = "any"  # Meta-backend: AIC will check all backends and find best performance
+
+    @classmethod
+    def all_backends(cls) -> list[str]:
+        """Return concrete backends that can actually run inference (excludes meta-backends like 'any')."""
+        return [cls.trtllm.value, cls.sglang.value, cls.vllm.value]
+
+    @classmethod
+    def resolve_backends(cls, backend: str) -> list[str]:
+        """Expand 'any' backend into all concrete backends, or return single list."""
+        return [backend] if backend != cls.any.value else cls.all_backends()
 
 
 class PerfDataFilename(Enum):

--- a/src/aiconfigurator/sdk/task.py
+++ b/src/aiconfigurator/sdk/task.py
@@ -51,10 +51,10 @@ class ConfigLayer:
 class TaskContext:
     """Context for building a TaskConfig.
 
-    For agg mode: uses backend_name, backend_version, backend_deploy_version.
+    For agg mode: uses backend_name, backend_version, generated_config_version.
     For disagg mode:
-      - Prefill workers use backend_name, backend_version, backend_deploy_version
-      - Decode workers use decode_backend_name, decode_backend_version, decode_backend_deploy_version
+      - Prefill workers use backend_name, backend_version, generated_config_version
+      - Decode workers use decode_backend_name, decode_backend_version, generated_decode_config_version
         (with fallback to the main backend_* fields if not specified)
     """
 
@@ -66,11 +66,11 @@ class TaskContext:
     # Backend for agg mode, or prefill workers in disagg mode
     backend_name: str
     backend_version: str | None
-    backend_deploy_version: str | None
+    generated_config_version: str | None
     # Backend for decode workers in disagg mode (falls back to backend_* if None)
     decode_backend_name: str | None
     decode_backend_version: str | None
-    decode_backend_deploy_version: str | None
+    generated_decode_config_version: str | None
     use_specific_quant_mode: str | None
     isl: int
     osl: int
@@ -105,11 +105,11 @@ class TaskContext:
 
     @property
     def effective_decode_backend_deploy_version(self) -> str | None:
-        """Get the deploy version for decode workers (falls back to backend_deploy_version)."""
+        """Get the deploy version for decode workers (falls back to generated_config_version)."""
         return (
-            self.decode_backend_deploy_version
-            if self.decode_backend_deploy_version is not None
-            else self.backend_deploy_version
+            self.generated_decode_config_version
+            if self.generated_decode_config_version is not None
+            else self.generated_config_version
         )
 
     def resolved_backend_version(self, system_name: str, backend_name: str, explicit_version: str | None = None) -> str:
@@ -760,10 +760,10 @@ class TaskConfig:
         decode_system_name: str | None = None,
         backend_name: str = "trtllm",
         backend_version: str | None = None,
-        backend_deploy_version: str | None = None,
+        generated_config_version: str | None = None,
         decode_backend_name: str | None = None,
         decode_backend_version: str | None = None,
-        decode_backend_deploy_version: str | None = None,
+        generated_decode_config_version: str | None = None,
         use_specific_quant_mode: str | None = None,
         isl: int = 4000,
         osl: int = 1000,
@@ -795,13 +795,13 @@ class TaskConfig:
             decode_system_name: The name of the decode system (disagg only).
             backend_name: Backend for agg mode, or prefill workers in disagg mode.
             backend_version: Backend version for performance estimation (agg/prefill).
-            backend_deploy_version: Backend version for deployment artifacts (agg/prefill).
+            generated_config_version: Backend version for deployment artifacts (agg/prefill).
             decode_backend_name: For disagg mode, backend for decode workers.
                 If None, falls back to backend_name.
             decode_backend_version: For disagg mode, backend version for decode workers.
                 If None, falls back to backend_version.
-            decode_backend_deploy_version: For disagg mode, deploy version for decode workers.
-                If None, falls back to backend_deploy_version.
+            generated_decode_config_version: For disagg mode, deploy version for decode workers.
+                If None, falls back to generated_config_version.
             use_specific_quant_mode: The specific quant mode to use.
             isl: The input sequence length.
             osl: The output sequence length.
@@ -820,10 +820,10 @@ class TaskConfig:
         self.decode_system_name = decode_system_name
         self.backend_name = backend_name
         self.backend_version = backend_version
-        self.backend_deploy_version = backend_deploy_version
+        self.generated_config_version = generated_config_version
         self.decode_backend_name = decode_backend_name
         self.decode_backend_version = decode_backend_version
-        self.decode_backend_deploy_version = decode_backend_deploy_version
+        self.generated_decode_config_version = generated_decode_config_version
         self.use_specific_quant_mode = use_specific_quant_mode
         yaml_mode = "patch"
         yaml_patch: dict = {}
@@ -852,10 +852,10 @@ class TaskConfig:
             decode_system_name=decode_system_name,
             backend_name=backend_name,
             backend_version=backend_version,
-            backend_deploy_version=backend_deploy_version,
+            generated_config_version=generated_config_version,
             decode_backend_name=decode_backend_name,
             decode_backend_version=decode_backend_version,
-            decode_backend_deploy_version=decode_backend_deploy_version,
+            generated_decode_config_version=generated_decode_config_version,
             use_specific_quant_mode=use_specific_quant_mode,
             isl=isl,
             osl=osl,

--- a/src/aiconfigurator/webapp/components/profiling/sdk/config.py
+++ b/src/aiconfigurator/webapp/components/profiling/sdk/config.py
@@ -99,8 +99,8 @@ def generate_config_yaml(
         params = generate_config_from_input_dict(input_params, backend=backend)
         artifacts = generate_backend_artifacts(
             params=params,
-            backend=backend,
-            backend_version=version,
+            role_backends={"agg": backend},
+            role_versions={"agg": version} if version else None,
         )
     except (FileNotFoundError, ValueError) as exc:
         message = str(exc)

--- a/tests/integration/test_backend_flags.py
+++ b/tests/integration/test_backend_flags.py
@@ -1,0 +1,305 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Integration tests for backend flag combinations from BACKEND_FLAGS_TEST_SCENARIOS.md.
+
+These tests actually execute CLI commands to ensure they work end-to-end.
+"""
+
+import pytest
+
+from aiconfigurator.cli.main import build_default_task_configs
+
+pytestmark = pytest.mark.unit
+
+
+class TestBackendFlagsIntegration:
+    """Integration tests that execute CLI logic with various backend flag combinations."""
+
+    def test_scenario_1_basic_agg_defaults(self):
+        """Scenario 1: Basic agg mode with all defaults."""
+        task_configs = build_default_task_configs(
+            model_path="Qwen/Qwen3-32B",
+            total_gpus=8,
+            system="h200_sxm",
+        )
+
+        # Should create 2 configs (agg_trtllm + disagg_trtllm_trtllm)
+        assert len(task_configs) == 2
+        assert "agg_trtllm" in task_configs
+        assert "disagg_trtllm_trtllm" in task_configs
+
+        # Verify default backend is trtllm
+        agg_config = task_configs["agg_trtllm"]
+        assert agg_config.backend_name == "trtllm"
+        assert agg_config.backend_version is not None  # Uses latest
+
+    def test_scenario_2_agg_with_vllm_backend(self):
+        """Scenario 2: Agg mode with vLLM backend."""
+        task_configs = build_default_task_configs(
+            model_path="Qwen/Qwen3-32B",
+            total_gpus=8,
+            system="h200_sxm",
+            backend="vllm",
+        )
+
+        assert len(task_configs) == 2
+
+        # Verify vllm backend is used
+        agg_config = task_configs["agg_vllm"]
+        assert agg_config.backend_name == "vllm"
+        assert agg_config.backend_version is not None
+
+    def test_scenario_3_agg_with_specific_version(self):
+        """Scenario 3: Agg mode with specific estimation version."""
+        task_configs = build_default_task_configs(
+            model_path="Qwen/Qwen3-32B",
+            total_gpus=8,
+            system="h200_sxm",
+            backend="trtllm",
+            backend_version="1.0.0rc3",
+        )
+
+        assert len(task_configs) == 2
+
+        # Verify specific version is used for estimation
+        agg_config = task_configs["agg_trtllm"]
+        assert agg_config.backend_name == "trtllm"
+        assert agg_config.backend_version == "1.0.0rc3"
+        # generated_config_version is None here, fallback happens during artifact generation
+        assert agg_config.generated_config_version is None
+
+    def test_scenario_4_agg_different_estimation_vs_deployment(self):
+        """Scenario 4: Agg mode with different estimation vs deployment versions."""
+        task_configs = build_default_task_configs(
+            model_path="Qwen/Qwen3-32B",
+            total_gpus=8,
+            system="h200_sxm",
+            backend="trtllm",
+            backend_version="1.0.0rc3",
+            generated_config_version="1.2.0rc5",
+        )
+
+        assert len(task_configs) == 2
+
+        # Verify estimation uses 1.0.0rc3, deployment uses 1.2.0rc5
+        agg_config = task_configs["agg_trtllm"]
+        assert agg_config.backend_version == "1.0.0rc3"
+        assert agg_config.generated_config_version == "1.2.0rc5"
+
+    def test_scenario_5_basic_disagg_homogeneous(self):
+        """Scenario 5: Basic disagg mode with homogeneous backend."""
+        task_configs = build_default_task_configs(
+            model_path="Qwen/Qwen3-32B",
+            total_gpus=16,
+            system="h200_sxm",
+        )
+
+        assert len(task_configs) == 2
+
+        # Verify disagg uses same backend for prefill and decode
+        disagg_config = list(task_configs.values())[1]  # Get disagg config
+        assert disagg_config.backend_name == "trtllm"
+        assert disagg_config.decode_backend_name == "trtllm"  # Falls back
+
+    def test_scenario_6_disagg_heterogeneous_backends(self):
+        """Scenario 6: Disagg mode with heterogeneous backends."""
+        task_configs = build_default_task_configs(
+            model_path="Qwen/Qwen3-32B",
+            total_gpus=16,
+            system="h200_sxm",
+            backend="sglang",
+            decode_backend="trtllm",
+        )
+
+        assert len(task_configs) == 2
+
+        # Verify different backends for prefill and decode
+        disagg_config = list(task_configs.values())[1]  # Get disagg config
+        assert disagg_config.backend_name == "sglang"
+        assert disagg_config.decode_backend_name == "trtllm"
+
+    def test_scenario_7_disagg_same_backend_same_version(self):
+        """Scenario 7: Disagg mode with explicit backend/version (same for prefill/decode)."""
+        task_configs = build_default_task_configs(
+            model_path="Qwen/Qwen3-32B",
+            total_gpus=16,
+            system="h200_sxm",
+            backend="trtllm",
+            backend_version="1.0.0rc3",
+            decode_backend="trtllm",
+            # Same version for both prefill and decode
+        )
+
+        assert len(task_configs) == 2
+
+        # Verify version is used consistently
+        disagg_config = list(task_configs.values())[1]  # Get disagg config
+        assert "1.0.0rc3" in str(disagg_config.backend_version)
+
+    def test_scenario_8_disagg_prefill_deployment_override(self):
+        """Scenario 8: Disagg mode with estimation vs deployment version split for prefill."""
+        task_configs = build_default_task_configs(
+            model_path="Qwen/Qwen3-32B",
+            total_gpus=16,
+            system="h200_sxm",
+            backend="trtllm",
+            backend_version="1.0.0rc3",
+            generated_config_version="1.2.0rc5",
+        )
+
+        assert len(task_configs) == 2
+
+        # Verify prefill has different estimation/deployment versions
+        disagg_config = list(task_configs.values())[1]  # Get disagg config
+        assert disagg_config.backend_version == "1.0.0rc3"
+        assert disagg_config.generated_config_version == "1.2.0rc5"
+        # Decode should fall back to prefill values
+        assert disagg_config.decode_backend_version == "1.0.0rc3"
+        assert disagg_config.generated_decode_config_version == "1.2.0rc5"
+
+    def test_scenario_9_disagg_heterogeneous_with_versions(self):
+        """Scenario 9: Disagg mode with heterogeneous backends and explicit versions."""
+        task_configs = build_default_task_configs(
+            model_path="Qwen/Qwen3-32B",
+            total_gpus=16,
+            system="h200_sxm",
+            backend="sglang",
+            backend_version="0.5.6.post2",
+            generated_config_version="0.5.6.post2",
+            decode_backend="trtllm",
+            decode_backend_version="1.0.0rc3",  # Explicitly set decode version
+            generated_decode_config_version="1.2.0rc5",
+        )
+
+        assert len(task_configs) == 2
+
+        # Verify backends and versions are set correctly
+        disagg_config = list(task_configs.values())[1]  # Get disagg config
+        assert disagg_config.backend_name == "sglang"
+        assert disagg_config.decode_backend_name == "trtllm"
+        assert disagg_config.generated_config_version == "0.5.6.post2"
+        assert disagg_config.generated_decode_config_version == "1.2.0rc5"
+
+    def test_scenario_10_disagg_with_generated_versions(self):
+        """Scenario 10: Disagg mode with generated_config_version override."""
+        task_configs = build_default_task_configs(
+            model_path="Qwen/Qwen3-32B",
+            total_gpus=16,
+            system="h200_sxm",
+            backend="trtllm",
+            backend_version="1.0.0rc3",
+            generated_config_version="1.2.0rc5",
+            generated_decode_config_version="1.2.0rc5",
+        )
+
+        assert len(task_configs) == 2
+
+        # Verify deployment version overrides are set
+        disagg_config = list(task_configs.values())[1]  # Get disagg config
+        assert disagg_config.generated_config_version == "1.2.0rc5"
+        assert disagg_config.generated_decode_config_version == "1.2.0rc5"
+
+    def test_scenario_11_any_backend_mode(self):
+        """Scenario 11: Any backend mode to compare all backends."""
+        task_configs = build_default_task_configs(
+            model_path="Qwen/Qwen3-32B",
+            total_gpus=32,
+            system="h200_sxm",
+            backend="any",
+        )
+
+        # Should create 12 configs (3 agg + 9 disagg for all backend combinations)
+        assert len(task_configs) == 12
+
+        # Check that we have agg configs for each backend
+        agg_backends = [name for name in task_configs if name.startswith("agg_")]
+        assert len(agg_backends) == 3
+
+        # Check that we have disagg configs for all combinations
+        disagg_backends = [name for name in task_configs if name.startswith("disagg_")]
+        assert len(disagg_backends) == 9
+
+    @pytest.mark.skip(reason="Any backend with specific version requires that version to exist for all backends")
+    def test_scenario_12_any_backend_with_version(self):
+        """Scenario 12: Any backend mode with version override."""
+        # NOTE: This scenario would fail if the specified version doesn't exist for all backends
+        # In practice, when using backend="any", you should use default versions
+        task_configs = build_default_task_configs(
+            model_path="Qwen/Qwen3-32B",
+            total_gpus=32,
+            system="h200_sxm",
+            backend="any",
+            backend_version="1.0.0rc3",
+        )
+
+        # Should create 12 configs
+        assert len(task_configs) == 12
+
+        # Verify that trtllm configs use the specified version
+        trtllm_configs = [cfg for name, cfg in task_configs.items() if "trtllm" in name]
+        for cfg in trtllm_configs:
+            if cfg.backend_name == "trtllm":
+                assert cfg.backend_version == "1.0.0rc3"
+            if cfg.decode_backend_name == "trtllm":
+                assert cfg.decode_backend_version == "1.0.0rc3"
+
+    def test_scenario_13_mixed_system_hardware(self):
+        """Scenario 13: Mixed system with different hardware for decode."""
+        task_configs = build_default_task_configs(
+            model_path="Qwen/Qwen3-32B",
+            total_gpus=16,
+            system="h200_sxm",
+            decode_system="h200_sxm",  # Use same system to avoid validation issues
+            backend="trtllm",
+            decode_backend="trtllm",
+        )
+
+        assert len(task_configs) == 2
+
+        # Verify systems for prefill and decode (using h200 for both to avoid profile issues)
+        disagg_config = list(task_configs.values())[1]  # Get disagg config
+        assert disagg_config.system_name == "h200_sxm"
+        assert disagg_config.decode_system_name == "h200_sxm"
+        assert disagg_config.backend_name == "trtllm"
+        assert disagg_config.decode_backend_name == "trtllm"
+
+
+class TestBackendVersionValidation:
+    """Test that invalid backend versions are properly rejected."""
+
+    def test_invalid_backend_version_raises_error(self):
+        """Test that specifying a non-existent backend version raises an error."""
+        with pytest.raises(SystemExit):
+            build_default_task_configs(
+                model_path="Qwen/Qwen3-32B",
+                total_gpus=8,
+                system="h200_sxm",
+                backend="trtllm",
+                backend_version="99.99.99",  # Non-existent version
+            )
+
+    def test_invalid_decode_backend_version_raises_error(self):
+        """Test that specifying a non-existent decode backend version raises an error."""
+        with pytest.raises(SystemExit):
+            build_default_task_configs(
+                model_path="Qwen/Qwen3-32B",
+                total_gpus=16,
+                system="h200_sxm",
+                backend="trtllm",
+                decode_backend="trtllm",
+                decode_backend_version="99.99.99",  # Non-existent version
+            )
+
+    def test_valid_version_does_not_raise(self):
+        """Test that valid versions execute without errors."""
+        # Should not raise
+        task_configs = build_default_task_configs(
+            model_path="Qwen/Qwen3-32B",
+            total_gpus=8,
+            system="h200_sxm",
+            backend="trtllm",
+            backend_version="1.0.0rc3",
+        )
+        assert len(task_configs) == 2

--- a/tests/unit/cli/test_any_backend.py
+++ b/tests/unit/cli/test_any_backend.py
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for the 'any' backend feature.
+
+Tests that the 'any' backend option correctly expands into all concrete backend combinations.
+"""
+
+import pytest
+
+from aiconfigurator.cli.main import build_default_task_configs
+from aiconfigurator.sdk import common
+
+pytestmark = pytest.mark.unit
+
+
+class TestAnyBackendEnum:
+    """Test that 'any' is a valid BackendName."""
+
+    def test_any_backend_exists(self):
+        """Test that 'any' is a valid BackendName enum value."""
+        assert hasattr(common.BackendName, "any")
+        assert common.BackendName.any.value == "any"
+
+    def test_all_backends_excludes_any(self):
+        """Test that all_backends() does not include 'any'."""
+        concrete = common.BackendName.all_backends()
+        assert common.BackendName.any.value not in concrete
+        assert len(concrete) == 3
+        assert common.BackendName.trtllm.value in concrete
+        assert common.BackendName.sglang.value in concrete
+        assert common.BackendName.vllm.value in concrete
+
+
+class TestGetBackendsToCheck:
+    """Test the resolve_backends classmethod."""
+
+    def test_any_expands_to_all_backends(self):
+        """Test that 'any' expands to all concrete backends."""
+        backends = common.BackendName.resolve_backends("any")
+        assert len(backends) == 3
+        assert "trtllm" in backends
+        assert "sglang" in backends
+        assert "vllm" in backends
+
+    def test_single_backend_returns_single_list(self):
+        """Test that a single backend returns a single-element list."""
+        assert common.BackendName.resolve_backends("trtllm") == ["trtllm"]
+        assert common.BackendName.resolve_backends("sglang") == ["sglang"]
+        assert common.BackendName.resolve_backends("vllm") == ["vllm"]
+
+
+class TestBuildDefaultTaskConfigsWithAny:
+    """Test build_default_task_configs with 'any' backend."""
+
+    def test_any_backend_creates_12_configs(self):
+        """Test that 'any' backend creates 12 task configs (3 agg + 9 disagg)."""
+        task_configs = build_default_task_configs(
+            model_path="Qwen/Qwen3-32B",
+            total_gpus=8,
+            system="h200_sxm",
+            backend="any",
+        )
+
+        # Should have 3 agg configs + 9 disagg configs = 12 total
+        assert len(task_configs) == 12
+
+        # Check agg configs exist
+        assert "agg_trtllm" in task_configs
+        assert "agg_sglang" in task_configs
+        assert "agg_vllm" in task_configs
+
+        # Check disagg configs exist (all 9 combinations)
+        for prefill in ["trtllm", "sglang", "vllm"]:
+            for decode in ["trtllm", "sglang", "vllm"]:
+                assert f"disagg_{prefill}_{decode}" in task_configs
+
+    def test_single_backend_creates_2_configs(self):
+        """Test that a single backend creates 2 task configs (1 agg + 1 disagg)."""
+        task_configs = build_default_task_configs(
+            model_path="Qwen/Qwen3-32B",
+            total_gpus=8,
+            system="h200_sxm",
+            backend="trtllm",
+        )
+
+        # Should have 1 agg + 1 disagg = 2 total
+        # Uses same naming pattern as 'any' mode for consistency
+        assert len(task_configs) == 2
+        assert "agg_trtllm" in task_configs
+        assert "disagg_trtllm_trtllm" in task_configs
+
+    def test_any_backend_agg_configs_have_correct_backend(self):
+        """Test that agg configs have the correct backend name."""
+        task_configs = build_default_task_configs(
+            model_path="Qwen/Qwen3-32B",
+            total_gpus=8,
+            system="h200_sxm",
+            backend="any",
+        )
+
+        assert task_configs["agg_trtllm"].config.worker_config.backend_name == "trtllm"
+        assert task_configs["agg_sglang"].config.worker_config.backend_name == "sglang"
+        assert task_configs["agg_vllm"].config.worker_config.backend_name == "vllm"
+
+    def test_any_backend_disagg_configs_have_correct_backends(self):
+        """Test that disagg configs have correct prefill/decode backend names."""
+        task_configs = build_default_task_configs(
+            model_path="Qwen/Qwen3-32B",
+            total_gpus=8,
+            system="h200_sxm",
+            backend="any",
+        )
+
+        # Check a few disagg configs
+        disagg_trtllm_trtllm = task_configs["disagg_trtllm_trtllm"]
+        assert disagg_trtllm_trtllm.config.prefill_worker_config.backend_name == "trtllm"
+        assert disagg_trtllm_trtllm.config.decode_worker_config.backend_name == "trtllm"
+
+        disagg_trtllm_sglang = task_configs["disagg_trtllm_sglang"]
+        assert disagg_trtllm_sglang.config.prefill_worker_config.backend_name == "trtllm"
+        assert disagg_trtllm_sglang.config.decode_worker_config.backend_name == "sglang"
+
+        disagg_sglang_vllm = task_configs["disagg_sglang_vllm"]
+        assert disagg_sglang_vllm.config.prefill_worker_config.backend_name == "sglang"
+        assert disagg_sglang_vllm.config.decode_worker_config.backend_name == "vllm"
+
+    def test_explicit_heterogeneous_backends(self):
+        """Test specifying different prefill and decode backends explicitly."""
+        task_configs = build_default_task_configs(
+            model_path="Qwen/Qwen3-32B",
+            total_gpus=8,
+            system="h200_sxm",
+            backend="sglang",
+            decode_backend="trtllm",
+        )
+
+        # Should have 1 agg config (sglang) and 1 disagg config (sglang prefill, trtllm decode)
+        assert len(task_configs) == 2
+        assert "agg_sglang" in task_configs
+        assert "disagg_sglang_trtllm" in task_configs
+
+        disagg = task_configs["disagg_sglang_trtllm"]
+        assert disagg.config.prefill_worker_config.backend_name == "sglang"
+        assert disagg.config.decode_worker_config.backend_name == "trtllm"
+
+
+class TestBackendChoicesIncludesAny:
+    """Test that CLI argument parsing includes 'any' as a valid choice."""
+
+    def test_backend_choices_includes_any(self, cli_parser):
+        """Test that backend argument includes 'any' as a valid choice."""
+        subparser_action = next(action for action in cli_parser._actions if action.dest == "mode")
+        default_parser = subparser_action.choices["default"]
+        action = next(action for action in default_parser._actions if action.dest == "backend")
+        assert "any" in action.choices
+
+    def test_any_backend_parses_successfully(self, cli_parser):
+        """Test that --backend any parses successfully."""
+        args = cli_parser.parse_args(
+            [
+                "default",
+                "--model_path",
+                "Qwen/Qwen3-32B",
+                "--total_gpus",
+                "8",
+                "--system",
+                "h200_sxm",
+                "--backend",
+                "any",
+            ]
+        )
+        assert args.backend == "any"

--- a/tests/unit/cli/test_argument_parsing.py
+++ b/tests/unit/cli/test_argument_parsing.py
@@ -109,7 +109,10 @@ class TestCLIArgumentParsing:
         assert args.database_mode == common.DatabaseMode.SILICON.name
         assert args.debug is False
         assert args.decode_system is None
-        assert args.generated_config_version is None
+        assert args.decode_backend is None
+        assert args.decode_backend_version is None
+        assert args.decode_backend_deploy_version is None
+        assert args.backend_deploy_version is None
         assert args.isl == 4000
         assert args.osl == 1000
         assert args.save_dir is None

--- a/tests/unit/cli/test_cli_api.py
+++ b/tests/unit/cli/test_cli_api.py
@@ -39,6 +39,7 @@ class TestCLIExpUnit:
             {"exp_agg_simplified": pd.DataFrame()},
             {"exp_agg_simplified": pd.DataFrame()},
             {"exp_agg_simplified": 100.0},
+            {"exp_agg_simplified": mock_task_config},
         )
 
         # Simplified version based on example.yaml exp_agg_simplified

--- a/tests/unit/cli/test_cli_workflow.py
+++ b/tests/unit/cli/test_cli_workflow.py
@@ -37,6 +37,7 @@ class TestCLIIntegration:
             mock_best_configs,
             {"agg": mock_results_df},
             mock_best_throughputs,
+            {"agg": mock_task_config},
         )
 
         with patch("aiconfigurator.cli.main.save_results") as mock_save:
@@ -78,6 +79,7 @@ class TestCLIIntegration:
             mock_best_configs,
             {"my_exp": mock_results_df},
             mock_best_throughputs,
+            {"my_exp": mock_task_config},
         )
 
         args = cli_args_factory(
@@ -112,7 +114,7 @@ class TestCLIIntegration:
     @patch("aiconfigurator.cli.main._execute_task_configs")
     def test_cli_main_build_dispatch(self, mock_execute, mode, build_patch, cli_args_factory, mock_exp_yaml_path):
         """Main should dispatch to the correct builder based on CLI mode."""
-        mock_execute.return_value = ("agg", {}, {}, {})
+        mock_execute.return_value = ("agg", {}, {}, {}, {"agg": MagicMock()})
         mock_task_config = MagicMock(name="TaskConfig")
 
         with patch(build_patch) as mock_builder:
@@ -198,7 +200,7 @@ exp_with_db_mode:
 
         mock_task_config = MagicMock(name="TaskConfig")
         mock_build_exp.return_value = {"exp_with_db_mode": mock_task_config}
-        mock_execute.return_value = ("exp_with_db_mode", {}, {}, {})
+        mock_execute.return_value = ("exp_with_db_mode", {}, {}, {}, {"exp_with_db_mode": MagicMock()})
 
         parser = argparse.ArgumentParser()
         configure_parser(parser)

--- a/tests/unit/cli/test_cli_workflow.py
+++ b/tests/unit/cli/test_cli_workflow.py
@@ -124,7 +124,7 @@ class TestCLIIntegration:
             cli_main(args)
 
         mock_builder.assert_called_once()
-        mock_execute.assert_called_once_with({"agg": mock_task_config}, mode)
+        mock_execute.assert_called_once_with({"agg": mock_task_config}, mode, top_n=5)
 
     @pytest.mark.parametrize(
         "builder_patch",


### PR DESCRIPTION
## Overview:

Add --backend any to compare all backends (trtllm, vllm, sglang) simultaneously and support for heterogeneous disaggregated serving with different backends for prefill and decode workers. 

Key changes:                                                                                                                                                                         
                                                                                                                                                                                       
  1. "Any" backend mode (--backend any)                                                                                                                                                
     - Expands to 12 task configs: 3 agg + 9 disagg (all combinations)                                                                                                                 
     - Aggregates results into unified "agg" and "disagg" top-N recommendations                                                                                                        
     - Tracks source backend via "source_experiment" column                                                                                                                            
                                                                                                                                                                                       
  2. Heterogeneous backend support                                                                                                                                                     
     - New --decode_backend and --decode_backend_version CLI args                                                                                                                      
     - Enables prefill/decode with different backends (e.g., sglang + trtllm)                                                                                                          
     - Backend info displayed per worker role in results tables                                                                                                                        
                                                                                                                                                                                       
  3. Backend version separation                                                                                                                                                        
     - backend_version: performance estimation (database queries)                                                                                                                      
     - backend_deploy_version: artifact generation (falls back to backend_version)                                                                                     
                                                                                                                                                                                       
  4. Generator refactoring                                                                                                                                                             
     - Change generate_backend_artifacts() from single backend to role_backends dict                                                                                                   
     - Support role-based backend mapping: {prefill: backend1, decode: backend2}                                                                                                       
                                                                                                                                                                                       
  5. Result display enhancements                                                                                                                                                       
     - Show backend columns in "any" mode tables                                                                                                                                       
     - Capitalize mode names (agg → Agg, disagg → Disagg)                                                                                                                              
                                                                                                                                                                                       
  **Usage examples:**                                                                                                                                                                      
  ```bash                                                                                                                                                                             
   # Compare all backends simultaneously                                                                                                                                               
   aiconfigurator cli default --model QWEN3_32B --total_gpus 32 --system h200_sxm --backend any                                                                                                                                                   
                                                                                                                                                                                       
   # Use heterogeneous backends in disagg mode                                                                                                                                         
   aiconfigurator cli default --model QWEN3_32B --total_gpus 32 --system h200_sxm --backend sglang --decode_backend trtllm                                                                                                                        
                                                                                                                                                                                       
   # Separate estimation and deployment versions                                                                                                                                       
   aiconfigurator cli default --model QWEN3_32B --total_gpus 32 \                                                                                                                      
     --system h200_sxm --backend trtllm \                                                                                                                                              
     --backend_version 1.0.0 --backend_deploy_version 1.0.1  

  # full control
  aiconfigurator cli default \
    --model_path Qwen/Qwen3-32B \
    --total_gpus 16 \
    --system h200_sxm \
    --backend sglang \
    --backend_version 0.5.6.post2 \
    --generated_config_version 0.6.0 \
    --decode_backend trtllm \
    --decode_backend_version 1.0.0rc3 \
    --generated_decode_config_version 1.1.0rc5

```

## Details:
                                                                                                                                                                                                                                                                                                                                             
Example of `--backend any` 

```
$ aiconfigurator cli default   --model_path Qwen/Qwen3-32B   --total_gpus 8   --system h200_sxm   --backend any   --save_dir ./output --top_n 6
2026-01-27 21:23:17,913 - aiconfigurator.sdk.task - INFO - Task disagg_Qwen/Qwen3-32B_h200_sxm_h200_sxm_vllm_0.12.0_4000_1000_0_2000.0_30.0: Running disagg pareto
2026-01-27 21:23:19,206 - aiconfigurator.sdk.inference_session - WARNING - No decode worker candidates found for tpot 1ms.
2026-01-27 21:23:19,207 - aiconfigurator.sdk.inference_session - WARNING - No decode worker candidates found for tpot 2ms.
2026-01-27 21:23:19,208 - aiconfigurator.sdk.inference_session - WARNING - No decode worker candidates found for tpot 3ms.
2026-01-27 21:23:19,209 - aiconfigurator.sdk.inference_session - WARNING - No decode worker candidates found for tpot 4ms.
2026-01-27 21:23:19,210 - aiconfigurator.sdk.inference_session - WARNING - No decode worker candidates found for tpot 5ms.
2026-01-27 21:23:19,211 - aiconfigurator.sdk.inference_session - WARNING - No decode worker candidates found for tpot 6ms.
2026-01-27 21:23:19,212 - aiconfigurator.sdk.inference_session - WARNING - No decode worker candidates found for tpot 7ms.
2026-01-27 21:23:19,713 - aiconfigurator.cli.main - INFO - Experiment disagg_vllm_vllm completed with 49 results.
2026-01-27 21:23:19,753 - aiconfigurator.cli.report_and_save - INFO - 
********************************************************************************
*                     Dynamo aiconfigurator Final Results                      *
********************************************************************************
  ----------------------------------------------------------------------------
  Input Configuration & SLA Target:
    Model: Qwen/Qwen3-32B (is_moe: False)
    Total GPUs: 8
    Best Experiment Chosen: disagg at 1668.15 tokens/s/gpu (disagg 1.08x better)
  ----------------------------------------------------------------------------
  Overall Best Configuration:
    - Best Throughput: 13,345.20 tokens/s
    - Per-GPU Throughput: 1668.15 tokens/s/gpu
    - Per-User Throughput: 33.46 tokens/s/user
    - TTFT: 485.60ms
    - TPOT: 29.89ms
    - Request Latency: 30343.71ms
  ----------------------------------------------------------------------------
  Pareto Frontier:
        Qwen/Qwen3-32B Pareto Frontier: tokens/s/gpu_cluster vs tokens/s/user   
    ┌──────────────────────────────────────────────────────────────────────────┐
2400┤ •• agg                                                                   │
    │ ff disagg                                                                │
2000┤ xx disagg best                                                           │
    │     •                                                                    │
    │    ••••••xfffffff                                                        │
1600┤    •••••••ff    f                                                        │
    │     fff••fffffffff                                                       │
1200┤      ffffffffffffffffffff                                                │
    │        fffffffff•ff•••••f•••                                             │
 800┤           ffffffffffff•••fffffff•••                                      │
    │               fffffffffff•••••••ff ••••••                                │
    │                   ffffffffffffff••ff•••• ••••••                          │
 400┤                       fffffffff ffffff•••••••••••••••••••                │
    │                         ffffffff••••••ffffff•••      •••••••••••••       │
   0┤                            fffffff     •••••fffffff        •••••••       │
    └┬─────────────────┬──────────────────┬─────────────────┬─────────────────┬┘
     0                60                 120               180              240 
tokens/s/gpu_cluster                tokens/s/user                               

  ----------------------------------------------------------------------------
  Deployment Details:
    (p) stands for prefill, (d) stands for decode, bs stands for batch size, a replica stands for the smallest scalable unit xPyD of the disagg system
    Some math: total gpus used = replicas * gpus/replica
               gpus/replica = (p)gpus/worker * (p)workers + (d)gpus/worker * (d)workers; for Agg, gpus/replica = gpus/worker
               gpus/worker = tp * pp * dp = etp * ep * pp for MoE models; tp * pp for dense models (underlined numbers are the actual values in math)

Agg Top Configurations: (Sorted by tokens/s/gpu)
+------+--------------+---------------+---------+-----------------+--------------+-------------------+----------+--------------+---------+-------------+----------+-----+
| Rank | tokens/s/gpu | tokens/s/user |   TTFT  | request_latency | concurrency  | total_gpus (used) | replicas | gpus/replica | backend | gpus/worker | parallel |  bs |
+------+--------------+---------------+---------+-----------------+--------------+-------------------+----------+--------------+---------+-------------+----------+-----+
|  1   |   1550.75    |     34.16     | 1764.99 |     31009.25    | 384 (=48x8)  |     8 (8=8x1)     |    8     |      1       |  trtllm |  1 (=1x1x1) |  tp1pp1  |  48 |
|  2   |   1454.60    |     47.54     | 1155.35 |     22169.92    | 256 (=64x4)  |     8 (8=4x2)     |    4     |      2       |  trtllm |  2 (=2x1x1) |  tp2pp1  |  64 |
|  3   |   1342.49    |     43.00     |  832.26 |     24066.96    | 256 (=128x2) |     8 (8=2x4)     |    2     |      4       |  trtllm |  4 (=4x1x1) |  tp4pp1  | 128 |
|  4   |   1253.69    |     39.83     |  625.58 |     25705.76    | 256 (=64x4)  |     8 (8=4x2)     |    4     |      2       |  sglang |  2 (=2x1x1) |  tp2pp1  |  64 |
|  5   |   1153.98    |     36.76     |  771.10 |     27949.49    | 256 (=128x2) |     8 (8=2x4)     |    2     |      4       |  sglang |  4 (=4x1x1) |  tp4pp1  | 128 |
|  6   |   1123.42    |     36.01     |  882.75 |     28626.53    | 256 (=32x8)  |     8 (8=8x1)     |    8     |      1       |  sglang |  1 (=1x1x1) |  tp1pp1  |  32 |
+------+--------------+---------------+---------+-----------------+--------------+-------------------+----------+--------------+---------+-------------+----------+-----+

Disagg Top Configurations: (Sorted by tokens/s/gpu)
+------+--------------+---------------+--------+-----------------+--------------+-------------------+----------+--------------+------------+------------+----------------+-------------+-------+------------+------------+----------------+-------------+-------+
| Rank | tokens/s/gpu | tokens/s/user |  TTFT  | request_latency | concurrency  | total_gpus (used) | replicas | gpus/replica | (p)backend | (p)workers | (p)gpus/worker | (p)parallel | (p)bs | (d)backend | (d)workers | (d)gpus/worker | (d)parallel | (d)bs |
+------+--------------+---------------+--------+-----------------+--------------+-------------------+----------+--------------+------------+------------+----------------+-------------+-------+------------+------------+----------------+-------------+-------+
|  1   |   1668.15    |     33.46     | 485.60 |     30343.71    | 496 (=248x2) |     8 (8=2x4)     |    2     | 4 (=2x1+1x2) |   sglang   |     2      |    1 (=1x1)    |    tp1pp1   |   1   |   trtllm   |     1      |    2 (=2x1)    |    tp2pp1   |  248  |
|  2   |   1668.15    |     33.35     | 485.60 |     30440.62    | 448 (=112x4) |     8 (8=4x2)     |    4     | 2 (=1x1+1x1) |   sglang   |     1      |    1 (=1x1)    |    tp1pp1   |   1   |   trtllm   |     1      |    1 (=1x1)    |    tp1pp1   |  112  |
|  3   |   1663.02    |     33.44     | 485.60 |     30358.70    | 432 (=432x1) |     8 (8=1x8)     |    1     | 8 (=4x1+1x4) |   sglang   |     4      |    1 (=1x1)    |    tp1pp1   |   1   |   trtllm   |     1      |    4 (=4x1)    |    tp4pp1   |  432  |
|  4   |   1415.70    |     55.94     | 572.09 |     18430.21    | 256 (=128x2) |     8 (8=2x4)     |    2     | 4 (=2x1+1x2) |   trtllm   |     2      |    1 (=1x1)    |    tp1pp1   |   1   |   trtllm   |     1      |    2 (=2x1)    |    tp2pp1   |  128  |
|  5   |   1415.70    |     33.35     | 572.09 |     30527.10    | 448 (=112x4) |     8 (8=4x2)     |    4     | 2 (=1x1+1x1) |   trtllm   |     1      |    1 (=1x1)    |    tp1pp1   |   1   |   trtllm   |     1      |    1 (=1x1)    |    tp1pp1   |  112  |
|  6   |   1415.70    |     50.46     | 572.09 |     20369.27    | 264 (=264x1) |     8 (8=1x8)     |    1     | 8 (=4x1+1x4) |   trtllm   |     4      |    1 (=1x1)    |    tp1pp1   |   1   |   trtllm   |     1      |    4 (=4x1)    |    tp4pp1   |  264  |
+------+--------------+---------------+--------+-----------------+--------------+-------------------+----------+--------------+------------+------------+----------------+-------------+-------+------------+------------+----------------+-------------+-------+
********************************************************************************
2026-01-29 20:11:12,511 - aiconfigurator.cli.main - INFO - All experiments completed in 39.96 seconds
2026-01-29 20:11:12,512 - aiconfigurator.cli.report_and_save - INFO - Saving results to ./output/Qwen_Qwen3-32B_h200_sxm_any_isl4000_osl1000_ttft2000_tpot30_343020
2026-01-29 20:11:12,613 - aiconfigurator.cli.report_and_save - INFO - Generating config for top1 from trtllm_agg (trtllm(1.2.0rc5))
2026-01-29 20:11:12,649 - aiconfigurator.cli.report_and_save - INFO - Generating config for top2 from trtllm_agg (trtllm(1.2.0rc5))
2026-01-29 20:11:12,658 - aiconfigurator.cli.report_and_save - INFO - Generating config for top3 from trtllm_agg (trtllm(1.2.0rc5))
2026-01-29 20:11:12,665 - aiconfigurator.cli.report_and_save - INFO - Generating config for top4 from sglang_agg (sglang(1.2.0rc5))
2026-01-29 20:11:12,697 - aiconfigurator.cli.report_and_save - INFO - Generating config for top5 from sglang_agg (sglang(1.2.0rc5))
2026-01-29 20:11:12,705 - aiconfigurator.cli.report_and_save - INFO - Generating config for top6 from sglang_agg (sglang(1.2.0rc5))
2026-01-29 20:11:12,717 - aiconfigurator.cli.report_and_save - INFO - Generating config for top1 from sglang_trtllm_disagg (prefill=sglang(1.2.0rc5), decode=trtllm(1.2.0rc5))
2026-01-29 20:11:12,774 - aiconfigurator.cli.report_and_save - INFO - Generating config for top2 from sglang_trtllm_disagg (prefill=sglang(1.2.0rc5), decode=trtllm(1.2.0rc5))
2026-01-29 20:11:12,786 - aiconfigurator.cli.report_and_save - INFO - Generating config for top3 from sglang_trtllm_disagg (prefill=sglang(1.2.0rc5), decode=trtllm(1.2.0rc5))
2026-01-29 20:11:12,797 - aiconfigurator.cli.report_and_save - INFO - Generating config for top4 from trtllm_trtllm_disagg (prefill=trtllm(1.2.0rc5), decode=trtllm(1.2.0rc5))
2026-01-29 20:11:12,809 - aiconfigurator.cli.report_and_save - INFO - Generating config for top5 from trtllm_trtllm_disagg (prefill=trtllm(1.2.0rc5), decode=trtllm(1.2.0rc5))
2026-01-29 20:11:12,820 - aiconfigurator.cli.report_and_save - INFO - Generating config for top6 from trtllm_trtllm_disagg (prefill=trtllm(1.2.0rc5), decode=trtllm(1.2.0rc5))
```

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
