### PR TITLE
feat: add CLI estimate command for single-point TTFT/TPOT/power prediction

### DIFF
--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -421,6 +421,11 @@ def cli_estimate(
     attention_dp_size: int = 1,
     moe_tp_size: int | None = None,
     moe_ep_size: int | None = None,
+    gemm_quant_mode: str | None = None,
+    kvcache_quant_mode: str | None = None,
+    fmha_quant_mode: str | None = None,
+    moe_quant_mode: str | None = None,
+    comm_quant_mode: str | None = None,
     systems_paths: str | None = None,
 ) -> EstimateResult:
     """
@@ -450,6 +455,16 @@ def cli_estimate(
         attention_dp_size: Attention data parallelism size. Default is 1.
         moe_tp_size: MoE tensor parallelism size. Default is None (auto).
         moe_ep_size: MoE expert parallelism size. Default is None (auto).
+        gemm_quant_mode: GEMM quantization mode (e.g., 'fp8', 'float16', 'int8_wo').
+            Default is None (auto-inferred from model config).
+        kvcache_quant_mode: KV cache quantization mode (e.g., 'fp8', 'float16').
+            Default is None (auto-inferred from model config).
+        fmha_quant_mode: FMHA quantization mode (e.g., 'fp8', 'float16').
+            Default is None (auto-inferred from model config).
+        moe_quant_mode: MoE quantization mode (e.g., 'fp8', 'float16', 'fp8_block').
+            Default is None (auto-inferred from model config).
+        comm_quant_mode: Communication quantization mode (e.g., 'fp8', 'half').
+            Default is None (auto-inferred, defaults to 'half').
         systems_paths: Comma-separated systems search paths. Use 'default' for built-in.
 
     Returns:
@@ -511,13 +526,26 @@ def cli_estimate(
             f"These must be equal. Adjust --moe-tp-size/--moe-ep-size or --tp-size/--attention-dp-size."
         )
 
-    # Build model config — quant defaults are auto-applied inside get_model
+    # Build model config — quant defaults are auto-applied inside get_model for any None fields
+    from aiconfigurator.sdk.common import (
+        CommQuantMode,
+        FMHAQuantMode,
+        GEMMQuantMode,
+        KVCacheQuantMode,
+        MoEQuantMode,
+    )
+
     model_config = ModelConfig(
         tp_size=tp_size,
         pp_size=pp_size,
         attention_dp_size=attention_dp_size,
         moe_tp_size=moe_tp_size,
         moe_ep_size=moe_ep_size,
+        gemm_quant_mode=GEMMQuantMode[gemm_quant_mode] if gemm_quant_mode else None,
+        kvcache_quant_mode=KVCacheQuantMode[kvcache_quant_mode] if kvcache_quant_mode else None,
+        fmha_quant_mode=FMHAQuantMode[fmha_quant_mode] if fmha_quant_mode else None,
+        moe_quant_mode=MoEQuantMode[moe_quant_mode] if moe_quant_mode else None,
+        comm_quant_mode=CommQuantMode[comm_quant_mode] if comm_quant_mode else None,
     )
 
     runtime_config = RuntimeConfig(

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -394,6 +394,9 @@ class EstimateResult:
     raw: dict
     """Full result dict from the InferenceSummary."""
 
+    per_ops_data: dict | None = None
+    """Per-operation latency breakdown (populated when available)."""
+
     def __repr__(self) -> str:
         return (
             f"EstimateResult(ttft={self.ttft:.3f}ms, tpot={self.tpot:.3f}ms, "
@@ -557,6 +560,7 @@ def cli_estimate(
         backend_name=backend_name,
         backend_version=resolved_version,
         raw=result_dict,
+        per_ops_data=summary.get_per_ops_data(),
     )
 
 

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -197,10 +197,23 @@ def _add_estimate_mode_arguments(parser):
         "local path to directory containing config.json.",
     )
     parser.add_argument(
+        "--estimate-mode",
+        choices=["agg", "disagg"],
+        type=str,
+        default="agg",
+        help="Estimation mode: 'agg' for aggregated (default), 'disagg' for disaggregated.",
+    )
+    parser.add_argument(
         "--system",
         type=str,
         required=True,
         help="System name (GPU type). Example: h200_sxm,h100_sxm,b200_sxm,gb200,a100_sxm,l40s,gb300.",
+    )
+    parser.add_argument(
+        "--decode-system",
+        type=str,
+        default=None,
+        help="System name for disagg decode workers. Defaults to --system if omitted.",
     )
     parser.add_argument(
         "--backend",
@@ -218,7 +231,7 @@ def _add_estimate_mode_arguments(parser):
     parser.add_argument("--isl", type=int, default=1024, help="Input sequence length. Default: 1024.")
     parser.add_argument("--osl", type=int, default=1024, help="Output sequence length. Default: 1024.")
     parser.add_argument(
-        "--batch-size", type=int, default=128, help="Batch size (max concurrent requests). Default: 128."
+        "--batch-size", type=int, default=128, help="Batch size (max concurrent requests, used for agg). Default: 128."
     )
     parser.add_argument(
         "--ctx-tokens",
@@ -226,11 +239,73 @@ def _add_estimate_mode_arguments(parser):
         default=None,
         help="Context tokens budget for IFB scheduling. Default: same as ISL.",
     )
+
+    # Shared parallelism defaults (also used as fallback for prefill/decode-specific args)
     parser.add_argument("--tp-size", type=int, default=1, help="Tensor parallelism size. Default: 1.")
     parser.add_argument("--pp-size", type=int, default=1, help="Pipeline parallelism size. Default: 1.")
     parser.add_argument("--attention-dp-size", type=int, default=1, help="Attention data parallelism size. Default: 1.")
     parser.add_argument("--moe-tp-size", type=int, default=None, help="MoE tensor parallelism size.")
     parser.add_argument("--moe-ep-size", type=int, default=None, help="MoE expert parallelism size.")
+
+    # Disagg: prefill-specific overrides (fall back to shared args when None)
+    parser.add_argument(
+        "--prefill-tp-size", type=int, default=None, help="Prefill TP size (disagg). Defaults to --tp-size."
+    )
+    parser.add_argument(
+        "--prefill-pp-size", type=int, default=None, help="Prefill PP size (disagg). Defaults to --pp-size."
+    )
+    parser.add_argument(
+        "--prefill-attention-dp-size",
+        type=int,
+        default=None,
+        help="Prefill attention DP size (disagg). Defaults to --attention-dp-size.",
+    )
+    parser.add_argument(
+        "--prefill-moe-tp-size", type=int, default=None, help="Prefill MoE TP size (disagg). Defaults to --moe-tp-size."
+    )
+    parser.add_argument(
+        "--prefill-moe-ep-size", type=int, default=None, help="Prefill MoE EP size (disagg). Defaults to --moe-ep-size."
+    )
+    parser.add_argument(
+        "--prefill-batch-size", type=int, default=None, help="Prefill batch size (disagg). Required for disagg mode."
+    )
+    parser.add_argument(
+        "--prefill-num-workers",
+        type=int,
+        default=None,
+        help="Number of prefill workers (disagg). Required for disagg mode.",
+    )
+
+    # Disagg: decode-specific overrides (fall back to shared args when None)
+    parser.add_argument(
+        "--decode-tp-size", type=int, default=None, help="Decode TP size (disagg). Defaults to --tp-size."
+    )
+    parser.add_argument(
+        "--decode-pp-size", type=int, default=None, help="Decode PP size (disagg). Defaults to --pp-size."
+    )
+    parser.add_argument(
+        "--decode-attention-dp-size",
+        type=int,
+        default=None,
+        help="Decode attention DP size (disagg). Defaults to --attention-dp-size.",
+    )
+    parser.add_argument(
+        "--decode-moe-tp-size", type=int, default=None, help="Decode MoE TP size (disagg). Defaults to --moe-tp-size."
+    )
+    parser.add_argument(
+        "--decode-moe-ep-size", type=int, default=None, help="Decode MoE EP size (disagg). Defaults to --moe-ep-size."
+    )
+    parser.add_argument(
+        "--decode-batch-size", type=int, default=None, help="Decode batch size (disagg). Required for disagg mode."
+    )
+    parser.add_argument(
+        "--decode-num-workers",
+        type=int,
+        default=None,
+        help="Number of decode workers (disagg). Required for disagg mode.",
+    )
+
+    # Quantization
     parser.add_argument(
         "--gemm-quant-mode",
         choices=[m.name for m in common.GEMMQuantMode],
@@ -924,41 +999,58 @@ def _run_support_mode(args):
     print("=" * 60 + "\n")
 
 
-def _print_per_ops_latency(per_ops_data: dict) -> None:
-    """Print per-operation latency breakdown from run_agg."""
-    scheduling = per_ops_data.get("scheduling", {})
-    num_mix = scheduling.get("num_mix_steps", 0)
-    num_genonly = scheduling.get("num_genonly_steps", 0)
-    mix_total = scheduling.get("mix_step_latency_ms", 0)
-    genonly_total = scheduling.get("genonly_step_latency_ms", 0)
+def _print_per_ops_section(title: str, ops: dict) -> None:
+    """Print a single section of per-op latency breakdown."""
+    total = sum(ops.values())
+    print(f"  {title} (total: {total:.3f} ms)")
+    for op_name, latency in sorted(ops.items(), key=lambda x: -x[1]):
+        pct = latency / total * 100 if total > 0 else 0
+        print(f"    {op_name:<40s} {latency:>10.3f} ms  ({pct:>5.1f}%)")
 
+
+def _print_per_ops_latency(per_ops_data: dict) -> None:
+    """Print per-operation latency breakdown from run_agg or run_disagg."""
     print("\n" + "-" * 60)
     print("  Per-Operation Latency Breakdown")
     print("-" * 60)
-    print(f"  Scheduling: {num_mix:.0f} mix steps + {num_genonly:.0f} gen-only steps")
-    print()
+
+    # Agg mode: mix_step + genonly_step + scheduling
+    scheduling = per_ops_data.get("scheduling")
+    if scheduling:
+        num_mix = scheduling.get("num_mix_steps", 0)
+        num_genonly = scheduling.get("num_genonly_steps", 0)
+        print(f"  Scheduling: {num_mix:.0f} mix steps + {num_genonly:.0f} gen-only steps")
+        print()
 
     mix_ops = per_ops_data.get("mix_step", {})
     if mix_ops:
-        print(f"  Mix Step (total: {mix_total:.3f} ms)")
-        for op_name, latency in sorted(mix_ops.items(), key=lambda x: -x[1]):
-            pct = latency / mix_total * 100 if mix_total > 0 else 0
-            print(f"    {op_name:<40s} {latency:>10.3f} ms  ({pct:>5.1f}%)")
+        _print_per_ops_section("Mix Step", mix_ops)
 
     genonly_ops = per_ops_data.get("genonly_step", {})
     if genonly_ops:
-        print(f"\n  Gen-Only Step (total: {genonly_total:.3f} ms)")
-        for op_name, latency in sorted(genonly_ops.items(), key=lambda x: -x[1]):
-            pct = latency / genonly_total * 100 if genonly_total > 0 else 0
-            print(f"    {op_name:<40s} {latency:>10.3f} ms  ({pct:>5.1f}%)")
+        print()
+        _print_per_ops_section("Gen-Only Step", genonly_ops)
+
+    # Disagg mode: prefill + decode
+    prefill_ops = per_ops_data.get("prefill", {})
+    if prefill_ops:
+        _print_per_ops_section("Prefill (static_ctx)", prefill_ops)
+
+    decode_ops = per_ops_data.get("decode", {})
+    if decode_ops:
+        print()
+        _print_per_ops_section("Decode (static_gen)", decode_ops)
 
 
 def _run_estimate_mode(args):
     """Run the estimate mode to predict TTFT, TPOT, and power for a single config."""
     from aiconfigurator.cli.api import cli_estimate
 
+    estimate_mode = args.estimate_mode
+
     logger.info(
-        "Estimating performance for %s on %s (backend=%s, tp=%d, bs=%d)",
+        "Estimating performance (%s) for %s on %s (backend=%s, tp=%d, bs=%d)",
+        estimate_mode,
         args.model_path,
         args.system,
         args.backend,
@@ -966,9 +1058,11 @@ def _run_estimate_mode(args):
         args.batch_size,
     )
 
-    result = cli_estimate(
+    # Build kwargs shared between agg and disagg
+    estimate_kwargs = dict(
         model_path=args.model_path,
         system_name=args.system,
+        mode=estimate_mode,
         backend_name=args.backend,
         backend_version=args.backend_version,
         database_mode=args.database_mode,
@@ -988,8 +1082,29 @@ def _run_estimate_mode(args):
         comm_quant_mode=args.comm_quant_mode,
     )
 
+    if estimate_mode == "disagg":
+        estimate_kwargs.update(
+            decode_system_name=args.decode_system,
+            prefill_tp_size=args.prefill_tp_size,
+            prefill_pp_size=args.prefill_pp_size,
+            prefill_attention_dp_size=args.prefill_attention_dp_size,
+            prefill_moe_tp_size=args.prefill_moe_tp_size,
+            prefill_moe_ep_size=args.prefill_moe_ep_size,
+            prefill_batch_size=args.prefill_batch_size,
+            prefill_num_workers=args.prefill_num_workers,
+            decode_tp_size=args.decode_tp_size,
+            decode_pp_size=args.decode_pp_size,
+            decode_attention_dp_size=args.decode_attention_dp_size,
+            decode_moe_tp_size=args.decode_moe_tp_size,
+            decode_moe_ep_size=args.decode_moe_ep_size,
+            decode_batch_size=args.decode_batch_size,
+            decode_num_workers=args.decode_num_workers,
+        )
+
+    result = cli_estimate(**estimate_kwargs)
+
     print("\n" + "=" * 60)
-    print("  Performance Estimate")
+    print(f"  Performance Estimate ({result.mode})")
     print("=" * 60)
     print(f"  Model:            {result.model_path}")
     print(f"  System:           {result.system_name}")
@@ -997,10 +1112,24 @@ def _run_estimate_mode(args):
     print("-" * 60)
     print(f"  ISL:              {result.isl}")
     print(f"  OSL:              {result.osl}")
-    print(f"  Batch Size:       {result.batch_size}")
-    print(f"  Context Tokens:   {result.ctx_tokens}")
-    print(f"  TP Size:          {result.tp_size}")
-    print(f"  PP Size:          {result.pp_size}")
+
+    if result.mode == "agg":
+        print(f"  Batch Size:       {result.batch_size}")
+        print(f"  Context Tokens:   {result.ctx_tokens}")
+        print(f"  TP Size:          {result.tp_size}")
+        print(f"  PP Size:          {result.pp_size}")
+    else:
+        raw = result.raw
+        print(f"  (p) TP:           {raw.get('(p)tp', 'N/A')}")
+        print(f"  (p) PP:           {raw.get('(p)pp', 'N/A')}")
+        print(f"  (p) BS:           {raw.get('(p)bs', 'N/A')}")
+        print(f"  (p) Workers:      {raw.get('(p)workers', 'N/A')}")
+        print(f"  (d) TP:           {raw.get('(d)tp', 'N/A')}")
+        print(f"  (d) PP:           {raw.get('(d)pp', 'N/A')}")
+        print(f"  (d) BS:           {raw.get('(d)bs', 'N/A')}")
+        print(f"  (d) Workers:      {raw.get('(d)workers', 'N/A')}")
+        print(f"  Total GPUs:       {raw.get('num_total_gpus', 'N/A')}")
+
     print("-" * 60)
     print(f"  TTFT:             {result.ttft:.3f} ms")
     print(f"  TPOT:             {result.tpot:.3f} ms")

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -231,6 +231,16 @@ def _add_estimate_mode_arguments(parser):
     parser.add_argument("--attention-dp-size", type=int, default=1, help="Attention data parallelism size. Default: 1.")
     parser.add_argument("--moe-tp-size", type=int, default=None, help="MoE tensor parallelism size.")
     parser.add_argument("--moe-ep-size", type=int, default=None, help="MoE expert parallelism size.")
+    parser.add_argument(
+        "--database-mode",
+        choices=[mode.name for mode in common.DatabaseMode if mode != common.DatabaseMode.SOL_FULL],
+        type=str,
+        default=common.DatabaseMode.SILICON.name,
+        help="Database mode for performance estimation. Options: SILICON (default, uses silicon data), "
+        "HYBRID (uses silicon data when available, otherwise SOL+empirical factor), "
+        "EMPIRICAL (SOL+empirical factor), SOL (provide SOL time only). "
+        "Please be careful, only SILICON mode's results are reproducible.",
+    )
 
 
 def _add_support_mode_arguments(parser):
@@ -891,6 +901,7 @@ def _run_estimate_mode(args):
         system_name=args.system,
         backend_name=args.backend,
         backend_version=args.backend_version,
+        database_mode=args.database_mode,
         isl=args.isl,
         osl=args.osl,
         batch_size=args.batch_size,

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -232,6 +232,41 @@ def _add_estimate_mode_arguments(parser):
     parser.add_argument("--moe-tp-size", type=int, default=None, help="MoE tensor parallelism size.")
     parser.add_argument("--moe-ep-size", type=int, default=None, help="MoE expert parallelism size.")
     parser.add_argument(
+        "--gemm-quant-mode",
+        choices=[m.name for m in common.GEMMQuantMode],
+        type=str,
+        default=None,
+        help="GEMM quantization mode. Auto-inferred from model config if omitted.",
+    )
+    parser.add_argument(
+        "--kvcache-quant-mode",
+        choices=[m.name for m in common.KVCacheQuantMode],
+        type=str,
+        default=None,
+        help="KV cache quantization mode. Auto-inferred from model config if omitted.",
+    )
+    parser.add_argument(
+        "--fmha-quant-mode",
+        choices=[m.name for m in common.FMHAQuantMode],
+        type=str,
+        default=None,
+        help="FMHA quantization mode. Auto-inferred from model config if omitted.",
+    )
+    parser.add_argument(
+        "--moe-quant-mode",
+        choices=[m.name for m in common.MoEQuantMode],
+        type=str,
+        default=None,
+        help="MoE quantization mode. Auto-inferred from model config if omitted.",
+    )
+    parser.add_argument(
+        "--comm-quant-mode",
+        choices=[m.name for m in common.CommQuantMode],
+        type=str,
+        default=None,
+        help="Communication quantization mode. Auto-inferred (default: half) if omitted.",
+    )
+    parser.add_argument(
         "--database-mode",
         choices=[mode.name for mode in common.DatabaseMode if mode != common.DatabaseMode.SOL_FULL],
         type=str,
@@ -946,6 +981,11 @@ def _run_estimate_mode(args):
         attention_dp_size=args.attention_dp_size,
         moe_tp_size=args.moe_tp_size,
         moe_ep_size=args.moe_ep_size,
+        gemm_quant_mode=args.gemm_quant_mode,
+        kvcache_quant_mode=args.kvcache_quant_mode,
+        fmha_quant_mode=args.fmha_quant_mode,
+        moe_quant_mode=args.moe_quant_mode,
+        comm_quant_mode=args.comm_quant_mode,
     )
 
     print("\n" + "=" * 60)

--- a/src/aiconfigurator/sdk/backends/sglang_backend.py
+++ b/src/aiconfigurator/sdk/backends/sglang_backend.py
@@ -78,6 +78,9 @@ class SGLANGBackend(BaseBackend):
                 num_genonly_tokens = 1
                 num_mix_steps_for_tpot_calc = 0
 
+            # Per-ops latency collection
+            per_ops_data = {}
+
             # FIXME, fix for DS. DS has different ops for attn in ctx and gen.
             def _get_mix_step_latency(
                 model: BaseModel,
@@ -109,10 +112,12 @@ class SGLANGBackend(BaseBackend):
                 energy_wms_dict = summary.get_context_energy_wms_dict()
                 non_attention_latency_ms = 0.0
                 non_attention_energy_wms = 0.0
+                mix_non_attn_ops = {}
                 for layer_name, latency in latency_dict.items():
                     if layer_name != "context_attention":
                         non_attention_latency_ms += latency
                         non_attention_energy_wms += energy_wms_dict.get(layer_name, 0.0)
+                        mix_non_attn_ops[layer_name] = latency
 
                 # second pass to get ctx attn, split full isl over
                 # num_steps(=np.ceil(isl/ctx_tokens))
@@ -148,6 +153,13 @@ class SGLANGBackend(BaseBackend):
                     gen_attention_latency_ms = 0.0
                     gen_attention_energy_wms = 0.0
 
+                # Collect per-op breakdown for mix step
+                per_ops_data["mix_step"] = {
+                    **mix_non_attn_ops,
+                    "context_attention (scaled)": ctx_attention_latency_ms,
+                    "generation_attention": gen_attention_latency_ms,
+                }
+
                 # Combine all components (simple addition)
                 total_latency_ms = non_attention_latency_ms + ctx_attention_latency_ms + gen_attention_latency_ms
                 total_energy_wms = non_attention_energy_wms + ctx_attention_energy_wms + gen_attention_energy_wms
@@ -176,9 +188,13 @@ class SGLANGBackend(BaseBackend):
                 energy_wms_dict = summary.get_generation_energy_wms_dict()
                 genonly_step_latency_ms = 0.0
                 genonly_step_energy_wms = 0.0
+                genonly_ops = {}
                 for layer_name, latency in latency_dict.items():
                     genonly_step_latency_ms += latency
                     genonly_step_energy_wms += energy_wms_dict.get(layer_name, 0.0)
+                    genonly_ops[layer_name] = latency
+
+                per_ops_data["genonly_step"] = genonly_ops
 
                 return genonly_step_latency_ms, genonly_step_energy_wms
 
@@ -329,6 +345,15 @@ class SGLANGBackend(BaseBackend):
             summary.set_memory_and_check_oom(memory, database.system_spec["gpu"]["mem_capacity"])
             summary.set_summary_df(result)
             summary.set_result_dict(result_dict)
+
+            # Store per-ops latency breakdown
+            per_ops_data["scheduling"] = {
+                "num_mix_steps": float(num_mix_steps),
+                "num_genonly_steps": float(num_genonly_steps),
+                "mix_step_latency_ms": float(mix_step_latency_ms),
+                "genonly_step_latency_ms": float(genonly_step_latency_ms),
+            }
+            summary.set_per_ops_data(per_ops_data)
 
             # caching
             self._agg_cache[isl][osl][b][ctx_tokens] = summary

--- a/src/aiconfigurator/sdk/backends/trtllm_backend.py
+++ b/src/aiconfigurator/sdk/backends/trtllm_backend.py
@@ -80,6 +80,9 @@ class TRTLLMBackend(BaseBackend):
                 num_genonly_tokens = 1
                 num_mix_steps_for_tpot_calc = 0
 
+            # Per-ops latency collection
+            per_ops_data = {}
+
             # FIXME, fix for DS. DS has different ops for attn in ctx and gen.
             def _get_mix_step_latency(
                 model: BaseModel,
@@ -111,10 +114,12 @@ class TRTLLMBackend(BaseBackend):
                 energy_wms_dict = summary.get_context_energy_wms_dict()  # CHANGED from get_context_power_dict()
                 non_attention_latency_ms = 0.0
                 non_attention_energy_wms = 0.0  # RENAMED from non_attention_power_weighted
+                mix_non_attn_ops = {}
                 for layer_name, latency in latency_dict.items():
                     if layer_name != "context_attention":
                         non_attention_latency_ms += latency
                         non_attention_energy_wms += energy_wms_dict.get(layer_name, 0.0)  # SIMPLIFIED
+                        mix_non_attn_ops[layer_name] = latency
 
                 # second pass to get ctx attn, split full isl over
                 # num_steps(=np.ceil(isl/ctx_tokens))
@@ -149,6 +154,13 @@ class TRTLLMBackend(BaseBackend):
                     gen_attention_latency_ms = latency_dict["generation_attention"]
                     gen_attention_energy_wms = energy_wms_dict.get("generation_attention", 0.0)  # CHANGED
 
+                # Collect per-op breakdown for mix step
+                per_ops_data["mix_step"] = {
+                    **mix_non_attn_ops,
+                    "context_attention (scaled)": ctx_attention_latency_ms,
+                    "generation_attention": gen_attention_latency_ms,
+                }
+
                 # Combine all components (simple addition)
                 total_latency_ms = non_attention_latency_ms + ctx_attention_latency_ms + gen_attention_latency_ms
                 total_energy_wms = non_attention_energy_wms + ctx_attention_energy_wms + gen_attention_energy_wms
@@ -177,9 +189,13 @@ class TRTLLMBackend(BaseBackend):
                 energy_wms_dict = summary.get_generation_energy_wms_dict()  # CHANGED
                 genonly_step_latency_ms = 0.0
                 genonly_step_energy_wms = 0.0  # RENAMED from genonly_power_weighted
+                genonly_ops = {}
                 for layer_name, latency in latency_dict.items():
                     genonly_step_latency_ms += latency
                     genonly_step_energy_wms += energy_wms_dict.get(layer_name, 0.0)  # SIMPLIFIED
+                    genonly_ops[layer_name] = latency
+
+                per_ops_data["genonly_step"] = genonly_ops
 
                 return genonly_step_latency_ms, genonly_step_energy_wms
 
@@ -330,6 +346,15 @@ class TRTLLMBackend(BaseBackend):
             summary.set_memory_and_check_oom(memory, database.system_spec["gpu"]["mem_capacity"])
             summary.set_summary_df(result)
             summary.set_result_dict(result_dict)
+
+            # Store per-ops latency breakdown
+            per_ops_data["scheduling"] = {
+                "num_mix_steps": float(num_mix_steps),
+                "num_genonly_steps": float(num_genonly_steps),
+                "mix_step_latency_ms": float(mix_step_latency_ms),
+                "genonly_step_latency_ms": float(genonly_step_latency_ms),
+            }
+            summary.set_per_ops_data(per_ops_data)
 
             # caching
             self._agg_cache[isl][osl][b][ctx_tokens] = summary

--- a/src/aiconfigurator/sdk/backends/vllm_backend.py
+++ b/src/aiconfigurator/sdk/backends/vllm_backend.py
@@ -80,6 +80,9 @@ class VLLMBackend(BaseBackend):
                 num_genonly_tokens = 1
                 num_mix_steps_for_tpot_calc = 0
 
+            # Per-ops latency collection
+            per_ops_data = {}
+
             # FIXME, fix for DS. DS has different ops for attn in ctx and gen.
             def _get_mix_step_latency(
                 model: BaseModel,
@@ -111,10 +114,12 @@ class VLLMBackend(BaseBackend):
                 energy_wms_dict = summary.get_context_energy_wms_dict()
                 non_attention_latency_ms = 0.0
                 non_attention_energy_wms = 0.0
+                mix_non_attn_ops = {}
                 for layer_name, latency in latency_dict.items():
                     if layer_name != "context_attention":
                         non_attention_latency_ms += latency
                         non_attention_energy_wms += energy_wms_dict.get(layer_name, 0.0)
+                        mix_non_attn_ops[layer_name] = latency
 
                 # second pass to get ctx attn, split full isl over
                 # num_steps(=np.ceil(isl/ctx_tokens))
@@ -149,6 +154,13 @@ class VLLMBackend(BaseBackend):
                     gen_attention_latency_ms = latency_dict["generation_attention"]
                     gen_attention_energy_wms = energy_wms_dict.get("generation_attention", 0.0)
 
+                # Collect per-op breakdown for mix step
+                per_ops_data["mix_step"] = {
+                    **mix_non_attn_ops,
+                    "context_attention (scaled)": ctx_attention_latency_ms,
+                    "generation_attention": gen_attention_latency_ms,
+                }
+
                 # Combine all components (simple addition)
                 total_latency_ms = non_attention_latency_ms + ctx_attention_latency_ms + gen_attention_latency_ms
                 total_energy_wms = non_attention_energy_wms + ctx_attention_energy_wms + gen_attention_energy_wms
@@ -177,9 +189,13 @@ class VLLMBackend(BaseBackend):
                 energy_wms_dict = summary.get_generation_energy_wms_dict()
                 genonly_step_latency_ms = 0.0
                 genonly_step_energy_wms = 0.0
+                genonly_ops = {}
                 for layer_name, latency in latency_dict.items():
                     genonly_step_latency_ms += latency
                     genonly_step_energy_wms += energy_wms_dict.get(layer_name, 0.0)
+                    genonly_ops[layer_name] = latency
+
+                per_ops_data["genonly_step"] = genonly_ops
 
                 return genonly_step_latency_ms, genonly_step_energy_wms
 
@@ -330,6 +346,15 @@ class VLLMBackend(BaseBackend):
             summary.set_memory_and_check_oom(memory, database.system_spec["gpu"]["mem_capacity"])
             summary.set_summary_df(result)
             summary.set_result_dict(result_dict)
+
+            # Store per-ops latency breakdown
+            per_ops_data["scheduling"] = {
+                "num_mix_steps": float(num_mix_steps),
+                "num_genonly_steps": float(num_genonly_steps),
+                "mix_step_latency_ms": float(mix_step_latency_ms),
+                "genonly_step_latency_ms": float(genonly_step_latency_ms),
+            }
+            summary.set_per_ops_data(per_ops_data)
 
             # caching
             self._agg_cache[isl][osl][b][ctx_tokens] = summary

--- a/src/aiconfigurator/sdk/inference_session.py
+++ b/src/aiconfigurator/sdk/inference_session.py
@@ -356,6 +356,18 @@ class DisaggInferenceSession:
 
         disagg_summary = InferenceSummary(runtime_config=runtime_config)
         disagg_summary.set_summary_df(disagg_summary_df)
+
+        # Carry per-op latency breakdowns from prefill/decode static runs
+        per_ops_data = {}
+        prefill_ctx_latency = prefill_summary.get_context_latency_dict()
+        if prefill_ctx_latency:
+            per_ops_data["prefill"] = dict(prefill_ctx_latency)
+        decode_gen_latency = decode_summary.get_generation_latency_dict()
+        if decode_gen_latency:
+            per_ops_data["decode"] = dict(decode_gen_latency)
+        if per_ops_data:
+            disagg_summary.set_per_ops_data(per_ops_data)
+
         return disagg_summary
 
     # optimization

--- a/src/aiconfigurator/sdk/inference_summary.py
+++ b/src/aiconfigurator/sdk/inference_summary.py
@@ -70,7 +70,7 @@ class InferenceSummary:
         # cached result dict for efficient batch operations
         self._result_dict = None
 
-        # per-ops latency breakdown (populated by run_agg when requested)
+        # per-ops latency breakdown (populated by run_agg or run_disagg)
         self._per_ops_data: dict | None = None
 
     def set_memory_and_check_oom(self, memory_dict: dict, mem_capacity: int) -> None:

--- a/src/aiconfigurator/sdk/inference_summary.py
+++ b/src/aiconfigurator/sdk/inference_summary.py
@@ -70,6 +70,9 @@ class InferenceSummary:
         # cached result dict for efficient batch operations
         self._result_dict = None
 
+        # per-ops latency breakdown (populated by run_agg when requested)
+        self._per_ops_data: dict | None = None
+
     def set_memory_and_check_oom(self, memory_dict: dict, mem_capacity: int) -> None:
         """
         Set memory and check oom.
