### PR TITLE
feat: add configurable top_n parameter for result limiting

### DIFF
--- a/docs/cli_user_guide.md
+++ b/docs/cli_user_guide.md
@@ -261,7 +261,7 @@ results/Qwen_Qwen3-32B_h200_sxm_trtllm_isl4000_osl1000_ttft1000_tpot20_904495
 │   ...
 └── pareto_frontier.png
 ```
-By default, we output top3 configs we have found. You can get the configs and scripts to deploy under each experiment's folder. `agg_config.yaml` and `node_0_run.sh` are the files you need to deploy with Dynamo. If you want to deploy using k8s, you can leverage `k8s_deploy.yaml`. Refer to [deployment guide](dynamo_deployment_guide.md) for info about deployment.
+By default, we output top 5 configs we have found. You can get the configs and scripts to deploy under each experiment's folder. `agg_config.yaml` and `node_0_run.sh` are the files you need to deploy with Dynamo. If you want to deploy using k8s, you can leverage `k8s_deploy.yaml`. Refer to [deployment guide](dynamo_deployment_guide.md) for info about deployment.
 
 `--save_dir DIR` allows you to specify more information such as generating the config for a different version of the backend, say estimating the performance using trtllm 1.0.0rc3 but generate config for 1.0.0rc6. This is allowed and feasible. By passing `--generated_config_version 1.0.0rc6` can give you the right result.
 

--- a/src/aiconfigurator/cli/__init__.py
+++ b/src/aiconfigurator/cli/__init__.py
@@ -7,7 +7,7 @@ CLI module for aiconfigurator.
 Provides both command-line interface and programmatic Python API.
 
 Python API usage:
-    from aiconfigurator.cli import cli_default, cli_exp, cli_generate
+    from aiconfigurator.cli import cli_default, cli_exp, cli_generate, cli_support
 
     # cli_default: Run agg vs disagg comparison
     result = cli_default(
@@ -28,6 +28,12 @@ Python API usage:
         system="h200_sxm",
         backend="trtllm",
         output_dir="./output",
+    )
+
+    # cli_support: Check model/hardware support
+    agg_ok, disagg_ok = cli_support(
+        model_path="Qwen/Qwen3-32B",
+        system="h200_sxm",
     )
 """
 

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -98,9 +98,12 @@ class CLIResult:
 def _execute_and_wrap_result(
     task_configs: dict[str, TaskConfig],
     mode: str,
+    top_n: int = 5,
 ) -> CLIResult:
     """Execute task configs using main.py's function and wrap result in CLIResult."""
-    chosen_exp, best_configs, pareto_fronts, best_throughputs = _execute_task_configs_internal(task_configs, mode)
+    chosen_exp, best_configs, pareto_fronts, best_throughputs = _execute_task_configs_internal(
+        task_configs, mode, top_n=top_n
+    )
 
     return CLIResult(
         chosen_exp=chosen_exp,
@@ -127,6 +130,7 @@ def cli_default(
     tpot: float = 30.0,
     request_latency: float | None = None,
     prefix: int = 0,
+    top_n: int = 5,
     save_dir: str | None = None,
 ) -> CLIResult:
     """
@@ -151,6 +155,7 @@ def cli_default(
         request_latency: Optional end-to-end request latency target (ms).
             Enables request-latency optimization mode.
         prefix: Prefix cache length. Default is 0.
+        top_n: Number of top configurations to return for each mode (agg/disagg). Default is 5.
         save_dir: Directory to save results. If None, results are not saved to disk.
 
     Returns:
@@ -184,7 +189,7 @@ def cli_default(
         prefix=prefix,
     )
 
-    result = _execute_and_wrap_result(task_configs, mode="default")
+    result = _execute_and_wrap_result(task_configs, mode="default", top_n=top_n)
 
     if save_dir:
         # Create a mock args object for save_results compatibility
@@ -203,6 +208,7 @@ def cli_default(
         mock_args.ttft = ttft
         mock_args.tpot = tpot
         mock_args.request_latency = request_latency
+        mock_args.top_n = top_n
         mock_args.generated_config_version = None
 
         save_results(
@@ -221,6 +227,7 @@ def cli_exp(
     *,
     yaml_path: str | None = None,
     config: dict[str, dict] | None = None,
+    top_n: int = 5,
     save_dir: str | None = None,
 ) -> CLIResult:
     """
@@ -235,6 +242,7 @@ def cli_exp(
         yaml_path: Path to a YAML file containing experiment definitions.
         config: Dict containing experiment definitions (alternative to yaml_path).
             Keys are experiment names, values are experiment configs.
+        top_n: Number of top configurations to return for each experiment. Default is 5.
         save_dir: Directory to save results. If None, results are not saved to disk.
 
     Returns:
@@ -300,7 +308,7 @@ def cli_exp(
     if not task_configs:
         raise ValueError("No valid experiments found in configuration.")
 
-    result = _execute_and_wrap_result(task_configs, mode="exp")
+    result = _execute_and_wrap_result(task_configs, mode="exp", top_n=top_n)
 
     if save_dir:
         # Create a mock args object for save_results compatibility
@@ -311,6 +319,7 @@ def cli_exp(
         mock_args.save_dir = save_dir
         mock_args.mode = "exp"
         mock_args.yaml_path = yaml_path
+        mock_args.top_n = top_n
         mock_args.generated_config_version = None
 
         save_results(

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -36,6 +36,13 @@ def _build_common_cli_parser() -> argparse.ArgumentParser:
     common_parser = argparse.ArgumentParser(add_help=False)
     common_parser.add_argument("--save_dir", type=str, default=None, help="Directory to save the results.")
     common_parser.add_argument("--debug", action="store_true", help="Enable debug mode.")
+    common_parser.add_argument(
+        "--top_n",
+        type=int,
+        default=5,
+        help="Number of top configurations to output for each experiment (in exp mode) "
+        "or for each mode (agg/disagg) in default mode. Default: 5.",
+    )
     add_generator_override_arguments(common_parser)
     return common_parser
 
@@ -518,6 +525,7 @@ def build_experiment_task_configs(
 def _execute_task_configs(
     task_configs: dict[str, TaskConfig],
     mode: str,
+    top_n: int = 5,
 ) -> tuple[str, dict[str, pd.DataFrame], dict[str, pd.DataFrame], dict[str, float]]:
     """Execute the task configs and return the chosen experiment, best configs, results, and best
     throughputs."""
@@ -584,7 +592,7 @@ def _execute_task_configs(
                 total_gpus=total_gpus,
                 pareto_df=pareto_df,
                 target_request_latency=target_request_latency,
-                top_n=5,
+                top_n=top_n,
                 group_by=group_by_key,
             )
         else:
@@ -592,7 +600,7 @@ def _execute_task_configs(
                 total_gpus=total_gpus,
                 pareto_df=pareto_df,
                 target_tpot=target_tpot,
-                top_n=5,
+                top_n=top_n,
                 group_by=group_by_key,
             )
         best_configs[name] = best_config_df
@@ -613,6 +621,7 @@ def _execute_task_configs(
         task_configs=task_configs,  # for info in summary
         mode=mode,
         pareto_x_axis=pareto_x_axis,
+        top_n=top_n,
     )
 
     end_time = time.time()
@@ -740,6 +749,7 @@ def main(args):
     )
 
     logger.info(f"Loading Dynamo AIConfigurator version: {__version__}")
+    logger.info(f"Number of top configurations to output: {args.top_n} (change with --top_n)")
 
     # Handle generate mode separately (no sweeping)
     if args.mode == "generate":
@@ -782,6 +792,7 @@ def main(args):
     chosen_exp, best_configs, pareto_fronts, best_throughputs = _execute_task_configs(
         task_configs,
         args.mode,
+        top_n=args.top_n,
     )
 
     if args.save_dir:

--- a/src/aiconfigurator/cli/report_and_save.py
+++ b/src/aiconfigurator/cli/report_and_save.py
@@ -244,6 +244,7 @@ def log_final_summary(
     task_configs: dict[str, TaskConfig],
     mode: str,
     pareto_x_axis: dict[str, str] | None = None,
+    top_n: int = 5,
 ):
     """Log final summary of configuration results"""
 
@@ -356,7 +357,7 @@ def log_final_summary(
             config_df,
             total_gpus,
             exp_task_config.runtime_config.tpot,
-            5,
+            top_n,
             exp_task_config.is_moe,
             exp_task_config.runtime_config.request_latency,
             show_power,

--- a/tests/unit/cli/test_cli_workflow.py
+++ b/tests/unit/cli/test_cli_workflow.py
@@ -124,7 +124,7 @@ class TestCLIIntegration:
             cli_main(args)
 
         mock_builder.assert_called_once()
-        mock_execute.assert_called_once_with({"agg": mock_task_config}, mode)
+        mock_execute.assert_called_once_with({"agg": mock_task_config}, mode, top_n=5)
 
     @pytest.mark.parametrize(
         "builder_patch",


### PR DESCRIPTION
#### Overview:

2nd PR out of the 3 to support the any backend feature.
Support the `--top_n` command flag.

#### Details:

Add --top_n CLI argument and top_n parameter to Python API functions (cli_default, cli_exp) to make the number of returned top configurations configurable. Default remains 5.

Also update module docstring to include cli_support usage example.

Changes:
- Add --top_n argument to common CLI parser
- Add top_n parameter to cli_default() and cli_exp() API functions
- Thread top_n through _execute_task_configs() and log_final_summary()
- Update test expectations to match new function signatures
- Add cli_support usage example to module docstring

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
