### PR TITLE
feat: Fix ANSI codes when redirecting stdout and Add --no-color flag

### DIFF
--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -49,6 +49,12 @@ def _build_common_cli_parser() -> argparse.ArgumentParser:
             "Example: default,/opt/aic/systems,/data/aic/systems."
         ),
     )
+    common_parser.add_argument(
+        "--no-color",
+        dest="no_color",
+        action="store_true",
+        help="Disable ANSI colors in output.",
+    )
     add_generator_override_arguments(common_parser)
     return common_parser
 
@@ -1392,7 +1398,10 @@ def _run_estimate_mode(args):
 
 
 def main(args):
-    setup_logging(level=logging.DEBUG if args.debug else logging.INFO)
+    setup_logging(
+        level=logging.DEBUG if args.debug else logging.INFO,
+        no_color=getattr(args, "no_color", False),
+    )
 
     # Handle support mode early — it doesn't need systems_paths or top_n
     if args.mode == "support":

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -31,8 +31,22 @@ logger = logging.getLogger(__name__)
 
 def _build_common_cli_parser() -> argparse.ArgumentParser:
     common_parser = argparse.ArgumentParser(add_help=False)
-    common_parser.add_argument("--save-dir", type=str, default=None, help="Directory to save the results.")
     common_parser.add_argument("--debug", action="store_true", help="Enable debug mode.")
+    common_parser.add_argument(
+        "--no-color",
+        dest="no_color",
+        action="store_true",
+        help="Disable ANSI colors in output.",
+    )
+    # TODO: maybe move --systems-path here?
+    return common_parser
+
+
+def _build_common_cli_experiments_parser() -> argparse.ArgumentParser:
+    # TODO: some arguments might be unused in some modes.
+    # Example: --top-n not used for generate mode.
+    common_parser = argparse.ArgumentParser(add_help=False)
+    common_parser.add_argument("--save-dir", type=str, default=None, help="Directory to save the results.")
     common_parser.add_argument(
         "--top-n",
         type=int,
@@ -48,12 +62,6 @@ def _build_common_cli_parser() -> argparse.ArgumentParser:
             "Systems search paths (comma-separated). Use 'default' for the built-in systems path. "
             "Example: default,/opt/aic/systems,/data/aic/systems."
         ),
-    )
-    common_parser.add_argument(
-        "--no-color",
-        dest="no_color",
-        action="store_true",
-        help="Disable ANSI colors in output.",
     )
     add_generator_override_arguments(common_parser)
     return common_parser
@@ -449,11 +457,12 @@ aiconfigurator cli default --model Qwen/Qwen3-32B-FP8 \\
 
 def configure_parser(parser):
     common_cli_parser = _build_common_cli_parser()
