### PR TITLE
fix: add cache_transceiver_config.backend in trtllm templates for release 0.8.0

### DIFF
--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.3.0rc11.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.3.0rc11.yaml.j2
@@ -32,6 +32,12 @@ kv_cache_config:
   {% endif %}
   enable_block_reuse: {{ kv_cache_config.enable_block_reuse | default(false) }}
 
+{% if cache_transceiver_config.max_tokens_in_buffer is defined %}
+cache_transceiver_config:
+  backend: {{ cache_transceiver_config.backend | default('DEFAULT') }} # The communication backend type to use for the cache transceiver ("DEFAULT","UCX","NIXL","MPI")
+  max_tokens_in_buffer: {{ cache_transceiver_config.max_tokens_in_buffer }}
+{% endif %}
+
 cuda_graph_config:
   enable_padding: {{ cuda_graph_config.enable_padding | default(false) }} # Pad CUDA graph
   batch_sizes: [{% for s in cuda_graph_config.batch_sizes

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.3.0rc5.post1.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.3.0rc5.post1.yaml.j2
@@ -32,6 +32,12 @@ kv_cache_config:
   {% endif %}
   enable_block_reuse: {{ kv_cache_config.enable_block_reuse | default(false) }}
 
+{% if cache_transceiver_config.max_tokens_in_buffer is defined %}
+cache_transceiver_config:
+  backend: {{ cache_transceiver_config.backend | default('DEFAULT') }} # The communication backend type to use for the cache transceiver ("DEFAULT","UCX","NIXL","MPI")
+  max_tokens_in_buffer: {{ cache_transceiver_config.max_tokens_in_buffer }}
+{% endif %}
+
 cuda_graph_config:
   enable_padding: {{ cuda_graph_config.enable_padding | default(false) }} # Pad CUDA graph
   batch_sizes: [{% for s in cuda_graph_config.batch_sizes


### PR DESCRIPTION
#### Overview:

Add cache_transceiver_config.backend field to avoid hang issue for disagg deployment.

Related Issue [DYN-2726]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for optional cache transceiver configuration in TensorRT-LLM backend deployments
  * Enables configuration of cache transceiver backend type (defaults to DEFAULT if unspecified)
  * Allows configuration of maximum tokens in buffer setting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->