### PR TITLE
feat: add Llama 4 Scout and Maverick support

### DIFF
--- a/src/aiconfigurator/model_configs/meta-llama--Llama-4-Maverick-17B-128E-Instruct_config.json
+++ b/src/aiconfigurator/model_configs/meta-llama--Llama-4-Maverick-17B-128E-Instruct_config.json
@@ -1,0 +1,35 @@
+{
+  "architectures": [
+    "Llama4ForConditionalGeneration"
+  ],
+  "model_type": "llama4",
+  "text_config": {
+    "attention_bias": false,
+    "attention_chunk_size": 8192,
+    "attention_dropout": 0.0,
+    "head_dim": 128,
+    "hidden_act": "silu",
+    "hidden_size": 5120,
+    "interleave_moe_layer_step": 2,
+    "intermediate_size": 8192,
+    "intermediate_size_mlp": 16384,
+    "max_position_embeddings": 1048576,
+    "model_type": "llama4_text",
+    "num_attention_heads": 40,
+    "num_experts_per_tok": 1,
+    "num_hidden_layers": 48,
+    "num_key_value_heads": 8,
+    "num_local_experts": 128,
+    "output_router_logits": false,
+    "rms_norm_eps": 1e-05,
+    "rope_scaling": null,
+    "rope_theta": 500000.0,
+    "router_aux_loss_coef": 0.001,
+    "torch_dtype": "bfloat16",
+    "use_cache": true,
+    "use_qk_norm": false,
+    "vocab_size": 202048
+  },
+  "torch_dtype": "bfloat16",
+  "transformers_version": "4.51.0.dev0"
+}

--- a/src/aiconfigurator/model_configs/meta-llama--Llama-4-Scout-17B-16E-Instruct_config.json
+++ b/src/aiconfigurator/model_configs/meta-llama--Llama-4-Scout-17B-16E-Instruct_config.json
@@ -1,0 +1,41 @@
+{
+  "architectures": [
+    "Llama4ForConditionalGeneration"
+  ],
+  "model_type": "llama4",
+  "text_config": {
+    "attention_bias": false,
+    "attention_chunk_size": 8192,
+    "attention_dropout": 0.0,
+    "head_dim": 128,
+    "hidden_act": "silu",
+    "hidden_size": 5120,
+    "interleave_moe_layer_step": 1,
+    "intermediate_size": 8192,
+    "intermediate_size_mlp": 16384,
+    "max_position_embeddings": 10485760,
+    "model_type": "llama4_text",
+    "num_attention_heads": 40,
+    "num_experts_per_tok": 1,
+    "num_hidden_layers": 48,
+    "num_key_value_heads": 8,
+    "num_local_experts": 16,
+    "output_router_logits": false,
+    "rms_norm_eps": 1e-05,
+    "rope_scaling": {
+      "factor": 16.0,
+      "high_freq_factor": 1.0,
+      "low_freq_factor": 1.0,
+      "original_max_position_embeddings": 8192,
+      "rope_type": "llama3"
+    },
+    "rope_theta": 500000.0,
+    "router_aux_loss_coef": 0.001,
+    "torch_dtype": "bfloat16",
+    "use_cache": true,
+    "use_qk_norm": true,
+    "vocab_size": 202048
+  },
+  "torch_dtype": "bfloat16",
+  "transformers_version": "4.51.0.dev0"
+}

--- a/src/aiconfigurator/sdk/common.py
+++ b/src/aiconfigurator/sdk/common.py
@@ -60,6 +60,25 @@ class NemotronHConfig:
     moe_shared_expert_intermediate_size: int = 0  # Optional: 0 for non-MoE NemotronH models
 
 
