### PR TITLE
feat: pd split wideep/eplb config

### DIFF
--- a/src/aiconfigurator/cli/exps/deepseek_disagg_mixed_wideep_trtllm.yaml
+++ b/src/aiconfigurator/cli/exps/deepseek_disagg_mixed_wideep_trtllm.yaml
@@ -39,10 +39,10 @@ exp_disagg_prefill_wideep_decode_standard:
     prefill_worker_config:
       enable_wideep: true
       enable_eplb: true
-      gemm_quant_mode: "fp8_block"
-      moe_quant_mode: "fp8_block"
+      gemm_quant_mode: "nvfp4"
+      moe_quant_mode: "nvfp4"
       kvcache_quant_mode: "fp8"
-      fmha_quant_mode: "fp8_block"
+      fmha_quant_mode: "fp8"
       comm_quant_mode: "half"
       num_gpu_per_worker: [4, 8, 16, 32]
       tp_list: [1, 2, 4, 8]
@@ -53,8 +53,8 @@ exp_disagg_prefill_wideep_decode_standard:
     decode_worker_config:
       enable_wideep: false
       enable_eplb: false
-      gemm_quant_mode: "fp8_block"
-      moe_quant_mode: "fp8_block"
+      gemm_quant_mode: "nvfp4"
+      moe_quant_mode: "nvfp4"
       kvcache_quant_mode: "fp8"
       fmha_quant_mode: "float16"
       comm_quant_mode: "half"
@@ -146,10 +146,10 @@ exp_disagg_both_wideep:
     nextn_accept_rates: [0.85,0,0,0,0]
     prefill_worker_config:
       enable_eplb: true
-      gemm_quant_mode: "fp8_block"
-      moe_quant_mode: "fp8_block"
+      gemm_quant_mode: "nvfp4"
+      moe_quant_mode: "nvfp4"
       kvcache_quant_mode: "fp8"
-      fmha_quant_mode: "fp8_block"
+      fmha_quant_mode: "fp8"
       comm_quant_mode: "half"
       num_gpu_per_worker: [4, 8, 16, 32]
       tp_list: [1, 2, 4, 8]
@@ -159,10 +159,10 @@ exp_disagg_both_wideep:
       moe_ep_list: [4, 8, 16, 32]
     decode_worker_config:
       enable_eplb: false
-      gemm_quant_mode: "fp8_block"
-      moe_quant_mode: "fp8_block"
+      gemm_quant_mode: "nvfp4"
+      moe_quant_mode: "nvfp4"
       kvcache_quant_mode: "fp8"
-      fmha_quant_mode: "fp8_block"
+      fmha_quant_mode: "fp8"
       comm_quant_mode: "half"
       num_gpu_per_worker: [4, 8, 16, 32, 64]
       tp_list: [1, 2, 4, 8]

