### PR TITLE
fix: make old version trtllm template support build_config for generator

### DIFF
--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.0.0.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.0.0.yaml.j2
@@ -18,11 +18,12 @@ enable_chunked_prefill: {{ enable_chunked_prefill | default(false) }}
 
 {% set _max_seq_len = build_config.max_seq_len | default(none) %}
 
-max_batch_size: {{ build_config.max_batch_size }}
-max_num_tokens: {{ build_config.max_num_tokens }}
-{% if _max_seq_len is not none and _max_seq_len != '' %}
-max_seq_len: {{ _max_seq_len }}
-{% endif %}
+build_config:
+  max_batch_size: {{ build_config.max_batch_size }}
+  max_num_tokens: {{ build_config.max_num_tokens }}
+  {% if _max_seq_len is not none and _max_seq_len != '' %}
+  max_seq_len: {{ _max_seq_len }}
+  {% endif %}
 
 kv_cache_config:
   free_gpu_memory_fraction: {{ kv_cache_config.free_gpu_memory_fraction | default(0.80) }}

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.0.0rc3.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.0.0rc3.yaml.j2
@@ -20,11 +20,12 @@ enable_chunked_prefill: {{ enable_chunked_prefill | default(false) }}
 
 {% set _max_seq_len = build_config.max_seq_len | default(none) %}
 
-max_batch_size: {{ build_config.max_batch_size }}
-max_num_tokens: {{ build_config.max_num_tokens }}
-{% if _max_seq_len is not none and _max_seq_len != '' %}
-max_seq_len: {{ _max_seq_len }}
-{% endif %}
+build_config:
+  max_batch_size: {{ build_config.max_batch_size }}
+  max_num_tokens: {{ build_config.max_num_tokens }}
+  {% if _max_seq_len is not none and _max_seq_len != '' %}
+  max_seq_len: {{ _max_seq_len }}
+  {% endif %}
 
 kv_cache_config:
   free_gpu_memory_fraction: {{ kv_cache_config.free_gpu_memory_fraction | default(0.80) }}

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.0.0rc4.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.0.0rc4.yaml.j2
@@ -18,11 +18,12 @@ enable_chunked_prefill: {{ enable_chunked_prefill | default(false) }}
 
 {% set _max_seq_len = build_config.max_seq_len | default(none) %}
 
-max_batch_size: {{ build_config.max_batch_size }}
-max_num_tokens: {{ build_config.max_num_tokens }}
-{% if _max_seq_len is not none and _max_seq_len != '' %}
-max_seq_len: {{ _max_seq_len }}
-{% endif %}
+build_config:
+  max_batch_size: {{ build_config.max_batch_size }}
+  max_num_tokens: {{ build_config.max_num_tokens }}
+  {% if _max_seq_len is not none and _max_seq_len != '' %}
+  max_seq_len: {{ _max_seq_len }}
+  {% endif %}
 
 kv_cache_config:
   free_gpu_memory_fraction: {{ kv_cache_config.free_gpu_memory_fraction | default(0.80) }}

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.0.0rc6.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.0.0rc6.yaml.j2
@@ -18,11 +18,12 @@ enable_chunked_prefill: {{ enable_chunked_prefill | default(false) }}
 
 {% set _max_seq_len = build_config.max_seq_len | default(none) %}
 
-max_batch_size: {{ build_config.max_batch_size }}
-max_num_tokens: {{ build_config.max_num_tokens }}
-{% if _max_seq_len is not none and _max_seq_len != '' %}
-max_seq_len: {{ _max_seq_len }}
-{% endif %}
+build_config:
+  max_batch_size: {{ build_config.max_batch_size }}
+  max_num_tokens: {{ build_config.max_num_tokens }}
+  {% if _max_seq_len is not none and _max_seq_len != '' %}
+  max_seq_len: {{ _max_seq_len }}
+  {% endif %}
 
 kv_cache_config:
   free_gpu_memory_fraction: {{ kv_cache_config.free_gpu_memory_fraction | default(0.80) }}

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.1.0rc1.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.1.0rc1.yaml.j2
@@ -18,11 +18,12 @@ enable_chunked_prefill: {{ enable_chunked_prefill | default(false) }}
 
 {% set _max_seq_len = build_config.max_seq_len | default(none) %}
 
-max_batch_size: {{ build_config.max_batch_size }}
-max_num_tokens: {{ build_config.max_num_tokens }}
-{% if _max_seq_len is not none and _max_seq_len != '' %}
-max_seq_len: {{ _max_seq_len }}
-{% endif %}
+build_config:
+  max_batch_size: {{ build_config.max_batch_size }}
+  max_num_tokens: {{ build_config.max_num_tokens }}
+  {% if _max_seq_len is not none and _max_seq_len != '' %}
+  max_seq_len: {{ _max_seq_len }}
+  {% endif %}
 
 kv_cache_config:
   free_gpu_memory_fraction: {{ kv_cache_config.free_gpu_memory_fraction | default(0.80) }}

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.1.0rc4.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.1.0rc4.yaml.j2
@@ -18,11 +18,12 @@ enable_chunked_prefill: {{ enable_chunked_prefill | default(false) }}
 
 {% set _max_seq_len = build_config.max_seq_len | default(none) %}
 
