### PR TITLE
fix: inter-node bw in system yaml file

### DIFF
--- a/src/aiconfigurator/systems/b200_sxm.yaml
+++ b/src/aiconfigurator/systems/b200_sxm.yaml
@@ -15,7 +15,7 @@ gpu:
 
 node:
   num_gpus_per_node: 8
-  inter_node_bw: 50000000000  # Byte/s per GPU, single direction, assume 1:1 CX8 per node
+  inter_node_bw: 100000000000  # Byte/s per GPU, single direction, 1:1 CX8 XDR 800Gb/s per node
   intra_node_bw: 900000000000  # Byte/s per gpu, single direction
   pcie_bw: 128000000000  # Byte/s, single direction, pcie 6.0
   p2p_latency: 0.00001  # 10us some nonofficial correction based on observations, you should try to modify based on your own observations

--- a/src/aiconfigurator/systems/gb200.yaml
+++ b/src/aiconfigurator/systems/gb200.yaml
@@ -19,7 +19,7 @@ gpu:
 node:
   num_gpus_per_node: 4  # 4 GPUs per physical node (2 Grace CPUs x 2 GPUs each)
   num_gpus_per_rack: 72  # 72 GPUs per rack (18 compute trays x 4 GPUs each)
-  inter_rack_bw: 25000000000  # Byte/s per GPU, single direction - InfiniBand between racks
+  inter_rack_bw: 100000000000  # Byte/s per GPU, single direction - CX8 XDR 800Gb/s InfiniBand between racks
   inter_node_bw: 900000000000  # Byte/s per GPU, single direction - NVLink via NVSwitch within rack
   intra_node_bw: 900000000000  # Byte/s per GPU, single direction - NVLink 5th gen within node
   pcie_bw: 64000000000  # Byte/s, single direction, pcie 5.0

--- a/src/aiconfigurator/systems/gb300.yaml
+++ b/src/aiconfigurator/systems/gb300.yaml
@@ -19,7 +19,7 @@ gpu:
 node:
   num_gpus_per_node: 4  # 4 GPUs per physical node (2 Grace CPUs x 2 GPUs each)
   num_gpus_per_rack: 72  # 72 GPUs per rack (18 compute trays x 4 GPUs each)
-  inter_rack_bw: 25000000000  # Byte/s per GPU, single direction - InfiniBand between racks
+  inter_rack_bw: 100000000000  # Byte/s per GPU, single direction - CX8 XDR 800Gb/s InfiniBand between racks
   inter_node_bw: 900000000000  # Byte/s per GPU, single direction - NVLink via NVSwitch within rack
   intra_node_bw: 900000000000  # Byte/s per GPU, single direction - NVLink 5th gen within node
   pcie_bw: 64000000000  # Byte/s, single direction, pcie 5.0

--- a/src/aiconfigurator/systems/h100_sxm.yaml
+++ b/src/aiconfigurator/systems/h100_sxm.yaml
@@ -15,7 +15,7 @@ gpu:
 
 node:
   num_gpus_per_node: 8
-  inter_node_bw: 25000000000  # Byte/s per GPU, single direction, 1:1 CX7 per node
+  inter_node_bw: 50000000000  # Byte/s per GPU, single direction, 1:1 CX7 NDR 400Gb/s per node
   intra_node_bw: 450000000000  # Byte/s per gpu, single direction
   pcie_bw: 64000000000  # Byte/s, single direction, pcie 5.0
   p2p_latency: 0.00001  # 10us some nonofficial correction based on observations, you should try to modify based on your own observations

--- a/src/aiconfigurator/systems/h200_sxm.yaml
+++ b/src/aiconfigurator/systems/h200_sxm.yaml
@@ -15,7 +15,7 @@ gpu:
 
 node:
   num_gpus_per_node: 8
-  inter_node_bw: 25000000000  # Byte/s per GPU, single direction, 1:1 CX7 per node
+  inter_node_bw: 50000000000  # Byte/s per GPU, single direction, 1:1 CX7 NDR 400Gb/s per node
   intra_node_bw: 450000000000  # Byte/s per gpu, single direction
   pcie_bw: 64000000000  # Byte/s, single direction, pcie 5.0
   p2p_latency: 0.00001  # 10us some nonofficial correction based on observations, you should try to modify based on your own observations

--- a/src/aiconfigurator/systems/l40s.yaml
+++ b/src/aiconfigurator/systems/l40s.yaml
@@ -15,7 +15,7 @@ gpu:
 
 node:
   num_gpus_per_node: 8
-  inter_node_bw: 25000000000  # Byte/s per GPU, single direction, 1:1 CX7 per node
+  inter_node_bw: 50000000000  # Byte/s per GPU, single direction, 1:1 CX7 NDR 400Gb/s per node
   intra_node_bw: 32000000000  # Byte/s per gpu, single direction (pcie 4.0)
   pcie_bw: 32000000000  # Byte/s, single direction, pcie 4.0
   p2p_latency: 0.00001  # 10us some nonofficial correction based on observations, you should try to modify based on your own observations


### PR DESCRIPTION
Here's a PR description for you:

---

#### Overview:

Fix incorrect `inter_node_bw` and `inter_rack_bw` values across all system YAML files. The bandwidth values were consistently one generation behind — CX7 files had CX6 speeds, CX8 files had CX7 speeds.

#### Details:

All ConnectX bandwidth values were off by one generation:

| File | Field | Before | After | NIC |
|------|-------|--------|-------|-----|
| `h100_sxm.yaml` | `inter_node_bw` | 25 GB/s | **50 GB/s** | CX7 NDR 400Gb/s |
| `h200_sxm.yaml` | `inter_node_bw` | 25 GB/s | **50 GB/s** | CX7 NDR 400Gb/s |
| `l40s.yaml` | `inter_node_bw` | 25 GB/s | **50 GB/s** | CX7 NDR 400Gb/s |
| `b200_sxm.yaml` | `inter_node_bw` | 50 GB/s | **100 GB/s** | CX8 XDR 800Gb/s |
| `gb200.yaml` | `inter_rack_bw` | 25 GB/s | **100 GB/s** | CX8 XDR 800Gb/s |
| `gb300.yaml` | `inter_rack_bw` | 25 GB/s | **100 GB/s** | CX8 XDR 800Gb/s |

Reference (single-direction effective bandwidth per NIC):
- CX6 HDR 200Gb/s → 25 GB/s (`a100_sxm.yaml` was already correct)
- CX7 NDR 400Gb/s → 50 GB/s
- CX8 XDR 800Gb/s → 100 GB/s

#### Where should the reviewer start?

All changes are in `src/aiconfigurator/systems/`. Each file has a one-line change to the `inter_node_bw` or `inter_rack_bw` value and its comment.

#### Related Issues:

- Closes #471

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated interconnect and inter-node bandwidth specifications for B200, GB200, GB300, H100, H200, and L40S system configurations to align with current networking capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->