### PR TITLE
chore: Add data from auto-collector pipeline 48754219 (gb300_vllm_0.14.0)

### DIFF
--- a/src/aiconfigurator/systems/data/gb300/vllm/0.14.0/moe_perf.txt
+++ b/src/aiconfigurator/systems/data/gb300/vllm/0.14.0/moe_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:11111c91bcd47c0de2f4e535b9775cc67283e406d1ebf80d3c1380fd0e2e7e06
-size 5375575
+oid sha256:36d8ea2798c42530b68ba1329f5325d58f8c677ce2b5c1d76dd3d695ff1ca718
+size 3476454


### PR DESCRIPTION
# Error Summary for Auto-Collector Run
## Collection summary for gb300 vllm:0.14.0
### Error summary
```
{
    "backend": "vllm",
    "version": "0.14.1.dev1+gd68209402",
    "timestamp": "2026-04-16T22:17:17.945571",
    "total_errors": 981,
    "errors_by_module": {
        "vllm.moe": 981
    },
    "errors_by_type": {
        "PTXASError": 751,
        "AssertionError": 48,
        "AcceleratorError": 179,
        "WorkerAbnormalExit": 3
    }
}
```

