### PR TITLE
chore: update trtllm alltoall data

### DIFF
--- a/src/aiconfigurator/systems/data/gb200/trtllm/1.2.0rc6/trtllm_alltoall_perf.txt
+++ b/src/aiconfigurator/systems/data/gb200/trtllm/1.2.0rc6/trtllm_alltoall_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fd5567969ba6c29d020d21e7e57cb85530531c78d5c66817bf1bfa2d8a39b03d
-size 406399
+oid sha256:f51fcf2451066814d6452f2347415b4891fd40baebc94fb160a637c41d179a1b
+size 221416


### PR DESCRIPTION
#### Overview:

update gb200 trtllm alltoall data

#### Details:
1. Naming issue of NVLinkTwoSided: replace mmnvlmoe
2. Incorrect data of NVLinkOneSided

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GB200 TensorRT-LLM performance data file references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->