### PR TITLE
feat: agent skill for adding a new hybrid architecture model

### DIFF
--- a/agents/add-hybrid-model/SKILL.md
+++ b/agents/add-hybrid-model/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: add-hybrid-model
+description: |
+  Add support for a new hybrid architecture model to aiconfigurator.
+  Use when adding a model with heterogeneous layer types: mixed attention variants
+  (SWA + global, linear + full), mixed FFN types (dense + MoE), or both.
+  This skill guides through: Situation Assessment → Model Config → Registration → Parsing → Model Class → Testing.
+---
+
+# Add Hybrid Architecture Model Skill
+
+> **Background**: "Hybrid" means the model has layers of different types rather than a uniform stack.
+> Examples: MiMo-V2-Flash (SWA + global attention + MoE), Qwen3.5-MoE (linear attention + full attention + MoE),
+> NemotronH (Mamba + Transformer + MoE). Each layer type needs separate op cost modeling.
+
+## Step 0: Determine the Situation (Mandatory)
+
+Before making any changes, classify which situation you are in. Required effort varies significantly.
+
+| Situation | Description | Required Phases |
+|-----------|-------------|-----------------|
+| **S1: Existing family, same ops** | Architecture fits an existing family (e.g., another LLAMA or MOE variant) | Phase 1 only |
+| **S2: Existing family, new config fields** | Architecture fits an existing family but has extra config params (e.g., MTP support, MLA dims) | Phases 1–2 + part of 3 |
+| **S3: New hybrid family** | Model has fundamentally new layer-type heterogeneity needing a new model class | Full Phases 1–5 |
+
+**How to decide**:
+
+```
+1. Read config.json; note the architecture field.
+2. Check whether config["architectures"][0] exists in ARCHITECTURE_TO_MODEL_FAMILY (common.py line ~283).
+   -> Exists AND layer structure is uniform -> S1
+   -> Exists but has new config fields (MTP, MLA, VLM nesting) -> S2
+3. If architecture is unknown, check whether any existing model class can represent it:
+   -> All layer types already modeled (e.g., standard attention + standard MoE) -> S1 or S2
+   -> At least one layer type combination is new (e.g., linear-attention + MoE, SWA + dense) -> S3
+```
+
+---
+
+## Key File Paths (Quick Reference)
+
+| File | Path | Purpose |
+|------|------|---------|
+| Architecture mapping & families | `src/aiconfigurator/sdk/common.py` | `ModelFamily`, `ARCHITECTURE_TO_MODEL_FAMILY`, `DefaultHFModels`, config dataclasses |
+| Config parsing | `src/aiconfigurator/sdk/utils.py` | `_parse_hf_config_json()` |
+| Model classes | `src/aiconfigurator/sdk/models.py` | `BaseModel`, all model subclasses, `get_model()`, `check_is_moe()` |
+| Model config JSONs | `src/aiconfigurator/model_configs/` | One JSON per model; filename = `<Org>--<Model>_config.json` |
+| Unit tests | `tests/unit/sdk/test_utils.py` | Config parsing tests |
+| Support matrix | `src/aiconfigurator/systems/support_matrix.csv` | Tested model/system/backend combinations |
+
+---
+
+## Phase 1: Model Config JSON
+
+**Goal**: Create the HuggingFace-format config file for aiconfigurator to read.
+
+**Reference**: `agents/add-hybrid-model/references/phase1-model-config.md`
+
+**Done criteria**: File exists at `src/aiconfigurator/model_configs/<Org>--<Model>_config.json` with all required fields, including hybrid-specific per-layer pattern fields.
+
+---
+
+## Phase 2: Registration in `common.py`
+
+**Goal**: Register the new architecture, family, model ID, and config dataclass so the rest of the codebase can recognize it.
+
+**Reference**: `agents/add-hybrid-model/references/phase2-registration.md`
+
+**Done criteria**: `_architecture_to_model_family("NewArchForCausalLM")` returns the expected family string; model ID appears in `DefaultHFModels`.
+
+---
+
+## Phase 3: Config Parsing in `utils.py`
+
+**Goal**: Extend `_parse_hf_config_json()` to parse hybrid-specific fields (layer type patterns, special attention dims, etc.) into the config dataclass as `extra_params`.
+
+**Reference**: `agents/add-hybrid-model/references/phase3-config-parsing.md`
+
+**Done criteria**: `get_model_config_from_model_path("<model-id>")["extra_params"]` returns the correct config dataclass instance with all fields populated.
+
+---
+
+## Phase 4: Model Class in `models.py`
+
+**Goal**: Implement a new model class (S3 only) that separates ops by layer type and correctly accounts for each layer type's compute cost, then wire it into `get_model()`.
+
+**Reference**: `agents/add-hybrid-model/references/phase4-model-class.md`
+
+**Done criteria**: `get_model("<model-id>", model_config, backend)` returns a model with non-empty `context_ops` and `generation_ops`; `check_is_moe()` returns correct value.
+
+---
+
+## Phase 5: Testing and Verification
+
+**Goal**: Add unit tests for config parsing and run end-to-end CLI validation.
+
+**Reference**: `agents/add-hybrid-model/references/phase5-testing.md`
+
+**Done criteria**: `pytest tests/unit/sdk/test_utils.py -v` passes; `aiconfigurator cli support` recognizes the model.
+
+---
+
+## Full Integration Checklist
+
+```
+□ Phase 1 — model_configs/<Org>--<Model>_config.json created with all fields
+□ Phase 2 — ARCHITECTURE_TO_MODEL_FAMILY entry added in common.py
+□ Phase 2 — ModelFamily set updated (if new family)
+□ Phase 2 — Model HF ID added to DefaultHFModels in common.py
+□ Phase 2 — Config dataclass added to common.py (if hybrid-specific params exist)
+□ Phase 3 — _parse_hf_config_json() updated in utils.py
+□ Phase 3 — VLM: text_config nesting handled (if ForConditionalGeneration)
+□ Phase 4 — New model class created in models.py (S3 only)
+□ Phase 4 — get_model() dispatches to new class
+□ Phase 4 — check_is_moe() updated (if model contains MoE layers)
+□ Phase 5 — Unit test added to tests/unit/sdk/test_utils.py
+□ Phase 5 — CLI validation passes
+```
+
+---
+
+## Lessons Learned (From Real Hybrid Model PRs)
+
+### 1. Deferred Initialization for Per-Layer-Pattern Models
+
+**Problem**: Layer type breakdown (which layers are SWA, which are global, etc.) is only known after the config is loaded, but `BaseModel.__init__` builds ops immediately.
+
+**Rule**: Store the hybrid config as an instance variable _before_ calling `super().__init__()`, then use it inside `_build_ops()` (or `set_<model>_config()`). See `NemotronHModel` as the reference pattern.
+
+### 2. Scale Factor Must Reflect Actual Layer Counts
+
+**Problem**: Using `self._num_layers` as the scale factor for all ops in a hybrid model double-counts or under-counts.
+
+**Rule**: Count layers of each type from the pattern (e.g., `pattern.count("G")` for global layers) and use those counts as individual scale factors.
+
+### 3. MoE Check Must Cover New Families
+
+**Problem**: `check_is_moe()` in `models.py` only knows about `MOE` and `DEEPSEEK`; new hybrid families are missed.
+
+**Rule**: Whenever a new family contains MoE layers, add it to the `if family in (...)` check in `check_is_moe()`.
+
+### 4. VLM Config Nesting
+
+**Problem**: VLMs (architectures ending in `ForConditionalGeneration`) nest LLM params under `text_config`. Standard field access (`config["num_hidden_layers"]`) will fail.
+
+**Rule**: Add the architecture to `VLM_ARCHITECTURES` in `utils.py` and use `config = config.get("text_config", config)` before reading standard fields. Parse `vision_config` separately.
+
+### 5. MTP Scale Factor for Non-DeepSeek Models
+
+**Problem**: MTP (Multi-Token Prediction) was originally only in DeepSeek. Extending it to other families (e.g., MOE for MiniMax-M2.5) requires removing `assert self._nextn == 0` guards.
+
+**Rule**: Apply the same `_mtp_scale_factor` formula used in `DeepSeekModel` wherever generation ops are built. Read `nextn` from `raw_config["num_mtp_modules"]` (or `num_nextn_predict_layers`).
+
+### 6. Pattern Fields Can Be List or Scalar
+
+**Problem**: Some models express layer types as a per-layer list (`["full", "linear", "full", ...]`), others as a scalar interval (`full_attention_interval: 4`).
+
+**Rule**: Normalize in `_parse_hf_config_json()`: if a list exists, use it; otherwise generate it from the scalar. Store the canonical list in the dataclass.

