### PR TITLE
feat: attention imbalance correction scale interface && qwen3 qk norm io

### DIFF
--- a/src/aiconfigurator/sdk/backends/base_backend.py
+++ b/src/aiconfigurator/sdk/backends/base_backend.py
@@ -86,6 +86,7 @@ class BaseBackend(ABC):
                     s=isl,
                     prefix=prefix,
                     model_name=getattr(model, "model_name", ""),
+                    seq_imbalance_correction_scale=runtime_config.seq_imbalance_correction_scale,
                 )
 
                 # ✅ IMMEDIATELY extract values - do NOT use PerformanceResult arithmetic!
@@ -126,6 +127,7 @@ class BaseBackend(ABC):
                         beam_width=beam_width,
                         s=isl + i + 1,
                         model_name=getattr(model, "model_name", ""),
+                        gen_seq_imbalance_correction_scale=runtime_config.gen_seq_imbalance_correction_scale,
                     )
 
                     latency_ms = float(result)

--- a/src/aiconfigurator/sdk/backends/sglang_backend.py
+++ b/src/aiconfigurator/sdk/backends/sglang_backend.py
@@ -37,6 +37,8 @@ class SGLANGBackend(BaseBackend):
         osl = runtime_config.osl
         prefix = runtime_config.prefix
         b = runtime_config.batch_size
+        ctx_seq_imbalance_correction_scale = runtime_config.seq_imbalance_correction_scale
+        gen_seq_imbalance_correction_scale = runtime_config.gen_seq_imbalance_correction_scale
         ctx_tokens = kwargs.get("ctx_tokens")
         assert ctx_tokens is not None, "ctx_tokens is required"
         balance_score = isl * b / ctx_tokens / osl
@@ -104,7 +106,12 @@ class SGLANGBackend(BaseBackend):
                     database,
                     # num tokens for gemm needs to be adjusted for prefix, depends on the avg prefix len per request
                     RuntimeConfig(
-                        batch_size=1, beam_width=1, isl=num_tokens, osl=1, prefix=prefix * np.floor(ctx_tokens / isl)
+                        batch_size=1,
+                        beam_width=1,
+                        isl=num_tokens,
+                        osl=1,
+                        prefix=prefix * np.floor(ctx_tokens / isl),
+                        seq_imbalance_correction_scale=ctx_seq_imbalance_correction_scale,
                     ),
                     mode="static_ctx",
                 )
@@ -127,7 +134,14 @@ class SGLANGBackend(BaseBackend):
                 summary = self.run_static(
                     model,
                     database,
-                    RuntimeConfig(batch_size=batch_size, beam_width=1, isl=num_tokens, osl=1, prefix=prefix),
+                    RuntimeConfig(
+                        batch_size=batch_size,
+                        beam_width=1,
+                        isl=num_tokens,
+                        osl=1,
+                        prefix=prefix,
+                        seq_imbalance_correction_scale=ctx_seq_imbalance_correction_scale,
+                    ),
                     mode="static_ctx",
                 )
                 latency_dict = summary.get_context_latency_dict()
