### PR TITLE
fix: correct TRT-LLM version-specific engine templates (build_config nesting + missing backend)

### DIFF
--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.0.0.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.0.0.yaml.j2
@@ -18,12 +18,11 @@ enable_chunked_prefill: {{ enable_chunked_prefill | default(false) }}
 
 {% set _max_seq_len = build_config.max_seq_len | default(none) %}
 
-build_config:
-  max_batch_size: {{ build_config.max_batch_size }}
-  max_num_tokens: {{ build_config.max_num_tokens }}
-  {% if _max_seq_len is not none and _max_seq_len != '' %}
-  max_seq_len: {{ _max_seq_len }}
-  {% endif %}
+max_batch_size: {{ build_config.max_batch_size }}
+max_num_tokens: {{ build_config.max_num_tokens }}
+{% if _max_seq_len is not none and _max_seq_len != '' %}
+max_seq_len: {{ _max_seq_len }}
+{% endif %}
 
 kv_cache_config:
   free_gpu_memory_fraction: {{ kv_cache_config.free_gpu_memory_fraction | default(0.80) }}

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.0.0rc6.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.0.0rc6.yaml.j2
@@ -18,12 +18,11 @@ enable_chunked_prefill: {{ enable_chunked_prefill | default(false) }}
 
 {% set _max_seq_len = build_config.max_seq_len | default(none) %}
 
-build_config:
-  max_batch_size: {{ build_config.max_batch_size }}
-  max_num_tokens: {{ build_config.max_num_tokens }}
-  {% if _max_seq_len is not none and _max_seq_len != '' %}
-  max_seq_len: {{ _max_seq_len }}
-  {% endif %}
+max_batch_size: {{ build_config.max_batch_size }}
+max_num_tokens: {{ build_config.max_num_tokens }}
+{% if _max_seq_len is not none and _max_seq_len != '' %}
+max_seq_len: {{ _max_seq_len }}
+{% endif %}
 
 kv_cache_config:
   free_gpu_memory_fraction: {{ kv_cache_config.free_gpu_memory_fraction | default(0.80) }}

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.1.0rc1.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.1.0rc1.yaml.j2
@@ -18,12 +18,11 @@ enable_chunked_prefill: {{ enable_chunked_prefill | default(false) }}
 
 {% set _max_seq_len = build_config.max_seq_len | default(none) %}
 
-build_config:
-  max_batch_size: {{ build_config.max_batch_size }}
-  max_num_tokens: {{ build_config.max_num_tokens }}
-  {% if _max_seq_len is not none and _max_seq_len != '' %}
-  max_seq_len: {{ _max_seq_len }}
-  {% endif %}
+max_batch_size: {{ build_config.max_batch_size }}
+max_num_tokens: {{ build_config.max_num_tokens }}
+{% if _max_seq_len is not none and _max_seq_len != '' %}
+max_seq_len: {{ _max_seq_len }}
+{% endif %}
 
 kv_cache_config:
   free_gpu_memory_fraction: {{ kv_cache_config.free_gpu_memory_fraction | default(0.80) }}

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.1.0rc4.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.1.0rc4.yaml.j2
@@ -1,3 +1,5 @@
+backend: pytorch
+
 {% if is_moe is defined %}  # is_moe from sdk
 moe_expert_parallel_size: {{ moe_expert_parallel_size }}
 moe_tensor_parallel_size: {{ moe_tensor_parallel_size }}
@@ -16,12 +18,11 @@ enable_chunked_prefill: {{ enable_chunked_prefill | default(false) }}
 
 {% set _max_seq_len = build_config.max_seq_len | default(none) %}
 
-build_config:
-  max_batch_size: {{ build_config.max_batch_size }}
-  max_num_tokens: {{ build_config.max_num_tokens }}
-  {% if _max_seq_len is not none and _max_seq_len != '' %}
-  max_seq_len: {{ _max_seq_len }}
-  {% endif %}
+max_batch_size: {{ build_config.max_batch_size }}
+max_num_tokens: {{ build_config.max_num_tokens }}
+{% if _max_seq_len is not none and _max_seq_len != '' %}
+max_seq_len: {{ _max_seq_len }}
+{% endif %}
 
 kv_cache_config:
   free_gpu_memory_fraction: {{ kv_cache_config.free_gpu_memory_fraction | default(0.80) }}

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.1.0rc5.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.1.0rc5.yaml.j2
@@ -1,3 +1,5 @@
+backend: pytorch
+
 {% if is_moe is defined %}  # is_moe from sdk
 moe_expert_parallel_size: {{ moe_expert_parallel_size }}
 moe_tensor_parallel_size: {{ moe_tensor_parallel_size }}
@@ -16,12 +18,11 @@ enable_chunked_prefill: {{ enable_chunked_prefill | default(false) }}
 
 {% set _max_seq_len = build_config.max_seq_len | default(none) %}
 
-build_config:
-  max_batch_size: {{ build_config.max_batch_size }}
-  max_num_tokens: {{ build_config.max_num_tokens }}
-  {% if _max_seq_len is not none and _max_seq_len != '' %}
-  max_seq_len: {{ _max_seq_len }}
-  {% endif %}
+max_batch_size: {{ build_config.max_batch_size }}
+max_num_tokens: {{ build_config.max_num_tokens }}
+{% if _max_seq_len is not none and _max_seq_len != '' %}
+max_seq_len: {{ _max_seq_len }}
+{% endif %}
 
 kv_cache_config:
   free_gpu_memory_fraction: {{ kv_cache_config.free_gpu_memory_fraction | default(0.80) }}  # Fraction of GPU memory usable for KV‑cache

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.2.0rc2.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.2.0rc2.yaml.j2
@@ -1,3 +1,5 @@
+backend: pytorch
+
 {% if is_moe is defined %}  # is_moe from sdk
 moe_expert_parallel_size: {{ moe_expert_parallel_size }}
 moe_tensor_parallel_size: {{ moe_tensor_parallel_size }}
