### PR TITLE
fix: model WideEP generation overlap and fix shared expert dimensions

### DIFF
--- a/src/aiconfigurator/sdk/models.py
+++ b/src/aiconfigurator/sdk/models.py
@@ -1749,14 +1749,12 @@ class TrtllmWideEPDeepSeekModel(BaseModel):
         )
 
         # ===================== Generation Phase =====================
-        gen_sf = self._num_layers * self._mtp_scale_factor  # common scale factor
-
         self.generation_ops.extend(
             [
                 ops.Embedding("generation_embedding", 1 * self._mtp_scale_factor, self._vocab_size, h, 0.3),
                 ops.ElementWise(
                     "generation_add_norm_1",
-                    gen_sf,
+                    self._num_layers * self._mtp_scale_factor,
                     2 * h,
                     2 * h,
                     0.8,
@@ -1764,7 +1762,7 @@ class TrtllmWideEPDeepSeekModel(BaseModel):
                 # kv_a_proj_with_mqa: projects hidden_size -> compressed_dim (1536+512+64=2112)
                 ops.GEMM(
                     "generation_downscale_gemm",
-                    gen_sf,
+                    self._num_layers * self._mtp_scale_factor,
                     2112,
                     h,
                     gemm_quant_mode,
@@ -1774,14 +1772,14 @@ class TrtllmWideEPDeepSeekModel(BaseModel):
                 # so we model only q_a_layernorm as the dominant one.
                 ops.ElementWise(
                     "generation_q_a_layernorm",
-                    gen_sf,
+                    self._num_layers * self._mtp_scale_factor,
                     1536,
                     1536,
                     0.8,
                 ),
                 ops.GEMM(
                     "generation_q_b_proj_gemm",
-                    gen_sf,
+                    self._num_layers * self._mtp_scale_factor,
                     24576 // tp_size,
                     1536,
                     gemm_quant_mode,
@@ -1795,7 +1793,7 @@ class TrtllmWideEPDeepSeekModel(BaseModel):
                     group_a=[
                         ops.MLABmm(
                             "generation_bmm_pre",
-                            gen_sf,
+                            self._num_layers * self._mtp_scale_factor,
                             self._num_heads // tp_size,
                             mla_bmm_quant_mode,
                             if_pre=True,
@@ -1805,7 +1803,7 @@ class TrtllmWideEPDeepSeekModel(BaseModel):
                         # mla_rope_generation: RoPE on q_pe (64d) + KV cache write (512+64=576d)
                         ops.ElementWise(
                             "generation_rope_kvcache",
-                            gen_sf,
+                            self._num_layers * self._mtp_scale_factor,
                             576,  # kv_lora_rank(512) + qk_rope_head_dim(64)
                             576,
                             0.8,
@@ -1814,27 +1812,27 @@ class TrtllmWideEPDeepSeekModel(BaseModel):
                 ),
                 ops.GenerationMLA(
                     "generation_attention",
-                    gen_sf,
+                    self._num_layers * self._mtp_scale_factor,
                     128 // tp_size,
                     kvcache_quant_mode,
                 ),
                 ops.MLABmm(
                     "generation_bmm_post",
-                    gen_sf,
+                    self._num_layers * self._mtp_scale_factor,
                     self._num_heads // tp_size,
                     mla_bmm_quant_mode,
                     if_pre=False,
                 ),
                 ops.GEMM(
                     "generation_proj_gemm",
-                    gen_sf,
+                    self._num_layers * self._mtp_scale_factor,
                     h,
                     h // tp_size,
                     gemm_quant_mode,
                 ),
                 ops.ElementWise(
                     "generation_add_norm_2",
-                    gen_sf,
+                    self._num_layers * self._mtp_scale_factor,
                     2 * h,
                     2 * h,
                     0.8,
@@ -1854,21 +1852,21 @@ class TrtllmWideEPDeepSeekModel(BaseModel):
         _shared_expert_ops = [
             ops.GEMM(
                 "generation_shared_gate_up_gemm",
-                gen_sf,
+                self._num_layers * self._mtp_scale_factor,
                 2 * self._moe_inter_size,
                 h,
                 gemm_quant_mode,
             ),
             ops.ElementWise(
                 "generation_shared_act_gate",
-                gen_sf,
+                self._num_layers * self._mtp_scale_factor,
                 2 * self._moe_inter_size,
                 self._moe_inter_size,
                 0.8,
             ),
             ops.GEMM(
                 "generation_shared_ffn2_gemm",
-                gen_sf,
+                self._num_layers * self._mtp_scale_factor,
                 h,
                 self._moe_inter_size,
                 gemm_quant_mode,
@@ -1879,14 +1877,14 @@ class TrtllmWideEPDeepSeekModel(BaseModel):
         _routed_expert_ops = [
             ops.GEMM(
                 "generation_router_gemm",
-                gen_sf,
+                self._num_layers * self._mtp_scale_factor,
                 self._num_experts,
                 h,
                 common.GEMMQuantMode.float16,
             ),
             ops.TrtLLMWideEPMoEDispatch(
                 "generation_moe_pre_dispatch",
-                gen_sf,
+                self._num_layers * self._mtp_scale_factor,
                 h,
                 self._topk,
                 self._num_experts,
@@ -1898,7 +1896,7 @@ class TrtllmWideEPDeepSeekModel(BaseModel):
             ),
             ops.TrtLLMWideEPMoE(
                 "generation_moe",
-                gen_sf,
+                self._num_layers * self._mtp_scale_factor,
                 h,
                 self._moe_inter_size,
                 self._topk,
@@ -1912,7 +1910,7 @@ class TrtllmWideEPDeepSeekModel(BaseModel):
             ),
             ops.TrtLLMWideEPMoEDispatch(
                 "generation_moe_post_dispatch",
-                gen_sf,
+                self._num_layers * self._mtp_scale_factor,
                 h,
                 self._topk,
                 self._num_experts,
@@ -1921,7 +1919,7 @@ class TrtllmWideEPDeepSeekModel(BaseModel):
                 attention_dp_size,
                 False,  # post_dispatch (combine)
                 quant_mode=moe_quant_mode,
-                low_precision_combine=True,
+                use_low_precision_combine=True,
             ),
         ]
 
@@ -1938,7 +1936,7 @@ class TrtllmWideEPDeepSeekModel(BaseModel):
         self.generation_ops.append(
             ops.ElementWise(
                 "generation_moe_reduce_add",
-                gen_sf,
+                self._num_layers * self._mtp_scale_factor,
                 2 * h,
                 h,
                 0.8,

--- a/src/aiconfigurator/sdk/models.py
+++ b/src/aiconfigurator/sdk/models.py
@@ -1591,11 +1591,16 @@ class TrtllmWideEPDeepSeekModel(BaseModel):
             )
 
         # ===================== Context Phase =====================
+        # Note: Context phase does NOT use CUDA Graph, so maybe_execute_in_parallel
+        # falls back to sequential execution. All ops are modeled sequentially here.
         self.context_ops.extend(
             [
                 ops.Embedding("context_embedding", 1, self._vocab_size, h, 0.3),
                 ops.ElementWise("context_add_norm_1", self._num_layers, 2 * h, 2 * h, 0.8),
+                # kv_a_proj_with_mqa: projects hidden_size -> compressed_dim (1536+512+64=2112)
                 ops.GEMM("context_downscale_gemm", self._num_layers, 2112, h, gemm_quant_mode),
+                # q_a_layernorm: RMSNorm on q_compressed (dim=1536)
+                ops.ElementWise("context_q_a_layernorm", self._num_layers, 1536, 1536, 0.8),
                 ops.GEMM(
                     "context_q_b_proj_gemm",
                     self._num_layers,
@@ -1622,35 +1627,30 @@ class TrtllmWideEPDeepSeekModel(BaseModel):
             ]
         )
 
-        # shared moe
+        # shared moe (sequential in context phase - no CUDA Graph overlap)
+        # In WideEP ADP mode, shared_tp_size=1: each rank computes full shared expert.
+        # TRT-LLM uses fused gate_up_proj: one GEMM with output dim = 2 * inter_size.
         self.context_ops.extend(
             [
                 ops.GEMM(
-                    "context_shared_gate_gemm",
+                    "context_shared_gate_up_gemm",
                     self._num_layers,
-                    self._moe_inter_size // tp_size,
-                    h,
-                    gemm_quant_mode,
-                ),
-                ops.GEMM(
-                    "context_shared_ffn1_gemm",
-                    self._num_layers,
-                    self._moe_inter_size // tp_size,
+                    2 * self._moe_inter_size,
                     h,
                     gemm_quant_mode,
                 ),
                 ops.ElementWise(
                     "context_shared_act_gate",
                     self._num_layers,
-                    2 * self._moe_inter_size // tp_size,
-                    self._moe_inter_size // tp_size,
+                    2 * self._moe_inter_size,
+                    self._moe_inter_size,
                     0.8,
                 ),
                 ops.GEMM(
                     "context_shared_ffn2_gemm",
                     self._num_layers,
                     h,
-                    self._moe_inter_size // tp_size,
+                    self._moe_inter_size,
                     gemm_quant_mode,
                 ),
             ]
@@ -1725,6 +1725,17 @@ class TrtllmWideEPDeepSeekModel(BaseModel):
             ]
         )
 
+        # moe_reduce_add_shared_output: sum routed output over top_k + add shared output
+        self.context_ops.append(
+            ops.ElementWise(
+                "context_moe_reduce_add",
+                self._num_layers,
+                2 * h,
+                h,
+                0.8,
+            )
+        )
+
         self.context_ops.extend(
             [
                 ops.GEMM(
@@ -1738,60 +1749,92 @@ class TrtllmWideEPDeepSeekModel(BaseModel):
         )
 
         # ===================== Generation Phase =====================
+        gen_sf = self._num_layers * self._mtp_scale_factor  # common scale factor
+
         self.generation_ops.extend(
             [
                 ops.Embedding("generation_embedding", 1 * self._mtp_scale_factor, self._vocab_size, h, 0.3),
                 ops.ElementWise(
                     "generation_add_norm_1",
-                    self._num_layers * self._mtp_scale_factor,
+                    gen_sf,
                     2 * h,
                     2 * h,
                     0.8,
                 ),
+                # kv_a_proj_with_mqa: projects hidden_size -> compressed_dim (1536+512+64=2112)
                 ops.GEMM(
                     "generation_downscale_gemm",
-                    self._num_layers * self._mtp_scale_factor,
+                    gen_sf,
                     2112,
                     h,
                     gemm_quant_mode,
                 ),
+                # q_a_layernorm: RMSNorm on q_compressed (dim=1536)
+                # In TRT-LLM, kv_a_layernorm (dim=512) runs in parallel but is much smaller,
+                # so we model only q_a_layernorm as the dominant one.
+                ops.ElementWise(
+                    "generation_q_a_layernorm",
+                    gen_sf,
+                    1536,
+                    1536,
+                    0.8,
+                ),
                 ops.GEMM(
                     "generation_q_b_proj_gemm",
-                    self._num_layers * self._mtp_scale_factor,
+                    gen_sf,
                     24576 // tp_size,
                     1536,
                     gemm_quant_mode,
                 ),
-                ops.MLABmm(
-                    "generation_bmm_pre",
-                    self._num_layers * self._mtp_scale_factor,
-                    self._num_heads // tp_size,
-                    mla_bmm_quant_mode,
-                    if_pre=True,
+                # BMM_pre (Absorption) || RoPE+KV cache prep (overlap on two streams)
+                # Main stream: q_nope * W_absorption -> absorbed_q
+                # Aux stream: RoPE(q_pe) + write compressed_kv to KV cache
+                # Effective latency = max(bmm_pre, rope_kvcache)
+                ops.OverlapOp(
+                    "generation_bmm_rope_overlap",
+                    group_a=[
+                        ops.MLABmm(
+                            "generation_bmm_pre",
+                            gen_sf,
+                            self._num_heads // tp_size,
+                            mla_bmm_quant_mode,
+                            if_pre=True,
+                        ),
+                    ],
+                    group_b=[
+                        # mla_rope_generation: RoPE on q_pe (64d) + KV cache write (512+64=576d)
+                        ops.ElementWise(
+                            "generation_rope_kvcache",
+                            gen_sf,
+                            576,  # kv_lora_rank(512) + qk_rope_head_dim(64)
+                            576,
+                            0.8,
+                        ),
+                    ],
                 ),
                 ops.GenerationMLA(
                     "generation_attention",
-                    self._num_layers * self._mtp_scale_factor,
+                    gen_sf,
                     128 // tp_size,
                     kvcache_quant_mode,
                 ),
                 ops.MLABmm(
                     "generation_bmm_post",
-                    self._num_layers * self._mtp_scale_factor,
+                    gen_sf,
                     self._num_heads // tp_size,
                     mla_bmm_quant_mode,
                     if_pre=False,
                 ),
                 ops.GEMM(
                     "generation_proj_gemm",
-                    self._num_layers * self._mtp_scale_factor,
+                    gen_sf,
                     h,
                     h // tp_size,
                     gemm_quant_mode,
                 ),
                 ops.ElementWise(
                     "generation_add_norm_2",
-                    self._num_layers * self._mtp_scale_factor,
+                    gen_sf,
                     2 * h,
                     2 * h,
                     0.8,
@@ -1799,107 +1842,107 @@ class TrtllmWideEPDeepSeekModel(BaseModel):
             ]
         )
 
-        # shared moe
-        self.generation_ops.extend(
-            [
-                ops.GEMM(
-                    "generation_shared_gate_gemm",
-                    self._num_layers * self._mtp_scale_factor,
-                    self._moe_inter_size // tp_size,
-                    h,
-                    gemm_quant_mode,
-                ),
-                ops.GEMM(
-                    "generation_shared_ffn1_gemm",
-                    self._num_layers * self._mtp_scale_factor,
-                    self._moe_inter_size // tp_size,
-                    h,
-                    gemm_quant_mode,
-                ),
-                ops.ElementWise(
-                    "generation_shared_act_gate",
-                    self._num_layers * self._mtp_scale_factor,
-                    2 * self._moe_inter_size // tp_size,
-                    self._moe_inter_size // tp_size,
-                    0.8,
-                ),
-                ops.GEMM(
-                    "generation_shared_ffn2_gemm",
-                    self._num_layers * self._mtp_scale_factor,
-                    h,
-                    self._moe_inter_size // tp_size,
-                    gemm_quant_mode,
-                ),
-            ]
+        # ---- MoE: Shared Expert || Routed Expert (OverlapOp) ----
+        # In TRT-LLM generation phase (CUDA Graph enabled), shared expert runs
+        # on aux stream in parallel with routed expert on main stream.
+        # Latency = max(routed_path, shared_path) instead of sum.
+
+        # Group B (Aux Stream): Shared Expert
+        # Note: In WideEP ADP mode, shared_tp_size=1 (no TP for shared expert),
+        # so we use full moe_inter_size without dividing by tp_size.
+        # TRT-LLM uses fused gate_up_proj: one GEMM with output dim = 2 * inter_size.
+        _shared_expert_ops = [
+            ops.GEMM(
+                "generation_shared_gate_up_gemm",
+                gen_sf,
+                2 * self._moe_inter_size,
+                h,
+                gemm_quant_mode,
+            ),
+            ops.ElementWise(
+                "generation_shared_act_gate",
+                gen_sf,
+                2 * self._moe_inter_size,
+                self._moe_inter_size,
+                0.8,
+            ),
+            ops.GEMM(
+                "generation_shared_ffn2_gemm",
+                gen_sf,
+                h,
+                self._moe_inter_size,
+                gemm_quant_mode,
+            ),
+        ]
+
+        # Group A (Main Stream): Router + AllToAll Dispatch + MoE Compute + AllToAll Combine
+        _routed_expert_ops = [
+            ops.GEMM(
+                "generation_router_gemm",
+                gen_sf,
+                self._num_experts,
+                h,
+                common.GEMMQuantMode.float16,
+            ),
+            ops.TrtLLMWideEPMoEDispatch(
+                "generation_moe_pre_dispatch",
+                gen_sf,
+                h,
+                self._topk,
+                self._num_experts,
+                moe_tp_size,
+                moe_ep_size,
+                attention_dp_size,
+                True,  # pre_dispatch
+                quant_mode=moe_quant_mode,
+            ),
+            ops.TrtLLMWideEPMoE(
+                "generation_moe",
+                gen_sf,
+                h,
+                self._moe_inter_size,
+                self._topk,
+                self._num_experts,
+                moe_tp_size,
+                moe_ep_size,
+                moe_quant_mode,
+                workload_distribution,
+                attention_dp_size,
+                num_slots=wideep_num_slots,
+            ),
+            ops.TrtLLMWideEPMoEDispatch(
+                "generation_moe_post_dispatch",
+                gen_sf,
+                h,
+                self._topk,
+                self._num_experts,
+                moe_tp_size,
+                moe_ep_size,
+                attention_dp_size,
+                False,  # post_dispatch (combine)
+                quant_mode=moe_quant_mode,
+                low_precision_combine=True,
+            ),
+        ]
+
+        self.generation_ops.append(
+            ops.OverlapOp(
+                "generation_moe_overlap",
+                group_a=_routed_expert_ops,
+                group_b=_shared_expert_ops,
+            )
         )
 
-        # router gemm
-        self.generation_ops.extend(
-            [
-                ops.GEMM(
-                    "generation_router_gemm",
-                    self._num_layers * self._mtp_scale_factor,
-                    self._num_experts,
-                    h,
-                    common.GEMMQuantMode.float16,
-                )
-            ]
-        )
-
-        # WideEP: dispatch tokens to experts, pre-dispatch
-        self.generation_ops.extend(
-            [
-                ops.TrtLLMWideEPMoEDispatch(
-                    "generation_moe_pre_dispatch",
-                    self._num_layers * self._mtp_scale_factor,
-                    h,
-                    self._topk,
-                    self._num_experts,
-                    moe_tp_size,
-                    moe_ep_size,
-                    attention_dp_size,
-                    True,  # pre_dispatch
-                    quant_mode=moe_quant_mode,
-                )
-            ]
-        )
-
-        # WideEP: MoE computation with EPLB support
-        self.generation_ops.extend(
-            [
-                ops.TrtLLMWideEPMoE(
-                    "generation_moe",
-                    self._num_layers * self._mtp_scale_factor,
-                    h,
-                    self._moe_inter_size,
-                    self._topk,
-                    self._num_experts,
-                    moe_tp_size,
-                    moe_ep_size,
-                    moe_quant_mode,
-                    workload_distribution,
-                    attention_dp_size,
-                    num_slots=wideep_num_slots,
-                ),
-            ]
-        )
-
-        # WideEP: dispatch tokens to experts, post-dispatch (combine)
-        self.generation_ops.extend(
-            [
-                ops.TrtLLMWideEPMoEDispatch(
-                    "generation_moe_post_dispatch",
-                    self._num_layers * self._mtp_scale_factor,
-                    h,
-                    self._topk,
-                    self._num_experts,
-                    moe_tp_size,
-                    moe_ep_size,
-                    attention_dp_size,
-                    False,  # post_dispatch (combine)
-                    quant_mode=moe_quant_mode,
-                )
-            ]
+        # moe_reduce_add_shared_output: sum routed output over top_k + add shared output
+        # This runs after both streams synchronize.
+        self.generation_ops.append(
+            ops.ElementWise(
+                "generation_moe_reduce_add",
+                gen_sf,
+                2 * h,
+                h,
+                0.8,
+            )
         )
 
         self.generation_ops.extend(

--- a/tests/unit/sdk/database/test_overlap_op.py
+++ b/tests/unit/sdk/database/test_overlap_op.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for OverlapOp operation."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from aiconfigurator.sdk.operations import OverlapOp, PerformanceResult
+
+pytestmark = pytest.mark.unit
+
+
+def _make_mock_op(latency: float, energy: float, weights: float = 0.0):
+    """Create a mock operation that returns the given latency/energy/weights."""
+    op = MagicMock()
+    op.query.return_value = PerformanceResult(latency, energy=energy)
+    op.get_weights.return_value = weights
+    return op
+
+
+class TestOverlapOp:
+    """Test cases for OverlapOp class."""
+
+    def test_initialization(self):
+        """Test that group_a and group_b are stored correctly."""
+        op_a = _make_mock_op(10.0, 1.0)
+        op_b = _make_mock_op(5.0, 2.0)
+
+        overlap = OverlapOp("test_overlap", group_a=[op_a], group_b=[op_b])
+
+        assert overlap._name == "test_overlap"
+        assert overlap._group_a == [op_a]
+        assert overlap._group_b == [op_b]
+
+    def test_query_group_a_slower(self):
+        """Latency should equal group_a when group_a is slower."""
+        mock_db = MagicMock()
+        op_a1 = _make_mock_op(10.0, 100.0)
+        op_a2 = _make_mock_op(8.0, 80.0)
+        op_b1 = _make_mock_op(5.0, 50.0)
+
+        overlap = OverlapOp("test", group_a=[op_a1, op_a2], group_b=[op_b1])
+        result = overlap.query(mock_db, x=16)
+
+        assert isinstance(result, PerformanceResult)
+        assert float(result) == 18.0  # max(10+8, 5) = 18
+        assert result.energy == 230.0  # 100+80+50
+
+    def test_query_group_b_slower(self):
+        """Latency should equal group_b when group_b is slower."""
+        mock_db = MagicMock()
+        op_a1 = _make_mock_op(3.0, 30.0)
+        op_b1 = _make_mock_op(7.0, 70.0)
+        op_b2 = _make_mock_op(6.0, 60.0)
+
+        overlap = OverlapOp("test", group_a=[op_a1], group_b=[op_b1, op_b2])
+        result = overlap.query(mock_db, x=16)
+
+        assert float(result) == 13.0  # max(3, 7+6) = 13
+        assert result.energy == 160.0  # 30+70+60
+
+    def test_query_equal_latency(self):
+        """Latency should be correct when both groups have identical latency."""
+        mock_db = MagicMock()
+        op_a = _make_mock_op(10.0, 100.0)
+        op_b = _make_mock_op(10.0, 200.0)
+
+        overlap = OverlapOp("test", group_a=[op_a], group_b=[op_b])
+        result = overlap.query(mock_db, x=16)
+
+        assert float(result) == 10.0
+        assert result.energy == 300.0
+
+    def test_query_empty_group_b(self):
+        """When group_b is empty, latency equals group_a total."""
+        mock_db = MagicMock()
+        op_a = _make_mock_op(10.0, 100.0)
+
+        overlap = OverlapOp("test", group_a=[op_a], group_b=[])
+        result = overlap.query(mock_db, x=16)
+
+        assert float(result) == 10.0  # max(10, 0)
+        assert result.energy == 100.0
+
+    def test_query_empty_group_a(self):
+        """When group_a is empty, latency equals group_b total."""
+        mock_db = MagicMock()
+        op_b = _make_mock_op(7.0, 70.0)
+
+        overlap = OverlapOp("test", group_a=[], group_b=[op_b])
+        result = overlap.query(mock_db, x=16)
+
+        assert float(result) == 7.0  # max(0, 7)
+        assert result.energy == 70.0
+
+    def test_query_passes_kwargs_to_inner_ops(self):
+        """Verify that kwargs (e.g. x) are forwarded to inner ops."""
+        mock_db = MagicMock()
+        op_a = _make_mock_op(1.0, 1.0)
+        op_b = _make_mock_op(1.0, 1.0)
+
+        overlap = OverlapOp("test", group_a=[op_a], group_b=[op_b])
+        overlap.query(mock_db, x=32)
+
+        op_a.query.assert_called_once_with(mock_db, x=32)
+        op_b.query.assert_called_once_with(mock_db, x=32)
+
+    def test_get_weights_sums_all_ops(self):
+        """get_weights should return sum of weights from both groups."""
+        op_a1 = _make_mock_op(1.0, 1.0, weights=100.0)
+        op_a2 = _make_mock_op(1.0, 1.0, weights=200.0)
+        op_b1 = _make_mock_op(1.0, 1.0, weights=50.0)
+
+        overlap = OverlapOp("test", group_a=[op_a1, op_a2], group_b=[op_b1])
+
+        assert overlap.get_weights() == 350.0  # 100+200+50
+
+    def test_get_weights_empty_groups(self):
+        """get_weights should return 0 when both groups are empty."""
+        overlap = OverlapOp("test", group_a=[], group_b=[])
+        assert overlap.get_weights() == 0.0
+
+    def test_query_multiple_ops_per_group(self):
+        """Test with multiple ops in both groups to verify summation logic."""
+        mock_db = MagicMock()
+        group_a = [_make_mock_op(3.0, 30.0), _make_mock_op(4.0, 40.0), _make_mock_op(5.0, 50.0)]
+        group_b = [_make_mock_op(6.0, 60.0), _make_mock_op(7.0, 70.0)]
+
+        overlap = OverlapOp("test", group_a=group_a, group_b=group_b)
+        result = overlap.query(mock_db, x=16)
+
+        assert float(result) == 13.0  # max(3+4+5=12, 6+7=13) = 13
+        assert result.energy == 250.0  # 30+40+50+60+70
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
- Add OverlapOp class to operations.py for modeling parallel execution of two op groups (latency=max, energy=sum), matching TRT-LLM's maybe_execute_in_parallel behavior in CUDA Graph generation phase
- Wrap shared expert (aux stream) and routed expert (main stream) in OverlapOp for generation phase MoE, reducing overestimated latency
- Model BMM_pre || RoPE+KV cache overlap in MLA attention
- Replace two separate shared expert GEMMs with fused gate_up_proj GEMM (2*inter_size output) matching TRT-LLM GatedMLP implementation
- Fix shared expert TP division: use full moe_inter_size (shared_tp=1 in ADP mode) instead of incorrectly dividing by tp_size
- Add missing q_a_layernorm RMSNorm op between downscale and q_b_proj
- Add missing moe_reduce_add_shared_output op after MoE combine
- Update wideep_alltoall_perf.txt benchmark data

#### Overview:

Fix `TrtllmWideEPDeepSeekModel` generation/context phase latency estimation to more accurately reflect the actual TRT-LLM DeepSeek-V3 WideEP inference execution flow on GB200. The core issue was that all operations were modeled as purely sequential, while TRT-LLM leverages multi-stream parallelism (via `maybe_execute_in_parallel` under CUDA Graph) to overlap shared expert computation with routed expert + AllToAll communication during the generation phase.

#### Details:

**New `OverlapOp` class (`operations.py`)**
- Introduces `OverlapOp(Operation)` that wraps two groups of ops executing in parallel on different CUDA streams
- Latency = `max(sum(group_a), sum(group_b))`, Energy = `sum(all ops)`
- Fully backward-compatible: the backend iteration loop requires zero changes — `OverlapOp.query()` returns a standard `PerformanceResult` like any other op

**Generation phase — MoE overlap (most impactful fix)**
- In TRT-LLM, `Deepseekv3MoE.forward` calls `maybe_execute_in_parallel(_compute_routed_output, _compute_shared_output, ...)` which runs:
  - Main stream: router GEMM → AllToAll dispatch → FusedMoE compute → AllToAll combine
  - Aux stream: shared expert gate_up GEMM → SwiGLU → down_proj GEMM
- Previously modeled as sequential sum of all ops (overestimating MoE latency by ~30-50%)
- Now wrapped in `OverlapOp("generation_moe_overlap", group_a=routed_ops, group_b=shared_ops)`
- Context phase remains sequential (no CUDA Graph → `maybe_execute_in_parallel` falls back to serial)

**Generation phase — MLA attention overlap**
- `bmm_pre` (absorption BMM) runs in parallel with `mla_rope_generation` (RoPE + KV cache write) on aux stream
- Added `OverlapOp("generation_bmm_rope_overlap", group_a=[bmm_pre], group_b=[rope_kvcache])`

**Shared expert dimension fixes (context + generation)**
- Fused gate_up_proj: replaced two separate GEMMs `[inter_size, h]` with one fused GEMM `[2*inter_size, h]`, matching TRT-LLM's `GatedMLP` which uses `ColumnLinear(h, 2*inter_size)`
- TP division fix: in WideEP ADP mode (`attention_dp_size > 1`), TRT-LLM sets `shared_tp_size = 1` — each rank computes the full shared expert without TP splitting. Removed incorrect `// tp_size` division from all shared expert ops

**Missing ops added (context + generation)**
- `q_a_layernorm`: RMSNorm (dim=1536) between `downscale_gemm` and `q_b_proj_gemm`
- `moe_reduce_add_shared_output`: ElementWise op after MoE combine that sums routed output over top-k and adds shared expert output

#### Where should the reviewer start?

1. `src/aiconfigurator/sdk/operations.py` — review the `OverlapOp` class at the end of the file (~60 lines)
2. `src/aiconfigurator/sdk/models.py` — review the `TrtllmWideEPDeepSeekModel` class, specifically:
   - Context phase ops (~L1557-1713): sequential fixes (fused GEMM, TP, missing ops)
   - Generation phase ops (~L1715-1907): overlap modeling with `OverlapOp` + same sequential fixes

#### Related Issues:

- Relates to: TRT-LLM WideEP DeepSeek-V3 generation latency estimation accuracy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added `OverlapOp` class to represent parallel execution of operation groups with combined performance metrics.

**Refactor**
* Updated internal operation sequencing and aggregation patterns for improved computational efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->