### PR TITLE
feat: add PDL discount factor for DeepSeek model on GB200

### DIFF
--- a/src/aiconfigurator/sdk/inference_session.py
+++ b/src/aiconfigurator/sdk/inference_session.py
@@ -232,8 +232,14 @@ class DisaggInferenceSession:
         Returns:
             InferenceSummary: the summary of the inference result
         """
-        prefill_model = models.get_model(model_path, prefill_model_config, self._prefill_backend.name.value)
-        decode_model = models.get_model(model_path, decode_model_config, self._decode_backend.name.value)
+        prefill_sm = self._prefill_database.system_spec.get("gpu", {}).get("sm_version", 0)
+        decode_sm = self._decode_database.system_spec.get("gpu", {}).get("sm_version", 0)
+        prefill_model = models.get_model(
+            model_path, prefill_model_config, self._prefill_backend.name.value, sm_version=prefill_sm
+        )
+        decode_model = models.get_model(
+            model_path, decode_model_config, self._decode_backend.name.value, sm_version=decode_sm
+        )
         prefill_sess = InferenceSession(
             model=prefill_model, database=self._prefill_database, backend=self._prefill_backend
         )
@@ -340,6 +346,7 @@ class DisaggInferenceSession:
                     model_path=model_path,
                     model_config=overwritten_model_config,
                     backend_name=self._prefill_backend.name.value,
+                    sm_version=self._prefill_database.system_spec.get("gpu", {}).get("sm_version", 0),
                 )
                 if mode == "static_ctx":
                     sess = InferenceSession(

--- a/src/aiconfigurator/sdk/models.py
+++ b/src/aiconfigurator/sdk/models.py
@@ -153,6 +153,7 @@ def get_model(
     model_path: str,
     model_config: config.ModelConfig,
     backend_name: str,
+    sm_version: int = 0,
 ) -> BaseModel:
     """
     Get model.
@@ -267,6 +268,7 @@ def get_model(
                 vocab,
                 context,
                 model_config,
+                sm_version=sm_version,
             )
         else:
             logger.debug(f"WideEP is not enabled for model {model_path} with backend {backend_name}")
