### PR TITLE
feat: make rate_matching degradation factors configurable

### DIFF
--- a/src/aiconfigurator/sdk/inference_session.py
+++ b/src/aiconfigurator/sdk/inference_session.py
@@ -195,6 +195,9 @@ class DisaggInferenceSession:
         self._prefill_latency_correction_scale = 1.0
         self._decode_latency_correction_scale = 1.0
 
+        self._rate_matching_prefill_degradation_factor = _RATE_MATCHING_PREFILL_DEGRADATION_FACTOR
+        self._rate_matching_decode_degradation_factor = _RATE_MATCHING_DECODE_DEGRADATION_FACTOR
+
     def set_latency_correction_scales(
         self, prefill_latency_correction_scale: float, decode_latency_correction_scale: float
     ):
@@ -203,6 +206,23 @@ class DisaggInferenceSession:
         """
         self._prefill_latency_correction_scale = prefill_latency_correction_scale
         self._decode_latency_correction_scale = decode_latency_correction_scale
+
+    def set_rate_matching_degradation_factors(
+        self,
+        prefill_degradation_factor: float = _RATE_MATCHING_PREFILL_DEGRADATION_FACTOR,
+        decode_degradation_factor: float = _RATE_MATCHING_DECODE_DEGRADATION_FACTOR,
+    ):
+        """
+        Set the degradation factors used during rate matching between prefill and decode workers.
+
+        Args:
+            prefill_degradation_factor: Multiplicative factor applied to prefill throughput
+                to account for pipeline bubbles (default 0.9).
+            decode_degradation_factor: Multiplicative factor applied to decode throughput
+                to account for batch-size under-saturation (default 0.92).
+        """
+        self._rate_matching_prefill_degradation_factor = prefill_degradation_factor
+        self._rate_matching_decode_degradation_factor = decode_degradation_factor
 
     def _get_disagg_summary_df(
         self,
@@ -223,8 +243,8 @@ class DisaggInferenceSession:
             prefill_num_worker,
             decode_dict,
             decode_num_worker,
-            prefill_degradation_factor=_RATE_MATCHING_PREFILL_DEGRADATION_FACTOR,
-            decode_degradation_factor=_RATE_MATCHING_DECODE_DEGRADATION_FACTOR,
+            prefill_degradation_factor=self._rate_matching_prefill_degradation_factor,
+            decode_degradation_factor=self._rate_matching_decode_degradation_factor,
         )
         return pd.DataFrame([summary_dict], columns=common.ColumnsDisagg).round(3)
 
@@ -768,8 +788,8 @@ class DisaggInferenceSession:
                 decode_summary_df=decode_summary_df,
                 return_top_k=5,
                 num_gpu_list=num_gpu_list,
-                rate_matching_prefill_degradation_factor=_RATE_MATCHING_PREFILL_DEGRADATION_FACTOR,
-                rate_matching_decode_degradation_factor=_RATE_MATCHING_DECODE_DEGRADATION_FACTOR,
+                rate_matching_prefill_degradation_factor=self._rate_matching_prefill_degradation_factor,
+                rate_matching_decode_degradation_factor=self._rate_matching_decode_degradation_factor,
                 require_same_tp=require_same_tp,
             )
             if filtered_disagg_summary_df is not None:

--- a/src/aiconfigurator/sdk/pareto_analysis.py
+++ b/src/aiconfigurator/sdk/pareto_analysis.py
@@ -240,6 +240,16 @@ def disagg_pareto(
     disagg_sess = DisaggInferenceSession(prefill_database, prefill_backend, decode_database, decode_backend)
     disagg_sess.set_latency_correction_scales(prefill_latency_correction_scale, decode_latency_correction_scale)
 
+    rate_matching_prefill = kwargs.pop("rate_matching_prefill_degradation_factor", None)
+    rate_matching_decode = kwargs.pop("rate_matching_decode_degradation_factor", None)
+    if rate_matching_prefill is not None or rate_matching_decode is not None:
+        kw = {}
+        if rate_matching_prefill is not None:
+            kw["prefill_degradation_factor"] = rate_matching_prefill
+        if rate_matching_decode is not None:
+            kw["decode_degradation_factor"] = rate_matching_decode
+        disagg_sess.set_rate_matching_degradation_factors(**kw)
+
     prefill_max_num_tokens = kwargs.get("prefill_max_num_tokens", 16384)
     decode_max_num_tokens = kwargs.get("decode_max_num_tokens", 512)
     logger.debug(f"prefill_max_num_tokens: {prefill_max_num_tokens}, decode_max_num_tokens: {decode_max_num_tokens}")

--- a/src/aiconfigurator/sdk/pareto_analysis.py
+++ b/src/aiconfigurator/sdk/pareto_analysis.py
@@ -240,6 +240,7 @@ def disagg_pareto(
     disagg_sess = DisaggInferenceSession(prefill_database, prefill_backend, decode_database, decode_backend)
     disagg_sess.set_latency_correction_scales(prefill_latency_correction_scale, decode_latency_correction_scale)
 
+    # None means we use internally tuned default values for rate-matching degradation factors.
     rate_matching_prefill = kwargs.pop("rate_matching_prefill_degradation_factor", None)
     rate_matching_decode = kwargs.pop("rate_matching_decode_degradation_factor", None)
     if rate_matching_prefill is not None or rate_matching_decode is not None:

--- a/src/aiconfigurator/sdk/task.py
+++ b/src/aiconfigurator/sdk/task.py
@@ -493,6 +493,8 @@ class TaskConfigFactory:
             "decode_latency_correction_scale": DEFAULT_DECODE_LATENCY_CORRECTION_SCALE,
             "prefill_max_batch_size": 1,
             "decode_max_batch_size": 512,
+            "rate_matching_prefill_degradation_factor": None,
+            "rate_matching_decode_degradation_factor": None,
         }
 
         return {
@@ -1350,6 +1352,12 @@ class TaskRunner:
             decode_max_num_tokens=task_config.advanced_tuning_config.decode_max_batch_size,
             prefill_latency_correction_scale=task_config.advanced_tuning_config.prefill_latency_correction_scale,
             decode_latency_correction_scale=task_config.advanced_tuning_config.decode_latency_correction_scale,
+            rate_matching_prefill_degradation_factor=getattr(
+                task_config.advanced_tuning_config, "rate_matching_prefill_degradation_factor", None
+            ),
+            rate_matching_decode_degradation_factor=getattr(
+                task_config.advanced_tuning_config, "rate_matching_decode_degradation_factor", None
+            ),
             require_same_tp=require_same_tp,
             autoscale=autoscale,
             target_tpot=task_config.runtime_config.tpot if autoscale else None,

--- a/tests/unit/sdk/task/test_task.py
+++ b/tests/unit/sdk/task/test_task.py
@@ -100,6 +100,8 @@ def test_taskconfig_disagg_default():
     assert cfg.advanced_tuning_config.decode_max_batch_size == 512
     assert cfg.advanced_tuning_config.prefill_latency_correction_scale == 1.1
     assert cfg.advanced_tuning_config.decode_latency_correction_scale == 1.08
+    assert cfg.advanced_tuning_config.rate_matching_prefill_degradation_factor is None
+    assert cfg.advanced_tuning_config.rate_matching_decode_degradation_factor is None
     assert "disagg-defaults" in cfg.applied_layers
 
 
@@ -943,3 +945,75 @@ class TestTaskrunnerDisaggMixedWideepModelConfig:
         assert prefill_mc.enable_eplb is True
         assert decode_mc.enable_wideep is False
         assert decode_mc.enable_eplb is False
+
+
+class TestRateMatchingFactorsForwarding:
+    """Verify rate_matching degradation factors flow from TaskConfig to disagg_pareto."""
+
+    def test_defaults_forward_none(self, monkeypatch):
+        """When no override is set, None is passed to disagg_pareto."""
+        captured = {}
+        pa_stub = sys.modules["aiconfigurator.sdk.pareto_analysis"]
+        monkeypatch.setattr(pa_stub, "disagg_pareto", _make_capturing_disagg_pareto(captured))
+
+        task = TaskConfig(
+            serving_mode="disagg",
+            model_path="Qwen/Qwen3-32B",
+            system_name="h200_sxm",
+            total_gpus=8,
+        )
+        TaskRunner().run(task)
+
+        assert captured.get("rate_matching_prefill_degradation_factor") is None
+        assert captured.get("rate_matching_decode_degradation_factor") is None
+
+    def test_custom_values_forwarded(self, monkeypatch):
+        """Custom rate_matching factors in advanced_tuning_config reach disagg_pareto."""
+        captured = {}
+        pa_stub = sys.modules["aiconfigurator.sdk.pareto_analysis"]
+        monkeypatch.setattr(pa_stub, "disagg_pareto", _make_capturing_disagg_pareto(captured))
+
+        task = TaskConfig(
+            serving_mode="disagg",
+            model_path="Qwen/Qwen3-32B",
+            system_name="h200_sxm",
+            total_gpus=8,
+            yaml_config={
+                "mode": "patch",
+                "config": {
+                    "advanced_tuning_config": {
+                        "rate_matching_prefill_degradation_factor": 1.0,
+                        "rate_matching_decode_degradation_factor": 1.0,
+                    }
+                },
+            },
+        )
+        TaskRunner().run(task)
+
+        assert captured.get("rate_matching_prefill_degradation_factor") == 1.0
+        assert captured.get("rate_matching_decode_degradation_factor") == 1.0
+
+    def test_partial_override_prefill_only(self, monkeypatch):
+        """Setting only prefill factor leaves decode as None."""
+        captured = {}
+        pa_stub = sys.modules["aiconfigurator.sdk.pareto_analysis"]
+        monkeypatch.setattr(pa_stub, "disagg_pareto", _make_capturing_disagg_pareto(captured))
+
+        task = TaskConfig(
+            serving_mode="disagg",
+            model_path="Qwen/Qwen3-32B",
+            system_name="h200_sxm",
+            total_gpus=8,
+            yaml_config={
+                "mode": "patch",
+                "config": {
+                    "advanced_tuning_config": {
+                        "rate_matching_prefill_degradation_factor": 0.85,
+                    }
+                },
+            },
+        )
+        TaskRunner().run(task)
+
+        assert captured.get("rate_matching_prefill_degradation_factor") == 0.85
+        assert captured.get("rate_matching_decode_degradation_factor") is None

--- a/tests/unit/sdk/test_inference_session.py
+++ b/tests/unit/sdk/test_inference_session.py
@@ -246,3 +246,60 @@ class TestRequireSameTPFiltering:
         assert df is not None and not df.empty
         for _, row in df.iterrows():
             assert row["(p)tp"] == row["(d)tp"], f"Mismatch: (p)tp={row['(p)tp']}, (d)tp={row['(d)tp']}"
+
+
+class TestRateMatchingDegradationFactors:
+    """Verify set_rate_matching_degradation_factors on DisaggInferenceSession."""
+
+    def test_default_values(self, disagg_session):
+        """New session has the module-level defaults (0.9 / 0.92)."""
+        assert disagg_session._rate_matching_prefill_degradation_factor == 0.9
+        assert disagg_session._rate_matching_decode_degradation_factor == 0.92
+
+    def test_setter_updates_both(self, disagg_session):
+        """Calling the setter with both args updates both attributes."""
+        disagg_session.set_rate_matching_degradation_factors(0.5, 0.6)
+        assert disagg_session._rate_matching_prefill_degradation_factor == 0.5
+        assert disagg_session._rate_matching_decode_degradation_factor == 0.6
+
+    def test_setter_partial_prefill_only(self, disagg_session):
+        """Setting only prefill keeps decode at default."""
+        disagg_session.set_rate_matching_degradation_factors(prefill_degradation_factor=0.7)
+        assert disagg_session._rate_matching_prefill_degradation_factor == 0.7
+        assert disagg_session._rate_matching_decode_degradation_factor == 0.92
+
+    def test_setter_partial_decode_only(self, disagg_session):
+        """Setting only decode keeps prefill at default."""
+        disagg_session.set_rate_matching_degradation_factors(decode_degradation_factor=0.8)
+        assert disagg_session._rate_matching_prefill_degradation_factor == 0.9
+        assert disagg_session._rate_matching_decode_degradation_factor == 0.8
+
+    def test_factors_used_in_disagg_result(self, disagg_session, runtime_config, model_config):
+        """Custom factors propagate into find_best_disagg_result_under_constraints output."""
+        disagg_session.set_rate_matching_degradation_factors(1.0, 1.0)
+        result_1 = _run(
+            disagg_session,
+            runtime_config,
+            model_config,
+            prefill_cfgs=[(1, 1, 1, 1, 1)],
+            decode_cfgs=[(1, 1, 1, 1, 1)],
+            require_same_tp=False,
+        )
+
+        disagg_session.set_rate_matching_degradation_factors(0.5, 0.5)
+        result_05 = _run(
+            disagg_session,
+            runtime_config,
+            model_config,
+            prefill_cfgs=[(1, 1, 1, 1, 1)],
+            decode_cfgs=[(1, 1, 1, 1, 1)],
+            require_same_tp=False,
+        )
+
+        assert result_1 is not None and result_05 is not None
+        df_1 = result_1.get_summary_df()
+        df_05 = result_05.get_summary_df()
+        assert df_1 is not None and df_05 is not None
+        tsg_1 = df_1["tokens/s/gpu"].iloc[0]
+        tsg_05 = df_05["tokens/s/gpu"].iloc[0]
+        assert tsg_1 > tsg_05, f"factor=1.0 should yield higher tokens/s/gpu ({tsg_1}) than factor=0.5 ({tsg_05})"


### PR DESCRIPTION
Convert module-level constants _RATE_MATCHING_PREFILL_DEGRADATION_FACTOR and _RATE_MATCHING_DECODE_DEGRADATION_FACTOR into configurable instance attributes on DisaggInferenceSession with a dedicated setter method. Propagate these parameters through TaskConfig.advanced_tuning_config and disagg_pareto() kwargs, eliminating the need for monkey-patching.
Add unit tests covering default values, setter behavior, and end-to-end parameter forwarding from TaskConfig to disagg_pareto.
Made-with: Cursor
#### Overview:
Previously, `_RATE_MATCHING_PREFILL_DEGRADATION_FACTOR` (0.9) and `_RATE_MATCHING_DECODE_DEGRADATION_FACTOR` (0.92) were module-level constants in `picking.py`, imported at module load time by `inference_session.py`. This made them impossible to override at runtime via monkey-patching—experiment scripts that attempted `picking._RATE_MATCHING_*_DEGRADATION_FACTOR = 1.0` had no effect on already-imported copies inside `DisaggInferenceSession`.
This PR converts these constants into configurable instance attributes with a proper setter API (`set_rate_matching_degradation_factors`), and threads the values through `TaskConfig.advanced_tuning_config` → `TaskRunner.run_disagg()` → `disagg_pareto()` → `DisaggInferenceSession`, making them fully configurable without monkey-patching.
#### Details:
- **`inference_session.py`**: Add `_rate_matching_prefill_degradation_factor` and `_rate_matching_decode_degradation_factor` as instance attributes on `DisaggInferenceSession.__init__` (defaulting to the module constants). Add `set_rate_matching_degradation_factors()` setter. Replace all internal references to the module constants with `self._rate_matching_*` attributes in `_get_disagg_summary_df` and `_find_best_result_under_constraints`.
- **`pareto_analysis.py`**: `disagg_pareto()` now accepts `rate_matching_prefill_degradation_factor` and `rate_matching_decode_degradation_factor` via `**kwargs`, and calls `disagg_sess.set_rate_matching_degradation_factors()` when either is provided.
- **`task.py`**: Add `rate_matching_prefill_degradation_factor: None` and `rate_matching_decode_degradation_factor: None` to the default `advanced_tuning_config`. `TaskRunner.run_disagg()` forwards these values to `disagg_pareto()`.
- **`test_inference_session.py`**: Add `TestRateMatchingDegradationFactors` class (5 tests): default values, setter with both/partial args, and end-to-end impact on `tokens/s/gpu` output.
- **`test_task.py`**: Add default-value assertions in `test_taskconfig_disagg_default`. Add `TestRateMatchingFactorsForwarding` class (3 tests): None forwarding, custom values, and partial override.
#### Where should the reviewer start?
- `src/aiconfigurator/sdk/inference_session.py` — the core change: new instance attributes and setter method (lines 175–202), and the two call sites that now use `self._rate_matching_*` (lines 220–221, 765–766).
- `src/aiconfigurator/sdk/pareto_analysis.py` — kwargs extraction and conditional setter call (lines 239–247).
- `src/aiconfigurator/sdk/task.py` — default config addition (lines 494–495) and forwarding in `run_disagg` (lines 1346–1351).
#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Relates to: disagg rate-matching configurability improvement


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customizable rate-matching degradation factors for disaggregated inference optimization. Users can now configure prefill and decode degradation factors through task configuration or runtime API calls to fine-tune performance analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->