### PR TITLE
fix: update wideep_alltoall_perf data for gb200 trtllm 1.2.0rc6

### DIFF
--- a/src/aiconfigurator/systems/data/gb200/trtllm/1.2.0rc6/wideep_alltoall_perf.txt
+++ b/src/aiconfigurator/systems/data/gb200/trtllm/1.2.0rc6/wideep_alltoall_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e8449b81fb0617f88b9682070a6c89a7281108bcc52d289776a95dce767bef8b
-size 291710
+oid sha256:88b4f805fd56a37b1f87b20c9c7861e6f48f69e1aea42329265a18a332fc6b4f
+size 196963


### PR DESCRIPTION
Update All2All performance data with revised measurements.


#### Overview:

Update All2All performance data for gb200 trtllm 1.2.0rc6 with revised measurements.

#### Details:

- Updated `src/aiconfigurator/systems/data/gb200/trtllm/1.2.0rc6/wideep_alltoall_perf.txt` with new WideEP All2All communication performance measurements.

#### Where should the reviewer start?

- `src/aiconfigurator/systems/data/gb200/trtllm/1.2.0rc6/wideep_alltoall_perf.txt`

#### Related Issues:

- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration data files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->