### PR TITLE
fix: improve OOM error handling in estimation functions

### DIFF
--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -738,9 +738,17 @@ def _run_agg_estimate(
     session = InferenceSession(model, database, backend)
     summary = session.run_agg(runtime_config, ctx_tokens=ctx_tokens)
 
+    if summary.check_oom():
+        raise RuntimeError(
+            f"OOM: the model '{model_path}' does not fit in GPU memory on system '{system_name}' "
+            f"with the given parallelism (tp={tp_size}, pp={pp_size}, dp={attention_dp_size}). "
+            "Try increasing tp_size/pp_size, using a quantized model, or "
+            "using a system with more VRAM per GPU."
+        )
+
     result_dict = summary.get_result_dict()
     if result_dict is None:
-        raise RuntimeError("Estimation produced no results. The configuration may be invalid or OOM.")
+        raise RuntimeError("Estimation produced no results. The configuration may be invalid.")
 
     return EstimateResult(
         ttft=result_dict["ttft"],
@@ -862,9 +870,22 @@ def _run_disagg_estimate(
         decode_num_worker=decode_num_workers,
     )
 
+    if summary.check_oom():
+        oom_details = []
+        if decode_system_name != system_name:
+            oom_details.append(f"prefill system '{system_name}' or decode system '{decode_system_name}'")
+        else:
+            oom_details.append(f"system '{system_name}'")
+        raise RuntimeError(
+            f"OOM: the model '{model_path}' does not fit in GPU memory on {oom_details[0]} "
+            f"with the given parallelism. "
+            "Try increasing tp_size/pp_size, using a quantized model, or "
+            "using a system with more VRAM per GPU."
+        )
+
     result_dict = summary.get_result_dict()
     if result_dict is None:
-        raise RuntimeError("Disagg estimation produced no results. The configuration may be invalid or OOM.")
+        raise RuntimeError("Disagg estimation produced no results. The configuration may be invalid.")
 
     return EstimateResult(
         ttft=result_dict["ttft"],

--- a/src/aiconfigurator/sdk/inference_session.py
+++ b/src/aiconfigurator/sdk/inference_session.py
@@ -262,6 +262,11 @@ class DisaggInferenceSession:
         disagg_summary = InferenceSummary(runtime_config=runtime_config)
         disagg_summary.set_summary_df(disagg_summary_df)
 
+        prefill_oom = prefill_summary.check_oom()
+        decode_oom = decode_summary.check_oom()
+        if prefill_oom or decode_oom:
+            disagg_summary.set_oom(True)
+
         # Carry per-op latency breakdowns from prefill/decode static runs
         per_ops_data = {}
         prefill_ctx_latency = prefill_summary.get_context_latency_dict()


### PR DESCRIPTION
## Description
- Added checks for out-of-memory (OOM) conditions in both _run_agg_estimate and _run_disagg_estimate functions.
- Enhanced error messages to provide clearer guidance on potential solutions when OOM occurs.
- Updated RuntimeError messages to remove ambiguity regarding invalid configurations.

This change aims to improve user experience by providing more informative feedback during memory-related issues.

## Test

Before
```
(aic) $ aiconfigurator cli estimate --system h100_sxm --backend trtllm --model-path meta-llama/Llama-3.1-405B
============================================================
  Performance Estimate (agg)
============================================================
  Model:            meta-llama/Llama-3.1-405B
  System:           h100_sxm
  Backend:          trtllm (1.2.0rc5)
------------------------------------------------------------
  ISL:              1024
  OSL:              1024
  Batch Size:       128
  Context Tokens:   1024
  TP Size:          1
  PP Size:          1
------------------------------------------------------------
  TTFT:             5635.419 ms
  TPOT:             459.695 ms
  Power (per GPU):  0.0 W
============================================================
```

After
```
$ aiconfigurator cli estimate --system h100_sxm --backend trtllm --model-path meta-llama/Llama-3.1-405B --tp-size 8
Traceback (most recent call last):
  File "/home/harrli/Projects/aiconfigurator/.venv/bin/aiconfigurator", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/harrli/Projects/aiconfigurator/src/aiconfigurator/main.py", line 84, in main
    handler(extras)
  File "/home/harrli/Projects/aiconfigurator/src/aiconfigurator/main.py", line 50, in _run_cli
    cli_main(cli_args)
  File "/home/harrli/Projects/aiconfigurator/src/aiconfigurator/cli/main.py", line 1317, in main
    _run_estimate_mode(args)
  File "/home/harrli/Projects/aiconfigurator/src/aiconfigurator/cli/main.py", line 1253, in _run_estimate_mode
    result = cli_estimate(**estimate_kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/harrli/Projects/aiconfigurator/src/aiconfigurator/cli/api.py", line 615, in cli_estimate
    return _run_agg_estimate(
           ^^^^^^^^^^^^^^^^^^
  File "/home/harrli/Projects/aiconfigurator/src/aiconfigurator/cli/api.py", line 742, in _run_agg_estimate
    raise RuntimeError(
RuntimeError: OOM: the model 'meta-llama/Llama-3.1-405B' does not fit in GPU memory on system 'h100_sxm' with the given parallelism (tp=8, pp=1, dp=1). Try increasing tp_size/pp_size, using a quantized model, or using a system with more VRAM per GPU.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved out-of-memory detection with clearer error messages that distinguish between GPU memory constraints and invalid configurations
  * Enhanced error messages now include system configuration and parallelism details with suggested remedies for memory issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->