### PR TITLE
fix: gracefully skip unsupported backends when --backend auto (#511)

### DIFF
--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -413,10 +413,48 @@ def build_default_task_configs(
     # Expand "auto" backend to all available backends
     backends_to_sweep = [b.value for b in common.BackendName] if backend == "auto" else [backend]
 
-    for backend_name in backends_to_sweep:
-        _ensure_backend_version_available(system, backend_name, backend_version)
+    if backend == "auto":
+        supported = perf_database.get_supported_databases()
+        available = []
+        for backend_name in backends_to_sweep:
+            sys_backends = supported.get(system, {})
+            decode_backends = supported.get(decode_system, {}) if decode_system != system else sys_backends
+            if backend_name not in sys_backends:
+                logger.warning("Skipping backend %s: not supported for system %s.", backend_name, system)
+                continue
+            if decode_system != system and backend_name not in decode_backends:
+                logger.warning("Skipping backend %s: not supported for decode system %s.", backend_name, decode_system)
+                continue
+            if backend_version is not None:
+                if backend_version not in sys_backends.get(backend_name, []):
+                    logger.warning(
+                        "Skipping backend %s: version %s not available for system %s.",
+                        backend_name,
+                        backend_version,
+                        system,
+                    )
+                    continue
+                if decode_system != system and backend_version not in decode_backends.get(backend_name, []):
+                    logger.warning(
+                        "Skipping backend %s: version %s not available for decode system %s.",
+                        backend_name,
+                        backend_version,
+                        decode_system,
+                    )
+                    continue
+            available.append(backend_name)
+        if not available:
+            logger.error(
+                "No backends available for system %s. Supported backends: %s",
+                system,
+                ", ".join(sorted(supported.get(system, {}).keys())),
+            )
+            raise SystemExit(1)
+        backends_to_sweep = available
+    else:
+        _ensure_backend_version_available(system, backend, backend_version)
         if decode_system != system:
-            _ensure_backend_version_available(decode_system, backend_name, backend_version)
+            _ensure_backend_version_available(decode_system, backend, backend_version)
 
     common_kwargs: dict[str, Any] = {
         "model_path": model_path,
@@ -659,6 +697,8 @@ def _execute_task_configs(
             logger.info("Starting experiment: %s", exp_name)
             logger.debug("Task config: \n%s", task_config.to_yaml())
             task_result = runner.run(task_config)
+            if task_result is None:
+                raise RuntimeError(f"Task runner returned no result for {exp_name}")
             pareto_df = task_result["pareto_df"]
             if pareto_df is not None and not pareto_df.empty:
                 results[exp_name] = task_result

--- a/src/aiconfigurator/cli/utils.py
+++ b/src/aiconfigurator/cli/utils.py
@@ -101,7 +101,11 @@ def _merge_into_top_n(
     """Merge the best configs and pareto fronts into top N."""
     best_configs_dfs = []
     pareto_dfs = []
+    retained_exps: list[str] = []
     for exp_name in exps:
+        if exp_name not in best_configs:
+            continue
+        retained_exps.append(exp_name)
         backend_name = task_configs[exp_name].backend_name
         df = best_configs[exp_name].copy()
         if not df.empty:
@@ -126,7 +130,8 @@ def _merge_into_top_n(
     # Merge pareto fronts for plotting and recompute Pareto frontier
     if pareto_dfs:
         df_combined_pareto = pd.concat(pareto_dfs, ignore_index=True)
-        x_col = pareto_x_axis.get(exps[0], "tokens/s/user")
+        ref_exp = next((name for name in retained_exps if name in pareto_x_axis), None)
+        x_col = pareto_x_axis.get(ref_exp, "tokens/s/user")
         df_merged_pareto_front = get_pareto_front(
             df_combined_pareto,
             x_col,

--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -254,6 +254,10 @@ def get_database(
     elif isinstance(systems_paths, str):
         systems_paths = [systems_paths]
 
+    if version is None:
+        logger.error(f"No database version available for {system=}, {backend=}")
+        return None
+
     for systems_root in systems_paths:
         system_yaml_path = os.path.join(systems_root, f"{system}.yaml")
         if not os.path.isfile(system_yaml_path):


### PR DESCRIPTION
Cherry-pick of 96b12fbf0b829f828884d3bf1c45f1bd7ef9bf8f from main

Original commit: https://github.com/ai-dynamo/aiconfigurator/commit/96b12fbf0b829f828884d3bf1c45f1bd7ef9bf8f
Original PR: https://github.com/ai-dynamo/aiconfigurator/pull/511

## Summary

- When using `--backend auto`, aiconfigurator crashed with `SystemExit(1)` if any backend (e.g. vllm) lacked a perf database for the target system. Now unsupported backends are skipped with a warning log, and only backends with available data are swept.
- Adds defensive handling for related downstream crashes: `get_database()` returns `None` early when `version` is `None` (prevents `TypeError` in `os.path.join`), `_execute_task_configs()` handles `task_result=None`, and `_merge_into_top_n()` skips experiments missing from `best_configs` (prevents `KeyError`).
