### PR TITLE
fix: project global MoE routing onto rank-1 workload

### DIFF
--- a/collector/helper.py
+++ b/collector/helper.py
@@ -1319,6 +1319,36 @@ def power_law_logits_v3(
         return router_logits
 
 
+def build_rank0_local_workload(rank0_info: dict) -> dict[str, object]:
+    """Convert global rank0 routing info into local-rank MoE inputs.
+
+    Keeps the original global top-k probabilities and masks out remote experts
+    so the returned tensors describe only the work executed by rank 0.
+    """
+    import torch
+
+    rank0_selected_slots = rank0_info["rank0_selected_slots"].to(torch.int64)
+    rank0_logits = rank0_info["rank0_logits"].to(torch.float32)
+    slots_per_rank = int(rank0_info["slots_per_rank"])
+
+    topk_weights = torch.gather(rank0_logits, 1, rank0_selected_slots.long()).to(torch.float32)
+
+    local_mask = rank0_selected_slots < slots_per_rank
+    topk_ids = rank0_selected_slots.to(torch.int32).clone()
+    topk_ids[~local_mask] = -1
+    topk_weights[~local_mask] = 0.0
+
+    local_ids = topk_ids[topk_ids >= 0]
+    masked_m = torch.bincount(local_ids, minlength=slots_per_rank).to(torch.int32)
+
+    return {
+        "num_tokens": int(rank0_info["rank0_num_tokens"]),
+        "topk_ids": topk_ids.contiguous(),
+        "topk_weights": topk_weights.contiguous(),
+        "masked_m": masked_m.contiguous(),
+    }
+
+
 def power_law_deepep_prefill(num_tokens, num_experts, topk, ep, alpha):
     """Generate power law distribution for DeepEP MoE prefill phase.
 

--- a/collector/sglang/collect_moe.py
+++ b/collector/sglang/collect_moe.py
@@ -23,7 +23,7 @@ from sglang.srt.layers.moe.fused_moe_triton.fused_moe_triton_config import (
     get_default_config,
     get_moe_configs,
 )
-from sglang.srt.layers.moe.topk import TopKConfig, select_experts
+from sglang.srt.layers.moe.topk import StandardTopKOutput, TopKConfig, select_experts
 from sglang.srt.utils import is_hip
 
 try:
@@ -39,7 +39,14 @@ except ImportError:
 try:
     from common_test_cases import get_common_moe_test_cases
 
-    from helper import balanced_logits, benchmark_with_power, get_sm_version, log_perf, power_law_logits_v3
+    from helper import (
+        balanced_logits,
+        benchmark_with_power,
+        build_rank0_local_workload,
+        get_sm_version,
+        log_perf,
+        power_law_logits_v3,
+    )
 except ModuleNotFoundError:
     import os
     import sys
@@ -47,7 +54,14 @@ except ModuleNotFoundError:
     sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     from common_test_cases import get_common_moe_test_cases
 
-    from helper import balanced_logits, benchmark_with_power, get_sm_version, log_perf, power_law_logits_v3
+    from helper import (
+        balanced_logits,
+        benchmark_with_power,
+        build_rank0_local_workload,
+        get_sm_version,
+        log_perf,
+        power_law_logits_v3,
+    )
 
 
 _is_hip = is_hip()
@@ -132,11 +146,17 @@ def benchmark_config(
     num_iters: int = 10,
     distributed: str = "power_law",
     power_law_alpha: float = 0,
+    workloads: list["Rank0Workload"] | None = None,
 ) -> float:
     device = torch.device("cuda")
+    if workloads is not None:
+        num_iters = len(workloads)
+        num_tokens = max(workload["hidden_states"].shape[0] for workload in workloads)
 
     # 1. Gating Output Generation (Common)
-    if distributed == "uniform":
+    if workloads is not None:
+        gating_output = None
+    elif distributed == "uniform":
         gating_output = torch.randn(num_iters, num_tokens, num_experts, dtype=torch.float32, device=device)
     elif distributed == "balanced":
         gating_output = [balanced_logits(num_tokens, num_experts, topk).to(device) for _ in range(num_iters)]
@@ -182,7 +202,11 @@ def benchmark_config(
             counts = [(topk_idx.view(-1) == i).sum() for i in range(num_experts)]
             return torch.tensor(counts, dtype=torch.int32, device=device)
 
-        masked_m_list = [get_masked_m(logits) for logits in gating_output]
+        masked_m_list = (
+            [workload["masked_m"] for workload in workloads]
+            if workloads is not None
+            else [get_masked_m(logits) for logits in gating_output]
+        )
 
         # Calculate the maximum tokens any single expert will handle across all iterations
         max_m = 0
@@ -208,7 +232,7 @@ def benchmark_config(
             )
     else:
         init_dtype = torch.float16 if use_fp8_w8a8 else dtype
-        x = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device)
+        x = None if workloads is not None else torch.randn(num_tokens, hidden_size, dtype=dtype, device=device)
         if use_int8_w8a16 or use_int8_w8a8:
             w1 = torch.randint(
                 -127, 127, (num_experts, shard_intermediate_size, hidden_size), dtype=torch.int8, device=device
@@ -250,23 +274,33 @@ def benchmark_config(
             f8_type = torch.float8_e4m3fnuz if _is_hip else torch.float8_e4m3fn
             w1, w2 = w1.to(f8_type), w2.to(f8_type)
 
-        topk_output = select_experts(x, torch.randn(num_tokens, num_experts, device=device), TopKConfig(top_k=topk))
+        topk_output = (
+            None
+            if workloads is not None
+            else select_experts(x, torch.randn(num_tokens, num_experts, device=device), TopKConfig(top_k=topk))
+        )
 
         def run_op(i):
             from sglang.srt.layers.moe.fused_moe_triton import override_config
 
-            input_gating = gating_output[i % num_iters]
-            new_topk = select_experts(x, input_gating, TopKConfig(top_k=topk))
-            topk_output.topk_weights.copy_(new_topk.topk_weights)
-            topk_output.topk_ids.copy_(new_topk.topk_ids)
-            topk_output.router_logits.copy_(new_topk.router_logits)
+            if workloads is None:
+                input_gating = gating_output[i % num_iters]
+                new_topk = select_experts(x, input_gating, TopKConfig(top_k=topk))
+                topk_output.topk_weights.copy_(new_topk.topk_weights)
+                topk_output.topk_ids.copy_(new_topk.topk_ids)
+                topk_output.router_logits.copy_(new_topk.router_logits)
+                current_hidden_states = x
+                current_topk_output = topk_output
+            else:
+                current_hidden_states = workloads[i % num_iters]["hidden_states"]
+                current_topk_output = workloads[i % num_iters]["topk_output"]
 
             with override_config(config):
                 fused_moe(
-                    x,
+                    current_hidden_states,
                     w1,
                     w2,
-                    topk_output,
+                    current_topk_output,
                     use_fp8_w8a8=use_fp8_w8a8,
                     use_int8_w8a8=use_int8_w8a8,
                     use_int8_w8a16=use_int8_w8a16,
@@ -310,14 +344,18 @@ def benchmark(
     block_shape: list[int] | None = None,
     distributed: str = "power_law",
     power_law_alpha: float = 0,
+    workloads: list["Rank0Workload"] | None = None,
 ) -> tuple[dict[str, int], float]:
     torch.cuda.manual_seed_all(0)
+    benchmark_num_tokens = (
+        max(workload["hidden_states"].shape[0] for workload in workloads) if workloads is not None else num_tokens
+    )
 
     if use_nvfp4:
         # nvfp4 uses flashinfer cutedsl backend, which doesn't need triton configs
         kernel_time, power_stats = benchmark_config(
             None,
-            num_tokens,
+            benchmark_num_tokens,
             num_experts,
             shard_intermediate_size,
             hidden_size,
@@ -330,6 +368,7 @@ def benchmark(
             block_shape,
             distributed=distributed,
             power_law_alpha=power_law_alpha,
+            workloads=workloads,
         )
         return kernel_time, power_stats
 
@@ -345,7 +384,7 @@ def benchmark(
     op_config = get_moe_configs(num_experts, shard_intermediate_size // 2, dtype_str, block_n, block_k)
     if op_config is None:
         config = get_default_config(
-            num_tokens,
+            benchmark_num_tokens,
             num_experts,
             shard_intermediate_size,
             hidden_size,
@@ -355,10 +394,10 @@ def benchmark(
             block_shape,
         )
     else:
-        config = op_config[min(op_config.keys(), key=lambda x: abs(x - num_tokens))]
+        config = op_config[min(op_config.keys(), key=lambda x: abs(x - benchmark_num_tokens))]
     kernel_time, power_stats = benchmark_config(
         config,
-        num_tokens,
+        benchmark_num_tokens,
         num_experts,
         shard_intermediate_size,
         hidden_size,
@@ -371,8 +410,54 @@ def benchmark(
         block_shape,
         distributed=distributed,
         power_law_alpha=power_law_alpha,
+        workloads=workloads,
     )
     return kernel_time, power_stats
+
+
+class Rank0Workload(TypedDict):
+    hidden_states: torch.Tensor
+    topk_output: StandardTopKOutput
+    masked_m: torch.Tensor
+
+
+def build_power_law_rank0_workloads(
+    num_workloads: int,
+    num_tokens: int,
+    hidden_size: int,
+    topk: int,
+    num_experts: int,
+    moe_ep_size: int,
+    power_law_alpha: float,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> list[Rank0Workload]:
+    workloads: list[Rank0Workload] = []
+
+    for _ in range(num_workloads):
+        _, rank0_info = power_law_logits_v3(
+            num_tokens,
+            num_experts,
+            topk,
+            moe_ep_size,
+            power_law_alpha,
+            return_rank0_info=True,
+        )
+        rank0_local = build_rank0_local_workload(rank0_info)
+        rank0_num_tokens = int(rank0_local["num_tokens"])
+        workloads.append(
+            {
+                "hidden_states": torch.randn(rank0_num_tokens, hidden_size, dtype=dtype, device=device),
+                "topk_output": StandardTopKOutput(
+                    topk_weights=rank0_local["topk_weights"].to(device=device, dtype=torch.float32),
+                    topk_ids=rank0_local["topk_ids"].to(device=device, dtype=torch.int32),
+                    router_logits=torch.empty((rank0_num_tokens, 0), dtype=torch.float32, device=device),
+                ),
+                "masked_m": rank0_local["masked_m"].to(device=device, dtype=torch.int32),
+            }
+        )
+
+    return workloads
 
 
 def run_moe_torch(
@@ -401,34 +486,52 @@ def run_moe_torch(
     assert inter_size % moe_tp_size == 0, "inter_size % moe_tp_size must be 0"
     assert num_experts % moe_ep_size == 0, "num_experts must be divisible by moe_ep_size"
 
-    # With EP, each GPU processes only its local experts
     num_local_experts = num_experts // moe_ep_size
 
-    # For EP > 1, filter tokens to rank-local workload so the benchmark
-    # measures per-rank latency instead of the full-batch latency.
-    if moe_ep_size > 1:
-        _, rank0_info = power_law_logits_v3(
-            num_tokens, num_experts, topk, moe_ep_size, power_law_alpha, return_rank0_info=True
+    if moe_ep_size > 1 and distributed == "power_law":
+        rank0_workloads = build_power_law_rank0_workloads(
+            num_workloads=5,
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            topk=topk,
+            num_experts=num_experts,
+            moe_ep_size=moe_ep_size,
+            power_law_alpha=power_law_alpha,
+            dtype=torch.bfloat16,
+            device=torch.device(device),
         )
-        rank_num_tokens = rank0_info["rank0_num_tokens"]
+        latency, power_stats = benchmark(
+            num_tokens,
+            num_local_experts,
+            2 * inter_size // moe_tp_size,
+            hidden_size,
+            topk,
+            torch.bfloat16,
+            moe_type == "fp8_block",
+            False,
+            False,
+            use_nvfp4=moe_type == "nvfp4",
+            block_shape=None,
+            distributed=distributed,
+            power_law_alpha=power_law_alpha,
+            workloads=rank0_workloads,
+        )
     else:
-        rank_num_tokens = num_tokens
-
-    latency, power_stats = benchmark(
-        rank_num_tokens,
-        num_local_experts,
-        2 * inter_size // moe_tp_size,
-        hidden_size,
-        topk,
-        torch.bfloat16,
-        moe_type == "fp8_block",
-        False,
-        False,
-        use_nvfp4=moe_type == "nvfp4",
-        block_shape=None,
-        distributed=distributed,
-        power_law_alpha=power_law_alpha,
-    )
+        latency, power_stats = benchmark(
+            num_tokens,
+            num_local_experts,
+            2 * inter_size // moe_tp_size,
+            hidden_size,
+            topk,
+            torch.bfloat16,
+            moe_type == "fp8_block",
+            False,
+            False,
+            use_nvfp4=moe_type == "nvfp4",
+            block_shape=None,
+            distributed=distributed,
+            power_law_alpha=power_law_alpha,
+        )
 
     log_perf(
         item_list=[

--- a/collector/trtllm/collect_wideep_moe_compute.py
+++ b/collector/trtllm/collect_wideep_moe_compute.py
@@ -840,9 +840,8 @@ def run_wideep_moe_compute(
 
                 # Use EPLB's actual slot assignments (the TRUE distribution after load balancing)
                 rank0_selected_slots = rank0_info["rank0_selected_slots"].to(torch.int32).to(device)
-                # Compute scales from logits using EPLB's slot assignments
-                gathered_logits = torch.gather(rank0_logits, 1, rank0_selected_slots.long())
-                token_final_scales = torch.softmax(gathered_logits, dim=1).to(torch.float32)
+                # rank0_logits already contains the global routing probabilities.
+                token_final_scales = torch.gather(rank0_logits, 1, rank0_selected_slots.long()).to(torch.float32)
 
                 # Create hidden states for rank0 tokens
                 rank0_hidden = torch.randn([rank0_num_tokens, hidden_size]).bfloat16().to(torch.device(device))

--- a/tests/unit/collector/test_sglang_moe_ep_routing.py
+++ b/tests/unit/collector/test_sglang_moe_ep_routing.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# test_parallel_run.py injects a MagicMock as "torch" into sys.modules so
+# collector code can be imported without CUDA.  This test needs real tensors,
+# so evict the mock and attempt a real import.  If torch is not installed
+# (CI Docker image), restore the mock and skip the entire module.
+_saved_mock = None
+if isinstance(sys.modules.get("torch"), MagicMock):
+    _saved_mock = sys.modules.pop("torch")
+
+try:
+    import torch
+except ImportError:
+    if _saved_mock is not None:
+        sys.modules["torch"] = _saved_mock
+    pytest.skip("real torch required for tensor operations", allow_module_level=True)
+
+
+def _import_helper_module():
+    module_name = "collector.helper_test_copy"
+    helper_path = Path(__file__).resolve().parents[3] / "collector" / "helper.py"
+    spec = importlib.util.spec_from_file_location(module_name, helper_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.unit
+def test_build_rank0_local_workload_masks_remote_experts():
+    helper = _import_helper_module()
+
+    rank0_info = {
+        "rank0_logits": torch.tensor(
+            [
+                [0.5, 0.0, 0.5, 0.0],
+                [0.0, 0.5, 0.0, 0.5],
+            ],
+            dtype=torch.float32,
+        ),
+        "rank0_selected_slots": torch.tensor(
+            [
+                [0, 2],
+                [1, 3],
+            ],
+            dtype=torch.int64,
+        ),
+        "rank0_num_tokens": 2,
+        "slots_per_rank": 2,
+        "rank0_total_selections": 2,
+    }
+
+    workload = helper.build_rank0_local_workload(rank0_info)
+
+    assert workload["num_tokens"] == 2
+    assert torch.equal(workload["topk_ids"], torch.tensor([[0, -1], [1, -1]], dtype=torch.int32))
+    assert torch.allclose(workload["topk_weights"], torch.tensor([[0.5, 0.0], [0.5, 0.0]], dtype=torch.float32))
+    assert torch.equal(workload["masked_m"], torch.tensor([1, 1], dtype=torch.int32))
+
+
+@pytest.mark.unit
+def test_global_power_law_rank0_workload_keeps_global_distribution():
+    helper = _import_helper_module()
+
+    torch.manual_seed(0)
+    _, rank0_info = helper.power_law_logits_v3(
+        num_tokens=1024,
+        num_experts=128,
+        topk=8,
+        ep=8,
+        alpha=1.01,
+        return_rank0_info=True,
+    )
+
+    workload = helper.build_rank0_local_workload(rank0_info)
+    local_ids = workload["topk_ids"][workload["topk_ids"] >= 0]
+
+    assert workload["num_tokens"] == rank0_info["rank0_num_tokens"]
+    assert torch.all(local_ids < rank0_info["slots_per_rank"])
+    assert torch.all(workload["topk_weights"][workload["topk_ids"] == -1] == 0)
+    assert torch.all(workload["topk_weights"] >= 0)
+    assert workload["masked_m"].sum().item() == rank0_info["rank0_total_selections"]
+    assert (workload["topk_ids"] == -1).any()
+    assert rank0_info["rank0_total_selections"] < workload["num_tokens"] * workload["topk_ids"].shape[1]


### PR DESCRIPTION
#### Overview:

Fix SGLang EP MoE collection so rank-local benchmarking preserves the global routing distribution instead of re-routing over local experts. This keeps the collector aligned with the intended 128-top8 semantics while still measuring only gpu0's local workload.

#### Details:

- add a helper to project global `rank0_info` routing results onto rank0-local MoE workload
- update SGLang `collect_moe.py` to consume prebuilt rank0 workloads for `ep > 1` power-law cases
- mask remote experts instead of recomputing local top-k routing
- stop re-applying softmax to already-normalized top-k probabilities
- add unit coverage for rank0 workload construction and masking behavior
- fix the same top-k probability handling issue in TRT-LLM wideep MoE compute

#### Where should the reviewer start?

- `aiconfigurator/collector/helper.py`
- `aiconfigurator/collector/sglang/collect_moe.py`
- `aiconfigurator/collector/trtllm/collect_wideep_moe_compute.py`
- `aiconfigurator/tests/unit/collector/test_sglang_moe_ep_routing.py`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to GitHub issue: #xxx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced workload-driven execution mode for MoE benchmarking, enabling flexible configuration of iteration and token counts from precomputed workloads
  * Extended benchmark functions to support alternative execution paths with precomputed expert routing data

* **Improvements**
  * Simplified routing probability calculation by directly using global probabilities, improving computational efficiency

* **Tests**
  * Added unit tests validating MoE workload generation and expert masking behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->