### PR TITLE
fix(generator): SGLang MoE — stop passing invalid moe-dense-tp-size

### DIFF
--- a/src/aiconfigurator/generator/config/backend_config_mapping.yaml
+++ b/src/aiconfigurator/generator/config/backend_config_mapping.yaml
@@ -36,7 +36,8 @@ parameters:
 - param_key: moe_tensor_parallel_size
   vllm: null
   # https://github.com/sgl-project/sglang/issues/8530
-  # sglang moe_tensor_parallel_size only supports 1 or None for now
+  # SGLang: expert MoE TP is folded into tensor-parallel-size (see sglang.rule). Do not map to
+  # --moe-dense-tp-size (dense sublayers only; SGLang allows 1 or None).
   sglang: null
   trtllm: null
 

--- a/src/aiconfigurator/generator/config/backend_templates/sglang/cli_args.0.5.1.post1.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/sglang/cli_args.0.5.1.post1.j2
@@ -12,7 +12,6 @@
 {%- if sglang['trust-remote-code'] -%}{%- set _ = args.append('--trust-remote-code') -%}{%- endif -%}
 {%- if sglang['enable-dp-attention'] -%}{%- set _ = args.append('--enable-dp-attention') -%}{%- endif -%}
 {%- if sglang['expert-parallel-size'] is defined -%}{%- set _ = args.append('--expert-parallel-size "' ~ sglang['expert-parallel-size'] ~ '"') -%}{%- endif -%}
-{%- if sglang['moe-dense-tp-size'] is defined -%}{%- set _ = args.append('--moe-dense-tp-size "' ~ sglang['moe-dense-tp-size'] ~ '"') -%}{%- endif -%}
 {%- if sglang['disable-cuda-graph'] -%}{%- set _ = args.append('--disable-cuda-graph') -%}{%- endif -%}
 {%- if sglang['cuda-graph-bs'] is defined -%}{%- set _ = args.append('--cuda-graph-bs ' ~ (sglang['cuda-graph-bs'] | join(' '))) -%}{%- endif -%}
 {%- if sglang['disable-cuda-graph-padding'] -%}{%- set _ = args.append('--disable-cuda-graph-padding') -%}{%- endif -%}

--- a/src/aiconfigurator/generator/config/backend_templates/sglang/cli_args.0.5.3.post2.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/sglang/cli_args.0.5.3.post2.j2
@@ -12,7 +12,6 @@
 {%- if sglang['trust-remote-code'] -%}{%- set _ = args.append('--trust-remote-code') -%}{%- endif -%}
 {%- if sglang['enable-dp-attention'] -%}{%- set _ = args.append('--enable-dp-attention') -%}{%- endif -%}
 {%- if sglang['expert-parallel-size'] is defined -%}{%- set _ = args.append('--expert-parallel-size "' ~ sglang['expert-parallel-size'] ~ '"') -%}{%- endif -%}
-{%- if sglang['moe-dense-tp-size'] is defined -%}{%- set _ = args.append('--moe-dense-tp-size "' ~ sglang['moe-dense-tp-size'] ~ '"') -%}{%- endif -%}
 {%- if sglang['disable-cuda-graph'] -%}{%- set _ = args.append('--disable-cuda-graph') -%}{%- endif -%}
 {%- if sglang['cuda-graph-bs'] is defined -%}{%- set _ = args.append('--cuda-graph-bs ' ~ (sglang['cuda-graph-bs'] | join(' '))) -%}{%- endif -%}
 {%- if sglang['disable-cuda-graph-padding'] -%}{%- set _ = args.append('--disable-cuda-graph-padding') -%}{%- endif -%}

