### PR TITLE
chore: Add data from auto-collector pipeline 48674340 (gb200_vllm_0.14.0)

### DIFF
--- a/src/aiconfigurator/systems/data/gb200/vllm/0.14.0/moe_perf.txt
+++ b/src/aiconfigurator/systems/data/gb200/vllm/0.14.0/moe_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3b0a11dabd28c2a98ab79db8ebb2589881a471dbf3abd98632ec8925a7f29352
-size 4107514
+oid sha256:7b3e930666b55bc2a55820bb98fdf023eb089b18a2c4f8a7e9e6e3c1732e63e9
+size 5394999


### PR DESCRIPTION
# Error Summary for Auto-Collector Run
## Collection summary for gb200 vllm:0.14.0
### Error summary
```
{
    "backend": "vllm",
    "version": "0.14.1.dev1+gd68209402",
    "timestamp": "2026-04-16T01:28:39.384787",
    "total_errors": 48,
    "errors_by_module": {
        "vllm.moe": 48
    },
    "errors_by_type": {
        "AssertionError": 48
    }
}
```

