### PR TITLE
feat: agent skills for adding a new op (draft PR for discussion)

### DIFF
--- a/agents/new-op-integration/SKILL.md
+++ b/agents/new-op-integration/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: new-op-integration
+description: |
+  Integrate new operations into aiconfigurator to support new models. 
+  Use when adding support for new model architectures or new attention/compute mechanisms.
+  This skill guides through: Situation Assessment → Analysis → Mock → Profile → Integration → Collection.
+---
+
+# New Operation Integration Skill
+
+> **Official reference**: `docs/add_a_new_model.md` — read it first for the overall decision tree.
+
+## Step 0: Determine the Situation (Mandatory)
+
+Before making any changes, determine which situation you are in. The required effort varies significantly.
+
+| Situation | Description | Required Phases |
+|-----------|-------------|-----------------|
+| **S1: Simple Variant** | The model architecture is already supported (e.g., a new Llama variant); only an architecture mapping is needed | Partial Phase 1 |
+| **S2: New Data Needed** | The architecture mapping exists, but operation parameters differ (e.g., a new MoE model with different `num_experts`/`topk`) | Phases 1 + 5 |
+| **S3: New Operation Needed** | The model introduces a brand-new compute primitive (e.g., convolution, new attention mechanism) | Full Phases 1 → 5 |
+
+**How to decide**:
+
+```
+1. Read the target model's config.json.
+2. Check whether config["architectures"][0] exists in ARCHITECTURE_TO_MODEL_FAMILY.
+   -> If yes, it is likely S1 or S2.
+3. Analyze model structure for compute units unsupported by aiconfigurator.
+   -> No unsupported op -> S1 or S2
+   -> Unsupported op exists -> S3
+4. For S2, verify whether existing perf data covers the new parameter combinations.
+   -> Covered -> S1
+   -> Not covered -> S2
+```
+
+---
+
+## Key File Paths (Quick Reference)
+
+| File | Path | Purpose |
+|------|------|---------|
+| Architecture mapping & enums | `src/aiconfigurator/sdk/common.py` | `ModelFamily` enum, `ARCHITECTURE_TO_MODEL_FAMILY` mapping |
+| Config parsing | `src/aiconfigurator/sdk/utils.py` | `_parse_hf_config_json()`, `get_model_config_from_model_path()` |
+| Operation definitions | `src/aiconfigurator/sdk/operations.py` | `Operation` base class and all subclasses |
+| Performance database | `src/aiconfigurator/sdk/perf_database.py` | Data loading + query methods |
+| Model definitions | `src/aiconfigurator/sdk/models.py` | `BaseModel` and model subclasses |
+| Performance result type | `src/aiconfigurator/sdk/performance_result.py` | `PerformanceResult` (float-like, includes power/energy) |
+| Performance data directory | `src/aiconfigurator/systems/data/{system}/{backend}/{version}/` | `*_perf.txt` data files |
+| Test case definitions | `collector/common_test_cases.py` | Standard benchmark parameter grids |
+| Collection utilities | `collector/helper.py` | `benchmark_with_power()`, `log_perf()` |
+| Collection entrypoint | `collector/collect.py` | Unified collection orchestration |
+| Backend collection scripts | `collector/{backend}/collect_{op}.py` | Backend-specific collection implementations |
+
+---
+
+## Phase 1: Model Architecture Analysis
+
+**Goal**: Understand model configuration and add architecture recognition support.
+
+**Reference**: `agents/new-op-integration/references/phase1-analysis.md`
+
+**Done criteria**: `aiconfigurator cli support --model-path <model> --system h200_sxm` correctly identifies the model.
+
+---
+
+## Phase 2: Build a Mock Layer
+
+**Goal**: Build a standalone runnable operation layer for profiling and data collection, and define the collector-facing modeling contract.
+
+**Reference**: `agents/new-op-integration/references/phase2-mock-layer.md`
+
+**Done criteria**: The mock layer runs independently with correct input/output shapes; axis choice (`x=b*s` vs separate `b,s`) and collector schema are documented in this phase.
+
+---
+
+## Phase 3: Align nsys Profiles
+
+**Goal**: Validate that mock-layer kernel behavior matches full-model E2E inference.
+
+**Reference**: `agents/new-op-integration/references/phase3-nsys-alignment.md`
+
+**Done criteria**: Kernel names match and latency is within a reasonable range (<2x gap).
+
+---
+
+## Phase 4: SDK Integration
+
+**Goal**: Integrate the new operation into the aiconfigurator modeling stack.
+
+**Reference**: `agents/new-op-integration/references/phase4-integration.md`
+
+**Done criteria**: `operation.query(db, x=...)` returns `PerformanceResult`; CLI outputs complete modeling results.
+
+---
+
+## Phase 5: Performance Data Collection
+
+**Goal**: Collect benchmark data across batch/sequence combinations.
+
+**Reference**: `agents/new-op-integration/references/phase5-collection.md`
+
+**Done criteria**: `*_perf.txt` files are generated with expected data point counts.
+
+---
+
+## Full Integration Checklist
+
+After all phases are complete, run final verification:
+
+```
+□ common.py: `ModelFamily` enum value added (if needed)
+□ common.py: `ARCHITECTURE_TO_MODEL_FAMILY` mapping added
+□ utils.py: `config.json` parsing logic added
+□ operations.py: new `Operation` subclass implemented (`query` + `get_weights`)
+□ perf_database.py: data loader + query method implemented
+□ models.py: new model class implemented (or existing one updated)
+□ systems/data/: performance data files placed correctly
+□ collector/: collection scripts run correctly
+□ CLI validation: `aiconfigurator cli support/default` works
+□ Tests: existing tests remain intact
+□ Phase 2 documented: axis decision (`x=b*s` vs separate `b,s`) justified from SOL and reflected in collector schema
+```
+
+---
+
+## Lessons Learned (From Real Integration Work)
+
+The following lessons come from DeepSeek-V3.2 DSA integration and apply to any new operation.
+
+### 1. Operation Granularity Must Match Existing Operations
+
+**Problem**: If a new op includes sub-ops already modeled independently (such as GEMMs), you will double-count.
+**Rule**: Align granularity with the most similar existing op (for example, MLA).
+- If MLA collects attention kernels only, your new op should do the same.
+- If the new op must be collected at a coarser granularity (whole attention block), remove included GEMMs in `models.py`.
+- Verification: compare static per-layer latency with `cli default` between baseline and new model under the same config.
+
+### 2. Data Format Must Exactly Match Existing Patterns
+
+**Problem**: `perf_database.py` interpolation/query infrastructure assumes strict dict structures.
+**Rule**: Copy the load/query/interpolation pattern of the closest existing op.
+- **Nested dict levels**: MLA context uses 5 levels `data[quant][kv_dtype][num_heads][s][b]`
+- **Leaf type**: use `defaultdict()` (not `defaultdict(dict)`), otherwise dedup logic with `try/except KeyError` breaks because keys are created silently
+- **Interpolation axis order**: context `(x=num_heads, y=s, z=b)`; generation `(x=num_heads, y=b, z=s)`; must match dict nesting
+- **`_interp_3d` returns dict**: wrap `{"latency": ..., "energy": ...}` into `PerformanceResult`
+- **TP emulation**: collect on single GPU with `local_num_heads = global_heads // tp_size` and `Mapping(world_size=1, tp_size=1)`
+
+### 3. Do Not Fallback to a Different-Granularity Operation
+
+**Problem**: If fallback op granularity differs, estimates are wrong.
+**Rule**: When new-op data is unavailable, raise `PerfDataNotAvailableError` rather than silently falling back. Fallback is allowed only when granularity is truly equivalent.
+
+### 4. Validate FP8 / Quantization Support in the Runtime Framework
+
+**Problem**: Model configs may infer FP8, but framework implementation of the new op may not support it.
+**Rule**:
+- Validate FP8 KV-cache execution in collector (with `try/except`).
+- If unsupported, force override to supported dtype in `models.py` and log it.
+- Verify support differences by SM generation (for example SM90 vs SM100+ kernel paths).
+
+### 5. Proper Phase 3 Alignment Method
+
+**Do**: extract the target submodule from a full decoder layer (for example `decoder.self_attn`) and benchmark it with exactly the same inputs as the standalone collector mock layer.
+**Do not**: compare only kernel-name lists (necessary but not sufficient).
+**Pass criteria**: latency gap < 10% and consistent CUDA Graph capture behavior.
+
+### 6. Use Static Mode for Per-Op Differential Diagnosis
+
+When modeling looks wrong, compare per-op per-layer latency directly via `op.query(db, ...)` to isolate problematic ops quickly:
+```python
+for op in model.context_ops:
+    r = op.query(db, x=b*s, batch_size=b, s=s, prefix=0, beam_width=1)
+    print(f"{op._name}: {float(r)/op._scale_factor:.4f} ms/layer")
+```

