### PR TITLE
feat: unified HYBRIDMOE family (Llama 4 Scout/Maverick + MiMo-V2-Flash)

### DIFF
--- a/src/aiconfigurator/model_configs/XiaomiMiMo--MiMo-7B-Base_config.json
+++ b/src/aiconfigurator/model_configs/XiaomiMiMo--MiMo-7B-Base_config.json
@@ -1,0 +1,28 @@
+{
+  "architectures": [
+    "MiMoForCausalLM"
+  ],
+  "model_type": "mimo",
+  "num_hidden_layers": 36,
+  "hidden_size": 4096,
+  "num_attention_heads": 32,
+  "num_key_value_heads": 8,
+  "head_dim": 128,
+  "intermediate_size": 11008,
+  "vocab_size": 151680,
+  "max_position_embeddings": 32768,
+  "rope_theta": 640000,
+  "rms_norm_eps": 1e-05,
+  "hidden_act": "silu",
+  "attention_bias": true,
+  "attention_dropout": 0.0,
+  "sliding_window": 32768,
+  "max_window_layers": 32,
+  "use_sliding_window": false,
+  "use_mrope": false,
+  "num_nextn_predict_layers": 1,
+  "tie_word_embeddings": false,
+  "torch_dtype": "bfloat16",
+  "transformers_version": "4.40.1",
+  "use_cache": true
+}

--- a/src/aiconfigurator/model_configs/XiaomiMiMo--MiMo-V2-Flash_config.json
+++ b/src/aiconfigurator/model_configs/XiaomiMiMo--MiMo-V2-Flash_config.json
@@ -1,0 +1,60 @@
+{
+  "architectures": [
+    "MiMoV2FlashForCausalLM"
+  ],
+  "model_type": "mimo_v2_flash",
+  "num_hidden_layers": 48,
+  "hidden_size": 4096,
+  "num_attention_heads": 64,
+  "num_key_value_heads": 4,
+  "head_dim": 192,
+  "v_head_dim": 128,
+  "intermediate_size": 16384,
+  "vocab_size": 152576,
+  "max_position_embeddings": 262144,
+  "rope_theta": 5000000,
+  "swa_rope_theta": 10000,
+  "partial_rotary_factor": 0.334,
+  "sliding_window": 128,
+  "sliding_window_size": 128,
+  "attention_chunk_size": 128,
+  "swa_num_attention_heads": 64,
+  "swa_num_key_value_heads": 8,
+  "swa_head_dim": 192,
+  "swa_v_head_dim": 128,
+  "hybrid_layer_pattern": [
+    0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0,
+    1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0
+  ],
+  "moe_layer_freq": [
+    0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+  ],
+  "moe_intermediate_size": 2048,
+  "n_routed_experts": 256,
+  "n_shared_experts": null,
+  "num_experts_per_tok": 8,
+  "norm_topk_prob": true,
+  "scoring_func": "sigmoid",
+  "n_group": 1,
+  "topk_group": 1,
+  "topk_method": "noaux_tc",
+  "routed_scaling_factor": null,
+  "hidden_act": "silu",
+  "layernorm_epsilon": 1e-05,
+  "attention_dropout": 0.0,
+  "attention_bias": false,
+  "attention_value_scale": 0.707,
+  "add_swa_attention_sink_bias": true,
+  "add_full_attention_sink_bias": false,
+  "tie_word_embeddings": false,
+  "torch_dtype": "bfloat16",
+  "transformers_version": "4.40.1",
+  "use_cache": true,
+  "quantization_config": {
+    "activation_scheme": "dynamic",
+    "fmt": "e4m3",
+    "quant_method": "fp8",
+    "weight_block_size": [128, 128]
+  }
+}

--- a/src/aiconfigurator/model_configs/meta-llama--Llama-4-Maverick-17B-128E-Instruct_config.json
+++ b/src/aiconfigurator/model_configs/meta-llama--Llama-4-Maverick-17B-128E-Instruct_config.json
@@ -1,0 +1,35 @@
+{
+  "architectures": [
+    "Llama4ForConditionalGeneration"
+  ],
+  "model_type": "llama4",
+  "text_config": {
+    "attention_bias": false,
+    "attention_chunk_size": 8192,
+    "attention_dropout": 0.0,
+    "head_dim": 128,
+    "hidden_act": "silu",
+    "hidden_size": 5120,
+    "interleave_moe_layer_step": 2,
+    "intermediate_size": 8192,
+    "intermediate_size_mlp": 16384,
+    "max_position_embeddings": 1048576,
+    "model_type": "llama4_text",
+    "num_attention_heads": 40,
+    "num_experts_per_tok": 1,
+    "num_hidden_layers": 48,
+    "num_key_value_heads": 8,
+    "num_local_experts": 128,
+    "output_router_logits": false,
+    "rms_norm_eps": 1e-05,
+    "rope_scaling": null,
+    "rope_theta": 500000.0,
+    "router_aux_loss_coef": 0.001,
+    "torch_dtype": "bfloat16",
+    "use_cache": true,
+    "use_qk_norm": false,
+    "vocab_size": 202048
+  },
+  "torch_dtype": "bfloat16",
+  "transformers_version": "4.51.0.dev0"
+}

--- a/src/aiconfigurator/model_configs/meta-llama--Llama-4-Scout-17B-16E-Instruct_config.json
+++ b/src/aiconfigurator/model_configs/meta-llama--Llama-4-Scout-17B-16E-Instruct_config.json
@@ -1,0 +1,41 @@
+{
+  "architectures": [
+    "Llama4ForConditionalGeneration"
+  ],
+  "model_type": "llama4",
+  "text_config": {
+    "attention_bias": false,
+    "attention_chunk_size": 8192,
+    "attention_dropout": 0.0,
+    "head_dim": 128,
+    "hidden_act": "silu",
+    "hidden_size": 5120,
+    "interleave_moe_layer_step": 1,
+    "intermediate_size": 8192,
+    "intermediate_size_mlp": 16384,
+    "max_position_embeddings": 10485760,
+    "model_type": "llama4_text",
+    "num_attention_heads": 40,
+    "num_experts_per_tok": 1,
+    "num_hidden_layers": 48,
+    "num_key_value_heads": 8,
+    "num_local_experts": 16,
+    "output_router_logits": false,
+    "rms_norm_eps": 1e-05,
+    "rope_scaling": {
+      "factor": 16.0,
+      "high_freq_factor": 1.0,
+      "low_freq_factor": 1.0,
+      "original_max_position_embeddings": 8192,
+      "rope_type": "llama3"
+    },
+    "rope_theta": 500000.0,
+    "router_aux_loss_coef": 0.001,
+    "torch_dtype": "bfloat16",
+    "use_cache": true,
+    "use_qk_norm": true,
+    "vocab_size": 202048
+  },
+  "torch_dtype": "bfloat16",
+  "transformers_version": "4.51.0.dev0"
+}

--- a/src/aiconfigurator/sdk/common.py
+++ b/src/aiconfigurator/sdk/common.py
@@ -61,7 +61,7 @@ class NemotronHConfig:
 
 
 @dataclass(frozen=True)
-class HybridConfig:
+class HybridMoEConfig:
     """
     Unified config for hybrid attention (SWA/local + global) + mixed FFN (MoE + dense) models.
     Covers MiMo-V2-Flash, Llama 4 Scout/Maverick, and similar architectures.

--- a/src/aiconfigurator/sdk/common.py
+++ b/src/aiconfigurator/sdk/common.py
@@ -61,22 +61,35 @@ class NemotronHConfig:
 
 
 @dataclass(frozen=True)
-class Llama4Config:
+class HybridConfig:
     """
-    Configuration for Llama 4 Scout/Maverick (interleaved local/global attention + interleaved MoE/dense FFN).
+    Unified config for hybrid attention (SWA/local + global) + mixed FFN (MoE + dense) models.
+    Covers MiMo-V2-Flash, Llama 4 Scout/Maverick, and similar architectures.
 
-    Attributes:
-        interleave_moe_layer_step: Step between MoE layers.
-            Layer i has MoE FFN if (i+1) % interleave_moe_layer_step == 0.
-            step=1 → all layers are MoE (Scout); step=2 → every other layer (odd) is MoE (Maverick).
-        dense_inter_size: Intermediate size for dense FFN layers (intermediate_size_mlp in HF config).
-        attention_chunk_size: Local (chunked) attention window size; even-indexed layers use this,
-            odd-indexed layers use full (global) attention.
+    Both patterns are stored as normalized per-layer tuples of length num_layers:
+        attn_layer_pattern: 0 = SWA/local attention, 1 = global (full) attention
+        moe_layer_freq:     0 = dense SwiGLU FFN,    1 = MoE FFN
+
+    SWA/local attention dims — set to 0 to fall back to model-level defaults
+    (head_dim / num_kv_heads). MiMo-V2-Flash has different dims per attention type;
+    Llama 4 uses the same dims for all layers so all four fields are 0.
+        swa_num_kv_heads: KV heads for SWA/local layers  (0 → num_kv_heads)
+        swa_head_dim:     Q/K head dim for SWA layers     (0 → head_dim)
+        swa_v_head_dim:   V head dim for SWA layers       (0 → head_dim)
+        global_v_head_dim: V head dim for global layers   (0 → head_dim)
+
+    sliding_window_size: token window for SWA/local attention layers
+    dense_inter_size: intermediate size for dense FFN layers (0 → use inter_size)
     """
 
-    interleave_moe_layer_step: int
-    dense_inter_size: int
-    attention_chunk_size: int
+    attn_layer_pattern: tuple[int, ...]  # per-layer: 0=SWA/local, 1=global
+    moe_layer_freq: tuple[int, ...]      # per-layer: 0=dense, 1=MoE
+    swa_num_kv_heads: int = 0
+    swa_head_dim: int = 0
+    swa_v_head_dim: int = 0
+    global_v_head_dim: int = 0
+    sliding_window_size: int = 0
+    dense_inter_size: int = 0
 
 
 def _get_support_matrix_resource():
@@ -268,6 +281,9 @@ DefaultHFModels = {
     # Llama 4 Models
     "meta-llama/Llama-4-Scout-17B-16E-Instruct",
     "meta-llama/Llama-4-Maverick-17B-128E-Instruct",
+    # MiMo Models
+    "XiaomiMiMo/MiMo-V2-Flash",
+    "XiaomiMiMo/MiMo-7B-Base",
     # NVIDIA Nemotron
     "nvidia/Llama-3_3-Nemotron-Super-49B-v1",
     "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
@@ -291,11 +307,12 @@ SupportedSystems = {
 """
 Model family for model definition
 """
-ModelFamily = {"GPT", "LLAMA", "MOE", "DEEPSEEK", "NEMOTRONNAS", "NEMOTRONH"}
+ModelFamily = {"GPT", "LLAMA", "MOE", "DEEPSEEK", "NEMOTRONNAS", "NEMOTRONH", "HYBRIDMOE"}
 ARCHITECTURE_TO_MODEL_FAMILY = {
     "LlamaForCausalLM": "LLAMA",
     "Qwen2ForCausalLM": "LLAMA",
     "Qwen3ForCausalLM": "LLAMA",
+    "MiMoForCausalLM": "LLAMA",
     "DeepSeekForCausalLM": "DEEPSEEK",
     "DeepseekV3ForCausalLM": "DEEPSEEK",
     "KimiK25ForConditionalGeneration": "DEEPSEEK",
@@ -306,7 +323,8 @@ ARCHITECTURE_TO_MODEL_FAMILY = {
     "GptOssForCausalLM": "MOE",
     "Qwen3MoeForCausalLM": "MOE",
     "MiniMaxM2ForCausalLM": "MOE",
-    "Llama4ForConditionalGeneration": "MOE",
+    "MiMoV2FlashForCausalLM": "HYBRIDMOE",
+    "Llama4ForConditionalGeneration": "HYBRIDMOE",
 }
 
 # Multimodal architectures whose LLM config lives under a nested key (e.g. "text_config").

--- a/src/aiconfigurator/sdk/common.py
+++ b/src/aiconfigurator/sdk/common.py
@@ -83,7 +83,7 @@ class HybridConfig:
     """
 
     attn_layer_pattern: tuple[int, ...]  # per-layer: 0=SWA/local, 1=global
-    moe_layer_freq: tuple[int, ...]      # per-layer: 0=dense, 1=MoE
+    moe_layer_freq: tuple[int, ...]  # per-layer: 0=dense, 1=MoE
     swa_num_kv_heads: int = 0
     swa_head_dim: int = 0
     swa_v_head_dim: int = 0

--- a/src/aiconfigurator/sdk/common.py
+++ b/src/aiconfigurator/sdk/common.py
@@ -60,6 +60,25 @@ class NemotronHConfig:
     moe_shared_expert_intermediate_size: int = 0  # Optional: 0 for non-MoE NemotronH models
 
 
+@dataclass(frozen=True)
+class Llama4Config:
+    """
+    Configuration for Llama 4 Scout/Maverick (interleaved local/global attention + interleaved MoE/dense FFN).
+
+    Attributes:
+        interleave_moe_layer_step: Step between MoE layers.
+            Layer i has MoE FFN if (i+1) % interleave_moe_layer_step == 0.
+            step=1 → all layers are MoE (Scout); step=2 → every other layer (odd) is MoE (Maverick).
+        dense_inter_size: Intermediate size for dense FFN layers (intermediate_size_mlp in HF config).
+        attention_chunk_size: Local (chunked) attention window size; even-indexed layers use this,
+            odd-indexed layers use full (global) attention.
+    """
+
+    interleave_moe_layer_step: int
+    dense_inter_size: int
+    attention_chunk_size: int
+
+
 def _get_support_matrix_resource():
     """Get the support_matrix.csv as a Traversable resource."""
     return pkg_resources.files("aiconfigurator") / "systems" / "support_matrix.csv"
@@ -246,6 +265,9 @@ DefaultHFModels = {
     # GPT-OSS Models
     "openai/gpt-oss-120b",
     "openai/gpt-oss-20b",
+    # Llama 4 Models
+    "meta-llama/Llama-4-Scout-17B-16E-Instruct",
+    "meta-llama/Llama-4-Maverick-17B-128E-Instruct",
     # NVIDIA Nemotron
     "nvidia/Llama-3_3-Nemotron-Super-49B-v1",
     "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
@@ -284,12 +306,14 @@ ARCHITECTURE_TO_MODEL_FAMILY = {
     "GptOssForCausalLM": "MOE",
     "Qwen3MoeForCausalLM": "MOE",
     "MiniMaxM2ForCausalLM": "MOE",
+    "Llama4ForConditionalGeneration": "MOE",
 }
 
 # Multimodal architectures whose LLM config lives under a nested key (e.g. "text_config").
 # _parse_hf_config_json will flatten these before parsing.
 MULTIMODAL_TEXT_CONFIG_KEY = {
     "KimiK25ForConditionalGeneration": "text_config",
+    "Llama4ForConditionalGeneration": "text_config",
 }
 
 """

--- a/src/aiconfigurator/sdk/models.py
+++ b/src/aiconfigurator/sdk/models.py
@@ -3122,13 +3122,13 @@ class HybridMoEModel(BaseModel):
     """
     Hybrid attention + mixed FFN model (MiMo-V2-Flash, Llama 4 Scout/Maverick, and similar).
 
-    Handles four layer types derived from HybridConfig.attn_layer_pattern and moe_layer_freq:
+    Handles four layer types derived from HybridMoEConfig.attn_layer_pattern and moe_layer_freq:
     - global_moe:  global (full) attention + MoE FFN
     - swa_moe:     SWA/local attention + MoE FFN
     - swa_dense:   SWA/local attention + dense SwiGLU FFN
     - global_dense: global attention + dense SwiGLU FFN (rare but supported)
 
-    SWA/local attention dims fall back to model-level defaults when HybridConfig fields are 0.
+    SWA/local attention dims fall back to model-level defaults when HybridMoEConfig fields are 0.
     This lets same-dim models (Llama 4) and different-dim models (MiMo-V2-Flash) share one class.
     """
 
@@ -3158,7 +3158,7 @@ class HybridMoEModel(BaseModel):
             else 1.0
         )
         self._validate_fp8_block_quantized_moe_config()
-        self._hybrid_config: common.HybridConfig | None = None
+        self._hybrid_config: common.HybridMoEConfig | None = None
         self._power_law_alpha = 1.01
 
     def _validate_fp8_block_quantized_moe_config(self) -> None:
@@ -3176,22 +3176,22 @@ class HybridMoEModel(BaseModel):
                 f"% weight_block_size={weight_block_size} != 0. "
             )
 
-    def set_hybrid_config(self, cfg: common.HybridConfig) -> None:
-        """Apply HybridConfig and rebuild context/generation ops.
+    def set_hybrid_config(self, cfg: common.HybridMoEConfig) -> None:
+        """Apply HybridMoEConfig and rebuild context/generation ops.
 
         Validates that attn_layer_pattern and moe_layer_freq have the same length
         and contain only 0/1 values before accepting the config.
         """
         if len(cfg.attn_layer_pattern) != len(cfg.moe_layer_freq):
             raise ValueError(
-                f"HybridConfig pattern length mismatch: "
+                f"HybridMoEConfig pattern length mismatch: "
                 f"attn_layer_pattern has {len(cfg.attn_layer_pattern)} entries "
                 f"but moe_layer_freq has {len(cfg.moe_layer_freq)}"
             )
         for i, (a, m) in enumerate(zip(cfg.attn_layer_pattern, cfg.moe_layer_freq)):
             if a not in (0, 1) or m not in (0, 1):
                 raise ValueError(
-                    f"HybridConfig layer {i} has invalid values: "
+                    f"HybridMoEConfig layer {i} has invalid values: "
                     f"attn={a}, moe={m} (expected 0 or 1)"
                 )
         self._hybrid_config = cfg

--- a/src/aiconfigurator/sdk/models.py
+++ b/src/aiconfigurator/sdk/models.py
@@ -211,24 +211,44 @@ def get_model(
             model_config,
         )
     elif model_family == "MOE":
-        # currently we don't support wideep for sglang moe models (other than DS V3)
-        model = MOEModel(
-            topk,
-            num_experts,
-            moe_inter_size,
-            model_path,
-            model_family,
-            architecture,
-            layers,
-            n,
-            n_kv,
-            d,
-            hidden,
-            inter,
-            vocab,
-            context,
-            model_config,
-        )
+        if architecture == "Llama4ForConditionalGeneration":
+            model = Llama4Model(
+                topk,
+                num_experts,
+                moe_inter_size,
+                model_path,
+                model_family,
+                architecture,
+                layers,
+                n,
+                n_kv,
+                d,
+                hidden,
+                inter,
+                vocab,
+                context,
+                model_config,
+            )
+            model.set_llama4_config(extra_params)
+        else:
+            # currently we don't support wideep for sglang moe models (other than DS V3)
+            model = MOEModel(
+                topk,
+                num_experts,
+                moe_inter_size,
+                model_path,
+                model_family,
+                architecture,
+                layers,
+                n,
+                n_kv,
+                d,
+                hidden,
+                inter,
+                vocab,
+                context,
+                model_config,
+            )
     elif model_family == "DEEPSEEK":
         if backend_name == "sglang" and model_config.enable_wideep:
             logger.debug(f"WideEP is enabled for model {model_path} with backend {backend_name}")
@@ -3096,6 +3116,355 @@ class NemotronHModel(BaseModel):
                 h,
                 common.GEMMQuantMode.float16,
             )
