### PR TITLE
fix(trtllm): use top-level vars in engine templates for max_batch_size/max_num_tokens (NVBug 5956640)

### DIFF
--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.0.20.0.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.0.20.0.yaml.j2
@@ -10,10 +10,10 @@ pipeline_parallel_size: {{ pipeline_parallel_size }}
 enable_attention_dp: {{ enable_attention_dp | default(false) }}
 enable_chunked_prefill: {{ enable_chunked_prefill | default(false) }}
 
-{% set _max_seq_len = build_config.max_seq_len | default(none) %}
+{% set _max_seq_len = max_seq_len | default(none) %}
 
-max_batch_size: {{ build_config.max_batch_size }}
-max_num_tokens: {{ build_config.max_num_tokens }}
+max_batch_size: {{ max_batch_size }}
+max_num_tokens: {{ max_num_tokens }}
 {% if _max_seq_len is not none and _max_seq_len != '' %}
 max_seq_len: {{ _max_seq_len }}
 {% endif %}

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.0.0.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.0.0.yaml.j2
@@ -16,11 +16,11 @@ pipeline_parallel_size: {{ pipeline_parallel_size }}
 enable_attention_dp: {{ enable_attention_dp | default(false) }}
 enable_chunked_prefill: {{ enable_chunked_prefill | default(false) }}
 
-{% set _max_seq_len = build_config.max_seq_len | default(none) %}
+{% set _max_seq_len = max_seq_len | default(none) %}
 
 build_config:
-  max_batch_size: {{ build_config.max_batch_size }}
-  max_num_tokens: {{ build_config.max_num_tokens }}
+  max_batch_size: {{ max_batch_size }}
+  max_num_tokens: {{ max_num_tokens }}
   {% if _max_seq_len is not none and _max_seq_len != '' %}
   max_seq_len: {{ _max_seq_len }}
   {% endif %}

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.0.0rc3.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.0.0rc3.yaml.j2
@@ -18,11 +18,11 @@ pipeline_parallel_size: {{ pipeline_parallel_size }}
 enable_attention_dp: {{ enable_attention_dp | default(false) }}
 enable_chunked_prefill: {{ enable_chunked_prefill | default(false) }}
 
-{% set _max_seq_len = build_config.max_seq_len | default(none) %}
+{% set _max_seq_len = max_seq_len | default(none) %}
 
 build_config:
-  max_batch_size: {{ build_config.max_batch_size }}
-  max_num_tokens: {{ build_config.max_num_tokens }}
+  max_batch_size: {{ max_batch_size }}
+  max_num_tokens: {{ max_num_tokens }}
   {% if _max_seq_len is not none and _max_seq_len != '' %}
   max_seq_len: {{ _max_seq_len }}
   {% endif %}

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.0.0rc4.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.0.0rc4.yaml.j2
@@ -16,11 +16,11 @@ pipeline_parallel_size: {{ pipeline_parallel_size }}
 enable_attention_dp: {{ enable_attention_dp | default(false) }}
 enable_chunked_prefill: {{ enable_chunked_prefill | default(false) }}
 
-{% set _max_seq_len = build_config.max_seq_len | default(none) %}
+{% set _max_seq_len = max_seq_len | default(none) %}
 
 build_config:
-  max_batch_size: {{ build_config.max_batch_size }}
-  max_num_tokens: {{ build_config.max_num_tokens }}
+  max_batch_size: {{ max_batch_size }}
+  max_num_tokens: {{ max_num_tokens }}
   {% if _max_seq_len is not none and _max_seq_len != '' %}
   max_seq_len: {{ _max_seq_len }}
   {% endif %}

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.0.0rc6.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.0.0rc6.yaml.j2
@@ -16,11 +16,11 @@ pipeline_parallel_size: {{ pipeline_parallel_size }}
 enable_attention_dp: {{ enable_attention_dp | default(false) }}
 enable_chunked_prefill: {{ enable_chunked_prefill | default(false) }}
 
-{% set _max_seq_len = build_config.max_seq_len | default(none) %}
+{% set _max_seq_len = max_seq_len | default(none) %}
 
 build_config:
-  max_batch_size: {{ build_config.max_batch_size }}
-  max_num_tokens: {{ build_config.max_num_tokens }}
+  max_batch_size: {{ max_batch_size }}
+  max_num_tokens: {{ max_num_tokens }}
   {% if _max_seq_len is not none and _max_seq_len != '' %}
   max_seq_len: {{ _max_seq_len }}
   {% endif %}

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.1.0rc1.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.1.0rc1.yaml.j2
@@ -16,11 +16,11 @@ pipeline_parallel_size: {{ pipeline_parallel_size }}
 enable_attention_dp: {{ enable_attention_dp | default(false) }}
 enable_chunked_prefill: {{ enable_chunked_prefill | default(false) }}
 
