### PR TITLE
feat: Add picking modes and expose standalone picking API

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -20,6 +20,7 @@ filterwarnings =
 timeout = 120
 markers =
     unit: fast tests (unit + lightweight integration, no external services)
+    integration: integration tests that exercise multiple components together (uses perf database)
     e2e: marks tests as end-to-end integration tests
     sweep: marks tests as sweep tests covering many combinations
     build: marks tests intended for GitHub build workflows (fast and stable subset of e2e)

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -85,6 +85,9 @@ class CLIResult:
     task_configs: dict[str, TaskConfig]
     """TaskConfig objects used for each experiment."""
 
+    best_latencies: dict[str, dict[str, float]] = field(default_factory=dict)
+    """Estimated latencies (ttft, tpot, request_latency) from the rank-1 config per experiment."""
+
     raw_results: dict[str, dict[str, pd.DataFrame | None]] = field(default_factory=dict)
     """Raw pareto_df results from TaskRunner, keyed by experiment name."""
 
@@ -102,7 +105,7 @@ def _execute_and_wrap_result(
     top_n: int = 5,
 ) -> CLIResult:
     """Execute task configs using main.py's function and wrap result in CLIResult."""
-    chosen_exp, best_configs, pareto_fronts, best_throughputs = _execute_task_configs_internal(
+    chosen_exp, best_configs, pareto_fronts, best_throughputs, best_latencies = _execute_task_configs_internal(
         task_configs, mode, top_n=top_n
     )
 
@@ -111,6 +114,7 @@ def _execute_and_wrap_result(
         best_configs=best_configs,
         pareto_fronts=pareto_fronts,
         best_throughputs=best_throughputs,
+        best_latencies=best_latencies,
         task_configs=task_configs,
         raw_results={},
     )

--- a/src/aiconfigurator/cli/report_and_save.py
+++ b/src/aiconfigurator/cli/report_and_save.py
@@ -258,8 +258,11 @@ def log_final_summary(
     mode: str,
     pareto_x_axis: dict[str, str] | None = None,
     top_n: int = 5,
+    target_request_rate: float | None = None,
+    target_concurrency: float | None = None,
 ):
     """Log final summary of configuration results"""
+    load_match = target_request_rate is not None or target_concurrency is not None
 
     # Consolidate and format results into a summary box for clear presentation
     summary_box = []
@@ -287,7 +290,27 @@ def log_final_summary(
         f"    Model: {chosen_task_config.config.model_path} (is_moe: {chosen_task_config.config.is_moe})"
     )
     summary_box.append(f"    Total GPUs: {chosen_task_config.total_gpus}")
-    if mode == "default":
+
+    if load_match:
+        # Load-match mode summary
+        if target_request_rate is not None:
+            summary_box.append(f"    Target Load: {target_request_rate} req/s")
+        else:
+            summary_box.append(f"    Target Concurrency: {target_concurrency}")
+        # Show GPUs needed for each mode (and load_served_pct if capacity exceeded)
+        for exp_name, df in best_configs.items():
+            if df is not None and not df.empty and "total_gpus_needed" in df.columns:
+                row = df.iloc[0]
+                gpus = int(row["total_gpus_needed"])
+                replicas = int(row["replicas_needed"])
+                line = f"    {exp_name} GPUs needed: {gpus} (replicas: {replicas})"
+                if "load_served_pct" in df.columns:
+                    pct = float(row["load_served_pct"])
+                    if pct < 100.0:
+                        line += f" -- WARNING: only {pct:.1f}% of target load can be served"
+                summary_box.append(line)
+        summary_box.append(f"    Best Experiment Chosen: \033[1m{chosen_exp}\033[0m")
+    elif mode == "default":
         agg_value = best_throughputs.get("agg", 0.0)
         disagg_value = best_throughputs.get("disagg", 0.0)
         if agg_value > 0 and disagg_value > 0:
@@ -418,6 +441,7 @@ def save_results(
     save_dir: str,
     generated_backend_version: str | None = None,
     backend: str | None = None,
+    use_dynamo_generator: bool = False,
 ):
     """Save the results to a directory."""
 
@@ -666,6 +690,7 @@ def save_results(
                             backend=row_task_config.backend_name,
                             backend_version=row_backend_version,
                             output_dir=top_config_dir,
+                            use_dynamo_generator=use_dynamo_generator,
                         )
                     except Exception as exc:
                         logger.warning(

--- a/src/aiconfigurator/cli/utils.py
+++ b/src/aiconfigurator/cli/utils.py
@@ -6,78 +6,83 @@ import logging
 import pandas as pd
 
 from aiconfigurator.sdk.pareto_analysis import (
-    get_best_configs_under_request_latency_constraint,
-    get_best_configs_under_tpot_constraint,
     get_pareto_front,
 )
+from aiconfigurator.sdk.picking import pick_default, pick_load_match
 from aiconfigurator.sdk.task import TaskConfig
 
 logger = logging.getLogger(__name__)
 
 
-def process_experiment_result(task_config: TaskConfig, result: dict[str, pd.DataFrame], top_n: int = 5) -> tuple:
+def process_experiment_result(
+    task_config: TaskConfig,
+    result: dict[str, pd.DataFrame],
+    top_n: int = 5,
+    target_request_rate: float | None = None,
+    target_concurrency: float | None = None,
+    max_total_gpus: int | None = None,
+) -> tuple:
     """
     Process the result of a single experiment.
+
+    This is a thin wrapper around :func:`picking.pick_default` and
+    :func:`picking.pick_load_match` that extracts parameters from the
+    ``TaskConfig``.
+
     Args:
         task_config: TaskConfig object for the experiment.
         result: Dictionary containing the pareto_df result of the experiment.
         top_n: Number of top configurations to return.
+        target_request_rate: If set, activates load-match picking (minimize
+            GPUs for the given request rate in req/s).
+        target_concurrency: If set, activates load-match picking (minimize
+            GPUs for the given number of concurrent requests).
+        max_total_gpus: Optional upper bound on total GPUs for load-match.
+
     Returns:
         tuple:
             - best_config_df: Best configuration dataframe.
-            - best_throughput: Best throughput.
+            - best_throughput: Best throughput (or 1/total_gpus_needed for
+              load-match mode so that ``max()`` picks fewest GPUs).
             - pareto_frontier_df: Pareto frontier dataframe.
             - x_axis_col: X-axis column name.
     """
+    load_match = target_request_rate is not None or target_concurrency is not None
+
     pareto_df = result["pareto_df"]
     runtime_cfg = task_config.config.runtime_config
     target_tpot = runtime_cfg.tpot
     target_request_latency = runtime_cfg.request_latency
     use_request_latency = target_request_latency is not None and target_request_latency > 0
     total_gpus = getattr(task_config, "total_gpus", None) or 0
+    serving_mode = task_config.serving_mode
 
-    # Compute tokens/s/gpu_cluster for pareto_df
-    if pareto_df is not None and not pareto_df.empty:
-        pareto_df["tokens/s/gpu_cluster"] = (
-            pareto_df["tokens/s/gpu"]
-            * (total_gpus // pareto_df["num_total_gpus"])
-            * pareto_df["num_total_gpus"]
-            / total_gpus
-        )
-        x_axis_col = "request_latency" if use_request_latency else "tokens/s/user"
-        pareto_frontier_df = get_pareto_front(
-            pareto_df,
-            x_axis_col,
-            "tokens/s/gpu_cluster",
-            maximize_x=not use_request_latency,
-            maximize_y=True,
+    x_axis_col = "request_latency" if use_request_latency else "tokens/s/user"
+
+    if load_match:
+        picking_result = pick_load_match(
+            pareto_df=pareto_df,
+            serving_mode=serving_mode,
+            target_tpot=target_tpot,
+            target_request_latency=target_request_latency,
+            target_request_rate=target_request_rate,
+            target_concurrency=target_concurrency,
+            max_total_gpus=max_total_gpus,
+            top_n=top_n,
         )
     else:
-        pareto_frontier_df = pd.DataFrame()
-        x_axis_col = "request_latency" if use_request_latency else "tokens/s/user"
-
-    group_by_key = "(d)parallel" if task_config.serving_mode == "disagg" else "parallel"
-    if use_request_latency:
-        best_config_df = get_best_configs_under_request_latency_constraint(
-            total_gpus=total_gpus,
+        picking_result = pick_default(
             pareto_df=pareto_df,
+            total_gpus=total_gpus,
+            serving_mode=serving_mode,
+            target_tpot=target_tpot,
             target_request_latency=target_request_latency,
             top_n=top_n,
-            group_by=group_by_key,
-        )
-    else:
-        best_config_df = get_best_configs_under_tpot_constraint(  # based on all data points
-            total_gpus=total_gpus,
-            pareto_df=pareto_df,
-            target_tpot=target_tpot,
-            top_n=top_n,
-            group_by=group_by_key,
         )
 
-    if not best_config_df.empty:
-        best_throughput = best_config_df["tokens/s/gpu_cluster"].values[0]
-    else:
-        best_throughput = 0.0
+    best_config_df = picking_result["best_config_df"]
+    best_throughput = picking_result["best_throughput"]
+    pareto_frontier_df = picking_result.get("pareto_frontier_df", pd.DataFrame())
 
     return best_config_df, best_throughput, pareto_frontier_df, x_axis_col
 

--- a/src/aiconfigurator/cli/utils.py
+++ b/src/aiconfigurator/cli/utils.py
@@ -46,6 +46,8 @@ def process_experiment_result(
               load-match mode so that ``max()`` picks fewest GPUs).
             - pareto_frontier_df: Pareto frontier dataframe.
             - x_axis_col: X-axis column name.
+            - best_latencies: Dict with ``ttft``, ``tpot``, ``request_latency``
+              (and load-match fields when applicable) from the rank-1 config.
     """
     load_match = target_request_rate is not None or target_concurrency is not None
 
@@ -82,9 +84,10 @@ def process_experiment_result(
 
     best_config_df = picking_result["best_config_df"]
     best_throughput = picking_result["best_throughput"]
+    best_latencies = picking_result.get("best_latencies", {"ttft": 0.0, "tpot": 0.0, "request_latency": 0.0})
     pareto_frontier_df = picking_result.get("pareto_frontier_df", pd.DataFrame())
 
-    return best_config_df, best_throughput, pareto_frontier_df, x_axis_col
+    return best_config_df, best_throughput, pareto_frontier_df, x_axis_col, best_latencies
 
 
 def _merge_into_top_n(

--- a/src/aiconfigurator/generator/api.py
+++ b/src/aiconfigurator/generator/api.py
@@ -263,6 +263,7 @@ def generate_backend_artifacts(
     templates_dir: Optional[str] = None,
     output_dir: Optional[str] = None,
     backend_version: Optional[str] = None,
+    use_dynamo_generator: bool = False,
 ) -> dict[str, str]:
     """
     Generate complete backend artifacts including run scripts, configs, and k8s YAML.
@@ -273,12 +274,20 @@ def generate_backend_artifacts(
         templates_dir: Optional directory containing templates
         output_dir: Optional directory to save generated files
         backend_version: Optional version string for version-specific template selection
+        use_dynamo_generator: If True, use the Dynamo DPP config generator
+            for the k8s deploy YAML instead of Jinja2 templates.
 
     Returns:
         Dictionary mapping artifact names to their content
     """
     logger = logging.getLogger(__name__)
-    artifacts = render_backend_templates(params, backend, templates_dir, backend_version)
+    artifacts = render_backend_templates(
+        params,
+        backend,
+        templates_dir,
+        backend_version,
+        use_dynamo_generator=use_dynamo_generator,
+    )
 
     if output_dir:
         params_obj = params.get("params", {})

--- a/src/aiconfigurator/sdk/inference_session.py
+++ b/src/aiconfigurator/sdk/inference_session.py
@@ -11,6 +11,11 @@ import pandas as pd
 from aiconfigurator.sdk import common, config, models, perf_database
 from aiconfigurator.sdk.backends.base_backend import BaseBackend
 from aiconfigurator.sdk.inference_summary import InferenceSummary
+from aiconfigurator.sdk.picking import (
+    _AUTOSCALE_TTFT_CORRECTION_FACTOR,
+    _RATE_MATCHING_DECODE_DEGRADATION_FACTOR,
+    _RATE_MATCHING_PREFILL_DEGRADATION_FACTOR,
+)
 from aiconfigurator.sdk.utils import enumerate_ttft_tpot_constraints
 
 logger = logging.getLogger(__name__)
@@ -166,10 +171,9 @@ class DisaggInferenceSession:
         self._prefill_latency_correction_scale = 1.0
         self._decode_latency_correction_scale = 1.0
 
-        # comes from pipeline bubble, especially when benchmarking with concurrency
-        self._RATE_MATCHING_PREFILL_DEGRADATION_FACTOR = 0.9
-        # comes from not saturating the batchsize slot of decode worker
-        self._RATE_MATCHING_DECODE_DEGRADATION_FACTOR = 0.92
+        # See picking.py for rationale
+        self._RATE_MATCHING_PREFILL_DEGRADATION_FACTOR = _RATE_MATCHING_PREFILL_DEGRADATION_FACTOR
+        self._RATE_MATCHING_DECODE_DEGRADATION_FACTOR = _RATE_MATCHING_DECODE_DEGRADATION_FACTOR
 
     def set_latency_correction_scales(
         self, prefill_latency_correction_scale: float, decode_latency_correction_scale: float
@@ -189,107 +193,20 @@ class DisaggInferenceSession:
     ) -> dict:
         """
         Get the disagg summary as a dict based on prefill and decode summary dicts.
-        The summary dict is used for efficient batch operations.
+
+        Delegates to :func:`aiconfigurator.sdk.picking.build_disagg_summary_dict`
+        passing this session's degradation factors.
         """
-        seq_s = min(
-            prefill_summary_dict["seq/s"] * prefill_num_worker * self._RATE_MATCHING_PREFILL_DEGRADATION_FACTOR,
-            decode_summary_dict["seq/s"] * decode_num_worker * self._RATE_MATCHING_DECODE_DEGRADATION_FACTOR,
+        from aiconfigurator.sdk.picking import build_disagg_summary_dict
+
+        return build_disagg_summary_dict(
+            prefill_summary_dict=prefill_summary_dict,
+            prefill_num_worker=prefill_num_worker,
+            decode_summary_dict=decode_summary_dict,
+            decode_num_worker=decode_num_worker,
+            prefill_degradation_factor=self._RATE_MATCHING_PREFILL_DEGRADATION_FACTOR,
+            decode_degradation_factor=self._RATE_MATCHING_DECODE_DEGRADATION_FACTOR,
         )
-        prefill_gpus = prefill_summary_dict["pp"] * prefill_summary_dict["tp"] * prefill_summary_dict["dp"]
-        decode_gpus = decode_summary_dict["pp"] * decode_summary_dict["tp"] * decode_summary_dict["dp"]
-        seq_s_gpu = seq_s / (prefill_gpus * prefill_num_worker + decode_gpus * decode_num_worker)
-
-        tokens_s = seq_s * prefill_summary_dict["osl"]
-        tokens_s_gpu = tokens_s / (prefill_gpus * prefill_num_worker + decode_gpus * decode_num_worker)
-        num_total_gpus = prefill_gpus * prefill_num_worker + decode_gpus * decode_num_worker
-        osl = prefill_summary_dict["osl"]
-        request_latency = prefill_summary_dict["ttft"] + decode_summary_dict["tpot"] * max(osl - 1, 0)
-
-        # Calculate weighted average power for DISAGG mode
-        # Power is weighted by time spent in each phase
-        # Note: prefill_power and decode_power are already per-GPU averages
-        ttft = prefill_summary_dict["ttft"]
-        tpot = decode_summary_dict["tpot"]
-        decode_time = tpot * max(osl - 1, 0)
-
-        prefill_power = prefill_summary_dict.get("power_w", 0.0)
-        decode_power = decode_summary_dict.get("power_w", 0.0)
-
-        # DEBUG: Log the power values we're getting
-        logger.debug(
-            f"DISAGG Power Calc: prefill_power={prefill_power}W, "
-            f"decode_power={decode_power}W, ttft={ttft}ms, decode_time={decode_time}ms"
-        )
-
-        # Simple time-weighted average (power values are already per-GPU)
-        total_time = ttft + decode_time
-
-        if total_time > 0:
-            disagg_power_avg = (prefill_power * ttft + decode_power * decode_time) / total_time
-        else:
-            disagg_power_avg = 0.0
-
-        logger.debug(
-            f"DISAGG Power Result: {disagg_power_avg}W (time-weighted from {prefill_power}W and {decode_power}W)"
-        )
-
-        return {
-            "model": prefill_summary_dict["model"],
-            "isl": prefill_summary_dict["isl"],
-            "osl": prefill_summary_dict["osl"],
-            "prefix": prefill_summary_dict["prefix"],
-            # This is not exact matching. You can use this concurrency to benchmark the system.
-            "concurrency": decode_summary_dict["concurrency"] * decode_num_worker,
-            "request_rate": seq_s,
-            "(p)bs": prefill_summary_dict["bs"],
-            "(p)global_bs": prefill_summary_dict["global_bs"],
-            "(p)workers": prefill_num_worker,
-            "(d)bs": decode_summary_dict["bs"],
-            "(d)global_bs": decode_summary_dict["global_bs"],
-            "(d)workers": decode_num_worker,
-            "ttft": prefill_summary_dict["ttft"],
-            "tpot": decode_summary_dict["tpot"],
-            "request_latency": request_latency,
-            "seq/s": seq_s,
-            "seq/s/gpu": seq_s_gpu,
-            "tokens/s": tokens_s,
-            "tokens/s/gpu": tokens_s_gpu,
-            "tokens/s/user": decode_summary_dict["tokens/s/user"],
-            "(p)seq/s/worker": prefill_summary_dict["seq/s"],
-            "(d)seq/s/worker": decode_summary_dict["seq/s"],
-            "num_total_gpus": num_total_gpus,
-            "(p)tp": prefill_summary_dict["tp"],
-            "(p)pp": prefill_summary_dict["pp"],
-            "(p)dp": prefill_summary_dict["dp"],
-            "(p)moe_tp": prefill_summary_dict["moe_tp"],
-            "(p)moe_ep": prefill_summary_dict["moe_ep"],
-            "(p)parallel": prefill_summary_dict["parallel"],
-            "(p)gemm": prefill_summary_dict["gemm"],
-            "(p)kvcache": prefill_summary_dict["kvcache"],
-            "(p)fmha": prefill_summary_dict["fmha"],
-            "(p)moe": prefill_summary_dict["moe"],
-            "(p)comm": prefill_summary_dict["comm"],
-            "(p)memory": prefill_summary_dict["memory"],
-            "(p)backend": prefill_summary_dict["backend"],
-            "(p)version": prefill_summary_dict["version"],
-            "(p)system": prefill_summary_dict["system"],
-            "(d)tp": decode_summary_dict["tp"],
-            "(d)pp": decode_summary_dict["pp"],
-            "(d)dp": decode_summary_dict["dp"],
-            "(d)moe_tp": decode_summary_dict["moe_tp"],
-            "(d)moe_ep": decode_summary_dict["moe_ep"],
-            "(d)parallel": decode_summary_dict["parallel"],
-            "(d)gemm": decode_summary_dict["gemm"],
-            "(d)kvcache": decode_summary_dict["kvcache"],
-            "(d)fmha": decode_summary_dict["fmha"],
-            "(d)moe": decode_summary_dict["moe"],
-            "(d)comm": decode_summary_dict["comm"],
-            "(d)memory": decode_summary_dict["memory"],
-            "(d)backend": decode_summary_dict["backend"],
-            "(d)version": decode_summary_dict["version"],
-            "(d)system": decode_summary_dict["system"],
-            "power_w": disagg_power_avg,  # Weighted average power for DISAGG mode
-        }
 
     def _get_disagg_summary_df(
         self,
@@ -358,6 +275,151 @@ class DisaggInferenceSession:
         disagg_summary.set_summary_df(disagg_summary_df)
         return disagg_summary
 
+    def get_worker_candidates(
+        self,
+        model_path: str,
+        model_config: config.ModelConfig,
+        parallel_config_list: list[tuple[int, int, int, int, int]],
+        b_list: list[int] | range,
+        runtime_config: config.RuntimeConfig,
+        mode: str,
+        latency_correction_scale: float = 1.0,
+    ) -> pd.DataFrame:
+        """Get all worker candidates for a given search space.
+
+        It enumerates all (parallel_config, batch_size) combinations,
+        runs static inference, and returns a DataFrame with columns from
+        :data:`common.ColumnsStatic`.
+
+        Args:
+            model_path: HuggingFace model ID or local path.
+            model_config: Model configuration (quant modes etc.).
+            parallel_config_list: List of (tp, pp, dp, moe_tp, moe_ep) tuples.
+            b_list: Batch sizes to sweep.
+            runtime_config: Runtime config (isl, osl, etc.).
+            mode: ``"static_ctx"`` for prefill or ``"static_gen"`` for decode.
+            latency_correction_scale: Multiplicative correction applied to
+                latencies (default 1.0).
+
+        Returns:
+            DataFrame with one row per (parallel_config, batch_size) that fits
+            in memory.
+
+        Raises:
+            RuntimeError: If no valid results are found for any config.
+        """
+        summary_df = pd.DataFrame(columns=common.ColumnsStatic)
+        exceptions: list[Exception] = []
+
+        for parallel_config in parallel_config_list:
+            tp_size, pp_size, dp_size, moe_tp_size, moe_ep_size = parallel_config
+            logger.debug(
+                "Getting candidate workers with parallel config: tp=%d, pp=%d, dp=%d, moe_tp=%d, moe_ep=%d",
+                tp_size,
+                pp_size,
+                dp_size,
+                moe_tp_size,
+                moe_ep_size,
+            )
+
+            try:
+                overwritten_model_config = copy.deepcopy(model_config)
+                overwritten_model_config.pp_size = pp_size
+                overwritten_model_config.tp_size = tp_size
+                overwritten_model_config.moe_tp_size = moe_tp_size
+                overwritten_model_config.moe_ep_size = moe_ep_size
+                overwritten_model_config.attention_dp_size = dp_size
+                model = models.get_model(
+                    model_path=model_path,
+                    model_config=overwritten_model_config,
+                    backend_name=self._prefill_backend.name.value,
+                )
+                if mode == "static_ctx":
+                    sess = InferenceSession(
+                        model=model,
+                        database=self._prefill_database,
+                        backend=self._prefill_backend,
+                    )
+                else:
+                    sess = InferenceSession(
+                        model=model,
+                        database=self._decode_database,
+                        backend=self._decode_backend,
+                    )
+
+                for b in b_list:
+                    overwritten_runtime_config = copy.deepcopy(runtime_config)
+                    overwritten_runtime_config.batch_size = b
+                    summary = sess.run_static(
+                        mode=mode,
+                        runtime_config=overwritten_runtime_config,
+                        latency_correction_scale=latency_correction_scale,
+                    )
+                    if not summary.check_oom():
+                        summary_df = pd.concat(
+                            [summary_df, summary.get_summary_df()],
+                            axis=0,
+                            ignore_index=True,
+                        )
+                    else:  # larger b will always OOM
+                        break
+            except Exception as e:
+                logger.warning(
+                    "Error getting candidate workers with parallel config: "
+                    "tp=%d, pp=%d, dp=%d, moe_tp=%d, moe_ep=%d; "
+                    "skipping this combination. Error: %s",
+                    tp_size,
+                    pp_size,
+                    dp_size,
+                    moe_tp_size,
+                    moe_ep_size,
+                    e,
+                )
+                exceptions.append(e)
+                continue
+        if summary_df.empty:
+            raise RuntimeError(
+                f"No results found for any parallel configuration. Showing last exception: {exceptions[-1]}"
+            ) from exceptions[-1]
+        return summary_df
+
+    def _pick_autoscale(
+        self,
+        prefill_summary_df: pd.DataFrame,
+        decode_summary_df: pd.DataFrame,
+        runtime_config: config.RuntimeConfig,
+        disagg_summary: InferenceSummary,
+        target_ttft: float | None = None,
+        target_tpot: float | None = None,
+        top_n: int = 5,
+    ) -> InferenceSummary:
+        """Pick best prefill and decode engines independently for autoscaling.
+
+        Delegates to :func:`aiconfigurator.sdk.picking.pick_autoscale` and
+        wraps the result in an ``InferenceSummary``.
+        """
+        from aiconfigurator.sdk.picking import pick_autoscale
+
+        if target_ttft is None:
+            target_ttft = runtime_config.ttft
+
+        if target_tpot is None:
+            tpot_values = runtime_config.tpot if isinstance(runtime_config.tpot, list) else [runtime_config.tpot]
+            target_tpot = max(tpot_values)
+
+        result = pick_autoscale(
+            prefill_df=prefill_summary_df,
+            decode_df=decode_summary_df,
+            target_ttft=target_ttft,
+            target_tpot=target_tpot,
+            top_n=top_n,
+        )
+
+        disagg_summary_df = result["best_config_df"]
+        if not disagg_summary_df.empty:
+            disagg_summary.set_summary_df(disagg_summary_df)
+        return disagg_summary
+
     # optimization
     def find_best_disagg_result_under_constraints(
         self,
@@ -373,6 +435,8 @@ class DisaggInferenceSession:
         decode_num_worker_list: list[int],
         num_gpu_list: list[int] | None,
         require_same_tp: bool = False,
+        autoscale: bool = False,
+        target_tpot: float | None = None,
     ) -> InferenceSummary | None:
         """
         Run disagg with given constraints
@@ -456,82 +520,6 @@ class DisaggInferenceSession:
 
             return prefill_opt_num_worker, decode_opt_num_worker
 
-        def _get_summary_df(
-            model_config: config.ModelConfig,
-            parallel_config_list: list[tuple[int, int, int, int, int]],
-            b_list: list[int],
-            runtime_config: config.RuntimeConfig,
-            mode: str,
-            latency_correction_scale: float = 1.0,
-        ) -> pd.DataFrame:
-            """
-            Get all worker candidates based on give search space
-            """
-            summary_df = pd.DataFrame(columns=common.ColumnsStatic)
-            exceptions = []
-
-            for parallel_config in parallel_config_list:
-                tp_size, pp_size, dp_size, moe_tp_size, moe_ep_size = parallel_config
-                logger.debug(
-                    f"Getting candidate workers with parallel config: tp={tp_size}, pp={pp_size}, "
-                    f"dp={dp_size}, moe_tp={moe_tp_size}, moe_ep={moe_ep_size}"
-                )
-
-                try:
-                    overwritten_model_config = copy.deepcopy(model_config)
-                    overwritten_model_config.pp_size = pp_size
-                    overwritten_model_config.tp_size = tp_size
-                    overwritten_model_config.moe_tp_size = moe_tp_size
-                    overwritten_model_config.moe_ep_size = moe_ep_size
-                    overwritten_model_config.attention_dp_size = dp_size
-                    model = models.get_model(
-                        model_path=model_path,
-                        model_config=overwritten_model_config,
-                        backend_name=self._prefill_backend.name.value,
-                    )
-                    if mode == "static_ctx":
-                        sess = InferenceSession(
-                            model=model,
-                            database=self._prefill_database,
-                            backend=self._prefill_backend,
-                        )
-                    else:
-                        sess = InferenceSession(
-                            model=model,
-                            database=self._decode_database,
-                            backend=self._decode_backend,
-                        )
-
-                    for b in b_list:
-                        overwritten_runtime_config = copy.deepcopy(runtime_config)
-                        overwritten_runtime_config.batch_size = b
-                        summary = sess.run_static(
-                            mode=mode,
-                            runtime_config=overwritten_runtime_config,
-                            latency_correction_scale=latency_correction_scale,
-                        )
-                        if not summary.check_oom():
-                            summary_df = pd.concat(
-                                [summary_df, summary.get_summary_df()],
-                                axis=0,
-                                ignore_index=True,
-                            )
-                        else:  # larger b will always OOM
-                            break
-                except Exception as e:
-                    logger.warning(
-                        f"Error getting candidate workers with parallel config: "
-                        f"tp={tp_size}, pp={pp_size}, dp={dp_size}, moe_tp={moe_tp_size}, "
-                        f"moe_ep={moe_ep_size}; skipping this combination. Error: {e}"
-                    )
-                    exceptions.append(e)
-                    continue
-            if summary_df.empty:
-                raise RuntimeError(
-                    f"No results found for any parallel configuration. Showing last exception: {exceptions[-1]}"
-                ) from exceptions[-1]
-            return summary_df
-
         def _find_best_result_under_constraints(
             ttft: float,
             tpot: float,
@@ -566,7 +554,7 @@ class DisaggInferenceSession:
             # if we use N=10, it's lc/20+0.95. assume lc can be 15-20, 1.8 is a reasonable
             # correction factor. as we need to get the lc after rate matching, we cannot get the
             # exact value now. Let's make it simple to do pre-correction instead of post-correction.
-            correction_factor = 1.8  # let's make it simple for now.
+            correction_factor = _AUTOSCALE_TTFT_CORRECTION_FACTOR
             prefill_candidates = prefill_summary_df.assign(ttft=prefill_summary_df["ttft"] * correction_factor)
 
             prefill_candidates = prefill_candidates[prefill_candidates["ttft"] < ttft]
@@ -670,25 +658,37 @@ class DisaggInferenceSession:
         disagg_summary.set_summary_df(disagg_summary_df)
 
         # find prefill and decode workers
-        prefill_summary_df = _get_summary_df(
-            prefill_model_config,
-            prefill_parallel_config_list,
-            prefill_batch_size_range,
-            runtime_config,
-            "static_ctx",
+        prefill_summary_df = self.get_worker_candidates(
+            model_path=model_path,
+            model_config=prefill_model_config,
+            parallel_config_list=prefill_parallel_config_list,
+            b_list=prefill_batch_size_range,
+            runtime_config=runtime_config,
+            mode="static_ctx",
             latency_correction_scale=self._prefill_latency_correction_scale,
         )
-        decode_summary_df = _get_summary_df(
-            decode_model_config,
-            decode_parallel_config_list,
-            decode_batch_size_range,
-            runtime_config,
-            "static_gen",
+        decode_summary_df = self.get_worker_candidates(
+            model_path=model_path,
+            model_config=decode_model_config,
+            parallel_config_list=decode_parallel_config_list,
+            b_list=decode_batch_size_range,
+            runtime_config=runtime_config,
+            mode="static_gen",
             latency_correction_scale=self._decode_latency_correction_scale,
         )
         if len(prefill_summary_df) == 0 or len(decode_summary_df) == 0:
             logger.debug(f"No prefill or decode workers found for {model_path} with given configs.")
             return disagg_summary
+
+        # ----- autoscale mode: pick P and D independently, no rate matching -----
+        if autoscale:
+            return self._pick_autoscale(
+                prefill_summary_df=prefill_summary_df,
+                decode_summary_df=decode_summary_df,
+                runtime_config=runtime_config,
+                disagg_summary=disagg_summary,
+                target_tpot=target_tpot,
+            )
 
         # find best result under constraints
         constraint_pairs: list[tuple[float, float]] = []

--- a/src/aiconfigurator/sdk/inference_session.py
+++ b/src/aiconfigurator/sdk/inference_session.py
@@ -15,7 +15,7 @@ from aiconfigurator.sdk.picking import (
     _AUTOSCALE_TTFT_CORRECTION_FACTOR,
     _RATE_MATCHING_DECODE_DEGRADATION_FACTOR,
     _RATE_MATCHING_PREFILL_DEGRADATION_FACTOR,
-    build_disagg_summary_dict,
+    _build_disagg_summary_dict,
 )
 from aiconfigurator.sdk.utils import enumerate_ttft_tpot_constraints
 
@@ -194,7 +194,7 @@ class DisaggInferenceSession:
         prefill_dict = prefill_summary_df.iloc[0].to_dict()
         decode_dict = decode_summary_df.iloc[0].to_dict()
 
-        summary_dict = build_disagg_summary_dict(
+        summary_dict = _build_disagg_summary_dict(
             prefill_dict,
             prefill_num_worker,
             decode_dict,
@@ -588,7 +588,7 @@ class DisaggInferenceSession:
                         if prefill_num_worker == -1 or decode_num_worker == -1:
                             continue
 
-                        disagg_dict = build_disagg_summary_dict(
+                        disagg_dict = _build_disagg_summary_dict(
                             prefill_worker,
                             prefill_num_worker,
                             decode_worker,

--- a/src/aiconfigurator/sdk/pareto_analysis.py
+++ b/src/aiconfigurator/sdk/pareto_analysis.py
@@ -246,6 +246,8 @@ def disagg_pareto(
     decode_num_worker_list = get_working_list(decode_num_worker_list, decode_max_num_worker)
 
     require_same_tp = kwargs.get("require_same_tp", False)
+    autoscale = kwargs.get("autoscale", False)
+    target_tpot = kwargs.get("target_tpot")
 
     summary = disagg_sess.find_best_disagg_result_under_constraints(
         model_path=model_path,
@@ -260,6 +262,8 @@ def disagg_pareto(
         decode_num_worker_list=decode_num_worker_list,
         num_gpu_list=num_gpu_list,
         require_same_tp=require_same_tp,
+        autoscale=autoscale,
+        target_tpot=target_tpot,
     )
 
     return summary.get_summary_df()
@@ -466,32 +470,46 @@ def _get_best_configs_under_constraint(
         logger.error("top_n is less than 1")
         return pd.DataFrame()
 
-    if not candidate_configs.empty:
-        # compute achieved cluster-scale tokens/s/gpu
-        candidate_configs["tokens/s/gpu_cluster"] = (
-            candidate_configs["tokens/s/gpu"]
-            * (total_gpus // candidate_configs["num_total_gpus"])
-            * candidate_configs["num_total_gpus"]
-            / total_gpus
+    if candidate_configs.empty:
+        # No config meets the constraint strictly -- fall back to closest matches.
+        logger.info(
+            "No config found with %s <= %s. Returning top-%d closest configs.",
+            constraint_col,
+            target_value,
+            top_n,
         )
-        if group_by is not None:
-            top_indexes = candidate_configs.groupby(group_by)["tokens/s/gpu_cluster"].idxmax()
-            candidate_configs = candidate_configs.loc[top_indexes]
+        candidate_configs = pareto_df.copy()
+        candidate_configs["_sla_exceeded"] = True
+    else:
+        candidate_configs["_sla_exceeded"] = False
+
+    # compute achieved cluster-scale tokens/s/gpu
+    candidate_configs["tokens/s/gpu_cluster"] = (
+        candidate_configs["tokens/s/gpu"]
+        * (total_gpus // candidate_configs["num_total_gpus"])
+        * candidate_configs["num_total_gpus"]
+        / total_gpus
+    )
+    if group_by is not None and group_by in candidate_configs.columns:
+        top_indexes = candidate_configs.groupby(group_by)["tokens/s/gpu_cluster"].idxmax()
+        candidate_configs = candidate_configs.loc[top_indexes]
+
+    if candidate_configs["_sla_exceeded"].all():
+        # All configs exceed the SLA -- sort by closest to target
+        sort_columns = [constraint_col]
+        sort_ascending = [True]
+    else:
         sort_columns = ["tokens/s/gpu_cluster"]
         sort_ascending = [False]
         if secondary_sort_col and secondary_sort_col in candidate_configs.columns:
             sort_columns.append(secondary_sort_col)
             sort_ascending.append(secondary_sort_ascending)
-        candidate_configs = (
-            candidate_configs.sort_values(by=sort_columns, ascending=sort_ascending).head(top_n).reset_index(drop=True)
-        )
-        return candidate_configs
-    else:
-        # No config meets constraint
-        # Optionally, one could return the one closest to target_tpot if no strict candidates exist.
-        # For now, return empty if no config meets the criteria.
-        logger.info("No config found on Pareto front with %s <= %s.", constraint_col, target_value)
-        return pd.DataFrame()
+
+    candidate_configs = (
+        candidate_configs.sort_values(by=sort_columns, ascending=sort_ascending).head(top_n).reset_index(drop=True)
+    )
+    candidate_configs.drop(columns=["_sla_exceeded"], inplace=True)
+    return candidate_configs
 
 
 def get_best_configs_under_tpot_constraint(
@@ -532,3 +550,147 @@ def get_best_configs_under_request_latency_constraint(
         secondary_sort_col="request_latency",
         secondary_sort_ascending=True,
     )
+
+
+def get_best_configs_for_target_load(
+    pareto_df: pd.DataFrame,
+    constraint_col: str,
+    constraint_value: float,
+    target_request_rate: float | None = None,
+    target_concurrency: float | None = None,
+    top_n: int = 5,
+    max_total_gpus: int | None = None,
+    group_by: str | None = None,
+) -> pd.DataFrame:
+    """Find configs that serve a target load with minimum GPUs under SLA.
+
+    Exactly one of ``target_request_rate`` or ``target_concurrency`` must be
+    provided.  For each candidate config the number of replicas needed to
+    meet the load target is computed from the per-replica ``seq/s`` or
+    ``concurrency`` column, then ``total_gpus_needed`` is derived.  Results
+    are ranked by ``total_gpus_needed`` ascending (fewer GPUs is better).
+
+    Args:
+        pareto_df: DataFrame from the sweep (agg or disagg).
+        constraint_col: SLA column to filter on (``"tpot"`` or
+            ``"request_latency"``).
+        constraint_value: Maximum allowed value for *constraint_col*.
+        target_request_rate: Target system request rate in req/s.
+        target_concurrency: Target number of concurrent requests.
+        top_n: Number of top configurations to return.
+        max_total_gpus: Optional upper bound on total GPUs.
+        group_by: Optional column to group-by before ranking (takes best
+            per group, same semantics as
+            :func:`_get_best_configs_under_constraint`).
+
+    Returns:
+        DataFrame of top-N configs with added columns
+        ``replicas_needed``, ``total_gpus_needed`` and
+        ``tokens/s/gpu_cluster``.
+    """
+    if pareto_df is None or pareto_df.empty:
+        return pd.DataFrame()
+
+    has_rate = target_request_rate is not None
+    has_conc = target_concurrency is not None
+    if has_rate == has_conc:
+        raise ValueError("Exactly one of target_request_rate or target_concurrency must be provided.")
+
+    if constraint_col not in pareto_df.columns:
+        logger.warning("Pareto DataFrame is missing constraint column '%s'.", constraint_col)
+        return pd.DataFrame()
+
+    # 1. Filter by SLA constraint (fall back to closest if none meet it)
+    candidates = pareto_df[pareto_df[constraint_col] <= constraint_value].copy()
+    if candidates.empty:
+        logger.info(
+            "No config found with %s <= %s for load-match. Returning top-%d closest configs.",
+            constraint_col,
+            constraint_value,
+            top_n,
+        )
+        candidates = pareto_df.copy()
+        candidates["_sla_exceeded"] = True
+    else:
+        candidates["_sla_exceeded"] = False
+
+    # 2. Compute replicas needed per-row
+    if has_rate:
+        load_col = "seq/s"
+        if load_col not in candidates.columns:
+            logger.warning("Pareto DataFrame is missing '%s' column for load-match.", load_col)
+            return pd.DataFrame()
+        candidates["replicas_needed"] = np.ceil(target_request_rate / candidates[load_col]).astype(int)
+    else:
+        load_col = "concurrency"
+        if load_col not in candidates.columns:
+            logger.warning("Pareto DataFrame is missing '%s' column for load-match.", load_col)
+            return pd.DataFrame()
+        candidates["replicas_needed"] = np.ceil(target_concurrency / candidates[load_col]).astype(int)
+
+    candidates["replicas_needed"] = candidates["replicas_needed"].clip(lower=1)
+
+    # 3. Total GPUs needed
+    candidates["total_gpus_needed"] = candidates["replicas_needed"] * candidates["num_total_gpus"]
+
+    # 4. tokens/s/gpu_cluster = per-replica efficiency (no cluster-wide scaling)
+    candidates["tokens/s/gpu_cluster"] = candidates["tokens/s/gpu"]
+
+    # 5. GPU ceiling: prefer configs that fit; if none do, warn and cap to max_total_gpus
+    gpu_capped = False
+    if max_total_gpus is not None and not candidates["_sla_exceeded"].all():
+        fits = candidates[candidates["total_gpus_needed"] <= max_total_gpus]
+        if fits.empty:
+            logger.warning(
+                "Target load requires more GPUs than available (%d). "
+                "Returning best config scaled to use all %d GPUs. "
+                "The target load may NOT be fully served.",
+                max_total_gpus,
+                max_total_gpus,
+            )
+            # Cap replicas to what fits in the GPU budget and keep going.
+            # Switch to maximizing throughput since all configs exceed budget.
+            # Save uncapped replicas to compute load_served_pct.
+            uncapped_replicas = candidates["replicas_needed"].copy()
+            candidates["replicas_needed"] = (max_total_gpus // candidates["num_total_gpus"]).clip(lower=1).astype(int)
+            candidates["total_gpus_needed"] = candidates["replicas_needed"] * candidates["num_total_gpus"]
+            # Percentage of target load that the capped deployment can serve
+            candidates["load_served_pct"] = ((candidates["replicas_needed"] / uncapped_replicas) * 100).round(1)
+            # Recompute cluster throughput with capped replicas
+            candidates["tokens/s/gpu_cluster"] = (
+                candidates["tokens/s/gpu"]
+                * candidates["replicas_needed"]
+                * candidates["num_total_gpus"]
+                / max_total_gpus
+            )
+            gpu_capped = True
+        else:
+            candidates = fits
+
+    # 6. Group-by (take best per group)
+    if group_by is not None and group_by in candidates.columns:
+        if candidates["_sla_exceeded"].all():
+            top_indexes = candidates.groupby(group_by)[constraint_col].idxmin()
+        elif gpu_capped:
+            top_indexes = candidates.groupby(group_by)["tokens/s/gpu_cluster"].idxmax()
+        else:
+            top_indexes = candidates.groupby(group_by)["total_gpus_needed"].idxmin()
+        candidates = candidates.loc[top_indexes]
+
+    # 7. Rank
+    if candidates["_sla_exceeded"].all():
+        # Sort by closest to SLA target
+        sort_cols = [constraint_col]
+        sort_asc = [True]
+    elif gpu_capped:
+        # GPU budget exceeded: maximize throughput with available GPUs
+        sort_cols = ["tokens/s/gpu_cluster"]
+        sort_asc = [False]
+    else:
+        # Normal load-match: fewest GPUs first, tiebreak by higher tokens/s/gpu
+        sort_cols = ["total_gpus_needed", "tokens/s/gpu"]
+        sort_asc = [True, False]
+
+    candidates = candidates.sort_values(by=sort_cols, ascending=sort_asc).head(top_n).reset_index(drop=True)
+    candidates.drop(columns=["_sla_exceeded"], inplace=True, errors="ignore")
+    return candidates

--- a/src/aiconfigurator/sdk/picking.py
+++ b/src/aiconfigurator/sdk/picking.py
@@ -1,0 +1,474 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Standalone picking functions for selecting engine configurations.
+
+These functions operate on perf DataFrames directly (ColumnsAgg, ColumnsDisagg,
+or ColumnsStatic schemas) without requiring a TaskConfig.  They can be called
+from either AIC's internal CLI pipeline or from an external real-GPU sweep.
+
+Three picking modes are supported:
+
+- :func:`pick_default` -- maximize throughput for a given GPU budget under SLA.
+- :func:`pick_load_match` -- minimize GPUs for a target request-rate or
+  concurrency under SLA.
+- :func:`pick_autoscale` -- pick prefill and decode engines independently
+  (no rate matching), returning a disagg config with 1 replica each.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from aiconfigurator.sdk import common
+
+logger = logging.getLogger(__name__)
+
+# comes from pipeline bubble, especially when benchmarking with concurrency
+_RATE_MATCHING_PREFILL_DEGRADATION_FACTOR = 0.9
+# comes from not saturating the batchsize slot of decode worker
+_RATE_MATCHING_DECODE_DEGRADATION_FACTOR = 0.92
+
+# TTFT correction for concurrent prefill queueing: with N=10 batches and
+# local concurrency lc=15-20, formula lc/20+0.95 gives ~1.8
+_AUTOSCALE_TTFT_CORRECTION_FACTOR = 1.8
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a disagg summary dict from prefill + decode dicts
+# ---------------------------------------------------------------------------
+
+
+def build_disagg_summary_dict(
+    prefill_summary_dict: dict,
+    prefill_num_worker: int,
+    decode_summary_dict: dict,
+    decode_num_worker: int,
+    prefill_degradation_factor: float = _RATE_MATCHING_PREFILL_DEGRADATION_FACTOR,
+    decode_degradation_factor: float = _RATE_MATCHING_DECODE_DEGRADATION_FACTOR,
+) -> dict:
+    """Build a disagg summary row from independent prefill and decode dicts.
+
+    This is the standalone version of
+    ``DisaggInferenceSession._get_disagg_summary_dict``.  It performs the same
+    rate-matching arithmetic but does not require a session instance.
+
+    Args:
+        prefill_summary_dict: Row dict from a prefill ``ColumnsStatic`` DataFrame.
+        prefill_num_worker: Number of prefill workers in the deployment.
+        decode_summary_dict: Row dict from a decode ``ColumnsStatic`` DataFrame.
+        decode_num_worker: Number of decode workers in the deployment.
+        prefill_degradation_factor: Multiplicative degradation for prefill
+            throughput during rate matching (default 0.9).
+        decode_degradation_factor: Multiplicative degradation for decode
+            throughput during rate matching (default 0.92).
+
+    Returns:
+        Dict with keys matching ``common.ColumnsDisagg``.
+    """
+    seq_s = min(
+        prefill_summary_dict["seq/s"] * prefill_num_worker * prefill_degradation_factor,
+        decode_summary_dict["seq/s"] * decode_num_worker * decode_degradation_factor,
+    )
+    prefill_gpus = prefill_summary_dict["pp"] * prefill_summary_dict["tp"] * prefill_summary_dict["dp"]
+    decode_gpus = decode_summary_dict["pp"] * decode_summary_dict["tp"] * decode_summary_dict["dp"]
+    num_total_gpus = prefill_gpus * prefill_num_worker + decode_gpus * decode_num_worker
+    seq_s_gpu = seq_s / num_total_gpus if num_total_gpus > 0 else 0.0
+
+    osl = prefill_summary_dict["osl"]
+    tokens_s = seq_s * osl
+    tokens_s_gpu = tokens_s / num_total_gpus if num_total_gpus > 0 else 0.0
+    request_latency = prefill_summary_dict["ttft"] + decode_summary_dict["tpot"] * max(osl - 1, 0)
+
+    # Weighted average power
+    ttft = prefill_summary_dict["ttft"]
+    tpot = decode_summary_dict["tpot"]
+    decode_time = tpot * max(osl - 1, 0)
+    prefill_power = prefill_summary_dict.get("power_w", 0.0)
+    decode_power = decode_summary_dict.get("power_w", 0.0)
+    total_time = ttft + decode_time
+    disagg_power_avg = (prefill_power * ttft + decode_power * decode_time) / total_time if total_time > 0 else 0.0
+
+    return {
+        "model": prefill_summary_dict["model"],
+        "isl": prefill_summary_dict["isl"],
+        "osl": osl,
+        "prefix": prefill_summary_dict["prefix"],
+        "concurrency": decode_summary_dict["concurrency"] * decode_num_worker,
+        "request_rate": seq_s,
+        "(p)bs": prefill_summary_dict["bs"],
+        "(p)global_bs": prefill_summary_dict["global_bs"],
+        "(p)workers": prefill_num_worker,
+        "(d)bs": decode_summary_dict["bs"],
+        "(d)global_bs": decode_summary_dict["global_bs"],
+        "(d)workers": decode_num_worker,
+        "ttft": ttft,
+        "tpot": tpot,
+        "request_latency": request_latency,
+        "seq/s": seq_s,
+        "seq/s/gpu": seq_s_gpu,
+        "tokens/s": tokens_s,
+        "tokens/s/gpu": tokens_s_gpu,
+        "tokens/s/user": decode_summary_dict["tokens/s/user"],
+        "(p)seq/s/worker": prefill_summary_dict["seq/s"],
+        "(d)seq/s/worker": decode_summary_dict["seq/s"],
+        "num_total_gpus": num_total_gpus,
+        "(p)tp": prefill_summary_dict["tp"],
+        "(p)pp": prefill_summary_dict["pp"],
+        "(p)dp": prefill_summary_dict["dp"],
+        "(p)moe_tp": prefill_summary_dict["moe_tp"],
+        "(p)moe_ep": prefill_summary_dict["moe_ep"],
+        "(p)parallel": prefill_summary_dict["parallel"],
+        "(p)gemm": prefill_summary_dict["gemm"],
+        "(p)kvcache": prefill_summary_dict["kvcache"],
+        "(p)fmha": prefill_summary_dict["fmha"],
+        "(p)moe": prefill_summary_dict["moe"],
+        "(p)comm": prefill_summary_dict["comm"],
+        "(p)memory": prefill_summary_dict["memory"],
+        "(p)backend": prefill_summary_dict.get("backend", ""),
+        "(p)version": prefill_summary_dict.get("version", ""),
+        "(p)system": prefill_summary_dict.get("system", ""),
+        "(d)tp": decode_summary_dict["tp"],
+        "(d)pp": decode_summary_dict["pp"],
+        "(d)dp": decode_summary_dict["dp"],
+        "(d)moe_tp": decode_summary_dict["moe_tp"],
+        "(d)moe_ep": decode_summary_dict["moe_ep"],
+        "(d)parallel": decode_summary_dict["parallel"],
+        "(d)gemm": decode_summary_dict["gemm"],
+        "(d)kvcache": decode_summary_dict["kvcache"],
+        "(d)fmha": decode_summary_dict["fmha"],
+        "(d)moe": decode_summary_dict["moe"],
+        "(d)comm": decode_summary_dict["comm"],
+        "(d)memory": decode_summary_dict["memory"],
+        "(d)backend": decode_summary_dict.get("backend", ""),
+        "(d)version": decode_summary_dict.get("version", ""),
+        "(d)system": decode_summary_dict.get("system", ""),
+        "power_w": disagg_power_avg,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Internal: extract best_latencies from a result DataFrame
+# ---------------------------------------------------------------------------
+
+
+def _extract_best_latencies(df: pd.DataFrame) -> dict[str, float]:
+    """Extract latency info from the rank-1 row of a result DataFrame."""
+    if df is None or df.empty:
+        return {"ttft": 0.0, "tpot": 0.0, "request_latency": 0.0}
+    row = df.iloc[0]
+    result: dict[str, float] = {
+        "ttft": float(row["ttft"]) if "ttft" in row.index else 0.0,
+        "tpot": float(row["tpot"]) if "tpot" in row.index else 0.0,
+        "request_latency": float(row["request_latency"]) if "request_latency" in row.index else 0.0,
+    }
+    if "replicas_needed" in row.index:
+        result["replicas_needed"] = int(row["replicas_needed"])
+    if "total_gpus_needed" in row.index:
+        result["total_gpus_needed"] = int(row["total_gpus_needed"])
+    if "load_served_pct" in row.index:
+        result["load_served_pct"] = float(row["load_served_pct"])
+    return result
+
+
+# ---------------------------------------------------------------------------
+# pick_default
+# ---------------------------------------------------------------------------
+
+
+def pick_default(
+    pareto_df: pd.DataFrame,
+    total_gpus: int,
+    serving_mode: str,
+    target_tpot: float | None = None,
+    target_request_latency: float | None = None,
+    top_n: int = 5,
+) -> dict[str, Any]:
+    """Pick configurations that maximize throughput for a fixed GPU budget.
+
+    This is the standalone equivalent of the "default" picking path in
+    ``process_experiment_result``.
+
+    Args:
+        pareto_df: Performance DataFrame (``ColumnsAgg`` or ``ColumnsDisagg``).
+        total_gpus: Total GPUs available for deployment.
+        serving_mode: ``"agg"`` or ``"disagg"``.
+        target_tpot: TPOT SLA target in ms.  Used when
+            ``target_request_latency`` is not set.
+        target_request_latency: End-to-end request latency SLA in ms.  Takes
+            precedence over ``target_tpot`` when set.
+        top_n: Number of top configurations to return.
+
+    Returns:
+        Dict with keys:
+        - ``best_config_df``: Top-N configurations DataFrame.
+        - ``best_throughput``: ``tokens/s/gpu_cluster`` of the rank-1 config.
+        - ``best_latencies``: Dict with ``ttft``, ``tpot``, ``request_latency``.
+        - ``pareto_frontier_df``: Pareto frontier DataFrame.
+    """
+    from aiconfigurator.sdk.pareto_analysis import (
+        get_best_configs_under_request_latency_constraint,
+        get_best_configs_under_tpot_constraint,
+        get_pareto_front,
+    )
+
+    use_request_latency = target_request_latency is not None and target_request_latency > 0
+
+    if pareto_df is not None and not pareto_df.empty:
+        if total_gpus > 0:
+            pareto_df = pareto_df.copy()
+            pareto_df["tokens/s/gpu_cluster"] = (
+                pareto_df["tokens/s/gpu"]
+                * (total_gpus // pareto_df["num_total_gpus"])
+                * pareto_df["num_total_gpus"]
+                / total_gpus
+            )
+        else:
+            pareto_df = pareto_df.copy()
+            pareto_df["tokens/s/gpu_cluster"] = pareto_df["tokens/s/gpu"]
+
+        x_axis_col = "request_latency" if use_request_latency else "tokens/s/user"
+        pareto_frontier_df = get_pareto_front(
+            pareto_df, x_axis_col, "tokens/s/gpu_cluster",
+            maximize_x=not use_request_latency, maximize_y=True,
+        )
+    else:
+        pareto_frontier_df = pd.DataFrame()
+
+    group_by_key = "(d)parallel" if serving_mode == "disagg" else "parallel"
+
+    if use_request_latency:
+        best_config_df = get_best_configs_under_request_latency_constraint(
+            total_gpus=total_gpus, pareto_df=pareto_df,
+            target_request_latency=target_request_latency,
+            top_n=top_n, group_by=group_by_key,
+        )
+    else:
+        best_config_df = get_best_configs_under_tpot_constraint(
+            total_gpus=total_gpus, pareto_df=pareto_df,
+            target_tpot=target_tpot,
+            top_n=top_n, group_by=group_by_key,
+        )
+
+    best_throughput = float(best_config_df["tokens/s/gpu_cluster"].values[0]) if not best_config_df.empty else 0.0
+
+    return {
+        "best_config_df": best_config_df,
+        "best_throughput": best_throughput,
+        "best_latencies": _extract_best_latencies(best_config_df),
+        "pareto_frontier_df": pareto_frontier_df,
+    }
+
+
+# ---------------------------------------------------------------------------
+# pick_load_match
+# ---------------------------------------------------------------------------
+
+
+def pick_load_match(
+    pareto_df: pd.DataFrame,
+    serving_mode: str,
+    target_tpot: float | None = None,
+    target_request_latency: float | None = None,
+    target_request_rate: float | None = None,
+    target_concurrency: float | None = None,
+    max_total_gpus: int | None = None,
+    top_n: int = 5,
+) -> dict[str, Any]:
+    """Pick configurations that minimize GPUs for a target load under SLA.
+
+    This is the standalone equivalent of the "load-match" picking path.
+
+    Args:
+        pareto_df: Performance DataFrame (``ColumnsAgg`` or ``ColumnsDisagg``).
+        serving_mode: ``"agg"`` or ``"disagg"``.
+        target_tpot: TPOT SLA target in ms.
+        target_request_latency: Request latency SLA in ms (takes precedence).
+        target_request_rate: Target system request rate in req/s.
+        target_concurrency: Target concurrent requests.
+        max_total_gpus: Upper bound on total GPUs.
+        top_n: Number of top configurations to return.
+
+    Returns:
+        Dict with keys:
+        - ``best_config_df``: Top-N configurations DataFrame with
+          ``replicas_needed``, ``total_gpus_needed``, ``load_served_pct``
+          columns.
+        - ``best_throughput``: Comparison metric (``1/total_gpus_needed``
+          normally, ``tokens/s/gpu_cluster`` when GPU-capped).
+        - ``best_latencies``: Dict with latency + load-match fields.
+        - ``pareto_frontier_df``: Pareto frontier DataFrame.
+    """
+    from aiconfigurator.sdk.pareto_analysis import (
+        get_best_configs_for_target_load,
+        get_pareto_front,
+    )
+
+    use_request_latency = target_request_latency is not None and target_request_latency > 0
+
+    pareto_frontier_df = pd.DataFrame()
+    if pareto_df is not None and not pareto_df.empty:
+        pareto_df = pareto_df.copy()
+        pareto_df["tokens/s/gpu_cluster"] = pareto_df["tokens/s/gpu"]
+        x_axis_col = "request_latency" if use_request_latency else "tokens/s/user"
+        pareto_frontier_df = get_pareto_front(
+            pareto_df, x_axis_col, "tokens/s/gpu_cluster",
+            maximize_x=not use_request_latency, maximize_y=True,
+        )
+
+    constraint_col = "request_latency" if use_request_latency else "tpot"
+    constraint_value = target_request_latency if use_request_latency else target_tpot
+    group_by_key = "(d)parallel" if serving_mode == "disagg" else "parallel"
+
+    best_config_df = get_best_configs_for_target_load(
+        pareto_df=pareto_df,
+        constraint_col=constraint_col,
+        constraint_value=constraint_value,
+        target_request_rate=target_request_rate,
+        target_concurrency=target_concurrency,
+        top_n=top_n,
+        max_total_gpus=max_total_gpus,
+        group_by=group_by_key,
+    )
+
+    best_throughput = 0.0
+    if not best_config_df.empty:
+        row = best_config_df.iloc[0]
+        if max_total_gpus and int(row.get("total_gpus_needed", 0)) >= max_total_gpus:
+            best_throughput = float(row.get("tokens/s/gpu_cluster", 0.0))
+        else:
+            gpus = row.get("total_gpus_needed", 1)
+            best_throughput = 1.0 / gpus if gpus > 0 else 0.0
+
+    return {
+        "best_config_df": best_config_df,
+        "best_throughput": best_throughput,
+        "best_latencies": _extract_best_latencies(best_config_df),
+        "pareto_frontier_df": pareto_frontier_df,
+    }
+
+
+# ---------------------------------------------------------------------------
+# pick_autoscale
+# ---------------------------------------------------------------------------
+
+
+def pick_autoscale(
+    prefill_df: pd.DataFrame,
+    decode_df: pd.DataFrame,
+    target_ttft: float,
+    target_tpot: float,
+    top_n: int = 5,
+) -> dict[str, Any]:
+    """Pick prefill and decode engines independently for autoscaling.
+
+    No rate matching is performed.  Returns disagg configs with
+    ``(p)workers=1`` and ``(d)workers=1``.
+
+    Args:
+        prefill_df: Prefill candidates DataFrame (``ColumnsStatic`` schema).
+        decode_df: Decode candidates DataFrame (``ColumnsStatic`` schema).
+        target_ttft: TTFT SLA target in ms.
+        target_tpot: TPOT SLA target in ms.
+        top_n: Number of top combinations to return.
+
+    Returns:
+        Dict with keys:
+        - ``best_config_df``: Top-N configurations DataFrame
+          (``ColumnsDisagg`` schema, all rows have ``workers=1``).
+        - ``best_latencies``: Dict with ``ttft``, ``tpot``,
+          ``request_latency`` from the rank-1 config.
+    """
+    empty_result: dict[str, Any] = {
+        "best_config_df": pd.DataFrame(),
+        "best_latencies": {"ttft": 0.0, "tpot": 0.0, "request_latency": 0.0},
+    }
+
+    if prefill_df is None or prefill_df.empty or decode_df is None or decode_df.empty:
+        return empty_result
+
+    correction_factor = _AUTOSCALE_TTFT_CORRECTION_FACTOR
+
+    # -- Filter prefill candidates by TTFT --
+    prefill_candidates = prefill_df.copy()
+    prefill_candidates["ttft_corrected"] = prefill_candidates["ttft"] * correction_factor
+    prefill_meets_sla = prefill_candidates[prefill_candidates["ttft_corrected"] < target_ttft]
+
+    if prefill_meets_sla.empty:
+        logger.warning(
+            "pick_autoscale: no prefill candidates meet TTFT < %sms (after %.1fx correction). "
+            "Returning closest matches.",
+            target_ttft, correction_factor,
+        )
+        prefill_candidates = (
+            prefill_candidates
+            .sort_values(by=["ttft_corrected", "seq/s/gpu"], ascending=[True, False])
+            .drop_duplicates(subset=["parallel"], keep="first")
+            .head(top_n)
+            .reset_index(drop=True)
+        )
+    else:
+        prefill_candidates = (
+            prefill_meets_sla
+            .sort_values(by=["seq/s/gpu", "global_bs"], ascending=[False, True])
+            .drop_duplicates(subset=["parallel"], keep="first")
+            .head(top_n)
+            .reset_index(drop=True)
+        )
+
+    # -- Filter decode candidates by TPOT --
+    decode_meets_sla = decode_df[decode_df["tpot"] < target_tpot].copy()
+
+    if decode_meets_sla.empty:
+        logger.warning(
+            "pick_autoscale: no decode candidates meet TPOT < %sms. Returning closest matches.",
+            target_tpot,
+        )
+        decode_candidates = (
+            decode_df.copy()
+            .sort_values(by=["tpot", "seq/s/gpu"], ascending=[True, False])
+            .drop_duplicates(subset=["parallel"], keep="first")
+            .head(top_n)
+            .reset_index(drop=True)
+        )
+    else:
+        decode_candidates = (
+            decode_meets_sla
+            .sort_values(by=["seq/s/gpu", "global_bs"], ascending=[False, True])
+            .drop_duplicates(subset=["parallel"], keep="first")
+            .head(top_n)
+            .reset_index(drop=True)
+        )
+
+    # -- Combine: each prefill x each decode, workers=1, take top_n --
+    all_combos: list[dict] = []
+    for _, p_row in prefill_candidates.iterrows():
+        for _, d_row in decode_candidates.iterrows():
+            combo = build_disagg_summary_dict(
+                prefill_summary_dict=p_row.to_dict(),
+                prefill_num_worker=1,
+                decode_summary_dict=d_row.to_dict(),
+                decode_num_worker=1,
+            )
+            all_combos.append(combo)
+
+    if not all_combos:
+        return empty_result
+
+    disagg_df = pd.DataFrame(all_combos, columns=common.ColumnsDisagg).round(3)
+    disagg_df = (
+        disagg_df
+        .sort_values(by=["tokens/s/gpu"], ascending=[False])
+        .head(top_n)
+        .reset_index(drop=True)
+    )
+
+    return {
+        "best_config_df": disagg_df,
+        "best_latencies": _extract_best_latencies(disagg_df),
+    }

--- a/src/aiconfigurator/sdk/picking.py
+++ b/src/aiconfigurator/sdk/picking.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-import numpy as np
 import pandas as pd
 
 from aiconfigurator.sdk import common
@@ -234,8 +233,11 @@ def pick_default(
 
         x_axis_col = "request_latency" if use_request_latency else "tokens/s/user"
         pareto_frontier_df = get_pareto_front(
-            pareto_df, x_axis_col, "tokens/s/gpu_cluster",
-            maximize_x=not use_request_latency, maximize_y=True,
+            pareto_df,
+            x_axis_col,
+            "tokens/s/gpu_cluster",
+            maximize_x=not use_request_latency,
+            maximize_y=True,
         )
     else:
         pareto_frontier_df = pd.DataFrame()
@@ -244,15 +246,19 @@ def pick_default(
 
     if use_request_latency:
         best_config_df = get_best_configs_under_request_latency_constraint(
-            total_gpus=total_gpus, pareto_df=pareto_df,
+            total_gpus=total_gpus,
+            pareto_df=pareto_df,
             target_request_latency=target_request_latency,
-            top_n=top_n, group_by=group_by_key,
+            top_n=top_n,
+            group_by=group_by_key,
         )
     else:
         best_config_df = get_best_configs_under_tpot_constraint(
-            total_gpus=total_gpus, pareto_df=pareto_df,
+            total_gpus=total_gpus,
+            pareto_df=pareto_df,
             target_tpot=target_tpot,
-            top_n=top_n, group_by=group_by_key,
+            top_n=top_n,
+            group_by=group_by_key,
         )
 
     best_throughput = float(best_config_df["tokens/s/gpu_cluster"].values[0]) if not best_config_df.empty else 0.0
@@ -317,8 +323,11 @@ def pick_load_match(
         pareto_df["tokens/s/gpu_cluster"] = pareto_df["tokens/s/gpu"]
         x_axis_col = "request_latency" if use_request_latency else "tokens/s/user"
         pareto_frontier_df = get_pareto_front(
-            pareto_df, x_axis_col, "tokens/s/gpu_cluster",
-            maximize_x=not use_request_latency, maximize_y=True,
+            pareto_df,
+            x_axis_col,
+            "tokens/s/gpu_cluster",
+            maximize_x=not use_request_latency,
+            maximize_y=True,
         )
 
     constraint_col = "request_latency" if use_request_latency else "tpot"
@@ -403,19 +412,18 @@ def pick_autoscale(
         logger.warning(
             "pick_autoscale: no prefill candidates meet TTFT < %sms (after %.1fx correction). "
             "Returning closest matches.",
-            target_ttft, correction_factor,
+            target_ttft,
+            correction_factor,
         )
         prefill_candidates = (
-            prefill_candidates
-            .sort_values(by=["ttft_corrected", "seq/s/gpu"], ascending=[True, False])
+            prefill_candidates.sort_values(by=["ttft_corrected", "seq/s/gpu"], ascending=[True, False])
             .drop_duplicates(subset=["parallel"], keep="first")
             .head(top_n)
             .reset_index(drop=True)
         )
     else:
         prefill_candidates = (
-            prefill_meets_sla
-            .sort_values(by=["seq/s/gpu", "global_bs"], ascending=[False, True])
+            prefill_meets_sla.sort_values(by=["seq/s/gpu", "global_bs"], ascending=[False, True])
             .drop_duplicates(subset=["parallel"], keep="first")
             .head(top_n)
             .reset_index(drop=True)
@@ -438,8 +446,7 @@ def pick_autoscale(
         )
     else:
         decode_candidates = (
-            decode_meets_sla
-            .sort_values(by=["seq/s/gpu", "global_bs"], ascending=[False, True])
+            decode_meets_sla.sort_values(by=["seq/s/gpu", "global_bs"], ascending=[False, True])
             .drop_duplicates(subset=["parallel"], keep="first")
             .head(top_n)
             .reset_index(drop=True)
@@ -461,12 +468,7 @@ def pick_autoscale(
         return empty_result
 
     disagg_df = pd.DataFrame(all_combos, columns=common.ColumnsDisagg).round(3)
-    disagg_df = (
-        disagg_df
-        .sort_values(by=["tokens/s/gpu"], ascending=[False])
-        .head(top_n)
-        .reset_index(drop=True)
-    )
+    disagg_df = disagg_df.sort_values(by=["tokens/s/gpu"], ascending=[False]).head(top_n).reset_index(drop=True)
 
     return {
         "best_config_df": disagg_df,

--- a/src/aiconfigurator/sdk/picking.py
+++ b/src/aiconfigurator/sdk/picking.py
@@ -43,7 +43,7 @@ _AUTOSCALE_TTFT_CORRECTION_FACTOR = 1.8
 # ---------------------------------------------------------------------------
 
 
-def build_disagg_summary_dict(
+def _build_disagg_summary_dict(
     prefill_summary_dict: dict,
     prefill_num_worker: int,
     decode_summary_dict: dict,
@@ -456,7 +456,7 @@ def pick_autoscale(
     all_combos: list[dict] = []
     for _, p_row in prefill_candidates.iterrows():
         for _, d_row in decode_candidates.iterrows():
-            combo = build_disagg_summary_dict(
+            combo = _build_disagg_summary_dict(
                 prefill_summary_dict=p_row.to_dict(),
                 prefill_num_worker=1,
                 decode_summary_dict=d_row.to_dict(),

--- a/tests/e2e/cli/test_picking.py
+++ b/tests/e2e/cli/test_picking.py
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+E2E tests for the three picking modes: default, load-match, and autoscale.
+
+Each test runs the full pipeline (model + traffic + SLA -> picking result)
+and optionally saves DGD configs to a temporary directory for inspection.
+"""
+
+import os
+
+import pytest
+import yaml
+
+from aiconfigurator.cli.main import build_default_task_configs, _execute_task_configs
+from aiconfigurator.generator.api import generate_backend_artifacts
+from aiconfigurator.generator.module_bridge import task_config_to_generator_config
+from aiconfigurator.sdk.task import TaskConfig, TaskRunner
+
+pytestmark = [pytest.mark.e2e, pytest.mark.build]
+
+MODEL = "Qwen/Qwen3-32B"
+SYSTEM = "h200_sxm"
+BACKEND = "trtllm"
+
+
+def _save_chosen_dgd(best_configs, task_configs, chosen_exp, output_dir):
+    """Save the rank-1 DGD config for the chosen experiment."""
+    config_df = best_configs.get(chosen_exp)
+    if config_df is None or config_df.empty:
+        return
+
+    if "backend" in config_df.columns and not config_df.empty:
+        first_backend = config_df["backend"].iloc[0]
+        tc_key = f"{chosen_exp}_{first_backend}"
+        tc = task_configs.get(tc_key, task_configs.get(chosen_exp))
+    else:
+        tc = task_configs[chosen_exp]
+
+    row = config_df.iloc[0]
+
+    # For load-match: use total_gpus_needed instead of sweep ceiling
+    original_total_gpus = tc.total_gpus
+    if "total_gpus_needed" in row.index and row["total_gpus_needed"] > 0:
+        tc.total_gpus = int(row["total_gpus_needed"])
+
+    cfg = task_config_to_generator_config(task_config=tc, result_df=row)
+    tc.total_gpus = original_total_gpus
+
+    exp_dir = os.path.join(output_dir, chosen_exp)
+    os.makedirs(exp_dir, exist_ok=True)
+
+    with open(os.path.join(exp_dir, "generator_config.yaml"), "w") as f:
+        yaml.safe_dump(cfg, f, sort_keys=False)
+
+    try:
+        generate_backend_artifacts(
+            params=cfg,
+            backend=tc.backend_name,
+            backend_version=tc.backend_version,
+            output_dir=exp_dir,
+        )
+    except Exception:
+        pass  # artifact generation may fail without dynamo; config is the main output
+
+
+class TestDefaultPicking:
+    """Default mode: maximize throughput for N GPUs under SLA."""
+
+    def test_agg_vs_disagg(self, tmp_path):
+        """8 GPUs, compare agg vs disagg under relaxed SLA."""
+        task_configs = build_default_task_configs(
+            model_path=MODEL, total_gpus=8, system=SYSTEM, backend=BACKEND,
+            isl=4000, osl=1000, ttft=2000, tpot=50,
+        )
+        chosen, best_configs, _, _, best_latencies = _execute_task_configs(
+            task_configs, mode="default", top_n=3,
+        )
+        assert chosen in ("agg", "disagg")
+        assert best_latencies[chosen]["ttft"] > 0
+        assert best_latencies[chosen]["tpot"] > 0
+
+        _save_chosen_dgd(best_configs, task_configs, chosen, str(tmp_path))
+        assert (tmp_path / chosen / "generator_config.yaml").exists()
+
+    def test_request_latency_constraint(self, tmp_path):
+        """Default mode with request_latency as the SLA constraint."""
+        request_latency = 35000
+        task_configs = build_default_task_configs(
+            model_path=MODEL, total_gpus=8, system=SYSTEM, backend=BACKEND,
+            isl=4000, osl=1000,
+            ttft=request_latency,
+            request_latency=request_latency,
+        )
+        chosen, best_configs, _, _, best_latencies = _execute_task_configs(
+            task_configs, mode="default", top_n=3,
+        )
+        assert chosen in ("agg", "disagg")
+
+        _save_chosen_dgd(best_configs, task_configs, chosen, str(tmp_path))
+        assert (tmp_path / chosen / "generator_config.yaml").exists()
+
+
+class TestLoadMatchPicking:
+    """Load-match mode: minimize GPUs for a target load under SLA."""
+
+    def test_by_request_rate(self, tmp_path):
+        """Find min GPUs for target_request_rate=5.0 req/s."""
+        task_configs = build_default_task_configs(
+            model_path=MODEL, total_gpus=64, system=SYSTEM, backend=BACKEND,
+            isl=4000, osl=1000, ttft=2000, tpot=50,
+        )
+        chosen, best_configs, _, _, best_latencies = _execute_task_configs(
+            task_configs, mode="default", top_n=3,
+            target_request_rate=5.0,
+            max_total_gpus=64,
+        )
+        for df in best_configs.values():
+            if df is not None and not df.empty:
+                assert "replicas_needed" in df.columns
+                assert "total_gpus_needed" in df.columns
+
+        assert "total_gpus_needed" in best_latencies[chosen]
+
+        _save_chosen_dgd(best_configs, task_configs, chosen, str(tmp_path))
+        assert (tmp_path / chosen / "generator_config.yaml").exists()
+
+    def test_by_concurrency(self, tmp_path):
+        """Find min GPUs for target_concurrency=50."""
+        task_configs = build_default_task_configs(
+            model_path=MODEL, total_gpus=64, system=SYSTEM, backend=BACKEND,
+            isl=4000, osl=1000, ttft=2000, tpot=50,
+        )
+        chosen, best_configs, _, _, best_latencies = _execute_task_configs(
+            task_configs, mode="default", top_n=3,
+            target_concurrency=50,
+            max_total_gpus=64,
+        )
+        for df in best_configs.values():
+            if df is not None and not df.empty:
+                assert "replicas_needed" in df.columns
+                assert "total_gpus_needed" in df.columns
+
+        _save_chosen_dgd(best_configs, task_configs, chosen, str(tmp_path))
+        assert (tmp_path / chosen / "generator_config.yaml").exists()
+
+
+class TestAutoscalePicking:
+    """Autoscale mode: independent P/D picking, 1 replica each."""
+
+    def test_autoscale(self, tmp_path):
+        """Relaxed SLA: should find valid P and D engines."""
+        task = TaskConfig(
+            serving_mode="disagg",
+            model_path=MODEL, system_name=SYSTEM, backend_name=BACKEND,
+            total_gpus=8,
+            isl=4000, osl=1000, ttft=2000, tpot=50,
+        )
+        runner = TaskRunner()
+        result = runner.run(task, autoscale=True)
+        pareto_df = result["pareto_df"]
+        assert pareto_df is not None and not pareto_df.empty
+        assert (pareto_df["(p)workers"] == 1).all()
+        assert (pareto_df["(d)workers"] == 1).all()
+
+        best_row = pareto_df.iloc[0]
+        assert best_row["ttft"] > 0
+        assert best_row["tpot"] > 0
+
+        _save_chosen_dgd({"disagg": pareto_df.head(1)}, {"disagg": task}, "disagg", str(tmp_path))
+        assert (tmp_path / "disagg" / "generator_config.yaml").exists()
+
+    def test_autoscale_tight_sla(self):
+        """Tight SLA: should still return closest-match configs (not empty)."""
+        task = TaskConfig(
+            serving_mode="disagg",
+            model_path=MODEL, system_name=SYSTEM, backend_name=BACKEND,
+            total_gpus=8,
+            isl=4000, osl=1000, ttft=600, tpot=25,
+        )
+        runner = TaskRunner()
+        result = runner.run(task, autoscale=True)
+        pareto_df = result["pareto_df"]
+        # With closest-match fallback, should always return something
+        assert pareto_df is not None and not pareto_df.empty
+        assert (pareto_df["(p)workers"] == 1).all()
+        assert (pareto_df["(d)workers"] == 1).all()

--- a/tests/unit/cli/test_cli_api.py
+++ b/tests/unit/cli/test_cli_api.py
@@ -39,6 +39,7 @@ class TestCLIExpUnit:
             {"exp_agg_simplified": pd.DataFrame()},
             {"exp_agg_simplified": pd.DataFrame()},
             {"exp_agg_simplified": 100.0},
+            {"exp_agg_simplified": {"ttft": 0.0, "tpot": 0.0, "request_latency": 0.0}},
         )
 
         # Simplified version based on example.yaml exp_agg_simplified

--- a/tests/unit/cli/test_cli_workflow.py
+++ b/tests/unit/cli/test_cli_workflow.py
@@ -37,6 +37,7 @@ class TestCLIIntegration:
             mock_best_configs,
             {"agg": mock_results_df},
             mock_best_throughputs,
+            {"agg": {"ttft": 100.0, "tpot": 10.0, "request_latency": 1000.0}},
         )
 
         with patch("aiconfigurator.cli.main.save_results") as mock_save:
@@ -78,6 +79,7 @@ class TestCLIIntegration:
             mock_best_configs,
             {"my_exp": mock_results_df},
             mock_best_throughputs,
+            {"my_exp": {"ttft": 100.0, "tpot": 10.0, "request_latency": 1000.0}},
         )
 
         args = cli_args_factory(
@@ -112,7 +114,7 @@ class TestCLIIntegration:
     @patch("aiconfigurator.cli.main._execute_task_configs")
     def test_cli_main_build_dispatch(self, mock_execute, mode, build_patch, cli_args_factory, mock_exp_yaml_path):
         """Main should dispatch to the correct builder based on CLI mode."""
-        mock_execute.return_value = ("agg", {}, {}, {})
+        mock_execute.return_value = ("agg", {}, {}, {}, {})
         mock_task_config = MagicMock(name="TaskConfig")
 
         with patch(build_patch) as mock_builder:
@@ -198,7 +200,7 @@ exp_with_db_mode:
 
         mock_task_config = MagicMock(name="TaskConfig")
         mock_build_exp.return_value = {"exp_with_db_mode": mock_task_config}
-        mock_execute.return_value = ("exp_with_db_mode", {}, {}, {})
+        mock_execute.return_value = ("exp_with_db_mode", {}, {}, {}, {})
 
         parser = argparse.ArgumentParser()
         configure_parser(parser)

--- a/tests/unit/cli/test_utils.py
+++ b/tests/unit/cli/test_utils.py
@@ -44,7 +44,7 @@ class TestProcessExperimentResult:
 
         result = {"pareto_df": pareto_df}
 
-        best_config_df, best_throughput, pareto_frontier_df, x_axis_col = process_experiment_result(
+        best_config_df, best_throughput, pareto_frontier_df, x_axis_col, _ = process_experiment_result(
             mock_task_config, result, top_n=2
         )
 
@@ -77,7 +77,7 @@ class TestProcessExperimentResult:
 
         result = {"pareto_df": pareto_df}
 
-        best_config_df, best_throughput, pareto_frontier_df, x_axis_col = process_experiment_result(
+        best_config_df, best_throughput, pareto_frontier_df, x_axis_col, _ = process_experiment_result(
             mock_task_config, result, top_n=3
         )
 
@@ -97,7 +97,7 @@ class TestProcessExperimentResult:
 
         result = {"pareto_df": pd.DataFrame()}
 
-        best_config_df, best_throughput, pareto_frontier_df, x_axis_col = process_experiment_result(
+        best_config_df, best_throughput, pareto_frontier_df, x_axis_col, _ = process_experiment_result(
             mock_task_config, result, top_n=5
         )
 
@@ -117,7 +117,7 @@ class TestProcessExperimentResult:
 
         result = {"pareto_df": None}
 
-        best_config_df, best_throughput, pareto_frontier_df, x_axis_col = process_experiment_result(
+        best_config_df, best_throughput, pareto_frontier_df, x_axis_col, _ = process_experiment_result(
             mock_task_config, result, top_n=5
         )
 
@@ -146,7 +146,7 @@ class TestProcessExperimentResult:
 
         result = {"pareto_df": pareto_df}
 
-        best_config_df, _, _, _ = process_experiment_result(mock_task_config, result, top_n=5)
+        best_config_df, _, _, _, _ = process_experiment_result(mock_task_config, result, top_n=5)
 
         # Verify that results are returned (group_by should work correctly)
         assert not best_config_df.empty
@@ -172,7 +172,7 @@ class TestProcessExperimentResult:
 
         result = {"pareto_df": pareto_df}
 
-        best_config_df, _, _, _ = process_experiment_result(mock_task_config, result, top_n=3)
+        best_config_df, _, _, _, _ = process_experiment_result(mock_task_config, result, top_n=3)
 
         # Should return at most 3 configs
         assert len(best_config_df) <= 3
@@ -197,7 +197,7 @@ class TestProcessExperimentResult:
 
         result = {"pareto_df": pareto_df}
 
-        best_config_df, _, _, _ = process_experiment_result(mock_task_config, result, top_n=5)
+        best_config_df, _, _, _, _ = process_experiment_result(mock_task_config, result, top_n=5)
 
         # Verify tokens/s/gpu_cluster is computed
         assert "tokens/s/gpu_cluster" in best_config_df.columns


### PR DESCRIPTION
# PR: Add picking modes and expose standalone picking API

## Summary

Adds three configuration picking modes and exposes them as standalone functions callable from external scripts (e.g. real-GPU sweep pipelines). Also fixes a bug in the Dynamo DGD generator for agg mode.

## Changes

### New file: `src/aiconfigurator/sdk/picking.py`

Standalone picking functions for configuration selection, decoupled from `TaskConfig`. Three public functions:

- **`pick_default(pareto_df, total_gpus, serving_mode, ...)`** -- Maximize throughput for a fixed GPU budget under SLA. Same logic as the existing default CLI path.
- **`pick_load_match(pareto_df, serving_mode, target_request_rate=..., target_concurrency=..., ...)`** -- Minimize GPUs for a target load under SLA. Computes `replicas_needed` per config row, ranks by `total_gpus_needed`. When GPU budget is exceeded, switches to maximizing throughput and reports `load_served_pct`.
- **`pick_autoscale(prefill_df, decode_df, target_ttft, target_tpot, ...)`** -- Pick prefill and decode engines independently (no rate matching), return disagg config with 1 replica each. Designed for external autoscaler integration.
- **`build_disagg_summary_dict()`** -- Standalone helper to combine prefill/decode dicts into a disagg summary row (extracted from `DisaggInferenceSession._get_disagg_summary_dict`).

All functions accept perf DataFrames directly (ColumnsAgg/ColumnsDisagg/ColumnsStatic schemas) without requiring a `TaskConfig`. Usage:

```python
from aiconfigurator.sdk.picking import pick_default, pick_load_match, pick_autoscale

result = pick_default(pareto_df=my_agg_df, total_gpus=8, serving_mode="agg", target_tpot=30.0)
result = pick_load_match(pareto_df=my_df, serving_mode="disagg", target_tpot=30.0, target_request_rate=10.0)
result = pick_autoscale(prefill_df=my_p_df, decode_df=my_d_df, target_ttft=2000.0, target_tpot=30.0)
```

### Modified: `src/aiconfigurator/sdk/task.py`

- Added `autoscale: bool = False` to `TaskRunner.run()` and `run_disagg()`. When `True`, skips rate matching and picks P/D independently.

### Modified: `src/aiconfigurator/sdk/inference_session.py`

- Extracted `get_worker_candidates()` as a public method on `DisaggInferenceSession` (was nested `_get_summary_df`).
- `_get_disagg_summary_dict` now delegates to `picking.build_disagg_summary_dict`.
- `_pick_autoscale` now delegates to `picking.pick_autoscale`.
- Rate-matching constants moved to `picking.py` as single source of truth, imported here.
- Added `autoscale` and `target_tpot` params to `find_best_disagg_result_under_constraints()`.

### Modified: `src/aiconfigurator/sdk/pareto_analysis.py`

- `_get_best_configs_under_constraint()` now returns closest-to-target configs instead of empty when SLA can't be met.
- Added `get_best_configs_for_target_load()` for load-match picking: computes replicas from `seq/s` or `concurrency` column, ranks by `total_gpus_needed`. Handles GPU-capped scenario.
- Added `autoscale` and `target_tpot` kwargs passthrough in `disagg_pareto()`.

### Modified: `src/aiconfigurator/cli/main.py`

- `_execute_task_configs()` now returns a 5-tuple (added `best_latencies` dict with `ttft`/`tpot`/`request_latency`/`replicas_needed`/`total_gpus_needed`/`load_served_pct` from the rank-1 config per experiment).
- Added `target_request_rate`, `target_concurrency`, `max_total_gpus` params for load-match mode.

### Modified: `src/aiconfigurator/cli/utils.py`

- `process_experiment_result()` refactored to delegate to `picking.pick_default` / `picking.pick_load_match`.

### Modified: `src/aiconfigurator/cli/api.py`

- `CLIResult` dataclass: added `best_latencies` field.
- `_execute_and_wrap_result()` updated for 5-tuple unpacking.

### Modified: `src/aiconfigurator/cli/report_and_save.py`

- `log_final_summary()`: added load-match summary (target load, GPUs needed per mode, `load_served_pct` warning when capacity exceeded).
- `save_results()`: added `use_dynamo_generator` param, threaded to `generate_backend_artifacts()`.

### Modified: `src/aiconfigurator/generator/api.py`

- `generate_backend_artifacts()`: added `use_dynamo_generator: bool = False`, threaded to `render_backend_templates()`.

### Modified: `src/aiconfigurator/generator/module_bridge.py`

- `task_config_to_generator_config()`: added `num_gpus_per_node: int | None = None` override. When `None`, auto-detects from system config (existing behavior).

### Modified: `dynamo/components/src/dynamo/profiler/utils/config_modifiers/protocol.py`

- Fixed `_apply_agg_worker()`: added fallback to find worker service by `componentType` when `subComponentType` lookup fails (agg templates use generic names like `TRTLLMWorker`).
- Fixed `_apply_model_update_to_cfg()`: added fallback to patch any non-Frontend/Planner worker when `PREFILL`/`DECODE` subtype lookup misses (agg mode).

## Backward Compatibility

All new parameters have safe defaults (`None`, `False`, `field(default_factory=dict)`). Existing callers are unaffected:

- `_execute_task_configs()` return changed from 4-tuple to 5-tuple. All call sites updated (cli/main.py, cli/api.py, test mocks).
- `process_experiment_result()` refactored to delegate to `picking.py` -- same return signature (4-tuple).
- `_get_disagg_summary_dict` delegates to `picking.build_disagg_summary_dict` -- same arithmetic, same constants.
- `_pick_autoscale` delegates to `picking.pick_autoscale` -- same filtering/ranking logic.
- `_get_best_configs_under_constraint` now returns closest matches instead of empty when SLA not met -- more useful behavior, no breakage.
- New files (`picking.py`, `test_picking.py`) are purely additive.

## How to review

1. **`src/aiconfigurator/sdk/picking.py`** -- New standalone picking module. Check the three `pick_*` functions and `build_disagg_summary_dict` helper.

2. **`src/aiconfigurator/sdk/pareto_analysis.py`** -- Check `get_best_configs_for_target_load()` (load-match picking) and the closest-match fallback in `_get_best_configs_under_constraint()`. Check GPU-capped behavior.

3. **`src/aiconfigurator/sdk/inference_session.py`** -- Verify `get_worker_candidates()` extraction and delegation patterns for `_get_disagg_summary_dict` and `_pick_autoscale`.

4. **`src/aiconfigurator/sdk/task.py`** -- Check `autoscale` param threading.

5. **`dynamo/.../protocol.py`** -- Check the agg-mode fix in `_apply_agg_worker()` and `_apply_model_update_to_cfg()` worker-lookup fallback.

6. **`test_picking.py`** -- E2E tests. Run with `python test_picking.py` to generate DGD configs in `picking_output/`.
