### PR TITLE
chore: Add backend version templates and version matrix entry for Dynamo 1.1.0

### DIFF
--- a/src/aiconfigurator/generator/config/backend_templates/sglang/cli_args.0.5.10.post1.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/sglang/cli_args.0.5.10.post1.j2
@@ -1,0 +1,23 @@
+{%- set args = [] -%}
+{%- if sglang['tensor-parallel-size'] is defined -%}{%- set _ = args.append('--tensor-parallel-size "' ~ sglang['tensor-parallel-size'] ~ '"') -%}{%- endif -%}
+{%- if sglang['pipeline-parallel-size'] is defined -%}{%- set _ = args.append('--pipeline-parallel-size "' ~ sglang['pipeline-parallel-size'] ~ '"') -%}{%- endif -%}
+{%- if sglang['data-parallel-size'] is defined -%}{%- set _ = args.append('--data-parallel-size "' ~ sglang['data-parallel-size'] ~ '"') -%}{%- endif -%}
+{%- if sglang['page-size'] is defined -%}{%- set _ = args.append('--page-size "' ~ sglang['page-size'] ~ '"') -%}{%- endif -%}
+{%- if sglang['kv-cache-dtype'] is defined -%}{%- set _ = args.append('--kv-cache-dtype "' ~ sglang['kv-cache-dtype'] ~ '"') -%}{%- endif -%}
+{%- if sglang['max-prefill-tokens'] is defined -%}{%- set _ = args.append('--max-prefill-tokens "' ~ sglang['max-prefill-tokens'] ~ '"') -%}{%- endif -%}
+{%- if sglang['enable-mixed-chunk'] -%}{%- set _ = args.append('--enable-mixed-chunk') -%}{%- endif -%}
+{%- if sglang['context-length'] is defined -%}{%- set _ = args.append('--context-length "' ~ sglang['context-length'] ~ '"') -%}{%- endif -%}
+{%- if sglang['max-running-requests'] is defined -%}{%- set _ = args.append('--max-running-requests "' ~ sglang['max-running-requests'] ~ '"') -%}{%- endif -%}
+{%- if sglang['skip-tokenizer-init'] -%}{%- set _ = args.append('--skip-tokenizer-init') -%}{%- endif -%}
+{%- if sglang['trust-remote-code'] -%}{%- set _ = args.append('--trust-remote-code') -%}{%- endif -%}
+{%- if sglang['enable-dp-attention'] -%}{%- set _ = args.append('--enable-dp-attention') -%}{%- endif -%}
+{%- if sglang['expert-parallel-size'] is defined -%}{%- set _ = args.append('--expert-parallel-size "' ~ sglang['expert-parallel-size'] ~ '"') -%}{%- endif -%}
+{%- if sglang['moe-dense-tp-size'] is defined -%}{%- set _ = args.append('--moe-dense-tp-size "' ~ sglang['moe-dense-tp-size'] ~ '"') -%}{%- endif -%}
+{%- if sglang['disable-cuda-graph'] -%}{%- set _ = args.append('--disable-cuda-graph') -%}{%- endif -%}
+{%- if sglang['cuda-graph-bs'] is defined -%}{%- set _ = args.append('--cuda-graph-bs ' ~ (sglang['cuda-graph-bs'] | join(' '))) -%}{%- endif -%}
+{%- if sglang['speculative-algorithm'] is defined -%}{%- set _ = args.append('--speculative-algorithm "' ~ sglang['speculative-algorithm'] ~ '"') -%}{%- endif -%}
+{%- if sglang['speculative-num-steps'] is defined -%}{%- set _ = args.append('--speculative-num-steps "' ~ sglang['speculative-num-steps'] ~ '"') -%}{%- endif -%}
+{%- if sglang['disable-cuda-graph-padding'] -%}{%- set _ = args.append('--disable-cuda-graph-padding') -%}{%- endif -%}
+{%- if sglang['cuda-graph-max-bs'] is defined -%}{%- set _ = args.append('--cuda-graph-max-bs "' ~ sglang['cuda-graph-max-bs'] ~ '"') -%}{%- endif -%}
+{%- if sglang['disaggregation-transfer-backend'] is defined -%}{%- set _ = args.append('--disaggregation-transfer-backend "' ~ sglang['disaggregation-transfer-backend'] ~ '"') -%}{%- endif -%}
+{{ args | join(' ') }}

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.3.0rc11.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.3.0rc11.yaml.j2
@@ -1,0 +1,50 @@
+backend: pytorch
+
+{% if is_moe is defined %}  # is_moe from sdk
+moe_expert_parallel_size: {{ moe_expert_parallel_size }}
+moe_tensor_parallel_size: {{ moe_tensor_parallel_size }}
+
+moe_config:
+    backend: {{ moe_config.backend | default('CUTLASS') }} # MOE backend to use (CUTLASS, CUTEDSL, WIDEEP, TRTLLM, VANILLA)
+    {% if moe_config.load_balancer is defined %}  # Configuration for MoE load balancing
+    load_balancer: {{ moe_config.load_balancer }} # moe load balancer
+    {% endif %}
+{% endif %}
+
+tensor_parallel_size: {{ tensor_parallel_size }}
+pipeline_parallel_size: {{ pipeline_parallel_size }}
+enable_attention_dp: {{ enable_attention_dp | default(false) }}
+enable_chunked_prefill: {{ enable_chunked_prefill | default(false) }}
+
+{% set _max_seq_len = max_seq_len | default(none) %}
+
+max_batch_size: {{ max_batch_size }}
+max_num_tokens: {{ max_num_tokens }}
+{% if _max_seq_len is not none and _max_seq_len != '' %}
+max_seq_len: {{ _max_seq_len }}
+{% endif %}
+
+kv_cache_config:
+  free_gpu_memory_fraction: {{ kv_cache_config.free_gpu_memory_fraction | default(0.80) }}  # Fraction of GPU memory usable for KV-cache
+  dtype: {{ kv_cache_config.dtype | default('auto') }}
+  {% if kv_cache_config.tokens_per_block is defined %}
+  tokens_per_block: {{ kv_cache_config.tokens_per_block }}
+  {% endif %}
+  enable_block_reuse: {{ kv_cache_config.enable_block_reuse | default(false) }}
+
+cuda_graph_config:
+  enable_padding: {{ cuda_graph_config.enable_padding | default(false) }} # Pad CUDA graph
+  batch_sizes: [{% for s in cuda_graph_config.batch_sizes
+                               | default([1,2,4,8,16,32,64,128,256]) -%}
+                    {{- s }}{{ ',' if not loop.last else '' }} {%- endfor %}]
+
+disable_overlap_scheduler: {{ disable_overlap_scheduler | default(true) }}
+print_iter_log: {{ print_iter_log | default(false) }}
+
+{% if speculative_config.decoding_type is defined %}  # speculative decoding
+speculative_config:
+  decoding_type: {{ speculative_config.decoding_type }}
+  {% if speculative_config.decoding_type == 'MTP' %}
+  num_nextn_predict_layers: {{ num_nextn_predict_layers }}
+  {% endif %}
+{% endif %}

