### PR TITLE
chore: Add data from auto-collector pipeline 46453141 (gb200_trtllm_1.2.0rc5)

### DIFF
--- a/src/aiconfigurator/systems/data/gb200/trtllm/1.2.0rc5/gemm_perf.txt
+++ b/src/aiconfigurator/systems/data/gb200/trtllm/1.2.0rc5/gemm_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:88dc8efc41a5695965d32c86daa5d1dc06a97a4faa3077b653f8addf9f91ded6
-size 2210437
+oid sha256:ebfc5b7173de69d1a8ee2b1a5c247b69d9ddea2dd8d6e6488e471d62f705929d
+size 11297644


### PR DESCRIPTION
# Error Summary for Auto-Collector Run
## Collection summary for gb200 trtllm:1.2.0rc5
### Error summary
```
{
    "backend": "trtllm",
    "version": "1.2.0rc5",
    "timestamp": "2026-03-18T22:59:40.054473",
    "total_errors": 4,
    "errors_by_module": {
        "trtllm.gemm": 4
    },
    "errors_by_type": {
        "AcceleratorError": 2,
        "WorkerSignalCrash": 2
    }
}
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal performance data files to reflect latest configurations and metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->