### PR TITLE
fix: bump the image version of webapp

### DIFF
--- a/src/aiconfigurator/webapp/components/profiling/sdk/config.py
+++ b/src/aiconfigurator/webapp/components/profiling/sdk/config.py
@@ -15,7 +15,10 @@ import re
 
 import yaml
 
-from aiconfigurator.generator.api import generate_backend_artifacts, generate_config_from_input_dict
+from aiconfigurator.generator.api import (
+    generate_backend_artifacts,
+    generate_config_from_input_dict,
+)
 
 # Constants
 DECODE_MAX_CONCURRENCY = 1024
@@ -71,7 +74,7 @@ def generate_config_yaml(
         "K8sConfig": {
             "name_prefix": name_prefix,
             "k8s_namespace": "dynamo",
-            "k8s_image": "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.0",
+            "k8s_image": "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.9.0",
             "k8s_model_cache": "model-cache",
             "k8s_engine_mode": "inline",
         },


### PR DESCRIPTION
#### Overview:

- Bump up container version to 0.9.0 for release/v0.6.0 cherry-pick

