### PR TITLE
fix: vLLM --cudagraph-capture-sizes causes startup failure in k8s_deploy.yaml

### DIFF
--- a/src/aiconfigurator/generator/config/backend_templates/vllm/cli_args.0.11.0.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/vllm/cli_args.0.11.0.j2
@@ -10,7 +10,7 @@
 {%- if vllm['skip-tokenizer-init'] -%}{%- set _ = args.append('--skip-tokenizer-init') -%}{%- endif -%}
 {%- if vllm['trust-remote-code'] -%}{%- set _ = args.append('--trust-remote-code') -%}{%- endif -%}
 {%- if vllm['enforce-eager'] -%}{%- set _ = args.append('--enforce-eager') -%}{%- endif -%}
-{%- if vllm['cudagraph-capture-sizes'] is defined -%}{%- set _ = args.append('--cudagraph-capture-sizes "' ~ (vllm['cudagraph-capture-sizes'] | join(',')) ~ '"') -%}{%- endif -%}
+{%- if vllm['cudagraph-capture-sizes'] is defined -%}{%- set _ = args.append('--cudagraph-capture-sizes ' ~ (vllm['cudagraph-capture-sizes'] | join(' '))) -%}{%- endif -%}
 
 
 {%- if vllm['no-enable-prefix-caching'] -%}{%- set _ = args.append('--no-enable-prefix-caching') -%}{%- endif -%}

--- a/src/aiconfigurator/generator/config/backend_templates/vllm/cli_args.0.12.0.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/vllm/cli_args.0.12.0.j2
@@ -11,7 +11,7 @@
 {%- if vllm['skip-tokenizer-init'] -%}{%- set _ = args.append('--skip-tokenizer-init') -%}{%- endif -%}
 {%- if vllm['trust-remote-code'] -%}{%- set _ = args.append('--trust-remote-code') -%}{%- endif -%}
 {%- if vllm['enforce-eager'] -%}{%- set _ = args.append('--enforce-eager') -%}{%- endif -%}
-{%- if vllm['cudagraph-capture-sizes'] is defined -%}{%- set _ = args.append('--cudagraph-capture-sizes "' ~ (vllm['cudagraph-capture-sizes'] | join(',')) ~ '"') -%}{%- endif -%}
+{%- if vllm['cudagraph-capture-sizes'] is defined -%}{%- set _ = args.append('--cudagraph-capture-sizes ' ~ (vllm['cudagraph-capture-sizes'] | join(' '))) -%}{%- endif -%}
 
 
 {%- if vllm['no-enable-prefix-caching'] -%}{%- set _ = args.append('--no-enable-prefix-caching') -%}{%- endif -%}

--- a/src/aiconfigurator/generator/config/backend_templates/vllm/cli_args.0.14.1.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/vllm/cli_args.0.14.1.j2
@@ -11,7 +11,7 @@
 {%- if vllm['skip-tokenizer-init'] -%}{%- set _ = args.append('--skip-tokenizer-init') -%}{%- endif -%}
 {%- if vllm['trust-remote-code'] -%}{%- set _ = args.append('--trust-remote-code') -%}{%- endif -%}
 {%- if vllm['enforce-eager'] -%}{%- set _ = args.append('--enforce-eager') -%}{%- endif -%}
-{%- if vllm['cudagraph-capture-sizes'] is defined -%}{%- set _ = args.append('--cudagraph-capture-sizes "' ~ (vllm['cudagraph-capture-sizes'] | join(',')) ~ '"') -%}{%- endif -%}
+{%- if vllm['cudagraph-capture-sizes'] is defined -%}{%- set _ = args.append('--cudagraph-capture-sizes ' ~ (vllm['cudagraph-capture-sizes'] | join(' '))) -%}{%- endif -%}
 
 
 {%- if vllm['no-enable-prefix-caching'] -%}{%- set _ = args.append('--no-enable-prefix-caching') -%}{%- endif -%}


### PR DESCRIPTION

#### Overview:

fix: vLLM --cudagraph-capture-sizes causes startup failure in k8s_deploy.yaml

#### Details:

What was fixed in this repo
The vLLM CLI templates were updated so the option is emitted as separate integers (matching the base template and vLLM’s nargs='*'):
Before: join(',') inside quotes → one string "1,2,3,...,128".
After: join(' ') with no quotes → --cudagraph-capture-sizes 1 2 3 ... 128.
So after the fix, shlex.split(cli) produces:
["--cudagraph-capture-sizes", "1", "2", "3", ..., "128"]
and the Dynamo-generated k8s spec gets one argument per integer, which vLLM accepts.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
