### PR TITLE
feat: unify cli estimate with csv

### DIFF
--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -23,7 +23,12 @@ from aiconfigurator.cli.main import (
     build_experiment_task_configs,
 )
 from aiconfigurator.cli.report_and_save import save_results
-from aiconfigurator.sdk.task import TaskConfig
+from aiconfigurator.sdk.models import check_is_moe
+from aiconfigurator.sdk.task import (
+    DEFAULT_DECODE_LATENCY_CORRECTION_SCALE,
+    DEFAULT_PREFILL_LATENCY_CORRECTION_SCALE,
+    TaskConfig,
+)
 
 
 def cli_support(
@@ -404,6 +409,68 @@ class EstimateResult:
     per_ops_data: dict | None = None
     """Per-operation latency breakdown (populated when available)."""
 
+    @property
+    def request_latency(self) -> float:
+        """End-to-end request latency (ms)."""
+        return self.raw.get("request_latency", 0.0)
+
+    @property
+    def tokens_per_second(self) -> float:
+        """Total output throughput (tokens/s)."""
+        return self.raw.get("tokens/s", 0.0)
+
+    @property
+    def tokens_per_second_per_gpu(self) -> float:
+        """Per-GPU output throughput (tokens/s/gpu)."""
+        return self.raw.get("tokens/s/gpu", 0.0)
+
+    @property
+    def tokens_per_second_per_user(self) -> float:
+        """Per-user output throughput (tokens/s/user)."""
+        return self.raw.get("tokens/s/user", 0.0)
+
+    @property
+    def concurrency(self) -> float:
+        """Effective concurrency (requests in flight)."""
+        return self.raw.get("concurrency", 0.0)
+
+    @property
+    def seq_per_second(self) -> float:
+        """Sequence throughput (seq/s)."""
+        return self.raw.get("seq/s", 0.0)
+
+    @property
+    def num_total_gpus(self) -> int:
+        """Total GPUs used by the parallelism config."""
+        return int(self.raw.get("num_total_gpus", 0))
+
+    @property
+    def memory(self) -> float:
+        """Estimated GPU memory usage (GB).
+
+        For disagg mode there is no single memory value; use
+        ``raw["(p)memory"]`` and ``raw["(d)memory"]`` instead.
+        """
+        if self.mode == "disagg":
+            return 0.0
+        return self.raw.get("memory", 0.0)
+
+    def get(self) -> dict:
+        """
+        Return all metrics as a dict matching the CSV column schema.
+
+        Includes ``tokens/s/gpu_cluster`` (equals ``tokens/s/gpu`` for
+        single-point estimates where only one replica group is evaluated).
+
+        Verified by ``tests/e2e/cli/test_cli_estimate_vs_default.py`` which
+        asserts that the returned keys and values match the
+        ``best_config_topn.csv`` output from ``cli_default``.
+        """
+        result = dict(self.raw)
+        if "tokens/s/gpu_cluster" not in result:
+            result["tokens/s/gpu_cluster"] = result.get("tokens/s/gpu", 0.0)
+        return result
+
     def __repr__(self) -> str:
         return (
             f"EstimateResult(mode={self.mode!r}, ttft={self.ttft:.3f}ms, tpot={self.tpot:.3f}ms, "
@@ -417,8 +484,13 @@ def _resolve_moe_parallelism(
     attention_dp_size: int,
     moe_tp_size: int | None,
     moe_ep_size: int | None,
+    model_path: str | None = None,
 ) -> tuple[int, int]:
-    """Resolve and validate MoE parallelism widths, returning (moe_tp_size, moe_ep_size)."""
+    """Resolve and validate MoE parallelism widths, returning (moe_tp_size, moe_ep_size).
+
+    For dense (non-MoE) models the width constraint is not enforced because
+    MoE parallelism has no effect on the computation.
+    """
     if moe_tp_size is None and moe_ep_size is None:
         moe_tp_size = tp_size
         moe_ep_size = attention_dp_size
@@ -429,7 +501,7 @@ def _resolve_moe_parallelism(
 
     attn_width = tp_size * attention_dp_size
     moe_width = moe_tp_size * moe_ep_size
-    if attn_width != moe_width:
+    if attn_width != moe_width and (model_path is None or check_is_moe(model_path)):
         raise ValueError(
             f"Parallelism width mismatch: tp_size({tp_size}) * attention_dp_size({attention_dp_size}) = {attn_width}, "
             f"but moe_tp_size({moe_tp_size}) * moe_ep_size({moe_ep_size}) = {moe_width}. "
@@ -716,7 +788,9 @@ def _run_agg_estimate(
     from aiconfigurator.sdk.config import RuntimeConfig
     from aiconfigurator.sdk.inference_session import InferenceSession
 
-    moe_tp_size, moe_ep_size = _resolve_moe_parallelism(tp_size, attention_dp_size, moe_tp_size, moe_ep_size)
+    moe_tp_size, moe_ep_size = _resolve_moe_parallelism(
+        tp_size, attention_dp_size, moe_tp_size, moe_ep_size, model_path=model_path
+    )
 
     model_config = _build_model_config(
         tp_size,
@@ -812,12 +886,14 @@ def _run_disagg_estimate(
         prefill_attention_dp_size,
         prefill_moe_tp_size,
         prefill_moe_ep_size,
+        model_path=model_path,
     )
     d_moe_tp, d_moe_ep = _resolve_moe_parallelism(
         decode_tp_size,
         decode_attention_dp_size,
         decode_moe_tp_size,
         decode_moe_ep_size,
+        model_path=model_path,
     )
 
     prefill_model_config = _build_model_config(
@@ -857,6 +933,10 @@ def _run_disagg_estimate(
         prefill_backend=prefill_backend,
         decode_database=decode_database,
         decode_backend=decode_backend,
+    )
+    session.set_latency_correction_scales(
+        DEFAULT_PREFILL_LATENCY_CORRECTION_SCALE,
+        DEFAULT_DECODE_LATENCY_CORRECTION_SCALE,
     )
 
     summary = session.run_disagg(

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -1322,7 +1322,20 @@ def _run_estimate_mode(args):
     print("-" * 60)
     print(f"  TTFT:             {result.ttft:.3f} ms")
     print(f"  TPOT:             {result.tpot:.3f} ms")
+    print(f"  Request Latency:  {result.request_latency:.3f} ms")
     print(f"  Power (per GPU):  {result.power_w:.1f} W")
+    print("-" * 60)
+    print(f"  tokens/s:         {result.tokens_per_second:,.2f}")
+    print(f"  tokens/s/gpu:     {result.tokens_per_second_per_gpu:,.2f}")
+    print(f"  tokens/s/user:    {result.tokens_per_second_per_user:,.2f}")
+    print(f"  seq/s:            {result.seq_per_second:,.3f}")
+    print(f"  Concurrency:      {result.concurrency:.0f}")
+    if result.mode == "agg":
+        print(f"  Memory (GPU):     {result.memory:.2f} GB")
+    else:
+        raw = result.raw
+        print(f"  (p) Memory:       {raw.get('(p)memory', 'N/A')} GB")
+        print(f"  (d) Memory:       {raw.get('(d)memory', 'N/A')} GB")
     print("=" * 60)
 
     if args.print_per_ops_latency and result.per_ops_data:

--- a/src/aiconfigurator/sdk/inference_session.py
+++ b/src/aiconfigurator/sdk/inference_session.py
@@ -192,6 +192,7 @@ class DisaggInferenceSession:
         Get the disagg summary df based on prefill and decode summary df
         """
         prefill_dict = prefill_summary_df.iloc[0].to_dict()
+        prefill_dict["ttft"] = prefill_dict["ttft"] * _AUTOSCALE_TTFT_CORRECTION_FACTOR
         decode_dict = decode_summary_df.iloc[0].to_dict()
 
         summary_dict = _build_disagg_summary_dict(

--- a/src/aiconfigurator/sdk/picking.py
+++ b/src/aiconfigurator/sdk/picking.py
@@ -455,9 +455,11 @@ def pick_autoscale(
     # -- Combine: each prefill x each decode, workers=1, take top_n --
     all_combos: list[dict] = []
     for _, p_row in prefill_candidates.iterrows():
+        p_dict = p_row.to_dict()
+        p_dict["ttft"] = p_row["ttft_corrected"]
         for _, d_row in decode_candidates.iterrows():
             combo = _build_disagg_summary_dict(
-                prefill_summary_dict=p_row.to_dict(),
+                prefill_summary_dict=p_dict,
                 prefill_num_worker=1,
                 decode_summary_dict=d_row.to_dict(),
                 decode_num_worker=1,

--- a/src/aiconfigurator/sdk/task.py
+++ b/src/aiconfigurator/sdk/task.py
@@ -21,6 +21,9 @@ from aiconfigurator.sdk.utils import enumerate_parallel_config, get_model_config
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_PREFILL_LATENCY_CORRECTION_SCALE = 1.1
+DEFAULT_DECODE_LATENCY_CORRECTION_SCALE = 1.08
+
 
 @dataclass(frozen=True)
 class ConfigLayer:
@@ -444,8 +447,8 @@ class TaskConfigFactory:
             replica_config["max_gpu_per_replica"] = 512
 
         advanced_tuning_config = {
-            "prefill_latency_correction_scale": 1.1,
-            "decode_latency_correction_scale": 1.08,
+            "prefill_latency_correction_scale": DEFAULT_PREFILL_LATENCY_CORRECTION_SCALE,
+            "decode_latency_correction_scale": DEFAULT_DECODE_LATENCY_CORRECTION_SCALE,
             "prefill_max_batch_size": 1,
             "decode_max_batch_size": 512,
         }


### PR DESCRIPTION
## Summary

- **Universal TTFT scaling:** Apply the 1.8× TTFT correction factor everywhere (estimate path, autoscale, and pareto disagg) so disaggregated metrics are defined consistently.
- **`cli estimate` matches CSV:** Single-point estimate results now align with the corresponding rows in `best_config_topn.csv` from `cli default` (agg and disagg). E2E tests assert full column and value parity.
- **API cleanup:** Move `check_is_moe` and task latency-correction constants to top-level imports in `api.py`.

## Details

### 1. TTFT correction (1.8×) applied uniformly

- **`inference_session.py` — `_get_disagg_summary_df`:** After building the prefill row dict, set `prefill_dict["ttft"] *= _AUTOSCALE_TTFT_CORRECTION_FACTOR` before calling `_build_disagg_summary_dict`. Thus `run_disagg` (and therefore `cli estimate` disagg) uses the same corrected TTFT and derived metrics (request_latency, tokens/s, etc.) as the default disagg CSV.
- **`picking.py` — `pick_autoscale`:** When building combos, pass a prefill dict whose `ttft` is the already-corrected value (`ttft_corrected` from the candidates DataFrame) into `_build_disagg_summary_dict`. Autoscale disagg CSV now uses the same 1.8×-corrected TTFT.
- **Pareto path** (`find_best_disagg_result_under_constraints`) already applied the correction; no change.

Result: one definition of disagg TTFT (1.8× corrected) for pareto search, autoscale, and estimate.

### 2. E2E test: full disagg comparison

- **`tests/e2e/cli/test_cli_estimate_vs_default.py`:** For disagg, removed the logic that skipped throughput-derived columns. The test now uses `_assert_get_matches_csv(est, got, best_df, row, idx)` for every row (same as agg), so all CSV columns—including `ttft`, `request_latency`, `tokens/s`, etc.—are compared. Docstring updated to state that disagg rows must match `cli_estimate` output the same way as agg.

### 3. Imports in `api.py`

- **Top-level imports:** `check_is_moe` (from `aiconfigurator.sdk.models`) and `DEFAULT_DECODE_LATENCY_CORRECTION_SCALE` / `DEFAULT_PREFILL_LATENCY_CORRECTION_SCALE` (from `aiconfigurator.sdk.task`) are now imported at module top and used in `_resolve_moe_parallelism` and the disagg estimate helper. Nested `if` in `_resolve_moe_parallelism` combined into a single condition for Ruff.

---

## Usage

### Programmatic API: `cli_estimate` and **`.get()`**

Use `cli_estimate(...)` for a single-point performance estimate. The returned **`EstimateResult`** exposes common fields as properties (e.g. `ttft`, `tpot`, `request_latency`, `tokens_per_second`, `memory`) and exposes the **full CSV-shaped payload** via **`.get()`**.

- **`.get()`** returns a `dict` whose **keys and value types match the CSV column schema** of `best_config_topn.csv` from `cli default`. That includes:
  - All config/input columns (e.g. `tp`, `pp`, `bs`, `isl`, `osl`; for disagg, `(p)tp`, `(d)bs`, etc.).
  - All metric columns: `ttft`, `tpot`, `request_latency`, `seq/s`, `tokens/s`, `tokens/s/gpu`, **`tokens/s/gpu_cluster`** (filled from `tokens/s/gpu` when absent), `memory` (or `(p)memory` / `(d)memory` in disagg), and the rest.

Use **`.get()`** when you need:

- **Schema parity with CSV:** Same keys and structure as the rows written by `cli default`, so you can merge or compare estimate output with CSV data without column mapping.
- **Full row dict:** One call returns the entire row (config + metrics) instead of reading many properties.
- **Downstream pipelines:** Feeding into tools that expect the CSV column set (e.g. dashboards, reports, or scripts that consume `best_config_topn.csv`).

Example:

```python
from aiconfigurator.cli.api import cli_estimate

# Agg estimate
result = cli_estimate(
    model_path="Qwen/Qwen3-32B",
    system_name="h100_sxm",
    backend_name="trtllm",
    mode="agg",
    tp_size=2,
    batch_size=64,
    isl=2048,
    osl=512,
)
# Property access for common metrics
print(result.ttft, result.tpot, result.request_latency)

# Full CSV-shaped dict — same columns as best_config_topn.csv (agg)
row = result.get()
assert "tokens/s/gpu_cluster" in row
# Use row for CSV-like processing, logging, or comparison with cli default output
```

```python
# Disagg estimate — .get() matches disagg best_config_topn.csv columns
result = cli_estimate(
    model_path="Qwen/Qwen3-32B",
    system_name="h100_sxm",
    mode="disagg",
    prefill_tp_size=2,
    prefill_batch_size=32,
    prefill_num_workers=1,
    decode_tp_size=2,
    decode_batch_size=64,
    decode_num_workers=1,
    isl=2048,
    osl=512,
)
row = result.get()
# row has (p)/(d) prefixed columns, ttft (1.8× corrected), request_latency, tokens/s, etc.
```

E2E test **`tests/e2e/cli/test_cli_estimate_vs_default.py`** verifies that for each row in `cli default`’s agg and disagg best_configs, calling `cli_estimate` with that row’s parameters yields an **`EstimateResult`** such that **`est.get()`** matches the CSV row (column set and values within tolerance).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Exposed end-to-end performance metrics: request latency, tokens per second (total, per GPU, per user), sequences per second, and concurrency measurements.
  * Enhanced estimate mode output with detailed performance summaries and memory usage metrics.

* **Bug Fixes**
  * Improved Mixture of Experts model detection and parallelism optimization.
  * Refined latency correction scaling for more accurate performance estimation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->