--- a/agents/add-hybrid-model/references/phase1-model-config.md
+++ b/agents/add-hybrid-model/references/phase1-model-config.md
@@ -1,0 +1,182 @@
+# Phase 1: Model Config JSON
+
+## Goal
+
+Create the HuggingFace-format config file so aiconfigurator can read the model's architecture parameters.
+
+## Steps
+
+### 1. Obtain the model's `config.json`
+
+```bash
+# Download from HuggingFace
+wget https://huggingface.co/<org>/<model>/raw/main/config.json
+
+# Or copy from a local model directory
+cp /path/to/model/config.json /tmp/
+```
+
+Focus on these fields:
+
+**Standard fields (always required):**
+- `architectures` — list with one architecture class name, e.g. `["MiMoV2FlashForCausalLM"]`
+- `num_hidden_layers`, `hidden_size`, `num_attention_heads`, `num_key_value_heads`
+- `head_dim` (or derivable as `hidden_size / num_attention_heads`)
+- `intermediate_size`, `vocab_size`, `max_position_embeddings`
+
+**MoE fields (if model has MoE layers):**
+- `num_experts_per_tok` — number of experts selected per token
+- `num_local_experts` or `n_routed_experts` — total number of experts
+- `moe_intermediate_size` — FFN hidden size inside each expert
+
+**Hybrid-specific fields (new per-layer pattern fields):**
+- Layer type patterns: `hybrid_layer_pattern`, `layer_types`, `full_attention_interval`
+- Alternative attention dims: `swa_num_kv_heads`, `swa_head_dim`, `sliding_window_size`
+- Linear attention dims: `linear_num_kv_heads`, `linear_key_head_dim`, `linear_value_head_dim`
+- Shared expert: `shared_expert_intermediate_size`, `shared_intermediate_size`
+
+**MTP (Multi-Token Prediction) fields:**
+- `num_mtp_modules` or `num_nextn_predict_layers` — number of extra draft tokens
+- `use_mtp` — boolean flag
+
+**Quantization (if pre-quantized):**
+- `quantization_config` — nested object with `quant_type`, `weight_bits`, etc.
+
+### 2. Name the file correctly
+
+```
+src/aiconfigurator/model_configs/<Org>--<Model>_config.json
+```
+
+Replace `/` with `--` in the HuggingFace model ID.
+
+| HuggingFace ID | Config filename |
+|---|---|
+| `XiaomiMiMo/MiMo-V2-Flash` | `XiaomiMiMo--MiMo-V2-Flash_config.json` |
+| `Qwen/Qwen3.5-397B-A17B` | `Qwen--Qwen3.5-397B-A17B_config.json` |
+| `nvidia/DeepSeek-V3.2-NVFP4` | `nvidia--DeepSeek-V3.2-NVFP4_config.json` |
+
+If the model has a separate quantization config (e.g. NVFP4), also create:
+```
+src/aiconfigurator/model_configs/<Org>--<Model>_hf_quant_config.json
+```
+
+### 3. Identify new hybrid-specific fields
+
+Compare against existing model configs and mark fields that are new:
+
+```json
+{
+  "architectures": ["MiMoV2FlashForCausalLM"],
+  "num_hidden_layers": 28,
+  "hidden_size": 2048,
+  "num_attention_heads": 16,
+  "num_key_value_heads": 8,             // standard field
+  "head_dim": 128,                      // standard field
+  "intermediate_size": 2048,
+  "vocab_size": 151936,
+  "max_position_embeddings": 32768,
+  "num_experts_per_tok": 2,             // standard MoE field
+  "num_local_experts": 64,              // standard MoE field
+  "moe_intermediate_size": 1024,        // standard MoE field
+  "hybrid_layer_pattern": "GSGS...",    // <- new hybrid field
+  "moe_layer_freq": 1,                  // <- new hybrid field
+  "swa_num_kv_heads": 8,                // <- new hybrid field
+  "swa_head_dim": 64,                   // <- new hybrid field
+  "sliding_window_size": 4096           // <- new hybrid field
+}
+```
+
+### 4. Minimal required content
+
+At minimum, include every field that `_parse_hf_config_json()` reads. Check `utils.py` line ~449–507 for the full list of parsed fields. Missing fields cause a `KeyError` at parse time.
+
+Fields read unconditionally:
+```python
+config["architectures"][0]
+config["num_hidden_layers"]
+config["hidden_size"]
+config["num_attention_heads"]
+config["vocab_size"]
+config["max_position_embeddings"]
+```
+
+Fields read with `.get()` (optional, have defaults):
+```python
+config.get("num_key_value_heads") or 0
+config.get("intermediate_size") or 0
+config.get("head_dim") or config.get("attention_head_dim") or (hidden_size // n)
+config.get("num_experts_per_tok", 0)
+config.get("num_local_experts") or config.get("n_routed_experts") or 0
+config.get("moe_intermediate_size", 0) or config.get("intermediate_size", 0)
+```
+
+## Example: MiMo-V2-Flash
+
+```json
+{
+  "architectures": ["MiMoV2FlashForCausalLM"],
+  "model_type": "mimo_v2_flash",
+  "num_hidden_layers": 28,
+  "hidden_size": 2048,
+  "num_attention_heads": 16,
+  "num_key_value_heads": 8,
+  "head_dim": 128,
+  "intermediate_size": 2048,
+  "vocab_size": 151936,
+  "max_position_embeddings": 32768,
+  "num_experts_per_tok": 2,
+  "num_local_experts": 64,
+  "moe_intermediate_size": 1024,
+  "hybrid_layer_pattern": "GSGSGSGSGSGSGSG...",
+  "moe_layer_freq": 1,
+  "swa_num_kv_heads": 8,
+  "swa_head_dim": 64,
+  "swa_v_head_dim": 64,
+  "global_v_head_dim": 128,
+  "sliding_window_size": 4096
+}
+```
+
+## Example: VLM (Qwen3-VL style)
+
+VLMs nest LLM parameters under `text_config`. Include the full nested structure:
+
+```json
+{
+  "architectures": ["Qwen3VLMoeForConditionalGeneration"],
+  "model_type": "qwen3_vl_moe",
+  "text_config": {
+    "num_hidden_layers": 94,
+    "hidden_size": 3584,
+    "num_attention_heads": 28,
+    "num_key_value_heads": 4,
+    "intermediate_size": 2048,
+    "num_experts_per_tok": 4,
+    "num_local_experts": 128,
+    "moe_intermediate_size": 2560,
+    "vocab_size": 152064,
+    "max_position_embeddings": 32768
+  },
+  "vision_config": {
+    "depth": 32,
+    "hidden_size": 1280,
+    "num_heads": 16,
+    "intermediate_size": 5120,
+    "patch_size": 14,
+    "out_hidden_size": 3584,
+    "spatial_merge_size": 2,
+    "temporal_patch_size": 2,
+    "in_channels": 3
+  }
+}
+```
+
+## Common Issues
+
+| Issue | Cause | Fix |
+|------|------|------|
+| `KeyError: 'num_hidden_layers'` | Standard field missing from JSON | Add the missing field |
+| `ValueError: architecture X not supported` | Architecture not in `ARCHITECTURE_TO_MODEL_FAMILY` | Complete Phase 2 |
+| Incorrect `head_dim` computed | Config has `head_dim` but code falls through to formula | Ensure `head_dim` is present in JSON |
+| `moe_inter_size` is 0 when it shouldn't be | Field named `moe_intermediate_size` vs `intermediate_size` | Match exact key name in config |

