### PR TITLE
fix: add shebang and error handling to bench_run.sh template

### DIFF
--- a/src/aiconfigurator/generator/config/backend_templates/benchmark/bench_run.sh.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/benchmark/bench_run.sh.j2
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
 {% set base_concurrency = [1, 2, 8, 16, 32, 64, 128] %}
 {% if BenchConfig.estimated_concurrency and BenchConfig.estimated_concurrency > 0 %}
 {% set eff = BenchConfig.estimated_concurrency | int %}


### PR DESCRIPTION
## Summary
- Adds `#!/bin/bash` shebang and `set -euo pipefail` to the `bench_run.sh.j2` template.
- Without these, the generated benchmark script lacks an explicit interpreter declaration and silently continues past failed `aiperf` invocations, which can produce incomplete or misleading benchmark results.

## Test plan
- [ ] Generate a benchmark config and verify `bench_run.sh` starts with `#!/bin/bash` and `set -euo pipefail`
- [ ] Verify the script exits immediately if an `aiperf profile` invocation fails

Fixes: NVBug 5924869

Made with [Cursor](https://cursor.com)