--- a/agents/new-op-integration/references/phase1-analysis.md
+++ b/agents/new-op-integration/references/phase1-analysis.md
@@ -1,0 +1,150 @@
+# Phase 1: Model Architecture Analysis
+
+## Goal
+
+Understand the new model configuration so that aiconfigurator can recognize and parse it correctly.
+
+## Steps
+
+### 1. Obtain and analyze `config.json`
+
+```bash
+# Download from HuggingFace
+wget https://huggingface.co/<org>/<model>/raw/main/config.json
+
+# Or use a local model directory
+ls /path/to/model/config.json
+```
+
+Focus on these fields:
+- `architectures` — model architecture identifier (for example `["NewModelForCausalLM"]`)
+- `num_hidden_layers`, `hidden_size`, `num_attention_heads`, `num_key_value_heads`
+- `intermediate_size`, `vocab_size`, `max_position_embeddings`
+- MoE fields: `num_experts_per_tok`, `num_local_experts`/`n_routed_experts`, `moe_intermediate_size`
+- Special fields: any new keys not in the list above
+
+### 2. Compare with known models and identify new fields
+
+Compare with existing model configs and mark fields that are new or different:
+
+```json
+{
+  "architectures": ["NewModelForCausalLM"],
+  "num_hidden_layers": 32,
+  "hidden_size": 4096,
+  "num_attention_heads": 32,
+        "num_key_value_heads": 8,        // standard field
+        "new_specific_field_1": 64,      // <- new field
+        "new_specific_field_2": 2048     // <- new field
+}
+```
+
+### 3. Add `ModelFamily` (if a new family is required)
+
+**File**: `src/aiconfigurator/sdk/common.py`
+
+If the new model requires a completely new model class (Situation S3), add a value to `ModelFamily`:
+
+```python
+# common.py (around line 280)
+ModelFamily = {"GPT", "LLAMA", "MOE", "DEEPSEEK", "NEMOTRONNAS", "NEMOTRONH", "NEW_MODEL"}  # <- add
+```
+
+> **Note**: If the model is only a variant of an existing family (for example another Llama architecture), you can skip this step.
+
+### 4. Add architecture mapping
+
+**File**: `src/aiconfigurator/sdk/common.py`
+
+Add the mapping in `ARCHITECTURE_TO_MODEL_FAMILY`:
+
+```python
+# common.py (around line 281)
+ARCHITECTURE_TO_MODEL_FAMILY = {
+    "LlamaForCausalLM": "LLAMA",
+    "Qwen2ForCausalLM": "LLAMA",
+    # ... existing mappings ...
+    "NewModelForCausalLM": "NEW_MODEL",  # <- add
+}
+```
+
+### 5. Add a config dataclass (if there are special structured fields)
+
+**File**: `src/aiconfigurator/sdk/common.py`
+
+Only required if the model has **unique structured config** (see `NemotronHConfig`).
+Most models do not require this; parameters can be parsed directly.
+
+```python
+# common.py — use only when there are multiple related special parameters
+@dataclass(frozen=True)
+class NewModelConfig:
+    """Configuration for NewModel-specific parameters."""
+    new_field_1: int
+    new_field_2: int
+    # ...
+```
+
+### 6. Add parsing logic
+
+**File**: `src/aiconfigurator/sdk/utils.py`
+
+Add new-model field parsing in `_parse_hf_config_json()`:
+
+```python
+# utils.py — inside `_parse_hf_config_json()` (after around line 466)
+
+# After existing NemotronH handling:
+extra_params = None
+if architecture == "NemotronHForCausalLM":
+    extra_params = common.NemotronHConfig(...)
+elif architecture == "NewModelForCausalLM":                    # <- add
+    extra_params = common.NewModelConfig(                       # <- add
+        new_field_1=config["new_field_1"],                      # <- add
+        new_field_2=config.get("new_field_2", 2048),            # <- add (with default)
+    )                                                           # <- add
+```
+
+> **Important**: Parsed data is passed to `models.py` through `extra_params`.
+> Standard fields (`layers`, `hidden_size`, `n`, `n_kv`, etc.) are already parsed by `_parse_hf_config_json`.
+> You only need to handle **new non-standard fields**.
+
+### 7. Consume new parameters in `models.py` (if a new model class is required)
+
+**File**: `src/aiconfigurator/sdk/models.py`
+
+Add instantiation logic in `get_model()`. Follow existing models as reference:
+
+```python
+# models.py — inside `get_model()`
+
+# Follow DeepSeekModel or NemotronHModel initialization patterns
+if model_family == "NEW_MODEL":
+    model = NewModel(
+        topk, num_experts, moe_inter_size,  # if MoE
+        model_path, model_family, architecture, layers, n, n_kv, d,
+        hidden, inter, vocab, context, model_config,
+    )
+    if extra_params is not None:
+        model.set_extra_config(extra_params)  # pass special config
+```
+
+## Validation
+
+```bash
+# Verify CLI recognizes the new model
+aiconfigurator cli support --model-path <new-model-path-or-hf-id> --system h200_sxm --backend trtllm
+
+# Expected: architecture is recognized even if perf data is not ready.
+# If you see "architecture is not supported", mapping is missing/incorrect.
+# If you see "data not found", mapping works but data collection (Phase 5) is still needed.
+```
+
+## Common Issues
+
+| Issue | Cause | Fix |
+|------|------|------|
+| `architecture is not supported` | Missing mapping in `ARCHITECTURE_TO_MODEL_FAMILY` | Add mapping in `common.py` |
+| `num_key_value_heads is None` | Field is null in `config.json` | Use `config.get(field) or 0` in `utils.py` |
+| `extra_params` not propagated | New dataclass is not returned by `_parse_hf_config_json` | Check `extra_params` assignment path |
+| Parsed values are incorrect | Mismatch between config key names and code | Re-check HuggingFace config keys carefully |

