### PR TITLE
fix: add --artifact-dir to benchmark templates to prevent Permission denied (#433)

### DIFF
--- a/src/aiconfigurator/generator/config/backend_templates/benchmark/bench_run.sh.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/benchmark/bench_run.sh.j2
@@ -11,9 +11,12 @@ concurrency_array=({{ (base_concurrency + [eff_low, eff, eff_high]) | join(' ') 
 concurrency_array=({{ base_concurrency | join(' ') }})
 {% endif %}
 
+ARTIFACT_DIR="${BENCH_ARTIFACT_DIR:-/tmp/bench_artifacts}"
+
 for concurrency in "${concurrency_array[@]}"; do
   echo "Run concurrency: $concurrency"
   aiperf profile \
+    --artifact-dir "${ARTIFACT_DIR}" \
     -m {{ BenchConfig.model }} \
     --endpoint-type {{ BenchConfig.endpoint_type }} \
     -u http://{{ ServiceConfig.head_node_ip }}:{{ ServiceConfig.port }} \

--- a/src/aiconfigurator/generator/config/backend_templates/benchmark/k8s_bench.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/benchmark/k8s_bench.yaml.j2
@@ -29,9 +29,11 @@ spec:
               {% else %}
               concurrency_array=({{ base_concurrency | join(' ') }})
               {% endif %}
+              ARTIFACT_DIR="${BENCH_ARTIFACT_DIR:-/tmp/bench_artifacts}"
               for concurrency in "${concurrency_array[@]}"; do
                 echo "Run concurrency: $concurrency"
                 aiperf profile \
+                  --artifact-dir "${ARTIFACT_DIR}" \
                   -m {{ BenchConfig.model }} \
                   --endpoint-type {{ BenchConfig.endpoint_type }} \
                   -u {{ BenchConfig.endpoint_url }} \


### PR DESCRIPTION
## Summary
Cherry-pick of #433 into `release/0.7.0`.

* Adds `--artifact-dir` flag to all `aiperf profile` invocations in both `bench_run.sh.j2` and `k8s_bench.yaml.j2` templates.
* Without this, aiperf defaults to writing to `./artifacts/` relative to the current working directory, which causes `[Errno 13] Permission denied` in read-only or restricted directories.
* The artifact directory is configurable via the `BENCH_ARTIFACT_DIR` environment variable, defaulting to `/tmp/bench_artifacts`.

Fixes: NVBug 5924798

Original PR: https://github.com/ai-dynamo/aiconfigurator/pull/433

Made with [Cursor](https://cursor.com)