### PR TITLE
fix: replace Unicode box-drawing with ASCII in piped output for cat -v

### DIFF
--- a/src/aiconfigurator/sdk/pareto_analysis.py
+++ b/src/aiconfigurator/sdk/pareto_analysis.py
@@ -4,7 +4,6 @@
 import copy
 import logging
 import math
-import re
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -18,7 +17,7 @@ from aiconfigurator.sdk.common import ColumnsAgg
 from aiconfigurator.sdk.inference_session import DisaggInferenceSession, InferenceSession
 from aiconfigurator.sdk.models import get_model
 from aiconfigurator.sdk.perf_database import PerfDatabase
-from aiconfigurator.sdk.utils import enumerate_ttft_tpot_constraints
+from aiconfigurator.sdk.utils import enumerate_ttft_tpot_constraints, strip_unicode_to_ascii
 
 logger = logging.getLogger(__name__)
 
@@ -480,11 +479,10 @@ def draw_pareto_to_string(
 
     try:
         buf = plotext.build()
-        # Remove ANSI if plain output is needed.
-        # https://stackoverflow.com/questions/14693701/how-can-i-remove-the-ansi-escape-sequences-from-a-string-in-python
+        # Strip ANSI escapes and Unicode box-drawing / block characters
+        # so piped output (e.g. `| cat -v`) is readable pure ASCII.
         if use_plain_cli_output():
-            ansi_escape_8bit = re.compile(r"(?:\x1B[@-Z\\-_]|[\x80-\x9A\x9C-\x9F]|(?:\x1B\[|\x9B)[0-?]*[ -/]*[@-~])")
-            buf = ansi_escape_8bit.sub("", buf)
+            buf = strip_unicode_to_ascii(buf)
     except Exception:
         logger.exception("failed to build plotext")
         buf = ""

--- a/src/aiconfigurator/sdk/utils.py
+++ b/src/aiconfigurator/sdk/utils.py
@@ -922,3 +922,61 @@ def represent_list_flow(dumper, data):
 
 
 ListFlowDumper.add_representer(list, represent_list_flow)
+
+
+# ---------------------------------------------------------------------------
+# Plain-text helpers (cat -v safe output)
+# ---------------------------------------------------------------------------
+
+_ANSI_ESCAPE_RE = re.compile(r"(?:\x1B[@-Z\\-_]|[\x80-\x9A\x9C-\x9F]|(?:\x1B\[|\x9B)[0-?]*[ -/]*[@-~])")
+
+# Compact mapping of Unicode characters emitted by plotext to ASCII.
+# Only the characters actually produced by plotext's "clear" theme are
+# included: box-drawing frame (U+2500 range), block/quadrant elements
+# used for sub-cell plotting, the bullet marker, and braille dots.
+_UNICODE_TO_ASCII = str.maketrans(
+    {
+        # Box-drawing (frame)
+        "\u2500": "-",
+        "\u2502": "|",
+        "\u250c": "+",
+        "\u2510": "+",
+        "\u2514": "+",
+        "\u2518": "+",
+        "\u251c": "+",
+        "\u2524": "+",
+        "\u252c": "+",
+        "\u2534": "+",
+        "\u253c": "+",
+        # Block elements
+        "\u2580": "-",
+        "\u2581": "_",
+        "\u2584": "_",
+        "\u2588": "#",
+        "\u258c": "|",
+        "\u2590": "|",
+        # Quadrant block elements
+        "\u2596": ".",
+        "\u2597": ".",
+        "\u2598": "'",
+        "\u2599": "|",
+        "\u259a": ":",
+        "\u259b": "|",
+        "\u259c": "|",
+        "\u259d": "'",
+        "\u259e": "/",
+        "\u259f": "|",
+        # Marker / bullet
+        "\u2022": "*",
+    }
+)
+
+
+def strip_unicode_to_ascii(text: str) -> str:
+    """Strip ANSI escapes and replace Unicode graphics with ASCII.
+
+    Intended for piped / redirected CLI output so that tools like
+    ``cat -v`` render clean text instead of M-bM-^T... mojibake.
+    """
+    text = _ANSI_ESCAPE_RE.sub("", text)
+    return text.translate(_UNICODE_TO_ASCII)

--- a/tests/unit/cli/test_plain_output.py
+++ b/tests/unit/cli/test_plain_output.py
@@ -151,3 +151,23 @@ def test_log_final_summary(caplog, use_ansi):
     )
     assert (_ESC in text) == use_ansi
     assert "tokens/s/gpu" in text
+
+
+def test_draw_pareto_plain_output_is_pure_ascii():
+    """Ensure piped Pareto chart output is pure ASCII (no mojibake under `cat -v`).
+
+    Prior to this fix, plotext's Unicode box-drawing characters (U+2500-U+257F)
+    and block elements (U+2580-U+259F) appeared as M-bM-^T... sequences when
+    piped through `cat -v`, breaking CI logs and scripted post-processing.
+    """
+    setup_logging(no_color=True)
+    df = pd.DataFrame({"tokens/s/user": [1.0, 2.0, 3.0], "tokens/s/gpu_cluster": [10.0, 40.0, 90.0]})
+    out = draw_pareto_to_string(
+        "cat-v test",
+        [{"df": df, "label": "series"}],
+    )
+    non_ascii = [c for c in out if ord(c) > 127]
+    assert non_ascii == [], (
+        f"Plain output contains non-ASCII characters that would break `cat -v`: "
+        f"{[f'U+{ord(c):04X}' for c in set(non_ascii)]}"
+    )


### PR DESCRIPTION
PR #710 correctly strips ANSI escape codes when stdout is not a TTY, fixing `<cmd> | cat`. However, plotext also emits Unicode box-drawing (U+2500 range), block elements (U+2580-U+259F), and bullet markers which are multi-byte UTF-8. These appear as M-bM-^T... mojibake under `<cmd> | cat -v`, commonly used in CI/CD log capture and scripted post-processing.

Add strip_unicode_to_ascii() in sdk/utils.py with a compact mapping of only the characters actually emitted by plotext, and call it from draw_pareto_to_string() when plain output is active.

Add test_draw_pareto_plain_output_is_pure_ascii to verify the Pareto chart output contains only ASCII characters when piped.


### Example

<img width="1379" height="1316" alt="image" src="https://github.com/user-attachments/assets/27161878-5549-4cfa-a656-cda35512b714" />