--- a/agents/add-hybrid-model/references/phase2-registration.md
+++ b/agents/add-hybrid-model/references/phase2-registration.md
@@ -1,0 +1,164 @@
+# Phase 2: Registration in `common.py`
+
+## Goal
+
+Register the new model so aiconfigurator can recognize its architecture, route it to the correct model class, and expose it as a supported model.
+
+## File
+
+`src/aiconfigurator/sdk/common.py`
+
+---
+
+## Step 1: Add to `ModelFamily` (new families only)
+
+**When**: Only if the model requires a new model class (Situation S3). Skip if reusing an existing family.
+
+```python
+# common.py line ~282
+# Before:
+ModelFamily = {"GPT", "LLAMA", "MOE", "DEEPSEEK", "NEMOTRONNAS", "NEMOTRONH"}
+
+# After (example adding HYBRIDMOE):
+ModelFamily = {"GPT", "LLAMA", "MOE", "DEEPSEEK", "NEMOTRONNAS", "NEMOTRONH", "HYBRIDMOE"}
+```
+
+Naming convention: use ALL_CAPS, descriptive of the primary architectural characteristic.
+
+| Example family | Used for |
+|---|---|
+| `HYBRIDMOE` | SWA + global attention + MoE (MiMo-V2-Flash) |
+| `QWEN35MOE` | Linear attention + full attention + MoE (Qwen3.5-MoE) |
+| `NEMOTRONH` | Mamba + Transformer + MoE (NemotronH) |
+
+---
+
+## Step 2: Add to `ARCHITECTURE_TO_MODEL_FAMILY`
+
+**Always required.** Without this, `_parse_hf_config_json()` raises `ValueError: architecture not supported`.
+
+```python
+# common.py line ~283
+ARCHITECTURE_TO_MODEL_FAMILY = {
+    # ... existing entries ...
+    "MiMoV2FlashForCausalLM": "HYBRIDMOE",          # add
+    "Qwen3_5MoeForConditionalGeneration": "QWEN35MOE", # add (VLM wrapper)
+    "Qwen3NextForCausalLM": "QWEN35MOE",             # add (same family, different arch)
+}
+```
+
+> **Important**: For VLMs, the architecture string is the wrapper (e.g. `ForConditionalGeneration`), not the inner LLM architecture. Register the wrapper.
+
+---
+
+## Step 3: Add to `DefaultHFModels`
+
+**Always required** for the model to be accepted by the CLI without explicit HuggingFace download.
+
+```python
+# common.py line ~220
+DefaultHFModels = {
+    # ... existing models ...
+    # New Hybrid Models
+    "XiaomiMiMo/MiMo-V2-Flash",
+    "Qwen/Qwen3.5-397B-A17B",
+}
+```
+
+---
+
+## Step 4: Add a config dataclass (if hybrid-specific params exist)
+
+**When**: Only if the model has structured config fields beyond the standard set (layers, hidden, n, n_kv, d, inter, vocab, context, topk, num_experts, moe_inter). Standard fields are already handled by `_parse_hf_config_json()` without a dataclass.
+
+Use a frozen `@dataclass` so it can be stored in `extra_params` and passed through the system unchanged.
+
+```python
+# common.py — add near other config dataclasses (search for NemotronHConfig)
+
+import dataclasses  # already imported
+
+@dataclasses.dataclass(frozen=True)
+class MiMoConfig:
+    """Configuration for MiMo V2 Flash hybrid model (SWA + Global Attention + MoE)."""
+    hybrid_layer_pattern: str   # per-layer type string, e.g. "GSGSGSGSG..." (G=global, S=SWA)
+    moe_layer_freq: int         # how often MoE appears in the layer pattern
+    swa_num_kv_heads: int       # KV heads for SWA attention layers
+    swa_head_dim: int           # head dim for SWA queries
+    swa_v_head_dim: int         # value head dim for SWA layers
+    global_v_head_dim: int      # value head dim for global attention layers
+    sliding_window_size: int    # SWA window length
+```
+
+```python
+@dataclasses.dataclass(frozen=True)
+class Qwen35MoEConfig:
+    """Configuration for Qwen3.5-MoE hybrid model (linear + full attention + MoE)."""
+    layer_types: list           # per-layer type list: "full_attention" or "linear_attention"
+    linear_num_kv_heads: int
+    linear_num_value_heads: int
+    linear_key_head_dim: int
+    linear_value_head_dim: int
+    shared_expert_inter_size: int  # dense shared expert size (0 if absent)
+```
+
+### Existing reference dataclasses
+
+| Dataclass | Used by |
+|---|---|
+| `NemotronHConfig` | NemotronH (Mamba + Transformer + MoE) |
+| `DeepSeekMLAConfig` | GLM5, DeepSeek MLA variants (MLA attention dims) |
+| `VisionEncoderConfig` | Qwen3-VL, KimiK2.5 (VLM vision tower params) |
+
+---
+
+## Special cases
+
+### MLA (Multi-head Latent Attention) variants
+
+Models like GLM5 use MLA attention from DeepSeek but with different dims. Use the **existing** `DEEPSEEK` family and `DeepSeekMLAConfig` dataclass:
+
+```python
+ARCHITECTURE_TO_MODEL_FAMILY = {
+    "GlmMoeDsaForCausalLM": "DEEPSEEK",  # MLA variant -> reuse DEEPSEEK family
+}
+```
+
+### Models sharing a family
+
+Multiple architecture strings can map to the same family. The model class handles config differences via `extra_params`:
+
+```python
+ARCHITECTURE_TO_MODEL_FAMILY = {
+    "Qwen3_5MoeForConditionalGeneration": "QWEN35MOE",  # VLM wrapper
+    "Qwen3NextForCausalLM": "QWEN35MOE",                # Pure LLM variant
+}
+```
+
+### MTP models
+
+Models with Multi-Token Prediction (e.g. MiniMax-M2.5) do **not** need a new family — use `MOE` family. The MTP behavior is controlled by `nextn` from `raw_config["num_mtp_modules"]` in `task.py`.
+
+---
+
+## Validation
+
+```bash
+# Quick Python check — no GPU needed
+python3 -c "
+from aiconfigurator.sdk.common import ARCHITECTURE_TO_MODEL_FAMILY, ModelFamily
+assert 'MiMoV2FlashForCausalLM' in ARCHITECTURE_TO_MODEL_FAMILY, 'mapping missing'
+assert ARCHITECTURE_TO_MODEL_FAMILY['MiMoV2FlashForCausalLM'] in ModelFamily, 'family missing'
+print('OK:', ARCHITECTURE_TO_MODEL_FAMILY['MiMoV2FlashForCausalLM'])
+"
+```
+
+## Common Issues
+
+| Issue | Cause | Fix |
+|------|------|------|
+| `ValueError: architecture X is not supported` | Missing entry in `ARCHITECTURE_TO_MODEL_FAMILY` | Add entry |
+| `ValueError: model family Y not valid` | Family string not in `ModelFamily` set | Add to `ModelFamily` |
+| CLI rejects model path | HF ID not in `DefaultHFModels` | Add to `DefaultHFModels` |
+| `dataclass` not frozen | Forgot `frozen=True` | Always use `@dataclasses.dataclass(frozen=True)` |
+| Two architectures needed for same model | VLM has a wrapper arch + inner LLM arch | Register the wrapper arch only; parse inner from `text_config` in `utils.py` |

