### PR TITLE
fix: model qkv_a_proj as standalone GEMM in WideEP pipeline

### DIFF
--- a/src/aiconfigurator/sdk/models.py
+++ b/src/aiconfigurator/sdk/models.py
@@ -1933,6 +1933,23 @@ class WideEPDeepSeekModel(BaseModel):
 
         sms = self.config.sms
 
+        # qkv_a projection (fused q_a + kv_a + rope): hidden_size -> q_lora_rank + kv_lora_rank + qk_rope_head_dim
+        # This is replicated on every GPU (not TP-sharded), matching narrow EP's context_downscale_gemm.
+        # In sglang >=0.5.6, qkv_a_proj is computed outside the MLA attention forward via communicator,
+        # so it must be modeled as a separate GEMM op rather than included in WideEPContextMLA.
+        self.context_ops.extend(
+            [
+                ops.GEMM(
+                    "context_qkv_a_proj_gemm",
+                    self._num_layers,
+                    1536 + 512 + 64,  # q_lora_rank + kv_lora_rank + qk_rope_head_dim = 2112
+                    h,
+                    gemm_quant_mode,
+                    scale_num_tokens=tp_size,
+                ),
+            ]
+        )
+
         # context mla attention
         self.context_ops.extend(
             [
@@ -2046,6 +2063,19 @@ class WideEPDeepSeekModel(BaseModel):
                     moe_backend=moe_backend,
                     enable_eplb=self.config.enable_eplb,
                 )
+            ]
+        )
+
+        # qkv_a projection for generation (same as context but per-token, not per-seq)
+        self.generation_ops.extend(
+            [
+                ops.GEMM(
+                    "generation_qkv_a_proj_gemm",
+                    self._num_layers * self._mtp_scale_factor,
+                    1536 + 512 + 64,  # q_lora_rank + kv_lora_rank + qk_rope_head_dim = 2112
+                    h,
+                    gemm_quant_mode,
+                ),
             ]
         )
 


### PR DESCRIPTION
In sglang >=0.5.6, qkv_a_proj was moved outside MLA attention forward() into a lazy qkv_latent_func via the communicator pattern. The AIC collector correctly excludes it (uses dummy func), but the WideEP pipeline had no standalone GEMM for it — causing qkv_a compute to be entirely missing from prefill/decode predictions.

Add context_qkv_a_proj_gemm and generation_qkv_a_proj_gemm standalone GEMM ops to WideEPDeepSeekModel, and remove qkv_a from SOL calculations in query_wideep_context_mla and query_wideep_generation_mla to avoid double-counting.

#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new projection operations to enhance model configuration support for DeepSeek contexts.

* **Refactor**
  * Improved how projection operations are accounted for in performance modeling by restructuring internal calculations for better separation and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->