### PR TITLE
chore: Add data from auto-collector pipeline 48831401 (b300_sxm_trtllm_1.3.0rc10)

### DIFF
--- a/src/aiconfigurator/systems/data/b300_sxm/trtllm/1.3.0rc10/generation_mla_perf.txt
+++ b/src/aiconfigurator/systems/data/b300_sxm/trtllm/1.3.0rc10/generation_mla_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c48d2299dcdb96f8a0a71ee918bb1f412a70bfad99d41e205e5a04c7d1413d98
+size 318212

--- a/src/aiconfigurator/systems/data/b300_sxm/trtllm/1.3.0rc10/mla_generation_module_perf.txt
+++ b/src/aiconfigurator/systems/data/b300_sxm/trtllm/1.3.0rc10/mla_generation_module_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:83ace60aafb31da406e11d879214f621df79a567284c7b83bca6b6a37466ddbb
+size 701639


### PR DESCRIPTION
# Error Summary for Auto-Collector Run
## Collection summary for b300_sxm trtllm:1.3.0rc10
### Error summary
```
{
    "backend": "trtllm",
    "version": "1.3.0rc10",
    "timestamp": "2026-04-18T01:51:46.373714",
    "total_errors": 2,
    "errors_by_module": {
        "trtllm.mla_generation_module": 2
    },
    "errors_by_type": {
        "AcceleratorError": 1,
        "WorkerSignalCrash": 1
    }
}
```