--- a/agents/add-hybrid-model/references/phase3-config-parsing.md
+++ b/agents/add-hybrid-model/references/phase3-config-parsing.md
@@ -1,0 +1,192 @@
+# Phase 3: Config Parsing in `utils.py`
+
+## Goal
+
+Extend `_parse_hf_config_json()` to read hybrid-specific fields from the JSON and populate `extra_params` with the dataclass defined in Phase 2.
+
+## File
+
+`src/aiconfigurator/sdk/utils.py`
+
+---
+
+## Understanding `_parse_hf_config_json()`
+
+**Location**: line ~429
+
+This function converts a raw HuggingFace `config.json` dict into a normalized dict used throughout the codebase. It:
+1. Reads standard fields (`layers`, `hidden_size`, `n`, `n_kv`, `d`, `inter`, `vocab`, `context`, `topk`, `num_experts`, `moe_inter`)
+2. Reads architecture-specific fields into `extra_params` (a frozen dataclass or `None`)
+3. Returns a flat dict with all values
+
+**The `extra_params` block** (line ~466) is where to add new hybrid model parsing:
+
+```python
+extra_params = None
+if architecture == "NemotronHForCausalLM":
+    extra_params = common.NemotronHConfig(...)
+elif architecture == "DeciLMForCausalLM":
+    ...
+# <- add your elif branch here
+```
+
+---
+
+## Step 1: Add parsing for standard hybrid models
+
+Add an `elif` branch for each new architecture that has extra fields:
+
+```python
+elif architecture == "MiMoV2FlashForCausalLM":
+    extra_params = common.MiMoConfig(
+        hybrid_layer_pattern=config["hybrid_layer_pattern"],
+        moe_layer_freq=config.get("moe_layer_freq", 1),
+        swa_num_kv_heads=config["swa_num_kv_heads"],
+        swa_head_dim=config.get("swa_head_dim", config.get("head_dim", hidden_size // n)),
+        swa_v_head_dim=config.get("swa_v_head_dim", config.get("head_dim", hidden_size // n)),
+        global_v_head_dim=config.get("global_v_head_dim", config.get("head_dim", hidden_size // n)),
+        sliding_window_size=config["sliding_window_size"],
+    )
+```
+
+> **Tip**: Use `.get("field", default)` for optional fields so old/incomplete configs still parse.
+
+---
+
+## Step 2: Normalize layer pattern fields
+
+Some models express layer types as a per-layer list; others use a scalar interval. Normalize to a canonical list in the parser so `models.py` always receives a list:
+
+```python
+elif architecture in ("Qwen3_5MoeForConditionalGeneration", "Qwen3NextForCausalLM"):
+    # Normalize layer_types: list or derive from full_attention_interval
+    layer_types = config.get("layer_types")
+    if layer_types is None:
+        interval = config.get("full_attention_interval", 4)
+        num_layers = config["num_hidden_layers"]
+        layer_types = [
+            "full_attention" if i % interval == 0 else "linear_attention"
+            for i in range(num_layers)
+        ]
+
+    extra_params = common.Qwen35MoEConfig(
+        layer_types=layer_types,
+        linear_num_kv_heads=config.get("linear_num_kv_heads", config.get("num_key_value_heads", 0)),
+        linear_num_value_heads=config.get("linear_num_value_heads", 0),
+        linear_key_head_dim=config.get("linear_key_head_dim", config.get("head_dim", hidden_size // n)),
+        linear_value_head_dim=config.get("linear_value_head_dim", config.get("head_dim", hidden_size // n)),
+        shared_expert_inter_size=config.get("shared_intermediate_size", 0),
+    )
+```
+
+---
+
+## Step 3: Handle VLM `text_config` nesting
+
+VLMs (architectures ending in `ForConditionalGeneration`) nest LLM params under `text_config`. Without special handling, standard field access (`config["num_hidden_layers"]`) will `KeyError`.
+
+Add the architecture to `VLM_ARCHITECTURES` (defined near top of `utils.py`):
+
+```python
+VLM_ARCHITECTURES = {
+    "KimiK25ForConditionalGeneration",
+    "Qwen3VLMoeForConditionalGeneration",
+    "Qwen3_5MoeForConditionalGeneration",  # <- add if VLM wrapper
+}
+```
+
+The existing guard at the start of `_parse_hf_config_json()` then automatically uses `text_config`:
+
+```python
+# Already in utils.py — just add your arch to VLM_ARCHITECTURES
+if architecture in VLM_ARCHITECTURES:
+    config = config.get("text_config", config)
+```
+
+Then for VLMs with a vision tower, also parse `vision_config`. Check whether `VisionEncoderConfig` already covers your case, or add new fields:
+
+```python
+elif architecture == "Qwen3VLMoeForConditionalGeneration":
+    vc = original_config.get("vision_config", {})  # use original_config before text_config override
+    extra_params = common.VisionEncoderConfig(
+        depth=vc["depth"],
+        hidden_size=vc["hidden_size"],
+        num_heads=vc["num_heads"],
+        intermediate_size=vc["intermediate_size"],
+        patch_size=vc["patch_size"],
+        out_hidden_size=vc.get("out_hidden_size", vc["hidden_size"]),
+        spatial_merge_size=vc.get("spatial_merge_size", 2),
+        temporal_patch_size=vc.get("temporal_patch_size", 2),
+        in_channels=vc.get("in_channels", 3),
+    )
+```
+
+---
+
+## Step 4: Handle MLA (Multi-head Latent Attention) variants
+
+Models that use MLA attention (have `kv_lora_rank` in config) should map to `DEEPSEEK` family and use `DeepSeekMLAConfig`:
+
+```python
+elif architecture == "GlmMoeDsaForCausalLM":
+    if "kv_lora_rank" in config:
+        extra_params = common.DeepSeekMLAConfig(
+            q_lora_rank=config.get("q_lora_rank", 0),
+            kv_lora_rank=config["kv_lora_rank"],
+            qk_nope_head_dim=config["qk_nope_head_dim"],
+            qk_rope_head_dim=config["qk_rope_head_dim"],
+            v_head_dim=config["v_head_dim"],
+        )
+```
+
+---
+
+## Return value
+
+`_parse_hf_config_json()` returns a dict. The `extra_params` key carries the dataclass (or `None`):
+
+```python
+return {
+    "architecture": architecture,
+    "layers": layers,
+    "n": n,
+    "n_kv": n_kv,
+    "d": d,
+    "hidden_size": hidden_size,
+    "inter_size": inter_size,
+    "vocab": vocab,
+    "context": context,
+    "topk": topk,
+    "num_experts": num_experts,
+    "moe_inter_size": moe_inter_size,
+    "extra_params": extra_params,   # <- your dataclass lands here
+}
+```
+
+This dict is then passed to `get_model()` via `model_info = _get_model_info(model_path)`, and `extra_params` is forwarded to the model class constructor.
+
+---
+
+## Validation
+
+```python
+from aiconfigurator.sdk.utils import get_model_config_from_model_path
+
+info = get_model_config_from_model_path("XiaomiMiMo/MiMo-V2-Flash")
+print(info["architecture"])   # "MiMoV2FlashForCausalLM"
+print(info["extra_params"])   # MiMoConfig(hybrid_layer_pattern=..., ...)
+assert info["extra_params"].swa_num_kv_heads == 8
+```
+
+---
+
+## Common Issues
+
+| Issue | Cause | Fix |
+|------|------|------|
+| `KeyError: 'num_hidden_layers'` | VLM config needs `text_config` nesting but arch not in `VLM_ARCHITECTURES` | Add architecture to `VLM_ARCHITECTURES` |
+| `extra_params` is `None` | `elif` branch not reached (architecture string mismatch) | Print `config["architectures"][0]` and compare exactly |
+| `TypeError: __init__() missing argument` | Dataclass field not in config JSON | Use `.get("field", default)` in parser |
+| Field value is wrong type | JSON stores as string, code expects int | Cast: `int(config["field"])` |
+| `frozen=True` dataclass mutated | Tried to set field after init | Frozen dataclasses are immutable; all values must be in `__init__` |
+| Layer count mismatch | `layer_types` list length != `num_hidden_layers` | Assert `len(layer_types) == layers` in parser |