--- a/src/aiconfigurator/generator/config/backend_templates/vllm/cli_args.0.19.0.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/vllm/cli_args.0.19.0.j2
@@ -1,0 +1,28 @@
+{%- set args = [] -%}
+{%- if vllm['tensor-parallel-size'] is defined -%}{%- set _ = args.append('--tensor-parallel-size "' ~ vllm['tensor-parallel-size'] ~ '"') -%}{%- endif -%}
+{%- if vllm['pipeline-parallel-size'] is defined -%}{%- set _ = args.append('--pipeline-parallel-size "' ~ vllm['pipeline-parallel-size'] ~ '"') -%}{%- endif -%}
+{%- if vllm['data-parallel-size'] is defined -%}{%- set _ = args.append('--data-parallel-size "' ~ vllm['data-parallel-size'] ~ '"') -%}{%- endif -%}
+{%- if vllm['enable-expert-parallel'] -%}{%- set _ = args.append('--enable-expert-parallel') -%}{%- endif -%}
+{%- if vllm['block-size'] is defined -%}{%- set _ = args.append('--block-size "' ~ vllm['block-size'] ~ '"') -%}{%- endif -%}
+{%- if vllm['kv-cache-dtype'] is defined -%}{%- set _ = args.append('--kv-cache-dtype "' ~ vllm['kv-cache-dtype'] ~ '"') -%}{%- endif -%}
+{%- if vllm['max-model-len'] is defined -%}{%- set _ = args.append('--max-model-len "' ~ vllm['max-model-len'] ~ '"') -%}{%- endif -%}
+{%- if vllm['max-num-seqs'] is defined -%}{%- set _ = args.append('--max-num-seqs "' ~ vllm['max-num-seqs'] ~ '"') -%}{%- endif -%}
+{%- if vllm['max-num-batched-tokens'] is defined -%}{%- set _ = args.append('--max-num-batched-tokens ' ~ vllm['max-num-batched-tokens']) -%}{%- endif -%}
+{%- if vllm['skip-tokenizer-init'] -%}{%- set _ = args.append('--skip-tokenizer-init') -%}{%- endif -%}
+{%- if vllm['trust-remote-code'] -%}{%- set _ = args.append('--trust-remote-code') -%}{%- endif -%}
+{%- if vllm['enforce-eager'] -%}{%- set _ = args.append('--enforce-eager') -%}{%- endif -%}
+{%- if vllm['cudagraph-capture-sizes'] is defined -%}{%- set _ = args.append('--cudagraph-capture-sizes ' ~ (vllm['cudagraph-capture-sizes'] | join(' '))) -%}{%- endif -%}
+
+
+{%- if vllm['no-enable-prefix-caching'] -%}{%- set _ = args.append('--no-enable-prefix-caching') -%}{%- endif -%}
+{%- set spec_cfg = namespace(value={}) -%}
+{%- if speculative_config.method is defined and speculative_config.method -%}
+    {%- set _ = spec_cfg.value.update({'method': speculative_config.method}) -%}
+{%- endif -%}
+{%- if speculative_config.num_speculative_tokens is defined and speculative_config.num_speculative_tokens is not none -%}
+    {%- set _ = spec_cfg.value.update({'num_speculative_tokens': speculative_config.num_speculative_tokens}) -%}
+{%- endif -%}
+{%- if spec_cfg.value -%}
+    {%- set _ = args.append('--speculative-config \'' ~ (spec_cfg.value | tojson) ~ '\'') -%}
+{%- endif -%}
+{{ args | join(' ') }}

--- a/src/aiconfigurator/generator/config/backend_version_matrix.yaml
+++ b/src/aiconfigurator/generator/config/backend_version_matrix.yaml
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 matrix:
+  1.1.0:
+    vllm: "0.19.0"
+    sglang: "0.5.10.post1"
+    trtllm: "1.3.0rc11"
   1.0.0:
     vllm: "0.16.0"
     sglang: "0.5.9"


### PR DESCRIPTION
#### Overview:

- Add 1.1.0 entry to backend_version_matrix.yaml
- Add cli_args.0.19.0.j2 for vLLM
- Add cli_args.0.5.10.post1.j2 for SGLang
- Add extra_engine_args.1.3.0rc11.yaml.j2 for TRT-LLM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configuration template support for new backend framework versions: vLLM 0.19.0, sglang 0.5.10.post1, and TRT-LLM 1.3.0rc11, bundled as backend version 1.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->