--- a/src/aiconfigurator/generator/config/backend_templates/sglang/cli_args.0.5.4.post3.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/sglang/cli_args.0.5.4.post3.j2
@@ -12,7 +12,6 @@
 {%- if sglang['trust-remote-code'] -%}{%- set _ = args.append('--trust-remote-code') -%}{%- endif -%}
 {%- if sglang['enable-dp-attention'] -%}{%- set _ = args.append('--enable-dp-attention') -%}{%- endif -%}
 {%- if sglang['expert-parallel-size'] is defined -%}{%- set _ = args.append('--expert-parallel-size "' ~ sglang['expert-parallel-size'] ~ '"') -%}{%- endif -%}
-{%- if sglang['moe-dense-tp-size'] is defined -%}{%- set _ = args.append('--moe-dense-tp-size "' ~ sglang['moe-dense-tp-size'] ~ '"') -%}{%- endif -%}
 {%- if sglang['disable-cuda-graph'] -%}{%- set _ = args.append('--disable-cuda-graph') -%}{%- endif -%}
 {%- if sglang['cuda-graph-bs'] is defined -%}{%- set _ = args.append('--cuda-graph-bs ' ~ (sglang['cuda-graph-bs'] | join(' '))) -%}{%- endif -%}
 {%- if sglang['speculative-algorithm'] is defined -%}{%- set _ = args.append('--speculative-algorithm "' ~ sglang['speculative-algorithm'] ~ '"') -%}{%- endif -%}

--- a/src/aiconfigurator/generator/config/backend_templates/sglang/cli_args.0.5.6.post2.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/sglang/cli_args.0.5.6.post2.j2
@@ -12,7 +12,6 @@
 {%- if sglang['trust-remote-code'] -%}{%- set _ = args.append('--trust-remote-code') -%}{%- endif -%}
 {%- if sglang['enable-dp-attention'] -%}{%- set _ = args.append('--enable-dp-attention') -%}{%- endif -%}
 {%- if sglang['expert-parallel-size'] is defined -%}{%- set _ = args.append('--expert-parallel-size "' ~ sglang['expert-parallel-size'] ~ '"') -%}{%- endif -%}
-{%- if sglang['moe-dense-tp-size'] is defined -%}{%- set _ = args.append('--moe-dense-tp-size "' ~ sglang['moe-dense-tp-size'] ~ '"') -%}{%- endif -%}
 {%- if sglang['disable-cuda-graph'] -%}{%- set _ = args.append('--disable-cuda-graph') -%}{%- endif -%}
 {%- if sglang['cuda-graph-bs'] is defined -%}{%- set _ = args.append('--cuda-graph-bs ' ~ (sglang['cuda-graph-bs'] | join(' '))) -%}{%- endif -%}
 {%- if sglang['speculative-algorithm'] is defined -%}{%- set _ = args.append('--speculative-algorithm "' ~ sglang['speculative-algorithm'] ~ '"') -%}{%- endif -%}

--- a/src/aiconfigurator/generator/config/backend_templates/sglang/cli_args.0.5.8.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/sglang/cli_args.0.5.8.j2
@@ -12,7 +12,6 @@
 {%- if sglang['trust-remote-code'] -%}{%- set _ = args.append('--trust-remote-code') -%}{%- endif -%}
 {%- if sglang['enable-dp-attention'] -%}{%- set _ = args.append('--enable-dp-attention') -%}{%- endif -%}
 {%- if sglang['expert-parallel-size'] is defined -%}{%- set _ = args.append('--expert-parallel-size "' ~ sglang['expert-parallel-size'] ~ '"') -%}{%- endif -%}
-{%- if sglang['moe-dense-tp-size'] is defined -%}{%- set _ = args.append('--moe-dense-tp-size "' ~ sglang['moe-dense-tp-size'] ~ '"') -%}{%- endif -%}
 {%- if sglang['disable-cuda-graph'] -%}{%- set _ = args.append('--disable-cuda-graph') -%}{%- endif -%}
 {%- if sglang['cuda-graph-bs'] is defined -%}{%- set _ = args.append('--cuda-graph-bs ' ~ (sglang['cuda-graph-bs'] | join(' '))) -%}{%- endif -%}
 {%- if sglang['speculative-algorithm'] is defined -%}{%- set _ = args.append('--speculative-algorithm "' ~ sglang['speculative-algorithm'] ~ '"') -%}{%- endif -%}

