### PR TITLE
feat(sdk): add static latency-only fast path

### DIFF
--- a/src/aiconfigurator/sdk/backends/base_backend.py
+++ b/src/aiconfigurator/sdk/backends/base_backend.py
@@ -168,6 +168,12 @@ class BaseBackend(ABC):
         stride: int = 32,
         latency_correction_scale: float = 1.0,
     ) -> float:
+        """
+        Run static inference and return only the total latency in milliseconds.
+
+        This shares the same latency breakdown path as ``run_static`` but skips
+        building an ``InferenceSummary``.
+        """
         (
             context_latency_dict,
             _,

--- a/src/aiconfigurator/sdk/backends/base_backend.py
+++ b/src/aiconfigurator/sdk/backends/base_backend.py
@@ -34,6 +34,148 @@ class BaseBackend(ABC):
         _get_memory_usage: this is backend-specific. It should be implemented in the subclass.
     """
 
+    def _run_context_phase(
+        self,
+        model: BaseModel,
+        database: PerfDatabase,
+        runtime_config: RuntimeConfig,
+        batch_size: int,
+        isl: int,
+        prefix: int,
+    ) -> tuple[dict[str, float], dict[str, float]]:
+        context_latency_dict = defaultdict(float)
+        context_energy_wms_dict = defaultdict(float)
+
+        effective_isl = isl - prefix
+        if effective_isl <= 0:
+            raise ValueError(f"isl must be greater than 0 after removing prefix, but got {effective_isl}")
+
+        for op in model.context_ops:
+            x = batch_size * effective_isl if "logits_gemm" not in op._name else batch_size
+            result = op.query(
+                database,
+                x=x,
+                batch_size=batch_size,
+                beam_width=1,
+                s=effective_isl,
+                prefix=prefix,
+                model_name=getattr(model, "model_name", ""),
+                seq_imbalance_correction_scale=runtime_config.seq_imbalance_correction_scale,
+            )
+            context_latency_dict[op._name] += float(result)
+            context_energy_wms_dict[op._name] += getattr(result, "energy", 0.0)
+
+        return context_latency_dict, context_energy_wms_dict
+
+    def _run_generation_phase(
+        self,
+        model: BaseModel,
+        database: PerfDatabase,
+        runtime_config: RuntimeConfig,
+        batch_size: int,
+        beam_width: int,
+        isl: int,
+        osl: int,
+        stride: int,
+    ) -> tuple[dict[str, float], dict[str, float]]:
+        generation_latency_dict = defaultdict(float)
+        generation_energy_wms_dict = defaultdict(float)
+
+        batch_size = batch_size * (model._nextn + 1)
+
+        for i in range(0, osl - 1, stride):
+            latency_dict = defaultdict(float)
+            energy_wms_dict = defaultdict(float)
+
+            for op in model.generation_ops:
+                result = op.query(
+                    database,
+                    x=batch_size * beam_width,
+                    batch_size=batch_size,
+                    beam_width=beam_width,
+                    s=isl + i + 1,
+                    model_name=getattr(model, "model_name", ""),
+                    gen_seq_imbalance_correction_scale=runtime_config.gen_seq_imbalance_correction_scale,
+                )
+                latency_dict[op._name] += float(result)
+                energy_wms_dict[op._name] += getattr(result, "energy", 0.0)
+
+            repeat_count = min(stride, osl - 1 - i)
+            for op in latency_dict:
+                generation_latency_dict[op] += latency_dict[op] * repeat_count
+                generation_energy_wms_dict[op] += energy_wms_dict[op] * repeat_count
+
+        return generation_latency_dict, generation_energy_wms_dict
+
+    def _run_static_breakdown(
+        self,
+        model: BaseModel,
+        database: PerfDatabase,
+        runtime_config: RuntimeConfig,
+        mode: str,
+        stride: int = 32,
+        latency_correction_scale: float = 1.0,
+    ) -> tuple[dict[str, float], dict[str, float], dict[str, float], dict[str, float]]:
+        batch_size, beam_width, isl, osl, prefix = (
+            runtime_config.batch_size,
+            runtime_config.beam_width,
+            runtime_config.isl,
+            runtime_config.osl,
+            runtime_config.prefix,
+        )
+
+        context_latency_dict, context_energy_wms_dict = {}, {}
+        generation_latency_dict, generation_energy_wms_dict = {}, {}
+
+        if mode == "static_ctx":
+            context_latency_dict, context_energy_wms_dict = self._run_context_phase(
+                model, database, runtime_config, batch_size, isl, prefix
+            )
+        elif mode == "static_gen":
+            generation_latency_dict, generation_energy_wms_dict = self._run_generation_phase(
+                model, database, runtime_config, batch_size, beam_width, isl, osl, stride
+            )
+        else:
+            context_latency_dict, context_energy_wms_dict = self._run_context_phase(
+                model, database, runtime_config, batch_size, isl, prefix
+            )
+            generation_latency_dict, generation_energy_wms_dict = self._run_generation_phase(
+                model, database, runtime_config, batch_size, beam_width, isl, osl, stride
+            )
+
+        if latency_correction_scale != 1.0:
+            logger.debug(f"latency_correction_scale: {latency_correction_scale} is applied")
+            for op in context_latency_dict:
+                context_latency_dict[op] *= latency_correction_scale
+                context_energy_wms_dict[op] *= latency_correction_scale
+            for op in generation_latency_dict:
+                generation_latency_dict[op] *= latency_correction_scale
+                generation_energy_wms_dict[op] *= latency_correction_scale
+
+        return (
+            context_latency_dict,
+            context_energy_wms_dict,
+            generation_latency_dict,
+            generation_energy_wms_dict,
+        )
+
+    def run_static_latency_only(
+        self,
+        model: BaseModel,
+        database: PerfDatabase,
+        runtime_config: RuntimeConfig,
+        mode: str,
+        stride: int = 32,
+        latency_correction_scale: float = 1.0,
+    ) -> float:
+        (
+            context_latency_dict,
+            _,
+            generation_latency_dict,
+            _,
+        ) = self._run_static_breakdown(model, database, runtime_config, mode, stride, latency_correction_scale)
+        return sum(context_latency_dict.values()) + sum(generation_latency_dict.values())
+
     def run_static(
         self,
         model: BaseModel,
@@ -58,94 +200,6 @@ class BaseBackend(ABC):
                 corrected latency = latency * latency_correction_scale
         """
 
-        def _run_context(batch_size: int, isl: int, prefix) -> tuple[dict[str, float], dict[str, float]]:
-            """
-            Run context phase.
-
-            Returns:
-                tuple: (context_latency_dict, context_energy_wms_dict)
-                       latency in ms, energy in W·ms (watt-milliseconds)
-            """
-            context_latency_dict = defaultdict(float)  # milliseconds
-            context_energy_wms_dict = defaultdict(float)  # W·ms (watt-milliseconds)
-
-            # isl is corrected based on prefix.
-            # Please handle the real logic in your context attention related operations.
-            isl = isl - prefix
-            if isl <= 0:
-                raise ValueError(f"isl must be greater than 0 after removing prefix, but got {isl}")
-
-            for op in model.context_ops:
-                # query latency and store the latency
-                x = batch_size * isl if "logits_gemm" not in op._name else batch_size
-                result = op.query(
-                    database,
-                    x=x,
-                    batch_size=batch_size,
-                    beam_width=1,
-                    s=isl,
-                    prefix=prefix,
-                    model_name=getattr(model, "model_name", ""),
-                    seq_imbalance_correction_scale=runtime_config.seq_imbalance_correction_scale,
-                )
-
-                # ✅ IMMEDIATELY extract values - do NOT use PerformanceResult arithmetic!
-                latency_ms = float(result)  # Extract latency in milliseconds
-                energy_wms = getattr(result, "energy", 0.0)  # Extract energy in watt-milliseconds
-
-                # Aggregate in separate dicts (simple addition)
-                context_latency_dict[op._name] += latency_ms
-                context_energy_wms_dict[op._name] += energy_wms
-
-            return context_latency_dict, context_energy_wms_dict
-
-        def _run_generation(
-            batch_size: int, beam_width: int, isl: int, osl: int, stride: int
-        ) -> tuple[dict[str, float], dict[str, float]]:
-            """
-            Run generation phase.
-
-            Returns:
-                tuple: (generation_latency_dict, generation_energy_wms_dict)
-                       latency in ms, energy in W·ms
-            """
-            # mtp/speculative decoding correction
-            batch_size = batch_size * (model._nextn + 1)
-
-            generation_latency_dict = defaultdict(float)  # milliseconds
-            generation_energy_wms_dict = defaultdict(float)  # W·ms
-
-            for i in range(0, osl - 1, stride):
-                latency_dict = defaultdict(float)
-                energy_wms_dict = defaultdict(float)  # W·ms
-
-                for op in model.generation_ops:
-                    result = op.query(
-                        database,
-                        x=batch_size * beam_width,
-                        batch_size=batch_size,
-                        beam_width=beam_width,
-                        s=isl + i + 1,
-                        model_name=getattr(model, "model_name", ""),
-                        gen_seq_imbalance_correction_scale=runtime_config.gen_seq_imbalance_correction_scale,
-                    )
-
-                    latency_ms = float(result)
-                    energy_wms = getattr(result, "energy", 0.0)
-
-                    latency_dict[op._name] += latency_ms
-                    energy_wms_dict[op._name] += energy_wms
-
-                # usually stride, but might be less at the end
-                repeat_count = min(stride, osl - 1 - i)
-
-                for op in latency_dict:
-                    # Both latency and energy are additive - multiply by repeat_count
-                    generation_latency_dict[op] += latency_dict[op] * repeat_count
-                    generation_energy_wms_dict[op] += energy_wms_dict[op] * repeat_count  # SIMPLIFIED
-
-            return generation_latency_dict, generation_energy_wms_dict
-
         summary = InferenceSummary(runtime_config)
         batch_size, beam_width, isl, osl, prefix = (
             runtime_config.batch_size,
@@ -155,17 +209,16 @@ class BaseBackend(ABC):
             runtime_config.prefix,
         )
 
-        # Execute phases (UPDATED to return energy_wms dicts)
-        context_latency_dict, context_energy_wms_dict = {}, {}
-        generation_latency_dict, generation_energy_wms_dict = {}, {}
+        (
+            context_latency_dict,
+            context_energy_wms_dict,
+            generation_latency_dict,
+            generation_energy_wms_dict,
+        ) = self._run_static_breakdown(model, database, runtime_config, mode, stride, latency_correction_scale)
 
         if mode == "static_ctx":
-            context_latency_dict, context_energy_wms_dict = _run_context(batch_size, isl, prefix)
             memory = self._get_memory_usage(model, database, batch_size, beam_width, isl, 1, prefix=prefix)
         elif mode == "static_gen":
-            generation_latency_dict, generation_energy_wms_dict = _run_generation(
-                batch_size, beam_width, isl, osl, stride
-            )
             memory = self._get_memory_usage(
                 model,
                 database,
@@ -177,20 +230,7 @@ class BaseBackend(ABC):
                 prefix=prefix,
             )  # for gen only, all kvcache is needed.
         else:
-            context_latency_dict, context_energy_wms_dict = _run_context(batch_size, isl, prefix)
-            generation_latency_dict, generation_energy_wms_dict = _run_generation(
-                batch_size, beam_width, isl, osl, stride
-            )
             memory = self._get_memory_usage(model, database, batch_size, beam_width, isl, osl, prefix=prefix)
-
-        if latency_correction_scale != 1.0:
-            logger.debug(f"latency_correction_scale: {latency_correction_scale} is applied")
-            for op in context_latency_dict:
-                context_latency_dict[op] *= latency_correction_scale
-                context_energy_wms_dict[op] *= latency_correction_scale  # Energy scales with latency!
-            for op in generation_latency_dict:
-                generation_latency_dict[op] *= latency_correction_scale
-                generation_energy_wms_dict[op] *= latency_correction_scale  # Energy scales with latency!
 
         # Calculate total latencies and energies (simple sums - decoupled!)
         context_latency_ms = sum(context_latency_dict.values())  # milliseconds

--- a/src/aiconfigurator/sdk/inference_session.py
+++ b/src/aiconfigurator/sdk/inference_session.py
@@ -73,6 +73,29 @@ class InferenceSession:
             self._model, self._database, runtime_config, mode, stride, latency_correction_scale
         )
 