--- a/agents/new-op-integration/references/phase2-mock-layer.md
+++ b/agents/new-op-integration/references/phase2-mock-layer.md
@@ -1,0 +1,210 @@
+# Phase 2: Build a Mock Layer
+
+## Goal
+
+Create a standalone runnable operation layer (mock layer) for:
+1. Validating operation behavior
+2. Subsequent nsys profile alignment
+3. Serving as the foundation for Phase 5 data collection
+
+## Option A: Use Framework-Provided Classes (Recommended)
+
+Prefer existing layer classes from TensorRT-LLM / vLLM / SGLang whenever possible.
+
+Reference pattern: `collector/trtllm/collect_mla.py`
+
+```python
+import tensorrt_llm
+import torch
+from tensorrt_llm._torch.attention_backend import AttentionInputType, TrtllmAttentionMetadata
+from tensorrt_llm._torch.attention_backend.utils import create_attention
+from tensorrt_llm._torch.metadata import KVCacheParams
+from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManager
+from tensorrt_llm.mapping import Mapping
+
+# 1. Build pretrained config (derived from model config)
+pretrained_config = ...
+
+# 2. Build model config
+model_config = ModelConfig(
+    pretrained_config=pretrained_config,
+    mapping=Mapping(world_size=1, rank=0, tp_size=1),
+)
+
+# 3. Instantiate operation/layer
+layer = XxxAttention(model_config=model_config, layer_idx=0)
+# or
+layer = create_attention(...)
+```
+
+## Option B: Custom Implementation (Use Only If Necessary)
+
+Use this only when framework classes cannot be reused directly (heavy dependencies, special runtime constraints, etc.).
+
+```python
+import torch
+import torch.nn as nn
+
+class XxxOp(nn.Module):
+    """Mock implementation of the XXX operation."""
+    
+    def __init__(self, param1: int, param2: int, dtype=torch.bfloat16):
+        super().__init__()
+        self.param1 = param1
+        self.param2 = param2
+        self.dtype = dtype
+        # Initialize weights and submodules
+        self.weight = nn.Parameter(
+            torch.randn(param1, param2, dtype=dtype, device="cuda")
+        )
+    
+    def forward(self, hidden_states: torch.Tensor, **kwargs) -> torch.Tensor:
+        # Implement core operation logic
+        output = ...
+        return output
+```
+
+## Context vs Generation Differences
+
+Some operations behave differently in context (prefill) vs generation (decode), especially attention-like ops:
+
+| Dimension | Context Phase | Generation Phase |
+|------|--------------|------------------|
+| **Input tokens** | `batch_size * seq_len` (multi-token) | `batch_size * 1` (single token per request) |
+| **KV Cache** | No read or small prefix read | Read full historical KV |
+| **Compute pattern** | Usually compute-bound | Usually memory-bound |
+| **Typical parameter range** | batch 1~256, seq 1~32768 | batch 1~1024, kv_len 1~131072 |
+
+**Your mock layer must cover both modes.**
+
+## Modeling Contract for Collector (Do This in Phase 2)
+
+When a new op requires modeling, define the collector contract in this phase (not later), because
+collector test-case schema depends on the modeling axes.
+
+### SOL-first axis decision
+
+1. Derive a first-pass SOL expression with symbolic variables (`b`, `s`, and op params).
+2. Decide whether the op is:
+   - **Token-equivalent**: model primarily by `x=b*s`
+   - **Token-non-equivalent**: keep `b` and `s` as separate axes
+3. Freeze collector input schema and downstream query signature from this decision.
+
+### Practical rule of thumb
+
+- GEMM-like paths are often close to token-equivalent.
+- Attention-like paths are usually token-non-equivalent and should keep both `b` and `s`.
+
+### Required output of this step
+
+- Axis decision note (`x` vs `b,s`) with SOL justification
+- Collector test-case layout matching that decision
+- Planned query signature shape for `perf_database.py` and `operations.py`
+
+## Key Validation Checks
+
+| Check | Description | Validation Method |
+|--------|------|----------|
+| **Input format** | Verify shape, dtype, and device | `print(input.shape, input.dtype, input.device)` |
+| **Output format** | Output shape should align with hidden size | `assert output.shape[-1] == hidden_size` |
+| **KV Cache Manager** | Attention ops typically require cache manager | Confirm `KVCacheManager` initialization exists |
+| **Boundary cases** | batch=1, seq=1, large batch, etc. | Test multiple parameter combinations |
+| **Dtype support** | BF16/FP16/FP8 constraints | Validate under target dtype |
+| **CUDA Graph compatibility** | Collection uses CUDA Graph acceleration | Verify graph capture succeeds |
+
+## Standalone Test Script Template
+
+```python
+#!/usr/bin/env python3
+"""Test script for Xxx mock layer."""
+
+import torch
+
+def create_xxx_layer(param1, param2, dtype=torch.bfloat16):
+    """Create and return the mock layer."""
+    # ... build logic ...
+    return layer
+
+def test_context_phase():
+    """Test context (prefill) phase."""
+    layer = create_xxx_layer(param1=64, param2=2048)
+    
+    batch_size, seq_len = 4, 1024
+    hidden_size = 4096
+    hidden = torch.randn(
+        [batch_size * seq_len, hidden_size],
+        dtype=torch.bfloat16, device="cuda"
+    )
+    
+    # Forward pass
+    output = layer(hidden)
+    print(f"Context - Input: {hidden.shape}, Output: {output.shape}")
+    assert output.shape == hidden.shape, f"Shape mismatch: {output.shape} != {hidden.shape}"
+    
+    # Verify no NaN
+    assert not torch.isnan(output).any(), "Output contains NaN!"
+
+def test_generation_phase():
+    """Test generation (decode) phase."""
+    layer = create_xxx_layer(param1=64, param2=2048)
+    
+    batch_size = 32
+    hidden_size = 4096
+    hidden = torch.randn(
+        [batch_size, hidden_size],  # single token per request
+        dtype=torch.bfloat16, device="cuda"
+    )
+    
+    output = layer(hidden)
+    print(f"Generation - Input: {hidden.shape}, Output: {output.shape}")
+    assert output.shape == hidden.shape
+
+def test_cuda_graph_compatibility():
+    """Test that the layer works with CUDA Graph capture."""
+    layer = create_xxx_layer(param1=64, param2=2048)
+    hidden = torch.randn([32, 4096], dtype=torch.bfloat16, device="cuda")
+    
+    # Warmup
+    for _ in range(3):
+        layer(hidden)
+    torch.cuda.synchronize()
+    
+    # Graph capture
+    g = torch.cuda.CUDAGraph()
+    try:
+        with torch.cuda.graph(g):
+            output = layer(hidden)
+        torch.cuda.synchronize()
+        print("CUDA Graph capture: SUCCESS")
+    except Exception as e:
+        print(f"CUDA Graph capture: FAILED - {e}")
+        print("Note: benchmark_with_power has allow_graph_fail fallback")
+
+if __name__ == "__main__":
+    test_context_phase()
+    test_generation_phase()
+    test_cuda_graph_compatibility()
+    print("\nAll tests passed!")
+```
+
+## Deliverables
+
+After completing Phase 2, you should have:
+1. **Runnable mock-layer code** — either standalone `.py` or integrated into collector
+2. **Test script** — validates both context and generation modes
+3. **Parameter documentation** — records all required mock-layer parameters and meanings
+
+## Common Issues
+
+| Issue | Cause | Fix |
+|------|------|------|
+| `ImportError` for missing module | TRT-LLM version mismatch | Verify required TRT-LLM version (`frameworks/` as reference) |
+| CUDA OOM | Input too large | Reduce `batch_size` or `seq_len` |
+| CUDA Graph capture fails | Dynamic control flow in op | Use `allow_graph_fail=True` to fall back to eager path |
+| Output is all zeros or NaN | Weights not initialized correctly | Check weight init and forward logic |
+| KV cache not initialized | Attention ops need cache manager | Follow `KVCacheManager` usage in `collect_mla.py` |
+| MPI initialization failure | TRT-LLM import requires MPI | Set `export OPAL_PREFIX=/opt/hpcx/ompi` |
+
+## TP Emulation (Critical)
+
+Follow `collect_mla.py`: **multi-GPU is not required** for collection. Compute `local_num_heads = global_heads // tp_size` on a single GPU, then instantiate the layer with `Mapping(world_size=1, tp_size=1)`. Store local heads in the `num_heads` column of perf data.