+        )
+
+
+class Llama4Model(BaseModel):
+    """
+    Llama 4 Scout/Maverick: interleaved local (chunked) + global attention, interleaved MoE + dense FFN.
+
+    Layer structure for N layers:
+    - Attention: even-indexed layers → local (SWA, window=attention_chunk_size),
+                 odd-indexed layers  → global (full attention). Same KV dims for both.
+    - FFN:       layer i has MoE if (i+1) % interleave_moe_layer_step == 0, else dense SwiGLU.
+                 step=1 → all MoE (Scout); step=2 → odd layers MoE, even layers dense (Maverick).
+    """
+
+    def __init__(self, topk: int, num_experts: int, moe_inter_size: int, *args) -> None:
+        super().__init__(*args)
+        assert (
+            self.config.tp_size * self.config.attention_dp_size == self.config.moe_tp_size * self.config.moe_ep_size
+        ), (
+            f"tp_size ({self.config.tp_size}) * attention_dp_size "
+            f"({self.config.attention_dp_size}) should equal moe_tp_size "
+            f"({self.config.moe_tp_size}) * moe_ep_size ({self.config.moe_ep_size})"
+        )
+        assert num_experts >= self.config.moe_ep_size, f"ep size cannot be larger than num_experts {num_experts}"
+        self._topk = topk
+        self._num_experts = num_experts
+        self._moe_inter_size = moe_inter_size
+        self._llama4_config: common.Llama4Config | None = None
+        self._power_law_alpha = 1.2
+
+    def set_llama4_config(self, cfg: common.Llama4Config) -> None:
+        self._llama4_config = cfg
+        self._build_context_ops()
+        self._build_generation_ops()
+
+    def _count_layer_types(self) -> dict[str, int]:
+        step = self._llama4_config.interleave_moe_layer_step
+        moe_count = sum(1 for i in range(self._num_layers) if (i + 1) % step == 0)
+        # Even-indexed layers use local (SWA) attention; odd-indexed use global.
+        local_count = (self._num_layers + 1) // 2
+        global_count = self._num_layers // 2
+        return {
+            "moe": moe_count,
+            "dense": self._num_layers - moe_count,
+            "local": local_count,
+            "global": global_count,
+        }
+
+    def _build_context_ops(self) -> None:
+        if not self._llama4_config:
+            return
+
+        cfg = self._llama4_config
+        counts = self._count_layer_types()
+        moe_count = counts["moe"]
+        dense_count = counts["dense"]
+        local_count = counts["local"]
+        global_count = counts["global"]
+
+        h = self._hidden_size
+        tp_size = self.config.tp_size
+        moe_tp_size = self.config.moe_tp_size
+        moe_ep_size = self.config.moe_ep_size
+        attention_dp_size = self.config.attention_dp_size
+        pp_size = self.config.pp_size
+        num_kv_heads_per_gpu = self._num_kv_heads_per_gpu
+        gemm_quant_mode = self.config.gemm_quant_mode
+        kvcache_quant_mode = self.config.kvcache_quant_mode
+        fmha_quant_mode = self.config.fmha_quant_mode
+        moe_quant_mode = self.config.moe_quant_mode
+        workload_distribution = (
+            self.config.workload_distribution + f"_{self._power_law_alpha}"
+            if self.config.workload_distribution == "power_law"
+            else self.config.workload_distribution
+        )
+
+        # KV dims are the same for local and global attention layers.
+        qkv_out = self._num_heads * self._head_size // tp_size + self._head_size * num_kv_heads_per_gpu * 2
+        proj_in = self._num_heads * self._head_size // tp_size
+
+        self.context_ops = [ops.Embedding("context_embedding", 1, self._vocab_size, h, 0.3)]
+
+        # Pre-attention norm + QKV GEMM applied to all layers (same shape for local and global).
+        self.context_ops.extend(
+            [
+                ops.ElementWise("context_add_norm_1", self._num_layers, 2 * h, 2 * h, 0.8),
+                ops.GEMM("context_qkv_gemm", self._num_layers, qkv_out, h, gemm_quant_mode),
+            ]
+        )
+
+        # Local (chunked/SWA) context attention — even-indexed layers.
+        if local_count > 0:
+            self.context_ops.append(
+                ops.ContextAttention(
+                    "context_attention",
+                    local_count,
+                    self._num_heads // tp_size,
+                    num_kv_heads_per_gpu,
+                    kvcache_quant_mode,
+                    fmha_quant_mode,
+                    window_size=cfg.attention_chunk_size,
+                    head_size=self._head_size,
+                )
+            )
+
+        # Global (full) context attention — odd-indexed layers.
+        if global_count > 0:
+            self.context_ops.append(
+                ops.ContextAttention(
+                    "context_attention",
+                    global_count,
+                    self._num_heads // tp_size,
+                    num_kv_heads_per_gpu,
+                    kvcache_quant_mode,
+                    fmha_quant_mode,
+                    window_size=0,
+                    head_size=self._head_size,
+                )
+            )
+
+        # Proj GEMM + post-attention norm (all layers).
+        self.context_ops.extend(
+            [
+                ops.GEMM("context_proj_gemm", self._num_layers, h, proj_in, gemm_quant_mode, low_precision_input=True),
+                ops.ElementWise("context_add_norm_2", self._num_layers, 2 * h, 2 * h, 0.8),
+            ]
+        )
+
+        # MoE FFN layers.
+        if moe_count > 0:
+            if self._num_experts >= 128:
+                self.context_ops.append(
+                    ops.GEMM(
+                        "context_router_gemm", moe_count, self._num_experts, h, common.GEMMQuantMode.float16
+                    )
+                )
+            self.context_ops.extend(
+                [
+                    ops.MoEDispatch(
+                        "context_moe_pre_dispatch",
+                        moe_count,
+                        h,
+                        self._topk,
+                        self._num_experts,
+                        moe_tp_size,
+                        moe_ep_size,
+                        attention_dp_size,
+                        True,
+                    ),
+                    ops.MoE(
+                        "context_moe",
+                        moe_count,
+                        h,
+                        self._moe_inter_size,
+                        self._topk,
+                        self._num_experts,
+                        moe_tp_size,
+                        moe_ep_size,
+                        moe_quant_mode,
+                        workload_distribution,
+                        attention_dp_size,
+                    ),
+                    ops.MoEDispatch(
+                        "context_moe_post_dispatch",
+                        moe_count,
+                        h,
+                        self._topk,
+                        self._num_experts,
+                        moe_tp_size,
+                        moe_ep_size,
+                        attention_dp_size,
+                        False,
+                    ),
+                ]
+            )
+
+        # Dense SwiGLU FFN layers (Maverick only; zero for Scout where step=1).
+        if dense_count > 0:
+            dense_inter_per_tp = cfg.dense_inter_size // tp_size
+            self.context_ops.extend(
+                [
+                    ops.GEMM("context_dense_gate_gemm", dense_count, dense_inter_per_tp, h, gemm_quant_mode),
+                    ops.GEMM("context_dense_up_gemm", dense_count, dense_inter_per_tp, h, gemm_quant_mode),
+                    ops.ElementWise(
+                        "context_dense_act", dense_count, dense_inter_per_tp, dense_inter_per_tp, 0.8
+                    ),
+                    ops.GEMM(
+                        "context_dense_down_gemm",
+                        dense_count,
+                        h,
+                        dense_inter_per_tp,
+                        gemm_quant_mode,
+                        low_precision_input=True,
+                    ),
+                ]
+            )
+
+        self.context_ops.append(ops.P2P("context_p2p", pp_size - 1, h, pp_size))
+
+    def _build_generation_ops(self) -> None:
+        if not self._llama4_config:
+            return
+
+        cfg = self._llama4_config
+        counts = self._count_layer_types()
+        moe_count = counts["moe"]
+        dense_count = counts["dense"]
+        local_count = counts["local"]
+        global_count = counts["global"]
+
+        h = self._hidden_size
+        tp_size = self.config.tp_size
+        moe_tp_size = self.config.moe_tp_size
+        moe_ep_size = self.config.moe_ep_size
+        attention_dp_size = self.config.attention_dp_size
+        pp_size = self.config.pp_size
+        num_kv_heads_per_gpu = self._num_kv_heads_per_gpu
+        gemm_quant_mode = self.config.gemm_quant_mode
+        kvcache_quant_mode = self.config.kvcache_quant_mode
+        moe_quant_mode = self.config.moe_quant_mode
+        workload_distribution = (
+            self.config.workload_distribution + f"_{self._power_law_alpha}"
+            if self.config.workload_distribution == "power_law"
+            else self.config.workload_distribution
+        )
+
+        qkv_out = self._num_heads * self._head_size // tp_size + self._head_size * num_kv_heads_per_gpu * 2
+        proj_in = self._num_heads * self._head_size // tp_size
+
+        self.generation_ops = [ops.Embedding("generation_embedding", 1, self._vocab_size, h, 0.3)]
+
+        self.generation_ops.extend(
+            [
+                ops.ElementWise("generation_add_norm_1", self._num_layers, 2 * h, 2 * h, 0.8),
+                ops.GEMM("generation_qkv_gemm", self._num_layers, qkv_out, h, gemm_quant_mode),
+            ]
+        )
+
+        # Local generation attention — even-indexed layers.
+        if local_count > 0:
+            self.generation_ops.append(
+                ops.GenerationAttention(
+                    "generation_attention",
+                    local_count,
+                    self._num_heads // tp_size,
+                    num_kv_heads_per_gpu,
+                    kvcache_quant_mode,
+                    window_size=cfg.attention_chunk_size,
+                    head_size=self._head_size,
+                )
+            )
+
+        # Global generation attention — odd-indexed layers.
+        if global_count > 0:
+            self.generation_ops.append(
+                ops.GenerationAttention(
+                    "generation_attention",
+                    global_count,
+                    self._num_heads // tp_size,
+                    num_kv_heads_per_gpu,
+                    kvcache_quant_mode,
+                    window_size=0,
+                    head_size=self._head_size,
+                )
+            )
+
+        self.generation_ops.extend(
+            [
+                ops.GEMM(
+                    "generation_proj_gemm", self._num_layers, h, proj_in, gemm_quant_mode, low_precision_input=True
+                ),
+                ops.ElementWise("generation_add_norm_2", self._num_layers, 2 * h, 2 * h, 0.8),
+            ]
+        )
+
+        if moe_count > 0:
+            if self._num_experts >= 128:
+                self.generation_ops.append(
+                    ops.GEMM(
+                        "generation_router_gemm", moe_count, self._num_experts, h, common.GEMMQuantMode.float16
+                    )
+                )
+            self.generation_ops.extend(
+                [
+                    ops.MoEDispatch(
+                        "generation_moe_pre_dispatch",
+                        moe_count,
+                        h,
+                        self._topk,
+                        self._num_experts,
+                        moe_tp_size,
+                        moe_ep_size,
+                        attention_dp_size,
+                        True,
+                    ),
+                    ops.MoE(
+                        "generation_moe",
+                        moe_count,
+                        h,
+                        self._moe_inter_size,
+                        self._topk,
+                        self._num_experts,
+                        moe_tp_size,
+                        moe_ep_size,
+                        moe_quant_mode,
+                        workload_distribution,
+                        attention_dp_size,
+                    ),
+                    ops.MoEDispatch(
+                        "generation_moe_post_dispatch",
+                        moe_count,
+                        h,
+                        self._topk,
+                        self._num_experts,
+                        moe_tp_size,
+                        moe_ep_size,
+                        attention_dp_size,
+                        False,
+                    ),
+                ]
+            )
+
+        if dense_count > 0:
+            dense_inter_per_tp = cfg.dense_inter_size // tp_size
+            self.generation_ops.extend(
+                [
+                    ops.GEMM("generation_dense_gate_gemm", dense_count, dense_inter_per_tp, h, gemm_quant_mode),
+                    ops.GEMM("generation_dense_up_gemm", dense_count, dense_inter_per_tp, h, gemm_quant_mode),
+                    ops.ElementWise(
+                        "generation_dense_act", dense_count, dense_inter_per_tp, dense_inter_per_tp, 0.8
+                    ),
+                    ops.GEMM(
+                        "generation_dense_down_gemm",
+                        dense_count,
+                        h,
+                        dense_inter_per_tp,
+                        gemm_quant_mode,
+                        low_precision_input=True,
+                    ),
+                ]
+            )
+
+        self.generation_ops.extend(
+            [
+                ops.GEMM(
+                    "generation_logits_gemm", 1, self._vocab_size // tp_size, h, common.GEMMQuantMode.float16
+                ),
+                ops.P2P("generation_p2p", pp_size - 1, h, pp_size),
+            ]
         )
 
 

--- a/src/aiconfigurator/sdk/models.py
+++ b/src/aiconfigurator/sdk/models.py
@@ -3149,6 +3149,14 @@ class HybridMoEModel(BaseModel):
         self._topk = topk
         self._num_experts = num_experts
         self._moe_inter_size = moe_inter_size
+        self._mtp_scale_factor = (
+            1.0
+            / (1 + calc_expectation(self._nextn, self._nextn_accept_rates))
+            * (self._nextn + self._num_layers)
+            / self._num_layers
+            if self._nextn > 0
+            else 1.0
+        )
         self._validate_fp8_block_quantized_moe_config()
         self._hybrid_config: common.HybridConfig | None = None
         self._power_law_alpha = 1.01
@@ -3169,7 +3177,23 @@ class HybridMoEModel(BaseModel):
             )
 
     def set_hybrid_config(self, cfg: common.HybridConfig) -> None:
-        """Apply HybridConfig and rebuild context/generation ops."""
+        """Apply HybridConfig and rebuild context/generation ops.
+
+        Validates that attn_layer_pattern and moe_layer_freq have the same length
+        and contain only 0/1 values before accepting the config.
+        """
+        if len(cfg.attn_layer_pattern) != len(cfg.moe_layer_freq):
+            raise ValueError(
+                f"HybridConfig pattern length mismatch: "
+                f"attn_layer_pattern has {len(cfg.attn_layer_pattern)} entries "
+                f"but moe_layer_freq has {len(cfg.moe_layer_freq)}"
+            )
+        for i, (a, m) in enumerate(zip(cfg.attn_layer_pattern, cfg.moe_layer_freq)):
+            if a not in (0, 1) or m not in (0, 1):
+                raise ValueError(
+                    f"HybridConfig layer {i} has invalid values: "
+                    f"attn={a}, moe={m} (expected 0 or 1)"
+                )
         self._hybrid_config = cfg
         self._build_context_ops()
         self._build_generation_ops()
@@ -3393,12 +3417,17 @@ class HybridMoEModel(BaseModel):
         )
 
     def _build_generation_ops(self) -> None:
-        """Build the generation (decoding) operations for all four layer types."""
+        """Build the generation (decoding) operations for all four layer types.
+
+        All generation op counts are scaled by _mtp_scale_factor to account for
+        multi-token prediction (nextn > 0), mirroring MOEModel's behavior.
+        """
         if not self._hybrid_config:
             return
 
         cfg = self._hybrid_config
         counts = self._count_layer_types()
+        sf = self._mtp_scale_factor
         h = self._hidden_size
         tp = self.config.tp_size
         moe_tp = self.config.moe_tp_size
@@ -3415,11 +3444,11 @@ class HybridMoEModel(BaseModel):
         )
         d = self._resolve_dims(tp)
 
-        self.generation_ops = [ops.Embedding("generation_embedding", 1, self._vocab_size, h, 0.3)]
+        self.generation_ops = [ops.Embedding("generation_embedding", 1 * sf, self._vocab_size, h, 0.3)]
 
         # --- global attention + MoE FFN ---
         if counts["global_moe"] > 0:
