### PR TITLE
chore: Add data from auto-collector pipeline 46632824 (gb300_trtllm_1.2.0rc5)

### DIFF
--- a/src/aiconfigurator/systems/data/gb300/trtllm/1.2.0rc5/moe_perf.txt
+++ b/src/aiconfigurator/systems/data/gb300/trtllm/1.2.0rc5/moe_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:459bc729c54fb238276529d4a01df622af79ec893f713332b4701feffbf19788
+size 9525842


### PR DESCRIPTION
# Error Summary for Auto-Collector Run
## Collection summary for gb300 trtllm:1.2.0rc5
### Error summary
```
{
    "backend": "trtllm",
    "version": "1.2.0rc5",
    "timestamp": "2026-03-21T02:25:04.438314",
    "total_errors": 82,
    "errors_by_module": {
        "trtllm.moe": 82
    },
    "errors_by_type": {
        "AcceleratorError": 32,
        "WorkerSignalCrash": 31,
        "ModuleNotFoundError": 19
    }
}
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added external file storage reference infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->