### PR TITLE
feat: enable gptoss simulation on blackwell for trtllm backend

### DIFF
--- a/collector/README.md
+++ b/collector/README.md
@@ -258,7 +258,7 @@ with benchmark_with_power(
 
 ## For TensorRT-LLM
 ### Optional( Read if collecting for mxfp4 kernels)
-To collect performance data for mxfp4 kernels used in GPTOSS models, depending on the version of TensorRT-LLM, you might need to manually install triton-kernels. If your version is **>= 1.3.0rc2**, nothing needs to be done and you can run the collection process directly. For any version before **1.3.0rc2**. Follow the below instructions to install triton-kernels an expose them to TensorRT-LLM
+To collect performance data for mxfp4 kernels used in GPTOSS models, depending on the version of TensorRT-LLM, you might need to manually install triton-kernels. If your version is **>= 1.3.0rc2**, nothing needs to be done and you can run the collection process directly. For any version before **1.3.0rc2**. Follow the below instructions to install triton-kernels and expose them to TensorRT-LLM
 1. Build and install Triton (tested with the commit below):
 ```bash
 git clone https://github.com/triton-lang/triton.git

--- a/collector/README.md
+++ b/collector/README.md
@@ -258,7 +258,7 @@ with benchmark_with_power(
 
 ## For TensorRT-LLM
 ### Optional( Read if collecting for mxfp4 kernels)
-To collect performance data for mxfp4 kernels used in GPTOSS models, depending on the version TensorRT-LLM, you might need to manually install triton-kernels. If your version is **>= 1.3.0rc2**, nothing needs to be done and you can run the collection process directly. For any version before **1.3.0rc2**. Follow the below instructions to install triton-kernels an expose them to TensorRT-LLM
+To collect performance data for mxfp4 kernels used in GPTOSS models, depending on the version of TensorRT-LLM, you might need to manually install triton-kernels. If your version is **>= 1.3.0rc2**, nothing needs to be done and you can run the collection process directly. For any version before **1.3.0rc2**. Follow the below instructions to install triton-kernels an expose them to TensorRT-LLM
 1. Build and install Triton (tested with the commit below):
 ```bash
 git clone https://github.com/triton-lang/triton.git

--- a/collector/README.md
+++ b/collector/README.md
@@ -257,8 +257,33 @@ with benchmark_with_power(
 - Only opt-in when needed for specific use cases
 
 ## For TensorRT-LLM
-If you need to use w4a16_mxfp4 kernel, install the triton according to https://github.com/NVIDIA/TensorRT-LLM/tree/main/examples/models/core/gpt_oss#using-openai-triton-kernels-for-moe
-
+### Optional( Read if collecting for mxfp4 kernels)
+To collect performance data for mxfp4 kernels used in GPTOSS models, depending on the version TensorRT-LLM, you might need to manually install triton-kernels. If your version is **>= 1.3.0rc2**, nothing needs to be done and you can run the collection process directly. For any version before **1.3.0rc2**. Follow the below instructions to install triton-kernels an expose them to TensorRT-LLM
+1. Build and install Triton (tested with the commit below):
+```bash
+git clone https://github.com/triton-lang/triton.git
+cd triton
+# Specific commit verified with TensorRT-LLM
+git checkout f3067cd3bd0c29065fa4ecdb724b6f29cbabea5f
+pip install -r python/requirements.txt # build-time dependencies
+pip install wheel build
+python3 setup.py bdist_wheel # if this step fails due cuda related error, you might need to set CUDA_HOME following the optional step
+pip install ./dist/*.whl
+```
+2. (Optional) You may need to set CUDA_HOME env variable to successfully build triton
+```bash
+export CUDA_HOME=/usr/local/cuda
+export CPLUS_INCLUDE_PATH=$CUDA_HOME/include:$CPLUS_INCLUDE_PATH
+export C_INCLUDE_PATH=$CUDA_HOME/include:$C_INCLUDE_PATH
+python3 setup.py bdist_wheel
+```
+3. Expose the Triton kernels to TensorRT-LLM The kernels are not packaged in the wheel, so set the environment variable TRITON_ROOT to your Triton clone:
+```bash
+export TRITON_ROOT=/local/user/triton
+# TensorRT-LLM expects the kernels at:
+#   $TRITON_ROOT/python/triton_kernels
+```
+### Run collection for all available operations
 ```bash
 python3 collect.py --backend trtllm
 ```
@@ -325,7 +350,4 @@ of the GPU system and kernel optimization.
 **Solution**: Use `/tmp/` for output files, then copy results after collection.
 
 # Support Matrix
-aiconfigurator 0.1.0
-trtllm: 0.20.0, 1.0.0rc3 on Hopper GPUs
-vllm: NA
-sglang: 0.5.6.post2 on Hopper GPUs
+refer to the [**support matrix CSV**](src/aiconfigurator/systems/support_matrix.csv)

--- a/collector/collect.py
+++ b/collector/collect.py
@@ -36,6 +36,12 @@ def setup_warning_filters():
         category=UserWarning,
     )
 
+    # Suppress pynvml deprecation warning from torch.cuda
+    warnings.filterwarnings(
+        "ignore",
+        message="The pynvml package is deprecated",
+        category=FutureWarning,
+    )
 
 import random
 import resource
@@ -44,17 +50,22 @@ import torch
 from tqdm import tqdm
 
 setup_warning_filters()
+
 import argparse
 import cProfile
 import io
 import json
 import multiprocessing as mp
 import pstats
+import random
 import signal
 import time
 import traceback
 from datetime import datetime
 from pathlib import Path
+
+import torch
+from tqdm import tqdm
 
 from helper import EXIT_CODE_RESTART, create_test_case_id, save_error_report, setup_logging, setup_signal_handlers
 

--- a/collector/collect.py
+++ b/collector/collect.py
@@ -43,6 +43,7 @@ def setup_warning_filters():
         category=FutureWarning,
     )
 
