### PR TITLE
fix: remove cache_transceiver_config from trtllm 1.3.0+ engine templates

### DIFF
--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.3.0rc1.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.3.0rc1.yaml.j2
@@ -32,12 +32,6 @@ kv_cache_config:
   {% endif %}
   enable_block_reuse: {{ kv_cache_config.enable_block_reuse | default(false) }}
 
-cache_transceiver_config:
-  backend: {{ cache_transceiver_config.backend | default('DEFAULT') }} # The communication backend type to use for the cache transceiver ("DEFAULT","UCX","NIXL","MPI")
-  {% if cache_transceiver_config.max_tokens_in_buffer is defined %}
-  max_tokens_in_buffer: {{ cache_transceiver_config.max_tokens_in_buffer }}
-  {% endif %}
-
 cuda_graph_config:
   enable_padding: {{ cuda_graph_config.enable_padding | default(false) }} # Pad CUDA graph
   batch_sizes: [{% for s in cuda_graph_config.batch_sizes

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.yaml.j2
@@ -32,12 +32,6 @@ kv_cache_config:
   {% endif %}
   enable_block_reuse: {{ kv_cache_config.enable_block_reuse | default(false) }}
 
-cache_transceiver_config:
-  backend: {{ cache_transceiver_config.backend | default('DEFAULT') }}
-  {% if cache_transceiver_config.max_tokens_in_buffer is defined %}
-  max_tokens_in_buffer: {{ cache_transceiver_config.max_tokens_in_buffer }}
-  {% endif %}
-
 cuda_graph_config:
   enable_padding: {{ cuda_graph_config.enable_padding | default(false) }}
   batch_sizes: [{% for s in cuda_graph_config.batch_sizes


### PR DESCRIPTION
Cherry-pick of 683b0f1 from main

Original commit: https://github.com/ai-dynamo/aiconfigurator/commit/683b0f1
Original PR: https://github.com/ai-dynamo/aiconfigurator/pull/541

## Summary

Removes `cache_transceiver_config` block from the TRT-LLM 1.3.0+ engine templates (`extra_engine_args.1.3.0rc1.yaml.j2` and `extra_engine_args.yaml.j2`).

Fixes NVBug 5953595

Made with [Cursor](https://cursor.com)