--- a/agents/add-hybrid-model/references/phase4-model-class.md
+++ b/agents/add-hybrid-model/references/phase4-model-class.md
@@ -1,0 +1,273 @@
+# Phase 4: Model Class in `models.py`
+
+## Goal
+
+Implement a new model class that separates compute ops by layer type, wire it into `get_model()`, and update `check_is_moe()`.
+
+## File
+
+`src/aiconfigurator/sdk/models.py`
+
+---
+
+## When to add a new class vs reuse an existing one
+
+| Situation | Action |
+|---|---|
+| New architecture, same op structure as an existing family | Add to `get_model()` `elif` chain only — no new class needed |
+| Existing family, but with new config fields (`extra_params`) | Add `elif` in `get_model()` and pass `extra_params` to existing class constructor |
+| Genuinely new layer-type combination (new hybrid) | Create a new model class |
+
+For hybrid models (S3), a new class is always required because op counts differ per layer type.
+
+---
+
+## Step 1: Understand `BaseModel`
+
+**Location**: line ~362
+
+`BaseModel.__init__()` takes standard params and builds `self.context_ops` / `self.generation_ops`.
+
+Key attributes:
+```python
+self._num_layers    # total transformer layers
+self._num_heads     # attention heads
+self._n_kv          # key-value heads
+self._d             # head dim
+self._hidden        # hidden size
+self._inter         # FFN intermediate size
+self._vocab         # vocabulary size
+self._context       # max context length
+self._nextn         # MTP extra tokens (0 = disabled)
+
+self.context_ops    # list[Operation] — prefill compute ops
+self.generation_ops # list[Operation] — decode compute ops
+```
+
+---
+
+## Step 2: Create the new model class
+
+Place the new class **before** `get_model()`. Follow `NemotronHModel` as the closest reference for hybrid models.
+
+### Key design pattern: deferred initialization
+
+For hybrid models, op construction requires the per-layer pattern from `extra_params`. Store the config as instance variables *before* calling `super().__init__()`, which triggers `_build_ops()`:
+
+```python
+class HybridMoEModel(BaseModel):
+    """
+    Hybrid MoE model with heterogeneous layers (e.g. SWA attention + global attention + MoE FFN).
+    Op costs are computed per layer type rather than uniformly scaled.
+    """
+
+    def __init__(
+        self,
+        model_path, model_family, architecture,
+        layers, n, n_kv, d, hidden, inter, vocab, context,
+        model_config,
+        nextn,
+        moe_inter, num_experts, topk,
+        extra_params,  # MiMoConfig
+    ):
+        # Store hybrid config BEFORE super().__init__ which calls _build_ops
+        self._hybrid_config = extra_params
+        self._moe_inter = moe_inter
+        self._num_experts = num_experts
+        self._topk = topk
+
+        super().__init__(
+            model_path, model_family, architecture, layers, n, n_kv, d,
+            hidden, inter, vocab, context, model_config, nextn,
+        )
+
+    def _build_ops(self):
+        """Override to build separate op lists for each layer type."""
+        cfg = self._hybrid_config
+        pattern = cfg.hybrid_layer_pattern  # e.g. "GSGSGSGSG..."
+
+        # Count layer types
+        n_global = pattern.count("G")  # global attention + MoE
+        n_swa = pattern.count("S")     # SWA attention + MoE
+
+        # ... build context_ops and generation_ops using n_global / n_swa as scale factors ...
+        # See existing MOEModel for op construction patterns
+        pass
+```
+
+### Scale factors for each layer type
+
+The scale factor in each `Operation(name, scale_factor, ...)` call represents "how many identical copies exist". For hybrid models, use the layer counts per type rather than `self._num_layers`:
+
+```python
+# Wrong: uses total layers (mixes different layer types)
+ops.ContextAttention("ctx_attn", self._num_layers, ...)
+
+# Correct: separate scale factors per type
+ops.ContextAttention("ctx_global_attn", n_global, ...)   # global attention layers only
+ops.ContextAttention("ctx_swa_attn", n_swa, ...)         # SWA layers only
+```
+
+### MTP scale factor (if model has MTP)
+
+If `self._nextn > 0`, apply the same MTP scaling used in `MOEModel` and `DeepSeekModel`:
+
+```python
+from aiconfigurator.sdk.models import calc_expectation
+
+self._mtp_scale_factor = (
+    1.0 / (1 + calc_expectation(self._nextn, self._nextn_accept_rates))
+    * (self._nextn + self._num_layers) / self._num_layers
+    if self._nextn > 0
+    else 1.0
+)
+# Apply to all generation ops that are token-batch-size-dependent
+```
+
+---
+
+## Step 3: Wire into `get_model()`
+
+**Location**: line ~137
+
+Find the `elif model_family == "NEMOTRONH":` block and add after it:
+
+```python
+elif model_family == "HYBRIDMOE":
+    model = HybridMoEModel(
+        model_path, model_family, architecture,
+        layers, n, n_kv, d, hidden, inter, vocab, context,
+        model_config,
+        nextn,
+        moe_inter_size, num_experts, topk,
+        extra_params,
+    )
+```
+
+> **Note**: The argument order must match the constructor. Check what `model_info` provides:
+> - `layers, n, n_kv, d, hidden, inter, vocab, context` — from standard parsing
+> - `topk, num_experts, moe_inter_size` — MoE fields
+> - `extra_params` — your hybrid config dataclass
+> - `nextn` — from `model_config.nextn` (set by `task.py` before calling `get_model`)
+
+---
+
+## Step 4: Update `check_is_moe()`
+
+**Location**: line ~325
+
+If the new family contains MoE layers, it must return `True`:
+
+```python
+def check_is_moe(model_path: str) -> bool:
+    family = get_model_family(model_path)
+    if family in ("MOE", "DEEPSEEK", "HYBRIDMOE", "QWEN35MOE"):  # add new family
+        return True
+    if family == "NEMOTRONH":
+        ...
+    return False
+```
+
+---
+
+## Reference op construction patterns
+
+### Standard ops shared across most models
+
+```python
+# Embedding
+ops.Embedding("embedding", 1, self._vocab, self._hidden)
+
+# LayerNorm / RMSNorm
+ops.ElementWise("norm", self._num_layers, self._hidden)
+
+# Dense FFN (SwiGLU: 2 GEMMs + activation)
+ops.GEMM("ffn_gate", self._num_layers, self._hidden, self._inter)
+ops.GEMM("ffn_up",   self._num_layers, self._hidden, self._inter)
+ops.GEMM("ffn_down", self._num_layers, self._inter,  self._hidden)
+
+# Output projection
+ops.GEMM("lm_head", 1, self._hidden, self._vocab)
+```
+
+### Attention ops
+
+```python
+# Context (prefill) attention
+ops.ContextAttention("ctx_attn", n_layers, self._n_kv, self._d, self._context)
+
+# Generation (decode) attention
+ops.GenerationAttention("gen_attn", n_layers, self._n_kv, self._d, self._context)
+
+# QKV projection
+ops.GEMM("qkv_proj", n_layers,
+         self._hidden, (self._num_heads + 2 * self._n_kv) * self._d)
+
+# Output projection
+ops.GEMM("o_proj", n_layers, self._num_heads * self._d, self._hidden)
+```
+
+### MoE ops
+
+```python
+# Router
+ops.GEMM("moe_router", n_moe_layers, self._hidden, self._num_experts)
+
+# MoE dispatch (gather/scatter communication)
+ops.MoEDispatch("moe_dispatch", n_moe_layers,
+                self._num_experts, self._topk, self._moe_ep_size)
+
+# MoE compute (experts)
+ops.MoE("moe_experts", n_moe_layers,
+        self._hidden, self._moe_inter, self._num_experts, self._topk)
+```
+
+### Sliding-window attention
+
+Same op class as standard attention, but with different head dimensions from the hybrid config:
+
+```python
+ops.ContextAttention("ctx_swa_attn", n_swa_layers,
+                     cfg.swa_num_kv_heads, cfg.swa_head_dim, cfg.sliding_window_size)
+```
+
+---
+
+## Example: NemotronH (reference hybrid model)
+
+`NemotronHModel` is the closest existing reference. Key features:
+- Uses `set_nemotronh_config(extra_params)` for deferred initialization
+- Builds separate ops for Mamba layers, attention layers, MoE layers
+- Uses `pattern.count("M")`, `pattern.count("T")`, `pattern.count("E")` for counts
+
+---
+
+## Validation
+
+```python
+from aiconfigurator.sdk import models, config as cfg_module
+
+mc = cfg_module.ModelConfig(tp_size=8, moe_ep_size=4)
+model = models.get_model("XiaomiMiMo/MiMo-V2-Flash", mc, "trtllm")
+
+print("context ops:", [op._name for op in model.context_ops])
+print("generation ops:", [op._name for op in model.generation_ops])
+assert len(model.context_ops) > 0
+assert len(model.generation_ops) > 0
+
+from aiconfigurator.sdk.models import check_is_moe
+assert check_is_moe("XiaomiMiMo/MiMo-V2-Flash") == True
+```
+
+---
+
+## Common Issues
+
+| Issue | Cause | Fix |
+|------|------|------|
+| `AssertionError: num_heads not divisible by tp_size` | `BaseModel.__init__` validates head divisibility | Verify tp_size choices in tests; not a code bug |
+| `context_ops` is empty | `_build_ops()` not called or returned early | Ensure `_build_ops()` is called from `__init__` (base class does this) |
+| `extra_params is None` in `get_model()` | Phase 3 parsing not reached | Verify `elif` branch in `_parse_hf_config_json()` |
+| `TypeError: cannot unpack non-sequence` | Constructor arg order mismatch | Match exactly the order in `model_info` dict |
+| Wrong total latency | Scale factors use `self._num_layers` instead of per-type counts | Use `pattern.count(type_char)` for each type |
+| `check_is_moe()` returns False | New family not added to the `if family in (...)` check | Update `check_is_moe()` |

