### PR TITLE
feat: Qwen3-235B SGLang WideEP and EP>1 in Non-WideEP Mode

### DIFF
--- a/collector/helper.py
+++ b/collector/helper.py
@@ -1428,6 +1428,58 @@ def _get_deepseek_model_path():
     return "/deepseek-v3"
 
 
+def _get_moe_model_path():
+    """Get MoE model path, supporting multiple MoE models (DeepSeek, Qwen3, etc.).
+
+    Checks environment variables in priority order:
+    1. MOE_MODEL_PATH - generic, for any MoE model
+    2. DEEPSEEK_MODEL_PATH - backward compatibility for DeepSeek models
+    Otherwise, download only the necessary config files from HuggingFace.
+    This allows running the collector without downloading the full model weights.
+    """
+    # Try MOE_MODEL_PATH first (generic)
+    env_path = os.environ.get("MOE_MODEL_PATH")
+    if env_path:
+        return env_path
+
+    # Backward compatibility: try DEEPSEEK_MODEL_PATH
+    env_path = os.environ.get("DEEPSEEK_MODEL_PATH")
+    if env_path:
+        return env_path
+
+    # Download config files from HuggingFace (no model weights needed)
+    try:
+        from huggingface_hub import hf_hub_download
+
+        repo_id = "deepseek-ai/DeepSeek-V3"
+        config_files = [
+            "config.json",
+            "configuration_deepseek.py",
+            "tokenizer_config.json",
+            "tokenizer.json",
+        ]
+
+        snapshot_dir = None
+        for filename in config_files:
+            try:
+                path = hf_hub_download(repo_id=repo_id, filename=filename)
+                if snapshot_dir is None:
+                    snapshot_dir = os.path.dirname(path)
+            except Exception as e:
+                print(f"Warning: Failed to download {filename}: {e}")
+
+        if snapshot_dir:
+            print(f"Using DeepSeek-V3 config from HuggingFace cache: {snapshot_dir}")
+            return snapshot_dir
+    except ImportError:
+        print("Warning: huggingface_hub not installed, cannot auto-download config")
+    except Exception as e:
+        print(f"Warning: Failed to download DeepSeek-V3 config: {e}")
+
+    # Fallback to default path
+    return "/deepseek-v3"
+
+
 @functools.lru_cache(maxsize=1)
 def get_device_module():
     import torch

--- a/collector/sglang/collect_moe.py
+++ b/collector/sglang/collect_moe.py
@@ -70,11 +70,6 @@ def get_moe_test_cases():
         if common_moe_testcase.token_expert_distribution != "power_law":
             continue
 
-        # Skip EP > 1 test cases - this collector only supports single-GPU MOE (ep_size=1)
-        # For EP > 1 (multi-GPU expert parallelism), use collect_wideep_deepep_moe.py instead
-        if common_moe_testcase.ep != 1:
-            continue
-
         model_name = common_moe_testcase.model_name
         if model_name in ["openai/gpt-oss-20b", "openai/gpt-oss-120b"]:
             continue
