### PR TITLE
fix: raise error in _estimate_model_weight_bytes when a model name is invalid

### DIFF
--- a/src/aiconfigurator/generator/naive.py
+++ b/src/aiconfigurator/generator/naive.py
@@ -92,6 +92,10 @@ def _estimate_model_weight_bytes(model_path: str) -> int:
 
     Returns:
         Estimated model weight size in bytes.
+
+    Raises:
+        RuntimeError: If the model config cannot be fetched (e.g. model not found
+            on HuggingFace). Callers must not proceed with guessed parameters.
     """
     from aiconfigurator.sdk.utils import get_model_config_from_model_path
 
@@ -142,9 +146,8 @@ def _estimate_model_weight_bytes(model_path: str) -> int:
         return weight_bytes
 
     except Exception as e:
-        logger.warning(f"Could not estimate model size for {model_path}: {e}")
-        # Return a large fallback to be safe (assume 70B model @ FP16 = ~140GB)
-        return 140 * 1024 * 1024 * 1024
+        logger.exception("Could not estimate model size for %s.", model_path)
+        raise RuntimeError(f"Model {model_path!r} not found or config unavailable") from e
 
 
 def _calculate_min_tp(

--- a/tests/unit/generator/test_naive.py
+++ b/tests/unit/generator/test_naive.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import pytest
 
 from aiconfigurator.generator.naive import (
+    _estimate_model_weight_bytes,
     _sanitize_rfc1123,
     build_naive_generator_params,
 )
@@ -148,6 +149,30 @@ class TestBuildNaiveGeneratorParams:
             backend_name="vllm",
         )
         assert result["ServiceConfig"]["include_frontend"] is True
+
+
+@pytest.mark.unit
+class TestEstimateModelWeightBytesFailsOnMissingModel:
+    @patch("aiconfigurator.sdk.utils.get_model_config_from_model_path")
+    def test_raises_when_config_download_fails(self, mock_get_config):
+        mock_get_config.side_effect = Exception(
+            "Failed to download nonexistent-org/fake-model-12345's config.json from HuggingFace: "
+            "HuggingFace returned HTTP error 401: Unauthorized."
+        )
+        with pytest.raises(RuntimeError, match=r"Model .* not found or config unavailable"):
+            _estimate_model_weight_bytes("nonexistent-org/fake-model-12345")
+
+    @patch("aiconfigurator.generator.naive._get_system_config")
+    @patch("aiconfigurator.generator.naive._estimate_model_weight_bytes")
+    def test_build_naive_generator_params_propagates_model_not_found(self, mock_est, _mock_sys):
+        mock_est.side_effect = RuntimeError("Model 'nonexistent-org/fake-model-12345' not found or config unavailable")
+        with pytest.raises(RuntimeError, match="not found or config unavailable"):
+            build_naive_generator_params(
+                model_name="nonexistent-org/fake-model-12345",
+                total_gpus=8,
+                system_name="h200_sxm",
+                backend_name="vllm",
+            )
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Cherry-pick of 57622cc from main

Original commit: https://github.com/ai-dynamo/aiconfigurator/commit/57622cc9c883ae67d6c122c5a25bce1c65296221

## Summary

Instead of using a fallback guess, `_estimate_model_weight_bytes` should directly raise an error when a model config is not available.

## Related Issues

- Fixes https://nvbugspro.nvidia.com/bug/5949346
- Original PR: https://github.com/ai-dynamo/aiconfigurator/pull/528

Made with [Cursor](https://cursor.com)