### PR TITLE
chore: Add data from auto-collector pipeline 48633782 (gb200_vllm_0.19.0)

### DIFF
--- a/src/aiconfigurator/systems/data/gb200/vllm/0.19.0/gdn_perf.txt
+++ b/src/aiconfigurator/systems/data/gb200/vllm/0.19.0/gdn_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:214fd0db1151665d9d5a489e97c22394596023e55890e2ed2e543b48b2b339ec
+size 11688


### PR DESCRIPTION
# Error Summary for Auto-Collector Run
## Collection summary for gb200 vllm:0.19.0
### Error summary
```
{
    "backend": "vllm",
    "version": "0.19.0",
    "timestamp": "2026-04-15T21:47:49.455483",
    "total_errors": 0,
    "errors_by_module": {},
    "errors_by_type": {}
}
```

