### PR TITLE
fix: Remove vllm 0.16.0, add vllm 0.14.0+nvfp4

### DIFF
--- a/src/aiconfigurator/systems/data/a100_sxm/vllm/0.16.0/context_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/a100_sxm/vllm/0.16.0/context_attention_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5f92cb34e5cb316eb0adac8221e29cd538bece6ccff6d244e8b48d46bfb5256e
-size 676520

--- a/src/aiconfigurator/systems/data/a100_sxm/vllm/0.16.0/context_mla_perf.txt
+++ b/src/aiconfigurator/systems/data/a100_sxm/vllm/0.16.0/context_mla_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4d96736e483c087bbc4372afc2568a303e5b27cb013dfaf86522567a1c23fac6
-size 98679

--- a/src/aiconfigurator/systems/data/a100_sxm/vllm/0.16.0/custom_allreduce_perf.txt
+++ b/src/aiconfigurator/systems/data/a100_sxm/vllm/0.16.0/custom_allreduce_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:719e69bd5bb137e654f9852185d7e71a90e999e70d0ff599ba064980cc95d429
-size 15402

--- a/src/aiconfigurator/systems/data/a100_sxm/vllm/0.16.0/gemm_perf.txt
+++ b/src/aiconfigurator/systems/data/a100_sxm/vllm/0.16.0/gemm_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3f65a5dffb3b5657f43c7d717139e5b9343f953d983b6c68b70bc7c57c3a8577
-size 873268

--- a/src/aiconfigurator/systems/data/a100_sxm/vllm/0.16.0/generation_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/a100_sxm/vllm/0.16.0/generation_attention_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:da1d32ac32d85b0068667320afd8024d266fd59ca7218c9f145279dbc6c2512c
-size 693322

--- a/src/aiconfigurator/systems/data/a100_sxm/vllm/0.16.0/generation_mla_perf.txt
+++ b/src/aiconfigurator/systems/data/a100_sxm/vllm/0.16.0/generation_mla_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6527da6630b021b974afbc3fdc939e0d21aebf2d466fa8ffd872904259c42145
-size 157017

--- a/src/aiconfigurator/systems/data/a100_sxm/vllm/0.16.0/moe_perf.txt
+++ b/src/aiconfigurator/systems/data/a100_sxm/vllm/0.16.0/moe_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6ab0a7049f6b600044de6ca45517587dc234e47c533095bb4fb1632221751716
-size 761576

--- a/src/aiconfigurator/systems/data/b200_sxm/vllm/0.14.1/gemm_perf.txt
+++ b/src/aiconfigurator/systems/data/b200_sxm/vllm/0.14.1/gemm_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fc54554aaff9a579d023b50fe3ce80b9bc50552a23d9f5c59c5907b1dcaa5d20
-size 2123116
+oid sha256:71960c8a35f7a5d84882eb24ada694d34b85e9964eb55a37cb60016864bc56df
+size 2748775

--- a/src/aiconfigurator/systems/data/b200_sxm/vllm/0.14.1/moe_perf.txt
+++ b/src/aiconfigurator/systems/data/b200_sxm/vllm/0.14.1/moe_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2e03e2ec49f490436ec59dd54af7d3bc58e7c70ebff105212ee9f5a5988c07a9
-size 1898289
+oid sha256:fe8f0b32d11c62691503df9853be5ef296b865c2e54eb450f5d7a5bebdf3a1ec
+size 2194639

--- a/src/aiconfigurator/systems/data/b200_sxm/vllm/0.16.0/context_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/b200_sxm/vllm/0.16.0/context_attention_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b02dd37632f485136f1d0e8dac0026210d2d952e0b86283ce97b12a876b16314
-size 601659

--- a/src/aiconfigurator/systems/data/b200_sxm/vllm/0.16.0/custom_allreduce_perf.txt
+++ b/src/aiconfigurator/systems/data/b200_sxm/vllm/0.16.0/custom_allreduce_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5af3bb00db8589f8eef6c6fce78a1660ae5e65105db82dd74089823d87f257ab
-size 14208

--- a/src/aiconfigurator/systems/data/b200_sxm/vllm/0.16.0/gemm_perf.txt
+++ b/src/aiconfigurator/systems/data/b200_sxm/vllm/0.16.0/gemm_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c94a1f91a14914714acab291a68803de8369964715ebe3f9c362b4b936f0e6ca
-size 2751170

--- a/src/aiconfigurator/systems/data/b200_sxm/vllm/0.16.0/generation_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/b200_sxm/vllm/0.16.0/generation_attention_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a7847d805e6132333e65d8df23183654c899c22c6b7461bcb7ea7c04f92c8c9d
-size 500048

--- a/src/aiconfigurator/systems/data/b200_sxm/vllm/0.16.0/moe_perf.txt
+++ b/src/aiconfigurator/systems/data/b200_sxm/vllm/0.16.0/moe_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:92c871a881ed12d41ef78b42444fe7540c0914dc73a8af2c6f37cc89122e490a
-size 2205229

