### PR TITLE
fix(support_matrix): enable wideep for support matrix test

### DIFF
--- a/tools/support_matrix/support_matrix.py
+++ b/tools/support_matrix/support_matrix.py
@@ -28,8 +28,8 @@ TOTAL_GPUS = 128
 ISL = 4000
 OSL = 500
 PREFIX = 500
-TTFT = 2000.0
-TPOT = 50.0
+TTFT = 1e4
+TPOT = 1e2
 
 
 class SupportMatrix:

--- a/tools/support_matrix/support_matrix.py
+++ b/tools/support_matrix/support_matrix.py
@@ -122,6 +122,7 @@ class SupportMatrix:
                     "prefix": PREFIX,
                     "ttft": TTFT,
                     "tpot": TPOT,
+                    "enable_wideep": True,
                 }
 
                 # For disagg mode, set decode_system_name


### PR DESCRIPTION
Fix https://github.com/ai-dynamo/aiconfigurator/pull/298#issuecomment-3844456205
When `wide_ep` is not enabled, Qwen/Qwen3-Coder-480B-A35B-Instruct fail on SGLANG x h100

TODO
- [ ] Check no originally passed test cases are failing due to this change. https://github.com/ai-dynamo/aiconfigurator/actions/runs/21654463375