### PR TITLE
fix(generator): pass explicit --quantization for NVFP4 models on SGLang

### DIFF
--- a/src/aiconfigurator/generator/config/backend_config_mapping.yaml
+++ b/src/aiconfigurator/generator/config/backend_config_mapping.yaml
@@ -40,6 +40,12 @@ parameters:
   sglang: null
   trtllm: null
 
+# Quantization
+- param_key: quantization
+  vllm: quantization
+  sglang: quantization
+  trtllm: null
+
 # KV Cache
 - param_key: kv_cache_dtype
   vllm: kv-cache-dtype

--- a/src/aiconfigurator/generator/config/backend_templates/sglang/cli_args.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/sglang/cli_args.j2
@@ -1,4 +1,5 @@
 {%- set args = [] -%}
+{%- if sglang['quantization'] is defined -%}{%- set _ = args.append('--quantization "' ~ sglang['quantization'] ~ '"') -%}{%- endif -%}
 {%- if sglang['tensor-parallel-size'] is defined -%}{%- set _ = args.append('--tensor-parallel-size "' ~ sglang['tensor-parallel-size'] ~ '"') -%}{%- endif -%}
 {%- if sglang['pipeline-parallel-size'] is defined -%}{%- set _ = args.append('--pipeline-parallel-size "' ~ sglang['pipeline-parallel-size'] ~ '"') -%}{%- endif -%}
 {%- if sglang['data-parallel-size'] is defined -%}{%- set _ = args.append('--data-parallel-size "' ~ sglang['data-parallel-size'] ~ '"') -%}{%- endif -%}

--- a/src/aiconfigurator/generator/rule_plugin/benchmark/sglang.rule
+++ b/src/aiconfigurator/generator/rule_plugin/benchmark/sglang.rule
@@ -11,6 +11,10 @@ agg_prefill_decode cuda_graph_batch_sizes = ((range(1, max_batch_size + 1) | lis
 agg_prefill_decode gpus_per_worker = (tensor_parallel_size or 1) * (pipeline_parallel_size or 1) * (data_parallel_size or 1)
 
 agg_prefill_decode kv_cache_dtype = ("fp8_e4m3" if kv_cache_dtype == "fp8" else kv_cache_dtype)
+
+# Explicitly set quantization for NVFP4 models to avoid SGLang auto-detection picking FP8
+when gemm_quant_mode == "nvfp4":
+    agg_prefill_decode quantization = "modelopt_fp4"
 prefill_decode kv_transfer_backend = (kv_transfer_backend if kv_transfer_backend else "nixl")
 
 when kv_cache_dtype == "float16":

--- a/src/aiconfigurator/generator/rule_plugin/sglang.rule
+++ b/src/aiconfigurator/generator/rule_plugin/sglang.rule
@@ -13,6 +13,10 @@ agg enable_mixed_chunk = true
 agg_prefill_decode gpus_per_worker = (tensor_parallel_size or 1) * (pipeline_parallel_size or 1) * (data_parallel_size or 1)
 
 agg_prefill_decode kv_cache_dtype = ("fp8_e4m3" if kv_cache_dtype == "fp8" else kv_cache_dtype)
+
+# Explicitly set quantization for NVFP4 models to avoid SGLang auto-detection picking FP8
+when gemm_quant_mode == "nvfp4":
+    agg_prefill_decode quantization = "modelopt_fp4"
 prefill_decode kv_transfer_backend = (kv_transfer_backend if kv_transfer_backend else "nixl")
 
 when kv_cache_dtype == "float16":


### PR DESCRIPTION
#### Overview:
Fix SGLang config generation for NVFP4 models. SGLang's auto-detection picks `ModelOptFp8Config` instead of `ModelOptFp4Config`, crashing at model load time.

#### Details:
| Failure Mode | Tasks Fixed | Root Cause | Fix |
|---|---|---|---|
| fp4_fp8_mismatch | 4 tasks | SGLang auto-detection of quantization format from `hf_quant_config.json` selects the wrong quant class for NVFP4 checkpoints | Pass `--quantization modelopt_fp4` explicitly when `gemm_quant_mode == "nvfp4"` |

**Changes:**
- `backend_config_mapping.yaml`: Add `quantization` parameter mapping for SGLang and vLLM
- `sglang.rule` + `benchmark/sglang.rule`: Set `quantization = "modelopt_fp4"` when model uses NVFP4 weights
- `cli_args.j2`: Add `--quantization` flag to SGLang CLI args template

#### Where should the reviewer start?
- `src/aiconfigurator/generator/rule_plugin/sglang.rule`

#### Verification:
- [ ] Fix verified on silicon

#### Related Issues:
- Affected models: Qwen3-32B-FP4 on B200 with SGLang (agg + disagg)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added quantization configuration support across backend frameworks
  * Enabled quantization parameter handling in SGLang CLI
  * Introduced explicit FP4 quantization support for NVFP4 models

<!-- end of auto-generated comment: release notes by coderabbit.ai -->