### PR TITLE
chore: Add data from auto-collector pipeline 48565538 (gb200_trtllm_1.3.0rc10)

### DIFF
--- a/src/aiconfigurator/systems/data/gb200/trtllm/1.3.0rc10/gemm_perf.txt
+++ b/src/aiconfigurator/systems/data/gb200/trtllm/1.3.0rc10/gemm_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:971f3dcbaf5bd24c7fa705c7e277629eb886be30cf65c84ff6c4b463b275c8c7
+size 11438415


### PR DESCRIPTION
# Error Summary for Auto-Collector Run
## Collection summary for gb200 trtllm:1.3.0rc10
### Error summary
```
{
    "backend": "trtllm",
    "version": "1.3.0rc10",
    "timestamp": "2026-04-15T10:38:14.009924",
    "total_errors": 2,
    "errors_by_module": {
        "trtllm.gemm": 2
    },
    "errors_by_type": {
        "AcceleratorError": 1,
        "WorkerSignalCrash": 1
    }
}
```

