### PR TITLE
fix: use single copy for activations & KV Cache, remove duplicate

### DIFF
--- a/src/aiconfigurator/sdk/backends/sglang_backend.py
+++ b/src/aiconfigurator/sdk/backends/sglang_backend.py
@@ -547,6 +547,17 @@ class SGLANGBackend(BaseBackend):
             * kvcache_per_token
         )
 
+        # Split kvcache into prefill and decode portions to avoid double-counting
+        # with activations. During prefill, activations and kvcache_prefill both scale
+        # with batch_size * isl and overlap in memory (the empirical activation coefficient
+        # already captures KV cache writes). During decode, activations are tiny and
+        # kvcache_decode is separate.
+        kvcache_prefill = batch_size * isl * model.config.kvcache_quant_mode.value.memory * kvcache_per_token
+        kvcache_decode = (
+            batch_size * beam_width * osl * model.config.kvcache_quant_mode.value.memory * kvcache_per_token
+        )
+        runtime_memory = max(activations, kvcache_prefill) + kvcache_decode
+
         # ==== Communication and system memory ====
         nccl_mem = database.system_spec["misc"]["nccl_mem"][min(model.config.tp_size, 8)]
 
@@ -558,7 +569,7 @@ class SGLANGBackend(BaseBackend):
 
         one_gib = 1 << 30
         return {
-            "total": (weights + activations + kvcache + nccl_mem + others_mem) / one_gib,
+            "total": (weights + runtime_memory + nccl_mem + others_mem) / one_gib,
             "weights": weights / one_gib,
             "activations": activations / one_gib,
             "kvcache": kvcache / one_gib,

--- a/src/aiconfigurator/sdk/backends/trtllm_backend.py
+++ b/src/aiconfigurator/sdk/backends/trtllm_backend.py
@@ -547,6 +547,17 @@ class TRTLLMBackend(BaseBackend):
         #    kvcache = kvcache * model.config.attention_dp_size # this is incorrect. tp will
         #    duplicate the kvcache while attn_dp will not.
 
+        # Split kvcache into prefill and decode portions to avoid double-counting
+        # with activations. During prefill, activations and kvcache_prefill both scale
+        # with batch_size * isl and overlap in memory (the empirical activation coefficient
+        # already captures KV cache writes). During decode, activations are tiny and
+        # kvcache_decode is separate.
+        kvcache_prefill = batch_size * isl * model.config.kvcache_quant_mode.value.memory * kvcache_per_token
+        kvcache_decode = (
+            batch_size * beam_width * osl * model.config.kvcache_quant_mode.value.memory * kvcache_per_token
+        )
+        runtime_memory = max(activations, kvcache_prefill) + kvcache_decode
+
         # starting from 2.22
         nccl_mem = database.system_spec["misc"]["nccl_mem"][min(model.config.tp_size, 8)]
 
@@ -555,7 +566,7 @@ class TRTLLMBackend(BaseBackend):
 
         one_gib = 1 << 30
         return {
-            "total": (weights + activations + kvcache + nccl_mem + others_mem) / one_gib,
+            "total": (weights + runtime_memory + nccl_mem + others_mem) / one_gib,
             "weights": weights / one_gib,
             "activations": activations / one_gib,
             "kvcache": kvcache / one_gib,


### PR DESCRIPTION
Overview:
Fix prefill memory estimation double-counting KV cache and activations.

Details:
During prefill, both activations and kvcache scale with batch_size * isl. The empirical activation coefficient (c_dict) already captures KV cache write overhead during the forward pass, so adding a separate kvcache term for the prefill portion results in over-estimation of GPU memory.

The fix splits KV cache into two components:

kvcache_prefill (batch_size * isl): overlaps with activations during prefill, so we use max(activations, kvcache_prefill) instead of summing both.
kvcache_decode (batch_size * beam_width * osl): does not overlap with activations (decode activations are tiny), added separately as before.
This change only affects the total field used for OOM checks. The breakdown fields (activations, kvcache) still report raw values for debugging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced memory calculation precision in model configuration backends, resulting in more accurate memory allocation estimates across different inference phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->