### PR TITLE
fix: fix indefinite hang of custom all_reduce collector on B200 system

### DIFF
--- a/collector/collect_all_reduce.py
+++ b/collector/collect_all_reduce.py
@@ -29,6 +29,7 @@ Usage:
     python collect_all_reduce.py --range "128,1000000,2" --perf-filename "my_perf.txt"
 """
 
+import inspect
 import os
 import sys
 from argparse import ArgumentParser
@@ -38,6 +39,28 @@ import torch
 import torch.distributed as dist
 
 from helper import PowerMonitor, get_device_module, get_device_str, log_perf
+
+
+def _init_process_group_with_device_id(backend: str, init_method: str, world_size: int, rank: int, local_rank: int):
+    """Pre-initialize torch.distributed with explicit device_id.
+
+    Without device_id, PyTorch guesses the rank-to-GPU mapping which can hang
+    on multi-GPU nodes (e.g. B200 SXM 8-GPU) when nproc < total GPUs.
+    Calling this before vLLM/SGLang's own init_distributed_environment() is
+    safe because those functions check is_initialized() and skip the call.
+
+    Uses inspect to stay compatible with older PyTorch that lacks device_id.
+    """
+    sig = inspect.signature(dist.init_process_group)
+    params = {
+        "backend": backend,
+        "init_method": init_method,
+        "world_size": world_size,
+        "rank": rank,
+    }
+    if "device_id" in sig.parameters:
+        params["device_id"] = torch.device(f"cuda:{local_rank}")
+    dist.init_process_group(**params)
 
 
 def get_input_shape_and_comm_size(size, token_dim=4096):
@@ -313,6 +336,18 @@ def setup_vllm_distributed(world_size, rank, use_slurm):
                     backend="xccl",
                     init_method="env://",
                 )
+            else:
+                # Pre-initialize with explicit device_id to prevent hangs
+                # on multi-GPU nodes where PyTorch guesses wrong rank-to-GPU
+                # mapping. vLLM's init will skip init_process_group since
+                # is_initialized() is already True.
+                _init_process_group_with_device_id(
+                    backend="nccl",
+                    init_method=distributed_init_method,
+                    world_size=world_size,
+                    rank=rank,
+                    local_rank=local_rank,
+                )
             vllm_mods["init_distributed_environment"](
                 world_size=world_size,
                 rank=rank,
@@ -396,6 +431,15 @@ def setup_sglang_distributed(world_size, rank, use_slurm):
         print(f"  Local rank: {local_rank}")
 
         try:
+            # Pre-initialize with explicit device_id to prevent hangs
+            # on multi-GPU nodes (same fix as vLLM path above).
+            _init_process_group_with_device_id(
+                backend="nccl",
+                init_method=distributed_init_method,
+                world_size=world_size,
+                rank=rank,
+                local_rank=local_rank,
+            )
             sglang_mods["init_distributed_environment"](
                 world_size=world_size,
                 rank=rank,

--- a/collector/collect_all_reduce.py
+++ b/collector/collect_all_reduce.py
@@ -683,13 +683,12 @@ def benchmark_vllm_allreduce(
 
         size *= ratio
 
-    # Synchronize all ranks before cleanup
+    # Skip barrier + destroy_model_parallel — they can deadlock when
+    # vLLM's internal NCCL communicators (pynccl / custom_all_reduce)
+    # have pending async ops that ncclCommDestroy blocks on.
+    # torchrun manages process lifecycle; let it handle cleanup.
     get_device_module().synchronize()
-    if torch.distributed.is_initialized():
-        torch.distributed.barrier()
-
-    # Cleanup vLLM distributed environment
-    vllm_mods["destroy_model_parallel"]()
+    os._exit(0)
 
 
 def benchmark_sglang_allreduce(
@@ -916,13 +915,10 @@ def benchmark_sglang_allreduce(
 
         size *= ratio
 
-    # Synchronize all ranks before cleanup
+    # Skip barrier + destroy_model_parallel — same deadlock risk as vLLM
+    # path. torchrun manages process lifecycle.
     torch.cuda.synchronize()
-    if torch.distributed.is_initialized():
-        torch.distributed.barrier()
-
-    # Cleanup SGLang distributed environment
-    sglang_mods["destroy_model_parallel"]()
+    os._exit(0)
 
 
 def allreduce_benchmark(


### PR DESCRIPTION
## Summary

The custom allreduce collector (`collect_all_reduce.py`) hangs indefinitely after
completing the 2-GPU benchmark when run via `torchrun` on multi-GPU nodes (e.g., B200
SXM 8-GPU). This blocks the `collect_comm.sh` loop from advancing to 4-GPU and 8-GPU
runs, causing the entire CI pipeline to time out with zero useful comm data for higher
GPU counts.

## Root Cause

After the benchmark loop finishes, the cleanup path calls:

```python
torch.distributed.barrier()
vllm_mods["destroy_model_parallel"]()
```

This deadlocks because vLLM's custom allreduce layer creates **internal NCCL
communicators** (via `pynccl` and `CustomAllreduce`) that are independent of the
default `torch.distributed` process group. During cleanup:

1. `torch.distributed.barrier()` waits on the default NCCL process group
2. `destroy_model_parallel()` -> `GroupCoordinator.destroy()` calls
   `torch.distributed.destroy_process_group()` on sub-groups and
   `ncclCommDestroy()` on internal communicators
3. These operations conflict with pending async state in the custom allreduce
   communicators, causing a permanent deadlock

The same issue affects both vLLM and SGLang code paths.

## Fix

**1. Replace `barrier()` + `destroy_model_parallel()` with `os._exit(0)`**

Since each GPU count (2, 4, 8) is launched as a separate `torchrun` invocation from
`collect_comm.sh`, there is no state to carry between runs. `torchrun` manages the
process lifecycle and will clean up child processes. Calling `os._exit(0)` after
`cuda.synchronize()` is safe because:

- All perf data is already flushed to disk (`log_perf` does `fsync` after each write)
- Each `torchrun` invocation spawns fresh processes
- `cuda.synchronize()` ensures all GPU work completes before exit

**2. Pre-initialize `torch.distributed` with explicit `device_id`**

Adds `_init_process_group_with_device_id()` which calls `dist.init_process_group()`
with an explicit `device_id=torch.device(f"cuda:{local_rank}")` before vLLM/SGLang's
own initialization. This suppresses the PyTorch warning about guessing rank-to-GPU
mapping and prevents a secondary class of hangs. Uses `inspect.signature` for
backward compatibility with older PyTorch versions that lack the `device_id` parameter.

## Testing

Verified on B200 SXM 8-GPU via auto-collect CI pipeline
(`aic-auto-collector` pipeline #993):

**Before (pipeline #989):** 2-GPU run completes, torchrun hangs at barrier,
4-GPU and 8-GPU never start, pipeline times out after ~4 hours.

**After (pipeline #993):** All three GPU counts (2, 4, 8) complete successfully,
`All benchmarks completed!` printed, `custom_allreduce_perf.txt` collected and
uploaded. Slurm job exits with `COMPLETED` status.

Pipeline URL: https://gitlab-master.nvidia.com/dl/ai-dynamo/aic-auto-collector/-/pipelines/48504286



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced distributed training setup with improved device compatibility and initialization handling

* **Bug Fixes**
  * Optimized process group initialization for better reliability across different hardware configurations
  * Refined benchmark cleanup procedures for more efficient resource management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->