### PR TITLE
chore: Add data from auto-collector pipeline 46632824 (rtxpro6000_blackwell_server_sglang_0.5.9)

### DIFF
--- a/src/aiconfigurator/systems/data/rtxpro6000_blackwell_server/sglang/0.5.9/moe_perf.txt
+++ b/src/aiconfigurator/systems/data/rtxpro6000_blackwell_server/sglang/0.5.9/moe_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1946ffaf016b3caae99a21f0d9d8753150689c9856e22307fd8e8f329e50c870
+size 648902


### PR DESCRIPTION
# Error Summary for Auto-Collector Run
## Collection summary for rtxpro6000_blackwell_server sglang:0.5.9
### Error summary
```
{
    "backend": "sglang",
    "version": "0.5.9",
    "timestamp": "2026-03-20T21:59:51.534589",
    "total_errors": 4392,
    "errors_by_module": {
        "sglang.moe": 4392
    },
    "errors_by_type": {
        "OutOfResources": 1563,
        "AssertionError": 2738,
        "OutOfMemoryError": 51,
        "AcceleratorError": 22,
        "RuntimeError": 18
    }
}
```

