### PR TITLE
chore: update gradio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ dev = [
     "import-ipynb==0.2",
 ]
 webapp = [
-    "gradio==5.47.1"
+    "gradio==6.8.0"
 ]
 service = [
     "fastapi>=0.115.12",


### PR DESCRIPTION
#### Overview:

Update gradio to 6.8.0

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Relates to OPS-3547

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Gradio framework dependency to version 6.8.0 for the web application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->