### PR TITLE
feat(ci): multi-process support matrix on a large runner

### DIFF
--- a/.github/workflows/daily-support-matrix.yml
+++ b/.github/workflows/daily-support-matrix.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   update-support-matrix:
     name: Update Support Matrix
-    runs-on: self-hosted
+    runs-on: prod-aiconfigurator-default-amd64-v1
     timeout-minutes: 480 # 8 hours
     permissions:
       contents: write

--- a/tools/support_matrix/generate_support_matrix.py
+++ b/tools/support_matrix/generate_support_matrix.py
@@ -41,6 +41,12 @@ def main():
         default=default_output,
         help=f"Output file to save results (CSV format) (default: {default_output})",
     )
+    parser.add_argument(
+        "--max-workers",
+        type=int,
+        default=None,
+        help="Maximum number of threads for parallel execution (default: auto)",
+    )
 
     args = parser.parse_args()
 
@@ -53,7 +59,7 @@ def main():
     )
 
     support_matrix = SupportMatrix()
-    results = support_matrix.test_support_matrix()
+    results = support_matrix.test_support_matrix(max_workers=args.max_workers)
 
     # Always save results (now has a default output location)
     support_matrix.save_results_to_csv(results, args.output)

--- a/tools/support_matrix/generate_support_matrix.py
+++ b/tools/support_matrix/generate_support_matrix.py
@@ -45,7 +45,7 @@ def main():
         "--max-workers",
         type=int,
         default=None,
-        help="Maximum number of threads for parallel execution (default: auto)",
+        help="Maximum number of processes for parallel execution (default: auto)",
     )
 
     args = parser.parse_args()

--- a/tools/support_matrix/support_matrix.py
+++ b/tools/support_matrix/support_matrix.py
@@ -13,7 +13,7 @@ import csv
 import logging
 import os
 import traceback
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ProcessPoolExecutor, as_completed
 
 from packaging.version import Version
 from tqdm import tqdm
@@ -31,6 +31,37 @@ OSL = 500
 PREFIX = 500
 TTFT = 2000.0
 TPOT = 50.0
+
+# Per-process SupportMatrix instance for ProcessPoolExecutor workers (avoids GIL).
+_worker_matrix: "SupportMatrix | None" = None
+
+
+def _init_worker() -> None:
+    """Initialize one SupportMatrix per worker process (called once per process)."""
+    global _worker_matrix
+    _worker_matrix = SupportMatrix()
+
+
+def _process_combination_worker(
+    combo: tuple[str, str, str, str],
+) -> list[tuple[str, str, str, str, str, str, bool, str | None]]:
+    """
+    Run a single combination in a worker process. Uses the process-local SupportMatrix.
+    Must be a module-level function for pickling by ProcessPoolExecutor.
+    """
+    assert _worker_matrix is not None
+    model, system, backend, version = combo
+    success_dict, error_dict = _worker_matrix.run_single_test(
+        model=model,
+        system=system,
+        backend=backend,
+        version=version,
+    )
+    architecture = _worker_matrix.get_architecture(model)
+    return [
+        (model, architecture, system, backend, version, mode, success_dict[mode], error_dict[mode])
+        for mode in success_dict
+    ]
 
 
 class SupportMatrix:
@@ -185,8 +216,8 @@ class SupportMatrix:
         Tests both agg and disagg modes for each combination and captures error messages.
 
         Args:
-            max_workers: Maximum number of threads for parallel execution.
-                         Defaults to None, which uses min(32, os.cpu_count()).
+            max_workers: Maximum number of worker processes for parallel execution.
+                         Defaults to None, which uses os.cpu_count() or 1.
 
         Returns:
             List of tuples (huggingface_id, architecture, system, backend, version, mode, success, err_msg)
@@ -204,29 +235,15 @@ class SupportMatrix:
         print(f"Target TTFT: {TTFT}ms")
         print(f"Target TPOT: {TPOT}ms")
         if max_workers is None:
-            max_workers = max(1, (os.cpu_count() or 1) - 1)
+            max_workers = os.cpu_count() or 1
         print(f"Max workers: {max_workers}")
         print("=" * 80 + "\n")
 
         combinations = self.generate_combinations()
         results = []
 
