### PR TITLE
fix: restore fp8 block config and refine power-law routing

### DIFF
--- a/collector/helper.py
+++ b/collector/helper.py
@@ -950,6 +950,29 @@ def _assign_experts_from_counts(num_tokens_per_expert, num_tokens, topk):
     return torch.from_numpy(h_selected).to(device=num_tokens_per_expert.device)
 
 
+def _round_robin_adjust_per_rank(counts_2d, remaining, is_valid, pick_local_index, step):
+    """Adjust local expert counts one rank at a time in round-robin order."""
+    import torch
+
+    while remaining > 0:
+        progressed = False
+        for rank_idx in range(counts_2d.size(0)):
+            local_counts = counts_2d[rank_idx]
+            valid_local = torch.nonzero(is_valid(local_counts)).flatten()
+            if valid_local.numel() == 0:
+                continue
+
+            chosen_local_idx = valid_local[pick_local_index(local_counts[valid_local])].item()
+            counts_2d[rank_idx, chosen_local_idx] += step
+            remaining -= 1
+            progressed = True
+            if remaining == 0:
+                break
+        if not progressed:
+            break
+    return counts_2d
+
+
 def _generate_power_law_distribution(num_tokens, num_experts, topk, ep, alpha):
     """Core function to generate power law token distribution across experts.
 
@@ -985,40 +1008,44 @@ def _generate_power_law_distribution(num_tokens, num_experts, topk, ep, alpha):
     upper_bound = num_tokens
     overflow = (num_tokens_per_expert - upper_bound).clamp(min=0).sum().item()
     num_tokens_per_expert = num_tokens_per_expert.clamp(max=upper_bound)
+    experts_per_rank = num_experts // ep
 
     # Redistribute overflow to experts that haven't reached the bound
     if overflow > 0:
-        sorted_indices = torch.argsort(num_tokens_per_expert, descending=True)
-        for i in range(int(overflow)):
-            # Find an expert that hasn't reached the bound
-            for j in range(len(sorted_indices)):
-                expert_idx = sorted_indices[-(j + 1)]  # Start from smallest
-                if num_tokens_per_expert[expert_idx] < upper_bound:
-                    num_tokens_per_expert[expert_idx] += 1
-                    break
+        num_tokens_per_expert_reshaped = num_tokens_per_expert.view(ep, experts_per_rank)
+        num_tokens_per_expert_reshaped = _round_robin_adjust_per_rank(
+            num_tokens_per_expert_reshaped,
+            remaining=int(overflow),
+            is_valid=lambda local_counts: local_counts < upper_bound,
+            pick_local_index=torch.argmin,
+            step=1,
+        )
+        num_tokens_per_expert = num_tokens_per_expert_reshaped.view(-1)
 
     # Adjust to match exact target sum (respecting upper bound)
     current_sum = num_tokens_per_expert.sum().item()
     delta = target_sum - current_sum
     if delta != 0:
-        sorted_indices = torch.argsort(num_tokens_per_expert, descending=True)
         if delta > 0:
-            # Add to experts that haven't reached the bound
-            added = 0
-            for i in range(int(delta) * len(sorted_indices)):  # Extra iterations for safety
-                if added >= delta:
-                    break
-                expert_idx = sorted_indices[-(i % len(sorted_indices)) - 1]  # Start from smallest
-                if num_tokens_per_expert[expert_idx] < upper_bound:
-                    num_tokens_per_expert[expert_idx] += 1
-                    added += 1
+            num_tokens_per_expert_reshaped = num_tokens_per_expert.view(ep, experts_per_rank)
+            num_tokens_per_expert_reshaped = _round_robin_adjust_per_rank(
+                num_tokens_per_expert_reshaped,
+                remaining=int(delta),
+                is_valid=lambda local_counts: local_counts < upper_bound,
+                pick_local_index=torch.argmin,
+                step=1,
+            )
+            num_tokens_per_expert = num_tokens_per_expert_reshaped.view(-1)
         else:
-            for i in range(-delta):
-                expert_idx = sorted_indices[-(i % len(sorted_indices)) - 1]
-                if num_tokens_per_expert[expert_idx] > 0:
-                    num_tokens_per_expert[expert_idx] -= 1
-                else:
-                    num_tokens_per_expert[torch.argmax(num_tokens_per_expert)] -= 1
+            num_tokens_per_expert_reshaped = num_tokens_per_expert.view(ep, experts_per_rank)
+            num_tokens_per_expert_reshaped = _round_robin_adjust_per_rank(
+                num_tokens_per_expert_reshaped,
+                remaining=int(-delta),
+                is_valid=lambda local_counts: local_counts > 0,
+                pick_local_index=torch.argmax,
+                step=-1,
+            )
+            num_tokens_per_expert = num_tokens_per_expert_reshaped.view(-1)
 
     # Validate distribution
     if len(num_tokens_per_expert) > 1:

--- a/collector/sglang/collect_moe.py
+++ b/collector/sglang/collect_moe.py
@@ -530,7 +530,9 @@ def run_moe_torch(
             False,
             False,
             use_nvfp4=moe_type == "nvfp4",
-            block_shape=None,
+            block_shape=[128, 128]
+            if (moe_type == "fp8_block" and inter_size // moe_tp_size % 128 == 0 and hidden_size % 128 == 0)
+            else None,
             distributed=distributed,
             power_law_alpha=power_law_alpha,
             workloads=rank0_workloads,
@@ -547,7 +549,9 @@ def run_moe_torch(
             False,
             False,
             use_nvfp4=moe_type == "nvfp4",
-            block_shape=None,
+            block_shape=[128, 128]
+            if (moe_type == "fp8_block" and inter_size // moe_tp_size % 128 == 0 and hidden_size % 128 == 0)
+            else None,
             distributed=distributed,
             power_law_alpha=power_law_alpha,
         )

--- a/tests/unit/collector/test_sglang_moe_ep_routing.py
+++ b/tests/unit/collector/test_sglang_moe_ep_routing.py
@@ -89,3 +89,35 @@ def test_global_power_law_rank0_workload_keeps_global_distribution():
     assert workload["masked_m"].sum().item() == rank0_info["rank0_total_selections"]
     assert (workload["topk_ids"] == -1).any()
     assert rank0_info["rank0_total_selections"] < workload["num_tokens"] * workload["topk_ids"].shape[1]
+
+
+@pytest.mark.unit
+def test_round_robin_adjust_per_rank_adds_to_local_minimums():
+    helper = _import_helper_module()
+
+    counts = torch.tensor([[3, 1], [2, 0]], dtype=torch.int64)
+    adjusted = helper._round_robin_adjust_per_rank(
+        counts.clone(),
+        remaining=3,
+        is_valid=lambda local_counts: local_counts < 4,
+        pick_local_index=torch.argmin,
+        step=1,
+    )
+
+    assert torch.equal(adjusted, torch.tensor([[3, 3], [2, 1]], dtype=torch.int64))
+
+
+@pytest.mark.unit
+def test_round_robin_adjust_per_rank_subtracts_from_local_maximums():
+    helper = _import_helper_module()
+
+    counts = torch.tensor([[3, 1], [2, 0]], dtype=torch.int64)
+    adjusted = helper._round_robin_adjust_per_rank(
+        counts.clone(),
+        remaining=3,
+        is_valid=lambda local_counts: local_counts > 0,
+        pick_local_index=torch.argmax,
+        step=-1,
+    )
+
+    assert torch.equal(adjusted, torch.tensor([[1, 1], [1, 0]], dtype=torch.int64))


### PR DESCRIPTION
Overview:
This PR fixes an SGLang MoE collection issue where fp8_block benchmarks were not passing the expected block shape, and cleans up the power-law routing path used by the collector. It also adds focused unit coverage around the per-rank round-robin redistribution logic to make the routing behavior easier to verify and maintain.

Details:
Restore block_shape=[128, 128] in collector/sglang/collect_moe.py for both the rank0 workload path and the default benchmark path when fp8_block is enabled and dimensions are compatible.
Refactor the repeated per-rank round-robin redistribution logic in collector/helper.py into a shared helper to reduce duplication in the power-law distribution adjustment path.
Add targeted unit tests covering round-robin add/subtract behavior and preserving rank0 workload routing expectations.
Where should the reviewer start?
Start with:

collector/sglang/collect_moe.py
collector/helper.py
tests/unit/collector/test_sglang_moe_ep_routing.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Optimizations**
  * Improved expert count distribution through round-robin adjustment mechanism for more efficient load balancing in MOE configurations
  * Enhanced FP8 block shape parameter handling in MOE benchmarking to automatically apply optimal settings when tensor dimensions align

* **Tests**
  * Added unit tests validating round-robin adjustment behavior under various constraint scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->