### PR TITLE
fix: OOM not raised in disagg get_worker_candidates(), causes IndexEr…

### DIFF
--- a/src/aiconfigurator/sdk/inference_session.py
+++ b/src/aiconfigurator/sdk/inference_session.py
@@ -290,6 +290,7 @@ class DisaggInferenceSession:
         """
         summary_df = pd.DataFrame(columns=common.ColumnsStatic)
         exceptions: list[Exception] = []
+        all_configs_oom = True
 
         for parallel_config in parallel_config_list:
             tp_size, pp_size, dp_size, moe_tp_size, moe_ep_size = parallel_config
@@ -336,6 +337,7 @@ class DisaggInferenceSession:
                         latency_correction_scale=latency_correction_scale,
                     )
                     if not summary.check_oom():
+                        all_configs_oom = False
                         summary_df = pd.concat(
                             [summary_df, summary.get_summary_df()],
                             axis=0,
@@ -358,9 +360,21 @@ class DisaggInferenceSession:
                 exceptions.append(e)
                 continue
         if summary_df.empty:
+            if exceptions:
+                raise RuntimeError(
+                    f"No results found for any parallel configuration. Showing last exception: {exceptions[-1]}"
+                ) from exceptions[-1]
+            if all_configs_oom:
+                raise RuntimeError(
+                    "No results found: the model does not fit in GPU memory for any parallel "
+                    "configuration. Try increasing --total-gpus, using a quantized model, or "
+                    "using a system with more VRAM per GPU."
+                )
             raise RuntimeError(
-                f"No results found for any parallel configuration. Showing last exception: {exceptions[-1]}"
-            ) from exceptions[-1]
+                "No results found for any parallel configuration. No configuration satisfied the "
+                "TTFT/TPOT or request-latency constraints. Try relaxing --ttft, --tpot, or "
+                "--request_latency (e.g., higher ttft/tpot or higher request_latency)."
+            )
         return summary_df
 
     def _pick_autoscale(


### PR DESCRIPTION
…ror (#456)

In disagg mode, when all parallel configurations exceed GPU memory, check_oom() returns True and the batch-size loop breaks, but OOM is never raised as an exception. This leaves summary_df empty AND the exceptions list empty, causing IndexError on exceptions[-1].

Root cause: the OOM detected by check_oom() silently breaks out of the inner loop without propagating as an exception or tracking OOM state.

Fix: track all_configs_oom (same pattern as agg_pareto from PR #437). When all configs OOM, raise a descriptive RuntimeError about memory. This mirrors the three-tier error handling in agg_pareto:
1. exceptions non-empty → show last exception
2. all_configs_oom → OOM-specific message
3. otherwise → TTFT/TPOT constraints message