-        def _process_combination(combo):
-            model, system, backend, version = combo
-            success_dict, error_dict = self.run_single_test(
-                model=model,
-                system=system,
-                backend=backend,
-                version=version,
-            )
-            architecture = self.get_architecture(model)
-            return [
-                (model, architecture, system, backend, version, mode, success_dict[mode], error_dict[mode])
-                for mode in success_dict
-            ]
-
-        with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            futures = {executor.submit(_process_combination, combo): combo for combo in combinations}
+        with ProcessPoolExecutor(max_workers=max_workers, initializer=_init_worker) as executor:
+            futures = {executor.submit(_process_combination_worker, combo): combo for combo in combinations}
             for future in tqdm(
                 as_completed(futures),
                 total=len(combinations),

--- a/tools/support_matrix/support_matrix.py
+++ b/tools/support_matrix/support_matrix.py
@@ -13,6 +13,7 @@ import csv
 import logging
 import os
 import traceback
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from packaging.version import Version
 from tqdm import tqdm
@@ -176,10 +177,16 @@ class SupportMatrix:
                     error_messages[mode] = None
         return results, error_messages
 
-    def test_support_matrix(self) -> list[tuple[str, str, str, str, str, str, bool, str | None]]:
+    def test_support_matrix(
+        self, max_workers: int | None = None
+    ) -> list[tuple[str, str, str, str, str, str, bool, str | None]]:
         """
         Test whether each combination is supported by AIC.
         Tests both agg and disagg modes for each combination and captures error messages.
+
+        Args:
+            max_workers: Maximum number of threads for parallel execution.
+                         Defaults to None, which uses min(32, os.cpu_count()).
 
         Returns:
             List of tuples (huggingface_id, architecture, system, backend, version, mode, success, err_msg)
@@ -196,34 +203,37 @@ class SupportMatrix:
         print(f"Prefix: {PREFIX}")
         print(f"Target TTFT: {TTFT}ms")
         print(f"Target TPOT: {TPOT}ms")
+        if max_workers is None:
+            max_workers = max(1, (os.cpu_count() or 1) - 1)
+        print(f"Max workers: {max_workers}")
         print("=" * 80 + "\n")
 
         combinations = self.generate_combinations()
         results = []
 
-        # Use tqdm for progress tracking
-        for model, system, backend, version in tqdm(
-            combinations,
-            desc="Testing support matrix",
-            unit="config",
-        ):
-            # model is already a HuggingFace ID (e.g., 'meta-llama/Llama-2-7b-hf')
-            huggingface_id = model
+        def _process_combination(combo):
+            model, system, backend, version = combo
             success_dict, error_dict = self.run_single_test(
-                model=huggingface_id,
+                model=model,
                 system=system,
                 backend=backend,
                 version=version,
             )
+            architecture = self.get_architecture(model)
+            return [
+                (model, architecture, system, backend, version, mode, success_dict[mode], error_dict[mode])
+                for mode in success_dict
+            ]
 
-            # Get the architecture for this model
-            architecture = self.get_architecture(huggingface_id)
-
-            # Add separate entries for agg and disagg modes
-            for mode in success_dict:
-                results.append(
-                    (huggingface_id, architecture, system, backend, version, mode, success_dict[mode], error_dict[mode])
-                )
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = {executor.submit(_process_combination, combo): combo for combo in combinations}
+            for future in tqdm(
+                as_completed(futures),
+                total=len(combinations),
+                desc="Testing support matrix",
+                unit="config",
+            ):
+                results.extend(future.result())
 
         # Sort results by (huggingface_id, architecture, system, backend, version, mode)
         results.sort(key=lambda x: (x[0], x[1], x[2], x[3], Version(x[4]), x[5]))

--- a/tools/support_matrix/support_matrix.py
+++ b/tools/support_matrix/support_matrix.py
@@ -44,7 +44,7 @@ def _process_combination_worker(
     Run a single combination in a worker process. Uses the process-local SupportMatrix.
     Must be a module-level function for pickling by ProcessPoolExecutor.
     """
-    assert _worker_matrix is not None
+    assert _worker_matrix is not None  # this only works in linux, not in windows/macos
     model, system, backend, version = combo
     success_dict, error_dict = _worker_matrix.run_single_test(
         model=model,

--- a/tools/support_matrix/support_matrix.py
+++ b/tools/support_matrix/support_matrix.py
@@ -32,14 +32,9 @@ PREFIX = 500
 TTFT = 2000.0
 TPOT = 50.0
 
-# Per-process SupportMatrix instance for ProcessPoolExecutor workers (avoids GIL).
+# Per-process SupportMatrix instance for ProcessPoolExecutor workers.
+# Set in the parent before forking; children inherit it via copy-on-write.
 _worker_matrix: "SupportMatrix | None" = None
-
-
-def _init_worker() -> None:
-    """Initialize one SupportMatrix per worker process (called once per process)."""
-    global _worker_matrix
-    _worker_matrix = SupportMatrix()
 
 
 def _process_combination_worker(
@@ -242,7 +237,10 @@ class SupportMatrix:
         combinations = self.generate_combinations()
         results = []
 
-        with ProcessPoolExecutor(max_workers=max_workers, initializer=_init_worker) as executor:
+        global _worker_matrix
+        _worker_matrix = self
+
+        with ProcessPoolExecutor(max_workers=max_workers) as executor:
             futures = {executor.submit(_process_combination_worker, combo): combo for combo in combinations}
             for future in tqdm(
                 as_completed(futures),


### PR DESCRIPTION
1. Use multi process for support matrix
2. Use a larger runner

The full support matrix generation pipeline was shorten to 25 min (was 1 hr+): https://github.com/ai-dynamo/aiconfigurator/actions/runs/22895079870

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added --max-workers command-line option to control parallel execution of support matrix tests.
  * Support matrix tests now execute in parallel for improved generation performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->