### PR TITLE
fix: align max_num_tokens and cache_transceiver_max_tokens_in_buffer to tokens_per_block in benchmark trtllm rule (#453)

### DIFF
--- a/src/aiconfigurator/generator/rule_plugin/benchmark/trtllm.rule
+++ b/src/aiconfigurator/generator/rule_plugin/benchmark/trtllm.rule
@@ -6,10 +6,12 @@ prefill disable_overlap_scheduler = true
 decode disable_overlap_scheduler = false
 agg disable_overlap_scheduler = false
 
-prefill max_num_tokens = SlaConfig.isl + 1500
-decode max_num_tokens = max_batch_size
-agg max_num_tokens = max_batch_size + SlaConfig.isl + 1500
-prefill_decode cache_transceiver_max_tokens_in_buffer = SlaConfig.isl + SlaConfig.osl + 1500
+# Ensure maxNumTokens.value() % tokensPerBlock == 0
+agg_prefill_decode tokens_per_block = (tokens_per_block if tokens_per_block else 32)
+prefill max_num_tokens = (((SlaConfig.isl + 1500) + tokens_per_block - 1) // tokens_per_block) * tokens_per_block
+decode max_num_tokens = ((max_batch_size + tokens_per_block - 1) // tokens_per_block) * tokens_per_block
+agg max_num_tokens = ((max_batch_size + SlaConfig.isl + 1500 + tokens_per_block - 1) // tokens_per_block) * tokens_per_block
+prefill_decode cache_transceiver_max_tokens_in_buffer = (((SlaConfig.isl + SlaConfig.osl + 1500) + tokens_per_block - 1) // tokens_per_block) * tokens_per_block
 
 agg_prefill_decode cuda_graph_batch_sizes = ((range(1, max_batch_size + 1) | list) if max_batch_size else [])
 


### PR DESCRIPTION

The benchmark trtllm.rule computed max_num_tokens and cache_transceiver_max_tokens_in_buffer as raw sums without ceil-aligning to tokens_per_block (default 32). With isl=4000 and osl=1000 this produced 6500, which fails TRT-LLM's assertion `maxNumTokens % tokensPerBlock == 0` and crashes all disagg workers on startup.

The main trtllm.rule was already fixed but the benchmark variant was missed. Apply the same ceil-alignment pattern.

NVBug 5925425

