### PR TITLE
feat(collector): nvfp4 MoE and GEMM support (Blackwell SM100+)

### DIFF
--- a/collector/vllm/collect_gemm.py
+++ b/collector/vllm/collect_gemm.py
@@ -6,8 +6,12 @@ __compat__ = "vllm>=0.11.0"
 import os
 
 import torch
+from vllm._custom_ops import scaled_fp4_quant
 from vllm.config import VllmConfig, set_current_vllm_config
 from vllm.model_executor.layers.linear import RowParallelLinear
+from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors import (
+    CompressedTensorsConfig,
+)
 from vllm.model_executor.layers.quantization.fp8 import Fp8Config
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     maybe_post_process_fp8_weight_block,
@@ -21,6 +25,15 @@ from collector.vllm.utils import setup_distributed, with_exit_stack
 
 FP8_BLOCK_SHAPE = (128, 128)
 
+_NVFP4_QUANT_ARGS = {
+    "num_bits": 4,
+    "type": "float",
+    "strategy": "tensor_group",
+    "group_size": 16,
+    "symmetric": True,
+    "dynamic": False,
+}
+
 
 def get_gemm_test_cases():
     sm = get_sm_version()
@@ -31,9 +44,9 @@ def get_gemm_test_cases():
     # Blockwise FP8 kernels are available on Hopper/Blackwell+
     if sm >= 90:
         gemm_list += ["fp8_block"]
-
-    # if get_sm_version() >= 100:
-    #     gemm_list += ["nvfp4"]
+    # NVFP4 available on Blackwell+
+    if sm >= 100:
+        gemm_list += ["nvfp4"]
 
     test_cases = []
 
@@ -44,6 +57,10 @@ def get_gemm_test_cases():
         for gemm_type in gemm_list:
             if gemm_type in ("nvfp4", "fp8_block") and (n < 128 or k < 128):
                 continue
+            if gemm_type == "nvfp4":  # noqa: SIM102
+                # group_size=16; both dims must be divisible by 16
+                if (n % 16) != 0 or (k % 16) != 0:
+                    continue
             if gemm_type == "fp8_block":
                 block_n, block_k = FP8_BLOCK_SHAPE
                 # Block-wise kernels expect dimensions that align with the block.
@@ -65,7 +82,8 @@ def run_gemm(exit_stack, gemm_type, m, n, k, perf_filename, device="cuda:0"):
 
     setup_distributed(device)
 
-    dtype = torch.float16
+    # nvfp4 uses bfloat16 activations; everything else uses float16.
+    dtype = torch.bfloat16 if gemm_type == "nvfp4" else torch.float16
     torch.set_default_dtype(dtype)
     torch.cuda.set_device(device)
     torch.set_default_device(device)
@@ -84,6 +102,22 @@ def run_gemm(exit_stack, gemm_type, m, n, k, perf_filename, device="cuda:0"):
             is_checkpoint_fp8_serialized=True,
             activation_scheme="dynamic",
             weight_block_size=list(FP8_BLOCK_SHAPE),
+        )
+    elif gemm_type == "nvfp4":
+        qc = CompressedTensorsConfig.from_config(
+            {
+                "quant_type": "compressed-tensors",
+                "format": "nvfp4-pack-quantized",
+                "global_compression_ratio": 1.0,
+                "config_groups": {
+                    "group_0": {
+                        "weights": _NVFP4_QUANT_ARGS,
+                        "input_activations": _NVFP4_QUANT_ARGS,
+                        "targets": ["Linear"],
+                        "output_activations": None,
+                    }
+                },
+            }
         )
     else:
         qc = None
@@ -133,6 +167,23 @@ def run_gemm(exit_stack, gemm_type, m, n, k, perf_filename, device="cuda:0"):
                 # for dynamic activation); set it if create_weights didn't.
                 if not hasattr(gemm, "input_scale"):
                     gemm.input_scale = None