@@ -142,7 +156,13 @@ class SGLANGBackend(BaseBackend):
                     summary = self.run_static(
                         model,
                         database,
-                        RuntimeConfig(batch_size=num_tokens, beam_width=1, isl=isl + osl // 2, osl=2),
+                        RuntimeConfig(
+                            batch_size=num_tokens,
+                            beam_width=1,
+                            isl=isl + osl // 2,
+                            osl=2,
+                            gen_seq_imbalance_correction_scale=gen_seq_imbalance_correction_scale,
+                        ),
                         mode="static_gen",
                     )
                     latency_dict = summary.get_generation_latency_dict()
@@ -181,7 +201,13 @@ class SGLANGBackend(BaseBackend):
                 summary = self.run_static(
                     model,
                     database,
-                    RuntimeConfig(batch_size=num_tokens, beam_width=1, isl=isl + osl // 2, osl=2),
+                    RuntimeConfig(
+                        batch_size=num_tokens,
+                        beam_width=1,
+                        isl=isl + osl // 2,
+                        osl=2,
+                        gen_seq_imbalance_correction_scale=gen_seq_imbalance_correction_scale,
+                    ),
                     mode="static_gen",
                 )
                 latency_dict = summary.get_generation_latency_dict()
@@ -438,7 +464,13 @@ class SGLANGBackend(BaseBackend):
                 summary = self.run_agg(
                     model=model,
                     database=database,
-                    runtime_config=RuntimeConfig(batch_size=b, isl=isl, osl=osl, prefix=prefix),
+                    runtime_config=RuntimeConfig(
+                        batch_size=b,
+                        isl=isl,
+                        osl=osl,
+                        prefix=prefix,
+                        seq_imbalance_correction_scale=runtime_config.seq_imbalance_correction_scale,
+                    ),
                     ctx_tokens=ctx_tokens,
                 )
 

--- a/src/aiconfigurator/sdk/backends/trtllm_backend.py
+++ b/src/aiconfigurator/sdk/backends/trtllm_backend.py
@@ -39,6 +39,8 @@ class TRTLLMBackend(BaseBackend):
         osl = runtime_config.osl
         prefix = runtime_config.prefix
         b = runtime_config.batch_size
+        ctx_seq_imbalance_correction_scale = runtime_config.seq_imbalance_correction_scale
+        gen_seq_imbalance_correction_scale = runtime_config.gen_seq_imbalance_correction_scale
         ctx_tokens = kwargs.get("ctx_tokens")
         assert ctx_tokens is not None, "ctx_tokens is required"
         balance_score = isl * b / ctx_tokens / osl
@@ -106,7 +108,12 @@ class TRTLLMBackend(BaseBackend):
                     database,
                     # num tokens for gemm needs to be adjusted for prefix, depends on the avg prefix len per request
                     RuntimeConfig(
-                        batch_size=1, beam_width=1, isl=num_tokens, osl=1, prefix=prefix * np.floor(ctx_tokens / isl)
+                        batch_size=1,
+                        beam_width=1,
+                        isl=num_tokens,
+                        osl=1,
+                        prefix=prefix * np.floor(ctx_tokens / isl),
+                        seq_imbalance_correction_scale=ctx_seq_imbalance_correction_scale,
                     ),
                     mode="static_ctx",
                 )
@@ -129,7 +136,14 @@ class TRTLLMBackend(BaseBackend):
                 summary = self.run_static(
                     model,
                     database,
-                    RuntimeConfig(batch_size=batch_size, beam_width=1, isl=num_tokens, osl=1, prefix=prefix),
+                    RuntimeConfig(
+                        batch_size=batch_size,
+                        beam_width=1,
+                        isl=num_tokens,
+                        osl=1,
+                        prefix=prefix,
+                        seq_imbalance_correction_scale=ctx_seq_imbalance_correction_scale,
+                    ),
                     mode="static_ctx",
                 )
                 latency_dict = summary.get_context_latency_dict()
@@ -146,7 +160,13 @@ class TRTLLMBackend(BaseBackend):
                     summary = self.run_static(
                         model,
                         database,
-                        RuntimeConfig(batch_size=num_tokens, beam_width=1, isl=isl + osl // 2, osl=2),
+                        RuntimeConfig(
+                            batch_size=num_tokens,
+                            beam_width=1,
+                            isl=isl + osl // 2,
+                            osl=2,
+                            gen_seq_imbalance_correction_scale=gen_seq_imbalance_correction_scale,
+                        ),
                         mode="static_gen",
                     )
                     latency_dict = summary.get_generation_latency_dict()
@@ -182,7 +202,13 @@ class TRTLLMBackend(BaseBackend):
                 summary = self.run_static(
                     model,
                     database,
-                    RuntimeConfig(batch_size=num_tokens, beam_width=1, isl=isl + osl // 2, osl=2),
+                    RuntimeConfig(
+                        batch_size=num_tokens,
+                        beam_width=1,
+                        isl=isl + osl // 2,
+                        osl=2,
+                        gen_seq_imbalance_correction_scale=gen_seq_imbalance_correction_scale,
+                    ),
                     mode="static_gen",
                 )
                 latency_dict = summary.get_generation_latency_dict()
@@ -439,7 +465,13 @@ class TRTLLMBackend(BaseBackend):
                 summary = self.run_agg(
                     model=model,
                     database=database,
-                    runtime_config=RuntimeConfig(batch_size=b, isl=isl, osl=osl, prefix=prefix),
+                    runtime_config=RuntimeConfig(
+                        batch_size=b,
+                        isl=isl,
+                        osl=osl,
+                        prefix=prefix,
+                        seq_imbalance_correction_scale=runtime_config.seq_imbalance_correction_scale,
+                    ),
                     ctx_tokens=ctx_tokens,
                 )
 

--- a/src/aiconfigurator/sdk/backends/vllm_backend.py
+++ b/src/aiconfigurator/sdk/backends/vllm_backend.py
@@ -39,6 +39,8 @@ class VLLMBackend(BaseBackend):
         osl = runtime_config.osl
         prefix = runtime_config.prefix
         b = runtime_config.batch_size
+        ctx_seq_imbalance_correction_scale = runtime_config.seq_imbalance_correction_scale
+        gen_seq_imbalance_correction_scale = runtime_config.gen_seq_imbalance_correction_scale
         ctx_tokens = kwargs.get("ctx_tokens")
         assert ctx_tokens is not None, "ctx_tokens is required"
         balance_score = isl * b / ctx_tokens / osl
@@ -106,7 +108,12 @@ class VLLMBackend(BaseBackend):
                     database,
                     # num tokens for gemm needs to be adjusted for prefix, depends on the avg prefix len per request
                     RuntimeConfig(
-                        batch_size=1, beam_width=1, isl=num_tokens, osl=1, prefix=prefix * np.floor(ctx_tokens / isl)
+                        batch_size=1,
+                        beam_width=1,
+                        isl=num_tokens,
+                        osl=1,
+                        prefix=prefix * np.floor(ctx_tokens / isl),
+                        seq_imbalance_correction_scale=ctx_seq_imbalance_correction_scale,
                     ),
                     mode="static_ctx",
                 )
@@ -129,7 +136,14 @@ class VLLMBackend(BaseBackend):
                 summary = self.run_static(
                     model,
                     database,
-                    RuntimeConfig(batch_size=batch_size, beam_width=1, isl=num_tokens, osl=1, prefix=prefix),
+                    RuntimeConfig(
+                        batch_size=batch_size,
+                        beam_width=1,
+                        isl=num_tokens,
+                        osl=1,
+                        prefix=prefix,
+                        seq_imbalance_correction_scale=ctx_seq_imbalance_correction_scale,
+                    ),
                     mode="static_ctx",
                 )
                 latency_dict = summary.get_context_latency_dict()
@@ -146,7 +160,13 @@ class VLLMBackend(BaseBackend):
                     summary = self.run_static(
                         model,
                         database,
-                        RuntimeConfig(batch_size=num_tokens, beam_width=1, isl=isl + osl // 2, osl=2),
+                        RuntimeConfig(
+                            batch_size=num_tokens,
+                            beam_width=1,
+                            isl=isl + osl // 2,
+                            osl=2,
+                            gen_seq_imbalance_correction_scale=gen_seq_imbalance_correction_scale,
+                        ),
                         mode="static_gen",
                     )
                     latency_dict = summary.get_generation_latency_dict()
@@ -182,7 +202,13 @@ class VLLMBackend(BaseBackend):
                 summary = self.run_static(
                     model,
                     database,
-                    RuntimeConfig(batch_size=num_tokens, beam_width=1, isl=isl + osl // 2, osl=2),
+                    RuntimeConfig(
+                        batch_size=num_tokens,
+                        beam_width=1,
+                        isl=isl + osl // 2,
+                        osl=2,
+                        gen_seq_imbalance_correction_scale=gen_seq_imbalance_correction_scale,
+                    ),
                     mode="static_gen",
                 )
                 latency_dict = summary.get_generation_latency_dict()
@@ -439,7 +465,13 @@ class VLLMBackend(BaseBackend):
                 summary = self.run_agg(
                     model=model,
                     database=database,
-                    runtime_config=RuntimeConfig(batch_size=b, isl=isl, osl=osl, prefix=prefix),
+                    runtime_config=RuntimeConfig(
+                        batch_size=b,
+                        isl=isl,
+                        osl=osl,
+                        prefix=prefix,
+                        seq_imbalance_correction_scale=runtime_config.seq_imbalance_correction_scale,
+                    ),
                     ctx_tokens=ctx_tokens,
                 )
 

--- a/src/aiconfigurator/sdk/config.py
+++ b/src/aiconfigurator/sdk/config.py
@@ -51,3 +51,6 @@ class RuntimeConfig:
     ttft: float = None
     tpot: Union[float, list] = None
     request_latency: float = None  # it works together with ttft. 1. <= req_lat 2. <= req_lat and <= ttft
+    seq_imbalance_correction_scale: float = 1.0
+    # Separate correction scale for generation/decoding stage (do NOT reuse ctx scale).
+    gen_seq_imbalance_correction_scale: float = 1.0

--- a/src/aiconfigurator/sdk/models.py
+++ b/src/aiconfigurator/sdk/models.py
@@ -194,6 +194,7 @@ def get_model(
             vocab,
             context,
             model_config,
+            extra_params,
         )
     elif model_family == "LLAMA":
         model = LLAMAModel(
@@ -209,6 +210,7 @@ def get_model(
             vocab,
             context,
             model_config,
+            extra_params,
         )
     elif model_family == "HYBRIDMOE":
         model = HybridMoEModel(
@@ -247,6 +249,7 @@ def get_model(
             vocab,
             context,
             model_config,
+            extra_params,
         )
     elif model_family == "DEEPSEEK":
         if backend_name == "sglang" and model_config.enable_wideep:
@@ -286,6 +289,7 @@ def get_model(
                 vocab,
                 context,
                 model_config,
+                extra_params,
             )
         else:
             logger.debug(f"WideEP is not enabled for model {model_path} with backend {backend_name}")
@@ -305,6 +309,7 @@ def get_model(
                 vocab,
                 context,
                 model_config,
+                extra_params,
             )
     elif model_family == "NEMOTRONNAS":
         model = NemotronNas(
@@ -321,8 +326,18 @@ def get_model(
             context,
             model_config,
         )
-        model.context_ops = extra_params
-        model.generation_ops = extra_params
+        # NemotronNAS uses extra_params as a list of BlockConfig to build its pipelines.
+        # Not all model metadata sources carry these NAS block configs, so only apply them when provided.
+        if isinstance(extra_params, list):
+            model.context_ops = extra_params
+            model.generation_ops = extra_params
+        else:
+            logger.warning(
+                "NemotronNAS model '%s' missing block configs in model metadata; leaving pipelines empty.",
+                model_path,
+            )
+            model.context_ops = []
+            model.generation_ops = []
     elif model_family == "NEMOTRONH":
         model = NemotronHModel(
             topk,
@@ -412,11 +427,14 @@ class BaseModel:
         vocab_size: int,
         context_length: int,
         model_config: config.ModelConfig,
+        extra_params=None,
     ) -> None:
         self.model_path = model_path
         self.model_family = model_family
         self.architecture = architecture
         self.config = model_config
+        self.extra_params = extra_params
+        self._use_qk_norm = bool(extra_params.get("use_qk_norm", False)) if isinstance(extra_params, dict) else False
         self.context_ops = []
         self.generation_ops = []
 
@@ -647,6 +665,8 @@ class LLAMAModel(BaseModel):
                     num_kv_heads_per_gpu,
                     kvcache_quant_mode,
                     fmha_quant_mode,
+                    head_size=self._head_size,
+                    use_qk_norm=self._use_qk_norm,
                 ),
                 ops.GEMM(
                     "context_proj_gemm",
@@ -706,6 +726,8 @@ class LLAMAModel(BaseModel):
                     self._num_heads // tp_size,
                     num_kv_heads_per_gpu,
                     kvcache_quant_mode,
+                    head_size=self._head_size,
+                    use_qk_norm=self._use_qk_norm,
                 ),
                 ops.GEMM(
                     "generation_proj_gemm",
@@ -841,8 +863,9 @@ class MOEModel(BaseModel):
                     num_kv_heads_per_gpu,
                     kvcache_quant_mode,
                     fmha_quant_mode,
-                    window_size,
-                    self._head_size,
+                    window_size=window_size,
+                    head_size=self._head_size,
+                    use_qk_norm=self._use_qk_norm,
                 )
             )
             self.generation_ops.append(
@@ -852,8 +875,9 @@ class MOEModel(BaseModel):
                     self._num_heads // tp_size,
                     num_kv_heads_per_gpu,
                     kvcache_quant_mode,
-                    window_size,
-                    self._head_size,
+                    window_size=window_size,
+                    head_size=self._head_size,
+                    use_qk_norm=self._use_qk_norm,
                 )
             )
         else:
@@ -878,6 +902,7 @@ class MOEModel(BaseModel):
                     kvcache_quant_mode,
                     fmha_quant_mode,
                     head_size=self._head_size,
+                    use_qk_norm=self._use_qk_norm,
                 ),
                 ops.GEMM(
                     "context_proj_gemm",
@@ -966,6 +991,7 @@ class MOEModel(BaseModel):
                     num_kv_heads_per_gpu,
                     kvcache_quant_mode,
                     head_size=self._head_size,
+                    use_qk_norm=self._use_qk_norm,
                 ),
                 ops.GEMM(
                     "generation_proj_gemm",

--- a/src/aiconfigurator/sdk/models.py
+++ b/src/aiconfigurator/sdk/models.py
@@ -429,6 +429,7 @@ class BaseModel:
         model_config: config.ModelConfig,
         extra_params=None,
     ) -> None:
+        """Initialize base model metadata and derived runtime flags."""
         self.model_path = model_path
         self.model_family = model_family
         self.architecture = architecture

--- a/src/aiconfigurator/sdk/operations.py
+++ b/src/aiconfigurator/sdk/operations.py
@@ -851,6 +851,7 @@ class ContextAttention(Operation):
         head_size: int = 128,
         use_qk_norm: bool = False,
     ) -> None:
+        """Initialize context attention query parameters."""
         super().__init__(name, scale_factor)
         self._n = n
         self._weights = 0.0
@@ -919,6 +920,7 @@ class GenerationAttention(Operation):
         head_size: int = 128,
         use_qk_norm: bool = False,
     ) -> None:
+        """Initialize generation attention query parameters."""
         super().__init__(name, scale_factor)
         self._n = n
         self._weights = 0.0

--- a/src/aiconfigurator/sdk/operations.py
+++ b/src/aiconfigurator/sdk/operations.py
@@ -849,6 +849,7 @@ class ContextAttention(Operation):
         fmha_quant_mode: common.FMHAQuantMode,
         window_size: int = 0,
         head_size: int = 128,
+        use_qk_norm: bool = False,
     ) -> None:
         super().__init__(name, scale_factor)
         self._n = n
