### PR TITLE
chore: Add data from auto-collector pipeline 43056436

### DIFF
--- a/src/aiconfigurator/systems/data/a100_sxm/sglang/0.5.8/gemm_perf.txt
+++ b/src/aiconfigurator/systems/data/a100_sxm/sglang/0.5.8/gemm_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9cbbdf29e17da5befe16c399dd57fa53eca9b791fc303dbae236f645c0505be9
+size 817544

--- a/src/aiconfigurator/systems/data/a100_sxm/sglang/0.5.8/mla_bmm_perf.txt
+++ b/src/aiconfigurator/systems/data/a100_sxm/sglang/0.5.8/mla_bmm_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec67c0ee1b6e48094d5279f943fee4bba116c9010a59ef743f0fe86af49077c5
+size 38488

--- a/src/aiconfigurator/systems/data/a100_sxm/sglang/0.5.8/moe_perf.txt
+++ b/src/aiconfigurator/systems/data/a100_sxm/sglang/0.5.8/moe_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f594a3a27c83c525ffc8700bc52c4c264b7e6247393d65b9cbb69dd8221e85cc
+size 323057

--- a/src/aiconfigurator/systems/data/gb200_sxm/nccl/2.23/nccl_perf.txt
+++ b/src/aiconfigurator/systems/data/gb200_sxm/nccl/2.23/nccl_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:113a3be6bd5b1dd9d4a5fffb6ba9d667748777b2607802944480dd94fb531ad4
-size 58475
+oid sha256:51b685b7684aa218fc66e751aee6713ea5a1fa91537bd2b1c734fa21c884976a
+size 7462


### PR DESCRIPTION
# Sanity Check Charts and Error Summary
## Summary and charts for a100_sxm sglang:0.5.8
### Error summary
```
{
    "backend": "sglang",
    "version": "0.5.8",
    "timestamp": "2026-02-02T01:22:36.252778",
    "total_errors": 20233,
    "errors_by_module": {
        "sglang.gemm": 9240,
        "sglang.mla_bmm_gen_pre": 23,
        "sglang.mla_bmm_gen_post": 224,
        "sglang.attention_context": 5627,
        "sglang.attention_generation": 5093,
        "sglang.wideep_mla_context": 8,
        "sglang.wideep_mla_generation": 8,
        "sglang.wideep_mlp_context": 1,
        "sglang.wideep_mlp_generation": 1,
        "sglang.wideep_moe": 8
    },
    "errors_by_type": {
        "NotImplementedError": 9240,
        "CompilationError": 247,
        "AttributeError": 10720,
        "RuntimeError": 24,
        "OSError": 2
    }
}
```

### Sanity check plots
#### Sanity check plot for a100_sxm, sglang:0.5.8, gemm
<img alt="Sanity check plot for a100_sxm, sglang:0.5.8, gemm" src="https://d30yme62x0z0c8.cloudfront.net/pipeline_43056436/charts/gemm_a100_sxm_sglang_0.5.8.png" />

Error creating chart for moe: ```values is None or len(values) < 2```
## Summary and charts for gb200_sxm trtllm:1.3.0rc1
### Sanity check plots
#### Sanity check plot for gb200_sxm, trtllm:1.3.0rc1, nccl_all_gather
<img alt="Sanity check plot for gb200_sxm, trtllm:1.3.0rc1, nccl_all_gather" src="https://d30yme62x0z0c8.cloudfront.net/pipeline_43056436/charts/nccl_all_gather_gb200_sxm_trtllm_1.3.0rc1.png" />

Error creating chart for nccl_all_reduce: ```max() iterable argument is empty```
#### Sanity check plot for gb200_sxm, trtllm:1.3.0rc1, nccl_alltoall
<img alt="Sanity check plot for gb200_sxm, trtllm:1.3.0rc1, nccl_alltoall" src="https://d30yme62x0z0c8.cloudfront.net/pipeline_43056436/charts/nccl_alltoall_gb200_sxm_trtllm_1.3.0rc1.png" />

#### Sanity check plot for gb200_sxm, trtllm:1.3.0rc1, nccl_reduce_scatter
<img alt="Sanity check plot for gb200_sxm, trtllm:1.3.0rc1, nccl_reduce_scatter" src="https://d30yme62x0z0c8.cloudfront.net/pipeline_43056436/charts/nccl_reduce_scatter_gb200_sxm_trtllm_1.3.0rc1.png" />

