### PR TITLE
fix: ensure quantization block sizes can be divided by moe intermediate size per GPU

### DIFF
--- a/src/aiconfigurator/sdk/inference_session.py
+++ b/src/aiconfigurator/sdk/inference_session.py
@@ -518,10 +518,10 @@ class DisaggInferenceSession:
                         else:  # larger b will always OOM
                             break
                 except Exception as e:
-                    logger.exception(
+                    logger.warning(
                         f"Error getting candidate workers with parallel config: "
                         f"tp={tp_size}, pp={pp_size}, dp={dp_size}, moe_tp={moe_tp_size}, "
-                        f"moe_ep={moe_ep_size}; skipping this combination"
+                        f"moe_ep={moe_ep_size}; skipping this combination. Error: {e}"
                     )
                     exceptions.append(e)
                     continue

--- a/src/aiconfigurator/sdk/utils.py
+++ b/src/aiconfigurator/sdk/utils.py
@@ -4,9 +4,11 @@
 import importlib.resources as pkg_resources
 import json
 import logging
+import os
 import re
 import tempfile
 import urllib.request
+from functools import cache
 from pathlib import Path
 
 from aiconfigurator.sdk import common
@@ -438,7 +440,8 @@ def _load_local_config(path: str) -> dict:
     return _load_json_with_infinity(config_path)
 
 
-def get_model_config_from_model_path(model_path: str) -> list:
+@cache
+def _load_model_config_from_model_path(model_path: str) -> dict:
     """
     Get model configuration from model path.
 
@@ -450,24 +453,34 @@ def get_model_config_from_model_path(model_path: str) -> list:
         model_path: HuggingFace model path or local directory path
 
     Returns:
-        list: Model configuration parameters
-              [architecture, layers, n, n_kv, d, hidden_size, inter_size, vocab, context,
-               topk, num_experts, moe_inter_size, extra_params]
+        dict: Raw model configuration dictionary
 
     Raises:
         ValueError: If the model config cannot be found
         HuggingFaceDownloadError: If fetching from HuggingFace fails
     """
-    import os
-
     # Check if it's a local path
     if os.path.isdir(model_path):
-        config = _load_local_config(model_path)
-        return _parse_hf_config_json(config)
+        return _load_local_config(model_path)
 
     # Otherwise treat as HuggingFace path
     if model_path in DefaultHFModels:
         config = _load_pre_downloaded_hf_config(model_path)
     else:
         config = _download_hf_config(model_path)
-    return _parse_hf_config_json(config)
+    return config
+
+
+def get_model_config_from_model_path(model_path: str) -> list:
+    """
+    Get model configuration from model path and parse it into a list of model configuration parameters
+
+    Args:
+        model_path: HuggingFace model path or local directory path
+
+    Returns:
+        list: Model configuration parameters
+              [architecture, layers, n, n_kv, d, hidden_size, inter_size, vocab, context,
+               topk, num_experts, moe_inter_size, extra_params]
+    """
+    return _parse_hf_config_json(_load_model_config_from_model_path(model_path))

--- a/tests/unit/sdk/models/test_model_config.py
+++ b/tests/unit/sdk/models/test_model_config.py
@@ -7,10 +7,12 @@ Unit tests for model configuration functionality.
 Tests model validation, default models, and model-specific configurations.
 """
 
+from unittest.mock import patch
+
 import pytest
 
-from aiconfigurator.sdk import common
-from aiconfigurator.sdk.models import check_is_moe, get_model_family
+from aiconfigurator.sdk import common, config
+from aiconfigurator.sdk.models import check_is_moe, get_model, get_model_family
 from aiconfigurator.sdk.utils import get_model_config_from_model_path
 
 pytestmark = pytest.mark.unit
@@ -178,3 +180,102 @@ class TestQuantizationModes:
 
         assert "float16" in mode_names
         assert "fp8" in mode_names
+
+
+class TestMOEModelFP8BlockQuantizationValidation:
+    """Test MOEModel._validate_fp8_block_quantized_moe_config() method."""
+
+    @pytest.mark.parametrize(
+        "moe_quant_mode,moe_tp_size,quantization_config,should_raise,test_id",
+        [
+            # Valid fp8_block config: 1536/4 = 384, 384 % 128 = 0
+            (
+                common.MoEQuantMode.fp8_block,
+                4,
+                {"weight_block_size": [128, 128]},
+                False,
+                "valid_fp8_block",
+            ),
+            # Invalid fp8_block config: 1536/8 = 192, 192 % 128 = 64
+            (
+                common.MoEQuantMode.fp8_block,
+                8,
+                {"weight_block_size": [128, 128]},
+                True,
+                "invalid_fp8_block",
+            ),
+            # Skip validation for float16 (even with invalid moe_tp)
+            (
+                common.MoEQuantMode.float16,
+                8,
+                {"weight_block_size": [128, 128]},
+                False,
+                "skip_validation_float16",
+            ),
+            # Skip validation for fp8 non-block mode
+            (
+                common.MoEQuantMode.fp8,
+                8,
+                {"weight_block_size": [128, 128]},
+                False,
+                "skip_validation_fp8_no_block",
+            ),
+            # Default block size when not in config: 1536/4 = 384, 384 % 128 = 0
+            (
+                common.MoEQuantMode.fp8_block,
+                4,
+                None,
+                False,
+                "default_block_size",
+            ),
+        ],
+    )
+    @patch("aiconfigurator.sdk.models._get_model_info")
+    @patch("aiconfigurator.sdk.utils._load_model_config_from_model_path")
+    def test_fp8_block_quantization_validation(
+        self,
+        mock_load_config,
+        mock_get_info,
+        moe_quant_mode,
+        moe_tp_size,
+        quantization_config,
+        should_raise,
+        test_id,
+    ):
+        """Parametrized test for fp8_block quantization validation."""
+        # Setup mocks
+        mock_get_info.return_value = (
+            "MixtralForCausalLM",  # architecture
+            32,  # layers
+            32,  # n
+            8,  # n_kv
+            128,  # d
+            4096,  # hidden
+            14336,  # inter
+            32000,  # vocab
+            32768,  # context
+            2,  # topk
+            8,  # num_experts
+            1536,  # moe_inter_size
+            None,  # extra_params
+        )
+        config_dict = {"moe_intermediate_size": 1536}
+        if quantization_config is not None:
+            config_dict["quantization_config"] = quantization_config
+        mock_load_config.return_value = config_dict
+
+        # Create model config (tp_size * attention_dp_size must equal moe_tp_size * moe_ep_size)
+        model_config = config.ModelConfig()
+        model_config.moe_quant_mode = moe_quant_mode
+        model_config.tp_size = moe_tp_size
+        model_config.moe_tp_size = moe_tp_size
+        model_config.moe_ep_size = 1
+        model_config.attention_dp_size = 1
+
+        # Test validation
+        if should_raise:
+            with pytest.raises(ValueError, match="Invalid quantized MoE configuration"):
+                get_model("Qwen/Qwen3-235B-A22B", model_config, "trtllm")
+        else:
+            model = get_model("Qwen/Qwen3-235B-A22B", model_config, "trtllm")
+            assert model is not None


### PR DESCRIPTION
#### Overview:

Avoid the error with AIC configs:
`ValueError: For quantized MoE models, please make sure (moe_intermediate_size=1536 / moe_tp_size=8) % weight_block_size_n=128 == 0 where moe_tp_size is equal to tp_size (8) divided by ep_size (1). You can fix this by setting arguments --tp and --ep correctly.`
#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