--- a/src/aiconfigurator/generator/config/backend_templates/sglang/cli_args.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/sglang/cli_args.j2
@@ -16,7 +16,6 @@
 {%- if sglang['disable-radix-cache'] -%}{%- set _ = args.append('--disable-radix-cache') -%}{%- endif -%}
 {%- if sglang['enable-dp-attention'] -%}{%- set _ = args.append('--enable-dp-attention') -%}{%- endif -%}
 {%- if sglang['expert-parallel-size'] is defined -%}{%- set _ = args.append('--expert-parallel-size "' ~ sglang['expert-parallel-size'] ~ '"') -%}{%- endif -%}
-{%- if sglang['moe-dense-tp-size'] is defined -%}{%- set _ = args.append('--moe-dense-tp-size "' ~ sglang['moe-dense-tp-size'] ~ '"') -%}{%- endif -%}
 {%- if sglang['moe-runner-backend'] is defined -%}{%- set _ = args.append('--moe-runner-backend "' ~ sglang['moe-runner-backend'] ~ '"') -%}{%- endif -%}
 {%- if sglang['moe-a2a-backend'] is defined -%}{%- set _ = args.append('--moe-a2a-backend "' ~ sglang['moe-a2a-backend'] ~ '"') -%}{%- endif -%}
 {%- if sglang['attention-backend'] is defined -%}{%- set _ = args.append('--attention-backend "' ~ sglang['attention-backend'] ~ '"') -%}{%- endif -%}

--- a/src/aiconfigurator/generator/sflow.py
+++ b/src/aiconfigurator/generator/sflow.py
@@ -488,10 +488,6 @@ def _build_sflow_variables(
             rp.get("moe_expert_parallel_size"),
             _int(_extract_option_value(cli_args, "--expert-parallel-size"), 1),
         )
