### PR TITLE
fix: warn on implicit SLA defaults and document undocumented CLI flags

### DIFF
--- a/docs/cli_user_guide.md
+++ b/docs/cli_user_guide.md
@@ -5,6 +5,28 @@ As mentioned in root Readme, CLI supports five modes: `default`, `exp`, `generat
 Quantization defaults are inferred from the Hugging Face model config (`config.json` plus optional `hf_quant_config.json`).  
 For low-precision models, use a quantized HF ID (for example, `Qwen/Qwen3-32B-FP8`) or a local model directory containing those files.
 
+## Defaults and Implicit Behavior
+
+When using `default` mode, several parameters have default values that affect
+which configurations are considered feasible. These defaults are applied when
+the corresponding flag is not specified:
+
+| Parameter | Default | Flag | Effect |
+|-----------|---------|------|--------|
+| ISL (Input Sequence Length) | 4000 | `--isl` | Assumed input prompt length |
+| OSL (Output Sequence Length) | 1000 | `--osl` | Assumed output generation length |
+| TTFT (Time to First Token) | 2000 ms | `--ttft` | Max acceptable time to first token |
+| TPOT (Time per Output Token) | 30 ms | `--tpot` | Max acceptable time per output token |
+| Backend | trtllm | `--backend` | Inference backend used for estimation |
+| Prefix Cache Length | 0 | `--prefix` | Prefix cache length for KV reuse |
+| Database Mode | SILICON | `--database-mode` | Source of performance data |
+
+> **Important:** The TTFT and TPOT defaults act as **SLA filters** — configurations
+> that exceed these thresholds are excluded from results. If you see fewer
+> results than expected, consider relaxing these values or setting them
+> explicitly. When defaults are used, a warning is printed at the start of the
+> run so you can verify what values are in effect.
+
 ### Generate mode (Quick Start)
 This mode generates a working configuration without running the full parameter sweep. It's useful when you want a quick deployment config without SLA optimization.
 
@@ -228,6 +250,10 @@ aiconfigurator cli default --model-path Qwen/Qwen3-32B-FP8 --total-gpus 32 --sys
 # Use SGLang (dense and MoE models, currently being evaluated)
 aiconfigurator cli default --model-path Qwen/Qwen3-32B-FP8 --total-gpus 32 --system h200_sxm --backend sglang
 ```
+
+Use `--backend auto` to sweep across all supported backends and compare results side by side.
+Both agg and disagg results are merged across backends and the globally optimal configuration
+is selected. This is useful for finding the best backend without running separate commands.
 
 The command will create two experiments for the given problem, one is `agg` and another one is `disagg`. Compare them to find the better one and estimates the perf gain.
 
