### PR TITLE
feat: optimize GEMM lookup with exact hit and 1D interpolation

### DIFF
--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -3612,7 +3612,20 @@ class PerfDatabase:
                         f"quant_mode='{quant_mode.name}'. "
                         f"Supported gemm modes: {supported}"
                     )
-                result = self._interp_3d(m, n, k, self._gemm_data[table_quant_mode], "cubic")
+
+                gemm_data = self._gemm_data[table_quant_mode]
+
+                if m in gemm_data and n in gemm_data[m] and k in gemm_data[m][n]:
+                    result = gemm_data[m][n][k]
+                    return PerformanceResult(result["latency"], energy=result.get("energy", 0.0))
+
+                m_values = sorted(m_key for m_key in gemm_data if n in gemm_data[m_key] and k in gemm_data[m_key][n])
+                if len(m_values) >= 2:
+                    m_left, m_right = self._nearest_1d_point_helper(m, m_values, inner_only=False)
+                    result = self._interp_1d([m_left, m_right], [gemm_data[m_left][n][k], gemm_data[m_right][n][k]], m)
+                    return PerformanceResult(result["latency"], energy=result.get("energy", 0.0))
+
+                result = self._interp_3d(m, n, k, gemm_data, "cubic")
                 # Result is dict: {"latency": ..., "power": ..., "energy": ...}
                 return PerformanceResult(result["latency"], energy=result.get("energy", 0.0))
 

--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -3604,6 +3604,7 @@ class PerfDatabase:
             # SILICON or HYBRID mode - use database
             def get_silicon():
                 def _to_performance_result(result):
+                    """Normalize GEMM table entries into a PerformanceResult."""
                     if isinstance(result, dict):
                         return PerformanceResult(result["latency"], energy=result.get("energy", 0.0))
                     return PerformanceResult(result, energy=0.0)

--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -3603,6 +3603,11 @@ class PerfDatabase:
         else:
             # SILICON or HYBRID mode - use database
             def get_silicon():
+                def _to_performance_result(result):
+                    if isinstance(result, dict):
+                        return PerformanceResult(result["latency"], energy=result.get("energy", 0.0))
+                    return PerformanceResult(result, energy=0.0)
+
                 self._gemm_data.raise_if_not_loaded()
                 if table_quant_mode not in self._gemm_data:
                     supported = sorted([k.name for k in self._gemm_data])
@@ -3617,17 +3622,16 @@ class PerfDatabase:
 
                 if m in gemm_data and n in gemm_data[m] and k in gemm_data[m][n]:
                     result = gemm_data[m][n][k]
-                    return PerformanceResult(result["latency"], energy=result.get("energy", 0.0))
+                    return _to_performance_result(result)
 
                 m_values = sorted(m_key for m_key in gemm_data if n in gemm_data[m_key] and k in gemm_data[m_key][n])
                 if len(m_values) >= 2:
                     m_left, m_right = self._nearest_1d_point_helper(m, m_values, inner_only=False)
                     result = self._interp_1d([m_left, m_right], [gemm_data[m_left][n][k], gemm_data[m_right][n][k]], m)
-                    return PerformanceResult(result["latency"], energy=result.get("energy", 0.0))
+                    return _to_performance_result(result)
 
                 result = self._interp_3d(m, n, k, gemm_data, "cubic")
