### PR TITLE
feat: add support for `--backend any` (homogenous)

### DIFF
--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -144,7 +144,8 @@ def cli_default(
         total_gpus: Total number of GPUs for deployment.
         system: System name (GPU type), e.g., 'h200_sxm', 'b200_sxm'.
         decode_system: System name for disagg decode workers. Defaults to `system`.
-        backend: Backend name ('trtllm', 'sglang', 'vllm'). Default is 'trtllm'.
+        backend: Backend name ('trtllm', 'sglang', 'vllm', 'any'). Default is 'trtllm'.
+            Use 'any' to sweep across all three backends and compare results.
         backend_version: Backend database version. Default is latest.
         database_mode: Database mode for performance estimation
             ('SILICON', 'HYBRID', 'EMPIRICAL', 'SOL'). Default is 'SILICON'.
@@ -171,6 +172,18 @@ def cli_default(
         ... )
         >>> print(result.chosen_exp)  # 'agg' or 'disagg'
         >>> print(result.best_throughputs)
+
+        >>> # Compare all backends
+        >>> result = cli_default(
+        ...     model_path="Qwen/Qwen3-32B",
+        ...     total_gpus=8,
+        ...     system="h200_sxm",
+        ...     backend="any",
+        ...     ttft=2000,
+        ...     tpot=30,
+        ... )
+        >>> print(result.chosen_exp)  # e.g., 'agg_trtllm' or 'disagg_vllm'
+        >>> print(result.best_throughputs)  # Shows all 6 backend/mode combinations
     """
     # Reuse build_default_task_configs from main.py
     task_configs = build_default_task_configs(

--- a/src/aiconfigurator/cli/report_and_save.py
+++ b/src/aiconfigurator/cli/report_and_save.py
@@ -103,6 +103,7 @@ def _plot_worker_setup_table(
 
     # Check if it is disagg config by checking for prefill/decode specific columns
     is_disagg = "(p)tp" in top_configs.columns
+    has_backend = "backend" in top_configs.columns
 
     if is_disagg:
         field_names = [
@@ -124,6 +125,8 @@ def _plot_worker_setup_table(
             "(d)parallel",
             "(d)bs",
         ]
+        if has_backend:
+            field_names.insert(1, "backend")  # Add after Rank
         if show_power:
             field_names.append("power_w")
         table.field_names = field_names
@@ -156,27 +159,33 @@ def _plot_worker_setup_table(
                 )
             row_data = [
                 i + 1,
-                f"\033[1m{row['tokens/s/gpu_cluster']:.2f}\033[0m",
-                f"{row['tokens/s/user']:.2f}",
-                f"{row['ttft']:.2f}",
-                f"{row['request_latency']:.2f}",
-                f"{row['concurrency'] * row['replicas']} (={row['concurrency']}x{row['replicas']})",
-                f"{total_gpus} ({row['total_gpus_used']}={row['replicas']}x{row['num_total_gpus']})",
-                row["replicas"],
-                (
-                    f"{row['num_total_gpus']} "
-                    f"(={row['(p)workers']}x{row['(p)pp'] * row['(p)tp'] * row['(p)dp']}"
-                    f"+{row['(d)workers']}x{row['(d)pp'] * row['(d)tp'] * row['(d)dp']})"
-                ),
-                row["(p)workers"],
-                p_gpus_worker,
-                p_parallel,
-                row["(p)bs"],
-                row["(d)workers"],
-                d_gpus_worker,
-                d_parallel,
-                row["(d)bs"],
             ]
+            if has_backend:
+                row_data.append(row["backend"])
+            row_data.extend(
+                [
+                    f"\033[1m{row['tokens/s/gpu_cluster']:.2f}\033[0m",
+                    f"{row['tokens/s/user']:.2f}",
+                    f"{row['ttft']:.2f}",
+                    f"{row['request_latency']:.2f}",
+                    f"{row['concurrency'] * row['replicas']} (={row['concurrency']}x{row['replicas']})",
+                    f"{total_gpus} ({row['total_gpus_used']}={row['replicas']}x{row['num_total_gpus']})",
+                    row["replicas"],
+                    (
+                        f"{row['num_total_gpus']} "
+                        f"(={row['(p)workers']}x{row['(p)pp'] * row['(p)tp'] * row['(p)dp']}"
+                        f"+{row['(d)workers']}x{row['(d)pp'] * row['(d)tp'] * row['(d)dp']})"
+                    ),
+                    row["(p)workers"],
+                    p_gpus_worker,
+                    p_parallel,
+                    row["(p)bs"],
+                    row["(d)workers"],
+                    d_gpus_worker,
+                    d_parallel,
+                    row["(d)bs"],
+                ]
+            )
             if show_power:
                 row_data.append(f"{row['power_w']:.1f}W")
             table.add_row(row_data)
@@ -195,6 +204,8 @@ def _plot_worker_setup_table(
             "parallel",
             "bs",
         ]
+        if has_backend:
+            field_names.insert(1, "backend")  # Add after Rank
         if show_power:
             field_names.append("power_w")
         table.field_names = field_names
@@ -216,18 +227,24 @@ def _plot_worker_setup_table(
                 )
             row_data = [
                 i + 1,
-                f"\033[1m{row['tokens/s/gpu_cluster']:.2f}\033[0m",
-                f"{row['tokens/s/user']:.2f}",
-                f"{row['ttft']:.2f}",
-                f"{row['request_latency']:.2f}",
-                f"{row['concurrency'] * row['replicas']} (={row['concurrency']}x{row['replicas']})",
-                f"{total_gpus} ({row['total_gpus_used']}={row['replicas']}x{row['num_total_gpus']})",
-                row["replicas"],
-                row["num_total_gpus"],
-                gpus_worker,
-                parallel,
-                row["bs"],
             ]
+            if has_backend:
+                row_data.append(row["backend"])
+            row_data.extend(
+                [
+                    f"\033[1m{row['tokens/s/gpu_cluster']:.2f}\033[0m",
+                    f"{row['tokens/s/user']:.2f}",
+                    f"{row['ttft']:.2f}",
+                    f"{row['request_latency']:.2f}",
+                    f"{row['concurrency'] * row['replicas']} (={row['concurrency']}x{row['replicas']})",
+                    f"{total_gpus} ({row['total_gpus_used']}={row['replicas']}x{row['num_total_gpus']})",
+                    row["replicas"],
+                    row["num_total_gpus"],
+                    gpus_worker,
+                    parallel,
+                    row["bs"],
+                ]
+            )
             if show_power:
                 row_data.append(f"{row['power_w']:.1f}W")
             table.add_row(row_data)
@@ -256,10 +273,24 @@ def log_final_summary(
 
     summary_box.append("  " + "-" * 76)
     summary_box.append("  Input Configuration & SLA Target:")
+
+    # For multi-backend mode, get task_config using the backend from best_configs
+    chosen_best_config = best_configs.get(chosen_exp)
+    if chosen_best_config is not None and "backend" in chosen_best_config.columns and not chosen_best_config.empty:
+        chosen_backend = chosen_best_config["backend"].iloc[0]
+        task_config_key = f"{chosen_exp}_{chosen_backend}"
+        # Verify the key exists (for multi-backend mode)
+        if task_config_key in task_configs:
+            chosen_task_config = task_configs[task_config_key]
+        else:
+            chosen_task_config = task_configs[chosen_exp]
+    else:
+        chosen_task_config = task_configs[chosen_exp]
+
     summary_box.append(
-        f"    Model: {task_configs[chosen_exp].config.model_path} (is_moe: {task_configs[chosen_exp].config.is_moe})"
+        f"    Model: {chosen_task_config.config.model_path} (is_moe: {chosen_task_config.config.is_moe})"
     )
-    summary_box.append(f"    Total GPUs: {task_configs[chosen_exp].total_gpus}")
+    summary_box.append(f"    Total GPUs: {chosen_task_config.total_gpus}")
     if mode == "default":
         agg_value = best_throughputs.get("agg", 0.0)
         disagg_value = best_throughputs.get("disagg", 0.0)
@@ -288,7 +319,7 @@ def log_final_summary(
     best_config_df = best_configs[chosen_exp]
     best_throughput = best_throughputs[chosen_exp]
 
-    summary_box.append(f"    - Best Throughput: {best_throughput * task_configs[chosen_exp].total_gpus:,.2f} tokens/s")
+    summary_box.append(f"    - Best Throughput: {best_throughput * chosen_task_config.total_gpus:,.2f} tokens/s")
     summary_box.append(f"    - Per-GPU Throughput: {best_throughput:.2f} tokens/s/gpu")
     if not best_config_df.empty:
         best_conf_details = best_config_df.iloc[0]
@@ -320,7 +351,7 @@ def log_final_summary(
                 "label": f"{chosen_exp} best",
             }
         pareto_plot_buf = draw_pareto_to_string(
-            f"{task_configs[chosen_exp].config.model_path} Pareto Frontier",
+            f"{chosen_task_config.config.model_path} Pareto Frontier",
             series_payload,
             highlight=highlight_series,
             x_label=target_x_axis,
@@ -350,8 +381,19 @@ def log_final_summary(
 
     # Plot worker setup tables for all experiments
     for exp_name, config_df in best_configs.items():
-        exp_task_config = task_configs[exp_name].config
-        total_gpus = getattr(task_configs[exp_name], "total_gpus", None) or 0
+        # For multi-backend mode, use the first backend's config for table display
+        # (total_gpus, is_moe, etc. should be the same across backends)
+        if "backend" in config_df.columns and not config_df.empty:
+            first_backend = config_df["backend"].iloc[0]
+            task_config_key = f"{exp_name}_{first_backend}"
+            # Verify the key exists (for multi-backend mode)
+            if task_config_key not in task_configs:
+                task_config_key = exp_name
+        else:
+            task_config_key = exp_name
+
+        exp_task_config = task_configs[task_config_key].config
+        total_gpus = getattr(task_configs[task_config_key], "total_gpus", None) or 0
         table_buf = _plot_worker_setup_table(
             exp_name,
             config_df,
@@ -382,8 +424,17 @@ def save_results(
     first_task = task_configs[first_exp_name]
     first_task_config = first_task.config
 
+    # Check if results contain "backend" column (indicates multi-backend mode)
+    has_backend_column = False
+    for exp_name, config_df in best_configs.items():
+        if not config_df.empty and "backend" in config_df.columns:
+            has_backend_column = True
+            break
+
+    backend_str = "multi_backend" if has_backend_column else first_task.backend_name
+
     result_prefix = (
-        f"{first_task_config.model_path}_{first_task.system_name}_{first_task.backend_name}_"
+        f"{first_task_config.model_path}_{first_task.system_name}_{backend_str}_"
         f"isl{first_task_config.runtime_config.isl}_osl{first_task_config.runtime_config.osl}_"
         f"ttft{int(first_task_config.runtime_config.ttft)}_tpot{int(first_task_config.runtime_config.tpot)}"
     )
@@ -407,7 +458,19 @@ def save_results(
         global_x_axis = "request_latency" if all_request_latency else "tokens/s/user"
         maximize_x = not all_request_latency
         plt.title(f"{first_task_config.model_path} tokens/s/gpu vs {global_x_axis}")
-        colors = [
+
+        # Define markers for backends and colors for serving modes
+        backend_markers = {
+            "trtllm": "o",  # circle
+            "vllm": "s",  # square
+            "sglang": "^",  # triangle
+        }
+        serving_mode_colors = {
+            "agg": "#1f77b4",  # blue
+            "disagg": "#ff7f0e",  # orange
+        }
+        # Fallback colors for non-standard experiment names
+        exp_colors = [
             "blue",
             "red",
             "green",
@@ -420,20 +483,52 @@ def save_results(
             "magenta",
         ]
         color_idx = 0
+
         for exp_name, pareto_df in pareto_fronts.items():
             if pareto_axis.get(exp_name, global_x_axis) != global_x_axis:
                 continue
-            if not pareto_df.empty:
+            if pareto_df.empty:
+                continue
+
+            # Check if this is multi-backend mode (pareto_df has "backend" column)
+            if "backend" in pareto_df.columns:
+                # Plot each backend with different marker, color by serving mode (agg/disagg)
+                # Note: pareto_df is already the combined Pareto frontier, so we just plot points
+                # grouped by backend, without recomputing Pareto per backend
+                color = serving_mode_colors.get(exp_name, exp_colors[color_idx % len(exp_colors)])
+                for backend_name in pareto_df["backend"].unique():
+                    backend_df = pareto_df[pareto_df["backend"] == backend_name].sort_values(by=global_x_axis)
+                    marker = backend_markers.get(backend_name, "o")
+                    label = f"{exp_name} ({backend_name})"
+                    # Plot directly without recomputing Pareto
+                    ax.plot(
+                        backend_df[global_x_axis],
+                        backend_df["tokens/s/gpu"],
+                        color=color,
+                        marker=marker,
+                        label=label,
+                        linestyle="-",
+                        markersize=8,
+                    )
+                color_idx += 1
+            else:
+                # Single backend mode
                 pareto_analysis.draw_pareto(
                     pareto_df,
                     global_x_axis,
                     "tokens/s/gpu",
                     ax,
-                    colors[color_idx % len(colors)],
+                    exp_colors[color_idx % len(exp_colors)],
                     exp_name,
                     maximize_x=maximize_x,
                 )
                 color_idx += 1
+
+        # Add axis labels and legend
+        ax.set_xlabel(global_x_axis)
+        ax.set_ylabel("tokens/s/gpu")
+        ax.legend()
+
         plt.savefig(os.path.join(safe_result_dir, "pareto_frontier.png"))
         plt.close()
 
@@ -452,8 +547,23 @@ def save_results(
                 pareto_df.to_csv(os.path.join(exp_dir, "pareto.csv"), index=False)
 
             # 3. Save the config for this experiment
-            exp_task_config = task_configs[exp_name]
-            effective_generated_version = generated_backend_version or exp_task_config.backend_version
+            # For multi-backend mode, we'll get task_config per row later
+            # For single-backend mode, get it once here
+            is_multi_backend = best_config_df is not None and "backend" in best_config_df.columns
+            if not is_multi_backend:
+                exp_task_config = task_configs[exp_name]
+                effective_generated_version = generated_backend_version or exp_task_config.backend_version
+            else:
+                # For multi-backend, we'll use the first backend's version for warnings
+                # but actual generation will use per-row backend
+                first_backend = best_config_df["backend"].iloc[0]
+                task_config_key = f"{exp_name}_{first_backend}"
+                # Verify the key exists (for multi-backend mode)
+                if task_config_key not in task_configs:
+                    task_config_key = exp_name
+                    is_multi_backend = False  # Treat as single backend
+                exp_task_config = task_configs[task_config_key]
+                effective_generated_version = generated_backend_version or exp_task_config.backend_version
 
             if generated_backend_version:
                 logger.warning(
@@ -487,8 +597,23 @@ def save_results(
             # 4. Save the generated config for this experiment, sub-directory for each best config
             if best_config_df is not None:
                 for i, (idx, result_df) in enumerate(best_config_df.iterrows()):
+                    # For multi-backend mode, get the task_config for this row's backend
+                    if is_multi_backend and "backend" in result_df:
+                        row_backend = result_df["backend"]
+                        row_task_config_key = f"{exp_name}_{row_backend}"
+                        # Verify the key exists (for multi-backend mode)
+                        if row_task_config_key in task_configs:
+                            row_task_config = task_configs[row_task_config_key]
+                            row_backend_version = generated_backend_version or row_task_config.backend_version
+                        else:
+                            row_task_config = exp_task_config
+                            row_backend_version = effective_generated_version
+                    else:
+                        row_task_config = exp_task_config
+                        row_backend_version = effective_generated_version
+
                     cfg = task_config_to_generator_config(
-                        task_config=exp_task_config,
+                        task_config=row_task_config,
                         result_df=result_df,
                         generator_overrides=generator_overrides,
                     )
@@ -501,8 +626,8 @@ def save_results(
                     try:
                         generate_backend_artifacts(
                             params=cfg,
-                            backend=exp_task_config.backend_name,
-                            backend_version=effective_generated_version,
+                            backend=row_task_config.backend_name,
+                            backend_version=row_backend_version,
                             output_dir=top_config_dir,
                         )
                     except Exception as exc:

--- a/src/aiconfigurator/cli/utils.py
+++ b/src/aiconfigurator/cli/utils.py
@@ -1,0 +1,183 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+
+import pandas as pd
+
+from aiconfigurator.sdk.pareto_analysis import (
+    get_best_configs_under_request_latency_constraint,
+    get_best_configs_under_tpot_constraint,
+    get_pareto_front,
+)
+from aiconfigurator.sdk.task import TaskConfig
+
+logger = logging.getLogger(__name__)
+
+
+def process_experiment_result(task_config: TaskConfig, result: dict[str, pd.DataFrame], top_n: int = 5) -> tuple:
+    """
+    Process the result of a single experiment.
+    Args:
+        task_config: TaskConfig object for the experiment.
+        result: Dictionary containing the pareto_df result of the experiment.
+        top_n: Number of top configurations to return.
+    Returns:
+        tuple:
+            - best_config_df: Best configuration dataframe.
+            - best_throughput: Best throughput.
+            - pareto_frontier_df: Pareto frontier dataframe.
+            - x_axis_col: X-axis column name.
+    """
+    pareto_df = result["pareto_df"]
+    runtime_cfg = task_config.config.runtime_config
+    target_tpot = runtime_cfg.tpot
+    target_request_latency = runtime_cfg.request_latency
+    use_request_latency = target_request_latency is not None and target_request_latency > 0
+    total_gpus = getattr(task_config, "total_gpus", None) or 0
+
+    # Compute tokens/s/gpu_cluster for pareto_df
+    if pareto_df is not None and not pareto_df.empty:
+        pareto_df["tokens/s/gpu_cluster"] = (
+            pareto_df["tokens/s/gpu"]
+            * (total_gpus // pareto_df["num_total_gpus"])
+            * pareto_df["num_total_gpus"]
+            / total_gpus
+        )
+        x_axis_col = "request_latency" if use_request_latency else "tokens/s/user"
+        pareto_frontier_df = get_pareto_front(
+            pareto_df,
+            x_axis_col,
+            "tokens/s/gpu_cluster",
+            maximize_x=not use_request_latency,
+            maximize_y=True,
+        )
+    else:
+        pareto_frontier_df = pd.DataFrame()
+        x_axis_col = "request_latency" if use_request_latency else "tokens/s/user"
+
+    group_by_key = "(d)parallel" if task_config.serving_mode == "disagg" else "parallel"
+    if use_request_latency:
+        best_config_df = get_best_configs_under_request_latency_constraint(
+            total_gpus=total_gpus,
+            pareto_df=pareto_df,
+            target_request_latency=target_request_latency,
+            top_n=top_n,
+            group_by=group_by_key,
+        )
+    else:
+        best_config_df = get_best_configs_under_tpot_constraint(  # based on all data points
+            total_gpus=total_gpus,
+            pareto_df=pareto_df,
+            target_tpot=target_tpot,
+            top_n=top_n,
+            group_by=group_by_key,
+        )
+
+    if not best_config_df.empty:
+        best_throughput = best_config_df["tokens/s/gpu_cluster"].values[0]
+    else:
+        best_throughput = 0.0
+
+    return best_config_df, best_throughput, pareto_frontier_df, x_axis_col
+
+
+def _merge_into_top_n(
+    exps: list[str],
+    task_configs: dict[str, TaskConfig],
+    best_configs: dict[str, pd.DataFrame],
+    pareto_fronts: dict[str, pd.DataFrame],
+    pareto_x_axis: dict[str, str],
+    top_n: int = 5,
+) -> tuple:
+    """Merge the best configs and pareto fronts into top N."""
+    best_configs_dfs = []
+    pareto_dfs = []
+    for exp_name in exps:
+        backend_name = task_configs[exp_name].backend_name
+        df = best_configs[exp_name].copy()
+        if not df.empty:
+            df["backend"] = backend_name
+            best_configs_dfs.append(df)
+
+        pf = pareto_fronts.get(exp_name)
+        if pf is not None and not pf.empty:
+            pf_copy = pf.copy()
+            pf_copy["backend"] = backend_name
+            pareto_dfs.append(pf_copy)
+
+    # Merge all best configs and take top N
+    if best_configs_dfs:
+        df_best_configs = pd.concat(best_configs_dfs, ignore_index=True)
+        df_best_configs = df_best_configs.sort_values("tokens/s/gpu_cluster", ascending=False).head(top_n)
+    else:
+        df_best_configs = pd.DataFrame()
+    best_throughput = df_best_configs["tokens/s/gpu_cluster"].values[0] if not df_best_configs.empty else 0.0
+
+    df_merged_pareto_front = x_col = None
+    # Merge pareto fronts for plotting and recompute Pareto frontier
+    if pareto_dfs:
+        df_combined_pareto = pd.concat(pareto_dfs, ignore_index=True)
+        x_col = pareto_x_axis.get(exps[0], "tokens/s/user")
+        df_merged_pareto_front = get_pareto_front(
+            df_combined_pareto,
+            x_col,
+            "tokens/s/gpu_cluster",
+            maximize_x=(x_col != "request_latency"),
+            maximize_y=True,
+        )
+
+    return df_best_configs, best_throughput, df_merged_pareto_front, x_col
+
+
+def merge_experiment_results_by_mode(
+    task_configs: dict[str, TaskConfig],
+    best_configs: dict[str, pd.DataFrame],
+    pareto_fronts: dict[str, pd.DataFrame],
+    pareto_x_axis: dict[str, str],
+    top_n: int = 5,
+) -> tuple[dict[str, pd.DataFrame], dict[str, float], dict[str, pd.DataFrame], dict[str, str]]:
+    """
+    Merge results from multiple experiments into Top N agg and disagg.
+    For example, when backend="any", we have 6 experiments: agg_trtllm, agg_vllm, agg_sglang,
+    disagg_trtllm, disagg_vllm, disagg_sglang. This function merges them into 2:
+    agg (with top N from all backends) and disagg (with top N from all backends).
+
+    Args:
+        results: Dictionary containing the results of the experiments.
+        task_configs: Dictionary containing the task configs of the experiments.
+        best_configs: Dictionary containing the best configs of the experiments.
+        best_throughputs: Dictionary containing the best throughputs of the experiments.
+        pareto_fronts: Dictionary containing the pareto fronts of the experiments.
+        pareto_x_axis: Dictionary containing the pareto x-axis of the experiments.
+        top_n: Number of top configurations to return.
+
+    Returns:
+        tuple:
+            - best_configs: Dictionary containing the best configs of the merged experiments.
+            - best_throughputs: Dictionary containing the best throughputs of the merged experiments.
+            - pareto_fronts: Dictionary containing the pareto fronts of the merged experiments.
+            - pareto_x_axis: Dictionary containing the pareto x-axis of the merged experiments.
+            - task_configs: Dictionary containing the task configs of the merged experiments.
+    """
+    agg_exps = [name for name, task_config in task_configs.items() if task_config.serving_mode == "agg"]
+    disagg_exps = [name for name, task_config in task_configs.items() if task_config.serving_mode == "disagg"]
+
+    merged_best_configs = {}
+    merged_best_throughputs = {}
+    merged_pareto_fronts = {}
+    merged_pareto_x_axis = {}
+
+    agg_merged = _merge_into_top_n(agg_exps, task_configs, best_configs, pareto_fronts, pareto_x_axis, top_n)
+    disagg_merged = _merge_into_top_n(disagg_exps, task_configs, best_configs, pareto_fronts, pareto_x_axis, top_n)
+
+    merged_best_configs["agg"] = agg_merged[0]
+    merged_best_throughputs["agg"] = agg_merged[1]
+    merged_pareto_fronts["agg"] = agg_merged[2]
+    merged_pareto_x_axis["agg"] = agg_merged[3]
+    merged_best_configs["disagg"] = disagg_merged[0]
+    merged_best_throughputs["disagg"] = disagg_merged[1]
+    merged_pareto_fronts["disagg"] = disagg_merged[2]
+    merged_pareto_x_axis["disagg"] = disagg_merged[3]
+
+    return merged_best_configs, merged_best_throughputs, merged_pareto_fronts, merged_pareto_x_axis

--- a/tests/unit/cli/test_argument_parsing.py
+++ b/tests/unit/cli/test_argument_parsing.py
@@ -86,7 +86,7 @@ class TestCLIArgumentParsing:
         subparser_action = next(action for action in cli_parser._actions if action.dest == "mode")
         default_parser = subparser_action.choices["default"]
         action = next(action for action in default_parser._actions if action.dest == "backend")
-        expected_choices = [backend.value for backend in common.BackendName]
+        expected_choices = [backend.value for backend in common.BackendName] + ["any"]
         assert sorted(action.choices) == sorted(expected_choices)
 
     @pytest.mark.parametrize("system_value", ["h200_sxm", "b200_sxm", "gb200_sxm"])

--- a/tests/unit/cli/test_backend_any.py
+++ b/tests/unit/cli/test_backend_any.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for --backend any functionality.
+"""
+
+import pytest
+
+from aiconfigurator.cli.main import build_default_task_configs
+from aiconfigurator.sdk.common import BackendName
+
+pytestmark = pytest.mark.unit
+
+
+class TestBackendAny:
+    """Tests for --backend any functionality."""
+
+    def test_build_default_task_configs_single_backend(self):
+        """Single backend should create 2 task configs (agg, disagg)."""
+        task_configs = build_default_task_configs(
+            model_path="Qwen/Qwen3-32B",
+            total_gpus=8,
+            system="h200_sxm",
+            backend="trtllm",
+        )
+
+        assert len(task_configs) == 2
+        assert "agg" in task_configs
+        assert "disagg" in task_configs
+        assert task_configs["agg"].backend_name == "trtllm"
+        assert task_configs["disagg"].backend_name == "trtllm"
+
+    def test_build_default_task_configs_any_backend(self):
+        """Backend 'any' should create 6 internal task configs but they will be merged later."""
+        task_configs = build_default_task_configs(
+            model_path="Qwen/Qwen3-32B",
+            total_gpus=8,
+            system="h200_sxm",
+            backend="any",
+        )
+
+        # Should have 6 internal configs: agg_trtllm, agg_vllm, agg_sglang, disagg_trtllm, disagg_vllm, disagg_sglang
+        # These will be merged in _execute_task_configs to produce 2 results (agg, disagg)
+        assert len(task_configs) == 6
+
+        # Check all expected experiment names exist
+        expected_names = {
+            "agg_trtllm",
+            "agg_vllm",
+            "agg_sglang",
+            "disagg_trtllm",
+            "disagg_vllm",
+            "disagg_sglang",
+        }
+        assert set(task_configs.keys()) == expected_names
+
+        # Verify each config has the correct backend
+        for backend in BackendName:
+            backend_name = backend.value
+            assert task_configs[f"agg_{backend_name}"].backend_name == backend_name
+            assert task_configs[f"disagg_{backend_name}"].backend_name == backend_name
+            assert task_configs[f"agg_{backend_name}"].serving_mode == "agg"
+            assert task_configs[f"disagg_{backend_name}"].serving_mode == "disagg"
+
+    def test_build_default_task_configs_any_backend_parameters(self):
+        """Backend 'any' should preserve all parameters for each backend config."""
+        task_configs = build_default_task_configs(
+            model_path="Qwen/Qwen3-32B",
+            total_gpus=32,
+            system="h200_sxm",
+            backend="any",
+            isl=4000,
+            osl=1000,
+            ttft=2000.0,
+            tpot=30.0,
+            prefix=500,
+        )
+
+        # Check that all configs have the same parameters (except backend_name)
+        for exp_name, task_config in task_configs.items():
+            assert task_config.config.model_path == "Qwen/Qwen3-32B"
+            assert task_config.total_gpus == 32
+            assert task_config.system_name == "h200_sxm"
+            assert task_config.config.runtime_config.isl == 4000
+            assert task_config.config.runtime_config.osl == 1000
+            assert task_config.config.runtime_config.ttft == 2000.0
+            assert task_config.config.runtime_config.tpot == 30.0
+            assert task_config.config.runtime_config.prefix == 500
+
+            # Disagg configs should have decode_system set (defaults to system)
+            if exp_name.startswith("disagg"):
+                assert task_config.decode_system_name == "h200_sxm"

--- a/tests/unit/cli/test_utils.py
+++ b/tests/unit/cli/test_utils.py
@@ -1,0 +1,547 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for CLI utility functions in utils.py.
+"""
+
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from aiconfigurator.cli.utils import (
+    _merge_into_top_n,
+    merge_experiment_results_by_mode,
+    process_experiment_result,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestProcessExperimentResult:
+    """Tests for process_experiment_result function."""
+
+    def test_process_result_with_tpot_constraint(self):
+        """Test processing result with TPOT constraint."""
+        # Create mock task config
+        mock_task_config = MagicMock()
+        mock_task_config.config.runtime_config.tpot = 30.0
+        mock_task_config.config.runtime_config.request_latency = None
+        mock_task_config.serving_mode = "agg"
+        mock_task_config.total_gpus = 32
+
+        # Create sample pareto_df
+        pareto_df = pd.DataFrame(
+            {
+                "tokens/s/gpu": [100.0, 120.0, 90.0],
+                "tokens/s/user": [10.0, 12.0, 9.0],
+                "num_total_gpus": [8, 8, 8],
+                "tpot": [25.0, 28.0, 20.0],
+                "parallel": ["tp4_pp1_dp2", "tp2_pp1_dp4", "tp1_pp1_dp8"],
+            }
+        )
+
+        result = {"pareto_df": pareto_df}
+
+        best_config_df, best_throughput, pareto_frontier_df, x_axis_col = process_experiment_result(
+            mock_task_config, result, top_n=2
+        )
+
+        # Verify results
+        assert not best_config_df.empty
+        assert "tokens/s/gpu_cluster" in best_config_df.columns
+        assert best_throughput > 0.0
+        assert x_axis_col == "tokens/s/user"
+        assert not pareto_frontier_df.empty
+
+    def test_process_result_with_request_latency_constraint(self):
+        """Test processing result with request_latency constraint."""
+        # Create mock task config
+        mock_task_config = MagicMock()
+        mock_task_config.config.runtime_config.tpot = None
+        mock_task_config.config.runtime_config.request_latency = 1200.0
+        mock_task_config.serving_mode = "disagg"
+        mock_task_config.total_gpus = 32
+
+        # Create sample pareto_df
+        pareto_df = pd.DataFrame(
+            {
+                "tokens/s/gpu": [100.0, 120.0, 90.0],
+                "tokens/s/user": [10.0, 12.0, 9.0],
+                "num_total_gpus": [8, 8, 8],
+                "request_latency": [1000.0, 1100.0, 900.0],
+                "(d)parallel": ["tp4_pp1_dp2", "tp2_pp1_dp4", "tp1_pp1_dp8"],
+            }
+        )
+
+        result = {"pareto_df": pareto_df}
+
+        best_config_df, best_throughput, pareto_frontier_df, x_axis_col = process_experiment_result(
+            mock_task_config, result, top_n=3
+        )
+
+        # Verify results
+        assert not best_config_df.empty
+        assert x_axis_col == "request_latency"
+        assert "tokens/s/gpu_cluster" in best_config_df.columns
+        assert best_throughput > 0.0
+
+    def test_process_result_with_empty_pareto_df(self):
+        """Test processing result with empty pareto_df."""
+        mock_task_config = MagicMock()
+        mock_task_config.config.runtime_config.tpot = 30.0
+        mock_task_config.config.runtime_config.request_latency = None
+        mock_task_config.serving_mode = "agg"
+        mock_task_config.total_gpus = 32
+
+        result = {"pareto_df": pd.DataFrame()}
+
+        best_config_df, best_throughput, pareto_frontier_df, x_axis_col = process_experiment_result(
+            mock_task_config, result, top_n=5
+        )
+
+        # Verify results
+        assert best_config_df.empty
+        assert best_throughput == 0.0
+        assert pareto_frontier_df.empty
+        assert x_axis_col in ["tokens/s/user", "request_latency"]
+
+    def test_process_result_with_none_pareto_df(self):
+        """Test processing result with None pareto_df."""
+        mock_task_config = MagicMock()
+        mock_task_config.config.runtime_config.tpot = 30.0
+        mock_task_config.config.runtime_config.request_latency = None
+        mock_task_config.serving_mode = "agg"
+        mock_task_config.total_gpus = 32
+
+        result = {"pareto_df": None}
+
+        best_config_df, best_throughput, pareto_frontier_df, x_axis_col = process_experiment_result(
+            mock_task_config, result, top_n=5
+        )
+
+        # Verify results
+        assert best_config_df.empty
+        assert best_throughput == 0.0
+        assert pareto_frontier_df.empty
+
+    def test_process_result_disagg_mode_uses_correct_group_by(self):
+        """Test that disagg mode uses (d)parallel as group_by key."""
+        mock_task_config = MagicMock()
+        mock_task_config.config.runtime_config.tpot = 30.0
+        mock_task_config.config.runtime_config.request_latency = None
+        mock_task_config.serving_mode = "disagg"
+        mock_task_config.total_gpus = 32
+
+        pareto_df = pd.DataFrame(
+            {
+                "tokens/s/gpu": [100.0, 120.0],
+                "tokens/s/user": [10.0, 12.0],
+                "num_total_gpus": [8, 8],
+                "tpot": [25.0, 28.0],
+                "(d)parallel": ["tp4_pp1_dp2", "tp2_pp1_dp4"],
+            }
+        )
+
+        result = {"pareto_df": pareto_df}
+
+        best_config_df, _, _, _ = process_experiment_result(mock_task_config, result, top_n=5)
+
+        # Verify that results are returned (group_by should work correctly)
+        assert not best_config_df.empty
+
+    def test_process_result_top_n_limiting(self):
+        """Test that top_n correctly limits the number of returned configs."""
+        mock_task_config = MagicMock()
+        mock_task_config.config.runtime_config.tpot = 30.0
+        mock_task_config.config.runtime_config.request_latency = None
+        mock_task_config.serving_mode = "agg"
+        mock_task_config.total_gpus = 32
+
+        # Create sample with more configs than top_n
+        pareto_df = pd.DataFrame(
+            {
+                "tokens/s/gpu": [100.0, 120.0, 90.0, 110.0, 95.0, 105.0],
+                "tokens/s/user": [10.0, 12.0, 9.0, 11.0, 9.5, 10.5],
+                "num_total_gpus": [8, 8, 8, 8, 8, 8],
+                "tpot": [25.0, 28.0, 20.0, 26.0, 22.0, 24.0],
+                "parallel": [f"config_{i}" for i in range(6)],
+            }
+        )
+
+        result = {"pareto_df": pareto_df}
+
+        best_config_df, _, _, _ = process_experiment_result(mock_task_config, result, top_n=3)
+
+        # Should return at most 3 configs
+        assert len(best_config_df) <= 3
+
+    def test_process_result_computes_tokens_per_gpu_cluster(self):
+        """Test that tokens/s/gpu_cluster is correctly computed."""
+        mock_task_config = MagicMock()
+        mock_task_config.config.runtime_config.tpot = 30.0
+        mock_task_config.config.runtime_config.request_latency = None
+        mock_task_config.serving_mode = "agg"
+        mock_task_config.total_gpus = 32
+
+        pareto_df = pd.DataFrame(
+            {
+                "tokens/s/gpu": [100.0],
+                "tokens/s/user": [10.0],
+                "num_total_gpus": [8],
+                "tpot": [25.0],
+                "parallel": ["tp4_pp1_dp2"],
+            }
+        )
+
+        result = {"pareto_df": pareto_df}
+
+        best_config_df, _, _, _ = process_experiment_result(mock_task_config, result, top_n=5)
+
+        # Verify tokens/s/gpu_cluster is computed
+        assert "tokens/s/gpu_cluster" in best_config_df.columns
+        # Expected: 100 * (32 // 8) * 8 / 32 = 100 * 4 * 8 / 32 = 100
+        assert best_config_df["tokens/s/gpu_cluster"].values[0] > 0
+
+
+class TestMergeIntoTopN:
+    """Tests for _merge_into_top_n helper function."""
+
+    def test_merge_multiple_backends(self):
+        """Test merging configs from multiple backends."""
+        # Create mock task configs
+        task_configs = {}
+        for backend in ["trtllm", "vllm", "sglang"]:
+            mock_config = MagicMock()
+            mock_config.backend_name = backend
+            task_configs[f"agg_{backend}"] = mock_config
+
+        # Create mock best configs
+        best_configs = {
+            "agg_trtllm": pd.DataFrame({"tokens/s/gpu_cluster": [100.0], "tokens/s/user": [10.0]}),
+            "agg_vllm": pd.DataFrame({"tokens/s/gpu_cluster": [120.0], "tokens/s/user": [12.0]}),
+            "agg_sglang": pd.DataFrame({"tokens/s/gpu_cluster": [110.0], "tokens/s/user": [11.0]}),
+        }
+
+        pareto_fronts = {
+            "agg_trtllm": pd.DataFrame({"tokens/s/gpu_cluster": [100.0], "tokens/s/user": [10.0]}),
+            "agg_vllm": pd.DataFrame({"tokens/s/gpu_cluster": [120.0], "tokens/s/user": [12.0]}),
+            "agg_sglang": pd.DataFrame({"tokens/s/gpu_cluster": [110.0], "tokens/s/user": [11.0]}),
+        }
+
+        pareto_x_axis = {"agg_trtllm": "tokens/s/user", "agg_vllm": "tokens/s/user", "agg_sglang": "tokens/s/user"}
+
+        exps = ["agg_trtllm", "agg_vllm", "agg_sglang"]
+
+        merged_best, merged_throughput, merged_pareto, x_col = _merge_into_top_n(
+            exps, task_configs, best_configs, pareto_fronts, pareto_x_axis, top_n=5
+        )
+
+        # Verify results
+        assert not merged_best.empty
+        assert "backend" in merged_best.columns
+        assert merged_throughput == 120.0  # Best from vllm
+        assert not merged_pareto.empty
+        assert "backend" in merged_pareto.columns
+        assert x_col == "tokens/s/user"
+
+    def test_merge_with_top_n_limiting(self):
+        """Test that merging respects top_n limit."""
+        task_configs = {}
+        best_configs = {}
+        pareto_fronts = {}
+        pareto_x_axis = {}
+
+        for i, backend in enumerate(["trtllm", "vllm", "sglang"]):
+            mock_config = MagicMock()
+            mock_config.backend_name = backend
+            exp_name = f"agg_{backend}"
+            task_configs[exp_name] = mock_config
+
+            # Create configs with different throughputs
+            best_configs[exp_name] = pd.DataFrame(
+                {
+                    "tokens/s/gpu_cluster": [100.0 + i * 10, 95.0 + i * 10],
+                    "tokens/s/user": [10.0 + i, 9.5 + i],
+                }
+            )
+            pareto_fronts[exp_name] = best_configs[exp_name].copy()
+            pareto_x_axis[exp_name] = "tokens/s/user"
+
+        exps = list(task_configs.keys())
+
+        merged_best, _, _, _ = _merge_into_top_n(
+            exps, task_configs, best_configs, pareto_fronts, pareto_x_axis, top_n=3
+        )
+
+        # Should return at most 3 configs
+        assert len(merged_best) <= 3
+        # Should be sorted by throughput descending
+        assert merged_best["tokens/s/gpu_cluster"].is_monotonic_decreasing
+
+    def test_merge_with_empty_dataframes(self):
+        """Test merging when some configs are empty."""
+        task_configs = {
+            "agg_trtllm": MagicMock(backend_name="trtllm"),
+            "agg_vllm": MagicMock(backend_name="vllm"),
+        }
+
+        best_configs = {
+            "agg_trtllm": pd.DataFrame(),  # Empty
+            "agg_vllm": pd.DataFrame({"tokens/s/gpu_cluster": [120.0], "tokens/s/user": [12.0]}),
+        }
+
+        pareto_fronts = {
+            "agg_trtllm": pd.DataFrame(),
+            "agg_vllm": pd.DataFrame({"tokens/s/gpu_cluster": [120.0], "tokens/s/user": [12.0]}),
+        }
+
+        pareto_x_axis = {"agg_trtllm": "tokens/s/user", "agg_vllm": "tokens/s/user"}
+
+        exps = ["agg_trtllm", "agg_vllm"]
+
+        merged_best, merged_throughput, merged_pareto, x_col = _merge_into_top_n(
+            exps, task_configs, best_configs, pareto_fronts, pareto_x_axis, top_n=5
+        )
+
+        # Should only contain vllm results
+        assert not merged_best.empty
+        assert len(merged_best) == 1
+        assert merged_best["backend"].values[0] == "vllm"
+        assert merged_throughput == 120.0
+
+    def test_merge_with_missing_pareto_fronts(self):
+        """Test merging when pareto fronts are missing."""
+        task_configs = {"agg_trtllm": MagicMock(backend_name="trtllm")}
+
+        best_configs = {"agg_trtllm": pd.DataFrame({"tokens/s/gpu_cluster": [100.0], "tokens/s/user": [10.0]})}
+
+        pareto_fronts = {}  # No pareto fronts
+
+        pareto_x_axis = {"agg_trtllm": "tokens/s/user"}
+
+        exps = ["agg_trtllm"]
+
+        merged_best, merged_throughput, merged_pareto, x_col = _merge_into_top_n(
+            exps, task_configs, best_configs, pareto_fronts, pareto_x_axis, top_n=5
+        )
+
+        # Should still merge best configs
+        assert not merged_best.empty
+        assert merged_throughput == 100.0
+        # Pareto front should be None or empty
+        assert merged_pareto is None or merged_pareto.empty
+
+    def test_merge_recomputes_pareto_frontier(self):
+        """Test that merge recomputes Pareto frontier from combined data."""
+        task_configs = {}
+        best_configs = {}
+        pareto_fronts = {}
+        pareto_x_axis = {}
+
+        for backend in ["trtllm", "vllm"]:
+            mock_config = MagicMock()
+            mock_config.backend_name = backend
+            exp_name = f"agg_{backend}"
+            task_configs[exp_name] = mock_config
+
+            # Create different pareto fronts
+            if backend == "trtllm":
+                pareto_fronts[exp_name] = pd.DataFrame(
+                    {
+                        "tokens/s/gpu_cluster": [100.0, 90.0],
+                        "tokens/s/user": [10.0, 12.0],
+                    }
+                )
+            else:
+                pareto_fronts[exp_name] = pd.DataFrame(
+                    {
+                        "tokens/s/gpu_cluster": [110.0, 95.0],
+                        "tokens/s/user": [11.0, 13.0],
+                    }
+                )
+
+            best_configs[exp_name] = pareto_fronts[exp_name].copy()
+            pareto_x_axis[exp_name] = "tokens/s/user"
+
+        exps = ["agg_trtllm", "agg_vllm"]
+
+        _, _, merged_pareto, _ = _merge_into_top_n(
+            exps, task_configs, best_configs, pareto_fronts, pareto_x_axis, top_n=5
+        )
+
+        # Should combine and recompute pareto frontier
+        assert not merged_pareto.empty
+        assert "backend" in merged_pareto.columns
+
+
+class TestMergeExperimentResultsByMode:
+    """Tests for merge_experiment_results_by_mode function."""
+
+    def test_merge_six_backends_into_two_modes(self):
+        """Test merging 6 backend experiments into agg and disagg."""
+        # Create mock task configs for all 6 experiments
+        task_configs = {}
+        for backend in ["trtllm", "vllm", "sglang"]:
+            for mode in ["agg", "disagg"]:
+                mock_config = MagicMock()
+                mock_config.backend_name = backend
+                mock_config.serving_mode = mode
+                task_configs[f"{mode}_{backend}"] = mock_config
+
+        # Create mock best configs with different throughputs
+        best_configs = {
+            "agg_trtllm": pd.DataFrame({"tokens/s/gpu_cluster": [100.0], "tokens/s/user": [10.0]}),
+            "agg_vllm": pd.DataFrame({"tokens/s/gpu_cluster": [120.0], "tokens/s/user": [12.0]}),
+            "agg_sglang": pd.DataFrame({"tokens/s/gpu_cluster": [110.0], "tokens/s/user": [11.0]}),
+            "disagg_trtllm": pd.DataFrame({"tokens/s/gpu_cluster": [150.0], "tokens/s/user": [15.0]}),
+            "disagg_vllm": pd.DataFrame({"tokens/s/gpu_cluster": [140.0], "tokens/s/user": [14.0]}),
+            "disagg_sglang": pd.DataFrame({"tokens/s/gpu_cluster": [130.0], "tokens/s/user": [13.0]}),
+        }
+
+        pareto_fronts = {name: df.copy() for name, df in best_configs.items()}
+        pareto_x_axis = dict.fromkeys(best_configs.keys(), "tokens/s/user")
+
+        # Merge results
+        merged_configs, merged_throughputs, merged_fronts, merged_axis = merge_experiment_results_by_mode(
+            task_configs, best_configs, pareto_fronts, pareto_x_axis, top_n=5
+        )
+
+        # Should have only 2 merged results: agg and disagg
+        assert len(merged_configs) == 2
+        assert "agg" in merged_configs
+        assert "disagg" in merged_configs
+
+        # Merged configs should have "backend" column
+        assert "backend" in merged_configs["agg"].columns
+        assert "backend" in merged_configs["disagg"].columns
+
+        # Best throughput should be from vllm for agg (120.0) and trtllm for disagg (150.0)
+        assert merged_throughputs["agg"] == 120.0
+        assert merged_throughputs["disagg"] == 150.0
+
+        # Pareto fronts should be merged
+        assert not merged_fronts["agg"].empty
+        assert not merged_fronts["disagg"].empty
+
+        # X-axis should be preserved
+        assert merged_axis["agg"] == "tokens/s/user"
+        assert merged_axis["disagg"] == "tokens/s/user"
+
+    def test_merge_with_top_n_limiting(self):
+        """Test that merge respects top_n limit across backends."""
+        task_configs = {}
+        best_configs = {}
+        pareto_fronts = {}
+        pareto_x_axis = {}
+
+        for i, backend in enumerate(["trtllm", "vllm", "sglang"]):
+            mock_config = MagicMock()
+            mock_config.backend_name = backend
+            mock_config.serving_mode = "agg"
+            exp_name = f"agg_{backend}"
+            task_configs[exp_name] = mock_config
+
+            # Each backend has 3 configs
+            best_configs[exp_name] = pd.DataFrame(
+                {
+                    "tokens/s/gpu_cluster": [100.0 + i * 10 + j for j in range(3)],
+                    "tokens/s/user": [10.0 + i + j * 0.1 for j in range(3)],
+                }
+            )
+            pareto_fronts[exp_name] = best_configs[exp_name].copy()
+            pareto_x_axis[exp_name] = "tokens/s/user"
+
+        # Merge with top_n=5
+        merged_configs, _, _, _ = merge_experiment_results_by_mode(
+            task_configs, best_configs, pareto_fronts, pareto_x_axis, top_n=5
+        )
+
+        # Should return at most 5 configs for agg
+        assert len(merged_configs["agg"]) <= 5
+
+    def test_merge_with_mixed_agg_disagg(self):
+        """Test merging with mix of agg and disagg experiments."""
+        task_configs = {
+            "agg_trtllm": MagicMock(backend_name="trtllm", serving_mode="agg"),
+            "agg_vllm": MagicMock(backend_name="vllm", serving_mode="agg"),
+            "disagg_trtllm": MagicMock(backend_name="trtllm", serving_mode="disagg"),
+        }
+
+        best_configs = {
+            "agg_trtllm": pd.DataFrame({"tokens/s/gpu_cluster": [100.0], "tokens/s/user": [10.0]}),
+            "agg_vllm": pd.DataFrame({"tokens/s/gpu_cluster": [120.0], "tokens/s/user": [12.0]}),
+            "disagg_trtllm": pd.DataFrame({"tokens/s/gpu_cluster": [150.0], "tokens/s/user": [15.0]}),
+        }
+
+        pareto_fronts = {name: df.copy() for name, df in best_configs.items()}
+        pareto_x_axis = dict.fromkeys(best_configs.keys(), "tokens/s/user")
+
+        merged_configs, merged_throughputs, _, _ = merge_experiment_results_by_mode(
+            task_configs, best_configs, pareto_fronts, pareto_x_axis, top_n=5
+        )
+
+        # Should have 2 results: agg (from 2 backends) and disagg (from 1 backend)
+        assert len(merged_configs) == 2
+        assert not merged_configs["agg"].empty
+        assert not merged_configs["disagg"].empty
+
+        # Agg should have 2 configs, disagg should have 1
+        assert len(merged_configs["agg"]) == 2
+        assert len(merged_configs["disagg"]) == 1
+
+    def test_merge_preserves_backend_information(self):
+        """Test that backend information is preserved in merged results."""
+        task_configs = {}
+        best_configs = {}
+        pareto_fronts = {}
+        pareto_x_axis = {}
+
+        for backend in ["trtllm", "vllm"]:
+            mock_config = MagicMock()
+            mock_config.backend_name = backend
+            mock_config.serving_mode = "agg"
+            exp_name = f"agg_{backend}"
+            task_configs[exp_name] = mock_config
+
+            best_configs[exp_name] = pd.DataFrame({"tokens/s/gpu_cluster": [100.0], "tokens/s/user": [10.0]})
+            pareto_fronts[exp_name] = best_configs[exp_name].copy()
+            pareto_x_axis[exp_name] = "tokens/s/user"
+
+        merged_configs, _, _, _ = merge_experiment_results_by_mode(
+            task_configs, best_configs, pareto_fronts, pareto_x_axis, top_n=5
+        )
+
+        # Backend column should exist and contain correct values
+        assert "backend" in merged_configs["agg"].columns
+        backends = set(merged_configs["agg"]["backend"].values)
+        assert backends.issubset({"trtllm", "vllm"})
+
+    def test_merge_with_empty_experiments(self):
+        """Test merging when some experiments have no results."""
+        task_configs = {
+            "agg_trtllm": MagicMock(backend_name="trtllm", serving_mode="agg"),
+            "agg_vllm": MagicMock(backend_name="vllm", serving_mode="agg"),
+            "disagg_trtllm": MagicMock(backend_name="trtllm", serving_mode="disagg"),
+        }
+
+        best_configs = {
+            "agg_trtllm": pd.DataFrame(),  # Empty
+            "agg_vllm": pd.DataFrame({"tokens/s/gpu_cluster": [120.0], "tokens/s/user": [12.0]}),
+            "disagg_trtllm": pd.DataFrame({"tokens/s/gpu_cluster": [150.0], "tokens/s/user": [15.0]}),
+        }
+
+        pareto_fronts = {name: df.copy() for name, df in best_configs.items()}
+        pareto_x_axis = dict.fromkeys(best_configs.keys(), "tokens/s/user")
+
+        merged_configs, merged_throughputs, _, _ = merge_experiment_results_by_mode(
+            task_configs, best_configs, pareto_fronts, pareto_x_axis, top_n=5
+        )
+
+        # Should still produce results for both modes
+        assert len(merged_configs) == 2
+        # Agg should only have vllm result
+        assert not merged_configs["agg"].empty
+        assert len(merged_configs["agg"]) == 1
+        assert merged_throughputs["agg"] == 120.0


### PR DESCRIPTION
  #### Overview:                                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                     
Add support for `--backend any` to sweep across TensorRT-LLM, vLLM, and SGLang simultaneously and identify the optimal backend for a given workload. 

This PR does NOT support
- heterogenous hardware for P/D
- heterogenous backend for P/D

```
> aiconfigurator cli default --model Qwen/Qwen3-32B --backend any --total_gpus 8 --system h100_sxm --backend any --save_dir results                                                       
```
<img width="1950" height="362" alt="Screenshot 2026-02-04 at 5 18 07 PM" src="https://github.com/user-attachments/assets/f6484752-3dfe-4706-88e1-3956398c2842" />