### PR TITLE
chore: Add data from auto-collector pipeline 46632824 (h200_sxm_vllm_0.14.0)

### DIFF
--- a/src/aiconfigurator/systems/data/h200_sxm/vllm/0.14.0/moe_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/vllm/0.14.0/moe_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56384955a57067503a00cc390f92c8488781c1c68153a37476f31887cee5b6bd
+size 1936877


### PR DESCRIPTION
# Error Summary for Auto-Collector Run
## Collection summary for h200_sxm vllm:0.14.0
### Error summary
```
{
    "backend": "vllm",
    "version": "0.14.0",
    "timestamp": "2026-03-20T15:50:34.614022",
    "total_errors": 0,
    "errors_by_module": {},
    "errors_by_type": {}
}
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added performance data files for H200 SXM configurations in VLLM 0.14.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->