-                # Result is dict: {"latency": ..., "power": ..., "energy": ...}
-                return PerformanceResult(result["latency"], energy=result.get("energy", 0.0))
+                return _to_performance_result(result)
 
             return self._query_silicon_or_hybrid(
                 get_silicon=get_silicon,

--- a/tests/unit/sdk/database/test_base_queries.py
+++ b/tests/unit/sdk/database/test_base_queries.py
@@ -90,6 +90,22 @@ def test_query_gemm_interpolates_only_on_m_when_nk_match(comprehensive_perf_db, 
     assert calls["value"] == m
 
 
+def test_query_gemm_fast_paths_support_legacy_scalar_leaves(comprehensive_perf_db, monkeypatch):
+    quant_mode = common.GEMMQuantMode.float16
+    comprehensive_perf_db._gemm_data[quant_mode] = {
+        8: {128: {128: 0.5}},
+        16: {128: {128: 0.9}},
+    }
+
+    exact = comprehensive_perf_db.query_gemm(8, 128, 128, quant_mode, database_mode=common.DatabaseMode.SILICON)
+    interp = comprehensive_perf_db.query_gemm(12, 128, 128, quant_mode, database_mode=common.DatabaseMode.SILICON)
+
+    assert math.isclose(float(exact), 0.5)
+    assert math.isclose(float(interp), 0.7)
+    assert exact.energy == 0.0
+    assert interp.energy == 0.0
+
+
 def test_query_trtllm_alltoall_normalizes_fp8_block_lookup(stub_perf_db):
     """
     fp8_block reuses the fp8 TRT-LLM alltoall perf tables.

--- a/tests/unit/sdk/database/test_base_queries.py
+++ b/tests/unit/sdk/database/test_base_queries.py
@@ -46,6 +46,50 @@ def test_query_gemm_empirical_mode(stub_perf_db):
     )
 
 
+def test_query_gemm_exact_match_skips_3d_interpolation(comprehensive_perf_db, monkeypatch):
+    quant_mode = common.GEMMQuantMode.float16
+    m, n, k = 16, 128, 128
+
+    def _fail_interp_3d(*args, **kwargs):
+        raise AssertionError("_interp_3d should not be used for exact GEMM matches")
+
+    def _fail_interp_1d(*args, **kwargs):
+        raise AssertionError("_interp_1d should not be used for exact GEMM matches")
+
+    monkeypatch.setattr(comprehensive_perf_db, "_interp_3d", _fail_interp_3d)
+    monkeypatch.setattr(comprehensive_perf_db, "_interp_1d", _fail_interp_1d)
+
+    observed = comprehensive_perf_db.query_gemm(m, n, k, quant_mode, database_mode=common.DatabaseMode.SILICON)
+    expected = 0.1 + m * 0.001 + n * 0.0001 + k * 0.00001
+
+    assert math.isclose(float(observed), expected)
+
+
+def test_query_gemm_interpolates_only_on_m_when_nk_match(comprehensive_perf_db, monkeypatch):
+    quant_mode = common.GEMMQuantMode.float16
+    m, n, k = 12, 128, 128
+    calls = {}
+
+    def _fail_interp_3d(*args, **kwargs):
+        raise AssertionError("_interp_3d should not be used when n/k match and only m needs interpolation")
+
+    def _spy_interp_1d(x, y, value):
+        calls["x"] = x
+        calls["y"] = y
+        calls["value"] = value
+        return {"latency": 0.1 + value * 0.001 + n * 0.0001 + k * 0.00001, "power": 0.0, "energy": 0.0}
+
+    monkeypatch.setattr(comprehensive_perf_db, "_interp_3d", _fail_interp_3d)
+    monkeypatch.setattr(comprehensive_perf_db, "_interp_1d", _spy_interp_1d)
+
+    observed = comprehensive_perf_db.query_gemm(m, n, k, quant_mode, database_mode=common.DatabaseMode.SILICON)
+    expected = 0.1 + m * 0.001 + n * 0.0001 + k * 0.00001
+
+    assert math.isclose(float(observed), expected)
+    assert calls["x"] == [8, 16]
+    assert calls["value"] == m
+
+
 def test_query_trtllm_alltoall_normalizes_fp8_block_lookup(stub_perf_db):
     """
     fp8_block reuses the fp8 TRT-LLM alltoall perf tables.

--- a/tests/unit/sdk/database/test_base_queries.py
+++ b/tests/unit/sdk/database/test_base_queries.py
@@ -47,6 +47,7 @@ def test_query_gemm_empirical_mode(stub_perf_db):
 
 
 def test_query_gemm_exact_match_skips_3d_interpolation(comprehensive_perf_db, monkeypatch):
+    """Exact GEMM hits should bypass both 1D and 3D interpolation."""
     quant_mode = common.GEMMQuantMode.float16
     m, n, k = 16, 128, 128
 
@@ -66,6 +67,7 @@ def test_query_gemm_exact_match_skips_3d_interpolation(comprehensive_perf_db, mo
 
 
 def test_query_gemm_interpolates_only_on_m_when_nk_match(comprehensive_perf_db, monkeypatch):
+    """GEMM lookup should use 1D interpolation on m when n and k match."""
     quant_mode = common.GEMMQuantMode.float16
     m, n, k = 12, 128, 128
     calls = {}
@@ -91,6 +93,7 @@ def test_query_gemm_interpolates_only_on_m_when_nk_match(comprehensive_perf_db, 
 
 
 def test_query_gemm_fast_paths_support_legacy_scalar_leaves(comprehensive_perf_db, monkeypatch):
+    """Fast GEMM paths should support legacy scalar-leaf tables."""
     quant_mode = common.GEMMQuantMode.float16
     comprehensive_perf_db._gemm_data[quant_mode] = {
         8: {128: {128: 0.5}},


### PR DESCRIPTION
Overview:
Improve GEMM lookup behavior in PerfDatabase by avoiding unnecessary 3D interpolation when simpler matches are available, and add focused unit tests covering the new query paths.

Details:
Update query_gemm() in src/aiconfigurator/sdk/perf_database.py so that:
exact (m, n, k) matches return directly from the loaded GEMM table
when n and k are present in the table, interpolation is performed only along the m dimension
all other cases continue to use the existing 3D cubic interpolation path
Add unit tests in tests/unit/sdk/database/test_base_queries.py to verify:
exact GEMM matches bypass interpolation
n/k exact matches with missing m use the new 1D-on-m path instead of 3D interpolation
Where should the reviewer start?
src/aiconfigurator/sdk/perf_database.py
tests/unit/sdk/database/test_base_queries.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Optimized GEMM performance lookup queries with improved short-circuit logic for exact table matches, reducing interpolation overhead
  * Reduced interpolation complexity by using specialized algorithms when applicable, with graceful fallback to cubic interpolation for remaining cases

* **Tests**
  * Added comprehensive test coverage for exact GEMM lookups and interpolation behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->