### PR TITLE
feat: make generator support both dynamo version and backend version

### DIFF
--- a/docs/cli_user_guide.md
+++ b/docs/cli_user_guide.md
@@ -283,6 +283,11 @@ By default, we output top 5 configs we have found. You can get the configs and s
 
 `--save_dir DIR` allows you to specify more information such as generating the config for a different version of the backend, say estimating the performance using trtllm 1.0.0rc3 but generate config for 1.0.0rc6. This is allowed and feasible. By passing `--generated_config_version 1.0.0rc6` can give you the right result.
 
+**Generator Dynamo version**
+- Use `--generator-dynamo-version v0.7.1` to select the Dynamo release. This affects both the generated backend config version and the default K8s image tag.
+- If `--generator-dynamo-version` is not provided, the default is the first entry in `generator/config/backend_version_matrix.yaml`.
+- If `--generated_config_version` is provided, it overrides the generated backend version, but the default K8s image tag still follows the first entry in `backend_version_matrix.yaml`.
+
 Use `--generator-config path/to/file.yaml` to provide ServiceConfig/K8sConfig/DynConfig/WorkerConfig/Workers.<role> sections, or add inline overrides via `--generator-set KEY=VALUE`. Examples:
 
 - `--generator-set ServiceConfig.model_path=Qwen/Qwen3-32B-FP8`

