### PR TITLE
feat: add --strict-sla flag for opt-in TTFT+TPOT constraint filtering

### DIFF
--- a/docs/cli_user_guide.md
+++ b/docs/cli_user_guide.md
@@ -17,6 +17,7 @@ the corresponding flag is not specified:
 | OSL (Output Sequence Length) | 1000 | `--osl` | Assumed output generation length |
 | TTFT (Time to First Token) | 2000 ms | `--ttft` | Max acceptable time to first token |
 | TPOT (Time per Output Token) | 30 ms | `--tpot` | Max acceptable time per output token |
+| Strict SLA | off | `--strict-sla` | Pre-filter Pareto frontier to only SLA-compliant configs |
 | Backend | trtllm | `--backend` | Inference backend used for estimation |
 | Prefix Cache Length | 0 | `--prefix` | Prefix cache length for KV reuse |
 | Database Mode | SILICON | `--database-mode` | Source of performance data |
@@ -25,7 +26,9 @@ the corresponding flag is not specified:
 > that exceed these thresholds are excluded from results. If you see fewer
 > results than expected, consider relaxing these values or setting them
 > explicitly. When defaults are used, a warning is printed at the start of the
-> run so you can verify what values are in effect.
+> run so you can verify what values are in effect. By default, only the top-N
+> picking step filters on TPOT; pass `--strict-sla` to also pre-filter the
+> Pareto frontier (see [Strict SLA filtering](#strict-sla-filtering---strict-sla)).
 
 ### Generate mode (Quick Start)
 This mode generates a working configuration without running the full parameter sweep. It's useful when you want a quick deployment config without SLA optimization.
@@ -551,6 +554,41 @@ disagg Top Configurations: (Sorted by tokens/s/gpu)
 +------+--------------+---------------+--------+-----------------+--------------+-------------------+----------+----------------+------------+----------------+-------------+-------+------------+----------------+-------------+-------+
 ********************************************************************************
 2025-12-01 23:36:41,892 - aiconfigurator.cli.main - INFO - All experiments completed in 1.92 seconds
+```
+
+#### Strict SLA filtering (`--strict-sla`)
+
+By default, the Pareto frontier includes all configurations regardless of whether they meet the `--tpot` (or `--request-latency`) constraint — only the final top-N picking step filters on TPOT. This means `pareto.csv` and the Pareto plot may show configurations that violate your SLA targets.
+
+Pass `--strict-sla` to pre-filter the Pareto frontier so that **only SLA-compliant configurations** are included. When this flag is active:
+
+- Configurations exceeding `--tpot` (or `--request-latency`) are removed *before* the Pareto frontier is computed.
+- The resulting `pareto.csv`, Pareto plot, and `best_config_topn` only contain configs that meet the SLA.
+- TTFT filtering is already enforced at sweep time by all backends, so `--strict-sla` only adds TPOT / request-latency pre-filtering.
+
+```bash
+aiconfigurator cli default \
+  --model-path Qwen/Qwen3-32B-FP8 \
+  --total-gpus 32 \
+  --system h200_sxm \
+  --tpot 15 \
+  --strict-sla
+```
+
+> **Note:** With `--strict-sla`, if no configuration meets the SLA targets, the Pareto frontier and best configs will be empty. Without the flag, the Pareto frontier preserves the full search space and you can still see which configs came closest to meeting the target.
+
+The Python API equivalent accepts a `strict_sla` keyword argument:
+
+```python
+from aiconfigurator.cli import cli_default
+
+result = cli_default(
+    model_path="Qwen/Qwen3-32B-FP8",
+    total_gpus=32,
+    system="h200_sxm",
+    tpot=15,
+    strict_sla=True,
+)
 ```
 
 #### Database Mode

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -108,10 +108,11 @@ def _execute_and_wrap_result(
     task_configs: dict[str, TaskConfig],
     mode: str,
     top_n: int = 5,
+    strict_sla: bool = False,
 ) -> CLIResult:
     """Execute task configs using main.py's function and wrap result in CLIResult."""
     chosen_exp, best_configs, pareto_fronts, best_throughputs, best_latencies = _execute_task_configs_internal(
-        task_configs, mode, top_n=top_n
+        task_configs, mode, top_n=top_n, strict_sla=strict_sla
     )
 
     return CLIResult(
@@ -140,6 +141,7 @@ def cli_default(
     tpot: float = 30.0,
     request_latency: float | None = None,
     prefix: int = 0,
+    strict_sla: bool = False,
     free_gpu_memory_fraction: float | None = None,
     max_seq_len: int | None = None,
     top_n: int = 5,
@@ -171,6 +173,11 @@ def cli_default(
         request_latency: Optional end-to-end request latency target (ms).
             Enables request-latency optimization mode.
         prefix: Prefix cache length. Default is 0.
+        strict_sla: When True, ``pareto_df`` is filtered to only
+            SLA-compliant data points (TPOT or request-latency) *before*
+            the Pareto frontier is computed.  TTFT is already enforced at
+            sweep time.  Default is False (full Pareto frontier, TPOT-only
+            constraint at picking time).
         free_gpu_memory_fraction: Fraction of free GPU memory allocated for KV cache
             (default ``None``, meaning the backend default is used). Must be > 0 and <= 1.
             Used to filter batch sizes that would exceed KV cache capacity.
@@ -238,7 +245,7 @@ def cli_default(
         max_seq_len=max_seq_len,
     )
 
-    result = _execute_and_wrap_result(task_configs, mode="default", top_n=top_n)
+    result = _execute_and_wrap_result(task_configs, mode="default", top_n=top_n, strict_sla=strict_sla)
 
     if save_dir:
         # Create a mock args object for save_results compatibility

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -158,14 +158,24 @@ def _add_default_mode_arguments(parser):
         type=float,
         default=2000.0,
         help="Time to first token SLA target in ms. Configurations exceeding this value are "
-        "filtered out. Default: 2000.0.",
+        "filtered from the pareto and topN configs. (Default: 2000)",
     )
     parser.add_argument(
         "--tpot",
         type=float,
         default=30.0,
         help="Time per output token SLA target in ms. Configurations exceeding this value are "
-        "filtered out. Default: 30.0.",
+        "filtered from the topN configs. (Default: 30) \n"
+        "**Note: the pareto may still include configs exceeding the given tpot. "
+        "Pass --strict-sla to only keep configs that meet the given tpot constraint.**",
+    )
+    parser.add_argument(
+        "--strict-sla",
+        action="store_true",
+        default=False,
+        help="Filter the Pareto frontier and best configs to only SLA-compliant data points "
+        "(--ttft + --tpot, or --request-latency). Without this flag, the Pareto frontier "
+        "may include configs that exceed --tpot.",
     )
     parser.add_argument(
         "--request-latency",
@@ -1005,6 +1015,7 @@ def _execute_task_configs(
     target_request_rate: float | None = None,
     target_concurrency: float | None = None,
     max_total_gpus: int | None = None,
+    strict_sla: bool = False,
 ) -> tuple[str, dict[str, pd.DataFrame], dict[str, pd.DataFrame], dict[str, float], dict[str, dict[str, float]]]:
     """
     Execute task configs and return the chosen experiment, best configs, results, best
@@ -1019,6 +1030,8 @@ def _execute_task_configs(
         target_concurrency: If set, activates load-match picking (minimize
             GPUs for the given number of concurrent requests).
         max_total_gpus: Optional upper bound on total GPUs for load-match.
+        strict_sla: When True, enforce both TTFT and TPOT SLA constraints
+            during picking.
 
     Returns:
         tuple:
@@ -1095,6 +1108,7 @@ def _execute_task_configs(
             target_request_rate=target_request_rate,
             target_concurrency=target_concurrency,
             max_total_gpus=max_total_gpus,
+            strict_sla=strict_sla,
         )
         best_configs[name] = best_config_df
         best_throughputs[name] = best_throughput
@@ -1584,10 +1598,14 @@ def main(args):
     else:
         raise SystemExit(f"Unsupported mode: {args.mode}")
 
+    execute_kwargs: dict = {}
+    if getattr(args, "strict_sla", False):
+        execute_kwargs["strict_sla"] = True
     _, best_configs, pareto_fronts, _, _ = _execute_task_configs(
         task_configs,
         args.mode,
         top_n=args.top_n,
+        **execute_kwargs,
     )
 
     if args.save_dir:

--- a/src/aiconfigurator/cli/utils.py
+++ b/src/aiconfigurator/cli/utils.py
@@ -21,6 +21,7 @@ def process_experiment_result(
     target_request_rate: float | None = None,
     target_concurrency: float | None = None,
     max_total_gpus: int | None = None,
+    strict_sla: bool = False,
 ) -> tuple:
     """
     Process the result of a single experiment.
@@ -38,6 +39,11 @@ def process_experiment_result(
         target_concurrency: If set, activates load-match picking (minimize
             GPUs for the given number of concurrent requests).
         max_total_gpus: Optional upper bound on total GPUs for load-match.
+        strict_sla: When ``True``, ``pareto_df`` is filtered to only
+            SLA-compliant data points (TPOT or request-latency) *before*
+            the Pareto frontier is computed.  TTFT is already enforced at
+            sweep time.  The resulting frontier, plot, and ``pareto.csv``
+            will only contain configs that meet the user's SLA targets.
 
     Returns:
         tuple:
@@ -80,6 +86,7 @@ def process_experiment_result(
             target_tpot=target_tpot,
             target_request_latency=target_request_latency,
             top_n=top_n,
+            strict_sla=strict_sla,
         )
 
     best_config_df = picking_result["best_config_df"]

--- a/src/aiconfigurator/sdk/picking.py
+++ b/src/aiconfigurator/sdk/picking.py
@@ -187,6 +187,7 @@ def pick_default(
     target_tpot: float | None = None,
     target_request_latency: float | None = None,
     top_n: int = 5,
+    strict_sla: bool = False,
 ) -> dict[str, Any]:
     """Pick configurations that maximize throughput for a fixed GPU budget.
 
@@ -202,6 +203,9 @@ def pick_default(
         target_request_latency: End-to-end request latency SLA in ms.  Takes
             precedence over ``target_tpot`` when set.
         top_n: Number of top configurations to return.
+        strict_sla: When ``True``, filter ``pareto_df`` to only SLA-compliant
+            data points (TPOT or request-latency) *before* the Pareto frontier
+            is computed.  TTFT is already enforced at sweep time by the backends.
 
     Returns:
         Dict with keys:
@@ -219,8 +223,20 @@ def pick_default(
     use_request_latency = target_request_latency is not None and target_request_latency > 0
 
     if pareto_df is not None and not pareto_df.empty:
+        pareto_df = pareto_df.copy()
+
+        # --strict-sla: drop data points that violate the user's TPOT (or
+        # request-latency) SLA *before* computing the Pareto frontier so that
+        # the frontier (and the plot / pareto.csv) only contains SLA-compliant
+        # configs.  TTFT filtering is already done at sweep time by all backends.
+        if strict_sla:
+            if use_request_latency:
+                if target_request_latency is not None and "request_latency" in pareto_df.columns:
+                    pareto_df = pareto_df[pareto_df["request_latency"] <= target_request_latency]
+            elif target_tpot is not None and "tpot" in pareto_df.columns:
+                pareto_df = pareto_df[pareto_df["tpot"] <= target_tpot]
+
         if total_gpus > 0:
-            pareto_df = pareto_df.copy()
             pareto_df["tokens/s/gpu_cluster"] = (
                 pareto_df["tokens/s/gpu"]
                 * (total_gpus // pareto_df["num_total_gpus"])
@@ -228,7 +244,6 @@ def pick_default(
                 / total_gpus
             )
         else:
-            pareto_df = pareto_df.copy()
             pareto_df["tokens/s/gpu_cluster"] = pareto_df["tokens/s/gpu"]
 
         x_axis_col = "request_latency" if use_request_latency else "tokens/s/user"

--- a/tests/unit/sdk/picking/test_pareto_sla_filtering.py
+++ b/tests/unit/sdk/picking/test_pareto_sla_filtering.py
@@ -1,0 +1,250 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for SLA constraint filtering in the picking layer.
+
+Covers:
+- TPOT constraint filtering excludes configs that violate the target
+- --strict-sla pre-filters the full pareto_df (TTFT + TPOT) before the
+  Pareto frontier is computed, so pareto.csv only shows SLA-compliant data
+- Default (non-strict) preserves the full Pareto frontier
+"""
+
+import pandas as pd
+import pytest
+
+from aiconfigurator.sdk.pareto_analysis import (
+    get_best_configs_under_tpot_constraint,
+)
+from aiconfigurator.sdk.picking import pick_default
+
+pytestmark = pytest.mark.unit
+
+
+def _make_pareto_df(rows: list[dict]) -> pd.DataFrame:
+    """Build a minimal pareto-style DataFrame for testing picking logic."""
+    defaults = {
+        "model": "test-model",
+        "isl": 4000,
+        "osl": 1000,
+        "prefix": 0,
+        "concurrency": 1,
+        "request_rate": 1.0,
+        "bs": 1,
+        "global_bs": 1,
+        "seq/s": 10.0,
+        "seq/s/gpu": 5.0,
+        "tokens/s": 1000.0,
+        "tokens/s/user": 100.0,
+        "num_total_gpus": 1,
+        "tp": 1,
+        "pp": 1,
+        "dp": 1,
+        "moe_tp": 0,
+        "moe_ep": 0,
+        "parallel": "tp1_pp1_dp1",
+        "gemm": "fp16",
+        "kvcache": "fp16",
+        "fmha": "fp16",
+        "moe": "none",
+        "comm": "none",
+        "memory": 0.5,
+        "balance_score": 1.0,
+        "num_ctx_reqs": 1,
+        "num_gen_reqs": 1,
+        "num_tokens": 1000,
+        "ctx_tokens": 500,
+        "gen_tokens": 500,
+        "backend": "trtllm",
+        "version": "1.0.0",
+        "system": "h100_sxm",
+        "power_w": 300.0,
+        "request_latency": 0.0,
+    }
+    records = []
+    for row in rows:
+        record = {**defaults, **row}
+        records.append(record)
+    return pd.DataFrame(records)
+
+
+class TestTpotConstraintFiltering:
+    """Configs violating the user's --tpot must not appear in best_config_topn."""
+
+    def test_only_sla_compliant_configs_returned(self):
+        """Configs with tpot > target should be excluded."""
+        df = _make_pareto_df(
+            [
+                {"tpot": 10.0, "ttft": 500.0, "tokens/s/gpu": 800.0},
+                {"tpot": 20.0, "ttft": 500.0, "tokens/s/gpu": 1200.0},  # violates --tpot 15
+                {"tpot": 45.0, "ttft": 500.0, "tokens/s/gpu": 1500.0},  # violates --tpot 15
+            ]
+        )
+        result = get_best_configs_under_tpot_constraint(
+            total_gpus=8,
+            pareto_df=df,
+            target_tpot=15.0,
+            top_n=5,
+        )
+        assert not result.empty
+        assert (result["tpot"] <= 15.0).all(), "All returned configs must meet the TPOT SLA"
+
+    def test_fallback_when_nothing_meets_sla(self):
+        """When no config meets the SLA, fallback returns closest violators."""
+        df = _make_pareto_df(
+            [
+                {"tpot": 20.0, "ttft": 500.0, "tokens/s/gpu": 800.0},
+                {"tpot": 30.0, "ttft": 500.0, "tokens/s/gpu": 1200.0},
+            ]
+        )
+        result = get_best_configs_under_tpot_constraint(
+            total_gpus=8,
+            pareto_df=df,
+            target_tpot=5.0,
+            top_n=5,
+        )
+        # Should return something (fallback), sorted by closest to target
+        assert not result.empty
+        assert result.iloc[0]["tpot"] == 20.0, "Fallback should return the config closest to the SLA target"
+
+
+class TestStrictSlaFiltering:
+    """--strict-sla pre-filters pareto_df on TPOT so the Pareto frontier is SLA-clean."""
+
+    def test_strict_filters_pareto_frontier_on_tpot(self):
+        """With strict_sla=True, TPOT violators are removed from pareto_df
+        *before* the Pareto frontier is computed."""
+        df = _make_pareto_df(
+            [
+                {"tpot": 10.0, "ttft": 500.0, "tokens/s/gpu": 800.0, "tokens/s/user": 100.0},
+                {"tpot": 50.0, "ttft": 500.0, "tokens/s/gpu": 1500.0, "tokens/s/user": 300.0},  # TPOT violation
+                {"tpot": 14.0, "ttft": 400.0, "tokens/s/gpu": 600.0, "tokens/s/user": 80.0},  # meets SLA
+            ]
+        )
+        result = pick_default(
+            pareto_df=df,
+            total_gpus=8,
+            serving_mode="agg",
+            target_tpot=15.0,
+            top_n=5,
+            strict_sla=True,
+        )
+        frontier = result["pareto_frontier_df"]
+        best = result["best_config_df"]
+
+        # Pareto frontier should only contain TPOT-compliant configs
+        assert not frontier.empty
+        assert (frontier["tpot"] <= 15.0).all(), "Pareto frontier must be TPOT-clean"
+
+        # Best config should also be clean
+        assert not best.empty
+        assert (best["tpot"] <= 15.0).all()
+
+    def test_strict_returns_empty_when_nothing_meets_tpot(self):
+        """When no config meets --tpot, strict filtering returns empty results."""
+        df = _make_pareto_df(
+            [
+                {"tpot": 20.0, "ttft": 500.0, "tokens/s/gpu": 800.0},
+                {"tpot": 30.0, "ttft": 500.0, "tokens/s/gpu": 1200.0},
+            ]
+        )
+        result = pick_default(
+            pareto_df=df,
+            total_gpus=8,
+            serving_mode="agg",
+            target_tpot=15.0,
+            top_n=5,
+            strict_sla=True,
+        )
+        assert result["pareto_frontier_df"].empty
+        assert result["best_config_df"].empty
+
+    def test_strict_filters_request_latency_path(self):
+        """Strict filtering works when using request-latency constraint."""
+        df = _make_pareto_df(
+            [
+                {"tpot": 10.0, "ttft": 500.0, "tokens/s/gpu": 800.0, "request_latency": 8000.0},
+                {"tpot": 12.0, "ttft": 500.0, "tokens/s/gpu": 1200.0, "request_latency": 9000.0},
+                {"tpot": 8.0, "ttft": 400.0, "tokens/s/gpu": 600.0, "request_latency": 15000.0},  # req_lat violation
+            ]
+        )
+        result = pick_default(
+            pareto_df=df,
+            total_gpus=8,
+            serving_mode="agg",
+            target_request_latency=10000.0,
+            top_n=5,
+            strict_sla=True,
+        )
+        frontier = result["pareto_frontier_df"]
+        assert not frontier.empty
+        assert (frontier["request_latency"] <= 10000.0).all()
+
+
+class TestNonStrictPreservesFullPareto:
+    """Without --strict-sla, the full Pareto frontier is preserved."""
+
+    def test_full_frontier_preserved(self):
+        """Without strict_sla, all configs remain in the Pareto frontier."""
+        # Two non-dominated points: one wins on tokens/s/user, the other on tokens/s/gpu.
+        # Both are on the Pareto frontier.  The second violates --tpot 15
+        # but should still appear in the frontier when strict mode is off.
+        df = _make_pareto_df(
+            [
+                {"tpot": 10.0, "ttft": 500.0, "tokens/s/gpu": 2000.0, "tokens/s/user": 100.0},
+                {"tpot": 200.0, "ttft": 500.0, "tokens/s/gpu": 800.0, "tokens/s/user": 400.0},
+            ]
+        )
+        result = pick_default(
+            pareto_df=df,
+            total_gpus=8,
+            serving_mode="agg",
+            target_tpot=15.0,
+            top_n=5,
+        )
+        frontier = result["pareto_frontier_df"]
+        # Full frontier preserved — includes configs that violate TPOT
+        assert len(frontier) == 2, "Non-strict mode must preserve the full Pareto frontier"
+
+    def test_default_behavior_high_tpot_wins(self):
+        """Without strict_sla, high-TPOT config can be in frontier if it has best throughput."""
+        df = _make_pareto_df(
+            [
+                {"tpot": 10.0, "ttft": 500.0, "tokens/s/gpu": 800.0, "tokens/s/user": 300.0},  # meets TPOT
+                {"tpot": 50.0, "ttft": 500.0, "tokens/s/gpu": 1500.0, "tokens/s/user": 100.0},  # violates TPOT
+            ]
+        )
+        result = pick_default(
+            pareto_df=df,
+            total_gpus=8,
+            serving_mode="agg",
+            target_tpot=15.0,
+            top_n=5,
+        )
+        frontier = result["pareto_frontier_df"]
+        # Both should be in the frontier (non-strict doesn't filter)
+        assert len(frontier) == 2, "Non-strict mode preserves TPOT-violating configs in frontier"
+        # But best_config_topn is still TPOT-filtered by get_best_configs_under_tpot_constraint
+        best = result["best_config_df"]
+        assert (best["tpot"] <= 15.0).all(), "Best config is always TPOT-filtered"
+
+    def test_strict_excludes_tpot_violators_from_frontier(self):
+        """With strict_sla, TPOT violators are excluded from the Pareto frontier."""
+        df = _make_pareto_df(
+            [
+                {"tpot": 10.0, "ttft": 500.0, "tokens/s/gpu": 800.0},  # meets TPOT
+                {"tpot": 50.0, "ttft": 500.0, "tokens/s/gpu": 1500.0},  # violates TPOT
+            ]
+        )
+        result = pick_default(
+            pareto_df=df,
+            total_gpus=8,
+            serving_mode="agg",
+            target_tpot=15.0,
+            top_n=5,
+            strict_sla=True,
+        )
+        frontier = result["pareto_frontier_df"]
+        assert len(frontier) == 1, "Strict mode removes TPOT violators from frontier"
+        assert (frontier["tpot"] <= 15.0).all()


### PR DESCRIPTION
#### Overview:

Add a `--strict-sla` flag to `cli default` mode that pre-filters the full Pareto frontier to only SLA-compliant data points. Without the flag, existing behavior is preserved — the Pareto shows the full trade-off space and picking filters on TPOT only.

#### Details:

- **`--strict-sla` CLI flag**: When set, the entire `pareto_df` is filtered on both `--ttft` and `--tpot` (or `--request-latency`) *before* the Pareto frontier is computed. This means `pareto.csv`, the plot, and `best_config_topn.csv` only contain configs meeting every user-specified SLA target.
- **SLA pre-filter in `pick_default`**: The filtering happens once in `pick_default()` before computing the Pareto frontier, rather than being duplicated in downstream constraint functions.
- **Updated `--ttft` / `--tpot` help text**: Clarifies that `--tpot` is enforced as an SLA constraint only with `--strict-sla`.
- **Python API**: `cli_default()` gains a `strict_sla` parameter.
- **compat**: no breaking changes — `strict_sla` defaults to `False` everywhere.

The help text now says:
<img width="1263" height="72" alt="Screenshot 2026-04-14 at 11 42 42 PM" src="https://github.com/user-attachments/assets/409a916d-9d80-42fc-b6ef-f30373a69fda" />

#### Experiment comparison:

`Qwen/Qwen3-32B-FP8`, 32 GPUs, h200_sxm, `--ttft 1000 --tpot 15`:

| | Non-strict (default) | `--strict-sla` |
|---|---|---|
| agg `pareto.csv` rows | 46 | 32 |
| TPOT range in Pareto | 4.6 – 96.2 ms | 4.6 – 14.6 ms |
| `best_config_topn.csv` | identical | identical |

Without `--strict-sla`, the Pareto frontier includes configs across the full TPOT sweep range (up to ~96 ms), well beyond the user's `--tpot 15` target. With `--strict-sla`, those are filtered out so the frontier only shows SLA-compliant configs.

#### Where should the reviewer start?

`src/aiconfigurator/sdk/picking.py` — the SLA pre-filter in `pick_default()`, then `src/aiconfigurator/cli/utils.py` for how `strict_sla` controls it.

#### Related Issues:

- Relates to #725