+    common_cli_experiments_parser = _build_common_cli_experiments_parser()
     subparsers = parser.add_subparsers(dest="mode", required=True)
 
     default_parser = subparsers.add_parser(
         "default",
-        parents=[common_cli_parser],
+        parents=[common_cli_parser, common_cli_experiments_parser],
         help="Run the default agg vs disagg comparison.",
         description="Run the default agg vs disagg comparison.",
         epilog=_USAGE_EXAMPLES,
@@ -470,7 +479,7 @@ def configure_parser(parser):
 
     experiments_parser = subparsers.add_parser(
         "exp",
-        parents=[common_cli_parser],
+        parents=[common_cli_parser, common_cli_experiments_parser],
         help=help_text,
         description=description,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -480,7 +489,7 @@ def configure_parser(parser):
     # Generate mode - naive config without sweeping
     generate_parser = subparsers.add_parser(
         "generate",
-        parents=[common_cli_parser],
+        parents=[common_cli_parser, common_cli_experiments_parser],
         help="Generate naive agg config without SLA optimization (no sweeping).",
         description=(
             "Generate a working agg configuration without running the parameter sweep. "
@@ -493,7 +502,7 @@ def configure_parser(parser):
     # Estimate mode - single-point performance estimation
     estimate_parser = subparsers.add_parser(
         "estimate",
-        parents=[common_cli_parser],
+        parents=[common_cli_parser, common_cli_experiments_parser],
         help="Estimate TTFT, TPOT, and power for a single model/system/config.",
         description=(
             "Run a single-point performance estimation to predict TTFT (time to first token), "
@@ -506,12 +515,12 @@ def configure_parser(parser):
     # Support mode - support matrix check
     support_parser = subparsers.add_parser(
         "support",
+        parents=[common_cli_parser],
         help="(Optional) Check if AIC supports the model/hardware combo for (agg, disagg).",
         description="Optional pre-flight check to verify support for a specific model and system "
         "combination using the support matrix. You can skip this and run 'cli default' directly. "
         "Use --system all for a consolidated matrix view across all systems and backends.",
     )
-    support_parser.add_argument("--debug", action="store_true", help="Enable debug mode.")
     _add_support_mode_arguments(support_parser)
 
 

--- a/src/aiconfigurator/cli/report_and_save.py
+++ b/src/aiconfigurator/cli/report_and_save.py
@@ -18,6 +18,7 @@ from aiconfigurator.generator.api import (
     resolve_backend_version_for_dynamo,
 )
 from aiconfigurator.generator.module_bridge import task_config_to_generator_config
+from aiconfigurator.logging_utils import _cli_bold, _cli_underline
 from aiconfigurator.sdk import pareto_analysis
 from aiconfigurator.sdk.pareto_analysis import draw_pareto_to_string
 from aiconfigurator.sdk.task import TaskConfig
@@ -111,7 +112,7 @@ def _plot_worker_setup_table(
         field_names = [
             "Rank",
             "backend",
-            "\033[1mtokens/s/gpu\033[0m",
+            _cli_bold("tokens/s/gpu"),
             "tokens/s/user",
             "req/s",
             "TTFT",
@@ -135,29 +136,41 @@ def _plot_worker_setup_table(
         for i, row in enumerate(top_configs.to_dict("records")):
             if is_moe:
                 p_parallel = (
-                    f"tp\033[4m{row['(p)tp']}\033[0mpp\033[4m{row['(p)pp']}\033[0m"
-                    f"dp\033[4m{row['(p)dp']}\033[0metp{row['(p)moe_tp']}ep{row['(p)moe_ep']}"
+                    f"tp{_cli_underline(str(row['(p)tp']))}"
+                    f"pp{_cli_underline(str(row['(p)pp']))}"
+                    f"dp{_cli_underline(str(row['(p)dp']))}"
+                    f"etp{row['(p)moe_tp']}ep{row['(p)moe_ep']}"
                 )
                 d_parallel = (
-                    f"tp\033[4m{row['(d)tp']}\033[0mpp\033[4m{row['(d)pp']}\033[0m"
-                    f"dp\033[4m{row['(d)dp']}\033[0metp{row['(d)moe_tp']}ep{row['(d)moe_ep']}"
+                    f"tp{_cli_underline(str(row['(d)tp']))}"
+                    f"pp{_cli_underline(str(row['(d)pp']))}"
+                    f"dp{_cli_underline(str(row['(d)dp']))}"
+                    f"etp{row['(d)moe_tp']}ep{row['(d)moe_ep']}"
                 )
                 p_gpus_worker = (
                     f"{row['(p)pp'] * row['(p)tp'] * row['(p)dp']} "
-                    f"(=\033[4m{row['(p)tp']}\033[0mx\033[4m{row['(p)pp']}\033[0mx\033[4m{row['(p)dp']}\033[0m)"
+                    f"(={_cli_underline(str(row['(p)tp']))}x"
+                    f"{_cli_underline(str(row['(p)pp']))}x"
+                    f"{_cli_underline(str(row['(p)dp']))})"
                 )
                 d_gpus_worker = (
                     f"{row['(d)pp'] * row['(d)tp'] * row['(d)dp']} "
-                    f"(=\033[4m{row['(d)tp']}\033[0mx\033[4m{row['(d)pp']}\033[0mx\033[4m{row['(d)dp']}\033[0m)"
+                    f"(={_cli_underline(str(row['(d)tp']))}x"
+                    f"{_cli_underline(str(row['(d)pp']))}x"
+                    f"{_cli_underline(str(row['(d)dp']))})"
                 )
             else:
-                p_parallel = f"tp\033[4m{row['(p)tp']}\033[0mpp\033[4m{row['(p)pp']}\033[0m"
-                d_parallel = f"tp\033[4m{row['(d)tp']}\033[0mpp\033[4m{row['(d)pp']}\033[0m"
+                p_parallel = f"tp{_cli_underline(str(row['(p)tp']))}pp{_cli_underline(str(row['(p)pp']))}"
+                d_parallel = f"tp{_cli_underline(str(row['(d)tp']))}pp{_cli_underline(str(row['(d)pp']))}"
                 p_gpus_worker = (
-                    f"{row['(p)pp'] * row['(p)tp']} (=\033[4m{row['(p)tp']}\033[0mx\033[4m{row['(p)pp']}\033[0m)"
+                    f"{row['(p)pp'] * row['(p)tp']} "
+                    f"(={_cli_underline(str(row['(p)tp']))}x"
+                    f"{_cli_underline(str(row['(p)pp']))})"
                 )
                 d_gpus_worker = (
-                    f"{row['(d)pp'] * row['(d)tp']} (=\033[4m{row['(d)tp']}\033[0mx\033[4m{row['(d)pp']}\033[0m)"
+                    f"{row['(d)pp'] * row['(d)tp']} "
+                    f"(={_cli_underline(str(row['(d)tp']))}x"
+                    f"{_cli_underline(str(row['(d)pp']))})"
                 )
             row_data = [
                 i + 1,
@@ -165,7 +178,7 @@ def _plot_worker_setup_table(
             ]
             row_data.extend(
                 [
-                    f"\033[1m{row['tokens/s/gpu_cluster']:.2f}\033[0m",
+                    _cli_bold(f"{row['tokens/s/gpu_cluster']:.2f}"),
                     f"{row['tokens/s/user']:.2f}",
                     f"{row['cluster_request_rate']:.2f}",
                     f"{row['ttft']:.2f}",
@@ -195,7 +208,7 @@ def _plot_worker_setup_table(
         field_names = [
             "Rank",
             "backend",
-            "\033[1mtokens/s/gpu\033[0m",
+            _cli_bold("tokens/s/gpu"),
             "tokens/s/user",
             "req/s",
             "TTFT",
@@ -214,18 +227,24 @@ def _plot_worker_setup_table(
         for i, row in enumerate(top_configs.to_dict("records")):
             if is_moe:
                 parallel = (
-                    f"tp\033[4m{row['tp']}\033[0mpp\033[4m{row['pp']}\033[0m"
-                    f"dp\033[4m{row['dp']}\033[0metp{row['moe_tp']}ep{row['moe_ep']}"
+                    f"tp{_cli_underline(str(row['tp']))}"
+                    f"pp{_cli_underline(str(row['pp']))}"
+                    f"dp{_cli_underline(str(row['dp']))}"
+                    f"etp{row['moe_tp']}ep{row['moe_ep']}"
                 )
                 gpus_worker = (
                     f"{row['pp'] * row['tp'] * row['dp']} "
-                    f"(=\033[4m{row['tp']}\033[0mx\033[4m{row['pp']}\033[0mx\033[4m{row['dp']}\033[0m)"
+                    f"(={_cli_underline(str(row['tp']))}x"
+                    f"{_cli_underline(str(row['pp']))}x"
+                    f"{_cli_underline(str(row['dp']))})"
                 )
             else:
-                parallel = f"tp\033[4m{row['tp']}\033[0mpp\033[4m{row['pp']}\033[0m"
+                parallel = f"tp{_cli_underline(str(row['tp']))}pp{_cli_underline(str(row['pp']))}"
                 gpus_worker = (
-                    f"{row['pp'] * row['tp']} (=\033[4m{row['tp']}\033[0mx\033[4m{row['pp']}"
-                    f"\033[0mx\033[4m{row['dp']}\033[0m)"
+                    f"{row['pp'] * row['tp']} "
+                    f"(={_cli_underline(str(row['tp']))}x"
+                    f"{_cli_underline(str(row['pp']))}x"
+                    f"{_cli_underline(str(row['dp']))})"
                 )
             row_data = [
                 i + 1,
@@ -233,7 +252,7 @@ def _plot_worker_setup_table(
             ]
             row_data.extend(
                 [
-                    f"\033[1m{row['tokens/s/gpu_cluster']:.2f}\033[0m",
+                    _cli_bold(f"{row['tokens/s/gpu_cluster']:.2f}"),
                     f"{row['tokens/s/user']:.2f}",
                     f"{row['cluster_request_rate']:.2f}",
                     f"{row['ttft']:.2f}",
@@ -315,7 +334,7 @@ def log_final_summary(
                     if pct < 100.0:
                         line += f" -- WARNING: only {pct:.1f}% of target load can be served"
                 summary_box.append(line)
-        summary_box.append(f"    Best Experiment Chosen: \033[1m{chosen_exp}\033[0m")
+        summary_box.append(f"    Best Experiment Chosen: {_cli_bold(chosen_exp)}")
     elif mode == "default":
         agg_value = best_throughputs.get("agg", 0.0)
         disagg_value = best_throughputs.get("disagg", 0.0)
@@ -327,15 +346,13 @@ def log_final_summary(
             benefit_ratio = 0.0
         else:
             benefit_ratio = 0.0  # handle case where both are 0
-        summary_box.append(
-            f"    Best Experiment Chosen: \033[1m{chosen_exp} at "
-            f"{best_throughputs[chosen_exp]:.2f} tokens/s/gpu "
-            f"(disagg {benefit_ratio:.2f}x better)\033[0m"
+        bold_msg = _cli_bold(
+            f"{chosen_exp} at {best_throughputs[chosen_exp]:.2f} tokens/s/gpu (disagg {benefit_ratio:.2f}x better)"
         )
+        summary_box.append(f"    Best Experiment Chosen: {bold_msg}")
     else:
-        summary_box.append(
-            f"    Best Experiment Chosen: \033[1m{chosen_exp} at {best_throughputs[chosen_exp]:.2f} tokens/s/gpu\033[0m"
-        )
+        bold_msg = _cli_bold(f"{chosen_exp} at {best_throughputs[chosen_exp]:.2f} tokens/s/gpu")
+        summary_box.append(f"    Best Experiment Chosen: {bold_msg}")
 
     summary_box.append("  " + "-" * 76)
 
@@ -401,7 +418,7 @@ def log_final_summary(
     )
     summary_box.append(
         "               gpus/worker = tp * pp * dp = etp * ep * pp for MoE models; "
-        "tp * pp for dense models (underlined \033[4mnumbers\033[0m are the actual values in math)"
+        f"tp * pp for dense models (underlined {_cli_underline('numbers')} are the actual values in math)"
     )
 
     # Check if power data is available before plotting tables

--- a/src/aiconfigurator/cli/report_and_save.py
+++ b/src/aiconfigurator/cli/report_and_save.py
@@ -241,10 +241,7 @@ def _plot_worker_setup_table(
             else:
                 parallel = f"tp{_cli_underline(str(row['tp']))}pp{_cli_underline(str(row['pp']))}"
                 gpus_worker = (
-                    f"{row['pp'] * row['tp']} "
-                    f"(={_cli_underline(str(row['tp']))}x"
-                    f"{_cli_underline(str(row['pp']))}x"
-                    f"{_cli_underline(str(row['dp']))})"
+                    f"{row['pp'] * row['tp']} (={_cli_underline(str(row['tp']))}x{_cli_underline(str(row['pp']))}"
                 )
             row_data = [
                 i + 1,

--- a/src/aiconfigurator/logging_utils.py
+++ b/src/aiconfigurator/logging_utils.py
@@ -10,7 +10,10 @@ import sys
 
 def _stdout_env_suggests_plain() -> bool:
     """True when NO_COLOR or non-TTY stdout indicates avoiding ANSI."""
-    if os.environ.get("NO_COLOR", "").strip() != "":
+    if "NO_COLOR" in os.environ:
+        return True
+    # Hack to support --no-color arg before argparse.parse_args() is completed.
+    if "--no-color" in sys.argv:
         return True
     try:
         return not sys.stdout.isatty()

--- a/src/aiconfigurator/logging_utils.py
+++ b/src/aiconfigurator/logging_utils.py
@@ -8,6 +8,48 @@ import os
 import sys
 
 
+def _stdout_env_suggests_plain() -> bool:
+    """True when NO_COLOR or non-TTY stdout indicates avoiding ANSI."""
+    if os.environ.get("NO_COLOR", "").strip() != "":
+        return True
+    try:
+        return not sys.stdout.isatty()
+    except (AttributeError, OSError, ValueError):
+        return True
+
+
+def use_plain_cli_output() -> bool:
+    """Return True if human-oriented output should avoid ANSI.
+
+    True when the root logger was configured with setup_logging and
+    no_color=True (--no-color), or when NO_COLOR is set, or when stdout
+    is not a TTY.
+
+    .. NO_COLOR: https://no-color.org/
+    """
+    # Check if the root logger was configured with setup_logging and no_color=True
+    for handler in logging.getLogger().handlers:
+        fmt = getattr(handler, "formatter", None)
+        if isinstance(fmt, ColoredFormatter) and fmt.force_no_color:
+            return True
+
+    return _stdout_env_suggests_plain()
+
+
+def _cli_bold(text: str) -> str:
+    """Wrap *text* in bold SGR when use_plain_cli_output is false."""
+    if use_plain_cli_output():
+        return text
+    return f"\033[1m{text}\033[0m"
+
+
+def _cli_underline(text: str) -> str:
+    """Wrap *text* in underline SGR when use_plain_cli_output is false."""
+    if use_plain_cli_output():
+        return text
+    return f"\033[4m{text}\033[0m"
+
+
 class ColoredFormatter(logging.Formatter):
     """Custom formatter that adds colors to log output.
 
@@ -32,10 +74,10 @@ class ColoredFormatter(logging.Formatter):
     CYAN = "\033[96m"
     RESET = "\033[0m"
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, force_no_color: bool = False, **kwargs):
         super().__init__(*args, **kwargs)
-        # Check if colors should be disabled (e.g., when output is redirected)
-        self.use_colors = sys.stdout.isatty() and os.environ.get("NO_COLOR") is None
+        self.force_no_color = force_no_color
+        self.use_colors = not force_no_color and not _stdout_env_suggests_plain()
 
     def format(self, record):
         # Get the base formatted message
@@ -79,7 +121,15 @@ class ColoredFormatter(logging.Formatter):
         return level_part
 
 
-def setup_logging(level=logging.INFO):
+def setup_logging(level=logging.INFO, *, no_color: bool = False):
+    """Configure root logging to stdout.
+
+    Args:
+        level: Minimum log level for the root logger.
+        no_color: If True (CLI --no-color), disable ANSI in log lines and treat all
+            CLI summaries as plain; see use_plain_cli_output. TTY and NO_COLOR
+            are combined inside ColoredFormatter and use_plain_cli_output.
+    """
     root_logger = logging.getLogger()
     root_logger.setLevel(level)
 
@@ -91,6 +141,7 @@ def setup_logging(level=logging.INFO):
     formatter = ColoredFormatter(
         "%(asctime)s [aiconfigurator] [%(levelname).1s] [%(filename)s:%(lineno)d] %(message)s",
         datefmt="%H:%M:%S",
+        force_no_color=no_color,
     )
     console_handler.setFormatter(formatter)
     root_logger.addHandler(console_handler)

--- a/src/aiconfigurator/sdk/pareto_analysis.py
+++ b/src/aiconfigurator/sdk/pareto_analysis.py
@@ -4,12 +4,14 @@
 import copy
 import logging
 import math
+import re
 
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import plotext
 
+from aiconfigurator.logging_utils import use_plain_cli_output
 from aiconfigurator.sdk import config
 from aiconfigurator.sdk.backends.factory import get_backend
 from aiconfigurator.sdk.common import ColumnsAgg
@@ -461,6 +463,12 @@ def draw_pareto_to_string(
 
     try:
         buf = plotext.build()
+        # Remove ANSI if plain output is needed.
+        # https://stackoverflow.com/questions/14693701/how-can-i-remove-the-ansi-escape-sequences-from-a-string-in-python
+        if use_plain_cli_output():
+            print("removed ANSI", use_plain_cli_output())
+            ansi_escape_8bit = re.compile(r"(?:\x1B[@-Z\\-_]|[\x80-\x9A\x9C-\x9F]|(?:\x1B\[|\x9B)[0-?]*[ -/]*[@-~])")
+            buf = ansi_escape_8bit.sub("", buf)
     except Exception:
         logger.exception("failed to build plotext")
         buf = ""

--- a/src/aiconfigurator/sdk/pareto_analysis.py
+++ b/src/aiconfigurator/sdk/pareto_analysis.py
@@ -466,7 +466,6 @@ def draw_pareto_to_string(
         # Remove ANSI if plain output is needed.
         # https://stackoverflow.com/questions/14693701/how-can-i-remove-the-ansi-escape-sequences-from-a-string-in-python
         if use_plain_cli_output():
-            print("removed ANSI", use_plain_cli_output())
             ansi_escape_8bit = re.compile(r"(?:\x1B[@-Z\\-_]|[\x80-\x9A\x9C-\x9F]|(?:\x1B\[|\x9B)[0-?]*[ -/]*[@-~])")
             buf = ansi_escape_8bit.sub("", buf)
     except Exception:

--- a/tests/unit/cli/test_plain_output.py
+++ b/tests/unit/cli/test_plain_output.py
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for plain (non-TTY) CLI summary output without ANSI escapes."""
+
+from __future__ import annotations
+
+import logging
+import sys
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from aiconfigurator.cli.report_and_save import _plot_worker_setup_table, log_final_summary
+from aiconfigurator.logging_utils import setup_logging, use_plain_cli_output
+from aiconfigurator.sdk.pareto_analysis import draw_pareto_to_string
+
+pytestmark = pytest.mark.unit
+
+_ESC = "\x1b["
+
+
+@pytest.fixture(autouse=True)
+def mock_stdout_isatty(monkeypatch):
+    mock = MagicMock(return_value=True)
+    monkeypatch.setattr(sys.stdout, "isatty", mock)
+    return mock
+
+
+@pytest.fixture(autouse=True)
+def _reset_logging_after_test(monkeypatch):
+    yield
+    setup_logging(no_color=False)
+    monkeypatch.delenv("NO_COLOR", raising=False)
+
+
+def test_cli_parser_accepts_no_color(cli_parser):
+    base = [
+        "default",
+        "--model-path",
+        "Qwen/Qwen3-32B",
+        "--total-gpus",
+        "8",
+        "--system",
+        "h200_sxm",
+    ]
+    assert cli_parser.parse_args([*base, "--no-color"]).no_color is True
+
+
+@pytest.mark.parametrize("isatty", [True, False])
+def test_use_plain_when_stdout_not_a_tty(mock_stdout_isatty, isatty):
+    mock_stdout_isatty.return_value = isatty
+    assert use_plain_cli_output() is not isatty
+
+
+@pytest.mark.parametrize("nocolor_env_set", [True, False])
+def test_use_plain_when_no_color_env_set(monkeypatch, nocolor_env_set):
+    if nocolor_env_set:
+        monkeypatch.setenv("NO_COLOR", "1")
+    assert use_plain_cli_output() is nocolor_env_set
+
+
+def test_colored_formatter_force_no_color_disables_colors():
+    setup_logging(no_color=True)
+    handler = logging.getLogger().handlers[0]
+    assert handler.formatter.use_colors is False
+    assert handler.formatter.force_no_color is True
+    assert use_plain_cli_output() is True
+
+
+@pytest.mark.parametrize("use_ansi", [True, False])
+def test_draw_pareto_to_string(use_ansi):
+    setup_logging(no_color=not use_ansi)
+    df = pd.DataFrame({"tokens/s/user": [1.0, 2.0], "tokens/s/gpu_cluster": [10.0, 20.0]})
+    out = draw_pareto_to_string(
+        "Test",
+        [{"df": df, "label": "a"}],
+        highlight={"df": df.head(1), "label": "best"},
+    )
+    assert (_ESC in out) == use_ansi
+
+
+@pytest.mark.parametrize("use_ansi", [True, False])
+def test_log_final_summary(caplog, use_ansi):
+    caplog.set_level("INFO")
+    setup_logging(no_color=not use_ansi)
+    # setup_logging clears root handlers; reattach pytest's capture handler.
+    logging.getLogger().addHandler(caplog.handler)
+
+    model_path = "unit-test-model"
+    tc = MagicMock()
+    tc.config.model_path = model_path
+    tc.config.is_moe = False
+    tc.config.runtime_config.tpot = 50.0
+    tc.config.runtime_config.request_latency = None
+    tc.backend_name = "trtllm"
+    tc.total_gpus = 8
+
+    best_row = {
+        "backend": "trtllm",
+        "tokens/s/gpu": 100.0,
+        "tokens/s/user": 50.0,
+        "tokens/s/gpu_cluster": 100.0,
+        "request_rate": 2.0,
+        "ttft": 100.0,
+        "request_latency": 200.0,
+        "tpot": 10.0,
+        "concurrency": 4.0,
+        "num_total_gpus": 8,
+        "tp": 4,
+        "pp": 2,
+        "dp": 1,
+        "moe_tp": 1,
+        "moe_ep": 1,
+        "bs": 64,
+        "power_w": 400.0,
+    }
+    best_configs = {"agg": pd.DataFrame([best_row])}
+    pareto_df = pd.DataFrame(
+        {
+            "tokens/s/user": [1.0, 2.0],
+            "tokens/s/gpu_cluster": [10.0, 15.0],
+        }
+    )
+    pareto_fronts = {"agg": pareto_df}
+
+    log_final_summary(
+        chosen_exp="agg",
+        best_throughputs={"agg": 100.0, "disagg": 0.0},
+        best_configs=best_configs,
+        pareto_fronts=pareto_fronts,
+        task_configs={"agg": tc},
+        mode="default",
+        pareto_x_axis={"agg": "tokens/s/user"},
+        top_n=1,
+    )
+
+    logged = "\n".join(r.message for r in caplog.records)
+    assert (_ESC in logged) == use_ansi
+
+    text = _plot_worker_setup_table(
+        "agg",
+        best_configs["agg"],
+        total_gpus=8,
+        tpot_target=50.0,
+        top=3,
+        is_moe=False,
+        request_latency_target=None,
+        show_power=True,
+    )
+    assert (_ESC in text) == use_ansi
+    assert "tokens/s/gpu" in text


### PR DESCRIPTION
AIC uses ANSI escape codes to print colored output. When writing to a file, this causes the output to be unreadable. This PR disables the ANSI output when the stdout is not a terminal. Also adds a `--no-color` CLI flag to disable color.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--no-color` command-line flag to disable ANSI color codes in CLI output
  * Automatic detection of plain output mode respects `NO_COLOR` environment variable and terminal capabilities

* **Refactor**
  * Standardized color code handling throughout the application for improved consistency and flexibility

* **Tests**
  * Added comprehensive test coverage for plain output mode detection and behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->