+
 import random
 import resource
 
@@ -57,15 +58,11 @@ import io
 import json
 import multiprocessing as mp
 import pstats
-import random
 import signal
 import time
 import traceback
 from datetime import datetime
 from pathlib import Path
-
-import torch
-from tqdm import tqdm
 
 from helper import EXIT_CODE_RESTART, create_test_case_id, save_error_report, setup_logging, setup_signal_handlers
 

--- a/collector/trtllm/collect_moe_v3.py
+++ b/collector/trtllm/collect_moe_v3.py
@@ -43,6 +43,52 @@ aic_debug = int(os.getenv("aic_moe_debug", "0"))  # noqa: SIM112
 moe_tune_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "moe_tuned_cache_path")
 
 
+def _patch_moe_runners_for_tuple_tactics():
+    """Monkey-patch MoE runners whose forward() asserts isinstance(tactic, list).
+
+    In trtllm 1.2.0rc5, the C++ get_valid_configs() can return tuples instead
+    of lists for some runners, causing the assertion to fail. This patch wraps
+    forward() to coerce tuples to lists before the call.
+    """
+    if tensorrt_llm.__version__ != "1.2.0rc5" or get_sm_version() < 100:
+        return
+
+    try:
+        from tensorrt_llm._torch.custom_ops import trtllm_gen_custom_ops as ops
+    except ImportError:
+        return
+
+    runner_classes = []
+    for name in [
+        "MxE4m3MxE2m1BlockScaleMoERunner",
+        "E4m3MxE2m1BlockScaleMoERunner",
+        "Bf16MxE2m1BlockScaleMoERunner",
+    ]:
+        cls = getattr(ops, name, None)
+        if cls is not None:
+            runner_classes.append(cls)
+
+    for cls in runner_classes:
+        orig_forward = cls.forward
+
+        def _patched_forward(self, inputs, tactic=[-1, -1], _orig=orig_forward, **kwargs):
+            if not isinstance(tactic, list):
+                if isinstance(tactic, str):
+                    import ast
+
+                    tactic = ast.literal_eval(tactic)
+                elif isinstance(tactic, (tuple, range)):
+                    tactic = list(tactic)
+                else:
+                    tactic = [tactic]
+            return _orig(self, inputs, tactic=tactic, **kwargs)
+
+        cls.forward = _patched_forward
+
+
+_patch_moe_runners_for_tuple_tactics()
+
+
 def gc_collect():
     """Run GC and clear CUDA cache to reduce fragmentation between runs."""
     for _ in range(2):

