### PR TITLE
fix: mitigate intermittent CI hang on test_validate_database

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 .git
 .github
 .claude

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.github
+.claude
+.claude-config
+.codex
+.hypothesis
+.pytest_cache
+.ruff_cache
+__pycache__
+*.pyc
+*.egg-info
+dist
+build
+.venv

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -14,6 +14,7 @@ jobs:
   build-and-test:
     name: Build and Test
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -31,7 +32,7 @@ jobs:
             pytest \
             -m "unit or build" \
             -v --tb=short --maxfail=1 --timeout=600 \
-            -n 4 \
+            -n 4 --dist loadgroup \
             --md-report --md-report-verbose=1 --md-report-flavor gfm --md-report-output test_report.md
       - name: Copy test report from test Container
         if: always()

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -32,7 +32,7 @@ jobs:
             pytest \
             -m "unit or build" \
             -v --tb=short --maxfail=1 --timeout=600 \
-            -n 4 --dist loadgroup \
+            -n 2 \
             --md-report --md-report-verbose=1 --md-report-flavor gfm --md-report-output test_report.md
       - name: Copy test report from test Container
         if: always()

--- a/tests/e2e/tools/test_sanity_check.py
+++ b/tests/e2e/tools/test_sanity_check.py
@@ -30,7 +30,6 @@ def _supported_system_backend_latest():
     return result
 
 
-@pytest.mark.xdist_group("validate_db")
 @pytest.mark.parametrize(
     "system,backend,version,fail_ok",
     _supported_system_backend_latest(),

--- a/tests/e2e/tools/test_sanity_check.py
+++ b/tests/e2e/tools/test_sanity_check.py
@@ -30,6 +30,7 @@ def _supported_system_backend_latest():
     return result
 
 
+@pytest.mark.xdist_group("validate_db")
 @pytest.mark.parametrize(
     "system,backend,version,fail_ok",
     _supported_system_backend_latest(),
@@ -46,13 +47,20 @@ def test_validate_database(system, backend, version, fail_ok):
         "AIC_VALIDATE_VERSION": version,
         "MPLBACKEND": "agg",
     }
-    result = sp.run(
-        [sys.executable, "-c", "import import_ipynb; import validate_database"],
-        cwd=SANITY_CHECK_DIR,
-        env=env,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = sp.run(
+            [sys.executable, "-c", "import import_ipynb; import validate_database"],
+            cwd=SANITY_CHECK_DIR,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+    except sp.TimeoutExpired:
+        error_message = f"validate_database timed out (300s) for {system}/{backend}/{version}"
+        if fail_ok:
+            pytest.xfail(error_message)
+        pytest.fail(error_message)
     success = result.returncode == 0
     error_message = (
         f"validate_database failed for {system}/{backend}/{version}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"


### PR DESCRIPTION
## Summary

Fix CI hangs at ~97% completion affecting multiple PRs (#615, #662, #663).

## Changes

- **use -n 2 instead of -n 4**: avoid excessaive memory consumption in loading database 
- **Add 300s subprocess timeout**: `subprocess.run()` now has `timeout=300`, turning an infinite hang into a clean failure if a single test stalls.
- **Add 30-min job timeout**: safety net at the workflow level.
- **Add `.dockerignore`**: excludes `.git`, `__pycache__`, etc., reducing Docker build context from 816 MB to ~400 MB.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized Docker build contexts by excluding development and build artifacts from deployment packages
  * Enhanced CI/CD pipeline reliability with job timeout controls and improved parallel test execution distribution
  * Strengthened end-to-end test robustness with timeout handling and execution constraints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->