### PR TITLE
fix: align max_num_tokens and cache_transceiver_max_tokens_in_buffer to tokens_per_block in benchmark trtllm rule

### DIFF
--- a/src/aiconfigurator/generator/rule_plugin/benchmark/trtllm.rule
+++ b/src/aiconfigurator/generator/rule_plugin/benchmark/trtllm.rule
@@ -6,10 +6,12 @@ prefill disable_overlap_scheduler = true
 decode disable_overlap_scheduler = false
 agg disable_overlap_scheduler = false
 
-prefill max_num_tokens = SlaConfig.isl + 1500
-decode max_num_tokens = max_batch_size
-agg max_num_tokens = max_batch_size + SlaConfig.isl + 1500
-prefill_decode cache_transceiver_max_tokens_in_buffer = SlaConfig.isl + SlaConfig.osl + 1500
+# Ensure maxNumTokens.value() % tokensPerBlock == 0
+agg_prefill_decode tokens_per_block = (tokens_per_block if tokens_per_block else 32)
+prefill max_num_tokens = (((SlaConfig.isl + 1500) + tokens_per_block - 1) // tokens_per_block) * tokens_per_block
+decode max_num_tokens = ((max_batch_size + tokens_per_block - 1) // tokens_per_block) * tokens_per_block
+agg max_num_tokens = ((max_batch_size + SlaConfig.isl + 1500 + tokens_per_block - 1) // tokens_per_block) * tokens_per_block
+prefill_decode cache_transceiver_max_tokens_in_buffer = (((SlaConfig.isl + SlaConfig.osl + 1500) + tokens_per_block - 1) // tokens_per_block) * tokens_per_block
 
 agg_prefill_decode cuda_graph_batch_sizes = ((range(1, max_batch_size + 1) | list) if max_batch_size else [])
 


### PR DESCRIPTION
The benchmark trtllm.rule computed max_num_tokens and cache_transceiver_max_tokens_in_buffer as raw sums without ceil-aligning to tokens_per_block (default 32). With isl=4000 and osl=1000 this produced 6500, which fails TRT-LLM's assertion `maxNumTokens % tokensPerBlock == 0` and crashes all disagg workers on startup.

The main trtllm.rule was already fixed but the benchmark variant was missed. Apply the same ceil-alignment pattern.

NVBug 5925425

Passed:
```
cd /Users/jasonzho/repo/aiconfigurator && source ../aic_venv/bin/activate && aiconfigurator cli default \
--backend trtllm \
--generated-config-version 1.2.0rc6.post1 \
--model Qwen/Qwen3-0.6B \
--system h100_sxm \
--total-gpus 8 \
--isl 4000 --osl 1000 --ttft 1000 --tpot 50 \
--generator-set ServiceConfig.model_path=Qwen/Qwen3-0.6B \
--generator-set ServiceConfig.served_model_name=Qwen/Qwen3-0.6B \
--generator-set K8sConfig.k8s_engine_mode=inline \
--generator-set K8sConfig.k8s_namespace=qchi-dynamo \
--generator-set K8sConfig.k8s_image=nvcr.io/nvstaging/ai-dynamo/tensorrtllm-runtime:0.8.0rc8-amd64 \
--generator-set K8sConfig.k8s_image_pull_secret=docker-repo-imagepullsecret \
--generator-set K8sConfig.k8s_model_cache=model-cache-pvc \
--generator-set rule=benchmark \
--save-dir ./results 2>&1
```
