### PR TITLE
chore: Add data from auto-collector pipeline 48565538 (gb300_trtllm_1.3.0rc10)

### DIFF
--- a/src/aiconfigurator/systems/data/gb300/trtllm/1.3.0rc10/gemm_perf.txt
+++ b/src/aiconfigurator/systems/data/gb300/trtllm/1.3.0rc10/gemm_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53d339c9c5b3df2ed9fb8a18103e8c79b8867feabbf6c72a5934039baa53fd99
+size 11440188


### PR DESCRIPTION
# Error Summary for Auto-Collector Run
## Collection summary for gb300 trtllm:1.3.0rc10
### Error summary
```
{
    "backend": "trtllm",
    "version": "1.3.0rc10",
    "timestamp": "2026-04-15T10:41:19.151200",
    "total_errors": 2,
    "errors_by_module": {
        "trtllm.gemm": 2
    },
    "errors_by_type": {
        "AcceleratorError": 1,
        "WorkerSignalCrash": 1
    }
}
```