--- a/agents/add-hybrid-model/references/phase5-testing.md
+++ b/agents/add-hybrid-model/references/phase5-testing.md
@@ -1,0 +1,220 @@
+# Phase 5: Testing and Verification
+
+## Goal
+
+Add unit tests for config parsing and run end-to-end CLI validation to confirm the model is fully integrated.
+
+---
+
+## Step 1: Unit tests for config parsing
+
+**File**: `tests/unit/sdk/test_utils.py`
+
+Add a test function for each new architecture. The test exercises `_parse_hf_config_json()` directly so it runs without a GPU or network access.
+
+### Template
+
+```python
+def test_parse_<model_name>_config():
+    """Test that <ModelName> config is parsed correctly."""
+    config = {
+        "architectures": ["<ArchForCausalLM>"],
+        # --- all standard fields ---
+        "num_hidden_layers": 28,
+        "hidden_size": 2048,
+        "num_attention_heads": 16,
+        "num_key_value_heads": 8,
+        "head_dim": 128,
+        "intermediate_size": 2048,
+        "vocab_size": 151936,
+        "max_position_embeddings": 32768,
+        # --- MoE fields (if applicable) ---
+        "num_experts_per_tok": 2,
+        "num_local_experts": 64,
+        "moe_intermediate_size": 1024,
+        # --- hybrid-specific fields ---
+        "hybrid_layer_pattern": "GSGSGSGSG...",
+        "moe_layer_freq": 1,
+        "swa_num_kv_heads": 8,
+        "swa_head_dim": 64,
+        "swa_v_head_dim": 64,
+        "global_v_head_dim": 128,
+        "sliding_window_size": 4096,
+    }
+
+    result = _parse_hf_config_json(config)
+
+    # Standard field assertions
+    assert result["architecture"] == "<ArchForCausalLM>"
+    assert result["layers"] == 28
+    assert result["n"] == 16
+    assert result["n_kv"] == 8
+    assert result["d"] == 128
+    assert result["topk"] == 2
+    assert result["num_experts"] == 64
+
+    # Hybrid-specific assertions
+    assert isinstance(result["extra_params"], common.MiMoConfig)
+    assert result["extra_params"].swa_num_kv_heads == 8
+    assert result["extra_params"].sliding_window_size == 4096
+```
+
+### Example: Qwen3.5-MoE (layer_types list input)
+
+```python
+def test_parse_qwen35_moe_config():
+    config = {
+        "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+        "text_config": {
+            "num_hidden_layers": 94,
+            "hidden_size": 3584,
+            "num_attention_heads": 28,
+            "num_key_value_heads": 4,
+            "intermediate_size": 2048,
+            "vocab_size": 152064,
+            "max_position_embeddings": 32768,
+            "num_experts_per_tok": 4,
+            "num_local_experts": 128,
+            "moe_intermediate_size": 2560,
+            "layer_types": ["full_attention", "linear_attention"] * 47,
+        }
+    }
+    result = _parse_hf_config_json(config)
+    assert result["architecture"] == "Qwen3_5MoeForConditionalGeneration"
+    assert isinstance(result["extra_params"], common.Qwen35MoEConfig)
+    assert len(result["extra_params"].layer_types) == 94
+    assert result["extra_params"].layer_types[0] == "full_attention"
+```
+
+### Example: Qwen3-Next (full_attention_interval scalar fallback)
+
+```python
+def test_parse_qwen3_next_config():
+    config = {
+        "architectures": ["Qwen3NextForCausalLM"],
+        "num_hidden_layers": 28,
+        "hidden_size": 2048,
+        "num_attention_heads": 16,
+        "num_key_value_heads": 8,
+        "head_dim": 128,
+        "intermediate_size": 2048,
+        "vocab_size": 151936,
+        "max_position_embeddings": 32768,
+        "num_experts_per_tok": 2,
+        "num_local_experts": 64,
+        "moe_intermediate_size": 1024,
+        "full_attention_interval": 4,   # scalar instead of list
+    }
+    result = _parse_hf_config_json(config)
+    assert isinstance(result["extra_params"], common.Qwen35MoEConfig)
+    # Scalar interval=4 should produce a list of length 28
+    assert len(result["extra_params"].layer_types) == 28
+    # Layer 0 is full attention (0 % 4 == 0)
+    assert result["extra_params"].layer_types[0] == "full_attention"
+    # Layer 1 is linear attention (1 % 4 != 0)
+    assert result["extra_params"].layer_types[1] == "linear_attention"
+```
+
+---
+
+## Step 2: Run unit tests
+
+```bash
+# Run only the config parsing tests
+pytest tests/unit/sdk/test_utils.py -v
+
+# Run just the new test
+pytest tests/unit/sdk/test_utils.py::test_parse_mimo_v2_flash_config -v
+```
+
+All existing tests must still pass — the change should be purely additive.
+
+---
+
+## Step 3: End-to-end CLI validation
+
+These checks run without GPU hardware; they exercise the model registration and config parsing code paths.
+
+### 3a. Check architecture recognition
+
+```bash
+python3 -c "
+from aiconfigurator.sdk.models import get_model_family
+family = get_model_family('XiaomiMiMo/MiMo-V2-Flash')
+print('family:', family)
+assert family == 'HYBRIDMOE', f'Expected HYBRIDMOE, got {family}'
+print('OK')
+"
+```
+
+### 3b. Check model instantiation (CPU only)
+
+```python
+from aiconfigurator.sdk import models, config as cfg_module
+
+mc = cfg_module.ModelConfig(tp_size=1)
+model = models.get_model("XiaomiMiMo/MiMo-V2-Flash", mc, "trtllm")
+print("context_ops:", [op._name for op in model.context_ops])
+print("generation_ops:", [op._name for op in model.generation_ops])
+assert len(model.context_ops) > 0
+assert len(model.generation_ops) > 0
+```
+
+### 3c. CLI support check
+
+```bash
+aiconfigurator cli support --model-path XiaomiMiMo/MiMo-V2-Flash --system h200_sxm --backend trtllm
+```
+
+Expected output: architecture recognized, even if perf data is not yet available.
+
+- If you see `"architecture is not supported"` → Phase 2 registration missing
+- If you see `"data not found"` → registration works but perf data needed (expected for new models)
+- If you see a full support table → model is fully integrated
+
+---
+
+## Step 4: Verify `check_is_moe()`
+
+```python
+from aiconfigurator.sdk.models import check_is_moe
+
+result = check_is_moe("XiaomiMiMo/MiMo-V2-Flash")
+print("is_moe:", result)  # should be True if model has MoE layers
+assert result == True
+```
+
+---
+
+## Reference PR test patterns
+
+| PR | New test function | What it tests |
+|---|---|---|
+| PR 410 | `test_parse_qwen35_moe_config()` | `Qwen35MoEConfig` from list `layer_types` |
+| PR 410 | `test_parse_qwen3_next_config()` | `Qwen35MoEConfig` from scalar `full_attention_interval` |
+| PR 406 | Inline assertions in integration test | `DeepSeekMLAConfig` from GLM5 config |
+
+---
+
+## Checklist before opening PR
+
+```
+□ pytest tests/unit/sdk/test_utils.py -v → all PASSED
+□ get_model_family("<HF ID>") → returns correct family
+□ get_model("<HF ID>", mc, "trtllm") → non-empty context_ops and generation_ops
+□ check_is_moe("<HF ID>") → correct True/False
+□ aiconfigurator cli support → no "architecture not supported" error
+□ No changes to existing tests
+```
+
+---
+
+## Common Issues
+
+| Issue | Cause | Fix |
+|------|------|------|
+| `ModuleNotFoundError` in test | Import path wrong | Use `from aiconfigurator.sdk.utils import _parse_hf_config_json` |
+| Test fails with `KeyError` | Config dict missing a field that the parser requires | Add the missing field to the test config dict |
+| `extra_params is None` in test | `elif` branch not reached (architecture mismatch) | Print `config["architectures"][0]` to verify exact string |
+| `AssertionError` on layer count | `layer_types` list length != `num_hidden_layers` | Fix normalization logic in Phase 3 parser |
+| CLI gives `data not found` | Expected; perf data not yet collected | Not a bug; data collection is a separate workflow |


