### PR TITLE
chore: Expose chunked prefill parameter in cli

### DIFF
--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -158,6 +158,13 @@ def _add_default_mode_arguments(parser):
         help="Acceptance rates for MTP draft tokens. Comma-separated list of 5 floats. "
         "Default is '0.85,0.3,0,0,0' meaning 1st token has 85%% acceptance, 2nd has 30%%, rest are 0.",
     )
+    parser.add_argument(
+        "--enable-chunked-prefill",
+        action="store_true",
+        default=False,
+        help="Enable chunked prefill for finer-grained context token sweep during optimization. "
+        "When off (default), context token stride is aligned to ISL for faster sweeping.",
+    )
 
 
 def _add_experiments_mode_arguments(parser):
@@ -591,6 +598,7 @@ def build_default_task_configs(
     prefix: int = 0,
     nextn: int = 0,
     nextn_accept_rates: list[float] | None = None,
+    enable_chunked_prefill: bool = False,
 ) -> dict[str, TaskConfig]:
     """Build agg and disagg task configs for default mode comparison.
 
@@ -611,6 +619,7 @@ def build_default_task_configs(
         prefix: Prefix cache length.
         nextn: Number of draft tokens for MTP speculative decoding.
         nextn_accept_rates: Acceptance rates for MTP draft tokens.
+        enable_chunked_prefill: Whether to enable chunked prefill for finer context token sweep.
 
     Returns:
         Dict with TaskConfig objects. When backend='auto', returns 6 configs
@@ -677,6 +686,7 @@ def build_default_task_configs(
         "request_latency": request_latency,
         "prefix": prefix,
         "database_mode": database_mode,
+        "enable_chunked_prefill": enable_chunked_prefill,
     }
 
     # Create yaml_config to pass nextn and nextn_accept_rates if specified
@@ -869,6 +879,8 @@ def build_experiment_task_configs(
             task_kwargs["enable_wideep"] = exp_config["enable_wideep"]
         if "enable_eplb" in exp_config:
             task_kwargs["enable_eplb"] = exp_config["enable_eplb"]
+        if "enable_chunked_prefill" in exp_config:
+            task_kwargs["enable_chunked_prefill"] = exp_config["enable_chunked_prefill"]
         if "database_mode" in exp_config:
             task_kwargs["database_mode"] = exp_config["database_mode"]
 
@@ -1422,6 +1434,7 @@ def main(args):
             prefix=args.prefix,
             nextn=args.nextn,
             nextn_accept_rates=[float(x) for x in args.nextn_accept_rates.split(",")],
+            enable_chunked_prefill=args.enable_chunked_prefill,
         )
     elif args.mode == "exp":
         try:

--- a/src/aiconfigurator/sdk/pareto_analysis.py
+++ b/src/aiconfigurator/sdk/pareto_analysis.py
@@ -28,6 +28,7 @@ def agg_pareto(
     backend_name: str,
     model_config: config.ModelConfig,
     parallel_config_list: list[list[int]],
+    enable_chunked_prefill: bool = False,
 ) -> pd.DataFrame:
     """
     Find Pareto front for agg.
@@ -42,14 +43,12 @@ def agg_pareto(
         backend_name: name of the backend
         model_config: model config
         parallel_config_list: list of parallel configurations
+        enable_chunked_prefill: whether the inference framework will have chunked prefill enabled.
+            Affects the context tokens sweep granularity. Default is False.
 
     Returns:
         results_df: dataframe of the results
     """
-    if backend_name in ["vllm", "sglang"]:
-        enable_chunked_prefill = True
-    else:
-        enable_chunked_prefill = False
 
     # agg is agg server, the loop over parallel is outside here.
     results_df = pd.DataFrame(columns=ColumnsAgg)

--- a/src/aiconfigurator/sdk/task.py
+++ b/src/aiconfigurator/sdk/task.py
@@ -61,6 +61,7 @@ class TaskContext:
     tpot: float | None
     request_latency: float | None
     enable_wideep: bool
+    enable_chunked_prefill: bool
     total_gpus: int | None
     profiles: list[str] = field(default_factory=list)
     yaml_patch: dict = field(default_factory=dict)
@@ -331,6 +332,7 @@ class TaskConfigFactory:
                 "request_latency": ctx.request_latency,
             },
             "enable_wideep": ctx.enable_wideep,
+            "enable_chunked_prefill": ctx.enable_chunked_prefill,
             "enable_eplb": False,
             "moe_backend": None,  # sglang wideep only
             "attention_backend": "flashinfer",  # sglang wideep only
@@ -602,6 +604,7 @@ class TaskConfig:
         tpot: float = 50,
         request_latency: float | None = None,
         enable_wideep: bool = False,
+        enable_chunked_prefill: bool = False,
         enable_eplb: bool = False,
         total_gpus: int | None = None,
         profiles: list[str] | None = None,
@@ -632,6 +635,7 @@ class TaskConfig:
             tpot: The target TPOT.
             request_latency: The target end-to-end request latency.
             enable_wideep: Whether to enable wideep.
+            enable_chunked_prefill: Whether the inference framework will have chunked prefill enabled.
             total_gpus: The total number of GPUs.
             profiles: The profiles to use.
             yaml_config: The YAML configuration.
@@ -676,6 +680,7 @@ class TaskConfig:
             tpot=tpot,
             request_latency=request_latency,
             enable_wideep=enable_wideep,
+            enable_chunked_prefill=enable_chunked_prefill,
             total_gpus=total_gpus,
             profiles=effective_profiles,
             yaml_patch=yaml_patch,
@@ -1122,6 +1127,7 @@ class TaskRunner:
             logger.info(f"{i + 1}) tp={tp}, pp={pp}, dp={dp}, moe_tp={moe_tp}, moe_ep={moe_ep}")
 
         logger.info("Task %s: Running agg pareto", task_config.task_name)
+        enable_chunked_prefill = getattr(task_config, "enable_chunked_prefill", False)
         result_df = pa.agg_pareto(
             model_path=task_config.model_path,
             runtime_config=runtime_config,
@@ -1129,6 +1135,7 @@ class TaskRunner:
             backend_name=task_config.worker_config.backend_name,
             model_config=model_config,
             parallel_config_list=parallel_config_list,
+            enable_chunked_prefill=enable_chunked_prefill,
         )
         return {
             "pareto_df": result_df,


### PR DESCRIPTION
#### Overview:

Expose chunked prefill parameter in cli

#### Details:

chunked prefill is enabled by default on vLLM. When we did correlation study, we found that there are huge gap on AIC's projected TTFT (chunked prefill off) vs. real TTFT (chunked prefill on by default). Although there is code in https://github.com/ai-dynamo/aiconfigurator/blob/main/src/aiconfigurator/sdk/backends/vllm_backend.py#L414 that handles this computation, there is no way `enable_chunked_prefill` parameter passed to `find_best_agg_result_under_constraints`. This PR adds this option.

To use it, e.g.
```bash
aiconfigurator cli default --model-path Qwen/Qwen3-8B --backend vllm --backend-version 0.12.0 --total-gpus 4 --system b60 --isl 1500 --osl 150 --ttft 5000 --tpot 100 --enable-chunked-prefill
```


#### Where should the reviewer start?

As above

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: [#501](https://github.com/ai-dynamo/aiconfigurator/issues/501)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized aggregation and summarization operations with improved prefill handling for vllm and sglang backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->