### PR TITLE
fix: ensure cache_transceiver_max_tokens_in_buffer % block_size == 0 for trtllm

### DIFF
--- a/src/aiconfigurator/generator/rule_plugin/trtllm.rule
+++ b/src/aiconfigurator/generator/rule_plugin/trtllm.rule
@@ -15,7 +15,7 @@ agg_prefill_decode tokens_per_block = (tokens_per_block if tokens_per_block else
 prefill max_num_tokens = (((SlaConfig.isl + 1500) + tokens_per_block - 1) // tokens_per_block) * tokens_per_block
 decode max_num_tokens = ((max_batch_size + tokens_per_block - 1) // tokens_per_block) * tokens_per_block
 agg max_num_tokens = ((max_batch_size + SlaConfig.isl + 1500 + tokens_per_block - 1) // tokens_per_block) * tokens_per_block
-prefill_decode cache_transceiver_max_tokens_in_buffer = SlaConfig.isl + SlaConfig.osl + 1500
+prefill_decode cache_transceiver_max_tokens_in_buffer = (((SlaConfig.isl + SlaConfig.osl + 1500) + tokens_per_block - 1) // tokens_per_block) * tokens_per_block
 
 # Enforce TensorRT-LLM MoE parallelism: moe_tp × moe_ep = tp
 when ModelConfig.is_moe and (moe_tensor_parallel_size and moe_expert_parallel_size):


### PR DESCRIPTION
#### Overview:

TRTLLM raises error when deploying AIC generated config

```
2026-02-13T00:15:52.483521Z ERROR engine.get_llm_engine: Error in engine context: Executor worker returned error
RuntimeError: [TensorRT-LLM[][ERROR[] Assertion failed: maxNumTokens.value() % tokensPerBlock == 0 (../tensorrt_llm/batch_manager/cacheTransBuffer.cpp:206)
1       0x7f8524ec97bf tensorrt_llm::_v1::common::throwRuntimeError(char const*, int, char const*) + 76
2       0x7f84ec42d3c8 /opt/dynamo/venv/lib/python3.12/site-packages/tensorrt_llm/libs/libtensorrt_llm.so(+0x18473c8) [0x7f84ec42d3c8[]
3       0x7f84ed8af610 tensorrt_llm::batch_manager::CacheTransceiver::CacheTransceiver(tensorrt_llm::batch_manager::kv_cache_manager::BaseKVCacheManager*, tensorrt_llm::executor::kv_cache::CacheState::ModelConfig const&, tensorrt_llm::runtime::WorldConfig const&, std::vector<int, std::allocator<int> > const&, nvinfer1::DataType, tensorrt_llm::executor::kv_cache::CacheState::AttentionType, std::optional<tensorrt_llm::executor::CacheTransceiverConfig>) + 1312
```

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