@@ -286,6 +288,7 @@ def get_model(
                 vocab,
                 context,
                 model_config,
+                sm_version=sm_version,
             )
     elif model_family == "NEMOTRONNAS":
         model = NemotronNas(
@@ -1075,7 +1078,7 @@ class DeepSeekModel(BaseModel):
     DeepSeek V3/R1 uses this model impl.
     """
 
-    def __init__(self, topk: int, num_experts: int, moe_inter_size: int, *args) -> None:
+    def __init__(self, topk: int, num_experts: int, moe_inter_size: int, *args, sm_version: int = 0) -> None:
         super().__init__(*args)
 
         # make sure the paralel width is same
@@ -1111,6 +1114,7 @@ class DeepSeekModel(BaseModel):
             * (self._nextn + self._num_layers)
             / self._num_layers
         )
+        self._pdl_factor = 0.9 if sm_version >= 100 else 1.0
         self._power_law_alpha = 1.01
 
         gemm_quant_mode = self.config.gemm_quant_mode
@@ -1284,55 +1288,55 @@ class DeepSeekModel(BaseModel):
                 ops.Embedding("generation_embedding", 1 * self._mtp_scale_factor, self._vocab_size, h, 0.3),
                 ops.ElementWise(
                     "generation_add_norm_1",
-                    self._num_layers * self._mtp_scale_factor,
+                    self._num_layers * self._mtp_scale_factor * self._pdl_factor,
                     2 * h,
                     2 * h,
                     0.8,
                 ),
                 ops.GEMM(
                     "generation_downscale_gemm",
-                    self._num_layers * self._mtp_scale_factor,
+                    self._num_layers * self._mtp_scale_factor * self._pdl_factor,
                     2112,
                     h,
                     gemm_quant_mode,
                 ),
                 ops.GEMM(
                     "generation_q_b_proj_gemm",
-                    self._num_layers * self._mtp_scale_factor,
+                    self._num_layers * self._mtp_scale_factor * self._pdl_factor,
                     24576 // tp_size,
                     1536,
                     gemm_quant_mode,
                 ),
                 ops.MLABmm(
                     "generation_bmm_pre",
-                    self._num_layers * self._mtp_scale_factor,
+                    self._num_layers * self._mtp_scale_factor * self._pdl_factor,
                     self._num_heads // tp_size,
                     mla_bmm_quant_mode,
                     if_pre=True,
-                ),  # agg gen attn part
+                ),
                 ops.GenerationMLA(
                     "generation_attention",
-                    self._num_layers * self._mtp_scale_factor,
+                    self._num_layers * self._mtp_scale_factor * self._pdl_factor,
                     128 // tp_size,
                     kvcache_quant_mode,
-                ),  # agg gen attn part
+                ),
                 ops.MLABmm(
                     "generation_bmm_post",
-                    self._num_layers * self._mtp_scale_factor,
+                    self._num_layers * self._mtp_scale_factor * self._pdl_factor,
                     self._num_heads // tp_size,
                     mla_bmm_quant_mode,
                     if_pre=False,
-                ),  # agg gen attn part
+                ),
                 ops.GEMM(
                     "generation_proj_gemm",
-                    self._num_layers * self._mtp_scale_factor,
+                    self._num_layers * self._mtp_scale_factor * self._pdl_factor,
                     h,
                     h // tp_size,
                     gemm_quant_mode,
                 ),
                 ops.ElementWise(
                     "generation_add_norm_2",
-                    self._num_layers * self._mtp_scale_factor,
+                    self._num_layers * self._mtp_scale_factor * self._pdl_factor,
                     2 * h,
                     2 * h,
                     0.8,
@@ -1348,21 +1352,21 @@ class DeepSeekModel(BaseModel):
         gen_shared_ops = [
             ops.GEMM(
                 "generation_shared_gate_up_gemm",
-                self._num_layers * self._mtp_scale_factor,
+                self._num_layers * self._mtp_scale_factor * self._pdl_factor,
                 2 * self._moe_inter_size // tp_size,
                 h,
                 gemm_quant_mode,
             ),
             ops.ElementWise(
                 "generation_shared_act_gate",
-                self._num_layers * self._mtp_scale_factor,
+                self._num_layers * self._mtp_scale_factor * self._pdl_factor,
                 2 * self._moe_inter_size // tp_size,
                 self._moe_inter_size // tp_size,
                 0.8,
             ),
             ops.GEMM(
                 "generation_shared_ffn2_gemm",
-                self._num_layers * self._mtp_scale_factor,
+                self._num_layers * self._mtp_scale_factor * self._pdl_factor,
                 h,
                 self._moe_inter_size // tp_size,
                 gemm_quant_mode,
@@ -1373,14 +1377,14 @@ class DeepSeekModel(BaseModel):
         gen_routed_ops = [
             ops.GEMM(
                 "generation_router_gemm",
-                self._num_layers * self._mtp_scale_factor,
+                self._num_layers * self._mtp_scale_factor * self._pdl_factor,
                 self._num_experts,
                 h,
                 common.GEMMQuantMode.float16,
             ),
             ops.MoEDispatch(
                 "generation_moe_pre_dispatch",
-                self._num_layers * self._mtp_scale_factor,
+                self._num_layers * self._mtp_scale_factor * self._pdl_factor,
                 h,
                 self._topk,
                 self._num_experts,
@@ -1392,7 +1396,7 @@ class DeepSeekModel(BaseModel):
             ),
             ops.MoE(
                 "generation_moe",
-                self._num_layers * self._mtp_scale_factor,
+                self._num_layers * self._mtp_scale_factor * self._pdl_factor,
                 h,
                 self._moe_inter_size,
                 self._topk,
@@ -1405,7 +1409,7 @@ class DeepSeekModel(BaseModel):
             ),
             ops.MoEDispatch(
                 "generation_moe_post_dispatch",
-                self._num_layers * self._mtp_scale_factor,
+                self._num_layers * self._mtp_scale_factor * self._pdl_factor,
                 h,
                 self._topk,
                 self._num_experts,
@@ -1459,7 +1463,7 @@ class TrtllmWideEPDeepSeekModel(BaseModel):
     - All2All kernel: NVLinkTwoSided (SM>=100), DeepEP/DeepEPLowLatency (SM>=90), NCCL (fallback)
     """
 
-    def __init__(self, topk: int, num_experts: int, moe_inter_size: int, *args) -> None:
+    def __init__(self, topk: int, num_experts: int, moe_inter_size: int, *args, sm_version: int = 0) -> None:
         super().__init__(*args)
 
         # make sure the parallel width is same
@@ -1488,7 +1492,7 @@ class TrtllmWideEPDeepSeekModel(BaseModel):
             * (self._nextn + self._num_layers)
             / self._num_layers
         )
