### PR TITLE
fix: remove cache_transceiver_config from trtllm 1.3.0+ engine templates

### DIFF
--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.3.0rc1.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.3.0rc1.yaml.j2
@@ -32,12 +32,6 @@ kv_cache_config:
   {% endif %}
   enable_block_reuse: {{ kv_cache_config.enable_block_reuse | default(false) }}
 
-cache_transceiver_config:
-  backend: {{ cache_transceiver_config.backend | default('DEFAULT') }} # The communication backend type to use for the cache transceiver ("DEFAULT","UCX","NIXL","MPI")
-  {% if cache_transceiver_config.max_tokens_in_buffer is defined %}
-  max_tokens_in_buffer: {{ cache_transceiver_config.max_tokens_in_buffer }}
-  {% endif %}
-
 cuda_graph_config:
   enable_padding: {{ cuda_graph_config.enable_padding | default(false) }} # Pad CUDA graph
   batch_sizes: [{% for s in cuda_graph_config.batch_sizes

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.yaml.j2
@@ -32,12 +32,6 @@ kv_cache_config:
   {% endif %}
   enable_block_reuse: {{ kv_cache_config.enable_block_reuse | default(false) }}
 
-cache_transceiver_config:
-  backend: {{ cache_transceiver_config.backend | default('DEFAULT') }}
-  {% if cache_transceiver_config.max_tokens_in_buffer is defined %}
-  max_tokens_in_buffer: {{ cache_transceiver_config.max_tokens_in_buffer }}
-  {% endif %}
-
 cuda_graph_config:
   enable_padding: {{ cuda_graph_config.enable_padding | default(false) }}
   batch_sizes: [{% for s in cuda_graph_config.batch_sizes


### PR DESCRIPTION
## Summary

- TRT-LLM 1.3.0+ (bundled with Dynamo 1.0.0rc5+) rejects `cache_transceiver_config` with a Pydantic `extra_forbidden` validation error, causing TRTLLMWorker pods to crash on startup
- Removed `cache_transceiver_config` block from `extra_engine_args.1.3.0rc1.yaml.j2` (explicit TRT-LLM 1.3.0rc1 path) and `extra_engine_args.yaml.j2` (default fallback used when no perf-database entry exists for the system, e.g. B200)
- Older templates (1.2.0rc6 and below) are untouched — the corresponding Dynamo versions support the field

Fixes: NVBug 5953595

## Test plan

- [ ] Verify naive config generation for trtllm backend on B200 no longer includes `cache_transceiver_config` in the generated `agg_config.yaml`
- [ ] Verify TRTLLMWorker pod starts successfully without Pydantic validation error on Dynamo 1.0.0rc5/rc6
- [ ] Verify configs generated for older Dynamo versions (0.8.x, 0.7.x) still include `cache_transceiver_config` where expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified backend configuration by removing an optional cache configuration block, reducing template complexity and eliminating unused conditional settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->