@@ -858,6 +859,7 @@ class ContextAttention(Operation):
         self._fmha_quant_mode = fmha_quant_mode
         self._window_size = window_size
         self._head_size = head_size
+        self._use_qk_norm = use_qk_norm
 
     def query(self, database: PerfDatabase, **kwargs) -> PerformanceResult:
         """Query context attention latency with energy data."""
@@ -876,6 +878,25 @@ class ContextAttention(Operation):
             window_size=self._window_size,
             head_size=self._head_size,
         )
+        q_num = self._n * self._head_size
+        k_num = self._n_kv * self._head_size
+        v_num = self._n_kv * self._head_size
+        extra_latency = 0
+        if self._use_qk_norm:
+            qk_norm_latency = 2 * database.query_mem_op(q_num * 2) + 2 * database.query_mem_op(k_num * 2)
+            extra_latency += qk_norm_latency * 2  # elementwise before norm
+        apply_rope_latency = 2 * database.query_mem_op(q_num * 2 + k_num * 2)  # apply rope
+
+        kv_write_latency = database.query_mem_op(k_num * self._fmha_quant_mode.value.memory) + database.query_mem_op(
+            v_num * self._fmha_quant_mode.value.memory
+        )
+        extra_latency += apply_rope_latency + kv_write_latency
+        result += extra_latency * 1.1  # correction factor for extra latency
+
+        seq_imbalance_correction_scale = float(kwargs.get("seq_imbalance_correction_scale", 1.0))
+        if seq_imbalance_correction_scale != 1.0:
+            result = result * seq_imbalance_correction_scale
+
         return PerformanceResult(float(result) * self._scale_factor, energy=result.energy * self._scale_factor)
 
     def get_weights(self, **kwargs):
