### PR TITLE
chore: cherry-pick #594 — update default Dynamo image and version references to 1.0.0

### DIFF
--- a/docs/cli_user_guide.md
+++ b/docs/cli_user_guide.md
@@ -292,8 +292,8 @@ By default, we output top 5 configs we have found. You can get the configs and s
 
 **Generator Dynamo version**
 - Use `--generator-dynamo-version 0.7.1` to select the Dynamo release. This affects both the generated backend config version and the default K8s image tag.
-- If `--generator-dynamo-version` is not provided, the default is the latest database version for the backend.
-- If `--generated_config_version` is provided, it overrides the generated backend version, but the default K8s image tag still follows the first entry in `--generator-dynamo-version`.
+- If `--generator-dynamo-version` is not provided, the default is the first entry in `backend_version_matrix.yaml` (currently `1.0.0`).
+- If `--generated-config-version` is provided, it overrides the generated backend version, but the default K8s image tag still follows the selected Dynamo version mapping.
 
 Use `--generator-config path/to/file.yaml` to provide ServiceConfig/K8sConfig/DynConfig/WorkerConfig/Workers.<role> sections, or add inline overrides via `--generator-set KEY=VALUE`. Examples:
 

--- a/docs/dynamo_deployment_guide.md
+++ b/docs/dynamo_deployment_guide.md
@@ -454,7 +454,7 @@ aiconfigurator cli default \
   --generator-set Workers.decode.cache_transceiver_backend=default
 ```
 
-Since different versions of TensorRT-LLM often have variations in configuration, please specify `--generated-config-version` to match the version used when generating configs. For the specific TensorRT-LLM version corresponding to a official dynamo image, you can refer to, for example, this [pyproject](https://github.com/ai-dynamo/dynamo/blob/v0.5.0/pyproject.toml#L51), or check directly inside the container by running: `python -c import tensorrt_llm; print(tensorrt_llm.__version__)`. In this case, since the image is nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.5.0, you should set `--generated-config-version 1.0.0rc6`.
+Since different TensorRT-LLM versions can require different config fields, set `--generated-config-version` to match the runtime used to deploy. For the TensorRT-LLM version corresponding to an official Dynamo image, refer to this [pyproject](https://github.com/ai-dynamo/dynamo/blob/v0.5.0/pyproject.toml#L51), or check directly in the container via `python -c "import tensorrt_llm; print(tensorrt_llm.__version__)"`. For `nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.5.0`, use `--generated-config-version 1.0.0rc6`.
 
 
 ### Apply (inline mode - default)

--- a/docs/generator_overview.md
+++ b/docs/generator_overview.md
@@ -78,8 +78,8 @@ You can use the generator in three ways: AIConfigurator CLI, webapp, or standalo
   ```
   Notes:
   - Use `--generator-dynamo-version 0.7.1` to select the Dynamo release. This affects both the generated backend config version and the default K8s image tag.
