### PR TITLE
chore: Add data from auto-collector pipeline 48831401 (gb300_trtllm_1.3.0rc10)

### DIFF
--- a/src/aiconfigurator/systems/data/gb300/trtllm/1.3.0rc10/generation_mla_perf.txt
+++ b/src/aiconfigurator/systems/data/gb300/trtllm/1.3.0rc10/generation_mla_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9fd32b6bb71e8896be9d726f9ec031e087dfa088369b0e49df4e7e608e07f080
+size 297875

--- a/src/aiconfigurator/systems/data/gb300/trtllm/1.3.0rc10/mla_generation_module_perf.txt
+++ b/src/aiconfigurator/systems/data/gb300/trtllm/1.3.0rc10/mla_generation_module_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58a735c8cd1ec5ff2e062df7de5c164b5c696f0dca8b28a8cf7a73626f6b1b34
+size 670732


### PR DESCRIPTION
# Error Summary for Auto-Collector Run
## Collection summary for gb300 trtllm:1.3.0rc10
### Error summary
```
{
    "backend": "trtllm",
    "version": "1.3.0rc10",
    "timestamp": "2026-04-18T01:56:41.279760",
    "total_errors": 2,
    "errors_by_module": {
        "trtllm.mla_generation_module": 2
    },
    "errors_by_type": {
        "AcceleratorError": 1,
        "WorkerSignalCrash": 1
    }
}
```

