### PR TITLE
fix: fail wheel build on unmaterialized Git

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,6 +15,16 @@ ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 FROM base AS build
 COPY src/ /workspace/src/
 COPY LICENSE pyproject.toml README.md /workspace/
+# Fail fast if Git LFS content wasn't materialized before the build — otherwise
+# the wheel ships pointer stubs in place of perf data (see DYN-2725).
+RUN set -e; \
+    bad=$(grep -rlE "^version https://git-lfs" /workspace/src/aiconfigurator/systems 2>/dev/null || true); \
+    if [ -n "$bad" ]; then \
+        echo "ERROR: Unmaterialized Git LFS pointer files found:" >&2; \
+        echo "$bad" >&2; \
+        echo "Run 'git lfs install && git lfs pull' in the source tree before building." >&2; \
+        exit 1; \
+    fi
 RUN uv build --wheel --out-dir /workspace/dist
 
 FROM base AS runtime

--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -284,7 +284,10 @@ def get_database(
                     databases_cache[cache_key][backend][version] = database
                     return database
                 except Exception:
-                    logger.warning(f"failed to load {system=}, {backend=}, {version=}, continuing searching")
+                    logger.warning(
+                        f"failed to load {system=}, {backend=}, {version=}, continuing searching",
+                        exc_info=True,
+                    )
             else:
                 logger.warning(f"data path {data_path} not found, continuing searching")
 


### PR DESCRIPTION
### Problem

Nothing in `docker/Dockerfile`'s `build` stage verifies that the `src/` tree it's about to pack into a wheel actually contains the materialized Git LFS content. `.gitattributes` declares `src/aiconfigurator/systems/**/*.txt` as LFS-tracked, but if the source tree was checked out without `git lfs pull` (e.g. a `git clone` on a host without git-lfs, or a CI step that skipped LFS), every perf file on disk is a ~132-byte pointer stub. The existing Dockerfile does a straight `COPY src/ /workspace/src/` followed by `uv build --wheel` — no validation — so the stubs are faithfully copied into the image and packed into the wheel. The failure surfaces at runtime in an unhelpful way:

```
KeyError: 'gemm_dtype'   # perf_database.py:521
```

`csv.DictReader` reads the LFS pointer's `version https://git-lfs.github.com/spec/v1` line as a CSV header, so no expected column exists. The real cause (wrong file content) is hidden because `perf_database.py:286-287` catches the exception with a bare `except Exception: logger.warning(...)` and no `exc_info`.

### Changes

1. **`docker/Dockerfile` (build stage).** New `RUN` step between `COPY src/` and `uv build` that greps `/workspace/src/aiconfigurator/systems` for `^version https://git-lfs` signatures and exits 1 with a clear error if any file matches. Converts a silent wheel-corruption bug into a loud build failure in ~250 ms.

2. **`src/aiconfigurator/sdk/perf_database.py:287`.** Add `exc_info=True` to the `logger.warning` inside the `except Exception` block that wraps `PerfDatabase(...)`. Preserves the real loader exception so future failures don't require a debugger to diagnose.

### Test plan

Executed in a clean `git clone --branch release/0.8.0` with these changes applied.

**Positive — normal build, LFS materialized.** `docker build --no-cache --target build .` exits 0. Resulting wheel is 62 MB (vs. a stub-shipping wheel, which is orders of magnitude smaller). Spot check: `unzip -p <wheel> aiconfigurator/systems/data/h200_sxm/trtllm/1.2.0rc5/gemm_perf.txt | head -3` returns the real CSV header `framework,version,device,op_name,kernel_source,gemm_dtype,m,n,k,latency` followed by data rows. Perf-file sizes in the wheel listing are 800 KB – 6 MB, consistent with materialized LFS content.

**Negative — simulated stub, guard must fire.** Replaced one perf file with a synthesized 132-byte LFS pointer (`version https://git-lfs.github.com/spec/v1` + oid + size), then rebuilt. Build failed at step 3/4 — the new guard — **before** `uv build` ran, with exit code 1 and this output:

```
ERROR: Unmaterialized Git LFS pointer files found:
/workspace/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.2.0rc5/gemm_perf.txt
Run 'git lfs install && git lfs pull' in the source tree before building.
```

**End-to-end — installed wheel actually works.** `pip install` the positive-test wheel into a throwaway venv, then:

```python
from aiconfigurator.sdk.perf_database import PerfDatabase, get_systems_paths
db = PerfDatabase('h200_sxm', 'trtllm', '1.2.0rc5', get_systems_paths()[0])
```

Completes without raising. Confirms the wheel produced by the patched build path is functionally correct.