### PR TITLE
feat: add k8s_etcd_endpoints support to K8s deployment templates

### DIFF
--- a/src/aiconfigurator/generator/aggregators.py
+++ b/src/aiconfigurator/generator/aggregators.py
@@ -124,6 +124,7 @@ def collect_generator_params(
             "k8s_namespace": k8s.get("k8s_namespace"),
             "k8s_image": k8s.get("k8s_image"),
             "k8s_image_pull_secret": k8s.get("k8s_image_pull_secret"),
+            "k8s_etcd_endpoints": k8s.get("k8s_etcd_endpoints"),
             "k8s_engine_mode": k8s.get("k8s_engine_mode"),
             "use_engine_cm": use_engine_cm,
             "k8s_pvc_name": k8s_pvc_name,

--- a/src/aiconfigurator/generator/config/backend_templates/sglang/k8s_deploy.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/sglang/k8s_deploy.yaml.j2
@@ -8,10 +8,16 @@
 {%- macro render_worker(component_name, role, replicas, gpu, cli_args) -%}
 {{ "    " ~ component_name ~ ":" }}
       envFromSecret: hf-token-secret
-      {% if K8sConfig.k8s_hf_home %}
+      {% if K8sConfig.k8s_hf_home or K8sConfig.k8s_etcd_endpoints %}
       envs:
+        {% if K8sConfig.k8s_etcd_endpoints %}
+        - name: ETCD_ENDPOINTS
+          value: {{ K8sConfig.k8s_etcd_endpoints }}
+        {% endif %}
+        {% if K8sConfig.k8s_hf_home %}
         - name: HF_HOME
           value: {{ K8sConfig.k8s_hf_home }}
+        {% endif %}
       {% endif %}
       componentType: worker
       {% if role %}
@@ -80,8 +86,12 @@ spec:
         mainContainer:
           image: {{ K8sConfig.k8s_image }}
           imagePullPolicy: IfNotPresent
-      {% if enable_router or K8sConfig.k8s_hf_home %}
+      {% if enable_router or K8sConfig.k8s_hf_home or K8sConfig.k8s_etcd_endpoints %}
       envs:
+        {% if K8sConfig.k8s_etcd_endpoints %}
+        - name: ETCD_ENDPOINTS
+          value: {{ K8sConfig.k8s_etcd_endpoints }}
+        {% endif %}
         {% if enable_router %}
         - name: DYN_ROUTER_MODE
           value: kv

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/k8s_deploy.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/k8s_deploy.yaml.j2
@@ -73,10 +73,16 @@ readinessProbe:
 {%- macro render_worker(component_name, sub_component_type, replicas, gpu, engine_path, inline_payload, cli_args_list=None, disagg_mode=None, publish_metrics=False) -%}
 {{ "    " ~ component_name ~ ":" }}
       envFromSecret: hf-token-secret
-      {% if K8sConfig.k8s_hf_home %}
+      {% if K8sConfig.k8s_hf_home or K8sConfig.k8s_etcd_endpoints %}
       envs:
+        {% if K8sConfig.k8s_etcd_endpoints %}
+        - name: ETCD_ENDPOINTS
+          value: {{ K8sConfig.k8s_etcd_endpoints }}
+        {% endif %}
+        {% if K8sConfig.k8s_hf_home %}
         - name: HF_HOME
           value: {{ K8sConfig.k8s_hf_home }}
+        {% endif %}
       {% endif %}
       componentType: worker
       {% if sub_component_type %}
@@ -182,8 +188,12 @@ spec:
             - name: model-cache
               mountPath: {{ k8s_model_cache_mount }}
           {% endif %}
-      {% if enable_router or K8sConfig.k8s_hf_home %}
+      {% if enable_router or K8sConfig.k8s_hf_home or K8sConfig.k8s_etcd_endpoints %}
       envs:
+        {% if K8sConfig.k8s_etcd_endpoints %}
+        - name: ETCD_ENDPOINTS
+          value: {{ K8sConfig.k8s_etcd_endpoints }}
+        {% endif %}
         {% if enable_router %}
         - name: DYN_ROUTER_MODE
           value: kv

--- a/src/aiconfigurator/generator/config/backend_templates/vllm/k8s_deploy.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/vllm/k8s_deploy.yaml.j2
@@ -13,10 +13,16 @@
     {%- set parsed_args = cli_args_list | default([]) -%}
 {{ "    " ~ component_name ~ ":" }}
       envFromSecret: hf-token-secret
-      {% if K8sConfig.k8s_hf_home %}
+      {% if K8sConfig.k8s_hf_home or K8sConfig.k8s_etcd_endpoints %}
       envs:
+        {% if K8sConfig.k8s_etcd_endpoints %}
+        - name: ETCD_ENDPOINTS
+          value: {{ K8sConfig.k8s_etcd_endpoints }}
+        {% endif %}
+        {% if K8sConfig.k8s_hf_home %}
         - name: HF_HOME
           value: {{ K8sConfig.k8s_hf_home }}
+        {% endif %}
       {% endif %}
       componentType: worker
       {% if role %}
@@ -76,10 +82,16 @@ spec:
   services:
     Frontend:
       envFromSecret: hf-token-secret
-      {% if K8sConfig.k8s_hf_home %}
+      {% if K8sConfig.k8s_hf_home or K8sConfig.k8s_etcd_endpoints %}
       envs:
+        {% if K8sConfig.k8s_etcd_endpoints %}
+        - name: ETCD_ENDPOINTS
+          value: {{ K8sConfig.k8s_etcd_endpoints }}
+        {% endif %}
+        {% if K8sConfig.k8s_hf_home %}
         - name: HF_HOME
           value: {{ K8sConfig.k8s_hf_home }}
+        {% endif %}
       {% endif %}
       componentType: frontend
       replicas: {{ frontend_replicas | default(1) }}

--- a/src/aiconfigurator/generator/config/deployment_config.yaml
+++ b/src/aiconfigurator/generator/config/deployment_config.yaml
@@ -89,6 +89,9 @@ inputs:
   - key: K8sConfig.k8s_model_cache
     required: false
     default: ""
+  - key: K8sConfig.k8s_etcd_endpoints
+    required: false
+    default: ""
   - key: K8sConfig.k8s_hf_home
     required: false
     default: ""


### PR DESCRIPTION
## Summary

- Adds a new optional `k8s_etcd_endpoints` config key to `deployment_config.yaml`. Dynamo default is localhost but when we deploy to a k8s cluster it is namespace based path.
- Collects the value in the generator aggregator (`aggregators.py`) and passes it to Jinja2 templates
- Injects `ETCD_ENDPOINTS` as an environment variable into worker and frontend containers across all three K8s backend templates (TRT-LLM, vLLM, SGLang)

## Test plan

- [ ] Verify `k8s_deploy.yaml` output includes `ETCD_ENDPOINTS` when `k8s_etcd_endpoints` is set in the deployment config
- [ ] Verify no `ETCD_ENDPOINTS` entry is rendered when the key is absent or empty (default `""`)
- [ ] Run existing unit tests: `pytest tests/`
