### PR TITLE
fix: sglang moe_dense_tp_size only support 1 or None

### DIFF
--- a/src/aiconfigurator/generator/config/backend_config_mapping.yaml
+++ b/src/aiconfigurator/generator/config/backend_config_mapping.yaml
@@ -35,7 +35,9 @@ parameters:
 
 - param_key: moe_tensor_parallel_size
   vllm: null
-  sglang: moe-dense-tp-size
+  # https://github.com/sgl-project/sglang/issues/8530
+  # sglang moe_tensor_parallel_size only supports 1 or None for now
+  sglang: null
   trtllm: moe_tensor_parallel_size
 
 # KV Cache


### PR DESCRIPTION
#### Overview:

Limit the etp list to [1] as SGLang moe_dense_tp_size only support 1 or None right now: [code pointer](https://github.com/sgl-project/sglang/blob/b77b0ffd6021ef787c9ca7084731578c2f2f4687/python/sglang/srt/server_args.py#L4895). 

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