@@ -896,6 +917,7 @@ class GenerationAttention(Operation):
         kv_cache_dtype: common.KVCacheQuantMode,
         window_size: int = 0,
         head_size: int = 128,
+        use_qk_norm: bool = False,
     ) -> None:
         super().__init__(name, scale_factor)
         self._n = n
@@ -904,6 +926,7 @@ class GenerationAttention(Operation):
         self._kv_cache_dtype = kv_cache_dtype
         self._window_size = window_size
         self._head_size = head_size
+        self._use_qk_norm = use_qk_norm
 
     def query(self, database: PerfDatabase, **kwargs) -> PerformanceResult:
         """Query generation attention latency with energy data."""
@@ -922,6 +945,16 @@ class GenerationAttention(Operation):
             window_size=self._window_size,
             head_size=self._head_size,
         )
+        # Generation/decoding stage uses a separate correction scale (do NOT reuse ctx scale).
+        # Backward-compatible fallback: if only the old key is provided, use it.
+        gen_seq_imbalance_correction_scale = float(
+            kwargs.get(
+                "gen_seq_imbalance_correction_scale",
+                kwargs.get("seq_imbalance_correction_scale", 1.0),
+            )
+        )
+        if gen_seq_imbalance_correction_scale != 1.0:
+            result = result * gen_seq_imbalance_correction_scale
         return PerformanceResult(float(result) * self._scale_factor, energy=result.energy * self._scale_factor)
 
     def get_weights(self, **kwargs):

