### PR TITLE
fix: early catch unsupported system/backend/version combos at CLI side (#360)

### DIFF
--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -312,10 +312,31 @@ def _get_backend_data_path(system_name: str, backend_name: str, backend_version:
     return None
 
 
-def _ensure_backend_version_available(system_name: str, backend_name: str, backend_version: str) -> None:
+def _ensure_backend_version_available(system_name: str, backend_name: str, backend_version: str | None = None) -> None:
+    """
+    Validate that the backend is supported for the given system and version.
+
+    Args:
+        system_name: System name (e.g., 'gb200_sxm')
+        backend_name: Backend name (e.g., 'vllm')
+        backend_version: Backend database version. Default is None, which means latest version.
+
+    Raises:
+        SystemExit: If the backend is not supported for the given system and version.
+    """
     supported = perf_database.get_supported_databases()
+    backends = supported.get(system_name, {}).keys()
+    if backend_name not in backends:
+        logger.error(
+            "Backend %s is not supported for system %s. Supported backends: %s",
+            backend_name,
+            system_name,
+            ", ".join(sorted(backends)),
+        )
+        raise SystemExit(1)
+
     versions = supported.get(system_name, {}).get(backend_name, [])
-    if backend_version in versions:
+    if backend_version is None or backend_version in versions:
         return
 
     systems_paths = perf_database.get_systems_paths()
@@ -392,11 +413,10 @@ def build_default_task_configs(
     # Expand "auto" backend to all available backends
     backends_to_sweep = [b.value for b in common.BackendName] if backend == "auto" else [backend]
 
-    if backend_version:
-        for backend_name in backends_to_sweep:
-            _ensure_backend_version_available(system, backend_name, backend_version)
-            if decode_system != system:
-                _ensure_backend_version_available(decode_system, backend_name, backend_version)
+    for backend_name in backends_to_sweep:
+        _ensure_backend_version_available(system, backend_name, backend_version)
+        if decode_system != system:
+            _ensure_backend_version_available(decode_system, backend_name, backend_version)
 
     common_kwargs: dict[str, Any] = {
         "model_path": model_path,


### PR DESCRIPTION
Cherry-pick of b762174 from main

Original commit: https://github.com/ai-dynamo/aiconfigurator/commit/b7621746029edb252f62111bcd426b0b17b14b85
Original PR: #360

## Summary

- Updates `_ensure_backend_version_available` to accept `backend_version: str | None = None` and return early when `backend_version is None` (prevents `TypeError` in `os.path.join`)
- Adds early validation that the backend name is supported for the given system before checking versions
- Removes the `if backend_version:` guard in `build_default_task_configs` since the function itself now handles `None`

This is a prerequisite for PR #516 (cherry-pick of #511), which depends on these changes to `_ensure_backend_version_available` being present on the release branch.

Made with [Cursor](https://cursor.com)