@@ -270,6 +273,14 @@ class InferenceSummary:
         if self._summary_df is None:
             logger.warning("WARNING: summary df is not set")
         return self._summary_df
+
+    def set_per_ops_data(self, per_ops_data: dict) -> None:
+        """Set per-operation latency breakdown data from run_agg."""
+        self._per_ops_data = per_ops_data
+
+    def get_per_ops_data(self) -> dict | None:
+        """Get per-operation latency breakdown data (populated by run_agg)."""
+        return self._per_ops_data
 
     def set_result_dict(self, result_dict: dict) -> None:
         """

--- a/tests/unit/cli/test_argument_parsing.py
+++ b/tests/unit/cli/test_argument_parsing.py
@@ -48,7 +48,7 @@ class TestCLIArgumentParsing:
     def test_mode_choices(self, cli_parser):
         """Ensure supported CLI modes are exposed."""
         action = next(action for action in cli_parser._actions if action.dest == "mode")
-        assert set(action.choices.keys()) == {"default", "exp", "generate", "support"}
+        assert set(action.choices.keys()) == {"default", "exp", "generate", "support", "estimate"}
 
     def test_generate_mode_required_args(self, cli_parser):
         """Test that generate mode requires the correct arguments."""


### PR DESCRIPTION
#### Overview

- Add `aiconfigurator cli estimate` command and `cli_estimate()` Python API for predicting TTFT, TPOT, and power consumption for a single model/system/config combination without running a full parameter sweep or SLA optimization.
- Supports both aggregated (`--estimate-mode agg`, default) and disaggregated (`--estimate-mode disagg`) serving estimation.
- Accepts model_path, system, backend, ISL/OSL, batch_size, ctx_tokens, tp/pp size, MoE parallelism, quantization overrides, and database_mode; auto-resolves backend version and quantization defaults.
- For disagg mode, accepts separate prefill/decode parallelism (`--prefill-tp-size`, `--decode-tp-size`, etc.), batch sizes, worker counts, and optionally a different decode system (`--decode-system`). All prefill/decode args fall back to the shared args when omitted.
- Returns a structured `EstimateResult` dataclass with latency/power metrics, full raw result dict, per-operation latency breakdown, and mode indicator.
- Add `--print-per-ops-latency` flag to print per-operation latency breakdown for mix step and generation-only step, useful for profiling bottlenecks.
- Validates MoE parallelism width (`tp_size * attention_dp_size == moe_tp_size * moe_ep_size`) upfront with a clear error message.

#### Details

CLI Example (agg):
```bash
aiconfigurator cli estimate \
  --model-path Qwen/Qwen3-32B \
  --system h100_sxm \
  --isl 520 --osl 512 \
  --batch-size 2 --tp-size 1

# MoE example with per-ops breakdown
aiconfigurator cli estimate \
    --model-path deepseek-ai/DeepSeek-V3 \
    --system h100_sxm \
    --isl 2048 --osl 512 \
    --batch-size 32 \
    --tp-size 8 \
    --moe-tp-size 1 --moe-ep-size 8 \
    --database-mode HYBRID \
    --print-per-ops-latency
```

CLI Example (disagg with full arguments):
```bash
aiconfigurator cli estimate \
    --model-path deepseek-ai/DeepSeek-V3 \
    --estimate-mode disagg \
    --system h100_sxm \
    --decode-system h100_sxm \
    --backend trtllm \
    --backend-version 1.2.0rc5 \
    --database-mode SILICON \
    --isl 4000 --osl 1000 \
    --tp-size 8 --pp-size 1 --attention-dp-size 1 \
    --moe-tp-size 1 --moe-ep-size 8 \
    --gemm-quant-mode fp8 \
    --kvcache-quant-mode fp8 \
    --fmha-quant-mode float16 \
    --moe-quant-mode fp8_block \
    --prefill-tp-size 8 --prefill-pp-size 1 \
    --prefill-moe-tp-size 1 --prefill-moe-ep-size 8 \
    --prefill-batch-size 4 --prefill-num-workers 2 \
    --decode-tp-size 8 --decode-pp-size 1 \
    --decode-moe-tp-size 1 --decode-moe-ep-size 8 \
    --decode-batch-size 128 --decode-num-workers 6
```

Python Example:
```python
from aiconfigurator.cli.api import cli_estimate

# Agg mode
result = cli_estimate("Qwen/Qwen3-32B", "h100_sxm", batch_size=2, isl=520, osl=512)
print(f"TTFT: {result.ttft:.2f}ms, TPOT: {result.tpot:.2f}ms, Power: {result.power_w:.1f}W")

# Per-ops breakdown is always available in the Python API
if result.per_ops_data:
    for op, latency in result.per_ops_data["mix_step"].items():
        print(f"  mix_step  {op}: {latency:.3f} ms")
    for op, latency in result.per_ops_data["genonly_step"].items():
        print(f"  genonly   {op}: {latency:.3f} ms")

# Disagg mode
result = cli_estimate(
    "deepseek-ai/DeepSeek-V3", "h100_sxm",
    mode="disagg",
    isl=4000, osl=1000,
    tp_size=8,
    moe_tp_size=1, moe_ep_size=8,
    gemm_quant_mode="fp8",
    kvcache_quant_mode="fp8",
    moe_quant_mode="fp8_block",
    prefill_batch_size=4, prefill_num_workers=2,
    decode_batch_size=128, decode_num_workers=6,
)
print(f"[{result.mode}] TTFT: {result.ttft:.2f}ms, TPOT: {result.tpot:.2f}ms")
print(f"  Prefill: tp={result.raw['(p)tp']}, bs={result.raw['(p)bs']}, workers={result.raw['(p)workers']}")
print(f"  Decode:  tp={result.raw['(d)tp']}, bs={result.raw['(d)bs']}, workers={result.raw['(d)workers']}")
```

<img width="961" height="1345" alt="image" src="https://github.com/user-attachments/assets/0e01b21e-3d42-4853-b91d-0f19d20ce482" />
