### PR TITLE
fix: make --backend a required argument in generator validator

### DIFF
--- a/tools/generator_validator/validator.py
+++ b/tools/generator_validator/validator.py
@@ -73,9 +73,9 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Validate engine configs for TRT-LLM, vLLM, or SGLang.")
     parser.add_argument(
         "--backend",
-        default="trtllm",
+        required=True,
         choices=["trtllm", "vllm", "sglang"],
-        help="Which engine backend to validate (default: trtllm).",
+        help="Which engine backend to validate.",
     )
     parser.add_argument(
         "--path",


### PR DESCRIPTION
## Summary
- Makes `--backend` a required argument in the generator validator (`tools/generator_validator/validator.py`) instead of silently defaulting to `trtllm`.
- When `--backend` is omitted, the validator previously defaulted to TRT-LLM, causing misleading errors if the results directory belonged to a different backend (e.g. SGLang or vLLM). Now users get a clear argparse error: `error: the following arguments are required: --backend`.

## Test plan
- [ ] Run `python tools/generator_validator/validator.py --path <results_dir>` without `--backend` and verify a clear argparse error is shown
- [ ] Run with `--backend trtllm`, `--backend vllm`, `--backend sglang` and verify each still works correctly

Fixes: NVBug 5925274

Made with [Cursor](https://cursor.com)