### PR TITLE
feat: Enable oneCCL benchmarking support for xpu

### DIFF
--- a/collector/README_oneccl_xpu.md
+++ b/collector/README_oneccl_xpu.md
@@ -1,0 +1,129 @@
+# oneCCL Communication Benchmarking for Intel XPU
+
+This guide explains how to set up and run oneCCL collective communication benchmarks on Intel XPU (GPU) devices using `collect_oneccl_xpu.py` or `collect_comm.sh --device xpu`.
+
+## Prerequisites
+
+### 1. Intel oneAPI Packages
+
+The following Intel oneAPI components must be installed:
+
+- **oneCCL** (`intel-oneapi-ccl-devel`) — collective communications library and headers
+- **Intel MPI** (`intel-oneapi-mpi`) — MPI runtime (`mpirun`)
+- **Intel DPC++ Compiler** (`intel-oneapi-compiler-dpcpp-cpp`) — needed to compile the benchmark binary (`icpx`)
+
+Verify installation:
+
+```bash
+dpkg -l | grep -i "intel-oneapi-ccl-devel\|intel-oneapi-mpi\|intel-oneapi-compiler"
+```
+
+### 2. Intel GPU Devices
+
+At least 2 Intel GPU (XPU) devices must be available. Verify with:
+
+```bash
+sycl-ls | grep "level_zero:gpu"
+```
+
+### 3. Compile the oneCCL Benchmark Binary
+
+The oneCCL package ships benchmark source code but **no pre-compiled binary**. You must compile it once.
+
+```bash
+# Source the oneAPI environment
+source /opt/intel/oneapi/ccl/latest/env/vars.sh
+
+# Create a temporary build directory
+mkdir -p /tmp/oneccl_benchmark_build
+cp -r /opt/intel/oneapi/ccl/latest/share/doc/ccl/examples/benchmark/* /tmp/oneccl_benchmark_build/
+cd /tmp/oneccl_benchmark_build
+
+# Compile with SYCL (GPU) support
+icpx -std=c++17 -fsycl \
+  -I./include -I./src \
+  -I/opt/intel/oneapi/ccl/latest/share/doc/ccl/examples/include \
+  -I/opt/intel/oneapi/ccl/latest/include \
+  -I/opt/intel/oneapi/mpi/latest/include \
+  -L/opt/intel/oneapi/ccl/latest/lib \
+  -L/opt/intel/oneapi/mpi/latest/lib/release \
+  -L/opt/intel/oneapi/mpi/latest/lib \
+  src/benchmark.cpp \
+  -lccl -lmpi -lpthread -lrt -lm -ldl \
+  -o benchmark
+
+# Install to a location on PATH
+cp benchmark /usr/local/bin/oneccl_benchmark
+```
+
+Verify it works:
+
+```bash
+oneccl_benchmark --help
+```
+
+### 4. Environment Variables
+
+The following environment variables must be set at runtime (the script sets them automatically):
+
+| Variable | Value | Purpose |
+|----------|-------|---------|
+| `CCL_TOPO_FABRIC_VERTEX_CONNECTION_CHECK` | `0` | Avoids topology detection errors on PCIe-connected GPUs |
+| `FI_PROVIDER` | `tcp` | Uses TCP fabric provider (avoids UCX assertion failures) |
+| `I_MPI_OFI_PROVIDER` | `tcp` | Forces Intel MPI to use TCP OFI provider |
+
+## Usage
+
+### Option A: Run All Benchmarks via `collect_comm.sh`
+
+This runs all collective operations (`all_gather`, `alltoall`, `reduce_scatter`, `all_reduce`) with both `half` and `int8` data types across all detected GPU counts:
+
+```bash
+cd collector/
+bash collect_comm.sh --device xpu
+```
+
+### Option B: Run Individual Operations via `collect_oneccl_xpu.py`
+
+```bash
+cd collector/
+
+# all_gather with 2 GPUs, half precision, default range (512B to 512MB)
+python collect_oneccl_xpu.py --oneccl_op all_gather --dtype half --num_gpus 2
+
+# reduce_scatter with 2 GPUs
+python collect_oneccl_xpu.py --oneccl_op reduce_scatter --dtype half --num_gpus 2
+
+# all_reduce with 4 GPUs, custom range
+python collect_oneccl_xpu.py --oneccl_op all_reduce --dtype half --num_gpus 4 --range "1024,268435456,2"
+
+# alltoall with int8
+python collect_oneccl_xpu.py --oneccl_op alltoall --dtype int8 --num_gpus 4
+```
+
+### CLI Options for `collect_oneccl_xpu.py`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--oneccl_op`, `-O` | `all_gather` | Collective operation: `all_gather`, `alltoall`, `reduce_scatter`, `all_reduce` |
+| `--dtype`, `-t` | `half` | Data type: `half` (fp16, 2 bytes), `int8` (1 byte) |
+| `--range`, `-r` | `512,536870913,2` | `min_bytes,max_bytes,multiplicative_ratio` |
+| `--num_gpus`, `-n` | `2` | Number of GPUs (MPI ranks) |
+| `--iters`, `-i` | `100` | Benchmark iterations per message size |
+| `--warmup_iters`, `-w` | `20` | Warmup iterations per message size |
+
+## Output
+
+Results are appended to `oneccl_perf.txt` in the working directory with the following CSV format:
+
+```
+framework,version,device,op_name,kernel_source,nccl_dtype,num_gpus,message_size,latency
+oneCCL,2021.17.2-5,Intel(R) Graphics [0xe211],all_gather,oneCCL,half,2,256,0.015538
+```
+
+## Troubleshooting
+
+- **`oneCCL benchmark binary not found`** — Compile and install the benchmark binary (see step 3 above).
+- **`BAD TERMINATION ... KILLED BY SIGNAL: 6`** — Usually a UCX assertion failure. Ensure `FI_PROVIDER=tcp` is set.
+- **`topology recognition shows PCIe connection`** — Set `CCL_TOPO_FABRIC_VERTEX_CONNECTION_CHECK=0`.
+- **Only 1 GPU detected** — The script requires at least 2 GPUs. Check `sycl-ls` output.