--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -3884,9 +3884,22 @@ class PerfDatabase:
                 attention_dict = self._generation_attention_data[kvcache_quant_mode][n_kv_lookup][head_size][
                     window_size
                 ]
-                result = self._interp_3d(n, b, s, attention_dict, "bilinear")
-                latency = result["latency"]
-                energy = result.get("energy", 0.0)
+                # Decode batches often contain a mix of sequence lengths around the nominal KV length `s`.
+                # Using a single point (n,b,s) can be noisy/inaccurate, so average a small neighborhood.
+                s_min = max(1, int(s * 0.9))
+                s_max = max(s_min, int(s * 1.1))
+                sample_cnt = 5
+                s_samples = [s_min + (s_max - s_min) * i // (sample_cnt - 1) for i in range(sample_cnt)]
+
+                latency_sum = 0.0
+                energy_sum = 0.0
+                for s_i in s_samples:
+                    r = self._interp_3d(n, b, s_i, attention_dict, "bilinear")
+                    latency_sum += float(r["latency"])
+                    energy_sum += float(r.get("energy", 0.0))
+
+                latency = latency_sum / sample_cnt
+                energy = energy_sum / sample_cnt
                 return PerformanceResult(latency, energy=energy)
 
             return self._query_silicon_or_hybrid(

--- a/src/aiconfigurator/sdk/utils.py
+++ b/src/aiconfigurator/sdk/utils.py
@@ -561,6 +561,10 @@ def _parse_hf_config_json(config: dict) -> dict:
             f"moe_layers={sum(moe_freq)}, dense_layers={moe_freq.count(0)}, "
             f"sliding_window_size={extra_params.sliding_window_size}"
         )
+    elif architecture in {"Qwen3ForCausalLM", "Qwen3MoeForCausalLM"}:
+        # Qwen3-family attention may include additional Q/K normalization.
+        extra_params = {"architecture": architecture, "use_qk_norm": True}
+
     return {
         "architecture": architecture,
         "layers": layers,

--- a/tests/unit/sdk/database/test_attention.py
+++ b/tests/unit/sdk/database/test_attention.py
@@ -181,7 +181,15 @@ class TestGenerationAttention:
         )
 
         # Should use n_kv=0 for MHA
-        expected = comprehensive_perf_db._generation_attention_data[kv_cache_quant_mode][0][128][0][n][b][s]
+        attention_dict = comprehensive_perf_db._generation_attention_data[kv_cache_quant_mode][0][128][0]
+        s_min = max(1, int(s * 0.9))
+        s_max = max(s_min, int(s * 1.1))
+        sample_cnt = 5
+        s_samples = [s_min + (s_max - s_min) * i // (sample_cnt - 1) for i in range(sample_cnt)]
+        expected = (
+            sum(comprehensive_perf_db._interp_3d(n, b, s_i, attention_dict, "bilinear")["latency"] for s_i in s_samples)
+            / sample_cnt
+        )
 
         assert math.isclose(result, expected, rel_tol=1e-6)
 


### PR DESCRIPTION
## Overview
Add attention imbalance correction scale interfaces and wire Qwen3 qk_norm metadata through model config parsing and model IO.
## Details
- `aiconfigurator/src/aiconfigurator/sdk/operations.py`
  - Add attention imbalance correction scale interface for attention latency estimation.
- `aiconfigurator/src/aiconfigurator/sdk/utils.py`
  - Parse Qwen3-specific qk_norm metadata from model configs.
- `aiconfigurator/src/aiconfigurator/sdk/models.py`
  - Propagate Qwen3 qk_norm-related metadata through model construction paths.
- `aiconfigurator/src/aiconfigurator/sdk/common.py`
  - Remove legacy static model table usage and keep the flow aligned with config-driven parsing.
- `aiconfigurator/src/aiconfigurator/sdk/perf_database.py`
  - Update related query path handling for the new correction-scale interface.
## Where should the reviewer start
Start with `aiconfigurator/src/aiconfigurator/sdk/operations.py`, then review `aiconfigurator/src/aiconfigurator/sdk/utils.py` and `aiconfigurator/src/aiconfigurator/sdk/models.py`.
## Related Issues
- N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced sequence imbalance correction scale parameters to independently fine-tune performance estimation for context and generation phases.
  * Added QK-normalization support in attention mechanisms.

* **Improvements**
  * Enhanced generation attention performance estimation accuracy through neighborhood sampling of KV cache lengths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->