### PR TITLE
feat: Add --profile option for collector

### DIFF
--- a/collector/collect.py
+++ b/collector/collect.py
@@ -223,55 +223,6 @@ class ProfilerContext:
         logger.info(f"Full profile saved to: {profile_file}")
 
 
-def sequential_run(tasks, func, module_name="unknown"):
-    """Sequential runner for profiling mode - runs all tasks in main process"""
-    errors = []
-    device = torch.device("cuda:0")
-    torch.cuda.set_device(0)
-
-    with tqdm(total=len(tasks), desc=f"{module_name}", dynamic_ncols=True, leave=True) as pbar:
-        for i, task in enumerate(tasks):
-            # Handle both old format (tuple) and new format (dict)
-            if isinstance(task, dict):
-                task_id = task.get("id", "unknown")
-                task_params = task.get("params", task)
-            else:
-                task_params = task
-                task_id = create_test_case_id(task, func.__name__, module_name)
-
-            try:
-                func(*task_params, device)
-            except Exception as e:
-                error_info = {
-                    "module": module_name,
-                    "device_id": 0,
-                    "task_id": task_id,
-                    "task_params": str(task_params),
-                    "error_type": type(e).__name__,
-                    "error_message": str(e),
-                    "traceback": traceback.format_exc(),
-                    "timestamp": datetime.now().isoformat(),
-                }
-                errors.append(error_info)
-                logger.exception(f"Task {task_id} failed")
-
-            pbar.update(1)
-            if len(errors) > 0:
-                pbar.set_postfix({"errors": len(errors)})
-
-    # Log summary
-    if errors:
-        log_dir = os.environ.get("COLLECTOR_LOG_DIR", "")
-        logger.error(f"{module_name}: Completed with {len(errors)} errors")
-        error_file = f"{log_dir}/errors_{module_name}.json"
-        save_error_report(errors, error_file)
-        logger.error(f"Error details saved to {error_file}")
-    else:
-        logger.info(f"{module_name}: Completed successfully with no errors")
-
-    return errors
-
-
 def collect_module_safe(module_name, test_type, get_test_cases_func, run_func, num_processes, resume_options=None):
     """
     Safely collect module with comprehensive error handling
@@ -288,20 +239,13 @@ def collect_module_safe(module_name, test_type, get_test_cases_func, run_func, n
         logger.info(f"Generated {len(test_cases)} test cases for {full_name}")
 
         # Run collection
-        if num_processes == 0:
-            errors = sequential_run(
-                test_cases,
-                run_func,
-                full_name
-            )
-        else:
-            errors = parallel_run(
-                test_cases,
-                run_func,
-                num_processes,
-                full_name,
-                resume_options=resume_options,
-            )
+        errors = parallel_run(
+            test_cases,
+            run_func,
+            num_processes,
+            full_name,
+            resume_options=resume_options,
+        )
 
         return errors
 
@@ -429,7 +373,11 @@ def worker(
 
 
 def parallel_run(tasks, func, num_processes, module_name="unknown", resume_options=None):
-    """parallel runner with error collection"""
+    """parallel runner with error collection
+
+    Args:
+        num_processes: Number of parallel processes. If 0, runs sequentially in main process.
+    """
     raw_task_infos = []
     for i, task in enumerate(tasks):
         if isinstance(task, dict) and "id" in task and "params" in task:
@@ -551,6 +499,40 @@ def parallel_run(tasks, func, num_processes, module_name="unknown", resume_optio
         last_progress = 0
         stall_count = 0
         last_error_count = 0
+
+        if num_processes == 0:
+            # Special handling for --profile
+            # Run tasks sequentially in main process
+            device = torch.device("cuda:0")
+            torch.cuda.set_device(0)
+
+            for task_info in task_infos:
+                task_id = task_info["id"]
+                task_params = task_info["params"]
+
+                try:
+                    func(*task_params, device)
+                    resume_tracker.mark_done(task_id)
+                except Exception as e:
+                    error_info = {
+                        "module": module_name,
+                        "device_id": 0,
+                        "task_id": task_id,
+                        "task_params": str(task_params),
+                        "error_type": type(e).__name__,
+                        "error_message": str(e),
+                        "traceback": traceback.format_exc(),
+                        "timestamp": datetime.now().isoformat(),
+                    }
+                    errors.append(error_info)
+                    logger.exception(f"Task {task_id} failed")
+
+                pbar.update(1)
+                progress_value.value += 1
+                if len(errors) > 0:
+                    pbar.set_postfix({"errors": len(errors)})
+                resume_tracker.flush()
+            resume_tracker.flush(force=True)
 
         while progress_value.value < len(task_infos):
             # Drain errors


### PR DESCRIPTION
#### Overview:
Adds a `--profile` option for running collector. This is helpful identifying bottlenecks in the collector code. This will profile the tests and dump the result at the end. Recommended to use with `--limit`.


Example
```
root@ac2d3d8f109a:/aic/collector# python3 collect.py --ops gemm --limit 10 --shuffle --profile
/usr/local/lib/python3.12/dist-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
[2026-03-05 23:16:05,485] [INFO] [root] Starting collection in sequential mode (profiling enabled)
[2026-03-05 23:16:05,485] [INFO] [root] Profiling enabled - running sequentially in main process (no parallel workers)
[2026-03-05 23:16:18,323] [INFO] [root] TensorRT LLM version: 1.2.0rc6
[2026-03-05 23:16:18,327] [INFO] [root] Starting collection: trtllm.gemm
[2026-03-05 23:16:18,347] [INFO] [root] Generated 10 test cases for trtllm.gemm
trtllm.gemm: 100%|█████████████████████████████████████████████████████| 10/10 [00:00<00:00, 28.84it/s]
[2026-03-05 23:16:18,781] [INFO] [root] trtllm.gemm: Completed successfully with no errors
[2026-03-05 23:16:18,782] [INFO] [root] ============================================================
[2026-03-05 23:16:18,782] [INFO] [root] COLLECTION SUMMARY - trtllm v1.2.0rc6
[2026-03-05 23:16:18,782] [INFO] [root] ============================================================
[2026-03-05 23:16:18,782] [INFO] [root] Total errors: 0
[2026-03-05 23:16:18,782] [INFO] [root] 
Detailed error report saved to: gemm_20260305_231605/collection_summary_trtllm.json
[2026-03-05 23:16:19,360] [INFO] [root] ================================================================================
[2026-03-05 23:16:19,360] [INFO] [root] PROFILING SUMMARY
[2026-03-05 23:16:19,360] [INFO] [root] ================================================================================
[2026-03-05 23:16:19,360] [INFO] [root] Total elapsed time: 13.87 seconds (0.23 minutes)
[2026-03-05 23:16:19,360] [INFO] [root] Profile file: gemm_20260305_231605/collector_profile_trtllm.prof
[2026-03-05 23:16:19,360] [INFO] [root] ================================================================================
[2026-03-05 23:16:20,071] [INFO] [root] Top 20 functions by tottime (time in function excluding subcalls):
[2026-03-05 23:16:20,071] [INFO] [root] ================================================================================
         17855128 function calls (17169065 primitive calls) in 27.102 seconds

   Ordered by: internal time
   List reduced from 22580 to 20 due to restriction <20>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    72/19   10.651    0.148    9.454    0.498 frontend.py:888(build_Attribute)
        4    3.191    0.798    3.191    0.798 frontend.py:1030(build_Compare)
  258/256    1.006    0.004    1.009    0.004 {built-in method _imp.create_dynamic}
  10530/1    0.473    0.000    0.012    0.012 {built-in method builtins.exec}
     5217    0.456    0.000    0.456    0.000 {built-in method marshal.loads}
  258/187    0.442    0.002    0.695    0.004 {built-in method _imp.exec_dynamic}
     5217    0.438    0.000    0.898    0.000 <frozen importlib._bootstrap_external>:751(_compile_bytecode)
  2401831    0.357    0.000    0.357    0.000 {method 'startswith' of 'str' objects}
     2850    0.312    0.000    0.705    0.000 import_utils.py:2457(fetch__all__)
        1    0.288    0.288    0.288    0.288 _nvvm_ops_gen.py:5882(MBarrierTryWaitTimeLimitOp)
     5933    0.274    0.000    0.308    0.000 hipify_python.py:686(add)
    64630    0.254    0.000    0.587    0.000 {built-in method posix.stat}
   825/37    0.251    0.000    1.172    0.032 import_utils.py:2499(create_import_structure_from_path)
1778223/1774919    0.205    0.000    0.218    0.000 {built-in method builtins.isinstance}
       67    0.178    0.003    0.178    0.003 python_message.py:877(_AddHasFieldMethod)
    50930    0.146    0.000    0.275    0.000 pathlib.py:387(_parse_path)
13334/7478    0.145    0.000    2.444    0.000 {built-in method builtins.__build_class__}
    16643    0.142    0.000    0.142    0.000 {method 'splitlines' of 'str' objects}
641396/640939    0.128    0.000    1.593    0.000 {built-in method builtins.getattr}
  52846/2    0.127    0.000    0.221    0.111 hipify_python.py:718(_pattern)


[2026-03-05 23:16:20,144] [INFO] [root] ================================================================================
[2026-03-05 23:16:20,144] [INFO] [root] Top 20 functions by cumtime (cumulative time including subcalls):
[2026-03-05 23:16:20,144] [INFO] [root] ================================================================================
         17855128 function calls (17169065 primitive calls) in 27.102 seconds

   Ordered by: cumulative time
   List reduced from 22580 to 20 due to restriction <20>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      711    0.015    0.000   24.217    0.034 __init__.py:1(<module>)
       18    0.000    0.000   18.244    1.014 ops.py:77(decorator)
    314/9    0.001    0.000   10.850    1.206 frontend.py:404(__call__)
       38    0.000    0.000    9.884    0.260 _ops.py:370(fallthrough)
    72/19   10.651    0.148    9.454    0.498 frontend.py:888(build_Attribute)
     12/6    0.000    0.000    7.056    1.176 frontend.py:701(build_Assign)
    58/52    0.001    0.000    6.641    0.128 custom_ops.py:334(inner)
     21/9    0.000    0.000    6.326    0.703 frontend.py:905(build_Call)
    58/52    0.001    0.000    6.035    0.116 custom_ops.py:185(__init__)
        4    0.000    0.000    5.444    1.361 _script.py:351(script_method)
      6/4    0.000    0.000    5.440    1.360 frontend.py:318(get_jit_def)
    58/52    0.001    0.000    5.348    0.103 custom_ops.py:598(_register_to_dispatcher)
      6/4    0.000    0.000    5.247    1.312 frontend.py:420(build_def)
     11/4    0.000    0.000    4.988    1.247 frontend.py:187(build_stmts)
      6/3    0.000    0.000    3.795    1.265 frontend.py:739(build_Return)
     13/9    0.003    0.000    3.517    0.391 frontend.py:448(build_param_list)
        4    3.191    0.798    3.191    0.798 frontend.py:1030(build_Compare)
        1    0.000    0.000    3.173    3.173 convert_frame.py:1(<module>)
        1    0.000    0.000    3.167    3.167 symbolic_convert.py:1(<module>)
        2    0.000    0.000    2.914    1.457 frontend.py:1022(build_IfExp)


[2026-03-05 23:16:20,219] [INFO] [root] ================================================================================
[2026-03-05 23:16:20,219] [INFO] [root] Full profile saved to: gemm_20260305_231605/collector_profile_trtllm.prof
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added performance profiling support via new `--profile` CLI flag. When enabled, the collector captures and logs profiling metrics for analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->