### PR TITLE
fix: naive config generator produces RFC 1123-invalid DGD name 'None-agg'

### DIFF
--- a/src/aiconfigurator/generator/api.py
+++ b/src/aiconfigurator/generator/api.py
@@ -620,6 +620,13 @@ def generate_naive_config(
     # Determine backend version
     if backend_version is None:
         backend_version = get_latest_database_version(system=system, backend=backend)
+    if backend_version is None:
+        logger.warning(
+            "No perf-database version found for system=%s, backend=%s; "
+            "falling back to default templates.",
+            system,
+            backend,
+        )
     logger.info("Using backend version: %s", backend_version)
 
     # Prepare output directory if provided

--- a/src/aiconfigurator/generator/api.py
+++ b/src/aiconfigurator/generator/api.py
@@ -622,8 +622,7 @@ def generate_naive_config(
         backend_version = get_latest_database_version(system=system, backend=backend)
     if backend_version is None:
         logger.warning(
-            "No perf-database version found for system=%s, backend=%s; "
-            "falling back to default templates.",
+            "No perf-database version found for system=%s, backend=%s; falling back to default templates.",
             system,
             backend,
         )

--- a/src/aiconfigurator/generator/config/backend_templates/vllm/k8s_deploy.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/vllm/k8s_deploy.yaml.j2
@@ -90,8 +90,8 @@ spec:
 
     {% if DynConfig.mode | default('disagg') == 'agg' %}
 {{ render_worker(
-    "VllmDecodeWorker",
-    "decode",
+    "VllmWorker",
+    None,
     agg_workers,
     agg_gpu,
     agg_cli_args_list | default([])

--- a/src/aiconfigurator/generator/naive.py
+++ b/src/aiconfigurator/generator/naive.py
@@ -10,6 +10,7 @@ the smallest TP that fits the model in memory, with PP=1.
 
 import logging
 import os
+import re
 from typing import Any
 
 import yaml
@@ -18,11 +19,29 @@ from aiconfigurator.sdk import perf_database
 
 logger = logging.getLogger(__name__)
 
+_RFC1123_MAX_LEN = 63
+
 # Default fallbacks
 _DEFAULT_GPUS_PER_NODE = 8
 _DEFAULT_VRAM_BYTES = 141 * 1024 * 1024 * 1024  # 141 GiB (H200)
 _MEMORY_MULTIPLIER = 1.5  # Require 1.5x model weight to fit in VRAM
 _BYTES_PER_PARAM = 2  # FP16/BF16
+
+
+def _sanitize_rfc1123(name: str) -> str:
+    """Sanitize a string to be a valid RFC 1123 subdomain label prefix.
+
+    Converts ``"Qwen/Qwen3-32B"`` → ``"qwen-qwen3-32b"``, etc.
+    Falls back to ``"dynamo"`` when the input is empty or None.
+    """
+    if not name:
+        return "dynamo"
+    sanitized = name.lower()
+    sanitized = re.sub(r"[^a-z0-9\-.]", "-", sanitized)
+    sanitized = re.sub(r"-{2,}", "-", sanitized)
+    sanitized = sanitized.strip("-.")
+    sanitized = sanitized[:_RFC1123_MAX_LEN].rstrip("-.")
+    return sanitized or "dynamo"
 
 
 def _get_system_config(system_name: str) -> dict[str, Any]:
@@ -247,14 +266,18 @@ def build_naive_generator_params(
     gpus_per_worker = tensor_parallel_size * pipeline_parallel_size
     agg_workers = total_gpus // gpus_per_worker
 
+    name_prefix = _sanitize_rfc1123(model_name)
+
     params = {
-        "service": {
+        "ServiceConfig": {
             "model_name": model_name,
             "served_model_name": model_name,
             "model_path": model_name,
+            "include_frontend": True,
         },
-        "k8s": {
+        "K8sConfig": {
             "system_name": system_name,
+            "name_prefix": name_prefix,
         },
         "params": {
             "agg": {
@@ -274,7 +297,6 @@ def build_naive_generator_params(
         "NodeConfig": {
             "num_gpus_per_node": gpus_per_node,
         },
-        # WorkerConfig is used by the run script generator
         "WorkerConfig": {
             "agg_workers": agg_workers,
             "agg_gpus_per_worker": gpus_per_worker,

--- a/src/aiconfigurator/generator/rendering/engine.py
+++ b/src/aiconfigurator/generator/rendering/engine.py
@@ -540,7 +540,7 @@ def prepare_template_context(param_values: dict[str, Any], backend: str) -> dict
 
     # Extract K8s configuration
     k8s_config = param_values.get("K8sConfig", {})
-    context["name_prefix"] = k8s_config.get("name_prefix")
+    context["name_prefix"] = k8s_config.get("name_prefix") or "dynamo"
     context["k8s_namespace"] = k8s_config.get("k8s_namespace")
     context["k8s_image"] = k8s_config.get("k8s_image")
     context["k8s_image_pull_secret"] = k8s_config.get("k8s_image_pull_secret")

--- a/tests/unit/generator/test_naive.py
+++ b/tests/unit/generator/test_naive.py
@@ -1,0 +1,195 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for generator naive module — nvbug 5941223."""
+
+import re
+from unittest.mock import patch
+
+import pytest
+
+from aiconfigurator.generator.naive import (
+    _sanitize_rfc1123,
+    build_naive_generator_params,
+)
+
+_RFC1123_LABEL_RE = re.compile(r"^[a-z0-9]([a-z0-9\-.]*[a-z0-9])?$")
+
+
+@pytest.mark.unit
+class TestSanitizeRfc1123:
+    """Verify _sanitize_rfc1123 produces valid RFC 1123 subdomain labels."""
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            ("Qwen/Qwen3-32B", "qwen-qwen3-32b"),
+            ("meta-llama/Llama-3.1-70B", "meta-llama-llama-3.1-70b"),
+            ("deepseek-ai/DeepSeek-V3", "deepseek-ai-deepseek-v3"),
+            ("simple-model", "simple-model"),
+            ("ALLCAPS", "allcaps"),
+            ("a" * 100, "a" * 63),
+        ],
+    )
+    def test_known_models(self, raw, expected):
+        assert _sanitize_rfc1123(raw) == expected
+
+    @pytest.mark.parametrize("bad_input", [None, "", "---", "///"])
+    def test_fallback_to_dynamo(self, bad_input):
+        assert _sanitize_rfc1123(bad_input) == "dynamo"
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "Qwen/Qwen3-32B",
+            "meta-llama/Llama-3.1-70B",
+            "nvidia/Nemotron-4-340B",
+            "a",
+            "a-b.c",
+        ],
+    )
+    def test_result_matches_rfc1123(self, raw):
+        result = _sanitize_rfc1123(raw)
+        assert _RFC1123_LABEL_RE.match(result), f"{result!r} is not RFC 1123 compliant"
+        assert len(result) <= 63
+
+
+@pytest.mark.unit
+class TestBuildNaiveGeneratorParams:
+    """Verify build_naive_generator_params produces correct keys for the rendering engine."""
+
+    @patch(
+        "aiconfigurator.generator.naive._estimate_model_weight_bytes",
+        return_value=30 * 1024**3,
+    )
+    @patch(
+        "aiconfigurator.generator.naive._get_system_config",
+        return_value={"gpus_per_node": 8, "vram_per_gpu": 141 * 1024**3},
+    )
+    def test_uses_service_config_and_k8s_config_keys(self, _mock_sys, _mock_est):
+        result = build_naive_generator_params(
+            model_name="Qwen/Qwen3-32B",
+            total_gpus=8,
+            system_name="h200_sxm",
+            backend_name="vllm",
+        )
+        assert "ServiceConfig" in result, "expected ServiceConfig key, got 'service'"
+        assert "K8sConfig" in result, "expected K8sConfig key, got 'k8s'"
+        assert "service" not in result
+        assert "k8s" not in result
+
+    @patch(
+        "aiconfigurator.generator.naive._estimate_model_weight_bytes",
+        return_value=30 * 1024**3,
+    )
+    @patch(
+        "aiconfigurator.generator.naive._get_system_config",
+        return_value={"gpus_per_node": 8, "vram_per_gpu": 141 * 1024**3},
+    )
+    def test_name_prefix_is_rfc1123_valid(self, _mock_sys, _mock_est):
+        result = build_naive_generator_params(
+            model_name="Qwen/Qwen3-32B",
+            total_gpus=8,
+            system_name="h200_sxm",
+            backend_name="vllm",
+        )
+        prefix = result["K8sConfig"]["name_prefix"]
+        assert prefix is not None
+        assert _RFC1123_LABEL_RE.match(prefix), f"{prefix!r} is not RFC 1123 compliant"
+
+    @patch(
+        "aiconfigurator.generator.naive._estimate_model_weight_bytes",
+        return_value=30 * 1024**3,
+    )
+    @patch(
+        "aiconfigurator.generator.naive._get_system_config",
+        return_value={"gpus_per_node": 8, "vram_per_gpu": 141 * 1024**3},
+    )
+    def test_model_path_propagated(self, _mock_sys, _mock_est):
+        result = build_naive_generator_params(
+            model_name="Qwen/Qwen3-32B",
+            total_gpus=8,
+            system_name="h200_sxm",
+            backend_name="vllm",
+        )
+        assert result["ServiceConfig"]["model_path"] == "Qwen/Qwen3-32B"
+        assert result["ServiceConfig"]["model_name"] == "Qwen/Qwen3-32B"
+
+    @patch(
+        "aiconfigurator.generator.naive._estimate_model_weight_bytes",
+        return_value=30 * 1024**3,
+    )
+    @patch(
+        "aiconfigurator.generator.naive._get_system_config",
+        return_value={"gpus_per_node": 8, "vram_per_gpu": 141 * 1024**3},
+    )
+    def test_agg_mode_set(self, _mock_sys, _mock_est):
+        result = build_naive_generator_params(
+            model_name="Qwen/Qwen3-32B",
+            total_gpus=8,
+            system_name="h200_sxm",
+            backend_name="vllm",
+        )
+        assert result["DynConfig"]["mode"] == "agg"
+
+    @patch(
+        "aiconfigurator.generator.naive._estimate_model_weight_bytes",
+        return_value=30 * 1024**3,
+    )
+    @patch(
+        "aiconfigurator.generator.naive._get_system_config",
+        return_value={"gpus_per_node": 8, "vram_per_gpu": 141 * 1024**3},
+    )
+    def test_include_frontend_true(self, _mock_sys, _mock_est):
+        result = build_naive_generator_params(
+            model_name="Qwen/Qwen3-32B",
+            total_gpus=8,
+            system_name="h200_sxm",
+            backend_name="vllm",
+        )
+        assert result["ServiceConfig"]["include_frontend"] is True
+
+
+@pytest.mark.unit
+class TestRenderingNameFallback:
+    """Verify prepare_template_context uses 'dynamo' fallback for missing name_prefix."""
+
+    def test_none_name_prefix_becomes_dynamo(self):
+        from aiconfigurator.generator.rendering.engine import prepare_template_context
+
+        params = {
+            "K8sConfig": {},
+            "ServiceConfig": {"model_path": "test"},
+            "DynConfig": {"mode": "agg"},
+            "params": {"agg": {}},
+            "WorkerConfig": {},
+        }
+        ctx = prepare_template_context(params, "vllm")
+        assert ctx["name_prefix"] == "dynamo"
+        assert ctx["name"] == "dynamo-agg"
+
+    def test_include_frontend_yields_one_replica(self):
+        from aiconfigurator.generator.rendering.engine import prepare_template_context
+
+        params = {
+            "K8sConfig": {"name_prefix": "test"},
+            "ServiceConfig": {"model_path": "test", "include_frontend": True},
+            "DynConfig": {"mode": "agg"},
+            "params": {"agg": {}},
+            "WorkerConfig": {},
+        }
+        ctx = prepare_template_context(params, "vllm")
+        assert ctx["frontend_replicas"] == 1
+
+    def test_no_include_frontend_yields_zero_replica(self):
+        from aiconfigurator.generator.rendering.engine import prepare_template_context
+
+        params = {
+            "K8sConfig": {"name_prefix": "test"},
+            "ServiceConfig": {"model_path": "test"},
+            "DynConfig": {"mode": "agg"},
+            "params": {"agg": {}},
+            "WorkerConfig": {},
+        }
+        ctx = prepare_template_context(params, "vllm")
+        assert ctx["frontend_replicas"] == 0


### PR DESCRIPTION
## Summary

Fixes nvbug 5941223 — the naive config generator (`generate_naive_config`) produces a broken DGD spec that blocks all rapid-path deployments on every GPU system (reproduced on B200 and H200 clusters).

### Root cause

`build_naive_generator_params()` used `service` / `k8s` as dictionary keys, but the rendering engine (`prepare_template_context`) expects `ServiceConfig` / `K8sConfig`. As a result:
- `model_path` was never found → empty `--model ""` in the generated spec
- `name_prefix` was never found → Python `None` was f-string interpolated as `"None"`, producing `"None-agg"` (invalid RFC 1123)
- `include_frontend` was never set → `Frontend.replicas: 0`

Additionally, the vllm k8s template incorrectly rendered agg-mode workers as `VllmDecodeWorker` with `role="decode"` and `--is-decode-worker` flag (should be role-less in agg mode, matching the trtllm/sglang templates).

### Before / After

| Field | Before | After |
|---|---|---|
| DGD name | `None-agg` (invalid RFC 1123) | `qwen-qwen3-32b-agg` (valid) |
| `--model` arg | `""` (empty) | `"Qwen/Qwen3-32B"` (correct) |
| `Frontend.replicas` | `0` | `1` |
| Worker name (vllm) | `VllmDecodeWorker` | `VllmWorker` |
| Worker role flag | `--is-decode-worker` | _(none — correct for agg)_ |

### Changes

- **`generator/naive.py`**: Rename `service` → `ServiceConfig`, `k8s` → `K8sConfig` to match the rendering engine. Add `include_frontend: True`. Add `_sanitize_rfc1123()` helper that derives a valid RFC 1123 `name_prefix` from the model name (e.g. `Qwen/Qwen3-32B` → `qwen-qwen3-32b`).
- **`generator/rendering/engine.py`**: Add defensive `or "dynamo"` fallback for `name_prefix` in `prepare_template_context`, matching the existing fallback in `aggregators.py:67`.
- **`generator/api.py`**: Log a warning (instead of silently proceeding) when `get_latest_database_version()` returns `None`.
- **`generator/config/backend_templates/vllm/k8s_deploy.yaml.j2`**: In agg mode, render workers as `VllmWorker` with `None` role (no `--is-decode-worker` flag), matching the trtllm and sglang templates.
- **`tests/unit/generator/test_naive.py`**: 23 new unit tests covering RFC 1123 sanitization, correct key names, model_path propagation, `include_frontend`, and the rendering engine fallback.

## Test plan

- [x] All 23 new unit tests pass
- [x] All existing unit tests pass (no regressions)
- [ ] Verify on a Dynamo cluster that the generated DGD name is valid and the deployment succeeds



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model names are now automatically normalized for system compatibility.
  * Added frontend configuration option to service settings.

* **Improvements**
  * Enhanced logging when performance database information is unavailable.
  * Improved default naming behavior for Kubernetes deployments.
  * Updated configuration structure for better organization.

* **Tests**
  * Added comprehensive unit tests for configuration generation and rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->