### PR TITLE
fix: add missing SGLang 0.5.8.post1 perf data files (NVBug 5952935) (#520)

### DIFF
--- a/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.8.post1/custom_allreduce_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.8.post1/custom_allreduce_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:452649c88fbe86e1e29459837e1ed4c320ecbbce186919244adf2fbd1df0cd06
+size 7038

--- a/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.8.post1/wideep_deepep_ll_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.8.post1/wideep_deepep_ll_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8478eb53164c994480a2da47608e7f3e2dfd8ca24414102f59093035f85a67fd
+size 7400

--- a/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.8.post1/wideep_deepep_normal_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/sglang/0.5.8.post1/wideep_deepep_normal_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c75dfd072a4c13e690cf7239deb1a69ec466c2d2f407a11cf917970518cc1761
+size 37830


### PR DESCRIPTION
Cherry-pick of c43d29b2c8eea53d0f5a199df05859a8c08b242a from main

Original commit: https://github.com/ai-dynamo/aiconfigurator/commit/c43d29b2c8eea53d0f5a199df05859a8c08b242a
Original PR: https://github.com/ai-dynamo/aiconfigurator/pull/520

Made with [Cursor](https://cursor.com)