### PR TITLE
feat: add B200_sxm vllm 0.14.1 ver data collection

### DIFF
--- a/src/aiconfigurator/systems/data/b200_sxm/nccl/2.27.5/nccl_perf.txt
+++ b/src/aiconfigurator/systems/data/b200_sxm/nccl/2.27.5/nccl_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65b627cc78204167f72a877d31e6ede0d29feff3953994d7d931417315304c5d
+size 34615

--- a/src/aiconfigurator/systems/data/b200_sxm/vllm/0.14.1/context_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/b200_sxm/vllm/0.14.1/context_attention_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0870fab2e1f6fdc4db720e9dfdc1b0ac1103ce8d0e8d9155e0d821258afbf6b1
+size 1210300

--- a/src/aiconfigurator/systems/data/b200_sxm/vllm/0.14.1/custom_allreduce_perf.txt
+++ b/src/aiconfigurator/systems/data/b200_sxm/vllm/0.14.1/custom_allreduce_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c55eb5480c23ecc440fb4fd3af0955fca0bdb1aea0f3e7e2afb817c770cbce37
+size 14201

--- a/src/aiconfigurator/systems/data/b200_sxm/vllm/0.14.1/gemm_perf.txt
+++ b/src/aiconfigurator/systems/data/b200_sxm/vllm/0.14.1/gemm_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc54554aaff9a579d023b50fe3ce80b9bc50552a23d9f5c59c5907b1dcaa5d20
+size 2123116

--- a/src/aiconfigurator/systems/data/b200_sxm/vllm/0.14.1/generation_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/b200_sxm/vllm/0.14.1/generation_attention_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3bb615e4a23e84e90925b320a14fb6895c7d9fb51ea7554161f2306557e64fc7
+size 1016973

--- a/src/aiconfigurator/systems/data/b200_sxm/vllm/0.14.1/moe_perf.txt
+++ b/src/aiconfigurator/systems/data/b200_sxm/vllm/0.14.1/moe_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e03e2ec49f490436ec59dd54af7d3bc58e7c70ebff105212ee9f5a5988c07a9
+size 1898289


### PR DESCRIPTION
#### Overview:

add B200_sxm vllm 0.14.1 ver data collection

#### Details:
<img width="3392" height="1404" alt="cb49a997ef803551a1c2bde42ec44b78" src="https://github.com/user-attachments/assets/89ee0f7c-bb08-4182-aef6-4eceab430621" />

total error：4830
by modules：
vllm.attention_context: 144
vllm.mla_context: 1760
vllm.mla_generation: 2896
vllm.moe: 30

by error types：
AssertionError: 30
KeyError: 1632
RuntimeError: 3168

need further sanity checks and moe collection fix.

# sanity check result:
Here's the B200 MoE sanity chart.

<img width="3734" height="2946" alt="image" src="https://github.com/user-attachments/assets/ea956e82-14ac-4988-b539-be67fc56f4ae" />

Key findings from the analysis:
1. The CI moe chart error is caused by missing "balanced" distribution data. The moe_perf.txt only contains power_law_1.01 and power_law_1.2 distributions, but the sanity chart code (visualize_moe) also expects balanced. This is why the CI reported: Error: values is None or len(values) < 2.
2. The chart above shows the available data (power_law distributions) across 5 tp/ep configurations: (tp=1,ep=4), (tp=1,ep=8), (tp=1,ep=16), (tp=1,ep=32), and (tp=4,ep=1), for all 3 available quant modes (float16, fp8, fp8_block).
3. The data itself looks reasonable -- math SOL % increases with num_tokens as expected, and mem SOL % shows the expected decreasing pattern. The fp8/fp8_block modes show higher math SOL than float16.
4. The 30 AssertionErrors mentioned in the PR description are all caused by the missing balanced distribution.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added performance optimization data assets for AI accelerator system configuration and benchmarking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->