-        moe_tp = _int(
-            rp.get("moe_tensor_parallel_size"),
-            _int(_extract_option_value(cli_args, "--moe-dense-tp-size"), 1),
-        )
         max_batch = _int(rp.get("max_batch_size"), _int(_extract_option_value(cli_args, "--max-running-requests"), 1))
         max_num_tokens = _int(
             rp.get("max_num_tokens")
@@ -515,7 +511,6 @@ def _build_sflow_variables(
         vars_out.append(_var(f"{prefix}_PP_SIZE", f"{role_label} pipeline parallel size", pp, "integer"))
         vars_out.append(_var(f"{prefix}_DP_SIZE", f"{role_label} data parallel size", dp, "integer"))
         vars_out.append(_var(f"{prefix}_EP_SIZE", f"{role_label} expert parallel size", ep, "integer"))
-        vars_out.append(_var(f"{prefix}_MOE_TP_SIZE", f"{role_label} MOE tensor parallel size", moe_tp, "integer"))
         vars_out.append(_var(f"{prefix}_BATCH_SIZE", f"{role_label} batch size", max_batch, "integer"))
         vars_out.append(
             _var(f"{prefix}_MAX_NUM_TOKENS", f"{role_label} max number of tokens", max_num_tokens, "integer")
@@ -596,7 +591,6 @@ def _bind_sglang_cli_args(cli_args: str, prefix: str) -> str:
         "--pipeline-parallel-size": f"$[[ variables.{prefix}_PP_SIZE ]]",
         "--data-parallel-size": f"$[[ variables.{prefix}_DP_SIZE ]]",
         "--expert-parallel-size": f"$[[ variables.{prefix}_EP_SIZE ]]",
-        "--moe-dense-tp-size": f"$[[ variables.{prefix}_MOE_TP_SIZE ]]",
         "--max-running-requests": f"$[[ variables.{prefix}_BATCH_SIZE ]]",
         "--max-prefill-tokens": f"$[[ variables.{prefix}_MAX_NUM_TOKENS ]]",
         "--max-total-tokens": f"$[[ variables.{prefix}_MAX_NUM_TOKENS ]]",
@@ -615,6 +609,15 @@ def _bind_sglang_cli_args(cli_args: str, prefix: str) -> str:
     idx = 0
     while idx < len(tokens):
         token = tokens[idx]
+        # SGLang accepts moe_dense_tp_size 1 or None only; expert TP is tensor_parallel_size.
+        if token.startswith("--moe-dense-tp-size"):
+            if "=" in token:
+                idx += 1
+                continue
+            idx += 1
+            if idx < len(tokens) and not tokens[idx].startswith("--"):
+                idx += 1
+            continue
         if token == "--enable-dp-attention":
             out.append(attention_var)
             attention_bound = True
@@ -656,7 +659,6 @@ def _bind_sglang_cli_args(cli_args: str, prefix: str) -> str:
         ("--pipeline-parallel-size", f"$[[ variables.{prefix}_PP_SIZE ]]"),
         ("--data-parallel-size", f"$[[ variables.{prefix}_DP_SIZE ]]"),
         ("--expert-parallel-size", f"$[[ variables.{prefix}_EP_SIZE ]]"),
-        ("--moe-dense-tp-size", f"$[[ variables.{prefix}_MOE_TP_SIZE ]]"),
         ("--max-running-requests", f"$[[ variables.{prefix}_BATCH_SIZE ]]"),
         ("--max-prefill-tokens", f"$[[ variables.{prefix}_MAX_NUM_TOKENS ]]"),
         ("--kv-cache-dtype", "$[[ variables.KV_CACHE_DTYPE ]]"),


### PR DESCRIPTION
SGLang only allows moe_dense_tp_size 1 or None; expert TP is via tensor-parallel-size × expert-parallel-size. Remove CLI flag from templates, strip legacy flag in sflow binding, drop unused MOE_TP_SIZE vars.

```
                    INFO     [agg_server_0] 0:   File "/sgl-workspace/sglang/python/sglang/srt/entrypoints/engine.py", line 163, in __init__                                             launcher.py:161
                    INFO     [agg_server_0] 0:     _launch_subprocesses(                                                                                                                 launcher.py:161
                    INFO     [agg_server_0] 0:   File "/sgl-workspace/sglang/python/sglang/srt/entrypoints/engine.py", line 1026, in _launch_subprocesses                                launcher.py:161
                    INFO     [agg_server_0] 0:     server_args.check_server_args()                                                                                                       launcher.py:161
                    INFO     [agg_server_0] 0:   File "/sgl-workspace/sglang/python/sglang/srt/server_args.py", line 5150, in check_server_args                                          launcher.py:161
                    INFO     [agg_server_0] 0:     assert self.moe_dense_tp_size in {                                                                                                    launcher.py:161
                    INFO     [agg_server_0] 0:                                                                                                                                           launcher.py:161
                    INFO     [agg_server_0] 0:                                                                                                                                           launcher.py:161
                    INFO     [agg_server_0] 0:  ^^^^^^^^^^^^^^                                                                                                                           launcher.py:161
                    INFO     [agg_server_0] 0: ^^^^^^^^^^^^^                                                                                                                             launcher.py:161
                    INFO     [agg_server_0] 0:                                                                                                                                           launcher.py:161
                    INFO     [agg_server_0] 0: AssertionError: moe_dense_tp_size only support 1 and None currently 
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the `moe-dense-tp-size` configuration parameter. Expert parallelism for Mixture of Experts models is now automatically handled through the tensor-parallel-size setting.
  * Updated configuration documentation to clarify MOE tensor parallel handling in SGLang backend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->