### PR TITLE
fix: align balanced EP routing with rank0 workload projection

### DIFF
--- a/collector/collect_comm.sh
+++ b/collector/collect_comm.sh
@@ -7,6 +7,7 @@ all_reduce_backend="trtllm"
 device="cuda"
 measure_power=false
 power_test_duration=1.0
+skip_nccl=false
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
@@ -36,6 +37,10 @@ while [[ $# -gt 0 ]]; do
             power_test_duration="$2"
             shift 2
             ;;
+        --skip-nccl|--skip_nccl)
+            skip_nccl=true
+            shift
+            ;;
         -h|--help)
             echo "Usage: $0 [OPTIONS]"
             echo ""
@@ -44,6 +49,7 @@ while [[ $# -gt 0 ]]; do
             echo "                             Choices: trtllm, vllm, sglang"
             echo "  --measure_power            Enable power monitoring during execution"
             echo "  --power_test_duration      Minimum test duration for power measurement in seconds (default: 1.0)"
+            echo "  --skip-nccl               Skip NCCL benchmark collection"
             echo "  -h, --help                 Show this help message and exit"
             echo ""
             echo "Examples:"
@@ -51,6 +57,7 @@ while [[ $# -gt 0 ]]; do
             echo "  $0 --measure_power --power_test_duration 2.0"
             echo "  $0 --all_reduce_backend vllm --measure_power"
             echo "  $0 --all_reduce_backend sglang"
+            echo "  $0 --skip-nccl --all_reduce_backend sglang"
             exit 0
             ;;
         *)
@@ -67,6 +74,11 @@ if [[ "$measure_power" == "true" ]]; then
     echo "Power monitoring: ENABLED (duration: ${power_test_duration}s)"
 else
     echo "Power monitoring: DISABLED"
+fi
+if [[ "$skip_nccl" == "true" ]]; then
+    echo "NCCL benchmarks: SKIPPED"
+else
+    echo "NCCL benchmarks: ENABLED"
 fi
 echo "================================================"
 
@@ -92,7 +104,9 @@ else
 fi
 
 # NCCL
-if [[ "$device" == "cuda" ]]; then
+if [[ "$skip_nccl" == "true" ]]; then
+    echo "Skipping NCCL benchmarks (--skip-nccl enabled)"
+elif [[ "$device" == "cuda" ]]; then
     nccl_ops=("all_gather" "alltoall" "reduce_scatter" "all_reduce")
     dtypes=("half" "int8")
 

--- a/collector/sglang/collect_moe.py
+++ b/collector/sglang/collect_moe.py
@@ -81,9 +81,6 @@ def get_moe_test_cases():
     test_cases = []
 
     for common_moe_testcase in get_common_moe_test_cases():
-        if common_moe_testcase.token_expert_distribution != "power_law":
-            continue
-
         model_name = common_moe_testcase.model_name
         if model_name in ["openai/gpt-oss-20b", "openai/gpt-oss-120b"]:
             continue
@@ -421,28 +418,46 @@ class Rank0Workload(TypedDict):
     masked_m: torch.Tensor
 
 
-def build_power_law_rank0_workloads(
+def build_rank0_workloads(
     num_workloads: int,
     num_tokens: int,
     hidden_size: int,
     topk: int,
     num_experts: int,
     moe_ep_size: int,
-    power_law_alpha: float,
+    distributed: str,
+    power_law_alpha: float | None,
     dtype: torch.dtype,
     device: torch.device,
 ) -> list[Rank0Workload]:
     workloads: list[Rank0Workload] = []
+    experts_per_rank = num_experts // moe_ep_size
 
     for _ in range(num_workloads):
-        _, rank0_info = power_law_logits_v3(
-            num_tokens,
-            num_experts,
-            topk,
-            moe_ep_size,
-            power_law_alpha,
-            return_rank0_info=True,
-        )
+        if distributed == "power_law":
+            if power_law_alpha is None:
+                raise ValueError("power_law_alpha is required for power_law distribution")
+            _, rank0_info = power_law_logits_v3(
+                num_tokens,
+                num_experts,
+                topk,
+                moe_ep_size,
+                power_law_alpha,
+                return_rank0_info=True,
+            )
+        elif distributed == "balanced":
+            router_logits = balanced_logits(num_tokens, num_experts, topk).to(device=device, dtype=torch.float32)
+            rank0_selected_slots = torch.topk(router_logits, topk, dim=-1).indices.to(torch.int64)
+            rank0_token_mask = (rank0_selected_slots < experts_per_rank).any(dim=1)
+            rank0_info = {
+                "rank0_selected_slots": rank0_selected_slots[rank0_token_mask],
+                "rank0_logits": router_logits[rank0_token_mask],
+                "rank0_num_tokens": int(rank0_token_mask.sum().item()),
+                "slots_per_rank": experts_per_rank,
+            }
+        else:
+            raise ValueError(f"Unsupported distribution for rank0 workloads: {distributed}")
+
         rank0_local = build_rank0_local_workload(rank0_info)
         rank0_num_tokens = int(rank0_local["num_tokens"])
         workloads.append(
@@ -488,18 +503,22 @@ def run_moe_torch(
 
     num_local_experts = num_experts // moe_ep_size
 
-    if moe_ep_size > 1 and distributed == "power_law":
-        rank0_workloads = build_power_law_rank0_workloads(
+    rank0_workloads: list[Rank0Workload] | None = None
+    if moe_ep_size > 1 and distributed in ("power_law", "balanced"):
+        rank0_workloads = build_rank0_workloads(
             num_workloads=5,
             num_tokens=num_tokens,
             hidden_size=hidden_size,
             topk=topk,
             num_experts=num_experts,
             moe_ep_size=moe_ep_size,
-            power_law_alpha=power_law_alpha,
+            distributed=distributed,
+            power_law_alpha=power_law_alpha if distributed == "power_law" else None,
             dtype=torch.bfloat16,
             device=torch.device(device),
         )
+
+    if rank0_workloads is not None:
         latency, power_stats = benchmark(
             num_tokens,
             num_local_experts,


### PR DESCRIPTION
Overview:
Align MoE collector routing semantics for EP workloads and add a CLI option to skip NCCL collection when not needed.

Details:
Refactored SGLang MoE EP workload generation in collect_moe.py:
Unified balanced and power_law EP>1 paths into a shared rank0 workload builder.
Kept power_law_alpha as an optional parameter (required only for power_law).
Removed duplicated workload construction logic.
Added --skip-nccl (--skip_nccl) flag to collect_comm.sh:
Skips NCCL benchmark collection block when enabled.
Updated help text and examples.
Added explicit runtime status output for NCCL collection mode.
Where should the reviewer start?
aiconfigurator/collector/sglang/collect_moe.py
Focus on build_rank0_workloads(...) and run_moe_torch(...) EP branch behavior.
aiconfigurator/collector/collect_comm.sh
Focus on argument parsing and NCCL skip flow (--skip-nccl).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--skip-nccl` CLI option to control NCCL benchmark execution.

* **Improvements**
  * Expanded test-case generation to include various token-expert distributions.
  * Added support for balanced distribution in workload generation alongside existing power-law distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->