### PR TITLE
fix: correctly obtaining inter_size for gpt-oss and use w4a16_mxfp4 as default moe quant mode

### DIFF
--- a/src/aiconfigurator/sdk/task.py
+++ b/src/aiconfigurator/sdk/task.py
@@ -596,7 +596,7 @@ class TaskConfigFactory:
             gemm_quant_mode = fp8_gemm_quant
             moe_quant_mode = _pick([fp8_moe_quant, "fp8", "float16"], supported_moe, fp8_moe_quant)
 
-        if model_path in ["GPT_OSS_120B", "GPT_OSS_20B"]:
+        if model_path in ["openai/gpt-oss-120b", "openai/gpt-oss-20b"]:
             moe_quant_mode = "w4a16_mxfp4"
 
         if use_specific_quant_mode is not None:

--- a/src/aiconfigurator/sdk/utils.py
+++ b/src/aiconfigurator/sdk/utils.py
@@ -372,7 +372,7 @@ def _parse_hf_config_json(config: dict) -> list:
     # MoE parameters
     topk = config.get("num_experts_per_tok", 0)
     num_experts = config.get("num_local_experts") or config.get("n_routed_experts") or config.get("num_experts", 0)
-    moe_inter_size = config.get("moe_intermediate_size", 0)
+    moe_inter_size = config.get("moe_intermediate_size", 0) or config.get("intermediate_size", 0)
 
     # Handle NemotronH-specific configuration (only fields unique to NemotronH)
     extra_params = None


### PR DESCRIPTION
#### Overview:

1. Getting the correct inter_size for openai/gpt-oss models
2. Use HF model name when set default moe quant mode for openai/gpt-oss models
