### PR TITLE
fix(collector_mamba2): add missing columns

### DIFF
--- a/collector/trtllm/collect_mamba2.py
+++ b/collector/trtllm/collect_mamba2.py
@@ -482,6 +482,8 @@ def run_mamba2_generation_benchmark(
                 common_log_data = {
                     "phase": "generation",
                     "batch_size": batch_size,
+                    "seq_len": 1,
+                    "num_tokens": batch_size,
                     "d_model": d_model,
                     "d_state": d_state,
                     "d_conv": d_conv,
@@ -578,6 +580,8 @@ def run_mamba2_generation_benchmark(
                 common_log_data = {
                     "phase": "generation",
                     "batch_size": batch_size,
+                    "seq_len": 1,
+                    "num_tokens": batch_size,
                     "d_model": d_model,
                     "d_state": d_state,
                     "d_conv": d_conv,

--- a/src/aiconfigurator/systems/data/gb200_sxm/trtllm/1.2.0rc5/mamba2_perf.txt
+++ b/src/aiconfigurator/systems/data/gb200_sxm/trtllm/1.2.0rc5/mamba2_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4f2955a0b99aab9c3096577cb9d202633ab355cdd2de8108e8ca99b0fbd9f7e9
-size 128473
+oid sha256:7c3de6d4a634b41e67130824cc9b0b741bd89a17a4e009f58ac7284129650db8
+size 128921


### PR DESCRIPTION
The Mamba 2 collector result generates a malformed csv. This PR adds the missing columns to the collector along with the updated data.