--- a/collector/collect_comm.sh
+++ b/collector/collect_comm.sh
@@ -116,6 +116,10 @@ if [[ "$device" == "cuda" ]]; then
         done
     done
 elif [[ "$device" == "xpu" ]]; then
+    if [[ "$measure_power" == "true" ]]; then
+        echo "Error: --measure_power is not yet supported for oneCCL XPU benchmarks"
+        exit 1
+    fi
     # Note: alltoall hangs on oneCCL SYCL/GPU backend and is excluded.
     # vLLM XPU uses allgather+reduce_scatter (AgRs) for MoE, not alltoall.
     oneccl_ops=("all_gather" "reduce_scatter" "all_reduce")

--- a/collector/collect_comm.sh
+++ b/collector/collect_comm.sh
@@ -4,6 +4,7 @@
 
 # Default backend
 all_reduce_backend="trtllm"
+all_reduce_backend_set=false
 device="cuda"
 measure_power=false
 power_test_duration=1.0
@@ -13,6 +14,7 @@ while [[ $# -gt 0 ]]; do
     case $1 in
         --all_reduce_backend)
             all_reduce_backend="$2"
+            all_reduce_backend_set=true
             if [[ "$all_reduce_backend" != "trtllm" && "$all_reduce_backend" != "vllm" && "$all_reduce_backend" != "sglang" ]]; then
                 echo "Error: --all_reduce_backend must be 'trtllm', 'vllm', or 'sglang'"
                 echo "Usage: $0 [OPTIONS]"
@@ -62,6 +64,11 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# Default to vllm backend for XPU if not explicitly set
+if [[ "$device" == "xpu" && "$all_reduce_backend_set" == "false" ]]; then
+    all_reduce_backend="vllm"
+fi
+
 echo "Running benchmarks with all_reduce_backend: $all_reduce_backend"
 if [[ "$measure_power" == "true" ]]; then
     echo "Power monitoring: ENABLED (duration: ${power_test_duration}s)"
@@ -108,8 +115,22 @@ if [[ "$device" == "cuda" ]]; then
             done
         done
     done
+elif [[ "$device" == "xpu" ]]; then
+    # Note: alltoall hangs on oneCCL SYCL/GPU backend and is excluded.
+    # vLLM XPU uses allgather+reduce_scatter (AgRs) for MoE, not alltoall.
+    oneccl_ops=("all_gather" "reduce_scatter" "all_reduce")
+    dtypes=("half" "int8")
+
+    for n in "${gpu_count_list[@]}"; do
+        for op in "${oneccl_ops[@]}"; do
+            for dtype in "${dtypes[@]}"; do
+                echo "Running oneCCL $op benchmark with $n GPUs, dtype=$dtype"
+                python3 "$SCRIPT_DIR/collect_oneccl_xpu.py" -n "$n" -O "$op" --dtype "$dtype"
+            done
+        done
+    done
 else
-    echo "Skipping NCCL benchmarks because device is $device"
+    echo "Skipping NCCL/oneCCL benchmarks because device is $device"
 fi
 
 echo "Running AllReduce Benchmarks with $all_reduce_backend backend..."

--- a/collector/collect_oneccl_xpu.py
+++ b/collector/collect_oneccl_xpu.py
@@ -1,0 +1,294 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Collect oneCCL communication performance data for XPU (Intel GPU).
+
+This script uses the oneCCL benchmark binary (compiled from oneCCL examples)
+to measure collective communication latencies on Intel XPU devices.
+It produces nccl_perf.txt compatible output for use in projection models.
+
+Prerequisites:
+  - oneCCL benchmark binary installed at /usr/local/bin/oneccl_benchmark
+    (compile from /opt/intel/oneapi/ccl/*/share/doc/ccl/examples/benchmark/)
+  - Intel MPI (mpirun) available on PATH
+  - Intel GPU (XPU) devices available
+
+Usage:
+  python collect_oneccl_xpu.py --oneccl_op all_gather --dtype half --num_gpus 4
+  python collect_oneccl_xpu.py --oneccl_op reduce_scatter --dtype half --num_gpus 4
+  python collect_oneccl_xpu.py --oneccl_op all_reduce --dtype half --num_gpus 4
+  python collect_oneccl_xpu.py --oneccl_op alltoall --dtype half --num_gpus 4
+"""
+
+import csv
+import os
+import subprocess
+import tempfile
+from argparse import ArgumentParser
+
+from helper import log_perf
+
+# Mapping from our op names to oneCCL benchmark collective names
+OP_NAME_TO_CCL = {
+    "all_gather": "allgather",
+    "alltoall": "alltoall",
+    "reduce_scatter": "reduce_scatter",
+    "all_reduce": "allreduce",
+}
+
+# Mapping from our dtype names to oneCCL benchmark dtype names
+DTYPE_TO_CCL = {
+    "half": "float16",
+    "int8": "int8",
+}
+
+BYTES_PER_ELEMENT = {
+    "half": 2,
+    "int8": 1,
+}
+
+BENCHMARK_BIN = "oneccl_benchmark"
+BENCHMARK_BIN_FALLBACK = "/usr/local/bin/oneccl_benchmark"
+
+
+def find_benchmark_binary():
+    """Locate the oneCCL benchmark binary."""
+    result = subprocess.run(["which", BENCHMARK_BIN], capture_output=True, text=True)
+    if result.returncode == 0:
+        return BENCHMARK_BIN
+    if os.path.exists(BENCHMARK_BIN_FALLBACK):
+        return BENCHMARK_BIN_FALLBACK
+    raise FileNotFoundError(
+        "oneCCL benchmark binary not found. "
+        "Compile from /opt/intel/oneapi/ccl/*/share/doc/ccl/examples/benchmark/ "
+        "and install to /usr/local/bin/oneccl_benchmark"
+    )
+
+
+def get_oneccl_version():
+    """Get installed oneCCL version string."""
+    try:
+        result = subprocess.run(
+            ["dpkg-query", "-W", "-f", "${Version}", "intel-oneapi-ccl-devel"],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except Exception:
+        pass
+    return "unknown_version"
+
+
+def get_device_name():
+    """Get the Intel GPU device name via sycl-ls or fallback.
+
+    Parses sycl-ls output like:
+      [level_zero:gpu][level_zero:0] ..., Intel(R) Graphics [0xe211] 20.1.0 [...]
+    Extracts: "Intel(R) Graphics [0xe211]"
+    """
+    try:
+        result = subprocess.run(["sycl-ls"], capture_output=True, text=True)
+        for line in result.stdout.split("\n"):
+            if "level_zero:gpu" in line and "Intel" in line:
+                # Format: ..., Intel(R) Graphics [0xHEXID] VERSION [DRIVER]
+                # Extract the part after the last comma, before the version number
+                parts = line.split(",")
+                if len(parts) >= 2:
+                    device_part = parts[-1].strip()
+                    # Find "Intel..." up to the PCI ID bracket
+                    # e.g. "Intel(R) Graphics [0xe211] 20.1.0 [1.6.33578+15]"
+                    # We want "Intel(R) Graphics [0xe211]"
+                    import re
+
+                    match = re.search(r"(Intel\S*\s+Graphics\s+\[0x[0-9a-fA-F]+\])", device_part)
+                    if match:
+                        return match.group(1)
+                    # Fallback: return everything before the driver version bracket
+                    match = re.search(r"(Intel.*?)\s+\d+\.\d+", device_part)
+                    if match:
+                        return match.group(1).strip()
+    except Exception:
+        pass
+    return "Intel GPU"
+
+
+def generate_elem_counts(test_range, bytes_per_element):
+    """Generate element counts from byte-based test range.
+
+    Args:
+        test_range: "min_bytes,max_bytes,ratio" string
+        bytes_per_element: bytes per data element
+
+    Returns:
+        list of element counts
+    """
+    min_size, max_size, ratio = [int(i) for i in test_range.split(",")]
+    counts = []
+    size = min_size
+    while size < max_size:
+        elem_count = max(1, size // bytes_per_element)
+        counts.append(elem_count)
+        size *= ratio
+    return counts
+
+
+def oneccl_benchmark(
+    dtype: str,
+    oneccl_op: str = "all_gather",
+    test_range: str = "512,536870913,2",
+    num_gpus: int = 2,
+    iters: int = 100,
+    warmup_iters: int = 20,
+):
+    """Run oneCCL benchmark and log results.
+
+    Runs the compiled oneCCL benchmark binary via mpirun to measure
+    collective communication latency on Intel XPU devices.
+    """
+    benchmark_bin = find_benchmark_binary()
+    ccl_coll = OP_NAME_TO_CCL[oneccl_op]
+    ccl_dtype = DTYPE_TO_CCL[dtype]
+    bytes_per_elem = BYTES_PER_ELEMENT[dtype]
+
+    version = get_oneccl_version()
+    device_name = get_device_name()
+
+    # Generate element counts from byte-range specification
+    elem_counts = generate_elem_counts(test_range, bytes_per_elem)
+    if not elem_counts:
+        print("No element counts generated from range.")
+        return
+
+    print(f"Running oneCCL benchmark: op={oneccl_op}, dtype={dtype}, num_gpus={num_gpus}, {len(elem_counts)} sizes")
+
+    # Run in batches to avoid too-long command lines
+    batch_size = 50
+    for batch_start in range(0, len(elem_counts), batch_size):
+        batch = elem_counts[batch_start : batch_start + batch_size]
+        elem_counts_str = ",".join(str(c) for c in batch)
+
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False, mode="w") as f:
+            csv_path = f.name
+
+        try:
+            env = os.environ.copy()
+            env["CCL_TOPO_FABRIC_VERTEX_CONNECTION_CHECK"] = "0"
+            env["FI_PROVIDER"] = "tcp"
+            env["I_MPI_OFI_PROVIDER"] = "tcp"
+
+            cmd = [
+                "mpirun",
+                "-n",
+                str(num_gpus),
+                benchmark_bin,
+                "--backend",
+                "sycl",
+                "--coll",
+                ccl_coll,
+                "--dtype",
+                ccl_dtype,
+                "--elem_counts",
+                elem_counts_str,
+                "--iters",
+                str(iters),
+                "--warmup_iters",
+                str(warmup_iters),
+                "--csv_filepath",
+                csv_path,
+            ]
+
+            print(
+                f"  Batch {batch_start // batch_size + 1}: "
+                f"sizes {batch[0] * bytes_per_elem}-{batch[-1] * bytes_per_elem} bytes"
+            )
+
+            try:
+                result = subprocess.run(cmd, capture_output=True, text=True, env=env, timeout=300)
+            except subprocess.TimeoutExpired:
+                print(f"  Timeout: batch did not complete within 300s (op={oneccl_op} may not be supported). Skipping.")
+                continue
+
+            if result.returncode != 0:
+                print(f"  Error (exit {result.returncode}):")
+                print(f"  stderr: {result.stderr[:500]}")
+                continue
+
+            # Parse CSV output from oneCCL benchmark
+            if not os.path.exists(csv_path) or os.path.getsize(csv_path) == 0:
+                print("  Warning: no CSV output produced")
+                continue
+
+            with open(csv_path, encoding="utf-8") as csvf:
+                reader = csv.DictReader(csvf)
+                items = []
+                for row in reader:
+                    latency_us = float(row["t_avg[usec]"])
+                    latency_ms = latency_us * 1e-3
+                    msg_bytes = int(row["message_size"])
+                    msg_elements = msg_bytes // bytes_per_elem
+
+                    print(f"    {ccl_coll}: {msg_bytes} bytes ({msg_elements} elements), latency={latency_ms:.6f} ms")
+
+                    items.append(
+                        {
+                            "nccl_dtype": dtype,
+                            "num_gpus": num_gpus,
+                            "message_size": msg_elements,
+                            "latency": latency_ms,
+                        }
+                    )
+
+                if items:
+                    log_perf(
+                        item_list=items,
+                        framework="VLLM",
+                        version=version,
+                        device_name=device_name,
+                        op_name=oneccl_op,
+                        kernel_source="oneCCL",
+                        perf_filename="oneccl_perf.txt",
+                    )
+        finally:
+            if os.path.exists(csv_path):
+                os.unlink(csv_path)
+
+    print("Done. Results appended to oneccl_perf.txt")
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser(description="Collect oneCCL communication performance data for XPU")
+    parser.add_argument(
+        "--oneccl_op",
+        "-O",
+        default="all_gather",
+        choices=["all_gather", "alltoall", "reduce_scatter", "all_reduce"],
+        help="oneCCL operation to benchmark",
+    )
+    parser.add_argument(
+        "--dtype",
+        "-t",
+        default="half",
+        choices=["half", "int8"],
+        help="Data type for the collective operation",
+    )
+    parser.add_argument(
+        "--range",
+        "-r",
+        default="512,536870913,2",  # 512B to 512MB, multiply by 2
+        help="min_bytes,max_bytes,multiplicative_ratio",
+    )
+    parser.add_argument("--num_gpus", "-n", default=2, type=int, help="Number of GPUs (MPI ranks)")
+    parser.add_argument("--iters", "-i", default=100, type=int, help="Benchmark iterations per size")
+    parser.add_argument("--warmup_iters", "-w", default=20, type=int, help="Warmup iterations per size")
+    args = parser.parse_args()
+
+    oneccl_benchmark(
+        dtype=args.dtype,
+        oneccl_op=args.oneccl_op,
+        test_range=args.range,
+        num_gpus=args.num_gpus,
+        iters=args.iters,
+        warmup_iters=args.warmup_iters,
+    )

--- a/collector/collect_oneccl_xpu.py
+++ b/collector/collect_oneccl_xpu.py
@@ -124,7 +124,16 @@ def generate_elem_counts(test_range, bytes_per_element):
     Returns:
         list of element counts
     """
-    min_size, max_size, ratio = [int(i) for i in test_range.split(",")]
+    try:
+        min_size, max_size, ratio = [int(i) for i in test_range.split(",")]
+    except ValueError as exc:
+        raise ValueError("--range must be 'min_bytes,max_bytes,multiplicative_ratio' with integer values") from exc
+
+    if min_size <= 0 or max_size <= min_size:
+        raise ValueError("--range must satisfy 0 < min_bytes < max_bytes")
+    if ratio <= 1:
+        raise ValueError("--range multiplicative_ratio must be > 1")
+
     counts = []
     size = min_size
     while size < max_size:

--- a/src/aiconfigurator/sdk/common.py
+++ b/src/aiconfigurator/sdk/common.py
@@ -554,6 +554,7 @@ class PerfDataFilename(Enum):
 
     gemm = "gemm_perf.txt"
     nccl = "nccl_perf.txt"
+    oneccl = "oneccl_perf.txt"
     generation_attention = "generation_attention_perf.txt"
     context_attention = "context_attention_perf.txt"
     context_mla = "context_mla_perf.txt"

--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -2770,7 +2770,7 @@ class PerfDatabase:
                 "dsa_generation_module": _enum_key_names(getattr(self, "_generation_dsa_module_data", None)),
                 "mla_bmm": [],
                 "moe": _enum_key_names(getattr(self, "_moe_data", None)),
-                "nccl": _enum_key_names(getattr(self, "_nccl_data", None)),
+                "nccl": _enum_key_names(getattr(self, "_nccl_data", None) or getattr(self, "_oneccl_data", None)),
             }
 
     def is_inter_node(self, num_gpus: int) -> bool:

--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -2121,6 +2121,12 @@ class PerfDatabase:
             "nccl",
             self.system_spec["misc"]["nccl_version"],
         )
+        oneccl_version = self.system_spec.get("misc", {}).get("oneccl_version")
+        oneccl_data_dir = (
+            os.path.join(systems_root, self.system_spec["data_dir"], "oneccl", oneccl_version)
+            if oneccl_version
+            else None
+        )
 
         def _load_op_data(op_filename_enum: PerfDataFilename) -> LoadedOpData | tuple[LoadedOpData, ...]:
             func_map = {
@@ -2130,6 +2136,7 @@ class PerfDatabase:
                 PerfDataFilename.moe: load_moe_data,
                 PerfDataFilename.custom_allreduce: load_custom_allreduce_data,
                 PerfDataFilename.nccl: load_nccl_data,
+                PerfDataFilename.oneccl: load_nccl_data,
                 PerfDataFilename.context_mla: load_context_mla_data,
                 PerfDataFilename.generation_mla: load_generation_mla_data,
                 PerfDataFilename.mla_bmm: load_mla_bmm_data,
@@ -2151,6 +2158,8 @@ class PerfDatabase:
             perf_data_dir = data_dir
             if op_filename_enum == PerfDataFilename.nccl:
                 perf_data_dir = nccl_data_dir
+            elif op_filename_enum == PerfDataFilename.oneccl:
+                perf_data_dir = oneccl_data_dir if oneccl_data_dir else data_dir
 
             data_filepath = os.path.join(perf_data_dir, op_filename_enum.value)
             data_dict: Optional[dict] = func_map[op_filename_enum](data_filepath)
@@ -2174,6 +2183,7 @@ class PerfDatabase:
         # Comm ops
         self._custom_allreduce_data = _load_op_data(PerfDataFilename.custom_allreduce)
         self._nccl_data = _load_op_data(PerfDataFilename.nccl)
+        self._oneccl_data = _load_op_data(PerfDataFilename.oneccl) if oneccl_data_dir else None
 
         # More model-specific ops
         self._context_mla_data = _load_op_data(PerfDataFilename.context_mla)
@@ -4719,10 +4729,14 @@ class PerfDatabase:
                 if num_gpus == 1:
                     return PerformanceResult(0.0, energy=0.0)
 
-                self._nccl_data.raise_if_not_loaded()
+                # Use oneCCL data as fallback when NCCL data is not available (e.g. XPU systems)
+                nccl_source = self._nccl_data
+                if not nccl_source.loaded and self._oneccl_data is not None and self._oneccl_data.loaded:
+                    nccl_source = self._oneccl_data
+                nccl_source.raise_if_not_loaded()
 
-                max_num_gpus = max(self._nccl_data[dtype][operation].keys())
-                nccl_dict = self._nccl_data[dtype][operation][min(num_gpus, max_num_gpus)]
+                max_num_gpus = max(nccl_source[dtype][operation].keys())
+                nccl_dict = nccl_source[dtype][operation][min(num_gpus, max_num_gpus)]
                 size_left, size_right = self._nearest_1d_point_helper(
                     message_size,
                     list(nccl_dict.keys()),

--- a/src/aiconfigurator/systems/b60.yaml
+++ b/src/aiconfigurator/systems/b60.yaml
@@ -28,3 +28,4 @@ misc:
     8: 411041792 # 392MB
   other_mem: 3758096384 # increase from 551MB to 3.5GB for safer deployment, this will cover part of the inaccurate mem calc.
   nccl_version: '2.23'
+  oneccl_version: '2021.17.2'

--- a/src/aiconfigurator/systems/data/b60/oneccl/2021.17.2/oneccl_perf.txt
+++ b/src/aiconfigurator/systems/data/b60/oneccl/2021.17.2/oneccl_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:357f06ef9f3d1f522f509c8a42e77e8c27cb17f6b8a8aa27c11e2d5d882d82c3
+size 22892

--- a/tests/unit/sdk/database/test_comm_fallback.py
+++ b/tests/unit/sdk/database/test_comm_fallback.py
@@ -1,0 +1,256 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for NCCL/OneCCL fallback logic in query_nccl.
+
+When NCCL perf data is not available (e.g. on XPU systems), query_nccl should
+transparently fall back to OneCCL data if it has been loaded.
+"""
+
+import math
+from collections import defaultdict
+
+import pytest
+import yaml
+
+from aiconfigurator.sdk import common
+from aiconfigurator.sdk.perf_database import PerfDatabase, PerfDataNotAvailableError
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_comm_data(dtypes, operations, gpu_counts, msg_sizes, scale=0.001, power=0.0):
+    """Build a nested dict matching the NCCL/OneCCL data layout.
+
+    Args:
+        power: Power value. OneCCL data has no power measurement, so defaults to 0.0.
+    """
+    data = defaultdict(lambda: defaultdict(lambda: defaultdict(dict)))
+    for dtype in dtypes:
+        for op in operations:
+            for ng in gpu_counts:
+                for ms in msg_sizes:
+                    latency = scale * ms * ng
+                    data[dtype][op][ng][ms] = {
+                        "latency": latency,
+                        "power": power,
+                        "energy": latency * power,
+                    }
+    return dict(data)
+
+
+_DTYPES = [common.CommQuantMode.half, common.CommQuantMode.int8]
+_OPS = ["all_reduce", "all_gather", "reduce_scatter"]
+_NCCL_GPUS = [2, 4, 8]
+_ONECCL_GPUS = [2, 4]
+_MSG_SIZES = [512, 1024, 2048, 4096]
+
+
+@pytest.fixture
+def _db_factory(tmp_path, monkeypatch):
+    """
+    Factory that returns a PerfDatabase whose _nccl_data and _oneccl_data
+    can be independently controlled via keyword arguments.
+
+    Usage:
+        db = db_factory(nccl_data=<dict|None>, oneccl_data=<dict|None>,
+                        has_oneccl_version=True)
+    """
+    dummy_spec_base = {
+        "data_dir": "data",
+        "misc": {"nccl_version": "v1"},
+        "gpu": {
+            "float16_tc_flops": 1_000.0,
+            "mem_bw": 100.0,
+            "mem_empirical_constant_latency": 1.0,
+        },
+        "node": {
+            "inter_node_bw": 100.0,
+            "intra_node_bw": 100.0,
+            "num_gpus_per_node": 8,
+            "p2p_latency": 0.000001,
+        },
+    }
+
+    def _factory(*, nccl_data=None, oneccl_data=None, has_oneccl_version=True):
+        spec = dict(dummy_spec_base)
+        spec["misc"] = dict(spec["misc"])
+        if has_oneccl_version:
+            spec["misc"]["oneccl_version"] = "v1"
+
+        monkeypatch.setattr(yaml, "load", lambda stream, Loader=None: spec)  # noqa: N803
+
+        # Track which path each loader was called with so we can return the right data.
+        def _nccl_loader(path):
+            return nccl_data
+
+        def _oneccl_loader(path):
+            return oneccl_data
+
+        # We need load_nccl_data to differentiate between nccl and oneccl calls.
+        # PerfDataFilename.nccl -> nccl_data_dir, PerfDataFilename.oneccl -> oneccl_data_dir.
+        # Both map to load_nccl_data, but the path differs. We capture via closure.
+        call_count = {"n": 0}
+
+        def _nccl_load_dispatch(path):
+            # First call is for NCCL, second for OneCCL (per __init__ ordering)
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return nccl_data
+            return oneccl_data
+
+        monkeypatch.setattr("aiconfigurator.sdk.perf_database.load_nccl_data", _nccl_load_dispatch)
+
+        # Patch all other loaders to avoid file access
+        monkeypatch.setattr("aiconfigurator.sdk.perf_database.load_gemm_data", lambda p: {})
+        monkeypatch.setattr("aiconfigurator.sdk.perf_database.load_context_attention_data", lambda p: {})
+        monkeypatch.setattr("aiconfigurator.sdk.perf_database.load_generation_attention_data", lambda p: {})
+        monkeypatch.setattr("aiconfigurator.sdk.perf_database.load_moe_data", lambda p: ({}, {}))
+        monkeypatch.setattr("aiconfigurator.sdk.perf_database.load_custom_allreduce_data", lambda p: {})
+        monkeypatch.setattr("aiconfigurator.sdk.perf_database.load_context_mla_data", lambda p: {})
+        monkeypatch.setattr("aiconfigurator.sdk.perf_database.load_generation_mla_data", lambda p: {})
+        monkeypatch.setattr("aiconfigurator.sdk.perf_database.load_mla_bmm_data", lambda p: {})
+        monkeypatch.setattr("aiconfigurator.sdk.perf_database.load_context_dsa_module_data", lambda p: None)
+        monkeypatch.setattr("aiconfigurator.sdk.perf_database.load_generation_dsa_module_data", lambda p: None)
+
+        yaml_file = tmp_path / "sys.yaml"
+        yaml_file.write_text("dummy: data")
+        return PerfDatabase("sys", "backend", "v1", str(tmp_path))
+
+    return _factory
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestNcclOnecclFallback:
+    """Verify the NCCL → OneCCL fallback logic in query_nccl (SILICON mode)."""
+
+    def test_nccl_loaded_uses_nccl(self, _db_factory):
+        """When NCCL data is loaded, query_nccl should use it directly."""
+        nccl = _make_comm_data(_DTYPES, _OPS, _NCCL_GPUS, _MSG_SIZES, scale=0.001, power=5.0)
+        oneccl = _make_comm_data(_DTYPES, _OPS, _ONECCL_GPUS, _MSG_SIZES, scale=0.999)
+        db = _db_factory(nccl_data=nccl, oneccl_data=oneccl)
+
+        result = db.query_nccl(
+            common.CommQuantMode.half,
+            4,
+            "all_reduce",
+            1024,
+            database_mode=common.DatabaseMode.SILICON,
+        )
+        # Should match NCCL scale (0.001), not OneCCL scale (0.999)
+        expected_latency = 0.001 * 1024 * 4
+        assert math.isclose(float(result), expected_latency, rel_tol=1e-6), (
+            f"Expected NCCL latency {expected_latency}, got {float(result)}"
+        )
+
+    def test_fallback_to_oneccl_when_nccl_not_loaded(self, _db_factory):
+        """When NCCL data is not loaded but OneCCL is, query_nccl should use OneCCL."""
+        oneccl = _make_comm_data(_DTYPES, _OPS, _ONECCL_GPUS, _MSG_SIZES, scale=0.002)
+        db = _db_factory(nccl_data=None, oneccl_data=oneccl)
+
+        result = db.query_nccl(
+            common.CommQuantMode.half,
+            4,
+            "all_reduce",
+            1024,
+            database_mode=common.DatabaseMode.SILICON,
+        )
+        expected_latency = 0.002 * 1024 * 4
+        assert math.isclose(float(result), expected_latency, rel_tol=1e-6), (
+            f"Expected OneCCL fallback latency {expected_latency}, got {float(result)}"
+        )
+
+    def test_fallback_oneccl_has_no_power(self, _db_factory):
+        """OneCCL data has no power measurement — energy should be 0.0."""
+        oneccl = _make_comm_data(_DTYPES, _OPS, _ONECCL_GPUS, _MSG_SIZES, scale=0.002)  # power=0.0
+        db = _db_factory(nccl_data=None, oneccl_data=oneccl)
+
+        result = db.query_nccl(
+            common.CommQuantMode.half,
+            4,
+            "all_gather",
+            2048,
+            database_mode=common.DatabaseMode.SILICON,
+        )
+        expected_latency = 0.002 * 2048 * 4
+        assert math.isclose(float(result), expected_latency, rel_tol=1e-6)
+        assert result.energy == 0.0, "OneCCL has no power data, so energy should be 0.0"
+
+    def test_raises_when_neither_loaded(self, _db_factory):
+        """When neither NCCL nor OneCCL data is loaded, raise PerfDataNotAvailableError."""
+        db = _db_factory(nccl_data=None, oneccl_data=None)
+
+        with pytest.raises(PerfDataNotAvailableError):
+            db.query_nccl(
+                common.CommQuantMode.half,
+                4,
+                "all_reduce",
+                1024,
+                database_mode=common.DatabaseMode.SILICON,
+            )
+
+    def test_raises_when_nccl_not_loaded_and_no_oneccl_version(self, _db_factory):
+        """When NCCL is not loaded and system has no oneccl_version, should raise."""
+        db = _db_factory(nccl_data=None, oneccl_data=None, has_oneccl_version=False)
+
+        with pytest.raises(PerfDataNotAvailableError):
+            db.query_nccl(
+                common.CommQuantMode.half,
+                4,
+                "all_reduce",
+                1024,
+                database_mode=common.DatabaseMode.SILICON,
+            )
+
+    def test_hybrid_falls_back_to_empirical_when_neither_loaded(self, _db_factory):
+        """In HYBRID mode, when neither backend has data, fall back to empirical."""
+        db = _db_factory(nccl_data=None, oneccl_data=None)
+
+        # HYBRID mode should not raise — it falls back to empirical
+        result = db.query_nccl(
+            common.CommQuantMode.half,
+            4,
+            "all_gather",
+            1024,
+            database_mode=common.DatabaseMode.HYBRID,
+        )
+        assert float(result) > 0, "HYBRID empirical fallback should return positive latency"
+
+    def test_single_gpu_returns_zero(self, _db_factory):
+        """num_gpus=1 is a fast-path returning zero latency regardless of data."""
+        db = _db_factory(nccl_data=None, oneccl_data=None)
+
+        result = db.query_nccl(
+            common.CommQuantMode.half,
+            1,
+            "all_reduce",
+            1024,
+            database_mode=common.DatabaseMode.SILICON,
+        )
+        assert float(result) == 0.0
+        assert result.energy == 0.0
+
+    def test_fallback_multiple_operations(self, _db_factory):
+        """Verify fallback works for all supported collective operations."""
+        oneccl = _make_comm_data(_DTYPES, _OPS, _ONECCL_GPUS, _MSG_SIZES, scale=0.003)
+        db = _db_factory(nccl_data=None, oneccl_data=oneccl)
+
+        for op in ["all_reduce", "all_gather", "reduce_scatter"]:
+            result = db.query_nccl(
+                common.CommQuantMode.half,
+                4,
+                op,
+                1024,
+                database_mode=common.DatabaseMode.SILICON,
+            )
+            expected = 0.003 * 1024 * 4
+            assert math.isclose(float(result), expected, rel_tol=1e-6), (
+                f"Fallback failed for operation '{op}': expected {expected}, got {float(result)}"
+            )

--- a/tools/sanity_check/create_charts.py
+++ b/tools/sanity_check/create_charts.py
@@ -240,7 +240,8 @@ def main():
             backend_version = parts[3]
 
             # data/<system>/nccl/<nccl_version>/nccl_perf.txt
-            if backend == "nccl":
+            # data/<system>/oneccl/<oneccl_version>/oneccl_perf.txt
+            if backend in ("nccl", "oneccl"):
                 # Ignore for now
                 continue
 


### PR DESCRIPTION
Add oneCCL communication benchmarking support for Intel XPU (b60)

- Add collect_oneccl_xpu.py: benchmark collector for oneCCL collective
  ops (all_gather, reduce_scatter, all_reduce, alltoall) on Intel XPU
  devices using the oneCCL benchmark binary via mpirun
- Add README_oneccl_xpu.md: setup and usage guide for oneCCL collection
- Update collect_comm.sh: add XPU device path that invokes
  collect_oneccl_xpu.py, default to vllm backend for XPU
- Add PerfDataFilename.oneccl enum and wire it through PerfDatabase to
  load oneCCL perf data using the existing NCCL CSV parser
- Add NCCL-to-oneCCL fallback in get_silicon(): when NCCL data is not
  available, transparently use oneCCL data for comm op queries
- Add b60 system config: oneccl_version '2021.17.2' and collected
  oneCCL perf data for the b60 Intel GPU system

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive guide for benchmarking Intel oneCCL collective communication on Intel XPU (GPU) devices, including setup, prerequisites, and troubleshooting.

* **New Features**
  * Extended benchmarking tools to support Intel XPU collective communication operations (all-gather, reduce-scatter, all-reduce).
  * Added performance data collection and analysis for oneCCL benchmarks.
  * Added oneCCL version configuration and tracking support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->