### PR TITLE
feat: add SGLang backend support for AllReduce collector

### DIFF
--- a/collector/collect_all_reduce.py
+++ b/collector/collect_all_reduce.py
@@ -460,20 +460,32 @@ def benchmark_vllm_allreduce(
                 # Adaptive num_runs calculation for power measurement
                 actual_num_runs = num_runs
                 if measure_power:
-                    # Estimate single iteration time
-                    start_warmup = torch.cuda.Event(enable_timing=True)
-                    end_warmup = torch.cuda.Event(enable_timing=True)
+                    # Estimate single iteration time (only on rank 0)
+                    if rank == 0:
+                        start_warmup = torch.cuda.Event(enable_timing=True)
+                        end_warmup = torch.cuda.Event(enable_timing=True)
 
-                    torch.cuda.synchronize()
-                    start_warmup.record()
-                    for i in range(num_warmups):
-                        graph.replay()
-                    end_warmup.record()
-                    torch.cuda.synchronize()
+                        torch.cuda.synchronize()
+                        start_warmup.record()
+                        for i in range(num_warmups):
+                            graph.replay()
+                        end_warmup.record()
+                        torch.cuda.synchronize()
 
-                    single_iter_time = start_warmup.elapsed_time(end_warmup) / num_warmups / 1000.0  # seconds
-                    actual_num_runs = max(num_runs, int(power_min_duration / (single_iter_time * repeat_n)) + 1)
-                    actual_num_runs = min(actual_num_runs, 1000)
+                        single_iter_time = start_warmup.elapsed_time(end_warmup) / num_warmups / 1000.0  # seconds
+                        actual_num_runs = max(num_runs, int(power_min_duration / (single_iter_time * repeat_n)) + 1)
+                        actual_num_runs = min(actual_num_runs, 1000)
+                    else:
+                        # Other ranks do warmup but don't calculate
+                        torch.cuda.synchronize()
+                        for i in range(num_warmups):
+                            graph.replay()
+                        torch.cuda.synchronize()
+
+                    # Broadcast actual_num_runs from rank 0 to all ranks
+                    actual_num_runs_tensor = torch.tensor([actual_num_runs], device="cuda")
+                    torch.distributed.broadcast(actual_num_runs_tensor, src=0)
+                    actual_num_runs = actual_num_runs_tensor.item()
                 else:
                     # Normal warmup
                     torch.cuda.synchronize()
@@ -510,21 +522,34 @@ def benchmark_vllm_allreduce(
                 # Adaptive num_runs calculation for power measurement
                 actual_num_runs = num_runs
                 if measure_power:
-                    # Estimate single iteration time
-                    start_warmup = torch.cuda.Event(enable_timing=True)
-                    end_warmup = torch.cuda.Event(enable_timing=True)
+                    # Estimate single iteration time (only on rank 0)
+                    if rank == 0:
+                        start_warmup = torch.cuda.Event(enable_timing=True)
+                        end_warmup = torch.cuda.Event(enable_timing=True)
 
-                    torch.cuda.synchronize()
-                    start_warmup.record()
-                    for _ in range(num_warmups):
-                        for _ in range(repeat_n):
-                            _ = vllm_mods["tensor_model_parallel_all_reduce"](input_tensor.clone())
-                    end_warmup.record()
-                    torch.cuda.synchronize()
+                        torch.cuda.synchronize()
+                        start_warmup.record()
+                        for _ in range(num_warmups):
+                            for _ in range(repeat_n):
+                                _ = vllm_mods["tensor_model_parallel_all_reduce"](input_tensor.clone())
+                        end_warmup.record()
+                        torch.cuda.synchronize()
 
-                    single_iter_time = start_warmup.elapsed_time(end_warmup) / num_warmups / 1000.0  # seconds
-                    actual_num_runs = max(num_runs, int(power_min_duration / (single_iter_time * repeat_n)) + 1)
-                    actual_num_runs = min(actual_num_runs, 1000)
+                        single_iter_time = start_warmup.elapsed_time(end_warmup) / num_warmups / 1000.0  # seconds
+                        actual_num_runs = max(num_runs, int(power_min_duration / (single_iter_time * repeat_n)) + 1)
+                        actual_num_runs = min(actual_num_runs, 1000)
+                    else:
+                        # Other ranks do warmup but don't calculate
+                        torch.cuda.synchronize()
+                        for _ in range(num_warmups):
+                            for _ in range(repeat_n):
+                                _ = vllm_mods["tensor_model_parallel_all_reduce"](input_tensor.clone())
+                        torch.cuda.synchronize()
+
+                    # Broadcast actual_num_runs from rank 0 to all ranks
+                    actual_num_runs_tensor = torch.tensor([actual_num_runs], device="cuda")
+                    torch.distributed.broadcast(actual_num_runs_tensor, src=0)
+                    actual_num_runs = actual_num_runs_tensor.item()
                 else:
                     # Normal warmup
                     torch.cuda.synchronize()
@@ -612,9 +637,7 @@ def benchmark_sglang_allreduce(
     power_min_duration: float = 1.0,
 ):
     """Benchmark SGLang custom AllReduce implementation"""
-    sglang_mods, local_rank = setup_sglang_distributed(
-        world_size, rank, use_slurm
-    )
+    sglang_mods, local_rank = setup_sglang_distributed(world_size, rank, use_slurm)
 
     # Parse test range
     min_size, max_size, ratio = [int(i) for i in test_range.split(",")]
@@ -662,20 +685,32 @@ def benchmark_sglang_allreduce(
                 # Adaptive num_runs calculation for power measurement
                 actual_num_runs = num_runs
                 if measure_power:
-                    # Estimate single iteration time
-                    start_warmup = torch.cuda.Event(enable_timing=True)
-                    end_warmup = torch.cuda.Event(enable_timing=True)
+                    # Estimate single iteration time (only on rank 0)
+                    if rank == 0:
+                        start_warmup = torch.cuda.Event(enable_timing=True)
+                        end_warmup = torch.cuda.Event(enable_timing=True)
 
-                    torch.cuda.synchronize()
-                    start_warmup.record()
-                    for i in range(num_warmups):
-                        graph.replay()
-                    end_warmup.record()
-                    torch.cuda.synchronize()
+                        torch.cuda.synchronize()
+                        start_warmup.record()
+                        for i in range(num_warmups):
+                            graph.replay()
+                        end_warmup.record()
+                        torch.cuda.synchronize()
 
-                    single_iter_time = start_warmup.elapsed_time(end_warmup) / num_warmups / 1000.0  # seconds
-                    actual_num_runs = max(num_runs, int(power_min_duration / (single_iter_time * repeat_n)) + 1)
-                    actual_num_runs = min(actual_num_runs, 1000)
+                        single_iter_time = start_warmup.elapsed_time(end_warmup) / num_warmups / 1000.0  # seconds
+                        actual_num_runs = max(num_runs, int(power_min_duration / (single_iter_time * repeat_n)) + 1)
+                        actual_num_runs = min(actual_num_runs, 1000)
+                    else:
+                        # Other ranks do warmup but don't calculate
+                        torch.cuda.synchronize()
+                        for i in range(num_warmups):
+                            graph.replay()
+                        torch.cuda.synchronize()
+
+                    # Broadcast actual_num_runs from rank 0 to all ranks
+                    actual_num_runs_tensor = torch.tensor([actual_num_runs], device="cuda")
+                    torch.distributed.broadcast(actual_num_runs_tensor, src=0)
+                    actual_num_runs = actual_num_runs_tensor.item()
                 else:
                     # Normal warmup
                     torch.cuda.synchronize()
@@ -712,21 +747,34 @@ def benchmark_sglang_allreduce(
                 # Adaptive num_runs calculation for power measurement
                 actual_num_runs = num_runs
                 if measure_power:
-                    # Estimate single iteration time
-                    start_warmup = torch.cuda.Event(enable_timing=True)
-                    end_warmup = torch.cuda.Event(enable_timing=True)
+                    # Estimate single iteration time (only on rank 0)
+                    if rank == 0:
+                        start_warmup = torch.cuda.Event(enable_timing=True)
+                        end_warmup = torch.cuda.Event(enable_timing=True)
 
-                    torch.cuda.synchronize()
-                    start_warmup.record()
-                    for _ in range(num_warmups):
-                        for _ in range(repeat_n):
-                            _ = sglang_mods["tensor_model_parallel_all_reduce"](input_tensor.clone())
-                    end_warmup.record()
-                    torch.cuda.synchronize()
+                        torch.cuda.synchronize()
+                        start_warmup.record()
+                        for _ in range(num_warmups):
+                            for _ in range(repeat_n):
+                                _ = sglang_mods["tensor_model_parallel_all_reduce"](input_tensor.clone())
+                        end_warmup.record()
+                        torch.cuda.synchronize()
 
-                    single_iter_time = start_warmup.elapsed_time(end_warmup) / num_warmups / 1000.0  # seconds
-                    actual_num_runs = max(num_runs, int(power_min_duration / (single_iter_time * repeat_n)) + 1)
-                    actual_num_runs = min(actual_num_runs, 1000)
+                        single_iter_time = start_warmup.elapsed_time(end_warmup) / num_warmups / 1000.0  # seconds
+                        actual_num_runs = max(num_runs, int(power_min_duration / (single_iter_time * repeat_n)) + 1)
+                        actual_num_runs = min(actual_num_runs, 1000)
+                    else:
+                        # Other ranks do warmup but don't calculate
+                        torch.cuda.synchronize()
+                        for _ in range(num_warmups):
+                            for _ in range(repeat_n):
+                                _ = sglang_mods["tensor_model_parallel_all_reduce"](input_tensor.clone())
+                        torch.cuda.synchronize()
+
+                    # Broadcast actual_num_runs from rank 0 to all ranks
+                    actual_num_runs_tensor = torch.tensor([actual_num_runs], device="cuda")
+                    torch.distributed.broadcast(actual_num_runs_tensor, src=0)
+                    actual_num_runs = actual_num_runs_tensor.item()
                 else:
                     # Normal warmup
                     torch.cuda.synchronize()
@@ -767,8 +815,9 @@ def benchmark_sglang_allreduce(
 
                 # Get SGLang version
                 try:
-                    import sglang
-                    sglang_version = sglang.__version__ if hasattr(sglang, "__version__") else "unknown"
+                    import importlib.metadata
+
+                    sglang_version = importlib.metadata.version("sglang")
                 except:
                     sglang_version = "unknown"
 

--- a/collector/collect_all_reduce.py
+++ b/collector/collect_all_reduce.py
@@ -636,6 +636,14 @@ def benchmark_sglang_allreduce(
     measure_power: bool = False,
     power_min_duration: float = 1.0,
 ):
+    class MockServerArgs:
+        def __init__(self):
+            self.enable_symm_mem = False
+
+    from sglang.srt.server_args import set_global_server_args_for_scheduler
+
+    set_global_server_args_for_scheduler(MockServerArgs())
+
     """Benchmark SGLang custom AllReduce implementation"""
     sglang_mods, local_rank = setup_sglang_distributed(world_size, rank, use_slurm)
 

--- a/collector/collect_all_reduce.py
+++ b/collector/collect_all_reduce.py
@@ -2,14 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Gneeral-purpose AllReduce Performance Collector
+General-purpose AllReduce Performance Collector
 
 Supported Backends:
     TensorRT-LLM
     vLLM
+    SGLang
 
 This script uses CUDA Graph based benchmarking for AllReduce operations,
-supporting both TensorRT-LLM and vLLM backends.
+supporting TensorRT-LLM, vLLM, and SGLang backends.
 
 Usage:
     # With MPI for TensorRT-LLM
@@ -17,6 +18,9 @@ Usage:
 
     # With vLLM (requires appropriate environment setup)
     torchrun --nproc_per_node=8 collect_all_reduce.py --backend vllm
+
+    # With SGLang (requires appropriate environment setup)
+    torchrun --nproc_per_node=8 collect_all_reduce.py --backend sglang
 
     # With SLURM
     python collect_all_reduce.py --use-slurm
@@ -311,6 +315,92 @@ def setup_vllm_distributed(world_size, rank, use_slurm):
     return vllm_mods, local_rank
 
 
+def import_sglang():
+    """Import SGLang modules"""
+    try:
+        from sglang.srt.distributed.communication_op import tensor_model_parallel_all_reduce
+        from sglang.srt.distributed.parallel_state import (
+            destroy_model_parallel,
+            graph_capture,
+            init_distributed_environment,
+            initialize_model_parallel,
+            set_custom_all_reduce,
+            set_mscclpp_all_reduce,
+            set_torch_symm_mem_all_reduce,
+        )
+
+        return {
+            "tensor_model_parallel_all_reduce": tensor_model_parallel_all_reduce,
+            "init_distributed_environment": init_distributed_environment,
+            "initialize_model_parallel": initialize_model_parallel,
+            "graph_capture": graph_capture,
+            "destroy_model_parallel": destroy_model_parallel,
+            "set_custom_all_reduce": set_custom_all_reduce,
+            "set_mscclpp_all_reduce": set_mscclpp_all_reduce,
+            "set_torch_symm_mem_all_reduce": set_torch_symm_mem_all_reduce,
+        }
+    except ImportError as e:
+        print(f"Failed to import SGLang modules: {e}")
+        print("Please ensure SGLang is installed and PYTHONPATH is set correctly")
+        sys.exit(1)
+
+
+def setup_sglang_distributed(world_size, rank, use_slurm):
+    """Setup SGLang distributed environment"""
+    sglang_mods = import_sglang()
+
+    if use_slurm:
+        # Use SLURM environment variables
+        local_rank = int(os.environ.get("SLURM_LOCALID", "0"))
+    else:
+        # For non-SLURM, assume single node or use environment variables
+        local_rank = int(os.environ.get("LOCAL_RANK", str(rank)))
+
+    # Set CUDA device
+    torch.cuda.set_device(local_rank)
+
+    # Initialize distributed environment
+    if not torch.distributed.is_initialized():
+        # Get master address and port
+        master_addr = os.environ.get("MASTER_ADDR", "localhost")
+        master_port = os.environ.get("MASTER_PORT", "29500")
+
+        # Construct the init method string
+        distributed_init_method = f"tcp://{master_addr}:{master_port}"
+
+        print("Setting up SGLang distributed environment:")
+        print(f"  Init method: {distributed_init_method}")
+        print(f"  World size: {world_size}")
+        print(f"  Rank: {rank}")
+        print(f"  Local rank: {local_rank}")
+
+        try:
+            sglang_mods["init_distributed_environment"](
+                world_size=world_size,
+                rank=rank,
+                distributed_init_method=distributed_init_method,
+                local_rank=local_rank,
+                backend="nccl",
+            )
+        except Exception as e:
+            print(f"\nERROR: Failed to initialize distributed environment: {e}")
+            raise
+
+    # Initialize model parallel groups
+    # SGLang requires world_size == tensor_model_parallel_size * pipeline_model_parallel_size
+    sglang_mods["initialize_model_parallel"](
+        tensor_model_parallel_size=world_size,
+        pipeline_model_parallel_size=1,
+    )
+
+    # Enable CustomAllReduce and disable other allreduce implementations
+    sglang_mods["set_custom_all_reduce"](True)
+    sglang_mods["set_mscclpp_all_reduce"](False)
+    sglang_mods["set_torch_symm_mem_all_reduce"](False)
+
+    return sglang_mods, local_rank
+
+
 def benchmark_vllm_allreduce(
     dtype: str,
     test_range: str,
@@ -511,6 +601,207 @@ def benchmark_vllm_allreduce(
     vllm_mods["destroy_model_parallel"]()
 
 
+def benchmark_sglang_allreduce(
+    dtype: str,
+    test_range: str,
+    world_size: int,
+    rank: int,
+    use_slurm: bool,
+    perf_filename: str,
+    measure_power: bool = False,
+    power_min_duration: float = 1.0,
+):
+    """Benchmark SGLang custom AllReduce implementation"""
+    sglang_mods, local_rank = setup_sglang_distributed(
+        world_size, rank, use_slurm
+    )
+
+    # Parse test range
+    min_size, max_size, ratio = [int(i) for i in test_range.split(",")]
+
+    # Map dtype string to torch dtype
+    dtype_map = {"float16": torch.float16, "float32": torch.float32, "bfloat16": torch.bfloat16}
+    torch_dtype = dtype_map.get(dtype, torch.float16)
+
+    # Benchmark parameters
+    repeat_n = 5
+    num_warmups = 3
+    num_runs = 20
+
+    # Warmup communication
+    warmup_tensor = torch.ones(1, dtype=torch_dtype, device="cuda")
+    _ = sglang_mods["tensor_model_parallel_all_reduce"](warmup_tensor)
+    torch.cuda.synchronize()
+
+    size = min_size
+    while size < max_size:
+        input_shape = get_input_shape_and_comm_size(size)
+
+        # Test both graph capture and eager mode
+        for use_graph in [True, False]:
+            mode_str = "graph" if use_graph else "eager"
+
+            if use_graph:
+                # Graph capture mode
+                with sglang_mods["graph_capture"]() as graph_capture_context:
+                    # Create input tensors
+                    input_tensors = []
+                    for _ in range(repeat_n):
+                        inp = torch.ones(input_shape, dtype=torch_dtype, device="cuda")
+                        input_tensors.append(inp)
+
+                    torch.cuda.synchronize()
+                    graph = torch.cuda.CUDAGraph()
+
+                    with torch.cuda.graph(graph, stream=graph_capture_context.stream):
+                        outputs = []
+                        for inp in input_tensors:
+                            out = sglang_mods["tensor_model_parallel_all_reduce"](inp)
+                            outputs.append(out)
+
+                # Adaptive num_runs calculation for power measurement
+                actual_num_runs = num_runs
+                if measure_power:
+                    # Estimate single iteration time
+                    start_warmup = torch.cuda.Event(enable_timing=True)
+                    end_warmup = torch.cuda.Event(enable_timing=True)
+
+                    torch.cuda.synchronize()
+                    start_warmup.record()
+                    for i in range(num_warmups):
+                        graph.replay()
+                    end_warmup.record()
+                    torch.cuda.synchronize()
+
+                    single_iter_time = start_warmup.elapsed_time(end_warmup) / num_warmups / 1000.0  # seconds
+                    actual_num_runs = max(num_runs, int(power_min_duration / (single_iter_time * repeat_n)) + 1)
+                    actual_num_runs = min(actual_num_runs, 1000)
+                else:
+                    # Normal warmup
+                    torch.cuda.synchronize()
+                    for i in range(num_warmups):
+                        graph.replay()
+                    torch.cuda.synchronize()
+
+                # Initialize power monitoring
+                power_monitor = None
+                power_stats = None
+                if measure_power:
+                    power_monitor = PowerMonitor(local_rank)
+                    if not power_monitor.start_sampling():
+                        power_monitor = None
+
+                # Timing
+                start_event = torch.cuda.Event(enable_timing=True)
+                end_event = torch.cuda.Event(enable_timing=True)
+
+                start_event.record()
+                for i in range(actual_num_runs):
+                    graph.replay()
+                end_event.record()
+                torch.cuda.synchronize()
+
+                # Stop power monitoring
+                if power_monitor:
+                    power_stats = power_monitor.stop_sampling()
+
+            else:
+                # Eager mode
+                input_tensor = torch.ones(input_shape, dtype=torch_dtype, device="cuda")
+
+                # Adaptive num_runs calculation for power measurement
+                actual_num_runs = num_runs
+                if measure_power:
+                    # Estimate single iteration time
+                    start_warmup = torch.cuda.Event(enable_timing=True)
+                    end_warmup = torch.cuda.Event(enable_timing=True)
+
+                    torch.cuda.synchronize()
+                    start_warmup.record()
+                    for _ in range(num_warmups):
+                        for _ in range(repeat_n):
+                            _ = sglang_mods["tensor_model_parallel_all_reduce"](input_tensor.clone())
+                    end_warmup.record()
+                    torch.cuda.synchronize()
+
+                    single_iter_time = start_warmup.elapsed_time(end_warmup) / num_warmups / 1000.0  # seconds
+                    actual_num_runs = max(num_runs, int(power_min_duration / (single_iter_time * repeat_n)) + 1)
+                    actual_num_runs = min(actual_num_runs, 1000)
+                else:
+                    # Normal warmup
+                    torch.cuda.synchronize()
+                    for _ in range(num_warmups):
+                        for _ in range(repeat_n):
+                            _ = sglang_mods["tensor_model_parallel_all_reduce"](input_tensor.clone())
+                    torch.cuda.synchronize()
+
+                # Initialize power monitoring
+                power_monitor = None
+                power_stats = None
+                if measure_power:
+                    power_monitor = PowerMonitor(local_rank)
+                    if not power_monitor.start_sampling():
+                        power_monitor = None
+
+                # Timing
+                start_event = torch.cuda.Event(enable_timing=True)
+                end_event = torch.cuda.Event(enable_timing=True)
+
+                start_event.record()
+                for _ in range(actual_num_runs):
+                    for _ in range(repeat_n):
+                        _ = sglang_mods["tensor_model_parallel_all_reduce"](input_tensor.clone())
+                end_event.record()
+                torch.cuda.synchronize()
+
+                # Stop power monitoring
+                if power_monitor:
+                    power_stats = power_monitor.stop_sampling()
+
+            latency = start_event.elapsed_time(end_event) / actual_num_runs / repeat_n
+
+            if rank == 0:
+                print(f"[SGLang-{mode_str}] Size: {size}, Latency: {latency:.4f} ms")
+                if power_stats:
+                    print(f"  Power: {power_stats['power']:.2f}W (limit: {power_stats['power_limit']:.2f}W)")
+
+                # Get SGLang version
+                try:
+                    import sglang
+                    sglang_version = sglang.__version__ if hasattr(sglang, "__version__") else "unknown"
+                except:
+                    sglang_version = "unknown"
+
+                log_perf(
+                    item_list=[
+                        {
+                            "allreduce_dtype": dtype,
+                            "num_gpus": world_size,
+                            "message_size": size,
+                            "latency": latency,
+                            "backend": f"sglang_{mode_str}",
+                        }
+                    ],
+                    framework="SGLang",
+                    version=sglang_version,
+                    device_name=torch.cuda.get_device_name(),
+                    op_name="all_reduce",
+                    kernel_source=f"SGLang_CustomAllReduce_{mode_str}",
+                    perf_filename=perf_filename,
+                    power_stats=power_stats,
+                )
+
+        size *= ratio
+
+    # Synchronize all ranks before cleanup
+    torch.cuda.synchronize()
+    if torch.distributed.is_initialized():
+        torch.distributed.barrier()
+
+    # Cleanup SGLang distributed environment
+    sglang_mods["destroy_model_parallel"]()
+
+
 def allreduce_benchmark(
     backend: str,
     dtype: str,
@@ -524,6 +815,17 @@ def allreduce_benchmark(
 ):
     """
     CUDA Graph based AllReduce benchmark method supporting multiple backends
+
+    Args:
+        backend: Backend to benchmark ("trtllm", "vllm", or "sglang")
+        dtype: Data type for AllReduce operations
+        test_range: Comma-separated string "min_size,max_size,ratio"
+        use_slurm: Whether to use SLURM environment variables
+        perf_filename: Output file for performance results
+        world_size: Number of GPUs (for vLLM/SGLang without SLURM)
+        rank: Current rank (for vLLM/SGLang without SLURM)
+        measure_power: Enable GPU power monitoring
+        power_min_duration: Minimum duration for power measurement
     """
     # Setup distributed environment based on backend
     if backend == "trtllm":
@@ -568,6 +870,30 @@ def allreduce_benchmark(
         benchmark_vllm_allreduce(
             dtype, test_range, world_size, rank, use_slurm, perf_filename, measure_power, power_min_duration
         )
+
+    elif backend == "sglang":
+        if use_slurm:
+            world_size = int(os.environ["SLURM_NTASKS"])
+            rank = int(os.environ.get("SLURM_PROCID", os.environ.get("RANK", "0")))
+        else:
+            # Check if running under torchrun (it sets these env vars)
+            if "RANK" in os.environ and "WORLD_SIZE" in os.environ:
+                world_size = int(os.environ["WORLD_SIZE"])
+                rank = int(os.environ["RANK"])
+                print(f"Detected torchrun environment: world_size={world_size}, rank={rank}")
+            else:
+                # Use provided values or environment variables
+                if world_size is None:
+                    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+                if rank is None:
+                    rank = int(os.environ.get("RANK", "0"))
+
+        if world_size == 1:
+            raise RuntimeError("Benchmark must run with world_size > 1")
+
+        benchmark_sglang_allreduce(
+            dtype, test_range, world_size, rank, use_slurm, perf_filename, measure_power, power_min_duration
+        )
     else:
         raise ValueError(f"Unknown backend: {backend}")
 
@@ -575,7 +901,7 @@ def allreduce_benchmark(
 if __name__ == "__main__":
     parser = ArgumentParser()
     parser.add_argument(
-        "--backend", "-b", choices=["trtllm", "vllm"], default="trtllm", help="AllReduce backend to benchmark"
+        "--backend", "-b", choices=["trtllm", "vllm", "sglang"], default="trtllm", help="AllReduce backend to benchmark"
     )
     parser.add_argument("--dtype", "-t", default="float16")
     parser.add_argument(
@@ -591,9 +917,9 @@ if __name__ == "__main__":
         default="custom_allreduce_perf.txt",
         help="Output performance file name",
     )
-    # Additional arguments for vLLM when not using MPI/SLURM
-    parser.add_argument("--world-size", default=8, type=int, help="World size for distributed setup (vLLM)")
-    parser.add_argument("--rank", default=0, type=int, help="Rank for distributed setup (vLLM)")
+    # Additional arguments for vLLM/SGLang when not using MPI/SLURM
+    parser.add_argument("--world-size", default=8, type=int, help="World size for distributed setup (vLLM/SGLang)")
+    parser.add_argument("--rank", default=0, type=int, help="Rank for distributed setup (vLLM/SGLang)")
     # Power measurement arguments
     parser.add_argument(
         "--measure_power",

--- a/collector/collect_comm.sh
+++ b/collector/collect_comm.sh
@@ -12,8 +12,8 @@ while [[ $# -gt 0 ]]; do
     case $1 in
         --all_reduce_backend)
             all_reduce_backend="$2"
-            if [[ "$all_reduce_backend" != "trtllm" && "$all_reduce_backend" != "vllm" ]]; then
-                echo "Error: --all_reduce_backend must be either 'trtllm' or 'vllm'"
+            if [[ "$all_reduce_backend" != "trtllm" && "$all_reduce_backend" != "vllm" && "$all_reduce_backend" != "sglang" ]]; then
+                echo "Error: --all_reduce_backend must be 'trtllm', 'vllm', or 'sglang'"
                 echo "Usage: $0 [OPTIONS]"
                 exit 1
             fi
@@ -31,16 +31,17 @@ while [[ $# -gt 0 ]]; do
             echo "Usage: $0 [OPTIONS]"
             echo ""
             echo "Options:"
-            echo "  --all_reduce_backend  Backend for AllReduce benchmark (default: trtllm)"
-            echo "                        Choices: trtllm, vllm"
-            echo "  --measure_power       Enable power monitoring during execution"
-            echo "  --power_test_duration Minimum test duration for power measurement in seconds (default: 1.0)"
-            echo "  -h, --help           Show this help message and exit"
+            echo "  --all_reduce_backend       Backend for AllReduce benchmark (default: trtllm)"
+            echo "                             Choices: trtllm, vllm, sglang"
+            echo "  --measure_power            Enable power monitoring during execution"
+            echo "  --power_test_duration      Minimum test duration for power measurement in seconds (default: 1.0)"
+            echo "  -h, --help                 Show this help message and exit"
             echo ""
             echo "Examples:"
             echo "  $0 --all_reduce_backend trtllm"
             echo "  $0 --measure_power --power_test_duration 2.0"
             echo "  $0 --all_reduce_backend vllm --measure_power"
+            echo "  $0 --all_reduce_backend sglang"
             exit 0
             ;;
         *)
@@ -115,6 +116,19 @@ elif [[ "$all_reduce_backend" == "vllm" ]]; then
                 --measure_power --power_test_duration_sec "$power_test_duration"
         else
             torchrun --nproc_per_node=$n collect_all_reduce.py --backend vllm \
+                --perf-filename "custom_allreduce_perf.txt"
+        fi
+    done
+elif [[ "$all_reduce_backend" == "sglang" ]]; then
+    # SGLang allreduce implementation
+    for n in "${num_gpus_allreduce[@]}"; do
+        echo "Running SGLang AllReduce benchmark with $n GPUs"
+        if [[ "$measure_power" == "true" ]]; then
+            torchrun --nproc_per_node=$n collect_all_reduce.py --backend sglang \
+                --perf-filename "custom_allreduce_perf.txt" \
+                --measure_power --power_test_duration_sec "$power_test_duration"
+        else
+            torchrun --nproc_per_node=$n collect_all_reduce.py --backend sglang \
                 --perf-filename "custom_allreduce_perf.txt"
         fi
     done

--- a/collector/collect_comm.sh
+++ b/collector/collect_comm.sh
@@ -121,7 +121,7 @@ elif [[ "$all_reduce_backend" == "vllm" ]]; then
     done
 elif [[ "$all_reduce_backend" == "sglang" ]]; then
     # SGLang allreduce implementation
-    for n in "${num_gpus_allreduce[@]}"; do
+    for n in "${gpu_count_list[@]}"; do
         echo "Running SGLang AllReduce benchmark with $n GPUs"
         if [[ "$measure_power" == "true" ]]; then
             torchrun --nproc_per_node=$n collect_all_reduce.py --backend sglang \

--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -356,7 +356,14 @@ def get_all_databases(
 # by default float16
 def load_custom_allreduce_data(custom_allreduce_file):
     """
-    Load the custom allreduce data for trtllm with power support (backward compatible).
+    Load the custom allreduce data with power support (backward compatible).
+
+    Supports multiple data formats:
+    - TRTLLM: kernel_source="TRTLLM", last column="implementation"
+    - vLLM/SGLang: kernel_source="*_graph" or "*_eager", last column="backend"
+
+    For vLLM/SGLang with both graph and eager modes, only graph mode data is kept
+    (better performance for decode phase).
 
     Returns:
         dict: Nested dict structure where leaf values are dicts with 'latency' and 'power' keys.
@@ -376,6 +383,16 @@ def load_custom_allreduce_data(custom_allreduce_file):
         logger.debug(f"Legacy database format detected in {custom_allreduce_file} - power will default to 0.0")
 
     for row in rows:
+        # Check kernel_source to filter graph vs eager mode (for vLLM/SGLang)
+        kernel_source = row.get("kernel_source", "")
+        backend = row.get("backend", "")
+
+        # For vLLM/SGLang format: only keep graph mode data (skip eager mode)
+        # kernel_source patterns: "vLLM_custom_graph", "SGLang_CustomAllReduce_graph", etc.
+        # backend patterns: "vllm_graph", "sglang_graph", etc.
+        if kernel_source.endswith("_eager") or backend.endswith("_eager"):
+            continue  # Skip eager mode, use graph mode only
+
         dtype, tp_size, message_size, latency = (
             row["allreduce_dtype"],
             row["num_gpus"],


### PR DESCRIPTION
- Add `benchmark_sglang_allreduce` function with graph and eager mode support
- Add `setup_sglang_distributed` function for SGLang distributed environment initialization
- Update CLI args to support sglang backend selection
- Update collect_comm.sh script for SGLang benchmark execution
- Update `load_custom_allreduce_data` to filter vLLM/SGLang data (keep graph mode only)

#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SGLang backend support to AllReduce benchmarking infrastructure with distributed training initialization across SLURM and torchrun-style setups.
  * Extended command-line interface to accept SGLang as a backend option alongside existing backends.
  * Implemented power monitoring capabilities for SGLang benchmarks with adaptive run-count calculation.
  * Updated benchmark data ingestion to filter and focus on graph-mode results for clearer performance metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->