### PR TITLE
chore: Add data from auto-collector pipeline 48754219 (gb200_vllm_0.14.0)

### DIFF
--- a/src/aiconfigurator/systems/data/gb200/vllm/0.14.0/moe_perf.txt
+++ b/src/aiconfigurator/systems/data/gb200/vllm/0.14.0/moe_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7b3e930666b55bc2a55820bb98fdf023eb089b18a2c4f8a7e9e6e3c1732e63e9
-size 5394999
+oid sha256:27649c395b9c0c121a21f2b993c9eadff65326a60780f60df1f856a9655aefd2
+size 5984967


### PR DESCRIPTION
# Error Summary for Auto-Collector Run
## Collection summary for gb200 vllm:0.14.0
### Error summary
```
{
    "backend": "vllm",
    "version": "0.14.1.dev1+gd68209402",
    "timestamp": "2026-04-16T22:22:05.216227",
    "total_errors": 230,
    "errors_by_module": {
        "vllm.moe": 230
    },
    "errors_by_type": {
        "AssertionError": 48,
        "AcceleratorError": 180,
        "WorkerAbnormalExit": 2
    }
}
```

