### PR TITLE
chore: Add data from auto-collector pipeline 48565538 (b300_sxm_trtllm_1.3.0rc10)

### DIFF
--- a/src/aiconfigurator/systems/data/b300_sxm/trtllm/1.3.0rc10/gemm_perf.txt
+++ b/src/aiconfigurator/systems/data/b300_sxm/trtllm/1.3.0rc10/gemm_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73071460c38a946ab77a9490418c3a161f7520432fa8db41588380deb5ab2c80
+size 12338432


### PR DESCRIPTION
# Error Summary for Auto-Collector Run
## Collection summary for b300_sxm trtllm:1.3.0rc10
### Error summary
```
{
    "backend": "trtllm",
    "version": "1.3.0rc10",
    "timestamp": "2026-04-15T09:55:06.293185",
    "total_errors": 568,
    "errors_by_module": {
        "trtllm.gemm": 568
    },
    "errors_by_type": {
        "AcceleratorError": 284,
        "WorkerSignalCrash": 284
    }
}
```

