### PR TITLE
refactor: use multi-thread to accelerate support matrix

### DIFF
--- a/tools/support_matrix/generate_support_matrix.py
+++ b/tools/support_matrix/generate_support_matrix.py
@@ -41,6 +41,12 @@ def main():
         default=default_output,
         help=f"Output file to save results (CSV format) (default: {default_output})",
     )
+    parser.add_argument(
+        "--max-workers",
+        type=int,
+        default=None,
+        help="Maximum number of threads for parallel execution (default: auto)",
+    )
 
     args = parser.parse_args()
 
@@ -53,7 +59,7 @@ def main():
     )
 
     support_matrix = SupportMatrix()
-    results = support_matrix.test_support_matrix()
+    results = support_matrix.test_support_matrix(max_workers=args.max_workers)
 
     # Always save results (now has a default output location)
     support_matrix.save_results_to_csv(results, args.output)

--- a/tools/support_matrix/support_matrix.py
+++ b/tools/support_matrix/support_matrix.py
@@ -13,6 +13,7 @@ import csv
 import logging
 import os
 import traceback
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from packaging.version import Version
 from tqdm import tqdm
@@ -176,10 +177,16 @@ class SupportMatrix:
                     error_messages[mode] = None
         return results, error_messages
 
-    def test_support_matrix(self) -> list[tuple[str, str, str, str, str, str, bool, str | None]]:
+    def test_support_matrix(
+        self, max_workers: int | None = None
+    ) -> list[tuple[str, str, str, str, str, str, bool, str | None]]:
         """
         Test whether each combination is supported by AIC.
         Tests both agg and disagg modes for each combination and captures error messages.
+
+        Args:
+            max_workers: Maximum number of threads for parallel execution.
+                         Defaults to None, which uses min(32, os.cpu_count()).
 
         Returns:
             List of tuples (huggingface_id, architecture, system, backend, version, mode, success, err_msg)
@@ -196,34 +203,37 @@ class SupportMatrix:
         print(f"Prefix: {PREFIX}")
         print(f"Target TTFT: {TTFT}ms")
         print(f"Target TPOT: {TPOT}ms")
+        if max_workers is None:
+            max_workers = min(32, (os.cpu_count() or 1))
+        print(f"Max workers: {max_workers}")
         print("=" * 80 + "\n")
 
         combinations = self.generate_combinations()
         results = []
 
-        # Use tqdm for progress tracking
-        for model, system, backend, version in tqdm(
-            combinations,
-            desc="Testing support matrix",
-            unit="config",
-        ):
-            # model is already a HuggingFace ID (e.g., 'meta-llama/Llama-2-7b-hf')
-            huggingface_id = model
+        def _process_combination(combo):
+            model, system, backend, version = combo
             success_dict, error_dict = self.run_single_test(
-                model=huggingface_id,
+                model=model,
                 system=system,
                 backend=backend,
                 version=version,
             )
+            architecture = self.get_architecture(model)
+            return [
+                (model, architecture, system, backend, version, mode, success_dict[mode], error_dict[mode])
+                for mode in success_dict
+            ]
 
-            # Get the architecture for this model
-            architecture = self.get_architecture(huggingface_id)
-
-            # Add separate entries for agg and disagg modes
-            for mode in success_dict:
-                results.append(
-                    (huggingface_id, architecture, system, backend, version, mode, success_dict[mode], error_dict[mode])
-                )
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = {executor.submit(_process_combination, combo): combo for combo in combinations}
+            for future in tqdm(
+                as_completed(futures),
+                total=len(combinations),
+                desc="Testing support matrix",
+                unit="config",
+            ):
+                results.extend(future.result())
 
         # Sort results by (huggingface_id, architecture, system, backend, version, mode)
         results.sort(key=lambda x: (x[0], x[1], x[2], x[3], Version(x[4]), x[5]))


### PR DESCRIPTION
#### Overview:

Use multi-thread to accelerate support matrix generation.

#### Test Plan:

- [ ] Gather data on how much time saved on 2 CPU
    - [ ] 6 threads https://github.com/ai-dynamo/aiconfigurator/actions/runs/22562058223
    - [ ] 2 threads https://github.com/ai-dynamo/aiconfigurator/actions/runs/22562308175


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--max-workers` command-line option to control the number of parallel workers during test execution.

* **Improvements**
  * Test execution now supports parallelization with automatic worker count scaling based on system resources. Existing output behavior and defaults remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->