### PR TITLE
chore: Add data from auto-collector pipeline 48633782 (gb200_trtllm_1.3.0rc10)

### DIFF
--- a/src/aiconfigurator/systems/data/gb200/trtllm/1.3.0rc10/gdn_perf.txt
+++ b/src/aiconfigurator/systems/data/gb200/trtllm/1.3.0rc10/gdn_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6277011d95ba2f88326005dad85b6eb2be2db153badd807b0c10de6b40f1960
+size 252424


### PR DESCRIPTION
# Error Summary for Auto-Collector Run
## Collection summary for gb200 trtllm:1.3.0rc10
### Error summary
```
{
    "backend": "trtllm",
    "version": "1.3.0rc10",
    "timestamp": "2026-04-15T21:54:17.388611",
    "total_errors": 0,
    "errors_by_module": {},
    "errors_by_type": {}
}
```

