### PR TITLE
fix: add missing SGLang 0.5.8.post1 perf data files (NVBug 5952935)

### DIFF
--- a/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.8.post1/custom_allreduce_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.8.post1/custom_allreduce_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:452649c88fbe86e1e29459837e1ed4c320ecbbce186919244adf2fbd1df0cd06
+size 7038

--- a/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.8.post1/wideep_deepep_ll_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.8.post1/wideep_deepep_ll_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8478eb53164c994480a2da47608e7f3e2dfd8ca24414102f59093035f85a67fd
+size 7400

--- a/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.8.post1/wideep_deepep_normal_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.8.post1/wideep_deepep_normal_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c75dfd072a4c13e690cf7239deb1a69ec466c2d2f407a11cf917970518cc1761
+size 37830


### PR DESCRIPTION
## Summary

- Copies `custom_allreduce_perf.txt`, `wideep_deepep_ll_perf.txt`, and `wideep_deepep_normal_perf.txt` from `sglang/0.5.6.post2` to `sglang/0.5.8.post1` for `h100_sxm`.
- These files are required for tp>1 evaluation and MoE DeepEP evaluation. Without them, AIConfigurator skips all multi-GPU tensor-parallel configs (tp=2, tp=4) during Pareto analysis.

NVBug: 5952935

## Test plan

- [ ] Run `aiconfigurator cli default` with SGLang 0.5.8.post1 on h100_sxm and verify tp=2/tp=4 configs appear in results
- [ ] Verify the added perf data files match the content from 0.5.6.post2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added performance benchmarking data files for H100 SXM systems using sglang 0.5.8.post1, covering multiple execution patterns and test variants to support system configuration analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->