### PR TITLE
chore: Add data from auto-collector pipeline 47801427 (h200_sxm_trtllm_1.3.0rc10)

### DIFF
--- a/src/aiconfigurator/systems/data/h200_sxm/nccl/2.26.2/nccl_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/nccl/2.26.2/nccl_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fe6af52f8078785c5352e205be3d34b545e4cb87d626706d021c61b3d88ec2f2
-size 34175
+oid sha256:5ec61d99d043e47d33cd505c70fc461f343a796a04c354f1a02e1d36557571a1
+size 34789

--- a/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.3.0rc10/computescale_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.3.0rc10/computescale_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba2e036db3be6bf06366e0a719447269564ec49d1e176848b01537f0a3fce1b8
+size 142736

--- a/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.3.0rc10/context_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.3.0rc10/context_attention_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bfeae5529579a2d200356ed6a624c2d9872352674e6d1270bdee26f3674442c3
+size 5679249

--- a/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.3.0rc10/context_mla_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.3.0rc10/context_mla_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bfc2d99d4d7c7e3b0f574e4d931c70fca5021aab9b8514cb56aab416fc1015fd
+size 171935

--- a/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.3.0rc10/custom_allreduce_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.3.0rc10/custom_allreduce_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e5820a56c10e858826051c6d972bb174a2270a3219d2c5d5c0a23aee323166d
+size 6469

--- a/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.3.0rc10/dsa_context_module_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.3.0rc10/dsa_context_module_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2297f64c658e5d9ee1b09371a7e98bebe3ecb5260d720738b7fc68f6cfd97135
+size 297039

--- a/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.3.0rc10/dsa_generation_module_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.3.0rc10/dsa_generation_module_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50ec6fd567c9c7f67e4cb830f14a1c38b43bb6bd676639b7f561c53bd5016823
+size 456132

--- a/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.3.0rc10/gdn_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.3.0rc10/gdn_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29b9e3a38058c4db78ea740255914a1d38a105f3a3f38b9c800f8b3c2c4c1199
+size 240574

--- a/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.3.0rc10/gemm_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.3.0rc10/gemm_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de419818c7bc7654b98ac86f9a7e077e9935c12d4c820ee5fab02cfb74049c31
+size 8815104

--- a/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.3.0rc10/generation_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.3.0rc10/generation_attention_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02adbe5ce1206226234100a57209545470f8c1d0d21bd392b59dc7b83eb1083c
+size 2895439

--- a/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.3.0rc10/generation_mla_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.3.0rc10/generation_mla_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f338bf6df9612e9558f8cecd8347f734401f4aaef3461ebf47097c497bc46504
+size 294477

--- a/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.3.0rc10/mamba2_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.3.0rc10/mamba2_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56a68233681f8a6f051e5b63c8f178a0f44853e6f3264edf3a3aa277cbae3818
+size 63107

--- a/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.3.0rc10/mla_bmm_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.3.0rc10/mla_bmm_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e55fef4d456f2c160e11bdb4a2285ad074691c3caae0dfa3be954b3b9c2a2547
+size 71070

--- a/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.3.0rc10/scale_matrix_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.3.0rc10/scale_matrix_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:93e35604da7355ae66e1c941ac610d6880c44625bfe6ea47fb8e5f11e68343bc
+size 141757

--- a/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.3.0rc10/wideep_moe_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.3.0rc10/wideep_moe_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7026487dc7d12f63dfb983786ad6e0866370939c9a9d1e581d02c42b6b31bdb1
+size 880118


### PR DESCRIPTION
# Error Summary for Auto-Collector Run
## Collection summary for h200_sxm trtllm:1.3.0rc10
### Error summary
```
{
    "backend": "trtllm",
    "version": "1.3.0rc10",
    "timestamp": "2026-04-06T07:27:07.004874",
    "total_errors": 17383,
    "errors_by_module": {
        "trtllm.attention_context": 134,
        "trtllm.attention_generation": 6060,
        "trtllm.moe": 1,
        "trtllm.trtllm_moe_wideep": 10,
        "trtllm.mla_context_module": 3904,
        "trtllm.mla_generation_module": 5888,
        "trtllm.dsa_context_module": 635,
        "trtllm.dsa_generation_module": 751
    },
    "errors_by_type": {
        "AcceleratorError": 451,
        "WorkerSignalCrash": 451,
        "RuntimeError": 5292,
        "CompatibilityError": 1,
        "AssertionError": 10,
        "AttributeError": 9792,
        "OSError": 1386
    }
}
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated and added performance benchmark reference data for H200 SXM systems supporting NCCL version 2.26.2 and TensorRT-LLM version 1.3.0rc10, including metrics for compute, attention, model layers, and various optimization modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->