### PR TITLE
feat: add DeepSeek R1 to support matrix

### DIFF
--- a/src/aiconfigurator/model_configs/deepseek-ai--DeepSeek-R1_config.json
+++ b/src/aiconfigurator/model_configs/deepseek-ai--DeepSeek-R1_config.json
@@ -1,0 +1,67 @@
+{
+  "architectures": [
+    "DeepseekV3ForCausalLM"
+  ],
+  "attention_bias": false,
+  "attention_dropout": 0.0,
+  "auto_map": {
+    "AutoConfig": "configuration_deepseek.DeepseekV3Config",
+    "AutoModel": "modeling_deepseek.DeepseekV3Model",
+    "AutoModelForCausalLM": "modeling_deepseek.DeepseekV3ForCausalLM"
+  },
+  "bos_token_id": 0,
+  "eos_token_id": 1,
+  "ep_size": 1,
+  "first_k_dense_replace": 3,
+  "hidden_act": "silu",
+  "hidden_size": 7168,
+  "initializer_range": 0.02,
+  "intermediate_size": 18432,
+  "kv_lora_rank": 512,
+  "max_position_embeddings": 163840,
+  "model_type": "deepseek_v3",
+  "moe_intermediate_size": 2048,
+  "moe_layer_freq": 1,
+  "n_group": 8,
+  "n_routed_experts": 256,
+  "n_shared_experts": 1,
+  "norm_topk_prob": true,
+  "num_attention_heads": 128,
+  "num_experts_per_tok": 8,
+  "num_hidden_layers": 61,
+  "num_key_value_heads": 128,
+  "num_nextn_predict_layers": 1,
+  "q_lora_rank": 1536,
+  "qk_nope_head_dim": 128,
+  "qk_rope_head_dim": 64,
+  "quantization_config": {
+    "activation_scheme": "dynamic",
+    "fmt": "e4m3",
+    "quant_method": "fp8",
+    "weight_block_size": [
+      128,
+      128
+    ]
+  },
+  "rms_norm_eps": 1e-06,
+  "rope_scaling": {
+    "beta_fast": 32,
+    "beta_slow": 1,
+    "factor": 40,
+    "mscale": 1.0,
+    "mscale_all_dim": 1.0,
+    "original_max_position_embeddings": 4096,
+    "type": "yarn"
+  },
+  "rope_theta": 10000,
+  "routed_scaling_factor": 2.5,
+  "scoring_func": "sigmoid",
+  "tie_word_embeddings": false,
+  "topk_group": 4,
+  "topk_method": "noaux_tc",
+  "torch_dtype": "bfloat16",
+  "transformers_version": "4.46.3",
+  "use_cache": true,
+  "v_head_dim": 128,
+  "vocab_size": 129280
+}

--- a/src/aiconfigurator/sdk/common.py
+++ b/src/aiconfigurator/sdk/common.py
@@ -280,6 +280,8 @@ DefaultHFModels = {
     "meta-llama/Meta-Llama-3.1-70B",
     "meta-llama/Meta-Llama-3.1-405B",
     "nvidia/Llama-3.1-70B-Instruct-FP8",
+    # DeepSeek R1
+    "deepseek-ai/DeepSeek-R1",
     # DeepSeek V3/V3.1 Models
     "deepseek-ai/DeepSeek-V3",
     "nvidia/DeepSeek-V3.1-NVFP4",


### PR DESCRIPTION
## Summary
- Add `deepseek-ai/DeepSeek-R1` model config JSON (sourced from HuggingFace)
- Register R1 in `DefaultHFModels` for support matrix coverage

R1 shares the same architecture (`DeepseekV3ForCausalLM`) and model family (`DEEPSEEK`) as V3 — identical structure (61 layers, 256 experts, hidden_size=7168). Only the weights differ (R1 applies RL on V3 base). No new code paths needed.

Closes #850

## Test plan
- [ ] Run `aic check-support --model deepseek-ai/DeepSeek-R1` for h200_sxm with trtllm/vllm/sglang
- [ ] Re-run support matrix generator and verify R1 rows appear
- [ ] Verify DeepSeek V3 support is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for the DeepSeek-R1 AI model with complete configuration
  * Model is now available as a pre-configured default option

<!-- end of auto-generated comment: release notes by coderabbit.ai -->