--- a/src/aiconfigurator/cli/exps/deepseek_disagg_mixed_wideep_trtllm.yaml
+++ b/src/aiconfigurator/cli/exps/deepseek_disagg_mixed_wideep_trtllm.yaml
@@ -1,0 +1,181 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# ============================================================================
+# DeepSeek PD disaggregation with per-phase WideEP/EPLB on TensorRT-LLM.
+#
+# Three experiments covering the WideEP x EPLB per-phase matrix:
+#
+#   Exp 1 – prefill WideEP+EPLB ON  / decode WideEP OFF
+#   Exp 2 – prefill WideEP OFF      / decode WideEP+EPLB ON
+#   Exp 3 – both WideEP ON, EPLB differs (prefill ON / decode OFF)
+#
+# Per-phase WideEP/EPLB settings are specified inside each worker_config.
+# If not specified, they fall back to the global enable_wideep / enable_eplb.
+# ============================================================================
+
+exps:
+  - exp_disagg_prefill_wideep_decode_standard
+  - exp_disagg_prefill_standard_decode_wideep
+  - exp_disagg_both_wideep
+
+# ── Exp 1: Prefill WideEP+EPLB ON / Decode standard MoE ─────────────────────
+exp_disagg_prefill_wideep_decode_standard:
+  mode: "patch"
+  serving_mode: "disagg"
+  model_path: "deepseek-ai/DeepSeek-V3"
+  total_gpus: 128
+  system_name: "gb200"
+  decode_system_name: "gb200"
+  backend_name: "trtllm"
+  isl: 1000
+  osl: 100
+  ttft: 1000.0
+  tpot: 40.0
+  enable_wideep: true
+  enable_eplb: true
+  config:
+    nextn: 0
+    nextn_accept_rates: [0.85,0,0,0,0]
+    prefill_worker_config:
+      enable_wideep: true
+      enable_eplb: true
+      gemm_quant_mode: "fp8_block"
+      moe_quant_mode: "fp8_block"
+      kvcache_quant_mode: "fp8"
+      fmha_quant_mode: "fp8_block"
+      comm_quant_mode: "half"
+      num_gpu_per_worker: [4, 8, 16, 32]
+      tp_list: [1, 2, 4, 8]
+      pp_list: [1]
+      dp_list: [4, 8, 16, 32]
+      moe_tp_list: [1]
+      moe_ep_list: [4, 8, 16, 32]
+    decode_worker_config:
+      enable_wideep: false
+      enable_eplb: false
+      gemm_quant_mode: "fp8_block"
+      moe_quant_mode: "fp8_block"
+      kvcache_quant_mode: "fp8"
+      fmha_quant_mode: "float16"
+      comm_quant_mode: "half"
+      num_gpu_per_worker: [4, 8]
+      tp_list: [1, 2, 4, 8]
+      pp_list: [1]
+      dp_list: [1, 2, 4, 8]
+      moe_tp_list: [1, 2, 4, 8]
+      moe_ep_list: [1, 2, 4, 8]
+
+    replica_config:
+      max_gpu_per_replica: 512
+
+    advanced_tuning_config:
+      prefill_latency_correction_scale: 1.1
+      decode_latency_correction_scale: 1.08
+      prefill_max_batch_size: 1
+      decode_max_batch_size: 512
+
+# ── Exp 2: Prefill standard MoE / Decode WideEP+EPLB ON ─────────────────────
+exp_disagg_prefill_standard_decode_wideep:
+  mode: "patch"
+  serving_mode: "disagg"
+  model_path: "deepseek-ai/DeepSeek-V3"
+  total_gpus: 96
+  system_name: "gb200"
+  decode_system_name: "gb200"
+  backend_name: "trtllm"
+  isl: 8192
+  osl: 1024
+  ttft: 5000.0
+  tpot: 80
+  config:
+    prefill_worker_config:
+      enable_wideep: false
+      enable_eplb: false
+      gemm_quant_mode: "nvfp4"
+      moe_quant_mode: "nvfp4"
+      kvcache_quant_mode: "fp8"
+      fmha_quant_mode: "float16"
+      comm_quant_mode: "half"
+      num_gpu_per_worker: [4]
+      tp_list: [1]
+      pp_list: [1]
+      dp_list: [4]
+      moe_tp_list: [1]
+      moe_ep_list: [4]
+
+    decode_worker_config:
+      enable_wideep: true
+      enable_eplb: true
+      gemm_quant_mode: "nvfp4"
+      moe_quant_mode: "nvfp4"
+      kvcache_quant_mode: "fp8"
+      fmha_quant_mode: "float16"
+      comm_quant_mode: "half"
+      num_gpu_per_worker: [4, 8, 16, 32, 64]
+      tp_list: [1]
+      pp_list: [1]
+      dp_list: [4, 8, 16, 32, 64]
+      moe_tp_list: [1]
+      moe_ep_list: [4, 8, 16, 32, 64]
+
+    replica_config:
+      max_gpu_per_replica: 512
+
+    advanced_tuning_config:
+      prefill_latency_correction_scale: 1.1
+      decode_latency_correction_scale: 1.08
+      prefill_max_batch_size: 1
+      decode_max_batch_size: 512
+
+# ── Exp 3: Both WideEP ON, EPLB differs (prefill ON / decode OFF) ───────────
+exp_disagg_both_wideep:
+  mode: "patch"
+  serving_mode: "disagg"
+  model_path: "deepseek-ai/DeepSeek-V3"
+  total_gpus: 128
+  system_name: "gb200"
+  decode_system_name: "gb200"
+  backend_name: "trtllm"
+  isl: 1000
+  osl: 100
+  ttft: 1000.0
+  tpot: 40.0
+  enable_wideep: true
+  config:
+    nextn: 1
+    nextn_accept_rates: [0.85,0,0,0,0]
+    prefill_worker_config:
+      enable_eplb: true
+      gemm_quant_mode: "fp8_block"
+      moe_quant_mode: "fp8_block"
+      kvcache_quant_mode: "fp8"
+      fmha_quant_mode: "fp8_block"
+      comm_quant_mode: "half"
+      num_gpu_per_worker: [4, 8, 16, 32]
+      tp_list: [1, 2, 4, 8]
+      pp_list: [1]
+      dp_list: [4, 8, 16, 32]
+      moe_tp_list: [1]
+      moe_ep_list: [4, 8, 16, 32]
+    decode_worker_config:
+      enable_eplb: false
+      gemm_quant_mode: "fp8_block"
+      moe_quant_mode: "fp8_block"
+      kvcache_quant_mode: "fp8"
+      fmha_quant_mode: "fp8_block"
+      comm_quant_mode: "half"
+      num_gpu_per_worker: [4, 8, 16, 32, 64]
+      tp_list: [1, 2, 4, 8]
+      pp_list: [1]
+      dp_list: [4, 8, 16, 32, 64]
+      moe_tp_list: [1]
+      moe_ep_list: [4, 8, 16, 32, 64]
+
+    replica_config:
+      max_gpu_per_replica: 512
+
+    advanced_tuning_config:
+      prefill_latency_correction_scale: 1.1
+      decode_latency_correction_scale: 1.08
+      prefill_max_batch_size: 1
+      decode_max_batch_size: 512

