### PR TITLE
fix(generator): add MoE TP constraint to SGLang rule plugin

### DIFF
--- a/src/aiconfigurator/generator/rule_plugin/benchmark/sglang.rule
+++ b/src/aiconfigurator/generator/rule_plugin/benchmark/sglang.rule
@@ -7,8 +7,16 @@ agg enable_mixed_chunk = true
 
 agg_prefill_decode cuda_graph_batch_sizes = ((range(1, max_batch_size + 1) | list) if max_batch_size else [])
 
+# Enforce SGLang MoE parallelism: SGLang uses unified TP for both attention and MoE,
+# so tensor_parallel_size must account for moe_tp × moe_ep (same constraint as TRT-LLM).
+# Without this, MoE models get tp=1 and the full model is replicated per GPU, causing OOM.
+when ModelConfig.is_moe and (moe_tensor_parallel_size and moe_expert_parallel_size):
+    agg_prefill_decode tensor_parallel_size = moe_tensor_parallel_size * moe_expert_parallel_size
+
 # GPUs per worker follow the same TP/PP/DP product that SGLang expects
 agg_prefill_decode gpus_per_worker = (tensor_parallel_size or 1) * (pipeline_parallel_size or 1) * (data_parallel_size or 1)
+
+agg_prefill_decode enable_attention_dp = ((data_parallel_size or 1) > 1) and ModelConfig.is_moe
 
 agg_prefill_decode kv_cache_dtype = ("fp8_e4m3" if kv_cache_dtype == "fp8" else kv_cache_dtype)
 prefill_decode kv_transfer_backend = (kv_transfer_backend if kv_transfer_backend else "nixl")

--- a/src/aiconfigurator/generator/rule_plugin/sglang.rule
+++ b/src/aiconfigurator/generator/rule_plugin/sglang.rule
@@ -9,8 +9,16 @@ agg_decode max_batch_size = (512 if (max_batch_size or 0) < 512 else (max_batch_
 agg_prefill_decode max_prefill_tokens = SlaConfig.isl + 1500
 agg enable_mixed_chunk = true
 
+# Enforce SGLang MoE parallelism: SGLang uses unified TP for both attention and MoE,
+# so tensor_parallel_size must account for moe_tp × moe_ep (same constraint as TRT-LLM).
+# Without this, MoE models get tp=1 and the full model is replicated per GPU, causing OOM.
+when ModelConfig.is_moe and (moe_tensor_parallel_size and moe_expert_parallel_size):
+    agg_prefill_decode tensor_parallel_size = moe_tensor_parallel_size * moe_expert_parallel_size
+
 # GPUs per worker follow the same TP/PP/DP product that SGLang expects
 agg_prefill_decode gpus_per_worker = (tensor_parallel_size or 1) * (pipeline_parallel_size or 1) * (data_parallel_size or 1)
+
+agg_prefill_decode enable_attention_dp = ((data_parallel_size or 1) > 1) and ModelConfig.is_moe
 
 agg_prefill_decode kv_cache_dtype = ("fp8_e4m3" if kv_cache_dtype == "fp8" else kv_cache_dtype)
 prefill_decode kv_transfer_backend = (kv_transfer_backend if kv_transfer_backend else "nixl")


### PR DESCRIPTION
#### Overview:
Add missing MoE TP→TP mapping to SGLang rule plugin. Without this, MoE models (e.g., DeepSeek-V3.1) get `tensor_parallel_size=1` on SGLang, causing OOM (full model replicated per GPU) and tensor size mismatches during collective ops.

#### Details:
| Error | Tasks Affected | Root Cause | Fix |
|---|---|---|---|
| cuda_oom | 2 tasks (DeepSeek-V3.1 agg_sglang) | SGLang rule missing MoE TP remap → model not sharded | Added `tensor_parallel_size = moe_tp × moe_ep` for MoE models |
| tensor_size_mismatch | 2 tasks (DeepSeek-V3.1 disagg_sglang) | Same root cause → wrong world size for collective ops | Same fix |

**Changes:**
- `sglang.rule` + `benchmark/sglang.rule`: Add MoE TP constraint (matching existing TRT-LLM rule) and `enable_attention_dp` derivation

The TRT-LLM rule already had this constraint (line 20-22 of `trtllm.rule`). SGLang uses a unified `tensor_parallel_size` for both attention and MoE, so the same remap is required.

#### Where should the reviewer start?
- `src/aiconfigurator/generator/rule_plugin/sglang.rule`

#### Verification:
- [ ] Fix verified on silicon

#### Related Issues:
- Affected models: DeepSeek-V3.1-NVFP4 on B200/GB200 with SGLang (agg + disagg)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced support for Mixture of Experts (MoE) models with optimized parallelism configurations
  * Improved tensor and expert parallelism handling for MoE-based inference
  * Added attention data-parallel optimization flag to enhance performance for MoE models

<!-- end of auto-generated comment: release notes by coderabbit.ai -->