--- a/collector/trtllm/collect_moe_v3.py
+++ b/collector/trtllm/collect_moe_v3.py
@@ -109,7 +109,9 @@ def get_moe_test_cases():
         moe_list += ["w4a16_mxfp4"]
 
     if sm_version >= 100:
-        moe_list += ["nvfp4", "w4a16_mxfp4"]
+        moe_list += ["nvfp4", "w4a16_mxfp4", "w4a8_mxfp4_mxfp8"]
+
+    _GPTOSS_MOE_TYPES = {"w4a16_mxfp4", "w4a8_mxfp4_mxfp8"}  # noqa: N806
 
     test_cases = []
 
@@ -120,10 +122,10 @@ def get_moe_test_cases():
 
         for moe_type in moe_list:
             if model_name in ["openai/gpt-oss-20b", "openai/gpt-oss-120b"]:
-                if moe_type != "w4a16_mxfp4":
+                if moe_type not in _GPTOSS_MOE_TYPES:
                     continue
             else:
-                if moe_type == "w4a16_mxfp4":
+                if moe_type in _GPTOSS_MOE_TYPES:
                     continue
 
             # w4afp8 requires k shape to be multiple of 128
@@ -234,6 +236,9 @@ def run_moe_torch(
         quant_group_size = 16
     elif moe_type == "w4a16_mxfp4":
         quant_algo = QuantAlgo.W4A16_MXFP4
+        quant_group_size = 32
+    elif moe_type == "w4a8_mxfp4_mxfp8":
+        quant_algo = QuantAlgo.W4A8_MXFP4_MXFP8
         quant_group_size = 32
 
     if power_law_alpha - 0.0 < 1e-6:

--- a/collector/trtllm/collect_moe_v3.py
+++ b/collector/trtllm/collect_moe_v3.py
@@ -150,6 +150,7 @@ def get_moe_test_cases():
                 "fp8": 8,
                 "fp8_block": 8,
                 "w4a16_mxfp4": 4,
+                "w4a8_mxfp4_mxfp8": 4,
                 "w4afp8": 4,
                 "nvfp4": 4,
             }[moe_type]

--- a/collector/trtllm/collect_moe_v3.py
+++ b/collector/trtllm/collect_moe_v3.py
@@ -46,7 +46,7 @@ moe_tune_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "moe_tu
 def _patch_moe_runners_for_tuple_tactics():
     """Monkey-patch MoE runners whose forward() asserts isinstance(tactic, list).
 
-    In trtllm 1.2.0rc5, the C++ get_valid_configs() can return tuples instead
+    In trtllm 1.2.0rc5, the C++ get_valid_configs() can return strings instead
     of lists for some runners, causing the assertion to fail. This patch wraps
     forward() to coerce tuples to lists before the call.
     """

--- a/collector/trtllm/collect_moe_v3.py
+++ b/collector/trtllm/collect_moe_v3.py
@@ -359,7 +359,12 @@ def run_moe_torch(
     )
     moe.to(torch.device(device))
 
-    if moe_type == "w4a16_mxfp4":
+    # Both w4a16_mxfp4 and w4a8_mxfp4_mxfp8 use MXFP4 weights and share the same
+    # weight loading path in TRT-LLM (inherited from MXFP4WeightTRTLLMGenFusedMoEMethod).
+    # We must explicitly cast weights to MXFP4 format and call load_weights() so that
+    # the proper shuffle/permutation (torch.ops.trtllm.shuffle_matrix) is applied,
+    # which the kernel expects for correct memory access patterns.
+    if moe_type in ("w4a16_mxfp4", "w4a8_mxfp4_mxfp8"):
         w1_bias = torch.randn((num_experts, inter_size), dtype=dtype, device=device)
         w2_bias = torch.randn((num_experts, hidden_size), dtype=dtype, device=device)
         w3_bias = torch.randn((num_experts, inter_size), dtype=dtype, device=device)