--- a/src/aiconfigurator/cli/exps/deepseek_wideep_trtllm.yaml
+++ b/src/aiconfigurator/cli/exps/deepseek_wideep_trtllm.yaml
@@ -40,6 +40,9 @@ gb200_wideep_eplb_agg:
   config:
     nextn: 1
     nextn_accept_rates: [0.85,0.3,0,0,0]
+    worker_config:
+      gemm_quant_mode: "nvfp4"
+      moe_quant_mode: "nvfp4"
 
 gb200_wideep_eplb_slots288_agg:
   mode: "patch"
@@ -57,6 +60,9 @@ gb200_wideep_eplb_slots288_agg:
   config:
     nextn: 1
     nextn_accept_rates: [0.85,0.3,0,0,0]
+    worker_config:
+      gemm_quant_mode: "nvfp4"
+      moe_quant_mode: "nvfp4"
 
 gb200_wideep_disagg:
   mode: "patch"
@@ -90,6 +96,12 @@ gb200_wideep_eplb_disagg:
   config:
     nextn: 1
     nextn_accept_rates: [0.85,0.3,0,0,0]
+    prefill_worker_config:
+      gemm_quant_mode: "nvfp4"
+      moe_quant_mode: "nvfp4"
+    decode_worker_config:
+      gemm_quant_mode: "nvfp4"
+      moe_quant_mode: "nvfp4"
     replica_config:
       max_gpu_per_replica: 512
 
@@ -109,5 +121,11 @@ gb200_wideep_eplb_slots288_disagg:
   config:
     nextn: 1
     nextn_accept_rates: [0.85,0.3,0,0,0]
+    prefill_worker_config:
+      gemm_quant_mode: "nvfp4"
+      moe_quant_mode: "nvfp4"
+    decode_worker_config:
+      gemm_quant_mode: "nvfp4"
+      moe_quant_mode: "nvfp4"
     replica_config:
       max_gpu_per_replica: 512

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -701,6 +701,7 @@ _EXPERIMENT_RESERVED_KEYS = {
     "tpot",
     "request_latency",
     "enable_wideep",
+    "enable_eplb",
     "total_gpus",
     "database_mode",
 }