@@ -16,12 +18,11 @@ enable_chunked_prefill: {{ enable_chunked_prefill | default(false) }}
 
 {% set _max_seq_len = build_config.max_seq_len | default(none) %}
 
-build_config:
-  max_batch_size: {{ build_config.max_batch_size }}
-  max_num_tokens: {{ build_config.max_num_tokens }}
-  {% if _max_seq_len is not none and _max_seq_len != '' %}
-  max_seq_len: {{ _max_seq_len }}
-  {% endif %}
+max_batch_size: {{ build_config.max_batch_size }}
+max_num_tokens: {{ build_config.max_num_tokens }}
+{% if _max_seq_len is not none and _max_seq_len != '' %}
+max_seq_len: {{ _max_seq_len }}
+{% endif %}
 
 kv_cache_config:
   free_gpu_memory_fraction: {{ kv_cache_config.free_gpu_memory_fraction | default(0.80) }}  # Fraction of GPU memory usable for KV‑cache

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.2.0rc3.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.2.0rc3.yaml.j2
@@ -1,3 +1,5 @@
+backend: pytorch
+
 {% if is_moe is defined %}  # is_moe from sdk
 moe_expert_parallel_size: {{ moe_expert_parallel_size }}
 moe_tensor_parallel_size: {{ moe_tensor_parallel_size }}
@@ -16,12 +18,11 @@ enable_chunked_prefill: {{ enable_chunked_prefill | default(false) }}
 
 {% set _max_seq_len = build_config.max_seq_len | default(none) %}
 
-build_config:
-  max_batch_size: {{ build_config.max_batch_size }}
-  max_num_tokens: {{ build_config.max_num_tokens }}
-  {% if _max_seq_len is not none and _max_seq_len != '' %}
-  max_seq_len: {{ _max_seq_len }}
-  {% endif %}
+max_batch_size: {{ build_config.max_batch_size }}
+max_num_tokens: {{ build_config.max_num_tokens }}
+{% if _max_seq_len is not none and _max_seq_len != '' %}
+max_seq_len: {{ _max_seq_len }}
+{% endif %}
 
 kv_cache_config:
   free_gpu_memory_fraction: {{ kv_cache_config.free_gpu_memory_fraction | default(0.80) }}  # Fraction of GPU memory usable for KV‑cache

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.2.0rc5.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.2.0rc5.yaml.j2
@@ -1,3 +1,5 @@
+backend: pytorch
+
 {% if is_moe is defined %}  # is_moe from sdk
 moe_expert_parallel_size: {{ moe_expert_parallel_size }}
 moe_tensor_parallel_size: {{ moe_tensor_parallel_size }}

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.2.0rc6.post1.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.2.0rc6.post1.yaml.j2
@@ -1,3 +1,5 @@
+backend: pytorch
+
 {% if is_moe is defined %}  # is_moe from sdk
 moe_expert_parallel_size: {{ moe_expert_parallel_size }}
 moe_tensor_parallel_size: {{ moe_tensor_parallel_size }}

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.2.0rc6.post2.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.2.0rc6.post2.yaml.j2
@@ -1,3 +1,5 @@
+backend: pytorch
+
 {% if is_moe is defined %}  # is_moe from sdk
 moe_expert_parallel_size: {{ moe_expert_parallel_size }}
 moe_tensor_parallel_size: {{ moe_tensor_parallel_size }}

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.3.0rc1.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.3.0rc1.yaml.j2
@@ -1,3 +1,5 @@
+backend: pytorch
+
 {% if is_moe is defined %}  # is_moe from sdk
 moe_expert_parallel_size: {{ moe_expert_parallel_size }}
 moe_tensor_parallel_size: {{ moe_tensor_parallel_size }}


### PR DESCRIPTION
## Summary
Fixes two issues across 11 TRT-LLM version-specific engine templates that cause runtime failures or inconsistency:

### Issue 1: Invalid `build_config` nesting (7 templates)
- Templates wrapped `max_batch_size`, `max_num_tokens`, and `max_seq_len` under a `build_config:` section. TRT-LLM's PyTorch backend rejects `build_config` as a TensorRT-only argument, causing `ValueError` at runtime.
- Fixed by moving these to top-level keys, matching the default template (`extra_engine_args.yaml.j2`).
- **Affected:** `1.0.0`, `1.0.0rc6`, `1.1.0rc1`, `1.1.0rc4`, `1.1.0rc5`, `1.2.0rc2`, `1.2.0rc3`

### Issue 2: Missing `backend: pytorch` (8 templates)
- Templates omitted the explicit `backend: pytorch` declaration. While the validator/runtime may default to PyTorch, this is fragile and inconsistent with the default template.
- Fixed by adding `backend: pytorch` as the first line.
- **Affected:** `1.1.0rc4`, `1.1.0rc5`, `1.2.0rc2`, `1.2.0rc3`, `1.2.0rc5`, `1.2.0rc6.post1`, `1.2.0rc6.post2`, `1.3.0rc1`

## Test plan
- [ ] Generate configs with `--generated-config-version` for each affected version and verify the output YAML has top-level `max_batch_size`/`max_num_tokens`/`max_seq_len` (not nested under `build_config:`)
- [ ] Verify all generated configs start with `backend: pytorch`
- [ ] Run generated `run_0.sh` in a TRT-LLM runtime container to confirm no `ValueError` about `build_config`

Fixes: NVBug 5924504

Made with [Cursor](https://cursor.com)