### PR TITLE
fix: vLLM ≥0.19 MLA/DSA module collector compat

### DIFF
--- a/collector/helper.py
+++ b/collector/helper.py
@@ -172,6 +172,8 @@ def benchmark_with_power(
     measure_power: bool | None = None,  # Auto-detect from environment if None
     power_min_duration: float | None = None,  # Auto-detect from environment if None
     allow_graph_fail: bool = False,  # NEW: Enable graceful fallback on graph capture failure
+    use_cuda_graph: bool = True,  # NEW: set False to force eager execution (ops whose captured
+    # private pools retain memory across tasks — see collect_mla_module_v3 DSA context).
 ):
     """
     Context manager that handles warmup, graph capture, timing, and power monitoring.
@@ -187,6 +189,11 @@ def benchmark_with_power(
         allow_graph_fail: If True, gracefully fallback to eager execution when
                          CUDA graph capture fails. Power monitoring continues
                          to work in both paths. Default False for backward compatibility.
+        use_cuda_graph: If False, skip CUDA graph capture entirely and run every
+                         iteration eagerly. Defaults to True so all existing callers
+                         (~30 collectors) keep graph-mode measurement. Callers whose
+                         captured forward pass retains GiB-scale memory in the graph's
+                         private pool across tasks should pass False.
 
     Yields:
         dict with keys:
@@ -241,7 +248,8 @@ def benchmark_with_power(
     # ═══════════════════════════════════════════════════════════════════
     # CUDA Graph Capture with Optional Fallback
     # ═══════════════════════════════════════════════════════════════════
-    if torch.cuda.is_available():
+    g = None  # kept in scope so the finally block below can tear it down
+    if torch.cuda.is_available() and use_cuda_graph:
         use_graph = True
         g = torch.cuda.CUDAGraph()
 
@@ -253,7 +261,8 @@ def benchmark_with_power(
         except Exception as e:
             if allow_graph_fail:
                 logging.getLogger(__name__).warning(f"CUDA graph capture failed: {e}. Falling back to eager execution.")
-                torch.cuda.empty_cache()  # CRITICAL: Clean up partial allocations
+                g = None  # drop the partial capture so empty_cache can reclaim its private pool
+                torch.cuda.empty_cache()
                 use_graph = False
             else:
                 # Standard behavior: re-raise exception
@@ -261,88 +270,106 @@ def benchmark_with_power(
     else:
         use_graph = False
 
-    # ═══════════════════════════════════════════════════════════════════
-    # Warmup the ACTUAL execution path (after graph capture)
-    # ═══════════════════════════════════════════════════════════════════
-    if torch.cuda.is_available():
-        torch.cuda.synchronize()
-        for _ in range(num_warmups):
+    # Everything from here to the yield holds live references to the captured
+    # graph's private pool. A try/finally guarantees the graph (and therefore
+    # its pool) is released before we return to the caller, regardless of
+    # whether warmup raises, the yield body raises, or we finish cleanly.
+    try:
+        # ═══════════════════════════════════════════════════════════════
+        # Warmup the ACTUAL execution path (after graph capture)
+        # ═══════════════════════════════════════════════════════════════
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+            for _ in range(num_warmups):
+                if use_graph:
+                    g.replay()
+                else:
+                    # Fallback: Direct execution matching actual execution path
+                    for _ in range(repeat_n):
+                        kernel_func()
+            torch.cuda.synchronize()
+
+        # Initialize power monitor if enabled
+        power_monitor = None
+        power_stats = None
+        if measure_power:
+            power_monitor = PowerMonitor(device.index)
+            if not power_monitor.start_sampling():
+                power_monitor = None  # Failed to start
+
+        # Get initial clock info for throttling detection
+        initial_clocks = None
+        if measure_power and _NVML_INITIALIZED:
+            try:
+                import pynvml as nvml
+
+                handle = nvml.nvmlDeviceGetHandleByIndex(device.index)
+                initial_clocks = nvml.nvmlDeviceGetClockInfo(handle, nvml.NVML_CLOCK_SM)
+            except Exception:
+                pass
+
+        # ═══════════════════════════════════════════════════════════════════
+        # Execute with Graph or Eager (both paths measured!)
+        # ═══════════════════════════════════════════════════════════════════
+        start_event = get_device_module().Event(enable_timing=True)
+        end_event = get_device_module().Event(enable_timing=True)
+        start_event.record()
+        for _ in range(actual_num_runs):
             if use_graph:
                 g.replay()
             else:
-                # Fallback: Direct execution matching actual execution path
+                # Fallback: Direct execution
+                # This matches SGLang/VLLM pattern where kernel_func handles internal loops
                 for _ in range(repeat_n):
                     kernel_func()
-        torch.cuda.synchronize()
+        end_event.record()
+        get_device_module().synchronize()
 
-    # Initialize power monitor if enabled
-    power_monitor = None
-    power_stats = None
-    if measure_power:
-        power_monitor = PowerMonitor(device.index)
-        if not power_monitor.start_sampling():
-            power_monitor = None  # Failed to start
+        # Check for throttling
+        throttled = False
+        if initial_clocks is not None:
+            try:
+                import pynvml as nvml
 
-    # Get initial clock info for throttling detection
-    initial_clocks = None
-    if measure_power and _NVML_INITIALIZED:
-        try:
-            import pynvml as nvml
+                handle = nvml.nvmlDeviceGetHandleByIndex(device.index)
+                final_clocks = nvml.nvmlDeviceGetClockInfo(handle, nvml.NVML_CLOCK_SM)
+                # If clocks dropped by more than 10%, likely throttled
+                if final_clocks < initial_clocks * 0.9:
+                    throttled = True
+                    logging.getLogger(__name__).warning(
+                        f"Clock throttling detected: {initial_clocks}MHz -> {final_clocks}MHz"
+                    )
+            except Exception:
+                pass
 
-            handle = nvml.nvmlDeviceGetHandleByIndex(device.index)
-            initial_clocks = nvml.nvmlDeviceGetClockInfo(handle, nvml.NVML_CLOCK_SM)
-        except Exception:
-            pass
+        # Stop power monitoring
+        if power_monitor:
+            power_stats = power_monitor.stop_sampling()
 
-    # ═══════════════════════════════════════════════════════════════════
-    # Execute with Graph or Eager (both paths measured!)
-    # ═══════════════════════════════════════════════════════════════════
-    start_event = get_device_module().Event(enable_timing=True)
-    end_event = get_device_module().Event(enable_timing=True)
-    start_event.record()
-    for _ in range(actual_num_runs):
-        if use_graph:
-            g.replay()
-        else:
-            # Fallback: Direct execution
-            # This matches SGLang/VLLM pattern where kernel_func handles internal loops
-            for _ in range(repeat_n):
-                kernel_func()
-    end_event.record()
-    get_device_module().synchronize()
+        # Calculate latency
+        latency_ms = start_event.elapsed_time(end_event) / actual_num_runs / repeat_n
 
-    # Check for throttling
-    throttled = False
-    if initial_clocks is not None:
-        try:
-            import pynvml as nvml
-
-            handle = nvml.nvmlDeviceGetHandleByIndex(device.index)
-            final_clocks = nvml.nvmlDeviceGetClockInfo(handle, nvml.NVML_CLOCK_SM)
-            # If clocks dropped by more than 10%, likely throttled
-            if final_clocks < initial_clocks * 0.9:
-                throttled = True
-                logging.getLogger(__name__).warning(
-                    f"Clock throttling detected: {initial_clocks}MHz -> {final_clocks}MHz"
-                )
-        except Exception:
-            pass
-
-    # Stop power monitoring
-    if power_monitor:
-        power_stats = power_monitor.stop_sampling()
-
-    # Calculate latency
-    latency_ms = start_event.elapsed_time(end_event) / actual_num_runs / repeat_n
-
-    # Return results
-    yield {
-        "latency_ms": latency_ms,
-        "power_stats": power_stats,
-        "throttled": throttled,
-        "num_runs_executed": actual_num_runs,
-        "used_cuda_graph": use_graph,  # NEW: Inform caller which path was used
-    }
+        # Return results
+        yield {
+            "latency_ms": latency_ms,
+            "power_stats": power_stats,
+            "throttled": throttled,
+            "num_runs_executed": actual_num_runs,
+            "used_cuda_graph": use_graph,  # NEW: Inform caller which path was used
+        }
+    finally:
+        # Drop the CUDA graph and reclaim its private memory pool. CUDA graph
+        # captures sequester intermediate tensors into a private pool that
+        # outlives Python-level GC of the CUDAGraph object in some PyTorch
+        # versions — if we skip this explicit teardown, leaky ops (e.g. DSA
+        # context via flashmla-sparse, which captures ~18 GiB of scratch)
+        # accumulate pool memory across tasks until the worker saturates at
+        # ~146 GiB pinned and subsequent tasks OOM at _ensure_workspace_size.
+        if g is not None:
+            g = None
+            if torch.cuda.is_available():
+                torch.cuda.synchronize()
+                torch.cuda.empty_cache()
 
 
 @contextmanager

--- a/collector/helper.py
+++ b/collector/helper.py
@@ -171,8 +171,8 @@ def benchmark_with_power(
     repeat_n: int = 1,  # Default 1; GEMM files use 5
     measure_power: bool | None = None,  # Auto-detect from environment if None
     power_min_duration: float | None = None,  # Auto-detect from environment if None
-    allow_graph_fail: bool = False,  # NEW: Enable graceful fallback on graph capture failure
-    use_cuda_graph: bool = True,  # NEW: set False to force eager execution (ops whose captured
+    allow_graph_fail: bool = False,  # Enable graceful fallback on graph capture failure
+    use_cuda_graph: bool = True,  # set False to force eager execution (ops whose captured
     # private pools retain memory across tasks — see collect_mla_module_v3 DSA context).
 ):
     """