+        elif gemm_type == "nvfp4":
+            with torch.no_grad():
+                weight_bf16 = torch.randn(n, k, dtype=torch.bfloat16, device=device)
+                w_gscale_val = float(weight_bf16.abs().max()) / 6.0
+                weight_fp4, weight_scale_fp8 = scaled_fp4_quant(
+                    weight_bf16,
+                    torch.tensor(1.0 / w_gscale_val, dtype=torch.float32, device=device),
+                    is_sf_swizzled_layout=False,
+                    backend="cutlass",
+                )
+                in_gscale_val = float(x.abs().max()) / 6.0
+                # CT convention: global_scale parameters store the inverse (1/actual_scale).
+                gemm.weight_packed.data.copy_(weight_fp4)
+                gemm.weight_scale.data.copy_(weight_scale_fp8.to(torch.float8_e4m3fn))
+                gemm.weight_global_scale.data.fill_(1.0 / w_gscale_val)
+                gemm.input_global_scale.data.fill_(1.0 / in_gscale_val)
+            gemm.scheme.process_weights_after_loading(gemm)
 
         gemm.forward(x)  # dry run to init
 

--- a/collector/vllm/collect_moe.py
+++ b/collector/vllm/collect_moe.py
@@ -25,6 +25,20 @@ except Exception:
     except Exception:
         per_block_cast_to_fp8 = None  # type: ignore[assignment]
 
+# nvfp4 MoE helpers (Blackwell SM 100+).
+# Note: fused_experts does not support nvfp4; use flashinfer_cutlass_fused_moe directly.
+try:
+    from flashinfer.fused_moe.core import ActivationType as _ActivationType
+    from vllm._custom_ops import scaled_fp4_quant as _scaled_fp4_quant
+    from vllm.model_executor.layers.quantization.utils.flashinfer_fp4_moe import (
+        swizzle_blockscale as _swizzle_blockscale,
+    )
+    from vllm.utils.flashinfer import flashinfer_cutlass_fused_moe as _flashinfer_cutlass_fused_moe
+
+    _nvfp4_moe_available = True
+except Exception:
+    _nvfp4_moe_available = False
+
 from collector.common_test_cases import get_common_moe_test_cases
 from collector.helper import balanced_logits, benchmark_with_power, get_sm_version, log_perf, power_law_logits_v3
 
@@ -40,6 +54,8 @@ def get_moe_test_cases():
         moe_list += ["fp8"]
     if get_sm_version() >= 90 and per_block_cast_to_fp8 is not None:
         moe_list += ["fp8_block"]
+    if get_sm_version() >= 100 and _nvfp4_moe_available:
+        moe_list += ["nvfp4"]
 
     test_cases = []
 
@@ -60,6 +76,13 @@ def get_moe_test_cases():
         for moe_type in moe_list:
             # fp8_block requires hidden_size and local_inter_size divisible by 128.
             if moe_type == "fp8_block" and (common_moe_testcase.hidden_size % 128 != 0 or local_inter_size % 128 != 0):
