### PR TITLE
fix: ensure max_num_tokens % tokens_per_block == 0 in trtllm

### DIFF
--- a/src/aiconfigurator/generator/rule_plugin/trtllm.rule
+++ b/src/aiconfigurator/generator/rule_plugin/trtllm.rule
@@ -5,9 +5,11 @@ prefill disable_overlap_scheduler = true
 decode disable_overlap_scheduler = false
 agg disable_overlap_scheduler = false
 
-prefill max_num_tokens = SlaConfig.isl + 1500
-decode max_num_tokens = max_batch_size
-agg max_num_tokens = max_batch_size + SlaConfig.isl + 1500
+# Ensure maxNumTokens.value() % tokensPerBlock == 0 
+agg_prefill_decode tokens_per_block = (tokens_per_block if tokens_per_block else 32)
+prefill max_num_tokens = (((SlaConfig.isl + 1500) + tokens_per_block - 1) // tokens_per_block) * tokens_per_block
+decode max_num_tokens = ((max_batch_size + tokens_per_block - 1) // tokens_per_block) * tokens_per_block
+agg max_num_tokens = ((max_batch_size + SlaConfig.isl + 1500 + tokens_per_block - 1) // tokens_per_block) * tokens_per_block
 
 agg_prefill_decode cuda_graph_batch_sizes = ((range(1, max_batch_size + 1) | list) if max_batch_size else [])
 


### PR DESCRIPTION
#### Overview:

Fix for the TRTLLM error:

`[TRT-LLM] [I] max_seq_len=128, max_num_requests=96, max_num_tokens=96, max_batch_size=96 0: [01/23/2026-04:43:47] [TRT-LLM] [E] Failed to initialize executor on rank 0: [TensorRT-LLM][ERROR] Assertion failed: maxNumTokens.value() % tokensPerBlock == 0 (../tensorrt_llm/batch_manager/cacheTransBuffer.cpp:206)`

#### Details:

TRTLLM used not have this error in prior versions (v1.0.0) as its `mMaxNumTokens` is always None, and thus we didn't have this issue in prior experiments.

`# log from a past experiment where build_config.max_num_tokens=2060`
`CacheTransBufferManager: mMaxNumTokens:0, mRecvBufferCount:1, mSendBufferCount:1,mTransferBufferSize:536870912, mPreAllocBufferSize:1073741824,mOnlyUseDynamicBuffer:0 mUseFabricMemory:0 mDataType:6`

In newer versions (v1.2.0) this is fixed and `build_config.max_num_tokens` is correctly populated to `mMaxNumTokens` which enforces the  check`TLLM_CHECK(maxNumTokens.value() % tokensPerBlock == 0);`

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