-{% set _max_seq_len = build_config.max_seq_len | default(none) %}
+{% set _max_seq_len = max_seq_len | default(none) %}
 
 build_config:
-  max_batch_size: {{ build_config.max_batch_size }}
-  max_num_tokens: {{ build_config.max_num_tokens }}
+  max_batch_size: {{ max_batch_size }}
+  max_num_tokens: {{ max_num_tokens }}
   {% if _max_seq_len is not none and _max_seq_len != '' %}
   max_seq_len: {{ _max_seq_len }}
   {% endif %}

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.1.0rc4.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.1.0rc4.yaml.j2
@@ -16,11 +16,11 @@ pipeline_parallel_size: {{ pipeline_parallel_size }}
 enable_attention_dp: {{ enable_attention_dp | default(false) }}
 enable_chunked_prefill: {{ enable_chunked_prefill | default(false) }}
 
-{% set _max_seq_len = build_config.max_seq_len | default(none) %}
+{% set _max_seq_len = max_seq_len | default(none) %}
 
 build_config:
-  max_batch_size: {{ build_config.max_batch_size }}
-  max_num_tokens: {{ build_config.max_num_tokens }}
+  max_batch_size: {{ max_batch_size }}
+  max_num_tokens: {{ max_num_tokens }}
   {% if _max_seq_len is not none and _max_seq_len != '' %}
   max_seq_len: {{ _max_seq_len }}
   {% endif %}

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.1.0rc5.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.1.0rc5.yaml.j2
@@ -16,11 +16,11 @@ pipeline_parallel_size: {{ pipeline_parallel_size }}
 enable_attention_dp: {{ enable_attention_dp | default(false) }}
 enable_chunked_prefill: {{ enable_chunked_prefill | default(false) }}
 
-{% set _max_seq_len = build_config.max_seq_len | default(none) %}
+{% set _max_seq_len = max_seq_len | default(none) %}
 
 build_config:
-  max_batch_size: {{ build_config.max_batch_size }}
-  max_num_tokens: {{ build_config.max_num_tokens }}
+  max_batch_size: {{ max_batch_size }}
+  max_num_tokens: {{ max_num_tokens }}
   {% if _max_seq_len is not none and _max_seq_len != '' %}
   max_seq_len: {{ _max_seq_len }}
   {% endif %}

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.2.0rc2.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.2.0rc2.yaml.j2
@@ -16,11 +16,11 @@ pipeline_parallel_size: {{ pipeline_parallel_size }}
 enable_attention_dp: {{ enable_attention_dp | default(false) }}
 enable_chunked_prefill: {{ enable_chunked_prefill | default(false) }}
 
-{% set _max_seq_len = build_config.max_seq_len | default(none) %}
+{% set _max_seq_len = max_seq_len | default(none) %}
 
 build_config:
-  max_batch_size: {{ build_config.max_batch_size }}
-  max_num_tokens: {{ build_config.max_num_tokens }}
+  max_batch_size: {{ max_batch_size }}
+  max_num_tokens: {{ max_num_tokens }}
   {% if _max_seq_len is not none and _max_seq_len != '' %}
   max_seq_len: {{ _max_seq_len }}
   {% endif %}

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.2.0rc3.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.2.0rc3.yaml.j2
@@ -16,11 +16,11 @@ pipeline_parallel_size: {{ pipeline_parallel_size }}
 enable_attention_dp: {{ enable_attention_dp | default(false) }}
 enable_chunked_prefill: {{ enable_chunked_prefill | default(false) }}
 
-{% set _max_seq_len = build_config.max_seq_len | default(none) %}
+{% set _max_seq_len = max_seq_len | default(none) %}
 
 build_config:
-  max_batch_size: {{ build_config.max_batch_size }}
-  max_num_tokens: {{ build_config.max_num_tokens }}
+  max_batch_size: {{ max_batch_size }}
+  max_num_tokens: {{ max_num_tokens }}
   {% if _max_seq_len is not none and _max_seq_len != '' %}
   max_seq_len: {{ _max_seq_len }}
   {% endif %}

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.2.0rc5.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.2.0rc5.yaml.j2
@@ -16,10 +16,10 @@ pipeline_parallel_size: {{ pipeline_parallel_size }}
 enable_attention_dp: {{ enable_attention_dp | default(false) }}
 enable_chunked_prefill: {{ enable_chunked_prefill | default(false) }}
 
-{% set _max_seq_len = build_config.max_seq_len | default(none) %}
+{% set _max_seq_len = max_seq_len | default(none) %}
 