+                continue
+
+            # nvfp4 requires hidden_size and local_inter_size divisible by 16 (group_size).
+            # flashinfer_cutlass_fused_moe (the nvfp4 kernel) does not support EP > 1.
+            if moe_type == "nvfp4" and (
+                common_moe_testcase.hidden_size % 16 != 0 or local_inter_size % 16 != 0 or common_moe_testcase.ep > 1
+            ):
                 continue
 
             test_cases.append(
@@ -177,11 +200,53 @@ def run_moe_torch(
 
     use_inplace = not disable_inplace()
 
+    # nvfp4 MoE: quantize weights to fp4 and precompute quant scales.
+    # fused_experts does not support nvfp4; use flashinfer_cutlass_fused_moe directly.
+    nvfp4_w1_fp4 = nvfp4_w2_fp4 = None
+    nvfp4_quant_scales: list | None = None
+    if moe_type == "nvfp4":
+        dtype = torch.bfloat16  # nvfp4 uses bfloat16 activations
+
+        def _quant_expert_weights_nvfp4(w_bf16: torch.Tensor):
+            E = w_bf16.shape[0]  # noqa: N806
+            gscales = w_bf16.view(E, -1).abs().max(dim=1).values.float() / 6.0
+            fp4_list, sf_list = [], []
+            for i in range(E):
+                gscale_inv = torch.tensor(1.0 / gscales[i].item(), dtype=torch.float32, device=w_bf16.device)
+                w_fp4, w_sf = _scaled_fp4_quant(
+                    w_bf16[i].contiguous(), gscale_inv, is_sf_swizzled_layout=False, backend="cutlass"
+                )
+                fp4_list.append(w_fp4)
+                sf_list.append(w_sf)
+            fp4 = torch.stack(fp4_list)
+            scale = _swizzle_blockscale(torch.stack(sf_list))
+            return fp4, scale, gscales
+
+        nvfp4_w1_fp4, nvfp4_w1_scale, w1_gscales = _quant_expert_weights_nvfp4(w1.to(torch.bfloat16))
+        nvfp4_w2_fp4, nvfp4_w2_scale, w2_gscales = _quant_expert_weights_nvfp4(w2.to(torch.bfloat16))
+
+        # Input activation global scale (CT convention: store 1/actual_scale).
+        x_actual_scale = 1.0 / 6.0
+        a1_gscale = torch.full((local_num_experts,), 1.0 / x_actual_scale, dtype=torch.float32, device=device)
+        a2_gscale = a1_gscale.clone()
+        # Combined dequantization alpha: w_scale * x_scale.
+        g1_alphas = (w1_gscales * x_actual_scale).to(torch.float32)
+        g2_alphas = (w2_gscales * x_actual_scale).to(torch.float32)
+        nvfp4_quant_scales = [
+            a1_gscale,
+            nvfp4_w1_scale.view(torch.int32),
+            g1_alphas,
+            a2_gscale,
+            nvfp4_w2_scale.view(torch.int32),
+            g2_alphas,
+        ]
+
     # Performance testing for each token count
     for num_tokens_idx, num_tokens in enumerate(num_tokens_lists):
         print("num_tokens", num_tokens)
         print("topk", topk)
-        hidden_states = torch.randn([num_tokens, hidden_size]).half().to(device)
+        act_dtype = torch.bfloat16 if moe_type == "nvfp4" else torch.float16
+        hidden_states = torch.randn([num_tokens, hidden_size], dtype=act_dtype, device=device)
 
         # Generate topk_weights and topk_ids
         num_iter = 10 if distributed == "power_law" else 1
@@ -205,8 +270,6 @@ def run_moe_torch(
                 topk_weights_list.append(F.softmax(weights, dim=-1))
                 topk_ids_list.append(ids)
 
-            print("actual num_tokens: ", [topk_ids.shape[0] for topk_ids in topk_ids_list])
-
         elif distributed == "balanced":
             actual_logits = balanced_logits(num_tokens, num_experts, topk).half().to(device)
             topk_weights, topk_ids = torch.topk(actual_logits, topk, dim=-1)
@@ -221,33 +284,76 @@ def run_moe_torch(
             num_warmups = 1
             num_runs = 1
 
-        def run_single_iteration():
-            if distributed == "power_law":
-                for i, (tw, ti) in enumerate(zip(topk_weights_list, topk_ids_list)):
-                    local_num_tokens = tw.shape[0]
+        if moe_type == "nvfp4":
+
+            def run_single_iteration():
+                if distributed == "power_law":
+                    for tw, ti in zip(topk_weights_list, topk_ids_list):
+                        local_num_tokens = tw.shape[0]
+                        out = torch.empty(local_num_tokens, hidden_size, dtype=torch.bfloat16, device=device)
+                        _ = _flashinfer_cutlass_fused_moe(
+                            input=hidden_states[:local_num_tokens],
+                            token_selected_experts=ti.to(torch.int),
+                            token_final_scales=tw,
+                            fc1_expert_weights=nvfp4_w1_fp4.view(torch.long),
+                            fc2_expert_weights=nvfp4_w2_fp4.view(torch.long),
+                            output_dtype=torch.bfloat16,
+                            quant_scales=nvfp4_quant_scales,
+                            input_sf=None,
+                            tp_size=1,
+                            tp_rank=0,
+                            ep_size=1,
+                            ep_rank=0,
+                            output=out,
+                            activation_type=_ActivationType.Swiglu,
+                        )
+                else:
+                    out = torch.empty(hidden_states.shape[0], hidden_size, dtype=torch.bfloat16, device=device)
+                    _ = _flashinfer_cutlass_fused_moe(
+                        input=hidden_states,
+                        token_selected_experts=topk_ids.to(torch.int),
+                        token_final_scales=topk_weights.float(),
+                        fc1_expert_weights=nvfp4_w1_fp4.view(torch.long),
+                        fc2_expert_weights=nvfp4_w2_fp4.view(torch.long),
+                        output_dtype=torch.bfloat16,
+                        quant_scales=nvfp4_quant_scales,
+                        input_sf=None,
+                        tp_size=1,
+                        tp_rank=0,
+                        ep_size=1,
+                        ep_rank=0,
+                        output=out,
+                        activation_type=_ActivationType.Swiglu,
+                    )
+        else:
+
+            def run_single_iteration():
+                if distributed == "power_law":
+                    for i, (tw, ti) in enumerate(zip(topk_weights_list, topk_ids_list)):
+                        local_num_tokens = tw.shape[0]
+                        _ = fused_experts(
+                            hidden_states[:local_num_tokens],
+                            w1,
+                            w2,
+                            tw,
+                            ti,
+                            inplace=use_inplace,
+                            quant_config=quant_config,
+                            global_num_experts=num_experts,
+                            expert_map=expert_map,
+                        )
+                else:
                     _ = fused_experts(
-                        hidden_states[:local_num_tokens],
+                        hidden_states,
                         w1,
                         w2,
-                        tw,
-                        ti,
+                        topk_weights,
+                        topk_ids,
                         inplace=use_inplace,
                         quant_config=quant_config,
                         global_num_experts=num_experts,
                         expert_map=expert_map,
                     )
-            else:
-                _ = fused_experts(
-                    hidden_states,
-                    w1,
-                    w2,
-                    topk_weights,
-                    topk_ids,
-                    inplace=use_inplace,
-                    quant_config=quant_config,
-                    global_num_experts=num_experts,
-                    expert_map=expert_map,
-                )
 
         def run_iterations():
             # Use benchmark_with_power context manager
@@ -272,7 +378,7 @@ def run_moe_torch(
 
         print(f"moe latency: {latency}")
 
-        source = "vllm_fused_moe"
+        source = "flashinfer_cutlass_fused_moe" if moe_type == "nvfp4" else "vllm_fused_moe"
 
         log_perf(
             item_list=[

--- a/collector/vllm/collect_moe.py
+++ b/collector/vllm/collect_moe.py
@@ -294,7 +294,7 @@ def run_moe_torch(
                         _ = _flashinfer_cutlass_fused_moe(
                             input=hidden_states[:local_num_tokens],
                             token_selected_experts=ti.to(torch.int),
-                            token_final_scales=tw,
+                            token_final_scales=tw.to(torch.float32),
                             fc1_expert_weights=nvfp4_w1_fp4.view(torch.long),
                             fc2_expert_weights=nvfp4_w2_fp4.view(torch.long),
                             output_dtype=torch.bfloat16,
@@ -312,7 +312,7 @@ def run_moe_torch(
                     _ = _flashinfer_cutlass_fused_moe(
                         input=hidden_states,
                         token_selected_experts=topk_ids.to(torch.int),
-                        token_final_scales=topk_weights.float(),
+                        token_final_scales=topk_weights.to(torch.float32),
                         fc1_expert_weights=nvfp4_w1_fp4.view(torch.long),
                         fc2_expert_weights=nvfp4_w2_fp4.view(torch.long),
                         output_dtype=torch.bfloat16,


### PR DESCRIPTION
- collect_gemm: add nvfp4 GEMM via CompressedTensorsConfig (nvfp4-pack- quantized, group_size=16); quantize weights with scaled_fp4_quant; require n,k divisible by 16
- collect_moe: add nvfp4 MoE via flashinfer_cutlass_fused_moe (fused_experts does not support nvfp4); quantize per-expert weights with swizzle_blockscale; require hidden_size and local_inter_size divisible by 16; EP > 1 not supported
- collect_moe: use float32 topk_weights for nvfp4 (kernel requirement); use power_law_topk for routing generation

#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