--- a/agents/new-op-integration/references/phase3-nsys-alignment.md
+++ b/agents/new-op-integration/references/phase3-nsys-alignment.md
@@ -1,0 +1,150 @@
+# Phase 3: nsys Profile Alignment
+
+## Goal
+
+Validate that the GPU-kernel behavior of the Phase 2 mock layer matches full-model E2E inference.
+This is critical for data validity: if mock-layer kernels differ from real inference kernels, collected data will be unreliable.
+
+## Core Principle
+
+aiconfigurator models inference by decomposing it into Operations. Each operation (such as attention or MoE) corresponds to a set of GPU kernels.
+Alignment target: **kernel set launched by mock layer ≈ kernel set for that operation in E2E inference**.
+
+## Step 1: Profile Mock Layer
+
+```bash
+# Profile the Phase 2 test script
+nsys profile -o mock_layer_report \
+  -t cuda,nvtx \
+  --force-overwrite true \
+  python3 test_xxx_op.py
+```
+
+> **Note**: Ensure warmup steps exist in the test script so profiling captures steady-state behavior.
+
+## Step 2: Profile E2E Model
+
+Choose profiling strategy based on deployment mode:
+
+### Option A: Single-process model
+
+```bash
+nsys profile -o e2e_report \
+  -t cuda,nvtx \
+  --force-overwrite true \
+  python3 run_full_model.py
+```
+
+### Option B: MPI / Multi-process model (for example `trtllm-serve`)
+
+Multi-process deployments require system-wide sampling because workers are spawned internally by the framework:
+
+```bash
+# 1. Start service first
+trtllm-serve /path/to/model --tp_size 8 &
+
+# 2. Wait for model load + warmup
+sleep 300
+
+# 3. Run system-wide profiling
+nsys profile -o e2e_report \
+  -y 60 -d 20 \
+  --sample=system-wide \
+  --cpuctxsw=system-wide \
+  -t cuda,nvtx,osrt \
+  --cuda-graph-trace=node \
+  --force-overwrite true \
+  trtllm-serve /path/to/model --tp_size 8
+```
+
+Parameter notes:
+- `-y 60`: delay collection start by 60 seconds (to pass warmup)
+- `-d 20`: collect for 20 seconds
+- `--sample=system-wide`: capture all processes
+- `--cuda-graph-trace=node`: expand CUDA Graph nodes
+
+## Step 3: Extract Kernel Statistics
+
+```bash
+# Mock-layer kernel summary
+nsys stats --report cuda_gpu_kern_sum mock_layer_report.nsys-rep > mock_kernels.txt
+
+# E2E model kernel summary
+nsys stats --report cuda_gpu_kern_sum e2e_report.nsys-rep > e2e_kernels.txt
+```
+
+You can also open `.nsys-rep` files in Nsight Systems GUI for visual comparison.
+
+## Step 4: Alignment Analysis
+
+### Alignment Checklist
+
+| Check | Pass Criteria | If It Fails |
+|--------|----------|----------|
+| **Kernel name match** | Major kernel names appear in both traces | Verify mock layer uses the correct low-level implementation |
+| **Kernel count** | Similar kernel count per forward | If mock has extra kernels, check unnecessary initialization |
+| **Latency ratio** | Total per-forward latency gap < 2x | Check for extra overhead or missing compute |
+| **No missing critical kernels** | Critical kernels in E2E also appear in mock | Submodule init may be missing (for example cache manager) |
+| **No extra kernels** | Mock has no kernels absent in E2E | Remove unnecessary compute or debug code |
+
+### How to identify kernels of the target operation
+
+E2E profiles include kernels for all operations across all layers. Isolate target-op kernels via:
+
+1. **NVTX ranges**: many frameworks mark op scopes with NVTX; filter by range in GUI
+2. **Kernel-name patterns**: attention kernels often contain keywords like `fmha`, `flash`
+3. **Timeline sequence matching**: compare one-layer kernel sequence in E2E vs mock
+
+### Alignment metric example
+
+```
+Mock Layer:
+  flash_fwd_kernel          : 1 call, 0.42ms
+  void gemm_kernel<...>     : 2 calls, 0.15ms + 0.15ms
+  
+E2E Model (target op in one layer):
+  flash_fwd_kernel          : 1 call, 0.40ms  <- match
+  void gemm_kernel<...>     : 2 calls, 0.16ms + 0.14ms  <- match
+  
+Alignment result: PASS (kernel names and counts match, latency gap < 10%)
+```
+
+## Common Issues
+
+| Issue | Cause | Fix |
+|------|------|------|
+| nsys has no GPU data | MPI worker processes were not captured | Use `--sample=system-wide` |
+| Mock latency is much higher than E2E | Mock is missing optimizations (for example no CUDA Graph) | Ensure mock benchmark also uses graph replay |
+| Missing kernels in mock | Dependency modules not initialized | Check `KVCacheManager`, quantization modules, etc. |
+| Target op not identifiable in E2E | Missing NVTX or kernel fusion | Use kernel-name patterns; consider framework-level fusion |
+| Large latency gap with matching names | Input mismatch | Ensure mock input shapes match E2E exactly |
+
+## Correct Alignment Method (Practical Guidance)
+
+**Not sufficient**: only comparing kernel-name lists.
+**Correct approach**: build a full decoder layer, extract the target submodule (for example `decoder.self_attn`), and benchmark with the exact same inputs as collector mock layer:
+
+```python
+# Extract attention submodule from decoder layer
+decoder = DecoderLayer(model_config=mc, layer_idx=0, ...)
+decoder_attn = decoder.self_attn
+
+# Standalone attention from collector
+collector_attn = create_xxx_layer(tp_size=8)
+
+# Same inputs, compare latency
+for name, attn in [("collector", collector_attn), ("decoder", decoder_attn)]:
+    # ... create identical metadata, hidden_states, position_ids ...
+    with benchmark_with_power(...) as res:
+        pass
+    print(f"{name}: {res['latency_ms']:.4f}ms")
+```
+
+**Pass criteria**: latency gap < 10% and consistent CUDA Graph behavior.
+
+## Deliverables
+
+After Phase 3 you should have:
+1. **Alignment report** — kernel matching status and latency comparison
+2. **Known-difference notes** — reasons for any known deviations and modeling impact
+3. **Mock-layer fixes** (if needed) — Phase 2 implementation updates based on alignment findings

