### PR TITLE
chore: Add data from auto-collector pipeline 48674340 (gb300_vllm_0.14.0)

### DIFF
--- a/src/aiconfigurator/systems/data/gb300/vllm/0.14.0/moe_perf.txt
+++ b/src/aiconfigurator/systems/data/gb300/vllm/0.14.0/moe_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:512966667d5e727abb4bb2e616334e2ac04bea0999d3b9ba5d02dca1d0a38d02
-size 4085091
+oid sha256:11111c91bcd47c0de2f4e535b9775cc67283e406d1ebf80d3c1380fd0e2e7e06
+size 5375575


### PR DESCRIPTION
# Error Summary for Auto-Collector Run
## Collection summary for gb300 vllm:0.14.0
### Error summary
```
{
    "backend": "vllm",
    "version": "0.14.1.dev1+gd68209402",
    "timestamp": "2026-04-16T01:36:26.657320",
    "total_errors": 54,
    "errors_by_module": {
        "vllm.moe": 54
    },
    "errors_by_type": {
        "PTXASError": 6,
        "AssertionError": 48
    }
}
```

