### PR TITLE
chore: Add data from auto-collector pipeline 46632824 (rtxpro6000_blackwell_server_vllm_0.14.0)

### DIFF
--- a/src/aiconfigurator/systems/data/rtxpro6000_blackwell_server/vllm/0.14.0/moe_perf.txt
+++ b/src/aiconfigurator/systems/data/rtxpro6000_blackwell_server/vllm/0.14.0/moe_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75751214b21584d063bc4cd848c0bcc1206c871c41d9efd96be23bcd607056ea
+size 2803797


### PR DESCRIPTION
# Error Summary for Auto-Collector Run
## Collection summary for rtxpro6000_blackwell_server vllm:0.14.0
### Error summary
```
{
    "backend": "vllm",
    "version": "0.14.1.dev1+gd68209402",
    "timestamp": "2026-03-20T14:37:50.253151",
    "total_errors": 0,
    "errors_by_module": {},
    "errors_by_type": {}
}
```