-  - If `--generator-dynamo-version` is not provided, the default is the latest database version for the backend.
-  - If `--generated_config_version` is provided, it overrides the generated backend version, but the default K8s image tag still follows the first entry in `--generator-dynamo-version`.
+  - If `--generator-dynamo-version` is not provided, the default is the first entry in `backend_version_matrix.yaml` (currently `1.0.0`).
+  - If `--generated-config-version` is provided, it overrides the generated backend version, but the default K8s image tag still follows the selected Dynamo version mapping.
 - Webapp: start with `--enable_profiling` when launching the webapp to surface generator-driven configs.
 - Standalone:
   - In code:

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -222,7 +222,7 @@ def _add_support_mode_arguments(parser):
 
 _USAGE_EXAMPLES = """
 Examples:
-# Sweep across all backends for Dynamo 0.7.1
+# Sweep across all backends for Dynamo 1.0.0
 aiconfigurator cli default --model Qwen/Qwen3-32B-FP8 \\
     --backend auto \\
     --top-n 3 \\

--- a/src/aiconfigurator/generator/config/backend_templates/sglang/cli_args.0.5.3.post2.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/sglang/cli_args.0.5.3.post2.j2
@@ -5,7 +5,7 @@
 {%- if sglang['page-size'] is defined -%}{%- set _ = args.append('--page-size "' ~ sglang['page-size'] ~ '"') -%}{%- endif -%}
 {%- if sglang['kv-cache-dtype'] is defined -%}{%- set _ = args.append('--kv-cache-dtype "' ~ sglang['kv-cache-dtype'] ~ '"') -%}{%- endif -%}
 {%- if sglang['max-prefill-tokens'] is defined -%}{%- set _ = args.append('--max-prefill-tokens "' ~ sglang['max-prefill-tokens'] ~ '"') -%}{%- endif -%}
-{%- if sglang['enable-mixed-chunk'] is defined -%}{%- set _ = args.append('--enable-mixed-chunk') -%}{%- endif -%}
+{%- if sglang['enable-mixed-chunk'] is defined and sglang['enable-mixed-chunk'] -%}{%- set _ = args.append('--enable-mixed-chunk') -%}{%- endif -%}
 {%- if sglang['context-length'] is defined -%}{%- set _ = args.append('--context-length "' ~ sglang['context-length'] ~ '"') -%}{%- endif -%}
 {%- if sglang['max-running-requests'] is defined -%}{%- set _ = args.append('--max-running-requests "' ~ sglang['max-running-requests'] ~ '"') -%}{%- endif -%}
 {%- if sglang['skip-tokenizer-init'] -%}{%- set _ = args.append('--skip-tokenizer-init') -%}{%- endif -%}

--- a/src/aiconfigurator/generator/config/backend_templates/sglang/cli_args.0.5.4.post3.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/sglang/cli_args.0.5.4.post3.j2
@@ -5,7 +5,7 @@
 {%- if sglang['page-size'] is defined -%}{%- set _ = args.append('--page-size "' ~ sglang['page-size'] ~ '"') -%}{%- endif -%}
 {%- if sglang['kv-cache-dtype'] is defined -%}{%- set _ = args.append('--kv-cache-dtype "' ~ sglang['kv-cache-dtype'] ~ '"') -%}{%- endif -%}
 {%- if sglang['max-prefill-tokens'] is defined -%}{%- set _ = args.append('--max-prefill-tokens "' ~ sglang['max-prefill-tokens'] ~ '"') -%}{%- endif -%}
-{%- if sglang['enable-mixed-chunk'] is defined -%}{%- set _ = args.append('--enable-mixed-chunk') -%}{%- endif -%}
+{%- if sglang['enable-mixed-chunk'] is defined and sglang['enable-mixed-chunk'] -%}{%- set _ = args.append('--enable-mixed-chunk') -%}{%- endif -%}
 {%- if sglang['context-length'] is defined -%}{%- set _ = args.append('--context-length "' ~ sglang['context-length'] ~ '"') -%}{%- endif -%}
 {%- if sglang['max-running-requests'] is defined -%}{%- set _ = args.append('--max-running-requests "' ~ sglang['max-running-requests'] ~ '"') -%}{%- endif -%}
 {%- if sglang['skip-tokenizer-init'] -%}{%- set _ = args.append('--skip-tokenizer-init') -%}{%- endif -%}

--- a/src/aiconfigurator/generator/config/backend_templates/sglang/cli_args.0.5.6.post2.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/sglang/cli_args.0.5.6.post2.j2
@@ -5,7 +5,7 @@
 {%- if sglang['page-size'] is defined -%}{%- set _ = args.append('--page-size "' ~ sglang['page-size'] ~ '"') -%}{%- endif -%}
 {%- if sglang['kv-cache-dtype'] is defined -%}{%- set _ = args.append('--kv-cache-dtype "' ~ sglang['kv-cache-dtype'] ~ '"') -%}{%- endif -%}
 {%- if sglang['max-prefill-tokens'] is defined -%}{%- set _ = args.append('--max-prefill-tokens "' ~ sglang['max-prefill-tokens'] ~ '"') -%}{%- endif -%}
-{%- if sglang['enable-mixed-chunk'] is defined -%}{%- set _ = args.append('--enable-mixed-chunk') -%}{%- endif -%}
+{%- if sglang['enable-mixed-chunk'] is defined and sglang['enable-mixed-chunk'] -%}{%- set _ = args.append('--enable-mixed-chunk') -%}{%- endif -%}
 {%- if sglang['context-length'] is defined -%}{%- set _ = args.append('--context-length "' ~ sglang['context-length'] ~ '"') -%}{%- endif -%}
 {%- if sglang['max-running-requests'] is defined -%}{%- set _ = args.append('--max-running-requests "' ~ sglang['max-running-requests'] ~ '"') -%}{%- endif -%}
 {%- if sglang['skip-tokenizer-init'] -%}{%- set _ = args.append('--skip-tokenizer-init') -%}{%- endif -%}

--- a/src/aiconfigurator/generator/config/backend_templates/sglang/cli_args.0.5.8.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/sglang/cli_args.0.5.8.j2
@@ -5,7 +5,7 @@
 {%- if sglang['page-size'] is defined -%}{%- set _ = args.append('--page-size "' ~ sglang['page-size'] ~ '"') -%}{%- endif -%}
 {%- if sglang['kv-cache-dtype'] is defined -%}{%- set _ = args.append('--kv-cache-dtype "' ~ sglang['kv-cache-dtype'] ~ '"') -%}{%- endif -%}
 {%- if sglang['max-prefill-tokens'] is defined -%}{%- set _ = args.append('--max-prefill-tokens "' ~ sglang['max-prefill-tokens'] ~ '"') -%}{%- endif -%}
-{%- if sglang['enable-mixed-chunk'] is defined -%}{%- set _ = args.append('--enable-mixed-chunk') -%}{%- endif -%}
+{%- if sglang['enable-mixed-chunk'] is defined and sglang['enable-mixed-chunk'] -%}{%- set _ = args.append('--enable-mixed-chunk') -%}{%- endif -%}
 {%- if sglang['context-length'] is defined -%}{%- set _ = args.append('--context-length "' ~ sglang['context-length'] ~ '"') -%}{%- endif -%}
 {%- if sglang['max-running-requests'] is defined -%}{%- set _ = args.append('--max-running-requests "' ~ sglang['max-running-requests'] ~ '"') -%}{%- endif -%}
 {%- if sglang['skip-tokenizer-init'] -%}{%- set _ = args.append('--skip-tokenizer-init') -%}{%- endif -%}

--- a/src/aiconfigurator/generator/config/backend_templates/sglang/cli_args.0.5.9.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/sglang/cli_args.0.5.9.j2
@@ -3,9 +3,9 @@
 {%- if sglang['pipeline-parallel-size'] is defined -%}{%- set _ = args.append('--pipeline-parallel-size "' ~ sglang['pipeline-parallel-size'] ~ '"') -%}{%- endif -%}
 {%- if sglang['data-parallel-size'] is defined -%}{%- set _ = args.append('--data-parallel-size "' ~ sglang['data-parallel-size'] ~ '"') -%}{%- endif -%}
 {%- if sglang['page-size'] is defined -%}{%- set _ = args.append('--page-size "' ~ sglang['page-size'] ~ '"') -%}{%- endif -%}
-{%- if sglang['max-prefill-tokens'] is defined -%}{%- set _ = args.append('--max-prefill-tokens "' ~ sglang['max-prefill-tokens'] ~ '"') -%}{%- endif -%}
-{%- if sglang['enable-mixed-chunk'] is defined and sglang['enable-mixed-chunk'] -%}{%- set _ = args.append('--enable-mixed-chunk') -%}{%- endif -%}
 {%- if sglang['kv-cache-dtype'] is defined -%}{%- set _ = args.append('--kv-cache-dtype "' ~ sglang['kv-cache-dtype'] ~ '"') -%}{%- endif -%}
+{%- if sglang['max-prefill-tokens'] is defined -%}{%- set _ = args.append('--max-prefill-tokens "' ~ sglang['max-prefill-tokens'] ~ '"') -%}{%- endif -%}
+{%- if sglang['enable-mixed-chunk'] -%}{%- set _ = args.append('--enable-mixed-chunk') -%}{%- endif -%}
 {%- if sglang['context-length'] is defined -%}{%- set _ = args.append('--context-length "' ~ sglang['context-length'] ~ '"') -%}{%- endif -%}
 {%- if sglang['max-running-requests'] is defined -%}{%- set _ = args.append('--max-running-requests "' ~ sglang['max-running-requests'] ~ '"') -%}{%- endif -%}
 {%- if sglang['skip-tokenizer-init'] -%}{%- set _ = args.append('--skip-tokenizer-init') -%}{%- endif -%}
@@ -15,6 +15,9 @@
 {%- if sglang['moe-dense-tp-size'] is defined -%}{%- set _ = args.append('--moe-dense-tp-size "' ~ sglang['moe-dense-tp-size'] ~ '"') -%}{%- endif -%}
 {%- if sglang['disable-cuda-graph'] -%}{%- set _ = args.append('--disable-cuda-graph') -%}{%- endif -%}
 {%- if sglang['cuda-graph-bs'] is defined -%}{%- set _ = args.append('--cuda-graph-bs ' ~ (sglang['cuda-graph-bs'] | join(' '))) -%}{%- endif -%}
+{%- if sglang['speculative-algorithm'] is defined -%}{%- set _ = args.append('--speculative-algorithm "' ~ sglang['speculative-algorithm'] ~ '"') -%}{%- endif -%}
+{%- if sglang['speculative-num-steps'] is defined -%}{%- set _ = args.append('--speculative-num-steps "' ~ sglang['speculative-num-steps'] ~ '"') -%}{%- endif -%}
 {%- if sglang['disable-cuda-graph-padding'] -%}{%- set _ = args.append('--disable-cuda-graph-padding') -%}{%- endif -%}
 {%- if sglang['cuda-graph-max-bs'] is defined -%}{%- set _ = args.append('--cuda-graph-max-bs "' ~ sglang['cuda-graph-max-bs'] ~ '"') -%}{%- endif -%}
+{%- if sglang['disaggregation-transfer-backend'] is defined -%}{%- set _ = args.append('--disaggregation-transfer-backend "' ~ sglang['disaggregation-transfer-backend'] ~ '"') -%}{%- endif -%}
 {{ args | join(' ') }}

--- a/src/aiconfigurator/generator/config/backend_templates/sglang/cli_args.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/sglang/cli_args.j2
@@ -10,7 +10,7 @@
 {%- if sglang['max-running-requests'] is defined -%}{%- set _ = args.append('--max-running-requests "' ~ sglang['max-running-requests'] ~ '"') -%}{%- endif -%}
 {%- if sglang['chunked-prefill-size'] is defined -%}{%- set _ = args.append('--chunked-prefill-size "' ~ sglang['chunked-prefill-size'] ~ '"') -%}{%- endif -%}
 {%- if sglang['max-prefill-tokens'] is defined -%}{%- set _ = args.append('--max-prefill-tokens "' ~ sglang['max-prefill-tokens'] ~ '"') -%}{%- endif -%}
-{%- if sglang['enable-mixed-chunk'] is defined -%}{%- set _ = args.append('--enable-mixed-chunk') -%}{%- endif -%}
+{%- if sglang['enable-mixed-chunk'] is defined and sglang['enable-mixed-chunk'] -%}{%- set _ = args.append('--enable-mixed-chunk') -%}{%- endif -%}
 {%- if sglang['skip-tokenizer-init'] -%}{%- set _ = args.append('--skip-tokenizer-init') -%}{%- endif -%}
 {%- if sglang['trust-remote-code'] -%}{%- set _ = args.append('--trust-remote-code') -%}{%- endif -%}
 {%- if sglang['disable-radix-cache'] -%}{%- set _ = args.append('--disable-radix-cache') -%}{%- endif -%}

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.3.0rc5.post1.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.3.0rc5.post1.yaml.j2
@@ -1,0 +1,50 @@
+backend: pytorch
+
+{% if is_moe is defined %}  # is_moe from sdk
+moe_expert_parallel_size: {{ moe_expert_parallel_size }}
+moe_tensor_parallel_size: {{ moe_tensor_parallel_size }}
+
+moe_config:
+    backend: {{ moe_config.backend | default('CUTLASS') }} # MOE backend to use (CUTLASS, CUTEDSL, WIDEEP, TRTLLM, VANILLA)
+    {% if moe_config.load_balancer is defined %}  # Configuration for MoE load balancing
+    load_balancer: {{ moe_config.load_balancer }} # moe load balancer
+    {% endif %}
+{% endif %}
+
+tensor_parallel_size: {{ tensor_parallel_size }}
+pipeline_parallel_size: {{ pipeline_parallel_size }}
+enable_attention_dp: {{ enable_attention_dp | default(false) }}
+enable_chunked_prefill: {{ enable_chunked_prefill | default(false) }}
+
+{% set _max_seq_len = max_seq_len | default(none) %}
+
+max_batch_size: {{ max_batch_size }}
+max_num_tokens: {{ max_num_tokens }}
+{% if _max_seq_len is not none and _max_seq_len != '' %}
+max_seq_len: {{ _max_seq_len }}
+{% endif %}
+
+kv_cache_config:
+  free_gpu_memory_fraction: {{ kv_cache_config.free_gpu_memory_fraction | default(0.80) }}  # Fraction of GPU memory usable for KV-cache
+  dtype: {{ kv_cache_config.dtype | default('auto') }}
+  {% if kv_cache_config.tokens_per_block is defined %}
+  tokens_per_block: {{ kv_cache_config.tokens_per_block }}
+  {% endif %}
+  enable_block_reuse: {{ kv_cache_config.enable_block_reuse | default(false) }}
+
+cuda_graph_config:
+  enable_padding: {{ cuda_graph_config.enable_padding | default(false) }} # Pad CUDA graph
+  batch_sizes: [{% for s in cuda_graph_config.batch_sizes
+                               | default([1,2,4,8,16,32,64,128,256]) -%}
+                    {{- s }}{{ ',' if not loop.last else '' }} {%- endfor %}]
+
+disable_overlap_scheduler: {{ disable_overlap_scheduler | default(true) }}
+print_iter_log: {{ print_iter_log | default(false) }}
+
+{% if speculative_config.decoding_type is defined %}  # speculative decoding
+speculative_config:
+  decoding_type: {{ speculative_config.decoding_type }}
+  {% if speculative_config.decoding_type == 'MTP' %}
+  num_nextn_predict_layers: {{ num_nextn_predict_layers }}
+  {% endif %}
+{% endif %}

--- a/src/aiconfigurator/generator/config/backend_templates/vllm/cli_args.0.16.0.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/vllm/cli_args.0.16.0.j2
@@ -1,0 +1,28 @@
+{%- set args = [] -%}
+{%- if vllm['tensor-parallel-size'] is defined -%}{%- set _ = args.append('--tensor-parallel-size "' ~ vllm['tensor-parallel-size'] ~ '"') -%}{%- endif -%}
+{%- if vllm['pipeline-parallel-size'] is defined -%}{%- set _ = args.append('--pipeline-parallel-size "' ~ vllm['pipeline-parallel-size'] ~ '"') -%}{%- endif -%}
+{%- if vllm['data-parallel-size'] is defined -%}{%- set _ = args.append('--data-parallel-size "' ~ vllm['data-parallel-size'] ~ '"') -%}{%- endif -%}
+{%- if vllm['enable-expert-parallel'] -%}{%- set _ = args.append('--enable-expert-parallel') -%}{%- endif -%}
+{%- if vllm['block-size'] is defined -%}{%- set _ = args.append('--block-size "' ~ vllm['block-size'] ~ '"') -%}{%- endif -%}
+{%- if vllm['kv-cache-dtype'] is defined -%}{%- set _ = args.append('--kv-cache-dtype "' ~ vllm['kv-cache-dtype'] ~ '"') -%}{%- endif -%}
+{%- if vllm['max-model-len'] is defined -%}{%- set _ = args.append('--max-model-len "' ~ vllm['max-model-len'] ~ '"') -%}{%- endif -%}
+{%- if vllm['max-num-seqs'] is defined -%}{%- set _ = args.append('--max-num-seqs "' ~ vllm['max-num-seqs'] ~ '"') -%}{%- endif -%}
+{%- if vllm['max-num-batched-tokens'] is defined -%}{%- set _ = args.append('--max-num-batched-tokens ' ~ vllm['max-num-batched-tokens']) -%}{%- endif -%}
+{%- if vllm['skip-tokenizer-init'] -%}{%- set _ = args.append('--skip-tokenizer-init') -%}{%- endif -%}
+{%- if vllm['trust-remote-code'] -%}{%- set _ = args.append('--trust-remote-code') -%}{%- endif -%}
+{%- if vllm['enforce-eager'] -%}{%- set _ = args.append('--enforce-eager') -%}{%- endif -%}
+{%- if vllm['cudagraph-capture-sizes'] is defined -%}{%- set _ = args.append('--cudagraph-capture-sizes ' ~ (vllm['cudagraph-capture-sizes'] | join(' '))) -%}{%- endif -%}
+
+
+{%- if vllm['no-enable-prefix-caching'] -%}{%- set _ = args.append('--no-enable-prefix-caching') -%}{%- endif -%}
+{%- set spec_cfg = namespace(value={}) -%}
+{%- if speculative_config.method is defined and speculative_config.method -%}
+    {%- set _ = spec_cfg.value.update({'method': speculative_config.method}) -%}
+{%- endif -%}
+{%- if speculative_config.num_speculative_tokens is defined and speculative_config.num_speculative_tokens is not none -%}
+    {%- set _ = spec_cfg.value.update({'num_speculative_tokens': speculative_config.num_speculative_tokens}) -%}
+{%- endif -%}
+{%- if spec_cfg.value -%}
+    {%- set _ = args.append('--speculative-config \'' ~ (spec_cfg.value | tojson) ~ '\'') -%}
+{%- endif -%}
+{{ args | join(' ') }}

--- a/src/aiconfigurator/generator/config/backend_version_matrix.yaml
+++ b/src/aiconfigurator/generator/config/backend_version_matrix.yaml
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 matrix:
+  1.0.0:
+    vllm: "0.16.0"
+    sglang: "0.5.9"
+    trtllm: "1.3.0rc5.post1"
   0.9.0:
     vllm: "0.14.1"
     sglang: "0.5.8"

--- a/src/aiconfigurator/webapp/components/profiling/sdk/config.py
+++ b/src/aiconfigurator/webapp/components/profiling/sdk/config.py
@@ -71,7 +71,7 @@ def generate_config_yaml(
         "K8sConfig": {
             "name_prefix": name_prefix,
             "k8s_namespace": "dynamo",
-            "k8s_image": "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.9.0",
+            "k8s_image": "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.0.0",
             "k8s_pvc_name": "model-cache",
             "k8s_engine_mode": "inline",
         },


### PR DESCRIPTION
## Summary

Cherry-pick of #594 onto `release/0.7.0-post.1`.

- Adds Dynamo `1.0.0` entry to `backend_version_matrix.yaml` (vLLM 0.16.0, SGLang 0.5.9, TRT-LLM 1.3.0rc5.post1) as the new default
- Adds missing Jinja templates for the new backend versions (`cli_args.0.16.0.j2`, `cli_args.0.5.9.j2`, `extra_engine_args.1.3.0rc5.post1.yaml.j2`)
- Fixes `--enable-mixed-chunk` emitted when false in all SGLang cli_args templates
- Updates K8s runtime image tag to `tensorrtllm-runtime:1.0.0`
- Fixes doc inaccuracies in `cli_user_guide.md`, `generator_overview.md`, `dynamo_deployment_guide.md`
- Fixes stale comment in `main.py`

## Cherry-pick

Original PR: #594
Commit: `588f522`

🤖 Generated with [Claude Code](https://claude.com/claude-code)