-        self._pdl_factor = 0.9
+        self._pdl_factor = 0.9 if sm_version >= 100 else 1.0
         self._power_law_alpha = 1.01
 
         gemm_quant_mode = self.config.gemm_quant_mode

--- a/src/aiconfigurator/sdk/pareto_analysis.py
+++ b/src/aiconfigurator/sdk/pareto_analysis.py
@@ -69,6 +69,7 @@ def agg_pareto(
                 model_path=model_path,
                 model_config=overwritten_model_config,
                 backend_name=backend_name,
+                sm_version=database.system_spec.get("gpu", {}).get("sm_version", 0),
             )
             backend = get_backend(backend_name)
             sess = InferenceSession(model=model, database=database, backend=backend)

--- a/tests/unit/sdk/test_inference_session.py
+++ b/tests/unit/sdk/test_inference_session.py
@@ -121,7 +121,7 @@ def _build_mock_backend():
 def _patch_get_model(monkeypatch):
     """Replace ``models.get_model`` so no real model files are needed."""
 
-    def _fake_get_model(model_path, model_config, backend_name):
+    def _fake_get_model(model_path, model_config, backend_name, sm_version=0):
         m = MagicMock()
         m._tp = model_config.tp_size
         m._pp = model_config.pp_size


### PR DESCRIPTION

#### Overview:
Previously, only `TrtllmWideEPDeepSeekModel` had a PDL (Programmatic Dependent Launch) discount factor (hardcoded 0.9), while `DeepSeekModel` (cutlass MoE backend) had none. This meant GB200 non-WideEP DeepSeek configurations did not benefit from the PDL latency reduction in generation-phase ops.
This PR adds the same PDL discount to `DeepSeekModel` and unifies both models to use a conditional factor based on SM version, making the behavior consistent and architecture-aware.
#### Details:
- **`models.py`**:
  - `get_model()` gains an optional `sm_version: int = 0` parameter, propagated from the caller's database.
  - `DeepSeekModel.__init__` gains `sm_version=0` keyword arg; sets `self._pdl_factor = 0.9 if sm_version >= 100 else 1.0`. All generation-phase ops now multiply `self._num_layers * self._mtp_scale_factor * self._pdl_factor` (embedding, logits_gemm, and p2p are excluded, matching WideEP convention).
  - `TrtllmWideEPDeepSeekModel.__init__` updated from hardcoded `self._pdl_factor = 0.9` to the same conditional pattern `0.9 if sm_version >= 100 else 1.0`, with `sm_version` passed from `get_model()`.
  - Factory function `get_model()` passes `sm_version=sm_version` when constructing both `DeepSeekModel` and `TrtllmWideEPDeepSeekModel`.
- **`pareto_analysis.py`**:
  - `agg_pareto()` call to `get_model()` now passes `sm_version=database.system_spec["gpu"]["sm_version"]`.
- **`inference_session.py`**:
  - All three `models.get_model()` call sites (`_get_disagg_summary_df` prefill/decode, `get_worker_candidates`) now pass `sm_version` extracted from the corresponding database's `system_spec`.
- **`test_inference_session.py`**:
  - Mock `_fake_get_model` signature updated to accept `sm_version=0` for compatibility.
#### Where should the reviewer start?
- `src/aiconfigurator/sdk/models.py` — the core change: `DeepSeekModel.__init__` (line ~1079) for the new `sm_version` parameter and `_pdl_factor` conditional, and the generation ops block (lines ~1286–1440) where `self._pdl_factor` is now applied. Also `TrtllmWideEPDeepSeekModel.__init__` (line ~1465) for the unified conditional.
- `src/aiconfigurator/sdk/models.py` `get_model()` (line ~152) for the new parameter and factory wiring.
#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Relates to #564 (deepseek moe overlap & PDL discount)