-max_batch_size: {{ build_config.max_batch_size }}
-max_num_tokens: {{ build_config.max_num_tokens }}
+max_batch_size: {{ max_batch_size }}
+max_num_tokens: {{ max_num_tokens }}
 {% if _max_seq_len is not none and _max_seq_len != '' %}
 max_seq_len: {{ _max_seq_len }}
 {% endif %}

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.2.0rc6.post1.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.2.0rc6.post1.yaml.j2
@@ -16,10 +16,10 @@ pipeline_parallel_size: {{ pipeline_parallel_size }}
 enable_attention_dp: {{ enable_attention_dp | default(false) }}
 enable_chunked_prefill: {{ enable_chunked_prefill | default(false) }}
 
-{% set _max_seq_len = build_config.max_seq_len | default(none) %}
+{% set _max_seq_len = max_seq_len | default(none) %}
 
-max_batch_size: {{ build_config.max_batch_size }}
-max_num_tokens: {{ build_config.max_num_tokens }}
+max_batch_size: {{ max_batch_size }}
+max_num_tokens: {{ max_num_tokens }}
 {% if _max_seq_len is not none and _max_seq_len != '' %}
 max_seq_len: {{ _max_seq_len }}
 {% endif %}

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.2.0rc6.post2.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.2.0rc6.post2.yaml.j2
@@ -16,10 +16,10 @@ pipeline_parallel_size: {{ pipeline_parallel_size }}
 enable_attention_dp: {{ enable_attention_dp | default(false) }}
 enable_chunked_prefill: {{ enable_chunked_prefill | default(false) }}
 
-{% set _max_seq_len = build_config.max_seq_len | default(none) %}
+{% set _max_seq_len = max_seq_len | default(none) %}
 
-max_batch_size: {{ build_config.max_batch_size }}
-max_num_tokens: {{ build_config.max_num_tokens }}
+max_batch_size: {{ max_batch_size }}
+max_num_tokens: {{ max_num_tokens }}
 {% if _max_seq_len is not none and _max_seq_len != '' %}
 max_seq_len: {{ _max_seq_len }}
 {% endif %}

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.3.0rc1.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.3.0rc1.yaml.j2
@@ -16,10 +16,10 @@ pipeline_parallel_size: {{ pipeline_parallel_size }}
 enable_attention_dp: {{ enable_attention_dp | default(false) }}
 enable_chunked_prefill: {{ enable_chunked_prefill | default(false) }}
 
-{% set _max_seq_len = build_config.max_seq_len | default(none) %}
+{% set _max_seq_len = max_seq_len | default(none) %}
 
-max_batch_size: {{ build_config.max_batch_size }}
-max_num_tokens: {{ build_config.max_num_tokens }}
+max_batch_size: {{ max_batch_size }}
+max_num_tokens: {{ max_num_tokens }}
 {% if _max_seq_len is not none and _max_seq_len != '' %}
 max_seq_len: {{ _max_seq_len }}
 {% endif %}

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.yaml.j2
@@ -16,10 +16,10 @@ pipeline_parallel_size: {{ pipeline_parallel_size }}
 enable_attention_dp: {{ enable_attention_dp | default(false) }}
 enable_chunked_prefill: {{ enable_chunked_prefill | default(false) }}
 
-{% set _max_seq_len = build_config.max_seq_len | default(none) %}
+{% set _max_seq_len = max_seq_len | default(none) %}
 
-max_batch_size: {{ build_config.max_batch_size }}
-max_num_tokens: {{ build_config.max_num_tokens }}
+max_batch_size: {{ max_batch_size }}
+max_num_tokens: {{ max_num_tokens }}
 {% if _max_seq_len is not none and _max_seq_len != '' %}
 max_seq_len: {{ _max_seq_len }}
 {% endif %}


### PR DESCRIPTION
Cherry-pick of a20a78d from main

Original commit: https://github.com/ai-dynamo/aiconfigurator/commit/a20a78d
Original PR: https://github.com/ai-dynamo/aiconfigurator/pull/540

## Summary

Fix regression where AIConfigurator-generated TRT-LLM engine configs (prefill_config.yaml, decode_config.yaml, agg_config.yaml) had empty `max_batch_size` and `max_num_tokens`, causing TRT-LLM to crash on startup with `TypeError: unsupported operand type(s) for *: 'NoneType' and 'int'`.

## Root cause

PR #514 changed `backend_config_mapping.yaml` so trtllm uses flat keys (`max_batch_size`, `max_num_tokens`, `max_seq_len`) instead of dotted keys (`build_config.max_batch_size`, etc.). The TRT-LLM Jinja2 templates were still referencing `build_config.max_batch_size` and `build_config.max_num_tokens`, which are never populated.

## Change

Update all 15 TRT-LLM `extra_engine_args*.yaml.j2` templates to use top-level context variables (`max_seq_len`, `max_batch_size`, `max_num_tokens`).

Fixes NVBug 5956640

Made with [Cursor](https://cursor.com)