+@dataclass(frozen=True)
+class Llama4Config:
+    """
+    Configuration for Llama 4 Scout/Maverick (interleaved local/global attention + interleaved MoE/dense FFN).
+
+    Attributes:
+        interleave_moe_layer_step: Step between MoE layers.
+            Layer i has MoE FFN if (i+1) % interleave_moe_layer_step == 0.
+            step=1 → all layers are MoE (Scout); step=2 → every other layer (odd) is MoE (Maverick).
+        dense_inter_size: Intermediate size for dense FFN layers (intermediate_size_mlp in HF config).
+        attention_chunk_size: Local (chunked) attention window size; even-indexed layers use this,
+            odd-indexed layers use full (global) attention.
+    """
+
+    interleave_moe_layer_step: int
+    dense_inter_size: int
+    attention_chunk_size: int
+
+
 def _get_support_matrix_resource():
     """Get the support_matrix.csv as a Traversable resource."""
     return pkg_resources.files("aiconfigurator") / "systems" / "support_matrix.csv"
@@ -246,6 +265,9 @@ DefaultHFModels = {
     # GPT-OSS Models
     "openai/gpt-oss-120b",
     "openai/gpt-oss-20b",
+    # Llama 4 Models
+    "meta-llama/Llama-4-Scout-17B-16E-Instruct",
+    "meta-llama/Llama-4-Maverick-17B-128E-Instruct",
     # NVIDIA Nemotron
     "nvidia/Llama-3_3-Nemotron-Super-49B-v1",
     "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
@@ -284,12 +306,14 @@ ARCHITECTURE_TO_MODEL_FAMILY = {
     "GptOssForCausalLM": "MOE",
     "Qwen3MoeForCausalLM": "MOE",
     "MiniMaxM2ForCausalLM": "MOE",
+    "Llama4ForConditionalGeneration": "MOE",
 }
 
 # Multimodal architectures whose LLM config lives under a nested key (e.g. "text_config").
 # _parse_hf_config_json will flatten these before parsing.
 MULTIMODAL_TEXT_CONFIG_KEY = {
     "KimiK25ForConditionalGeneration": "text_config",
+    "Llama4ForConditionalGeneration": "text_config",
 }
 
 """

--- a/src/aiconfigurator/sdk/models.py
+++ b/src/aiconfigurator/sdk/models.py
@@ -211,24 +211,44 @@ def get_model(
             model_config,
         )
     elif model_family == "MOE":
-        # currently we don't support wideep for sglang moe models (other than DS V3)
-        model = MOEModel(
-            topk,
-            num_experts,
-            moe_inter_size,
-            model_path,
-            model_family,
-            architecture,
-            layers,
-            n,
-            n_kv,
-            d,
-            hidden,
-            inter,
-            vocab,
-            context,
-            model_config,
-        )
+        if architecture == "Llama4ForConditionalGeneration":
+            model = Llama4Model(
+                topk,
+                num_experts,
+                moe_inter_size,
+                model_path,
+                model_family,
+                architecture,
+                layers,
+                n,
+                n_kv,
+                d,
+                hidden,
+                inter,
+                vocab,
+                context,
+                model_config,
+            )
+            model.set_llama4_config(extra_params)
+        else:
+            # currently we don't support wideep for sglang moe models (other than DS V3)
+            model = MOEModel(
+                topk,
+                num_experts,
+                moe_inter_size,
+                model_path,
+                model_family,
+                architecture,
+                layers,
+                n,
+                n_kv,
+                d,
+                hidden,
+                inter,
+                vocab,
+                context,
+                model_config,
+            )
     elif model_family == "DEEPSEEK":
         if backend_name == "sglang" and model_config.enable_wideep:
             logger.debug(f"WideEP is enabled for model {model_path} with backend {backend_name}")
@@ -3096,6 +3116,355 @@ class NemotronHModel(BaseModel):
                 h,
                 common.GEMMQuantMode.float16,
             )
+        )
+
+
+class Llama4Model(BaseModel):
+    """
+    Llama 4 Scout/Maverick: interleaved local (chunked) + global attention, interleaved MoE + dense FFN.
+
+    Layer structure for N layers:
+    - Attention: even-indexed layers → local (SWA, window=attention_chunk_size),
+                 odd-indexed layers  → global (full attention). Same KV dims for both.
+    - FFN:       layer i has MoE if (i+1) % interleave_moe_layer_step == 0, else dense SwiGLU.
+                 step=1 → all MoE (Scout); step=2 → odd layers MoE, even layers dense (Maverick).
+    """
+
+    def __init__(self, topk: int, num_experts: int, moe_inter_size: int, *args) -> None:
+        super().__init__(*args)
+        assert (
+            self.config.tp_size * self.config.attention_dp_size == self.config.moe_tp_size * self.config.moe_ep_size
+        ), (
+            f"tp_size ({self.config.tp_size}) * attention_dp_size "
+            f"({self.config.attention_dp_size}) should equal moe_tp_size "
+            f"({self.config.moe_tp_size}) * moe_ep_size ({self.config.moe_ep_size})"
+        )
+        assert num_experts >= self.config.moe_ep_size, f"ep size cannot be larger than num_experts {num_experts}"
+        self._topk = topk
+        self._num_experts = num_experts
+        self._moe_inter_size = moe_inter_size
+        self._llama4_config: common.Llama4Config | None = None
+        self._power_law_alpha = 1.2
+
+    def set_llama4_config(self, cfg: common.Llama4Config) -> None:
+        self._llama4_config = cfg
+        self._build_context_ops()
+        self._build_generation_ops()
+
+    def _count_layer_types(self) -> dict[str, int]:
+        step = self._llama4_config.interleave_moe_layer_step
+        moe_count = sum(1 for i in range(self._num_layers) if (i + 1) % step == 0)
+        # Even-indexed layers use local (SWA) attention; odd-indexed use global.
+        local_count = (self._num_layers + 1) // 2
+        global_count = self._num_layers // 2
+        return {
+            "moe": moe_count,
+            "dense": self._num_layers - moe_count,
+            "local": local_count,
+            "global": global_count,
+        }
+
+    def _build_context_ops(self) -> None:
+        if not self._llama4_config:
+            return
+
+        cfg = self._llama4_config
+        counts = self._count_layer_types()
+        moe_count = counts["moe"]
+        dense_count = counts["dense"]
+        local_count = counts["local"]
+        global_count = counts["global"]
+
+        h = self._hidden_size
+        tp_size = self.config.tp_size
+        moe_tp_size = self.config.moe_tp_size
+        moe_ep_size = self.config.moe_ep_size
+        attention_dp_size = self.config.attention_dp_size
+        pp_size = self.config.pp_size
+        num_kv_heads_per_gpu = self._num_kv_heads_per_gpu
+        gemm_quant_mode = self.config.gemm_quant_mode
+        kvcache_quant_mode = self.config.kvcache_quant_mode
+        fmha_quant_mode = self.config.fmha_quant_mode
+        moe_quant_mode = self.config.moe_quant_mode
+        workload_distribution = (
+            self.config.workload_distribution + f"_{self._power_law_alpha}"
+            if self.config.workload_distribution == "power_law"
+            else self.config.workload_distribution
+        )
+
+        # KV dims are the same for local and global attention layers.
+        qkv_out = self._num_heads * self._head_size // tp_size + self._head_size * num_kv_heads_per_gpu * 2
+        proj_in = self._num_heads * self._head_size // tp_size
+
+        self.context_ops = [ops.Embedding("context_embedding", 1, self._vocab_size, h, 0.3)]
+
+        # Pre-attention norm + QKV GEMM applied to all layers (same shape for local and global).
+        self.context_ops.extend(
+            [
+                ops.ElementWise("context_add_norm_1", self._num_layers, 2 * h, 2 * h, 0.8),
+                ops.GEMM("context_qkv_gemm", self._num_layers, qkv_out, h, gemm_quant_mode),
+            ]
+        )
+
+        # Local (chunked/SWA) context attention — even-indexed layers.
+        if local_count > 0:
+            self.context_ops.append(
+                ops.ContextAttention(
+                    "context_attention",
+                    local_count,
+                    self._num_heads // tp_size,
+                    num_kv_heads_per_gpu,
+                    kvcache_quant_mode,
+                    fmha_quant_mode,
+                    window_size=cfg.attention_chunk_size,
+                    head_size=self._head_size,
+                )
+            )
+
+        # Global (full) context attention — odd-indexed layers.
+        if global_count > 0:
+            self.context_ops.append(
+                ops.ContextAttention(
+                    "context_attention",
+                    global_count,
+                    self._num_heads // tp_size,
+                    num_kv_heads_per_gpu,
+                    kvcache_quant_mode,
+                    fmha_quant_mode,
+                    window_size=0,
+                    head_size=self._head_size,
+                )
+            )
+
+        # Proj GEMM + post-attention norm (all layers).
+        self.context_ops.extend(
+            [
+                ops.GEMM("context_proj_gemm", self._num_layers, h, proj_in, gemm_quant_mode, low_precision_input=True),
+                ops.ElementWise("context_add_norm_2", self._num_layers, 2 * h, 2 * h, 0.8),
+            ]
+        )
+
+        # MoE FFN layers.
+        if moe_count > 0:
+            if self._num_experts >= 128:
+                self.context_ops.append(
+                    ops.GEMM(
+                        "context_router_gemm", moe_count, self._num_experts, h, common.GEMMQuantMode.float16
+                    )
+                )
+            self.context_ops.extend(
+                [
+                    ops.MoEDispatch(
+                        "context_moe_pre_dispatch",
+                        moe_count,
+                        h,
+                        self._topk,
+                        self._num_experts,
+                        moe_tp_size,
+                        moe_ep_size,
+                        attention_dp_size,
+                        True,
+                    ),
+                    ops.MoE(
+                        "context_moe",
+                        moe_count,
+                        h,
+                        self._moe_inter_size,
+                        self._topk,
+                        self._num_experts,
+                        moe_tp_size,
+                        moe_ep_size,
+                        moe_quant_mode,
+                        workload_distribution,
+                        attention_dp_size,
+                    ),
+                    ops.MoEDispatch(
+                        "context_moe_post_dispatch",
+                        moe_count,
+                        h,
+                        self._topk,
+                        self._num_experts,
+                        moe_tp_size,
+                        moe_ep_size,
+                        attention_dp_size,
+                        False,
+                    ),
+                ]
+            )
+
+        # Dense SwiGLU FFN layers (Maverick only; zero for Scout where step=1).
+        if dense_count > 0:
+            dense_inter_per_tp = cfg.dense_inter_size // tp_size
+            self.context_ops.extend(
+                [
+                    ops.GEMM("context_dense_gate_gemm", dense_count, dense_inter_per_tp, h, gemm_quant_mode),
+                    ops.GEMM("context_dense_up_gemm", dense_count, dense_inter_per_tp, h, gemm_quant_mode),
+                    ops.ElementWise(
+                        "context_dense_act", dense_count, dense_inter_per_tp, dense_inter_per_tp, 0.8
+                    ),
+                    ops.GEMM(
+                        "context_dense_down_gemm",
+                        dense_count,
+                        h,
+                        dense_inter_per_tp,
+                        gemm_quant_mode,
+                        low_precision_input=True,
+                    ),
+                ]
+            )
+
+        self.context_ops.append(ops.P2P("context_p2p", pp_size - 1, h, pp_size))
+
+    def _build_generation_ops(self) -> None:
+        if not self._llama4_config:
+            return
+
+        cfg = self._llama4_config
+        counts = self._count_layer_types()
+        moe_count = counts["moe"]
+        dense_count = counts["dense"]
+        local_count = counts["local"]
+        global_count = counts["global"]
+
+        h = self._hidden_size
+        tp_size = self.config.tp_size
+        moe_tp_size = self.config.moe_tp_size
+        moe_ep_size = self.config.moe_ep_size
+        attention_dp_size = self.config.attention_dp_size
+        pp_size = self.config.pp_size
+        num_kv_heads_per_gpu = self._num_kv_heads_per_gpu
+        gemm_quant_mode = self.config.gemm_quant_mode
+        kvcache_quant_mode = self.config.kvcache_quant_mode
+        moe_quant_mode = self.config.moe_quant_mode
+        workload_distribution = (
+            self.config.workload_distribution + f"_{self._power_law_alpha}"
+            if self.config.workload_distribution == "power_law"
+            else self.config.workload_distribution
+        )
+
+        qkv_out = self._num_heads * self._head_size // tp_size + self._head_size * num_kv_heads_per_gpu * 2
+        proj_in = self._num_heads * self._head_size // tp_size
+
+        self.generation_ops = [ops.Embedding("generation_embedding", 1, self._vocab_size, h, 0.3)]
+
+        self.generation_ops.extend(
+            [
+                ops.ElementWise("generation_add_norm_1", self._num_layers, 2 * h, 2 * h, 0.8),
+                ops.GEMM("generation_qkv_gemm", self._num_layers, qkv_out, h, gemm_quant_mode),
+            ]
+        )
+
+        # Local generation attention — even-indexed layers.
+        if local_count > 0:
+            self.generation_ops.append(
+                ops.GenerationAttention(
+                    "generation_attention",
+                    local_count,
+                    self._num_heads // tp_size,
+                    num_kv_heads_per_gpu,
+                    kvcache_quant_mode,
+                    window_size=cfg.attention_chunk_size,
+                    head_size=self._head_size,
+                )
+            )
+
+        # Global generation attention — odd-indexed layers.
+        if global_count > 0:
+            self.generation_ops.append(
+                ops.GenerationAttention(
+                    "generation_attention",
+                    global_count,
+                    self._num_heads // tp_size,
+                    num_kv_heads_per_gpu,
+                    kvcache_quant_mode,
+                    window_size=0,
+                    head_size=self._head_size,
+                )
+            )
+
+        self.generation_ops.extend(
+            [
+                ops.GEMM(
+                    "generation_proj_gemm", self._num_layers, h, proj_in, gemm_quant_mode, low_precision_input=True
+                ),
+                ops.ElementWise("generation_add_norm_2", self._num_layers, 2 * h, 2 * h, 0.8),
+            ]
+        )
+
+        if moe_count > 0:
+            if self._num_experts >= 128:
+                self.generation_ops.append(
+                    ops.GEMM(
+                        "generation_router_gemm", moe_count, self._num_experts, h, common.GEMMQuantMode.float16
+                    )
+                )
+            self.generation_ops.extend(
+                [
+                    ops.MoEDispatch(
+                        "generation_moe_pre_dispatch",
+                        moe_count,
+                        h,
+                        self._topk,
+                        self._num_experts,
+                        moe_tp_size,
+                        moe_ep_size,
+                        attention_dp_size,
+                        True,
+                    ),
+                    ops.MoE(
+                        "generation_moe",
+                        moe_count,
+                        h,
+                        self._moe_inter_size,
+                        self._topk,
+                        self._num_experts,
+                        moe_tp_size,
+                        moe_ep_size,
+                        moe_quant_mode,
+                        workload_distribution,
+                        attention_dp_size,
+                    ),
+                    ops.MoEDispatch(
+                        "generation_moe_post_dispatch",
+                        moe_count,
+                        h,
+                        self._topk,
+                        self._num_experts,
+                        moe_tp_size,
+                        moe_ep_size,
+                        attention_dp_size,
+                        False,
+                    ),
+                ]
+            )
+
+        if dense_count > 0:
+            dense_inter_per_tp = cfg.dense_inter_size // tp_size
+            self.generation_ops.extend(
+                [
+                    ops.GEMM("generation_dense_gate_gemm", dense_count, dense_inter_per_tp, h, gemm_quant_mode),
+                    ops.GEMM("generation_dense_up_gemm", dense_count, dense_inter_per_tp, h, gemm_quant_mode),
+                    ops.ElementWise(
+                        "generation_dense_act", dense_count, dense_inter_per_tp, dense_inter_per_tp, 0.8
+                    ),
+                    ops.GEMM(
+                        "generation_dense_down_gemm",
+                        dense_count,
+                        h,
+                        dense_inter_per_tp,
+                        gemm_quant_mode,
+                        low_precision_input=True,
+                    ),
+                ]
+            )
+
+        self.generation_ops.extend(
+            [
+                ops.GEMM(
+                    "generation_logits_gemm", 1, self._vocab_size // tp_size, h, common.GEMMQuantMode.float16
+                ),
+                ops.P2P("generation_p2p", pp_size - 1, h, pp_size),
+            ]
         )
 
 

--- a/src/aiconfigurator/sdk/utils.py
+++ b/src/aiconfigurator/sdk/utils.py
@@ -17,6 +17,7 @@ from aiconfigurator.sdk.common import (
     MULTIMODAL_TEXT_CONFIG_KEY,
     BlockConfig,
     DefaultHFModels,
+    Llama4Config,
 )
 
 logger = logging.getLogger(__name__)
@@ -505,6 +506,19 @@ def _parse_hf_config_json(config: dict) -> dict:
     elif architecture == "DeciLMForCausalLM":
         if "block_configs" in config:
             extra_params = _parse_nemotron_block_configs(config["block_configs"])
+    elif architecture == "Llama4ForConditionalGeneration":
+        extra_params = Llama4Config(
+            interleave_moe_layer_step=config.get("interleave_moe_layer_step", 1),
+            dense_inter_size=config.get("intermediate_size_mlp", 0),
+            attention_chunk_size=config.get("attention_chunk_size", 0),
+        )
+        moe_count = sum(1 for i in range(layers) if (i + 1) % extra_params.interleave_moe_layer_step == 0)
+        logger.info(
+            f"Llama4 config: interleave_moe_layer_step={extra_params.interleave_moe_layer_step}, "
+            f"moe_layers={moe_count}, dense_layers={layers - moe_count}, "
+            f"local_attn_layers={layers // 2}, global_attn_layers={layers - layers // 2}, "
+            f"attention_chunk_size={extra_params.attention_chunk_size}"
+        )
     return {
         "architecture": architecture,
         "layers": layers,

--- a/tests/unit/sdk/test_utils.py
+++ b/tests/unit/sdk/test_utils.py
@@ -186,6 +186,78 @@ class TestParseHFConfig:
         assert extra_params.moe_shared_expert_intermediate_size == 0
 
 
+    def test_parse_llama4_scout_config(self):
+        """Test parsing a Llama 4 Scout config (VLM with text_config nesting, all-MoE, step=1)."""
+        config = {
+            "architectures": ["Llama4ForConditionalGeneration"],
+            "model_type": "llama4",
+            "text_config": {
+                "num_hidden_layers": 48,
+                "hidden_size": 5120,
+                "num_attention_heads": 40,
+                "num_key_value_heads": 8,
+                "head_dim": 128,
+                "intermediate_size": 8192,
+                "intermediate_size_mlp": 16384,
+                "vocab_size": 202048,
+                "max_position_embeddings": 10485760,
+                "num_experts_per_tok": 1,
+                "num_local_experts": 16,
+                "interleave_moe_layer_step": 1,
+                "attention_chunk_size": 8192,
+            },
+        }
+
+        result = _parse_hf_config_json(config)
+
+        assert result["architecture"] == "Llama4ForConditionalGeneration"
+        assert result["layers"] == 48
+        assert result["hidden_size"] == 5120
+        assert result["n"] == 40
+        assert result["n_kv"] == 8
+        assert result["d"] == 128
+        assert result["topk"] == 1
+        assert result["num_experts"] == 16
+        assert result["moe_inter_size"] == 8192
+        extra_params = result["extra_params"]
+        assert extra_params is not None
+        assert extra_params.interleave_moe_layer_step == 1
+        assert extra_params.dense_inter_size == 16384
+        assert extra_params.attention_chunk_size == 8192
+
+    def test_parse_llama4_maverick_config(self):
+        """Test parsing a Llama 4 Maverick config (VLM, alternating MoE/dense, step=2)."""
+        config = {
+            "architectures": ["Llama4ForConditionalGeneration"],
+            "model_type": "llama4",
+            "text_config": {
+                "num_hidden_layers": 48,
+                "hidden_size": 5120,
+                "num_attention_heads": 40,
+                "num_key_value_heads": 8,
+                "head_dim": 128,
+                "intermediate_size": 8192,
+                "intermediate_size_mlp": 16384,
+                "vocab_size": 202048,
+                "max_position_embeddings": 1048576,
+                "num_experts_per_tok": 1,
+                "num_local_experts": 128,
+                "interleave_moe_layer_step": 2,
+                "attention_chunk_size": 8192,
+            },
+        }
+
+        result = _parse_hf_config_json(config)
+
+        assert result["architecture"] == "Llama4ForConditionalGeneration"
+        assert result["num_experts"] == 128
+        extra_params = result["extra_params"]
+        assert extra_params is not None
+        assert extra_params.interleave_moe_layer_step == 2
+        assert extra_params.dense_inter_size == 16384
+        assert extra_params.attention_chunk_size == 8192
+
+
 class TestGetModelConfigFromHFID:
     """Test getting model config from HuggingFace ID."""
 


### PR DESCRIPTION
## Summary

- **New models**: Llama 4 Scout (17B-16E) and Llama 4 Maverick (17B-128E) — Meta's latest MoE VLMs
- **New `Llama4Model` class** in `models.py` that handles Llama 4's unique hybrid architecture with deferred initialization via `set_llama4_config()`
- **VLM text_config unwrapping**: both models use `Llama4ForConditionalGeneration` with LLM params nested under `text_config`

## Architecture Details

Llama 4 has two interleaved patterns that differ between Scout and Maverick:

| | Scout (17B-16E) | Maverick (17B-128E) |
|---|---|---|
| Layers | 48 | 48 |
| Experts | 16 | 128 |
| Attention | 24 local (SWA, chunk=8192) + 24 global | same |
| FFN | 48 MoE (`step=1` → all MoE) | 24 MoE + 24 dense (`step=2` → alternating) |
| Dense FFN inter size | N/A | 16384 (`intermediate_size_mlp`) |
| MoE inter size | 8192 | 8192 |

**Key design decisions:**
- **Same KV dims for local and global attention** → no need for `HybridMoEModel`; two `ContextAttention` ops (one per type) suffice
- `interleave_moe_layer_step=1` for Scout means all 48 layers are MoE (zero dense layers)
- `interleave_moe_layer_step=2` for Maverick means odd-indexed layers are MoE, even-indexed use dense SwiGLU FFN
- Router GEMM (`context_router_gemm`) only included when `num_experts >= 128` (fires for Maverick, not Scout)

## Files Changed

- `src/aiconfigurator/sdk/common.py`: `Llama4Config` dataclass, `ARCHITECTURE_TO_MODEL_FAMILY`, `MULTIMODAL_TEXT_CONFIG_KEY`, `DefaultHFModels`
- `src/aiconfigurator/sdk/utils.py`: parse `interleave_moe_layer_step`, `intermediate_size_mlp`, `attention_chunk_size` into `Llama4Config`
- `src/aiconfigurator/sdk/models.py`: new `Llama4Model` class, wired into `get_model()` within the `MOE` branch
- `src/aiconfigurator/model_configs/meta-llama--Llama-4-Scout-17B-16E-Instruct_config.json`: HF config
- `src/aiconfigurator/model_configs/meta-llama--Llama-4-Maverick-17B-128E-Instruct_config.json`: HF config
- `tests/unit/sdk/test_utils.py`: two new unit tests for Llama 4 VLM config parsing

## Test plan

- [x] `pytest tests/unit/sdk/test_utils.py -v` — both new Llama 4 tests pass
- [x] Full unit suite: 457 passed (10 pre-existing multiprocessing sandbox failures unrelated to this PR)
- [x] CLI smoke test: `check_is_moe()` returns `True` for both models
- [x] Validated op scale factors: Scout has 48 MoE layers, Maverick has 24 MoE + 24 dense


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for two new Llama-4 model variants: Maverick 17B 128E and Scout 17B 16E with Mixture of Experts architecture.

* **Tests**
  * Added unit tests for new model configuration parsing and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->