### PR TITLE
fix: sign off the commit generated by daily-support-matrix workflow

### DIFF
--- a/.github/workflows/daily-support-matrix.yml
+++ b/.github/workflows/daily-support-matrix.yml
@@ -115,6 +115,7 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          signoff: true
           commit-message: "fix: update support matrix"
           title: "fix: update support matrix [${{ env.TARGET_BRANCH }}]"
           body-path: pr_body.md


### PR DESCRIPTION
#### Overview:

The automated workflow should always sign off the commit to pass DCO check.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->