### PR TITLE
fix: IndexError in agg_pareto() when all parallel configurations are skipped without exceptions (#378)

### DIFF
--- a/src/aiconfigurator/sdk/pareto_analysis.py
+++ b/src/aiconfigurator/sdk/pareto_analysis.py
@@ -139,9 +139,15 @@ def agg_pareto(
         results_df = results_df.drop_duplicates(ignore_index=True)
         results_df = results_df.sort_values(by="tokens/s/gpu", ascending=False).reset_index(drop=True)
     else:
+        if exceptions:
+            raise RuntimeError(
+                f"No results found for any parallel configuration. Showing last exception: {exceptions[-1]}"
+            ) from exceptions[-1]
         raise RuntimeError(
-            f"No results found for any parallel configuration. Showing last exception: {exceptions[-1]}"
-        ) from exceptions[-1]
+            "No results found for any parallel configuration. No configuration satisfied the "
+            "TTFT/TPOT or request-latency constraints. Try relaxing --ttft, --tpot, or "
+            "--request_latency (e.g., higher ttft/tpot or higher request_latency)."
+        )
 
     return results_df
 


### PR DESCRIPTION


#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
