### PR TITLE
chore: bump version number to 0.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "aiconfigurator"
-version = "0.6.0"
+version = "0.7.0"
 authors = [
     { name = "NVIDIA Inc.", email = "sw-dl-dynamo@nvidia.com" },
 ]


### PR DESCRIPTION
#### Overview:

Bump version number to `0.7.0`