--- a/src/aiconfigurator/systems/data/gb200/vllm/0.14.0/gemm_perf.txt
+++ b/src/aiconfigurator/systems/data/gb200/vllm/0.14.0/gemm_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3c601bd8c9b1458feaada43079f375bfa558e958d6e78a911dab38fec9c29118
-size 2125920
+oid sha256:16e3bb748871e15a162eeefac8f58621a43551845020a39fe54a5294527ad7c4
+size 3305929

--- a/src/aiconfigurator/systems/data/gb200/vllm/0.14.0/moe_perf.txt
+++ b/src/aiconfigurator/systems/data/gb200/vllm/0.14.0/moe_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f21771a5d042526d9d523877b60c7051b6d311f313b2ff90b77348c5f2a9437d
-size 1898667
+oid sha256:11e36f9c6c6408c38dcb6f9433bfe5a5921eda0f1a5dc5147f866eb8d7695be5
+size 2287636

--- a/src/aiconfigurator/systems/data/gb200/vllm/0.16.0/context_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/gb200/vllm/0.16.0/context_attention_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f0f21aec9037aa8c7355897af8f3cef308ae0a694c651a78358615e518f238de
-size 606158

--- a/src/aiconfigurator/systems/data/gb200/vllm/0.16.0/custom_allreduce_perf.txt
+++ b/src/aiconfigurator/systems/data/gb200/vllm/0.16.0/custom_allreduce_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3e2296ff46af309c553c0da8b971b5e6a9d5d0339a1aae27356a9eb01f13931d
-size 9596

--- a/src/aiconfigurator/systems/data/gb200/vllm/0.16.0/gemm_perf.txt
+++ b/src/aiconfigurator/systems/data/gb200/vllm/0.16.0/gemm_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d1c532d319edc04ba8d0b451f21535e0b44265c31b99fd600e6cad9e65461180
-size 2782161

--- a/src/aiconfigurator/systems/data/gb200/vllm/0.16.0/generation_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/gb200/vllm/0.16.0/generation_attention_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b669f655884806d54daedb8ad3b9d46837560e2384eab1ef5e587baac16c6a00
-size 504395

--- a/src/aiconfigurator/systems/data/gb200/vllm/0.16.0/moe_perf.txt
+++ b/src/aiconfigurator/systems/data/gb200/vllm/0.16.0/moe_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e7839fbbbb13f3ccb7086d534c0150f4690b9df25990df57712d90f527df36fe
-size 2214953

--- a/src/aiconfigurator/systems/data/l40s/vllm/0.16.0/context_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/l40s/vllm/0.16.0/context_attention_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:12fc7159d829a2599e7e3fa851c4979631f6714fcb0b9bb8983aa571f03f1b2c
-size 1222359

--- a/src/aiconfigurator/systems/data/l40s/vllm/0.16.0/context_mla_perf.txt
+++ b/src/aiconfigurator/systems/data/l40s/vllm/0.16.0/context_mla_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fe4243a845301431ef74b30907c0c56ce4dda9cb394611e8fbc27388302070ed
-size 89794

--- a/src/aiconfigurator/systems/data/l40s/vllm/0.16.0/custom_allreduce_perf.txt
+++ b/src/aiconfigurator/systems/data/l40s/vllm/0.16.0/custom_allreduce_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d3807bd748e163afba91f7db07ceb8ff87559277f9db38fc22455a17133627e3
-size 14081

--- a/src/aiconfigurator/systems/data/l40s/vllm/0.16.0/gemm_perf.txt
+++ b/src/aiconfigurator/systems/data/l40s/vllm/0.16.0/gemm_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9603c76a6aa37fef55d363f0ab5990bd20d8672f83f4f869ec3be08c45a45cd9
-size 1523507

--- a/src/aiconfigurator/systems/data/l40s/vllm/0.16.0/generation_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/l40s/vllm/0.16.0/generation_attention_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ca13aaf7d5f00f7a73fb81bccaab8d188b9273cbf3b483e9699eb4873748cff5
-size 1258221

--- a/src/aiconfigurator/systems/data/l40s/vllm/0.16.0/moe_perf.txt
+++ b/src/aiconfigurator/systems/data/l40s/vllm/0.16.0/moe_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ad4966d66aec647b81da71cf6ca7051075e517feb4c5e56d2c3e83ffb4560eb3
-size 1368856


### PR DESCRIPTION
#### Overview:
- vllm 0.16.0 was breaking due to missing float16 kvcache attention data. 
- Add vllm 0.14.0/0.14.1 for gb200 & b200_sxm, with nvfp4 moe and gemm working

Tested with:
```
aiconfigurator cli default   --model-path qwen/qwen3-0.6B   --total-gpus 64 --system b200_sxm   --backend vllm
aiconfigurator cli default   --model-path qwen/qwen3-0.6B   --total-gpus 64 --system gb200   --backend vllm
aiconfigurator cli default   --model-path nvidia/Qwen3-32B-NVFP4   --total-gpus 64 --system b200_sxm   --backend vllm
aiconfigurator cli default   --model-path nvidia/Qwen3-32B-NVFP4   --total-gpus 64 --system gb200   --backend vllm
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated performance configuration data for multiple hardware systems across vLLM versions 0.14.0 through 0.16.0.
  * Removed obsolete performance data entries across various GPU platforms to streamline system configurations.
  * Refreshed performance metrics for supported AI hardware systems to reflect current specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->