### PR TITLE
feat: add configurable k8s tolerations to all backend deploy templates

### DIFF
--- a/src/aiconfigurator/generator/config/backend_templates/sglang/k8s_deploy.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/sglang/k8s_deploy.yaml.j2
@@ -22,12 +22,16 @@
         limits:
           gpu: "{{ gpu }}"
       extraPodSpec:
+        {% if K8sConfig.k8s_tolerations %}
+        tolerations:
+{{ K8sConfig.k8s_tolerations | indent(10, True) }}
+        {% endif %}
         {% if k8s_use_model_cache %}
         volumes:
           - name: model-cache
             persistentVolumeClaim:
               claimName: {{ k8s_model_cache_pvc }}
-        {% endif %}  
+        {% endif %}
         {% if K8sConfig.k8s_image_pull_secret %}
         imagePullSecrets:
           - name: {{ K8sConfig.k8s_image_pull_secret }}
@@ -72,7 +76,11 @@ spec:
       envFromSecret: hf-token-secret
       componentType: frontend
       replicas: {{ frontend_replicas | default(1) }}
-      extraPodSpec:     
+      extraPodSpec:
+        {% if K8sConfig.k8s_tolerations %}
+        tolerations:
+{{ K8sConfig.k8s_tolerations | indent(10, True) }}
+        {% endif %}
         {% if K8sConfig.k8s_image_pull_secret %}
         imagePullSecrets:
           - name: {{ K8sConfig.k8s_image_pull_secret }}

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/k8s_deploy.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/k8s_deploy.yaml.j2
@@ -87,6 +87,10 @@ readinessProbe:
         limits:
           gpu: "{{ gpu }}"
       extraPodSpec:
+        {% if K8sConfig.k8s_tolerations %}
+        tolerations:
+{{ K8sConfig.k8s_tolerations | indent(10, True) }}
+        {% endif %}
 {{ render_volumes() | indent(8, True) }}
         {% if K8sConfig.k8s_image_pull_secret %}
         imagePullSecrets:
@@ -164,6 +168,10 @@ spec:
       componentType: frontend
       replicas: {{ frontend_replicas }}
       extraPodSpec:
+        {% if K8sConfig.k8s_tolerations %}
+        tolerations:
+{{ K8sConfig.k8s_tolerations | indent(10, True) }}
+        {% endif %}
         {% if k8s_use_model_cache %}
         volumes:
           - name: model-cache

--- a/src/aiconfigurator/generator/config/backend_templates/vllm/k8s_deploy.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/vllm/k8s_deploy.yaml.j2
@@ -27,12 +27,16 @@
         limits:
           gpu: "{{ gpu }}"
       extraPodSpec:
+        {% if K8sConfig.k8s_tolerations %}
+        tolerations:
+{{ K8sConfig.k8s_tolerations | indent(10, True) }}
+        {% endif %}
         {% if k8s_use_model_cache %}
         volumes:
           - name: model-cache
             persistentVolumeClaim:
               claimName: {{ k8s_model_cache_pvc }}
-        {% endif %}      
+        {% endif %}
         {% if K8sConfig.k8s_image_pull_secret %}
         imagePullSecrets:
           - name: {{ K8sConfig.k8s_image_pull_secret }}
@@ -84,6 +88,10 @@ spec:
       componentType: frontend
       replicas: {{ frontend_replicas | default(1) }}
       extraPodSpec:
+        {% if K8sConfig.k8s_tolerations %}
+        tolerations:
+{{ K8sConfig.k8s_tolerations | indent(10, True) }}
+        {% endif %}
         {% if K8sConfig.k8s_image_pull_secret %}
         imagePullSecrets:
           - name: {{ K8sConfig.k8s_image_pull_secret }}

--- a/src/aiconfigurator/generator/config/deployment_config.yaml
+++ b/src/aiconfigurator/generator/config/deployment_config.yaml
@@ -92,6 +92,16 @@ inputs:
   - key: K8sConfig.k8s_hf_home
     required: false
     default: ""
+  - key: K8sConfig.k8s_tolerations
+    required: false
+    default: |-
+      - key: dedicated
+        operator: Equal
+        value: user-workload
+        effect: NoExecute
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
 
   # Worker config
   - key: WorkerConfig.prefill_workers


### PR DESCRIPTION
Adds optional `K8sConfig.k8s_tolerations` field to deployment_config.yaml and plumbs it through the TRT-LLM, vLLM, and SGLang k8s_deploy.yaml.j2 templates so generated manifests can target tainted node pools.

The field is guarded by a Jinja2 if block, so omitting or setting it to an empty string produces no tolerations section. The default ships two common tolerations as an example:
  - dedicated=user-workload (GCP GKE node pools)
  - nvidia.com/gpu Exists (GPU-only nodes)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for configurable Kubernetes tolerations across all deployment backends (SgLang, TRTLLM, vLLM). Users can now specify custom tolerations to manage pod scheduling on nodes with specific taints, including default tolerations for dedicated workloads and GPU nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->