### PR TITLE
chore: Add data from auto-collector pipeline 48831401 (gb200_trtllm_1.3.0rc10)

### DIFF
--- a/src/aiconfigurator/systems/data/gb200/trtllm/1.3.0rc10/generation_mla_perf.txt
+++ b/src/aiconfigurator/systems/data/gb200/trtllm/1.3.0rc10/generation_mla_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5817004ecd6c9d3e62397208e6163104c70386244eb5680fbae3b673bb3b62b7
+size 297890

--- a/src/aiconfigurator/systems/data/gb200/trtllm/1.3.0rc10/mla_generation_module_perf.txt
+++ b/src/aiconfigurator/systems/data/gb200/trtllm/1.3.0rc10/mla_generation_module_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b73500c9389079c3ad039722b262663aa96bf4b6c65056ba114bdb2c5b75b83e
+size 670732


### PR DESCRIPTION
# Error Summary for Auto-Collector Run
## Collection summary for gb200 trtllm:1.3.0rc10
### Error summary
```
{
    "backend": "trtllm",
    "version": "1.3.0rc10",
    "timestamp": "2026-04-18T01:42:51.545002",
    "total_errors": 2,
    "errors_by_module": {
        "trtllm.mla_generation_module": 2
    },
    "errors_by_type": {
        "AcceleratorError": 1,
        "WorkerSignalCrash": 1
    }
}
```

