### PR TITLE
chore: Add nvfp4 vllm data

### DIFF
--- a/src/aiconfigurator/systems/data/a100_sxm/vllm/0.16.0/custom_allreduce_perf.txt
+++ b/src/aiconfigurator/systems/data/a100_sxm/vllm/0.16.0/custom_allreduce_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:719e69bd5bb137e654f9852185d7e71a90e999e70d0ff599ba064980cc95d429
+size 15402

--- a/src/aiconfigurator/systems/data/b200_sxm/vllm/0.16.0/context_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/b200_sxm/vllm/0.16.0/context_attention_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b02dd37632f485136f1d0e8dac0026210d2d952e0b86283ce97b12a876b16314
+size 601659

--- a/src/aiconfigurator/systems/data/b200_sxm/vllm/0.16.0/custom_allreduce_perf.txt
+++ b/src/aiconfigurator/systems/data/b200_sxm/vllm/0.16.0/custom_allreduce_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5af3bb00db8589f8eef6c6fce78a1660ae5e65105db82dd74089823d87f257ab
+size 14208

--- a/src/aiconfigurator/systems/data/b200_sxm/vllm/0.16.0/gemm_perf.txt
+++ b/src/aiconfigurator/systems/data/b200_sxm/vllm/0.16.0/gemm_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c94a1f91a14914714acab291a68803de8369964715ebe3f9c362b4b936f0e6ca
+size 2751170

--- a/src/aiconfigurator/systems/data/b200_sxm/vllm/0.16.0/generation_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/b200_sxm/vllm/0.16.0/generation_attention_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7847d805e6132333e65d8df23183654c899c22c6b7461bcb7ea7c04f92c8c9d
+size 500048

--- a/src/aiconfigurator/systems/data/b200_sxm/vllm/0.16.0/moe_perf.txt
+++ b/src/aiconfigurator/systems/data/b200_sxm/vllm/0.16.0/moe_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:92c871a881ed12d41ef78b42444fe7540c0914dc73a8af2c6f37cc89122e490a
+size 2205229

--- a/src/aiconfigurator/systems/data/gb200/vllm/0.16.0/custom_allreduce_perf.txt
+++ b/src/aiconfigurator/systems/data/gb200/vllm/0.16.0/custom_allreduce_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e2296ff46af309c553c0da8b971b5e6a9d5d0339a1aae27356a9eb01f13931d
+size 9596

--- a/src/aiconfigurator/systems/data/gb200/vllm/0.16.0/moe_perf.txt
+++ b/src/aiconfigurator/systems/data/gb200/vllm/0.16.0/moe_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dc111bf71876e155419fbee2416cb47e1124aa700a37e53acd3fb750006b3d21
-size 1916205
+oid sha256:e7839fbbbb13f3ccb7086d534c0150f4690b9df25990df57712d90f527df36fe
+size 2214953

--- a/src/aiconfigurator/systems/data/l40s/vllm/0.16.0/custom_allreduce_perf.txt
+++ b/src/aiconfigurator/systems/data/l40s/vllm/0.16.0/custom_allreduce_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d3807bd748e163afba91f7db07ceb8ff87559277f9db38fc22455a17133627e3
+size 14081


### PR DESCRIPTION
#### Overview:

- Add nvfp4 data for vllm
- Also add missing custom_allreduce_perf.txt files for vllm 0.16.0. For a100, I reused data from 0.14.0 due to lack of resources

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added performance data files for A100, B200, GB200, and L40S hardware configurations in vllm 0.16.0.
  * Updated performance metrics for GB200 configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->