### PR TITLE
feat: add MiniMax M2.5 model dimensions to MoE collector test cases

### DIFF
--- a/collector/common_test_cases.py
+++ b/collector/common_test_cases.py
@@ -75,6 +75,7 @@ def get_common_moe_test_cases():
         [4096, 1536, 8, 128, "Qwen/Qwen3-235B-A22B"],  # qwen3-moe, 235b-a22b
         [6144, 2560, 8, 160, "Qwen/Qwen3-Coder-480B-A35B-Instruct"],  # qwen3-moe, 480b-a35b
         [7168, 2048, 8, 384, "moonshotai/Kimi-K2-Instruct"],  # kimi k2
+        [3072, 1536, 8, 256, "MiniMaxAI/MiniMax-M2.5"],  # minimax m2.5
         [2880, 2880, 4, 128, "openai/gpt-oss-120b"],
         [2880, 2880, 4, 32, "openai/gpt-oss-20b"],
         [2688, 1856, 6, 128, "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"],  # nemotron-3 nano (uses relu2, non-gated)


### PR DESCRIPTION
## Summary

- Adds MiniMax M2.5 (`MiniMaxAI/MiniMax-M2.5`) model dimensions `[3072, 1536, 8, 256]` to the shared MoE collector test cases in `common_test_cases.py`.
- This is required for SILICON mode support: the MoE query path uses exact key lookup for `(hidden_size, inter_size, topk, num_experts)`, so data must be collected at these specific dimensions.
- GEMM and attention data already cover MiniMax M2.5 via interpolation and existing dimension coverage. MoE is the only missing piece.

## Context

MiniMax M2.5 works in HYBRID mode (empirical fallback) but not SILICON mode because no MoE perf data exists for its specific dimensions. The GEMM/MoE collectors already support `fp8_block` quantization — this PR adds the model dimensions so the next collection run will produce the needed data.

## Test plan

- [x] All 551 unit tests pass
- [ ] Run MoE collectors on real GPUs to verify data is collected for MiniMax M2.5 dimensions
- [ ] Verify SILICON mode works after data collection



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added support for the MiniMaxAI/MiniMax-M2.5 model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->