-            c = counts["global_moe"]
+            c = counts["global_moe"] * sf
             self.generation_ops.extend(
                 [
                     ops.ElementWise("generation_global_attn_norm", c, 2 * h, 2 * h, 0.8),
@@ -3443,7 +3472,7 @@ class HybridMoEModel(BaseModel):
 
         # --- SWA/local attention + MoE FFN ---
         if counts["swa_moe"] > 0:
-            c = counts["swa_moe"]
+            c = counts["swa_moe"] * sf
             self.generation_ops.extend(
                 [
                     ops.ElementWise("generation_swa_attn_norm", c, 2 * h, 2 * h, 0.8),
@@ -3465,7 +3494,7 @@ class HybridMoEModel(BaseModel):
 
         # --- SWA/local attention + dense FFN ---
         if counts["swa_dense"] > 0:
-            c = counts["swa_dense"]
+            c = counts["swa_dense"] * sf
             self.generation_ops.extend(
                 [
                     ops.ElementWise("generation_swa_dense_attn_norm", c, 2 * h, 2 * h, 0.8),
@@ -3489,7 +3518,7 @@ class HybridMoEModel(BaseModel):
 
         # --- global attention + dense FFN ---
         if counts["global_dense"] > 0:
-            c = counts["global_dense"]
+            c = counts["global_dense"] * sf
             self.generation_ops.extend(
                 [
                     ops.ElementWise("generation_global_dense_attn_norm", c, 2 * h, 2 * h, 0.8),
@@ -3518,8 +3547,10 @@ class HybridMoEModel(BaseModel):
 
         self.generation_ops.extend(
             [
-                ops.GEMM("generation_logits_gemm", 1, self._vocab_size // tp, h, common.GEMMQuantMode.float16),
-                ops.P2P("generation_p2p", pp - 1, h, pp),
+                ops.GEMM(
+                    "generation_logits_gemm", 1 * sf, self._vocab_size // tp, h, common.GEMMQuantMode.float16
+                ),
+                ops.P2P("generation_p2p", (pp - 1) * sf, h, pp),
             ]
         )
 

--- a/src/aiconfigurator/sdk/models.py
+++ b/src/aiconfigurator/sdk/models.py
@@ -210,45 +210,44 @@ def get_model(
             context,
             model_config,
         )
+    elif model_family == "HYBRIDMOE":
+        model = HybridMoEModel(
+            topk,
+            num_experts,
+            moe_inter_size,
+            model_path,
+            model_family,
+            architecture,
+            layers,
+            n,
+            n_kv,
+            d,
+            hidden,
+            inter,
+            vocab,
+            context,
+            model_config,
+        )
+        model.set_hybrid_config(extra_params)
     elif model_family == "MOE":
-        if architecture == "Llama4ForConditionalGeneration":
-            model = Llama4Model(
-                topk,
-                num_experts,
-                moe_inter_size,
-                model_path,
-                model_family,
-                architecture,
-                layers,
-                n,
-                n_kv,
-                d,
-                hidden,
-                inter,
-                vocab,
-                context,
-                model_config,
-            )
-            model.set_llama4_config(extra_params)
-        else:
-            # currently we don't support wideep for sglang moe models (other than DS V3)
-            model = MOEModel(
-                topk,
-                num_experts,
-                moe_inter_size,
-                model_path,
-                model_family,
-                architecture,
-                layers,
-                n,
-                n_kv,
-                d,
-                hidden,
-                inter,
-                vocab,
-                context,
-                model_config,
-            )
+        # currently we don't support wideep for sglang moe models (other than DS V3)
+        model = MOEModel(
+            topk,
+            num_experts,
+            moe_inter_size,
+            model_path,
+            model_family,
+            architecture,
+            layers,
+            n,
+            n_kv,
+            d,
+            hidden,
+            inter,
+            vocab,
+            context,
+            model_config,
+        )
     elif model_family == "DEEPSEEK":
         if backend_name == "sglang" and model_config.enable_wideep:
             logger.debug(f"WideEP is enabled for model {model_path} with backend {backend_name}")
@@ -365,7 +364,7 @@ def check_is_moe(model_path: str) -> bool:
     E.g., Nemotron_H is not an MoE model, but Nemotron_3 is an MoE model.
     """
     family = get_model_family(model_path)
-    if family in ("MOE", "DEEPSEEK"):
+    if family in ("MOE", "DEEPSEEK", "HYBRIDMOE"):
         return True
     if family == "NEMOTRONH":
         model_info = _get_model_info(model_path)
@@ -3119,353 +3118,259 @@ class NemotronHModel(BaseModel):
         )
 
 
-class Llama4Model(BaseModel):
+class HybridMoEModel(BaseModel):
     """
-    Llama 4 Scout/Maverick: interleaved local (chunked) + global attention, interleaved MoE + dense FFN.
+    Hybrid attention + mixed FFN model (MiMo-V2-Flash, Llama 4 Scout/Maverick, and similar).
 
-    Layer structure for N layers:
-    - Attention: even-indexed layers → local (SWA, window=attention_chunk_size),
-                 odd-indexed layers  → global (full attention). Same KV dims for both.
-    - FFN:       layer i has MoE if (i+1) % interleave_moe_layer_step == 0, else dense SwiGLU.
-                 step=1 → all MoE (Scout); step=2 → odd layers MoE, even layers dense (Maverick).
+    Handles four layer types derived from HybridConfig.attn_layer_pattern and moe_layer_freq:
+    - global_moe:  global (full) attention + MoE FFN
+    - swa_moe:     SWA/local attention + MoE FFN
+    - swa_dense:   SWA/local attention + dense SwiGLU FFN
+    - global_dense: global attention + dense SwiGLU FFN (rare but supported)
+
+    SWA/local attention dims fall back to model-level defaults when HybridConfig fields are 0.
+    This lets same-dim models (Llama 4) and different-dim models (MiMo-V2-Flash) share one class.
     """
 
     def __init__(self, topk: int, num_experts: int, moe_inter_size: int, *args) -> None:
         super().__init__(*args)
-        assert (
-            self.config.tp_size * self.config.attention_dp_size == self.config.moe_tp_size * self.config.moe_ep_size
-        ), (
-            f"tp_size ({self.config.tp_size}) * attention_dp_size "
-            f"({self.config.attention_dp_size}) should equal moe_tp_size "
-            f"({self.config.moe_tp_size}) * moe_ep_size ({self.config.moe_ep_size})"
-        )
-        assert num_experts >= self.config.moe_ep_size, f"ep size cannot be larger than num_experts {num_experts}"
         self._topk = topk
         self._num_experts = num_experts
         self._moe_inter_size = moe_inter_size
-        self._llama4_config: common.Llama4Config | None = None
-        self._power_law_alpha = 1.2
+        self._hybrid_config: common.HybridConfig | None = None
+        self._power_law_alpha = 1.01  # follow DeepSeek MoE
 
-    def set_llama4_config(self, cfg: common.Llama4Config) -> None:
-        self._llama4_config = cfg
+    def set_hybrid_config(self, cfg: common.HybridConfig) -> None:
+        self._hybrid_config = cfg
         self._build_context_ops()
         self._build_generation_ops()
 
     def _count_layer_types(self) -> dict[str, int]:
-        step = self._llama4_config.interleave_moe_layer_step
-        moe_count = sum(1 for i in range(self._num_layers) if (i + 1) % step == 0)
-        # Even-indexed layers use local (SWA) attention; odd-indexed use global.
-        local_count = (self._num_layers + 1) // 2
-        global_count = self._num_layers // 2
+        cfg = self._hybrid_config
+        counts: dict[str, int] = {"global_moe": 0, "swa_moe": 0, "swa_dense": 0, "global_dense": 0}
+        for attn, moe in zip(cfg.attn_layer_pattern, cfg.moe_layer_freq):
+            if attn == 1 and moe == 1:
+                counts["global_moe"] += 1
+            elif attn == 0 and moe == 1:
+                counts["swa_moe"] += 1
+            elif attn == 0 and moe == 0:
+                counts["swa_dense"] += 1
+            else:
+                counts["global_dense"] += 1
+        return counts
+
+    def _resolve_dims(self, tp_size: int) -> dict:
+        """Resolve SWA/local attention dims, falling back to model-level defaults when 0."""
+        cfg = self._hybrid_config
+        swa_n_kv = cfg.swa_num_kv_heads if cfg.swa_num_kv_heads > 0 else self._num_kv_heads
+        swa_hd = cfg.swa_head_dim if cfg.swa_head_dim > 0 else self._head_size
+        swa_v_hd = cfg.swa_v_head_dim if cfg.swa_v_head_dim > 0 else self._head_size
+        global_v_hd = cfg.global_v_head_dim if cfg.global_v_head_dim > 0 else self._head_size
+        swa_n_kv_per_gpu = (swa_n_kv + tp_size - 1) // tp_size
+        global_n_kv_per_gpu = (self._num_kv_heads + tp_size - 1) // tp_size
+        dense_inter = cfg.dense_inter_size if cfg.dense_inter_size > 0 else self._inter_size
         return {
-            "moe": moe_count,
-            "dense": self._num_layers - moe_count,
-            "local": local_count,
-            "global": global_count,
+            "swa_n_kv_per_gpu": swa_n_kv_per_gpu,
+            "global_n_kv_per_gpu": global_n_kv_per_gpu,
+            "swa_qkv_out": self._num_heads * swa_hd // tp_size + swa_n_kv_per_gpu * (swa_hd + swa_v_hd),
+            "global_qkv_out": self._num_heads * self._head_size // tp_size
+            + global_n_kv_per_gpu * (self._head_size + global_v_hd),
+            "swa_proj_in": self._num_heads * swa_v_hd // tp_size,
+            "global_proj_in": self._num_heads * global_v_hd // tp_size,
+            "swa_v_hd": swa_v_hd,
+            "global_v_hd": global_v_hd,
+            "dense_inter_per_tp": dense_inter // tp_size,
         }
 
+    def _moe_ops(self, prefix: str, count: float, h: int, moe_tp: int, moe_ep: int,
+                 attn_dp: int, moe_q: common.MoEQuantMode, wl_dist: str) -> list:
+        """Return the three MoE FFN ops (pre-dispatch, compute, post-dispatch)."""
+        router_ops = (
+            [ops.GEMM(f"{prefix}_router_gemm", count, self._num_experts, h, common.GEMMQuantMode.float16)]
+            if self._num_experts >= 128
+            else []
+        )
+        return router_ops + [
+            ops.MoEDispatch(f"{prefix}_moe_pre_dispatch", count, h, self._topk,
+                            self._num_experts, moe_tp, moe_ep, attn_dp, True),
+            ops.MoE(f"{prefix}_moe", count, h, self._moe_inter_size, self._topk,
+                    self._num_experts, moe_tp, moe_ep, moe_q, wl_dist, attn_dp),
+            ops.MoEDispatch(f"{prefix}_moe_post_dispatch", count, h, self._topk,
+                            self._num_experts, moe_tp, moe_ep, attn_dp, False),
+        ]
+
+    def _dense_ffn_ops(self, prefix: str, count: float, h: int, tp: int,
+                       dense_inter_per_tp: int, gemm_q: common.GEMMQuantMode) -> list:
+        """Return gate + up + activation + down ops for dense SwiGLU FFN."""
+        return [
+            ops.GEMM(f"{prefix}_dense_gate_gemm", count, dense_inter_per_tp, h, gemm_q),
+            ops.GEMM(f"{prefix}_dense_up_gemm", count, dense_inter_per_tp, h, gemm_q),
+            ops.ElementWise(f"{prefix}_dense_act", count, dense_inter_per_tp, dense_inter_per_tp, 0.8),
+            ops.GEMM(f"{prefix}_dense_down_gemm", count, h, dense_inter_per_tp, gemm_q, low_precision_input=True),
+        ]
+
     def _build_context_ops(self) -> None:
-        if not self._llama4_config:
+        if not self._hybrid_config:
             return
 
-        cfg = self._llama4_config
+        cfg = self._hybrid_config
         counts = self._count_layer_types()
-        moe_count = counts["moe"]
-        dense_count = counts["dense"]
-        local_count = counts["local"]
-        global_count = counts["global"]
-
         h = self._hidden_size
-        tp_size = self.config.tp_size
-        moe_tp_size = self.config.moe_tp_size
-        moe_ep_size = self.config.moe_ep_size
-        attention_dp_size = self.config.attention_dp_size
-        pp_size = self.config.pp_size
-        num_kv_heads_per_gpu = self._num_kv_heads_per_gpu
-        gemm_quant_mode = self.config.gemm_quant_mode
-        kvcache_quant_mode = self.config.kvcache_quant_mode
-        fmha_quant_mode = self.config.fmha_quant_mode
-        moe_quant_mode = self.config.moe_quant_mode
-        workload_distribution = (
+        tp = self.config.tp_size
+        moe_tp = self.config.moe_tp_size
+        moe_ep = self.config.moe_ep_size
+        attn_dp = self.config.attention_dp_size
+        pp = self.config.pp_size
+        gemm_q = self.config.gemm_quant_mode
+        kvcache_q = self.config.kvcache_quant_mode
+        fmha_q = self.config.fmha_quant_mode
+        moe_q = self.config.moe_quant_mode
+        wl_dist = (
             self.config.workload_distribution + f"_{self._power_law_alpha}"
             if self.config.workload_distribution == "power_law"
             else self.config.workload_distribution
         )
-
-        # KV dims are the same for local and global attention layers.
-        qkv_out = self._num_heads * self._head_size // tp_size + self._head_size * num_kv_heads_per_gpu * 2
-        proj_in = self._num_heads * self._head_size // tp_size
+        d = self._resolve_dims(tp)
 
         self.context_ops = [ops.Embedding("context_embedding", 1, self._vocab_size, h, 0.3)]
 
-        # Pre-attention norm + QKV GEMM applied to all layers (same shape for local and global).
-        self.context_ops.extend(
-            [
-                ops.ElementWise("context_add_norm_1", self._num_layers, 2 * h, 2 * h, 0.8),
-                ops.GEMM("context_qkv_gemm", self._num_layers, qkv_out, h, gemm_quant_mode),
-            ]
-        )
+        # --- global attention + MoE FFN ---
+        if counts["global_moe"] > 0:
+            c = counts["global_moe"]
+            self.context_ops.extend([
+                ops.ElementWise("context_global_attn_norm", c, 2 * h, 2 * h, 0.8),
+                ops.GEMM("context_global_qkv_gemm", c, d["global_qkv_out"], h, gemm_q),
+                ops.ContextAttention("context_attention", c, self._num_heads // tp,
+                                     d["global_n_kv_per_gpu"], kvcache_q, fmha_q,
+                                     window_size=0, head_size=d["global_v_hd"]),
+                ops.GEMM("context_global_proj_gemm", c, h, d["global_proj_in"], gemm_q, low_precision_input=True),
+                ops.ElementWise("context_global_moe_norm", c, 2 * h, 2 * h, 0.8),
+            ] + self._moe_ops("context_global", c, h, moe_tp, moe_ep, attn_dp, moe_q, wl_dist))
 
-        # Local (chunked/SWA) context attention — even-indexed layers.
-        if local_count > 0:
-            self.context_ops.append(
-                ops.ContextAttention(
-                    "context_attention",
-                    local_count,
-                    self._num_heads // tp_size,
-                    num_kv_heads_per_gpu,
-                    kvcache_quant_mode,
-                    fmha_quant_mode,
-                    window_size=cfg.attention_chunk_size,
-                    head_size=self._head_size,
-                )
-            )
+        # --- SWA/local attention + MoE FFN ---
+        if counts["swa_moe"] > 0:
+            c = counts["swa_moe"]
+            self.context_ops.extend([
+                ops.ElementWise("context_swa_attn_norm", c, 2 * h, 2 * h, 0.8),
+                ops.GEMM("context_swa_qkv_gemm", c, d["swa_qkv_out"], h, gemm_q),
+                ops.ContextAttention("context_attention", c, self._num_heads // tp,
+                                     d["swa_n_kv_per_gpu"], kvcache_q, fmha_q,
+                                     window_size=cfg.sliding_window_size, head_size=d["swa_v_hd"]),
+                ops.GEMM("context_swa_proj_gemm", c, h, d["swa_proj_in"], gemm_q, low_precision_input=True),
+                ops.ElementWise("context_swa_moe_norm", c, 2 * h, 2 * h, 0.8),
+            ] + self._moe_ops("context_swa", c, h, moe_tp, moe_ep, attn_dp, moe_q, wl_dist))
 
-        # Global (full) context attention — odd-indexed layers.
-        if global_count > 0:
-            self.context_ops.append(
-                ops.ContextAttention(
-                    "context_attention",
-                    global_count,
-                    self._num_heads // tp_size,
-                    num_kv_heads_per_gpu,
-                    kvcache_quant_mode,
-                    fmha_quant_mode,
-                    window_size=0,
-                    head_size=self._head_size,
-                )
-            )
+        # --- SWA/local attention + dense FFN ---
+        if counts["swa_dense"] > 0:
+            c = counts["swa_dense"]
+            self.context_ops.extend([
+                ops.ElementWise("context_swa_dense_attn_norm", c, 2 * h, 2 * h, 0.8),
+                ops.GEMM("context_swa_dense_qkv_gemm", c, d["swa_qkv_out"], h, gemm_q),
+                ops.ContextAttention("context_attention", c, self._num_heads // tp,
+                                     d["swa_n_kv_per_gpu"], kvcache_q, fmha_q,
+                                     window_size=cfg.sliding_window_size, head_size=d["swa_v_hd"]),
+                ops.GEMM("context_swa_dense_proj_gemm", c, h, d["swa_proj_in"], gemm_q, low_precision_input=True),
+                ops.ElementWise("context_swa_dense_ffn_norm", c, 2 * h, 2 * h, 0.8),
+            ] + self._dense_ffn_ops("context_swa", c, h, tp, d["dense_inter_per_tp"], gemm_q))
 
-        # Proj GEMM + post-attention norm (all layers).
-        self.context_ops.extend(
-            [
-                ops.GEMM("context_proj_gemm", self._num_layers, h, proj_in, gemm_quant_mode, low_precision_input=True),
-                ops.ElementWise("context_add_norm_2", self._num_layers, 2 * h, 2 * h, 0.8),
-            ]
-        )
+        # --- global attention + dense FFN ---
+        if counts["global_dense"] > 0:
+            c = counts["global_dense"]
+            self.context_ops.extend([
+                ops.ElementWise("context_global_dense_attn_norm", c, 2 * h, 2 * h, 0.8),
+                ops.GEMM("context_global_dense_qkv_gemm", c, d["global_qkv_out"], h, gemm_q),
+                ops.ContextAttention("context_attention", c, self._num_heads // tp,
+                                     d["global_n_kv_per_gpu"], kvcache_q, fmha_q,
+                                     window_size=0, head_size=d["global_v_hd"]),
+                ops.GEMM("context_global_dense_proj_gemm", c, h, d["global_proj_in"], gemm_q, low_precision_input=True),
+                ops.ElementWise("context_global_dense_ffn_norm", c, 2 * h, 2 * h, 0.8),
+            ] + self._dense_ffn_ops("context_global", c, h, tp, d["dense_inter_per_tp"], gemm_q))
 
-        # MoE FFN layers.
-        if moe_count > 0:
-            if self._num_experts >= 128:
-                self.context_ops.append(
-                    ops.GEMM(
-                        "context_router_gemm", moe_count, self._num_experts, h, common.GEMMQuantMode.float16
-                    )
-                )
-            self.context_ops.extend(
-                [
-                    ops.MoEDispatch(
-                        "context_moe_pre_dispatch",
-                        moe_count,
-                        h,
-                        self._topk,
-                        self._num_experts,
-                        moe_tp_size,
-                        moe_ep_size,
-                        attention_dp_size,
-                        True,
-                    ),
-                    ops.MoE(
-                        "context_moe",
-                        moe_count,
-                        h,
-                        self._moe_inter_size,
-                        self._topk,
-                        self._num_experts,
-                        moe_tp_size,
-                        moe_ep_size,
-                        moe_quant_mode,
-                        workload_distribution,
-                        attention_dp_size,
-                    ),
-                    ops.MoEDispatch(
-                        "context_moe_post_dispatch",
-                        moe_count,
-                        h,
-                        self._topk,
-                        self._num_experts,
-                        moe_tp_size,
-                        moe_ep_size,
-                        attention_dp_size,
-                        False,
-                    ),
-                ]
-            )
-
-        # Dense SwiGLU FFN layers (Maverick only; zero for Scout where step=1).
-        if dense_count > 0:
-            dense_inter_per_tp = cfg.dense_inter_size // tp_size
-            self.context_ops.extend(
-                [
-                    ops.GEMM("context_dense_gate_gemm", dense_count, dense_inter_per_tp, h, gemm_quant_mode),
-                    ops.GEMM("context_dense_up_gemm", dense_count, dense_inter_per_tp, h, gemm_quant_mode),
-                    ops.ElementWise(
-                        "context_dense_act", dense_count, dense_inter_per_tp, dense_inter_per_tp, 0.8
-                    ),
-                    ops.GEMM(
-                        "context_dense_down_gemm",
-                        dense_count,
-                        h,
-                        dense_inter_per_tp,
-                        gemm_quant_mode,
-                        low_precision_input=True,
-                    ),
-                ]
-            )
-
-        self.context_ops.append(ops.P2P("context_p2p", pp_size - 1, h, pp_size))
+        self.context_ops.extend([
+            ops.GEMM("context_logits_gemm", 1, self._vocab_size // tp, h, common.GEMMQuantMode.float16),
+            ops.P2P("context_p2p", pp - 1, h, pp),
+        ])
 
     def _build_generation_ops(self) -> None:
-        if not self._llama4_config:
+        if not self._hybrid_config:
             return
 
-        cfg = self._llama4_config
+        cfg = self._hybrid_config
         counts = self._count_layer_types()
-        moe_count = counts["moe"]
-        dense_count = counts["dense"]
-        local_count = counts["local"]
-        global_count = counts["global"]
-
         h = self._hidden_size
-        tp_size = self.config.tp_size
-        moe_tp_size = self.config.moe_tp_size
-        moe_ep_size = self.config.moe_ep_size
-        attention_dp_size = self.config.attention_dp_size
-        pp_size = self.config.pp_size
-        num_kv_heads_per_gpu = self._num_kv_heads_per_gpu
-        gemm_quant_mode = self.config.gemm_quant_mode
-        kvcache_quant_mode = self.config.kvcache_quant_mode
-        moe_quant_mode = self.config.moe_quant_mode
-        workload_distribution = (
+        tp = self.config.tp_size
+        moe_tp = self.config.moe_tp_size
+        moe_ep = self.config.moe_ep_size
+        attn_dp = self.config.attention_dp_size
+        pp = self.config.pp_size
+        gemm_q = self.config.gemm_quant_mode
+        kvcache_q = self.config.kvcache_quant_mode
+        moe_q = self.config.moe_quant_mode
+        wl_dist = (
             self.config.workload_distribution + f"_{self._power_law_alpha}"
             if self.config.workload_distribution == "power_law"
             else self.config.workload_distribution
         )
-
-        qkv_out = self._num_heads * self._head_size // tp_size + self._head_size * num_kv_heads_per_gpu * 2
-        proj_in = self._num_heads * self._head_size // tp_size
+        d = self._resolve_dims(tp)
 
         self.generation_ops = [ops.Embedding("generation_embedding", 1, self._vocab_size, h, 0.3)]
 
-        self.generation_ops.extend(
-            [
-                ops.ElementWise("generation_add_norm_1", self._num_layers, 2 * h, 2 * h, 0.8),
-                ops.GEMM("generation_qkv_gemm", self._num_layers, qkv_out, h, gemm_quant_mode),
-            ]
-        )
+        # --- global attention + MoE FFN ---
+        if counts["global_moe"] > 0:
+            c = counts["global_moe"]
+            self.generation_ops.extend([
+                ops.ElementWise("generation_global_attn_norm", c, 2 * h, 2 * h, 0.8),
+                ops.GEMM("generation_global_qkv_gemm", c, d["global_qkv_out"], h, gemm_q),
+                ops.GenerationAttention("generation_attention", c, self._num_heads // tp,
+                                        d["global_n_kv_per_gpu"], kvcache_q,
+                                        window_size=0, head_size=d["global_v_hd"]),
+                ops.GEMM("generation_global_proj_gemm", c, h, d["global_proj_in"], gemm_q, low_precision_input=True),
+                ops.ElementWise("generation_global_moe_norm", c, 2 * h, 2 * h, 0.8),
+            ] + self._moe_ops("generation_global", c, h, moe_tp, moe_ep, attn_dp, moe_q, wl_dist))
 
-        # Local generation attention — even-indexed layers.
-        if local_count > 0:
-            self.generation_ops.append(
-                ops.GenerationAttention(
-                    "generation_attention",
-                    local_count,
-                    self._num_heads // tp_size,
-                    num_kv_heads_per_gpu,
-                    kvcache_quant_mode,
-                    window_size=cfg.attention_chunk_size,
-                    head_size=self._head_size,
-                )
-            )
+        # --- SWA/local attention + MoE FFN ---
+        if counts["swa_moe"] > 0:
+            c = counts["swa_moe"]
+            self.generation_ops.extend([
+                ops.ElementWise("generation_swa_attn_norm", c, 2 * h, 2 * h, 0.8),
+                ops.GEMM("generation_swa_qkv_gemm", c, d["swa_qkv_out"], h, gemm_q),
+                ops.GenerationAttention("generation_attention", c, self._num_heads // tp,
+                                        d["swa_n_kv_per_gpu"], kvcache_q,
+                                        window_size=cfg.sliding_window_size, head_size=d["swa_v_hd"]),
+                ops.GEMM("generation_swa_proj_gemm", c, h, d["swa_proj_in"], gemm_q, low_precision_input=True),
+                ops.ElementWise("generation_swa_moe_norm", c, 2 * h, 2 * h, 0.8),
+            ] + self._moe_ops("generation_swa", c, h, moe_tp, moe_ep, attn_dp, moe_q, wl_dist))
 
-        # Global generation attention — odd-indexed layers.
-        if global_count > 0:
-            self.generation_ops.append(
-                ops.GenerationAttention(
-                    "generation_attention",
-                    global_count,
-                    self._num_heads // tp_size,
-                    num_kv_heads_per_gpu,
-                    kvcache_quant_mode,
-                    window_size=0,
-                    head_size=self._head_size,
-                )
-            )
+        # --- SWA/local attention + dense FFN ---
+        if counts["swa_dense"] > 0:
+            c = counts["swa_dense"]
+            self.generation_ops.extend([
+                ops.ElementWise("generation_swa_dense_attn_norm", c, 2 * h, 2 * h, 0.8),
+                ops.GEMM("generation_swa_dense_qkv_gemm", c, d["swa_qkv_out"], h, gemm_q),
+                ops.GenerationAttention("generation_attention", c, self._num_heads // tp,
+                                        d["swa_n_kv_per_gpu"], kvcache_q,
+                                        window_size=cfg.sliding_window_size, head_size=d["swa_v_hd"]),
+                ops.GEMM("generation_swa_dense_proj_gemm", c, h, d["swa_proj_in"], gemm_q, low_precision_input=True),
+                ops.ElementWise("generation_swa_dense_ffn_norm", c, 2 * h, 2 * h, 0.8),
+            ] + self._dense_ffn_ops("generation_swa", c, h, tp, d["dense_inter_per_tp"], gemm_q))
 
-        self.generation_ops.extend(
-            [
-                ops.GEMM(
-                    "generation_proj_gemm", self._num_layers, h, proj_in, gemm_quant_mode, low_precision_input=True
-                ),
-                ops.ElementWise("generation_add_norm_2", self._num_layers, 2 * h, 2 * h, 0.8),
-            ]
-        )
+        # --- global attention + dense FFN ---
+        if counts["global_dense"] > 0:
+            c = counts["global_dense"]
+            self.generation_ops.extend([
+                ops.ElementWise("generation_global_dense_attn_norm", c, 2 * h, 2 * h, 0.8),
+                ops.GEMM("generation_global_dense_qkv_gemm", c, d["global_qkv_out"], h, gemm_q),
+                ops.GenerationAttention("generation_attention", c, self._num_heads // tp,
+                                        d["global_n_kv_per_gpu"], kvcache_q,
+                                        window_size=0, head_size=d["global_v_hd"]),
+                ops.GEMM("generation_global_dense_proj_gemm", c, h, d["global_proj_in"], gemm_q, low_precision_input=True),
+                ops.ElementWise("generation_global_dense_ffn_norm", c, 2 * h, 2 * h, 0.8),
+            ] + self._dense_ffn_ops("generation_global", c, h, tp, d["dense_inter_per_tp"], gemm_q))
 
-        if moe_count > 0:
-            if self._num_experts >= 128:
-                self.generation_ops.append(
-                    ops.GEMM(
-                        "generation_router_gemm", moe_count, self._num_experts, h, common.GEMMQuantMode.float16
-                    )
-                )
-            self.generation_ops.extend(
-                [
-                    ops.MoEDispatch(
-                        "generation_moe_pre_dispatch",
-                        moe_count,
-                        h,
-                        self._topk,
-                        self._num_experts,
-                        moe_tp_size,
-                        moe_ep_size,
-                        attention_dp_size,
-                        True,
-                    ),
-                    ops.MoE(
-                        "generation_moe",
-                        moe_count,
-                        h,
-                        self._moe_inter_size,
-                        self._topk,
-                        self._num_experts,
-                        moe_tp_size,
-                        moe_ep_size,
-                        moe_quant_mode,
-                        workload_distribution,
-                        attention_dp_size,
-                    ),
-                    ops.MoEDispatch(
-                        "generation_moe_post_dispatch",
-                        moe_count,
-                        h,
-                        self._topk,
-                        self._num_experts,
-                        moe_tp_size,
-                        moe_ep_size,
-                        attention_dp_size,
-                        False,
-                    ),
-                ]
-            )
-
-        if dense_count > 0:
-            dense_inter_per_tp = cfg.dense_inter_size // tp_size
-            self.generation_ops.extend(
-                [
-                    ops.GEMM("generation_dense_gate_gemm", dense_count, dense_inter_per_tp, h, gemm_quant_mode),
-                    ops.GEMM("generation_dense_up_gemm", dense_count, dense_inter_per_tp, h, gemm_quant_mode),
-                    ops.ElementWise(
-                        "generation_dense_act", dense_count, dense_inter_per_tp, dense_inter_per_tp, 0.8
-                    ),
-                    ops.GEMM(
-                        "generation_dense_down_gemm",
-                        dense_count,
-                        h,
-                        dense_inter_per_tp,
-                        gemm_quant_mode,
-                        low_precision_input=True,
-                    ),
-                ]
-            )
-
-        self.generation_ops.extend(
-            [
-                ops.GEMM(
-                    "generation_logits_gemm", 1, self._vocab_size // tp_size, h, common.GEMMQuantMode.float16
-                ),
-                ops.P2P("generation_p2p", pp_size - 1, h, pp_size),
-            ]
-        )
+        self.generation_ops.extend([
+            ops.GEMM("generation_logits_gemm", 1, self._vocab_size // tp, h, common.GEMMQuantMode.float16),
+            ops.P2P("generation_p2p", pp - 1, h, pp),
+        ])
 
 
 if __name__ == "__main__":

--- a/src/aiconfigurator/sdk/models.py
+++ b/src/aiconfigurator/sdk/models.py
@@ -3141,9 +3141,7 @@ class HybridMoEModel(BaseModel):
             f"({self.config.attention_dp_size}) should be equal to moe_tp_size "
             f"({self.config.moe_tp_size}) * moe_ep_size ({self.config.moe_ep_size})"
         )
-        assert num_experts >= self.config.moe_ep_size, (
-            f"ep size cannot be larger than num_experts {num_experts}"
-        )
+        assert num_experts >= self.config.moe_ep_size, f"ep size cannot be larger than num_experts {num_experts}"
         assert self.config.tp_size * self.config.attention_dp_size <= 256, (
             f"moe ep size {self.config.moe_ep_size} * moe tp size {self.config.moe_tp_size} "
             f"should not be larger than 256"
@@ -3218,8 +3216,17 @@ class HybridMoEModel(BaseModel):
             "dense_inter_per_tp": dense_inter // tp_size,
         }
 
-    def _moe_ops(self, prefix: str, count: float, h: int, moe_tp: int, moe_ep: int,
-                 attn_dp: int, moe_q: common.MoEQuantMode, wl_dist: str) -> list:
+    def _moe_ops(
+        self,
+        prefix: str,
+        count: float,
+        h: int,
+        moe_tp: int,
+        moe_ep: int,
+        attn_dp: int,
+        moe_q: common.MoEQuantMode,
+        wl_dist: str,
+    ) -> list:
         """Return the three MoE FFN ops (pre-dispatch, compute, post-dispatch)."""
         router_ops = (
             [ops.GEMM(f"{prefix}_router_gemm", count, self._num_experts, h, common.GEMMQuantMode.float16)]
@@ -3227,16 +3234,30 @@ class HybridMoEModel(BaseModel):
             else []
         )
         return router_ops + [
-            ops.MoEDispatch(f"{prefix}_moe_pre_dispatch", count, h, self._topk,
-                            self._num_experts, moe_tp, moe_ep, attn_dp, True),
-            ops.MoE(f"{prefix}_moe", count, h, self._moe_inter_size, self._topk,
-                    self._num_experts, moe_tp, moe_ep, moe_q, wl_dist, attn_dp),
-            ops.MoEDispatch(f"{prefix}_moe_post_dispatch", count, h, self._topk,
-                            self._num_experts, moe_tp, moe_ep, attn_dp, False),
+            ops.MoEDispatch(
+                f"{prefix}_moe_pre_dispatch", count, h, self._topk, self._num_experts, moe_tp, moe_ep, attn_dp, True
+            ),
+            ops.MoE(
+                f"{prefix}_moe",
+                count,
+                h,
+                self._moe_inter_size,
+                self._topk,
+                self._num_experts,
+                moe_tp,
+                moe_ep,
+                moe_q,
+                wl_dist,
+                attn_dp,
+            ),
+            ops.MoEDispatch(
+                f"{prefix}_moe_post_dispatch", count, h, self._topk, self._num_experts, moe_tp, moe_ep, attn_dp, False
+            ),
         ]
 
-    def _dense_ffn_ops(self, prefix: str, count: float, h: int, tp: int,
-                       dense_inter_per_tp: int, gemm_q: common.GEMMQuantMode) -> list:
+    def _dense_ffn_ops(
+        self, prefix: str, count: float, h: int, tp: int, dense_inter_per_tp: int, gemm_q: common.GEMMQuantMode
+    ) -> list:
         """Return fused gate_up + activation + down ops for dense SwiGLU FFN."""
         return [
             ops.GEMM(f"{prefix}_dense_gate_up_gemm", count, 2 * dense_inter_per_tp, h, gemm_q),
@@ -3273,59 +3294,103 @@ class HybridMoEModel(BaseModel):
         # --- global attention + MoE FFN ---
         if counts["global_moe"] > 0:
             c = counts["global_moe"]
-            self.context_ops.extend([
-                ops.ElementWise("context_global_attn_norm", c, 2 * h, 2 * h, 0.8),
-                ops.GEMM("context_global_qkv_gemm", c, d["global_qkv_out"], h, gemm_q),
-                ops.ContextAttention("context_attention", c, self._num_heads // tp,
-                                     d["global_n_kv_per_gpu"], kvcache_q, fmha_q,
-                                     window_size=0, head_size=d["global_hd"]),
-                ops.GEMM("context_global_proj_gemm", c, h, d["global_proj_in"], gemm_q, low_precision_input=True),
-                ops.ElementWise("context_global_moe_norm", c, 2 * h, 2 * h, 0.8),
-            ] + self._moe_ops("context_global", c, h, moe_tp, moe_ep, attn_dp, moe_q, wl_dist))
+            self.context_ops.extend(
+                [
+                    ops.ElementWise("context_global_attn_norm", c, 2 * h, 2 * h, 0.8),
+                    ops.GEMM("context_global_qkv_gemm", c, d["global_qkv_out"], h, gemm_q),
+                    ops.ContextAttention(
+                        "context_attention",
+                        c,
+                        self._num_heads // tp,
+                        d["global_n_kv_per_gpu"],
+                        kvcache_q,
+                        fmha_q,
+                        window_size=0,
+                        head_size=d["global_hd"],
+                    ),
+                    ops.GEMM("context_global_proj_gemm", c, h, d["global_proj_in"], gemm_q, low_precision_input=True),
+                    ops.ElementWise("context_global_moe_norm", c, 2 * h, 2 * h, 0.8),
+                ]
+                + self._moe_ops("context_global", c, h, moe_tp, moe_ep, attn_dp, moe_q, wl_dist)
+            )
 
         # --- SWA/local attention + MoE FFN ---
         if counts["swa_moe"] > 0:
             c = counts["swa_moe"]
-            self.context_ops.extend([
-                ops.ElementWise("context_swa_attn_norm", c, 2 * h, 2 * h, 0.8),
-                ops.GEMM("context_swa_qkv_gemm", c, d["swa_qkv_out"], h, gemm_q),
-                ops.ContextAttention("context_attention", c, self._num_heads // tp,
-                                     d["swa_n_kv_per_gpu"], kvcache_q, fmha_q,
-                                     window_size=cfg.sliding_window_size, head_size=d["swa_hd"]),
-                ops.GEMM("context_swa_proj_gemm", c, h, d["swa_proj_in"], gemm_q, low_precision_input=True),
-                ops.ElementWise("context_swa_moe_norm", c, 2 * h, 2 * h, 0.8),
-            ] + self._moe_ops("context_swa", c, h, moe_tp, moe_ep, attn_dp, moe_q, wl_dist))
+            self.context_ops.extend(
+                [
+                    ops.ElementWise("context_swa_attn_norm", c, 2 * h, 2 * h, 0.8),
+                    ops.GEMM("context_swa_qkv_gemm", c, d["swa_qkv_out"], h, gemm_q),
+                    ops.ContextAttention(
+                        "context_attention",
+                        c,
+                        self._num_heads // tp,
+                        d["swa_n_kv_per_gpu"],
+                        kvcache_q,
+                        fmha_q,
+                        window_size=cfg.sliding_window_size,
+                        head_size=d["swa_hd"],
+                    ),
+                    ops.GEMM("context_swa_proj_gemm", c, h, d["swa_proj_in"], gemm_q, low_precision_input=True),
+                    ops.ElementWise("context_swa_moe_norm", c, 2 * h, 2 * h, 0.8),
+                ]
+                + self._moe_ops("context_swa", c, h, moe_tp, moe_ep, attn_dp, moe_q, wl_dist)
+            )
 
         # --- SWA/local attention + dense FFN ---
         if counts["swa_dense"] > 0:
             c = counts["swa_dense"]
-            self.context_ops.extend([
-                ops.ElementWise("context_swa_dense_attn_norm", c, 2 * h, 2 * h, 0.8),
-                ops.GEMM("context_swa_dense_qkv_gemm", c, d["swa_qkv_out"], h, gemm_q),
-                ops.ContextAttention("context_attention", c, self._num_heads // tp,
-                                     d["swa_n_kv_per_gpu"], kvcache_q, fmha_q,
-                                     window_size=cfg.sliding_window_size, head_size=d["swa_hd"]),
-                ops.GEMM("context_swa_dense_proj_gemm", c, h, d["swa_proj_in"], gemm_q, low_precision_input=True),
-                ops.ElementWise("context_swa_dense_ffn_norm", c, 2 * h, 2 * h, 0.8),
-            ] + self._dense_ffn_ops("context_swa", c, h, tp, d["dense_inter_per_tp"], gemm_q))
+            self.context_ops.extend(
+                [
+                    ops.ElementWise("context_swa_dense_attn_norm", c, 2 * h, 2 * h, 0.8),
+                    ops.GEMM("context_swa_dense_qkv_gemm", c, d["swa_qkv_out"], h, gemm_q),
+                    ops.ContextAttention(
+                        "context_attention",
+                        c,
+                        self._num_heads // tp,
+                        d["swa_n_kv_per_gpu"],
+                        kvcache_q,
+                        fmha_q,
+                        window_size=cfg.sliding_window_size,
+                        head_size=d["swa_hd"],
+                    ),
+                    ops.GEMM("context_swa_dense_proj_gemm", c, h, d["swa_proj_in"], gemm_q, low_precision_input=True),
+                    ops.ElementWise("context_swa_dense_ffn_norm", c, 2 * h, 2 * h, 0.8),
+                ]
+                + self._dense_ffn_ops("context_swa", c, h, tp, d["dense_inter_per_tp"], gemm_q)
+            )
 
         # --- global attention + dense FFN ---
         if counts["global_dense"] > 0:
             c = counts["global_dense"]
-            self.context_ops.extend([
-                ops.ElementWise("context_global_dense_attn_norm", c, 2 * h, 2 * h, 0.8),
-                ops.GEMM("context_global_dense_qkv_gemm", c, d["global_qkv_out"], h, gemm_q),
-                ops.ContextAttention("context_attention", c, self._num_heads // tp,
-                                     d["global_n_kv_per_gpu"], kvcache_q, fmha_q,
-                                     window_size=0, head_size=d["global_hd"]),
-                ops.GEMM("context_global_dense_proj_gemm", c, h, d["global_proj_in"], gemm_q, low_precision_input=True),
-                ops.ElementWise("context_global_dense_ffn_norm", c, 2 * h, 2 * h, 0.8),
-            ] + self._dense_ffn_ops("context_global", c, h, tp, d["dense_inter_per_tp"], gemm_q))
+            self.context_ops.extend(
+                [
+                    ops.ElementWise("context_global_dense_attn_norm", c, 2 * h, 2 * h, 0.8),
+                    ops.GEMM("context_global_dense_qkv_gemm", c, d["global_qkv_out"], h, gemm_q),
+                    ops.ContextAttention(
+                        "context_attention",
+                        c,
+                        self._num_heads // tp,
+                        d["global_n_kv_per_gpu"],
+                        kvcache_q,
+                        fmha_q,
+                        window_size=0,
+                        head_size=d["global_hd"],
+                    ),
+                    ops.GEMM(
+                        "context_global_dense_proj_gemm", c, h, d["global_proj_in"], gemm_q, low_precision_input=True
+                    ),
+                    ops.ElementWise("context_global_dense_ffn_norm", c, 2 * h, 2 * h, 0.8),
+                ]
+                + self._dense_ffn_ops("context_global", c, h, tp, d["dense_inter_per_tp"], gemm_q)
+            )
 
-        self.context_ops.extend([
-            ops.GEMM("context_logits_gemm", 1, self._vocab_size // tp, h, common.GEMMQuantMode.float16),
-            ops.P2P("context_p2p", pp - 1, h, pp),
-        ])
+        self.context_ops.extend(
+            [
+                ops.GEMM("context_logits_gemm", 1, self._vocab_size // tp, h, common.GEMMQuantMode.float16),
+                ops.P2P("context_p2p", pp - 1, h, pp),
+            ]
+        )
 
     def _build_generation_ops(self) -> None:
         """Build the generation (decoding) operations for all four layer types."""
@@ -3355,62 +3420,108 @@ class HybridMoEModel(BaseModel):
         # --- global attention + MoE FFN ---
         if counts["global_moe"] > 0:
             c = counts["global_moe"]
-            self.generation_ops.extend([
-                ops.ElementWise("generation_global_attn_norm", c, 2 * h, 2 * h, 0.8),
-                ops.GEMM("generation_global_qkv_gemm", c, d["global_qkv_out"], h, gemm_q),
-                ops.GenerationAttention("generation_attention", c, self._num_heads // tp,
-                                        d["global_n_kv_per_gpu"], kvcache_q,
-                                        window_size=0, head_size=d["global_hd"]),
-                ops.GEMM("generation_global_proj_gemm", c, h, d["global_proj_in"], gemm_q, low_precision_input=True),
-                ops.ElementWise("generation_global_moe_norm", c, 2 * h, 2 * h, 0.8),
-            ] + self._moe_ops("generation_global", c, h, moe_tp, moe_ep, attn_dp, moe_q, wl_dist))
+            self.generation_ops.extend(
+                [
+                    ops.ElementWise("generation_global_attn_norm", c, 2 * h, 2 * h, 0.8),
+                    ops.GEMM("generation_global_qkv_gemm", c, d["global_qkv_out"], h, gemm_q),
+                    ops.GenerationAttention(
+                        "generation_attention",
+                        c,
+                        self._num_heads // tp,
+                        d["global_n_kv_per_gpu"],
+                        kvcache_q,
+                        window_size=0,
+                        head_size=d["global_hd"],
+                    ),
+                    ops.GEMM(
+                        "generation_global_proj_gemm", c, h, d["global_proj_in"], gemm_q, low_precision_input=True
+                    ),
+                    ops.ElementWise("generation_global_moe_norm", c, 2 * h, 2 * h, 0.8),
+                ]
+                + self._moe_ops("generation_global", c, h, moe_tp, moe_ep, attn_dp, moe_q, wl_dist)
+            )
 
         # --- SWA/local attention + MoE FFN ---
         if counts["swa_moe"] > 0:
             c = counts["swa_moe"]
-            self.generation_ops.extend([
-                ops.ElementWise("generation_swa_attn_norm", c, 2 * h, 2 * h, 0.8),
-                ops.GEMM("generation_swa_qkv_gemm", c, d["swa_qkv_out"], h, gemm_q),
-                ops.GenerationAttention("generation_attention", c, self._num_heads // tp,
-                                        d["swa_n_kv_per_gpu"], kvcache_q,
-                                        window_size=cfg.sliding_window_size, head_size=d["swa_hd"]),
-                ops.GEMM("generation_swa_proj_gemm", c, h, d["swa_proj_in"], gemm_q, low_precision_input=True),
-                ops.ElementWise("generation_swa_moe_norm", c, 2 * h, 2 * h, 0.8),
-            ] + self._moe_ops("generation_swa", c, h, moe_tp, moe_ep, attn_dp, moe_q, wl_dist))
+            self.generation_ops.extend(
+                [
+                    ops.ElementWise("generation_swa_attn_norm", c, 2 * h, 2 * h, 0.8),
+                    ops.GEMM("generation_swa_qkv_gemm", c, d["swa_qkv_out"], h, gemm_q),
+                    ops.GenerationAttention(
+                        "generation_attention",
+                        c,
+                        self._num_heads // tp,
+                        d["swa_n_kv_per_gpu"],
+                        kvcache_q,
+                        window_size=cfg.sliding_window_size,
+                        head_size=d["swa_hd"],
+                    ),
+                    ops.GEMM("generation_swa_proj_gemm", c, h, d["swa_proj_in"], gemm_q, low_precision_input=True),
+                    ops.ElementWise("generation_swa_moe_norm", c, 2 * h, 2 * h, 0.8),
+                ]
+                + self._moe_ops("generation_swa", c, h, moe_tp, moe_ep, attn_dp, moe_q, wl_dist)
+            )
 
         # --- SWA/local attention + dense FFN ---
         if counts["swa_dense"] > 0:
             c = counts["swa_dense"]
-            self.generation_ops.extend([
-                ops.ElementWise("generation_swa_dense_attn_norm", c, 2 * h, 2 * h, 0.8),
-                ops.GEMM("generation_swa_dense_qkv_gemm", c, d["swa_qkv_out"], h, gemm_q),
-                ops.GenerationAttention("generation_attention", c, self._num_heads // tp,
-                                        d["swa_n_kv_per_gpu"], kvcache_q,
-                                        window_size=cfg.sliding_window_size, head_size=d["swa_hd"]),
-                ops.GEMM("generation_swa_dense_proj_gemm", c, h, d["swa_proj_in"], gemm_q, low_precision_input=True),
-                ops.ElementWise("generation_swa_dense_ffn_norm", c, 2 * h, 2 * h, 0.8),
-            ] + self._dense_ffn_ops("generation_swa", c, h, tp, d["dense_inter_per_tp"], gemm_q))
+            self.generation_ops.extend(
+                [
+                    ops.ElementWise("generation_swa_dense_attn_norm", c, 2 * h, 2 * h, 0.8),
+                    ops.GEMM("generation_swa_dense_qkv_gemm", c, d["swa_qkv_out"], h, gemm_q),
+                    ops.GenerationAttention(
+                        "generation_attention",
+                        c,
+                        self._num_heads // tp,
+                        d["swa_n_kv_per_gpu"],
+                        kvcache_q,
+                        window_size=cfg.sliding_window_size,
+                        head_size=d["swa_hd"],
+                    ),
+                    ops.GEMM(
+                        "generation_swa_dense_proj_gemm", c, h, d["swa_proj_in"], gemm_q, low_precision_input=True
+                    ),
+                    ops.ElementWise("generation_swa_dense_ffn_norm", c, 2 * h, 2 * h, 0.8),
+                ]
+                + self._dense_ffn_ops("generation_swa", c, h, tp, d["dense_inter_per_tp"], gemm_q)
+            )
 
         # --- global attention + dense FFN ---
         if counts["global_dense"] > 0:
             c = counts["global_dense"]
-            self.generation_ops.extend([
-                ops.ElementWise("generation_global_dense_attn_norm", c, 2 * h, 2 * h, 0.8),
-                ops.GEMM("generation_global_dense_qkv_gemm", c, d["global_qkv_out"], h, gemm_q),
-                ops.GenerationAttention("generation_attention", c, self._num_heads // tp,
-                                        d["global_n_kv_per_gpu"], kvcache_q,
-                                        window_size=0, head_size=d["global_hd"]),
-                ops.GEMM(
-                    "generation_global_dense_proj_gemm", c, h, d["global_proj_in"],
-                    gemm_q, low_precision_input=True,
-                ),
-                ops.ElementWise("generation_global_dense_ffn_norm", c, 2 * h, 2 * h, 0.8),
-            ] + self._dense_ffn_ops("generation_global", c, h, tp, d["dense_inter_per_tp"], gemm_q))
+            self.generation_ops.extend(
+                [
+                    ops.ElementWise("generation_global_dense_attn_norm", c, 2 * h, 2 * h, 0.8),
+                    ops.GEMM("generation_global_dense_qkv_gemm", c, d["global_qkv_out"], h, gemm_q),
+                    ops.GenerationAttention(
+                        "generation_attention",
+                        c,
+                        self._num_heads // tp,
+                        d["global_n_kv_per_gpu"],
+                        kvcache_q,
+                        window_size=0,
+                        head_size=d["global_hd"],
+                    ),
+                    ops.GEMM(
+                        "generation_global_dense_proj_gemm",
+                        c,
+                        h,
+                        d["global_proj_in"],
+                        gemm_q,
+                        low_precision_input=True,
+                    ),
+                    ops.ElementWise("generation_global_dense_ffn_norm", c, 2 * h, 2 * h, 0.8),
+                ]
+                + self._dense_ffn_ops("generation_global", c, h, tp, d["dense_inter_per_tp"], gemm_q)
+            )
 
-        self.generation_ops.extend([
-            ops.GEMM("generation_logits_gemm", 1, self._vocab_size // tp, h, common.GEMMQuantMode.float16),
-            ops.P2P("generation_p2p", pp - 1, h, pp),
-        ])
+        self.generation_ops.extend(
+            [
+                ops.GEMM("generation_logits_gemm", 1, self._vocab_size // tp, h, common.GEMMQuantMode.float16),
+                ops.P2P("generation_p2p", pp - 1, h, pp),
+            ]
+        )
 
 
 if __name__ == "__main__":

--- a/src/aiconfigurator/sdk/models.py
+++ b/src/aiconfigurator/sdk/models.py
@@ -3190,10 +3190,7 @@ class HybridMoEModel(BaseModel):
             )
         for i, (a, m) in enumerate(zip(cfg.attn_layer_pattern, cfg.moe_layer_freq)):
             if a not in (0, 1) or m not in (0, 1):
-                raise ValueError(
-                    f"HybridMoEConfig layer {i} has invalid values: "
-                    f"attn={a}, moe={m} (expected 0 or 1)"
-                )
+                raise ValueError(f"HybridMoEConfig layer {i} has invalid values: attn={a}, moe={m} (expected 0 or 1)")
         self._hybrid_config = cfg
         self._build_context_ops()
         self._build_generation_ops()
@@ -3547,9 +3544,7 @@ class HybridMoEModel(BaseModel):
 
         self.generation_ops.extend(
             [
-                ops.GEMM(
-                    "generation_logits_gemm", 1 * sf, self._vocab_size // tp, h, common.GEMMQuantMode.float16
-                ),
+                ops.GEMM("generation_logits_gemm", 1 * sf, self._vocab_size // tp, h, common.GEMMQuantMode.float16),
                 ops.P2P("generation_p2p", (pp - 1) * sf, h, pp),
             ]
         )

--- a/src/aiconfigurator/sdk/models.py
+++ b/src/aiconfigurator/sdk/models.py
@@ -3134,18 +3134,50 @@ class HybridMoEModel(BaseModel):
 
     def __init__(self, topk: int, num_experts: int, moe_inter_size: int, *args) -> None:
         super().__init__(*args)
+        assert (
+            self.config.tp_size * self.config.attention_dp_size == self.config.moe_tp_size * self.config.moe_ep_size
+        ), (
+            f"tp_size ({self.config.tp_size}) * attention_dp_size "
+            f"({self.config.attention_dp_size}) should be equal to moe_tp_size "
+            f"({self.config.moe_tp_size}) * moe_ep_size ({self.config.moe_ep_size})"
+        )
+        assert num_experts >= self.config.moe_ep_size, (
+            f"ep size cannot be larger than num_experts {num_experts}"
+        )
+        assert self.config.tp_size * self.config.attention_dp_size <= 256, (
+            f"moe ep size {self.config.moe_ep_size} * moe tp size {self.config.moe_tp_size} "
+            f"should not be larger than 256"
+        )
         self._topk = topk
         self._num_experts = num_experts
         self._moe_inter_size = moe_inter_size
+        self._validate_fp8_block_quantized_moe_config()
         self._hybrid_config: common.HybridConfig | None = None
-        self._power_law_alpha = 1.01  # follow DeepSeek MoE
+        self._power_law_alpha = 1.01
+
+    def _validate_fp8_block_quantized_moe_config(self) -> None:
+        """Validate fp8_block MoE alignment: (moe_inter_size / moe_tp_size) % block_size == 0."""
+        if self.config.moe_quant_mode != common.MoEQuantMode.fp8_block:
+            return
+        raw_config = _load_model_config_from_model_path(self.model_path)
+        default_size = [128, 128]
+        weight_block_size = raw_config.get("quantization_config", {}).get("weight_block_size", default_size)[0]
+        moe_size_per_gpu = self._moe_inter_size // self.config.moe_tp_size
+        if (moe_size_per_gpu % weight_block_size) != 0:
+            raise ValueError(
+                f"Invalid quantized MoE configuration: "
+                f"(moe_intermediate_size={self._moe_inter_size} / moe_tp_size={self.config.moe_tp_size}) "
+                f"% weight_block_size={weight_block_size} != 0. "
+            )
 
     def set_hybrid_config(self, cfg: common.HybridConfig) -> None:
+        """Apply HybridConfig and rebuild context/generation ops."""
         self._hybrid_config = cfg
         self._build_context_ops()
         self._build_generation_ops()
 
     def _count_layer_types(self) -> dict[str, int]:
+        """Count layers per type: global_moe, swa_moe, swa_dense, global_dense."""
         cfg = self._hybrid_config
         counts: dict[str, int] = {"global_moe": 0, "swa_moe": 0, "swa_dense": 0, "global_dense": 0}
         for attn, moe in zip(cfg.attn_layer_pattern, cfg.moe_layer_freq):
@@ -3160,7 +3192,11 @@ class HybridMoEModel(BaseModel):
         return counts
 
     def _resolve_dims(self, tp_size: int) -> dict:
-        """Resolve SWA/local attention dims, falling back to model-level defaults when 0."""
+        """Resolve SWA/local attention dims, falling back to model-level defaults when 0.
+
+        Returns a dict with per-TP KV head counts, QKV GEMM output widths, proj GEMM input widths,
+        Q/K head dims for attention kernels, and dense FFN intermediate size per TP.
+        """
         cfg = self._hybrid_config
         swa_n_kv = cfg.swa_num_kv_heads if cfg.swa_num_kv_heads > 0 else self._num_kv_heads
         swa_hd = cfg.swa_head_dim if cfg.swa_head_dim > 0 else self._head_size
@@ -3177,8 +3213,8 @@ class HybridMoEModel(BaseModel):
             + global_n_kv_per_gpu * (self._head_size + global_v_hd),
             "swa_proj_in": self._num_heads * swa_v_hd // tp_size,
             "global_proj_in": self._num_heads * global_v_hd // tp_size,
-            "swa_v_hd": swa_v_hd,
-            "global_v_hd": global_v_hd,
+            "swa_hd": swa_hd,
+            "global_hd": self._head_size,
             "dense_inter_per_tp": dense_inter // tp_size,
         }
 
@@ -3201,15 +3237,15 @@ class HybridMoEModel(BaseModel):
 
     def _dense_ffn_ops(self, prefix: str, count: float, h: int, tp: int,
                        dense_inter_per_tp: int, gemm_q: common.GEMMQuantMode) -> list:
-        """Return gate + up + activation + down ops for dense SwiGLU FFN."""
+        """Return fused gate_up + activation + down ops for dense SwiGLU FFN."""
         return [
-            ops.GEMM(f"{prefix}_dense_gate_gemm", count, dense_inter_per_tp, h, gemm_q),
-            ops.GEMM(f"{prefix}_dense_up_gemm", count, dense_inter_per_tp, h, gemm_q),
-            ops.ElementWise(f"{prefix}_dense_act", count, dense_inter_per_tp, dense_inter_per_tp, 0.8),
+            ops.GEMM(f"{prefix}_dense_gate_up_gemm", count, 2 * dense_inter_per_tp, h, gemm_q),
+            ops.ElementWise(f"{prefix}_dense_act", count, 2 * dense_inter_per_tp, dense_inter_per_tp, 0.8),
             ops.GEMM(f"{prefix}_dense_down_gemm", count, h, dense_inter_per_tp, gemm_q, low_precision_input=True),
         ]
 
     def _build_context_ops(self) -> None:
+        """Build the context (prefill) operations for all four layer types."""
         if not self._hybrid_config:
             return
 
@@ -3242,7 +3278,7 @@ class HybridMoEModel(BaseModel):
                 ops.GEMM("context_global_qkv_gemm", c, d["global_qkv_out"], h, gemm_q),
                 ops.ContextAttention("context_attention", c, self._num_heads // tp,
                                      d["global_n_kv_per_gpu"], kvcache_q, fmha_q,
-                                     window_size=0, head_size=d["global_v_hd"]),
+                                     window_size=0, head_size=d["global_hd"]),
                 ops.GEMM("context_global_proj_gemm", c, h, d["global_proj_in"], gemm_q, low_precision_input=True),
                 ops.ElementWise("context_global_moe_norm", c, 2 * h, 2 * h, 0.8),
             ] + self._moe_ops("context_global", c, h, moe_tp, moe_ep, attn_dp, moe_q, wl_dist))
@@ -3255,7 +3291,7 @@ class HybridMoEModel(BaseModel):
                 ops.GEMM("context_swa_qkv_gemm", c, d["swa_qkv_out"], h, gemm_q),
                 ops.ContextAttention("context_attention", c, self._num_heads // tp,
                                      d["swa_n_kv_per_gpu"], kvcache_q, fmha_q,
-                                     window_size=cfg.sliding_window_size, head_size=d["swa_v_hd"]),
+                                     window_size=cfg.sliding_window_size, head_size=d["swa_hd"]),
                 ops.GEMM("context_swa_proj_gemm", c, h, d["swa_proj_in"], gemm_q, low_precision_input=True),
                 ops.ElementWise("context_swa_moe_norm", c, 2 * h, 2 * h, 0.8),
             ] + self._moe_ops("context_swa", c, h, moe_tp, moe_ep, attn_dp, moe_q, wl_dist))
@@ -3268,7 +3304,7 @@ class HybridMoEModel(BaseModel):
                 ops.GEMM("context_swa_dense_qkv_gemm", c, d["swa_qkv_out"], h, gemm_q),
                 ops.ContextAttention("context_attention", c, self._num_heads // tp,
                                      d["swa_n_kv_per_gpu"], kvcache_q, fmha_q,
-                                     window_size=cfg.sliding_window_size, head_size=d["swa_v_hd"]),
+                                     window_size=cfg.sliding_window_size, head_size=d["swa_hd"]),
                 ops.GEMM("context_swa_dense_proj_gemm", c, h, d["swa_proj_in"], gemm_q, low_precision_input=True),
                 ops.ElementWise("context_swa_dense_ffn_norm", c, 2 * h, 2 * h, 0.8),
             ] + self._dense_ffn_ops("context_swa", c, h, tp, d["dense_inter_per_tp"], gemm_q))
@@ -3281,7 +3317,7 @@ class HybridMoEModel(BaseModel):
                 ops.GEMM("context_global_dense_qkv_gemm", c, d["global_qkv_out"], h, gemm_q),
                 ops.ContextAttention("context_attention", c, self._num_heads // tp,
                                      d["global_n_kv_per_gpu"], kvcache_q, fmha_q,
-                                     window_size=0, head_size=d["global_v_hd"]),
+                                     window_size=0, head_size=d["global_hd"]),
                 ops.GEMM("context_global_dense_proj_gemm", c, h, d["global_proj_in"], gemm_q, low_precision_input=True),
                 ops.ElementWise("context_global_dense_ffn_norm", c, 2 * h, 2 * h, 0.8),
             ] + self._dense_ffn_ops("context_global", c, h, tp, d["dense_inter_per_tp"], gemm_q))
@@ -3292,6 +3328,7 @@ class HybridMoEModel(BaseModel):
         ])
 
     def _build_generation_ops(self) -> None:
+        """Build the generation (decoding) operations for all four layer types."""
         if not self._hybrid_config:
             return
 
@@ -3323,7 +3360,7 @@ class HybridMoEModel(BaseModel):
                 ops.GEMM("generation_global_qkv_gemm", c, d["global_qkv_out"], h, gemm_q),
                 ops.GenerationAttention("generation_attention", c, self._num_heads // tp,
                                         d["global_n_kv_per_gpu"], kvcache_q,
-                                        window_size=0, head_size=d["global_v_hd"]),
+                                        window_size=0, head_size=d["global_hd"]),
                 ops.GEMM("generation_global_proj_gemm", c, h, d["global_proj_in"], gemm_q, low_precision_input=True),
                 ops.ElementWise("generation_global_moe_norm", c, 2 * h, 2 * h, 0.8),
             ] + self._moe_ops("generation_global", c, h, moe_tp, moe_ep, attn_dp, moe_q, wl_dist))
@@ -3336,7 +3373,7 @@ class HybridMoEModel(BaseModel):
                 ops.GEMM("generation_swa_qkv_gemm", c, d["swa_qkv_out"], h, gemm_q),
                 ops.GenerationAttention("generation_attention", c, self._num_heads // tp,
                                         d["swa_n_kv_per_gpu"], kvcache_q,
-                                        window_size=cfg.sliding_window_size, head_size=d["swa_v_hd"]),
+                                        window_size=cfg.sliding_window_size, head_size=d["swa_hd"]),
                 ops.GEMM("generation_swa_proj_gemm", c, h, d["swa_proj_in"], gemm_q, low_precision_input=True),
                 ops.ElementWise("generation_swa_moe_norm", c, 2 * h, 2 * h, 0.8),
             ] + self._moe_ops("generation_swa", c, h, moe_tp, moe_ep, attn_dp, moe_q, wl_dist))
@@ -3349,7 +3386,7 @@ class HybridMoEModel(BaseModel):
                 ops.GEMM("generation_swa_dense_qkv_gemm", c, d["swa_qkv_out"], h, gemm_q),
                 ops.GenerationAttention("generation_attention", c, self._num_heads // tp,
                                         d["swa_n_kv_per_gpu"], kvcache_q,
-                                        window_size=cfg.sliding_window_size, head_size=d["swa_v_hd"]),
+                                        window_size=cfg.sliding_window_size, head_size=d["swa_hd"]),
                 ops.GEMM("generation_swa_dense_proj_gemm", c, h, d["swa_proj_in"], gemm_q, low_precision_input=True),
                 ops.ElementWise("generation_swa_dense_ffn_norm", c, 2 * h, 2 * h, 0.8),
             ] + self._dense_ffn_ops("generation_swa", c, h, tp, d["dense_inter_per_tp"], gemm_q))
@@ -3362,8 +3399,11 @@ class HybridMoEModel(BaseModel):
                 ops.GEMM("generation_global_dense_qkv_gemm", c, d["global_qkv_out"], h, gemm_q),
                 ops.GenerationAttention("generation_attention", c, self._num_heads // tp,
                                         d["global_n_kv_per_gpu"], kvcache_q,
-                                        window_size=0, head_size=d["global_v_hd"]),
-                ops.GEMM("generation_global_dense_proj_gemm", c, h, d["global_proj_in"], gemm_q, low_precision_input=True),
+                                        window_size=0, head_size=d["global_hd"]),
+                ops.GEMM(
+                    "generation_global_dense_proj_gemm", c, h, d["global_proj_in"],
+                    gemm_q, low_precision_input=True,
+                ),
                 ops.ElementWise("generation_global_dense_ffn_norm", c, 2 * h, 2 * h, 0.8),
             ] + self._dense_ffn_ops("generation_global", c, h, tp, d["dense_inter_per_tp"], gemm_q))
 

--- a/src/aiconfigurator/sdk/models.py
+++ b/src/aiconfigurator/sdk/models.py
@@ -3179,15 +3179,18 @@ class HybridMoEModel(BaseModel):
     def set_hybrid_config(self, cfg: common.HybridMoEConfig) -> None:
         """Apply HybridMoEConfig and rebuild context/generation ops.
 
-        Validates that attn_layer_pattern and moe_layer_freq have the same length
-        and contain only 0/1 values before accepting the config.
+        Validates that attn_layer_pattern and moe_layer_freq have the same length,
+        match self._num_layers, and contain only 0/1 values before accepting the config.
         """
-        if len(cfg.attn_layer_pattern) != len(cfg.moe_layer_freq):
+        n = len(cfg.attn_layer_pattern)
+        if n != len(cfg.moe_layer_freq):
             raise ValueError(
                 f"HybridMoEConfig pattern length mismatch: "
-                f"attn_layer_pattern has {len(cfg.attn_layer_pattern)} entries "
+                f"attn_layer_pattern has {n} entries "
                 f"but moe_layer_freq has {len(cfg.moe_layer_freq)}"
             )
+        if n != self._num_layers:
+            raise ValueError(f"HybridMoEConfig pattern length ({n}) does not match num_layers ({self._num_layers})")
         for i, (a, m) in enumerate(zip(cfg.attn_layer_pattern, cfg.moe_layer_freq)):
             if a not in (0, 1) or m not in (0, 1):
                 raise ValueError(f"HybridMoEConfig layer {i} has invalid values: attn={a}, moe={m} (expected 0 or 1)")

--- a/src/aiconfigurator/sdk/utils.py
+++ b/src/aiconfigurator/sdk/utils.py
@@ -512,9 +512,7 @@ def _parse_hf_config_json(config: dict) -> dict:
         # MiMo-V2-Flash: per-layer attention + FFN patterns; different dims for SWA vs global.
         moe_layer_freq_raw = config.get("moe_layer_freq", [])
         moe_layer_freq = (
-            tuple(moe_layer_freq_raw)
-            if isinstance(moe_layer_freq_raw, list)
-            else tuple([moe_layer_freq_raw] * layers)
+            tuple(moe_layer_freq_raw) if isinstance(moe_layer_freq_raw, list) else tuple([moe_layer_freq_raw] * layers)
         )
         attn_pattern = tuple(config.get("hybrid_layer_pattern", []))
         if len(attn_pattern) != layers or len(moe_layer_freq) != layers:
@@ -523,9 +521,7 @@ def _parse_hf_config_json(config: dict) -> dict:
                 f"expected {layers} entries, got attn={len(attn_pattern)} moe={len(moe_layer_freq)}"
             )
         if any(v not in (0, 1) for v in (*attn_pattern, *moe_layer_freq)):
-            raise ValueError(
-                f"Hybrid patterns for {architecture} must contain only 0/1 values"
-            )
+            raise ValueError(f"Hybrid patterns for {architecture} must contain only 0/1 values")
         extra_params = HybridConfig(
             attn_layer_pattern=attn_pattern,
             moe_layer_freq=moe_layer_freq,
@@ -549,9 +545,7 @@ def _parse_hf_config_json(config: dict) -> dict:
         # FFN: layer i is MoE (1) if (i+1) % interleave_moe_layer_step == 0, else dense (0).
         step = config.get("interleave_moe_layer_step", 1)
         if not isinstance(step, int) or step <= 0:
-            raise ValueError(
-                f"interleave_moe_layer_step must be a positive integer, got {step}"
-            )
+            raise ValueError(f"interleave_moe_layer_step must be a positive integer, got {step}")
         attn_pattern = tuple(i % 2 for i in range(layers))
         moe_freq = tuple(1 if (i + 1) % step == 0 else 0 for i in range(layers))
         extra_params = HybridConfig(

--- a/src/aiconfigurator/sdk/utils.py
+++ b/src/aiconfigurator/sdk/utils.py
@@ -320,6 +320,7 @@ class HuggingFaceDownloadError(Exception):
 
 
 def _get_hf_auth_headers() -> dict[str, str]:
+    """Return HTTP auth headers using the cached HuggingFace token, if available."""
     # Load token from ~/.cache/huggingface/token, if available
     token_path = Path.home() / ".cache" / "huggingface" / "token"
     hf_token = None
@@ -333,6 +334,7 @@ def _get_hf_auth_headers() -> dict[str, str]:
 
 
 def _download_hf_json(hf_id: str, filename: str, *, raise_on_404: bool = True) -> dict | None:
+    """Download and parse a JSON file from a HuggingFace model repo."""
     url = f"https://huggingface.co/{hf_id}/raw/main/{filename}"
     try:
         req = urllib.request.Request(url, headers=_get_hf_auth_headers())
@@ -514,8 +516,18 @@ def _parse_hf_config_json(config: dict) -> dict:
             if isinstance(moe_layer_freq_raw, list)
             else tuple([moe_layer_freq_raw] * layers)
         )
+        attn_pattern = tuple(config.get("hybrid_layer_pattern", []))
+        if len(attn_pattern) != layers or len(moe_layer_freq) != layers:
+            raise ValueError(
+                f"Hybrid pattern length mismatch for {architecture}: "
+                f"expected {layers} entries, got attn={len(attn_pattern)} moe={len(moe_layer_freq)}"
+            )
+        if any(v not in (0, 1) for v in (*attn_pattern, *moe_layer_freq)):
+            raise ValueError(
+                f"Hybrid patterns for {architecture} must contain only 0/1 values"
+            )
         extra_params = HybridConfig(
-            attn_layer_pattern=tuple(config.get("hybrid_layer_pattern", [])),
+            attn_layer_pattern=attn_pattern,
             moe_layer_freq=moe_layer_freq,
             swa_num_kv_heads=config.get("swa_num_key_value_heads", 0),
             swa_head_dim=config.get("swa_head_dim", 0),
@@ -536,6 +548,10 @@ def _parse_hf_config_json(config: dict) -> dict:
         # Attention: even layers → local (0), odd layers → global (1).
         # FFN: layer i is MoE (1) if (i+1) % interleave_moe_layer_step == 0, else dense (0).
         step = config.get("interleave_moe_layer_step", 1)
+        if not isinstance(step, int) or step <= 0:
+            raise ValueError(
+                f"interleave_moe_layer_step must be a positive integer, got {step}"
+            )
         attn_pattern = tuple(i % 2 for i in range(layers))
         moe_freq = tuple(1 if (i + 1) % step == 0 else 0 for i in range(layers))
         extra_params = HybridConfig(
@@ -576,6 +592,7 @@ def _get_model_config_path():
 
 
 def _load_pre_downloaded_hf_config(hf_id: str) -> dict:
+    """Load a cached HuggingFace config.json from the model_configs package directory."""
     config_path = _get_model_config_path() / f"{hf_id.replace('/', '--')}_config.json"
     if not config_path.exists():
         raise ValueError(f"HuggingFace model {hf_id} is not cached in model_configs directory.")
@@ -583,6 +600,7 @@ def _load_pre_downloaded_hf_config(hf_id: str) -> dict:
 
 
 def _load_pre_downloaded_hf_quant_config(hf_id: str) -> dict | None:
+    """Load a cached hf_quant_config.json, returning None if not present."""
     config_path = _get_model_config_path() / f"{hf_id.replace('/', '--')}_hf_quant_config.json"
     if not config_path.exists():
         return None
@@ -606,6 +624,7 @@ def _load_local_quant_config(path: str) -> dict | None:
 
 
 def _normalize_hf_quant_config(hf_quant_config: dict) -> dict:
+    """Extract and normalize quant_method/kv_cache_quant_method from hf_quant_config."""
     quant_section = hf_quant_config.get("quantization")
     if not isinstance(quant_section, dict):
         return {}
@@ -620,6 +639,7 @@ def _normalize_hf_quant_config(hf_quant_config: dict) -> dict:
 
 
 def _normalize_quant_algo(value: object) -> str | None:
+    """Normalize a quantization algorithm string to a canonical form."""
     if value is None:
         return None
     algo = str(value).strip().lower()
@@ -636,6 +656,7 @@ def _normalize_quant_algo(value: object) -> str | None:
 
 
 def _normalize_kv_cache_algo(value: object) -> str | None:
+    """Normalize a KV cache quantization algorithm string."""
     if value is None:
         return None
     algo = str(value).strip().lower()
@@ -680,6 +701,7 @@ def _infer_quant_dynamic(quant_cfg: dict) -> bool | None:
 
 
 def _infer_quantization_fields(raw_config: dict) -> dict[str, object]:
+    """Infer quant_method, kv_cache_quant_method, and quant_dynamic from config."""
     quant_cfg = raw_config.get("quantization_config")
     quant_cfg = quant_cfg if isinstance(quant_cfg, dict) else {}
 
@@ -740,6 +762,7 @@ def _infer_quantization_fields(raw_config: dict) -> dict[str, object]:
 
 
 def _attach_inferred_quant_fields(raw_config: dict) -> dict:
+    """Attach inferred quantization fields to config, checking text_config for multimodal models."""
     # For multimodal models the quantization_config may live under text_config.
     # Promote it to the top level so downstream inference picks it up.
     if "quantization_config" not in raw_config:
@@ -756,6 +779,7 @@ def _attach_inferred_quant_fields(raw_config: dict) -> dict:
 
 
 def _attach_hf_quant_config(raw_config: dict, hf_quant_config: dict | None) -> dict:
+    """Merge normalized hf_quant_config fields into raw_config if present."""
     if not hf_quant_config:
         return raw_config
     raw_config["hf_quant_config"] = hf_quant_config

--- a/src/aiconfigurator/sdk/utils.py
+++ b/src/aiconfigurator/sdk/utils.py
@@ -17,7 +17,7 @@ from aiconfigurator.sdk.common import (
     MULTIMODAL_TEXT_CONFIG_KEY,
     BlockConfig,
     DefaultHFModels,
-    HybridConfig,
+    HybridMoEConfig,
 )
 
 logger = logging.getLogger(__name__)
@@ -522,7 +522,7 @@ def _parse_hf_config_json(config: dict) -> dict:
             )
         if any(v not in (0, 1) for v in (*attn_pattern, *moe_layer_freq)):
             raise ValueError(f"Hybrid patterns for {architecture} must contain only 0/1 values")
-        extra_params = HybridConfig(
+        extra_params = HybridMoEConfig(
             attn_layer_pattern=attn_pattern,
             moe_layer_freq=moe_layer_freq,
             swa_num_kv_heads=config.get("swa_num_key_value_heads", 0),
@@ -548,7 +548,7 @@ def _parse_hf_config_json(config: dict) -> dict:
             raise ValueError(f"interleave_moe_layer_step must be a positive integer, got {step}")
         attn_pattern = tuple(i % 2 for i in range(layers))
         moe_freq = tuple(1 if (i + 1) % step == 0 else 0 for i in range(layers))
-        extra_params = HybridConfig(
+        extra_params = HybridMoEConfig(
             attn_layer_pattern=attn_pattern,
             moe_layer_freq=moe_freq,
             # All attention dims are uniform (0 → fall back to model-level defaults).

--- a/src/aiconfigurator/sdk/utils.py
+++ b/src/aiconfigurator/sdk/utils.py
@@ -17,6 +17,7 @@ from aiconfigurator.sdk.common import (
     MULTIMODAL_TEXT_CONFIG_KEY,
     BlockConfig,
     DefaultHFModels,
+    Llama4Config,
 )
 
 logger = logging.getLogger(__name__)
@@ -505,6 +506,19 @@ def _parse_hf_config_json(config: dict) -> dict:
     elif architecture == "DeciLMForCausalLM":
         if "block_configs" in config:
             extra_params = _parse_nemotron_block_configs(config["block_configs"])
+    elif architecture == "Llama4ForConditionalGeneration":
+        extra_params = Llama4Config(
+            interleave_moe_layer_step=config.get("interleave_moe_layer_step", 1),
+            dense_inter_size=config.get("intermediate_size_mlp", 0),
+            attention_chunk_size=config.get("attention_chunk_size", 0),
+        )
+        moe_count = sum(1 for i in range(layers) if (i + 1) % extra_params.interleave_moe_layer_step == 0)
+        logger.info(
+            f"Llama4 config: interleave_moe_layer_step={extra_params.interleave_moe_layer_step}, "
+            f"moe_layers={moe_count}, dense_layers={layers - moe_count}, "
+            f"local_attn_layers={layers // 2}, global_attn_layers={layers - layers // 2}, "
+            f"attention_chunk_size={extra_params.attention_chunk_size}"
+        )
     return {
         "architecture": architecture,
         "layers": layers,

--- a/src/aiconfigurator/sdk/utils.py
+++ b/src/aiconfigurator/sdk/utils.py
@@ -17,7 +17,7 @@ from aiconfigurator.sdk.common import (
     MULTIMODAL_TEXT_CONFIG_KEY,
     BlockConfig,
     DefaultHFModels,
-    Llama4Config,
+    HybridConfig,
 )
 
 logger = logging.getLogger(__name__)
@@ -506,18 +506,50 @@ def _parse_hf_config_json(config: dict) -> dict:
     elif architecture == "DeciLMForCausalLM":
         if "block_configs" in config:
             extra_params = _parse_nemotron_block_configs(config["block_configs"])
-    elif architecture == "Llama4ForConditionalGeneration":
-        extra_params = Llama4Config(
-            interleave_moe_layer_step=config.get("interleave_moe_layer_step", 1),
-            dense_inter_size=config.get("intermediate_size_mlp", 0),
-            attention_chunk_size=config.get("attention_chunk_size", 0),
+    elif architecture == "MiMoV2FlashForCausalLM":
+        # MiMo-V2-Flash: per-layer attention + FFN patterns; different dims for SWA vs global.
+        moe_layer_freq_raw = config.get("moe_layer_freq", [])
+        moe_layer_freq = (
+            tuple(moe_layer_freq_raw)
+            if isinstance(moe_layer_freq_raw, list)
+            else tuple([moe_layer_freq_raw] * layers)
         )
-        moe_count = sum(1 for i in range(layers) if (i + 1) % extra_params.interleave_moe_layer_step == 0)
+        extra_params = HybridConfig(
+            attn_layer_pattern=tuple(config.get("hybrid_layer_pattern", [])),
+            moe_layer_freq=moe_layer_freq,
+            swa_num_kv_heads=config.get("swa_num_key_value_heads", 0),
+            swa_head_dim=config.get("swa_head_dim", 0),
+            swa_v_head_dim=config.get("swa_v_head_dim", 0),
+            global_v_head_dim=config.get("v_head_dim", 0),
+            sliding_window_size=config.get("sliding_window_size", 0),
+            dense_inter_size=0,  # dense layers use model-level inter_size
+        )
         logger.info(
-            f"Llama4 config: interleave_moe_layer_step={extra_params.interleave_moe_layer_step}, "
-            f"moe_layers={moe_count}, dense_layers={layers - moe_count}, "
-            f"local_attn_layers={layers // 2}, global_attn_layers={layers - layers // 2}, "
-            f"attention_chunk_size={extra_params.attention_chunk_size}"
+            f"MiMo-V2-Flash hybrid config: "
+            f"global_attn_layers={sum(extra_params.attn_layer_pattern)}, "
+            f"swa_layers={extra_params.attn_layer_pattern.count(0)}, "
+            f"moe_layers={sum(extra_params.moe_layer_freq)}, "
+            f"dense_layers={extra_params.moe_layer_freq.count(0)}"
+        )
+    elif architecture == "Llama4ForConditionalGeneration":
+        # Llama 4: step-based patterns — generate normalized per-layer tuples.
+        # Attention: even layers → local (0), odd layers → global (1).
+        # FFN: layer i is MoE (1) if (i+1) % interleave_moe_layer_step == 0, else dense (0).
+        step = config.get("interleave_moe_layer_step", 1)
+        attn_pattern = tuple(i % 2 for i in range(layers))
+        moe_freq = tuple(1 if (i + 1) % step == 0 else 0 for i in range(layers))
+        extra_params = HybridConfig(
+            attn_layer_pattern=attn_pattern,
+            moe_layer_freq=moe_freq,
+            # All attention dims are uniform (0 → fall back to model-level defaults).
+            sliding_window_size=config.get("attention_chunk_size", 0),
+            dense_inter_size=config.get("intermediate_size_mlp", 0),
+        )
+        logger.info(
+            f"Llama4 hybrid config: interleave_moe_layer_step={step}, "
+            f"global_attn_layers={sum(attn_pattern)}, local_attn_layers={attn_pattern.count(0)}, "
+            f"moe_layers={sum(moe_freq)}, dense_layers={moe_freq.count(0)}, "
+            f"sliding_window_size={extra_params.sliding_window_size}"
         )
     return {
         "architecture": architecture,

--- a/tests/unit/sdk/test_utils.py
+++ b/tests/unit/sdk/test_utils.py
@@ -187,7 +187,7 @@ class TestParseHFConfig:
 
 
     def test_parse_llama4_scout_config(self):
-        """Test parsing a Llama 4 Scout config (VLM with text_config nesting, all-MoE, step=1)."""
+        """Test Llama 4 Scout (VLM, step=1: all-MoE) → HybridConfig with alternating attn pattern."""
         config = {
             "architectures": ["Llama4ForConditionalGeneration"],
             "model_type": "llama4",
@@ -212,21 +212,22 @@ class TestParseHFConfig:
 
         assert result["architecture"] == "Llama4ForConditionalGeneration"
         assert result["layers"] == 48
-        assert result["hidden_size"] == 5120
-        assert result["n"] == 40
-        assert result["n_kv"] == 8
-        assert result["d"] == 128
-        assert result["topk"] == 1
         assert result["num_experts"] == 16
         assert result["moe_inter_size"] == 8192
-        extra_params = result["extra_params"]
-        assert extra_params is not None
-        assert extra_params.interleave_moe_layer_step == 1
-        assert extra_params.dense_inter_size == 16384
-        assert extra_params.attention_chunk_size == 8192
+        cfg = result["extra_params"]
+        assert cfg is not None
+        # step=1: all layers MoE
+        assert all(m == 1 for m in cfg.moe_layer_freq)
+        # alternating local(0)/global(1): even=0, odd=1
+        assert cfg.attn_layer_pattern == tuple(i % 2 for i in range(48))
+        assert cfg.sliding_window_size == 8192
+        assert cfg.dense_inter_size == 16384
+        # Llama 4 uses same dims for all layers → all four dim fields are 0
+        assert cfg.swa_num_kv_heads == 0
+        assert cfg.swa_head_dim == 0
 
     def test_parse_llama4_maverick_config(self):
-        """Test parsing a Llama 4 Maverick config (VLM, alternating MoE/dense, step=2)."""
+        """Test Llama 4 Maverick (VLM, step=2: alternating MoE/dense) → HybridConfig."""
         config = {
             "architectures": ["Llama4ForConditionalGeneration"],
             "model_type": "llama4",
@@ -251,11 +252,52 @@ class TestParseHFConfig:
 
         assert result["architecture"] == "Llama4ForConditionalGeneration"
         assert result["num_experts"] == 128
-        extra_params = result["extra_params"]
-        assert extra_params is not None
-        assert extra_params.interleave_moe_layer_step == 2
-        assert extra_params.dense_inter_size == 16384
-        assert extra_params.attention_chunk_size == 8192
+        cfg = result["extra_params"]
+        # step=2: odd layers are MoE (1), even layers are dense (0)
+        assert sum(cfg.moe_layer_freq) == 24   # 24 MoE layers
+        assert cfg.moe_layer_freq.count(0) == 24  # 24 dense layers
+        assert cfg.dense_inter_size == 16384
+
+    def test_parse_mimov2flash_config(self):
+        """Test MiMo-V2-Flash (explicit per-layer patterns, different SWA/global dims) → HybridConfig."""
+        hybrid_pattern = [0, 1, 1, 1, 1, 0, 1, 1, 1, 1]  # 10-layer test
+        moe_freq = [0, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+        config = {
+            "architectures": ["MiMoV2FlashForCausalLM"],
+            "num_hidden_layers": 10,
+            "hidden_size": 4096,
+            "num_attention_heads": 64,
+            "num_key_value_heads": 4,
+            "head_dim": 192,
+            "v_head_dim": 128,
+            "intermediate_size": 16384,
+            "vocab_size": 152576,
+            "max_position_embeddings": 262144,
+            "num_experts_per_tok": 8,
+            "num_local_experts": 64,
+            "moe_intermediate_size": 2048,
+            "hybrid_layer_pattern": hybrid_pattern,
+            "moe_layer_freq": moe_freq,
+            "swa_num_key_value_heads": 8,
+            "swa_head_dim": 192,
+            "swa_v_head_dim": 128,
+            "sliding_window_size": 128,
+        }
+
+        result = _parse_hf_config_json(config)
+
+        assert result["architecture"] == "MiMoV2FlashForCausalLM"
+        assert result["layers"] == 10
+        cfg = result["extra_params"]
+        assert cfg is not None
+        assert cfg.attn_layer_pattern == tuple(hybrid_pattern)
+        assert cfg.moe_layer_freq == tuple(moe_freq)
+        assert cfg.swa_num_kv_heads == 8
+        assert cfg.swa_head_dim == 192
+        assert cfg.swa_v_head_dim == 128
+        assert cfg.global_v_head_dim == 128  # from v_head_dim
+        assert cfg.sliding_window_size == 128
+        assert cfg.dense_inter_size == 0  # dense layers use model-level inter_size
 
 
 class TestGetModelConfigFromHFID:

--- a/tests/unit/sdk/test_utils.py
+++ b/tests/unit/sdk/test_utils.py
@@ -11,6 +11,8 @@ from unittest.mock import patch
 
 import pytest
 
+from aiconfigurator.sdk import common, config
+from aiconfigurator.sdk.models import HybridMoEModel
 from aiconfigurator.sdk.utils import (
     _parse_hf_config_json,
     enumerate_ttft_tpot_constraints,
@@ -262,7 +264,7 @@ class TestParseHFConfig:
         """Test MiMo-V2-Flash (explicit per-layer patterns, different SWA/global dims) → HybridConfig."""
         hybrid_pattern = [0, 1, 1, 1, 1, 0, 1, 1, 1, 1]  # 10-layer test
         moe_freq = [0, 1, 1, 1, 1, 1, 1, 1, 1, 1]
-        config = {
+        hf_config = {
             "architectures": ["MiMoV2FlashForCausalLM"],
             "num_hidden_layers": 10,
             "hidden_size": 4096,
@@ -284,7 +286,7 @@ class TestParseHFConfig:
             "sliding_window_size": 128,
         }
 
-        result = _parse_hf_config_json(config)
+        result = _parse_hf_config_json(hf_config)
 
         assert result["architecture"] == "MiMoV2FlashForCausalLM"
         assert result["layers"] == 10
@@ -298,6 +300,137 @@ class TestParseHFConfig:
         assert cfg.global_v_head_dim == 128  # from v_head_dim
         assert cfg.sliding_window_size == 128
         assert cfg.dense_inter_size == 0  # dense layers use model-level inter_size
+
+    def test_mimo_pattern_length_mismatch_raises(self):
+        """Test that mismatched hybrid pattern length raises ValueError."""
+        hf_config = {
+            "architectures": ["MiMoV2FlashForCausalLM"],
+            "num_hidden_layers": 10,
+            "hidden_size": 4096,
+            "num_attention_heads": 64,
+            "num_key_value_heads": 4,
+            "head_dim": 192,
+            "intermediate_size": 16384,
+            "vocab_size": 152576,
+            "max_position_embeddings": 262144,
+            "num_experts_per_tok": 8,
+            "num_local_experts": 64,
+            "moe_intermediate_size": 2048,
+            "hybrid_layer_pattern": [0, 1, 1],  # wrong length
+            "moe_layer_freq": [0, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+        }
+        with pytest.raises(ValueError, match="pattern length mismatch"):
+            _parse_hf_config_json(hf_config)
+
+    def test_llama4_invalid_step_raises(self):
+        """Test that interleave_moe_layer_step <= 0 raises ValueError."""
+        hf_config = {
+            "architectures": ["Llama4ForConditionalGeneration"],
+            "text_config": {
+                "num_hidden_layers": 8,
+                "hidden_size": 1024,
+                "num_attention_heads": 8,
+                "num_key_value_heads": 2,
+                "head_dim": 128,
+                "intermediate_size": 2048,
+                "vocab_size": 10000,
+                "max_position_embeddings": 4096,
+                "num_experts_per_tok": 1,
+                "num_local_experts": 4,
+                "interleave_moe_layer_step": 0,
+                "attention_chunk_size": 512,
+            },
+        }
+        with pytest.raises(ValueError, match="positive integer"):
+            _parse_hf_config_json(hf_config)
+
+
+class TestHybridMoEModelBuilder:
+    """Builder-level tests that verify HybridMoEModel wiring through set_hybrid_config."""
+
+    @staticmethod
+    def _make_model_config():
+        return config.ModelConfig(
+            tp_size=1,
+            pp_size=1,
+            moe_tp_size=1,
+            moe_ep_size=1,
+            attention_dp_size=1,
+            gemm_quant_mode=common.GEMMQuantMode.float16,
+            kvcache_quant_mode=common.KVCacheQuantMode.float16,
+            fmha_quant_mode=common.FMHAQuantMode.float16,
+            moe_quant_mode=common.MoEQuantMode.float16,
+        )
+
+    def test_mimov2flash_model_builds_all_three_layer_types(self):
+        """MiMo-V2-Flash config produces context/generation ops for global_moe, swa_moe, swa_dense."""
+        hybrid_cfg = common.HybridConfig(
+            attn_layer_pattern=(0, 1, 1, 1, 1, 0, 1, 1, 1, 1),
+            moe_layer_freq=(0, 1, 1, 1, 1, 1, 1, 1, 1, 1),
+            swa_num_kv_heads=8, swa_head_dim=192, swa_v_head_dim=128,
+            global_v_head_dim=128, sliding_window_size=128,
+        )
+        model = HybridMoEModel(
+            8, 64, 2048,   # topk, num_experts, moe_inter_size
+            "test-model", "HYBRIDMOE", "MiMoV2FlashForCausalLM",
+            10, 64, 4, 192, 4096, 16384, 152576, 262144,
+            self._make_model_config(),
+        )
+        model.set_hybrid_config(hybrid_cfg)
+
+        assert len(model.context_ops) > 0
+        assert len(model.generation_ops) > 0
+        op_names = [op._name for op in model.context_ops]
+        assert any("global" in n for n in op_names), "Missing global attention ops"
+        assert any("swa" in n and "moe" in n for n in op_names), "Missing swa_moe ops"
+        assert any("swa" in n and "dense" in n for n in op_names), "Missing swa_dense ops"
+
+    def test_llama4_scout_model_builds_global_and_swa_moe(self):
+        """Llama 4 Scout (step=1, all MoE) produces global_moe + swa_moe ops."""
+        layers = 8
+        hybrid_cfg = common.HybridConfig(
+            attn_layer_pattern=tuple(i % 2 for i in range(layers)),
+            moe_layer_freq=tuple(1 for _ in range(layers)),
+            sliding_window_size=8192,
+            dense_inter_size=16384,
+        )
+        model = HybridMoEModel(
+            1, 16, 8192,   # topk, num_experts, moe_inter_size
+            "test-model", "HYBRIDMOE", "Llama4ForConditionalGeneration",
+            layers, 40, 8, 128, 5120, 8192, 202048, 10485760,
+            self._make_model_config(),
+        )
+        model.set_hybrid_config(hybrid_cfg)
+
+        assert len(model.context_ops) > 0
+        assert len(model.generation_ops) > 0
+        op_names = [op._name for op in model.context_ops]
+        assert any("global" in n for n in op_names)
+        assert any("swa" in n for n in op_names)
+        assert not any("dense" in n for n in op_names), "Scout has no dense layers"
+
+    def test_llama4_maverick_model_builds_global_moe_and_swa_dense(self):
+        """Llama 4 Maverick (step=2) produces global_moe + swa_dense ops."""
+        layers = 8
+        step = 2
+        hybrid_cfg = common.HybridConfig(
+            attn_layer_pattern=tuple(i % 2 for i in range(layers)),
+            moe_layer_freq=tuple(1 if (i + 1) % step == 0 else 0 for i in range(layers)),
+            sliding_window_size=8192,
+            dense_inter_size=16384,
+        )
+        model = HybridMoEModel(
+            1, 128, 8192,   # topk, num_experts, moe_inter_size
+            "test-model", "HYBRIDMOE", "Llama4ForConditionalGeneration",
+            layers, 40, 8, 128, 5120, 8192, 202048, 1048576,
+            self._make_model_config(),
+        )
+        model.set_hybrid_config(hybrid_cfg)
+
+        assert len(model.context_ops) > 0
+        op_names = [op._name for op in model.context_ops]
+        assert any("global" in n and "moe" in n for n in op_names)
+        assert any("dense" in n for n in op_names), "Maverick needs dense FFN ops"
 
 
 class TestGetModelConfigFromHFID:

--- a/tests/unit/sdk/test_utils.py
+++ b/tests/unit/sdk/test_utils.py
@@ -186,6 +186,78 @@ class TestParseHFConfig:
         assert extra_params.moe_shared_expert_intermediate_size == 0
 
 
+    def test_parse_llama4_scout_config(self):
+        """Test parsing a Llama 4 Scout config (VLM with text_config nesting, all-MoE, step=1)."""
+        config = {
+            "architectures": ["Llama4ForConditionalGeneration"],
+            "model_type": "llama4",
+            "text_config": {
+                "num_hidden_layers": 48,
+                "hidden_size": 5120,
+                "num_attention_heads": 40,
+                "num_key_value_heads": 8,
+                "head_dim": 128,
+                "intermediate_size": 8192,
+                "intermediate_size_mlp": 16384,
+                "vocab_size": 202048,
+                "max_position_embeddings": 10485760,
+                "num_experts_per_tok": 1,
+                "num_local_experts": 16,
+                "interleave_moe_layer_step": 1,
+                "attention_chunk_size": 8192,
+            },
+        }
+
+        result = _parse_hf_config_json(config)
+
+        assert result["architecture"] == "Llama4ForConditionalGeneration"
+        assert result["layers"] == 48
+        assert result["hidden_size"] == 5120
+        assert result["n"] == 40
+        assert result["n_kv"] == 8
+        assert result["d"] == 128
+        assert result["topk"] == 1
+        assert result["num_experts"] == 16
+        assert result["moe_inter_size"] == 8192
+        extra_params = result["extra_params"]
+        assert extra_params is not None
+        assert extra_params.interleave_moe_layer_step == 1
+        assert extra_params.dense_inter_size == 16384
+        assert extra_params.attention_chunk_size == 8192
+
+    def test_parse_llama4_maverick_config(self):
+        """Test parsing a Llama 4 Maverick config (VLM, alternating MoE/dense, step=2)."""
+        config = {
+            "architectures": ["Llama4ForConditionalGeneration"],
+            "model_type": "llama4",
+            "text_config": {
+                "num_hidden_layers": 48,
+                "hidden_size": 5120,
+                "num_attention_heads": 40,
+                "num_key_value_heads": 8,
+                "head_dim": 128,
+                "intermediate_size": 8192,
+                "intermediate_size_mlp": 16384,
+                "vocab_size": 202048,
+                "max_position_embeddings": 1048576,
+                "num_experts_per_tok": 1,
+                "num_local_experts": 128,
+                "interleave_moe_layer_step": 2,
+                "attention_chunk_size": 8192,
+            },
+        }
+
+        result = _parse_hf_config_json(config)
+
+        assert result["architecture"] == "Llama4ForConditionalGeneration"
+        assert result["num_experts"] == 128
+        extra_params = result["extra_params"]
+        assert extra_params is not None
+        assert extra_params.interleave_moe_layer_step == 2
+        assert extra_params.dense_inter_size == 16384
+        assert extra_params.attention_chunk_size == 8192
+
+
 class TestGetModelConfigFromHFID:
     """Test getting model config from HuggingFace ID."""
 

--- a/tests/unit/sdk/test_utils.py
+++ b/tests/unit/sdk/test_utils.py
@@ -187,7 +187,6 @@ class TestParseHFConfig:
         assert "E" not in extra_params.hybrid_override_pattern  # No MoE layers
         assert extra_params.moe_shared_expert_intermediate_size == 0
 
-
     def test_parse_llama4_scout_config(self):
         """Test Llama 4 Scout (VLM, step=1: all-MoE) → HybridConfig with alternating attn pattern."""
         config = {
@@ -256,7 +255,7 @@ class TestParseHFConfig:
         assert result["num_experts"] == 128
         cfg = result["extra_params"]
         # step=2: odd layers are MoE (1), even layers are dense (0)
-        assert sum(cfg.moe_layer_freq) == 24   # 24 MoE layers
+        assert sum(cfg.moe_layer_freq) == 24  # 24 MoE layers
         assert cfg.moe_layer_freq.count(0) == 24  # 24 dense layers
         assert cfg.dense_inter_size == 16384
 
@@ -367,13 +366,27 @@ class TestHybridMoEModelBuilder:
         hybrid_cfg = common.HybridConfig(
             attn_layer_pattern=(0, 1, 1, 1, 1, 0, 1, 1, 1, 1),
             moe_layer_freq=(0, 1, 1, 1, 1, 1, 1, 1, 1, 1),
-            swa_num_kv_heads=8, swa_head_dim=192, swa_v_head_dim=128,
-            global_v_head_dim=128, sliding_window_size=128,
+            swa_num_kv_heads=8,
+            swa_head_dim=192,
+            swa_v_head_dim=128,
+            global_v_head_dim=128,
+            sliding_window_size=128,
         )
         model = HybridMoEModel(
-            8, 64, 2048,   # topk, num_experts, moe_inter_size
-            "test-model", "HYBRIDMOE", "MiMoV2FlashForCausalLM",
-            10, 64, 4, 192, 4096, 16384, 152576, 262144,
+            8,
+            64,
+            2048,  # topk, num_experts, moe_inter_size
+            "test-model",
+            "HYBRIDMOE",
+            "MiMoV2FlashForCausalLM",
+            10,
+            64,
+            4,
+            192,
+            4096,
+            16384,
+            152576,
+            262144,
             self._make_model_config(),
         )
         model.set_hybrid_config(hybrid_cfg)
@@ -395,9 +408,20 @@ class TestHybridMoEModelBuilder:
             dense_inter_size=16384,
         )
         model = HybridMoEModel(
-            1, 16, 8192,   # topk, num_experts, moe_inter_size
-            "test-model", "HYBRIDMOE", "Llama4ForConditionalGeneration",
-            layers, 40, 8, 128, 5120, 8192, 202048, 10485760,
+            1,
+            16,
+            8192,  # topk, num_experts, moe_inter_size
+            "test-model",
+            "HYBRIDMOE",
+            "Llama4ForConditionalGeneration",
+            layers,
+            40,
+            8,
+            128,
+            5120,
+            8192,
+            202048,
+            10485760,
             self._make_model_config(),
         )
         model.set_hybrid_config(hybrid_cfg)
@@ -420,9 +444,20 @@ class TestHybridMoEModelBuilder:
             dense_inter_size=16384,
         )
         model = HybridMoEModel(
-            1, 128, 8192,   # topk, num_experts, moe_inter_size
-            "test-model", "HYBRIDMOE", "Llama4ForConditionalGeneration",
-            layers, 40, 8, 128, 5120, 8192, 202048, 1048576,
+            1,
+            128,
+            8192,  # topk, num_experts, moe_inter_size
+            "test-model",
+            "HYBRIDMOE",
+            "Llama4ForConditionalGeneration",
+            layers,
+            40,
+            8,
+            128,
+            5120,
+            8192,
+            202048,
+            1048576,
             self._make_model_config(),
         )
         model.set_hybrid_config(hybrid_cfg)

--- a/tests/unit/sdk/test_utils.py
+++ b/tests/unit/sdk/test_utils.py
@@ -188,7 +188,7 @@ class TestParseHFConfig:
         assert extra_params.moe_shared_expert_intermediate_size == 0
 
     def test_parse_llama4_scout_config(self):
-        """Test Llama 4 Scout (VLM, step=1: all-MoE) → HybridConfig with alternating attn pattern."""
+        """Test Llama 4 Scout (VLM, step=1: all-MoE) → HybridMoEConfig with alternating attn pattern."""
         config = {
             "architectures": ["Llama4ForConditionalGeneration"],
             "model_type": "llama4",
@@ -228,7 +228,7 @@ class TestParseHFConfig:
         assert cfg.swa_head_dim == 0
 
     def test_parse_llama4_maverick_config(self):
-        """Test Llama 4 Maverick (VLM, step=2: alternating MoE/dense) → HybridConfig."""
+        """Test Llama 4 Maverick (VLM, step=2: alternating MoE/dense) → HybridMoEConfig."""
         config = {
             "architectures": ["Llama4ForConditionalGeneration"],
             "model_type": "llama4",
@@ -260,7 +260,7 @@ class TestParseHFConfig:
         assert cfg.dense_inter_size == 16384
 
     def test_parse_mimov2flash_config(self):
-        """Test MiMo-V2-Flash (explicit per-layer patterns, different SWA/global dims) → HybridConfig."""
+        """Test MiMo-V2-Flash (explicit per-layer patterns, different SWA/global dims) → HybridMoEConfig."""
         hybrid_pattern = [0, 1, 1, 1, 1, 0, 1, 1, 1, 1]  # 10-layer test
         moe_freq = [0, 1, 1, 1, 1, 1, 1, 1, 1, 1]
         hf_config = {
@@ -363,7 +363,7 @@ class TestHybridMoEModelBuilder:
 
     def test_mimov2flash_model_builds_all_three_layer_types(self):
         """MiMo-V2-Flash config produces context/generation ops for global_moe, swa_moe, swa_dense."""
-        hybrid_cfg = common.HybridConfig(
+        hybrid_cfg = common.HybridMoEConfig(
             attn_layer_pattern=(0, 1, 1, 1, 1, 0, 1, 1, 1, 1),
             moe_layer_freq=(0, 1, 1, 1, 1, 1, 1, 1, 1, 1),
             swa_num_kv_heads=8,
@@ -401,7 +401,7 @@ class TestHybridMoEModelBuilder:
     def test_llama4_scout_model_builds_global_and_swa_moe(self):
         """Llama 4 Scout (step=1, all MoE) produces global_moe + swa_moe ops."""
         layers = 8
-        hybrid_cfg = common.HybridConfig(
+        hybrid_cfg = common.HybridMoEConfig(
             attn_layer_pattern=tuple(i % 2 for i in range(layers)),
             moe_layer_freq=tuple(1 for _ in range(layers)),
             sliding_window_size=8192,
@@ -437,7 +437,7 @@ class TestHybridMoEModelBuilder:
         """Llama 4 Maverick (step=2) produces global_moe + swa_dense ops."""
         layers = 8
         step = 2
-        hybrid_cfg = common.HybridConfig(
+        hybrid_cfg = common.HybridMoEConfig(
             attn_layer_pattern=tuple(i % 2 for i in range(layers)),
             moe_layer_freq=tuple(1 if (i + 1) % step == 0 else 0 for i in range(layers)),
             sliding_window_size=8192,


### PR DESCRIPTION
## Summary

Introduces a unified `HYBRIDMOE` model family and `HybridMoEConfig` dataclass that covers all hybrid-attention + mixed-FFN models, replacing two separate implementations.

**Problem:** MiMo-V2-Flash and Llama 4 Scout/Maverick share the same fundamental structure — interleaved SWA/local + global attention, interleaved MoE + dense FFN layers — but were being treated as separate concerns requiring separate config classes and model implementations.

**Solution:** One `HybridMoEConfig`, one `HybridMoEModel`, one `HYBRIDMOE` family.

---

### `HybridMoEConfig` design

Normalizes both pattern styles into per-layer tuples:

| Field | Description |
|---|---|
| `attn_layer_pattern` | per-layer `0=SWA/local, 1=global`, len=`num_layers` |
| `moe_layer_freq` | per-layer `0=dense, 1=MoE`, len=`num_layers` |
| `swa_*` / `global_v_head_dim` | 0 = fall back to model defaults (Llama 4 has same dims; MiMo differs) |
| `sliding_window_size` | local attention window |
| `dense_inter_size` | 0 = use model-level `inter_size` |

MiMo-V2-Flash passes explicit per-layer lists from config. Llama 4 generates the lists at parse time from `interleave_moe_layer_step` and alternating attention.

---

### `HybridMoEModel` — 4 layer types

| Type | Attention | FFN |
|---|---|---|
| `global_moe` | global (full) | MoE |
| `swa_moe` | SWA/local | MoE |
| `swa_dense` | SWA/local | dense SwiGLU |
| `global_dense` | global (full) | dense SwiGLU |

---

### Layer type decomposition (validated)

| Model | global_moe | swa_moe | swa_dense | global_dense |
|---|---|---|---|---|
| Llama 4 Scout (16E, step=1) | 24 | 24 | 0 | 0 |
| Llama 4 Maverick (128E, step=2) | 24 | 0 | 24 | 0 |
| MiMo-V2-Flash | 39 | 8 | 1 | 0 |

---

### Files changed

- `sdk/common.py`: `HybridMoEConfig` dataclass; `HYBRIDMOE` added to `ModelFamily`; `MiMoV2FlashForCausalLM` + `Llama4ForConditionalGeneration` registered in `HYBRIDMOE`
- `sdk/utils.py`: unified parsing for both architectures → both produce `HybridMoEConfig`; input validation (pattern length, values ∈ {0,1}, step > 0)
- `sdk/models.py`: `HybridMoEModel` covers all 4 layer types; wired into `get_model()` and `check_is_moe()`; MTP/nextn scaling on generation ops (mirrors `MOEModel`); `set_hybrid_config()` validates pattern length == `num_layers` and 0/1 values
- `model_configs/`: Llama 4 Scout + Maverick + MiMo-V2-Flash + MiMo-7B-Base configs added
- `tests/`: parsing tests (Scout, Maverick, MiMo-V2-Flash), negative tests (pattern mismatch, invalid step), builder-level tests (all three model variants)

## Test plan

- [ ] `pytest tests/unit/sdk/test_utils.py` — all hybrid parsing + builder tests pass
- [ ] `pytest tests/unit/sdk/` — full suite passes
- [ ] Manually verify layer counts for Scout / Maverick / MiMo-V2-Flash via `get_model()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for four new models: Meta Llama‑4 Scout & Maverick (17B variants) and Xiaomi MiMo‑7B Base & MiMo V2 Flash.
  * Introduced Hybrid Mixture-of-Experts (HybridMoE) model runtime and registry integration.

* **Enhancements**
  * Improved model config handling with per-layer hybrid patterns, sliding-window/MoE settings, and enhanced quantization inference/normalization.
  * Expanded default model listings and architecture mappings.

* **Tests**
  * Added unit tests for HF config parsing and HybridMoE model wiring and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->