### PR TITLE
feat: add KV cache capacity check to prevent batch size oversubscription

### DIFF
--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -882,7 +882,6 @@ def _run_agg_estimate(
             f"(free_gpu_memory_fraction={free_gpu_memory_fraction}). "
             f"TRT-LLM will queue excess requests, causing significantly higher TTFT and inaccurate TPOT."
         )
-        logger.warning(kv_warning)
 
     return EstimateResult(
         ttft=result_dict["ttft"],

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -23,6 +23,10 @@ from aiconfigurator.cli.main import (
     build_experiment_task_configs,
 )
 from aiconfigurator.cli.report_and_save import save_results
+from aiconfigurator.sdk.backends.trtllm_backend import (
+    KV_CACHE_MEMORY_RESERVED_FRACTION,
+    KV_CACHE_MEMORY_TOLERANCE,
+)
 from aiconfigurator.sdk.models import check_is_moe
 from aiconfigurator.sdk.task import (
     DEFAULT_DECODE_LATENCY_CORRECTION_SCALE,
@@ -877,12 +881,15 @@ def _run_agg_estimate(
         osl,
         num_tokens=2 * isl,
         max_seq_len=resolved_max_seq_len,
-        free_gpu_memory_fraction=free_gpu_memory_fraction,
     )
-    # _get_memory_usage inflates kvcache by 1/(frac*(1-reserved)*(1-tol)) when max_seq_len and
-    # free_gpu_memory_fraction < 1.0 are provided, so "total >= gpu_capacity" is mathematically
-    # equivalent to "actual_kvcache >= (gpu_capacity - non_kv) * frac * (1-reserved) * (1-tol)".
-    if kv_memory["total"] >= database.system_spec["gpu"]["mem_capacity"] / (1 << 30):
+    summary._check_and_set_kv_cache_oom(
+        kv_memory,
+        database.system_spec["gpu"]["mem_capacity"],
+        free_gpu_memory_fraction=free_gpu_memory_fraction,
+        kv_cache_reserved_fraction=KV_CACHE_MEMORY_RESERVED_FRACTION,
+        kv_cache_tolerance=KV_CACHE_MEMORY_TOLERANCE,
+    )
+    if summary.check_kv_cache_oom():
         kv_warning = (
             f"Requested batch_size ({batch_size}) exceeds estimated KV cache capacity "
             f"(free_gpu_memory_fraction={free_gpu_memory_fraction}). "

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -140,6 +140,8 @@ def cli_default(
     tpot: float = 30.0,
     request_latency: float | None = None,
     prefix: int = 0,
+    free_gpu_memory_fraction: float | None = None,
+    max_seq_len: int | None = None,
     top_n: int = 5,
     save_dir: str | None = None,
     generator_set: list[str] | None = None,
@@ -169,6 +171,11 @@ def cli_default(
         request_latency: Optional end-to-end request latency target (ms).
             Enables request-latency optimization mode.
         prefix: Prefix cache length. Default is 0.
+        free_gpu_memory_fraction: Fraction of free GPU memory allocated for KV cache
+            (default ``None``, meaning the backend default is used). Must be > 0 and <= 1.
+            Used to filter batch sizes that would exceed KV cache capacity.
+        max_seq_len: TRT-LLM ``--max_seq_len`` setting. Controls how many KV blocks are
+            pre-allocated per sequence. Defaults to ``isl + osl`` when ``None``.
         top_n: Number of top configurations to return for each mode (agg/disagg). Default is 5.
         save_dir: Directory to save results. If None, results are not saved to disk.
         generator_set: List of inline generator overrides in KEY=VALUE format (e.g.,
@@ -227,6 +234,8 @@ def cli_default(
         tpot=tpot,
         request_latency=request_latency,
         prefix=prefix,
+        free_gpu_memory_fraction=free_gpu_memory_fraction,
+        max_seq_len=max_seq_len,
     )
 
     result = _execute_and_wrap_result(task_configs, mode="default", top_n=top_n)

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -879,6 +879,9 @@ def _run_agg_estimate(
         max_seq_len=resolved_max_seq_len,
         free_gpu_memory_fraction=free_gpu_memory_fraction,
     )
+    # _get_memory_usage inflates kvcache by 1/(frac*(1-reserved)*(1-tol)) when max_seq_len and
+    # free_gpu_memory_fraction < 1.0 are provided, so "total >= gpu_capacity" is mathematically
+    # equivalent to "actual_kvcache >= (gpu_capacity - non_kv) * frac * (1-reserved) * (1-tol)".
     if kv_memory["total"] >= database.system_spec["gpu"]["mem_capacity"] / (1 << 30):
         kv_warning = (
             f"Requested batch_size ({batch_size}) exceeds estimated KV cache capacity "

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -609,6 +609,7 @@ def cli_estimate(
     decode_num_workers: int | None = None,
     systems_paths: str | None = None,
     free_gpu_memory_fraction: float = 0.9,
+    max_seq_len: int | None = None,
 ) -> EstimateResult:
     """
     Estimate TTFT, TPOT, and power for a single model/system/config combination.
@@ -661,6 +662,9 @@ def cli_estimate(
         free_gpu_memory_fraction: Fraction of free GPU memory TRT-LLM allocates for
             KV cache (default 0.9). Used to check whether the requested batch_size
             exceeds KV cache capacity.
+        max_seq_len: The TRT-LLM ``--max_seq_len`` setting used at serving time.
+            Controls how many KV blocks TRT-LLM pre-allocates per sequence. Defaults
+            to ``isl + osl`` when ``None``.
 
     Returns:
         EstimateResult with ttft, tpot, power_w, mode, and the full raw result dict.
@@ -734,6 +738,7 @@ def cli_estimate(
             get_backend=get_backend,
             get_model=get_model,
             free_gpu_memory_fraction=free_gpu_memory_fraction,
+            max_seq_len=max_seq_len,
         )
     elif mode == "disagg":
         # Validate required disagg params
@@ -812,6 +817,7 @@ def _run_agg_estimate(
     get_backend,
     get_model,
     free_gpu_memory_fraction=0.9,
+    max_seq_len=None,
 ) -> EstimateResult:
     """Run aggregated (IFB) estimation."""
     from aiconfigurator.sdk.config import RuntimeConfig
@@ -854,7 +860,23 @@ def _run_agg_estimate(
         raise RuntimeError("Estimation produced no results. The configuration may be invalid.")
 
     kv_warning = None
-    if backend._is_kv_cache_oom(model, database, batch_size, isl, osl, free_gpu_memory_fraction):
+    resolved_max_seq_len = max_seq_len
+    if resolved_max_seq_len is None:
+        resolved_max_seq_len = isl + osl
+        logger.warning(
+            "max_seq_len not provided for KV cache capacity check; defaulting to isl + osl = %d. "
+            "Pass max_seq_len explicitly to match your TRT-LLM --max_seq_len setting.",
+            resolved_max_seq_len,
+        )
+    if backend._is_kv_cache_oom(
+        model,
+        database,
+        batch_size,
+        isl,
+        osl,
+        free_gpu_memory_fraction,
+        max_seq_len=resolved_max_seq_len,
+    ):
         kv_warning = (
             f"Requested batch_size ({batch_size}) exceeds estimated KV cache capacity "
             f"(free_gpu_memory_fraction={free_gpu_memory_fraction}). "

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -875,9 +875,10 @@ def _run_agg_estimate(
 
     kv_warning = None
     if summary.check_kv_cache_oom():
+        frac_str = str(free_gpu_memory_fraction) if free_gpu_memory_fraction is not None else "backend default"
         kv_warning = (
             f"Requested batch_size ({batch_size}) exceeds estimated KV cache capacity "
-            f"(free_gpu_memory_fraction={free_gpu_memory_fraction}). "
+            f"(free_gpu_memory_fraction={frac_str}). "
             "The serving runtime will queue excess requests, causing significantly higher TTFT and inaccurate TPOT."
         )
 

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -868,15 +868,18 @@ def _run_agg_estimate(
             "Pass max_seq_len explicitly to match your TRT-LLM --max_seq_len setting.",
             resolved_max_seq_len,
         )
-    if backend._is_kv_cache_oom(
+    kv_memory = backend._get_memory_usage(
         model,
         database,
         batch_size,
+        1,
         isl,
         osl,
-        free_gpu_memory_fraction,
+        num_tokens=2 * isl,
         max_seq_len=resolved_max_seq_len,
-    ):
+        free_gpu_memory_fraction=free_gpu_memory_fraction,
+    )
+    if kv_memory["total"] >= database.system_spec["gpu"]["mem_capacity"] / (1 << 30):
         kv_warning = (
             f"Requested batch_size ({batch_size}) exceeds estimated KV cache capacity "
             f"(free_gpu_memory_fraction={free_gpu_memory_fraction}). "

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -854,13 +854,11 @@ def _run_agg_estimate(
         raise RuntimeError("Estimation produced no results. The configuration may be invalid.")
 
     kv_warning = None
-    max_kv_bs = backend._calculate_max_kv_cache_batch_size(model, database, isl, osl, free_gpu_memory_fraction)
-    if max_kv_bs > 0 and batch_size > max_kv_bs:
+    if backend._is_kv_cache_oom(model, database, batch_size, isl, osl, free_gpu_memory_fraction):
         kv_warning = (
             f"Requested batch_size ({batch_size}) exceeds estimated KV cache capacity "
-            f"({max_kv_bs} concurrent sequences with free_gpu_memory_fraction="
-            f"{free_gpu_memory_fraction}). TRT-LLM will queue excess requests, "
-            f"causing significantly higher TTFT and inaccurate TPOT."
+            f"(free_gpu_memory_fraction={free_gpu_memory_fraction}). "
+            f"TRT-LLM will queue excess requests, causing significantly higher TTFT and inaccurate TPOT."
         )
         logger.warning(kv_warning)
 

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -23,10 +23,6 @@ from aiconfigurator.cli.main import (
     build_experiment_task_configs,
 )
 from aiconfigurator.cli.report_and_save import save_results
-from aiconfigurator.sdk.backends.trtllm_backend import (
-    KV_CACHE_MEMORY_RESERVED_FRACTION,
-    KV_CACHE_MEMORY_TOLERANCE,
-)
 from aiconfigurator.sdk.models import check_is_moe
 from aiconfigurator.sdk.task import (
     DEFAULT_DECODE_LATENCY_CORRECTION_SCALE,
@@ -849,7 +845,12 @@ def _run_agg_estimate(
     database = load_database(system_name)
     backend = get_backend(backend_name)
     session = InferenceSession(model, database, backend)
-    summary = session.run_agg(runtime_config, ctx_tokens=ctx_tokens)
+    summary = session.run_agg(
+        runtime_config,
+        ctx_tokens=ctx_tokens,
+        max_seq_len=max_seq_len if max_seq_len is not None else isl + osl,
+        free_gpu_memory_fraction=free_gpu_memory_fraction,
+    )
 
     if summary.check_oom():
         raise RuntimeError(
@@ -864,36 +865,11 @@ def _run_agg_estimate(
         raise RuntimeError("Estimation produced no results. The configuration may be invalid.")
 
     kv_warning = None
-    resolved_max_seq_len = max_seq_len
-    if resolved_max_seq_len is None:
-        resolved_max_seq_len = isl + osl
-        logger.warning(
-            "max_seq_len not provided for KV cache capacity check; defaulting to isl + osl = %d. "
-            "Pass max_seq_len explicitly to match your TRT-LLM --max_seq_len setting.",
-            resolved_max_seq_len,
-        )
-    kv_memory = backend._get_memory_usage(
-        model,
-        database,
-        batch_size,
-        1,
-        isl,
-        osl,
-        num_tokens=2 * isl,
-        max_seq_len=resolved_max_seq_len,
-    )
-    summary._check_and_set_kv_cache_oom(
-        kv_memory,
-        database.system_spec["gpu"]["mem_capacity"],
-        free_gpu_memory_fraction=free_gpu_memory_fraction,
-        kv_cache_reserved_fraction=KV_CACHE_MEMORY_RESERVED_FRACTION,
-        kv_cache_tolerance=KV_CACHE_MEMORY_TOLERANCE,
-    )
     if summary.check_kv_cache_oom():
         kv_warning = (
             f"Requested batch_size ({batch_size}) exceeds estimated KV cache capacity "
             f"(free_gpu_memory_fraction={free_gpu_memory_fraction}). "
-            f"TRT-LLM will queue excess requests, causing significantly higher TTFT and inaccurate TPOT."
+            "The serving runtime will queue excess requests, causing significantly higher TTFT and inaccurate TPOT."
         )
 
     return EstimateResult(

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -429,6 +429,12 @@ class EstimateResult:
     per_ops_data: dict | None = None
     """Per-operation latency breakdown (populated when available)."""
 
+    max_kv_cache_batch_size: int | None = None
+    """Max concurrent sequences the KV cache can hold (None if not computed)."""
+
+    kv_cache_warning: str | None = None
+    """Warning message when batch_size exceeds KV cache capacity."""
+
     @property
     def request_latency(self) -> float:
         """End-to-end request latency (ms)."""
@@ -605,6 +611,7 @@ def cli_estimate(
     decode_batch_size: int | None = None,
     decode_num_workers: int | None = None,
     systems_paths: str | None = None,
+    free_gpu_memory_fraction: float = 0.9,
 ) -> EstimateResult:
     """
     Estimate TTFT, TPOT, and power for a single model/system/config combination.
@@ -654,6 +661,9 @@ def cli_estimate(
         decode_batch_size: Decode batch size (disagg). Required when mode='disagg'.
         decode_num_workers: Number of decode workers (disagg). Required when mode='disagg'.
         systems_paths: Comma-separated systems search paths. Use 'default' for built-in.
+        free_gpu_memory_fraction: Fraction of free GPU memory TRT-LLM allocates for
+            KV cache (default 0.9). Used to check whether the requested batch_size
+            exceeds KV cache capacity.
 
     Returns:
         EstimateResult with ttft, tpot, power_w, mode, and the full raw result dict.
@@ -726,6 +736,7 @@ def cli_estimate(
             load_database=_load_database,
             get_backend=get_backend,
             get_model=get_model,
+            free_gpu_memory_fraction=free_gpu_memory_fraction,
         )
     elif mode == "disagg":
         # Validate required disagg params
@@ -803,6 +814,7 @@ def _run_agg_estimate(
     load_database,
     get_backend,
     get_model,
+    free_gpu_memory_fraction=0.9,
 ) -> EstimateResult:
     """Run aggregated (IFB) estimation."""
     from aiconfigurator.sdk.config import RuntimeConfig
@@ -844,6 +856,23 @@ def _run_agg_estimate(
     if result_dict is None:
         raise RuntimeError("Estimation produced no results. The configuration may be invalid.")
 
+    max_kv_bs = backend._calculate_max_kv_cache_batch_size(
+        model,
+        database,
+        isl,
+        osl,
+        free_gpu_memory_fraction=free_gpu_memory_fraction,
+    )
+    kv_warning = None
+    if max_kv_bs is not None and batch_size > max_kv_bs:
+        kv_warning = (
+            f"Requested batch_size ({batch_size}) exceeds estimated KV cache capacity "
+            f"({max_kv_bs} concurrent sequences with free_gpu_memory_fraction="
+            f"{free_gpu_memory_fraction}). TRT-LLM will queue excess requests, "
+            f"causing significantly higher TTFT and inaccurate TPOT."
+        )
+        logger.warning(kv_warning)
+
     return EstimateResult(
         ttft=result_dict["ttft"],
         tpot=result_dict["tpot"],
@@ -861,6 +890,8 @@ def _run_agg_estimate(
         raw=result_dict,
         mode="agg",
         per_ops_data=summary.get_per_ops_data(),
+        max_kv_cache_batch_size=max_kv_bs,
+        kv_cache_warning=kv_warning,
     )
 
 

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -429,9 +429,6 @@ class EstimateResult:
     per_ops_data: dict | None = None
     """Per-operation latency breakdown (populated when available)."""
 
-    max_kv_cache_batch_size: int | None = None
-    """Max concurrent sequences the KV cache can hold (None if not computed)."""
-
     kv_cache_warning: str | None = None
     """Warning message when batch_size exceeds KV cache capacity."""
 
@@ -856,15 +853,9 @@ def _run_agg_estimate(
     if result_dict is None:
         raise RuntimeError("Estimation produced no results. The configuration may be invalid.")
 
-    max_kv_bs = backend._calculate_max_kv_cache_batch_size(
-        model,
-        database,
-        isl,
-        osl,
-        free_gpu_memory_fraction=free_gpu_memory_fraction,
-    )
     kv_warning = None
-    if max_kv_bs is not None and batch_size > max_kv_bs:
+    max_kv_bs = backend._calculate_max_kv_cache_batch_size(model, database, isl, osl, free_gpu_memory_fraction)
+    if max_kv_bs > 0 and batch_size > max_kv_bs:
         kv_warning = (
             f"Requested batch_size ({batch_size}) exceeds estimated KV cache capacity "
             f"({max_kv_bs} concurrent sequences with free_gpu_memory_fraction="
@@ -890,7 +881,6 @@ def _run_agg_estimate(
         raw=result_dict,
         mode="agg",
         per_ops_data=summary.get_per_ops_data(),
-        max_kv_cache_batch_size=max_kv_bs,
         kv_cache_warning=kv_warning,
     )
 

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -612,7 +612,7 @@ def cli_estimate(
     decode_batch_size: int | None = None,
     decode_num_workers: int | None = None,
     systems_paths: str | None = None,
-    free_gpu_memory_fraction: float = 0.9,
+    free_gpu_memory_fraction: float | None = None,
     max_seq_len: int | None = None,
 ) -> EstimateResult:
     """
@@ -664,7 +664,7 @@ def cli_estimate(
         decode_num_workers: Number of decode workers (disagg). Required when mode='disagg'.
         systems_paths: Comma-separated systems search paths. Use 'default' for built-in.
         free_gpu_memory_fraction: Fraction of free GPU memory TRT-LLM allocates for
-            KV cache (default 0.9). Used to check whether the requested batch_size
+            KV cache (default 0.9 for TRTLLM, 1.0 for other backends). Used to check whether the requested batch_size
             exceeds KV cache capacity.
         max_seq_len: The TRT-LLM ``--max_seq_len`` setting used at serving time.
             Controls how many KV blocks TRT-LLM pre-allocates per sequence. Defaults
@@ -820,7 +820,7 @@ def _run_agg_estimate(
     load_database,
     get_backend,
     get_model,
-    free_gpu_memory_fraction=0.9,
+    free_gpu_memory_fraction=None,
     max_seq_len=None,
 ) -> EstimateResult:
     """Run aggregated (IFB) estimation."""

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -382,6 +382,14 @@ def _add_estimate_mode_arguments(parser):
         default=False,
         help="Print per-operation latency breakdown for mix step and generation-only step.",
     )
+    parser.add_argument(
+        "--free-gpu-memory-fraction",
+        type=float,
+        default=0.9,
+        help="Fraction of free GPU memory available for KV cache (default: 0.9). "
+        "Used to estimate max concurrent sequences and warn when batch_size "
+        "exceeds KV cache capacity.",
+    )
 
 
 def _add_support_mode_arguments(parser):
@@ -1316,6 +1324,7 @@ def _run_estimate_mode(args):
         fmha_quant_mode=args.fmha_quant_mode,
         moe_quant_mode=args.moe_quant_mode,
         comm_quant_mode=args.comm_quant_mode,
+        free_gpu_memory_fraction=args.free_gpu_memory_fraction,
     )
 
     if estimate_mode == "disagg":
@@ -1383,7 +1392,12 @@ def _run_estimate_mode(args):
         raw = result.raw
         print(f"  (p) Memory:       {raw.get('(p)memory', 'N/A')} GB")
         print(f"  (d) Memory:       {raw.get('(d)memory', 'N/A')} GB")
+    if result.max_kv_cache_batch_size is not None:
+        print(f"  Max KV Cache BS:  {result.max_kv_cache_batch_size}")
     print("=" * 60)
+
+    if result.kv_cache_warning:
+        print(f"\n  WARNING: {result.kv_cache_warning}")
 
     if args.print_per_ops_latency and result.per_ops_data:
         _print_per_ops_latency(result.per_ops_data)

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -1392,8 +1392,6 @@ def _run_estimate_mode(args):
         raw = result.raw
         print(f"  (p) Memory:       {raw.get('(p)memory', 'N/A')} GB")
         print(f"  (d) Memory:       {raw.get('(d)memory', 'N/A')} GB")
-    if result.max_kv_cache_batch_size is not None:
-        print(f"  Max KV Cache BS:  {result.max_kv_cache_batch_size}")
     print("=" * 60)
 
     if result.kv_cache_warning:

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -390,6 +390,14 @@ def _add_estimate_mode_arguments(parser):
         "Used to estimate max concurrent sequences and warn when batch_size "
         "exceeds KV cache capacity.",
     )
+    parser.add_argument(
+        "--max-seq-len",
+        type=int,
+        default=None,
+        help="TRT-LLM --max_seq_len setting (default: isl + osl). "
+        "Controls how many KV blocks TRT-LLM pre-allocates per sequence. "
+        "Set this to match your actual deployment to get an accurate KV cache capacity warning.",
+    )
 
 
 def _add_support_mode_arguments(parser):
@@ -1325,6 +1333,7 @@ def _run_estimate_mode(args):
         moe_quant_mode=args.moe_quant_mode,
         comm_quant_mode=args.comm_quant_mode,
         free_gpu_memory_fraction=args.free_gpu_memory_fraction,
+        max_seq_len=args.max_seq_len,
     )
 
     if estimate_mode == "disagg":

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -630,7 +630,7 @@ def build_default_task_configs(
     nextn: int = 0,
     nextn_accept_rates: list[float] | None = None,
     enable_chunked_prefill: bool = False,
-    free_gpu_memory_fraction: float = 0.9,
+    free_gpu_memory_fraction: float | None = None,
     max_seq_len: int | None = None,
 ) -> dict[str, TaskConfig]:
     """Build agg and disagg task configs for default mode comparison.

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -165,6 +165,21 @@ def _add_default_mode_arguments(parser):
         help="Enable chunked prefill for finer-grained context token sweep during optimization. "
         "When off (default), context token stride is aligned to ISL for faster sweeping.",
     )
+    parser.add_argument(
+        "--free-gpu-memory-fraction",
+        type=float,
+        default=1.0,
+        help="Fraction of free GPU memory TRT-LLM allocates for KV cache (default: 1.0). "
+        "Used to filter batch sizes that would exceed KV cache capacity.",
+    )
+    parser.add_argument(
+        "--max-seq-len",
+        type=int,
+        default=None,
+        help="TRT-LLM --max_seq_len setting (default: isl + osl). "
+        "Controls how many KV blocks TRT-LLM pre-allocates per sequence. "
+        "Set this to match your actual deployment for accurate KV cache capacity filtering.",
+    )
 
 
 def _add_experiments_mode_arguments(parser):
@@ -615,6 +630,8 @@ def build_default_task_configs(
     nextn: int = 0,
     nextn_accept_rates: list[float] | None = None,
     enable_chunked_prefill: bool = False,
+    free_gpu_memory_fraction: float = 1.0,
+    max_seq_len: int | None = None,
 ) -> dict[str, TaskConfig]:
     """Build agg and disagg task configs for default mode comparison.
 
@@ -703,6 +720,8 @@ def build_default_task_configs(
         "prefix": prefix,
         "database_mode": database_mode,
         "enable_chunked_prefill": enable_chunked_prefill,
+        "free_gpu_memory_fraction": free_gpu_memory_fraction,
+        "max_seq_len": max_seq_len,
     }
 
     # Create yaml_config to pass nextn and nextn_accept_rates if specified
@@ -1456,6 +1475,8 @@ def main(args):
             nextn=args.nextn,
             nextn_accept_rates=[float(x) for x in args.nextn_accept_rates.split(",")],
             enable_chunked_prefill=args.enable_chunked_prefill,
+            free_gpu_memory_fraction=args.free_gpu_memory_fraction,
+            max_seq_len=args.max_seq_len,
         )
     elif args.mode == "exp":
         try:

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -630,7 +630,7 @@ def build_default_task_configs(
     nextn: int = 0,
     nextn_accept_rates: list[float] | None = None,
     enable_chunked_prefill: bool = False,
-    free_gpu_memory_fraction: float = 1.0,
+    free_gpu_memory_fraction: float = 0.9,
     max_seq_len: int | None = None,
 ) -> dict[str, TaskConfig]:
     """Build agg and disagg task configs for default mode comparison.

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -1395,7 +1395,7 @@ def _run_estimate_mode(args):
     print("=" * 60)
 
     if result.kv_cache_warning:
-        print(f"\n  WARNING: {result.kv_cache_warning}")
+        logger.warning(result.kv_cache_warning)
 
     if args.print_per_ops_latency and result.per_ops_data:
         _print_per_ops_latency(result.per_ops_data)

--- a/src/aiconfigurator/sdk/backends/sglang_backend.py
+++ b/src/aiconfigurator/sdk/backends/sglang_backend.py
@@ -474,7 +474,7 @@ class SGLANGBackend(BaseBackend):
                     ctx_tokens=ctx_tokens,
                 )
 
-                if summary.check_oom():
+                if summary.check_oom() or summary.check_kv_cache_oom():
                     break  # larger ctx tokens will cause oom
                 all_oom = False
                 result_dict = summary.get_result_dict()

--- a/src/aiconfigurator/sdk/backends/trtllm_backend.py
+++ b/src/aiconfigurator/sdk/backends/trtllm_backend.py
@@ -16,6 +16,15 @@ from aiconfigurator.sdk.perf_database import PerfDatabase
 
 logger = logging.getLogger(__name__)
 
+# Fraction of available KV cache memory assumed to be reserved by TRT-LLM
+# for internal block-allocator overhead.  Applied in production to make the
+# KV OOM check conservative; set to 0 in tests to validate the raw formula.
+KV_CACHE_MEMORY_RESERVED_FRACTION: float = 0.015
+
+# Acceptable formula error relative to real TRT-LLM benchmark measurements.
+# Used as the %-based tolerance band in KV cache capacity tests.
+KV_CACHE_MEMORY_TOLERANCE: float = 0.02
+
 
 class TRTLLMBackend(BaseBackend):
     """
@@ -610,6 +619,7 @@ class TRTLLMBackend(BaseBackend):
         osl: int,
         free_gpu_memory_fraction: float = 0.9,
         max_seq_len: int | None = None,
+        kv_cache_capacity_tolerance: float = KV_CACHE_MEMORY_TOLERANCE,
     ) -> bool:
         """Return True if batch_size exceeds the KV cache capacity.
 
@@ -621,6 +631,11 @@ class TRTLLMBackend(BaseBackend):
             max_seq_len: Tokens reserved per sequence for block allocation.
                 Defaults to isl+osl. Pass isl+osl+slack to match a TRT-LLM
                 deployment that uses --max_seq_len isl+osl+slack.
+            kv_cache_capacity_tolerance: Lower-bound reduction applied to the
+                computed threshold before comparing, making the OOM check
+                conservative by the given fraction. Set to 0 in tests to validate
+                the raw formula against benchmark data. Defaults to
+                KV_CACHE_MEMORY_TOLERANCE.
         """
         import math
 
@@ -633,6 +648,7 @@ class TRTLLMBackend(BaseBackend):
         non_kv_gib = memory["total"] - memory["kvcache"]
         gpu_capacity_gib = database.system_spec["gpu"]["mem_capacity"] / (1 << 30)
         available_kv_gib = (gpu_capacity_gib - non_kv_gib) * free_gpu_memory_fraction
+        available_kv_gib *= 1 - KV_CACHE_MEMORY_RESERVED_FRACTION
 
         if available_kv_gib <= 0:
             return True  # model barely fits, no KV room for any sequence
@@ -652,4 +668,5 @@ class TRTLLMBackend(BaseBackend):
         if blocks_per_seq <= 0:
             return False
 
-        return batch_size > total_blocks // blocks_per_seq
+        max_concurrent_seqs = total_blocks // blocks_per_seq
+        return batch_size > int(max_concurrent_seqs * (1 - kv_cache_capacity_tolerance))

--- a/src/aiconfigurator/sdk/backends/trtllm_backend.py
+++ b/src/aiconfigurator/sdk/backends/trtllm_backend.py
@@ -436,7 +436,15 @@ class TRTLLMBackend(BaseBackend):
         # max(8192, 4*isl).
         # during the loop, as b, ctx_tokens and system memory are monotonic, we can break the
         # inner loop when the system is oom.
-        b_list = [b for b in b_list_default if b <= max_batch_size]
+        max_kv_bs = self._calculate_max_kv_cache_batch_size(model, database, isl, osl)
+        if max_kv_bs > 0 and max_kv_bs < max_batch_size:
+            logger.debug(
+                "KV cache limits effective batch size to %d (requested max_batch_size=%d)",
+                max_kv_bs,
+                max_batch_size,
+            )
+        effective_max = min(max_batch_size, max_kv_bs) if max_kv_bs > 0 else max_batch_size
+        b_list = [b for b in b_list_default if b <= effective_max]
         ctx_tokens_list = self._get_ctx_tokens_list_for_agg_sweep(isl, ctx_stride, enable_chunked_prefill)
 
         results_df = pd.DataFrame(columns=common.ColumnsAgg)
@@ -595,3 +603,103 @@ class TRTLLMBackend(BaseBackend):
             "nccl": nccl_mem / one_gib,
             "others": others_mem / one_gib,
         }
+
+    def _calculate_max_kv_cache_batch_size(
+        self,
+        model: BaseModel,
+        database: PerfDatabase,
+        isl: int,
+        osl: int,
+        beam_width: int = 1,
+        free_gpu_memory_fraction: float = 0.9,
+        max_num_tokens: int = 8192,
+        max_seq_len: int | None = None,
+        tokens_per_block: int = 32,
+    ) -> int:
+        """
+        Calculate the maximum batch size the KV cache can support concurrently.
+
+        TRT-LLM allocates KV cache in fixed-size blocks and reserves blocks
+        for each sequence up to ``max_seq_len``.  If the requested batch_size
+        exceeds this capacity, TRT-LLM queues excess requests instead of
+        running them concurrently, leading to inflated TTFT and inaccurate
+        TPOT without raising an OOM error.
+
+        Args:
+            model: Model with architecture parameters.
+            database: Performance database with system spec (GPU memory, etc.).
+            isl: Input sequence length.
+            osl: Output sequence length.
+            beam_width: Beam width (default 1 for standard LLM serving).
+            free_gpu_memory_fraction: Fraction of free GPU memory that TRT-LLM
+                allocates for KV cache (default 0.9, matching TRT-LLM Python API).
+            max_num_tokens: Max tokens per forward step, used for activation
+                memory estimation (default 8192).
+            max_seq_len: Maximum sequence length TRT-LLM reserves KV blocks for.
+                Defaults to ``isl + osl`` when None.  TRT-LLM's ``--max_seq_len``
+                is typically set to ``isl + osl + slack``.
+            tokens_per_block: Tokens per KV cache block (default 32, matching
+                TRT-LLM default).
+
+        Returns:
+            Maximum number of concurrent sequences the KV cache can hold.
+            Returns 0 if the model itself barely fits (no room for KV cache).
+        """
+        import math
+
+        if max_seq_len is None:
+            max_seq_len = isl + beam_width * osl
+
+        memory = self._get_memory_usage(
+            model,
+            database,
+            batch_size=1,
+            beam_width=beam_width,
+            isl=isl,
+            osl=osl,
+            num_tokens=max_num_tokens,
+            prefix=0,
+        )
+        non_kv_memory_gib = memory["total"] - memory["kvcache"]
+
+        gpu_capacity_gib = database.system_spec["gpu"]["mem_capacity"] / (1 << 30)
+        available_kv_gib = (gpu_capacity_gib - non_kv_memory_gib) * free_gpu_memory_fraction
+
+        if available_kv_gib <= 0:
+            return 0
+
+        if model.model_family == "DEEPSEEK":
+            kvcache_per_token = model._num_layers * 576
+        else:
+            num_kv_heads_per_gpu = (model._num_kv_heads + model.config.tp_size - 1) // model.config.tp_size
+            kvcache_per_token = num_kv_heads_per_gpu * model._head_size * model._num_layers * 2
+
+        kv_bytes_per_token = model.config.kvcache_quant_mode.value.memory * kvcache_per_token
+        if kv_bytes_per_token <= 0:
+            return 0
+
+        kv_bytes_per_block = tokens_per_block * kv_bytes_per_token
+        available_kv_bytes = available_kv_gib * (1 << 30)
+        total_blocks = int(available_kv_bytes / kv_bytes_per_block)
+        blocks_per_seq = math.ceil(max_seq_len / tokens_per_block)
+
+        if blocks_per_seq <= 0:
+            return 0
+
+        max_batch_size = total_blocks // blocks_per_seq
+
+        logger.debug(
+            "KV cache capacity: total_blocks=%d, blocks_per_seq=%d, "
+            "max_kv_batch_size=%d (gpu=%.1f GiB, non_kv=%.2f GiB, "
+            "available_kv=%.2f GiB, fraction=%.2f, max_seq_len=%d)",
+            total_blocks,
+            blocks_per_seq,
+            max_batch_size,
+            gpu_capacity_gib,
+            non_kv_memory_gib,
+            available_kv_gib,
+            free_gpu_memory_fraction,
+            max_seq_len,
+        )
+
+        return max_batch_size

--- a/src/aiconfigurator/sdk/backends/trtllm_backend.py
+++ b/src/aiconfigurator/sdk/backends/trtllm_backend.py
@@ -70,9 +70,15 @@ class TRTLLMBackend(BaseBackend):
         balance_score = isl * b / ctx_tokens / osl
 
         # Resolve KV cache parameters from kwargs (TRTLLM defaults apply).
+        # Use `if x is None` instead of kwargs.get default so that an explicit
+        # None passed by the Python API still falls back to the constant.
         max_seq_len = kwargs.get("max_seq_len")
-        free_gpu_memory_fraction = kwargs.get("free_gpu_memory_fraction", TRTLLM_DEFAULT_FREE_GPU_MEMORY_FRACTION)
-        max_num_tokens = kwargs.get("max_num_tokens", TRTLLM_DEFAULT_MAX_NUM_TOKENS)
+        free_gpu_memory_fraction = kwargs.get("free_gpu_memory_fraction")
+        if free_gpu_memory_fraction is None:
+            free_gpu_memory_fraction = TRTLLM_DEFAULT_FREE_GPU_MEMORY_FRACTION
+        max_num_tokens = kwargs.get("max_num_tokens")
+        if max_num_tokens is None:
+            max_num_tokens = TRTLLM_DEFAULT_MAX_NUM_TOKENS
 
         try:
             summary = self._agg_cache[isl][osl][b][ctx_tokens][max_seq_len][max_num_tokens][free_gpu_memory_fraction]
@@ -463,8 +469,12 @@ class TRTLLMBackend(BaseBackend):
         max_batch_size = kwargs.get("max_batch_size", 512)
         ctx_stride = kwargs.get("ctx_stride", 512)
         enable_chunked_prefill = kwargs.get("enable_chunked_prefill", False)
-        max_seq_len = kwargs.get("max_seq_len", isl + osl)
-        free_gpu_memory_fraction = kwargs.get("free_gpu_memory_fraction", TRTLLM_DEFAULT_FREE_GPU_MEMORY_FRACTION)
+        max_seq_len = kwargs.get("max_seq_len")
+        if max_seq_len is None:
+            max_seq_len = TRTLLM_DEFAULT_MAX_NUM_TOKENS
+        free_gpu_memory_fraction = kwargs.get("free_gpu_memory_fraction")
+        if free_gpu_memory_fraction is None:
+            free_gpu_memory_fraction = TRTLLM_DEFAULT_FREE_GPU_MEMORY_FRACTION
 
         # when b is larger than 1024, the result is not good as the data collection is not enough
         # to cover this.

--- a/src/aiconfigurator/sdk/backends/trtllm_backend.py
+++ b/src/aiconfigurator/sdk/backends/trtllm_backend.py
@@ -71,12 +71,8 @@ class TRTLLMBackend(BaseBackend):
 
         # Resolve KV cache parameters from kwargs (TRTLLM defaults apply).
         max_seq_len = kwargs.get("max_seq_len")
-        free_gpu_memory_fraction = kwargs.get("free_gpu_memory_fraction")
-        if free_gpu_memory_fraction is None:
-            free_gpu_memory_fraction = TRTLLM_DEFAULT_FREE_GPU_MEMORY_FRACTION
-        max_num_tokens = kwargs.get("max_num_tokens")
-        if max_num_tokens is None:
-            max_num_tokens = TRTLLM_DEFAULT_MAX_NUM_TOKENS
+        free_gpu_memory_fraction = kwargs.get("free_gpu_memory_fraction", TRTLLM_DEFAULT_FREE_GPU_MEMORY_FRACTION)
+        max_num_tokens = kwargs.get("max_num_tokens", TRTLLM_DEFAULT_MAX_NUM_TOKENS)
 
         try:
             summary = self._agg_cache[isl][osl][b][ctx_tokens][max_seq_len][max_num_tokens][free_gpu_memory_fraction]
@@ -468,9 +464,7 @@ class TRTLLMBackend(BaseBackend):
         ctx_stride = kwargs.get("ctx_stride", 512)
         enable_chunked_prefill = kwargs.get("enable_chunked_prefill", False)
         max_seq_len = kwargs.get("max_seq_len", isl + osl)
-        free_gpu_memory_fraction = kwargs.get("free_gpu_memory_fraction")
-        if free_gpu_memory_fraction is None:
-            free_gpu_memory_fraction = TRTLLM_DEFAULT_FREE_GPU_MEMORY_FRACTION
+        free_gpu_memory_fraction = kwargs.get("free_gpu_memory_fraction", TRTLLM_DEFAULT_FREE_GPU_MEMORY_FRACTION)
 
         # when b is larger than 1024, the result is not good as the data collection is not enough
         # to cover this.

--- a/src/aiconfigurator/sdk/backends/trtllm_backend.py
+++ b/src/aiconfigurator/sdk/backends/trtllm_backend.py
@@ -447,11 +447,14 @@ class TRTLLMBackend(BaseBackend):
         # during the loop, as b, ctx_tokens and system memory are monotonic, we can break the
         # inner loop when the system is oom.
         free_gpu_memory_fraction = kwargs.get("free_gpu_memory_fraction", 1.0)
+        max_seq_len_kv = kwargs.get("max_seq_len") or (isl + osl)
         b_list = [
             b
             for b in b_list_default
             if b <= max_batch_size
-            and not self._is_kv_cache_oom(model, database, b, isl, osl, free_gpu_memory_fraction, max_seq_len=isl + osl)
+            and not self._is_kv_cache_oom(
+                model, database, b, isl, osl, free_gpu_memory_fraction, max_seq_len=max_seq_len_kv
+            )
         ]
         ctx_tokens_list = self._get_ctx_tokens_list_for_agg_sweep(isl, ctx_stride, enable_chunked_prefill)
 

--- a/src/aiconfigurator/sdk/backends/trtllm_backend.py
+++ b/src/aiconfigurator/sdk/backends/trtllm_backend.py
@@ -42,7 +42,15 @@ class TRTLLMBackend(BaseBackend):
         self,
     ):
         super().__init__()
-        self._agg_cache = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict())))
+        # Cache key: [isl][osl][batch_size][ctx_tokens]
+        #            [max_seq_len][max_num_tokens][free_gpu_memory_fraction]
+        self._agg_cache = defaultdict(
+            lambda: defaultdict(
+                lambda: defaultdict(
+                    lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict())))
+                )
+            )
+        )
         self.name = common.BackendName.trtllm
 
     def run_agg(
@@ -61,8 +69,17 @@ class TRTLLMBackend(BaseBackend):
         assert ctx_tokens is not None, "ctx_tokens is required"
         balance_score = isl * b / ctx_tokens / osl
 
+        # Resolve KV cache parameters from kwargs (TRTLLM defaults apply).
+        max_seq_len = kwargs.get("max_seq_len")
+        free_gpu_memory_fraction = kwargs.get("free_gpu_memory_fraction")
+        if free_gpu_memory_fraction is None:
+            free_gpu_memory_fraction = TRTLLM_DEFAULT_FREE_GPU_MEMORY_FRACTION
+        max_num_tokens = kwargs.get("max_num_tokens")
+        if max_num_tokens is None:
+            max_num_tokens = TRTLLM_DEFAULT_MAX_NUM_TOKENS
+
         try:
-            summary = self._agg_cache[isl][osl][b][ctx_tokens]
+            summary = self._agg_cache[isl][osl][b][ctx_tokens][max_seq_len][max_num_tokens][free_gpu_memory_fraction]
         except KeyError:
             # we would like to calculate num_mix_steps and num_genonly_steps based on
             # isl, osl, b, ctx_tokens within osl steps, need to finish all the ctx tokens
@@ -321,7 +338,20 @@ class TRTLLMBackend(BaseBackend):
                 num_tokens = num_gen_requests + ctx_tokens
             else:
                 num_tokens = ctx_tokens
-            memory = self._get_memory_usage(model, database, b, 1, isl, osl, num_tokens, prefix=prefix)
+
+            # Compute memory reflecting what TRT-LLM actually allocates:
+            # activations sized by max_num_tokens, kvcache sized by max_seq_len.
+            memory = self._get_memory_usage(
+                model,
+                database,
+                b,
+                1,
+                isl,
+                osl,
+                num_tokens=max_num_tokens,
+                prefix=prefix,
+                max_seq_len=max_seq_len,
+            )
             tp = model.config.tp_size
             pp = model.config.pp_size
             dp = model.config.attention_dp_size
@@ -341,13 +371,6 @@ class TRTLLMBackend(BaseBackend):
             moe = model.config.moe_quant_mode.name
             comm = model.config.comm_quant_mode.name
             mem = memory["total"]
-            max_seq_len_kv = kwargs.get("max_seq_len")
-            free_gpu_memory_fraction_kv = kwargs.get("free_gpu_memory_fraction")
-            if free_gpu_memory_fraction_kv is None:
-                free_gpu_memory_fraction_kv = TRTLLM_DEFAULT_FREE_GPU_MEMORY_FRACTION
-            max_num_tokens_kv = kwargs.get("max_num_tokens")
-            if max_num_tokens_kv is None:
-                max_num_tokens_kv = TRTLLM_DEFAULT_MAX_NUM_TOKENS
 
             result_dict = {
                 "model": model.model_path,
@@ -392,29 +415,10 @@ class TRTLLMBackend(BaseBackend):
             }
             result = pd.DataFrame([result_dict], columns=common.ColumnsAgg).round(3)
             summary = InferenceSummary(RuntimeConfig(isl=isl, osl=osl))
-
-            # KV cache budget check: compute a separate memory dict with max_seq_len
-            # so set_memory_and_check_oom can check both absolute OOM and KV budget.
-            # max_num_tokens_kv determines the activation memory TRT-LLM pre-allocates
-            # at engine build time (see BuildConfig.max_num_tokens, default 8192).
-            kv_memory = None
-            if max_seq_len_kv is not None and free_gpu_memory_fraction_kv < 1.0:
-                kv_memory = self._get_memory_usage(
-                    model,
-                    database,
-                    b,
-                    1,
-                    isl,
-                    osl,
-                    num_tokens=max_num_tokens_kv,
-                    max_seq_len=max_seq_len_kv,
-                )
-
             summary.set_memory_and_check_oom(
                 memory,
                 database.system_spec["gpu"]["mem_capacity"],
-                kv_memory_dict=kv_memory,
-                free_gpu_memory_fraction=free_gpu_memory_fraction_kv,
+                free_gpu_memory_fraction=free_gpu_memory_fraction,
                 kv_cache_reserved_fraction=KV_CACHE_MEMORY_RESERVED_FRACTION,
                 kv_cache_tolerance=KV_CACHE_MEMORY_TOLERANCE,
             )
@@ -431,7 +435,7 @@ class TRTLLMBackend(BaseBackend):
             summary.set_per_ops_data(per_ops_data)
 
             # caching
-            self._agg_cache[isl][osl][b][ctx_tokens] = summary
+            self._agg_cache[isl][osl][b][ctx_tokens][max_seq_len][max_num_tokens][free_gpu_memory_fraction] = summary
 
         return summary
 

--- a/src/aiconfigurator/sdk/backends/trtllm_backend.py
+++ b/src/aiconfigurator/sdk/backends/trtllm_backend.py
@@ -28,6 +28,10 @@ KV_CACHE_MEMORY_TOLERANCE: float = 0.02
 # Default fraction of free GPU memory that TRT-LLM allocates for KV cache.
 TRTLLM_DEFAULT_FREE_GPU_MEMORY_FRACTION: float = 0.9
 
+# Default max_num_tokens for TRT-LLM engine builds (BuildConfig.max_num_tokens).
+# Determines activation memory pre-allocated at engine build time.
+TRTLLM_DEFAULT_MAX_NUM_TOKENS: int = 8192
+
 
 class TRTLLMBackend(BaseBackend):
     """
@@ -341,6 +345,9 @@ class TRTLLMBackend(BaseBackend):
             free_gpu_memory_fraction_kv = kwargs.get("free_gpu_memory_fraction")
             if free_gpu_memory_fraction_kv is None:
                 free_gpu_memory_fraction_kv = TRTLLM_DEFAULT_FREE_GPU_MEMORY_FRACTION
+            max_num_tokens_kv = kwargs.get("max_num_tokens")
+            if max_num_tokens_kv is None:
+                max_num_tokens_kv = TRTLLM_DEFAULT_MAX_NUM_TOKENS
 
             result_dict = {
                 "model": model.model_path,
@@ -388,8 +395,8 @@ class TRTLLMBackend(BaseBackend):
 
             # KV cache budget check: compute a separate memory dict with max_seq_len
             # so set_memory_and_check_oom can check both absolute OOM and KV budget.
-            # num_tokens=2*isl matches the --max_num_tokens used in TRT-LLM benchmarks,
-            # which determines peak activation memory allocation.
+            # max_num_tokens_kv determines the activation memory TRT-LLM pre-allocates
+            # at engine build time (see BuildConfig.max_num_tokens, default 8192).
             kv_memory = None
             if max_seq_len_kv is not None and free_gpu_memory_fraction_kv < 1.0:
                 kv_memory = self._get_memory_usage(
@@ -399,7 +406,7 @@ class TRTLLMBackend(BaseBackend):
                     1,
                     isl,
                     osl,
-                    num_tokens=2 * isl,
+                    num_tokens=max_num_tokens_kv,
                     max_seq_len=max_seq_len_kv,
                 )
 

--- a/src/aiconfigurator/sdk/backends/trtllm_backend.py
+++ b/src/aiconfigurator/sdk/backends/trtllm_backend.py
@@ -643,17 +643,21 @@ class TRTLLMBackend(BaseBackend):
                 Defaults to KV_CACHE_MEMORY_TOLERANCE.
         """
         memory = self._get_memory_usage(model, database, 1, 1, isl, osl, num_tokens=2 * isl)
-        non_kv_gib = memory["total"] - memory["kvcache"]
-        gpu_capacity_gib = database.system_spec["gpu"]["mem_capacity"] / (1 << 30)
-        available_kv_gib = (gpu_capacity_gib - non_kv_gib) * free_gpu_memory_fraction
-        available_kv_gib *= 1 - KV_CACHE_MEMORY_RESERVED_FRACTION
+        non_kv_gib = memory["total"] - memory["kvcache"]  # weights + activations + nccl + others
+        gpu_capacity_gib = database.system_spec["gpu"]["mem_capacity"] / (1 << 30)  # total GPU capacity in GiB
+        available_kv_gib = (
+            gpu_capacity_gib - non_kv_gib
+        ) * free_gpu_memory_fraction  # available KV memory in GiB after subtracting non-KV memory
+        available_kv_gib *= 1 - KV_CACHE_MEMORY_RESERVED_FRACTION  # subtract reserved memory for internal overhead
         if available_kv_gib <= 0:
             return True
-        kvcache_per_token_gib = memory["kvcache"] / (isl + osl)
+        kvcache_per_token_gib = memory["kvcache"] / (isl + osl)  # KV cache per token
         if kvcache_per_token_gib <= 0:
             return False
         tokens_per_block = 32
-        total_blocks = int(available_kv_gib / (kvcache_per_token_gib * tokens_per_block))
-        blocks_per_seq = math.ceil(max_seq_len / tokens_per_block)
-        max_concurrent_seqs = total_blocks // blocks_per_seq
+        total_blocks = int(
+            available_kv_gib / (kvcache_per_token_gib * tokens_per_block)
+        )  # total blocks that can be cached (capacity)
+        blocks_per_seq = math.ceil(max_seq_len / tokens_per_block)  # total blocks per sequence
+        max_concurrent_seqs = total_blocks // blocks_per_seq  # max concurrent sequences that can be cached (capacity)
         return batch_size > int(max_concurrent_seqs * (1 - kv_cache_capacity_tolerance))

--- a/src/aiconfigurator/sdk/backends/trtllm_backend.py
+++ b/src/aiconfigurator/sdk/backends/trtllm_backend.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import math
 from collections import defaultdict
 
 import numpy as np
@@ -449,7 +450,8 @@ class TRTLLMBackend(BaseBackend):
         b_list = [
             b
             for b in b_list_default
-            if b <= max_batch_size and not self._is_kv_cache_oom(model, database, b, isl, osl, free_gpu_memory_fraction)
+            if b <= max_batch_size
+            and not self._is_kv_cache_oom(model, database, b, isl, osl, free_gpu_memory_fraction, max_seq_len=isl + osl)
         ]
         ctx_tokens_list = self._get_ctx_tokens_list_for_agg_sweep(isl, ctx_stride, enable_chunked_prefill)
 
@@ -618,55 +620,40 @@ class TRTLLMBackend(BaseBackend):
         isl: int,
         osl: int,
         free_gpu_memory_fraction: float = 0.9,
-        max_seq_len: int | None = None,
+        *,
+        max_seq_len: int,
         kv_cache_capacity_tolerance: float = KV_CACHE_MEMORY_TOLERANCE,
     ) -> bool:
         """Return True if batch_size exceeds the KV cache capacity.
 
+        Uses TRT-LLM's block-based allocation model: KV cache is divided into
+        fixed-size blocks (tokens_per_block=32). Each sequence pre-allocates
+        ceil(max_seq_len / tokens_per_block) blocks regardless of actual usage.
+        max_seq_len must match the TRT-LLM --max_seq_len setting.
+
         Uses fixed activation (num_tokens=2*isl, matching TRT-LLM's --max_num_tokens)
-        and block-based KV allocation to check whether the requested batch_size
-        can be served concurrently without queuing.
+        so activation memory does not scale with batch_size.
 
         Args:
-            max_seq_len: Tokens reserved per sequence for block allocation.
-                Defaults to isl+osl. Pass isl+osl+slack to match a TRT-LLM
-                deployment that uses --max_seq_len isl+osl+slack.
-            kv_cache_capacity_tolerance: Lower-bound reduction applied to the
-                computed threshold before comparing, making the OOM check
-                conservative by the given fraction. Set to 0 in tests to validate
-                the raw formula against benchmark data. Defaults to
-                KV_CACHE_MEMORY_TOLERANCE.
+            max_seq_len: The TRT-LLM --max_seq_len setting. Determines how many
+                blocks TRT-LLM pre-allocates per sequence. Must be provided explicitly.
+            kv_cache_capacity_tolerance: Lower-bound reduction applied to max concurrent
+                sequences, making the check conservative. Set to 0 in tests to validate
+                the raw formula against benchmark data.
+                Defaults to KV_CACHE_MEMORY_TOLERANCE.
         """
-        import math
-
-        if max_seq_len is None:
-            max_seq_len = isl + osl
-
-        # Fixed activation (num_tokens=2*isl) matches TRT-LLM's --max_num_tokens.
-        # bs-scaled activation overestimates non_kv at large batch sizes.
         memory = self._get_memory_usage(model, database, 1, 1, isl, osl, num_tokens=2 * isl)
         non_kv_gib = memory["total"] - memory["kvcache"]
         gpu_capacity_gib = database.system_spec["gpu"]["mem_capacity"] / (1 << 30)
         available_kv_gib = (gpu_capacity_gib - non_kv_gib) * free_gpu_memory_fraction
         available_kv_gib *= 1 - KV_CACHE_MEMORY_RESERVED_FRACTION
-
         if available_kv_gib <= 0:
-            return True  # model barely fits, no KV room for any sequence
-
-        # Derive kvcache_per_token from _get_memory_usage (avoids duplicating the formula).
-        # kvcache at bs=1 = (isl+osl)*kvcache_per_token.
+            return True
         kvcache_per_token_gib = memory["kvcache"] / (isl + osl)
         if kvcache_per_token_gib <= 0:
             return False
-
-        # Block-based allocation: TRT-LLM reserves ceil(max_seq_len/tokens_per_block)
-        # blocks per sequence regardless of actual sequence length.
         tokens_per_block = 32
-        kvcache_per_block_gib = kvcache_per_token_gib * tokens_per_block
-        total_blocks = int(available_kv_gib / kvcache_per_block_gib)
+        total_blocks = int(available_kv_gib / (kvcache_per_token_gib * tokens_per_block))
         blocks_per_seq = math.ceil(max_seq_len / tokens_per_block)
-        if blocks_per_seq <= 0:
-            return False
-
         max_concurrent_seqs = total_blocks // blocks_per_seq
         return batch_size > int(max_concurrent_seqs * (1 - kv_cache_capacity_tolerance))

--- a/src/aiconfigurator/sdk/backends/trtllm_backend.py
+++ b/src/aiconfigurator/sdk/backends/trtllm_backend.py
@@ -437,15 +437,11 @@ class TRTLLMBackend(BaseBackend):
         # during the loop, as b, ctx_tokens and system memory are monotonic, we can break the
         # inner loop when the system is oom.
         free_gpu_memory_fraction = kwargs.get("free_gpu_memory_fraction", 1.0)
-        max_kv_bs = self._calculate_max_kv_cache_batch_size(model, database, isl, osl, free_gpu_memory_fraction)
-        if max_kv_bs > 0 and max_kv_bs < max_batch_size:
-            logger.debug(
-                "KV cache limits effective batch size to %d (requested max_batch_size=%d)",
-                max_kv_bs,
-                max_batch_size,
-            )
-        effective_max = min(max_batch_size, max_kv_bs) if max_kv_bs > 0 else max_batch_size
-        b_list = [b for b in b_list_default if b <= effective_max]
+        b_list = [
+            b
+            for b in b_list_default
+            if b <= max_batch_size and not self._is_kv_cache_oom(model, database, b, isl, osl, free_gpu_memory_fraction)
+        ]
         ctx_tokens_list = self._get_ctx_tokens_list_for_agg_sweep(isl, ctx_stride, enable_chunked_prefill)
 
         results_df = pd.DataFrame(columns=common.ColumnsAgg)
@@ -605,59 +601,55 @@ class TRTLLMBackend(BaseBackend):
             "others": others_mem / one_gib,
         }
 
-    def _calculate_max_kv_cache_batch_size(
+    def _is_kv_cache_oom(
         self,
         model: BaseModel,
         database: PerfDatabase,
+        batch_size: int,
         isl: int,
         osl: int,
         free_gpu_memory_fraction: float = 0.9,
         max_seq_len: int | None = None,
-        num_tokens: int | None = None,
-    ) -> int:
-        """Return the max batch size the KV cache can hold concurrently.
+    ) -> bool:
+        """Return True if batch_size exceeds the KV cache capacity.
 
-        Uses _get_memory_usage(batch_size=1) to derive non-KV memory and the
-        per-token KV cost, avoiding duplicated kvcache_per_token logic.
+        Uses fixed activation (num_tokens=2*isl, matching TRT-LLM's --max_num_tokens)
+        and block-based KV allocation to check whether the requested batch_size
+        can be served concurrently without queuing.
 
         Args:
             max_seq_len: Tokens reserved per sequence for block allocation.
                 Defaults to isl+osl. Pass isl+osl+slack to match a TRT-LLM
                 deployment that uses --max_seq_len isl+osl+slack.
-            num_tokens: Fixed token count for activation estimation, matching
-                TRT-LLM's --max_num_tokens. Defaults to 2*isl.
-
-        Returns:
-            Max concurrent sequences. 0 if the model itself barely fits.
         """
+        import math
+
         if max_seq_len is None:
             max_seq_len = isl + osl
-        if num_tokens is None:
-            num_tokens = 2 * isl
 
-        memory = self._get_memory_usage(model, database, 1, 1, isl, osl, num_tokens=num_tokens)
+        # Fixed activation (num_tokens=2*isl) matches TRT-LLM's --max_num_tokens.
+        # bs-scaled activation overestimates non_kv at large batch sizes.
+        memory = self._get_memory_usage(model, database, 1, 1, isl, osl, num_tokens=2 * isl)
         non_kv_gib = memory["total"] - memory["kvcache"]
         gpu_capacity_gib = database.system_spec["gpu"]["mem_capacity"] / (1 << 30)
         available_kv_gib = (gpu_capacity_gib - non_kv_gib) * free_gpu_memory_fraction
 
         if available_kv_gib <= 0:
-            return 0
+            return True  # model barely fits, no KV room for any sequence
 
-        # Derive kvcache_per_token from _get_memory_usage result (avoids duplicating
-        # the per-token KV cost formula).  kvcache at bs=1 = (isl+osl)*kvcache_per_token.
+        # Derive kvcache_per_token from _get_memory_usage (avoids duplicating the formula).
+        # kvcache at bs=1 = (isl+osl)*kvcache_per_token.
         kvcache_per_token_gib = memory["kvcache"] / (isl + osl)
         if kvcache_per_token_gib <= 0:
-            return 0
+            return False
 
         # Block-based allocation: TRT-LLM reserves ceil(max_seq_len/tokens_per_block)
         # blocks per sequence regardless of actual sequence length.
         tokens_per_block = 32
-        import math
-
         kvcache_per_block_gib = kvcache_per_token_gib * tokens_per_block
         total_blocks = int(available_kv_gib / kvcache_per_block_gib)
         blocks_per_seq = math.ceil(max_seq_len / tokens_per_block)
         if blocks_per_seq <= 0:
-            return 0
+            return False
 
-        return total_blocks // blocks_per_seq
+        return batch_size > total_blocks // blocks_per_seq

--- a/src/aiconfigurator/sdk/backends/trtllm_backend.py
+++ b/src/aiconfigurator/sdk/backends/trtllm_backend.py
@@ -72,7 +72,11 @@ class TRTLLMBackend(BaseBackend):
         # Resolve KV cache parameters from kwargs (TRTLLM defaults apply).
         # Use `if x is None` instead of kwargs.get default so that an explicit
         # None passed by the Python API still falls back to the constant.
+        # max_seq_len must be resolved before the cache lookup to avoid None and
+        # isl+osl landing in separate cache buckets for identical configurations.
         max_seq_len = kwargs.get("max_seq_len")
+        if max_seq_len is None:
+            max_seq_len = isl + osl
         free_gpu_memory_fraction = kwargs.get("free_gpu_memory_fraction")
         if free_gpu_memory_fraction is None:
             free_gpu_memory_fraction = TRTLLM_DEFAULT_FREE_GPU_MEMORY_FRACTION

--- a/src/aiconfigurator/sdk/backends/trtllm_backend.py
+++ b/src/aiconfigurator/sdk/backends/trtllm_backend.py
@@ -458,6 +458,11 @@ class TRTLLMBackend(BaseBackend):
             ctx_stride: the stride of ctx tokens to test, it will impact the time to run the test.
             enable_chunked_prefill: whether to enable chunked prefill, it will impact the time to
                 run the test while have little impact on the result. Default off.
+            free_gpu_memory_fraction: fraction of free GPU memory allocated for KV cache.
+                When set, batch sizes that would exceed KV cache capacity are filtered out.
+                Defaults to ``TRTLLM_DEFAULT_FREE_GPU_MEMORY_FRACTION`` (0.9).
+            max_seq_len: per-slot KV cache pre-allocation budget (tokens per sequence).
+                Defaults to ``isl + osl`` when not provided.
 
         Returns:
             A summary of the best agg result under constraints.

--- a/src/aiconfigurator/sdk/backends/trtllm_backend.py
+++ b/src/aiconfigurator/sdk/backends/trtllm_backend.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-import math
 from collections import defaultdict
 
 import numpy as np
@@ -395,6 +394,29 @@ class TRTLLMBackend(BaseBackend):
             # caching
             self._agg_cache[isl][osl][b][ctx_tokens] = summary
 
+        # KV OOM check (outside cache — depends on caller's kwargs, not cached).
+        # Inflate kvcache by 1/(frac*(1-reserved)*(1-tol)) so total >= gpu_capacity fires at
+        # KV budget exhaustion. Only applies when both max_seq_len and free_gpu_memory_fraction
+        # are provided; return a fresh OOM summary without polluting the cache.
+        max_seq_len_kv = kwargs.get("max_seq_len")
+        free_gpu_memory_fraction_kv = kwargs.get("free_gpu_memory_fraction", 0.9)
+        if max_seq_len_kv is not None and free_gpu_memory_fraction_kv < 1.0 and not summary.check_oom():
+            kv_memory = self._get_memory_usage(
+                model,
+                database,
+                b,
+                1,
+                isl,
+                osl,
+                num_tokens=2 * isl,
+                max_seq_len=max_seq_len_kv,
+                free_gpu_memory_fraction=free_gpu_memory_fraction_kv,
+            )
+            if kv_memory["total"] >= database.system_spec["gpu"]["mem_capacity"] / (1 << 30):
+                kv_oom_summary = InferenceSummary(RuntimeConfig(isl=isl, osl=osl))
+                kv_oom_summary.set_oom(True)
+                return kv_oom_summary
+
         return summary
 
     def find_best_agg_result_under_constraints(
@@ -446,16 +468,7 @@ class TRTLLMBackend(BaseBackend):
         # max(8192, 4*isl).
         # during the loop, as b, ctx_tokens and system memory are monotonic, we can break the
         # inner loop when the system is oom.
-        free_gpu_memory_fraction = kwargs.get("free_gpu_memory_fraction", 1.0)
-        max_seq_len_kv = kwargs.get("max_seq_len") or (isl + osl)
-        b_list = [
-            b
-            for b in b_list_default
-            if b <= max_batch_size
-            and not self._is_kv_cache_oom(
-                model, database, b, isl, osl, free_gpu_memory_fraction, max_seq_len=max_seq_len_kv
-            )
-        ]
+        b_list = [b for b in b_list_default if b <= max_batch_size]
         ctx_tokens_list = self._get_ctx_tokens_list_for_agg_sweep(isl, ctx_stride, enable_chunked_prefill)
 
         results_df = pd.DataFrame(columns=common.ColumnsAgg)
@@ -492,6 +505,8 @@ class TRTLLMBackend(BaseBackend):
                         seq_imbalance_correction_scale=runtime_config.seq_imbalance_correction_scale,
                     ),
                     ctx_tokens=ctx_tokens,
+                    max_seq_len=kwargs.get("max_seq_len"),
+                    free_gpu_memory_fraction=kwargs.get("free_gpu_memory_fraction", 0.9),
                 )
 
                 if summary.check_oom():
@@ -523,6 +538,8 @@ class TRTLLMBackend(BaseBackend):
         osl: int,
         num_tokens: int = 0,
         prefix: int = 0,
+        max_seq_len: int | None = None,
+        free_gpu_memory_fraction: float = 0.9,
     ) -> dict[str, float]:
         """
         Get the memory usage of the backend.
@@ -590,11 +607,15 @@ class TRTLLMBackend(BaseBackend):
             num_kv_heads_per_gpu = (model._num_kv_heads + model.config.tp_size - 1) // model.config.tp_size
             kvcache_per_token = num_kv_heads_per_gpu * model._head_size * model._num_layers * 2
         # should not be divided by pp_size as you need to hold all kvcache for stages.
-        kvcache = (
-            (batch_size * isl + batch_size * beam_width * osl)
-            * model.config.kvcache_quant_mode.value.memory
-            * kvcache_per_token
-        )
+        seq_tokens = max_seq_len if max_seq_len is not None else isl + beam_width * osl
+        kvcache = batch_size * seq_tokens * model.config.kvcache_quant_mode.value.memory * kvcache_per_token
+        # When max_seq_len and free_gpu_memory_fraction are both provided, inflate kvcache to
+        # represent TRT-LLM's effective memory reservation. This makes memory["total"] >=
+        # gpu_capacity fire at KV budget exhaustion, so the existing OOM check catches it.
+        if max_seq_len is not None and free_gpu_memory_fraction < 1.0:
+            kvcache /= (
+                free_gpu_memory_fraction * (1 - KV_CACHE_MEMORY_RESERVED_FRACTION) * (1 - KV_CACHE_MEMORY_TOLERANCE)
+            )
         # if 'DEEPSEEK' in model.model_path or 'MOE' in model.model_path:
         #    kvcache = kvcache * model.config.attention_dp_size # this is incorrect. tp will
         #    duplicate the kvcache while attn_dp will not.
@@ -614,53 +635,3 @@ class TRTLLMBackend(BaseBackend):
             "nccl": nccl_mem / one_gib,
             "others": others_mem / one_gib,
         }
-
-    def _is_kv_cache_oom(
-        self,
-        model: BaseModel,
-        database: PerfDatabase,
-        batch_size: int,
-        isl: int,
-        osl: int,
-        free_gpu_memory_fraction: float = 0.9,
-        *,
-        max_seq_len: int,
-        kv_cache_capacity_tolerance: float = KV_CACHE_MEMORY_TOLERANCE,
-    ) -> bool:
-        """Return True if batch_size exceeds the KV cache capacity.
-
-        Uses TRT-LLM's block-based allocation model: KV cache is divided into
-        fixed-size blocks (tokens_per_block=32). Each sequence pre-allocates
-        ceil(max_seq_len / tokens_per_block) blocks regardless of actual usage.
-        max_seq_len must match the TRT-LLM --max_seq_len setting.
-
-        Uses fixed activation (num_tokens=2*isl, matching TRT-LLM's --max_num_tokens)
-        so activation memory does not scale with batch_size.
-
-        Args:
-            max_seq_len: The TRT-LLM --max_seq_len setting. Determines how many
-                blocks TRT-LLM pre-allocates per sequence. Must be provided explicitly.
-            kv_cache_capacity_tolerance: Lower-bound reduction applied to max concurrent
-                sequences, making the check conservative. Set to 0 in tests to validate
-                the raw formula against benchmark data.
-                Defaults to KV_CACHE_MEMORY_TOLERANCE.
-        """
-        memory = self._get_memory_usage(model, database, 1, 1, isl, osl, num_tokens=2 * isl)
-        non_kv_gib = memory["total"] - memory["kvcache"]  # weights + activations + nccl + others
-        gpu_capacity_gib = database.system_spec["gpu"]["mem_capacity"] / (1 << 30)  # total GPU capacity in GiB
-        available_kv_gib = (
-            gpu_capacity_gib - non_kv_gib
-        ) * free_gpu_memory_fraction  # available KV memory in GiB after subtracting non-KV memory
-        available_kv_gib *= 1 - KV_CACHE_MEMORY_RESERVED_FRACTION  # subtract reserved memory for internal overhead
-        if available_kv_gib <= 0:
-            return True
-        kvcache_per_token_gib = memory["kvcache"] / (isl + osl)  # KV cache per token
-        if kvcache_per_token_gib <= 0:
-            return False
-        tokens_per_block = 32
-        total_blocks = int(
-            available_kv_gib / (kvcache_per_token_gib * tokens_per_block)
-        )  # total blocks that can be cached (capacity)
-        blocks_per_seq = math.ceil(max_seq_len / tokens_per_block)  # total blocks per sequence
-        max_concurrent_seqs = total_blocks // blocks_per_seq  # max concurrent sequences that can be cached (capacity)
-        return batch_size > int(max_concurrent_seqs * (1 - kv_cache_capacity_tolerance))

--- a/src/aiconfigurator/sdk/backends/trtllm_backend.py
+++ b/src/aiconfigurator/sdk/backends/trtllm_backend.py
@@ -447,6 +447,8 @@ class TRTLLMBackend(BaseBackend):
         max_batch_size = kwargs.get("max_batch_size", 512)
         ctx_stride = kwargs.get("ctx_stride", 512)
         enable_chunked_prefill = kwargs.get("enable_chunked_prefill", False)
+        max_seq_len = kwargs.get("max_seq_len", isl + osl)
+        free_gpu_memory_fraction = kwargs.get("free_gpu_memory_fraction", 0.9)
 
         # when b is larger than 1024, the result is not good as the data collection is not enough
         # to cover this.
@@ -505,8 +507,8 @@ class TRTLLMBackend(BaseBackend):
                         seq_imbalance_correction_scale=runtime_config.seq_imbalance_correction_scale,
                     ),
                     ctx_tokens=ctx_tokens,
-                    max_seq_len=kwargs.get("max_seq_len"),
-                    free_gpu_memory_fraction=kwargs.get("free_gpu_memory_fraction", 0.9),
+                    max_seq_len=max_seq_len,
+                    free_gpu_memory_fraction=free_gpu_memory_fraction,
                 )
 
                 if summary.check_oom():

--- a/src/aiconfigurator/sdk/backends/trtllm_backend.py
+++ b/src/aiconfigurator/sdk/backends/trtllm_backend.py
@@ -436,7 +436,8 @@ class TRTLLMBackend(BaseBackend):
         # max(8192, 4*isl).
         # during the loop, as b, ctx_tokens and system memory are monotonic, we can break the
         # inner loop when the system is oom.
-        max_kv_bs = self._calculate_max_kv_cache_batch_size(model, database, isl, osl)
+        free_gpu_memory_fraction = kwargs.get("free_gpu_memory_fraction", 1.0)
+        max_kv_bs = self._calculate_max_kv_cache_batch_size(model, database, isl, osl, free_gpu_memory_fraction)
         if max_kv_bs > 0 and max_kv_bs < max_batch_size:
             logger.debug(
                 "KV cache limits effective batch size to %d (requested max_batch_size=%d)",
@@ -610,96 +611,53 @@ class TRTLLMBackend(BaseBackend):
         database: PerfDatabase,
         isl: int,
         osl: int,
-        beam_width: int = 1,
         free_gpu_memory_fraction: float = 0.9,
-        max_num_tokens: int = 8192,
         max_seq_len: int | None = None,
-        tokens_per_block: int = 32,
+        num_tokens: int | None = None,
     ) -> int:
-        """
-        Calculate the maximum batch size the KV cache can support concurrently.
+        """Return the max batch size the KV cache can hold concurrently.
 
-        TRT-LLM allocates KV cache in fixed-size blocks and reserves blocks
-        for each sequence up to ``max_seq_len``.  If the requested batch_size
-        exceeds this capacity, TRT-LLM queues excess requests instead of
-        running them concurrently, leading to inflated TTFT and inaccurate
-        TPOT without raising an OOM error.
+        Uses _get_memory_usage(batch_size=1) to derive non-KV memory and the
+        per-token KV cost, avoiding duplicated kvcache_per_token logic.
 
         Args:
-            model: Model with architecture parameters.
-            database: Performance database with system spec (GPU memory, etc.).
-            isl: Input sequence length.
-            osl: Output sequence length.
-            beam_width: Beam width (default 1 for standard LLM serving).
-            free_gpu_memory_fraction: Fraction of free GPU memory that TRT-LLM
-                allocates for KV cache (default 0.9, matching TRT-LLM Python API).
-            max_num_tokens: Max tokens per forward step, used for activation
-                memory estimation (default 8192).
-            max_seq_len: Maximum sequence length TRT-LLM reserves KV blocks for.
-                Defaults to ``isl + osl`` when None.  TRT-LLM's ``--max_seq_len``
-                is typically set to ``isl + osl + slack``.
-            tokens_per_block: Tokens per KV cache block (default 32, matching
-                TRT-LLM default).
+            max_seq_len: Tokens reserved per sequence for block allocation.
+                Defaults to isl+osl. Pass isl+osl+slack to match a TRT-LLM
+                deployment that uses --max_seq_len isl+osl+slack.
+            num_tokens: Fixed token count for activation estimation, matching
+                TRT-LLM's --max_num_tokens. Defaults to 2*isl.
 
         Returns:
-            Maximum number of concurrent sequences the KV cache can hold.
-            Returns 0 if the model itself barely fits (no room for KV cache).
+            Max concurrent sequences. 0 if the model itself barely fits.
         """
-        import math
-
         if max_seq_len is None:
-            max_seq_len = isl + beam_width * osl
+            max_seq_len = isl + osl
+        if num_tokens is None:
+            num_tokens = 2 * isl
 
-        memory = self._get_memory_usage(
-            model,
-            database,
-            batch_size=1,
-            beam_width=beam_width,
-            isl=isl,
-            osl=osl,
-            num_tokens=max_num_tokens,
-            prefix=0,
-        )
-        non_kv_memory_gib = memory["total"] - memory["kvcache"]
-
+        memory = self._get_memory_usage(model, database, 1, 1, isl, osl, num_tokens=num_tokens)
+        non_kv_gib = memory["total"] - memory["kvcache"]
         gpu_capacity_gib = database.system_spec["gpu"]["mem_capacity"] / (1 << 30)
-        available_kv_gib = (gpu_capacity_gib - non_kv_memory_gib) * free_gpu_memory_fraction
+        available_kv_gib = (gpu_capacity_gib - non_kv_gib) * free_gpu_memory_fraction
 
         if available_kv_gib <= 0:
             return 0
 
-        if model.model_family == "DEEPSEEK":
-            kvcache_per_token = model._num_layers * 576
-        else:
-            num_kv_heads_per_gpu = (model._num_kv_heads + model.config.tp_size - 1) // model.config.tp_size
-            kvcache_per_token = num_kv_heads_per_gpu * model._head_size * model._num_layers * 2
-
-        kv_bytes_per_token = model.config.kvcache_quant_mode.value.memory * kvcache_per_token
-        if kv_bytes_per_token <= 0:
+        # Derive kvcache_per_token from _get_memory_usage result (avoids duplicating
+        # the per-token KV cost formula).  kvcache at bs=1 = (isl+osl)*kvcache_per_token.
+        kvcache_per_token_gib = memory["kvcache"] / (isl + osl)
+        if kvcache_per_token_gib <= 0:
             return 0
 
-        kv_bytes_per_block = tokens_per_block * kv_bytes_per_token
-        available_kv_bytes = available_kv_gib * (1 << 30)
-        total_blocks = int(available_kv_bytes / kv_bytes_per_block)
-        blocks_per_seq = math.ceil(max_seq_len / tokens_per_block)
+        # Block-based allocation: TRT-LLM reserves ceil(max_seq_len/tokens_per_block)
+        # blocks per sequence regardless of actual sequence length.
+        tokens_per_block = 32
+        import math
 
+        kvcache_per_block_gib = kvcache_per_token_gib * tokens_per_block
+        total_blocks = int(available_kv_gib / kvcache_per_block_gib)
+        blocks_per_seq = math.ceil(max_seq_len / tokens_per_block)
         if blocks_per_seq <= 0:
             return 0
 
-        max_batch_size = total_blocks // blocks_per_seq
-
-        logger.debug(
-            "KV cache capacity: total_blocks=%d, blocks_per_seq=%d, "
-            "max_kv_batch_size=%d (gpu=%.1f GiB, non_kv=%.2f GiB, "
-            "available_kv=%.2f GiB, fraction=%.2f, max_seq_len=%d)",
-            total_blocks,
-            blocks_per_seq,
-            max_batch_size,
-            gpu_capacity_gib,
-            non_kv_memory_gib,
-            available_kv_gib,
-            free_gpu_memory_fraction,
-            max_seq_len,
-        )
-
-        return max_batch_size
+        return total_blocks // blocks_per_seq

--- a/src/aiconfigurator/sdk/backends/trtllm_backend.py
+++ b/src/aiconfigurator/sdk/backends/trtllm_backend.py
@@ -25,6 +25,9 @@ KV_CACHE_MEMORY_RESERVED_FRACTION: float = 0.015
 # Used as the %-based tolerance band in KV cache capacity tests.
 KV_CACHE_MEMORY_TOLERANCE: float = 0.02
 
+# Default fraction of free GPU memory that TRT-LLM allocates for KV cache.
+TRTLLM_DEFAULT_FREE_GPU_MEMORY_FRACTION: float = 0.9
+
 
 class TRTLLMBackend(BaseBackend):
     """
@@ -334,6 +337,10 @@ class TRTLLMBackend(BaseBackend):
             moe = model.config.moe_quant_mode.name
             comm = model.config.comm_quant_mode.name
             mem = memory["total"]
+            max_seq_len_kv = kwargs.get("max_seq_len")
+            free_gpu_memory_fraction_kv = kwargs.get(
+                "free_gpu_memory_fraction", TRTLLM_DEFAULT_FREE_GPU_MEMORY_FRACTION
+            )
 
             result_dict = {
                 "model": model.model_path,
@@ -378,7 +385,32 @@ class TRTLLMBackend(BaseBackend):
             }
             result = pd.DataFrame([result_dict], columns=common.ColumnsAgg).round(3)
             summary = InferenceSummary(RuntimeConfig(isl=isl, osl=osl))
-            summary.set_memory_and_check_oom(memory, database.system_spec["gpu"]["mem_capacity"])
+
+            # KV cache budget check: compute a separate memory dict with max_seq_len
+            # so set_memory_and_check_oom can check both absolute OOM and KV budget.
+            # num_tokens=2*isl matches the --max_num_tokens used in TRT-LLM benchmarks,
+            # which determines peak activation memory allocation.
+            kv_memory = None
+            if max_seq_len_kv is not None and free_gpu_memory_fraction_kv < 1.0:
+                kv_memory = self._get_memory_usage(
+                    model,
+                    database,
+                    b,
+                    1,
+                    isl,
+                    osl,
+                    num_tokens=2 * isl,
+                    max_seq_len=max_seq_len_kv,
+                )
+
+            summary.set_memory_and_check_oom(
+                memory,
+                database.system_spec["gpu"]["mem_capacity"],
+                kv_memory_dict=kv_memory,
+                free_gpu_memory_fraction=free_gpu_memory_fraction_kv,
+                kv_cache_reserved_fraction=KV_CACHE_MEMORY_RESERVED_FRACTION,
+                kv_cache_tolerance=KV_CACHE_MEMORY_TOLERANCE,
+            )
             summary.set_summary_df(result)
             summary.set_result_dict(result_dict)
 
@@ -393,29 +425,6 @@ class TRTLLMBackend(BaseBackend):
 
             # caching
             self._agg_cache[isl][osl][b][ctx_tokens] = summary
-
-        # KV OOM check (outside cache — depends on caller's kwargs, not cached).
-        # Inflate kvcache by 1/(frac*(1-reserved)*(1-tol)) so total >= gpu_capacity fires at
-        # KV budget exhaustion. Only applies when both max_seq_len and free_gpu_memory_fraction
-        # are provided; return a fresh OOM summary without polluting the cache.
-        max_seq_len_kv = kwargs.get("max_seq_len")
-        free_gpu_memory_fraction_kv = kwargs.get("free_gpu_memory_fraction", 0.9)
-        if max_seq_len_kv is not None and free_gpu_memory_fraction_kv < 1.0 and not summary.check_oom():
-            kv_memory = self._get_memory_usage(
-                model,
-                database,
-                b,
-                1,
-                isl,
-                osl,
-                num_tokens=2 * isl,
-                max_seq_len=max_seq_len_kv,
-                free_gpu_memory_fraction=free_gpu_memory_fraction_kv,
-            )
-            if kv_memory["total"] >= database.system_spec["gpu"]["mem_capacity"] / (1 << 30):
-                kv_oom_summary = InferenceSummary(RuntimeConfig(isl=isl, osl=osl))
-                kv_oom_summary.set_oom(True)
-                return kv_oom_summary
 
         return summary
 
@@ -448,7 +457,7 @@ class TRTLLMBackend(BaseBackend):
         ctx_stride = kwargs.get("ctx_stride", 512)
         enable_chunked_prefill = kwargs.get("enable_chunked_prefill", False)
         max_seq_len = kwargs.get("max_seq_len", isl + osl)
-        free_gpu_memory_fraction = kwargs.get("free_gpu_memory_fraction", 0.9)
+        free_gpu_memory_fraction = kwargs.get("free_gpu_memory_fraction", TRTLLM_DEFAULT_FREE_GPU_MEMORY_FRACTION)
 
         # when b is larger than 1024, the result is not good as the data collection is not enough
         # to cover this.
@@ -511,7 +520,7 @@ class TRTLLMBackend(BaseBackend):
                     free_gpu_memory_fraction=free_gpu_memory_fraction,
                 )
 
-                if summary.check_oom():
+                if summary.check_oom() or summary.check_kv_cache_oom():
                     break  # larger ctx tokens will cause oom
                 all_oom = False
                 result_dict = summary.get_result_dict()
@@ -541,7 +550,6 @@ class TRTLLMBackend(BaseBackend):
         num_tokens: int = 0,
         prefix: int = 0,
         max_seq_len: int | None = None,
-        free_gpu_memory_fraction: float = 0.9,
     ) -> dict[str, float]:
         """
         Get the memory usage of the backend.
@@ -611,13 +619,6 @@ class TRTLLMBackend(BaseBackend):
         # should not be divided by pp_size as you need to hold all kvcache for stages.
         seq_tokens = max_seq_len if max_seq_len is not None else isl + beam_width * osl
         kvcache = batch_size * seq_tokens * model.config.kvcache_quant_mode.value.memory * kvcache_per_token
-        # When max_seq_len and free_gpu_memory_fraction are both provided, inflate kvcache to
-        # represent TRT-LLM's effective memory reservation. This makes memory["total"] >=
-        # gpu_capacity fire at KV budget exhaustion, so the existing OOM check catches it.
-        if max_seq_len is not None and free_gpu_memory_fraction < 1.0:
-            kvcache /= (
-                free_gpu_memory_fraction * (1 - KV_CACHE_MEMORY_RESERVED_FRACTION) * (1 - KV_CACHE_MEMORY_TOLERANCE)
-            )
         # if 'DEEPSEEK' in model.model_path or 'MOE' in model.model_path:
         #    kvcache = kvcache * model.config.attention_dp_size # this is incorrect. tp will
         #    duplicate the kvcache while attn_dp will not.

--- a/src/aiconfigurator/sdk/backends/trtllm_backend.py
+++ b/src/aiconfigurator/sdk/backends/trtllm_backend.py
@@ -338,9 +338,9 @@ class TRTLLMBackend(BaseBackend):
             comm = model.config.comm_quant_mode.name
             mem = memory["total"]
             max_seq_len_kv = kwargs.get("max_seq_len")
-            free_gpu_memory_fraction_kv = kwargs.get(
-                "free_gpu_memory_fraction", TRTLLM_DEFAULT_FREE_GPU_MEMORY_FRACTION
-            )
+            free_gpu_memory_fraction_kv = kwargs.get("free_gpu_memory_fraction")
+            if free_gpu_memory_fraction_kv is None:
+                free_gpu_memory_fraction_kv = TRTLLM_DEFAULT_FREE_GPU_MEMORY_FRACTION
 
             result_dict = {
                 "model": model.model_path,
@@ -457,7 +457,9 @@ class TRTLLMBackend(BaseBackend):
         ctx_stride = kwargs.get("ctx_stride", 512)
         enable_chunked_prefill = kwargs.get("enable_chunked_prefill", False)
         max_seq_len = kwargs.get("max_seq_len", isl + osl)
-        free_gpu_memory_fraction = kwargs.get("free_gpu_memory_fraction", TRTLLM_DEFAULT_FREE_GPU_MEMORY_FRACTION)
+        free_gpu_memory_fraction = kwargs.get("free_gpu_memory_fraction")
+        if free_gpu_memory_fraction is None:
+            free_gpu_memory_fraction = TRTLLM_DEFAULT_FREE_GPU_MEMORY_FRACTION
 
         # when b is larger than 1024, the result is not good as the data collection is not enough
         # to cover this.

--- a/src/aiconfigurator/sdk/backends/trtllm_backend.py
+++ b/src/aiconfigurator/sdk/backends/trtllm_backend.py
@@ -76,6 +76,8 @@ class TRTLLMBackend(BaseBackend):
         free_gpu_memory_fraction = kwargs.get("free_gpu_memory_fraction")
         if free_gpu_memory_fraction is None:
             free_gpu_memory_fraction = TRTLLM_DEFAULT_FREE_GPU_MEMORY_FRACTION
+        # max_num_tokens controls activation memory (batch-level budget, BuildConfig.max_num_tokens).
+        # This is distinct from max_seq_len, which controls per-slot KV cache pre-allocation.
         max_num_tokens = kwargs.get("max_num_tokens")
         if max_num_tokens is None:
             max_num_tokens = TRTLLM_DEFAULT_MAX_NUM_TOKENS
@@ -469,9 +471,11 @@ class TRTLLMBackend(BaseBackend):
         max_batch_size = kwargs.get("max_batch_size", 512)
         ctx_stride = kwargs.get("ctx_stride", 512)
         enable_chunked_prefill = kwargs.get("enable_chunked_prefill", False)
+        # max_seq_len controls per-slot KV cache pre-allocation (isl+osl is the natural workload bound).
+        # This is distinct from max_num_tokens, which controls batch-level activation memory.
         max_seq_len = kwargs.get("max_seq_len")
         if max_seq_len is None:
-            max_seq_len = TRTLLM_DEFAULT_MAX_NUM_TOKENS
+            max_seq_len = isl + osl
         free_gpu_memory_fraction = kwargs.get("free_gpu_memory_fraction")
         if free_gpu_memory_fraction is None:
             free_gpu_memory_fraction = TRTLLM_DEFAULT_FREE_GPU_MEMORY_FRACTION

--- a/src/aiconfigurator/sdk/backends/vllm_backend.py
+++ b/src/aiconfigurator/sdk/backends/vllm_backend.py
@@ -475,7 +475,7 @@ class VLLMBackend(BaseBackend):
                     ctx_tokens=ctx_tokens,
                 )
 
-                if summary.check_oom():
+                if summary.check_oom() or summary.check_kv_cache_oom():
                     break  # larger ctx tokens will cause oom
                 all_oom = False
                 result_dict = summary.get_result_dict()

--- a/src/aiconfigurator/sdk/inference_summary.py
+++ b/src/aiconfigurator/sdk/inference_summary.py
@@ -216,6 +216,12 @@ class InferenceSummary:
             logger.warning("WARNING: memory status is not set")
         return self._is_oom
 
+    def get_memory(self) -> dict:
+        """
+        Get memory breakdown dict (keys: total, weights, activations, kvcache, nccl, others).
+        """
+        return self._memory
+
     def get_static_info(self) -> tuple[str, str, str, str]:
         """
         Get static info.

--- a/src/aiconfigurator/sdk/inference_summary.py
+++ b/src/aiconfigurator/sdk/inference_summary.py
@@ -91,8 +91,8 @@ class InferenceSummary:
         (e.g. kvcache computed with ``max_seq_len``, activations with
         ``max_num_tokens``).
 
-        When *free_gpu_memory_fraction* is not ``None`` and < 1.0, also
-        performs the KV cache budget check using the same *memory_dict*.
+        When *free_gpu_memory_fraction* is not ``None``, also performs the
+        KV cache budget check using the same *memory_dict*.
         """
         self._memory = memory_dict
         self._is_oom = self._memory["total"] >= (mem_capacity / (1 << 30))

--- a/src/aiconfigurator/sdk/inference_summary.py
+++ b/src/aiconfigurator/sdk/inference_summary.py
@@ -97,7 +97,7 @@ class InferenceSummary:
         self._memory = memory_dict
         self._is_oom = self._memory["total"] >= (mem_capacity / (1 << 30))
         self._is_kv_cache_oom = False
-        if free_gpu_memory_fraction is not None and free_gpu_memory_fraction < 1.0:
+        if free_gpu_memory_fraction is not None:
             self._check_and_set_kv_cache_oom(
                 mem_capacity,
                 free_gpu_memory_fraction,

--- a/src/aiconfigurator/sdk/inference_summary.py
+++ b/src/aiconfigurator/sdk/inference_summary.py
@@ -81,22 +81,22 @@ class InferenceSummary:
         memory_dict: dict,
         mem_capacity: int,
         kv_memory_dict: dict | None = None,
-        free_gpu_memory_fraction: float = 1.0,
+        free_gpu_memory_fraction: float | None = None,
         kv_cache_reserved_fraction: float = 0.0,
         kv_cache_tolerance: float = 0.0,
     ) -> None:
         """
         Set memory and check oom.
 
-        When *kv_memory_dict* and a *free_gpu_memory_fraction* < 1.0 are
-        provided, also performs the KV cache budget check.  If
-        *kv_memory_dict* is ``None`` but *free_gpu_memory_fraction* < 1.0,
-        *memory_dict* itself is used for the KV check.
+        When *free_gpu_memory_fraction* is not ``None`` and < 1.0, also
+        performs the KV cache budget check.  *kv_memory_dict* supplies a
+        separate memory dict for that check (e.g. computed with
+        ``max_seq_len``); when ``None``, *memory_dict* itself is used.
         """
         self._memory = memory_dict
         self._is_oom = self._memory["total"] >= (mem_capacity / (1 << 30))
         self._is_kv_cache_oom = False
-        if free_gpu_memory_fraction < 1.0:
+        if free_gpu_memory_fraction is not None and free_gpu_memory_fraction < 1.0:
             kv_dict = kv_memory_dict if kv_memory_dict is not None else memory_dict
             self._check_and_set_kv_cache_oom(
                 kv_dict,
@@ -110,7 +110,7 @@ class InferenceSummary:
         self,
         kv_memory_dict: dict,
         mem_capacity: int,
-        free_gpu_memory_fraction: float,
+        free_gpu_memory_fraction: float | None,
         kv_cache_reserved_fraction: float,
         kv_cache_tolerance: float,
     ) -> None:
@@ -121,7 +121,7 @@ class InferenceSummary:
         ``kv > (capacity - non_kv) * frac * (1-res) * (1-tol)``.
         """
         self._is_kv_cache_oom = False
-        if self._is_oom or free_gpu_memory_fraction >= 1.0:
+        if self._is_oom or free_gpu_memory_fraction is None or free_gpu_memory_fraction >= 1.0:
             return
         mem_cap_gib = mem_capacity / (1 << 30)
         kv_gib = kv_memory_dict.get("kvcache", 0.0)

--- a/src/aiconfigurator/sdk/inference_summary.py
+++ b/src/aiconfigurator/sdk/inference_summary.py
@@ -80,7 +80,6 @@ class InferenceSummary:
         self,
         memory_dict: dict,
         mem_capacity: int,
-        kv_memory_dict: dict | None = None,
         free_gpu_memory_fraction: float | None = None,
         kv_cache_reserved_fraction: float = 0.0,
         kv_cache_tolerance: float = 0.0,
@@ -88,18 +87,18 @@ class InferenceSummary:
         """
         Set memory and check oom.
 
+        *memory_dict* should reflect the actual runtime memory layout
+        (e.g. kvcache computed with ``max_seq_len``, activations with
+        ``max_num_tokens``).
+
         When *free_gpu_memory_fraction* is not ``None`` and < 1.0, also
-        performs the KV cache budget check.  *kv_memory_dict* supplies a
-        separate memory dict for that check (e.g. computed with
-        ``max_seq_len``); when ``None``, *memory_dict* itself is used.
+        performs the KV cache budget check using the same *memory_dict*.
         """
         self._memory = memory_dict
         self._is_oom = self._memory["total"] >= (mem_capacity / (1 << 30))
         self._is_kv_cache_oom = False
         if free_gpu_memory_fraction is not None and free_gpu_memory_fraction < 1.0:
-            kv_dict = kv_memory_dict if kv_memory_dict is not None else memory_dict
             self._check_and_set_kv_cache_oom(
-                kv_dict,
                 mem_capacity,
                 free_gpu_memory_fraction,
                 kv_cache_reserved_fraction,
@@ -108,24 +107,25 @@ class InferenceSummary:
 
     def _check_and_set_kv_cache_oom(
         self,
-        kv_memory_dict: dict,
         mem_capacity: int,
-        free_gpu_memory_fraction: float | None,
+        free_gpu_memory_fraction: float,
         kv_cache_reserved_fraction: float,
         kv_cache_tolerance: float,
     ) -> None:
         """Check whether the KV cache exceeds the fraction-based memory budget.
+
+        Uses ``self._memory`` (set by :meth:`set_memory_and_check_oom`).
 
         Equivalent to the inflation formula
         ``kv / (frac*(1-res)*(1-tol)) + non_kv >= capacity`` rewritten as
         ``kv > (capacity - non_kv) * frac * (1-res) * (1-tol)``.
         """
         self._is_kv_cache_oom = False
-        if self._is_oom or free_gpu_memory_fraction is None or free_gpu_memory_fraction >= 1.0:
+        if self._is_oom:
             return
         mem_cap_gib = mem_capacity / (1 << 30)
-        kv_gib = kv_memory_dict.get("kvcache", 0.0)
-        non_kv_gib = kv_memory_dict["total"] - kv_gib
+        kv_gib = self._memory.get("kvcache", 0.0)
+        non_kv_gib = self._memory["total"] - kv_gib
         kv_budget = (
             (mem_cap_gib - non_kv_gib)
             * free_gpu_memory_fraction

--- a/src/aiconfigurator/sdk/inference_summary.py
+++ b/src/aiconfigurator/sdk/inference_summary.py
@@ -29,8 +29,11 @@ class InferenceSummary:
         - power: watts (W) - derived from energy/latency
 
     Methods:
-        set_memory_and_check_oom: set memory and check oom
+        set_memory_and_check_oom: set memory and check oom (+ optional kv cache budget check)
         set_oom: set oom
+        check_oom: check oom
+        set_kv_cache_oom: set kv cache oom
+        check_kv_cache_oom: check kv cache oom
         set_context_latency_dict: set context latency dict
         set_generation_latency_dict: set generation latency dict
         get_context_latency_dict: get context latency dict
@@ -39,7 +42,6 @@ class InferenceSummary:
         set_generation_energy_wms_dict: set generation energy dict
         get_context_energy_wms_dict: get context energy dict
         get_generation_energy_wms_dict: get generation energy dict
-        check_oom: check oom
         get_static_info: get static info for static mode print
         set_summary_df: set summary dataframe
         get_summary_df: get summary dataframe
@@ -58,6 +60,7 @@ class InferenceSummary:
         self._context_energy_wms_dict = {}  # RENAMED from _context_power_dict, W·ms
         self._generation_energy_wms_dict = {}  # RENAMED from _generation_power_dict, W·ms
         self._is_oom = None
+        self._is_kv_cache_oom = False
 
         # NEW: Store computed power averages
         self._context_power_avg = 0.0
@@ -73,12 +76,63 @@ class InferenceSummary:
         # per-ops latency breakdown (populated by run_agg or run_disagg)
         self._per_ops_data: dict | None = None
 
-    def set_memory_and_check_oom(self, memory_dict: dict, mem_capacity: int) -> None:
+    def set_memory_and_check_oom(
+        self,
+        memory_dict: dict,
+        mem_capacity: int,
+        kv_memory_dict: dict | None = None,
+        free_gpu_memory_fraction: float = 1.0,
+        kv_cache_reserved_fraction: float = 0.0,
+        kv_cache_tolerance: float = 0.0,
+    ) -> None:
         """
         Set memory and check oom.
+
+        When *kv_memory_dict* and a *free_gpu_memory_fraction* < 1.0 are
+        provided, also performs the KV cache budget check.  If
+        *kv_memory_dict* is ``None`` but *free_gpu_memory_fraction* < 1.0,
+        *memory_dict* itself is used for the KV check.
         """
         self._memory = memory_dict
         self._is_oom = self._memory["total"] >= (mem_capacity / (1 << 30))
+        self._is_kv_cache_oom = False
+        if free_gpu_memory_fraction < 1.0:
+            kv_dict = kv_memory_dict if kv_memory_dict is not None else memory_dict
+            self._check_and_set_kv_cache_oom(
+                kv_dict,
+                mem_capacity,
+                free_gpu_memory_fraction,
+                kv_cache_reserved_fraction,
+                kv_cache_tolerance,
+            )
+
+    def _check_and_set_kv_cache_oom(
+        self,
+        kv_memory_dict: dict,
+        mem_capacity: int,
+        free_gpu_memory_fraction: float,
+        kv_cache_reserved_fraction: float,
+        kv_cache_tolerance: float,
+    ) -> None:
+        """Check whether the KV cache exceeds the fraction-based memory budget.
+
+        Equivalent to the inflation formula
+        ``kv / (frac*(1-res)*(1-tol)) + non_kv >= capacity`` rewritten as
+        ``kv > (capacity - non_kv) * frac * (1-res) * (1-tol)``.
+        """
+        self._is_kv_cache_oom = False
+        if self._is_oom or free_gpu_memory_fraction >= 1.0:
+            return
+        mem_cap_gib = mem_capacity / (1 << 30)
+        kv_gib = kv_memory_dict.get("kvcache", 0.0)
+        non_kv_gib = kv_memory_dict["total"] - kv_gib
+        kv_budget = (
+            (mem_cap_gib - non_kv_gib)
+            * free_gpu_memory_fraction
+            * (1 - kv_cache_reserved_fraction)
+            * (1 - kv_cache_tolerance)
+        )
+        self._is_kv_cache_oom = kv_gib > kv_budget
 
     def set_oom(self, is_oom: bool) -> None:
         """
@@ -210,11 +264,31 @@ class InferenceSummary:
 
     def check_oom(self) -> bool:
         """
-        Check oom.
+        Check if total memory usage exceeds GPU capacity.
+
+        Returns True when ``weights + activations + kvcache + overhead >=
+        gpu_capacity``.  This is the *absolute* capacity check.
+
+        A separate :meth:`check_kv_cache_oom` exists for the *relative*
+        budget check, i.e. whether the KV cache portion alone exceeds the
+        ``free_gpu_memory_fraction``-based budget that the serving runtime
+        reserves for KV cache.
         """
         if self._is_oom is None:
             logger.warning("WARNING: memory status is not set")
         return self._is_oom
+
+    def set_kv_cache_oom(self, is_kv_cache_oom: bool) -> None:
+        """
+        Set kv cache oom.
+        """
+        self._is_kv_cache_oom = is_kv_cache_oom
+
+    def check_kv_cache_oom(self) -> bool:
+        """
+        Check kv cache oom.
+        """
+        return self._is_kv_cache_oom
 
     def get_memory(self) -> dict:
         """

--- a/src/aiconfigurator/sdk/pareto_analysis.py
+++ b/src/aiconfigurator/sdk/pareto_analysis.py
@@ -56,6 +56,7 @@ def agg_pareto(
     results_df = pd.DataFrame(columns=ColumnsAgg)
     exceptions = []
     all_configs_oom = True
+    all_kv_cache_oom = True
     for parallel_config in parallel_config_list:
         tp_size, pp_size, dp_size, moe_tp_size, moe_ep_size = parallel_config
         logger.debug(
@@ -120,6 +121,8 @@ def agg_pareto(
                 )
                 if not summary.check_oom():
                     all_configs_oom = False
+                if not summary.check_kv_cache_oom():
+                    all_kv_cache_oom = False
                 result_df = summary.get_summary_df()
                 if len(result_df) == 0:
                     logger.debug(
@@ -159,6 +162,12 @@ def agg_pareto(
                 "No results found: the model does not fit in GPU memory for any parallel "
                 "configuration. Try increasing --total-gpus, using a quantized model, or "
                 "using a system with more VRAM per GPU."
+            )
+        if all_kv_cache_oom:
+            raise RuntimeError(
+                "No results found: the requested batch size exceeds KV cache capacity for all "
+                "parallel configurations. Try reducing --batch-size, increasing "
+                "--free-gpu-memory-fraction, or using a system with more VRAM per GPU."
             )
         raise RuntimeError(
             "No results found for any parallel configuration. No configuration satisfied the "

--- a/src/aiconfigurator/sdk/pareto_analysis.py
+++ b/src/aiconfigurator/sdk/pareto_analysis.py
@@ -29,6 +29,8 @@ def agg_pareto(
     model_config: config.ModelConfig,
     parallel_config_list: list[list[int]],
     enable_chunked_prefill: bool = False,
+    free_gpu_memory_fraction: float = 1.0,
+    max_seq_len: int | None = None,
 ) -> pd.DataFrame:
     """
     Find Pareto front for agg.
@@ -113,6 +115,8 @@ def agg_pareto(
                     max_batch_size=512,
                     ctx_stride=512,
                     enable_chunked_prefill=enable_chunked_prefill,
+                    free_gpu_memory_fraction=free_gpu_memory_fraction,
+                    max_seq_len=max_seq_len,
                 )
                 if not summary.check_oom():
                     all_configs_oom = False

--- a/src/aiconfigurator/sdk/pareto_analysis.py
+++ b/src/aiconfigurator/sdk/pareto_analysis.py
@@ -29,7 +29,7 @@ def agg_pareto(
     model_config: config.ModelConfig,
     parallel_config_list: list[list[int]],
     enable_chunked_prefill: bool = False,
-    free_gpu_memory_fraction: float = 1.0,
+    free_gpu_memory_fraction: float = 0.9,
     max_seq_len: int | None = None,
 ) -> pd.DataFrame:
     """

--- a/src/aiconfigurator/sdk/pareto_analysis.py
+++ b/src/aiconfigurator/sdk/pareto_analysis.py
@@ -29,7 +29,7 @@ def agg_pareto(
     model_config: config.ModelConfig,
     parallel_config_list: list[list[int]],
     enable_chunked_prefill: bool = False,
-    free_gpu_memory_fraction: float = 0.9,
+    free_gpu_memory_fraction: float | None = None,
     max_seq_len: int | None = None,
 ) -> pd.DataFrame:
     """

--- a/src/aiconfigurator/sdk/task.py
+++ b/src/aiconfigurator/sdk/task.py
@@ -1161,8 +1161,8 @@ class TaskRunner:
 
         logger.info("Task %s: Running agg pareto", task_config.task_name)
         enable_chunked_prefill = getattr(task_config, "enable_chunked_prefill", False)
-        free_gpu_memory_fraction = getattr(task_config, "free_gpu_memory_fraction", 1.0)
-        max_seq_len = getattr(task_config, "max_seq_len", None)
+        free_gpu_memory_fraction = task_config.free_gpu_memory_fraction
+        max_seq_len = task_config.max_seq_len
         result_df = pa.agg_pareto(
             model_path=task_config.model_path,
             runtime_config=runtime_config,

--- a/src/aiconfigurator/sdk/task.py
+++ b/src/aiconfigurator/sdk/task.py
@@ -63,7 +63,7 @@ class TaskContext:
     enable_wideep: bool
     enable_chunked_prefill: bool
     total_gpus: int | None
-    free_gpu_memory_fraction: float = 0.9
+    free_gpu_memory_fraction: float | None = None
     max_seq_len: int | None = None
     profiles: list[str] = field(default_factory=list)
     yaml_patch: dict = field(default_factory=dict)
@@ -637,7 +637,7 @@ class TaskConfig:
         profiles: list[str] | None = None,
         yaml_config: dict | None = None,
         database_mode: str | None = None,
-        free_gpu_memory_fraction: float = 0.9,
+        free_gpu_memory_fraction: float | None = None,
         max_seq_len: int | None = None,
     ) -> None:
         """

--- a/src/aiconfigurator/sdk/task.py
+++ b/src/aiconfigurator/sdk/task.py
@@ -63,7 +63,7 @@ class TaskContext:
     enable_wideep: bool
     enable_chunked_prefill: bool
     total_gpus: int | None
-    free_gpu_memory_fraction: float = 1.0
+    free_gpu_memory_fraction: float = 0.9
     max_seq_len: int | None = None
     profiles: list[str] = field(default_factory=list)
     yaml_patch: dict = field(default_factory=dict)
@@ -637,7 +637,7 @@ class TaskConfig:
         profiles: list[str] | None = None,
         yaml_config: dict | None = None,
         database_mode: str | None = None,
-        free_gpu_memory_fraction: float = 1.0,
+        free_gpu_memory_fraction: float = 0.9,
         max_seq_len: int | None = None,
     ) -> None:
         """
@@ -730,6 +730,8 @@ class TaskConfig:
         self.enable_wideep = enable_wideep
         self.enable_eplb = enable_eplb
         self.total_gpus = total_gpus
+        self.free_gpu_memory_fraction = free_gpu_memory_fraction
+        self.max_seq_len = max_seq_len
         self.yaml_mode = yaml_mode
         self.yaml_patch = yaml_patch
         self.profiles = list(effective_profiles)

--- a/src/aiconfigurator/sdk/task.py
+++ b/src/aiconfigurator/sdk/task.py
@@ -63,6 +63,8 @@ class TaskContext:
     enable_wideep: bool
     enable_chunked_prefill: bool
     total_gpus: int | None
+    free_gpu_memory_fraction: float = 1.0
+    max_seq_len: int | None = None
     profiles: list[str] = field(default_factory=list)
     yaml_patch: dict = field(default_factory=dict)
     yaml_mode: Literal["patch", "replace"] = "patch"
@@ -356,6 +358,8 @@ class TaskConfigFactory:
             },
             "enable_wideep": ctx.enable_wideep,
             "enable_chunked_prefill": ctx.enable_chunked_prefill,
+            "free_gpu_memory_fraction": ctx.free_gpu_memory_fraction,
+            "max_seq_len": ctx.max_seq_len,
             "enable_eplb": False,
             "moe_backend": None,  # sglang wideep only
             "attention_backend": "flashinfer",  # sglang wideep only
@@ -633,6 +637,8 @@ class TaskConfig:
         profiles: list[str] | None = None,
         yaml_config: dict | None = None,
         database_mode: str | None = None,
+        free_gpu_memory_fraction: float = 1.0,
+        max_seq_len: int | None = None,
     ) -> None:
         """
         Initialize a TaskConfig object.
@@ -708,6 +714,8 @@ class TaskConfig:
             profiles=effective_profiles,
             yaml_patch=yaml_patch,
             yaml_mode=yaml_mode,
+            free_gpu_memory_fraction=free_gpu_memory_fraction,
+            max_seq_len=max_seq_len,
         )
 
         self.config, applied_layers = TaskConfigFactory.create(ctx)
@@ -1151,6 +1159,8 @@ class TaskRunner:
 
         logger.info("Task %s: Running agg pareto", task_config.task_name)
         enable_chunked_prefill = getattr(task_config, "enable_chunked_prefill", False)
+        free_gpu_memory_fraction = getattr(task_config, "free_gpu_memory_fraction", 1.0)
+        max_seq_len = getattr(task_config, "max_seq_len", None)
         result_df = pa.agg_pareto(
             model_path=task_config.model_path,
             runtime_config=runtime_config,
@@ -1159,6 +1169,8 @@ class TaskRunner:
             model_config=model_config,
             parallel_config_list=parallel_config_list,
             enable_chunked_prefill=enable_chunked_prefill,
+            free_gpu_memory_fraction=free_gpu_memory_fraction,
+            max_seq_len=max_seq_len,
         )
         return {
             "pareto_df": result_df,

--- a/tests/integration/test_kv_cache_capacity.py
+++ b/tests/integration/test_kv_cache_capacity.py
@@ -2,11 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Integration tests for TRTLLMBackend._calculate_max_kv_cache_batch_size().
+Integration tests for KV cache oversubscription detection.
 
-All tests use the real production pipeline (get_model, PerfDatabase,
-system YAML specs) with no mocks. Validates that the KV cache capacity
-formula produces accurate results against TRT-LLM benchmark data.
+_calculate_max_kv_cache_batch_size() returns the largest batch size that fits
+in the KV cache without queuing.  batch_size > result → KV OOM (warning).
+batch_size <= result → no KV OOM.
+
+Regular OOM (model doesn't fit at all) is a separate condition tested
+in test_model_too_large_is_regular_oom.
+
+All tests use the real production pipeline with no mocks.
 """
 
 import pytest
@@ -20,10 +25,10 @@ from aiconfigurator.sdk.perf_database import get_database, get_latest_database_v
 pytestmark = pytest.mark.integration
 
 _BACKEND = "trtllm"
+_BENCHMARK_SLACK = 1000  # TRT-LLM benchmark used --max_seq_len isl+osl+1000
 
 
 def _load(system, model_path, tp, kvcache_quant_mode=None, moe_ep_size=None):
-    """Load real model, database, and backend from production codebase."""
     version = get_latest_database_version(system=system, backend=_BACKEND)
     assert version is not None, f"No database for {system}/{_BACKEND}"
     database = get_database(system, _BACKEND, version)
@@ -44,175 +49,78 @@ def _load(system, model_path, tp, kvcache_quant_mode=None, moe_ep_size=None):
     return model, database, backend
 
 
-class TestKvCacheCapacityProperties:
-    """Property-based tests using real models and systems."""
+class TestKvCacheOomProperties:
+    """Property-based sanity tests using real models and systems."""
 
     def test_fraction_reduces_capacity(self):
-        """Lower free_gpu_memory_fraction should reduce max batch size."""
+        """Lower free_gpu_memory_fraction reduces max KV batch size."""
         model, db, backend = _load("h100_sxm", "Qwen/Qwen3-32B-FP8", tp=1)
-
-        bs_90 = backend._calculate_max_kv_cache_batch_size(
-            model,
-            db,
-            1024,
-            1024,
-            free_gpu_memory_fraction=0.9,
-        )
-        bs_50 = backend._calculate_max_kv_cache_batch_size(
-            model,
-            db,
-            1024,
-            1024,
-            free_gpu_memory_fraction=0.5,
-        )
-
-        assert bs_90 > bs_50
-        assert bs_50 > 0
+        bs_90 = backend._calculate_max_kv_cache_batch_size(model, db, 1024, 1024, 0.9)
+        bs_50 = backend._calculate_max_kv_cache_batch_size(model, db, 1024, 1024, 0.5)
+        assert bs_90 > bs_50 > 0
 
     def test_longer_sequences_reduce_capacity(self):
         """Longer ISL+OSL means fewer concurrent sequences fit."""
         model, db, backend = _load("h100_sxm", "Qwen/Qwen3-32B-FP8", tp=1)
-
-        bs_short = backend._calculate_max_kv_cache_batch_size(
-            model,
-            db,
-            512,
-            512,
-            free_gpu_memory_fraction=0.9,
-        )
-        bs_long = backend._calculate_max_kv_cache_batch_size(
-            model,
-            db,
-            4096,
-            4096,
-            free_gpu_memory_fraction=0.9,
-        )
-
+        bs_short = backend._calculate_max_kv_cache_batch_size(model, db, 512, 512, 0.9)
+        bs_long = backend._calculate_max_kv_cache_batch_size(model, db, 4096, 4096, 0.9)
         assert bs_short > bs_long
-        ratio = bs_short / bs_long
-        assert ratio > 6
+        assert bs_short / bs_long > 6
 
     def test_tp_increases_capacity(self):
-        """More TP shards reduce KV heads per GPU, increasing capacity."""
+        """More TP shards reduce KV heads per GPU, increasing KV capacity."""
         model_tp1, db, backend = _load("h100_sxm", "Qwen/Qwen3-32B-FP8", tp=1)
         model_tp2, _, _ = _load("h100_sxm", "Qwen/Qwen3-32B-FP8", tp=2)
-
-        bs_tp1 = backend._calculate_max_kv_cache_batch_size(
-            model_tp1,
-            db,
-            1024,
-            1024,
-            free_gpu_memory_fraction=0.9,
-        )
-        bs_tp2 = backend._calculate_max_kv_cache_batch_size(
-            model_tp2,
-            db,
-            1024,
-            1024,
-            free_gpu_memory_fraction=0.9,
-        )
-
+        bs_tp1 = backend._calculate_max_kv_cache_batch_size(model_tp1, db, 1024, 1024, 0.9)
+        bs_tp2 = backend._calculate_max_kv_cache_batch_size(model_tp2, db, 1024, 1024, 0.9)
         assert bs_tp2 > bs_tp1
 
     def test_larger_gpu_increases_capacity(self):
-        """GB300 (277 GiB) should fit more sequences than H100 (80 GiB)."""
+        """GB300 (277 GiB) fits more sequences than H100 (80 GiB)."""
         model_h100, db_h100, backend = _load("h100_sxm", "Qwen/Qwen3-32B-FP8", tp=1)
         model_gb300, db_gb300, _ = _load("gb300", "Qwen/Qwen3-32B-FP8", tp=1)
-
-        bs_h100 = backend._calculate_max_kv_cache_batch_size(
-            model_h100,
-            db_h100,
-            2048,
-            2048,
-            free_gpu_memory_fraction=0.9,
-        )
-        bs_gb300 = backend._calculate_max_kv_cache_batch_size(
-            model_gb300,
-            db_gb300,
-            2048,
-            2048,
-            free_gpu_memory_fraction=0.9,
-        )
-
+        bs_h100 = backend._calculate_max_kv_cache_batch_size(model_h100, db_h100, 2048, 2048, 0.9)
+        bs_gb300 = backend._calculate_max_kv_cache_batch_size(model_gb300, db_gb300, 2048, 2048, 0.9)
         assert bs_gb300 > bs_h100 * 3
 
-    def test_smaller_model_has_more_capacity(self):
-        """8B model should have much more KV capacity than 32B on same GPU."""
+    def test_smaller_model_has_more_kv_capacity(self):
+        """8B model has much more KV capacity than 32B on the same GPU."""
         model_8b, db, backend = _load("h100_sxm", "meta-llama/Meta-Llama-3.1-8B", tp=1)
         model_32b, _, _ = _load("h100_sxm", "Qwen/Qwen3-32B-FP8", tp=1)
-
-        bs_8b = backend._calculate_max_kv_cache_batch_size(
-            model_8b,
-            db,
-            2048,
-            2048,
-            free_gpu_memory_fraction=0.9,
-        )
-        bs_32b = backend._calculate_max_kv_cache_batch_size(
-            model_32b,
-            db,
-            2048,
-            2048,
-            free_gpu_memory_fraction=0.9,
-        )
-
+        bs_8b = backend._calculate_max_kv_cache_batch_size(model_8b, db, 2048, 2048, 0.9)
+        bs_32b = backend._calculate_max_kv_cache_batch_size(model_32b, db, 2048, 2048, 0.9)
         assert bs_8b > bs_32b
 
     def test_deepseek_fits_on_gb300(self):
-        """DeepSeek-V3 (671B, MLA) fits on GB300 TP=4 and has positive KV capacity."""
-        model_ds, db, backend = _load(
-            "gb300",
-            "deepseek-ai/DeepSeek-V3",
-            tp=4,
-            moe_ep_size=4,
-        )
-
-        bs = backend._calculate_max_kv_cache_batch_size(
-            model_ds,
-            db,
-            2048,
-            2048,
-            free_gpu_memory_fraction=0.9,
-        )
+        """DeepSeek-V3 (MLA) fits on GB300 TP=4 with positive KV capacity."""
+        model_ds, db, backend = _load("gb300", "deepseek-ai/DeepSeek-V3", tp=4, moe_ep_size=4)
+        bs = backend._calculate_max_kv_cache_batch_size(model_ds, db, 2048, 2048, 0.9)
         assert bs > 0
-
-        # Longer sequences should reduce capacity (verifies MLA code path)
-        bs_long = backend._calculate_max_kv_cache_batch_size(
-            model_ds,
-            db,
-            8192,
-            8192,
-            free_gpu_memory_fraction=0.9,
-        )
+        bs_long = backend._calculate_max_kv_cache_batch_size(model_ds, db, 8192, 8192, 0.9)
         assert bs > bs_long
 
-    def test_returns_zero_when_model_too_large(self):
-        """405B model on single H100 GPU (TP=1) should not fit."""
+    def test_model_too_large_is_regular_oom(self):
+        """405B on single H100 (TP=1) returns 0 — model doesn't fit (regular OOM, not KV OOM)."""
         model, db, backend = _load("h100_sxm", "meta-llama/Meta-Llama-3.1-405B", tp=1)
-
-        result = backend._calculate_max_kv_cache_batch_size(
-            model,
-            db,
-            1024,
-            1024,
-            free_gpu_memory_fraction=0.9,
-        )
+        result = backend._calculate_max_kv_cache_batch_size(model, db, 1024, 1024, 0.9)
         assert result == 0
 
 
 # ---------------------------------------------------------------------------
-# Benchmark validation: ±1 tolerance against real TRT-LLM data
+# Benchmark-anchored KV OOM boundary tests
 #
-# Benchmark collected on H100_SXM and GB300 with:
-#   Qwen/Qwen3-32B-FP8, meta-llama/Llama-3.1-8B
-# Server started with:
+# bench_max_bs: real TRT-LLM max concurrent sequences measured with:
 #   --max_seq_len $((ISL + OSL + 1000))
 #   --max_num_tokens $((2 * ISL))
 #   --free_gpu_memory_fraction FRAC
-#   kv_cache default dtype = float16
+#   KV cache dtype = float16 (TRT-LLM default)
+#
+# We call _calculate_max_kv_cache_batch_size with the same parameters and
+# assert the result is within ±2.5% (or ±1) of bench_max_bs.
+# This validates:
+#   - batch_size = bench - tolerance → NOT KV OOM  (result >= bench - tol)
+#   - batch_size = bench + tolerance + 1 → IS KV OOM  (result <= bench + tol)
 # ---------------------------------------------------------------------------
-
-_BENCHMARK_SLACK = 1000
 
 # fmt: off
 # (system, model, tp, isl, osl, frac, bench_max_bs)
@@ -302,7 +210,6 @@ _BENCHMARK_DATA = [
 
 
 def _short_model(model_path):
-    """Shorten model path for test ID."""
     return model_path.rsplit("/", 1)[-1].lower().replace("-", "").replace(".", "")
 
 
@@ -311,13 +218,18 @@ def _short_model(model_path):
     _BENCHMARK_DATA,
     ids=[f"{s}-{_short_model(m)}-tp{t}-isl{i}-osl{o}-f{f}" for s, m, t, i, o, f, _ in _BENCHMARK_DATA],
 )
-def test_benchmark_kv_capacity(system, model_path, tp, isl, osl, frac, bench_max_bs):
-    """Validate the full pipeline against real TRT-LLM benchmark data.
+def test_kv_oom_boundary(system, model_path, tp, isl, osl, frac, bench_max_bs):
+    """Validate KV OOM boundary against real TRT-LLM benchmark data.
 
-    Uses production get_model(), PerfDatabase, and system YAML specs.
-    The benchmark used float16 KV cache (TRT-LLM default).
-    Asserts ±1 tolerance; xfails cases where _get_memory_usage
-    underestimates non-KV overhead.
+    Calls _calculate_max_kv_cache_batch_size with the same parameters used
+    during benchmarking (max_seq_len=isl+osl+1000, num_tokens=2*isl) and
+    asserts the result is within ±2.5% or ±1 of bench_max_bs.
+
+    This means:
+      - batch_size = bench_max_bs - tolerance → NOT KV OOM (result >= bench - tol)
+      - batch_size = bench_max_bs + tolerance + 1 → IS KV OOM (result <= bench + tol)
+
+    Uses float16 KV cache to match benchmark conditions.
     """
     model, database, backend = _load(
         system,
@@ -333,13 +245,12 @@ def test_benchmark_kv_capacity(system, model_path, tp, isl, osl, frac, bench_max
         osl,
         free_gpu_memory_fraction=frac,
         max_seq_len=isl + osl + _BENCHMARK_SLACK,
-        max_num_tokens=2 * isl,
+        num_tokens=2 * isl,
     )
 
     diff = result - bench_max_bs
     rel_pct = abs(diff) / bench_max_bs * 100
-    ok = abs(diff) <= 1 or rel_pct < 3.5
-    assert ok, (
+    assert abs(diff) <= 1 or rel_pct < 3.5, (
         f"Formula ({result}) vs benchmark ({bench_max_bs}): "
-        f"diff {diff:+d} ({rel_pct:.1f}%) exceeds tolerance (+-1 or <3.5%)"
+        f"diff {diff:+d} ({rel_pct:.1f}%) exceeds tolerance (±1 or <3.5%)"
     )

--- a/tests/integration/test_kv_cache_capacity.py
+++ b/tests/integration/test_kv_cache_capacity.py
@@ -4,12 +4,12 @@
 """
 Integration tests for KV cache oversubscription detection.
 
-_calculate_max_kv_cache_batch_size() returns the largest batch size that fits
-in the KV cache without queuing.  batch_size > result → KV OOM (warning).
-batch_size <= result → no KV OOM.
+_is_kv_cache_oom() returns True when batch_size exceeds the KV cache capacity
+(TRT-LLM will queue excess requests).  Returns False when the batch_size fits.
 
-Regular OOM (model doesn't fit at all) is a separate condition tested
-in test_model_too_large_is_regular_oom.
+Regular OOM (model doesn't fit at all) is a separate condition: the total
+memory check in run_agg catches it; _is_kv_cache_oom returns True for any
+batch_size in that case (no KV room exists).
 
 All tests use the real production pipeline with no mocks.
 """
@@ -50,60 +50,82 @@ def _load(system, model_path, tp, kvcache_quant_mode=None, moe_ep_size=None):
 
 
 class TestKvCacheOomProperties:
-    """Property-based sanity tests using real models and systems."""
+    """Property-based sanity tests using real models and systems.
+
+    Batch sizes are chosen relative to known benchmark thresholds so that
+    each assertion is expected to be stable across formula changes within
+    the validated ±3.5% accuracy range.
+    """
 
     def test_fraction_reduces_capacity(self):
-        """Lower free_gpu_memory_fraction reduces max KV batch size."""
+        """Lower free_gpu_memory_fraction reduces max KV batch size.
+
+        h100_sxm / Qwen3-32B-FP8 / tp=1 / isl=osl=2048:
+          threshold at f=0.9 ≈ 78, at f=0.5 ≈ 43.
+          bs=60: fits at f=0.9, OOM at f=0.5.
+        """
         model, db, backend = _load("h100_sxm", "Qwen/Qwen3-32B-FP8", tp=1)
-        bs_90 = backend._calculate_max_kv_cache_batch_size(model, db, 1024, 1024, 0.9)
-        bs_50 = backend._calculate_max_kv_cache_batch_size(model, db, 1024, 1024, 0.5)
-        assert bs_90 > bs_50 > 0
+        assert not backend._is_kv_cache_oom(model, db, 60, 2048, 2048, 0.9)
+        assert backend._is_kv_cache_oom(model, db, 60, 2048, 2048, 0.5)
 
     def test_longer_sequences_reduce_capacity(self):
-        """Longer ISL+OSL means fewer concurrent sequences fit."""
+        """Longer ISL+OSL means fewer concurrent sequences fit.
+
+        h100_sxm / Qwen3-32B-FP8 / tp=1 / f=0.9:
+          threshold at isl=osl=512 ≈ 319, at isl=osl=4096 ≈ 38.
+          bs=100: fits for short seqs, OOM for long seqs.
+        """
         model, db, backend = _load("h100_sxm", "Qwen/Qwen3-32B-FP8", tp=1)
-        bs_short = backend._calculate_max_kv_cache_batch_size(model, db, 512, 512, 0.9)
-        bs_long = backend._calculate_max_kv_cache_batch_size(model, db, 4096, 4096, 0.9)
-        assert bs_short > bs_long
-        assert bs_short / bs_long > 6
+        assert not backend._is_kv_cache_oom(model, db, 100, 512, 512, 0.9)
+        assert backend._is_kv_cache_oom(model, db, 100, 4096, 4096, 0.9)
 
     def test_tp_increases_capacity(self):
-        """More TP shards reduce KV heads per GPU, increasing KV capacity."""
+        """More TP shards reduce KV heads per GPU, increasing KV capacity.
+
+        h100_sxm / Qwen3-32B-FP8 / isl=osl=2048 / f=0.9:
+          tp=1 threshold ≈ 78, tp=2 threshold ≈ 215.
+          bs=120: OOM at tp=1, fits at tp=2.
+        """
         model_tp1, db, backend = _load("h100_sxm", "Qwen/Qwen3-32B-FP8", tp=1)
         model_tp2, _, _ = _load("h100_sxm", "Qwen/Qwen3-32B-FP8", tp=2)
-        bs_tp1 = backend._calculate_max_kv_cache_batch_size(model_tp1, db, 1024, 1024, 0.9)
-        bs_tp2 = backend._calculate_max_kv_cache_batch_size(model_tp2, db, 1024, 1024, 0.9)
-        assert bs_tp2 > bs_tp1
+        assert backend._is_kv_cache_oom(model_tp1, db, 120, 2048, 2048, 0.9)
+        assert not backend._is_kv_cache_oom(model_tp2, db, 120, 2048, 2048, 0.9)
 
     def test_larger_gpu_increases_capacity(self):
-        """GB300 (277 GiB) fits more sequences than H100 (80 GiB)."""
+        """GB300 (277 GiB) fits more sequences than H100 (80 GiB).
+
+        Qwen3-32B-FP8 / tp=1 / isl=osl=2048 / f=0.9:
+          h100 threshold ≈ 78, gb300 threshold ≈ 434.
+          bs=200: OOM on h100, fits on gb300.
+        """
         model_h100, db_h100, backend = _load("h100_sxm", "Qwen/Qwen3-32B-FP8", tp=1)
         model_gb300, db_gb300, _ = _load("gb300", "Qwen/Qwen3-32B-FP8", tp=1)
-        bs_h100 = backend._calculate_max_kv_cache_batch_size(model_h100, db_h100, 2048, 2048, 0.9)
-        bs_gb300 = backend._calculate_max_kv_cache_batch_size(model_gb300, db_gb300, 2048, 2048, 0.9)
-        assert bs_gb300 > bs_h100 * 3
+        assert backend._is_kv_cache_oom(model_h100, db_h100, 200, 2048, 2048, 0.9)
+        assert not backend._is_kv_cache_oom(model_gb300, db_gb300, 200, 2048, 2048, 0.9)
 
     def test_smaller_model_has_more_kv_capacity(self):
-        """8B model has much more KV capacity than 32B on the same GPU."""
+        """8B model has much more KV capacity than 32B on the same GPU.
+
+        h100_sxm / tp=1 / isl=osl=2048 / f=0.9:
+          32B threshold ≈ 78, 8B threshold ≈ 110.
+          bs=90: OOM for 32B, fits for 8B.
+        """
         model_8b, db, backend = _load("h100_sxm", "meta-llama/Meta-Llama-3.1-8B", tp=1)
         model_32b, _, _ = _load("h100_sxm", "Qwen/Qwen3-32B-FP8", tp=1)
-        bs_8b = backend._calculate_max_kv_cache_batch_size(model_8b, db, 2048, 2048, 0.9)
-        bs_32b = backend._calculate_max_kv_cache_batch_size(model_32b, db, 2048, 2048, 0.9)
-        assert bs_8b > bs_32b
+        assert backend._is_kv_cache_oom(model_32b, db, 90, 2048, 2048, 0.9)
+        assert not backend._is_kv_cache_oom(model_8b, db, 90, 2048, 2048, 0.9)
 
     def test_deepseek_fits_on_gb300(self):
-        """DeepSeek-V3 (MLA) fits on GB300 TP=4 with positive KV capacity."""
+        """DeepSeek-V3 (MLA) fits on GB300 TP=4: bs=1 is not KV OOM, bs=10000 is."""
         model_ds, db, backend = _load("gb300", "deepseek-ai/DeepSeek-V3", tp=4, moe_ep_size=4)
-        bs = backend._calculate_max_kv_cache_batch_size(model_ds, db, 2048, 2048, 0.9)
-        assert bs > 0
-        bs_long = backend._calculate_max_kv_cache_batch_size(model_ds, db, 8192, 8192, 0.9)
-        assert bs > bs_long
+        assert not backend._is_kv_cache_oom(model_ds, db, 1, 2048, 2048, 0.9)
+        assert not backend._is_kv_cache_oom(model_ds, db, 1, 8192, 8192, 0.9)
+        assert backend._is_kv_cache_oom(model_ds, db, 10000, 2048, 2048, 0.9)
 
     def test_model_too_large_is_regular_oom(self):
-        """405B on single H100 (TP=1) returns 0 — model doesn't fit (regular OOM, not KV OOM)."""
+        """405B on single H100 (TP=1): model doesn't fit → _is_kv_cache_oom returns True for bs=1."""
         model, db, backend = _load("h100_sxm", "meta-llama/Meta-Llama-3.1-405B", tp=1)
-        result = backend._calculate_max_kv_cache_batch_size(model, db, 1024, 1024, 0.9)
-        assert result == 0
+        assert backend._is_kv_cache_oom(model, db, 1, 1024, 1024, 0.9)
 
 
 # ---------------------------------------------------------------------------
@@ -115,11 +137,10 @@ class TestKvCacheOomProperties:
 #   --free_gpu_memory_fraction FRAC
 #   KV cache dtype = float16 (TRT-LLM default)
 #
-# We call _calculate_max_kv_cache_batch_size with the same parameters and
-# assert the result is within ±2.5% (or ±1) of bench_max_bs.
-# This validates:
-#   - batch_size = bench - tolerance → NOT KV OOM  (result >= bench - tol)
-#   - batch_size = bench + tolerance + 1 → IS KV OOM  (result <= bench + tol)
+# We call _is_kv_cache_oom with the same parameters and assert:
+#   - batch_size = bench_max_bs - tolerance → NOT KV OOM
+#   - batch_size = bench_max_bs + tolerance + 1 → IS KV OOM
+# tolerance = max(1, int(bench_max_bs * 0.035))  (±3.5% or ±1)
 # ---------------------------------------------------------------------------
 
 # fmt: off
@@ -221,13 +242,11 @@ def _short_model(model_path):
 def test_kv_oom_boundary(system, model_path, tp, isl, osl, frac, bench_max_bs):
     """Validate KV OOM boundary against real TRT-LLM benchmark data.
 
-    Calls _calculate_max_kv_cache_batch_size with the same parameters used
-    during benchmarking (max_seq_len=isl+osl+1000, num_tokens=2*isl) and
-    asserts the result is within ±2.5% or ±1 of bench_max_bs.
-
-    This means:
-      - batch_size = bench_max_bs - tolerance → NOT KV OOM (result >= bench - tol)
-      - batch_size = bench_max_bs + tolerance + 1 → IS KV OOM (result <= bench + tol)
+    Calls _is_kv_cache_oom with the same parameters used during benchmarking
+    (max_seq_len=isl+osl+1000) and asserts:
+      - batch_size = bench_max_bs - tol → NOT KV OOM
+      - batch_size = bench_max_bs + tol + 1 → IS KV OOM
+    where tol = max(1, int(bench_max_bs * 0.035))  (±3.5% or ±1)
 
     Uses float16 KV cache to match benchmark conditions.
     """
@@ -238,19 +257,14 @@ def test_kv_oom_boundary(system, model_path, tp, isl, osl, frac, bench_max_bs):
         kvcache_quant_mode=common.KVCacheQuantMode.float16,
     )
 
-    result = backend._calculate_max_kv_cache_batch_size(
-        model,
-        database,
-        isl,
-        osl,
-        free_gpu_memory_fraction=frac,
-        max_seq_len=isl + osl + _BENCHMARK_SLACK,
-        num_tokens=2 * isl,
-    )
+    tol = max(1, int(bench_max_bs * 0.035))
+    bs_below = bench_max_bs - tol
+    bs_above = bench_max_bs + tol + 1
 
-    diff = result - bench_max_bs
-    rel_pct = abs(diff) / bench_max_bs * 100
-    assert abs(diff) <= 1 or rel_pct < 3.5, (
-        f"Formula ({result}) vs benchmark ({bench_max_bs}): "
-        f"diff {diff:+d} ({rel_pct:.1f}%) exceeds tolerance (±1 or <3.5%)"
-    )
+    assert not backend._is_kv_cache_oom(
+        model, database, bs_below, isl, osl, frac, max_seq_len=isl + osl + _BENCHMARK_SLACK
+    ), f"bs={bs_below} (bench={bench_max_bs}, tol={tol}) should NOT be KV OOM"
+
+    assert backend._is_kv_cache_oom(
+        model, database, bs_above, isl, osl, frac, max_seq_len=isl + osl + _BENCHMARK_SLACK
+    ), f"bs={bs_above} (bench={bench_max_bs}, tol={tol}) should be KV OOM"

--- a/tests/integration/test_kv_cache_capacity.py
+++ b/tests/integration/test_kv_cache_capacity.py
@@ -1,0 +1,345 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Integration tests for TRTLLMBackend._calculate_max_kv_cache_batch_size().
+
+All tests use the real production pipeline (get_model, PerfDatabase,
+system YAML specs) with no mocks. Validates that the KV cache capacity
+formula produces accurate results against TRT-LLM benchmark data.
+"""
+
+import pytest
+
+from aiconfigurator.sdk import common
+from aiconfigurator.sdk.backends.factory import get_backend
+from aiconfigurator.sdk.config import ModelConfig
+from aiconfigurator.sdk.models import get_model
+from aiconfigurator.sdk.perf_database import get_database, get_latest_database_version
+
+pytestmark = pytest.mark.integration
+
+_BACKEND = "trtllm"
+
+
+def _load(system, model_path, tp, kvcache_quant_mode=None, moe_ep_size=None):
+    """Load real model, database, and backend from production codebase."""
+    version = get_latest_database_version(system=system, backend=_BACKEND)
+    assert version is not None, f"No database for {system}/{_BACKEND}"
+    database = get_database(system, _BACKEND, version)
+    assert database is not None
+
+    moe_tp = tp if moe_ep_size is None else (tp // moe_ep_size if tp >= moe_ep_size else 1)
+    moe_ep = moe_ep_size or 1
+    model_config = ModelConfig(
+        tp_size=tp,
+        pp_size=1,
+        moe_tp_size=moe_tp,
+        moe_ep_size=moe_ep,
+    )
+    if kvcache_quant_mode is not None:
+        model_config.kvcache_quant_mode = kvcache_quant_mode
+    model = get_model(model_path, model_config, _BACKEND)
+    backend = get_backend(_BACKEND)
+    return model, database, backend
+
+
+class TestKvCacheCapacityProperties:
+    """Property-based tests using real models and systems."""
+
+    def test_fraction_reduces_capacity(self):
+        """Lower free_gpu_memory_fraction should reduce max batch size."""
+        model, db, backend = _load("h100_sxm", "Qwen/Qwen3-32B-FP8", tp=1)
+
+        bs_90 = backend._calculate_max_kv_cache_batch_size(
+            model,
+            db,
+            1024,
+            1024,
+            free_gpu_memory_fraction=0.9,
+        )
+        bs_50 = backend._calculate_max_kv_cache_batch_size(
+            model,
+            db,
+            1024,
+            1024,
+            free_gpu_memory_fraction=0.5,
+        )
+
+        assert bs_90 > bs_50
+        assert bs_50 > 0
+
+    def test_longer_sequences_reduce_capacity(self):
+        """Longer ISL+OSL means fewer concurrent sequences fit."""
+        model, db, backend = _load("h100_sxm", "Qwen/Qwen3-32B-FP8", tp=1)
+
+        bs_short = backend._calculate_max_kv_cache_batch_size(
+            model,
+            db,
+            512,
+            512,
+            free_gpu_memory_fraction=0.9,
+        )
+        bs_long = backend._calculate_max_kv_cache_batch_size(
+            model,
+            db,
+            4096,
+            4096,
+            free_gpu_memory_fraction=0.9,
+        )
+
+        assert bs_short > bs_long
+        ratio = bs_short / bs_long
+        assert ratio > 6
+
+    def test_tp_increases_capacity(self):
+        """More TP shards reduce KV heads per GPU, increasing capacity."""
+        model_tp1, db, backend = _load("h100_sxm", "Qwen/Qwen3-32B-FP8", tp=1)
+        model_tp2, _, _ = _load("h100_sxm", "Qwen/Qwen3-32B-FP8", tp=2)
+
+        bs_tp1 = backend._calculate_max_kv_cache_batch_size(
+            model_tp1,
+            db,
+            1024,
+            1024,
+            free_gpu_memory_fraction=0.9,
+        )
+        bs_tp2 = backend._calculate_max_kv_cache_batch_size(
+            model_tp2,
+            db,
+            1024,
+            1024,
+            free_gpu_memory_fraction=0.9,
+        )
+
+        assert bs_tp2 > bs_tp1
+
+    def test_larger_gpu_increases_capacity(self):
+        """GB300 (277 GiB) should fit more sequences than H100 (80 GiB)."""
+        model_h100, db_h100, backend = _load("h100_sxm", "Qwen/Qwen3-32B-FP8", tp=1)
+        model_gb300, db_gb300, _ = _load("gb300", "Qwen/Qwen3-32B-FP8", tp=1)
+
+        bs_h100 = backend._calculate_max_kv_cache_batch_size(
+            model_h100,
+            db_h100,
+            2048,
+            2048,
+            free_gpu_memory_fraction=0.9,
+        )
+        bs_gb300 = backend._calculate_max_kv_cache_batch_size(
+            model_gb300,
+            db_gb300,
+            2048,
+            2048,
+            free_gpu_memory_fraction=0.9,
+        )
+
+        assert bs_gb300 > bs_h100 * 3
+
+    def test_smaller_model_has_more_capacity(self):
+        """8B model should have much more KV capacity than 32B on same GPU."""
+        model_8b, db, backend = _load("h100_sxm", "meta-llama/Meta-Llama-3.1-8B", tp=1)
+        model_32b, _, _ = _load("h100_sxm", "Qwen/Qwen3-32B-FP8", tp=1)
+
+        bs_8b = backend._calculate_max_kv_cache_batch_size(
+            model_8b,
+            db,
+            2048,
+            2048,
+            free_gpu_memory_fraction=0.9,
+        )
+        bs_32b = backend._calculate_max_kv_cache_batch_size(
+            model_32b,
+            db,
+            2048,
+            2048,
+            free_gpu_memory_fraction=0.9,
+        )
+
+        assert bs_8b > bs_32b
+
+    def test_deepseek_fits_on_gb300(self):
+        """DeepSeek-V3 (671B, MLA) fits on GB300 TP=4 and has positive KV capacity."""
+        model_ds, db, backend = _load(
+            "gb300",
+            "deepseek-ai/DeepSeek-V3",
+            tp=4,
+            moe_ep_size=4,
+        )
+
+        bs = backend._calculate_max_kv_cache_batch_size(
+            model_ds,
+            db,
+            2048,
+            2048,
+            free_gpu_memory_fraction=0.9,
+        )
+        assert bs > 0
+
+        # Longer sequences should reduce capacity (verifies MLA code path)
+        bs_long = backend._calculate_max_kv_cache_batch_size(
+            model_ds,
+            db,
+            8192,
+            8192,
+            free_gpu_memory_fraction=0.9,
+        )
+        assert bs > bs_long
+
+    def test_returns_zero_when_model_too_large(self):
+        """405B model on single H100 GPU (TP=1) should not fit."""
+        model, db, backend = _load("h100_sxm", "meta-llama/Meta-Llama-3.1-405B", tp=1)
+
+        result = backend._calculate_max_kv_cache_batch_size(
+            model,
+            db,
+            1024,
+            1024,
+            free_gpu_memory_fraction=0.9,
+        )
+        assert result == 0
+
+
+# ---------------------------------------------------------------------------
+# Benchmark validation: ±1 tolerance against real TRT-LLM data
+#
+# Benchmark collected on H100_SXM and GB300 with:
+#   Qwen/Qwen3-32B-FP8, meta-llama/Llama-3.1-8B
+# Server started with:
+#   --max_seq_len $((ISL + OSL + 1000))
+#   --max_num_tokens $((2 * ISL))
+#   --free_gpu_memory_fraction FRAC
+#   kv_cache default dtype = float16
+# ---------------------------------------------------------------------------
+
+_BENCHMARK_SLACK = 1000
+
+# fmt: off
+# (system, model, tp, isl, osl, frac, bench_max_bs)
+_BENCHMARK_DATA = [
+    # ===== Qwen/Qwen3-32B-FP8 =====
+    # --- H100_SXM, fraction=0.8 ---
+    ("h100_sxm", "Qwen/Qwen3-32B-FP8", 1, 2048, 2048, 0.8,  27),
+    ("h100_sxm", "Qwen/Qwen3-32B-FP8", 2, 2048, 2048, 0.8,  75),
+    ("h100_sxm", "Qwen/Qwen3-32B-FP8", 4, 2048, 2048, 0.8, 169),
+    ("h100_sxm", "Qwen/Qwen3-32B-FP8", 1, 2048, 4096, 0.8,  19),
+    ("h100_sxm", "Qwen/Qwen3-32B-FP8", 2, 2048, 4096, 0.8,  53),
+    ("h100_sxm", "Qwen/Qwen3-32B-FP8", 4, 2048, 4096, 0.8, 121),
+    ("h100_sxm", "Qwen/Qwen3-32B-FP8", 1, 4096, 2048, 0.8,  19),
+    ("h100_sxm", "Qwen/Qwen3-32B-FP8", 2, 4096, 2048, 0.8,  53),
+    ("h100_sxm", "Qwen/Qwen3-32B-FP8", 4, 4096, 2048, 0.8, 120),
+    ("h100_sxm", "Qwen/Qwen3-32B-FP8", 1, 4096, 4096, 0.8,  14),
+    ("h100_sxm", "Qwen/Qwen3-32B-FP8", 2, 4096, 4096, 0.8,  41),
+    ("h100_sxm", "Qwen/Qwen3-32B-FP8", 4, 4096, 4096, 0.8,  93),
+    # --- GB300, Qwen3-32B-FP8, fraction=0.8 ---
+    ("gb300", "Qwen/Qwen3-32B-FP8", 1, 2048, 2048, 0.8, 153),
+    ("gb300", "Qwen/Qwen3-32B-FP8", 1, 2048, 4096, 0.8, 109),
+    ("gb300", "Qwen/Qwen3-32B-FP8", 1, 4096, 2048, 0.8, 108),
+    ("gb300", "Qwen/Qwen3-32B-FP8", 1, 4096, 4096, 0.8,  84),
+    ("gb300", "Qwen/Qwen3-32B-FP8", 2, 2048, 2048, 0.8, 326),
+    ("gb300", "Qwen/Qwen3-32B-FP8", 2, 2048, 4096, 0.8, 233),
+    ("gb300", "Qwen/Qwen3-32B-FP8", 2, 4096, 2048, 0.8, 232),
+    ("gb300", "Qwen/Qwen3-32B-FP8", 2, 4096, 4096, 0.8, 181),
+    ("gb300", "Qwen/Qwen3-32B-FP8", 4, 2048, 2048, 0.8, 673),
+    ("gb300", "Qwen/Qwen3-32B-FP8", 4, 2048, 4096, 0.8, 480),
+    ("gb300", "Qwen/Qwen3-32B-FP8", 4, 4096, 2048, 0.8, 479),
+    ("gb300", "Qwen/Qwen3-32B-FP8", 4, 4096, 4096, 0.8, 373),
+    # --- GB300, Qwen3-32B-FP8, fraction=0.9 ---
+    ("gb300", "Qwen/Qwen3-32B-FP8", 1, 2048, 2048, 0.9, 172),
+    ("gb300", "Qwen/Qwen3-32B-FP8", 1, 2048, 4096, 0.9, 123),
+    ("gb300", "Qwen/Qwen3-32B-FP8", 1, 4096, 2048, 0.9, 122),
+    ("gb300", "Qwen/Qwen3-32B-FP8", 1, 4096, 4096, 0.9,  95),
+    ("gb300", "Qwen/Qwen3-32B-FP8", 2, 2048, 2048, 0.9, 367),
+    ("gb300", "Qwen/Qwen3-32B-FP8", 2, 2048, 4096, 0.9, 262),
+    ("gb300", "Qwen/Qwen3-32B-FP8", 2, 4096, 2048, 0.9, 261),
+    ("gb300", "Qwen/Qwen3-32B-FP8", 2, 4096, 4096, 0.9, 203),
+    ("gb300", "Qwen/Qwen3-32B-FP8", 4, 2048, 2048, 0.9, 757),
+    ("gb300", "Qwen/Qwen3-32B-FP8", 4, 2048, 4096, 0.9, 541),
+    ("gb300", "Qwen/Qwen3-32B-FP8", 4, 4096, 2048, 0.9, 539),
+    ("gb300", "Qwen/Qwen3-32B-FP8", 4, 4096, 4096, 0.9, 419),
+    # ===== meta-llama/Llama-3.1-8B =====
+    # --- H100_SXM, fraction=0.8 ---
+    ("h100_sxm", "meta-llama/Meta-Llama-3.1-8B", 1, 2048, 2048, 0.8,  78),
+    ("h100_sxm", "meta-llama/Meta-Llama-3.1-8B", 2, 2048, 2048, 0.8, 173),
+    ("h100_sxm", "meta-llama/Meta-Llama-3.1-8B", 4, 2048, 2048, 0.8, 363),
+    ("h100_sxm", "meta-llama/Meta-Llama-3.1-8B", 1, 2048, 4096, 0.8,  56),
+    ("h100_sxm", "meta-llama/Meta-Llama-3.1-8B", 2, 2048, 4096, 0.8, 124),
+    ("h100_sxm", "meta-llama/Meta-Llama-3.1-8B", 4, 2048, 4096, 0.8, 259),
+    ("h100_sxm", "meta-llama/Meta-Llama-3.1-8B", 1, 4096, 2048, 0.8,  55),
+    ("h100_sxm", "meta-llama/Meta-Llama-3.1-8B", 2, 4096, 2048, 0.8, 123),
+    ("h100_sxm", "meta-llama/Meta-Llama-3.1-8B", 4, 4096, 2048, 0.8, 258),
+    ("h100_sxm", "meta-llama/Meta-Llama-3.1-8B", 1, 4096, 4096, 0.8,  43),
+    ("h100_sxm", "meta-llama/Meta-Llama-3.1-8B", 2, 4096, 4096, 0.8,  96),
+    ("h100_sxm", "meta-llama/Meta-Llama-3.1-8B", 4, 4096, 4096, 0.8, 201),
+    # --- GB300, Llama-3.1-8B, fraction=0.8 ---
+    ("gb300", "meta-llama/Meta-Llama-3.1-8B", 1, 2048, 2048, 0.8, 330),
+    ("gb300", "meta-llama/Meta-Llama-3.1-8B", 1, 2048, 4096, 0.8, 236),
+    ("gb300", "meta-llama/Meta-Llama-3.1-8B", 1, 4096, 2048, 0.8, 235),
+    ("gb300", "meta-llama/Meta-Llama-3.1-8B", 1, 4096, 4096, 0.8, 183),
+    ("gb300", "meta-llama/Meta-Llama-3.1-8B", 2, 2048, 2048, 0.8, 677),
+    ("gb300", "meta-llama/Meta-Llama-3.1-8B", 2, 2048, 4096, 0.8, 484),
+    ("gb300", "meta-llama/Meta-Llama-3.1-8B", 2, 4096, 2048, 0.8, 483),
+    ("gb300", "meta-llama/Meta-Llama-3.1-8B", 2, 4096, 4096, 0.8, 376),
+    ("gb300", "meta-llama/Meta-Llama-3.1-8B", 4, 2048, 2048, 0.8, 1371),
+    ("gb300", "meta-llama/Meta-Llama-3.1-8B", 4, 2048, 4096, 0.8, 979),
+    ("gb300", "meta-llama/Meta-Llama-3.1-8B", 4, 4096, 2048, 0.8, 978),
+    ("gb300", "meta-llama/Meta-Llama-3.1-8B", 4, 4096, 4096, 0.8, 761),
+    # --- GB300, Llama-3.1-8B, fraction=0.9 ---
+    ("gb300", "meta-llama/Meta-Llama-3.1-8B", 1, 2048, 2048, 0.9, 372),
+    ("gb300", "meta-llama/Meta-Llama-3.1-8B", 1, 2048, 4096, 0.9, 265),
+    ("gb300", "meta-llama/Meta-Llama-3.1-8B", 1, 4096, 2048, 0.9, 265),
+    ("gb300", "meta-llama/Meta-Llama-3.1-8B", 1, 4096, 4096, 0.9, 206),
+    ("gb300", "meta-llama/Meta-Llama-3.1-8B", 2, 2048, 2048, 0.9, 762),
+    ("gb300", "meta-llama/Meta-Llama-3.1-8B", 2, 2048, 4096, 0.9, 544),
+    ("gb300", "meta-llama/Meta-Llama-3.1-8B", 2, 4096, 2048, 0.9, 544),
+    ("gb300", "meta-llama/Meta-Llama-3.1-8B", 2, 4096, 4096, 0.9, 423),
+    ("gb300", "meta-llama/Meta-Llama-3.1-8B", 4, 2048, 2048, 0.9, 1542),
+    ("gb300", "meta-llama/Meta-Llama-3.1-8B", 4, 2048, 4096, 0.9, 1101),
+    ("gb300", "meta-llama/Meta-Llama-3.1-8B", 4, 4096, 2048, 0.9, 1100),
+    ("gb300", "meta-llama/Meta-Llama-3.1-8B", 4, 4096, 4096, 0.9, 856),
+]
+# fmt: on
+
+
+def _short_model(model_path):
+    """Shorten model path for test ID."""
+    return model_path.rsplit("/", 1)[-1].lower().replace("-", "").replace(".", "")
+
+
+@pytest.mark.parametrize(
+    "system, model_path, tp, isl, osl, frac, bench_max_bs",
+    _BENCHMARK_DATA,
+    ids=[f"{s}-{_short_model(m)}-tp{t}-isl{i}-osl{o}-f{f}" for s, m, t, i, o, f, _ in _BENCHMARK_DATA],
+)
+def test_benchmark_kv_capacity(system, model_path, tp, isl, osl, frac, bench_max_bs):
+    """Validate the full pipeline against real TRT-LLM benchmark data.
+
+    Uses production get_model(), PerfDatabase, and system YAML specs.
+    The benchmark used float16 KV cache (TRT-LLM default).
+    Asserts ±1 tolerance; xfails cases where _get_memory_usage
+    underestimates non-KV overhead.
+    """
+    model, database, backend = _load(
+        system,
+        model_path,
+        tp,
+        kvcache_quant_mode=common.KVCacheQuantMode.float16,
+    )
+
+    result = backend._calculate_max_kv_cache_batch_size(
+        model,
+        database,
+        isl,
+        osl,
+        free_gpu_memory_fraction=frac,
+        max_seq_len=isl + osl + _BENCHMARK_SLACK,
+        max_num_tokens=2 * isl,
+    )
+
+    diff = result - bench_max_bs
+    rel_pct = abs(diff) / bench_max_bs * 100
+    ok = abs(diff) <= 1 or rel_pct < 3.5
+    assert ok, (
+        f"Formula ({result}) vs benchmark ({bench_max_bs}): "
+        f"diff {diff:+d} ({rel_pct:.1f}%) exceeds tolerance (+-1 or <3.5%)"
+    )

--- a/tests/integration/test_trtllm_kv_cache_capacity.py
+++ b/tests/integration/test_trtllm_kv_cache_capacity.py
@@ -18,6 +18,7 @@ import pytest
 
 from aiconfigurator.sdk import common
 from aiconfigurator.sdk.backends.factory import get_backend
+from aiconfigurator.sdk.backends.trtllm_backend import KV_CACHE_MEMORY_TOLERANCE
 from aiconfigurator.sdk.config import ModelConfig
 from aiconfigurator.sdk.models import get_model
 from aiconfigurator.sdk.perf_database import get_database, get_latest_database_version
@@ -257,14 +258,28 @@ def test_kv_oom_boundary(system, model_path, tp, isl, osl, frac, bench_max_bs):
         kvcache_quant_mode=common.KVCacheQuantMode.float16,
     )
 
-    tol = max(1, int(bench_max_bs * 0.035))
+    tol = max(1, int(bench_max_bs * KV_CACHE_MEMORY_TOLERANCE))
     bs_below = bench_max_bs - tol
     bs_above = bench_max_bs + tol + 1
 
     assert not backend._is_kv_cache_oom(
-        model, database, bs_below, isl, osl, frac, max_seq_len=isl + osl + _BENCHMARK_SLACK
+        model,
+        database,
+        bs_below,
+        isl,
+        osl,
+        frac,
+        max_seq_len=isl + osl + _BENCHMARK_SLACK,
+        kv_cache_capacity_tolerance=0,
     ), f"bs={bs_below} (bench={bench_max_bs}, tol={tol}) should NOT be KV OOM"
 
     assert backend._is_kv_cache_oom(
-        model, database, bs_above, isl, osl, frac, max_seq_len=isl + osl + _BENCHMARK_SLACK
+        model,
+        database,
+        bs_above,
+        isl,
+        osl,
+        frac,
+        max_seq_len=isl + osl + _BENCHMARK_SLACK,
+        kv_cache_capacity_tolerance=0,
     ), f"bs={bs_above} (bench={bench_max_bs}, tol={tol}) should be KV OOM"

--- a/tests/integration/test_trtllm_kv_cache_capacity.py
+++ b/tests/integration/test_trtllm_kv_cache_capacity.py
@@ -4,12 +4,14 @@
 """
 Integration tests for KV cache oversubscription detection.
 
-_is_kv_cache_oom() returns True when batch_size exceeds the KV cache capacity
-(TRT-LLM will queue excess requests).  Returns False when the batch_size fits.
+The KV capacity check is embedded in _get_memory_usage() via the max_seq_len
+parameter.  When max_seq_len is provided:
+  kvcache = batch_size * max_seq_len * kvcache_per_token
+A batch_size exceeds KV capacity when memory["kvcache"] > available_kv_gib.
 
 Regular OOM (model doesn't fit at all) is a separate condition: the total
-memory check in run_agg catches it; _is_kv_cache_oom returns True for any
-batch_size in that case (no KV room exists).
+memory check in run_agg catches it; when available_kv_gib <= 0 the model
+doesn't fit and any batch_size is KV OOM.
 
 All tests use the real production pipeline with no mocks.
 """
@@ -18,7 +20,10 @@ import pytest
 
 from aiconfigurator.sdk import common
 from aiconfigurator.sdk.backends.factory import get_backend
-from aiconfigurator.sdk.backends.trtllm_backend import KV_CACHE_MEMORY_TOLERANCE
+from aiconfigurator.sdk.backends.trtllm_backend import (
+    KV_CACHE_MEMORY_RESERVED_FRACTION,
+    KV_CACHE_MEMORY_TOLERANCE,
+)
 from aiconfigurator.sdk.config import ModelConfig
 from aiconfigurator.sdk.models import get_model
 from aiconfigurator.sdk.perf_database import get_database, get_latest_database_version
@@ -50,6 +55,40 @@ def _load(system, model_path, tp, kvcache_quant_mode=None, moe_ep_size=None):
     return model, database, backend
 
 
+def _is_kv_oom(
+    backend,
+    model,
+    database,
+    batch_size,
+    isl,
+    osl,
+    free_gpu_memory_fraction,
+    *,
+    max_seq_len,
+    kv_cache_capacity_tolerance=KV_CACHE_MEMORY_TOLERANCE,
+):
+    """KV OOM check using _get_memory_usage directly."""
+    base = backend._get_memory_usage(model, database, 1, 1, isl, osl, num_tokens=2 * isl, free_gpu_memory_fraction=1.0)
+    non_kv_gib = base["total"] - base["kvcache"]
+    gpu_capacity_gib = database.system_spec["gpu"]["mem_capacity"] / (1 << 30)
+    available_kv_gib = (gpu_capacity_gib - non_kv_gib) * free_gpu_memory_fraction
+    available_kv_gib *= 1 - KV_CACHE_MEMORY_RESERVED_FRACTION
+    if available_kv_gib <= 0:
+        return True
+    memory = backend._get_memory_usage(
+        model,
+        database,
+        batch_size,
+        1,
+        isl,
+        osl,
+        num_tokens=2 * isl,
+        max_seq_len=max_seq_len,
+        free_gpu_memory_fraction=1.0,
+    )
+    return memory["kvcache"] > available_kv_gib * (1 - kv_cache_capacity_tolerance)
+
+
 class TestKvCacheOomProperties:
     """Property-based sanity tests using real models and systems.
 
@@ -67,8 +106,8 @@ class TestKvCacheOomProperties:
         """
         isl, osl = 2048, 2048
         model, db, backend = _load("h100_sxm", "Qwen/Qwen3-32B-FP8", tp=1)
-        assert not backend._is_kv_cache_oom(model, db, 60, isl, osl, 0.9, max_seq_len=isl + osl + _BENCHMARK_SLACK)
-        assert backend._is_kv_cache_oom(model, db, 60, isl, osl, 0.5, max_seq_len=isl + osl + _BENCHMARK_SLACK)
+        assert not _is_kv_oom(backend, model, db, 60, isl, osl, 0.9, max_seq_len=isl + osl + _BENCHMARK_SLACK)
+        assert _is_kv_oom(backend, model, db, 60, isl, osl, 0.5, max_seq_len=isl + osl + _BENCHMARK_SLACK)
 
     def test_longer_sequences_reduce_capacity(self):
         """Longer ISL+OSL means fewer concurrent sequences fit.
@@ -78,8 +117,8 @@ class TestKvCacheOomProperties:
           bs=100: fits for short seqs, OOM for long seqs.
         """
         model, db, backend = _load("h100_sxm", "Qwen/Qwen3-32B-FP8", tp=1)
-        assert not backend._is_kv_cache_oom(model, db, 100, 512, 512, 0.9, max_seq_len=512 + 512 + _BENCHMARK_SLACK)
-        assert backend._is_kv_cache_oom(model, db, 100, 4096, 4096, 0.9, max_seq_len=4096 + 4096 + _BENCHMARK_SLACK)
+        assert not _is_kv_oom(backend, model, db, 100, 512, 512, 0.9, max_seq_len=512 + 512 + _BENCHMARK_SLACK)
+        assert _is_kv_oom(backend, model, db, 100, 4096, 4096, 0.9, max_seq_len=4096 + 4096 + _BENCHMARK_SLACK)
 
     def test_tp_increases_capacity(self):
         """More TP shards reduce KV heads per GPU, increasing KV capacity.
@@ -91,8 +130,8 @@ class TestKvCacheOomProperties:
         isl, osl = 2048, 2048
         model_tp1, db, backend = _load("h100_sxm", "Qwen/Qwen3-32B-FP8", tp=1)
         model_tp2, _, _ = _load("h100_sxm", "Qwen/Qwen3-32B-FP8", tp=2)
-        assert backend._is_kv_cache_oom(model_tp1, db, 120, isl, osl, 0.9, max_seq_len=isl + osl + _BENCHMARK_SLACK)
-        assert not backend._is_kv_cache_oom(model_tp2, db, 120, isl, osl, 0.9, max_seq_len=isl + osl + _BENCHMARK_SLACK)
+        assert _is_kv_oom(backend, model_tp1, db, 120, isl, osl, 0.9, max_seq_len=isl + osl + _BENCHMARK_SLACK)
+        assert not _is_kv_oom(backend, model_tp2, db, 120, isl, osl, 0.9, max_seq_len=isl + osl + _BENCHMARK_SLACK)
 
     def test_larger_gpu_increases_capacity(self):
         """GB300 (277 GiB) fits more sequences than H100 (80 GiB).
@@ -104,11 +143,9 @@ class TestKvCacheOomProperties:
         isl, osl = 2048, 2048
         model_h100, db_h100, backend = _load("h100_sxm", "Qwen/Qwen3-32B-FP8", tp=1)
         model_gb300, db_gb300, _ = _load("gb300", "Qwen/Qwen3-32B-FP8", tp=1)
-        assert backend._is_kv_cache_oom(
-            model_h100, db_h100, 200, isl, osl, 0.9, max_seq_len=isl + osl + _BENCHMARK_SLACK
-        )
-        assert not backend._is_kv_cache_oom(
-            model_gb300, db_gb300, 200, isl, osl, 0.9, max_seq_len=isl + osl + _BENCHMARK_SLACK
+        assert _is_kv_oom(backend, model_h100, db_h100, 200, isl, osl, 0.9, max_seq_len=isl + osl + _BENCHMARK_SLACK)
+        assert not _is_kv_oom(
+            backend, model_gb300, db_gb300, 200, isl, osl, 0.9, max_seq_len=isl + osl + _BENCHMARK_SLACK
         )
 
     def test_smaller_model_has_more_kv_capacity(self):
@@ -128,26 +165,20 @@ class TestKvCacheOomProperties:
         model_32b, _, _ = _load(
             "h100_sxm", "Qwen/Qwen3-32B-FP8", tp=1, kvcache_quant_mode=common.KVCacheQuantMode.float16
         )
-        assert backend._is_kv_cache_oom(model_32b, db, 60, isl, osl, 0.9, max_seq_len=isl + osl + _BENCHMARK_SLACK)
-        assert not backend._is_kv_cache_oom(model_8b, db, 60, isl, osl, 0.9, max_seq_len=isl + osl + _BENCHMARK_SLACK)
+        assert _is_kv_oom(backend, model_32b, db, 60, isl, osl, 0.9, max_seq_len=isl + osl + _BENCHMARK_SLACK)
+        assert not _is_kv_oom(backend, model_8b, db, 60, isl, osl, 0.9, max_seq_len=isl + osl + _BENCHMARK_SLACK)
 
     def test_deepseek_fits_on_gb300(self):
         """DeepSeek-V3 (MLA) fits on GB300 TP=4: bs=1 is not KV OOM, bs=10000 is."""
         model_ds, db, backend = _load("gb300", "deepseek-ai/DeepSeek-V3", tp=4, moe_ep_size=4)
-        assert not backend._is_kv_cache_oom(
-            model_ds, db, 1, 2048, 2048, 0.9, max_seq_len=2048 + 2048 + _BENCHMARK_SLACK
-        )
-        assert not backend._is_kv_cache_oom(
-            model_ds, db, 1, 8192, 8192, 0.9, max_seq_len=8192 + 8192 + _BENCHMARK_SLACK
-        )
-        assert backend._is_kv_cache_oom(
-            model_ds, db, 10000, 2048, 2048, 0.9, max_seq_len=2048 + 2048 + _BENCHMARK_SLACK
-        )
+        assert not _is_kv_oom(backend, model_ds, db, 1, 2048, 2048, 0.9, max_seq_len=2048 + 2048 + _BENCHMARK_SLACK)
+        assert not _is_kv_oom(backend, model_ds, db, 1, 8192, 8192, 0.9, max_seq_len=8192 + 8192 + _BENCHMARK_SLACK)
+        assert _is_kv_oom(backend, model_ds, db, 10000, 2048, 2048, 0.9, max_seq_len=2048 + 2048 + _BENCHMARK_SLACK)
 
     def test_model_too_large_is_regular_oom(self):
-        """405B on single H100 (TP=1): model doesn't fit → _is_kv_cache_oom returns True for bs=1."""
+        """405B on single H100 (TP=1): model doesn't fit → KV OOM returns True for bs=1."""
         model, db, backend = _load("h100_sxm", "meta-llama/Meta-Llama-3.1-405B", tp=1)
-        assert backend._is_kv_cache_oom(model, db, 1, 1024, 1024, 0.9, max_seq_len=1024 + 1024 + _BENCHMARK_SLACK)
+        assert _is_kv_oom(backend, model, db, 1, 1024, 1024, 0.9, max_seq_len=1024 + 1024 + _BENCHMARK_SLACK)
 
 
 # ---------------------------------------------------------------------------
@@ -159,7 +190,7 @@ class TestKvCacheOomProperties:
 #   --free_gpu_memory_fraction FRAC
 #   KV cache dtype = float16 (TRT-LLM default)
 #
-# We call _is_kv_cache_oom with the same parameters and assert:
+# We call _is_kv_oom with the same parameters and assert:
 #   - batch_size = bench_max_bs - tolerance → NOT KV OOM
 #   - batch_size = bench_max_bs + tolerance + 1 → IS KV OOM
 # tolerance = max(1, int(bench_max_bs * KV_CACHE_MEMORY_TOLERANCE))
@@ -264,7 +295,7 @@ def _short_model(model_path):
 def test_kv_oom_boundary(system, model_path, tp, isl, osl, frac, bench_max_bs):
     """Validate KV OOM boundary against real TRT-LLM benchmark data.
 
-    Calls _is_kv_cache_oom with the same parameters used during benchmarking
+    Calls _is_kv_oom with the same parameters used during benchmarking
     (max_seq_len=isl+osl+1000) and asserts:
       - batch_size = bench_max_bs - tol → NOT KV OOM
       - batch_size = bench_max_bs + tol + 1 → IS KV OOM
@@ -283,7 +314,8 @@ def test_kv_oom_boundary(system, model_path, tp, isl, osl, frac, bench_max_bs):
     bs_below = bench_max_bs - tol
     bs_above = bench_max_bs + tol + 1
 
-    assert not backend._is_kv_cache_oom(
+    assert not _is_kv_oom(
+        backend,
         model,
         database,
         bs_below,
@@ -294,7 +326,8 @@ def test_kv_oom_boundary(system, model_path, tp, isl, osl, frac, bench_max_bs):
         kv_cache_capacity_tolerance=0,
     ), f"bs={bs_below} (bench={bench_max_bs}, tol={tol}) should NOT be KV OOM"
 
-    assert backend._is_kv_cache_oom(
+    assert _is_kv_oom(
+        backend,
         model,
         database,
         bs_above,

--- a/tests/integration/test_trtllm_kv_cache_capacity.py
+++ b/tests/integration/test_trtllm_kv_cache_capacity.py
@@ -13,6 +13,12 @@ Regular OOM (model doesn't fit at all) is a separate condition: the total
 memory check in run_agg catches it; when available_kv_gib <= 0 the model
 doesn't fit and any batch_size is KV OOM.
 
+All benchmark data was collected with --max_num_tokens $((2 * ISL)).  This
+value determines the activation memory TRT-LLM pre-allocates at engine build
+time (see BuildConfig.max_num_tokens, default 8192).  The activation memory
+in turn determines how much GPU memory remains for KV cache.  Tests pass
+max_num_tokens=2*isl explicitly to match the benchmark configuration.
+
 All tests use the real production pipeline with no mocks.
 """
 
@@ -66,11 +72,12 @@ def _is_kv_oom(
     free_gpu_memory_fraction,
     *,
     max_seq_len,
+    max_num_tokens,
     kv_cache_capacity_tolerance=KV_CACHE_MEMORY_TOLERANCE,
 ):
     """KV OOM check using InferenceSummary."""
     summary = InferenceSummary(RuntimeConfig(isl=isl, osl=osl))
-    base_memory = backend._get_memory_usage(model, database, 1, 1, isl, osl, num_tokens=2 * isl)
+    base_memory = backend._get_memory_usage(model, database, 1, 1, isl, osl, num_tokens=max_num_tokens)
     summary.set_memory_and_check_oom(base_memory, database.system_spec["gpu"]["mem_capacity"])
     if summary.check_oom():
         return True
@@ -81,7 +88,7 @@ def _is_kv_oom(
         1,
         isl,
         osl,
-        num_tokens=2 * isl,
+        num_tokens=max_num_tokens,
         max_seq_len=max_seq_len,
     )
     summary._check_and_set_kv_cache_oom(
@@ -111,8 +118,12 @@ class TestKvCacheOomProperties:
         """
         isl, osl = 2048, 2048
         model, db, backend = _load("h100_sxm", "Qwen/Qwen3-32B-FP8", tp=1)
-        assert not _is_kv_oom(backend, model, db, 60, isl, osl, 0.9, max_seq_len=isl + osl + _BENCHMARK_SLACK)
-        assert _is_kv_oom(backend, model, db, 60, isl, osl, 0.5, max_seq_len=isl + osl + _BENCHMARK_SLACK)
+        assert not _is_kv_oom(
+            backend, model, db, 60, isl, osl, 0.9, max_seq_len=isl + osl + _BENCHMARK_SLACK, max_num_tokens=2 * isl
+        )
+        assert _is_kv_oom(
+            backend, model, db, 60, isl, osl, 0.5, max_seq_len=isl + osl + _BENCHMARK_SLACK, max_num_tokens=2 * isl
+        )
 
     def test_longer_sequences_reduce_capacity(self):
         """Longer ISL+OSL means fewer concurrent sequences fit.
@@ -122,8 +133,20 @@ class TestKvCacheOomProperties:
           bs=100: fits for short seqs, OOM for long seqs.
         """
         model, db, backend = _load("h100_sxm", "Qwen/Qwen3-32B-FP8", tp=1)
-        assert not _is_kv_oom(backend, model, db, 100, 512, 512, 0.9, max_seq_len=512 + 512 + _BENCHMARK_SLACK)
-        assert _is_kv_oom(backend, model, db, 100, 4096, 4096, 0.9, max_seq_len=4096 + 4096 + _BENCHMARK_SLACK)
+        assert not _is_kv_oom(
+            backend, model, db, 100, 512, 512, 0.9, max_seq_len=512 + 512 + _BENCHMARK_SLACK, max_num_tokens=2 * 512
+        )
+        assert _is_kv_oom(
+            backend,
+            model,
+            db,
+            100,
+            4096,
+            4096,
+            0.9,
+            max_seq_len=4096 + 4096 + _BENCHMARK_SLACK,
+            max_num_tokens=2 * 4096,
+        )
 
     def test_tp_increases_capacity(self):
         """More TP shards reduce KV heads per GPU, increasing KV capacity.
@@ -135,8 +158,12 @@ class TestKvCacheOomProperties:
         isl, osl = 2048, 2048
         model_tp1, db, backend = _load("h100_sxm", "Qwen/Qwen3-32B-FP8", tp=1)
         model_tp2, _, _ = _load("h100_sxm", "Qwen/Qwen3-32B-FP8", tp=2)
-        assert _is_kv_oom(backend, model_tp1, db, 120, isl, osl, 0.9, max_seq_len=isl + osl + _BENCHMARK_SLACK)
-        assert not _is_kv_oom(backend, model_tp2, db, 120, isl, osl, 0.9, max_seq_len=isl + osl + _BENCHMARK_SLACK)
+        assert _is_kv_oom(
+            backend, model_tp1, db, 120, isl, osl, 0.9, max_seq_len=isl + osl + _BENCHMARK_SLACK, max_num_tokens=2 * isl
+        )
+        assert not _is_kv_oom(
+            backend, model_tp2, db, 120, isl, osl, 0.9, max_seq_len=isl + osl + _BENCHMARK_SLACK, max_num_tokens=2 * isl
+        )
 
     def test_larger_gpu_increases_capacity(self):
         """GB300 (277 GiB) fits more sequences than H100 (80 GiB).
@@ -148,9 +175,27 @@ class TestKvCacheOomProperties:
         isl, osl = 2048, 2048
         model_h100, db_h100, backend = _load("h100_sxm", "Qwen/Qwen3-32B-FP8", tp=1)
         model_gb300, db_gb300, _ = _load("gb300", "Qwen/Qwen3-32B-FP8", tp=1)
-        assert _is_kv_oom(backend, model_h100, db_h100, 200, isl, osl, 0.9, max_seq_len=isl + osl + _BENCHMARK_SLACK)
+        assert _is_kv_oom(
+            backend,
+            model_h100,
+            db_h100,
+            200,
+            isl,
+            osl,
+            0.9,
+            max_seq_len=isl + osl + _BENCHMARK_SLACK,
+            max_num_tokens=2 * isl,
+        )
         assert not _is_kv_oom(
-            backend, model_gb300, db_gb300, 200, isl, osl, 0.9, max_seq_len=isl + osl + _BENCHMARK_SLACK
+            backend,
+            model_gb300,
+            db_gb300,
+            200,
+            isl,
+            osl,
+            0.9,
+            max_seq_len=isl + osl + _BENCHMARK_SLACK,
+            max_num_tokens=2 * isl,
         )
 
     def test_smaller_model_has_more_kv_capacity(self):
@@ -170,20 +215,56 @@ class TestKvCacheOomProperties:
         model_32b, _, _ = _load(
             "h100_sxm", "Qwen/Qwen3-32B-FP8", tp=1, kvcache_quant_mode=common.KVCacheQuantMode.float16
         )
-        assert _is_kv_oom(backend, model_32b, db, 60, isl, osl, 0.9, max_seq_len=isl + osl + _BENCHMARK_SLACK)
-        assert not _is_kv_oom(backend, model_8b, db, 60, isl, osl, 0.9, max_seq_len=isl + osl + _BENCHMARK_SLACK)
+        assert _is_kv_oom(
+            backend, model_32b, db, 60, isl, osl, 0.9, max_seq_len=isl + osl + _BENCHMARK_SLACK, max_num_tokens=2 * isl
+        )
+        assert not _is_kv_oom(
+            backend, model_8b, db, 60, isl, osl, 0.9, max_seq_len=isl + osl + _BENCHMARK_SLACK, max_num_tokens=2 * isl
+        )
 
     def test_deepseek_fits_on_gb300(self):
         """DeepSeek-V3 (MLA) fits on GB300 TP=4: bs=1 is not KV OOM, bs=10000 is."""
         model_ds, db, backend = _load("gb300", "deepseek-ai/DeepSeek-V3", tp=4, moe_ep_size=4)
-        assert not _is_kv_oom(backend, model_ds, db, 1, 2048, 2048, 0.9, max_seq_len=2048 + 2048 + _BENCHMARK_SLACK)
-        assert not _is_kv_oom(backend, model_ds, db, 1, 8192, 8192, 0.9, max_seq_len=8192 + 8192 + _BENCHMARK_SLACK)
-        assert _is_kv_oom(backend, model_ds, db, 10000, 2048, 2048, 0.9, max_seq_len=2048 + 2048 + _BENCHMARK_SLACK)
+        assert not _is_kv_oom(
+            backend,
+            model_ds,
+            db,
+            1,
+            2048,
+            2048,
+            0.9,
+            max_seq_len=2048 + 2048 + _BENCHMARK_SLACK,
+            max_num_tokens=2 * 2048,
+        )
+        assert not _is_kv_oom(
+            backend,
+            model_ds,
+            db,
+            1,
+            8192,
+            8192,
+            0.9,
+            max_seq_len=8192 + 8192 + _BENCHMARK_SLACK,
+            max_num_tokens=2 * 8192,
+        )
+        assert _is_kv_oom(
+            backend,
+            model_ds,
+            db,
+            10000,
+            2048,
+            2048,
+            0.9,
+            max_seq_len=2048 + 2048 + _BENCHMARK_SLACK,
+            max_num_tokens=2 * 2048,
+        )
 
     def test_model_too_large_is_regular_oom(self):
         """405B on single H100 (TP=1): model doesn't fit → KV OOM returns True for bs=1."""
         model, db, backend = _load("h100_sxm", "meta-llama/Meta-Llama-3.1-405B", tp=1)
-        assert _is_kv_oom(backend, model, db, 1, 1024, 1024, 0.9, max_seq_len=1024 + 1024 + _BENCHMARK_SLACK)
+        assert _is_kv_oom(
+            backend, model, db, 1, 1024, 1024, 0.9, max_seq_len=1024 + 1024 + _BENCHMARK_SLACK, max_num_tokens=2 * 1024
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -301,7 +382,7 @@ def test_kv_oom_boundary(system, model_path, tp, isl, osl, frac, bench_max_bs):
     """Validate KV OOM boundary against real TRT-LLM benchmark data.
 
     Calls _is_kv_oom with the same parameters used during benchmarking
-    (max_seq_len=isl+osl+1000) and asserts:
+    (max_seq_len=isl+osl+1000, max_num_tokens=2*isl) and asserts:
       - batch_size = bench_max_bs - tol → NOT KV OOM
       - batch_size = bench_max_bs + tol + 1 → IS KV OOM
     where tol = max(1, int(bench_max_bs * KV_CACHE_MEMORY_TOLERANCE))
@@ -328,6 +409,7 @@ def test_kv_oom_boundary(system, model_path, tp, isl, osl, frac, bench_max_bs):
         osl,
         frac,
         max_seq_len=isl + osl + _BENCHMARK_SLACK,
+        max_num_tokens=2 * isl,
         kv_cache_capacity_tolerance=0,
     ), f"bs={bs_below} (bench={bench_max_bs}, tol={tol}) should NOT be KV OOM"
 
@@ -340,5 +422,6 @@ def test_kv_oom_boundary(system, model_path, tp, isl, osl, frac, bench_max_bs):
         osl,
         frac,
         max_seq_len=isl + osl + _BENCHMARK_SLACK,
+        max_num_tokens=2 * isl,
         kv_cache_capacity_tolerance=0,
     ), f"bs={bs_above} (bench={bench_max_bs}, tol={tol}) should be KV OOM"

--- a/tests/integration/test_trtllm_kv_cache_capacity.py
+++ b/tests/integration/test_trtllm_kv_cache_capacity.py
@@ -75,13 +75,8 @@ def _is_kv_oom(
     max_num_tokens,
     kv_cache_capacity_tolerance=KV_CACHE_MEMORY_TOLERANCE,
 ):
-    """KV OOM check using InferenceSummary."""
-    summary = InferenceSummary(RuntimeConfig(isl=isl, osl=osl))
-    base_memory = backend._get_memory_usage(model, database, 1, 1, isl, osl, num_tokens=max_num_tokens)
-    summary.set_memory_and_check_oom(base_memory, database.system_spec["gpu"]["mem_capacity"])
-    if summary.check_oom():
-        return True
-    kv_memory = backend._get_memory_usage(
+    """KV OOM check using InferenceSummary with a single unified memory dict."""
+    memory = backend._get_memory_usage(
         model,
         database,
         batch_size,
@@ -91,14 +86,15 @@ def _is_kv_oom(
         num_tokens=max_num_tokens,
         max_seq_len=max_seq_len,
     )
-    summary._check_and_set_kv_cache_oom(
-        kv_memory,
+    summary = InferenceSummary(RuntimeConfig(isl=isl, osl=osl))
+    summary.set_memory_and_check_oom(
+        memory,
         database.system_spec["gpu"]["mem_capacity"],
-        free_gpu_memory_fraction,
-        KV_CACHE_MEMORY_RESERVED_FRACTION,
-        kv_cache_capacity_tolerance,
+        free_gpu_memory_fraction=free_gpu_memory_fraction,
+        kv_cache_reserved_fraction=KV_CACHE_MEMORY_RESERVED_FRACTION,
+        kv_cache_tolerance=kv_cache_capacity_tolerance,
     )
-    return summary.check_kv_cache_oom()
+    return summary.check_oom() or summary.check_kv_cache_oom()
 
 
 class TestKvCacheOomProperties:

--- a/tests/integration/test_trtllm_kv_cache_capacity.py
+++ b/tests/integration/test_trtllm_kv_cache_capacity.py
@@ -102,7 +102,7 @@ class TestKvCacheOomProperties:
 
     Batch sizes are chosen relative to known benchmark thresholds so that
     each assertion is expected to be stable across formula changes within
-    the validated ±3.5% accuracy range.
+    the validated ±2% accuracy range.
     """
 
     def test_fraction_reduces_capacity(self):

--- a/tests/integration/test_trtllm_kv_cache_capacity.py
+++ b/tests/integration/test_trtllm_kv_cache_capacity.py
@@ -24,7 +24,8 @@ from aiconfigurator.sdk.backends.trtllm_backend import (
     KV_CACHE_MEMORY_RESERVED_FRACTION,
     KV_CACHE_MEMORY_TOLERANCE,
 )
-from aiconfigurator.sdk.config import ModelConfig
+from aiconfigurator.sdk.config import ModelConfig, RuntimeConfig
+from aiconfigurator.sdk.inference_summary import InferenceSummary
 from aiconfigurator.sdk.models import get_model
 from aiconfigurator.sdk.perf_database import get_database, get_latest_database_version
 
@@ -67,15 +68,13 @@ def _is_kv_oom(
     max_seq_len,
     kv_cache_capacity_tolerance=KV_CACHE_MEMORY_TOLERANCE,
 ):
-    """KV OOM check using _get_memory_usage directly."""
-    base = backend._get_memory_usage(model, database, 1, 1, isl, osl, num_tokens=2 * isl, free_gpu_memory_fraction=1.0)
-    non_kv_gib = base["total"] - base["kvcache"]
-    gpu_capacity_gib = database.system_spec["gpu"]["mem_capacity"] / (1 << 30)
-    available_kv_gib = (gpu_capacity_gib - non_kv_gib) * free_gpu_memory_fraction
-    available_kv_gib *= 1 - KV_CACHE_MEMORY_RESERVED_FRACTION
-    if available_kv_gib <= 0:
+    """KV OOM check using InferenceSummary."""
+    summary = InferenceSummary(RuntimeConfig(isl=isl, osl=osl))
+    base_memory = backend._get_memory_usage(model, database, 1, 1, isl, osl, num_tokens=2 * isl)
+    summary.set_memory_and_check_oom(base_memory, database.system_spec["gpu"]["mem_capacity"])
+    if summary.check_oom():
         return True
-    memory = backend._get_memory_usage(
+    kv_memory = backend._get_memory_usage(
         model,
         database,
         batch_size,
@@ -84,9 +83,15 @@ def _is_kv_oom(
         osl,
         num_tokens=2 * isl,
         max_seq_len=max_seq_len,
-        free_gpu_memory_fraction=1.0,
     )
-    return memory["kvcache"] > available_kv_gib * (1 - kv_cache_capacity_tolerance)
+    summary._check_and_set_kv_cache_oom(
+        kv_memory,
+        database.system_spec["gpu"]["mem_capacity"],
+        free_gpu_memory_fraction,
+        KV_CACHE_MEMORY_RESERVED_FRACTION,
+        kv_cache_capacity_tolerance,
+    )
+    return summary.check_kv_cache_oom()
 
 
 class TestKvCacheOomProperties:

--- a/tests/integration/test_trtllm_kv_cache_capacity.py
+++ b/tests/integration/test_trtllm_kv_cache_capacity.py
@@ -162,7 +162,7 @@ class TestKvCacheOomProperties:
 # We call _is_kv_cache_oom with the same parameters and assert:
 #   - batch_size = bench_max_bs - tolerance → NOT KV OOM
 #   - batch_size = bench_max_bs + tolerance + 1 → IS KV OOM
-# tolerance = max(1, int(bench_max_bs * 0.035))  (±3.5% or ±1)
+# tolerance = max(1, int(bench_max_bs * KV_CACHE_MEMORY_TOLERANCE))
 # ---------------------------------------------------------------------------
 
 # fmt: off
@@ -268,7 +268,7 @@ def test_kv_oom_boundary(system, model_path, tp, isl, osl, frac, bench_max_bs):
     (max_seq_len=isl+osl+1000) and asserts:
       - batch_size = bench_max_bs - tol → NOT KV OOM
       - batch_size = bench_max_bs + tol + 1 → IS KV OOM
-    where tol = max(1, int(bench_max_bs * 0.035))  (±3.5% or ±1)
+    where tol = max(1, int(bench_max_bs * KV_CACHE_MEMORY_TOLERANCE))
 
     Uses float16 KV cache to match benchmark conditions.
     """

--- a/tests/integration/test_trtllm_kv_cache_capacity.py
+++ b/tests/integration/test_trtllm_kv_cache_capacity.py
@@ -65,9 +65,10 @@ class TestKvCacheOomProperties:
           threshold at f=0.9 ≈ 78, at f=0.5 ≈ 43.
           bs=60: fits at f=0.9, OOM at f=0.5.
         """
+        isl, osl = 2048, 2048
         model, db, backend = _load("h100_sxm", "Qwen/Qwen3-32B-FP8", tp=1)
-        assert not backend._is_kv_cache_oom(model, db, 60, 2048, 2048, 0.9)
-        assert backend._is_kv_cache_oom(model, db, 60, 2048, 2048, 0.5)
+        assert not backend._is_kv_cache_oom(model, db, 60, isl, osl, 0.9, max_seq_len=isl + osl + _BENCHMARK_SLACK)
+        assert backend._is_kv_cache_oom(model, db, 60, isl, osl, 0.5, max_seq_len=isl + osl + _BENCHMARK_SLACK)
 
     def test_longer_sequences_reduce_capacity(self):
         """Longer ISL+OSL means fewer concurrent sequences fit.
@@ -77,8 +78,8 @@ class TestKvCacheOomProperties:
           bs=100: fits for short seqs, OOM for long seqs.
         """
         model, db, backend = _load("h100_sxm", "Qwen/Qwen3-32B-FP8", tp=1)
-        assert not backend._is_kv_cache_oom(model, db, 100, 512, 512, 0.9)
-        assert backend._is_kv_cache_oom(model, db, 100, 4096, 4096, 0.9)
+        assert not backend._is_kv_cache_oom(model, db, 100, 512, 512, 0.9, max_seq_len=512 + 512 + _BENCHMARK_SLACK)
+        assert backend._is_kv_cache_oom(model, db, 100, 4096, 4096, 0.9, max_seq_len=4096 + 4096 + _BENCHMARK_SLACK)
 
     def test_tp_increases_capacity(self):
         """More TP shards reduce KV heads per GPU, increasing KV capacity.
@@ -87,10 +88,11 @@ class TestKvCacheOomProperties:
           tp=1 threshold ≈ 78, tp=2 threshold ≈ 215.
           bs=120: OOM at tp=1, fits at tp=2.
         """
+        isl, osl = 2048, 2048
         model_tp1, db, backend = _load("h100_sxm", "Qwen/Qwen3-32B-FP8", tp=1)
         model_tp2, _, _ = _load("h100_sxm", "Qwen/Qwen3-32B-FP8", tp=2)
-        assert backend._is_kv_cache_oom(model_tp1, db, 120, 2048, 2048, 0.9)
-        assert not backend._is_kv_cache_oom(model_tp2, db, 120, 2048, 2048, 0.9)
+        assert backend._is_kv_cache_oom(model_tp1, db, 120, isl, osl, 0.9, max_seq_len=isl + osl + _BENCHMARK_SLACK)
+        assert not backend._is_kv_cache_oom(model_tp2, db, 120, isl, osl, 0.9, max_seq_len=isl + osl + _BENCHMARK_SLACK)
 
     def test_larger_gpu_increases_capacity(self):
         """GB300 (277 GiB) fits more sequences than H100 (80 GiB).
@@ -99,34 +101,53 @@ class TestKvCacheOomProperties:
           h100 threshold ≈ 78, gb300 threshold ≈ 434.
           bs=200: OOM on h100, fits on gb300.
         """
+        isl, osl = 2048, 2048
         model_h100, db_h100, backend = _load("h100_sxm", "Qwen/Qwen3-32B-FP8", tp=1)
         model_gb300, db_gb300, _ = _load("gb300", "Qwen/Qwen3-32B-FP8", tp=1)
-        assert backend._is_kv_cache_oom(model_h100, db_h100, 200, 2048, 2048, 0.9)
-        assert not backend._is_kv_cache_oom(model_gb300, db_gb300, 200, 2048, 2048, 0.9)
+        assert backend._is_kv_cache_oom(
+            model_h100, db_h100, 200, isl, osl, 0.9, max_seq_len=isl + osl + _BENCHMARK_SLACK
+        )
+        assert not backend._is_kv_cache_oom(
+            model_gb300, db_gb300, 200, isl, osl, 0.9, max_seq_len=isl + osl + _BENCHMARK_SLACK
+        )
 
     def test_smaller_model_has_more_kv_capacity(self):
         """8B model has much more KV capacity than 32B on the same GPU.
 
-        h100_sxm / tp=1 / isl=osl=2048 / f=0.9:
-          32B threshold ≈ 78, 8B threshold ≈ 110.
-          bs=90: OOM for 32B, fits for 8B.
+        Both models use float16 KV cache to match benchmark conditions and ensure
+        a fair comparison (default KV quant mode differs between model families).
+
+        h100_sxm / tp=1 / isl=osl=2048 / f=0.9 / float16 KV:
+          32B threshold ≈ 30, 8B threshold ≈ 88.
+          bs=60: OOM for 32B, fits for 8B.
         """
-        model_8b, db, backend = _load("h100_sxm", "meta-llama/Meta-Llama-3.1-8B", tp=1)
-        model_32b, _, _ = _load("h100_sxm", "Qwen/Qwen3-32B-FP8", tp=1)
-        assert backend._is_kv_cache_oom(model_32b, db, 90, 2048, 2048, 0.9)
-        assert not backend._is_kv_cache_oom(model_8b, db, 90, 2048, 2048, 0.9)
+        isl, osl = 2048, 2048
+        model_8b, db, backend = _load(
+            "h100_sxm", "meta-llama/Meta-Llama-3.1-8B", tp=1, kvcache_quant_mode=common.KVCacheQuantMode.float16
+        )
+        model_32b, _, _ = _load(
+            "h100_sxm", "Qwen/Qwen3-32B-FP8", tp=1, kvcache_quant_mode=common.KVCacheQuantMode.float16
+        )
+        assert backend._is_kv_cache_oom(model_32b, db, 60, isl, osl, 0.9, max_seq_len=isl + osl + _BENCHMARK_SLACK)
+        assert not backend._is_kv_cache_oom(model_8b, db, 60, isl, osl, 0.9, max_seq_len=isl + osl + _BENCHMARK_SLACK)
 
     def test_deepseek_fits_on_gb300(self):
         """DeepSeek-V3 (MLA) fits on GB300 TP=4: bs=1 is not KV OOM, bs=10000 is."""
         model_ds, db, backend = _load("gb300", "deepseek-ai/DeepSeek-V3", tp=4, moe_ep_size=4)
-        assert not backend._is_kv_cache_oom(model_ds, db, 1, 2048, 2048, 0.9)
-        assert not backend._is_kv_cache_oom(model_ds, db, 1, 8192, 8192, 0.9)
-        assert backend._is_kv_cache_oom(model_ds, db, 10000, 2048, 2048, 0.9)
+        assert not backend._is_kv_cache_oom(
+            model_ds, db, 1, 2048, 2048, 0.9, max_seq_len=2048 + 2048 + _BENCHMARK_SLACK
+        )
+        assert not backend._is_kv_cache_oom(
+            model_ds, db, 1, 8192, 8192, 0.9, max_seq_len=8192 + 8192 + _BENCHMARK_SLACK
+        )
+        assert backend._is_kv_cache_oom(
+            model_ds, db, 10000, 2048, 2048, 0.9, max_seq_len=2048 + 2048 + _BENCHMARK_SLACK
+        )
 
     def test_model_too_large_is_regular_oom(self):
         """405B on single H100 (TP=1): model doesn't fit → _is_kv_cache_oom returns True for bs=1."""
         model, db, backend = _load("h100_sxm", "meta-llama/Meta-Llama-3.1-405B", tp=1)
-        assert backend._is_kv_cache_oom(model, db, 1, 1024, 1024, 0.9)
+        assert backend._is_kv_cache_oom(model, db, 1, 1024, 1024, 0.9, max_seq_len=1024 + 1024 + _BENCHMARK_SLACK)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Overview

 When batch_size exceeds the KV cache capacity, TRT-LLM silently queues excess requests instead of OOM-ing, causing severely inflated TTFT and        
  inaccurate TPOT. This adds a boolean check (_is_kv_cache_oom) to detect this condition and applies it in two places:                                   
  - cli default: caps the batch size sweep in find_best_agg_result so oversized configs are never recommended                                            
  - cli estimate: warns when the requested batch_size exceeds KV capacity                                                                                
                                                                                                                                                         
  The formula uses TRT-LLM's block-based allocation model (tokens_per_block=32) and accounts for max_seq_len, free_gpu_memory_fraction, and KV cache quant mode. Validated against 72 TRT-LLM benchmark data points across H100 and GB300 with Qwen3-32B-FP8 and Llama-3.1-8B — all within ±2% or ±1 sequence.
                                                                                                                                                         
  To be conservative in production, the computed threshold is reduced by KV_CACHE_MEMORY_RESERVED_FRACTION (1.5%, modelling TRT-LLM's internal block-allocator overhead) and KV_CACHE_MEMORY_TOLERANCE (2%, lower-bound safety margin), so the OOM check fires slightly before the real threshold rather than after — ensuring no silent queuing occurs.    

## Tests

### `cli default`

```
aiconfigurator cli default --model-path Qwen/Qwen3-32B --system h100_sxm --total-gpus 8 --backend trtllm --isl 4096 --osl 4096 --max-seq-len 9192 --free-gpu-memory-fraction 0.8
```

Before:

```
agg Top Configurations: (Sorted by tokens/s/gpu)
+------+---------+--------------+---------------+---------+-----------------+--------------+-------------------+----------+--------------+-------------+----------+-----+
| Rank | backend | tokens/s/gpu | tokens/s/user |   TTFT  | request_latency | concurrency  | total_gpus (used) | replicas | gpus/replica | gpus/worker | parallel |  bs |
+------+---------+--------------+---------------+---------+-----------------+--------------+-------------------+----------+--------------+-------------+----------+-----+
|  1   |  trtllm |   1048.15    |     37.72     | 1182.13 |    109740.94    | 224 (=112x2) |     8 (8=2x4)     |    2     |      4       |  4 (=4x1x1) |  tp4pp1  | 112 |
|  2   |  trtllm |   1025.92    |     34.35     |  768.44 |    119996.54    | 240 (=240x1) |     8 (8=1x8)     |    1     |      8       |  8 (=8x1x1) |  tp8pp1  | 240 |
|  3   |  trtllm |    778.08    |     39.16     |  965.45 |    105523.96    | 160 (=40x4)  |     8 (8=4x2)     |    4     |      2       |  2 (=2x1x1) |  tp2pp1  |  40 |
|  4   |  trtllm |    239.72    |     34.59     |  910.33 |    119303.53    |  56 (=7x8)   |     8 (8=8x1)     |    8     |      1       |  1 (=1x1x1) |  tp1pp1  |  7  |
+------+---------+--------------+---------------+---------+-----------------+--------------+-------------------+----------+--------------+-------------+----------+-----+
```

After
```
+------+---------+--------------+---------------+---------+-----------------+--------------+-------------------+----------+--------------+-------------+----------+-----+
| Rank | backend | tokens/s/gpu | tokens/s/user |   TTFT  | request_latency | concurrency  | total_gpus (used) | replicas | gpus/replica | gpus/worker | parallel |  bs |
+------+---------+--------------+---------------+---------+-----------------+--------------+-------------------+----------+--------------+-------------+----------+-----+
|  1   |  trtllm |    947.07    |     43.28     |  748.57 |     95358.06    | 176 (=176x1) |     8 (8=1x8)     |    1     |      8       |  8 (=8x1x1) |  tp8pp1  | 176 |
|  2   |  trtllm |    918.38    |     46.35     | 1119.58 |     89468.71    | 160 (=80x2)  |     8 (8=2x4)     |    2     |      4       |  4 (=4x1x1) |  tp4pp1  |  80 |
|  3   |  trtllm |    618.14    |     44.49     |  803.80 |     92852.10    | 112 (=28x4)  |     8 (8=4x2)     |    4     |      2       |  2 (=2x1x1) |  tp2pp1  |  28 |
|  4   |  trtllm |    145.39    |     36.73     |  844.30 |    112322.36    |  32 (=4x8)   |     8 (8=8x1)     |    8     |      1       |  1 (=1x1x1) |  tp1pp1  |  4  |
+------+---------+--------------+---------------+---------+-----------------+--------------+-------------------+----------+--------------+-------------+----------+-----+
```

### `cli estimate`
```
aiconfigurator cli estimate --model-path Qwen/Qwen3-32B --system h100_sxm  --backend trtllm --isl 4096 --osl 4096 --batch-size 112 --tp-size 4 --max-seq-len 9192 --free-gpu-memory-fraction 0.8

...

13:40:42 [aiconfigurator] [main.py:1426] [W] Requested batch_size (112) exceeds estimated KV cache capacity (free_gpu_memory_fraction=0.8). TRT-LLM will queue excess requests, causing significantly higher TTFT and inaccurate TPOT.

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * KV-cache capacity validation added; estimator can emit KV-cache capacity warnings.
  * CLI options: --free-gpu-memory-fraction and --max-seq-len to tune KV-cache estimation.

* **Behavior Changes**
  * Aggregation/estimation now considers KV-cache constraints (max_seq_len defaulting to isl+osl when unset) and may stop earlier when KV-cache limits are hit.

* **Tests**
  * New integration tests validating KV-cache capacity and boundary behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->