### PR TITLE
fix: apply latency correction scales in run disagg

### DIFF
--- a/src/aiconfigurator/sdk/inference_session.py
+++ b/src/aiconfigurator/sdk/inference_session.py
@@ -240,10 +240,18 @@ class DisaggInferenceSession:
 
         prefill_runtime_config = copy.deepcopy(runtime_config)
         prefill_runtime_config.batch_size = prefill_batch_size
-        prefill_summary = prefill_sess.run_static(mode="static_ctx", runtime_config=prefill_runtime_config)
+        prefill_summary = prefill_sess.run_static(
+            mode="static_ctx",
+            runtime_config=prefill_runtime_config,
+            latency_correction_scale=self._prefill_latency_correction_scale,
+        )
         decode_runtime_config = copy.deepcopy(runtime_config)
         decode_runtime_config.batch_size = decode_batch_size
-        decode_summary = decode_sess.run_static(mode="static_gen", runtime_config=decode_runtime_config)
+        decode_summary = decode_sess.run_static(
+            mode="static_gen",
+            runtime_config=decode_runtime_config,
+            latency_correction_scale=self._decode_latency_correction_scale,
+        )
         disagg_summary_df = self._get_disagg_summary_df(
             prefill_summary.get_summary_df(),
             prefill_num_worker,


### PR DESCRIPTION
---

#### Overview:

Fix `DisaggInferenceSession.run_disagg` ignoring latency correction scales.

#### Details:

`run_disagg` called `run_static` for both prefill and decode without passing `latency_correction_scale`, so corrections set via `set_latency_correction_scales` were silently ignored (always defaulting to 1.0). The sibling method `find_best_disagg_result_under_constraints` already passes them correctly.

Fix: forward `self._prefill_latency_correction_scale` and `self._decode_latency_correction_scale` to the respective `run_static` calls.

#### Where should the reviewer start?

`src/aiconfigurator/sdk/inference_session.py` — the two `run_static` calls inside `run_disagg`.

#### Related Issues:

- Fixes #479

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined latency correction mechanisms during inference to apply section-specific adjustments for more accurate performance metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->