### PR TITLE
chore: Add data from auto-collector pipeline 48831401 (b200_sxm_trtllm_1.3.0rc10)

### DIFF
--- a/src/aiconfigurator/systems/data/b200_sxm/trtllm/1.3.0rc10/generation_mla_perf.txt
+++ b/src/aiconfigurator/systems/data/b200_sxm/trtllm/1.3.0rc10/generation_mla_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30f8573faf8143425d63bce09c7cef9fc1cfa466d634c42f829d801102796317
+size 294979

--- a/src/aiconfigurator/systems/data/b200_sxm/trtllm/1.3.0rc10/mla_generation_module_perf.txt
+++ b/src/aiconfigurator/systems/data/b200_sxm/trtllm/1.3.0rc10/mla_generation_module_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc47ac469fe30c8d26d2f809a12ec8841316a123c5c37c0d4ae084c9a63888c8
+size 666322


### PR DESCRIPTION
# Error Summary for Auto-Collector Run
## Collection summary for b200_sxm trtllm:1.3.0rc10
### Error summary
```
{
    "backend": "trtllm",
    "version": "1.3.0rc10",
    "timestamp": "2026-04-18T01:43:52.167000",
    "total_errors": 2,
    "errors_by_module": {
        "trtllm.mla_generation_module": 2
    },
    "errors_by_type": {
        "AcceleratorError": 1,
        "WorkerSignalCrash": 1
    }
}
```