+    def run_static_latency_only(
+        self,
+        runtime_config: config.RuntimeConfig,
+        mode: str,
+        stride: int = 32,
+        latency_correction_scale: float = 1.0,
+    ) -> float:
+        """
+        Run static inference and return only scalar latency in milliseconds.
+
+        Args:
+            runtime_config (RuntimeConfig): the runtime config
+            mode (str): the mode to run inference, static, static_ctx, static_gen
+            stride (int): the stride is used to accelerate the estimation, for a give osl,
+                will only computes the i, i+stride, i+2*stride, ... step, default is 32.
+
+        Returns:
+            float: the total latency in milliseconds
+        """
+        return self._backend.run_static_latency_only(
+            self._model, self._database, runtime_config, mode, stride, latency_correction_scale
+        )
+
     def run_agg(self, runtime_config: config.RuntimeConfig, **kwargs) -> InferenceSummary:
         """
         Run agg inference

--- a/tests/unit/sdk/backends/test_base_backend.py
+++ b/tests/unit/sdk/backends/test_base_backend.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from aiconfigurator.sdk import common
+from aiconfigurator.sdk.backends.base_backend import BaseBackend
+from aiconfigurator.sdk.config import ModelConfig, RuntimeConfig
+
+pytestmark = pytest.mark.unit
+
+
+class _LatencyResult:
+    def __init__(self, latency_ms: float, energy_wms: float) -> None:
+        self._latency_ms = latency_ms
+        self.energy = energy_wms
+
+    def __float__(self) -> float:
+        return self._latency_ms
+
+
+class _StaticOp:
+    def __init__(self, name: str, latency_ms: float, energy_wms: float) -> None:
+        self._name = name
+        self._latency_ms = latency_ms
+        self._energy_wms = energy_wms
+
+    def query(self, *args, **kwargs) -> _LatencyResult:
+        return _LatencyResult(self._latency_ms, self._energy_wms)
+
+
+class _TestBackend(BaseBackend):
+    def run_agg(self, model, database, runtime_config, **kwargs):
+        raise NotImplementedError
+
+    def find_best_agg_result_under_constraints(self, model, database, runtime_config, **kwargs):
+        raise NotImplementedError
+
+    def _get_memory_usage(
+        self,
+        model,
+        database,
+        batch_size,
+        beam_width,
+        isl,
+        osl,
+        num_tokens=0,
+        prefix=0,
+    ) -> dict[str, float]:
+        return {"total": 1.0}
+
+
+@pytest.fixture
+def backend() -> BaseBackend:
+    return _TestBackend()
+
+
+@pytest.fixture
+def database():
+    return SimpleNamespace(
+        backend="test-backend",
+        version="test-version",
+        system="test-system",
+        system_spec={"gpu": {"mem_capacity": 80 * (1 << 30)}},
+    )
+
+
+@pytest.fixture
+def model():
+    model = MagicMock()
+    model.model_path = "test-model"
+    model.model_name = "test-model"
+    model._nextn = 0
+    model.context_ops = [
+        _StaticOp("context_attention", latency_ms=11.0, energy_wms=110.0),
+        _StaticOp("logits_gemm", latency_ms=3.0, energy_wms=30.0),
+    ]
+    model.generation_ops = [
+        _StaticOp("generation_attention", latency_ms=2.0, energy_wms=20.0),
+        _StaticOp("generation_mlp", latency_ms=1.0, energy_wms=10.0),
+    ]
+    model.config = ModelConfig(
+        tp_size=1,
+        pp_size=1,
+        attention_dp_size=1,
+        moe_tp_size=1,
+        moe_ep_size=1,
+        gemm_quant_mode=common.GEMMQuantMode.float16,
+        moe_quant_mode=common.MoEQuantMode.float16,
+        kvcache_quant_mode=common.KVCacheQuantMode.float16,
+        fmha_quant_mode=common.FMHAQuantMode.float16,
+        comm_quant_mode=common.CommQuantMode.half,
+    )
+    return model
+
+
+@pytest.fixture
+def runtime_config() -> RuntimeConfig:
+    return RuntimeConfig(batch_size=2, beam_width=1, isl=8, osl=5, prefix=2)
+
+
+@pytest.mark.parametrize("mode", ["static", "static_ctx", "static_gen"])
+@pytest.mark.parametrize("latency_correction_scale", [1.0, 1.25])
+def test_run_static_latency_only_matches_run_static_latency(
+    backend: BaseBackend,
+    model,
+    database,
+    runtime_config: RuntimeConfig,
+    mode: str,
+    latency_correction_scale: float,
+) -> None:
+    summary = backend.run_static(
+        model,
+        database,
+        runtime_config,
+        mode=mode,
+        stride=2,
+        latency_correction_scale=latency_correction_scale,
+    )
+    latency_only = backend.run_static_latency_only(
+        model,
+        database,
+        runtime_config,
+        mode=mode,
+        stride=2,
+        latency_correction_scale=latency_correction_scale,
+    )
+
+    summary_latency = sum(summary.get_context_latency_dict().values()) + sum(summary.get_generation_latency_dict().values())
+    request_latency = float(summary.get_summary_df().iloc[0]["request_latency"])
+
+    assert latency_only == pytest.approx(summary_latency)
+    assert latency_only == pytest.approx(request_latency, abs=1e-3)

--- a/tests/unit/sdk/backends/test_base_backend.py
+++ b/tests/unit/sdk/backends/test_base_backend.py
@@ -129,7 +129,9 @@ def test_run_static_latency_only_matches_run_static_latency(
         latency_correction_scale=latency_correction_scale,
     )
 
-    summary_latency = sum(summary.get_context_latency_dict().values()) + sum(summary.get_generation_latency_dict().values())
+    summary_latency = sum(summary.get_context_latency_dict().values()) + sum(
+        summary.get_generation_latency_dict().values()
+    )
     request_latency = float(summary.get_summary_df().iloc[0]["request_latency"])
 
     assert latency_only == pytest.approx(summary_latency)


### PR DESCRIPTION
Add a latency-only static inference path for replay-style callers that only need the scalar latency result. This reuses the existing backend op walk, keeps run_static() behavior unchanged, and avoids summary/dataframe materialization for the new API.

Closes #664

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `run_static_latency_only()` method for efficient latency predictions. Accessible via both the backend and inference session APIs, this new method provides latency-only computation without energy metrics, enabling faster performance estimation for latency-focused workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->