--- a/collector/trtllm/collect_moe_v3.py
+++ b/collector/trtllm/collect_moe_v3.py
@@ -109,7 +109,7 @@ def get_moe_test_cases():
         moe_list += ["w4a16_mxfp4"]
 
     if sm_version >= 100:
-        moe_list += ["nvfp4"]
+        moe_list += ["nvfp4", "w4a16_mxfp4"]
 
     test_cases = []
 
@@ -286,17 +286,19 @@ def run_moe_torch(
     sm_version = get_sm_version()
 
     if model_name in ["openai/gpt-oss-120b", "openai/gpt-oss-20b"]:
-        # use triton backend for best performance on Hopper
-        model_config.moe_backend = "triton"
         swiglu_alpha = torch.tensor([1.702] * (num_experts // moe_ep_size), dtype=torch.float32).to(
             torch.device(device)
         )
         swiglu_beta = torch.tensor([1.0] * (num_experts // moe_ep_size), dtype=torch.float32).to(torch.device(device))
         swiglu_limit = torch.tensor([7.0] * (num_experts // moe_ep_size), dtype=torch.float32).to(torch.device(device))
-        if 86 < sm_version < 100:
+        if 86 < get_sm_version() < 100:
+            # Hopper: use triton backend for best performance
             model_config.moe_backend = "triton"
+        elif get_sm_version() >= 100:
+            # Blackwell: production uses TRTLLMGenFusedMoE (Bf16MxE2m1BlockScaleMoeRunner)
+            model_config.moe_backend = "trtllm"
         else:
-            model_config.moe_backend = "cutlass" if not min_latency_mode else "trtllm"
+            model_config.moe_backend = "cutlass"
     else:
         # Select backend based on platform and quant mode.
         if min_latency_mode:

--- a/src/aiconfigurator/sdk/common.py
+++ b/src/aiconfigurator/sdk/common.py
@@ -533,6 +533,8 @@ class MoEQuantMode(Enum):
     w4afp8 = QuantMapping(0.5, 2, "w4afp8")  # specific for trtllm torch ds w4a8
     nvfp4 = QuantMapping(9 / 16, 4, "nvfp4")  # nvfp4 on blackwell. 1 fp8 scale per 16 nvfp4 weights.
     w4a16_mxfp4 = QuantMapping(0.5, 1, "w4a16_mxfp4")  # native data format for gpt oss
+    w4a8_mxfp4_mxfp8 = QuantMapping(0.5, 2, "w4a8_mxfp4_mxfp8")
+    # mxfp4 weights, mxfp8 activations (recommended for Blackwell)
 
 
 class FMHAQuantMode(Enum):

--- a/src/aiconfigurator/sdk/models.py
+++ b/src/aiconfigurator/sdk/models.py
@@ -69,9 +69,6 @@ def _infer_quant_modes_from_raw_config(raw_config: dict) -> dict[str, object]:
     elif quant_algo == "mxfp4":
         overrides["gemm_quant_mode"] = common.GEMMQuantMode.float16
         overrides["moe_quant_mode"] = common.MoEQuantMode.w4a16_mxfp4
-    elif quant_algo == "mxfp4_mxfp8":
-        overrides["gemm_quant_mode"] = common.GEMMQuantMode.float16
-        overrides["moe_quant_mode"] = common.MoEQuantMode.w4a8_mxfp4_mxfp8
     elif quant_algo == "float16":
         overrides["gemm_quant_mode"] = common.GEMMQuantMode.float16
         overrides["moe_quant_mode"] = common.MoEQuantMode.float16

--- a/src/aiconfigurator/sdk/models.py
+++ b/src/aiconfigurator/sdk/models.py
@@ -69,6 +69,9 @@ def _infer_quant_modes_from_raw_config(raw_config: dict) -> dict[str, object]:
     elif quant_algo == "mxfp4":
         overrides["gemm_quant_mode"] = common.GEMMQuantMode.float16
         overrides["moe_quant_mode"] = common.MoEQuantMode.w4a16_mxfp4
+    elif quant_algo == "mxfp4_mxfp8":
+        overrides["gemm_quant_mode"] = common.GEMMQuantMode.float16
+        overrides["moe_quant_mode"] = common.MoEQuantMode.w4a8_mxfp4_mxfp8
     elif quant_algo == "float16":
         overrides["gemm_quant_mode"] = common.GEMMQuantMode.float16
         overrides["moe_quant_mode"] = common.MoEQuantMode.float16

--- a/src/aiconfigurator/sdk/task.py
+++ b/src/aiconfigurator/sdk/task.py
@@ -260,24 +260,26 @@ class TaskConfigFactory:
 
         # On Blackwell, GPT-OSS defaults to w4a8_mxfp4_mxfp8 (MXFP8 activations)
         # for higher tensor core throughput. Profiles applied after this can override.
-        if (
-            ctx.backend_name == "trtllm"
-            and ctx.model_path in ("openai/gpt-oss-120b", "openai/gpt-oss-20b")
-            and ctx.system_name
-            in (
-                "gb200",
-                "gb300",
-                "b200_sxm",
-            )
-        ):
+        # In disagg mode, prefill and decode may run on different hardware, so only
+        # promote the workers that are actually on Blackwell.
+        _blackwell_systems = ("gb200", "gb300", "b200_sxm")
+        if ctx.backend_name == "trtllm" and ctx.model_path in ("openai/gpt-oss-120b", "openai/gpt-oss-20b"):
             quant_override = {"moe_quant_mode": "w4a8_mxfp4_mxfp8"}
             if ctx.serving_mode == "agg":
-                _deep_merge(config_dict, {"worker_config": quant_override})
+                if ctx.system_name in _blackwell_systems:
+                    _deep_merge(config_dict, {"worker_config": quant_override})
+                    applied_layers.append("gptoss-blackwell-mxfp8")
             else:
-                _deep_merge(
-                    config_dict, {"prefill_worker_config": quant_override, "decode_worker_config": quant_override}
-                )
-            applied_layers.append("gptoss-blackwell-mxfp8")
+                prefill_system = ctx.system_name
+                decode_system = ctx.decode_system_name or ctx.system_name
+                promoted = {}
+                if prefill_system in _blackwell_systems:
+                    promoted["prefill_worker_config"] = quant_override
+                if decode_system in _blackwell_systems:
+                    promoted["decode_worker_config"] = quant_override
+                if promoted:
+                    _deep_merge(config_dict, promoted)
+                    applied_layers.append("gptoss-blackwell-mxfp8")
 
         for profile in ctx.profiles:
             layers = cls.PROFILE_REGISTRY.get(profile)

--- a/src/aiconfigurator/sdk/task.py
+++ b/src/aiconfigurator/sdk/task.py
@@ -260,10 +260,15 @@ class TaskConfigFactory:
 
         # On Blackwell, GPT-OSS defaults to w4a8_mxfp4_mxfp8 (MXFP8 activations)
         # for higher tensor core throughput. Profiles applied after this can override.
-        if ctx.model_path in ("openai/gpt-oss-120b", "openai/gpt-oss-20b") and ctx.system_name in (
-            "gb200",
-            "gb300",
-            "b200_sxm",
+        if (
+            ctx.backend_name == "trtllm"
+            and ctx.model_path in ("openai/gpt-oss-120b", "openai/gpt-oss-20b")
+            and ctx.system_name
+            in (
+                "gb200",
+                "gb300",
+                "b200_sxm",
+            )
         ):
             quant_override = {"moe_quant_mode": "w4a8_mxfp4_mxfp8"}
             if ctx.serving_mode == "agg":

--- a/src/aiconfigurator/sdk/task.py
+++ b/src/aiconfigurator/sdk/task.py
@@ -552,13 +552,6 @@ _quants = {
         "fmha_quant_mode": "float16",
         "comm_quant_mode": "half",
     },
-    "mxfp4_mxfp8": {
-        "gemm_quant_mode": "float16",
-        "moe_quant_mode": "w4a8_mxfp4_mxfp8",
-        "kvcache_quant_mode": "float16",
-        "fmha_quant_mode": "float16",
-        "comm_quant_mode": "half",
-    },
 }
 
 

--- a/src/aiconfigurator/sdk/task.py
+++ b/src/aiconfigurator/sdk/task.py
@@ -258,6 +258,22 @@ class TaskConfigFactory:
                 _deep_merge(config_dict, layer.resolve(ctx))
                 applied_layers.append(layer.name)
 
+        # On Blackwell, GPT-OSS defaults to w4a8_mxfp4_mxfp8 (MXFP8 activations)
+        # for higher tensor core throughput. Profiles applied after this can override.
+        if ctx.model_path in ("openai/gpt-oss-120b", "openai/gpt-oss-20b") and ctx.system_name in (
+            "gb200",
+            "gb300",
+            "b200_sxm",
+        ):
+            quant_override = {"moe_quant_mode": "w4a8_mxfp4_mxfp8"}
+            if ctx.serving_mode == "agg":
+                _deep_merge(config_dict, {"worker_config": quant_override})
+            else:
+                _deep_merge(
+                    config_dict, {"prefill_worker_config": quant_override, "decode_worker_config": quant_override}
+                )
+            applied_layers.append("gptoss-blackwell-mxfp8")
+
         for profile in ctx.profiles:
             layers = cls.PROFILE_REGISTRY.get(profile)
             if not layers:

--- a/src/aiconfigurator/sdk/task.py
+++ b/src/aiconfigurator/sdk/task.py
@@ -536,6 +536,13 @@ _quants = {
         "fmha_quant_mode": "float16",
         "comm_quant_mode": "half",
     },
+    "mxfp4_mxfp8": {
+        "gemm_quant_mode": "float16",
+        "moe_quant_mode": "w4a8_mxfp4_mxfp8",
+        "kvcache_quant_mode": "float16",
+        "fmha_quant_mode": "float16",
+        "comm_quant_mode": "half",
+    },
 }
 
 


### PR DESCRIPTION
## Summary

- Enable the collection of mxfp4 kernels on blackwell for trtllm backend, and this in turn should allow aiconfigurator to produce silicon mode estimation for gptoss deployment of trtllm backend on B200/GB200 

## Changes

| File | What changed |
|------|-------------|
| `collector/collect_moe_v3.py` | Allow collection for `w4a16_mxfp4`  and `w4a8_mxfp4_mxfp8` when sm>=100 and set `moe_backend` to trtllm to collect the right kernel on blackwell. Also added a monkeypatch to fix a collection issue that will occur for trtllm 1.2.0rc5
| `collector/README.md` | Add clear instructions on how to handle triton-kernels when collecting perf data for mxfp4 kernels
| `collector/collect.py` | Add a filter to filter out repeated pynvml warning during collection
|`sdk/common.py`| Add w4a8_mxfp4_mxfp8 quant mode
|`sdk/task.py`| Add an auto promotion logic for w4a8_mxfp4_mxfp8, that only triggers for trtllm gptoss on blackwell 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for w4a8_mxfp4_mxfp8 quantization and improved MoE handling, with optimized backend selection for GPT-OSS models on Blackwell systems.

* **Documentation**
  * Expanded mxfp4 kernel collection guide with step-by-step Triton setup and a central support-matrix reference link.

* **Chores**
  * Suppressed noisy deprecation warnings and refined warning/filter behavior during collection and runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->