@@ -834,6 +835,8 @@ def build_experiment_task_configs(
 
         if "enable_wideep" in exp_config:
             task_kwargs["enable_wideep"] = exp_config["enable_wideep"]
+        if "enable_eplb" in exp_config:
+            task_kwargs["enable_eplb"] = exp_config["enable_eplb"]
         if "database_mode" in exp_config:
             task_kwargs["database_mode"] = exp_config["database_mode"]
 

--- a/src/aiconfigurator/sdk/task.py
+++ b/src/aiconfigurator/sdk/task.py
@@ -104,6 +104,9 @@ def build_disagg_parallel_lists(
     is_moe: bool,
     enable_wideep: bool = False,
     should_enable_pp: bool = False,
+    *,
+    prefill_enable_wideep: bool | None = None,
+    decode_enable_wideep: bool | None = None,
 ) -> tuple[dict, dict]:
     """Build the TP/PP/DP/MoE-TP/MoE-EP search-space lists for disagg enumeration.
 
@@ -116,14 +119,19 @@ def build_disagg_parallel_lists(
         prefill_system: System name for the prefill worker (e.g. ``"h200_sxm"``).
         decode_system: System name for the decode worker.
         is_moe: Whether the model is a Mixture-of-Experts model.
-        enable_wideep: Enable wide expert-parallelism search space.
+        enable_wideep: Enable wide expert-parallelism search space (global fallback).
         should_enable_pp: Enable pipeline-parallelism candidates (default ``False``).
+        prefill_enable_wideep: Override WideEP for prefill (None = use *enable_wideep*).
+        decode_enable_wideep: Override WideEP for decode (None = use *enable_wideep*).
 
     Returns:
         ``(prefill_worker_config, decode_worker_config)`` - two dicts each containing
         the keys ``num_gpu_per_worker``, ``tp_list``, ``pp_list``, ``dp_list``,
         ``moe_tp_list``, ``moe_ep_list``.
     """
+    _prefill_wideep = prefill_enable_wideep if prefill_enable_wideep is not None else enable_wideep
+    _decode_wideep = decode_enable_wideep if decode_enable_wideep is not None else enable_wideep
+
     prefill_worker_config: dict = {
         "num_gpu_per_worker": [1, 2, 4, 8],
         "tp_list": [1, 2, 4, 8],
@@ -153,14 +161,23 @@ def build_disagg_parallel_lists(
             decode_worker_config["pp_list"] = [1]
     else:
         if backend_name == "trtllm":
-            if enable_wideep:
+            if _prefill_wideep:
                 prefill_worker_config["num_gpu_per_worker"] = [4, 8, 16, 32]
                 prefill_worker_config["tp_list"] = [1, 2, 4, 8]
                 prefill_worker_config["pp_list"] = [1, 2, 4, 8, 16, 32] if should_enable_pp else [1]
                 prefill_worker_config["dp_list"] = [4, 8, 16, 32]
                 prefill_worker_config["moe_tp_list"] = [1]
                 prefill_worker_config["moe_ep_list"] = [4, 8, 16, 32]
+            else:
+                parallel_config_list = [1, 2, 4, 8]
+                prefill_worker_config["num_gpu_per_worker"] = parallel_config_list
+                prefill_worker_config["tp_list"] = parallel_config_list
+                prefill_worker_config["pp_list"] = parallel_config_list if should_enable_pp else [1]
+                prefill_worker_config["dp_list"] = parallel_config_list
+                prefill_worker_config["moe_tp_list"] = parallel_config_list
+                prefill_worker_config["moe_ep_list"] = parallel_config_list
 
+            if _decode_wideep:
                 decode_worker_config["num_gpu_per_worker"] = [4, 8, 16, 32, 64]
                 decode_worker_config["tp_list"] = [1, 2, 4, 8]
                 decode_worker_config["pp_list"] = [1, 2, 4, 8, 16, 32, 64] if should_enable_pp else [1]
@@ -169,14 +186,6 @@ def build_disagg_parallel_lists(
                 decode_worker_config["moe_ep_list"] = [4, 8, 16, 32, 64]
             else:
                 parallel_config_list = [1, 2, 4, 8]
-
-                prefill_worker_config["num_gpu_per_worker"] = parallel_config_list
-                prefill_worker_config["tp_list"] = parallel_config_list
-                prefill_worker_config["pp_list"] = parallel_config_list if should_enable_pp else [1]
-                prefill_worker_config["dp_list"] = parallel_config_list
-                prefill_worker_config["moe_tp_list"] = parallel_config_list
-                prefill_worker_config["moe_ep_list"] = parallel_config_list
-
                 decode_worker_config["num_gpu_per_worker"] = parallel_config_list
                 decode_worker_config["tp_list"] = parallel_config_list
                 decode_worker_config["pp_list"] = parallel_config_list if should_enable_pp else [1]
@@ -321,6 +330,7 @@ class TaskConfigFactory:
                 "request_latency": ctx.request_latency,
             },
             "enable_wideep": ctx.enable_wideep,
+            "enable_eplb": False,
             "moe_backend": None,  # sglang wideep only
             "attention_backend": "flashinfer",  # sglang wideep only
         }
@@ -414,6 +424,12 @@ class TaskConfigFactory:
         decode_worker_config["system_name"] = decode_system
         decode_worker_config["backend_name"] = ctx.backend_name
         decode_worker_config["backend_version"] = ctx.resolved_backend_version_for(decode_system)
+
+        for wc in (prefill_worker_config, decode_worker_config):
+            wc.setdefault("enable_wideep", ctx.enable_wideep)
+            wc.setdefault("enable_eplb", None)
+            wc.setdefault("moe_backend", None)
+            wc.setdefault("attention_backend", "flashinfer")
 
         replica_config = {
             "num_gpu_per_replica": [
@@ -1122,6 +1138,22 @@ class TaskRunner:
         # Get database mode from config
         database_mode = getattr(task_config, "database_mode", None)
 
+        def _wc_get(wc: object, key: str, fallback):
+            """Read from worker_config; treat None/missing as 'not set'."""
+            val = getattr(wc, key, None)
+            return val if val is not None else fallback
+
+        _pwc = task_config.prefill_worker_config
+        _dwc = task_config.decode_worker_config
+        prefill_enable_wideep = _wc_get(_pwc, "enable_wideep", task_config.enable_wideep)
+        prefill_enable_eplb = _wc_get(_pwc, "enable_eplb", getattr(task_config, "enable_eplb", False))
+        prefill_moe_backend = _wc_get(_pwc, "moe_backend", task_config.moe_backend)
+        prefill_attention_backend = _wc_get(_pwc, "attention_backend", task_config.attention_backend)
+        decode_enable_wideep = _wc_get(_dwc, "enable_wideep", task_config.enable_wideep)
+        decode_enable_eplb = _wc_get(_dwc, "enable_eplb", getattr(task_config, "enable_eplb", False))
+        decode_moe_backend = _wc_get(_dwc, "moe_backend", task_config.moe_backend)
+        decode_attention_backend = _wc_get(_dwc, "attention_backend", task_config.attention_backend)
+
         logger.debug("Task %s: Setting up prefill database", task_config.task_name)
         try:
             prefill_database = self._get_database(
@@ -1149,9 +1181,10 @@ class TaskRunner:
             comm_quant_mode=task_config.prefill_worker_config.comm_quant_mode,
             nextn=task_config.nextn,
             nextn_accept_rates=task_config.nextn_accept_rates,
-            moe_backend=task_config.moe_backend,  # sglang wideep only
-            attention_backend=task_config.attention_backend,  # sglang wideep only
-            enable_wideep=task_config.enable_wideep,
+            moe_backend=prefill_moe_backend,
+            attention_backend=prefill_attention_backend,
+            enable_wideep=prefill_enable_wideep,
+            enable_eplb=prefill_enable_eplb,
         )
 
         try:
@@ -1166,7 +1199,7 @@ class TaskRunner:
                 moe_ep_list=task_config.prefill_worker_config.moe_ep_list,
                 is_moe=check_is_moe(task_config.model_path),
                 backend=common.BackendName(task_config.prefill_worker_config.backend_name),
-                enable_wideep=task_config.enable_wideep,
+                enable_wideep=prefill_enable_wideep,
             )
         except Exception:  # pragma: no cover
             logger.exception(
@@ -1209,9 +1242,10 @@ class TaskRunner:
             comm_quant_mode=task_config.decode_worker_config.comm_quant_mode,
             nextn=task_config.nextn,
             nextn_accept_rates=task_config.nextn_accept_rates,
-            moe_backend=task_config.moe_backend,  # sglang wideep only
-            attention_backend=task_config.attention_backend,  # sglang wideep only
-            enable_wideep=task_config.enable_wideep,
+            moe_backend=decode_moe_backend,
+            attention_backend=decode_attention_backend,
+            enable_wideep=decode_enable_wideep,
+            enable_eplb=decode_enable_eplb,
         )
 
         try:
@@ -1226,7 +1260,7 @@ class TaskRunner:
                 moe_ep_list=task_config.decode_worker_config.moe_ep_list,
                 is_moe=check_is_moe(task_config.model_path),
                 backend=common.BackendName(task_config.decode_worker_config.backend_name),
-                enable_wideep=task_config.enable_wideep,
+                enable_wideep=decode_enable_wideep,
             )
         except Exception:  # pragma: no cover
             logger.exception(

--- a/src/aiconfigurator/sdk/task.py
+++ b/src/aiconfigurator/sdk/task.py
@@ -594,6 +594,7 @@ class TaskConfig:
         tpot: float = 50,
         request_latency: float | None = None,
         enable_wideep: bool = False,
+        enable_eplb: bool = False,
         total_gpus: int | None = None,
         profiles: list[str] | None = None,
         yaml_config: dict | None = None,
@@ -683,6 +684,7 @@ class TaskConfig:
         self.decode_system_name = decode_system_name
         self.backend_name = backend_name
         self.enable_wideep = enable_wideep
+        self.enable_eplb = enable_eplb
         self.total_gpus = total_gpus
         self.yaml_mode = yaml_mode
         self.yaml_patch = yaml_patch

--- a/tests/unit/sdk/task/test_task.py
+++ b/tests/unit/sdk/task/test_task.py
@@ -743,3 +743,203 @@ def test_vllm_disagg_does_not_require_same_tp(monkeypatch):
     assert captured.get("require_same_tp") is False, (
         f"Expected require_same_tp=False for vllm disagg, got {captured.get('require_same_tp')}"
     )
+
+
+# ---------------------------------------------------------------------------
+# PD-split independent WideEP / EPLB configuration
+# ---------------------------------------------------------------------------
+
+from aiconfigurator.sdk.task import build_disagg_parallel_lists
+
+
+class TestBuildDisaggParallelListsMixedWideep:
+    """Verify build_disagg_parallel_lists honours per-phase WideEP overrides."""
+
+    def test_prefill_wideep_on_decode_off(self):
+        prefill, decode = build_disagg_parallel_lists(
+            backend_name="trtllm",
+            prefill_system="gb200",
+            decode_system="gb200",
+            is_moe=True,
+            enable_wideep=False,
+            prefill_enable_wideep=True,
+            decode_enable_wideep=False,
+        )
+        # Prefill: WideEP search space
+        assert prefill["moe_tp_list"] == [1]
+        assert prefill["moe_ep_list"] == [4, 8, 16, 32]
+        assert prefill["num_gpu_per_worker"] == [4, 8, 16, 32]
+
+        # Decode: standard (non-WideEP) search space
+        assert decode["moe_tp_list"] == [1, 2, 4, 8]
+        assert decode["moe_ep_list"] == [1, 2, 4, 8]
+        assert decode["num_gpu_per_worker"] == [1, 2, 4, 8]
+
+    def test_prefill_wideep_off_decode_on(self):
+        prefill, decode = build_disagg_parallel_lists(
+            backend_name="trtllm",
+            prefill_system="gb200",
+            decode_system="gb200",
+            is_moe=True,
+            enable_wideep=False,
+            prefill_enable_wideep=False,
+            decode_enable_wideep=True,
+        )
+        # Prefill: standard
+        assert prefill["moe_tp_list"] == [1, 2, 4, 8]
+        assert prefill["moe_ep_list"] == [1, 2, 4, 8]
+        assert prefill["num_gpu_per_worker"] == [1, 2, 4, 8]
+
+        # Decode: WideEP
+        assert decode["moe_tp_list"] == [1]
+        assert decode["moe_ep_list"] == [4, 8, 16, 32, 64]
+        assert decode["num_gpu_per_worker"] == [4, 8, 16, 32, 64]
+
+    def test_global_fallback_when_overrides_none(self):
+        """When per-phase overrides are None, global enable_wideep is used."""
+        prefill, decode = build_disagg_parallel_lists(
+            backend_name="trtllm",
+            prefill_system="gb200",
+            decode_system="gb200",
+            is_moe=True,
+            enable_wideep=True,
+            prefill_enable_wideep=None,
+            decode_enable_wideep=None,
+        )
+        assert prefill["moe_tp_list"] == [1]
+        assert decode["moe_tp_list"] == [1]
+        assert prefill["moe_ep_list"] == [4, 8, 16, 32]
+        assert decode["moe_ep_list"] == [4, 8, 16, 32, 64]
+
+
+class TestTaskconfigDisaggMixedWideepEplb:
+    """Verify YAML patch correctly sets per-worker WideEP/EPLB in TaskConfig."""
+
+    def test_yaml_patch_sets_independent_wideep_eplb(self):
+        task = TaskConfig(
+            serving_mode="disagg",
+            model_path="deepseek-ai/DeepSeek-V3",
+            system_name="gb200",
+            backend_name="trtllm",
+            enable_wideep=True,
+            total_gpus=128,
+            yaml_config={
+                "mode": "patch",
+                "config": {
+                    "prefill_worker_config": {
+                        "enable_wideep": True,
+                        "enable_eplb": True,
+                        "num_gpu_per_worker": [4, 8, 16, 32],
+                        "dp_list": [4, 8, 16, 32],
+                        "moe_tp_list": [1],
+                        "moe_ep_list": [4, 8, 16, 32],
+                    },
+                    "decode_worker_config": {
+                        "enable_wideep": False,
+                        "enable_eplb": False,
+                        "num_gpu_per_worker": [4, 8],
+                        "dp_list": [1, 2, 4, 8],
+                        "moe_tp_list": [1, 2, 4, 8],
+                        "moe_ep_list": [1, 2, 4, 8],
+                    },
+                },
+            },
+        )
+        cfg = task.config
+
+        assert cfg.prefill_worker_config.enable_wideep is True
+        assert cfg.prefill_worker_config.enable_eplb is True
+        assert cfg.decode_worker_config.enable_wideep is False
+        assert cfg.decode_worker_config.enable_eplb is False
+
+    def test_yaml_patch_reversed_wideep(self):
+        """Prefill OFF / Decode ON — the opposite direction."""
+        task = TaskConfig(
+            serving_mode="disagg",
+            model_path="deepseek-ai/DeepSeek-V3",
+            system_name="gb200",
+            backend_name="trtllm",
+            total_gpus=96,
+            yaml_config={
+                "mode": "patch",
+                "config": {
+                    "prefill_worker_config": {
+                        "enable_wideep": False,
+                        "enable_eplb": False,
+                    },
+                    "decode_worker_config": {
+                        "enable_wideep": True,
+                        "enable_eplb": True,
+                    },
+                },
+            },
+        )
+        cfg = task.config
+
+        assert cfg.prefill_worker_config.enable_wideep is False
+        assert cfg.prefill_worker_config.enable_eplb is False
+        assert cfg.decode_worker_config.enable_wideep is True
+        assert cfg.decode_worker_config.enable_eplb is True
+
+    def test_both_wideep_eplb_differs(self):
+        """Both phases WideEP, but EPLB only on prefill."""
+        task = TaskConfig(
+            serving_mode="disagg",
+            model_path="deepseek-ai/DeepSeek-V3",
+            system_name="gb200",
+            backend_name="trtllm",
+            enable_wideep=True,
+            total_gpus=128,
+            yaml_config={
+                "mode": "patch",
+                "config": {
+                    "prefill_worker_config": {"enable_eplb": True},
+                    "decode_worker_config": {"enable_eplb": False},
+                },
+            },
+        )
+        cfg = task.config
+
+        assert cfg.prefill_worker_config.enable_eplb is True
+        assert cfg.decode_worker_config.enable_eplb is False
+        assert cfg.prefill_worker_config.enable_wideep is True
+        assert cfg.decode_worker_config.enable_wideep is True
+
+
+class TestTaskrunnerDisaggMixedWideepModelConfig:
+    """Verify TaskRunner propagates per-phase WideEP/EPLB into ModelConfig."""
+
+    def test_model_configs_receive_independent_flags(self, monkeypatch):
+        captured = {}
+        pa_stub = sys.modules["aiconfigurator.sdk.pareto_analysis"]
+        monkeypatch.setattr(pa_stub, "disagg_pareto", _make_capturing_disagg_pareto(captured))
+
+        task = TaskConfig(
+            serving_mode="disagg",
+            model_path="deepseek-ai/DeepSeek-V3",
+            system_name="gb200",
+            backend_name="trtllm",
+            enable_wideep=True,
+            total_gpus=128,
+            yaml_config={
+                "mode": "patch",
+                "config": {
+                    "prefill_worker_config": {
+                        "enable_wideep": True,
+                        "enable_eplb": True,
+                    },
+                    "decode_worker_config": {
+                        "enable_wideep": False,
+                        "enable_eplb": False,
+                    },
+                },
+            },
+        )
+        TaskRunner().run(task)
+
+        prefill_mc = captured["prefill_model_config"]
+        decode_mc = captured["decode_model_config"]
+        assert prefill_mc.enable_wideep is True
+        assert prefill_mc.enable_eplb is True
+        assert decode_mc.enable_wideep is False
+        assert decode_mc.enable_eplb is False


### PR DESCRIPTION
#### Overview:

Support independent WideEP and EPLB configuration for prefill and decode phases in disaggregated mode, and propagate `enable_eplb` through the CLI experiment path.

#### Details:

- **Per-phase WideEP control**: `build_disagg_parallel_lists` now accepts `prefill_enable_wideep` / `decode_enable_wideep` overrides, allowing e.g. prefill with standard parallelism + decode with WideEP
- **`enable_eplb` propagation**: add `enable_eplb` to `TaskConfig.__init__`, `_EXPERIMENT_RESERVED_KEYS`, and `build_experiment_task_configs` so it flows correctly from YAML → CLI → TaskRunner
- **Worker-level config resolution**: `TaskRunner._run_disagg` reads `enable_wideep`, `enable_eplb`, `moe_backend`, `attention_backend` from per-worker config with fallback to global config via `_wc_get` helper
- **New experiment YAML**: `deepseek_disagg_mixed_wideep_trtllm.yaml` with mixed WideEP configurations (prefill-only, decode-only, both)
- **Fix EPLB YAML**: override `fp8_block` → `nvfp4` for `deepseek_wideep_trtllm.yaml` EPLB experiments (no `fp8_block` GEMM data in 1.2.0rc6)

#### Where should the reviewer start?

- `src/aiconfigurator/sdk/task.py` — `build_disagg_parallel_lists` per-phase WideEP + `TaskRunner._run_disagg` worker-level config resolution
- `src/aiconfigurator/cli/main.py` — `enable_eplb` CLI propagation

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new DeepSeek disaggregated serving configuration with three experiments supporting per-phase WideEP and EPLB settings.
  * Added NVFloat4 quantization support to existing DeepSeek configurations.
  * Added `enable_eplb` configuration option for improved load balancing in task configurations.

* **Tests**
  * Added comprehensive unit tests for per-phase WideEP/EPLB behavior validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->