### PR TITLE
fix: add additional doc section for estimate mode

### DIFF
--- a/docs/cli_user_guide.md
+++ b/docs/cli_user_guide.md
@@ -101,7 +101,7 @@ aiconfigurator cli estimate --model-path Qwen/Qwen3-32B --system h200_sxm --tp-s
 - `--decode-num-workers`: Number of decode workers (required for disagg)
 
 **Example output (agg):**
-```
+```text
 ============================================================
   Performance Estimate (agg)
 ============================================================
@@ -141,7 +141,7 @@ aiconfigurator cli estimate \
 
 **Python API equivalent:**
 ```python
-from aiconfigurator.cli import cli_estimate
+from aiconfigurator.cli.api import cli_estimate
 
 # Aggregated estimation
 result = cli_estimate(


### PR DESCRIPTION
#### Overview:

- Just adding an additional section in the cli user guide for estimate mode
- Addressing https://github.com/ai-dynamo/aiconfigurator/issues/602




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Updated CLI user guide with comprehensive documentation for "Estimate mode," including command flags, usage examples for aggregated and disaggregated modes, and Python API equivalent code snippets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->