@@ -398,17 +393,20 @@ def run_moe_torch(
     torch.cuda.set_device(device)
     torch.set_default_device(device)
 
-    assert moe_ep_size == 1, "only support moe ep size = 1"
     assert moe_type in [
         "fp8_block",
         "float16",
         "nvfp4",
     ], "only support moe type = fp8_block, float16 or nvfp4"
     assert inter_size % moe_tp_size == 0, "inter_size % moe_tp_size must be 0"
+    assert num_experts % moe_ep_size == 0, "num_experts must be divisible by moe_ep_size"
+
+    # With EP, each GPU processes only its local experts
+    num_local_experts = num_experts // moe_ep_size
 
     latency, power_stats = benchmark(
         num_tokens,
-        num_experts,
+        num_local_experts,
         2 * inter_size // moe_tp_size,
         hidden_size,
         topk,

--- a/collector/sglang/collect_moe.py
+++ b/collector/sglang/collect_moe.py
@@ -404,8 +404,18 @@ def run_moe_torch(
     # With EP, each GPU processes only its local experts
     num_local_experts = num_experts // moe_ep_size
 
+    # For EP > 1, filter tokens to rank-local workload so the benchmark
+    # measures per-rank latency instead of the full-batch latency.
+    if moe_ep_size > 1:
+        _, rank0_info = power_law_logits_v3(
+            num_tokens, num_experts, topk, moe_ep_size, power_law_alpha, return_rank0_info=True
+        )
+        rank_num_tokens = rank0_info["rank0_num_tokens"]
+    else:
+        rank_num_tokens = num_tokens
+
     latency, power_stats = benchmark(
-        num_tokens,
+        rank_num_tokens,
         num_local_experts,
         2 * inter_size // moe_tp_size,
         hidden_size,

--- a/collector/sglang/collect_wideep_deepep_moe.py
+++ b/collector/sglang/collect_wideep_deepep_moe.py
@@ -151,12 +151,18 @@ def benchmark_moe_layer_prefill(
     num_local_experts,
     simulated_ep_size,
     output_path,
+    model_hidden_size,
+    model_inter_size,
+    model_total_experts,
 ):
     """Benchmark MoE layer in prefill phase
 
     Args:
-        num_local_experts: Number of experts on this GPU (= model's n_routed_experts)
-        simulated_ep_size: The EP size being simulated (= 256 / num_local_experts)
+        num_local_experts: Number of experts on this GPU (= model's n_routed_experts or num_experts)
+        simulated_ep_size: The EP size being simulated (= total_experts / num_local_experts)
+        model_hidden_size: Model's hidden_size from config
+        model_inter_size: Model's moe_intermediate_size from config
+        model_total_experts: Total number of experts in the model (256 for DeepSeek-V3, 128 for Qwen3)
     """
 
     for case in prefill_test_cases:
@@ -200,7 +206,7 @@ def benchmark_moe_layer_prefill(
             topk_weights_iter = torch.zeros((num_tokens_iter, topk), device=device, dtype=torch.float32)
 
             if distributed == "uniform":
-                tokens_per_local_expert = int(num_token * topk * simulated_ep_size // 256)
+                tokens_per_local_expert = int(num_token * topk * simulated_ep_size // model_total_experts)
                 rank_print(f"tokens_per_local_expert: {tokens_per_local_expert}")
                 if tokens_per_local_expert <= 0:
                     continue
@@ -341,10 +347,10 @@ def benchmark_moe_layer_prefill(
                             {
                                 "moe_dtype": "fp8_block",
                                 "num_tokens": num_tokens_log,
-                                "hidden_size": 7168,
-                                "inter_size": 2048,
+                                "hidden_size": model_hidden_size,
+                                "inter_size": model_inter_size,
                                 "topk": 8,
-                                "num_experts": 256,
+                                "num_experts": model_total_experts,
                                 "moe_tp_size": moe_tp_size,
                                 "moe_ep_size": moe_ep_size,
                                 "distribution": distribution_str,
@@ -405,12 +411,18 @@ def benchmark_moe_layer_decode(
     num_local_experts,
     simulated_ep_size,
     output_path=None,
+    model_hidden_size=7168,
+    model_inter_size=2048,
+    model_total_experts=256,
 ):
     """Benchmark MoE layer in decode phase
 
     Args:
-        num_local_experts: Number of experts on this GPU (= model's n_routed_experts)
-        simulated_ep_size: The EP size being simulated (= 256 / num_local_experts)
+        num_local_experts: Number of experts on this GPU (= model's n_routed_experts or num_experts)
+        simulated_ep_size: The EP size being simulated (= total_experts / num_local_experts)
+        model_hidden_size: Model's hidden_size from config
+        model_inter_size: Model's moe_intermediate_size from config
+        model_total_experts: Total number of experts in the model (256 for DeepSeek-V3, 128 for Qwen3)
     """
     model_runner.req_to_token_pool.clear()
     model_runner.token_to_kv_pool_allocator.clear()
@@ -471,8 +483,8 @@ def benchmark_moe_layer_decode(
                     for _ in range(5)
                 ]
             elif distributed == "uniform":
-                # Total experts is 256, simulated_ep_size = 256 / num_local_experts
-                base_tokens_per_expert = int(num_token * top_k) * simulated_ep_size // 256
+                # Total experts = model_total_experts, simulated_ep_size = model_total_experts / num_local_experts
+                base_tokens_per_expert = int(num_token * top_k) * simulated_ep_size // model_total_experts
                 if base_tokens_per_expert == 0:
                     # Each expert that receives tokens gets exactly 1 token
                     # Number of experts with tokens on this card = total_calls / simulated_ep_size
@@ -618,10 +630,10 @@ def benchmark_moe_layer_decode(
                             {
                                 "moe_dtype": "fp8_block",
                                 "num_tokens": num_tokens_log,
-                                "hidden_size": 7168,
-                                "inter_size": 2048,
+                                "hidden_size": model_hidden_size,
+                                "inter_size": model_inter_size,
                                 "topk": 8,
-                                "num_experts": 256,
+                                "num_experts": model_total_experts,
                                 "moe_tp_size": moe_tp_size,
                                 "moe_ep_size": moe_ep_size,
                                 "distribution": distribution_str,
@@ -692,22 +704,49 @@ def run_moe(
         rank_print(f"Testing with {num_experts} experts")
         rank_print(f"{'=' * 50}")
 
+        # Get ORIGINAL model config BEFORE applying override
+        # This is needed to get the true total_experts count
         original_json_override = server_args.json_model_override_args
-        server_args.json_model_override_args = json.dumps({"num_hidden_layers": 4, "n_routed_experts": num_experts})
+        original_model_config = ModelConfig.from_server_args(server_args)
+        original_hf_config = original_model_config.hf_config
+        model_hidden_size = original_hf_config.hidden_size
+        model_inter_size = getattr(original_hf_config, 'moe_intermediate_size', 2048)
+        model_total_experts = getattr(original_hf_config, 'n_routed_experts', None) or getattr(original_hf_config, 'num_experts', 256)
+        rank_print(f"Original model config: hidden_size={model_hidden_size}, inter_size={model_inter_size}, total_experts={model_total_experts}")
+
+        # Now apply override to load model with reduced experts
+        # Support both DeepSeek-V3 (n_routed_experts) and Qwen3 (num_experts)
+        server_args.json_model_override_args = json.dumps({
+            "num_hidden_layers": 4,
+            "n_routed_experts": num_experts,
+            "num_experts": num_experts,
+        })
 
         model_runner = load_model_with_dummy_weights(server_args, port_args, tp_rank)
 
         moe_layer = model_runner.model.model.layers[test_layer].mlp
-        actual_num_experts = moe_layer.config.n_routed_experts
+        # Supports DeepSeek-V3 and Qwen3 MoE
+        if hasattr(moe_layer, 'config') and hasattr(moe_layer.config, 'n_routed_experts'):
+            # DeepSeek-V3 style
+            actual_num_experts = moe_layer.config.n_routed_experts
+        elif hasattr(moe_layer, 'experts') and hasattr(moe_layer.experts, 'num_experts'):
+            # Qwen3 MoE style - from experts submodule
+            actual_num_experts = moe_layer.experts.num_experts
+        elif hasattr(moe_layer, 'num_experts'):
+            # Direct attribute (deepep mode)
+            actual_num_experts = moe_layer.num_experts
+        else:
+            # Fall back to model_config
+            actual_num_experts = model_runner.model_config.hf_config.num_experts
 
-        rank_print(f"Loaded model with {actual_num_experts} experts")
+        rank_print(f"Loaded model with {actual_num_experts} local experts (simulating {model_total_experts} total)")
 
         server_args.json_model_override_args = original_json_override
 
-        # Calculate simulated EP size: 256 total experts / num_local_experts
+        # Calculate simulated EP size: total_experts / num_local_experts
         num_local_experts = actual_num_experts  # With ep_size=1, all experts are local
-        simulated_ep_size = 256 // num_local_experts
-        rank_print(f"Simulating EP size: {simulated_ep_size} (num_local_experts={num_local_experts})")
+        simulated_ep_size = model_total_experts // num_local_experts
+        rank_print(f"Simulating EP size: {simulated_ep_size} (num_local_experts={num_local_experts}, total_experts={model_total_experts})")
 
         prefill_test_cases = get_moe_prefill_test_cases(simulated_ep_size)
         rank_print(f"Testing {len(prefill_test_cases)} prefill configurations...")
@@ -729,6 +768,9 @@ def run_moe(
             num_local_experts,
             simulated_ep_size,
             output_path,
+            model_hidden_size=model_hidden_size,
+            model_inter_size=model_inter_size,
+            model_total_experts=model_total_experts,
         )
 
         decode_test_cases = get_moe_decode_test_cases()
@@ -750,6 +792,9 @@ def run_moe(
             num_local_experts,
             simulated_ep_size,
             output_path=output_path,
+            model_hidden_size=model_hidden_size,
+            model_inter_size=model_inter_size,
+            model_total_experts=model_total_experts,
         )
 
         del model_runner, moe_layer
@@ -774,10 +819,13 @@ def run_moe(
 # ============================================================================
 
 
-def get_wideep_moe_test_cases():
+def get_wideep_moe_test_cases(total_experts=128):
     """Returns list of [num_experts, perf_filename] for MOE collection.
 
-    Each num_experts value simulates a different EP size:
+    Each num_experts value simulates a different EP size based on model's total experts.
+    Starts from EP=2 (half experts per GPU) to focus on wideep multi-GPU scenarios.
+
+    For DeepSeek-V3 (256 experts):
     - num_experts=128 → EP=2
     - num_experts=64 → EP=4
     - num_experts=32 → EP=8
@@ -787,23 +835,44 @@ def get_wideep_moe_test_cases():
     - num_experts=2 → EP=128
     - num_experts=1 → EP=256
 
-    Formula: simulated_ep_size = 256 / num_experts
-    """
-    return [[n, "wideep_moe_perf.txt"] for n in [128, 64, 32, 16, 8, 4, 2, 1]]
+    For Qwen3-235B (128 experts):
+    - num_experts=64 → EP=2
+    - num_experts=32 → EP=4
+    - num_experts=16 → EP=8
+    - num_experts=8 → EP=16
+    - num_experts=4 → EP=32
+    - num_experts=2 → EP=64
+    - num_experts=1 → EP=128
 
+    Formula: simulated_ep_size = total_experts / num_experts
+
+    Args:
+        total_experts: Total number of experts in the model (256 for DeepSeek-V3, 128 for Qwen3)
+    """
+    # Generate test cases based on total_experts
+    # num_experts must be a power of 2 and <= total_experts
+    # Start from EP=2 (total_experts // 2) to avoid single-GPU OOM and focus on wideep scenarios
+    test_cases = []
+    n = total_experts // 2  # Start from EP=2
+    while n >= 1:
+        test_cases.append([n, "wideep_moe_perf.txt"])
+        n //= 2
+    return test_cases
 
 def run_moe_benchmark(num_experts, gpu_id, output_path=None):
     """Run MOE benchmark - called in subprocess with CUDA_VISIBLE_DEVICES set.
 
     This function contains all the initialization logic that must happen
     after CUDA_VISIBLE_DEVICES is set.
+
+    Supports both DeepSeek-V3 and Qwen3 MoE models.
     """
     # In subprocess, always use cuda:0 since CUDA_VISIBLE_DEVICES isolates the GPU
     torch.cuda.set_device("cuda:0")
 
     server_port = 30000 + gpu_id * 100
     server_args = ServerArgs(
-        model_path=DEEPSEEK_MODEL_PATH,
+        model_path=MOE_MODEL_PATH,
         dtype="auto",
         device="cuda",
         load_format="dummy",
@@ -827,9 +896,14 @@ def run_moe_benchmark(num_experts, gpu_id, output_path=None):
     # PortArgs.init_new() must be called in subprocess for proper isolation
     port_args = PortArgs.init_new(server_args)
 
-    simulated_ep_size = 256 // num_experts * server_args.ep_size
+    # Get total experts from model config to calculate simulated EP size
+    model_config = ModelConfig.from_server_args(server_args)
+    hf_config = model_config.hf_config
+    total_experts = getattr(hf_config, 'n_routed_experts', None) or getattr(hf_config, 'num_experts', 256)
+
+    simulated_ep_size = total_experts // num_experts * server_args.ep_size
     print(f"\n{'=' * 60}")
-    print(f"MOE Benchmark: num_experts={num_experts}, EP_size={simulated_ep_size}, GPU={gpu_id}")
+    print(f"MOE Benchmark: num_experts={num_experts}, EP_size={simulated_ep_size}, total_experts={total_experts}, GPU={gpu_id}")
     print(f"{'=' * 60}")
 
     # Run the actual benchmark
@@ -879,13 +953,13 @@ def run_wideep_moe(num_experts, perf_filename, device="cuda:0"):
     """Run wideep DeepEP MOE benchmark.
 
     Compatible with collect.py framework - uses subprocess for GPU isolation.
+    Supports both DeepSeek-V3 (256 experts) and Qwen3 (128 experts) models.
     """
     device_str = str(device) if not isinstance(device, str) else device
     gpu_id = int(device_str.split(":")[-1]) if ":" in device_str else 0
 
-    simulated_ep_size = 256 // num_experts
     print("\n" + "=" * 60)
-    print(f"MOE: num_experts={num_experts} (EP size {simulated_ep_size}), GPU={gpu_id}")
+    print(f"MOE: num_experts={num_experts}, GPU={gpu_id}")
     print("=" * 60)
 
     _run_moe_subprocess(num_experts, gpu_id, None)
@@ -898,7 +972,7 @@ if __name__ == "__main__":
     parser.add_argument("--output-path", default=None, help="Output directory for perf files")
     args = parser.parse_args()
 
-    print(f"Model path: {DEEPSEEK_MODEL_PATH}")
+    print(f"Model path: {MOE_MODEL_PATH}")
 
     # Run all MOE test cases
     for test_case in get_wideep_moe_test_cases():

--- a/collector/sglang/collect_wideep_deepep_moe.py
+++ b/collector/sglang/collect_wideep_deepep_moe.py
@@ -711,8 +711,14 @@ def run_moe(
         original_hf_config = original_model_config.hf_config
         model_hidden_size = original_hf_config.hidden_size
         model_inter_size = getattr(original_hf_config, 'moe_intermediate_size', 2048)
-        model_total_experts = getattr(original_hf_config, 'n_routed_experts', None) or getattr(original_hf_config, 'num_experts', 256)
-        rank_print(f"Original model config: hidden_size={model_hidden_size}, inter_size={model_inter_size}, total_experts={model_total_experts}")
+        model_total_experts = (
+            getattr(original_hf_config, 'n_routed_experts', None)
+            or getattr(original_hf_config, 'num_experts', 256)
+        )
+        rank_print(
+            f"Original model config: hidden_size={model_hidden_size}, "
+            f"inter_size={model_inter_size}, total_experts={model_total_experts}"
+        )
 
         # Now apply override to load model with reduced experts
         # Support both DeepSeek-V3 (n_routed_experts) and Qwen3 (num_experts)
@@ -746,7 +752,10 @@ def run_moe(
         # Calculate simulated EP size: total_experts / num_local_experts
         num_local_experts = actual_num_experts  # With ep_size=1, all experts are local
         simulated_ep_size = model_total_experts // num_local_experts
-        rank_print(f"Simulating EP size: {simulated_ep_size} (num_local_experts={num_local_experts}, total_experts={model_total_experts})")
+        rank_print(
+            f"Simulating EP size: {simulated_ep_size} "
+            f"(num_local_experts={num_local_experts}, total_experts={model_total_experts})"
+        )
 
         prefill_test_cases = get_moe_prefill_test_cases(simulated_ep_size)
         rank_print(f"Testing {len(prefill_test_cases)} prefill configurations...")
@@ -903,7 +912,10 @@ def run_moe_benchmark(num_experts, gpu_id, output_path=None):
 
     simulated_ep_size = total_experts // num_experts * server_args.ep_size
     print(f"\n{'=' * 60}")
-    print(f"MOE Benchmark: num_experts={num_experts}, EP_size={simulated_ep_size}, total_experts={total_experts}, GPU={gpu_id}")
+    print(
+        f"MOE Benchmark: num_experts={num_experts}, EP_size={simulated_ep_size}, "
+        f"total_experts={total_experts}, GPU={gpu_id}"
+    )
     print(f"{'=' * 60}")
 
     # Run the actual benchmark

--- a/collector/sglang/collect_wideep_deepep_moe.py
+++ b/collector/sglang/collect_wideep_deepep_moe.py
@@ -819,7 +819,7 @@ def run_moe(
 # ============================================================================
 
 
-def get_wideep_moe_test_cases(total_experts=128):
+def get_wideep_moe_test_cases(total_experts=256):
     """Returns list of [num_experts, perf_filename] for MOE collection.
 
     Each num_experts value simulates a different EP size based on model's total experts.

--- a/collector/sglang/collect_wideep_deepep_moe.py
+++ b/collector/sglang/collect_wideep_deepep_moe.py
@@ -201,7 +201,7 @@ def benchmark_moe_layer_prefill(
             )
 
             num_tokens_iter = hidden_states_per_token_iter.shape[0]
-            topk = 8
+            topk = moe_layer.topk.topk_config.top_k
             topk_idx_iter = torch.full((num_tokens_iter, topk), -1, device=device, dtype=torch.int32)
             topk_weights_iter = torch.zeros((num_tokens_iter, topk), device=device, dtype=torch.float32)
 
@@ -349,7 +349,7 @@ def benchmark_moe_layer_prefill(
                                 "num_tokens": num_tokens_log,
                                 "hidden_size": model_hidden_size,
                                 "inter_size": model_inter_size,
-                                "topk": 8,
+                                "topk": topk,
                                 "num_experts": model_total_experts,
                                 "moe_tp_size": moe_tp_size,
                                 "moe_ep_size": moe_ep_size,
@@ -632,7 +632,7 @@ def benchmark_moe_layer_decode(
                                 "num_tokens": num_tokens_log,
                                 "hidden_size": model_hidden_size,
                                 "inter_size": model_inter_size,
-                                "topk": 8,
+                                "topk": top_k,
                                 "num_experts": model_total_experts,
                                 "moe_tp_size": moe_tp_size,
                                 "moe_ep_size": moe_ep_size,

--- a/collector/sglang/collect_wideep_deepep_moe.py
+++ b/collector/sglang/collect_wideep_deepep_moe.py
@@ -24,16 +24,16 @@ from sglang.srt.utils import (
 )
 
 try:
-    from helper import _get_deepseek_model_path, log_perf, power_law_deepep_decode, power_law_deepep_prefill
+    from helper import _get_moe_model_path, log_perf, power_law_deepep_decode, power_law_deepep_prefill
 except ModuleNotFoundError:
     import os
     import sys
 
     sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-    from helper import _get_deepseek_model_path, log_perf, power_law_deepep_decode, power_law_deepep_prefill
+    from helper import _get_moe_model_path, log_perf, power_law_deepep_decode, power_law_deepep_prefill
 from importlib.metadata import version as get_version
 
-DEEPSEEK_MODEL_PATH = _get_deepseek_model_path()
+MOE_MODEL_PATH = _get_moe_model_path()
 
 
 def get_moe_prefill_test_cases(rank):

--- a/collector/sglang/collect_wideep_deepep_moe.py
+++ b/collector/sglang/collect_wideep_deepep_moe.py
@@ -710,10 +710,9 @@ def run_moe(
         original_model_config = ModelConfig.from_server_args(server_args)
         original_hf_config = original_model_config.hf_config
         model_hidden_size = original_hf_config.hidden_size
-        model_inter_size = getattr(original_hf_config, 'moe_intermediate_size', 2048)
-        model_total_experts = (
-            getattr(original_hf_config, 'n_routed_experts', None)
-            or getattr(original_hf_config, 'num_experts', 256)
+        model_inter_size = getattr(original_hf_config, "moe_intermediate_size", 2048)
+        model_total_experts = getattr(original_hf_config, "n_routed_experts", None) or getattr(
+            original_hf_config, "num_experts", 256
         )
         rank_print(
             f"Original model config: hidden_size={model_hidden_size}, "
@@ -722,23 +721,25 @@ def run_moe(
 
         # Now apply override to load model with reduced experts
         # Support both DeepSeek-V3 (n_routed_experts) and Qwen3 (num_experts)
-        server_args.json_model_override_args = json.dumps({
-            "num_hidden_layers": 4,
-            "n_routed_experts": num_experts,
-            "num_experts": num_experts,
-        })
+        server_args.json_model_override_args = json.dumps(
+            {
+                "num_hidden_layers": 4,
+                "n_routed_experts": num_experts,
+                "num_experts": num_experts,
+            }
+        )
 
         model_runner = load_model_with_dummy_weights(server_args, port_args, tp_rank)
 
         moe_layer = model_runner.model.model.layers[test_layer].mlp
         # Supports DeepSeek-V3 and Qwen3 MoE
-        if hasattr(moe_layer, 'config') and hasattr(moe_layer.config, 'n_routed_experts'):
+        if hasattr(moe_layer, "config") and hasattr(moe_layer.config, "n_routed_experts"):
             # DeepSeek-V3 style
             actual_num_experts = moe_layer.config.n_routed_experts
-        elif hasattr(moe_layer, 'experts') and hasattr(moe_layer.experts, 'num_experts'):
+        elif hasattr(moe_layer, "experts") and hasattr(moe_layer.experts, "num_experts"):
             # Qwen3 MoE style - from experts submodule
             actual_num_experts = moe_layer.experts.num_experts
-        elif hasattr(moe_layer, 'num_experts'):
+        elif hasattr(moe_layer, "num_experts"):
             # Direct attribute (deepep mode)
             actual_num_experts = moe_layer.num_experts
         else:
@@ -868,6 +869,7 @@ def get_wideep_moe_test_cases(total_experts=256):
         n //= 2
     return test_cases
 
+
 def run_moe_benchmark(num_experts, gpu_id, output_path=None):
     """Run MOE benchmark - called in subprocess with CUDA_VISIBLE_DEVICES set.
 
@@ -908,7 +910,7 @@ def run_moe_benchmark(num_experts, gpu_id, output_path=None):
     # Get total experts from model config to calculate simulated EP size
     model_config = ModelConfig.from_server_args(server_args)
     hf_config = model_config.hf_config
-    total_experts = getattr(hf_config, 'n_routed_experts', None) or getattr(hf_config, 'num_experts', 256)
+    total_experts = getattr(hf_config, "n_routed_experts", None) or getattr(hf_config, "num_experts", 256)
 
     simulated_ep_size = total_experts // num_experts * server_args.ep_size
     print(f"\n{'=' * 60}")

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -22,6 +22,7 @@ from aiconfigurator.generator.api import (
 )
 from aiconfigurator.logging_utils import setup_logging
 from aiconfigurator.sdk import common, perf_database
+from aiconfigurator.sdk.models import check_is_moe
 from aiconfigurator.sdk.task import TaskConfig, TaskRunner
 from aiconfigurator.sdk.utils import ListFlowDumper, get_model_config_from_model_path
 
@@ -749,6 +750,11 @@ def build_default_task_configs(
         "enable_wideep": enable_wideep,
     }
 
+    # Auto-set moe_backend for SGLang wideep, matching webapp behavior
+    # (webapp/events/event_fn.py sets moe_backend="deepep_moe" when enable_wideep + sglang)
+    if enable_wideep:
+        common_kwargs["moe_backend"] = "deepep_moe"
+
     # Create yaml_config to pass nextn and nextn_accept_rates if specified
     yaml_config = None
     if nextn > 0:
@@ -760,6 +766,7 @@ def build_default_task_configs(
         }
 
     task_configs: dict[str, TaskConfig] = {}
+    is_moe_model = check_is_moe(model_path)
 
     for backend_name in backends_to_sweep:
         # Create agg task for this backend
@@ -770,6 +777,14 @@ def build_default_task_configs(
         agg_task = TaskConfig(serving_mode="agg", **agg_kwargs)
         exp_name = f"agg_{backend_name}" if backend == "auto" else "agg"
         task_configs[exp_name] = agg_task
+
+        # For SGLang MoE without --enable-wideep, also sweep DeepEP intra-node
+        if backend_name == "sglang" and not enable_wideep and is_moe_model:
+            deepep_kwargs = dict(agg_kwargs)
+            deepep_kwargs["moe_backend"] = "deepep_moe"
+            deepep_task = TaskConfig(serving_mode="agg", **deepep_kwargs)
+            deepep_name = f"agg_{backend_name}_deepep" if backend == "auto" else "agg_deepep"
+            task_configs[deepep_name] = deepep_task
 
         if total_gpus < 2:
             logger.warning("Skipping disagg since it requires at least 2 GPUs.")
@@ -784,6 +799,14 @@ def build_default_task_configs(
         disagg_task = TaskConfig(serving_mode="disagg", **disagg_kwargs)
         exp_name = f"disagg_{backend_name}" if backend == "auto" else "disagg"
         task_configs[exp_name] = disagg_task
+
+        # For SGLang MoE without --enable-wideep, also sweep DeepEP intra-node
+        if backend_name == "sglang" and not enable_wideep and is_moe_model:
+            deepep_disagg_kwargs = dict(disagg_kwargs)
+            deepep_disagg_kwargs["moe_backend"] = "deepep_moe"
+            deepep_disagg_task = TaskConfig(serving_mode="disagg", **deepep_disagg_kwargs)
+            deepep_name = f"disagg_{backend_name}_deepep" if backend == "auto" else "disagg_deepep"
+            task_configs[deepep_name] = deepep_disagg_task
 
     return task_configs
 

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -193,6 +193,14 @@ def _add_default_mode_arguments(parser):
         "Controls how many KV blocks TRT-LLM pre-allocates per sequence. "
         "Set this to match your actual deployment for accurate KV cache capacity filtering.",
     )
+    parser.add_argument(
+        "--enable-wideep",
+        action="store_true",
+        default=False,
+        help="Enable Wide Expert Parallelism (WideEP) for MoE models. "
+        "When set, MoE models use EP-only parallelism with deepep_moe backend. "
+        "Applies to both DeepSeek and Qwen3-235B on SGLang.",
+    )
 
 
 def _add_experiments_mode_arguments(parser):
@@ -646,6 +654,7 @@ def build_default_task_configs(
     enable_chunked_prefill: bool = False,
     free_gpu_memory_fraction: float | None = None,
     max_seq_len: int | None = None,
+    enable_wideep: bool = False,
 ) -> dict[str, TaskConfig]:
     """Build agg and disagg task configs for default mode comparison.
 
@@ -667,6 +676,7 @@ def build_default_task_configs(
         nextn: Number of draft tokens for MTP speculative decoding.
         nextn_accept_rates: Acceptance rates for MTP draft tokens.
         enable_chunked_prefill: Whether to enable chunked prefill for finer context token sweep.
+        enable_wideep: Whether to enable Wide Expert Parallelism (WideEP) for MoE models.
 
     Returns:
         Dict with TaskConfig objects. When backend='auto', returns 6 configs
@@ -736,6 +746,7 @@ def build_default_task_configs(
         "enable_chunked_prefill": enable_chunked_prefill,
         "free_gpu_memory_fraction": free_gpu_memory_fraction,
         "max_seq_len": max_seq_len,
+        "enable_wideep": enable_wideep,
     }
 
     # Create yaml_config to pass nextn and nextn_accept_rates if specified
@@ -1494,6 +1505,7 @@ def main(args):
             enable_chunked_prefill=args.enable_chunked_prefill,
             free_gpu_memory_fraction=args.free_gpu_memory_fraction,
             max_seq_len=args.max_seq_len,
+            enable_wideep=getattr(args, "enable_wideep", False),
         )
     elif args.mode == "exp":
         try:

--- a/src/aiconfigurator/sdk/models.py
+++ b/src/aiconfigurator/sdk/models.py
@@ -240,8 +240,8 @@ def get_model(
         )
         model.set_hybrid_config(extra_params)
     elif model_family == "MOE":
-        if backend_name == "sglang":
-            logger.debug(f"Using SGLangEPMOEModel for MOE model {model_path} with backend {backend_name}")
+        if backend_name == "sglang" and model_config.moe_backend == "deepep_moe":
+            logger.debug(f"Using SGLangEPMOEModel (deepep) for MOE model {model_path} with backend {backend_name}")
             model = SGLangEPMOEModel(
                 topk,
                 num_experts,
@@ -280,8 +280,8 @@ def get_model(
                 extra_params,
             )
     elif model_family == "DEEPSEEK":
-        if backend_name == "sglang" and model_config.enable_wideep:
-            logger.debug(f"WideEP is enabled for model {model_path} with backend {backend_name}")
+        if backend_name == "sglang" and model_config.moe_backend == "deepep_moe":
+            logger.debug(f"DeepEP MoE backend enabled for model {model_path} with backend {backend_name}")
             model = WideEPDeepSeekModel(
                 topk,
                 num_experts,
@@ -3104,10 +3104,10 @@ class WideEPDeepSeekModel(BaseModel):
 
 class SGLangEPMOEModel(BaseModel):
     """
-    SGLang EP model for MoE family models (e.g. Qwen3-235B).
-    Used for all SGLang MoE models regardless of enable_wideep setting.
-    Uses wideep/deepep perf tables and moe_backend from config,
-    with standard GQA attention (not MLA) following the MOEModel op graph.
+    SGLang DeepEP model for MoE family models (e.g. Qwen3-235B).
+    Used when moe_backend="deepep_moe" (both intra-node and inter-node DeepEP).
+    Models fused all-to-all dispatch+compute with no post-dispatch ops.
+    Uses wideep/deepep perf tables for MoE kernel latency.
     """
 
     def __init__(self, topk: int, num_experts: int, moe_inter_size: int, *args) -> None:

--- a/src/aiconfigurator/sdk/models.py
+++ b/src/aiconfigurator/sdk/models.py
@@ -3400,6 +3400,21 @@ class SGLangWideEPMOEModel(BaseModel):
             ]
         )
 
+    def _validate_fp8_block_quantized_moe_config(self) -> None:
+        """Validate fp8_block MoE alignment: (moe_inter_size / moe_tp_size) % block_size == 0."""
+        if self.config.moe_quant_mode != common.MoEQuantMode.fp8_block:
+            return
+        raw_config = _load_model_config_from_model_path(self.model_path)
+        default_size = [128, 128]
+        weight_block_size = raw_config.get("quantization_config", {}).get("weight_block_size", default_size)[0]
+        moe_size_per_gpu = self._moe_inter_size // self.config.moe_tp_size
+        if (moe_size_per_gpu % weight_block_size) != 0:
+            raise ValueError(
+                f"Invalid quantized MoE configuration: "
+                f"(moe_intermediate_size={self._moe_inter_size} / moe_tp_size={self.config.moe_tp_size}) "
+                f"% weight_block_size={weight_block_size} != 0. "
+            )
+
 
 class NemotronNas(BaseModel):
     """

--- a/src/aiconfigurator/sdk/models.py
+++ b/src/aiconfigurator/sdk/models.py
@@ -240,9 +240,9 @@ def get_model(
         )
         model.set_hybrid_config(extra_params)
     elif model_family == "MOE":
-        if backend_name == "sglang" and model_config.enable_wideep:
-            logger.debug(f"WideEP is enabled for MOE model {model_path} with backend {backend_name}")
-            model = SGLangWideEPMOEModel(
+        if backend_name == "sglang":
+            logger.debug(f"Using SGLangEPMOEModel for MOE model {model_path} with backend {backend_name}")
+            model = SGLangEPMOEModel(
                 topk,
                 num_experts,
                 moe_inter_size,
@@ -3102,11 +3102,12 @@ class WideEPDeepSeekModel(BaseModel):
         )
 
 
-class SGLangWideEPMOEModel(BaseModel):
+class SGLangEPMOEModel(BaseModel):
     """
-    SGLang WideEP model for MoE family models (e.g. Qwen3-235B).
-    Uses the same wideep/deepep perf tables and moe_backend="deepep_moe" as WideEPDeepSeekModel,
-    but with standard GQA attention (not MLA) following the MOEModel op graph.
+    SGLang EP model for MoE family models (e.g. Qwen3-235B).
+    Used for all SGLang MoE models regardless of enable_wideep setting.
+    Uses wideep/deepep perf tables and moe_backend from config,
+    with standard GQA attention (not MLA) following the MOEModel op graph.
     """
 
     def __init__(self, topk: int, num_experts: int, moe_inter_size: int, *args) -> None:

--- a/src/aiconfigurator/sdk/models.py
+++ b/src/aiconfigurator/sdk/models.py
@@ -240,25 +240,45 @@ def get_model(
         )
         model.set_hybrid_config(extra_params)
     elif model_family == "MOE":
-        # currently we don't support wideep for sglang moe models (other than DS V3)
-        model = MOEModel(
-            topk,
-            num_experts,
-            moe_inter_size,
-            model_path,
-            model_family,
-            architecture,
-            layers,
-            n,
-            n_kv,
-            d,
-            hidden,
-            inter,
-            vocab,
-            context,
-            model_config,
-            extra_params,
-        )
+        if backend_name == "sglang" and model_config.enable_wideep:
+            logger.debug(f"WideEP is enabled for MOE model {model_path} with backend {backend_name}")
+            model = SGLangWideEPMOEModel(
+                topk,
+                num_experts,
+                moe_inter_size,
+                model_path,
+                model_family,
+                architecture,
+                layers,
+                n,
+                n_kv,
+                d,
+                hidden,
+                inter,
+                vocab,
+                context,
+                model_config,
+                extra_params,
+            )
+        else:
+            model = MOEModel(
+                topk,
+                num_experts,
+                moe_inter_size,
+                model_path,
+                model_family,
+                architecture,
+                layers,
+                n,
+                n_kv,
+                d,
+                hidden,
+                inter,
+                vocab,
+                context,
+                model_config,
+                extra_params,
+            )
     elif model_family == "DEEPSEEK":
         if backend_name == "sglang" and model_config.enable_wideep:
             logger.debug(f"WideEP is enabled for model {model_path} with backend {backend_name}")
@@ -3077,6 +3097,305 @@ class WideEPDeepSeekModel(BaseModel):
                     is_context=False,
                     moe_backend=moe_backend,
                     enable_eplb=False,
+                )
+            ]
+        )
+
+
+class SGLangWideEPMOEModel(BaseModel):
+    """
+    SGLang WideEP model for MoE family models (e.g. Qwen3-235B).
+    Uses the same wideep/deepep perf tables and moe_backend="deepep_moe" as WideEPDeepSeekModel,
+    but with standard GQA attention (not MLA) following the MOEModel op graph.
+    """
+
+    def __init__(self, topk: int, num_experts: int, moe_inter_size: int, *args) -> None:
+        super().__init__(*args)
+
+        # MTP scale factor: throughput boost / compute overhead
+        self._mtp_scale_factor = (
+            1.0
+            / (1 + calc_expectation(self._nextn, self._nextn_accept_rates))
+            * (self._nextn + self._num_layers)
+            / self._num_layers
+            if self._nextn > 0
+            else 1.0
+        )
+
+        # make sure the parallel width is same
+        assert (
+            self.config.tp_size * self.config.attention_dp_size == self.config.moe_tp_size * self.config.moe_ep_size
+        ), (
+            f"tp_size ({self.config.tp_size}) * attention_dp_size "
+            f"({self.config.attention_dp_size}) should be equal to moe_tp_size "
+            f"({self.config.moe_tp_size}) * moe_ep_size ({self.config.moe_ep_size})"
+        )
+
+        assert num_experts >= self.config.moe_ep_size, f"ep size cannot be larger than num_experts {num_experts}"
+        assert self.config.tp_size * self.config.attention_dp_size <= 256, (
+            f"moe ep size {self.config.moe_ep_size} * moe tp size {self.config.moe_tp_size} "
+            f"should not be larger than 256"
+        )
+
+        self._topk = topk
+        self._num_experts = num_experts
+        self._moe_inter_size = moe_inter_size
+
+        # Validate quantized MoE block size alignment
+        self._validate_fp8_block_quantized_moe_config()
+
+        self._power_law_alpha_prefill = 0.6 if self.config.enable_eplb else 1.2
+        self._power_law_alpha_decode = 1.2
+
+        moe_quant_mode = self.config.moe_quant_mode
+        moe_backend = self.config.moe_backend
+
+        h = self._hidden_size
+        tp_size = self.config.tp_size
+        moe_tp_size = self.config.moe_tp_size
+        moe_ep_size = self.config.moe_ep_size
+        attention_dp_size = self.config.attention_dp_size
+        pp_size = self.config.pp_size
+        num_kv_heads_per_gpu = self._num_kv_heads_per_gpu
+        gemm_quant_mode = self.config.gemm_quant_mode
+        kvcache_quant_mode = self.config.kvcache_quant_mode
+        fmha_quant_mode = self.config.fmha_quant_mode
+
+        context_workload_distribution = (
+            self.config.workload_distribution + f"_{self._power_law_alpha_prefill}"
+            if self.config.workload_distribution == "power_law"
+            else self.config.workload_distribution
+        )
+        generation_workload_distribution = (
+            self.config.workload_distribution + f"_{self._power_law_alpha_decode}"
+            if self.config.workload_distribution == "power_law"
+            else self.config.workload_distribution
+        )
+
+        sms = self.config.sms
+
+        if self.architecture == "GptOssForCausalLM":
+            attn_scale_factor = 2
+            window_size = 128
+            self.context_ops.append(
+                ops.ContextAttention(
+                    "context_attention",
+                    self._num_layers / attn_scale_factor,
+                    self._num_heads // tp_size,
+                    num_kv_heads_per_gpu,
+                    kvcache_quant_mode,
+                    fmha_quant_mode,
+                    window_size=window_size,
+                    head_size=self._head_size,
+                    use_qk_norm=self._use_qk_norm,
+                )
+            )
+            self.generation_ops.append(
+                ops.GenerationAttention(
+                    "generation_attention",
+                    self._num_layers * self._mtp_scale_factor / attn_scale_factor,
+                    self._num_heads // tp_size,
+                    num_kv_heads_per_gpu,
+                    kvcache_quant_mode,
+                    window_size=window_size,
+                    head_size=self._head_size,
+                    use_qk_norm=self._use_qk_norm,
+                )
+            )
+        else:
+            attn_scale_factor = 1
+
+        # === CONTEXT OPS ===
+        self.context_ops.extend(
+            [
+                ops.Embedding("context_embedding", 1, self._vocab_size, h, 0.3),
+                ops.ElementWise("context_add_norm_1", self._num_layers, 2 * h, 2 * h, 0.8),
+                ops.GEMM(
+                    "context_qkv_gemm",
+                    self._num_layers,
+                    self._num_heads * self._head_size // tp_size + self._head_size * num_kv_heads_per_gpu * 2,
+                    h,
+                    gemm_quant_mode,
+                ),
+                ops.ContextAttention(
+                    "context_attention",
+                    self._num_layers / attn_scale_factor,
+                    self._num_heads // tp_size,
+                    num_kv_heads_per_gpu,
+                    kvcache_quant_mode,
+                    fmha_quant_mode,
+                    head_size=self._head_size,
+                    use_qk_norm=self._use_qk_norm,
+                ),
+                ops.GEMM(
+                    "context_proj_gemm",
+                    self._num_layers,
+                    h,
+                    self._num_heads * self._head_size // tp_size,
+                    gemm_quant_mode,
+                    low_precision_input=True,
+                ),
+                ops.ElementWise("context_add_norm_2", self._num_layers, 2 * h, 2 * h, 0.8),
+            ]
+        )
+
+        # router, only take it into account when num_experts >= 128
+        if self._num_experts >= 128:
+            self.context_ops.extend(
+                [
+                    ops.GEMM(
+                        "context_router_gemm",
+                        self._num_layers,
+                        self._num_experts,
+                        h,
+                        common.GEMMQuantMode.float16,
+                    )
+                ]
+            )
+
+        # dispatch tokens to experts
+        self.context_ops.extend(
+            [
+                ops.MoEDispatch(
+                    "context_moe_pre_dispatch",
+                    self._num_layers,
+                    h,
+                    self._topk,
+                    self._num_experts,
+                    moe_tp_size,
+                    moe_ep_size,
+                    attention_dp_size,
+                    True,
+                    quant_mode=moe_quant_mode,
+                    sms=sms,
+                    moe_backend=moe_backend,
+                    is_context=True,
+                    scale_num_tokens=tp_size,
+                ),
+            ]
+        )
+
+        # moe computation
+        self.context_ops.extend(
+            [
+                ops.MoE(
+                    "context_moe",
+                    self._num_layers,
+                    h,
+                    self._moe_inter_size,
+                    self._topk,
+                    self._num_experts,
+                    moe_tp_size,
+                    moe_ep_size,
+                    moe_quant_mode,
+                    context_workload_distribution,
+                    attention_dp_size,
+                    is_context=True,
+                    moe_backend=moe_backend,
+                    enable_eplb=self.config.enable_eplb,
+                ),
+            ]
+        )
+
+        # === GENERATION OPS ===
+        self.generation_ops.extend(
+            [
+                ops.Embedding("generation_embedding", 1 * self._mtp_scale_factor, self._vocab_size, h, 0.3),
+                ops.ElementWise("generation_add_norm_1", self._num_layers * self._mtp_scale_factor, 2 * h, 2 * h, 0.8),
+                ops.GEMM(
+                    "generation_qkv_gemm",
+                    self._num_layers * self._mtp_scale_factor,
+                    self._num_heads * self._head_size // tp_size + self._head_size * num_kv_heads_per_gpu * 2,
+                    h,
+                    gemm_quant_mode,
+                ),
+                ops.GenerationAttention(
+                    "generation_attention",
+                    self._num_layers / attn_scale_factor * self._mtp_scale_factor,
+                    self._num_heads // tp_size,
+                    num_kv_heads_per_gpu,
+                    kvcache_quant_mode,
+                    head_size=self._head_size,
+                    use_qk_norm=self._use_qk_norm,
+                ),
+                ops.GEMM(
+                    "generation_proj_gemm",
+                    self._num_layers * self._mtp_scale_factor,
+                    h,
+                    self._num_heads * self._head_size // tp_size,
+                    gemm_quant_mode,
+                    low_precision_input=True,
+                ),
+                ops.ElementWise("generation_add_norm_2", self._num_layers * self._mtp_scale_factor, 2 * h, 2 * h, 0.8),
+            ]
+        )
+
+        # router, only take it into account when num_experts >= 128
+        if self._num_experts >= 128:
+            self.generation_ops.extend(
+                [
+                    ops.GEMM(
+                        "generation_router_gemm",
+                        self._num_layers * self._mtp_scale_factor,
+                        self._num_experts,
+                        h,
+                        common.GEMMQuantMode.float16,
+                    )
+                ]
+            )
+
+        # dispatch tokens to experts
+        self.generation_ops.extend(
+            [
+                ops.MoEDispatch(
+                    "generation_moe_pre_dispatch",
+                    self._num_layers * self._mtp_scale_factor,
+                    h,
+                    self._topk,
+                    self._num_experts,
+                    moe_tp_size,
+                    moe_ep_size,
+                    attention_dp_size,
+                    True,
+                    quant_mode=moe_quant_mode,
+                    sms=sms,
+                    moe_backend=moe_backend,
+                    is_context=False,
+                ),
+            ]
+        )
+
+        # moe computation
+        self.generation_ops.extend(
+            [
+                ops.MoE(
+                    "generation_moe",
+                    self._num_layers * self._mtp_scale_factor,
+                    h,
+                    self._moe_inter_size,
+                    self._topk,
+                    self._num_experts,
+                    moe_tp_size,
+                    moe_ep_size,
+                    moe_quant_mode,
+                    generation_workload_distribution,
+                    attention_dp_size,
+                    is_context=False,
+                    moe_backend=moe_backend,
+                    enable_eplb=False,
+                ),
+            ]
+        )
+
+        # logits gemm
+        self.generation_ops.extend(
+            [
+                ops.GEMM(
+                    "generation_logits_gemm",
+                    1 * self._mtp_scale_factor,
+                    self._vocab_size // tp_size,
+                    h,
+                    common.GEMMQuantMode.float16,
                 )
             ]
         )

--- a/src/aiconfigurator/sdk/models.py
+++ b/src/aiconfigurator/sdk/models.py
@@ -3156,7 +3156,6 @@ class SGLangEPMOEModel(BaseModel):
         moe_tp_size = self.config.moe_tp_size
         moe_ep_size = self.config.moe_ep_size
         attention_dp_size = self.config.attention_dp_size
-        pp_size = self.config.pp_size
         num_kv_heads_per_gpu = self._num_kv_heads_per_gpu
         gemm_quant_mode = self.config.gemm_quant_mode
         kvcache_quant_mode = self.config.kvcache_quant_mode

--- a/src/aiconfigurator/sdk/task.py
+++ b/src/aiconfigurator/sdk/task.py
@@ -724,6 +724,11 @@ class TaskConfig:
             effective_profiles = list(dict.fromkeys([*effective_profiles, *yaml_profiles]))
             yaml_patch = yaml_config.get("config", yaml_config)
 
+        # Normalize: enable_wideep implies deepep_moe backend.
+        # The CLI already does this, but SDK callers may not.
+        if enable_wideep and moe_backend is None:
+            moe_backend = "deepep_moe"
+
         ctx = TaskContext(
             serving_mode=serving_mode,
             model_path=model_path,

--- a/src/aiconfigurator/sdk/task.py
+++ b/src/aiconfigurator/sdk/task.py
@@ -62,6 +62,7 @@ class TaskContext:
     request_latency: float | None
     enable_wideep: bool
     enable_chunked_prefill: bool
+    moe_backend: str | None
     total_gpus: int | None
     free_gpu_memory_fraction: float | None = None
     max_seq_len: int | None = None
@@ -110,6 +111,7 @@ def build_disagg_parallel_lists(
     *,
     prefill_enable_wideep: bool | None = None,
     decode_enable_wideep: bool | None = None,
+    moe_backend: str | None = None,
 ) -> tuple[dict, dict]:
     """Build the TP/PP/DP/MoE-TP/MoE-EP search-space lists for disagg enumeration.
 
@@ -126,6 +128,7 @@ def build_disagg_parallel_lists(
         should_enable_pp: Enable pipeline-parallelism candidates (default ``False``).
         prefill_enable_wideep: Override WideEP for prefill (None = use *enable_wideep*).
         decode_enable_wideep: Override WideEP for decode (None = use *enable_wideep*).
+        moe_backend: MoE communication backend (``"deepep_moe"`` or ``None``).
 
     Returns:
         ``(prefill_worker_config, decode_worker_config)`` - two dicts each containing
@@ -197,6 +200,7 @@ def build_disagg_parallel_lists(
                 decode_worker_config["moe_ep_list"] = parallel_config_list
         elif backend_name == "sglang":
             if enable_wideep:
+                # Inter-node DeepEP (ep >= 8, cross-node)
                 prefill_worker_config["num_gpu_per_worker"] = [8, 16, 32]
                 prefill_worker_config["tp_list"] = [1, 2, 4, 8]
                 prefill_worker_config["pp_list"] = [1, 2, 4, 8, 16, 32] if should_enable_pp else [1]
@@ -210,7 +214,18 @@ def build_disagg_parallel_lists(
                 decode_worker_config["dp_list"] = [1, 2, 4, 8, 16, 32, 64]
                 decode_worker_config["moe_tp_list"] = [1]
                 decode_worker_config["moe_ep_list"] = [8, 16, 32, 64]
+            elif moe_backend == "deepep_moe":
+                # Intra-node DeepEP (ep 1-8, NVLink)
+                parallel_config_list = [1, 2, 4, 8]
+                for cfg in (prefill_worker_config, decode_worker_config):
+                    cfg["num_gpu_per_worker"] = parallel_config_list
+                    cfg["tp_list"] = parallel_config_list
+                    cfg["pp_list"] = parallel_config_list if should_enable_pp else [1]
+                    cfg["dp_list"] = parallel_config_list
+                    cfg["moe_tp_list"] = [1]
+                    cfg["moe_ep_list"] = [1, 2, 4, 8]
             else:
+                # Standard comm (fused_moe + allgather/RS)
                 parallel_config_list = [1, 2, 4, 8]
 
                 prefill_worker_config["num_gpu_per_worker"] = parallel_config_list
@@ -361,7 +376,7 @@ class TaskConfigFactory:
             "free_gpu_memory_fraction": ctx.free_gpu_memory_fraction,
             "max_seq_len": ctx.max_seq_len,
             "enable_eplb": False,
-            "moe_backend": None,  # sglang wideep only
+            "moe_backend": ctx.moe_backend,
             "attention_backend": "flashinfer",  # sglang wideep only
         }
 
@@ -404,14 +419,23 @@ class TaskConfigFactory:
                     worker_config["moe_ep_list"] = [1, 2, 4, 8]
             elif ctx.backend_name == "sglang":
                 if ctx.enable_wideep:
-                    # sglang + wideep (keep previous logic)
+                    # Inter-node DeepEP (ep >= 8, cross-node)
                     worker_config["num_gpu_per_worker"] = [8, 16, 32, 64]
                     worker_config["tp_list"] = [1, 2, 4, 8]
                     worker_config["pp_list"] = [1, 2, 4, 8, 16, 32, 64] if should_enable_pp else [1]
                     worker_config["dp_list"] = [1, 2, 4, 8, 16, 32, 64]
                     worker_config["moe_tp_list"] = [1]
                     worker_config["moe_ep_list"] = [8, 16, 32, 64]
+                elif ctx.moe_backend == "deepep_moe":
+                    # Intra-node DeepEP (ep 1-8, NVLink)
+                    worker_config["num_gpu_per_worker"] = [1, 2, 4, 8]
+                    worker_config["tp_list"] = [1, 2, 4, 8]
+                    worker_config["pp_list"] = [1, 2, 4, 8] if should_enable_pp else [1]
+                    worker_config["dp_list"] = [1, 2, 4, 8]
+                    worker_config["moe_tp_list"] = [1]
+                    worker_config["moe_ep_list"] = [1, 2, 4, 8]
                 else:
+                    # Standard comm (fused_moe + allgather/RS)
                     worker_config["num_gpu_per_worker"] = [1, 2, 4, 8]
                     worker_config["tp_list"] = [1, 2, 4, 8]
                     worker_config["pp_list"] = [1, 2, 4, 8] if should_enable_pp else [1]
@@ -443,6 +467,7 @@ class TaskConfigFactory:
             decode_system=decode_system,
             is_moe=ctx.is_moe,
             enable_wideep=ctx.enable_wideep,
+            moe_backend=ctx.moe_backend,
         )
 
         # Attach runtime metadata that _disagg_defaults_layer needs but
@@ -458,7 +483,7 @@ class TaskConfigFactory:
         for wc in (prefill_worker_config, decode_worker_config):
             wc.setdefault("enable_wideep", ctx.enable_wideep)
             wc.setdefault("enable_eplb", None)
-            wc.setdefault("moe_backend", None)
+            wc.setdefault("moe_backend", ctx.moe_backend)
             wc.setdefault("attention_backend", "flashinfer")
 
         replica_config = {
@@ -637,6 +662,7 @@ class TaskConfig:
         enable_wideep: bool = False,
         enable_chunked_prefill: bool = False,
         enable_eplb: bool = False,
+        moe_backend: str | None = None,
         total_gpus: int | None = None,
         profiles: list[str] | None = None,
         yaml_config: dict | None = None,
@@ -714,6 +740,7 @@ class TaskConfig:
             request_latency=request_latency,
             enable_wideep=enable_wideep,
             enable_chunked_prefill=enable_chunked_prefill,
+            moe_backend=moe_backend,
             total_gpus=total_gpus,
             profiles=effective_profiles,
             yaml_patch=yaml_patch,
@@ -733,6 +760,7 @@ class TaskConfig:
         self.backend_name = backend_name
         self.enable_wideep = enable_wideep
         self.enable_eplb = enable_eplb
+        self.moe_backend = moe_backend
         self.total_gpus = total_gpus
         self.free_gpu_memory_fraction = free_gpu_memory_fraction
         self.max_seq_len = max_seq_len
@@ -906,7 +934,7 @@ class TaskConfig:
             _supported_or_raise("gemm", gemm_mode)
 
             moe_mode = _to_name(_get_cfg_value(wc, "moe_quant_mode"))
-            if self.backend_name == "sglang" and enable_wideep and moe_backend == "deepep_moe":
+            if self.backend_name == "sglang" and moe_backend == "deepep_moe":
                 if validate_context:
                     _supported_or_raise("wideep_context_moe", moe_mode)
                 if validate_generation:
@@ -1132,6 +1160,7 @@ class TaskRunner:
                 is_moe=check_is_moe(task_config.model_path),
                 backend=common.BackendName(task_config.worker_config.backend_name),
                 enable_wideep=task_config.enable_wideep,
+                moe_backend=task_config.moe_backend,
             )
         except Exception:  # pragma: no cover
             logger.exception(
@@ -1242,6 +1271,7 @@ class TaskRunner:
                 is_moe=check_is_moe(task_config.model_path),
                 backend=common.BackendName(task_config.prefill_worker_config.backend_name),
                 enable_wideep=prefill_enable_wideep,
+                moe_backend=prefill_moe_backend,
             )
         except Exception:  # pragma: no cover
             logger.exception(
@@ -1303,6 +1333,7 @@ class TaskRunner:
                 is_moe=check_is_moe(task_config.model_path),
                 backend=common.BackendName(task_config.decode_worker_config.backend_name),
                 enable_wideep=decode_enable_wideep,
+                moe_backend=decode_moe_backend,
             )
         except Exception:  # pragma: no cover
             logger.exception(

--- a/src/aiconfigurator/sdk/task.py
+++ b/src/aiconfigurator/sdk/task.py
@@ -934,7 +934,8 @@ class TaskConfig:
             _supported_or_raise("gemm", gemm_mode)
 
             moe_mode = _to_name(_get_cfg_value(wc, "moe_quant_mode"))
-            if self.backend_name == "sglang" and moe_backend == "deepep_moe":
+            wc_moe_backend = getattr(wc, "moe_backend", None) or moe_backend
+            if self.backend_name == "sglang" and wc_moe_backend == "deepep_moe":
                 if validate_context:
                     _supported_or_raise("wideep_context_moe", moe_mode)
                 if validate_generation:

--- a/src/aiconfigurator/sdk/task.py
+++ b/src/aiconfigurator/sdk/task.py
@@ -218,14 +218,14 @@ def build_disagg_parallel_lists(
                 prefill_worker_config["pp_list"] = parallel_config_list if should_enable_pp else [1]
                 prefill_worker_config["dp_list"] = parallel_config_list
                 prefill_worker_config["moe_tp_list"] = parallel_config_list
-                prefill_worker_config["moe_ep_list"] = [1]
+                prefill_worker_config["moe_ep_list"] = [1, 2, 4, 8]
 
                 decode_worker_config["num_gpu_per_worker"] = parallel_config_list
                 decode_worker_config["tp_list"] = parallel_config_list
                 decode_worker_config["pp_list"] = parallel_config_list if should_enable_pp else [1]
                 decode_worker_config["dp_list"] = parallel_config_list
                 decode_worker_config["moe_tp_list"] = parallel_config_list
-                decode_worker_config["moe_ep_list"] = [1]
+                decode_worker_config["moe_ep_list"] = [1, 2, 4, 8]
         elif backend_name == "vllm":
             parallel_config_list = [1, 2, 4, 8]
 
@@ -417,7 +417,7 @@ class TaskConfigFactory:
                     worker_config["pp_list"] = [1, 2, 4, 8] if should_enable_pp else [1]
                     worker_config["dp_list"] = [1, 2, 4, 8]
                     worker_config["moe_tp_list"] = [1, 2, 4, 8]
-                    worker_config["moe_ep_list"] = [1]
+                    worker_config["moe_ep_list"] = [1, 2, 4, 8]
             elif ctx.backend_name == "vllm":
                 worker_config["num_gpu_per_worker"] = [1, 2, 4, 8]
                 worker_config["tp_list"] = [1, 2, 4, 8]

--- a/src/aiconfigurator/sdk/utils.py
+++ b/src/aiconfigurator/sdk/utils.py
@@ -158,9 +158,7 @@ def enumerate_parallel_config(
                                     continue
                                 # sglang
                                 elif backend == common.BackendName.sglang:
-                                    if (enable_wideep and moe_tp > 1) or (
-                                        not enable_wideep and moe_ep > 1
-                                    ):  # wideep only has ep
+                                    if enable_wideep and moe_tp > 1:  # wideep only has ep
                                         continue
                                 elif backend == common.BackendName.vllm:
                                     pass  # TODO

--- a/src/aiconfigurator/sdk/utils.py
+++ b/src/aiconfigurator/sdk/utils.py
@@ -108,6 +108,7 @@ def enumerate_parallel_config(
     is_moe: bool = False,
     backend: common.BackendName = common.BackendName.trtllm,
     enable_wideep: bool = False,
+    moe_backend: str | None = None,
     real_silicon_sweep: bool = False,
     min_num_gpus: int | None = None,
     max_num_gpus: int | None = None,
@@ -158,8 +159,8 @@ def enumerate_parallel_config(
                                     continue
                                 # sglang
                                 elif backend == common.BackendName.sglang:
-                                    if enable_wideep and moe_tp > 1:  # wideep only has ep
-                                        continue
+                                    if (enable_wideep or moe_backend == "deepep_moe") and moe_tp > 1:
+                                        continue  # DeepEP forces ep_size=tp_size, moe_tp must be 1
                                 elif backend == common.BackendName.vllm:
                                     pass  # TODO
                                 parallel_config_list.append([tp, pp, dp, moe_tp, moe_ep])

--- a/tests/unit/sdk/models/test_model_config.py
+++ b/tests/unit/sdk/models/test_model_config.py
@@ -308,14 +308,14 @@ class TestGetModelMOESGLangDispatch:
         assert isinstance(model, models.SGLangEPMOEModel)
 
     def test_sglang_moe_no_wideep_returns_sglang_ep_moe_model(self):
-        """Test that get_model returns SGLangEPMOEModel for MOE + SGLang (without wideep)."""
+        """Test that get_model returns SGLangEPMOEModel for MOE + SGLang (without wideep, EP-enabled)."""
         model_config = config.ModelConfig(
             tp_size=2,
             pp_size=1,
             gemm_quant_mode=common.GEMMQuantMode.float16,
             kvcache_quant_mode=common.KVCacheQuantMode.float16,
-            moe_tp_size=2,
-            moe_ep_size=1,
+            moe_tp_size=1,
+            moe_ep_size=2,
             attention_dp_size=1,
             enable_wideep=False,
         )

--- a/tests/unit/sdk/models/test_model_config.py
+++ b/tests/unit/sdk/models/test_model_config.py
@@ -11,8 +11,7 @@ from unittest.mock import patch
 
 import pytest
 
-from aiconfigurator.sdk import common, config
-from aiconfigurator.sdk import models
+from aiconfigurator.sdk import common, config, models
 from aiconfigurator.sdk.models import check_is_moe, get_model, get_model_family
 from aiconfigurator.sdk.utils import get_model_config_from_model_path
 

--- a/tests/unit/sdk/models/test_model_config.py
+++ b/tests/unit/sdk/models/test_model_config.py
@@ -289,10 +289,13 @@ class TestMOEModelFP8BlockQuantizationValidation:
 
 
 class TestGetModelMOESGLangDispatch:
-    """Test get_model() dispatch logic for MOE family with SGLang backend."""
+    """Test get_model() dispatch logic for MOE family with SGLang backend.
 
-    def test_sglang_moe_returns_sglang_ep_moe_model(self):
-        """Test that get_model returns SGLangEPMOEModel for MOE + SGLang (with wideep)."""
+    Dispatch keys on moe_backend (communication path), not enable_wideep (scale intent).
+    """
+
+    def test_sglang_moe_deepep_returns_sglang_ep_moe_model(self):
+        """DeepEP backend (inter-node, enable_wideep=True) → SGLangEPMOEModel."""
         model_config = config.ModelConfig(
             tp_size=1,
             pp_size=1,
@@ -307,8 +310,24 @@ class TestGetModelMOESGLangDispatch:
         model = models.get_model("Qwen/Qwen3-235B-A22B", model_config, "sglang")
         assert isinstance(model, models.SGLangEPMOEModel)
 
-    def test_sglang_moe_no_wideep_returns_sglang_ep_moe_model(self):
-        """Test that get_model returns SGLangEPMOEModel for MOE + SGLang (without wideep, EP-enabled)."""
+    def test_sglang_moe_deepep_intranode_returns_sglang_ep_moe_model(self):
+        """DeepEP intra-node (enable_wideep=False, moe_backend=deepep_moe) → SGLangEPMOEModel."""
+        model_config = config.ModelConfig(
+            tp_size=1,
+            pp_size=1,
+            gemm_quant_mode=common.GEMMQuantMode.float16,
+            kvcache_quant_mode=common.KVCacheQuantMode.float16,
+            moe_tp_size=1,
+            moe_ep_size=4,
+            attention_dp_size=4,
+            enable_wideep=False,
+            moe_backend="deepep_moe",
+        )
+        model = models.get_model("Qwen/Qwen3-235B-A22B", model_config, "sglang")
+        assert isinstance(model, models.SGLangEPMOEModel)
+
+    def test_sglang_moe_no_deepep_returns_moe_model(self):
+        """Standard comm (no moe_backend) → MOEModel."""
         model_config = config.ModelConfig(
             tp_size=2,
             pp_size=1,
@@ -320,10 +339,11 @@ class TestGetModelMOESGLangDispatch:
             enable_wideep=False,
         )
         model = models.get_model("Qwen/Qwen3-235B-A22B", model_config, "sglang")
-        assert isinstance(model, models.SGLangEPMOEModel)
+        assert isinstance(model, models.MOEModel)
+        assert not isinstance(model, models.SGLangEPMOEModel)
 
     def test_trtllm_moe_returns_moe_model(self):
-        """Test that get_model returns MOEModel (not SGLangEPMOEModel) for MOE + trtllm + enable_wideep=True."""
+        """trtllm always → MOEModel (moe_backend irrelevant for non-sglang)."""
         model_config = config.ModelConfig(
             tp_size=2,
             pp_size=1,

--- a/tests/unit/sdk/models/test_model_config.py
+++ b/tests/unit/sdk/models/test_model_config.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 import pytest
 
 from aiconfigurator.sdk import common, config
+from aiconfigurator.sdk import models
 from aiconfigurator.sdk.models import check_is_moe, get_model, get_model_family
 from aiconfigurator.sdk.utils import get_model_config_from_model_path
 
@@ -286,3 +287,55 @@ class TestMOEModelFP8BlockQuantizationValidation:
         else:
             model = get_model("Qwen/Qwen3-235B-A22B", model_config, "trtllm")
             assert model is not None
+
+
+class TestGetModelMOEWideEPDispatch:
+    """Test get_model() dispatch logic for MOE family with SGLang WideEP."""
+
+    def test_sglang_wideep_moe_returns_sglang_wideep_moe_model(self):
+        """Test that get_model returns SGLangWideEPMOEModel for MOE + SGLang + enable_wideep=True."""
+        model_config = config.ModelConfig(
+            tp_size=1,
+            pp_size=1,
+            gemm_quant_mode=common.GEMMQuantMode.float16,
+            kvcache_quant_mode=common.KVCacheQuantMode.float16,
+            moe_tp_size=1,
+            moe_ep_size=8,
+            attention_dp_size=8,
+            enable_wideep=True,
+            moe_backend="deepep_moe",
+        )
+        model = models.get_model("Qwen/Qwen3-235B-A22B", model_config, "sglang")
+        assert isinstance(model, models.SGLangWideEPMOEModel)
+
+    def test_sglang_no_wideep_moe_returns_moe_model(self):
+        """Test that get_model returns MOEModel for MOE + SGLang + enable_wideep=False."""
+        model_config = config.ModelConfig(
+            tp_size=2,
+            pp_size=1,
+            gemm_quant_mode=common.GEMMQuantMode.float16,
+            kvcache_quant_mode=common.KVCacheQuantMode.float16,
+            moe_tp_size=2,
+            moe_ep_size=1,
+            attention_dp_size=1,
+            enable_wideep=False,
+        )
+        model = models.get_model("Qwen/Qwen3-235B-A22B", model_config, "sglang")
+        assert isinstance(model, models.MOEModel)
+        assert not isinstance(model, models.SGLangWideEPMOEModel)
+
+    def test_trtllm_wideep_moe_returns_moe_model(self):
+        """Test that get_model returns MOEModel (not SGLangWideEPMOEModel) for MOE + trtllm + enable_wideep=True."""
+        model_config = config.ModelConfig(
+            tp_size=2,
+            pp_size=1,
+            gemm_quant_mode=common.GEMMQuantMode.float16,
+            kvcache_quant_mode=common.KVCacheQuantMode.float16,
+            moe_tp_size=2,
+            moe_ep_size=1,
+            attention_dp_size=1,
+            enable_wideep=True,
+        )
+        model = models.get_model("Qwen/Qwen3-235B-A22B", model_config, "trtllm")
+        assert isinstance(model, models.MOEModel)
+        assert not isinstance(model, models.SGLangWideEPMOEModel)

--- a/tests/unit/sdk/models/test_model_config.py
+++ b/tests/unit/sdk/models/test_model_config.py
@@ -289,11 +289,11 @@ class TestMOEModelFP8BlockQuantizationValidation:
             assert model is not None
 
 
-class TestGetModelMOEWideEPDispatch:
-    """Test get_model() dispatch logic for MOE family with SGLang WideEP."""
+class TestGetModelMOESGLangDispatch:
+    """Test get_model() dispatch logic for MOE family with SGLang backend."""
 
-    def test_sglang_wideep_moe_returns_sglang_wideep_moe_model(self):
-        """Test that get_model returns SGLangWideEPMOEModel for MOE + SGLang + enable_wideep=True."""
+    def test_sglang_moe_returns_sglang_ep_moe_model(self):
+        """Test that get_model returns SGLangEPMOEModel for MOE + SGLang (with wideep)."""
         model_config = config.ModelConfig(
             tp_size=1,
             pp_size=1,
@@ -306,10 +306,10 @@ class TestGetModelMOEWideEPDispatch:
             moe_backend="deepep_moe",
         )
         model = models.get_model("Qwen/Qwen3-235B-A22B", model_config, "sglang")
-        assert isinstance(model, models.SGLangWideEPMOEModel)
+        assert isinstance(model, models.SGLangEPMOEModel)
 
-    def test_sglang_no_wideep_moe_returns_moe_model(self):
-        """Test that get_model returns MOEModel for MOE + SGLang + enable_wideep=False."""
+    def test_sglang_moe_no_wideep_returns_sglang_ep_moe_model(self):
+        """Test that get_model returns SGLangEPMOEModel for MOE + SGLang (without wideep)."""
         model_config = config.ModelConfig(
             tp_size=2,
             pp_size=1,
@@ -321,11 +321,10 @@ class TestGetModelMOEWideEPDispatch:
             enable_wideep=False,
         )
         model = models.get_model("Qwen/Qwen3-235B-A22B", model_config, "sglang")
-        assert isinstance(model, models.MOEModel)
-        assert not isinstance(model, models.SGLangWideEPMOEModel)
+        assert isinstance(model, models.SGLangEPMOEModel)
 
-    def test_trtllm_wideep_moe_returns_moe_model(self):
-        """Test that get_model returns MOEModel (not SGLangWideEPMOEModel) for MOE + trtllm + enable_wideep=True."""
+    def test_trtllm_moe_returns_moe_model(self):
+        """Test that get_model returns MOEModel (not SGLangEPMOEModel) for MOE + trtllm + enable_wideep=True."""
         model_config = config.ModelConfig(
             tp_size=2,
             pp_size=1,
@@ -338,4 +337,4 @@ class TestGetModelMOEWideEPDispatch:
         )
         model = models.get_model("Qwen/Qwen3-235B-A22B", model_config, "trtllm")
         assert isinstance(model, models.MOEModel)
-        assert not isinstance(model, models.SGLangWideEPMOEModel)
+        assert not isinstance(model, models.SGLangEPMOEModel)

--- a/tests/unit/sdk/task/test_task.py
+++ b/tests/unit/sdk/task/test_task.py
@@ -563,7 +563,7 @@ def test_sglang_moe_configs():
     assert prefill_cfg2.tp_list == [1, 2, 4, 8], f"Expected [1, 2, 4, 8], got {prefill_cfg2.tp_list}"
     assert prefill_cfg2.dp_list == [1, 2, 4, 8], f"Expected [1, 2, 4, 8], got {prefill_cfg2.dp_list}"
     assert prefill_cfg2.moe_tp_list == [1, 2, 4, 8], f"Expected [1, 2, 4, 8], got {prefill_cfg2.moe_tp_list}"
-    assert prefill_cfg2.moe_ep_list == [1], f"Expected [1], got {prefill_cfg2.moe_ep_list}"
+    assert prefill_cfg2.moe_ep_list == [1, 2, 4, 8], f"Expected [1, 2, 4, 8], got {prefill_cfg2.moe_ep_list}"
 
     # Verify decode config
     assert decode_cfg2.num_gpu_per_worker == [1, 2, 4, 8], (
@@ -572,7 +572,7 @@ def test_sglang_moe_configs():
     assert decode_cfg2.tp_list == [1, 2, 4, 8], f"Expected [1, 2, 4, 8], got {decode_cfg2.tp_list}"
     assert decode_cfg2.dp_list == [1, 2, 4, 8], f"Expected [1, 2, 4, 8], got {decode_cfg2.dp_list}"
     assert decode_cfg2.moe_tp_list == [1, 2, 4, 8], f"Expected [1, 2, 4, 8], got {decode_cfg2.moe_tp_list}"
-    assert decode_cfg2.moe_ep_list == [1], f"Expected [1], got {decode_cfg2.moe_ep_list}"
+    assert decode_cfg2.moe_ep_list == [1, 2, 4, 8], f"Expected [1, 2, 4, 8], got {decode_cfg2.moe_ep_list}"
 
     # Test 3: trtllm + MoE + wideep (should use previous logic)
     # task_trtllm_wideep = TaskConfig(

--- a/tests/unit/sdk/test_utils.py
+++ b/tests/unit/sdk/test_utils.py
@@ -715,3 +715,24 @@ class TestEnumerateParallelConfigSGLangMoE:
         has_ep_gt_1 = any(c[4] > 1 for c in configs)
         assert has_pure_tp, "Should include pure TP configs (moe_ep=1, moe_tp>1)"
         assert has_ep_gt_1, "Should include configs with moe_ep > 1"
+
+    def test_sglang_deepep_intranode_excludes_moe_tp_gt_1(self):
+        """SGLang + moe_backend=deepep_moe + enable_wideep=False excludes moe_tp > 1."""
+        configs = enumerate_parallel_config(
+            num_gpu_list=[1, 2, 4, 8],
+            tp_list=[1, 2, 4, 8],
+            pp_list=[1],
+            dp_list=[1, 2, 4, 8],
+            moe_tp_list=[1, 2, 4, 8],
+            moe_ep_list=[1, 2, 4, 8],
+            is_moe=True,
+            backend=common.BackendName.sglang,
+            enable_wideep=False,
+            moe_backend="deepep_moe",
+        )
+        assert len(configs) > 0, "Should generate at least one config"
+        for c in configs:
+            assert c[3] == 1, f"DeepEP config should have moe_tp=1, got {c}"
+        # Should still include ep > 1 configs
+        moe_ep_values = [c[4] for c in configs]
+        assert any(ep > 1 for ep in moe_ep_values), "Should include configs with moe_ep > 1"

--- a/tests/unit/sdk/test_utils.py
+++ b/tests/unit/sdk/test_utils.py
@@ -15,6 +15,7 @@ from aiconfigurator.sdk import common, config
 from aiconfigurator.sdk.models import HybridMoEModel
 from aiconfigurator.sdk.utils import (
     _parse_hf_config_json,
+    enumerate_parallel_config,
     enumerate_ttft_tpot_constraints,
     get_model_config_from_model_path,
 )
@@ -653,3 +654,63 @@ class TestEnumerateTTFTTPOTConstraints:
         derived_pair = next((pair for pair in constraints if pair[0] == pytest.approx(expected_ttft)), None)
         assert derived_pair is not None
         assert derived_pair[1] == pytest.approx((1000 - 950) / (50 - 1))
+
+
+class TestEnumerateParallelConfigSGLangMoE:
+    """Test enumerate_parallel_config for SGLang MoE scenarios."""
+
+    def test_sglang_non_wideep_moe_includes_moe_ep_gt_1(self):
+        """Test that SGLang + enable_wideep=False includes configs with moe_ep > 1."""
+        configs = enumerate_parallel_config(
+            num_gpu_list=[1, 2, 4, 8],
+            tp_list=[1, 2, 4, 8],
+            pp_list=[1],
+            dp_list=[1, 2, 4, 8],
+            moe_tp_list=[1, 2, 4, 8],
+            moe_ep_list=[1, 2, 4, 8],
+            is_moe=True,
+            backend=common.BackendName.sglang,
+            enable_wideep=False,
+        )
+        assert len(configs) > 0, "Should generate at least one config"
+        moe_ep_values = [c[4] for c in configs]
+        assert any(ep > 1 for ep in moe_ep_values), (
+            f"Should include at least one config with moe_ep > 1, got moe_ep values: {set(moe_ep_values)}"
+        )
+
+    def test_sglang_wideep_moe_excludes_moe_tp_gt_1(self):
+        """Test that SGLang + enable_wideep=True excludes configs with moe_tp > 1."""
+        configs = enumerate_parallel_config(
+            num_gpu_list=[8, 16, 32],
+            tp_list=[1, 2, 4, 8],
+            pp_list=[1],
+            dp_list=[1, 2, 4, 8, 16, 32],
+            moe_tp_list=[1],
+            moe_ep_list=[8, 16, 32],
+            is_moe=True,
+            backend=common.BackendName.sglang,
+            enable_wideep=True,
+        )
+        # All configs should have moe_tp == 1 (EP-only for wideep)
+        for c in configs:
+            assert c[3] == 1, f"WideEP config should have moe_tp=1, got {c}"
+
+    def test_sglang_non_wideep_moe_allows_mixed_tp_ep(self):
+        """Test that SGLang + enable_wideep=False allows configs with both moe_tp > 1 and moe_ep > 1."""
+        configs = enumerate_parallel_config(
+            num_gpu_list=[1, 2, 4, 8],
+            tp_list=[1, 2, 4, 8],
+            pp_list=[1],
+            dp_list=[1, 2, 4, 8],
+            moe_tp_list=[1, 2, 4, 8],
+            moe_ep_list=[1, 2, 4, 8],
+            is_moe=True,
+            backend=common.BackendName.sglang,
+            enable_wideep=False,
+        )
+        # Should include configs with moe_ep == 1 (pure TP)
+        has_pure_tp = any(c[4] == 1 and c[3] > 1 for c in configs)
+        # Should include configs with moe_ep > 1
+        has_ep_gt_1 = any(c[4] > 1 for c in configs)
+        assert has_pure_tp, "Should include pure TP configs (moe_ep=1, moe_tp>1)"
+        assert has_ep_gt_1, "Should include configs with moe_ep > 1"

--- a/tests/unit/sdk/test_utils.py
+++ b/tests/unit/sdk/test_utils.py
@@ -713,8 +713,11 @@ class TestEnumerateParallelConfigSGLangMoE:
         has_pure_tp = any(c[4] == 1 and c[3] > 1 for c in configs)
         # Should include configs with moe_ep > 1
         has_ep_gt_1 = any(c[4] > 1 for c in configs)
+        # Should include truly mixed configs (both moe_tp > 1 and moe_ep > 1)
+        has_mixed = any(c[3] > 1 and c[4] > 1 for c in configs)
         assert has_pure_tp, "Should include pure TP configs (moe_ep=1, moe_tp>1)"
         assert has_ep_gt_1, "Should include configs with moe_ep > 1"
+        assert has_mixed, "Should include mixed configs with both moe_tp > 1 and moe_ep > 1"
 
     def test_sglang_deepep_intranode_excludes_moe_tp_gt_1(self):
         """SGLang + moe_backend=deepep_moe + enable_wideep=False excludes moe_tp > 1."""

--- a/tests/unit/sdk/test_utils.py
+++ b/tests/unit/sdk/test_utils.py
@@ -685,12 +685,13 @@ class TestEnumerateParallelConfigSGLangMoE:
             tp_list=[1, 2, 4, 8],
             pp_list=[1],
             dp_list=[1, 2, 4, 8, 16, 32],
-            moe_tp_list=[1],
+            moe_tp_list=[1, 2, 4, 8],
             moe_ep_list=[8, 16, 32],
             is_moe=True,
             backend=common.BackendName.sglang,
             enable_wideep=True,
         )
+        assert len(configs) > 0, "Should generate at least one config"
         # All configs should have moe_tp == 1 (EP-only for wideep)
         for c in configs:
             assert c[3] == 1, f"WideEP config should have moe_tp=1, got {c}"


### PR DESCRIPTION
## 1. Overview

With many thanks to @Arsene12358, this PR describes the design to:

1. **Enable WideEP for Qwen3-235B (and compatible SGLang MoE models)** using a dedicated model class (`SGLangEPMOEModel`), following the DeepSeek WideEP pattern, with the ability to use a different `moe_backend` when needed.
2. **Allow EP>1 in non-wideEP mode for SGLang** so that SGLang MoE can explore expert parallelism (e.g. `moe_ep` in `[1,2,4,8]`) when `enable_wideep=False`.
3. **Add a CLI flag `--enable-wideep`** so users can set WideEP without YAML (applies to both DeepSeek and Qwen3-235B).

### Out of scope / explicit decisions

- **No default change for `enable_wideep`**: It remains a conscious user choice (default `False`). We only ensure that when the user sets it explicitly, they get the correct behavior.
- **WideEP MoE (Qwen3-235B)** uses the same `moe_backend="deepep_moe"` and the same wideep/deepep perf tables as WideEP DeepSeek; we collect new data for Qwen3-235B's dimensions and add it to those existing tables (keyed by dimensions, so DeepSeek and Qwen3 data coexist).

---

## 2. Current State

### 2.1 SGLang + MoE today

- **WideEP is implemented only for DeepSeek**: `WideEPDeepSeekModel` uses wideep/deepep perf tables and `moe_backend="deepep_moe"`. Qwen3-235B is MOE family and always uses `MOEModel`; there is no WideEP model class for it (see `models.py`: "we don't support wideep for sglang moe models (other than DS V3)").
- **Search space**:
  - `build_disagg_parallel_lists` / `_agg_defaults_layer`: For SGLang + MoE, if `enable_wideep` → `moe_tp_list=[1]`, `moe_ep_list=[8,16,32]` (prefill) / `[8,16,32,64]` (decode). If not wideep → `moe_ep_list=[1]` only.
  - `enumerate_parallel_config` (`utils.py`): For `backend == sglang`, configs are skipped when `(enable_wideep and moe_tp > 1) or (not enable_wideep and moe_ep > 1)`.
- **CLI**: `enable_wideep` is not passed in `common_kwargs` for the default command; it can only be set via experiment YAML today.
- **Perf data**: SGLang `moe_perf.txt` exists but currently has mostly/only `moe_ep_size=1`. WideEP-style configs need data for `moe_ep` in `[8,16,32,64]` and `moe_tp=1`; non-wideEP EP>1 needs data for `moe_ep` in `[2,4,8]` (and corresponding `moe_tp`).

### 2.2 Design pattern to follow: DeepSeek

- **WideEP path**: `WideEPDeepSeekModel` (SGLang) or `TrtllmWideEPDeepSeekModel` (TensorRT-LLM). These classes set/use `moe_backend="deepep_moe"` and wideep perf tables.
- **Non-wideEP path**: `DeepSeekModel`. Uses standard MLA + MoE ops and tables.
- **Dispatch in `get_model()`**: by `model_family`, `backend_name`, and `model_config.enable_wideep`.

---

## 3. Design

### 3.1 Unified model class: SGLangEPMOEModel

Introduce `SGLangEPMOEModel` for **all SGLang MoE models** (e.g. Qwen3MoeForCausalLM — Qwen3-235B), regardless of `enable_wideep` setting.

**Dispatch in `get_model()` (`models.py`):**

```python
elif model_family == "MOE":
    if backend_name == "sglang":
        model = SGLangEPMOEModel(...)   # All SGLang MoE
    else:
        model = MOEModel(...)           # trtllm / vllm
```

The `enable_wideep` flag does **not** affect model class selection. It only controls the search space (see Section 3.2).

**Class responsibilities:**

- Build the same op graph as `MOEModel` for non-MoE parts (GQA attention, etc.).
- MoE ops pass `moe_backend=self.config.moe_backend` and `is_context=True/False` to enable proper perf table routing (wideep/deepep tables when `moe_backend="deepep_moe"`, standard `moe_perf` otherwise).
- Support phase-aware workload distribution:
  - Separate `_power_law_alpha_prefill` (0.6 when `enable_eplb`, else 1.2) and `_power_law_alpha_decode` (1.2).
  - Context ops use `context_workload_distribution`, generation ops use `generation_workload_distribution`.
- MoEDispatch passes `sms`, `moe_backend`, `is_context`, and `scale_num_tokens` (context only, set to `tp_size`).
- MoE ops pass `is_context`, `moe_backend`, `enable_eplb` (context uses config value, generation fixed `False`).
- **No post-dispatch ops** (unlike `MOEModel`), as WideEP all-to-all communication does not require explicit token collection.

**Key differences from `MOEModel`:**

| Aspect | MOEModel | SGLangEPMOEModel |
|--------|----------|------------------|
| Power Law Alpha | Single value `1.2` | Prefill: `0.6` (eplb) or `1.2`; Decode: `1.2` |
| Workload Distribution | Same for context/generation | Separate per phase |
| `moe_backend` | Not passed (uses default) | Passed from `self.config.moe_backend` |
| `is_context` | Not passed | `True` for context, `False` for generation |
| `sms` | Not passed | Passed from `self.config.sms` |
| `scale_num_tokens` | Not passed | `tp_size` (context MoEDispatch only) |
| `enable_eplb` | Not supported | Context: from config; Generation: `False` |
| Post-dispatch | Has `context/generation_moe_post_dispatch` | None |

**Perf data routing:**

When `enable_wideep=True`, `moe_backend` is set to `"deepep_moe"` (same as WideEP DeepSeek), so MoE ops query from wideep tables (`wideep_context_moe_perf.txt`, `wideep_generation_moe_perf.txt`, `wideep_deepep_normal_perf.txt`, `wideep_deepep_ll_perf.txt`). Qwen3-235B data coexists with DeepSeek data in these tables, keyed by model dimensions (hidden_size, num_experts, etc.).

When `enable_wideep=False`, `moe_backend` remains at its default, and ops query from standard `moe_perf` tables.

### 3.2 Search space controlled by `enable_wideep`

| Condition | `moe_tp_list` | `moe_ep_list` |
|-----------|--------------|--------------|
| SGLang + `enable_wideep=True` | `[1]` | prefill `[8,16,32]` / decode `[8,16,32,64]` |
| SGLang + `enable_wideep=False` + MoE | default | `[1, 2, 4, 8]` |

**Code changes:**

1. **`build_disagg_parallel_lists` (`task.py`):** For `backend_name == "sglang"` and `not enable_wideep` and `is_moe`, set `moe_ep_list = [1, 2, 4, 8]` (both prefill and decode), instead of `[1]`.

2. **`_agg_defaults_layer` (`task.py`):** Same change: `worker_config["moe_ep_list"] = [1, 2, 4, 8]`.

3. **`enumerate_parallel_config` (`utils.py`):** For `backend == sglang`, remove the branch that skips configs when `not enable_wideep and moe_ep > 1`. Keep the existing rule that skips when `enable_wideep and moe_tp > 1` (EP-only for wideep).

```python
# Before:
elif backend == common.BackendName.sglang:
    if (enable_wideep and moe_tp > 1) or (
        not enable_wideep and moe_ep > 1
    ):
        continue

# After:
elif backend == common.BackendName.sglang:
    if enable_wideep and moe_tp > 1:
        continue
```

### 3.3 CLI: `--enable-wideep` flag

Add `--enable-wideep` to the argument parser for the `default` command.

```python
parser.add_argument(
    "--enable-wideep",
    action="store_true",
    default=False,
    help="Enable Wide Expert Parallelism (WideEP) for MoE models. ...",
)
```

Include `enable_wideep` in `common_kwargs`:

```python
common_kwargs["enable_wideep"] = getattr(args, "enable_wideep", False)
```

**Usage example:**

```bash
aiconfigurator cli default \
  --model Qwen/Qwen3-235B-A22B \
  --backend sglang \
  --total-gpus 32 \
  --system h200_sxm \
  --enable-wideep
```

---

## 4. Summary of Changes

| Area | Change |
|------|--------|
| **`models.py`** | Add `SGLangEPMOEModel`; in `get_model()`, dispatch MOE + SGLang to it **unconditionally** (regardless of `enable_wideep`), else to `MOEModel`. |
| **`task.py`** | SGLang non-wideEP + MoE: set `moe_ep_list = [1, 2, 4, 8]` in `build_disagg_parallel_lists` and `_agg_defaults_layer`. |
| **`utils.py`** | In `enumerate_parallel_config`, for SGLang remove the skip when `not enable_wideep and moe_ep > 1`. |
| **`task.py` / webapp** | No change: keep setting `moe_backend="deepep_moe"` for all SGLang + `enable_wideep` (DeepSeek and MOE both use it; data is keyed by model dimensions). |
| **`cli/main.py`** | Add `--enable-wideep` to default command; pass into `common_kwargs` when creating TaskConfig. |
| **Perf data** | (1) WideEP: Collect new data for Qwen3-235B dimensions and add to existing wideep table files. (2) Non-wideEP EP>1: Collect SGLang data in `moe_perf.txt` for `(moe_tp, moe_ep)` combinations in `[1,2,4,8]`. |

---

## 5. Testing

### Unit Tests

| # | Test | Status |
|---|------|--------|
| 1 | `get_model()` returns `SGLangEPMOEModel` for MOE + SGLang (with `enable_wideep=True`) | ✅ Covered |
| 2 | `get_model()` returns `SGLangEPMOEModel` for MOE + SGLang (with `enable_wideep=False`) | ✅ Covered |
| 3 | `get_model()` returns `MOEModel` (not `SGLangEPMOEModel`) for MOE + trtllm | ✅ Covered |
| 4 | `build_disagg_parallel_lists` / `_agg_defaults_layer` yield `moe_ep_list = [1,2,4,8]` for SGLang non-wideEP MoE | ✅ Covered |
| 5 | `enumerate_parallel_config` for SGLang + `enable_wideep=False` includes at least one config with `moe_ep > 1` | ✅ Covered |
| 6 | `enumerate_parallel_config` for SGLang + `enable_wideep=True` excludes all configs with `moe_tp > 1` | ✅ Covered |

### Integration Tests

- Run `default` (and disagg) for Qwen3-235B on a supported system with SGLang, with and without `--enable-wideep`, and verify no crashes and correct model class / configs.
- Support matrix: Re-run SGLang + Qwen3-235B (and DeepSeek) after changes; fix any regressions (e.g. missing perf keys) via data or fallback.

---

## 6. Risks and Notes

- **SGLang runtime**: Confirm that SGLang supports EP>1 in non-wideEP mode (and the WideEP-style EP-only configs) for the versions/systems you target; document any version requirements.
- **Perf coverage**: Without SGLang MoE data for the new `(moe_tp, moe_ep)` combinations, estimation may fail or be inaccurate; prioritize data collection or a documented fallback (e.g. scale from `moe_ep=1` or interpolate from vLLM) for missing keys.

---

## 7. References

- **Model dispatch and EP classes**: `src/aiconfigurator/sdk/models.py` (e.g. `DeepSeekModel`, `WideEPDeepSeekModel`, `SGLangEPMOEModel`, `get_model()`).
- **Parallel lists and enumerator**: `src/aiconfigurator/sdk/task.py` (`build_disagg_parallel_lists`, `_agg_defaults_layer`), `src/aiconfigurator/sdk/utils.py` (`enumerate_parallel_config`).
- **MoE op and `moe_backend`**: `src/aiconfigurator/sdk/operations.py` (`MoEDispatch`), `src/aiconfigurator/sdk/perf_database.py` (SGLang MoE lookup).
- **CLI task config**: `src/aiconfigurator/cli/main.py` (default command, `common_kwargs`).




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI option to enable wideep MoE benchmarking and a new SGLang-wideep MoE model variant.

* **Improvements**
  * Dynamic MoE benchmarking that adapts to model architecture, local expert counts and ep-size math.
  * Expanded SGLang MoE configuration/search space to include wider expert-parallelism strategies.
  * Improved model-path resolution with auto-download and robust fallbacks.

* **Bug Fixes / Validation**
  * Relaxed EP validation to allow non‑unit EP sizes when divisible; adjusted benchmark sizing.

* **Tests**
  * Added unit tests for SGLang MoE dispatch and parallelism enumeration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->