### PR TITLE
fix: system path error handle

### DIFF
--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -319,6 +319,9 @@ def _ensure_backend_version_available(system_name: str, backend_name: str, backe
     if backend_version in versions:
         return
 
+    systems_paths = perf_database.get_systems_paths()
+    systems_paths_display = ", ".join(systems_paths) if systems_paths else "<none>"
+
     logger.error(
         "No perf database for system=%s backend=%s version=%s.",
         system_name,
@@ -328,11 +331,23 @@ def _ensure_backend_version_available(system_name: str, backend_name: str, backe
     data_path = _get_backend_data_path(system_name, backend_name, backend_version)
     if data_path:
         logger.error("Searched: %s", data_path)
+    logger.error("Configured systems paths: %s", systems_paths_display)
     if versions:
         logger.error("Available versions: %s", ", ".join(versions))
+        logger.error(
+            "Fix: switch --backend-version to one of the available versions, or remove --backend-version to use latest."
+        )
     else:
         logger.error("Available versions: none")
-    logger.error("Fix: remove --backend-version to use the latest, or provide one of the available versions.")
+        logger.error(
+            "Fix: no database was found for system=%s backend=%s in current --systems-paths.",
+            system_name,
+            backend_name,
+        )
+        logger.error(
+            "Try adding a path that contains this database via --systems-paths. "
+            'Example: --systems-paths "default,/path/to/extra/systems".'
+        )
     raise SystemExit(1)
 
 

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -784,7 +784,10 @@ def main(args):
         format="%(levelname)s %(asctime)s %(filename)s:%(lineno)d] %(message)s",
     )
 
-    perf_database.set_systems_paths(args.systems_paths)
+    try:
+        perf_database.set_systems_paths(args.systems_paths)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
 
     logger.info(f"Loading Dynamo AIConfigurator version: {__version__}")
     logger.info(f"Number of top configurations to output: {args.top_n} (change with --top-n)")

--- a/src/aiconfigurator/webapp/main.py
+++ b/src/aiconfigurator/webapp/main.py
@@ -47,7 +47,6 @@ def main(args):
     """
     from aiconfigurator.sdk import perf_database
 
-    perf_database.set_systems_paths(args.systems_paths)
     app_config = {
         "enable_agg": args.enable_agg,
         "enable_disagg_pd_ratio": args.enable_disagg_pd_ratio,
@@ -68,6 +67,14 @@ def main(args):
             format="%(levelname)s %(asctime)s] %(message)s",
             datefmt="%m-%d %H:%M:%S",
         )
+
+    try:
+        perf_database.set_systems_paths(args.systems_paths)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+
+    if not perf_database.get_all_databases():
+        raise SystemExit(perf_database.build_no_databases_message())
 
     with gr.Blocks(
         title="Dynamo aiconfigurator for Disaggregated Serving Deployment",

--- a/tests/unit/sdk/database/test_database_helpers.py
+++ b/tests/unit/sdk/database/test_database_helpers.py
@@ -130,6 +130,39 @@ def test_get_supported_databases_multiple_paths(temp_systems_dir: Path, perf_dat
     assert result["h200"]["vllm"] == ["0.6.0"]
 
 
+def test_build_no_databases_message_with_missing_path(temp_systems_dir: Path, perf_database):
+    custom_systems_dir = temp_systems_dir / "custom_systems"
+    custom_systems_dir.mkdir()
+    previous_paths = perf_database.get_systems_paths()
+    try:
+        perf_database.set_systems_paths(str(custom_systems_dir))
+        message = perf_database.build_no_databases_message()
+        assert "No loadable performance databases found under --systems-paths" in message
+        assert "Configured systems paths:" in message
+        assert str(custom_systems_dir) in message
+        assert "adding `default`" in message
+    finally:
+        perf_database.set_systems_paths(previous_paths)
+
+
+def test_build_no_databases_message_with_existing_empty_path(temp_systems_dir: Path, perf_database):
+    previous_paths = perf_database.get_systems_paths()
+    try:
+        perf_database.set_systems_paths("default")
+        message = perf_database.build_no_databases_message()
+        assert "No loadable performance databases found under --systems-paths" in message
+        assert "Configured systems paths:" in message
+        assert "already included" in message
+    finally:
+        perf_database.set_systems_paths(previous_paths)
+
+
+def test_set_systems_paths_invalid_entry_raises(temp_systems_dir: Path, perf_database):
+    missing_path = temp_systems_dir / "missing_systems_path"
+    with pytest.raises(ValueError, match="Invalid --systems-paths"):
+        perf_database.set_systems_paths(str(missing_path))
+
+
 # ----------------------------- get_latest_database_version -----------------------------
 
 


### PR DESCRIPTION
#### Overview:

improve the error message when the system path is incorrect or the target db cannot be loaded.

webapp invalid path
```bash
aiconfigurator webapp  --systems-paths /nonexistent/path
```
```text
Invalid --systems-paths: each entry must be an existing directory. Invalid entries: /nonexistent/path
```

cli invalid path
```bash
aiconfigurator cli default --model Qwen/Qwen3-32B-FP8 --total-gpus 8 --system h200_sxm --backend trtllm --backend-version 0.111 --isl 4000 --osl 500 --ttft 600 --tpot 20 --save-dir results/ --generated-config-version 1.2.0rc5 --systems-paths /ddd
```
```text
Invalid --systems-paths: each entry must be an existing directory. Invalid entries: /ddd
```

cli no db available
```bash
aiconfigurator cli default --model Qwen/Qwen3-32B-FP8 --total-gpus 8 --system h200_sxm --backend trtllm --backend-version 0.111 --isl 4000 --osl 500 --ttft 600 --tpot 20 --save-dir results/ --generated-config-version 1.2.0rc5 --systems-paths results
```
```text
2026-02-11 23:10:44,342 - aiconfigurator.cli.main - INFO - Loading Dynamo AIConfigurator version: 0.7.0
2026-02-11 23:10:44,342 - aiconfigurator.cli.main - INFO - Number of top configurations to output: 5 (change with --top-n)
2026-02-11 23:10:44,342 - aiconfigurator.cli.main - ERROR - No perf database for system=h200_sxm backend=trtllm version=0.111.
2026-02-11 23:10:44,342 - aiconfigurator.cli.main - ERROR - Configured systems paths: results
2026-02-11 23:10:44,342 - aiconfigurator.cli.main - ERROR - Available versions: none
2026-02-11 23:10:44,342 - aiconfigurator.cli.main - ERROR - Fix: no database was found for system=h200_sxm backend=trtllm in current --systems-paths.
2026-02-11 23:10:44,342 - aiconfigurator.cli.main - ERROR - Try adding a path that contains this database via --systems-paths. Example: --systems-paths "default,/path/to/extra/systems".
```

cli cannot load the target version
```bash
aiconfigurator cli default --model Qwen/Qwen3-32B-FP8 --total-gpus 8 --system h200_sxm --backend trtllm --backend-version 0.111 --isl 4000 --osl 500 --ttft 600 --tpot 20 --save-dir results/ --generated-config-version 1.2.0rc5
```
```text
2026-02-11 23:11:13,502 - aiconfigurator.cli.main - INFO - Loading Dynamo AIConfigurator version: 0.7.0
2026-02-11 23:11:13,502 - aiconfigurator.cli.main - INFO - Number of top configurations to output: 5 (change with --top-n)
2026-02-11 23:11:13,517 - aiconfigurator.cli.main - ERROR - No perf database for system=h200_sxm backend=trtllm version=0.111.
2026-02-11 23:11:13,518 - aiconfigurator.cli.main - ERROR - Searched: /Users/tianhaox/xProjects/nvidia_stack/aiconfigurator/src/aiconfigurator/systems/data/h200_sxm/trtllm/0.111
2026-02-11 23:11:13,518 - aiconfigurator.cli.main - ERROR - Configured systems paths: /Users/tianhaox/xProjects/nvidia_stack/aiconfigurator/src/aiconfigurator/systems
2026-02-11 23:11:13,518 - aiconfigurator.cli.main - ERROR - Available versions: 1.0.0rc3, 1.2.0rc2, 1.2.0rc5
2026-02-11 23:11:13,518 - aiconfigurator.cli.main - ERROR - Fix: switch --backend-version to one of the available versions, or remove --backend-version to use latest.
```