### PR TITLE
chore: Update allreduce data for B60, vLLM 0.12.0

### DIFF
--- a/src/aiconfigurator/systems/data/b60/vllm/0.12.0/custom_allreduce_perf.txt
+++ b/src/aiconfigurator/systems/data/b60/vllm/0.12.0/custom_allreduce_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:602b8561a37ece2a63fb2372acac9f9b4a4a4ed91d8fccd264dd7ca547cfa008
-size 5968
+oid sha256:7965aea3d371d51b77eaafc3f16cbed9cabf0d55665c3dc831b88e5f02a77778
+size 8901


### PR DESCRIPTION
#### Overview:

Add allreduce data for vLLM 0.12.0 on 8 B60 cards.

#### Details:

n/a

#### Where should the reviewer start?

- src/aiconfigurator/systems/data/b60/vllm/0.12.0/custom_all_reduce_perf.txt

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: n/a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal performance data files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->