### PR TITLE
feat: support --trtllm.* dynamic CLI flags in generator rendering

### DIFF
--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/cli_args.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/cli_args.j2
@@ -1,14 +1,4 @@
 {%- set args = [] -%}
-{%- set override_dict = {} -%}
-
-{#- Model configuration -#}
-{%- if ServiceConfig.model_path -%}
-  {%- set _ = args.append('--model-path "' + ServiceConfig.model_path + '"') -%}
-{%- endif -%}
-
-{%- if ServiceConfig.served_model_name -%}
-  {%- set _ = args.append('--served-model-name "' + ServiceConfig.served_model_name + '"') -%}
-{%- endif -%}
 
 {#- Direct CLI args: only flags accepted by dynamo.trtllm argparser -#}
 
@@ -42,47 +32,6 @@
 
 {%- if kv_cache_free_gpu_memory_fraction is defined -%}
   {%- set _ = args.append('--free-gpu-memory-fraction ' + kv_cache_free_gpu_memory_fraction|string) -%}
-{%- endif -%}
-
-{#- Engine configuration: parameters that go into --override-engine-args JSON -#}
-
-{%- if tokens_per_block is defined or (disable_prefix_cache is defined) or kv_cache_dtype is defined -%}
-  {%- set _ = override_dict.update({'kv_cache_config': {}}) -%}
-  {%- if tokens_per_block is defined -%}
-    {%- set _ = override_dict['kv_cache_config'].update({'tokens_per_block': tokens_per_block}) -%}
-  {%- endif -%}
-  {%- if disable_prefix_cache is defined -%}
-    {%- set _ = override_dict['kv_cache_config'].update({'enable_block_reuse': not disable_prefix_cache}) -%}
-  {%- endif -%}
-  {%- if kv_cache_dtype is defined -%}
-    {%- set _ = override_dict['kv_cache_config'].update({'dtype': kv_cache_dtype}) -%}
-  {%- endif -%}
-{%- endif -%}
-
-{%- if cache_transceiver_max_tokens_in_buffer is defined -%}
-  {%- set _ = override_dict.update({'cache_transceiver_config': {'max_tokens_in_buffer': cache_transceiver_max_tokens_in_buffer, 'backend': 'DEFAULT'}}) -%}
-{%- endif -%}
-
-{%- if disable_overlap_scheduler is defined -%}
-  {%- set _ = override_dict.update({'disable_overlap_scheduler': disable_overlap_scheduler}) -%}
-{%- endif -%}
-
-{%- if skip_tokenizer_init is defined -%}
-  {%- set _ = override_dict.update({'skip_tokenizer_init': skip_tokenizer_init}) -%}
-{%- endif -%}
-
-{%- if trust_remote_code is defined -%}
-  {%- set _ = override_dict.update({'trust_remote_code': trust_remote_code}) -%}
-{%- endif -%}
-
-{%- if enable_chunked_prefill is defined -%}
-  {%- set _ = override_dict.update({'enable_chunked_prefill': enable_chunked_prefill}) -%}
-{%- endif -%}
-
-{#- Emit --override-engine-args if we collected any engine config overrides -#}
-{%- if override_dict -%}
-  {%- set json_str = override_dict|tojson|replace('"', '\\"') -%}
-  {%- set _ = args.append('--override-engine-args "' + json_str + '"') -%}
 {%- endif -%}
 
 {#- Output the args -#}

--- a/src/aiconfigurator/generator/rendering/engine.py
+++ b/src/aiconfigurator/generator/rendering/engine.py
@@ -335,6 +335,35 @@ def render_backend_templates(
             context["agg_cli_args_list"] = cli_list
             rendered_templates["cli_args_agg"] = cli
 
+    # ── Translate: append --trtllm.* dynamic flags from extra_engine_args ──
+    # When the profiler path is active (use_dynamo_generator=True) and the
+    # backend is trtllm, convert the rendered extra_engine_args YAML into
+    # --trtllm.<key>.<subkey> <value> flags and merge them into cli_args.
+    # The full YAML is also kept via --extra-engine-args so that list-typed
+    # values (e.g. cuda_graph_config.batch_sizes) survive — dynamo's
+    # infer_type cannot round-trip lists.
+    if use_dynamo_generator and backend == "trtllm":
+        from .translate import yaml_to_dynamic_flags
+
+        for worker in worker_plan:
+            yaml_key = f"extra_engine_args_{worker}.yaml"
+            yaml_content = rendered_templates.get(yaml_key, "")
+            if not yaml_content:
+                continue
+
+            dynamic_flags = yaml_to_dynamic_flags(yaml_content)
+
+            cli_key = f"{worker}_cli_args"
+            list_key = f"{worker}_cli_args_list"
+            tmpl_key = f"cli_args_{worker}"
+
+            existing_list = list(context.get(list_key) or [])
+            existing_list.extend(dynamic_flags)
+            context[list_key] = existing_list
+            cli_str = " ".join(shlex.quote(a) for a in existing_list)
+            context[cli_key] = cli_str
+            rendered_templates[tmpl_key] = cli_str
+
     # Compute GPU counts per worker using rule outputs (minimal fallback)
     pv_params = param_values.get("params", {})
     prefill_gpu = int(pv_params.get("prefill", {}).get("gpus_per_worker") or 1)
@@ -359,8 +388,18 @@ def render_backend_templates(
         k8s_aux = template_path / "k8s_deploy.yaml.j2"
         if k8s_aux.exists():
             try:
+                k8s_context = context
+                # For backends with extra_engine_args templates (trtllm),
+                # suppress cli_args_list so the k8s template uses the
+                # --extra-engine-args file approach instead of inlining
+                # all parameters as redundant CLI flags.
+                if has_engine_templates:
+                    k8s_context = dict(context)
+                    k8s_context["agg_cli_args_list"] = None
+                    k8s_context["prefill_cli_args_list"] = None
+                    k8s_context["decode_cli_args_list"] = None
                 tmpl = env.get_template("k8s_deploy.yaml.j2")
-                rendered = tmpl.render(**context)
+                rendered = tmpl.render(**k8s_context)
                 rendered_templates["k8s_deploy.yaml"] = rendered
             except Exception as e:
                 logger.warning(f"Failed to render template k8s_deploy.yaml.j2: {e}")

--- a/src/aiconfigurator/generator/rendering/engine.py
+++ b/src/aiconfigurator/generator/rendering/engine.py
@@ -339,9 +339,9 @@ def render_backend_templates(
     # When the profiler path is active (use_dynamo_generator=True) and the
     # backend is trtllm, convert the rendered extra_engine_args YAML into
     # --trtllm.<key>.<subkey> <value> flags and merge them into cli_args.
-    # The full YAML is also kept via --extra-engine-args so that list-typed
-    # values (e.g. cuda_graph_config.batch_sizes) survive — dynamo's
-    # infer_type cannot round-trip lists.
+    # Note: list-typed values (e.g. cuda_graph_config.batch_sizes) are skipped
+    # because dynamo's infer_type cannot round-trip lists; the engine uses its
+    # built-in defaults for those fields.
     if use_dynamo_generator and backend == "trtllm":
         from .translate import yaml_to_dynamic_flags
 

--- a/src/aiconfigurator/generator/rendering/translate.py
+++ b/src/aiconfigurator/generator/rendering/translate.py
@@ -18,21 +18,25 @@ import yaml
 logger = logging.getLogger(__name__)
 
 # Top-level YAML keys that already have direct CLI flag equivalents in cli_args.j2.
-DEFAULT_SKIP_KEYS: frozenset[str] = frozenset({
-    "backend",
-    "tensor_parallel_size",
-    "pipeline_parallel_size",
-    "moe_expert_parallel_size",
-    "enable_attention_dp",
-    "max_batch_size",
-    "max_num_tokens",
-    "max_seq_len",
-})
+DEFAULT_SKIP_KEYS: frozenset[str] = frozenset(
+    {
+        "backend",
+        "tensor_parallel_size",
+        "pipeline_parallel_size",
+        "moe_expert_parallel_size",
+        "enable_attention_dp",
+        "max_batch_size",
+        "max_num_tokens",
+        "max_seq_len",
+    }
+)
 
 # Nested keys (as tuples of path components) that already have direct CLI flags.
-DEFAULT_SKIP_NESTED_KEYS: frozenset[tuple[str, ...]] = frozenset({
-    ("kv_cache_config", "free_gpu_memory_fraction"),
-})
+DEFAULT_SKIP_NESTED_KEYS: frozenset[tuple[str, ...]] = frozenset(
+    {
+        ("kv_cache_config", "free_gpu_memory_fraction"),
+    }
+)
 
 
 def _format_value(value: Any) -> str:

--- a/src/aiconfigurator/generator/rendering/translate.py
+++ b/src/aiconfigurator/generator/rendering/translate.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Translate rendered extra_engine_args YAML into --trtllm.* dynamic CLI flags.
+
+When ``use_dynamo_generator=True`` (profiler path), the rendering engine calls
+:func:`yaml_to_dynamic_flags` to convert the version-specific extra_engine_args
+YAML into flat ``--trtllm.<key>.<subkey> <value>`` flags accepted by dynamo >= 1.1.0.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+# Top-level YAML keys that already have direct CLI flag equivalents in cli_args.j2.
+DEFAULT_SKIP_KEYS: frozenset[str] = frozenset({
+    "backend",
+    "tensor_parallel_size",
+    "pipeline_parallel_size",
+    "moe_expert_parallel_size",
+    "enable_attention_dp",
+    "max_batch_size",
+    "max_num_tokens",
+    "max_seq_len",
+})
+
+# Nested keys (as tuples of path components) that already have direct CLI flags.
+DEFAULT_SKIP_NESTED_KEYS: frozenset[tuple[str, ...]] = frozenset({
+    ("kv_cache_config", "free_gpu_memory_fraction"),
+})
+
+
+def _format_value(value: Any) -> str:
+    """Serialize a scalar value for CLI consumption."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+def _walk(
+    data: dict[str, Any],
+    prefix: tuple[str, ...],
+    skip_keys: set[str],
+    skip_nested: set[tuple[str, ...]],
+    out: list[str],
+) -> None:
+    """Recursively walk *data* and append ``--trtllm.key value`` pairs to *out*."""
+    for key, value in data.items():
+        path = prefix + (key,)
+
+        if len(path) == 1 and key in skip_keys:
+            continue
+
+        if path in skip_nested:
+            continue
+
+        if value is None or value == "":
+            continue
+
+        if isinstance(value, dict):
+            _walk(value, path, skip_keys, skip_nested, out)
+            continue
+
+        if isinstance(value, list):
+            logger.debug("Skipping list value at %s", ".".join(path))
+            continue
+
+        flag = "--trtllm." + ".".join(path)
+        out.append(flag)
+        out.append(_format_value(value))
+
+
+def yaml_to_dynamic_flags(
+    yaml_content: str,
+    skip_keys: set[str] | None = None,
+    skip_nested_keys: set[tuple[str, ...]] | None = None,
+) -> list[str]:
+    """Convert rendered extra_engine_args YAML into ``--trtllm.*`` CLI flags.
+
+    Args:
+        yaml_content: Rendered YAML string (from extra_engine_args template).
+        skip_keys: Top-level keys to exclude. Defaults to :data:`DEFAULT_SKIP_KEYS`.
+        skip_nested_keys: Nested key paths to exclude.
+            Defaults to :data:`DEFAULT_SKIP_NESTED_KEYS`.
+
+    Returns:
+        Flat list of alternating flag / value strings, e.g.
+        ``["--trtllm.kv_cache_config.dtype", "auto", ...]``.
+    """
+    if skip_keys is None:
+        skip_keys = DEFAULT_SKIP_KEYS
+    if skip_nested_keys is None:
+        skip_nested_keys = DEFAULT_SKIP_NESTED_KEYS
+
+    data = yaml.safe_load(yaml_content)
+    if not isinstance(data, dict):
+        return []
+
+    out: list[str] = []
+    _walk(data, (), skip_keys, skip_nested_keys, out)
+    return out

--- a/tests/unit/generator/test_translate.py
+++ b/tests/unit/generator/test_translate.py
@@ -9,158 +9,11 @@ from aiconfigurator.generator.rendering.translate import yaml_to_dynamic_flags
 
 
 @pytest.mark.unit
-class TestScalarConversion:
-    """Basic scalar types are converted to --trtllm.key value pairs."""
+class TestYamlToDynamicFlags:
+    """Core behavior: convert rendered extra_engine_args YAML to --trtllm.* flags."""
 
-    def test_top_level_bool_true(self):
-        yaml_content = "disable_overlap_scheduler: true\n"
-        flags = yaml_to_dynamic_flags(yaml_content)
-        assert flags == ["--trtllm.disable_overlap_scheduler", "true"]
-
-    def test_top_level_bool_false(self):
-        yaml_content = "enable_chunked_prefill: false\n"
-        flags = yaml_to_dynamic_flags(yaml_content)
-        assert flags == ["--trtllm.enable_chunked_prefill", "false"]
-
-    def test_top_level_int(self):
-        yaml_content = "tokens_per_block: 32\n"
-        flags = yaml_to_dynamic_flags(yaml_content, skip_keys=set())
-        assert flags == ["--trtllm.tokens_per_block", "32"]
-
-    def test_top_level_float(self):
-        yaml_content = "some_fraction: 0.85\n"
-        flags = yaml_to_dynamic_flags(yaml_content, skip_keys=set())
-        assert flags == ["--trtllm.some_fraction", "0.85"]
-
-    def test_top_level_string(self):
-        yaml_content = "kv_cache_dtype: auto\n"
-        flags = yaml_to_dynamic_flags(yaml_content, skip_keys=set())
-        assert flags == ["--trtllm.kv_cache_dtype", "auto"]
-
-
-@pytest.mark.unit
-class TestNestedConversion:
-    """Nested dicts produce dotted key paths."""
-
-    def test_one_level_nesting(self):
-        yaml_content = (
-            "kv_cache_config:\n"
-            "  dtype: auto\n"
-            "  enable_block_reuse: true\n"
-        )
-        flags = yaml_to_dynamic_flags(yaml_content, skip_keys=set())
-        assert "--trtllm.kv_cache_config.dtype" in flags
-        idx = flags.index("--trtllm.kv_cache_config.dtype")
-        assert flags[idx + 1] == "auto"
-        assert "--trtllm.kv_cache_config.enable_block_reuse" in flags
-        idx2 = flags.index("--trtllm.kv_cache_config.enable_block_reuse")
-        assert flags[idx2 + 1] == "true"
-
-    def test_two_level_nesting(self):
-        yaml_content = (
-            "speculative_config:\n"
-            "  decoding_type: MTP\n"
-        )
-        flags = yaml_to_dynamic_flags(yaml_content, skip_keys=set())
-        assert flags == ["--trtllm.speculative_config.decoding_type", "MTP"]
-
-    def test_cache_transceiver_config(self):
-        yaml_content = (
-            "cache_transceiver_config:\n"
-            "  backend: DEFAULT\n"
-            "  max_tokens_in_buffer: 6528\n"
-        )
-        flags = yaml_to_dynamic_flags(yaml_content, skip_keys=set())
-        assert "--trtllm.cache_transceiver_config.backend" in flags
-        assert "--trtllm.cache_transceiver_config.max_tokens_in_buffer" in flags
-        idx = flags.index("--trtllm.cache_transceiver_config.max_tokens_in_buffer")
-        assert flags[idx + 1] == "6528"
-
-
-@pytest.mark.unit
-class TestSkipKeys:
-    """Keys in the skip lists are excluded from output."""
-
-    def test_default_skip_keys(self):
-        yaml_content = (
-            "backend: pytorch\n"
-            "tensor_parallel_size: 4\n"
-            "pipeline_parallel_size: 1\n"
-            "max_batch_size: 512\n"
-            "max_num_tokens: 8192\n"
-            "disable_overlap_scheduler: true\n"
-        )
-        flags = yaml_to_dynamic_flags(yaml_content)
-        flag_names = flags[::2]
-        assert "--trtllm.backend" not in flag_names
-        assert "--trtllm.tensor_parallel_size" not in flag_names
-        assert "--trtllm.pipeline_parallel_size" not in flag_names
-        assert "--trtllm.max_batch_size" not in flag_names
-        assert "--trtllm.max_num_tokens" not in flag_names
-        assert "--trtllm.disable_overlap_scheduler" in flag_names
-
-    def test_default_skip_nested_keys(self):
-        yaml_content = (
-            "kv_cache_config:\n"
-            "  free_gpu_memory_fraction: 0.80\n"
-            "  dtype: auto\n"
-        )
-        flags = yaml_to_dynamic_flags(yaml_content)
-        flag_names = flags[::2]
-        assert "--trtllm.kv_cache_config.free_gpu_memory_fraction" not in flag_names
-        assert "--trtllm.kv_cache_config.dtype" in flag_names
-
-    def test_custom_skip_keys(self):
-        yaml_content = "my_key: 42\n"
-        flags = yaml_to_dynamic_flags(yaml_content, skip_keys={"my_key"})
-        assert flags == []
-
-    def test_custom_skip_nested_keys(self):
-        yaml_content = (
-            "group:\n"
-            "  keep_me: 1\n"
-            "  skip_me: 2\n"
-        )
-        flags = yaml_to_dynamic_flags(
-            yaml_content,
-            skip_keys=set(),
-            skip_nested_keys={("group", "skip_me")},
-        )
-        assert "--trtllm.group.keep_me" in flags
-        assert "--trtllm.group.skip_me" not in flags
-
-
-@pytest.mark.unit
-class TestSkipValues:
-    """None, empty strings, and list values are skipped."""
-
-    def test_none_value_skipped(self):
-        yaml_content = "trust_remote_code:\n"
-        flags = yaml_to_dynamic_flags(yaml_content, skip_keys=set())
-        assert flags == []
-
-    def test_empty_string_skipped(self):
-        yaml_content = "trust_remote_code: ''\n"
-        flags = yaml_to_dynamic_flags(yaml_content, skip_keys=set())
-        assert flags == []
-
-    def test_list_value_skipped(self):
-        yaml_content = (
-            "cuda_graph_config:\n"
-            "  batch_sizes: [1, 2, 4, 8, 16]\n"
-            "  enable_padding: true\n"
-        )
-        flags = yaml_to_dynamic_flags(yaml_content, skip_keys=set())
-        flag_names = flags[::2]
-        assert "--trtllm.cuda_graph_config.batch_sizes" not in flag_names
-        assert "--trtllm.cuda_graph_config.enable_padding" in flag_names
-
-
-@pytest.mark.unit
-class TestRealisticYaml:
-    """End-to-end test with a realistic rendered extra_engine_args YAML."""
-
-    def test_full_yaml(self):
+    def test_realistic_yaml(self):
+        """Full YAML covering scalars, nesting, default skips, and list skip."""
         yaml_content = (
             "backend: pytorch\n"
             "\n"
@@ -193,16 +46,18 @@ class TestRealisticYaml:
         flags = yaml_to_dynamic_flags(yaml_content)
         pairs = dict(zip(flags[::2], flags[1::2]))
 
-        assert "--trtllm.backend" not in pairs
-        assert "--trtllm.tensor_parallel_size" not in pairs
-        assert "--trtllm.pipeline_parallel_size" not in pairs
-        assert "--trtllm.enable_attention_dp" not in pairs
-        assert "--trtllm.max_batch_size" not in pairs
-        assert "--trtllm.max_num_tokens" not in pairs
-        assert "--trtllm.max_seq_len" not in pairs
+        # DEFAULT_SKIP_KEYS must be absent
+        for key in ("backend", "tensor_parallel_size", "pipeline_parallel_size",
+                     "enable_attention_dp", "max_batch_size", "max_num_tokens", "max_seq_len"):
+            assert f"--trtllm.{key}" not in pairs
+
+        # DEFAULT_SKIP_NESTED_KEYS must be absent
         assert "--trtllm.kv_cache_config.free_gpu_memory_fraction" not in pairs
+
+        # List values must be absent
         assert "--trtllm.cuda_graph_config.batch_sizes" not in pairs
 
+        # Present scalar engine params (covers bool, int, str, nested)
         assert pairs["--trtllm.enable_chunked_prefill"] == "true"
         assert pairs["--trtllm.kv_cache_config.dtype"] == "auto"
         assert pairs["--trtllm.kv_cache_config.tokens_per_block"] == "32"
@@ -212,3 +67,36 @@ class TestRealisticYaml:
         assert pairs["--trtllm.cuda_graph_config.enable_padding"] == "true"
         assert pairs["--trtllm.disable_overlap_scheduler"] == "false"
         assert pairs["--trtllm.print_iter_log"] == "false"
+
+    def test_none_and_empty_values_skipped(self):
+        """None and empty-string values produce no flags."""
+        yaml_content = (
+            "trust_remote_code:\n"       # YAML null
+            "skip_tokenizer_init: ''\n"  # empty string
+            "enable_chunked_prefill: true\n"
+        )
+        flags = yaml_to_dynamic_flags(yaml_content, skip_keys=set())
+        assert flags == ["--trtllm.enable_chunked_prefill", "true"]
+
+    def test_custom_skip_keys(self):
+        """Callers can override the skip lists."""
+        yaml_content = (
+            "group:\n"
+            "  keep_me: 1\n"
+            "  skip_me: 2\n"
+            "skip_top: 42\n"
+        )
+        flags = yaml_to_dynamic_flags(
+            yaml_content,
+            skip_keys={"skip_top"},
+            skip_nested_keys={("group", "skip_me")},
+        )
+        flag_names = flags[::2]
+        assert "--trtllm.group.keep_me" in flag_names
+        assert "--trtllm.group.skip_me" not in flag_names
+        assert "--trtllm.skip_top" not in flag_names
+
+    def test_empty_yaml_returns_empty_list(self):
+        """Empty or null YAML input returns an empty flag list."""
+        assert yaml_to_dynamic_flags("") == []
+        assert yaml_to_dynamic_flags("---\n") == []

--- a/tests/unit/generator/test_translate.py
+++ b/tests/unit/generator/test_translate.py
@@ -44,7 +44,7 @@ class TestYamlToDynamicFlags:
             "print_iter_log: false\n"
         )
         flags = yaml_to_dynamic_flags(yaml_content)
-        pairs = dict(zip(flags[::2], flags[1::2]))
+        pairs = dict(zip(flags[::2], flags[1::2], strict=True))
 
         # DEFAULT_SKIP_KEYS must be absent
         for key in (

--- a/tests/unit/generator/test_translate.py
+++ b/tests/unit/generator/test_translate.py
@@ -1,0 +1,214 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for rendering.translate — YAML to --trtllm.* dynamic CLI flags."""
+
+import pytest
+
+from aiconfigurator.generator.rendering.translate import yaml_to_dynamic_flags
+
+
+@pytest.mark.unit
+class TestScalarConversion:
+    """Basic scalar types are converted to --trtllm.key value pairs."""
+
+    def test_top_level_bool_true(self):
+        yaml_content = "disable_overlap_scheduler: true\n"
+        flags = yaml_to_dynamic_flags(yaml_content)
+        assert flags == ["--trtllm.disable_overlap_scheduler", "true"]
+
+    def test_top_level_bool_false(self):
+        yaml_content = "enable_chunked_prefill: false\n"
+        flags = yaml_to_dynamic_flags(yaml_content)
+        assert flags == ["--trtllm.enable_chunked_prefill", "false"]
+
+    def test_top_level_int(self):
+        yaml_content = "tokens_per_block: 32\n"
+        flags = yaml_to_dynamic_flags(yaml_content, skip_keys=set())
+        assert flags == ["--trtllm.tokens_per_block", "32"]
+
+    def test_top_level_float(self):
+        yaml_content = "some_fraction: 0.85\n"
+        flags = yaml_to_dynamic_flags(yaml_content, skip_keys=set())
+        assert flags == ["--trtllm.some_fraction", "0.85"]
+
+    def test_top_level_string(self):
+        yaml_content = "kv_cache_dtype: auto\n"
+        flags = yaml_to_dynamic_flags(yaml_content, skip_keys=set())
+        assert flags == ["--trtllm.kv_cache_dtype", "auto"]
+
+
+@pytest.mark.unit
+class TestNestedConversion:
+    """Nested dicts produce dotted key paths."""
+
+    def test_one_level_nesting(self):
+        yaml_content = (
+            "kv_cache_config:\n"
+            "  dtype: auto\n"
+            "  enable_block_reuse: true\n"
+        )
+        flags = yaml_to_dynamic_flags(yaml_content, skip_keys=set())
+        assert "--trtllm.kv_cache_config.dtype" in flags
+        idx = flags.index("--trtllm.kv_cache_config.dtype")
+        assert flags[idx + 1] == "auto"
+        assert "--trtllm.kv_cache_config.enable_block_reuse" in flags
+        idx2 = flags.index("--trtllm.kv_cache_config.enable_block_reuse")
+        assert flags[idx2 + 1] == "true"
+
+    def test_two_level_nesting(self):
+        yaml_content = (
+            "speculative_config:\n"
+            "  decoding_type: MTP\n"
+        )
+        flags = yaml_to_dynamic_flags(yaml_content, skip_keys=set())
+        assert flags == ["--trtllm.speculative_config.decoding_type", "MTP"]
+
+    def test_cache_transceiver_config(self):
+        yaml_content = (
+            "cache_transceiver_config:\n"
+            "  backend: DEFAULT\n"
+            "  max_tokens_in_buffer: 6528\n"
+        )
+        flags = yaml_to_dynamic_flags(yaml_content, skip_keys=set())
+        assert "--trtllm.cache_transceiver_config.backend" in flags
+        assert "--trtllm.cache_transceiver_config.max_tokens_in_buffer" in flags
+        idx = flags.index("--trtllm.cache_transceiver_config.max_tokens_in_buffer")
+        assert flags[idx + 1] == "6528"
+
+
+@pytest.mark.unit
+class TestSkipKeys:
+    """Keys in the skip lists are excluded from output."""
+
+    def test_default_skip_keys(self):
+        yaml_content = (
+            "backend: pytorch\n"
+            "tensor_parallel_size: 4\n"
+            "pipeline_parallel_size: 1\n"
+            "max_batch_size: 512\n"
+            "max_num_tokens: 8192\n"
+            "disable_overlap_scheduler: true\n"
+        )
+        flags = yaml_to_dynamic_flags(yaml_content)
+        flag_names = flags[::2]
+        assert "--trtllm.backend" not in flag_names
+        assert "--trtllm.tensor_parallel_size" not in flag_names
+        assert "--trtllm.pipeline_parallel_size" not in flag_names
+        assert "--trtllm.max_batch_size" not in flag_names
+        assert "--trtllm.max_num_tokens" not in flag_names
+        assert "--trtllm.disable_overlap_scheduler" in flag_names
+
+    def test_default_skip_nested_keys(self):
+        yaml_content = (
+            "kv_cache_config:\n"
+            "  free_gpu_memory_fraction: 0.80\n"
+            "  dtype: auto\n"
+        )
+        flags = yaml_to_dynamic_flags(yaml_content)
+        flag_names = flags[::2]
+        assert "--trtllm.kv_cache_config.free_gpu_memory_fraction" not in flag_names
+        assert "--trtllm.kv_cache_config.dtype" in flag_names
+
+    def test_custom_skip_keys(self):
+        yaml_content = "my_key: 42\n"
+        flags = yaml_to_dynamic_flags(yaml_content, skip_keys={"my_key"})
+        assert flags == []
+
+    def test_custom_skip_nested_keys(self):
+        yaml_content = (
+            "group:\n"
+            "  keep_me: 1\n"
+            "  skip_me: 2\n"
+        )
+        flags = yaml_to_dynamic_flags(
+            yaml_content,
+            skip_keys=set(),
+            skip_nested_keys={("group", "skip_me")},
+        )
+        assert "--trtllm.group.keep_me" in flags
+        assert "--trtllm.group.skip_me" not in flags
+
+
+@pytest.mark.unit
+class TestSkipValues:
+    """None, empty strings, and list values are skipped."""
+
+    def test_none_value_skipped(self):
+        yaml_content = "trust_remote_code:\n"
+        flags = yaml_to_dynamic_flags(yaml_content, skip_keys=set())
+        assert flags == []
+
+    def test_empty_string_skipped(self):
+        yaml_content = "trust_remote_code: ''\n"
+        flags = yaml_to_dynamic_flags(yaml_content, skip_keys=set())
+        assert flags == []
+
+    def test_list_value_skipped(self):
+        yaml_content = (
+            "cuda_graph_config:\n"
+            "  batch_sizes: [1, 2, 4, 8, 16]\n"
+            "  enable_padding: true\n"
+        )
+        flags = yaml_to_dynamic_flags(yaml_content, skip_keys=set())
+        flag_names = flags[::2]
+        assert "--trtllm.cuda_graph_config.batch_sizes" not in flag_names
+        assert "--trtllm.cuda_graph_config.enable_padding" in flag_names
+
+
+@pytest.mark.unit
+class TestRealisticYaml:
+    """End-to-end test with a realistic rendered extra_engine_args YAML."""
+
+    def test_full_yaml(self):
+        yaml_content = (
+            "backend: pytorch\n"
+            "\n"
+            "tensor_parallel_size: 4\n"
+            "pipeline_parallel_size: 1\n"
+            "enable_attention_dp: false\n"
+            "enable_chunked_prefill: true\n"
+            "\n"
+            "max_batch_size: 512\n"
+            "max_num_tokens: 8192\n"
+            "max_seq_len: 4096\n"
+            "\n"
+            "kv_cache_config:\n"
+            "  free_gpu_memory_fraction: 0.80\n"
+            "  dtype: auto\n"
+            "  tokens_per_block: 32\n"
+            "  enable_block_reuse: false\n"
+            "\n"
+            "cache_transceiver_config:\n"
+            "  backend: DEFAULT\n"
+            "  max_tokens_in_buffer: 6528\n"
+            "\n"
+            "cuda_graph_config:\n"
+            "  enable_padding: true\n"
+            "  batch_sizes: [1, 2, 4, 8, 16, 32, 64, 128, 256]\n"
+            "\n"
+            "disable_overlap_scheduler: false\n"
+            "print_iter_log: false\n"
+        )
+        flags = yaml_to_dynamic_flags(yaml_content)
+        pairs = dict(zip(flags[::2], flags[1::2]))
+
+        assert "--trtllm.backend" not in pairs
+        assert "--trtllm.tensor_parallel_size" not in pairs
+        assert "--trtllm.pipeline_parallel_size" not in pairs
+        assert "--trtllm.enable_attention_dp" not in pairs
+        assert "--trtllm.max_batch_size" not in pairs
+        assert "--trtllm.max_num_tokens" not in pairs
+        assert "--trtllm.max_seq_len" not in pairs
+        assert "--trtllm.kv_cache_config.free_gpu_memory_fraction" not in pairs
+        assert "--trtllm.cuda_graph_config.batch_sizes" not in pairs
+
+        assert pairs["--trtllm.enable_chunked_prefill"] == "true"
+        assert pairs["--trtllm.kv_cache_config.dtype"] == "auto"
+        assert pairs["--trtllm.kv_cache_config.tokens_per_block"] == "32"
+        assert pairs["--trtllm.kv_cache_config.enable_block_reuse"] == "false"
+        assert pairs["--trtllm.cache_transceiver_config.backend"] == "DEFAULT"
+        assert pairs["--trtllm.cache_transceiver_config.max_tokens_in_buffer"] == "6528"
+        assert pairs["--trtllm.cuda_graph_config.enable_padding"] == "true"
+        assert pairs["--trtllm.disable_overlap_scheduler"] == "false"
+        assert pairs["--trtllm.print_iter_log"] == "false"

--- a/tests/unit/generator/test_translate.py
+++ b/tests/unit/generator/test_translate.py
@@ -47,8 +47,15 @@ class TestYamlToDynamicFlags:
         pairs = dict(zip(flags[::2], flags[1::2]))
 
         # DEFAULT_SKIP_KEYS must be absent
-        for key in ("backend", "tensor_parallel_size", "pipeline_parallel_size",
-                     "enable_attention_dp", "max_batch_size", "max_num_tokens", "max_seq_len"):
+        for key in (
+            "backend",
+            "tensor_parallel_size",
+            "pipeline_parallel_size",
+            "enable_attention_dp",
+            "max_batch_size",
+            "max_num_tokens",
+            "max_seq_len",
+        ):
             assert f"--trtllm.{key}" not in pairs
 
         # DEFAULT_SKIP_NESTED_KEYS must be absent
@@ -71,7 +78,7 @@ class TestYamlToDynamicFlags:
     def test_none_and_empty_values_skipped(self):
         """None and empty-string values produce no flags."""
         yaml_content = (
-            "trust_remote_code:\n"       # YAML null
+            "trust_remote_code:\n"  # YAML null
             "skip_tokenizer_init: ''\n"  # empty string
             "enable_chunked_prefill: true\n"
         )
@@ -80,12 +87,7 @@ class TestYamlToDynamicFlags:
 
     def test_custom_skip_keys(self):
         """Callers can override the skip lists."""
-        yaml_content = (
-            "group:\n"
-            "  keep_me: 1\n"
-            "  skip_me: 2\n"
-            "skip_top: 42\n"
-        )
+        yaml_content = "group:\n  keep_me: 1\n  skip_me: 2\nskip_top: 42\n"
         flags = yaml_to_dynamic_flags(
             yaml_content,
             skip_keys={"skip_top"},

--- a/tests/unit/generator/test_trtllm_cli_args.py
+++ b/tests/unit/generator/test_trtllm_cli_args.py
@@ -1,10 +1,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit tests for the trtllm cli_args.j2 template (NVBug 5974038)."""
+"""Unit tests for the trtllm cli_args.j2 template.
 
-import json
-import shlex
+After the translate module was introduced, cli_args.j2 only emits direct CLI
+flags accepted by dynamo.trtllm's argparser.  Model path, served model name,
+and override-engine-args are no longer part of this template.
+"""
+
 from pathlib import Path
 
 import pytest
@@ -36,77 +39,31 @@ def _render(template, **ctx) -> str:
     return template.render(**ctx).strip()
 
 
-def _parse_override_engine_args(rendered: str) -> dict:
-    """Extract and parse the JSON value of --override-engine-args from rendered CLI string."""
-    args = shlex.split(rendered)
-    idx = args.index("--override-engine-args")
-    return json.loads(args[idx + 1])
-
-
-@pytest.mark.unit
-class TestCacheTransceiverConfig:
-    """Regression tests for NVBug 5974038: cache_transceiver_config.backend missing in disagg config."""
-
-    def test_backend_field_present_when_cache_transceiver_defined(self, cli_args_template):
-        """cache_transceiver_config must include backend: DEFAULT — the missing field that caused AssertionError."""
-        rendered = _render(
-            cli_args_template,
-            ServiceConfig={"model_path": "Qwen/Qwen3-0.6B"},
-            cache_transceiver_max_tokens_in_buffer=6528,
-        )
-        override = _parse_override_engine_args(rendered)
-        assert "cache_transceiver_config" in override
-        assert override["cache_transceiver_config"]["backend"] == "DEFAULT"
-
-    def test_max_tokens_in_buffer_field_present(self, cli_args_template):
-        """cache_transceiver_config must also retain max_tokens_in_buffer."""
-        rendered = _render(
-            cli_args_template,
-            ServiceConfig={"model_path": "Qwen/Qwen3-0.6B"},
-            cache_transceiver_max_tokens_in_buffer=6528,
-        )
-        override = _parse_override_engine_args(rendered)
-        assert override["cache_transceiver_config"]["max_tokens_in_buffer"] == 6528
-
-    def test_cache_transceiver_absent_when_not_defined(self, cli_args_template):
-        """cache_transceiver_config must not appear if cache_transceiver_max_tokens_in_buffer is not set."""
-        rendered = _render(
-            cli_args_template,
-            ServiceConfig={"model_path": "Qwen/Qwen3-0.6B"},
-        )
-        assert "cache_transceiver_config" not in rendered
-
-    def test_cache_transceiver_combined_with_other_engine_args(self, cli_args_template):
-        """cache_transceiver_config coexists correctly with kv_cache_config and disable_overlap_scheduler."""
-        rendered = _render(
-            cli_args_template,
-            ServiceConfig={"model_path": "Qwen/Qwen3-0.6B"},
-            cache_transceiver_max_tokens_in_buffer=6528,
-            tokens_per_block=32,
-            kv_cache_dtype="auto",
-            disable_overlap_scheduler=True,
-        )
-        override = _parse_override_engine_args(rendered)
-        assert override["cache_transceiver_config"] == {"max_tokens_in_buffer": 6528, "backend": "DEFAULT"}
-        assert override["kv_cache_config"]["tokens_per_block"] == 32
-        assert override["kv_cache_config"]["dtype"] == "auto"
-        assert override["disable_overlap_scheduler"] is True
-
-
 @pytest.mark.unit
 class TestDirectCliArgs:
     """Tests for flags that map directly to dynamo.trtllm argparser."""
 
-    def test_model_path(self, cli_args_template):
+    def test_no_model_path(self, cli_args_template):
+        """model-path is no longer in cli_args.j2."""
         rendered = _render(cli_args_template, ServiceConfig={"model_path": "Qwen/Qwen3-32B"})
-        assert '--model-path "Qwen/Qwen3-32B"' in rendered
+        assert "--model-path" not in rendered
 
-    def test_served_model_name(self, cli_args_template):
+    def test_no_served_model_name(self, cli_args_template):
         rendered = _render(
             cli_args_template,
             ServiceConfig={"model_path": "m", "served_model_name": "my-model"},
         )
-        assert '--served-model-name "my-model"' in rendered
+        assert "--served-model-name" not in rendered
+
+    def test_no_override_engine_args(self, cli_args_template):
+        """override-engine-args block is removed."""
+        rendered = _render(
+            cli_args_template,
+            ServiceConfig={},
+            tokens_per_block=32,
+            disable_overlap_scheduler=True,
+        )
+        assert "--override-engine-args" not in rendered
 
     def test_tensor_parallel_size(self, cli_args_template):
         rendered = _render(cli_args_template, ServiceConfig={}, tensor_parallel_size=4)
@@ -151,65 +108,3 @@ class TestDirectCliArgs:
     def test_free_gpu_memory_fraction(self, cli_args_template):
         rendered = _render(cli_args_template, ServiceConfig={}, kv_cache_free_gpu_memory_fraction=0.9)
         assert "--free-gpu-memory-fraction 0.9" in rendered
-
-
-@pytest.mark.unit
-class TestOverrideEngineArgs:
-    """Tests for parameters that go into --override-engine-args JSON."""
-
-    def test_no_override_engine_args_when_empty(self, cli_args_template):
-        rendered = _render(cli_args_template, ServiceConfig={"model_path": "m"})
-        assert "--override-engine-args" not in rendered
-
-    def test_kv_cache_tokens_per_block(self, cli_args_template):
-        rendered = _render(cli_args_template, ServiceConfig={}, tokens_per_block=32)
-        override = _parse_override_engine_args(rendered)
-        assert override["kv_cache_config"]["tokens_per_block"] == 32
-
-    def test_kv_cache_dtype(self, cli_args_template):
-        rendered = _render(cli_args_template, ServiceConfig={}, kv_cache_dtype="fp8")
-        override = _parse_override_engine_args(rendered)
-        assert override["kv_cache_config"]["dtype"] == "fp8"
-
-    def test_disable_prefix_cache_sets_enable_block_reuse_false(self, cli_args_template):
-        rendered = _render(cli_args_template, ServiceConfig={}, disable_prefix_cache=True)
-        override = _parse_override_engine_args(rendered)
-        assert override["kv_cache_config"]["enable_block_reuse"] is False
-
-    def test_enable_prefix_cache_sets_enable_block_reuse_true(self, cli_args_template):
-        rendered = _render(cli_args_template, ServiceConfig={}, disable_prefix_cache=False)
-        override = _parse_override_engine_args(rendered)
-        assert override["kv_cache_config"]["enable_block_reuse"] is True
-
-    def test_disable_overlap_scheduler(self, cli_args_template):
-        rendered = _render(cli_args_template, ServiceConfig={}, disable_overlap_scheduler=True)
-        override = _parse_override_engine_args(rendered)
-        assert override["disable_overlap_scheduler"] is True
-
-    def test_skip_tokenizer_init(self, cli_args_template):
-        rendered = _render(cli_args_template, ServiceConfig={}, skip_tokenizer_init=True)
-        override = _parse_override_engine_args(rendered)
-        assert override["skip_tokenizer_init"] is True
-
-    def test_trust_remote_code(self, cli_args_template):
-        rendered = _render(cli_args_template, ServiceConfig={}, trust_remote_code=True)
-        override = _parse_override_engine_args(rendered)
-        assert override["trust_remote_code"] is True
-
-    def test_enable_chunked_prefill(self, cli_args_template):
-        rendered = _render(cli_args_template, ServiceConfig={}, enable_chunked_prefill=True)
-        override = _parse_override_engine_args(rendered)
-        assert override["enable_chunked_prefill"] is True
-
-    def test_override_engine_args_json_is_valid(self, cli_args_template):
-        """The escaped JSON in --override-engine-args must round-trip cleanly through shlex."""
-        rendered = _render(
-            cli_args_template,
-            ServiceConfig={"model_path": "Qwen/Qwen3-0.6B"},
-            cache_transceiver_max_tokens_in_buffer=6528,
-            tokens_per_block=32,
-            kv_cache_dtype="auto",
-            disable_overlap_scheduler=True,
-        )
-        override = _parse_override_engine_args(rendered)
-        assert isinstance(override, dict)

--- a/tests/unit/generator/test_trtllm_cli_args.py
+++ b/tests/unit/generator/test_trtllm_cli_args.py
@@ -35,7 +35,6 @@ def cli_args_template():
 
 @pytest.mark.unit
 class TestCliArgsTemplate:
-
     def test_emits_all_direct_flags(self, cli_args_template):
         """All direct argparser flags are present when their values are set."""
         rendered = cli_args_template.render(

--- a/tests/unit/generator/test_trtllm_cli_args.py
+++ b/tests/unit/generator/test_trtllm_cli_args.py
@@ -3,9 +3,8 @@
 
 """Unit tests for the trtllm cli_args.j2 template.
 
-After the translate module was introduced, cli_args.j2 only emits direct CLI
-flags accepted by dynamo.trtllm's argparser.  Model path, served model name,
-and override-engine-args are no longer part of this template.
+cli_args.j2 only emits direct CLI flags accepted by dynamo.trtllm's argparser.
+Model path, served model name, and override-engine-args are handled elsewhere.
 """
 
 from pathlib import Path
@@ -34,77 +33,48 @@ def cli_args_template():
     return env.get_template("cli_args.j2")
 
 
-def _render(template, **ctx) -> str:
-    """Render the template and return stripped output."""
-    return template.render(**ctx).strip()
-
-
 @pytest.mark.unit
-class TestDirectCliArgs:
-    """Tests for flags that map directly to dynamo.trtllm argparser."""
+class TestCliArgsTemplate:
 
-    def test_no_model_path(self, cli_args_template):
-        """model-path is no longer in cli_args.j2."""
-        rendered = _render(cli_args_template, ServiceConfig={"model_path": "Qwen/Qwen3-32B"})
+    def test_emits_all_direct_flags(self, cli_args_template):
+        """All direct argparser flags are present when their values are set."""
+        rendered = cli_args_template.render(
+            ServiceConfig={"model_path": "Qwen/Qwen3-32B", "served_model_name": "my-model"},
+            tensor_parallel_size=4,
+            pipeline_parallel_size=2,
+            moe_expert_parallel_size=8,
+            enable_attention_dp=True,
+            max_batch_size=64,
+            max_num_tokens=8192,
+            max_seq_len=4096,
+            kv_cache_free_gpu_memory_fraction=0.9,
+        ).strip()
+
+        assert "--tensor-parallel-size 4" in rendered
+        assert "--pipeline-parallel-size 2" in rendered
+        assert "--expert-parallel-size 8" in rendered
+        assert "--enable-attention-dp" in rendered
+        assert "--max-batch-size 64" in rendered
+        assert "--max-num-tokens 8192" in rendered
+        assert "--max-seq-len 4096" in rendered
+        assert "--free-gpu-memory-fraction 0.9" in rendered
+
+        # These must NOT be in the template (handled elsewhere)
         assert "--model-path" not in rendered
-
-    def test_no_served_model_name(self, cli_args_template):
-        rendered = _render(
-            cli_args_template,
-            ServiceConfig={"model_path": "m", "served_model_name": "my-model"},
-        )
         assert "--served-model-name" not in rendered
-
-    def test_no_override_engine_args(self, cli_args_template):
-        """override-engine-args block is removed."""
-        rendered = _render(
-            cli_args_template,
-            ServiceConfig={},
-            tokens_per_block=32,
-            disable_overlap_scheduler=True,
-        )
         assert "--override-engine-args" not in rendered
 
-    def test_tensor_parallel_size(self, cli_args_template):
-        rendered = _render(cli_args_template, ServiceConfig={}, tensor_parallel_size=4)
-        assert "--tensor-parallel-size 4" in rendered
+    def test_omits_flags_with_zero_or_false_values(self, cli_args_template):
+        """Flags are omitted when values are zero, False, or None."""
+        rendered = cli_args_template.render(
+            ServiceConfig={},
+            tensor_parallel_size=0,
+            pipeline_parallel_size=0,
+            moe_expert_parallel_size=None,
+            enable_attention_dp=False,
+        ).strip()
 
-    def test_tensor_parallel_size_zero_omitted(self, cli_args_template):
-        rendered = _render(cli_args_template, ServiceConfig={}, tensor_parallel_size=0)
         assert "--tensor-parallel-size" not in rendered
-
-    def test_pipeline_parallel_size(self, cli_args_template):
-        rendered = _render(cli_args_template, ServiceConfig={}, pipeline_parallel_size=2)
-        assert "--pipeline-parallel-size 2" in rendered
-
-    def test_expert_parallel_size(self, cli_args_template):
-        rendered = _render(cli_args_template, ServiceConfig={}, moe_expert_parallel_size=8)
-        assert "--expert-parallel-size 8" in rendered
-
-    def test_expert_parallel_size_none_omitted(self, cli_args_template):
-        rendered = _render(cli_args_template, ServiceConfig={}, moe_expert_parallel_size=None)
+        assert "--pipeline-parallel-size" not in rendered
         assert "--expert-parallel-size" not in rendered
-
-    def test_enable_attention_dp(self, cli_args_template):
-        rendered = _render(cli_args_template, ServiceConfig={}, enable_attention_dp=True)
-        assert "--enable-attention-dp" in rendered
-
-    def test_enable_attention_dp_false_omitted(self, cli_args_template):
-        rendered = _render(cli_args_template, ServiceConfig={}, enable_attention_dp=False)
         assert "--enable-attention-dp" not in rendered
-
-    def test_max_batch_size(self, cli_args_template):
-        rendered = _render(cli_args_template, ServiceConfig={}, max_batch_size=64)
-        assert "--max-batch-size 64" in rendered
-
-    def test_max_num_tokens(self, cli_args_template):
-        rendered = _render(cli_args_template, ServiceConfig={}, max_num_tokens=8192)
-        assert "--max-num-tokens 8192" in rendered
-
-    def test_max_seq_len(self, cli_args_template):
-        rendered = _render(cli_args_template, ServiceConfig={}, max_seq_len=4096)
-        assert "--max-seq-len 4096" in rendered
-
-    def test_free_gpu_memory_fraction(self, cli_args_template):
-        rendered = _render(cli_args_template, ServiceConfig={}, kv_cache_free_gpu_memory_fraction=0.9)
-        assert "--free-gpu-memory-fraction 0.9" in rendered

--- a/tests/unit/generator/test_trtllm_extra_engine_args.py
+++ b/tests/unit/generator/test_trtllm_extra_engine_args.py
@@ -1,0 +1,483 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for trtllm k8s_deploy generation with extra_engine_args vs cli_args.
+
+Verifies that:
+- use_dynamo_generator=False → k8s_deploy uses --extra-engine-args file approach
+  (no redundant CLI flags like --tensor-parallel-size in container args)
+- use_dynamo_generator=True  → cli_args_list is computed and available for
+  _generate_k8s_via_dynamo / build_dgd_config (profiler path)
+"""
+
+import json
+import shlex
+
+import pytest
+import yaml
+
+from aiconfigurator.generator.rendering.engine import render_backend_templates
+
+# Shared params dict that mirrors a typical CLI invocation:
+#   aiconfigurator cli default --backend trtllm --model-path Qwen/Qwen3-32B-FP8
+#   --system h200_sxm --total-gpus 8 --isl 5000 --osl 1000 --ttft 2000 --tpot 50
+_BASE_PARAMS = {
+    "ServiceConfig": {
+        "model_path": "Qwen/Qwen3-32B-FP8",
+        "served_model_path": "Qwen/Qwen3-32B-FP8",
+        "served_model_name": "Qwen/Qwen3-32B-FP8",
+    },
+    "K8sConfig": {
+        "k8s_image": "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.0.0",
+        "k8s_namespace": "ets-dynamo",
+    },
+    "DynConfig": {"mode": "agg"},
+    "WorkerConfig": {
+        "agg_workers": 8,
+        "agg_gpus_per_worker": 1,
+        "prefill_workers": 0,
+        "decode_workers": 0,
+    },
+    "NodeConfig": {"num_gpus_per_node": 8},
+    "params": {
+        "agg": {
+            "tensor_parallel_size": 1,
+            "pipeline_parallel_size": 1,
+            "max_batch_size": 128,
+            "max_num_tokens": 16384,
+            "kv_cache_free_gpu_memory_fraction": 0.80,
+            "enable_chunked_prefill": False,
+            "disable_overlap_scheduler": True,
+            "gpus_per_worker": 1,
+        }
+    },
+}
+
+
+def _build_params(**overrides):
+    """Deep-copy base params and apply top-level overrides."""
+    import copy
+
+    params = copy.deepcopy(_BASE_PARAMS)
+    for key, val in overrides.items():
+        if isinstance(val, dict) and isinstance(params.get(key), dict):
+            params[key].update(val)
+        else:
+            params[key] = val
+    return params
+
+
+def _extract_args_block(k8s_yaml: str) -> str:
+    """Extract the bash ``args=(...)`` block from rendered k8s_deploy.yaml."""
+    lines = k8s_yaml.split("\n")
+    collecting = False
+    block: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if "args=(" in stripped:
+            collecting = True
+            block = [stripped]
+            continue
+        if collecting:
+            block.append(stripped)
+            if stripped == ")":
+                break
+    return "\n".join(block)
+
+
+# ---------------------------------------------------------------------------
+# use_dynamo_generator=False  (normal / standalone path)
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestExtraEngineArgsMode:
+    """When use_dynamo_generator=False, trtllm k8s_deploy should use the
+    --extra-engine-args file approach with NO redundant inline CLI flags."""
+
+    def test_k8s_deploy_uses_extra_engine_args_file(self):
+        params = _build_params()
+        artifacts = render_backend_templates(
+            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=False
+        )
+        k8s = artifacts["k8s_deploy.yaml"]
+        args_block = _extract_args_block(k8s)
+
+        assert "--extra-engine-args" in args_block
+        assert "--model-path" in args_block
+        assert "--served-model-name" in args_block
+
+    def test_k8s_deploy_no_redundant_cli_flags(self):
+        params = _build_params()
+        artifacts = render_backend_templates(
+            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=False
+        )
+        args_block = _extract_args_block(artifacts["k8s_deploy.yaml"])
+
+        assert "--tensor-parallel-size" not in args_block
+        assert "--pipeline-parallel-size" not in args_block
+        assert "--max-batch-size" not in args_block
+        assert "--override-engine-args" not in args_block
+        assert "--free-gpu-memory-fraction" not in args_block
+
+    def test_extra_engine_args_yaml_embedded(self):
+        params = _build_params()
+        artifacts = render_backend_templates(
+            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=False
+        )
+        k8s = artifacts["k8s_deploy.yaml"]
+
+        assert "tensor_parallel_size:" in k8s
+        assert "kv_cache_config:" in k8s
+        assert "YAML" in k8s  # heredoc marker
+
+    def test_extra_engine_args_artifact_generated(self):
+        params = _build_params()
+        artifacts = render_backend_templates(
+            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=False
+        )
+        assert "extra_engine_args_agg.yaml" in artifacts
+        engine_yaml = yaml.safe_load(artifacts["extra_engine_args_agg.yaml"])
+        assert engine_yaml["tensor_parallel_size"] == 1
+        assert "kv_cache_config" in engine_yaml
+
+    def test_disagg_mode(self):
+        params = _build_params(
+            DynConfig={"mode": "disagg"},
+            WorkerConfig={
+                "prefill_workers": 2,
+                "prefill_gpus_per_worker": 2,
+                "decode_workers": 4,
+                "decode_gpus_per_worker": 1,
+                "agg_workers": 0,
+            },
+            params={
+                "prefill": {
+                    "tensor_parallel_size": 2,
+                    "pipeline_parallel_size": 1,
+                    "max_batch_size": 64,
+                    "max_num_tokens": 8192,
+                    "kv_cache_free_gpu_memory_fraction": 0.85,
+                    "gpus_per_worker": 2,
+                },
+                "decode": {
+                    "tensor_parallel_size": 1,
+                    "pipeline_parallel_size": 1,
+                    "max_batch_size": 256,
+                    "max_num_tokens": 16384,
+                    "kv_cache_free_gpu_memory_fraction": 0.80,
+                    "gpus_per_worker": 1,
+                },
+            },
+        )
+        artifacts = render_backend_templates(
+            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=False
+        )
+        k8s = artifacts["k8s_deploy.yaml"]
+
+        assert "extra_engine_args_prefill.yaml" in artifacts
+        assert "extra_engine_args_decode.yaml" in artifacts
+        assert "--tensor-parallel-size" not in _extract_args_block(k8s)
+
+
+# ---------------------------------------------------------------------------
+# use_dynamo_generator=True  (profiler path)
+# ---------------------------------------------------------------------------
+try:
+    from dynamo.profiler.utils.config_modifiers import CONFIG_MODIFIERS  # noqa: F401
+
+    _has_dynamo = True
+except ImportError:
+    _has_dynamo = False
+
+_requires_dynamo = pytest.mark.skipif(
+    not _has_dynamo,
+    reason="dynamo.profiler.utils.config_modifiers not installed",
+)
+
+
+@pytest.mark.unit
+class TestProfilerCliArgsMode:
+    """Verify cli_args artifacts are correctly computed (no dynamo needed)."""
+
+    def test_cli_args_artifact_has_required_flags(self):
+        params = _build_params()
+        artifacts = render_backend_templates(
+            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=False
+        )
+        cli = artifacts["cli_args_agg"]
+        args = shlex.split(cli)
+
+        # model-path is no longer in cli_args.j2 (handled by k8s_deploy fallback)
+        assert "--model-path" not in args
+        assert "--tensor-parallel-size" in args
+        assert "--max-batch-size" in args
+
+    def test_cli_args_override_engine_args_valid_json(self):
+        params = _build_params()
+        artifacts = render_backend_templates(
+            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=False
+        )
+        cli = artifacts["cli_args_agg"]
+        args = shlex.split(cli)
+
+        if "--override-engine-args" in args:
+            idx = args.index("--override-engine-args")
+            override = json.loads(args[idx + 1])
+            assert isinstance(override, dict)
+
+    def test_cli_args_disagg_both_roles(self):
+        params = _build_params(
+            DynConfig={"mode": "disagg"},
+            WorkerConfig={
+                "prefill_workers": 1,
+                "prefill_gpus_per_worker": 4,
+                "decode_workers": 1,
+                "decode_gpus_per_worker": 4,
+                "agg_workers": 0,
+            },
+            params={
+                "prefill": {
+                    "tensor_parallel_size": 4,
+                    "pipeline_parallel_size": 1,
+                    "max_batch_size": 64,
+                    "max_num_tokens": 8192,
+                    "gpus_per_worker": 4,
+                },
+                "decode": {
+                    "tensor_parallel_size": 4,
+                    "pipeline_parallel_size": 1,
+                    "max_batch_size": 128,
+                    "max_num_tokens": 16384,
+                    "gpus_per_worker": 4,
+                },
+            },
+        )
+        artifacts = render_backend_templates(
+            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=False
+        )
+        assert "cli_args_prefill" in artifacts
+        assert "cli_args_decode" in artifacts
+        assert "--tensor-parallel-size" in artifacts["cli_args_prefill"]
+        assert "--tensor-parallel-size" in artifacts["cli_args_decode"]
+
+
+@pytest.mark.unit
+class TestDynamoGeneratorPath:
+    """use_dynamo_generator=True end-to-end tests.
+
+    These call _generate_k8s_via_dynamo → build_dgd_config and verify the
+    resulting DGD config has the correct structure.  Skipped when dynamo is
+    not installed.
+    """
+
+    @_requires_dynamo
+    def test_agg_k8s_deploy_has_worker_args(self):
+        params = _build_params()
+        artifacts = render_backend_templates(
+            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=True
+        )
+        assert "k8s_deploy.yaml" in artifacts
+        dgd = yaml.safe_load(artifacts["k8s_deploy.yaml"])
+
+        services = dgd["spec"]["services"]
+        worker_names = [k for k in services if k != "Frontend"]
+        assert len(worker_names) >= 1
+
+        worker = services[worker_names[0]]
+        container = worker["extraPodSpec"]["mainContainer"]
+        args = container.get("args", [])
+        args_str = " ".join(str(a) for a in args)
+        assert "--model-path" in args_str
+
+    @_requires_dynamo
+    def test_agg_k8s_deploy_replicas_and_gpu(self):
+        params = _build_params()
+        artifacts = render_backend_templates(
+            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=True
+        )
+        dgd = yaml.safe_load(artifacts["k8s_deploy.yaml"])
+        services = dgd["spec"]["services"]
+        worker = next(v for k, v in services.items() if k != "Frontend")
+
+        assert worker["replicas"] == 8
+        assert str(worker["resources"]["limits"]["gpu"]) == "1"
+
+    @_requires_dynamo
+    def test_disagg_k8s_deploy_has_both_workers(self):
+        params = _build_params(
+            DynConfig={"mode": "disagg"},
+            WorkerConfig={
+                "prefill_workers": 2,
+                "prefill_gpus_per_worker": 2,
+                "decode_workers": 4,
+                "decode_gpus_per_worker": 1,
+                "agg_workers": 0,
+            },
+            params={
+                "prefill": {
+                    "tensor_parallel_size": 2,
+                    "pipeline_parallel_size": 1,
+                    "max_batch_size": 64,
+                    "max_num_tokens": 8192,
+                    "kv_cache_free_gpu_memory_fraction": 0.85,
+                    "gpus_per_worker": 2,
+                },
+                "decode": {
+                    "tensor_parallel_size": 1,
+                    "pipeline_parallel_size": 1,
+                    "max_batch_size": 256,
+                    "max_num_tokens": 16384,
+                    "kv_cache_free_gpu_memory_fraction": 0.80,
+                    "gpus_per_worker": 1,
+                },
+            },
+        )
+        artifacts = render_backend_templates(
+            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=True
+        )
+        dgd = yaml.safe_load(artifacts["k8s_deploy.yaml"])
+        services = dgd["spec"]["services"]
+        worker_names = [k for k in services if k != "Frontend"]
+        assert len(worker_names) == 2
+
+    @_requires_dynamo
+    def test_extra_engine_args_still_generated(self):
+        """Even with use_dynamo_generator=True, extra_engine_args artifacts
+        should still be rendered (they are always produced)."""
+        params = _build_params()
+        artifacts = render_backend_templates(
+            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=True
+        )
+        assert "extra_engine_args_agg.yaml" in artifacts
+        assert "cli_args_agg" in artifacts
+
+
+# ---------------------------------------------------------------------------
+# vllm / sglang remain unaffected
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestOtherBackendsUnaffected:
+    """vllm and sglang have no extra_engine_args templates, so their
+    k8s_deploy should continue using cli_args as before."""
+
+    def test_vllm_k8s_deploy_has_cli_args(self):
+        params = _build_params()
+        artifacts = render_backend_templates(
+            params, "vllm", use_dynamo_generator=False
+        )
+        assert "extra_engine_args_agg.yaml" not in artifacts
+        assert "cli_args_agg" in artifacts
+
+    def test_sglang_k8s_deploy_has_cli_args(self):
+        params = _build_params()
+        artifacts = render_backend_templates(
+            params, "sglang", use_dynamo_generator=False
+        )
+        assert "extra_engine_args_agg.yaml" not in artifacts
+        assert "cli_args_agg" in artifacts
+
+
+# ---------------------------------------------------------------------------
+# use_dynamo_generator=True  (profiler / translate path)
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestDynamicFlagsMode:
+    """When use_dynamo_generator=True and backend=trtllm, cli_args_list must
+    contain --trtllm.* flags converted from the rendered extra_engine_args YAML.
+    The --override-engine-args JSON blob must NOT appear."""
+
+    def test_cli_args_contain_trtllm_flags(self):
+        params = _build_params()
+        artifacts = render_backend_templates(
+            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=True
+        )
+        cli = artifacts.get("cli_args_agg", "")
+        assert "--trtllm.disable_overlap_scheduler" in cli
+        assert "--trtllm.kv_cache_config.dtype" in cli or "--trtllm.kv_cache_config.enable_block_reuse" in cli
+
+    def test_no_override_engine_args_json(self):
+        params = _build_params()
+        artifacts = render_backend_templates(
+            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=True
+        )
+        cli = artifacts.get("cli_args_agg", "")
+        assert "--override-engine-args" not in cli
+
+    def test_direct_cli_flags_still_present(self):
+        params = _build_params()
+        artifacts = render_backend_templates(
+            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=True
+        )
+        cli = artifacts.get("cli_args_agg", "")
+        assert "--tensor-parallel-size" in cli
+        assert "--max-batch-size" in cli
+
+    def test_skipped_keys_not_duplicated(self):
+        """Keys already emitted as direct CLI flags must not appear as --trtllm.* flags."""
+        params = _build_params()
+        artifacts = render_backend_templates(
+            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=True
+        )
+        cli = artifacts.get("cli_args_agg", "")
+        assert "--trtllm.tensor_parallel_size" not in cli
+        assert "--trtllm.max_batch_size" not in cli
+        assert "--trtllm.backend" not in cli
+
+    def test_list_values_skipped(self):
+        """List values (cuda_graph_config.batch_sizes) must not appear as --trtllm.* flags."""
+        params = _build_params()
+        artifacts = render_backend_templates(
+            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=True
+        )
+        cli = artifacts.get("cli_args_agg", "")
+        assert "--trtllm.cuda_graph_config.batch_sizes" not in cli
+
+    def test_disagg_mode_both_workers_get_flags(self):
+        params = _build_params(
+            DynConfig={"mode": "disagg"},
+            WorkerConfig={
+                "prefill_workers": 2,
+                "prefill_gpus_per_worker": 2,
+                "decode_workers": 4,
+                "decode_gpus_per_worker": 1,
+                "agg_workers": 0,
+            },
+            params={
+                "prefill": {
+                    "tensor_parallel_size": 2,
+                    "pipeline_parallel_size": 1,
+                    "max_batch_size": 64,
+                    "max_num_tokens": 8192,
+                    "kv_cache_free_gpu_memory_fraction": 0.85,
+                    "gpus_per_worker": 2,
+                },
+                "decode": {
+                    "tensor_parallel_size": 1,
+                    "pipeline_parallel_size": 1,
+                    "max_batch_size": 256,
+                    "max_num_tokens": 16384,
+                    "kv_cache_free_gpu_memory_fraction": 0.80,
+                    "gpus_per_worker": 1,
+                },
+            },
+        )
+        artifacts = render_backend_templates(
+            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=True
+        )
+        prefill_cli = artifacts.get("cli_args_prefill", "")
+        decode_cli = artifacts.get("cli_args_decode", "")
+        # Both workers should have --trtllm.* flags
+        assert "--trtllm." in prefill_cli
+        assert "--trtllm." in decode_cli
+        # Neither should have --override-engine-args
+        assert "--override-engine-args" not in prefill_cli
+        assert "--override-engine-args" not in decode_cli
+
+    def test_extra_engine_args_yaml_still_generated(self):
+        """The extra_engine_args YAML artifact is still generated (consumed by
+        translate and potentially by --extra-engine-args file path)."""
+        params = _build_params()
+        artifacts = render_backend_templates(
+            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=True
+        )
+        assert "extra_engine_args_agg.yaml" in artifacts
+        assert "kv_cache_config" in artifacts["extra_engine_args_agg.yaml"]

--- a/tests/unit/generator/test_trtllm_extra_engine_args.py
+++ b/tests/unit/generator/test_trtllm_extra_engine_args.py
@@ -10,7 +10,6 @@ Verifies that:
   _generate_k8s_via_dynamo / build_dgd_config (profiler path)
 """
 
-import json
 import shlex
 
 import pytest
@@ -198,7 +197,7 @@ _requires_dynamo = pytest.mark.skipif(
 class TestProfilerCliArgsMode:
     """Verify cli_args artifacts are correctly computed (no dynamo needed)."""
 
-    def test_cli_args_artifact_has_required_flags(self):
+    def test_cli_args_artifact_has_direct_flags_only(self):
         params = _build_params()
         artifacts = render_backend_templates(
             params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=False
@@ -206,58 +205,12 @@ class TestProfilerCliArgsMode:
         cli = artifacts["cli_args_agg"]
         args = shlex.split(cli)
 
-        # model-path is no longer in cli_args.j2 (handled by k8s_deploy fallback)
-        assert "--model-path" not in args
+        # Direct argparser flags present
         assert "--tensor-parallel-size" in args
         assert "--max-batch-size" in args
-
-    def test_cli_args_override_engine_args_valid_json(self):
-        params = _build_params()
-        artifacts = render_backend_templates(
-            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=False
-        )
-        cli = artifacts["cli_args_agg"]
-        args = shlex.split(cli)
-
-        if "--override-engine-args" in args:
-            idx = args.index("--override-engine-args")
-            override = json.loads(args[idx + 1])
-            assert isinstance(override, dict)
-
-    def test_cli_args_disagg_both_roles(self):
-        params = _build_params(
-            DynConfig={"mode": "disagg"},
-            WorkerConfig={
-                "prefill_workers": 1,
-                "prefill_gpus_per_worker": 4,
-                "decode_workers": 1,
-                "decode_gpus_per_worker": 4,
-                "agg_workers": 0,
-            },
-            params={
-                "prefill": {
-                    "tensor_parallel_size": 4,
-                    "pipeline_parallel_size": 1,
-                    "max_batch_size": 64,
-                    "max_num_tokens": 8192,
-                    "gpus_per_worker": 4,
-                },
-                "decode": {
-                    "tensor_parallel_size": 4,
-                    "pipeline_parallel_size": 1,
-                    "max_batch_size": 128,
-                    "max_num_tokens": 16384,
-                    "gpus_per_worker": 4,
-                },
-            },
-        )
-        artifacts = render_backend_templates(
-            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=False
-        )
-        assert "cli_args_prefill" in artifacts
-        assert "cli_args_decode" in artifacts
-        assert "--tensor-parallel-size" in artifacts["cli_args_prefill"]
-        assert "--tensor-parallel-size" in artifacts["cli_args_decode"]
+        # model-path and override-engine-args no longer in cli_args.j2
+        assert "--model-path" not in args
+        assert "--override-engine-args" not in args
 
 
 @pytest.mark.unit
@@ -382,56 +335,42 @@ class TestOtherBackendsUnaffected:
 @pytest.mark.unit
 class TestDynamicFlagsMode:
     """When use_dynamo_generator=True and backend=trtllm, cli_args_list must
-    contain --trtllm.* flags converted from the rendered extra_engine_args YAML.
-    The --override-engine-args JSON blob must NOT appear."""
+    contain --trtllm.* flags converted from the rendered extra_engine_args YAML."""
 
-    def test_cli_args_contain_trtllm_flags(self):
+    def test_agg_mode(self):
+        """Agg mode: --trtllm.* flags present, direct flags present, no duplication,
+        no --override-engine-args, extra_engine_args YAML still generated."""
         params = _build_params()
         artifacts = render_backend_templates(
             params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=True
         )
         cli = artifacts.get("cli_args_agg", "")
+
+        # --trtllm.* engine params present
         assert "--trtllm.disable_overlap_scheduler" in cli
-        assert "--trtllm.kv_cache_config.dtype" in cli or "--trtllm.kv_cache_config.enable_block_reuse" in cli
+        assert "--trtllm.kv_cache_config." in cli
 
-    def test_no_override_engine_args_json(self):
-        params = _build_params()
-        artifacts = render_backend_templates(
-            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=True
-        )
-        cli = artifacts.get("cli_args_agg", "")
-        assert "--override-engine-args" not in cli
-
-    def test_direct_cli_flags_still_present(self):
-        params = _build_params()
-        artifacts = render_backend_templates(
-            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=True
-        )
-        cli = artifacts.get("cli_args_agg", "")
+        # Direct CLI flags still present
         assert "--tensor-parallel-size" in cli
         assert "--max-batch-size" in cli
 
-    def test_skipped_keys_not_duplicated(self):
-        """Keys already emitted as direct CLI flags must not appear as --trtllm.* flags."""
-        params = _build_params()
-        artifacts = render_backend_templates(
-            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=True
-        )
-        cli = artifacts.get("cli_args_agg", "")
+        # No --override-engine-args JSON blob
+        assert "--override-engine-args" not in cli
+
+        # Skipped keys not duplicated as --trtllm.*
         assert "--trtllm.tensor_parallel_size" not in cli
         assert "--trtllm.max_batch_size" not in cli
         assert "--trtllm.backend" not in cli
 
-    def test_list_values_skipped(self):
-        """List values (cuda_graph_config.batch_sizes) must not appear as --trtllm.* flags."""
-        params = _build_params()
-        artifacts = render_backend_templates(
-            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=True
-        )
-        cli = artifacts.get("cli_args_agg", "")
+        # List values skipped
         assert "--trtllm.cuda_graph_config.batch_sizes" not in cli
 
-    def test_disagg_mode_both_workers_get_flags(self):
+        # extra_engine_args YAML artifact still generated
+        assert "extra_engine_args_agg.yaml" in artifacts
+        assert "kv_cache_config" in artifacts["extra_engine_args_agg.yaml"]
+
+    def test_disagg_mode(self):
+        """Disagg mode: both prefill and decode workers get --trtllm.* flags."""
         params = _build_params(
             DynConfig={"mode": "disagg"},
             WorkerConfig={
@@ -463,21 +402,7 @@ class TestDynamicFlagsMode:
         artifacts = render_backend_templates(
             params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=True
         )
-        prefill_cli = artifacts.get("cli_args_prefill", "")
-        decode_cli = artifacts.get("cli_args_decode", "")
-        # Both workers should have --trtllm.* flags
-        assert "--trtllm." in prefill_cli
-        assert "--trtllm." in decode_cli
-        # Neither should have --override-engine-args
-        assert "--override-engine-args" not in prefill_cli
-        assert "--override-engine-args" not in decode_cli
-
-    def test_extra_engine_args_yaml_still_generated(self):
-        """The extra_engine_args YAML artifact is still generated (consumed by
-        translate and potentially by --extra-engine-args file path)."""
-        params = _build_params()
-        artifacts = render_backend_templates(
-            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=True
-        )
-        assert "extra_engine_args_agg.yaml" in artifacts
-        assert "kv_cache_config" in artifacts["extra_engine_args_agg.yaml"]
+        for role in ("prefill", "decode"):
+            cli = artifacts.get(f"cli_args_{role}", "")
+            assert "--trtllm." in cli, f"{role} worker missing --trtllm.* flags"
+            assert "--override-engine-args" not in cli

--- a/tests/unit/generator/test_trtllm_extra_engine_args.py
+++ b/tests/unit/generator/test_trtllm_extra_engine_args.py
@@ -94,9 +94,7 @@ class TestExtraEngineArgsMode:
 
     def test_k8s_deploy_uses_extra_engine_args_file(self):
         params = _build_params()
-        artifacts = render_backend_templates(
-            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=False
-        )
+        artifacts = render_backend_templates(params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=False)
         k8s = artifacts["k8s_deploy.yaml"]
         args_block = _extract_args_block(k8s)
 
@@ -106,9 +104,7 @@ class TestExtraEngineArgsMode:
 
     def test_k8s_deploy_no_redundant_cli_flags(self):
         params = _build_params()
-        artifacts = render_backend_templates(
-            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=False
-        )
+        artifacts = render_backend_templates(params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=False)
         args_block = _extract_args_block(artifacts["k8s_deploy.yaml"])
 
         assert "--tensor-parallel-size" not in args_block
@@ -119,9 +115,7 @@ class TestExtraEngineArgsMode:
 
     def test_extra_engine_args_yaml_embedded(self):
         params = _build_params()
-        artifacts = render_backend_templates(
-            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=False
-        )
+        artifacts = render_backend_templates(params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=False)
         k8s = artifacts["k8s_deploy.yaml"]
 
         assert "tensor_parallel_size:" in k8s
@@ -130,9 +124,7 @@ class TestExtraEngineArgsMode:
 
     def test_extra_engine_args_artifact_generated(self):
         params = _build_params()
-        artifacts = render_backend_templates(
-            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=False
-        )
+        artifacts = render_backend_templates(params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=False)
         assert "extra_engine_args_agg.yaml" in artifacts
         engine_yaml = yaml.safe_load(artifacts["extra_engine_args_agg.yaml"])
         assert engine_yaml["tensor_parallel_size"] == 1
@@ -167,9 +159,7 @@ class TestExtraEngineArgsMode:
                 },
             },
         )
-        artifacts = render_backend_templates(
-            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=False
-        )
+        artifacts = render_backend_templates(params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=False)
         k8s = artifacts["k8s_deploy.yaml"]
 
         assert "extra_engine_args_prefill.yaml" in artifacts
@@ -199,9 +189,7 @@ class TestProfilerCliArgsMode:
 
     def test_cli_args_artifact_has_direct_flags_only(self):
         params = _build_params()
-        artifacts = render_backend_templates(
-            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=False
-        )
+        artifacts = render_backend_templates(params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=False)
         cli = artifacts["cli_args_agg"]
         args = shlex.split(cli)
 
@@ -225,9 +213,7 @@ class TestDynamoGeneratorPath:
     @_requires_dynamo
     def test_agg_k8s_deploy_has_worker_args(self):
         params = _build_params()
-        artifacts = render_backend_templates(
-            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=True
-        )
+        artifacts = render_backend_templates(params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=True)
         assert "k8s_deploy.yaml" in artifacts
         dgd = yaml.safe_load(artifacts["k8s_deploy.yaml"])
 
@@ -244,9 +230,7 @@ class TestDynamoGeneratorPath:
     @_requires_dynamo
     def test_agg_k8s_deploy_replicas_and_gpu(self):
         params = _build_params()
-        artifacts = render_backend_templates(
-            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=True
-        )
+        artifacts = render_backend_templates(params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=True)
         dgd = yaml.safe_load(artifacts["k8s_deploy.yaml"])
         services = dgd["spec"]["services"]
         worker = next(v for k, v in services.items() if k != "Frontend")
@@ -284,9 +268,7 @@ class TestDynamoGeneratorPath:
                 },
             },
         )
-        artifacts = render_backend_templates(
-            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=True
-        )
+        artifacts = render_backend_templates(params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=True)
         dgd = yaml.safe_load(artifacts["k8s_deploy.yaml"])
         services = dgd["spec"]["services"]
         worker_names = [k for k in services if k != "Frontend"]
@@ -297,9 +279,7 @@ class TestDynamoGeneratorPath:
         """Even with use_dynamo_generator=True, extra_engine_args artifacts
         should still be rendered (they are always produced)."""
         params = _build_params()
-        artifacts = render_backend_templates(
-            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=True
-        )
+        artifacts = render_backend_templates(params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=True)
         assert "extra_engine_args_agg.yaml" in artifacts
         assert "cli_args_agg" in artifacts
 
@@ -314,17 +294,13 @@ class TestOtherBackendsUnaffected:
 
     def test_vllm_k8s_deploy_has_cli_args(self):
         params = _build_params()
-        artifacts = render_backend_templates(
-            params, "vllm", use_dynamo_generator=False
-        )
+        artifacts = render_backend_templates(params, "vllm", use_dynamo_generator=False)
         assert "extra_engine_args_agg.yaml" not in artifacts
         assert "cli_args_agg" in artifacts
 
     def test_sglang_k8s_deploy_has_cli_args(self):
         params = _build_params()
-        artifacts = render_backend_templates(
-            params, "sglang", use_dynamo_generator=False
-        )
+        artifacts = render_backend_templates(params, "sglang", use_dynamo_generator=False)
         assert "extra_engine_args_agg.yaml" not in artifacts
         assert "cli_args_agg" in artifacts
 
@@ -341,9 +317,7 @@ class TestDynamicFlagsMode:
         """Agg mode: --trtllm.* flags present, direct flags present, no duplication,
         no --override-engine-args, extra_engine_args YAML still generated."""
         params = _build_params()
-        artifacts = render_backend_templates(
-            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=True
-        )
+        artifacts = render_backend_templates(params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=True)
         cli = artifacts.get("cli_args_agg", "")
 
         # --trtllm.* engine params present
@@ -399,9 +373,7 @@ class TestDynamicFlagsMode:
                 },
             },
         )
-        artifacts = render_backend_templates(
-            params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=True
-        )
+        artifacts = render_backend_templates(params, "trtllm", version="1.3.0rc5.post1", use_dynamo_generator=True)
         for role in ("prefill", "decode"):
             cli = artifacts.get(f"cli_args_{role}", "")
             assert "--trtllm." in cli, f"{role} worker missing --trtllm.* flags"


### PR DESCRIPTION
#### Overview:

Adapt the aiconfigurator generator to the --trtllm.* dynamic CLI flag syntax introduced in [dynamo#7335](https://github.com/ai-dynamo/dynamo/pull/7335). A new translate module converts extra_engine_args YAML into flat --trtllm.<group>.<key> flags at render time, replacing the old --override-engine-args JSON path. 

This also aligns with the profiler-side refactor in [dynamo#7884](https://github.com/ai-dynamo/dynamo/pull/7884). cli_args.j2 is slimmed to only emit direct argparser flags.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Redesigned how TensorRT-LLM backend processes engine configuration. Engine arguments are now dynamically converted to CLI flags from YAML configuration files, replacing the previous centralized override mechanism.

* **Tests**
  * Expanded test coverage for YAML-to-flag translation, dynamic argument generation, and Kubernetes deployment configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->