--- a/collector/vllm/collect_mla_module_v2.py
+++ b/collector/vllm/collect_mla_module_v2.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-__compat__ = "vllm>=0.17.0"
+__compat__ = "vllm>=0.17.0,<0.19.0"
 
 """
 MLA Module Collector for vLLM — unified MLA and DSA benchmarking.

--- a/collector/vllm/collect_mla_module_v3.py
+++ b/collector/vllm/collect_mla_module_v3.py
@@ -554,6 +554,23 @@ def _create_kv_cache_and_metadata(
         batch_spec, block_size, torch.device(device), arange_block_indices=True
     )
 
+    # TRT-LLM Gen MLA (and cutlass_mla) require the page table's block
+    # dimension to be a multiple of ``128 / block_size``; for block_size=64
+    # that means at least two blocks even when a request only fills one.
+    # Short sequences (seq_len <= block_size) otherwise produce block_num=1
+    # and the kernel raises ``Expected block_num % (128 / block_size) == 0``.
+    # Pad with zero-indexed blocks (they are not read for absent tokens).
+    required_divisor = max(1, 128 // block_size)
+    current_block_num = common_attn_metadata.block_table_tensor.shape[1]
+    if current_block_num % required_divisor != 0:
+        padded_block_num = ((current_block_num + required_divisor - 1) // required_divisor) * required_divisor
+        padding = torch.zeros(
+            (common_attn_metadata.block_table_tensor.shape[0], padded_block_num - current_block_num),
+            dtype=common_attn_metadata.block_table_tensor.dtype,
+            device=common_attn_metadata.block_table_tensor.device,
+        )
+        common_attn_metadata.block_table_tensor = torch.cat([common_attn_metadata.block_table_tensor, padding], dim=1)
+
     # Select the correct dtype for cache.
     # DSA fp8 uses a custom 656-byte ``fp8_ds_mla`` cache format that
     # stores quantised NoPE + per-128-element scales + BF16 RoPE.

--- a/collector/vllm/collect_mla_module_v3.py
+++ b/collector/vllm/collect_mla_module_v3.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-__compat__ = "vllm>=0.17.0"
+__compat__ = "vllm>=0.19.0"
 
 """
 MLA Module Collector for vLLM — unified MLA and DSA benchmarking.