### PR DESCRIPTION
#### Overview:

This PR adds a new agent skill and supporting reference docs for integrating new hybrid architecture models into `aiconfigurator`. It covers the full workflow from model config JSON creation through registration, config parsing, model class implementation, and testing.

#### Details:

- Added `agents/add-hybrid-model/SKILL.md` with the full integration flow:
  - Situation assessment (S1/S2/S3 decision path)
  - Phase 1: model config JSON creation
  - Phase 2: registration in `common.py`
  - Phase 3: config parsing in `utils.py`
  - Phase 4: model class in `models.py`
  - Phase 5: testing and verification
- Added phase reference documents:
  - `agents/add-hybrid-model/references/phase1-model-config.md`
  - `agents/add-hybrid-model/references/phase2-registration.md`
  - `agents/add-hybrid-model/references/phase3-config-parsing.md`
  - `agents/add-hybrid-model/references/phase4-model-class.md`
  - `agents/add-hybrid-model/references/phase5-testing.md`
- Distilled lessons from real PRs: MiMo-V2-Flash (#408), Qwen3.5-MoE (#410), GLM5 (#406), MiniMax-M2.5 (#405), Qwen3-VL (#409), Kimi-K2.5 (#403).
- Docs/process only; no runtime logic changes.

#### Where should the reviewer start?

- Start with `agents/add-hybrid-model/SKILL.md` for the overall flow and S1/S2/S3 decision logic.
- Then review `agents/add-hybrid-model/references/phase4-model-class.md` for hybrid-specific model class guidance.
- `references/phase3-config-parsing.md` covers the VLM nesting, MLA, MTP, and layer-pattern normalization edge cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)