--- a/docs/generator_overview.md
+++ b/docs/generator_overview.md
@@ -76,6 +76,10 @@ You can use the generator in three ways: AIConfigurator CLI, webapp, or standalo
     --generator-set K8sConfig.k8s_namespace=ets-dynamo \
     --save_dir ./results
   ```
+  Notes:
+  - Use `--generator-dynamo-version v0.7.1` to select the Dynamo release. This affects both the generated backend config version and the default K8s image tag.
+  - If `--generator-dynamo-version` is not provided, the default is the first entry in `generator/config/backend_version_matrix.yaml`.
+  - If `--generated_config_version` is provided, it overrides the generated backend version, but the default K8s image tag still follows the first entry in `backend_version_matrix.yaml`.
 - Webapp: start with `--enable_profiling` when launching the webapp to surface generator-driven configs.
 - Standalone:
   - In code:

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -210,12 +210,40 @@ def _add_support_mode_arguments(parser):
     )
 
 
+_USAGE_EXAMPLES = """
+Examples:
+# Sweep across all backends for Dynamo v0.7.1
+aiconfigurator cli default --model_path Qwen/Qwen3-32B-FP8 \\
+    --backend any \\
+    --top_n 3 \\
+    --total_gpus 8 --system h200_sxm \\
+    --ttft 600 --tpot 50 --isl 4000 --osl 500 \\
+    --generator-dynamo-version v0.7.1 \\
+    --generator-set K8sConfig.k8s_model_cache=model-cache \\
+    --generator-set K8sConfig.k8s_hf_home=/opt/models \\
+    --generator-set K8sConfig.k8s_namespace=ets-dynamo \\
+    --save_dir results
+
+# Sweep for trtllm 1.2.0rc5 but generate config matching trtllm 1.2.0rc6
+aiconfigurator cli default --model_path Qwen/Qwen3-32B-FP8 \\
+    --backend trtllm \\
+    --backend_version 1.2.0rc5 \\
+    --generated_config_version 1.2.0rc6 \\
+    --save_dir results
+"""
+
+
 def configure_parser(parser):
     common_cli_parser = _build_common_cli_parser()
     subparsers = parser.add_subparsers(dest="mode", required=True)
 
     default_parser = subparsers.add_parser(
-        "default", parents=[common_cli_parser], help="Run the default agg vs disagg comparison."
+        "default",
+        parents=[common_cli_parser],
+        help="Run the default agg vs disagg comparison.",
+        description="Run the default agg vs disagg comparison.",
+        epilog=_USAGE_EXAMPLES,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     _add_default_mode_arguments(default_parser)
 
@@ -810,7 +838,11 @@ def main(args):
 if __name__ == "__main__":
     if generator_cli_helper(sys.argv[1:]):
         sys.exit(0)
-    parser = argparse.ArgumentParser(description="Dynamo AIConfigurator for Disaggregated Serving Deployment")
+    parser = argparse.ArgumentParser(
+        description="Dynamo AIConfigurator for Disaggregated Serving Deployment",
+        epilog=_USAGE_EXAMPLES,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     configure_parser(parser)
     args = parser.parse_args()
     main(args)

--- a/src/aiconfigurator/cli/report_and_save.py
+++ b/src/aiconfigurator/cli/report_and_save.py
@@ -14,7 +14,7 @@ from prettytable import PrettyTable
 
 from aiconfigurator.generator.api import (
     generate_backend_artifacts,
-    get_default_backend_version_entry,
+    get_default_dynamo_version_mapping,
     load_generator_overrides_from_args,
     resolve_backend_version_for_dynamo,
 )

--- a/src/aiconfigurator/generator/api.py
+++ b/src/aiconfigurator/generator/api.py
@@ -20,79 +20,19 @@ from prettytable import PrettyTable
 
 from .artifacts import ArtifactWriter
 from .rendering import _cast_literal, render_backend_parameters, render_backend_templates
-from .utils import DEFAULT_BACKEND, normalize_backend
+from .utils import (
+    DEFAULT_BACKEND,
+    _load_yaml_payload,
+    get_default_dynamo_version_mapping,
+    normalize_backend,
+    resolve_backend_version_for_dynamo,
+)
 
 GENERATOR_CONFIG_DIR = os.path.join(os.path.dirname(__file__), "config")
 DEFAULT_DEPLOYMENT_SCHEMA_PATH = os.path.join(GENERATOR_CONFIG_DIR, "deployment_config.yaml")
 DEFAULT_BACKEND_MAPPING_PATH = os.path.join(GENERATOR_CONFIG_DIR, "backend_config_mapping.yaml")
 DEFAULT_BACKEND_VERSION_MATRIX_PATH = os.path.join(GENERATOR_CONFIG_DIR, "backend_version_matrix.yaml")
 _VALID_GENERATOR_HELP_SECTIONS = {"all", "deploy", "backend"}
-
-
-def _load_yaml_payload(path: str) -> Any:
-    with open(path, encoding="utf-8") as fh:
-        return yaml.safe_load(fh) or {}
-
-
-def _load_backend_version_matrix(
-    matrix_path: str = DEFAULT_BACKEND_VERSION_MATRIX_PATH,
-) -> dict[str, dict[str, Any]]:
-    payload = _load_yaml_payload(matrix_path)
-    if not isinstance(payload, dict):
-        raise TypeError(f"Backend version matrix must be a YAML mapping: {matrix_path}")
-    matrix = payload.get("matrix", payload)
-    if not isinstance(matrix, dict):
-        raise TypeError(f"Backend version matrix missing 'matrix' mapping: {matrix_path}")
-    return matrix
-
-
-def resolve_backend_version_for_dynamo(
-    dynamo_version: str,
-    backend: Optional[str],
-    matrix_path: str = DEFAULT_BACKEND_VERSION_MATRIX_PATH,
-) -> str:
-    """
-    Resolve backend template version from a Dynamo version via the matrix file.
-
-    Args:
-        dynamo_version: Dynamo release string (e.g., "v0.8.1").
-        backend: Backend name (e.g., "trtllm", "vllm", "sglang").
-        matrix_path: Optional backend version matrix YAML file.
-    """
-    version_key = str(dynamo_version).strip()
-    if not version_key:
-        raise ValueError("dynamo_version must be a non-empty string.")
-    matrix = _load_backend_version_matrix(matrix_path)
-    entry = matrix.get(version_key)
-    if not isinstance(entry, dict):
-        supported = ", ".join(sorted(matrix.keys()))
-        raise TypeError(f"Unsupported dynamo_version '{version_key}'. Supported versions: {supported or 'none'}.")
-    backend_key = normalize_backend(backend, DEFAULT_BACKEND)
-    backend_version = entry.get(backend_key)
-    if backend_version is None:
-        supported_backends = ", ".join(sorted(entry.keys()))
-        raise ValueError(
-            f"No backend version mapping for backend '{backend_key}' in dynamo '{version_key}'. "
-            f"Supported backends: {supported_backends or 'none'}."
-        )
-    return str(backend_version)
-
-
-def get_default_backend_version_entry(
-    matrix_path: str = DEFAULT_BACKEND_VERSION_MATRIX_PATH,
-) -> tuple[str, dict[str, Any]]:
-    """
-    Return the default Dynamo version and its backend-version mapping.
-
-    The default entry is the first item in backend_version_matrix.yaml.
-    """
-    matrix = _load_backend_version_matrix(matrix_path)
-    if not matrix:
-        raise ValueError(f"Backend version matrix is empty: {matrix_path}")
-    dynamo_version, entry = next(iter(matrix.items()))
-    if not isinstance(entry, dict):
-        raise TypeError(f"Invalid backend version entry for {dynamo_version}: {entry!r}")
-    return str(dynamo_version), entry
 
 
 def _format_default_value(value: Any) -> str:
@@ -744,7 +684,7 @@ __all__ = [
     "generate_config_from_yaml",
     "generate_naive_config",
     "generator_cli_helper",
-    "get_default_backend_version_entry",
+    "get_default_dynamo_version_mapping",
     "load_generator_overrides",
     "load_generator_overrides_from_args",
     "parse_backend_arg",

--- a/src/aiconfigurator/generator/config/backend_templates/vllm/cli_args.0.12.0.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/vllm/cli_args.0.12.0.j2
@@ -7,6 +7,7 @@
 {%- if vllm['kv-cache-dtype'] is defined -%}{%- set _ = args.append('--kv-cache-dtype "' ~ vllm['kv-cache-dtype'] ~ '"') -%}{%- endif -%}
 {%- if vllm['max-model-len'] is defined -%}{%- set _ = args.append('--max-model-len "' ~ vllm['max-model-len'] ~ '"') -%}{%- endif -%}
 {%- if vllm['max-num-seqs'] is defined -%}{%- set _ = args.append('--max-num-seqs "' ~ vllm['max-num-seqs'] ~ '"') -%}{%- endif -%}
+{%- if vllm['max-num-batched-tokens'] is defined -%}{%- set _ = args.append('--max-num-batched-tokens ' ~ vllm['max-num-batched-tokens']) -%}{%- endif -%}
 {%- if vllm['skip-tokenizer-init'] -%}{%- set _ = args.append('--skip-tokenizer-init') -%}{%- endif -%}
 {%- if vllm['trust-remote-code'] -%}{%- set _ = args.append('--trust-remote-code') -%}{%- endif -%}
 {%- if vllm['enforce-eager'] -%}{%- set _ = args.append('--enforce-eager') -%}{%- endif -%}

--- a/src/aiconfigurator/generator/config/backend_version_matrix.yaml
+++ b/src/aiconfigurator/generator/config/backend_version_matrix.yaml
@@ -1,4 +1,6 @@
-# Backend version matrix by Dynamo release.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 matrix:
   v0.8.1.post1:
     vllm: "0.12.0"

--- a/src/aiconfigurator/generator/config/backend_version_matrix.yaml
+++ b/src/aiconfigurator/generator/config/backend_version_matrix.yaml
@@ -1,0 +1,38 @@
+# Backend version matrix by Dynamo release.
+matrix:
+  v0.8.1.post1:
+    vllm: "0.12.0"
+    sglang: "0.5.6.post2"
+    trtllm: "1.2.0rc6.post1"
+  v0.8.1:
+    vllm: "0.12.0"
+    sglang: "0.5.6.post2"
+    trtllm: "1.2.0rc6.post1"
+  v0.8.0:
+    vllm: "0.12.0"
+    sglang: "0.5.6.post2"
+    trtllm: "1.2.0rc6.post1"
+  v0.7.1:
+    vllm: "0.11.0"
+    sglang: "0.5.4.post3"
+    trtllm: "1.2.0rc3"
+  v0.7.0.post1:
+    vllm: "0.11.0"
+    sglang: "0.5.4.post3"
+    trtllm: "1.2.0rc3"
+  v0.7.0:
+    vllm: "0.11.0"
+    sglang: "0.5.4.post3"
+    trtllm: "1.2.0rc2"
+  v0.6.1.post1:
+    vllm: "0.11.0"
+    sglang: "0.5.3.post2"
+    trtllm: "1.1.0rc5"
+  v0.6.1:
+    vllm: "0.11.0"
+    sglang: "0.5.3.post2"
+    trtllm: "1.1.0rc5"
+  v0.6.0:
+    vllm: "0.11.0"
+    sglang: "0.5.3.post2"
+    trtllm: "1.1.0rc5"

--- a/src/aiconfigurator/generator/config/deployment_config.yaml
+++ b/src/aiconfigurator/generator/config/deployment_config.yaml
@@ -4,7 +4,7 @@
 inputs:
   # Optional per-backend controls:
   # - "backends": restricts an entry to the listed backend names.
-  # - "backend_defaults": overrides "default" per backend (e.g. trtllm, vllm, sglang).
+  # - "backend_defaults": overrides "default" per backend (e.g. trtllm, vllm, sglang).  
   # SlaConfig
   - key: SlaConfig.isl
     required: false
@@ -42,6 +42,11 @@ inputs:
     default: 20097
     backends: ["vllm"]
 
+  # Generator-level defaults
+  - key: generator_dynamo_version
+    required: false
+    default: ""
+
   # DynConfig
   - key: DynConfig.mode
     required: false
@@ -59,11 +64,11 @@ inputs:
     default: "dynamo"
   - key: K8sConfig.k8s_image
     required: false
-    default: &default_trtllm_image "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.0"
+    default: &default_trtllm_image '"nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:" ~ generator_dynamo_version'
     backend_defaults:
       trtllm: *default_trtllm_image
-      vllm: "nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.8.0"
-      sglang: "nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.8.0"
+      vllm: '"nvcr.io/nvidia/ai-dynamo/vllm-runtime:" ~ generator_dynamo_version'
+      sglang: '"nvcr.io/nvidia/ai-dynamo/sglang-runtime:" ~ generator_dynamo_version'
   - key: K8sConfig.k8s_image_pull_secret
     required: false
     default: ""

--- a/src/aiconfigurator/generator/module_bridge.py
+++ b/src/aiconfigurator/generator/module_bridge.py
@@ -15,6 +15,23 @@ from .rendering import apply_defaults
 
 
 def _deep_merge(target: dict, extra: dict | None) -> dict:
+    """
+    Recursively merge the contents of the 'extra' dictionary into 'target',
+    performing a deep merge for nested dictionaries.
+
+    Args:
+        target: The base dictionary to update.
+        extra: An optional dictionary whose values will be merged into 'target'.
+
+    Returns:
+        The modified 'target' dictionary with merged values from 'extra'.
+
+    Example:
+        >>> a = {'a': 1, 'b': {'c': 2}}
+        >>> b = {'b': {'d': 3}, 'e': 4}
+        >>> _deep_merge(a, b)
+        {'a': 1, 'b': {'c': 2, 'd': 3}, 'e': 4}
+    """
     if not extra:
         return target
     for key, value in extra.items():

--- a/src/aiconfigurator/generator/module_bridge.py
+++ b/src/aiconfigurator/generator/module_bridge.py
@@ -141,15 +141,21 @@ def task_config_to_generator_config(
     model_cfg = _deep_merge(model_cfg, overrides.get("ModelConfig"))
     model_cfg = apply_defaults("ModelConfig", model_cfg, backend=backend_name)
 
-    k8s_cfg = {}
-    k8s_cfg = _deep_merge(k8s_cfg, overrides.get("K8sConfig"))
-    k8s_cfg = apply_defaults("K8sConfig", k8s_cfg, backend=backend_name)
-
     dyn_cfg = {
         "mode": task_config.serving_mode,
     }
     dyn_cfg = _deep_merge(dyn_cfg, overrides.get("DynConfig"))
     dyn_cfg = apply_defaults("DynConfig", dyn_cfg, backend=backend_name)
+
+    generator_dynamo_version = overrides.get("generator_dynamo_version")
+    k8s_cfg = {}
+    k8s_cfg = _deep_merge(k8s_cfg, overrides.get("K8sConfig"))
+    k8s_cfg = apply_defaults(
+        "K8sConfig",
+        k8s_cfg,
+        backend=backend_name,
+        extra_context={"generator_dynamo_version": generator_dynamo_version},
+    )
 
     worker_overrides = overrides.get("Workers", {})
     worker_count_overrides = overrides.get("WorkerCounts") or overrides.get("WorkerConfig") or {}
@@ -217,6 +223,7 @@ def task_config_to_generator_config(
         sla=sla_cfg,
         dyn_config=dyn_cfg,
         backend=backend_name,
+        generator_dynamo_version=generator_dynamo_version,
     )
 
     params = _deep_merge(params, overrides.get("Params"))

--- a/src/aiconfigurator/generator/rendering/schemas.py
+++ b/src/aiconfigurator/generator/rendering/schemas.py
@@ -15,6 +15,8 @@ _DEFAULT_BACKEND = "trtllm"
 _BASE_DIR = Path(__file__).resolve().parent
 _CONFIG_DIR = _BASE_DIR.parent / "config"
 _SCHEMA_FILE = (_CONFIG_DIR / "deployment_config.yaml").resolve()
+_BACKEND_VERSION_MATRIX_FILE = (_CONFIG_DIR / "backend_version_matrix.yaml").resolve()
+_MATRIX_CACHE: dict[str, dict[str, Any]] = {}
 
 
 def _load_schema_inputs(schema_path: str) -> list[dict[str, Any]]:
@@ -34,6 +36,30 @@ def _load_schema_inputs(schema_path: str) -> list[dict[str, Any]]:
         inputs = []
     _SCHEMA_CACHE[path] = inputs
     return inputs
+
+
+def _load_backend_version_matrix(matrix_path: str) -> dict[str, dict[str, Any]]:
+    path = os.path.abspath(str(matrix_path))
+    cached = _MATRIX_CACHE.get(path)
+    if cached is not None:
+        return cached
+    try:
+        with open(path, encoding="utf-8") as f:
+            payload = yaml.safe_load(f) or {}
+    except Exception:
+        payload = {}
+    matrix = payload.get("matrix", payload) if isinstance(payload, dict) else {}
+    if not isinstance(matrix, dict):
+        matrix = {}
+    _MATRIX_CACHE[path] = matrix
+    return matrix
+
+
+def get_default_dynamo_version() -> Optional[str]:
+    matrix = _load_backend_version_matrix(_BACKEND_VERSION_MATRIX_FILE)
+    if not matrix:
+        return None
+    return str(next(iter(matrix.keys())))
 
 
 def _normalize_backend(backend: Optional[str]) -> str:
@@ -64,9 +90,20 @@ def _select_backend_default(entry: dict[str, Any], backend: str) -> Any:
     return entry.get("default")
 
 
-def apply_defaults(group: str, cfg: dict[str, Any], backend: Optional[str] = None) -> dict[str, Any]:
+def apply_defaults(
+    group: str,
+    cfg: dict[str, Any],
+    backend: Optional[str] = None,
+    extra_context: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
     inputs = _load_schema_inputs(str(_SCHEMA_FILE))
     eval_ctx = {group: dict(cfg)}
+    if extra_context:
+        eval_ctx.update(extra_context)
+    if group == "K8sConfig" and not eval_ctx.get("generator_dynamo_version"):
+        default_version = get_default_dynamo_version()
+        if default_version:
+            eval_ctx["generator_dynamo_version"] = default_version
     out = dict(cfg)
     backend_key = _normalize_backend(backend)
     for entry in inputs:

--- a/src/aiconfigurator/generator/utils.py
+++ b/src/aiconfigurator/generator/utils.py
@@ -5,9 +5,15 @@
 
 from __future__ import annotations
 
+import os
+from functools import cache
 from typing import Any, Optional
 
+import yaml
+
 DEFAULT_BACKEND = "trtllm"
+GENERATOR_CONFIG_DIR = os.path.join(os.path.dirname(__file__), "config")
+DEFAULT_BACKEND_VERSION_MATRIX_PATH = os.path.join(GENERATOR_CONFIG_DIR, "backend_version_matrix.yaml")
 
 
 def normalize_backend(backend: Optional[str], default: str = DEFAULT_BACKEND) -> str:
@@ -40,3 +46,68 @@ def coerce_int(value: Optional[Any]) -> Optional[int]:
         return int(value)
     except (TypeError, ValueError):
         return None
+
+
+def _load_yaml_payload(path: str) -> Any:
+    with open(path, encoding="utf-8") as fh:
+        return yaml.safe_load(fh) or {}
+
+
+@cache
+def load_backend_version_matrix(matrix_path: str) -> dict[str, dict[str, Any]]:
+    payload = _load_yaml_payload(matrix_path)
+    if not isinstance(payload, dict):
+        raise TypeError(f"Backend version matrix must be a YAML mapping: {matrix_path}")
+    matrix = payload.get("matrix", payload)
+    if not isinstance(matrix, dict):
+        raise TypeError(f"Backend version matrix missing 'matrix' mapping: {matrix_path}")
+    return matrix
+
+
+def get_default_dynamo_version_mapping(
+    matrix_path: str = DEFAULT_BACKEND_VERSION_MATRIX_PATH,
+) -> tuple[str, dict[str, Any]]:
+    """
+    Return the default Dynamo version and its backend-version mapping.
+
+    The default entry is the first item in backend_version_matrix.yaml.
+    """
+    matrix = load_backend_version_matrix(matrix_path)
+    if not matrix:
+        raise ValueError(f"Backend version matrix is empty: {matrix_path}")
+    dynamo_version, entry = next(iter(matrix.items()))
+    if not isinstance(entry, dict):
+        raise TypeError(f"Invalid backend version entry for {dynamo_version}: {entry!r}")
+    return str(dynamo_version), entry
+
+
+def resolve_backend_version_for_dynamo(
+    dynamo_version: str,
+    backend: Optional[str],
+    matrix_path: str = DEFAULT_BACKEND_VERSION_MATRIX_PATH,
+) -> str:
+    """
+    Resolve backend template version from a Dynamo version via the matrix file.
+
+    Args:
+        dynamo_version: Dynamo release string (e.g., "v0.8.1").
+        backend: Backend name (e.g., "trtllm", "vllm", "sglang").
+        matrix_path: Optional backend version matrix YAML file.
+    """
+    version_key = str(dynamo_version).strip()
+    if not version_key:
+        raise ValueError("dynamo_version must be a non-empty string.")
+    matrix = load_backend_version_matrix(matrix_path)
+    entry = matrix.get(version_key)
+    if not isinstance(entry, dict):
+        supported = ", ".join(sorted(matrix.keys()))
+        raise TypeError(f"Unsupported dynamo_version '{version_key}'. Supported versions: {supported or 'none'}.")
+    backend_key = normalize_backend(backend, DEFAULT_BACKEND)
+    backend_version = entry.get(backend_key)
+    if backend_version is None:
+        supported_backends = ", ".join(sorted(entry.keys()))
+        raise ValueError(
+            f"No backend version mapping for backend '{backend_key}' in dynamo '{version_key}'. "
+            f"Supported backends: {supported_backends or 'none'}."
+        )
+    return str(backend_version)

--- a/tests/unit/cli/test_argument_parsing.py
+++ b/tests/unit/cli/test_argument_parsing.py
@@ -110,6 +110,7 @@ class TestCLIArgumentParsing:
         assert args.debug is False
         assert args.decode_system is None
         assert args.generated_config_version is None
+        assert args.generator_dynamo_version is None
         assert args.isl == 4000
         assert args.osl == 1000
         assert args.save_dir is None


### PR DESCRIPTION
#### Overview:

Let generator support both dynamo version and backend version

  - Use `--generator-dynamo-version v0.8.0` to select the Dynamo release. This affects both the generated backend config version and the default K8s image tag.
  - If `--generator-dynamo-version` is not provided, the default is the first entry in `generator/config/backend_version_matrix.yaml`.
  - If `--generated_config_version` is provided, it overrides the generated backend version, but the default K8s image tag still follows the first entry in `backend_version_matrix.yaml`.

- Added example usage to `aiconfigurator cli default --help`
<img width="535" height="280" alt="Screenshot 2026-02-09 at 6 05 08 PM" src="https://github.com/user-attachments/assets/0239ce60-692f-4178-9610-03d57e731eb3" />

Will create a separate PR to unify dash and underscores in CLI flags.