--- a/agents/new-op-integration/references/phase4-integration.md
+++ b/agents/new-op-integration/references/phase4-integration.md
@@ -1,0 +1,335 @@
+# Phase 4: SDK Integration
+
+## Goal
+
+Integrate a new operation into the aiconfigurator modeling stack so it can participate in end-to-end latency estimation.
+
+## Files to Modify
+
+| # | File | Change |
+|---|------|--------|
+| 1 | `src/aiconfigurator/sdk/common.py` | Add `PerfDataFilename` enum entries |
+| 2 | `src/aiconfigurator/sdk/perf_database.py` | Add data loading and query logic |
+| 3 | `src/aiconfigurator/sdk/operations.py` | Add operation subclasses |
+| 4 | `src/aiconfigurator/sdk/models.py` | Use new operations in model op lists |
+
+## Step 1: Add `PerfDataFilename`
+
+**File**: `src/aiconfigurator/sdk/common.py`
+
+```python
+class PerfDataFilename(Enum):
+    gemm = "gemm_perf.txt"
+    # ... existing files ...
+    mamba2 = "mamba2_perf.txt"
+    new_op_context = "new_op_context_perf.txt"        # add
+    new_op_generation = "new_op_generation_perf.txt"  # add if split by phase
+```
+
+## Step 2: Add Data Loading and Query
+
+**File**: `src/aiconfigurator/sdk/perf_database.py`
+
+### 2.0) Apply axis decision from Phase 2
+
+At this stage, do not redefine modeling axes. Reuse the axis decision made in Phase 2 mock-layer design.
+
+Use that Phase 2 decision to finalize:
+1. Query signature (`x` only vs separate `b`,`s`)
+2. Data schema in loader/interpolation
+3. Operation kwargs contract (`operations.py`)
+
+If Phase 2 marked the op as token-equivalent, query can be `x`-centric.
+If Phase 2 marked the op as token-non-equivalent, keep explicit `b` and `s`.
+
+### 2a) Data loader
+
+Use `load_context_mla_data()` / `load_mamba2_data()` as templates.
+
+```python
+def load_new_op_data(new_op_file):
+    """
+    Load new-op performance data from new_op_perf.txt.
+
+    CSV columns:
+      framework, version, device, op_name, kernel_source,
+      param1, param2, batch_size, seq_len, latency [, power]
+    """
+    if not os.path.exists(new_op_file):
+        logger.warning("New-op data file %s not found.", new_op_file)
+        return None
+
+    # data[param1][param2][batch_size][seq_len] = {"latency": ..., "power": ..., "energy": ...}
+    data = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(dict))))
+
+    with open(new_op_file, encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    has_power = len(rows) > 0 and "power" in rows[0]
+    if not has_power:
+        logger.debug("Legacy format in %s, power defaults to 0.0", new_op_file)
+
+    for row in rows:
+        param1 = int(row["param1"])
+        param2 = int(row["param2"])
+        b = int(row["batch_size"])
+        s = int(row["seq_len"])
+        latency = float(row["latency"])
+        power = float(row.get("power", 0.0)) if has_power else 0.0
+        energy = power * latency  # W*ms
+
+        data[param1][param2][b][s] = {
+            "latency": latency,
+            "power": power,
+            "energy": energy,
+        }
+
+    return data
+```
+
+### 2b) Load in `PerfDatabase.__init__`
+
+```python
+self._new_op_data = load_new_op_data(
+    os.path.join(data_dir, common.PerfDataFilename.new_op_context.value)
+)
+```
+
+### 2c) Query method with full database-mode support
+
+```python
+def query_new_op(
+    self,
+    b: int,
+    s: int,
+    param1: int,
+    param2: int,
+    database_mode: common.DatabaseMode | None = None,
+) -> PerformanceResult | tuple[float, float, float]:
+    """Query new-op latency/energy."""
+
+    def get_sol(b: int, s: int, param1: int, param2: int) -> tuple[float, float, float]:
+        # Example SOL model
+        flops = b * s * param1 * param2 * 2
+        sol_math = flops / self.system_spec["gpu"]["float16_tc_flops"] * 1000
+
+        mem_bytes = b * s * (param1 + param2) * 2
+        sol_mem = mem_bytes / self.system_spec["gpu"]["mem_bw"] * 1000
+        return max(sol_math, sol_mem), sol_math, sol_mem
+
+    def get_empirical(b: int, s: int, param1: int, param2: int) -> float:
+        return get_sol(b, s, param1, param2)[0] / 0.7
+
+    if database_mode is None:
+        database_mode = self._default_database_mode
+
+    if database_mode == common.DatabaseMode.SOL:
+        return PerformanceResult(get_sol(b, s, param1, param2)[0], energy=0.0)
+    elif database_mode == common.DatabaseMode.SOL_FULL:
+        return get_sol(b, s, param1, param2)
+    elif database_mode == common.DatabaseMode.EMPIRICAL:
+        return PerformanceResult(get_empirical(b, s, param1, param2), energy=0.0)
+    else:  # SILICON or HYBRID
+        try:
+            if self._new_op_data is None:
+                raise PerfDataNotAvailableError("New-op data not loaded.")
+
+            # After fixing param1, interpolate on param2 -> b -> s
+            result = self._interp_3d(param2, b, s, self._new_op_data[param1], "cubic")
+            return PerformanceResult(result["latency"], energy=result.get("energy", 0.0))
+        except Exception:
+            if database_mode == common.DatabaseMode.HYBRID:
+                return PerformanceResult(get_empirical(b, s, param1, param2), energy=0.0)
+            raise
+```
+
+If your op is token-equivalent, use `x` directly in query signature instead:
+
+```python
+def query_new_op(self, x: int, param1: int, ..., database_mode=None):
+    # SOL and empirical are functions of x
+    ...
+```
+
+### 2d) Interpolation support
+
+At the end of `PerfDatabase.__init__()`, add pre-interpolation for unseen points:
+
+```python
+if self._new_op_data is not None:
+    for param1 in self._new_op_data:
+        data_dict = self._new_op_data[param1]
+        target_x_list = [...]  # param2 targets
+        target_y_list = [...]  # batch_size targets
+        target_z_list = [...]  # seq_len targets
+
+        # Fixed param1, then x=param2, y=batch_size, z=seq_len
+        self._new_op_data[param1] = interp_3d(
+            data_dict, target_x_list, target_y_list, target_z_list
+        )
+```
+
+## Step 3: Add Operation Subclasses
+
+**File**: `src/aiconfigurator/sdk/operations.py`
+
+Do not use `@dataclass`; follow existing class-style operation definitions.
+
+Keep `Operation.query()` kwargs consistent with axis choice:
+- token-equivalent op: pass `x`
+- token-non-equivalent op: pass both `b` and `s` (or enough inputs to reconstruct both safely)
+
+```python
+class ContextNewOp(Operation):
+    def __init__(self, name: str, scale_factor: float, param1: int, param2: int) -> None:
+        super().__init__(name, scale_factor)
+        self._param1 = param1
+        self._param2 = param2
+        self._weights = param1 * param2 * 2  # FP16 bytes
+
+    def query(self, database: PerfDatabase, **kwargs) -> PerformanceResult:
+        x = kwargs.get("x")
+        result = database.query_new_op(
+            b=kwargs.get("batch_size", 1),
+            s=x,
+            param1=self._param1,
+            param2=self._param2,
+        )
+        return PerformanceResult(
+            latency=float(result) * self._scale_factor,
+            energy=result.energy * self._scale_factor,
+        )
+
+    def get_weights(self, **kwargs):
+        return self._weights * self._scale_factor
+
+
+class GenerationNewOp(Operation):
+    def __init__(self, name: str, scale_factor: float, param1: int, param2: int) -> None:
+        super().__init__(name, scale_factor)
+        self._param1 = param1
+        self._param2 = param2
+        self._weights = param1 * param2 * 2
+
+    def query(self, database: PerfDatabase, **kwargs) -> PerformanceResult:
+        result = database.query_new_op(
+            b=kwargs.get("x"),
+            s=kwargs.get("s"),
+            param1=self._param1,
+            param2=self._param2,
+        )
+        return PerformanceResult(
+            latency=float(result) * self._scale_factor,
+            energy=result.energy * self._scale_factor,
+        )
+
+    def get_weights(self, **kwargs):
+        return self._weights * self._scale_factor
+```
+
+## Step 4: Use New Ops in `models.py`
+
+**File**: `src/aiconfigurator/sdk/models.py`
+
+Add operations to `self.context_ops` / `self.generation_ops` following `LLAMAModel` or `DeepSeekModel` patterns:
+
+```python
+self.context_ops.extend([
+    # ... standard ops ...
+    ops.ContextNewOp(
+        "context_new_op",
+        self._num_layers,  # scale_factor
+        param1=self._param1,
+        param2=self._param2,
+    ),
+    # ... standard ops ...
+])
+
+self.generation_ops.extend([
+    # ... standard ops ...
+    ops.GenerationNewOp(
+        "generation_new_op",
+        self._num_layers,
+        param1=self._param1,
+        param2=self._param2,
+    ),
+    # ... standard ops ...
+])
+```
+
+## Step 5: Place Performance Data Files
+
+Put collected files under:
+
+```
+src/aiconfigurator/systems/data/{system_name}/{backend}/{version}/
+  |- new_op_context_perf.txt
+  |- new_op_generation_perf.txt
+```
+
+## CLI Validation
+
+```bash
+aiconfigurator cli support --model-path <model> --system h200_sxm --backend trtllm
+
+aiconfigurator cli default --model-path <model> --total-gpus 8 --system h200_sxm \
+  --isl 4000 --osl 1000 --ttft 2000 --tpot 30
+```
+
+## Common Issues
+
+| Issue | Cause | Fix |
+|------|------|------|
+| `query` returns 0 | Data not loaded or wrong file path | Check `PerfDataFilename` and init loading path |
+| `KeyError` in query | Parameter combo missing | Add interpolation or collect more data |
+| Large model-vs-real gap | Wrong op decomposition | Re-check Phase 3 kernel/latency alignment |
+| `_interp_3d` returns dict | Interpolation result is not a float | Wrap with `PerformanceResult(result["latency"], energy=result.get("energy", 0.0))` |
+| Empty dict leaves after loading | `defaultdict(dict)` at leaf level | Use `defaultdict()` leaf or explicit key checks |
+| Wrong interpolation axes | Dict nesting does not match `_interp_3d(x, y, z)` | Keep axis order aligned with key order |
+
+## `perf_database.py` Rules
+
+Use the closest existing op as the exact template:
+
+1. **Loader shape**: dict nesting must match existing patterns exactly
+2. **Interpolation registration**: add to `__init__` interpolation block
+3. **Query behavior**: return `PerformanceResult`, avoid cross-granularity fallback
+4. **Quantization keys**: only register supported quant modes; override unsupported ones in model logic
+
+## Query Must Support Full Database Modes
+
+Each query method must handle all modes: `SOL`, `SOL_FULL`, `EMPIRICAL`, `SILICON`, `HYBRID`.
+
+```python
+if database_mode == DatabaseMode.SOL:
+    ...
+elif database_mode == DatabaseMode.SOL_FULL:
+    ...
+elif database_mode == DatabaseMode.EMPIRICAL:
+    ...
+else:  # SILICON or HYBRID
+    try:
+        ...
+    except Exception:
+        if database_mode == DatabaseMode.HYBRID:
+            ...
+        raise
+```
+
+## SOL Derivation Notes
+
+1. Break op into sub-computations and compute FLOPs per part
+2. Compute bound: `total_flops / gpu_peak_flops * 1000`
+3. Memory bound: `total_bytes / gpu_mem_bw * 1000`
+4. `SOL = max(compute, memory)`
+5. Empirical mode typically uses `SOL / scale_factor`
+
+## Context vs Generation SOL Differences
+
+| Item | Context | Generation |
+|------|---------|------------|
+| Tokens | `b * s` | `b` |
+| Typical bottleneck | Usually compute-bound | Usually memory-bound |
+| Attention term | `O(tokens * s)` or `O(tokens * topk)` | `O(b * s)` or `O(b * topk)` |
+| GEMM behavior | Larger M, better compute efficiency | Smaller M (`=b`), often memory-dominated |

