### PR TITLE
chore: Add data from auto-collector pipeline 48633782 (gb300_vllm_0.19.0)

### DIFF
--- a/src/aiconfigurator/systems/data/gb300/vllm/0.19.0/gdn_perf.txt
+++ b/src/aiconfigurator/systems/data/gb300/vllm/0.19.0/gdn_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a9ce66eaaf8d7d9f082c13de578c36139ab78de11eb369c907a3aa71fca50f1a
+size 11688


### PR DESCRIPTION
# Error Summary for Auto-Collector Run
## Collection summary for gb300 vllm:0.19.0
### Error summary
```
{
    "backend": "vllm",
    "version": "0.19.0",
    "timestamp": "2026-04-15T21:43:36.649835",
    "total_errors": 0,
    "errors_by_module": {},
    "errors_by_type": {}
}
```

