### PR TITLE
fix: trtllm moe collector error

### DIFF
--- a/collector/trtllm/collect_moe_v3.py
+++ b/collector/trtllm/collect_moe_v3.py
@@ -433,7 +433,9 @@ def run_moe_torch(
         num_iter = 5 if distributed == "power_law" else 1
         if distributed == "power_law":
             actual_logits_list = [
-                power_law_logits_v3(num_tokens, num_experts, topk, moe_ep_size, power_law_alpha).to(router_logits_dtype)
+                power_law_logits_v3(num_tokens, num_experts, topk, moe_ep_size, power_law_alpha)
+                .to(router_logits_dtype)
+                .to(device)
                 for _ in range(num_iter)
             ]
         elif distributed == "balanced":


### PR DESCRIPTION
#### Overview:
Fixes error while running trtllm moe collector:

```
  File "/usr/local/lib/python3.12/dist-packages/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py", line 249, in fused_moe
    output = run_moe(input, token_selected_experts, token_final_scales,
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: token_selected_experts must be a CUDA tensor
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed device placement handling for mixture-of-experts model operations. Now ensures all computations execute on the correct target device in distributed and multi-device configurations. This prevents device mismatch errors and improves overall stability during model inference, training, and data collection across various hardware setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->