### PR TITLE
chore: Add data from auto-collector pipeline 48633782 (gb300_trtllm_1.3.0rc10)

### DIFF
--- a/src/aiconfigurator/systems/data/gb300/trtllm/1.3.0rc10/gdn_perf.txt
+++ b/src/aiconfigurator/systems/data/gb300/trtllm/1.3.0rc10/gdn_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f696f6830ca22ec9e35f7cb4e02e26ba4dfc8c1f0aecc89befaa510ed3d3ca99
+size 245639


### PR DESCRIPTION
# Error Summary for Auto-Collector Run
## Collection summary for gb300 trtllm:1.3.0rc10
### Error summary
```
{
    "backend": "trtllm",
    "version": "1.3.0rc10",
    "timestamp": "2026-04-15T21:49:42.742683",
    "total_errors": 1,
    "errors_by_module": {
        "trtllm.gdn": 1
    },
    "errors_by_type": {
        "AcceleratorError": 1
    }
}
```

