### PR TITLE
fix(cli-support): make support check case-insensitive, rephrase model not found

### DIFF
--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -1026,9 +1026,12 @@ def _run_support_mode(args):
     print(f"  Disaggregated Support: {'YES' if result.disagg_supported else 'NO'}")
 
     # Show explanation if support was inferred from architecture majority vote
-    if not result.exact_match and result.architecture:
+    if not result.exact_match and result.architecture and (result.agg_total_count > 0 or result.disagg_total_count > 0):
         print("-" * 60)
-        print(f"  Note: Model '{model}' not found in support matrix.")
+        print(
+            f"  Note: Model '{model}' not found in support matrix cache,\n\
+    but the model matches architecture '{result.architecture}'."
+        )
         print(f"  Support inferred from architecture '{result.architecture}' majority vote:")
         if result.agg_total_count:
             p, t = result.agg_pass_count, result.agg_total_count

--- a/src/aiconfigurator/sdk/common.py
+++ b/src/aiconfigurator/sdk/common.py
@@ -137,7 +137,9 @@ def check_support(
     exact_matches = [
         row
         for row in matrix
-        if row["HuggingFaceID"] == model and row["System"] == system and _matches_filters(row, backend, version)
+        if row["HuggingFaceID"].lower() == model.lower()
+        and row["System"].lower() == system.lower()
+        and _matches_filters(row, backend, version)
     ]
 
     # Resolve architecture from matrix if model is found anywhere


### PR DESCRIPTION
#### Overview

1. Make `cli support` command case insensitive.
2. Rephrase `Model '{model}' not found in support matrix` to `Model '{model}' not found in support matrix cache, but the model matches architecture '{result.architecture}` to avoid confusion.

#### Original VDR Issue

> Support check output is confusing and incomplete. The cli support command tells users a model is "not found in support matrix" immediately before confirming it is supported, a contradiction that will alarm any new user. The wording should be updated to reflect that the model was matched via architecture inference, e.g. "Model matched via architecture Qwen3ForCausalLM"

#### Fix Result

##### Before Fix
```
$ aiconfigurator cli support --model-path QWEN/QWEN3-32B-FP8 --system h100_sxm
2026-02-24 13:34:52,418 - aiconfigurator.sdk.utils - INFO - Quant inference result: quant_algo=fp8_block, kv_cache_quant_algo=None, quant_dynamic=True
2026-02-24 13:34:52,418 - aiconfigurator.sdk.utils - INFO - Model architecture: architecture=Qwen3ForCausalLM, layers=64, n=64, n_kv=8, d=128, hidden_size=5120, inter_size=25600, vocab=151936, context=40960, topk=0, num_experts=0, moe_inter_size=25600, extra_params=None
2026-02-24 13:34:52,419 - aiconfigurator.cli.main - INFO - Loading Dynamo AIConfigurator version: 0.6.0
2026-02-24 13:34:52,419 - aiconfigurator.cli.main - INFO - Number of top configurations to output: 5 (change with --top-n)
2026-02-24 13:34:52,425 - aiconfigurator.cli.main - INFO - Checking support for model=QWEN/QWEN3-32B-FP8, system=h100_sxm, backend=trtllm, version=1.2.0rc5
2026-02-24 13:34:52,425 - aiconfigurator.sdk.utils - INFO - Model architecture: architecture=Qwen3ForCausalLM, layers=64, n=64, n_kv=8, d=128, hidden_size=5120, inter_size=25600, vocab=151936, context=40960, topk=0, num_experts=0, moe_inter_size=25600, extra_params=None

============================================================
  AIC Support Check Results
============================================================
  Model:           QWEN/QWEN3-32B-FP8
  System:          h100_sxm
  Backend:         trtllm
  Version:         1.2.0rc5
------------------------------------------------------------
  Aggregated Support:    YES
  Disaggregated Support: YES
------------------------------------------------------------
  Note: Model 'QWEN/QWEN3-32B-FP8' not found in support matrix.
  Support inferred from architecture 'Qwen3ForCausalLM' majority vote:
    Aggregated:    4/4 passed (>2 required)
    Disaggregated: 4/4 passed (>2 required)
============================================================
```
##### After Fix
```
$ aiconfigurator cli support --model-path QWEN/QWEN3-32B-FP8 --system h100_sxm
2026-02-24 13:34:09,768 - aiconfigurator.sdk.utils - INFO - Quant inference result: quant_algo=fp8_block, kv_cache_quant_algo=None, quant_dynamic=True
2026-02-24 13:34:09,769 - aiconfigurator.sdk.utils - INFO - Model architecture: architecture=Qwen3ForCausalLM, layers=64, n=64, n_kv=8, d=128, hidden_size=5120, inter_size=25600, vocab=151936, context=40960, topk=0, num_experts=0, moe_inter_size=25600, extra_params=None
2026-02-24 13:34:09,769 - aiconfigurator.cli.main - INFO - Loading Dynamo AIConfigurator version: 0.6.0
2026-02-24 13:34:09,769 - aiconfigurator.cli.main - INFO - Number of top configurations to output: 5 (change with --top-n)
2026-02-24 13:34:09,777 - aiconfigurator.cli.main - INFO - Checking support for model=QWEN/QWEN3-32B-FP8, system=h100_sxm, backend=trtllm, version=1.2.0rc5
2026-02-24 13:34:09,777 - aiconfigurator.sdk.utils - INFO - Model architecture: architecture=Qwen3ForCausalLM, layers=64, n=64, n_kv=8, d=128, hidden_size=5120, inter_size=25600, vocab=151936, context=40960, topk=0, num_experts=0, moe_inter_size=25600, extra_params=None

============================================================
  AIC Support Check Results
============================================================
  Model:           QWEN/QWEN3-32B-FP8
  System:          h100_sxm
  Backend:         trtllm
  Version:         1.2.0rc5
------------------------------------------------------------
  Aggregated Support:    YES
  Disaggregated Support: YES
------------------------------------------------------------
  Note: Model 'QWEN/QWEN3-32B-FP8' not found in support matrix cache,
    but the model matches architecture 'Qwen3ForCausalLM'.
  Support inferred from architecture 'Qwen3ForCausalLM' majority vote:
    Aggregated:    4/4 passed (>2 required)
    Disaggregated: 4/4 passed (>2 required)
```