### PR TITLE
chore: Add data from auto-collector pipeline 48633782 (b300_sxm_trtllm_1.3.0rc10)

### DIFF
--- a/src/aiconfigurator/systems/data/b300_sxm/trtllm/1.3.0rc10/gdn_perf.txt
+++ b/src/aiconfigurator/systems/data/b300_sxm/trtllm/1.3.0rc10/gdn_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3296b73ce3f714a7f6e7a536b7c7050fd3842dab9720bc2a4743625ca1c42348
+size 191803


### PR DESCRIPTION
# Error Summary for Auto-Collector Run
## Collection summary for b300_sxm trtllm:1.3.0rc10
### Error summary
```
{
    "backend": "trtllm",
    "version": "1.3.0rc10",
    "timestamp": "2026-04-15T22:46:59.012961",
    "total_errors": 6,
    "errors_by_module": {
        "trtllm.gdn": 6
    },
    "errors_by_type": {
        "AcceleratorError": 6
    }
}
```

