### PR TITLE
fix: add --kv-transfer-config to vLLM disagg templates (NVBug 5952846) (#519)

### DIFF
--- a/src/aiconfigurator/generator/config/backend_templates/vllm/k8s_deploy.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/vllm/k8s_deploy.yaml.j2
@@ -58,8 +58,12 @@
             {% endfor %}
             {% if role == 'prefill' %}
             - --is-prefill-worker
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
             {% elif role == 'decode' %}
             - --is-decode-worker
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
             {% endif %}
 {%- endmacro %}
 

--- a/src/aiconfigurator/generator/config/backend_templates/vllm/run.sh.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/vllm/run.sh.j2
@@ -60,7 +60,7 @@ for ((w=0; w<PREFILL_WORKERS; w++)); do
     python3 -m dynamo.vllm \
       --model "$MODEL_PATH" \
       {% if enable_router %}--kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${EVENT_PORT}\",\"enable_kv_cache_events\":true}" {% endif %}\
-      {{ prefill_cli_args }} --is-prefill-worker 2>&1 | sed "s/^/[Prefill $w] /" ) &
+      {{ prefill_cli_args }} --is-prefill-worker --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' 2>&1 | sed "s/^/[Prefill $w] /" ) &
 done
 {% endif %}
 
@@ -80,7 +80,7 @@ for ((w=0; w<DECODE_WORKERS; w++)); do
     python3 -m dynamo.vllm \
       --model "$MODEL_PATH" \
       {% if enable_router %}--kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${EVENT_PORT}\",\"enable_kv_cache_events\":true}" {% endif %}\
-      {{ decode_cli_args }} --is-decode-worker 2>&1 | sed "s/^/[Decode $w] /" ) &
+      {{ decode_cli_args }} --is-decode-worker --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' 2>&1 | sed "s/^/[Decode $w] /" ) &
 done
 {% endif %}
 wait


### PR DESCRIPTION
Cherry-pick of f4679a9 from main

Original commit: https://github.com/ai-dynamo/aiconfigurator/commit/f4679a9
Original PR: #519

## Summary

* Starting from `vllm-runtime:1.0.0rc5`, `--connector` is deprecated and `--kv-transfer-config` must be explicitly provided for disaggregated prefill/decode deployments. Without it, `VllmPrefillWorker` enters CrashLoopBackOff with a `ValueError`.
* Adds `--kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'` to both `k8s_deploy.yaml.j2` and `run.sh.j2` templates for prefill and decode workers.

NVBug: 5952846

Made with [Cursor](https://cursor.com)