### PR TITLE
fix: adapt gemm collector for zig-zag pattern

### DIFF
--- a/collector/common_test_cases.py
+++ b/collector/common_test_cases.py
@@ -147,7 +147,7 @@ class GemmCommonTestCase:
 
 
 def get_gemm_common_test_cases() -> list[GemmCommonTestCase]:
-    x_list = [1, 2, 4, 8, 16, 32, 48, 64, 80, 96, 128, 160, 192]
+    x_list = [1, 2, 4, 8, 16, 32, 48, 64, 80, 96, 128, 129, 160, 192]
     # when x > 128, collect both x and x+1 due to the zig-zag pattern of the gemm.
     for x in range(256, 4096 + 257, 256):
         x_list.append(x)

--- a/collector/common_test_cases.py
+++ b/collector/common_test_cases.py
@@ -147,29 +147,16 @@ class GemmCommonTestCase:
 
 
 def get_gemm_common_test_cases() -> list[GemmCommonTestCase]:
-    x_list = [
-        1,
-        2,
-        4,
-        8,
-        16,
-        32,
-        48,
-        64,
-        80,
-        96,
-        128,
-        160,
-        192,
-        256,
-        384,
-        512,
-        768,
-        1024,
-        2048,
-        4096,
-        8192,
-    ]
+    x_list = [1, 2, 4, 8, 16, 32, 48, 64, 80, 96, 128, 160, 192]
+    # when x > 128, collect both x and x+1 due to the zig-zag pattern of the gemm.
+    for x in range(256, 4096 + 1, 256):
+        x_list.append(x)
+        x_list.append(x + 1)
+        # after 4096, the zig-zag pattern can be ignored
+    x = 8192
+    while x <= 32768:
+        x_list.append(x)
+        x *= 2
     nk_list = [
         32,
         64,

--- a/collector/common_test_cases.py
+++ b/collector/common_test_cases.py
@@ -149,7 +149,7 @@ class GemmCommonTestCase:
 def get_gemm_common_test_cases() -> list[GemmCommonTestCase]:
     x_list = [1, 2, 4, 8, 16, 32, 48, 64, 80, 96, 128, 160, 192]
     # when x > 128, collect both x and x+1 due to the zig-zag pattern of the gemm.
-    for x in range(256, 4096 + 1, 256):
+    for x in range(256, 4096 + 257, 256):
         x_list.append(x)
         x_list.append(x + 1)
         # after 4096, the zig-zag pattern can be ignored
@@ -178,7 +178,7 @@ def get_gemm_common_test_cases() -> list[GemmCommonTestCase]:
         10240,
         12288,
     ]
-    nk_list_ext = [16384, 65536]  # for coverage and interp purpose
+    nk_list_ext = [16384, 51200, 65536]  # for coverage and interp purpose
 
     test_cases = []
     # x_list_orig+add+ext  <==> nk_list+ext

--- a/collector/common_test_cases.py
+++ b/collector/common_test_cases.py
@@ -147,16 +147,19 @@ class GemmCommonTestCase:
 
 
 def get_gemm_common_test_cases() -> list[GemmCommonTestCase]:
-    x_list = [1, 2, 4, 8, 16, 32, 48, 64, 80, 96, 128, 129, 160, 192]
-    # when x > 128, collect both x and x+1 due to the zig-zag pattern of the gemm.
+    x_list = list(range(16))
+    x_list += list(range(16, 128, 16)) + [i + 1 for i in range(16, 128, 16)]
+    x_list += list(range(128, 256, 32)) + [i + 1 for i in range(128, 256, 32)]
     for x in range(256, 4096 + 257, 256):
         x_list.append(x)
         x_list.append(x + 1)
         # after 4096, the zig-zag pattern can be ignored
+
     x = 8192
     while x <= 32768:
         x_list.append(x)
         x *= 2
+    x_list.sort()  # sort the x_list to make it easier to debug
     nk_list = [
         32,
         64,

--- a/src/aiconfigurator/systems/data/h100_sxm/trtllm/1.2.0rc5/gemm_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/trtllm/1.2.0rc5/gemm_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2363e257468052a2785187ad6712635f849ab7d3600d72ac96181b957beaf746
-size 5740395
+oid sha256:6c18f0ba76c98da57de81aad223b72a72a42db3755c9e99f2e0f56edc2718aea
+size 9805057

--- a/src/aiconfigurator/systems/data/h100_sxm/trtllm/1.2.0rc5/gemm_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/trtllm/1.2.0rc5/gemm_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7fbeb21cfc0660edd6792f82380bf27bb1dabc1c0042c1ecae8907fd401f60d4
-size 6691814
+oid sha256:2363e257468052a2785187ad6712635f849ab7d3600d72ac96181b957beaf746
+size 5740395


### PR DESCRIPTION
### Overview

Change gemm collection base on observed zig-zag pattern.
<img width="2384" height="1769" alt="image" src="https://github.com/user-attachments/assets/1cebd0c2-e82b-485e-bb60-d324855b8284" />

<img width="2384" height="1769" alt="image" src="https://github.com/user-attachments/assets/0e39aed7-2740-4b40-96ec-8f109e6890ed" />



### TODO
Collect data on latest TRTLLM version
- [ ] L40S
- [ ] A100
- [x] H100
- [ ] H200
- [ ] GB200 (1.2.0rc5)
- [ ] GB200 (1.2.0rc6)
- [ ] GB300 (1.2.0rc5)
- [ ] GB300 (1.2.0rc6post3)
- [ ] B200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test case generation to provide more comprehensive coverage of edge cases and patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->