### PR TITLE
fix: environment variable HF_TOKEN is not supported to provide HF token

### DIFF
--- a/src/aiconfigurator/sdk/utils.py
+++ b/src/aiconfigurator/sdk/utils.py
@@ -327,12 +327,7 @@ def _get_hf_auth_headers() -> dict[str, str]:
     2. ``HUGGING_FACE_HUB_TOKEN`` environment variable
     3. ``~/.cache/huggingface/token`` file
     """
-    import os
-
-    hf_token = (
-        os.environ.get("HF_TOKEN")
-        or os.environ.get("HUGGING_FACE_HUB_TOKEN")
-    )
+    hf_token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
     if not hf_token:
         # Fall back to the token file written by `huggingface-cli login`
         token_path = Path.home() / ".cache" / "huggingface" / "token"


### PR DESCRIPTION
#### Overview:

The Hugging Face Hub supports using environment variables like `HF_TOKEN` or `HUGGING_FACE_HUB_TOKEN` to provide authentication tokens. Currently, AIConfigurator only retrieves tokens created via `huggingface-cli login`. It would be beneficial to align this with the standard Hugging Face Hub user experience.

#### Details:

This PR introduces the token resolution order (first non-empty wins) to align with the Huggingface Hub user experience:
1. ``HF_TOKEN`` environment variable
2. ``HUGGING_FACE_HUB_TOKEN`` environment variable
3. ``~/.cache/huggingface/token`` file

#### Where should the reviewer start?

- src/aiconfigurator/sdk/utils.py#_get_hf_auth_headers()
- src/aiconfigurator/sdk/utils.py#_download_hf_json()

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: n/a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved authentication token resolution to prioritize environment variables (`HF_TOKEN`, `HUGGING_FACE_HUB_TOKEN`) over cached credentials, with clearer error messages guiding users on authentication options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->