### PR TITLE
ci: Remove really long PR comment left by bot when tests fail

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -37,10 +37,3 @@ jobs:
         if: always()
         run: |
             docker cp aic:/workspace/test_report.md ./test_report.md
-      - name: Render the report to the PR when tests fail
-        uses: marocchino/sticky-pull-request-comment@v2
-        if: failure()
-        with:
-          header: test-report
-          recreate: true
-          path: test_report.md


### PR DESCRIPTION
#### Overview:
Removes this really long and broken comment left by github-actions bot:

<img width="881" height="815" alt="Screenshot 2026-02-25 at 4 15 02 PM" src="https://github.com/user-attachments/assets/4e510390-10b9-4b43-9f90-4795287a579e" />

It's easy to just look at the CI job logs instead
