### PR TITLE
fix: Allow --num-gpus 1 to test single-gpu agg only

### DIFF
--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -418,6 +418,10 @@ def build_default_task_configs(
         exp_name = f"agg_{backend_name}" if backend == "auto" else "agg"
         task_configs[exp_name] = agg_task
 
+        if total_gpus < 2:
+            logger.warning("Skipping disagg since it requires at least 2 GPUs.")
+            continue
+
         # Create disagg task for this backend
         disagg_kwargs = dict(common_kwargs)
         disagg_kwargs["backend_name"] = backend_name

--- a/tests/e2e/cli/test_cli_build_default.py
+++ b/tests/e2e/cli/test_cli_build_default.py
@@ -73,6 +73,19 @@ _DEFAULT_BUILD_CASES = [
             "tpot": 10,
         },
     ),
+    pytest.param(
+        {
+            "model_path": "Qwen/Qwen3-32B",
+            "system": "h200_sxm",
+            "backend": "vllm",
+            "total_gpus": 1,  # agg only
+            "isl": 4000,
+            "osl": 1000,
+            "prefix": 0,
+            "ttft": 5000,
+            "tpot": 100,
+        },
+    ),
 ]
 
 


### PR DESCRIPTION
#### Overview:
Previously CLI would error if user specified `--num-gpus=1`. Now it works, just skips disagg
