### PR TITLE
fix: make container compatible with OpenShift random UID

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,8 +9,11 @@ WORKDIR /workspace
 ENV VIRTUAL_ENV=/opt/aiconfigurator/venv
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 RUN mkdir /opt/aiconfigurator && \
-    uv venv --python 3.12 ${VIRTUAL_ENV} 
+    uv venv --python 3.12 ${VIRTUAL_ENV} && \
+    chmod a+rx /root && \
+    chmod -R a+rX /root/.local
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+ENV MPLCONFIGDIR=/tmp/matplotlib
 
 FROM base AS build
 COPY src/ /workspace/src/


### PR DESCRIPTION
#### Overview:

uv venv installs Python under /root/ which is inaccessible to OpenShift random non-root UID. Add chmod to allow access. Similarly, set MPLCONFIGDIR to avoid matplotlib warning when HOME is unwritable.

#### Details:

Changes are made to the Dockerfile to support use on OpenShift.

#### Where should the reviewer start?

docker/Dockerfile.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

This release contains no user-visible changes. Infrastructure and build configuration updates were made to optimize the Docker setup process.

* **Chores**
  * Updated Docker build configuration for improved environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->