### PR TITLE
fix: correct validator invocation syntax in generator docs (#430)

### DIFF
--- a/docs/generator_overview.md
+++ b/docs/generator_overview.md
@@ -189,19 +189,19 @@ The generator validator checks that generated engine configs or CLI args are acc
 **Usage (run inside the matching runtime image):**
 - TRT-LLM runtime image (e.g. `tensorrtllm-runtime`):
   ```
-  python -m aiconfigurator/tools/generator_validator/validator.py \
+  python tools/generator_validator/validator.py \
     --backend trtllm \
     --path /path/to/results
   ```
 - vLLM runtime image:
   ```
-  python -m aiconfigurator/tools/generator_validator/validator.py \
+  python tools/generator_validator/validator.py \
     --backend vllm \
     --path /path/to/results
   ```
 - SGLang runtime image:
   ```
-  python -m aiconfigurator/tools/generator_validator/validator.py \
+  python tools/generator_validator/validator.py \
     --backend sglang \
     --path /path/to/results
   ```


### PR DESCRIPTION
## Summary
Cherry-pick of #430 into `release/0.7.0`.

* Fixes all three documented validator commands in `docs/generator_overview.md` from `python -m aiconfigurator/tools/generator_validator/validator.py` to `python tools/generator_validator/validator.py`.
* The `python -m` flag treats forward slashes as module separators, causing `ModuleNotFoundError`. The script should be invoked directly with `python`.

Fixes: NVBug 5925207

Original PR: https://github.com/ai-dynamo/aiconfigurator/pull/430

Made with [Cursor](https://cursor.com)