### PR TITLE
fix: Fix vllm GEMM dtype inconsistency problem

### DIFF
--- a/collector/vllm/collect_gemm.py
+++ b/collector/vllm/collect_gemm.py
@@ -65,7 +65,7 @@ def run_gemm(exit_stack, gemm_type, m, n, k, perf_filename, device="cuda:0"):
 
     setup_distributed(device)
 
-    dtype = torch.bfloat16
+    dtype = torch.float16
     torch.set_default_dtype(dtype)
     torch.cuda.set_device(device)
     torch.set_default_device(device)


### PR DESCRIPTION
In vllm/collect_gemm.py, dtype used to measure is torch.bfloat16. But ["float16" ](https://github.com/ai-dynamo/aiconfigurator/blob/c5347197988584d8622041cf25b35c6f4f7c5cbd/collector/vllm/collect_gemm.py#L28C18-L28C27) was logged into the measurement result. This PR is to fix the inconsistency of what is being measured and what is being logged.
Additionally, all other vllm ops, such as atten, moe, all use "torch.float16".