--- a/agents/new-op-integration/references/phase5-collection.md
+++ b/agents/new-op-integration/references/phase5-collection.md
@@ -1,0 +1,173 @@
+# Phase 5: Performance Data Collection
+
+## Goal
+
+Collect latency data for the new operation across parameter combinations on target GPUs, and generate `*_perf.txt` files for aiconfigurator queries.
+
+## Architecture Overview
+
+```
+collector/
+├── collect.py                  # unified collection entrypoint (multi-process scheduling)
+├── helper.py                   # benchmark_with_power(), log_perf()
+├── common_test_cases.py        # standard test-case definitions
+├── trtllm/
+│   ├── collect_mla.py          # MLA collection (reference implementation)
+│   ├── collect_dsa.py          # DSA collection (V3.2 practical example)
+│   ├── collect_moe.py
+│   └── collect_xxx.py          # <- add your script here
+└── ...
+```
+
+**Key point**: New-op collection scripts must conform to `collect.py` orchestration. Do not create an unrelated standalone parallel pipeline.
+
+## Step 1: Implement the collection script
+
+**File**: `collector/trtllm/collect_new_op.py`
+
+Export these three entrypoints:
+1. `get_context_xxx_test_cases()` — returns a test-case list
+2. `get_generation_xxx_test_cases()` — same for generation
+3. `run_xxx()` — runs one test case
+
+### Test-case format
+
+Each test case is a **positional-argument list** and is expanded via `run_xxx(*test_case)`. Follow MLA conventions:
+
+```python
+# MLA: [input_len, batch_size, output_len, dtype, num_heads, world_size, tp_size, ...]
+# DSA: [seq_len, batch_size, tp_size, is_context, perf_filename]
+```
+
+Core rules:
+- List order must exactly match `run_xxx()` parameter order.
+- Include `perf_filename` in the list (do not hardcode it in `run_xxx`).
+
+### Choose collection axes from modeling decision
+
+Collection axes must follow the axis decision made in Phase 2 mock-layer design:
+
+- If op is token-equivalent (`x=b*s`), sweep `x` as the primary axis.
+- If op is token-non-equivalent, sweep `b` and `s` as separate axes.
+
+Do not use an `x`-only grid for attention-like ops.
+
+### Reuse existing range baselines
+
+For new ops, start from the nearest existing op range:
+
+- GEMM-like: reuse GEMM/linear token ranges.
+- Attention-like: reuse attention/MLA/DSA `b`/`s` ranges.
+- Keep existing guardrails (`b*s` limits, TP list, context/generation split).
+
+Only expand ranges when required by a clear model-specific reason.
+
+```python
+def get_context_xxx_test_cases():
+    test_cases = []
+    for tp_size in [1, 2, 4, 8, 16, 32, 64, 128]:
+        for b in [1, 2, 4, 8, 16, 32, 64, 128, 256]:
+            for s in [1, 16, 32, 64, 128, 256, 512, 1024, ...]:
+                if b * s > 65536:
+                    continue
+                test_cases.append([s, b, tp_size, True, "xxx_context_perf.txt"])
+    return test_cases
+```
+
+### `run_xxx` function
+
+```python
+def run_xxx(seq_len, batch_size, tp_size, is_context, perf_filename, device="cuda:0"):
+    """Run a single benchmark. Args match test case list order."""
+    # 1. Build mock layer (single-GPU TP emulation)
+    layer = create_xxx_layer(tp_size, device)  # local_heads = global_heads / tp_size
+    
+    # 2. Prepare inputs + metadata
+    # ...
+    
+    # 3. benchmark_with_power
+    def kernel_func():
+        layer.forward(...)
+    with benchmark_with_power(device, kernel_func, num_warmups=5, num_runs=6,
+                              repeat_n=1, allow_graph_fail=True) as res:
+        pass
+    
+    # 4. log_perf
+    log_perf(item_list=[{...}], framework="TRTLLM", version=...,
+             device_name=..., op_name="xxx_context", kernel_source="default",
+             perf_filename=perf_filename, power_stats=res["power_stats"])
+```
+
+### TP Emulation (Critical)
+
+**Multi-GPU is not required**. Follow MLA/GQA:
+```python
+local_num_heads = GLOBAL_HEADS // tp_size
+mapping = Mapping(world_size=1, rank=0, tp_size=1)  # always single-GPU
+# pass local_num_heads into layer constructor
+```
+
+## Step 2: Register in `collect.py`
+
+Add entries in the `collections` list inside `collect_trtllm()`:
+
+```python
+{
+    "name": "trtllm",
+    "type": "xxx_context",
+    "module": "collector.trtllm.collect_xxx",
+    "get_func": "get_context_xxx_test_cases",
+    "run_func": "run_xxx",
+},
+{
+    "name": "trtllm",
+    "type": "xxx_generation",
+    "module": "collector.trtllm.collect_xxx",
+    "get_func": "get_generation_xxx_test_cases",
+    "run_func": "run_xxx",
+},
+```
+
+Also add `"xxx_context"` and `"xxx_generation"` into `--ops` choices.
+
+## Step 3: Run collection
+
+```bash
+# Via unified collect.py entrypoint (recommended; handles multi-GPU scheduling)
+cd collector/
+python3 collect.py --backend trtllm --ops xxx_context xxx_generation
+
+# Or run standalone (debug only)
+cd collector/trtllm/
+python3 collect_xxx.py
+```
+
+## Step 4: Validate
+
+After collection, validate:
+1. Check row counts are as expected (you need to calculate how many cases there should be)
+2. Re-run several points with the same parameters; latency deviation should be < 10%
+3. After installation, run `aiconfigurator cli default` to confirm E2E works
+
+```python
+# Quick verification: rerun a few points and compare
+run_xxx(4096, 1, 8, True, "/tmp/verify.txt")
+# Compare last row of /tmp/verify.txt against existing data
+```
+
+## Step 5: Place data files
+
+```bash
+cp xxx_context_perf.txt src/aiconfigurator/systems/data/{system}/{backend}/{version}/
+cp xxx_generation_perf.txt src/aiconfigurator/systems/data/{system}/{backend}/{version}/
+```
+
+## Common Issues
+
+| Issue | Cause | Fix |
+|------|------|------|
+| CUDA OOM | `batch * seq` too large | Add `if b*s > limit: continue` in test-case generation |
+| High latency jitter | GPU throttling or background load | Check `results["throttled"]`; keep GPU idle |
+| Corrupted `log_perf` writes | Multiple processes writing same file | `log_perf` uses `fcntl.flock`; note NFS is not safe |
+| `collect.py` cannot import module | Import path issue | Add `sys.path.insert(0, str(Path(__file__).resolve().parent.parent))` at script top |
+| MPI init failure | TRT-LLM requires MPI | `export OPAL_PREFIX=/opt/hpcx/ompi` |


### PR DESCRIPTION
#### Overview:

This PR adds a new agent skill and supporting reference docs for integrating new operations into `aiconfigurator`. It standardizes the end-to-end workflow and clarifies the S1/S2/S3 decision path before implementation.

#### Details:

- Added `agents/new-op-integration/SKILL.md` with the full integration flow:
  - Situation assessment
  - Phase 1: analysis
  - Phase 2: mock layer
  - Phase 3: nsys alignment
  - Phase 4: SDK integration
  - Phase 5: data collection
- Added phase reference documents:
  - `agents/new-op-integration/references/phase1-analysis.md`
  - `agents/new-op-integration/references/phase2-mock-layer.md`
  - `agents/new-op-integration/references/phase3-nsys-alignment.md`
  - `agents/new-op-integration/references/phase4-integration.md`
  - `agents/new-op-integration/references/phase5-collection.md`
- Docs/process only; no runtime logic changes.

#### Where should the reviewer start?

- Start with `agents/new-op-integration/SKILL.md` for the overall flow and decision logic.
- Then review `agents/new-op-integration/references/phase4-integration.md` and `agents/new-op-integration/references/phase5-collection.md` for implementation-facing guidance.