--- a/collector/vllm/collect_mla_module_v3.py
+++ b/collector/vllm/collect_mla_module_v3.py
@@ -938,8 +938,24 @@ def run_mla_module_worker(
 
 
 def _cleanup():
-    torch.cuda.empty_cache()
+    # Release vLLM's WorkspaceManager singleton scratch buffers before
+    # returning to the worker loop. ``_ensure_workspace_size`` only grows —
+    # once a task demands N bytes, the manager pins N bytes for the worker's
+    # lifetime, so a single large task turns into a permanent allocator
+    # reservation that starves subsequent small tasks into OOM.
+    #
+    # The module-level ``_manager`` is private; vLLM offers no public
+    # teardown API. Nulling it drops the Python reference to the old
+    # manager (and its workspace tensors), and the next task's
+    # ``init_workspace_manager()`` call creates a fresh instance on demand.
+    import vllm.v1.worker.workspace as _ws_mod
+
+    _ws_mod._manager = None
+    # gc.collect() must run BEFORE empty_cache() — ``empty_cache`` only
+    # releases blocks with zero live allocations, so any Python-reachable
+    # tensors need to be dropped first or the pass is a no-op.
     gc.collect()
+    torch.cuda.empty_cache()
 
 
 # ═══════════════════════════════════════════════════════════════════════

--- a/collector/vllm/collect_mla_module_v3.py
+++ b/collector/vllm/collect_mla_module_v3.py
@@ -1,0 +1,1049 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+__compat__ = "vllm>=0.17.0"
+
+"""
+MLA Module Collector for vLLM — unified MLA and DSA benchmarking.
+
+Profiles the complete attention module forward pass (projections + attention +
+output), not just the bare attention kernel. Uses vLLM's own modeling code to
+construct a single `DeepseekV2MLAAttention` module with dummy weights, then
+benchmarks its forward.
+
+MLA vs DSA is determined by the presence of `index_topk` in the HF config.
+Op names and data schema are aligned with TRT-LLM's collect_mla_module.py
+so that queries can be reused across frameworks.
+
+Supported models and their attention types are defined in SUPPORTED_MODELS.
+The collector reads a real HF config, overrides the layer-local shape fields
+in-memory, and then instantiates just the attention module.
+
+Usage:
+    # MLA context phase (DeepSeek-V3 style)
+    python collect_mla_module.py --mode context --model mla
+
+    # DSA generation phase (DeepSeek-V3.2 style)
+    python collect_mla_module.py --mode generation --model dsa
+
+    # All models, context phase
+    python collect_mla_module.py --mode context
+
+    # Quick single-point test
+    python collect_mla_module.py --mode context --model mla --quick --batch-size 4 --seq-len 2048
+"""
+
+import argparse
+import gc
+import json
+import math
+import os
+import tempfile
+import traceback
+from pathlib import Path
+
+import torch
+from vllm.config import set_current_vllm_config
+from vllm.forward_context import set_forward_context
+from vllm.platforms import current_platform
+
+# ═══════════════════════════════════════════════════════════════════════
+# Config registry patch — vLLM 0.16.0 registers the GlmMoeDsaForCausalLM
+# model class but omits the config-type mapping for "glm_moe_dsa", so
+# AutoConfig.from_pretrained() fails.  The config layout is identical to
+# DeepSeek-V3 (GlmMoeDsaForCausalLM inherits DeepseekV2ForCausalLM), so
+# reusing DeepseekV3Config is safe.
+# ═══════════════════════════════════════════════════════════════════════
+from vllm.transformers_utils.config import _CONFIG_REGISTRY
+from vllm.version import __version__ as vllm_version
+
+from collector.helper import benchmark_with_power, get_sm_version, log_perf
+from collector.vllm.utils import (
+    BatchSpec,
+    create_and_prepopulate_kv_cache_mla,
+    create_common_attn_metadata,
+    create_vllm_config,
+    setup_distributed,
+    with_exit_stack,
+)
+
+if "glm_moe_dsa" not in _CONFIG_REGISTRY:
+    _CONFIG_REGISTRY["glm_moe_dsa"] = "DeepseekV3Config"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Local model config resolution — avoid HuggingFace Hub downloads
+# ═══════════════════════════════════════════════════════════════════════
+
+# Pre-cached HF configs live in src/aiconfigurator/model_configs/ as
+# "<org>--<model>_config.json".  vLLM's ModelConfig accepts a local
+# directory containing config.json, so we create a temp dir with a
+# symlink when the cached file exists.
+_MODEL_CONFIGS_DIR = Path(__file__).resolve().parents[2] / "src" / "aiconfigurator" / "model_configs"
+
+# Cache of model_name -> temp dir path (created once per process).
+_local_config_cache: dict[str, str] = {}
+
+
+def _resolve_model_path(model_name: str) -> str:
+    """Return a local directory path for *model_name* if a cached config exists, else return model_name as-is."""
+    if model_name in _local_config_cache:
+        return _local_config_cache[model_name]
+
+    config_file = _MODEL_CONFIGS_DIR / f"{model_name.replace('/', '--')}_config.json"
+    if not config_file.exists():
+        return model_name
+
+    # Create a temp directory with config.json so vLLM's ModelConfig
+    # loads from disk instead of downloading from HuggingFace Hub.
+    tmp_dir = tempfile.mkdtemp(prefix=f"aic_model_{model_name.replace('/', '_')}_")
+    os.symlink(config_file, os.path.join(tmp_dir, "config.json"))
+    # Strip auto_map if present.  Some models (e.g. DeepSeek-V3) ship
+    # config.json with auto_map pointing to a custom Python config class
+    # (configuration_deepseek.py).  HuggingFace's AutoConfig.from_pretrained()
+    # — called by vLLM's ModelConfig — unconditionally tries to import that
+    # module from the model directory where it doesn't exist; vLLM natively
+    # supports these architectures and only needs the JSON fields.
+    with open(config_file) as f:
+        config_data = json.load(f)
+    if "auto_map" in config_data:
+        config_data.pop("auto_map")
+        os.remove(os.path.join(tmp_dir, "config.json"))
+        with open(os.path.join(tmp_dir, "config.json"), "w") as f:
+            json.dump(config_data, f)
+
+    # Also symlink hf_quant_config.json if present (used by quantized models).
+    quant_file = _MODEL_CONFIGS_DIR / f"{model_name.replace('/', '--')}_hf_quant_config.json"
+    if quant_file.exists():
+        os.symlink(quant_file, os.path.join(tmp_dir, "hf_quant_config.json"))
+
+    _local_config_cache[model_name] = tmp_dir
+    return tmp_dir
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Supported Models — model_path → attention type
+# ═══════════════════════════════════════════════════════════════════════
+
+SUPPORTED_MODELS: dict[str, str] = {
+    "deepseek-ai/DeepSeek-V3": "mla",
+    "deepseek-ai/DeepSeek-V3.2": "dsa",
+    "zai-org/GLM-5": "dsa",
+}
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Test Cases — aligned with TRT-LLM's collect_mla_module.py
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def _get_precision_combos(phase: str):
+    """Return (compute_dtype, kv_cache_dtype, gemm_type) triples for a phase.
+
+    Each triple describes the full quantisation configuration for one
+    benchmark sweep.  GPU capability (SM version) determines which
+    combos are available.
+
+    Precision axes:
+      gemm_type    — linear-layer GEMMs (projections inside the module)
+        bfloat16:  always
+        fp8_block: SM >= 89 (Ada / Hopper / Blackwell)
+        nvfp4:     SM >= 100 (Blackwell)
+
+      (compute_dtype, kv_cache_dtype) — attention compute + KV cache
+        context:    (bf16, bf16) always;  (bf16, fp8) SM >= 90;  (fp8, fp8) SM >= 100
+        generation: (bf16, bf16) always;  (bf16, fp8) SM >= 90
+    """
+    sm = get_sm_version()
+
+    gemm_types = ["bfloat16"]
+    if sm >= 89:
+        gemm_types.append("fp8_block")
+    if sm >= 100:
+        gemm_types.append("nvfp4")
+
+    attn_combos = [("bfloat16", "bfloat16")]
+    if phase == "context":
+        if sm >= 90:
+            attn_combos.append(("bfloat16", "fp8"))
+        if sm >= 100:
+            attn_combos.append(("fp8", "fp8"))
+    else:
+        if sm >= 90:
+            attn_combos.append(("bfloat16", "fp8"))
+
+    return [(c, kv, g) for g in gemm_types for c, kv in attn_combos]
+
+
+def get_context_test_cases(attn_type: str):
+    """Context-phase test cases.
+
+    Returns list of [seq_len, batch_size, num_heads, kv_cache_dtype,
+                     compute_dtype, gemm_type, perf_filename].
+    """
+    cases = []
+    b_list = [1, 2, 4, 8, 16, 32, 64, 128, 256]
+    s_list = [1, 16, 32, 64, 128, 256, 512, 1024, 1536, 2048, 3072, 4096, 6144, 8192, 10240, 12288, 16384, 32768]
+    base_fname = f"{attn_type}_context_module_perf.txt"
+    for compute_dtype, kv_dtype, gemm_type in _get_precision_combos("context"):
+        for num_heads in [128, 64, 32, 16, 8, 4, 2, 1]:
+            for b in b_list:
+                for s in s_list:
+                    if b * s > 131072:
+                        continue
+                    cases.append([s, b, num_heads, kv_dtype, compute_dtype, gemm_type, base_fname])
+    return cases
+
+
+def get_generation_test_cases(attn_type: str):
+    """Generation-phase test cases.
+
+    Returns list of [kv_cache_len, batch_size, num_heads, kv_cache_dtype,
+                     compute_dtype, gemm_type, perf_filename].
+    """
+    cases = []
+    b_list = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024]
+    s_list = [2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072]
+    base_fname = f"{attn_type}_generation_module_perf.txt"
+    for compute_dtype, kv_dtype, gemm_type in _get_precision_combos("generation"):
+        for num_heads in [128, 64, 32, 16, 8, 4, 2, 1]:
+            for b in b_list:
+                for s in s_list:
+                    if b * s > 1024 * 4096 * 2 * 2 * 2:
+                        continue
+                    cases.append([s, b, num_heads, kv_dtype, compute_dtype, gemm_type, base_fname])
+    return cases
+
+
+def _build_module_test_cases(attn_type: str, mode: str):
+    """Build module-level test cases for a specific attention type and phase.
+
+    Output format: [seq_len, batch_size, num_heads, kv_cache_dtype,
+                    compute_dtype, gemm_type, perf_filename, model_path, attn_type]
+    """
+    base_cases = get_context_test_cases(attn_type) if mode == "context" else get_generation_test_cases(attn_type)
+    model_paths = [m for m, t in SUPPORTED_MODELS.items() if t == attn_type]
+    cases = []
+    for model_path in model_paths:
+        for s, b, h, kv_dtype, compute_dtype, gemm_type, fname in base_cases:
+            cases.append([s, b, h, kv_dtype, compute_dtype, gemm_type, fname, model_path, attn_type])
+    return cases
+
+
+def get_mla_context_module_test_cases():
+    """collect.py entrypoint for MLA context module collection."""
+    return _build_module_test_cases(attn_type="mla", mode="context")
+
+
+def get_mla_generation_module_test_cases():
+    """collect.py entrypoint for MLA generation module collection."""
+    return _build_module_test_cases(attn_type="mla", mode="generation")
+
+
+def get_dsa_context_module_test_cases():
+    """collect.py entrypoint for DSA context module collection."""
+    return _build_module_test_cases(attn_type="dsa", mode="context")
+
+
+def get_dsa_generation_module_test_cases():
+    """collect.py entrypoint for DSA generation module collection."""
+    return _build_module_test_cases(attn_type="dsa", mode="generation")
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Module Construction
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def _create_gemm_quant_config(gemm_type: str):
+    """Create the vLLM QuantizationConfig for a given gemm_type.
+
+    Returns None for bfloat16 (unquantised GEMMs).
+    For fp8_block / nvfp4, returns an online-quantisation config so that
+    dummy BF16 weights are dynamically quantised during
+    ``process_weights_after_loading``.
+    """
+    if gemm_type == "bfloat16":
+        return None
+    if gemm_type == "fp8_block":
+        from vllm.model_executor.layers.quantization.fp8 import Fp8Config
+
+        # vLLM requires is_checkpoint_fp8_serialized=True for block-scaled
+        # FP8 (fp8.py raises ValueError otherwise).  This routes through
+        # Fp8LinearMethod (block_quant=True) → W8A8BlockFp8LinearOp →
+        # DeepGEMM on SM≥89.
+        return Fp8Config(
+            is_checkpoint_fp8_serialized=True,
+            activation_scheme="dynamic",
+            weight_block_size=[128, 128],
+        )
+    if gemm_type == "nvfp4":
+        from vllm.model_executor.layers.quantization.modelopt import (
+            ModelOptNvFp4Config,
+        )
+
+        return ModelOptNvFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            kv_cache_quant_algo=None,
+            exclude_modules=[],
+        )
+    raise ValueError(f"Unknown gemm_type: {gemm_type!r}")
+
+
+def _create_attention_module(
+    model_path: str,
+    attn_type: str,
+    num_heads: int,
+    use_fp8_kv_cache: bool,
+    use_prefill_fp8: bool,
+    max_seq_len: int,
+    max_batch_size: int,
+    gemm_type: str = "bfloat16",
+    device: str = "cuda:0",
+    is_context: bool = True,
+):
+    """
+    Create a DeepseekV2MLAAttention module from vLLM's own modeling code.
+
+    Loads a real HF config from model_path, overrides the layer-local attention
+    dimensions we want to benchmark in-memory, and then constructs the module
+    with dummy weights. The module includes all projections + attention +
+    output.
+
+    Args:
+        model_path: HuggingFace model path (e.g. "deepseek-ai/DeepSeek-V3.2").
+        attn_type: Attention type ("mla" or "dsa").
+        use_prefill_fp8: When True and on SM100+, enable FP8 prefill
+            attention via ``attention_config.use_prefill_query_quantization``.
+        gemm_type: Precision for linear-layer GEMMs — "bfloat16",
+            "fp8_block", or "nvfp4".
+    """
+    from vllm.model_executor.models.deepseek_v2 import DeepseekV2MLAAttention
+
+    local_model_path = _resolve_model_path(model_path)
+
+    block_size = 64
+    max_model_len = max(max_seq_len + 1, 4096)
+    num_kv_cache_blocks = max(
+        1 + math.ceil((max_seq_len + 1) / block_size) * max_batch_size,
+        8192,
+    )
+
+    # Determine kv cache dtype string for sparse MLA.
+    # For DSA (DeepSeekV3.2), fp8 uses the custom ``fp8_ds_mla`` 656-byte
+    # cache format (512B quantized NoPE + 16B scales + 128B RoPE).
+    # For dense MLA, standard fp8 (fp8_e4m3) is used.
+    is_dsa = attn_type == "dsa"
+
+    vllm_config = create_vllm_config(
+        model_name=local_model_path,
+        max_model_len=max_model_len,
+        block_size=block_size,
+        num_gpu_blocks=num_kv_cache_blocks,
+        max_num_seqs=max_batch_size,
+        max_num_batched_tokens=max(max_batch_size * max_seq_len, 131072) if is_context else max_batch_size,
+        use_fp8_kv_cache=use_fp8_kv_cache,
+        trust_remote_code=True,
+    )
+
+    # Override quant_config to control linear-layer GEMM precision.
+    # DeepSeek-V3.2 ships with FP8 quantisation by default, so we
+    # must always set quant_config explicitly: None for bf16,
+    # Fp8Config (blockwise) for fp8_block, ModelOptNvFp4Config for nvfp4.
+    vllm_config.quant_config = _create_gemm_quant_config(gemm_type)
+
+    # For DSA, mirror the DeepseekV32ForCausalLM.verify_and_update_config()
+    # logic: fp8 cache must use ``fp8_ds_mla`` format.
+    if is_dsa and use_fp8_kv_cache:
+        vllm_config.cache_config.cache_dtype = "fp8_ds_mla"
+
+    # Enable FP8 prefill attention on SM100+ (Blackwell).
+    # This quantizes Q/K/V to FP8 before sending to the prefill kernel.
+    if use_prefill_fp8:
+        vllm_config.attention_config.use_prefill_query_quantization = True
+
+    # Override just the layer-local dimensions we sweep in the collector.
+    hf_config = vllm_config.model_config.hf_config
+    hf_config.num_hidden_layers = 1
+    hf_config.num_attention_heads = num_heads
+    hf_config.num_key_value_heads = num_heads
+
+    # Create topk_indices_buffer for DSA
+    topk_indices_buffer = None
+    if is_dsa and hasattr(hf_config, "index_topk"):
+        max_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        topk_indices_buffer = torch.empty(
+            max_tokens,
+            hf_config.index_topk,
+            dtype=torch.int32,
+            device=device,
+        )
+
+    # Build the attention module inside set_current_vllm_config() context.
+    # FP8 quantized Linear layers (QuantFP8 / CustomOp) call
+    # get_current_vllm_config() during __init__, so the config must be set.
+    # set_default_torch_dtype is required because MLAAttention.__init__
+    # calls torch.get_default_dtype() to select the attention backend
+    # (MLA backends only support bfloat16, not float32).
+    from vllm.utils.torch_utils import set_default_torch_dtype
+
+    with set_current_vllm_config(vllm_config), set_default_torch_dtype(vllm_config.model_config.dtype):
+        attn_module = DeepseekV2MLAAttention(
+            vllm_config=vllm_config,
+            config=hf_config,
+            hidden_size=hf_config.hidden_size,
+            num_heads=num_heads,
+            qk_nope_head_dim=hf_config.qk_nope_head_dim,
+            qk_rope_head_dim=hf_config.qk_rope_head_dim,
+            v_head_dim=hf_config.v_head_dim,
+            q_lora_rank=hf_config.q_lora_rank if hasattr(hf_config, "q_lora_rank") else None,
+            kv_lora_rank=hf_config.kv_lora_rank,
+            max_position_embeddings=hf_config.max_position_embeddings,
+            cache_config=vllm_config.cache_config,
+            quant_config=vllm_config.quant_config,
+            prefix="model.layers.0.self_attn",
+            topk_indices_buffer=topk_indices_buffer,
+        )
+
+    # Serialized block-scaled FP8 creates weight params on meta device;
+    # to() cannot copy meta tensors, so use to_empty() when needed.
+    if any(p.is_meta for p in attn_module.parameters()):
+        attn_module = attn_module.to_empty(device=torch.device(device))
+    else:
+        attn_module = attn_module.to(device)
+    attn_module.eval()
+    attn_module.requires_grad_(False)
+
+    # Initialize with random weights.
+    # FP8 weights → zero (safe dummy value).
+    # Scale params → 1.0 (avoid NaN during process_weights_after_loading).
+    # Everything else → small constant.
+    #
+    # Deterministic init — vLLM 0.17.0 DSA modules leave CUDA graph RNG
+    # offset tracking active after construction (likely from FlashInfer
+    # sparse MLA backend, vllm-project/vllm#33451 / vllm-project/vllm#34457).
+    # Any RNG call (normal_, uniform_, randn) crashes with "Offset increment
+    # outside graph capture".  Using fill_() is safe because kernel latency
+    # depends on shapes/dtypes, not values, and dummy weights are overwritten
+    # by process_weights_after_loading() anyway.
+    # See: https://github.com/vllm-project/vllm/issues/39371
+    with torch.no_grad():
+        for name, tensor in list(attn_module.named_parameters()) + list(attn_module.named_buffers()):
+            if tensor.is_meta:
+                continue
+            if tensor.dtype in (torch.float8_e4m3fn, torch.float8_e5m2, torch.uint8):
+                tensor.data.zero_()
+            elif tensor.dtype == torch.float32 and "scale" in name:
+                tensor.data.fill_(0.5)
+            else:
+                tensor.data.fill_(0.01)
+
+    return attn_module, vllm_config
+
+
+def _process_module_weights(attn_module, vllm_config, device):
+    """Process weights after loading, mimicking vLLM's model loader.
+
+    This must be called after module construction to:
+      1. Run FP8 quantization on linear layer weights.
+      2. Create W_UK_T and W_UV matrices in MLAAttention that are
+         required for the forward pass.
+    """
+    from vllm.model_executor.layers.attention.mla_attention import MLAAttention
+    from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
+
+    with set_current_vllm_config(vllm_config):
+        # 1. Process quantized linear layers (FP8 weight conversion).
+        for _, module in attn_module.named_modules():
+            quant_method = getattr(module, "quant_method", None)
+            if isinstance(quant_method, QuantizeMethodBase):
+                quant_method.process_weights_after_loading(module)
+
+        # 2. Process MLAAttention layers (creates W_UK_T, W_UV).
+        for _, module in attn_module.named_modules():
+            if isinstance(module, MLAAttention) and hasattr(module, "process_weights_after_loading"):
+                module.process_weights_after_loading(vllm_config.model_config.dtype)
+
+
+def _create_context_kv_inputs(batch_spec: BatchSpec, kv_lora_rank: int, qk_rope_head_dim: int, device: str):
+    """
+    Create cached KV tensors for the tokens that already exist in the paged KV
+    cache before the current forward() call.
+
+    Context phase: cache is empty because all tokens are processed in the same
+    prefill step.
+    Generation phase: cache holds seq_len - 1 historical tokens, and the
+    current forward processes exactly 1 new token per request.
+    """
+    kv_c_contexts = []
+    k_pe_contexts = []
+    for seq_len, query_len in zip(batch_spec.seq_lens, batch_spec.query_lens, strict=True):
+        context_len = max(0, int(seq_len) - int(query_len))
+        kv_c_contexts.append(torch.full((context_len, kv_lora_rank), 0.01, dtype=torch.bfloat16, device=device))
+        k_pe_contexts.append(torch.full((context_len, 1, qk_rope_head_dim), 0.01, dtype=torch.bfloat16, device=device))
+    return kv_c_contexts, k_pe_contexts
+
+
+def _populate_indexer_kv_cache(
+    indexer_kv_cache: torch.Tensor,
+    common_attn_metadata,
+    context_lens: list[int],
+) -> None:
+    """
+    Populate the DSA indexer cache so generation benchmarks see a realistic
+    historical K cache instead of an all-zero buffer.
+    """
+    block_table = common_attn_metadata.block_table_tensor
+    block_size = indexer_kv_cache.shape[1]
+    entry_dim = indexer_kv_cache.shape[2]
+    device = indexer_kv_cache.device
+
+    for i, context_len in enumerate(context_lens):
+        if context_len <= 0:
+            continue
+        token_offsets = torch.arange(context_len, dtype=torch.long, device=device)
+        block_indices = token_offsets // block_size
+        intra_block_offsets = token_offsets % block_size
+        block_ids = block_table[i, block_indices]
+        dummy_cache = torch.full((context_len, entry_dim), 42, dtype=torch.uint8, device=device)
+        indexer_kv_cache[block_ids, intra_block_offsets, :] = dummy_cache
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# KV Cache + Metadata
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def _create_kv_cache_and_metadata(
+    vllm_config,
+    attn_type: str,
+    batch_size: int,
+    seq_len: int,
+    num_heads: int,
+    is_context: bool,
+    use_fp8_kv_cache: bool,
+    device: str = "cuda:0",
+):
+    """Create KV cache and attention metadata for benchmarking."""
+    from vllm.v1.kv_cache_interface import MLAAttentionSpec
+
+    hf_config = vllm_config.model_config.hf_config
+    kv_lora_rank = hf_config.kv_lora_rank
+    qk_rope_head_dim = hf_config.qk_rope_head_dim
+    head_dim = kv_lora_rank + qk_rope_head_dim
+    block_size = vllm_config.cache_config.block_size
+    is_dsa = attn_type == "dsa"
+
+    if is_context:
+        batch_spec = BatchSpec(
+            seq_lens=[seq_len] * batch_size,
+            query_lens=[seq_len] * batch_size,
+        )
+    else:
+        batch_spec = BatchSpec(
+            seq_lens=[seq_len] * batch_size,
+            query_lens=[1] * batch_size,
+        )
+
+    num_kv_cache_blocks = max(
+        1 + math.ceil((seq_len + 1) / block_size) * batch_size,
+        8192,
+    )
+
+    common_attn_metadata = create_common_attn_metadata(
+        batch_spec, block_size, torch.device(device), arange_block_indices=True
+    )
+
+    # Select the correct dtype for cache.
+    # DSA fp8 uses a custom 656-byte ``fp8_ds_mla`` cache format that
+    # stores quantised NoPE + per-128-element scales + BF16 RoPE.
+    # Dense MLA fp8 uses standard fp8_e4m3.
+    if is_dsa and use_fp8_kv_cache:
+        cache_dtype = current_platform.fp8_dtype()
+        kv_cache_dtype_str = "fp8_ds_mla"
+    elif use_fp8_kv_cache:
+        cache_dtype = current_platform.fp8_dtype()
+        kv_cache_dtype_str = "fp8"
+    else:
+        cache_dtype = torch.bfloat16
+        kv_cache_dtype_str = None
+
+    # Populate KV cache with the tokens that exist before this forward.
+    kv_c_contexts, k_pe_contexts = _create_context_kv_inputs(
+        batch_spec=batch_spec,
+        kv_lora_rank=kv_lora_rank,
+        qk_rope_head_dim=qk_rope_head_dim,
+        device=device,
+    )
+
+    kv_cache = create_and_prepopulate_kv_cache_mla(
+        kv_c_contexts=kv_c_contexts,
+        k_pe_contexts=k_pe_contexts,
+        block_size=block_size,
+        head_size=head_dim,
+        dtype=cache_dtype,
+        device=torch.device(device),
+        num_blocks=num_kv_cache_blocks,
+        common_attn_metadata=common_attn_metadata,
+        randomize_blocks=False,
+        kv_cache_dtype=kv_cache_dtype_str,
+    )
+
+    # Build attention metadata via backend builder
+    backend_cls = _get_attention_backend(vllm_config, head_dim, use_fp8_kv_cache, is_dsa)
+    builder_cls = backend_cls.get_builder_cls()
+
+    kv_cache_spec = MLAAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=1,  # MLA uses 1 KV head
+        head_size=head_dim,
+        dtype=cache_dtype,
+        sliding_window=None,
+        cache_dtype_str=kv_cache_dtype_str,
+    )
+
+    attn_layer_name = "model.layers.0.self_attn.attn"
+    layer_names = [attn_layer_name]
+    builder = builder_cls(kv_cache_spec, layer_names, vllm_config, torch.device(device))
+    attn_metadata = builder.build(
+        common_prefix_len=0,
+        common_attn_metadata=common_attn_metadata,
+    )
+
+    # For DSA, the Indexer has its own KV cache and metadata builder.
+    indexer_kv_cache = None
+    indexer_metadata = None
+    if is_dsa:
+        from vllm.v1.attention.backends.mla.indexer import (
+            DeepseekV32IndexerBackend,
+        )
+
+        index_head_dim = hf_config.index_head_dim
+        quant_block_size = 128
+        indexer_head_dim = index_head_dim + index_head_dim // quant_block_size * 4
+
+        indexer_layer_name = "model.layers.0.self_attn.indexer.k_cache"
+        indexer_spec = MLAAttentionSpec(
+            block_size=block_size,
+            num_kv_heads=1,
+            head_size=indexer_head_dim,
+            dtype=torch.uint8,
+        )
+        indexer_kv_cache = torch.zeros(
+            num_kv_cache_blocks,
+            block_size,
+            indexer_head_dim,
+            dtype=torch.uint8,
+            device=device,
+        )
+        indexer_builder_cls = DeepseekV32IndexerBackend.get_builder_cls()
+        indexer_builder = indexer_builder_cls(indexer_spec, [indexer_layer_name], vllm_config, torch.device(device))
+        indexer_metadata = indexer_builder.build(
+            common_prefix_len=0,
+            common_attn_metadata=common_attn_metadata,
+        )
+        _populate_indexer_kv_cache(
+            indexer_kv_cache=indexer_kv_cache,
+            common_attn_metadata=common_attn_metadata,
+            context_lens=[tensor.shape[0] for tensor in kv_c_contexts],
+        )
+
+    return kv_cache, attn_metadata, common_attn_metadata, indexer_kv_cache, indexer_metadata
+
+
+def _get_attention_backend(vllm_config, head_dim, use_fp8_kv_cache, is_dsa):
+    """Select attention backend based on GPU capability and config.
+
+    The backend selector uses kv_cache_dtype to pick the right implementation:
+      - DSA fp8 → ``fp8_ds_mla`` (FlashMLA Sparse custom format)
+      - MLA fp8 → ``fp8`` (standard fp8_e4m3)
+      - BF16   → None / "auto"
+    """
+    dtype = torch.bfloat16
+
+    # Compute the kv_cache_dtype token the selector expects.
+    if is_dsa and use_fp8_kv_cache:
+        kv_cache_dtype_val = "fp8_ds_mla"
+    elif use_fp8_kv_cache:
+        kv_cache_dtype_val = "fp8"
+    else:
+        kv_cache_dtype_val = None
+
+    from vllm.utils.import_utils import resolve_obj_by_qualname
+    from vllm.v1.attention.selector import AttentionSelectorConfig
+
+    attn_selector_config = AttentionSelectorConfig(
+        head_size=head_dim,
+        dtype=dtype,
+        kv_cache_dtype=kv_cache_dtype_val,
+        block_size=vllm_config.cache_config.block_size,
+        use_mla=True,
+        has_sink=False,
+        use_sparse=is_dsa,
+    )
+    backend = current_platform.get_attn_backend_cls(None, attn_selector_config)
+
+    return resolve_obj_by_qualname(backend)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Benchmark Runner
+# ═══════════════════════════════════════════════════════════════════════
+
+
+@with_exit_stack
+def run_mla_module(
+    exit_stack,
+    seq_len: int,
+    batch_size: int,
+    num_heads: int,
+    kv_cache_dtype: str,
+    compute_dtype: str,
+    gemm_type: str,
+    perf_filename: str,
+    *,
+    model_path: str,
+    attn_type: str,
+    device: str = "cuda:0",
+    warming_up: int = 10,
+    test_ite: int = 6,
+):
+    """Run a single MLA / DSA module-level benchmark point."""
+    setup_distributed(device)
+    torch.cuda.set_device(device)
+
+    # DSA's sparse_attn_indexer requires a WorkspaceManager.
+    try:
+        from vllm.v1.worker.workspace import init_workspace_manager
+
+        init_workspace_manager(torch.device(device))
+    except (ImportError, RuntimeWarning):
+        pass
+
+    use_fp8_kv_cache = kv_cache_dtype == "fp8"
+    use_prefill_fp8 = compute_dtype == "fp8"
+    is_context = "context" in perf_filename
+    phase = "context" if is_context else "generation"
+    variant = attn_type.upper()
+    print(
+        f"\n[{variant} module] {phase} b={batch_size}, s={seq_len}, "
+        f"heads={num_heads}, gemm={gemm_type}, compute={compute_dtype}, kv={kv_cache_dtype}, model={model_path}"
+    )
+
+    # 1. Create attention module
+    attn_module, vllm_config = _create_attention_module(
+        model_path=model_path,
+        attn_type=attn_type,
+        num_heads=num_heads,
+        use_fp8_kv_cache=use_fp8_kv_cache,
+        use_prefill_fp8=use_prefill_fp8,
+        max_seq_len=seq_len,
+        max_batch_size=batch_size,
+        gemm_type=gemm_type,
+        device=device,
+        is_context=is_context,
+    )
+
+    # 1b. Process weights (FP8 quantization + create W_UK_T / W_UV for MLA)
+    _process_module_weights(attn_module, vllm_config, device)
+
+    # 2. Create KV cache + metadata
+    with set_current_vllm_config(vllm_config):
+        kv_cache, attn_metadata, _, indexer_kv_cache, indexer_metadata = _create_kv_cache_and_metadata(
+            vllm_config=vllm_config,
+            attn_type=attn_type,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            num_heads=num_heads,
+            is_context=is_context,
+            use_fp8_kv_cache=use_fp8_kv_cache,
+            device=device,
+        )
+
+    # 2b. Bind KV cache to the attention layer so forward() can access it.
+    #     vLLM >=0.19 reads self.kv_cache directly as a Tensor (the previous
+    #     per-virtual-engine list wrapping is gone); flashinfer_mla.forward_mqa,
+    #     mla_attention.forward_impl, and the sparse_attn_indexer custom op all
+    #     now typecheck Tensor, so a list wrapper raises.
+    attn_layer_name = "model.layers.0.self_attn.attn"
+    forward_ctx = vllm_config.compilation_config.static_forward_context
+    forward_ctx[attn_layer_name].kv_cache = kv_cache
+
+    # For DSA, also bind the indexer's KV cache.
+    indexer_layer_name = "model.layers.0.self_attn.indexer.k_cache"
+    if indexer_kv_cache is not None and indexer_layer_name in forward_ctx:
+        forward_ctx[indexer_layer_name].kv_cache = indexer_kv_cache
+
+    # 3. Input tensors
+    hidden_size = vllm_config.model_config.hf_config.hidden_size
+    if is_context:
+        num_tokens = seq_len * batch_size
+        positions = (
+            torch.arange(seq_len, device=device, dtype=torch.long)
+            .unsqueeze(0)
+            .expand(batch_size, -1)
+            .reshape(-1)
+            .contiguous()
+        )
+    else:
+        num_tokens = batch_size
+        positions = torch.full(
+            (batch_size,),
+            seq_len - 1,
+            device=device,
+            dtype=torch.long,
+        )
+
+    hidden_states = torch.full(
+        (num_tokens, hidden_size),
+        0.01,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+
+    # 4. Dry run
+    #    set_current_vllm_config — needed by quantised layers and RoPE.
+    #    set_forward_context — provides attn_metadata + kv_cache to the
+    #    MLAAttention.forward() path (it calls get_forward_context()).
+    exit_stack.enter_context(set_current_vllm_config(vllm_config))
+    attn_metadata_dict = {attn_layer_name: attn_metadata}
+    if indexer_metadata is not None:
+        attn_metadata_dict[indexer_layer_name] = indexer_metadata
+    exit_stack.enter_context(set_forward_context(attn_metadata_dict, vllm_config))
+    try:
+        with torch.inference_mode():
+            attn_module.forward(positions, hidden_states, None)
+    except Exception as e:
+        print(f"  Dry run failed: {e}")
+        traceback.print_exc()
+        _cleanup()
+        # Propagate to collect.py's worker so the failure is recorded in the
+        # error queue. Swallowing here lets a whole op complete with zero
+        # rows while the pipeline reports success.
+        raise
+
+    # 5. Benchmark
+    def kernel_func():
+        attn_module.forward(positions, hidden_states, None)
+
+    with benchmark_with_power(
+        device=torch.device(device),
+        kernel_func=kernel_func,
+        num_warmups=warming_up,
+        num_runs=test_ite,
+        repeat_n=1,
+        allow_graph_fail=True,
+    ) as results:
+        pass
+
+    latency = results["latency_ms"]
+
+    # 6. Log results — schema aligned with TRT-LLM
+    if is_context:
+        isl = seq_len
+        step = 0
+    else:
+        isl = 1
+        step = seq_len
+
+    op_name = f"{attn_type}_{phase}_module"
+
+    # Record architecture to distinguish different DSA models in the perf CSV.
+    # perf_database uses this as a dict key when loading data.
+    # Aligns with sdk/models.py which uses architectures[0] throughout.
+    hf_cfg = vllm_config.model_config.hf_config
+    architecture = getattr(hf_cfg, "architectures", [getattr(hf_cfg, "model_type", "unknown")])[0]
+
+    log_perf(
+        item_list=[
+            {
+                "model": model_path,
+                "architecture": architecture,
+                "mla_dtype": "float16" if compute_dtype == "bfloat16" else compute_dtype,
+                "kv_cache_dtype": "float16" if kv_cache_dtype == "bfloat16" else kv_cache_dtype,
+                "gemm_type": "float16" if gemm_type == "bfloat16" else gemm_type,
+                "num_heads": num_heads,
+                "batch_size": batch_size,
+                "isl": isl,
+                "tp_size": 1,
+                "step": step,
+                "latency": f"{latency:.4f}",
+            }
+        ],
+        framework="VLLM",
+        version=vllm_version,
+        device_name=torch.cuda.get_device_name(device),
+        op_name=op_name,
+        kernel_source="default",
+        perf_filename=perf_filename,
+        power_stats=results["power_stats"],
+    )
+
+    print(
+        f"  [{phase}] b={batch_size}, s={seq_len}, heads={num_heads}, "
+        f"gemm={gemm_type}, compute={compute_dtype}, kv={kv_cache_dtype}: {latency:.4f} ms"
+    )
+
+    _cleanup()
+    return latency
+
+
+def run_mla_module_worker(
+    seq_len: int,
+    batch_size: int,
+    num_heads: int,
+    kv_cache_dtype: str,
+    compute_dtype: str,
+    gemm_type: str,
+    perf_filename: str,
+    model_path: str,
+    attn_type: str,
+    device: str = "cuda:0",
+):
+    """Worker-compatible positional wrapper used by collector/collect.py."""
+    return run_mla_module(
+        seq_len=seq_len,
+        batch_size=batch_size,
+        num_heads=num_heads,
+        kv_cache_dtype=kv_cache_dtype,
+        compute_dtype=compute_dtype,
+        gemm_type=gemm_type,
+        perf_filename=perf_filename,
+        model_path=model_path,
+        attn_type=attn_type,
+        device=device,
+    )
+
+
+def _cleanup():
+    torch.cuda.empty_cache()
+    gc.collect()
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# CLI
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def main():
+    model_names = list(SUPPORTED_MODELS.keys())
+
+    parser = argparse.ArgumentParser(
+        description="MLA/DSA module-level collector for vLLM",
+    )
+    parser.add_argument("--mode", choices=["context", "generation"], required=True)
+    parser.add_argument(
+        "--model",
+        type=str,
+        default=None,
+        choices=model_names,
+        help=f"Model to benchmark. If not specified, runs all: {model_names}",
+    )
+    parser.add_argument("--num-heads", type=int, default=None, help="Filter by number of heads")
+    parser.add_argument("--batch-size", type=int, default=None, help="Single batch size (for --quick)")
+    parser.add_argument("--seq-len", type=int, default=None, help="Single seq len (for --quick)")
+    parser.add_argument(
+        "--kv-cache-dtype",
+        type=str,
+        choices=["bfloat16", "fp8"],
+        default=None,
+        help="KV cache dtype (default: run both bfloat16 and fp8 when GPU supports it)",
+    )
+    parser.add_argument(
+        "--compute-dtype",
+        type=str,
+        choices=["bfloat16", "fp8"],
+        default=None,
+        help="Compute dtype for attention (default: auto based on phase and GPU)",
+    )
+    parser.add_argument(
+        "--gemm-type",
+        type=str,
+        choices=["bfloat16", "fp8_block", "nvfp4"],
+        default=None,
+        help="GEMM quantisation type for linear layers (default: run all supported by GPU)",
+    )
+    parser.add_argument("--device", type=str, default="cuda:0")
+    parser.add_argument("--quick", action="store_true", help="Quick single-point test")
+    args = parser.parse_args()
+
+    # Select models to run
+    if args.model:
+        models_to_run = {args.model: SUPPORTED_MODELS[args.model]}
+    else:
+        models_to_run = SUPPORTED_MODELS
+
+    for model_path, attn_type in models_to_run.items():
+        print(f"\n{'=' * 60}")
+        print(f"Model: {model_path}  |  Attention: {attn_type.upper()}")
+        print(f"{'=' * 60}")
+
+        if args.quick:
+            b = args.batch_size or 4
+            s = args.seq_len or 2048
+            h = args.num_heads or 128
+            kv_dtype = args.kv_cache_dtype or "bfloat16"
+            compute = args.compute_dtype or "bfloat16"
+            gemm = args.gemm_type or "bfloat16"
+            fname = f"{attn_type}_{args.mode}_module_perf.txt"
+            run_mla_module(
+                seq_len=s,
+                batch_size=b,
+                num_heads=h,
+                kv_cache_dtype=kv_dtype,
+                compute_dtype=compute,
+                gemm_type=gemm,
+                perf_filename=fname,
+                model_path=model_path,
+                attn_type=attn_type,
+                device=args.device,
+            )
+            continue
+
+        if args.mode == "context":
+            test_cases = get_context_test_cases(attn_type=attn_type)
+        else:
+            test_cases = get_generation_test_cases(attn_type=attn_type)
+
+        if args.num_heads is not None:
+            test_cases = [tc for tc in test_cases if tc[2] == args.num_heads]
+
+        if args.kv_cache_dtype is not None:
+            test_cases = [tc for tc in test_cases if tc[3] == args.kv_cache_dtype]
+
+        if args.compute_dtype is not None:
+            test_cases = [tc for tc in test_cases if tc[4] == args.compute_dtype]
+
+        if args.gemm_type is not None:
+            test_cases = [tc for tc in test_cases if tc[5] == args.gemm_type]
+
+        print(f"Running {len(test_cases)} {args.mode} {attn_type.upper()} module test cases...")
+
+        for i, (s, b, h, kv_dtype, compute, gemm, fname) in enumerate(test_cases):
+            print(f"[{i + 1}/{len(test_cases)}]", end="")
+            try:
+                run_mla_module(
+                    seq_len=s,
+                    batch_size=b,
+                    num_heads=h,
+                    kv_cache_dtype=kv_dtype,
+                    compute_dtype=compute,
+                    gemm_type=gemm,
+                    perf_filename=fname,
+                    model_path=model_path,
+                    attn_type=attn_type,
+                    device=args.device,
+                )
+            except torch.cuda.OutOfMemoryError:
+                print(f"  OOM: b={b}, s={s}, heads={h}, gemm={gemm}, compute={compute}, kv={kv_dtype}")
+                torch.cuda.empty_cache()
+                gc.collect()
+            except Exception as e:
+                print(f"  FAILED: b={b}, s={s}, heads={h}, gemm={gemm}, compute={compute}, kv={kv_dtype}: {e}")
+                traceback.print_exc()
+                torch.cuda.empty_cache()
+                gc.collect()
+
+
+if __name__ == "__main__":
+    main()

--- a/collector/vllm/collect_mla_module_v3.py
+++ b/collector/vllm/collect_mla_module_v3.py
@@ -848,6 +848,19 @@ def run_mla_module(
     def kernel_func():
         attn_module.forward(positions, hidden_states, None)
 
+    # DSA context captures a ~18 GiB flashmla-sparse scratch into the CUDA
+    # graph's private pool on big shapes. PyTorch doesn't reclaim that pool
+    # aggressively enough between tasks, so after a handful of big captures
+    # the per-worker private-pool retention saturates at ~146 GiB and every
+    # subsequent task — regardless of size — OOMs at
+    # ``WorkspaceManager._ensure_workspace_size``. Running eagerly avoids the
+    # private-pool retention entirely; the bias is <0.5% for DSA context
+    # because per-forward latency is tens of ms while graph launch overhead
+    # is tens of μs. Other ops (MLA context, both generation phases) keep
+    # graph capture because they don't hit this retention pattern and the
+    # overhead matters more for their faster kernels.
+    use_cuda_graph = not (attn_type == "dsa" and is_context)
+
     with benchmark_with_power(
         device=torch.device(device),
         kernel_func=kernel_func,
@@ -855,6 +868,7 @@ def run_mla_module(
         num_runs=test_ite,
         repeat_n=1,
         allow_graph_fail=True,
+        use_cuda_graph=use_cuda_graph,
     ) as results:
         pass
 

--- a/collector/vllm/collect_mla_module_v3.py
+++ b/collector/vllm/collect_mla_module_v3.py
@@ -830,6 +830,11 @@ def run_mla_module(
     try:
         with torch.inference_mode():
             attn_module.forward(positions, hidden_states, None)
+    except torch.cuda.OutOfMemoryError as e:
+        # Capacity limit, not a bug — skip so total_errors stays meaningful.
+        print(f"  Dry run OOM (skipping): {e}")
+        _cleanup()
+        return None
     except Exception as e:
         print(f"  Dry run failed: {e}")
         traceback.print_exc()

--- a/collector/vllm/registry.py
+++ b/collector/vllm/registry.py
@@ -45,6 +45,7 @@ REGISTRY: list[OpEntry] = [
         get_func="get_mla_context_module_test_cases",
         run_func="run_mla_module_worker",
         versions=(
+            VersionRoute("0.19.0", "collector.vllm.collect_mla_module_v3"),
             VersionRoute("0.17.0", "collector.vllm.collect_mla_module_v2"),
             VersionRoute("0.0.0", "collector.vllm.collect_mla_module_v1"),
         ),
@@ -54,6 +55,7 @@ REGISTRY: list[OpEntry] = [
         get_func="get_mla_generation_module_test_cases",
         run_func="run_mla_module_worker",
         versions=(
+            VersionRoute("0.19.0", "collector.vllm.collect_mla_module_v3"),
             VersionRoute("0.17.0", "collector.vllm.collect_mla_module_v2"),
             VersionRoute("0.0.0", "collector.vllm.collect_mla_module_v1"),
         ),
@@ -63,6 +65,7 @@ REGISTRY: list[OpEntry] = [
         get_func="get_dsa_context_module_test_cases",
         run_func="run_mla_module_worker",
         versions=(
+            VersionRoute("0.19.0", "collector.vllm.collect_mla_module_v3"),
             VersionRoute("0.17.0", "collector.vllm.collect_mla_module_v2"),
             VersionRoute("0.0.0", "collector.vllm.collect_mla_module_v1"),
         ),
@@ -72,6 +75,7 @@ REGISTRY: list[OpEntry] = [
         get_func="get_dsa_generation_module_test_cases",
         run_func="run_mla_module_worker",
         versions=(
+            VersionRoute("0.19.0", "collector.vllm.collect_mla_module_v3"),
             VersionRoute("0.17.0", "collector.vllm.collect_mla_module_v2"),
             VersionRoute("0.0.0", "collector.vllm.collect_mla_module_v1"),
         ),

--- a/src/aiconfigurator/systems/data/b200_sxm/vllm/0.19.0/dsa_context_module_perf.txt
+++ b/src/aiconfigurator/systems/data/b200_sxm/vllm/0.19.0/dsa_context_module_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1e712a15907d90cc8bb1de72ee0d6dc6e4a0f16b5b14b4458ab74c6c631ad0f0
+size 2368019

--- a/src/aiconfigurator/systems/data/b200_sxm/vllm/0.19.0/dsa_generation_module_perf.txt
+++ b/src/aiconfigurator/systems/data/b200_sxm/vllm/0.19.0/dsa_generation_module_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:366e3b370ec49afb1fec92bad612d969ad9679060538e83c934f9cda72a30ddd
+size 2471092

--- a/src/aiconfigurator/systems/data/b200_sxm/vllm/0.19.0/mla_context_module_perf.txt
+++ b/src/aiconfigurator/systems/data/b200_sxm/vllm/0.19.0/mla_context_module_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a39b806b39345f6420b43720042cd88efe25b4d0ee53ae2c7a117606129abe78
+size 1216733

--- a/src/aiconfigurator/systems/data/b200_sxm/vllm/0.19.0/mla_generation_module_perf.txt
+++ b/src/aiconfigurator/systems/data/b200_sxm/vllm/0.19.0/mla_generation_module_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10dd0b0640ec5109de0f784d00a41937b532b71af2be109823436179f245c035
+size 1270957


### PR DESCRIPTION
# fix: vLLM ≥0.19 MLA/DSA module collector compat

## Summary

- Creates `collect_mla_module_v3.py` and routes vLLM ≥0.19 to it via the op registry. v2 (0.17–0.18) and v1 (<0.17) are unchanged.
- Drops the per-virtual-engine list wrapper on `forward_ctx[*].kv_cache` — vLLM 0.19's MLA/DSA paths typecheck `Tensor`, so the list wrapper crashes them.
- Re-raises dry-run failures instead of swallowing them, so the collector can no longer report "Completed successfully" while producing zero rows.
- Pads the MLA page table to a multiple of `128 / block_size` so short-sequence cases don't trip the TRT-LLM Gen kernel's `block_num` assertion.
- Classifies dry-run `torch.cuda.OutOfMemoryError` as skippable, keeping `total_errors` a signal of actual bugs rather than grid-size noise.
- Releases vLLM's module-level `WorkspaceManager` singleton in `_cleanup()` so the per-worker allocator doesn't inherit a ~18 GiB scratch reservation across tasks.
- Disables CUDA-graph capture for `dsa_context_module` only, and adds explicit graph teardown in `benchmark_with_power`, so the captured private memory pool releases between tasks instead of saturating the per-worker allocator.
- Corrects the `__compat__` ranges on v2 and v3 so the per-file compatibility metadata matches the registry routing.

## Motivation

A full b200 × vllm:0.19.0 collection run on `main` ([pipeline 48693778](https://gitlab-master.nvidia.com/dl/ai-dynamo/aic-auto-collector/-/pipelines/48693778)) for the four MLA/DSA module ops produced **41,352 tracebacks across 44,064 test cases**, then reported `"Completed successfully with no errors"` and auto-opened a PR with a 3-row diff on a single file.

Breakdown of the 41,352 errors (from `collector_errors.log`):

| Count  | Error |
|-------:|-------|
| 29,376 | `RuntimeError: vllm::sparse_attn_indexer() Expected a value of type 'Tensor' for argument 'kv_cache' but instead found type 'list'` (all DSA cases) |
|  7,344 | `AttributeError: 'list' object has no attribute 'view'` at `mla_attention.py:forward_impl` |
|  4,632 | `AttributeError: 'list' object has no attribute 'numel'` at `flashinfer_mla.py:forward_mqa` |

The common root cause is `collect_mla_module_v2.py` binding:

```python
forward_ctx[attn_layer_name].kv_cache = [kv_cache]
forward_ctx[indexer_layer_name].kv_cache = [indexer_kv_cache]
```

vLLM 0.19 reads `self.kv_cache` directly as a `Tensor` (per-virtual-engine list wrapping is gone in the MLA backend + the `sparse_attn_indexer` custom op). The list wrapper therefore raises on first access.

The reason these crashes never bubbled up is a `try/except` in the dry-run block that returned `None`:

```python
try:
    with torch.inference_mode():
        attn_module.forward(positions, hidden_states, None)
except Exception as e:
    print(f"  Dry run failed: {e}")
    traceback.print_exc()
    _cleanup()
    return None
```

`collect.py`'s worker only records an error when `run_func` raises. With every dry-run swallowed, the run looked clean to `collect_module_safe`, `collection_summary_vllm.json` reported `total_errors: 0`, and the auto-PR job shipped a near-empty diff as success.

A second pass surfaced two more issues once the kv_cache unwrap started producing real traffic (see **Verification / Run 1** below): short-sequence MLA cases hit a page-table `block_num` kernel assertion (addressed by the padding commit), and large DSA context sweeps OOMed. The OOMs were initially classified as capacity limits — tens of GiB is a plausible demand for the `flashmla-sparse` workspace on the biggest grid points — and a skip-on-OOM commit was added to keep `total_errors` meaningful under that assumption.

A third pass invalidated that capacity assumption. Instrumenting memory snapshots across tasks showed the same OOM signature on tiny tasks: every failure fired at `workspace.py:_ensure_workspace_size` with the worker already holding ~176 GiB on a 178 GiB B200, regardless of the current task's shape. A b=1, s=1, h=1 configuration can't legitimately need 170 GiB of live allocations. Two retention channels turned out to be holding that memory across task boundaries: vLLM's module-level `WorkspaceManager` never drops its scratch tensor on re-init, and PyTorch's CUDA-graph private memory pool doesn't return promptly to the caching allocator between distinct captures. The `WorkspaceManager` reset + CUDA-graph commits plug both.

## Changes

### `collector/vllm/collect_mla_module_v3.py` (new)

Copy of v2 with six targeted edits:

1. **Unwrap kv_cache bindings:**

   ```diff
   - forward_ctx[attn_layer_name].kv_cache = [kv_cache]
   + forward_ctx[attn_layer_name].kv_cache = kv_cache
   ...
   - forward_ctx[indexer_layer_name].kv_cache = [indexer_kv_cache]
   + forward_ctx[indexer_layer_name].kv_cache = indexer_kv_cache
   ```

2. **Propagate dry-run failures (non-OOM):**

   ```diff
     except Exception as e:
         print(f"  Dry run failed: {e}")
         traceback.print_exc()
         _cleanup()
   -     return None
   +     # Propagate to collect.py's worker so the failure is recorded in the
   +     # error queue. Swallowing here lets a whole op complete with zero
   +     # rows while the pipeline reports success.
   +     raise
   ```

   `print` + `traceback.print_exc()` + `_cleanup()` are kept so operators still see tracebacks in per-worker stderr logs and CUDA memory is released before the worker picks up the next task.

3. **Pad MLA page table to kernel-expected block_num:**

   TRT-LLM Gen MLA and `cutlass_mla` assert `block_num % (128 / block_size) == 0` on the page table. For `block_size=64` that requires at least two blocks, which is violated whenever `seq_len` fits in one block (`seq_len <= block_size`). Those cases were raising `ValueError: Expected block_num % (128 / block_size) == 0, got block_num=1 and block_size=64` during the dry run.

   ```python
   required_divisor = max(1, 128 // block_size)
   current_block_num = common_attn_metadata.block_table_tensor.shape[1]
   if current_block_num % required_divisor != 0:
       padded_block_num = (
           (current_block_num + required_divisor - 1) // required_divisor
       ) * required_divisor
       padding = torch.zeros(
           (common_attn_metadata.block_table_tensor.shape[0],
            padded_block_num - current_block_num),
           dtype=common_attn_metadata.block_table_tensor.dtype,
           device=common_attn_metadata.block_table_tensor.device,
       )
       common_attn_metadata.block_table_tensor = torch.cat(
           [common_attn_metadata.block_table_tensor, padding], dim=1
       )
   ```

   Same workaround as `vllm/tests/v1/attention/test_mla_backends.py:996-1013`. Padding slots are zero-indexed and aren't read for absent tokens.

4. **Treat dry-run OOM as skippable:**

   ```diff
     try:
         with torch.inference_mode():
             attn_module.forward(positions, hidden_states, None)
   + except torch.cuda.OutOfMemoryError as e:
   +     # Capacity limit, not a bug — skip so total_errors stays meaningful.
   +     print(f"  Dry run OOM (skipping): {e}")
   +     _cleanup()
   +     return None
     except Exception as e:
         ...
   ```

   (Fixes E + F below later showed that the large-shape DSA context OOMs were actually worker-level leaks, not capacity. The dry-run OOM skip is still correct policy — some grid points genuinely don't fit regardless — but after E + F the skipped-OOM count on `dsa_context_module` should be near zero.)

5. **Release the vLLM `WorkspaceManager` singleton in `_cleanup()`:**

   ```python
   import vllm.v1.worker.workspace as _ws_mod
   _ws_mod._manager = None
   gc.collect()              # drop refs before empty_cache so it has something to return
   torch.cuda.empty_cache()
   ```

   `vllm.v1.worker.workspace._manager` is a module-level singleton that caches a scratch tensor sized to the largest workspace any task has demanded so far. Its `_ensure_workspace_size` only grows — once a task asks for 18 GiB, the manager pins 18 GiB for the remainder of the worker's lifetime. `init_workspace_manager()` (called at the top of every task) overwrites `_manager` but doesn't drop the prior tensor, so if anything captured a reference to the old manager (a compiled graph, an `@lru_cache` helper) the big allocation survives. Nulling `_manager` explicitly before `empty_cache` makes the release deterministic; the next task's `init_workspace_manager()` creates a fresh instance on demand. Also reorders `gc.collect()` before `empty_cache()` — `empty_cache` only releases blocks with zero live allocations, so Python-reachable tensors must be dropped first or the pass is a no-op.

6. **Disable CUDA-graph capture for `dsa_context_module`:**

   ```python
   # Skip graph capture on the one op whose captured forward retains GiB of
   # scratch in the graph's private pool — see collector/helper.py below.
   use_cuda_graph = not (attn_type == "dsa" and is_context)
   with benchmark_with_power(..., use_cuda_graph=use_cuda_graph) as results:
       pass
   ```

   MLA context, MLA generation, and DSA generation keep graph capture — Run 1/Run 2 showed no leak on those ops, and their faster kernels benefit more from eliminating launch overhead. The bias from eager execution on DSA context is single-digit percent because per-forward latency is tens of ms while graph launch overhead is tens of μs.

### `collector/helper.py`

Two related changes to `benchmark_with_power`, the module-level measurement context manager used by ~30 collectors:

1. **New `use_cuda_graph: bool = True` kwarg.** When `False`, warmup + measurement run eagerly and no `torch.cuda.CUDAGraph` is captured. Default preserves behaviour for every existing caller; only `collect_mla_module_v3.run_mla_module` passes `False` today (for `dsa_context_module`, see Fix 6 above).

2. **Explicit graph teardown in a `try/finally`.** Warmup, measurement, and yield now live inside a `try` block; the matching `finally` drops the `CUDAGraph` reference and calls `torch.cuda.empty_cache()` before returning. The `allow_graph_fail` branch likewise drops the partial capture before calling `empty_cache`.

   The teardown is defence-in-depth for any op that hits the same private-pool retention pattern. CUDA-graph captures sequester intermediate tensors into a private memory pool; PyTorch's release of that pool after the graph object dies isn't aggressive enough in practice — Run 2 showed a DSA context worker pinning 146 GiB constant across 7,660 failures, even though each task's `g` local had long since gone out of scope. Explicit `del g` + `empty_cache()` inside the context manager closes that window.

### `collector/vllm/registry.py`

Added `VersionRoute("0.19.0", "collector.vllm.collect_mla_module_v3")` at the top of the `versions=(...)` tuple for all four ops: `mla_context_module`, `mla_generation_module`, `dsa_context_module`, `dsa_generation_module`.

### `__compat__` metadata (v2 + v3)

Per `collector/README.md`, each collector file owns its supported framework range via `__compat__`, validated independently of registry routing. When forking a module, both files should be updated (README §"Handling a Framework API Change", step 4). No behavior change — the registry already partitions traffic; this makes the compatibility check consistent with that partition and produces a fast `CompatibilityError` if either module is force-loaded outside its window.

```diff
# collect_mla_module_v3.py
- __compat__ = "vllm>=0.17.0"
+ __compat__ = "vllm>=0.19.0"

# collect_mla_module_v2.py
- __compat__ = "vllm>=0.17.0"
+ __compat__ = "vllm>=0.17.0,<0.19.0"
```

## Routing after this change

| Runtime vLLM     | Collector                         |
|------------------|-----------------------------------|
| `< 0.17.0`       | `collect_mla_module_v1` (unchanged) |
| `0.17.0 – 0.18.x`| `collect_mla_module_v2` (unchanged) |
| `>= 0.19.0`      | `collect_mla_module_v3` (new)      |

Previously collected 0.17/0.18 data remains reproducible with v2.

## Non-goals

- v2 still swallows dry-run failures and doesn't pad the page table. If we want 0.17/0.18 runs to fail loudly on future API drifts and pick up the kernel fix, Fixes B/C should be backported to v2 separately. (The `__compat__` upper-bound added here is metadata-only.)
- Same `try/except: return None` pattern may exist in `collect_moe_v2.py` and older collectors; not touched here.
- No unit test — these code paths need vLLM + a Blackwell GPU. Verification is via live collection (see below).

## Verification

Three verification runs on b200 × vllm:0.19.0 with `AIC_REVISION` pointing at this branch.

### Run 1 — after Fixes A + B (unwrap + surface errors)

[Pipeline 48778124](https://gitlab-master.nvidia.com/dl/ai-dynamo/aic-auto-collector/-/pipelines/48778124), all four ops, 3h 7m, success. Auto-PR: [#867](https://github.com/ai-dynamo/aiconfigurator/pull/867).

| Op | Cases | Errors | Passed | **Pass rate** | Before fix |
|---|---:|---:|---:|---:|---:|
| `mla_context_module`    |  5,856 |   648 |  5,208 |  **88.9%** |  46.3% |
| `mla_generation_module` |  8,832 | 3,168 |  5,664 |  **64.1%** |   0.0% |
| `dsa_context_module`    | 11,712 | 9,533 |  2,179 |  **18.6%** |   0.0% |
| `dsa_generation_module` | 17,664 |     0 | 17,664 | **100.0%** |   0.0% |
| **Total**               | **44,064** | **13,349** | **30,715** | **69.7%** | **6.2%** |

- `dsa_generation_module` — the op that most directly exercised the list→Tensor regression via `sparse_attn_indexer` — went from **0%** to **100%**.
- `mla_context_module` jumped from 46.3% to 88.9% because the cases that used to fall through the `forward_mqa` path now succeed.
- Remaining 13,349 errors split into two signatures:
  - 3,816 `ValueError @ mla.py:_check_trtllm_gen_mla_shape` (kernel `block_num` constraint) → addressed by Fix C.
  - 9,533 `OutOfMemoryError @ workspace.py / flashmla_sparse.py` → initially attributed to GPU capacity (addressed by Fix D), later re-diagnosed as a per-worker leak (addressed by Fixes E + F).

### Run 2 — after Fixes C + D (padding + OOM classification)

[Pipeline 48802224](https://gitlab-master.nvidia.com/dl/ai-dynamo/aic-auto-collector/-/pipelines/48802224), targeted re-run on `dsa_context_module` + `mla_generation_module` (26,400 cases), 1h 27m, success.

| Op | Cases | Errors | Passed | **Pass rate** | Change from Run 1 |
|---|---:|---:|---:|---:|---:|
| `mla_generation_module` |  8,832 |    **0** | 8,832 | **100.0%** | +35.9 pp |
| `dsa_context_module`    | 17,568 | 7,660 | 9,908 |  **56.4%** | +37.8 pp |

Padding fix (C) eliminated every `ValueError` on `mla_generation_module`. OOM classification (D) stopped DSA context's OOM count from propagating to fatal errors, but 7,660 of 17,568 tasks were still being skipped — still more than a third of the sweep.

Parsing `errors_vllm.dsa_context_module.json` revealed the OOMs were not capacity limits:

| Dimension | Value (all 7,660 records) |
|---|---|
| Traceback site | 100% at `workspace.py:175 _ensure_workspace_size` |
| Median / max in-use at failure | **177.9 GiB** on a 178.35 GiB B200 |
| Median in CUDA private pools | **146.4 GiB** (constant, not min / max) |
| b·s cohort | 1,873 small (b·s < 1024) + 5,787 big |

A `(b=1, s=1, h=1)` task OOMing against a 178 GiB GPU that's already 99% full on task entry is not a capacity problem — the worker is carrying memory across tasks. The 146.4 GiB constant pinned in CUDA private pools (unchanging regardless of which task is failing) said the retention channel is CUDA-graph-owned memory, and the `_ensure_workspace_size` site said the remaining headroom couldn't fit even the smallest workspace. Two retention channels plugged:

1. `vllm.v1.worker.workspace._manager`'s scratch tensor survives task boundaries → Fix E.
2. `torch.cuda.CUDAGraph`'s private memory pool accumulates across fresh captures and saturates at ~146 GiB → Fix F.

### Run 3 — after Fixes E + F (WorkspaceManager reset + CUDA-graph opt-out)

[Pipeline 48831937](https://gitlab-master.nvidia.com/dl/ai-dynamo/aic-auto-collector/-/pipelines/48831937), targeted re-run on `dsa_context_module` only (17,568 cases), 3h 10m, success.

| Op | Cases | Errors | Passed | **Pass rate** | Change from Run 2 |
|---|---:|---:|---:|---:|---:|
| `dsa_context_module`    | 17,568 | **0** | 17,568 | **100.0%** | +43.6 pp |

Every configuration in the grid — including the `(b=256, s=32768, h=128)` points that originally dominated the private-pool retention — completes with real latency data. `total_errors: 0`. 17,568 rows in `dsa_context_module_perf.txt`, evenly split between DeepSeek-V3.2 and GLM-5.

Wall-clock runtime is ~3.6× longer than Run 2 on the same op (3h 10m vs 52 min for dsa_context alone). Almost none of that is eager-vs-graph per-task overhead — the bulk is that Run 2 short-circuited 7,660 of 17,568 tasks via Fix D's OOM-skip and Run 3 benchmarks the whole grid for real, and the tasks that used to OOM-skip are the biggest, slowest ones. Per-task eager overhead on DSA context's tens-of-ms kernels is single-digit percent.

`mla_context_module` was not re-run but shares the padding fix code path with `mla_generation_module`; pass rate projected to **~100%** (up from 88.9%) on its next sweep.

## Test plan

- [x] **Run 1** (Fix A + B): [pipeline 48778124](https://gitlab-master.nvidia.com/dl/ai-dynamo/aic-auto-collector/-/pipelines/48778124) finishes green, all four `*_module_perf.txt` present in auto-PR [#867](https://github.com/ai-dynamo/aiconfigurator/pull/867) with non-trivial row counts.
- [x] **Run 1**: `collection_summary_vllm.json` reports a non-zero `total_errors` (13,349) that matches the traceback count in `collector_errors.log` — errors no longer swallowed.
- [x] **Run 2** (Fix C + D): [pipeline 48802224](https://gitlab-master.nvidia.com/dl/ai-dynamo/aic-auto-collector/-/pipelines/48802224) finishes green.
- [x] **Run 2**: `mla_generation_module` reports 0 errors; pass rate 100%.
- [x] **Run 2**: `dsa_context_module` reports only `OutOfMemoryError` in `total_errors`, no other error types — confirming the `ValueError` path no longer fires and surfacing the residual leak as a single-signature population for diagnosis.
- [x] **Run 3** (Fix E + F): [pipeline 48831937](https://gitlab-master.nvidia.com/dl/ai-dynamo/aic-auto-collector/-/pipelines/48831937) finishes green.
- [x] **Run 3**: `dsa_context_module` reports `total_errors: 0` with 17,568 rows in `dsa_context_module_perf.txt` — the leak is plugged, not worked around.
- [x] Spot-check routing: `resolve_module(entry, "0.17.5")` → `collect_mla_module_v2`; `"0.19.0"` → `collect_mla_module_v3`; `"0.16.0"` → `collect_mla_module_v1`.
- [x] **Final sweep** (all 4 ops, all models, `b200 × vllm:0.19.0`) to produce a single data bundle for the data PR.