@@ -554,6 +580,25 @@ exp_hybrid:
 ```
 
 Hybrid mode is a quick solution to support new models without modeling the operation and collecting the data. However, please be careful, only `SILICON` mode's result is reproducible. Other modes are for research purpose
+
+#### Speculative Decoding (`--nextn`, `--nextn-accept-rates`)
+
+These flags enable MTP (Multi-Token Prediction) speculative decoding in the
+configuration search:
+
+- `--nextn N` — Number of draft tokens. When > 0, the sweep includes
+  speculative decoding configurations. Requires the model to support MTP.
+  Default: 0 (disabled).
+- `--nextn-accept-rates RATES` — Comma-separated list of 5 floats representing
+  the acceptance probability of each draft token position. Only the first
+  `--nextn` values are used. Default: `0.85,0.3,0,0,0`.
+
+Example:
+```bash
+aiconfigurator cli default \
+  --model Qwen/Qwen3-32B-FP8 --total-gpus 8 --system h200_sxm \
+  --nextn 2 --nextn-accept-rates 0.9,0.4,0,0,0
+```
 
 
 **Python API equivalent:**

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -128,7 +128,10 @@ def _add_default_mode_arguments(parser):
         choices=[backend.value for backend in common.BackendName] + ["auto"],
         type=str,
         default=common.BackendName.trtllm.value,
-        help="Backend name. Use 'auto' to sweep across all backends (trtllm, vllm, sglang) and compare results.",
+        help="Backend name. Use a specific backend (trtllm, vllm, sglang) or 'auto' to sweep "
+        "across all supported backends for the given system and compare results side by side. "
+        "When 'auto' is used, both agg and disagg results are merged across backends and the "
+        "globally optimal configuration is selected. Default: trtllm.",
     )
     parser.add_argument(
         "--backend-version",
@@ -148,10 +151,22 @@ def _add_default_mode_arguments(parser):
         "for models released after the last silicon data collection. "
         "EMPIRICAL: SOL+empirical factor only. SOL: theoretical Speed-of-Light only.",
     )
-    parser.add_argument("--isl", type=int, default=4000, help="Input sequence length.")
-    parser.add_argument("--osl", type=int, default=1000, help="Output sequence length.")
-    parser.add_argument("--ttft", type=float, default=2000.0, help="Time to first token in ms.")
-    parser.add_argument("--tpot", type=float, default=30.0, help="Time per output token in ms.")
+    parser.add_argument("--isl", type=int, default=4000, help="Input sequence length. Default: 4000.")
+    parser.add_argument("--osl", type=int, default=1000, help="Output sequence length. Default: 1000.")
+    parser.add_argument(
+        "--ttft",
+        type=float,
+        default=2000.0,
+        help="Time to first token SLA target in ms. Configurations exceeding this value are "
+        "filtered out. Default: 2000.0.",
+    )
+    parser.add_argument(
+        "--tpot",
+        type=float,
+        default=30.0,
+        help="Time per output token SLA target in ms. Configurations exceeding this value are "
+        "filtered out. Default: 30.0.",
+    )
     parser.add_argument(
         "--request-latency",
         type=float,
@@ -163,14 +178,18 @@ def _add_default_mode_arguments(parser):
         "--nextn",
         type=int,
         default=0,
-        help="Number of draft tokens for MTP (Multi-Token Prediction) speculative decoding. Default is 0 (disabled).",
+        help="Number of draft tokens for MTP (Multi-Token Prediction) speculative decoding. "
+        "When set > 0, enables speculative decoding in the configuration search. "
+        "Requires the model to support MTP. Default: 0 (disabled).",
     )
     parser.add_argument(
         "--nextn-accept-rates",
         type=str,
         default="0.85,0.3,0,0,0",
-        help="Acceptance rates for MTP draft tokens. Comma-separated list of 5 floats. "
-        "Default is '0.85,0.3,0,0,0' meaning 1st token has 85%% acceptance, 2nd has 30%%, rest are 0.",
+        help="Comma-separated acceptance rates for MTP draft tokens (5 values). "
+        "Each value is the acceptance probability of the i-th draft token; only the first "
+        "--nextn values are used. Example: '0.85,0.3,0,0,0' means the 1st draft token has "
+        "85%% acceptance, 2nd has 30%%, rest unused. Default: '0.85,0.3,0,0,0'.",
     )
     parser.add_argument(
         "--enable-chunked-prefill",
@@ -1509,6 +1528,28 @@ def main(args):
         return
 
     if args.mode == "default":
+        # Warn when SLA/workload parameters are implicitly defaulted
+        _default_params = {"isl": 4000, "osl": 1000, "ttft": 2000.0, "tpot": 30.0}
+        _implicit = [
+            f"{k.upper()}={getattr(args, k)}"
+            for k, v in _default_params.items()
+            if f"--{k}" not in sys.argv and getattr(args, k) == v
+        ]
+        if _implicit:
+            logger.warning(
+                "Using default SLA/workload parameters: %s. "
+                "These act as filters — configurations exceeding these thresholds are excluded. "
+                "Set them explicitly (e.g. --ttft, --tpot, --isl, --osl) to avoid unexpected filtering.",
+                ", ".join(_implicit),
+            )
+        logger.info(
+            "Effective parameters: ISL=%d, OSL=%d, TTFT=%.1fms, TPOT=%.1fms, backend=%s",
+            args.isl,
+            args.osl,
+            args.ttft,
+            args.tpot,
+            args.backend,
+        )
         task_configs = build_default_task_configs(
             model_path=args.model_path,
             total_gpus=args.total_gpus,


### PR DESCRIPTION
### Summary

This is to fix the VDR 0.7 comment ([Slack](https://nvidia.slack.com/archives/C096945HE8M/p1775834358648369))

> Default SLA and workload parameters are applied silently, filtering results without the user's knowledge. When `--ttft`, `--tpot`, `--isl`, and `--osl` are not specified, the tool silently applies TTFT=2000ms, TPOT=30ms, ISL=4000, and OSL=1000 — values visible only in internal task names like `_4000_1000_0_2000.0_30.0`. A user who omits these flags may not realize their results are being filtered by hidden SLA constraints and may draw incorrect conclusions about which configurations are feasible. Additionally, `--backend auto` appears as a valid option in `--help` but is not explained anywhere in the documentation, and `--nextn` and `--nextn-accept-rates` flags for speculative decoding are exposed in `--help` with no documentation at all. A "Defaults and Implicit Behavior" section should be added to the CLI User Guide listing all default values, and undocumented flags should either be documented or hidden from `--help` until ready.

### Details

- Emit a WARNING when TTFT/TPOT/ISL/OSL use default values in default mode, clearly stating these act as SLA filters that exclude configs
- Log effective parameters (ISL/OSL/TTFT/TPOT/backend) at INFO level
- Update --isl, --osl, --ttft, --tpot help text to show default values and clarify that TTFT/TPOT are SLA filter thresholds
- Document --backend auto: explain multi-backend sweep and merge behavior
- Document --nextn and --nextn-accept-rates: explain MTP speculative decoding, per-position acceptance semantics, and provide usage example
- Add 'Defaults and Implicit Behavior' section to CLI User Guide with parameter defaults table, SLA filter warning, backend auto mode, and speculative decoding subsections

### Example

<img width="1211" height="71" alt="image" src="https://github.com/user-attachments/assets/1c7c60d5-27f4-43e8-9f78-5684943532cd" />
<img width="1211" height="1316" alt="image" src="https://github.com/user-attachments/assets/f2a03fe1-5636-41cd-8d60-ac5b7955eda4" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--backend auto` mode for automatic backend selection and optimal configuration comparison.
  * Speculative decoding options (`--nextn`, `--nextn-accept-rates`) now documented with examples.

* **Documentation**
  * Documented default parameter behavior and how TTFT/TPOT act as SLA filters.
  * Clarified implicit defaults for ISL/OSL, backend, and database-mode.
  * Added runtime warning notification when defaults are applied at startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->