### PR TITLE
feat: update vllm collector to 0.14.0 and add H100 data

### DIFF
--- a/collector/collect_all_reduce.py
+++ b/collector/collect_all_reduce.py
@@ -248,7 +248,12 @@ def setup_vllm_distributed(world_size, rank, use_slurm):
             init_distributed_environment,
             initialize_model_parallel,
         )
-        from vllm.utils import get_open_port
+
+        try:
+            from vllm.utils import get_open_port
+        except ImportError:
+            # vllm 0.14.0
+            from vllm.utils.network_utils import get_open_port
 
         vllm_mods = {
             "tensor_model_parallel_all_reduce": tensor_model_parallel_all_reduce,

--- a/collector/vllm/collect_moe.py
+++ b/collector/vllm/collect_moe.py
@@ -5,7 +5,6 @@ import os
 
 import torch
 import torch.nn.functional as F
-from common_test_cases import get_common_moe_test_cases
 from vllm.model_executor.layers.fused_moe import fused_experts
 from vllm.model_executor.layers.fused_moe.config import fp8_w8a8_moe_quant_config
 from vllm.model_executor.layers.fused_moe.layer import determine_expert_map
@@ -23,11 +22,12 @@ except Exception:
     except Exception:
         per_block_cast_to_fp8 = None  # type: ignore[assignment]
 
-from helper import balanced_logits, benchmark_with_power, get_sm_version, log_perf, power_law_logits_v3
+from collector.common_test_cases import get_common_moe_test_cases
+from collector.helper import balanced_logits, benchmark_with_power, get_sm_version, log_perf, power_law_logits_v3
 
 aic_debug = int(os.getenv("aic_moe_debug", "0"))  # noqa: SIM112
 
-compatible_version = ["0.11.0", "0.12.0"]
+compatible_version = ["0.11.0", "0.12.0", "0.14.0"]
 
 
 def get_moe_test_cases():
@@ -294,7 +294,7 @@ if __name__ == "__main__":
     test_cases = get_moe_test_cases()
     print(f"Total test cases: {len(test_cases)}")
 
-    for test_case in test_cases:
+    for test_case in test_cases[:4]:
         print(f"Running test case: {test_case}")
         try:
             run_moe_torch(*test_case)

--- a/src/aiconfigurator/systems/data/h100_sxm/vllm/0.14.0/context_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/vllm/0.14.0/context_attention_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b796aa49ebf8f765a7bb58a604c5e28ec357cef43059cc91763068022efa67c0
+size 1323404

--- a/src/aiconfigurator/systems/data/h100_sxm/vllm/0.14.0/context_mla_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/vllm/0.14.0/context_mla_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a30a72497930c8348ceecb4836e18780a923d84321b2f6e92b89fa23ac5a4b8b
+size 251237

--- a/src/aiconfigurator/systems/data/h100_sxm/vllm/0.14.0/custom_allreduce_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/vllm/0.14.0/custom_allreduce_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:abb8e9761b6255e4178bbe411c1ea720f285ab0aed4288c0336b7997b8609763
+size 15440

--- a/src/aiconfigurator/systems/data/h100_sxm/vllm/0.14.0/gemm_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/vllm/0.14.0/gemm_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c8bdef980f48a6758d9c0052b7a9d5f153c60bb5aabd3a56046379de215756fd
+size 2415973

--- a/src/aiconfigurator/systems/data/h100_sxm/vllm/0.14.0/generation_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/vllm/0.14.0/generation_attention_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc0a7be3fb4938b732a4f1c1c101015a4ef3ee53d62629e463d78fe38bbe37f5
+size 1356041

--- a/src/aiconfigurator/systems/data/h100_sxm/vllm/0.14.0/generation_mla_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/vllm/0.14.0/generation_mla_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:82f5bdcd0bf7d9343e51b979b30c779aa79947357c42f681e69d381d57c0709b
+size 330240

--- a/src/aiconfigurator/systems/data/h100_sxm/vllm/0.14.0/moe_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/vllm/0.14.0/moe_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67558488cd1f3f67505c8bfbae371bb0612f5bd58b186c09fe131e76df83aeee
+size 1606499


### PR DESCRIPTION
#### Overview:

Fixes for the vllm collector to work with vllm 0.14.0. Also collect h100_sxm data.

## Sanity check:
gemm
<img width="985" height="488" alt="Screenshot 2026-01-29 at 1 48 05 PM" src="https://github.com/user-attachments/assets/ee8a9db4-3895-430b-a0ed-08b49fe7385f" />
context_attention
<img width="982" height="398" alt="Screenshot 2026-01-29 at 1 48 21 PM" src="https://github.com/user-attachments/assets/c32ff5e5-f438-4508-b6d6-146c8f0f9699" />
context_attention with prefix
<img width="984" height="400" alt="Screenshot 2026-01-29 at 1 48 30 PM" src="https://github.com/user-attachments/assets/16aa2d41-36f6-42df-9796-f1c84050a42d" />
generation attention
<img width="982" height="488" alt="Screenshot 2026-01-29 at 1 48 41 PM" src="https://github.com/user-attachments/assets/a12c75fb-fad3-4e74-acb1-fd8d91e79f24" />
visualize_generation_attention_b
<img width="823" height="819" alt="Screenshot 2026-01-29 at 1 48 59 PM" src="https://github.com/user-attachments/assets/118c3bca-fc70-4758-a25c-6d97f652501a" />
visualize_context_mla_with_prefix
<img width="1090" height="433" alt="Screenshot 2026-01-29 at 1 49 13 PM" src="https://github.com/user-attachments/assets/65eaa26f-74b1-49ec-b2ed-9984c88a0be7" />
visualize_generation_mla
<img width="1092" height="435" alt="Screenshot 2026-01-29 at 1 49 22 PM" src="https://github.com/user-attachments/assets/4f2f75bc-2cdf-4ec4-9b5d-dd989c3c40a5" />
visualize_generation_mla_b
<img width="843" height="830" alt="Screenshot 2026-01-29 at 1 49 35 PM" src="https://github.com/user-attachments/assets/1a240ed2-d653-485e-8d0f-6bee98d38f0d" />
visualize_moe
<img width="927" height="740" alt="Screenshot 2026-01-29 at 2 05 30 PM" src="https://github.com/user-attachments/assets/6dfdc6ab-9bce-44d1-b130-340d15d31534" />
visualize_allreduce
<img width="1092" height="218" alt="Screenshot 2026-01-29 at 2 14 55 PM" src="https://github.com/user-attachments/assets/bcc280a0-23c7-4815-9421-4127bf225a8f" />

