### PR TITLE
chore: Add data from auto-collector pipeline 48633782 (h100_sxm_trtllm_1.3.0rc10)

### DIFF
--- a/src/aiconfigurator/systems/data/h100_sxm/trtllm/1.3.0rc10/gdn_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/trtllm/1.3.0rc10/gdn_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d30e04553e0a93f9f969f43737717ed6687cd864187b61d1d25c49b681e8187e
+size 257877


### PR DESCRIPTION
# Error Summary for Auto-Collector Run
## Collection summary for h100_sxm trtllm:1.3.0rc10
### Error summary
```
{
    "backend": "trtllm",
    "version": "1.3.0rc10",
    "timestamp": "2026-04-15T21:46:49.350094",
    "total_errors": 0,
    "errors_by_module": {},
    "errors_by_type": {}
}
```

