### PR TITLE
feat: add B300 support for vLLM 0.19.0

### DIFF
--- a/collector/vllm/collect_attn.py
+++ b/collector/vllm/collect_attn.py
@@ -84,6 +84,35 @@ def run_attention_torch(
     model = os.path.join(os.path.dirname(__file__), "fake_hf_model")
     block_size = 64
 
+    if is_context_phase:
+        batch_spec = BatchSpec(
+            seq_lens=[input_len] * batch_size,
+            query_lens=[input_len] * batch_size,
+        )
+    else:
+        batch_spec = BatchSpec(
+            seq_lens=[input_len] * batch_size,
+            query_lens=[1] * batch_size,
+        )
+
+    try:
+        vllm.utils.torch_utils.set_random_seed(42)
+    except AttributeError:
+        current_platform.seed_everything(42)
+
+    vllm_config = create_vllm_config(
+        model_name=model,
+        max_model_len=max(batch_spec.seq_lens),
+        block_size=block_size,
+        num_gpu_blocks=8192,
+        max_num_seqs=batch_size,
+        use_fp8_kv_cache=use_fp8_kv_cache,
+    )
+
+    # vLLM >=0.19.0 requires an active config context for backend selection
+    # (get_attn_backend_cls internally calls get_current_vllm_config).
+    exit_stack.enter_context(set_current_vllm_config(vllm_config))
+
     # Let vLLM choose the backend. Handle multiple historical signatures:
     # newest: (... use_mm_prefix=..., use_v1=True/False defaulted to True)
     # mid:    (... use_mm_prefix omitted)
@@ -147,31 +176,6 @@ def run_attention_torch(
         backend_name = LegacyBackendEnum[backend_name_str]
     else:
         backend_name = backend_name_str
-
-    if is_context_phase:
-        batch_spec = BatchSpec(
-            seq_lens=[input_len] * batch_size,
-            query_lens=[input_len] * batch_size,
-        )
-    else:
-        batch_spec = BatchSpec(
-            seq_lens=[input_len] * batch_size,
-            query_lens=[1] * batch_size,
-        )
-
-    try:
-        vllm.utils.torch_utils.set_random_seed(42)
-    except AttributeError:
-        current_platform.seed_everything(42)
-
-    vllm_config = create_vllm_config(
-        model_name=model,
-        max_model_len=max(batch_spec.seq_lens),
-        block_size=block_size,
-        num_gpu_blocks=8192,
-        max_num_seqs=batch_size,
-        use_fp8_kv_cache=use_fp8_kv_cache,
-    )
 
     kv_cache_spec = create_standard_kv_cache_spec(vllm_config, use_fp8_kv_cache)
 
@@ -247,8 +251,6 @@ def run_attention_torch(
 
     builder_cls, impl_cls = get_attention_backend(actual_backend)
     layer_names = ["placeholder"]
-
-    exit_stack.enter_context(set_current_vllm_config(vllm_config))
 
     # Mock flashinfer's get_per_layer_parameters if needed
     if backend_name_str == "FLASHINFER":

--- a/collector/vllm/utils.py
+++ b/collector/vllm/utils.py
@@ -262,11 +262,18 @@ def create_vllm_config(
         max_model_len=max_model_len,
     )
 
-    cache_config = CacheConfig(
-        block_size=block_size,
-        cache_dtype="fp8" if use_fp8_kv_cache else "auto",
-        swap_space=0,
-    )
+    try:
+        cache_config = CacheConfig(
+            block_size=block_size,
+            cache_dtype="fp8" if use_fp8_kv_cache else "auto",
+            swap_space=0,
+        )
+    except (TypeError, Exception):
+        # vLLM >=0.19.0 removed swap_space from CacheConfig
+        cache_config = CacheConfig(
+            block_size=block_size,
+            cache_dtype="fp8" if use_fp8_kv_cache else "auto",
+        )
     # Set cache blocks for testing
     #   (these may be set during initialization normally)
     cache_config.num_gpu_blocks = num_gpu_blocks

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -115,7 +115,7 @@ def _add_default_mode_arguments(parser):
         "--system",
         type=str,
         required=True,
-        help="System name (GPU type). Example: h200_sxm,h100_sxm,b200_sxm,gb200,a100_sxm,l40s,gb300.",
+        help="System name (GPU type). Example: h200_sxm,h100_sxm,b200_sxm,b300_sxm,gb200,a100_sxm,l40s,gb300.",
     )
     parser.add_argument(
         "--decode-system",
@@ -263,7 +263,7 @@ def _add_generate_mode_arguments(parser):
         "--system",
         type=str,
         required=True,
-        help="System name (GPU type). Example: h200_sxm,h100_sxm,b200_sxm,gb200,a100_sxm,l40s,gb300.",
+        help="System name (GPU type). Example: h200_sxm,h100_sxm,b200_sxm,b300_sxm,gb200,a100_sxm,l40s,gb300.",
     )
     parser.add_argument(
         "--backend",
@@ -296,7 +296,7 @@ def _add_estimate_mode_arguments(parser):
         "--system",
         type=str,
         required=True,
-        help="System name (GPU type). Example: h200_sxm,h100_sxm,b200_sxm,gb200,a100_sxm,l40s,gb300.",
+        help="System name (GPU type). Example: h200_sxm,h100_sxm,b200_sxm,b300_sxm,gb200,a100_sxm,l40s,gb300.",
     )
     parser.add_argument(
         "--decode-system",
@@ -482,7 +482,7 @@ def _add_support_mode_arguments(parser):
         type=str,
         required=True,
         help="System name (GPU type) or 'all' for a matrix view across every system. "
-        "Example: h200_sxm, h100_sxm, b200_sxm, gb200, a100_sxm, l40s, gb300.",
+        "Example: h200_sxm, h100_sxm, b200_sxm, b300_sxm, gb200, a100_sxm, l40s, gb300.",
     )
     parser.add_argument(
         "--backend",

--- a/src/aiconfigurator/sdk/common.py
+++ b/src/aiconfigurator/sdk/common.py
@@ -329,6 +329,7 @@ SupportedSystems = {
     "h100_sxm",
     "h200_sxm",
     "b200_sxm",
+    "b300_sxm",
     "gb200",
     "gb300",
     "a100_sxm",

--- a/src/aiconfigurator/sdk/task.py
+++ b/src/aiconfigurator/sdk/task.py
@@ -289,7 +289,7 @@ class TaskConfigFactory:
         # for higher tensor core throughput. Profiles applied after this can override.
         # In disagg mode, prefill and decode may run on different hardware, so only
         # promote the workers that are actually on Blackwell.
-        _blackwell_systems = ("gb200", "gb300", "b200_sxm")
+        _blackwell_systems = ("gb200", "gb300", "b200_sxm", "b300_sxm")
         if ctx.backend_name == "trtllm" and ctx.model_path in ("openai/gpt-oss-120b", "openai/gpt-oss-20b"):
             quant_override = {"moe_quant_mode": "w4a8_mxfp4_mxfp8"}
             if ctx.serving_mode == "agg":

--- a/src/aiconfigurator/systems/b300_sxm.yaml
+++ b/src/aiconfigurator/systems/b300_sxm.yaml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# https://resources.nvidia.com/en-us-blackwell-architecture/blackwell-ultra-datasheet
+
+data_dir: data/b300_sxm # relative to systems_dir
+gpu:
+  mem_bw: 7750000000000 # 7.75 TB/s (Total mem_bw: 62TB/s / 8 GPUs)
+  mem_bw_empirical_scaling_factor: 0.8 # some nonofficial correction based on observations, you should try to modify based on your own observations
+  mem_empirical_constant_latency: 0.000003 # 3us some nonofficial correction based on observations, you should try to modify based on your own observations
+  mem_capacity: 288400343040 # 275040MiB reported by nvidia-smi
+  float16_tc_flops: 2250000000000000 # 2250 TFLOPS (4.5 PFLOPS sparse / 2)
+  int8_tc_flops: 153500000000000 # 153.5 TFLOPS (307 TOPS sparse / 2)
+  fp8_tc_flops: 4500000000000000 # 4.5 PFLOPS (9 PFLOPS sparse / 2)
+  fp4_tc_flops: 14000000000000000 # 14 PFLOPS (18 PFLOPS sparse | 14 PFLOPS dense)
+  power: 1100  # Watt (configurable up to 1,100 W)
+  sm_version: 103
+
+node:
+  num_gpus_per_node: 8
+  inter_node_bw: 100000000000  # Byte/s per GPU, single direction, 1:1 CX8 XDR 800Gb/s per node
+  intra_node_bw: 900000000000  # Byte/s per gpu, single direction (1.8 TB/s NVLink bidir / 2)
+  pcie_bw: 128000000000  # Byte/s, single direction, PCIe Gen6 (256 GB/s bidir / 2)
+  p2p_latency: 0.00001  # 10us some nonofficial correction based on observations, you should try to modify based on your own observations
+
+misc:
+  nccl_mem: # some nonofficial correction based on observations, you should try to modify based on your own observations
+    1: 0
+    2: 358612992 # 342MB
+    4: 411041792 # 392MB
+    8: 411041792 # 392MB
+  other_mem: 3758096384 # increase from 551MB to 3.5GB for safer deployment, this will cover part of the inaccurate mem calc.
+  nccl_version: '2.27'

--- a/src/aiconfigurator/systems/data/b300_sxm/nccl/2.27/nccl_perf.txt
+++ b/src/aiconfigurator/systems/data/b300_sxm/nccl/2.27/nccl_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e19c42908dc241325b0304f5c26fb5bc747094fb7b895619081873c72397813e
+size 23183

--- a/src/aiconfigurator/systems/data/b300_sxm/vllm/0.19.0/context_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/b300_sxm/vllm/0.19.0/context_attention_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0257264387f3ccd358f5c1c55f528a2d61a87bdaca157c0cb40eb72cd3652f2d
+size 1315999

--- a/src/aiconfigurator/systems/data/b300_sxm/vllm/0.19.0/custom_allreduce_perf.txt
+++ b/src/aiconfigurator/systems/data/b300_sxm/vllm/0.19.0/custom_allreduce_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac36bd851c20755ab094afa9de2d3d580c54d7fe5fb206a77846af8705e38243
+size 15313

--- a/src/aiconfigurator/systems/data/b300_sxm/vllm/0.19.0/gemm_perf.txt
+++ b/src/aiconfigurator/systems/data/b300_sxm/vllm/0.19.0/gemm_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48021e0bf1bc999f4d62f7a96a5f1171440d8f8102e7bf0886719829663623c4
+size 10520354

--- a/src/aiconfigurator/systems/data/b300_sxm/vllm/0.19.0/generation_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/b300_sxm/vllm/0.19.0/generation_attention_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f208fa5a23709f2ef15481948f1aa1fd0e04a7b51e4171a1252fc0efdbc062f6
+size 1088280

--- a/src/aiconfigurator/systems/data/b300_sxm/vllm/0.19.0/moe_perf.txt
+++ b/src/aiconfigurator/systems/data/b300_sxm/vllm/0.19.0/moe_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a72a91d2405241ced3686756ba41b7dd7f3694a2734438491f1ab44dd3adc9d
+size 5042122


### PR DESCRIPTION
#### Overview:

Add B300 system support with vLLM 0.19.0 perf data, and fix two collector API breakages that prevented attention data collection.

#### Details:

- **B300 support**: Add `b300_sxm.yaml` system definition, register in `common.py` enum, update CLI and task resolution (cherry-pick from @harrli)
- **Collected data**: Include gemm, moe, custom_allreduce, and attention perf data from B300 + vLLM 0.19.0 collection runs
- **Fix 1 — config context**: vLLM 0.19.0 changed `get_attn_backend_cls()` to use `AttnSelectorConfig` and internally call `get_current_vllm_config()`. The collector created `vllm_config` *after* backend selection, so the config context wasn't active — every attention test case failed with `TypeError`. Fix moves `vllm_config` creation and `set_current_vllm_config()` entry before backend selection. Backward compatible with older vLLM versions.
- **Fix 2 — CacheConfig**: vLLM 0.19.0 made `CacheConfig` pydantic-validated and removed the `swap_space` parameter. `create_vllm_config()` passed `swap_space=0` which now throws `ValidationError`. Fix falls back to omitting `swap_space` when the old signature is rejected.

#### Where should the reviewer start?

`collector/vllm/collect_attn.py`, then `collector/vllm/utils.py`

#### Related Issues:

- Pipeline 48615359 + 48646497 (b300_sxm_vllm_0.19.0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for NVIDIA B300 SXM GPU system with complete performance configurations.

* **Bug Fixes**
  * Fixed compatibility with vLLM version 0.19.0 and later by handling swap space parameter changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->