### PR TITLE
feat: update SGLang performance collectors for v0.5.8

### DIFF
--- a/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.8/context_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.8/context_attention_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1bbeb4f97c5f5ba473b2e9829b5805a56932e6a7a5ed00e4321848187a7ac4bd
-size 2032213

--- a/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.8/context_mla_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.8/context_mla_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e56f5445802caff9b6dd535dde48387082641b1bade0ab9341f694b293e082b6
-size 339540

--- a/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.8/gemm_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.8/gemm_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:218019de754bcb4f045f945cca4eb07ac8bac82c218c4836b635e175b51a37db
-size 2291038

--- a/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.8/generation_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.8/generation_attention_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e7b44e1c03991660e1672a631a10bc93830d23658f37a0bf88f1dc04d33e326a
-size 1282012

--- a/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.8/generation_mla_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.8/generation_mla_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:515b29e3ba9d69d6fdbf319913d04b031fbadb6370f0e066b477f2a438ff82f9
-size 530281

--- a/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.8/mla_bmm_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.8/mla_bmm_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0e383102a507c108ca8078f5fdd27c162db9e1d474bd6f70f4b39abb841184de
-size 75235

--- a/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.8/moe_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.8/moe_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f36c708ae4212da2b649c381cf043be619119517c344f4fc195f7766584dfcfa
-size 652722


### PR DESCRIPTION
#### Overview:

The PR update SGLang's peformance data collectors to better supprot SGLang 0.5.8

#### Details:

- Add is_local_attention_model attribute to MocModelConfig, which is needed by sgl 0.5.8
- Move the utility _get_deepseek_model_path() to helper.py and apply it in all wideep collectors by default
- Tested on Hopepr