-max_batch_size: {{ build_config.max_batch_size }}
-max_num_tokens: {{ build_config.max_num_tokens }}
-{% if _max_seq_len is not none and _max_seq_len != '' %}
-max_seq_len: {{ _max_seq_len }}
-{% endif %}
+build_config:
+  max_batch_size: {{ build_config.max_batch_size }}
+  max_num_tokens: {{ build_config.max_num_tokens }}
+  {% if _max_seq_len is not none and _max_seq_len != '' %}
+  max_seq_len: {{ _max_seq_len }}
+  {% endif %}
 
 kv_cache_config:
   free_gpu_memory_fraction: {{ kv_cache_config.free_gpu_memory_fraction | default(0.80) }}

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.1.0rc5.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.1.0rc5.yaml.j2
@@ -18,11 +18,12 @@ enable_chunked_prefill: {{ enable_chunked_prefill | default(false) }}
 
 {% set _max_seq_len = build_config.max_seq_len | default(none) %}
 
-max_batch_size: {{ build_config.max_batch_size }}
-max_num_tokens: {{ build_config.max_num_tokens }}
-{% if _max_seq_len is not none and _max_seq_len != '' %}
-max_seq_len: {{ _max_seq_len }}
-{% endif %}
+build_config:
+  max_batch_size: {{ build_config.max_batch_size }}
+  max_num_tokens: {{ build_config.max_num_tokens }}
+  {% if _max_seq_len is not none and _max_seq_len != '' %}
+  max_seq_len: {{ _max_seq_len }}
+  {% endif %}
 
 kv_cache_config:
   free_gpu_memory_fraction: {{ kv_cache_config.free_gpu_memory_fraction | default(0.80) }}  # Fraction of GPU memory usable for KV‑cache

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.2.0rc2.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.2.0rc2.yaml.j2
@@ -18,11 +18,12 @@ enable_chunked_prefill: {{ enable_chunked_prefill | default(false) }}
 
 {% set _max_seq_len = build_config.max_seq_len | default(none) %}
 
-max_batch_size: {{ build_config.max_batch_size }}
-max_num_tokens: {{ build_config.max_num_tokens }}
-{% if _max_seq_len is not none and _max_seq_len != '' %}
-max_seq_len: {{ _max_seq_len }}
-{% endif %}
+build_config:
+  max_batch_size: {{ build_config.max_batch_size }}
+  max_num_tokens: {{ build_config.max_num_tokens }}
+  {% if _max_seq_len is not none and _max_seq_len != '' %}
+  max_seq_len: {{ _max_seq_len }}
+  {% endif %}
 
 kv_cache_config:
   free_gpu_memory_fraction: {{ kv_cache_config.free_gpu_memory_fraction | default(0.80) }}  # Fraction of GPU memory usable for KV‑cache

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.2.0rc3.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.2.0rc3.yaml.j2
@@ -18,11 +18,12 @@ enable_chunked_prefill: {{ enable_chunked_prefill | default(false) }}
 
 {% set _max_seq_len = build_config.max_seq_len | default(none) %}
 
-max_batch_size: {{ build_config.max_batch_size }}
-max_num_tokens: {{ build_config.max_num_tokens }}
-{% if _max_seq_len is not none and _max_seq_len != '' %}
-max_seq_len: {{ _max_seq_len }}
-{% endif %}
+build_config:
+  max_batch_size: {{ build_config.max_batch_size }}
+  max_num_tokens: {{ build_config.max_num_tokens }}
+  {% if _max_seq_len is not none and _max_seq_len != '' %}
+  max_seq_len: {{ _max_seq_len }}
+  {% endif %}
 
 kv_cache_config:
   free_gpu_memory_fraction: {{ kv_cache_config.free_gpu_memory_fraction | default(0.80) }}  # Fraction of GPU memory usable for KV‑cache

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.2.0rc5.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.2.0rc5.yaml.j2
@@ -18,12 +18,11 @@ enable_chunked_prefill: {{ enable_chunked_prefill | default(false) }}
 
 {% set _max_seq_len = build_config.max_seq_len | default(none) %}
 
-build_config:
-  max_batch_size: {{ build_config.max_batch_size }}
-  max_num_tokens: {{ build_config.max_num_tokens }}
-  {% if _max_seq_len is not none and _max_seq_len != '' %}
-  max_seq_len: {{ _max_seq_len }}
-  {% endif %}
+max_batch_size: {{ build_config.max_batch_size }}
+max_num_tokens: {{ build_config.max_num_tokens }}
+{% if _max_seq_len is not none and _max_seq_len != '' %}
+max_seq_len: {{ _max_seq_len }}
+{% endif %}
 
 kv_cache_config:
   free_gpu_memory_fraction: {{ kv_cache_config.free_gpu_memory_fraction | default(0.80) }}  # Fraction of GPU memory usable for KV‑cache


### PR DESCRIPTION
#### Overview:

Although build_config was deprecated in v1.2.0rc5, some settings for older TRT-LLM versions still need to be provided via build_config to work correctly.
