### PR TITLE
chore: Refactor collector to have perf filename in registry.py

### DIFF
--- a/collector/collect.py
+++ b/collector/collect.py
@@ -397,13 +397,16 @@ def parallel_run(tasks, func, num_processes, module_name="unknown", resume_optio
     Args:
         num_processes: Number of parallel processes. If 0, runs sequentially in main process.
     """
+    # func may be a functools.partial (perf_filename bound by collect_ops),
+    # which lacks __name__. Fall back to partial.func to get the wrapped function.
+    func_name = getattr(func, "__name__", None) or getattr(func, "func", func).__name__
     raw_task_infos = []
     for i, task in enumerate(tasks):
         if isinstance(task, dict) and "id" in task and "params" in task:
             task_id = task["id"]
             task_params = task["params"]
         else:
-            task_id = create_test_case_id(task, func.__name__, module_name)
+            task_id = create_test_case_id(task, func_name, module_name)
             task_params = task
         raw_task_infos.append({"id": task_id, "params": task_params, "index": i})
 
@@ -413,7 +416,7 @@ def parallel_run(tasks, func, num_processes, module_name="unknown", resume_optio
     resume_tracker = ResumeCheckpoint(
         backend=resume_options.get("backend", "unknown") if resume_options else "unknown",
         module_name=module_name,
-        run_func_name=func.__name__,
+        run_func_name=func_name,
         checkpoint_dir=checkpoint_dir,
     )
 
@@ -1024,8 +1027,6 @@ def main():
     if args.model_path:
         logger.info(f"Model filter active: collecting only for '{args.model_path}'")
 
-    num_processes = get_device_module().device_count()
-    logger.info(f"Starting collection with {num_processes} GPU processes")
     resume_options = {
         "resume": args.resume,
         "checkpoint_dir": args.checkpoint_dir,

--- a/collector/collect.py
+++ b/collector/collect.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import contextlib
+import functools
 import os
 import warnings
 
@@ -328,7 +329,7 @@ def worker(
 
         try:
             worker_logger.debug(f"Starting task {task_id}")
-            func(*task, device)
+            func(*task, device=device)
             worker_logger.debug(f"Completed task {task_id}")
         except Exception as e:
             # Build comprehensive error info
@@ -724,6 +725,7 @@ def collect_ops(
 
             get_func = getattr(get_module, collection["get_func"])
             run_func = getattr(run_module, collection["run_func"])
+            run_func = functools.partial(run_func, perf_filename=collection["perf_filename"])
 
             def get_func_with_limit(get_func=get_func):
                 cases = get_func()

--- a/collector/collect.py
+++ b/collector/collect.py
@@ -541,7 +541,7 @@ def parallel_run(tasks, func, num_processes, module_name="unknown", resume_optio
                 task_params = task_info["params"]
 
                 try:
-                    func(*task_params, device)
+                    func(*task_params, device=device)
                     resume_tracker.mark_done(task_id)
                 except Exception as e:
                     error_info = {

--- a/collector/registry_types.py
+++ b/collector/registry_types.py
@@ -16,6 +16,13 @@ class PerfFile(str, Enum):
     without ``.value``.
     """
 
+    def __str__(self) -> str:
+        """
+        Override behavior of str(x) and f"{x}" to return
+        the perf filename instead of the enum name like "PerfFile.GEMM".
+        """
+        return self.value
+
     GEMM = "gemm_perf.txt"
     CONTEXT_ATTENTION = "context_attention_perf.txt"
     GENERATION_ATTENTION = "generation_attention_perf.txt"

--- a/collector/registry_types.py
+++ b/collector/registry_types.py
@@ -6,6 +6,38 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import Enum
+
+
+class PerfFile(str, Enum):
+    """Canonical output filenames for collector operations.
+
+    Inherits from ``str`` so values pass directly to ``open()`` / ``log_perf()``
+    without ``.value``.
+    """
+
+    GEMM = "gemm_perf.txt"
+    CONTEXT_ATTENTION = "context_attention_perf.txt"
+    GENERATION_ATTENTION = "generation_attention_perf.txt"
+    MOE = "moe_perf.txt"
+    CONTEXT_MLA = "context_mla_perf.txt"
+    GENERATION_MLA = "generation_mla_perf.txt"
+    MLA_BMM = "mla_bmm_perf.txt"
+    GDN = "gdn_perf.txt"
+    MAMBA2 = "mamba2_perf.txt"
+    COMPUTESCALE = "computescale_perf.txt"
+    WIDEEP_MOE = "wideep_moe_perf.txt"
+    WIDEEP_CONTEXT_MLA = "wideep_context_mla_perf.txt"
+    WIDEEP_GENERATION_MLA = "wideep_generation_mla_perf.txt"
+    WIDEEP_CONTEXT_MOE = "wideep_context_moe_perf.txt"
+    WIDEEP_GENERATION_MOE = "wideep_generation_moe_perf.txt"
+    MLA_CONTEXT_MODULE = "mla_context_module_perf.txt"
+    MLA_GENERATION_MODULE = "mla_generation_module_perf.txt"
+    DSA_CONTEXT_MODULE = "dsa_context_module_perf.txt"
+    DSA_GENERATION_MODULE = "dsa_generation_module_perf.txt"
+    NCCL = "nccl_perf.txt"
+    CUSTOM_ALLREDUCE = "custom_allreduce_perf.txt"
+    TRTLLM_ALLTOALL = "trtllm_alltoall_perf.txt"
 
 
 @dataclass(frozen=True, slots=True)
@@ -32,6 +64,7 @@ class OpEntry:
     op: str
     get_func: str
     run_func: str
+    perf_filename: str
     module: str | None = None
     versions: tuple[VersionRoute, ...] = field(default_factory=tuple)
 

--- a/collector/sglang/collect_attn.py
+++ b/collector/sglang/collect_attn.py
@@ -175,12 +175,12 @@ def get_context_attention_test_cases():
                         continue
 
                     # BF16 attention - works on all GPUs
-                    test_cases.append([b, s, n, num_kv_heads, 128, False, False, True, "context_attention_perf.txt"])
+                    test_cases.append([b, s, n, num_kv_heads, 128, False, False, True])
 
                     # FP8 attention - requires SM90+ (Hopper)
                     if not skip_fp8:
-                        test_cases.append([b, s, n, num_kv_heads, 128, True, False, True, "context_attention_perf.txt"])
-                        test_cases.append([b, s, n, num_kv_heads, 128, True, True, True, "context_attention_perf.txt"])
+                        test_cases.append([b, s, n, num_kv_heads, 128, True, False, True])
+                        test_cases.append([b, s, n, num_kv_heads, 128, True, True, True])
 
     return test_cases
 
@@ -227,10 +227,10 @@ def get_generation_attention_test_cases():
                 target_s_list = target_s_list[:-1]
             for s in target_s_list:
                 # BF16 attention - works on all GPUs
-                test_cases.append([b, s, n, n, 128, False, False, False, "generation_attention_perf.txt"])
+                test_cases.append([b, s, n, n, 128, False, False, False])
                 # FP8 attention - requires SM90+ (Hopper)
                 if not skip_fp8:
-                    test_cases.append([b, s, n, n, 128, True, False, False, "generation_attention_perf.txt"])
+                    test_cases.append([b, s, n, n, 128, True, False, False])
 
     # XQA
     max_bsn = 8192 * 1024 * 2
@@ -263,10 +263,10 @@ def get_generation_attention_test_cases():
                     continue
                 for s in target_s_list:
                     # BF16 attention - works on all GPUs
-                    test_cases.append([b, s, n, n_kv, 128, False, False, False, "generation_attention_perf.txt"])
+                    test_cases.append([b, s, n, n_kv, 128, False, False, False])
                     # FP8 attention - requires SM90+ (Hopper)
                     if not skip_fp8:
-                        test_cases.append([b, s, n, n_kv, 128, True, False, False, "generation_attention_perf.txt"])
+                        test_cases.append([b, s, n, n_kv, 128, True, False, False])
     return test_cases
 
 
@@ -279,9 +279,9 @@ def run_attention_torch(
     use_fp8_kv_cache,
     use_fp8_context_fmha,
     is_context_phase,
+    *,
     perf_filename,
     device="cuda:0",
-    *,
     page_size: int = 64,
 ):
     if use_fp8_context_fmha:

--- a/collector/sglang/collect_gdn.py
+++ b/collector/sglang/collect_gdn.py
@@ -93,7 +93,6 @@ def get_gdn_test_cases():
                     common_case.batch_size_list,
                     common_case.seq_len_list,
                     common_case.model_name,
-                    "gdn_perf.txt",
                 ]
             )
         else:
@@ -109,7 +108,6 @@ def get_gdn_test_cases():
                     common_case.batch_size_list,
                     None,  # seq_len_list not used for generation
                     common_case.model_name,
-                    "gdn_perf.txt",
                 ]
             )
 
@@ -630,6 +628,7 @@ def run_gdn_torch(
     batch_size_list: list[int],
     seq_len_list: list[int] | None,
     model_name: str,
+    *,
     perf_filename: str,
     device: str = "cuda:0",
 ):
@@ -714,6 +713,8 @@ if __name__ == "__main__":
     import sys
     from importlib.metadata import version as _get_ver
 
+    from collector.registry_types import PerfFile
+
     print(f"GDN Collector - SGLang {_get_ver('sglang')}")
     print(f"SM Version: {get_sm_version()}")
     print(f"Device: {torch.cuda.get_device_name()}")
@@ -735,7 +736,6 @@ if __name__ == "__main__":
             batch_size_list,
             seq_len_list,
             model_name,
-            perf_filename,
         ) = test_case
 
         print(f"\n[{i + 1}/{len(test_cases)}] {model_name} - {phase}")
@@ -761,7 +761,7 @@ if __name__ == "__main__":
             batch_size_list=batch_size_list,
             seq_len_list=seq_len_list,
             model_name=model_name,
-            perf_filename=perf_filename,
+            perf_filename=PerfFile.GDN,
         )
 
     sys.exit(last_exit_code)

--- a/collector/sglang/collect_gemm.py
+++ b/collector/sglang/collect_gemm.py
@@ -65,7 +65,7 @@ def get_gemm_test_cases():
             if (gemm_type == "nvfp4" or gemm_type == "fp8_block") and (n < 128 or k < 128):
                 continue
 
-            test_cases.append([gemm_type, x, n, k, "gemm_perf.txt"])
+            test_cases.append([gemm_type, x, n, k])
 
     # Try to optimize number of JIT precompile cache hits by shuffling test cases.
     random.seed(42)
@@ -120,7 +120,7 @@ def per_token_quant_int8(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
     return x_int8, scale.squeeze(-1)
 
 
-def run_gemm(gemm_type, batch_size, N, K, perf_filename, device):  # noqa: N803
+def run_gemm(gemm_type, batch_size, N, K, *, perf_filename, device="cuda:0"):  # noqa: N803
     assert gemm_type in [
         "fp8_block",
         "fp8",

--- a/collector/sglang/collect_mla.py
+++ b/collector/sglang/collect_mla.py
@@ -205,7 +205,6 @@ def get_context_mla_test_cases():
                                 10,
                                 6,
                                 True,
-                                "context_mla_perf.txt",
                             ]
                         )
     return test_cases
@@ -273,7 +272,6 @@ def get_generation_mla_test_cases():
                                 10,
                                 6,
                                 False,
-                                "generation_mla_perf.txt",
                             ]
                         )
     return test_cases
@@ -291,6 +289,7 @@ def run_mla(
     warming_up,
     test_ite,
     is_context_phase,
+    *,
     perf_filename,
     device="cuda:0",
 ):
@@ -558,12 +557,14 @@ def run_mla(
 
 
 if __name__ == "__main__":
+    from registry_types import PerfFile
+
     test_cases = get_context_mla_test_cases()
     for test_case in test_cases[0:10]:
         print(test_case)
-        run_mla(*test_case)
+        run_mla(*test_case, perf_filename=PerfFile.CONTEXT_MLA)
 
     test_cases = get_generation_mla_test_cases()
     for test_case in test_cases[0:10]:
         print(test_case)
-        run_mla(*test_case)
+        run_mla(*test_case, perf_filename=PerfFile.GENERATION_MLA)

--- a/collector/sglang/collect_mla.py
+++ b/collector/sglang/collect_mla.py
@@ -19,7 +19,8 @@ from sglang.srt.mem_cache.memory_pool import MLATokenToKVPool, ReqToTokenPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.utils import is_blackwell
 
-from helper import benchmark_with_power, get_sm_version, log_perf
+from collector.helper import benchmark_with_power, get_sm_version, log_perf
+from collector.registry_types import PerfFile
 
 # Mocking for standalone collector script
 sglang.srt.layers.dp_attention._ATTN_TP_SIZE = 1
@@ -557,8 +558,6 @@ def run_mla(
 
 
 if __name__ == "__main__":
-    from registry_types import PerfFile
-
     test_cases = get_context_mla_test_cases()
     for test_case in test_cases[0:10]:
         print(test_case)

--- a/collector/sglang/collect_mla_bmm.py
+++ b/collector/sglang/collect_mla_bmm.py
@@ -44,7 +44,7 @@ def get_mla_gen_pre_test_cases():
     for num_tokens in gen_num_tokens:
         for num_head in num_heads:
             for dtype in dtype_list:
-                test_cases.append([num_tokens, num_head, dtype, 2, 10, "mla_bmm_perf.txt"])
+                test_cases.append([num_tokens, num_head, dtype, 2, 10])
     return test_cases
 
 
@@ -85,11 +85,11 @@ def get_mla_gen_post_test_cases():
     for num_tokens in ctx_num_tokens:
         for num_head in num_heads:
             for dtype in dtype_list:
-                test_cases.append([num_tokens, num_head, dtype, 2, 10, "mla_bmm_perf.txt"])
+                test_cases.append([num_tokens, num_head, dtype, 2, 10])
     return test_cases
 
 
-def run_mla_gen_pre(num_tokens, num_heads, dtype, num_warmups, num_runs, perf_filename, device="cuda:0"):
+def run_mla_gen_pre(num_tokens, num_heads, dtype, num_warmups, num_runs, *, perf_filename, device="cuda:0"):
     torch.cuda.set_device(device)
     torch.set_default_device(device)
 
@@ -151,7 +151,7 @@ def run_mla_gen_pre(num_tokens, num_heads, dtype, num_warmups, num_runs, perf_fi
     )
 
 
-def run_mla_gen_post(num_tokens, num_heads, dtype, num_warmups, num_runs, perf_filename, device="cuda:0"):
+def run_mla_gen_post(num_tokens, num_heads, dtype, num_warmups, num_runs, *, perf_filename, device="cuda:0"):
     torch.cuda.set_device(device)
     torch.set_default_device(device)
 

--- a/collector/sglang/collect_mla_module.py
+++ b/collector/sglang/collect_mla_module.py
@@ -1251,6 +1251,4 @@ def main():
 
 
 if __name__ == "__main__":
-    from collector.registry_types import PerfFile  # noqa: F401 — available for ad-hoc runs
-
     main()

--- a/collector/sglang/collect_mla_module.py
+++ b/collector/sglang/collect_mla_module.py
@@ -201,10 +201,9 @@ def get_context_test_cases(attn_type: str):
     """Context-phase test cases.
 
     Returns list of [seq_len, batch_size, num_heads, kv_cache_dtype,
-                     compute_dtype, gemm_type, perf_filename].
+                     compute_dtype, gemm_type].
     """
     cases = []
-    base_fname = f"{attn_type}_context_module_perf.txt"
     for compute_dtype, kv_dtype, gemm_type in _get_precision_combos("context"):
         for num_heads in _HEAD_NUMS:
             for batch_size in _BATCH_SIZES:
@@ -213,7 +212,7 @@ def get_context_test_cases(attn_type: str):
                         continue
                     if seq_len >= 8192 and batch_size > 8:
                         continue
-                    cases.append([seq_len, batch_size, num_heads, kv_dtype, compute_dtype, gemm_type, base_fname])
+                    cases.append([seq_len, batch_size, num_heads, kv_dtype, compute_dtype, gemm_type])
     return cases
 
 
@@ -221,10 +220,9 @@ def get_generation_test_cases(attn_type: str):
     """Generation-phase test cases.
 
     Returns list of [kv_cache_len, batch_size, num_heads, kv_cache_dtype,
-                     compute_dtype, gemm_type, perf_filename].
+                     compute_dtype, gemm_type].
     """
     cases = []
-    base_fname = f"{attn_type}_generation_module_perf.txt"
     for compute_dtype, kv_dtype, gemm_type in _get_precision_combos("generation"):
         for num_heads in _HEAD_NUMS:
             for batch_size in _BATCH_SIZES:
@@ -233,7 +231,7 @@ def get_generation_test_cases(attn_type: str):
                         continue
                     if seq_len >= 8192 and batch_size > 16:
                         continue
-                    cases.append([seq_len, batch_size, num_heads, kv_dtype, compute_dtype, gemm_type, base_fname])
+                    cases.append([seq_len, batch_size, num_heads, kv_dtype, compute_dtype, gemm_type])
     return cases
 
 
@@ -241,7 +239,7 @@ def _build_module_test_cases(attn_type: str, mode: str):
     """Build one test case per unique (num_heads, precision, model) group.
 
     Output format: [seq_len, batch_size, num_heads, kv_cache_dtype,
-                    compute_dtype, gemm_type, perf_filename, model_path,
+                    compute_dtype, gemm_type, model_path,
                     attn_type, attention_backend]
 
     Each test case triggers a subprocess that sweeps all (batch_size, seq_len)
@@ -249,10 +247,9 @@ def _build_module_test_cases(attn_type: str, mode: str):
     individual point. seq_len and batch_size are set to 0 as placeholders.
 
     attention_backend is None for DSA (resolved at runtime by _get_backends()).
-    All test cases are 10 elements so that collect.py's ``func(*task, device)``
-    maps positional args correctly to run_mla_module_worker().
+    perf_filename is supplied by collect.py via functools.partial as a keyword
+    argument, so it is not included in the test case tuple.
     """
-    base_fname = f"{attn_type}_{mode}_module_perf.txt"
     model_paths = [m for m, t in SUPPORTED_MODELS.items() if t == attn_type]
     cases = []
     for model_path in model_paths:
@@ -269,7 +266,6 @@ def _build_module_test_cases(attn_type: str, mode: str):
                         kv_dtype,
                         compute_dtype,
                         gemm_type,
-                        base_fname,
                         model_path,
                         attn_type,
                         None,
@@ -282,16 +278,17 @@ def _build_wideep_mla_test_cases(mode: str):
     """Build test cases for wideep MLA collection (backward-compatible).
 
     Output format: [seq_len, batch_size, num_heads, kv_cache_dtype,
-                    compute_dtype, gemm_type, perf_filename, model_path,
+                    compute_dtype, gemm_type, model_path,
                     attn_type, attention_backend]
 
     Matches the old collect_wideep_attn.py behavior:
     - Single precision combo (bfloat16 run, logged as fp8_block/fp8)
     - Sweeps multiple attention backends per SM version
     - Only DeepSeek-V3 (the MLA model), not V3.2/GLM-5 (DSA models)
+
+    perf_filename is supplied by collect.py via functools.partial as a keyword
+    argument, so it is not included in the test case tuple.
     """
-    phase = "context" if mode == "context" else "generation"
-    base_fname = f"wideep_{phase}_mla_perf.txt"
     model_paths = [m for m, t in SUPPORTED_MODELS.items() if t == "mla"]
     backends = _get_mla_backend_list()
     cases = []
@@ -310,7 +307,6 @@ def _build_wideep_mla_test_cases(mode: str):
                         "bfloat16",
                         "bfloat16",
                         "bfloat16",
-                        base_fname,
                         model_path,
                         "mla",
                         backend,
@@ -1029,7 +1025,7 @@ def run_mla_module(
         phase_name = "Generation"
 
     # Filter to matching precision combo.
-    # Test case format: [seq_len, batch_size, num_heads, kv_dtype, compute_dtype, gemm_type, ...]
+    # Test case format: [seq_len, batch_size, num_heads, kv_dtype, compute_dtype, gemm_type]
     # run_attention_torch expects: (batch_size, seq_length, is_prefill)
     cases = [
         (tc[1], tc[0], is_prefill)
@@ -1131,22 +1127,26 @@ def run_mla_module_worker(
     kv_cache_dtype: str,
     compute_dtype: str,
     gemm_type: str,
-    perf_filename: str,
     model_path: str,
     attn_type: str,
     attention_backend: str | None = None,
+    *,
+    perf_filename: str,
     device: str = "cuda:0",
 ):
-    """Worker-compatible positional wrapper used by collector/collect.py.
+    """Worker-compatible wrapper used by collector/collect.py.
 
     Each call runs ALL (batch_size, seq_len) combos for the given
     (attn_type, num_heads, precision, model) combo in a subprocess.
     The seq_len and batch_size args from the individual test case are
     ignored here because the subprocess sweeps all combos internally.
 
-    For wideep MLA test cases, attention_backend is the 10th positional
+    For wideep MLA test cases, attention_backend is the 9th positional
     element specifying which backend to benchmark (e.g. "flashinfer", "fa3").
     For DSA test cases, it defaults to None and _get_backends() is used.
+
+    perf_filename and device are keyword-only arguments supplied by
+    collect.py via functools.partial and the worker dispatch loop.
     """
     device_str = str(device) if not isinstance(device, str) else device
     gpu_id = int(device_str.split(":")[-1]) if ":" in device_str else 0
@@ -1251,4 +1251,6 @@ def main():
 
 
 if __name__ == "__main__":
+    from collector.registry_types import PerfFile  # noqa: F401 — available for ad-hoc runs
+
     main()

--- a/collector/sglang/collect_moe.py
+++ b/collector/sglang/collect_moe.py
@@ -129,7 +129,6 @@ def get_moe_test_cases():
                     common_moe_testcase.tp,
                     common_moe_testcase.ep,
                     common_moe_testcase.model_name,
-                    "moe_perf.txt",
                     common_moe_testcase.token_expert_distribution,
                     common_moe_testcase.power_law_alpha,
                 ]
@@ -625,9 +624,10 @@ def run_moe_torch(
     moe_tp_size,
     moe_ep_size,
     model_name,
-    perf_filename,
     distributed="power_law",
     power_law_alpha=0,
+    *,
+    perf_filename,
     device="cuda:0",
 ):
     torch.cuda.set_device(device)
@@ -735,7 +735,9 @@ def run_moe_torch(
 
 
 if __name__ == "__main__":
+    from collector.registry_types import PerfFile
+
     test_cases = get_moe_test_cases()
     for test_case in test_cases:
         print(test_case)
-        run_moe_torch(*test_case)
+        run_moe_torch(*test_case, perf_filename=PerfFile.MOE)

--- a/collector/sglang/collect_wideep_deepep_moe.py
+++ b/collector/sglang/collect_wideep_deepep_moe.py
@@ -830,7 +830,7 @@ def run_moe(
 
 
 def get_wideep_moe_test_cases(total_experts=256):
-    """Returns list of [num_experts, perf_filename] for MOE collection.
+    """Returns list of [num_experts] for MOE collection.
 
     Each num_experts value simulates a different EP size based on model's total experts.
     Starts from EP=2 (half experts per GPU) to focus on wideep multi-GPU scenarios.
@@ -865,7 +865,7 @@ def get_wideep_moe_test_cases(total_experts=256):
     test_cases = []
     n = total_experts // 2  # Start from EP=2
     while n >= 1:
-        test_cases.append([n, "wideep_moe_perf.txt"])
+        test_cases.append([n])
         n //= 2
     return test_cases
 
@@ -963,7 +963,7 @@ run_moe_benchmark({num_experts}, {gpu_id}, {output_path!r})
         raise RuntimeError(f"MOE subprocess failed with exit code {proc.returncode}")
 
 
-def run_wideep_moe(num_experts, perf_filename, device="cuda:0"):
+def run_wideep_moe(num_experts, *, perf_filename, device="cuda:0"):
     """Run wideep DeepEP MOE benchmark.
 
     Compatible with collect.py framework - uses subprocess for GPU isolation.
@@ -982,6 +982,8 @@ def run_wideep_moe(num_experts, perf_filename, device="cuda:0"):
 if __name__ == "__main__":
     import argparse
 
+    from registry_types import PerfFile
+
     parser = argparse.ArgumentParser(description="SGLang Wideep DeepEP MOE Benchmark")
     parser.add_argument("--output-path", default=None, help="Output directory for perf files")
     args = parser.parse_args()
@@ -990,7 +992,7 @@ if __name__ == "__main__":
 
     # Run all MOE test cases
     for test_case in get_wideep_moe_test_cases():
-        run_wideep_moe(*test_case)
+        run_wideep_moe(*test_case, perf_filename=PerfFile.WIDEEP_MOE)
 
     print("\n" + "=" * 60)
     print("SCRIPT COMPLETED SUCCESSFULLY")

--- a/collector/sglang/registry.py
+++ b/collector/sglang/registry.py
@@ -8,7 +8,7 @@ No version forks exist yet. When SGLang API changes require a fork,
 add a ``versions`` tuple following the trtllm registry pattern.
 """
 
-from collector.registry_types import OpEntry
+from collector.registry_types import OpEntry, PerfFile
 
 REGISTRY: list[OpEntry] = [
     OpEntry(
@@ -16,83 +16,97 @@ REGISTRY: list[OpEntry] = [
         module="collector.sglang.collect_gemm",
         get_func="get_gemm_test_cases",
         run_func="run_gemm",
+        perf_filename=PerfFile.GEMM,
     ),
     OpEntry(
         op="mla_context",
         module="collector.sglang.collect_mla",
         get_func="get_context_mla_test_cases",
         run_func="run_mla",
+        perf_filename=PerfFile.CONTEXT_MLA,
     ),
     OpEntry(
         op="mla_generation",
         module="collector.sglang.collect_mla",
         get_func="get_generation_mla_test_cases",
         run_func="run_mla",
+        perf_filename=PerfFile.GENERATION_MLA,
     ),
     OpEntry(
         op="mla_bmm_gen_pre",
         module="collector.sglang.collect_mla_bmm",
         get_func="get_mla_gen_pre_test_cases",
         run_func="run_mla_gen_pre",
+        perf_filename=PerfFile.MLA_BMM,
     ),
     OpEntry(
         op="mla_bmm_gen_post",
         module="collector.sglang.collect_mla_bmm",
         get_func="get_mla_gen_post_test_cases",
         run_func="run_mla_gen_post",
+        perf_filename=PerfFile.MLA_BMM,
     ),
     OpEntry(
         op="moe",
         module="collector.sglang.collect_moe",
         get_func="get_moe_test_cases",
         run_func="run_moe_torch",
+        perf_filename=PerfFile.MOE,
     ),
     OpEntry(
         op="attention_context",
         module="collector.sglang.collect_attn",
         get_func="get_context_attention_test_cases",
         run_func="run_attention_torch",
+        perf_filename=PerfFile.CONTEXT_ATTENTION,
     ),
     OpEntry(
         op="attention_generation",
         module="collector.sglang.collect_attn",
         get_func="get_generation_attention_test_cases",
         run_func="run_attention_torch",
+        perf_filename=PerfFile.GENERATION_ATTENTION,
     ),
     OpEntry(
         op="wideep_mla_context",
         module="collector.sglang.collect_mla_module",
         get_func="get_wideep_mla_context_test_cases",
         run_func="run_mla_module_worker",
+        perf_filename=PerfFile.WIDEEP_CONTEXT_MLA,
     ),
     OpEntry(
         op="wideep_mla_generation",
         module="collector.sglang.collect_mla_module",
         get_func="get_wideep_mla_generation_test_cases",
         run_func="run_mla_module_worker",
+        perf_filename=PerfFile.WIDEEP_GENERATION_MLA,
     ),
     OpEntry(
         op="dsa_context_module",
         module="collector.sglang.collect_mla_module",
         get_func="get_dsa_context_module_test_cases",
         run_func="run_mla_module_worker",
+        perf_filename=PerfFile.DSA_CONTEXT_MODULE,
     ),
     OpEntry(
         op="dsa_generation_module",
         module="collector.sglang.collect_mla_module",
         get_func="get_dsa_generation_module_test_cases",
         run_func="run_mla_module_worker",
+        perf_filename=PerfFile.DSA_GENERATION_MODULE,
     ),
     OpEntry(
         op="wideep_moe",
         module="collector.sglang.collect_wideep_deepep_moe",
         get_func="get_wideep_moe_test_cases",
         run_func="run_wideep_moe",
+        perf_filename=PerfFile.WIDEEP_MOE,
     ),
     OpEntry(
         op="gdn",
         module="collector.sglang.collect_gdn",
         get_func="get_gdn_test_cases",
         run_func="run_gdn_torch",
+        perf_filename=PerfFile.GDN,
     ),
 ]

--- a/collector/trtllm/collect_attn.py
+++ b/collector/trtllm/collect_attn.py
@@ -32,6 +32,7 @@ def run_attention_torch(
     use_fp8_kv_cache,
     use_fp8_context_fmha,
     is_context_phase,
+    *,
     perf_filename,
     device="cuda:0",
 ):
@@ -346,7 +347,6 @@ def get_context_attention_test_cases():
                                     False,
                                     False,
                                     True,
-                                    "context_attention_perf.txt",
                                 ]
                             )
                             test_cases.append(
@@ -360,7 +360,6 @@ def get_context_attention_test_cases():
                                     False,
                                     False,
                                     True,
-                                    "context_attention_perf.txt",
                                 ]
                             )
                             if has_fp8:
@@ -375,7 +374,6 @@ def get_context_attention_test_cases():
                                         True,
                                         False,
                                         True,
-                                        "context_attention_perf.txt",
                                     ]
                                 )
                                 test_cases.append(
@@ -389,7 +387,6 @@ def get_context_attention_test_cases():
                                         True,
                                         True,
                                         True,
-                                        "context_attention_perf.txt",
                                     ]
                                 )
                                 test_cases.append(
@@ -403,7 +400,6 @@ def get_context_attention_test_cases():
                                         True,
                                         False,
                                         True,
-                                        "context_attention_perf.txt",
                                     ]
                                 )
                                 test_cases.append(
@@ -417,7 +413,6 @@ def get_context_attention_test_cases():
                                         True,
                                         True,
                                         True,
-                                        "context_attention_perf.txt",
                                     ]
                                 )
                         else:
@@ -432,7 +427,6 @@ def get_context_attention_test_cases():
                                     False,
                                     False,
                                     True,
-                                    "context_attention_perf.txt",
                                 ]
                             )
                             if has_fp8:
@@ -447,7 +441,6 @@ def get_context_attention_test_cases():
                                         True,
                                         False,
                                         True,
-                                        "context_attention_perf.txt",
                                     ]
                                 )
                                 test_cases.append(
@@ -461,7 +454,6 @@ def get_context_attention_test_cases():
                                         True,
                                         True,
                                         True,
-                                        "context_attention_perf.txt",
                                     ]
                                 )
 
@@ -541,10 +533,10 @@ def get_generation_attention_test_cases():
                 # print(f'collecting MHA heads: {n} batchsize: {b}  steps: {s_list_limited}')
                 # fp8 kv cache, fp8 context fmha, is_context_phase
                 for s in target_s_list:
-                    test_cases.append([b, s, n, n, h, 0, False, False, False, "generation_attention_perf.txt"])
+                    test_cases.append([b, s, n, n, h, 0, False, False, False])
 
                     if has_fp8:
-                        test_cases.append([b, s, n, n, h, 0, True, False, False, "generation_attention_perf.txt"])
+                        test_cases.append([b, s, n, n, h, 0, True, False, False])
                         # currently, fp8 is not for generation compute
                         # test_cases.append(
                         #     [b, s, n, n, 128, True, True, False, "generation_attention_perf.txt"]
@@ -603,7 +595,6 @@ def get_generation_attention_test_cases():
                                     False,
                                     False,
                                     False,
-                                    "generation_attention_perf.txt",
                                 ]
                             )
                             test_cases.append(
@@ -617,7 +608,6 @@ def get_generation_attention_test_cases():
                                     False,
                                     False,
                                     False,
-                                    "generation_attention_perf.txt",
                                 ]
                             )
                             if has_fp8:
@@ -632,7 +622,6 @@ def get_generation_attention_test_cases():
                                         True,
                                         False,
                                         False,
-                                        "generation_attention_perf.txt",
                                     ]
                                 )
                                 test_cases.append(
@@ -646,7 +635,6 @@ def get_generation_attention_test_cases():
                                         True,
                                         False,
                                         False,
-                                        "generation_attention_perf.txt",
                                     ]
                                 )
                                 # currently, fp8 is not for generation compute
@@ -675,7 +663,6 @@ def get_generation_attention_test_cases():
                                     False,
                                     False,
                                     False,
-                                    "generation_attention_perf.txt",
                                 ]
                             )
                             if has_fp8:
@@ -690,17 +677,18 @@ def get_generation_attention_test_cases():
                                         True,
                                         False,
                                         False,
-                                        "generation_attention_perf.txt",
                                     ]
                                 )
     return test_cases
 
 
 if __name__ == "__main__":
+    from registry_types import PerfFile
+
     test_cases = get_context_attention_test_cases()
     for test_case in test_cases:
-        run_attention_torch(*test_case)
+        run_attention_torch(*test_case, perf_filename=PerfFile.CONTEXT_ATTENTION)
 
     test_cases = get_generation_attention_test_cases()
     for test_case in test_cases:
-        run_attention_torch(*test_case)
+        run_attention_torch(*test_case, perf_filename=PerfFile.GENERATION_ATTENTION)

--- a/collector/trtllm/collect_attn.py
+++ b/collector/trtllm/collect_attn.py
@@ -19,7 +19,8 @@ from tensorrt_llm.llmapi import KvCacheConfig
 from tensorrt_llm.mapping import Mapping
 from tensorrt_llm.models.modeling_utils import QuantAlgo, QuantConfig
 
-from helper import benchmark_with_power, get_sm_version, log_perf
+from collector.helper import benchmark_with_power, get_sm_version, log_perf
+from collector.registry_types import PerfFile
 
 
 def run_attention_torch(
@@ -683,8 +684,6 @@ def get_generation_attention_test_cases():
 
 
 if __name__ == "__main__":
-    from registry_types import PerfFile
-
     test_cases = get_context_attention_test_cases()
     for test_case in test_cases:
         run_attention_torch(*test_case, perf_filename=PerfFile.CONTEXT_ATTENTION)

--- a/collector/trtllm/collect_computescale.py
+++ b/collector/trtllm/collect_computescale.py
@@ -21,12 +21,12 @@ def get_computescale_test_cases():
         if (m, k) in seen_mk:
             continue
         seen_mk.add((m, k))
-        test_cases.append([m, k, "computescale_perf.txt"])
+        test_cases.append([m, k])
 
     return test_cases
 
 
-def run_computescale(m, k, perf_filename, device="cuda:0"):
+def run_computescale(m, k, *, perf_filename, device="cuda:0"):
     device = torch.device(device)
     torch.cuda.set_device(device)
     torch.set_default_device(device)

--- a/collector/trtllm/collect_gdn.py
+++ b/collector/trtllm/collect_gdn.py
@@ -94,7 +94,6 @@ def get_gdn_test_cases():
                     common_case.batch_size_list,
                     common_case.seq_len_list,
                     common_case.model_name,
-                    "gdn_perf.txt",
                 ]
             )
         else:
@@ -110,7 +109,6 @@ def get_gdn_test_cases():
                     common_case.batch_size_list,
                     None,  # seq_len_list not used for generation
                     common_case.model_name,
-                    "gdn_perf.txt",
                 ]
             )
 
@@ -631,6 +629,7 @@ def run_gdn_torch(
     batch_size_list: list[int],
     seq_len_list: list[int] | None,
     model_name: str,
+    *,
     perf_filename: str,
     device: str = "cuda:0",
 ):
@@ -715,6 +714,8 @@ if __name__ == "__main__":
 
     import tensorrt_llm
 
+    from collector.registry_types import PerfFile
+
     print(f"GDN Collector - TensorRT-LLM {tensorrt_llm.__version__}")
     print(f"SM Version: {get_sm_version()}")
     print(f"Device: {torch.cuda.get_device_name()}")
@@ -736,7 +737,6 @@ if __name__ == "__main__":
             batch_size_list,
             seq_len_list,
             model_name,
-            perf_filename,
         ) = test_case
 
         print(f"\n[{i + 1}/{len(test_cases)}] {model_name} - {phase}")
@@ -762,7 +762,7 @@ if __name__ == "__main__":
             batch_size_list=batch_size_list,
             seq_len_list=seq_len_list,
             model_name=model_name,
-            perf_filename=perf_filename,
+            perf_filename=PerfFile.GDN,
         )
 
     sys.exit(last_exit_code)

--- a/collector/trtllm/collect_gemm.py
+++ b/collector/trtllm/collect_gemm.py
@@ -118,12 +118,12 @@ def get_gemm_test_cases():
             if (gemm_type == "nvfp4" or gemm_type == "fp8_block") and (n < 128 or k < 128):
                 continue
             for x in x_list:
-                test_cases.append([gemm_type, x, n, k, "gemm_perf.txt"])
+                test_cases.append([gemm_type, x, n, k])
 
     return test_cases
 
 
-def run_gemm(gemm_type, m, n, k, perf_filename, device="cuda:0"):
+def run_gemm(gemm_type, m, n, k, *, perf_filename, device="cuda:0"):
     device = torch.device(device)
     torch.cuda.set_device(device)
     torch.set_default_device(device)
@@ -212,5 +212,7 @@ def run_gemm(gemm_type, m, n, k, perf_filename, device="cuda:0"):
 
 
 if __name__ == "__main__":
+    from collector.registry_types import PerfFile
+
     for test_case in get_gemm_test_cases():
-        run_gemm(*test_case)
+        run_gemm(*test_case, perf_filename=PerfFile.GEMM)

--- a/collector/trtllm/collect_mamba2.py
+++ b/collector/trtllm/collect_mamba2.py
@@ -101,7 +101,6 @@ def get_mamba2_test_cases():
                     common_case.batch_size_list,
                     common_case.seq_len_list,
                     common_case.model_name,
-                    "mamba2_perf.txt",
                 ]
             )
         else:
@@ -119,7 +118,6 @@ def get_mamba2_test_cases():
                     common_case.batch_size_list,
                     None,  # seq_len_list not used for generation
                     common_case.model_name,
-                    "mamba2_perf.txt",
                 ]
             )
 
@@ -728,6 +726,7 @@ def run_mamba2_torch(
     batch_size_list: list[int],
     seq_len_list: list[int] | None,
     model_name: str,
+    *,
     perf_filename: str,
     device: str = "cuda:0",
 ):
@@ -815,6 +814,7 @@ def run_mamba2_torch(
 
 if __name__ == "__main__":
     import tensorrt_llm
+    from registry_types import PerfFile
 
     print(f"Mamba2 Collector - TensorRT-LLM {tensorrt_llm.__version__}")
     print(f"SM Version: {get_sm_version()}")
@@ -837,7 +837,6 @@ if __name__ == "__main__":
             batch_size_list,
             seq_len_list,
             model_name,
-            perf_filename,
         ) = test_case
 
         print(f"\n[{i + 1}/{len(test_cases)}] {model_name} - {phase}")
@@ -861,5 +860,5 @@ if __name__ == "__main__":
             batch_size_list=batch_size_list,
             seq_len_list=seq_len_list,
             model_name=model_name,
-            perf_filename=perf_filename,
+            perf_filename=PerfFile.MAMBA2,
         )

--- a/collector/trtllm/collect_mla_bmm.py
+++ b/collector/trtllm/collect_mla_bmm.py
@@ -44,7 +44,7 @@ def get_mla_gen_pre_test_cases():
     for num_tokens in gen_num_tokens:
         for num_head in num_heads:
             for dtype in dtype_list:
-                test_cases.append([num_tokens, num_head, dtype, 2, 10, "mla_bmm_perf.txt"])
+                test_cases.append([num_tokens, num_head, dtype, 2, 10])
     return test_cases
 
 
@@ -87,11 +87,11 @@ def get_mla_gen_post_test_cases():
     for num_tokens in ctx_num_tokens:
         for num_head in num_heads:
             for dtype in dtype_list:
-                test_cases.append([num_tokens, num_head, dtype, 2, 10, "mla_bmm_perf.txt"])
+                test_cases.append([num_tokens, num_head, dtype, 2, 10])
     return test_cases
 
 
-def run_mla_gen_pre(num_tokens, num_heads, dtype, num_warmups, num_runs, perf_filename, device="cuda:0"):
+def run_mla_gen_pre(num_tokens, num_heads, dtype, num_warmups, num_runs, *, perf_filename, device="cuda:0"):
     torch.cuda.set_device(device)
     torch.set_default_device(device)
 
@@ -206,7 +206,7 @@ def run_mla_gen_pre(num_tokens, num_heads, dtype, num_warmups, num_runs, perf_fi
         raise ValueError(f"Unsupported dtype: {dtype}")
 
 
-def run_mla_gen_post(num_tokens, num_heads, dtype, num_warmups, num_runs, perf_filename, device="cuda:0"):
+def run_mla_gen_post(num_tokens, num_heads, dtype, num_warmups, num_runs, *, perf_filename, device="cuda:0"):
     torch.cuda.set_device(device)
     torch.set_default_device(device)
 
@@ -322,11 +322,13 @@ def run_mla_gen_post(num_tokens, num_heads, dtype, num_warmups, num_runs, perf_f
 
 
 if __name__ == "__main__":
+    from registry_types import PerfFile
+
     test_cases = get_mla_gen_pre_test_cases()
     for test_case in test_cases:
         print(test_case)
-        run_mla_gen_pre(*test_case)
+        run_mla_gen_pre(*test_case, perf_filename=PerfFile.MLA_BMM)
     test_cases = get_mla_gen_post_test_cases()
     for test_case in test_cases:
         print(test_case)
-        run_mla_gen_post(*test_case)
+        run_mla_gen_post(*test_case, perf_filename=PerfFile.MLA_BMM)

--- a/collector/trtllm/collect_mla_module.py
+++ b/collector/trtllm/collect_mla_module.py
@@ -79,6 +79,7 @@ if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
 from collector.helper import benchmark_with_power, get_sm_version, log_perf
+from collector.registry_types import PerfFile
 
 if "glm_moe_dsa" not in _CONFIG_REGISTRY:
     _CONFIG_REGISTRY["glm_moe_dsa"] = "DeepseekV3Config"
@@ -173,19 +174,18 @@ def get_context_test_cases(attn_type: str):
     """Context-phase test cases.
 
     Returns list of [seq_len, batch_size, num_heads, kv_cache_dtype,
-                     compute_dtype, gemm_type, perf_filename].
+                     compute_dtype, gemm_type].
     """
     cases = []
     b_list = [1, 2, 4, 8, 16, 32, 64, 128, 256]
     s_list = [1, 16, 32, 64, 128, 256, 512, 1024, 1536, 2048, 3072, 4096, 6144, 8192, 10240, 12288, 16384, 32768]
-    base_fname = f"{attn_type}_context_module_perf.txt"
     for compute_dtype, kv_dtype, gemm_type in _get_precision_combos("context", attn_type):
         for num_heads in [128, 64, 32, 16, 8, 4, 2, 1]:
             for b in b_list:
                 for s in s_list:
                     if b * s > 131072:
                         continue
-                    cases.append([s, b, num_heads, kv_dtype, compute_dtype, gemm_type, base_fname])
+                    cases.append([s, b, num_heads, kv_dtype, compute_dtype, gemm_type])
     return cases
 
 
@@ -193,19 +193,18 @@ def get_generation_test_cases(attn_type: str):
     """Generation-phase test cases.
 
     Returns list of [kv_cache_len, batch_size, num_heads, kv_cache_dtype,
-                     compute_dtype, gemm_type, perf_filename].
+                     compute_dtype, gemm_type].
     """
     cases = []
     b_list = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024]
     s_list = [2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072]
-    base_fname = f"{attn_type}_generation_module_perf.txt"
     for compute_dtype, kv_dtype, gemm_type in _get_precision_combos("generation", attn_type):
         for num_heads in [128, 64, 32, 16, 8, 4, 2, 1]:
             for b in b_list:
                 for s in s_list:
                     if b * s > 1024 * 4096 * 2 * 2 * 2:
                         continue
-                    cases.append([s, b, num_heads, kv_dtype, compute_dtype, gemm_type, base_fname])
+                    cases.append([s, b, num_heads, kv_dtype, compute_dtype, gemm_type])
     return cases
 
 
@@ -214,14 +213,14 @@ def _build_module_test_cases(attn_type: str, mode: str):
 
     Output test case format is positional args for run_mla_module_worker:
     [seq_len, batch_size, num_heads, kv_cache_dtype, compute_dtype, gemm_type,
-     perf_filename, model_path, attn_type]
+     model_path, attn_type]
     """
     base_cases = get_context_test_cases(attn_type) if mode == "context" else get_generation_test_cases(attn_type)
     model_paths = [m for m, t in SUPPORTED_MODELS.items() if t == attn_type]
     cases = []
     for model_path in model_paths:
-        for s, b, h, kv_dtype, compute_dtype, gemm_type, fname in base_cases:
-            cases.append([s, b, h, kv_dtype, compute_dtype, gemm_type, fname, model_path, attn_type])
+        for s, b, h, kv_dtype, compute_dtype, gemm_type in base_cases:
+            cases.append([s, b, h, kv_dtype, compute_dtype, gemm_type, model_path, attn_type])
     return cases
 
 
@@ -720,9 +719,10 @@ def run_mla_module_worker(
     kv_cache_dtype: str,
     compute_dtype: str,
     gemm_type: str,
-    perf_filename: str,
     model_path: str,
     attn_type: str,
+    *,
+    perf_filename: str,
     device: str = "cuda:0",
 ):
     """Worker-compatible positional wrapper used by collector/collect.py."""
@@ -750,6 +750,17 @@ def _cleanup(kv_cache_manager):
 # ═══════════════════════════════════════════════════════════════════════
 # CLI
 # ═══════════════════════════════════════════════════════════════════════
+
+
+def _perf_file_for(attn_type: str, mode: str) -> str:
+    """Return the canonical PerfFile for (attn_type, mode)."""
+    _map = {
+        ("mla", "context"): PerfFile.MLA_CONTEXT_MODULE,
+        ("mla", "generation"): PerfFile.MLA_GENERATION_MODULE,
+        ("dsa", "context"): PerfFile.DSA_CONTEXT_MODULE,
+        ("dsa", "generation"): PerfFile.DSA_GENERATION_MODULE,
+    }
+    return _map[(attn_type, mode)]
 
 
 def main():
@@ -805,6 +816,8 @@ def main():
         print(f"Model: {model_path}  |  Attention: {attn_type.upper()}")
         print(f"{'=' * 60}")
 
+        perf_filename = _perf_file_for(attn_type, args.mode)
+
         if args.quick:
             b = args.batch_size or 4
             s = args.seq_len or 2048
@@ -812,7 +825,6 @@ def main():
             kv_dtype = args.kv_cache_dtype or "bfloat16"
             compute = args.compute_dtype or "bfloat16"
             gemm = args.gemm_type or "bfloat16"
-            fname = f"{attn_type}_{args.mode}_module_perf.txt"
             run_mla_module(
                 seq_len=s,
                 batch_size=b,
@@ -820,7 +832,7 @@ def main():
                 kv_cache_dtype=kv_dtype,
                 compute_dtype=compute,
                 gemm_type=gemm,
-                perf_filename=fname,
+                perf_filename=perf_filename,
                 model_path=model_path,
                 attn_type=attn_type,
                 device=args.device,
@@ -846,7 +858,7 @@ def main():
 
         print(f"Running {len(test_cases)} {args.mode} {attn_type.upper()} module test cases...")
 
-        for i, (s, b, h, kv_dtype, compute, gemm, fname) in enumerate(test_cases):
+        for i, (s, b, h, kv_dtype, compute, gemm) in enumerate(test_cases):
             print(f"[{i + 1}/{len(test_cases)}]", end="")
             try:
                 run_mla_module(
@@ -856,7 +868,7 @@ def main():
                     kv_cache_dtype=kv_dtype,
                     compute_dtype=compute,
                     gemm_type=gemm,
-                    perf_filename=fname,
+                    perf_filename=perf_filename,
                     model_path=model_path,
                     attn_type=attn_type,
                     device=args.device,

--- a/collector/trtllm/collect_mla_v1.py
+++ b/collector/trtllm/collect_mla_v1.py
@@ -51,7 +51,6 @@ def get_context_mla_test_cases():
                                 10,
                                 6,
                                 True,
-                                "context_mla_perf.txt",
                             ]
                         )
     return test_cases
@@ -102,7 +101,6 @@ def get_generation_mla_test_cases():
                                 10,
                                 6,
                                 False,
-                                "generation_mla_perf.txt",
                             ]
                         )
     return test_cases
@@ -120,6 +118,7 @@ def run_mla(
     warming_up,
     test_ite,
     is_context_phase,
+    *,
     perf_filename,
     device="cuda:0",
 ):

--- a/collector/trtllm/collect_mla_v2.py
+++ b/collector/trtllm/collect_mla_v2.py
@@ -64,7 +64,6 @@ def get_context_mla_test_cases():
                                 10,
                                 6,
                                 True,
-                                "context_mla_perf.txt",
                             ]
                         )
     return test_cases
@@ -114,7 +113,6 @@ def get_generation_mla_test_cases():
                                 10,
                                 6,
                                 False,
-                                "generation_mla_perf.txt",
                             ]
                         )
     return test_cases
@@ -187,8 +185,9 @@ def run_mla(
     warming_up,
     test_ite,
     is_context_phase,
+    *,
     perf_filename,
-    device,
+    device="cuda:0",
 ):
     scenario = Scenario()
     q_lora_rank = scenario.q_lora_rank

--- a/collector/trtllm/collect_moe_v1.py
+++ b/collector/trtllm/collect_moe_v1.py
@@ -77,7 +77,6 @@ def get_moe_test_cases():
                         common_moe_testcase.tp,
                         common_moe_testcase.ep,
                         min_latency_mode,
-                        "moe_perf.txt",
                     ]
                 )
 
@@ -94,6 +93,7 @@ def run_moe_torch(
     moe_tp_size,
     moe_ep_size,
     cutlass_min_latency_mode,
+    *,
     perf_filename,
     device="cuda:0",
 ):

--- a/collector/trtllm/collect_moe_v2.py
+++ b/collector/trtllm/collect_moe_v2.py
@@ -90,7 +90,6 @@ def get_moe_test_cases():
                         common_moe_testcase.ep,
                         min_latency_mode,
                         common_moe_testcase.model_name,
-                        "moe_perf.txt",
                         common_moe_testcase.token_expert_distribution,
                         common_moe_testcase.power_law_alpha,
                     ]
@@ -110,9 +109,10 @@ def run_moe_torch(
     moe_ep_size,
     min_latency_mode,
     model_name,
-    perf_filename,
     distributed="power_law",
     power_law_alpha=0.0,
+    *,
+    perf_filename,
     device="cuda:0",
 ):
     """Run MoE forward passes and log latency/power to perf file (trtllm < 1.1 collector)."""

--- a/collector/trtllm/collect_moe_v3.py
+++ b/collector/trtllm/collect_moe_v3.py
@@ -225,7 +225,6 @@ def get_moe_test_cases():
                         common_moe_testcase.ep,
                         min_latency_mode,
                         common_moe_testcase.model_name,
-                        "moe_perf.txt",
                         common_moe_testcase.token_expert_distribution,
                         common_moe_testcase.power_law_alpha,
                     ]
@@ -250,9 +249,10 @@ def run_moe_torch(
     moe_ep_size,
     min_latency_mode,
     model_name,
-    perf_filename,
     distributed="power_law",
     power_law_alpha=0.0,
+    *,
+    perf_filename,
     device="cuda:0",
 ):
     """Run MoE forward passes and log latency/power to perf file (trtllm >= 1.1 collector)."""
@@ -670,6 +670,8 @@ def run_moe_torch(
 
 
 if __name__ == "__main__":
+    from collector.registry_types import PerfFile
+
     test_cases = get_moe_test_cases()
     for test_case in test_cases:
-        run_moe_torch(*test_case)
+        run_moe_torch(*test_case, perf_filename=PerfFile.MOE)

--- a/collector/trtllm/collect_wideep_moe_compute.py
+++ b/collector/trtllm/collect_wideep_moe_compute.py
@@ -589,7 +589,6 @@ def get_wideep_moe_compute_all_test_cases():
                         ep_size,
                         False,  # min_latency_mode = False (no min_latency_mode)
                         common_moe_testcase.model_name,
-                        None,  # perf_filename - determined dynamically based on use_eplb
                         common_moe_testcase.token_expert_distribution,
                         common_moe_testcase.power_law_alpha,
                         use_eplb,
@@ -616,12 +615,13 @@ def run_wideep_moe_compute(
     moe_ep_size,
     min_latency_mode,
     model_name,
-    perf_filename,
     distributed="power_law",
     power_law_alpha=0.0,
     use_eplb=False,
     num_slots=None,
     accurate_wideep_simulation=True,
+    *,
+    perf_filename,
     device="cuda:0",
 ):
     """
@@ -1003,7 +1003,7 @@ def run_wideep_moe_compute(
             device_name=torch.cuda.get_device_name(device),
             op_name="wideep_moe" if not use_eplb else "wideep_moe_eplb",
             kernel_source=source,
-            perf_filename="wideep_moe_perf.txt",
+            perf_filename=perf_filename,
             power_stats=power_stats,
         )
 
@@ -1041,11 +1041,13 @@ def run_wideep_moe_compute(
 # Main Entry Point
 # =============================================================================
 if __name__ == "__main__":
+    from registry_types import PerfFile
+
     all_test_cases = get_wideep_moe_compute_all_test_cases()
 
     print(f"Running {len(all_test_cases)} WideEP MOE compute test configurations...")
 
     for i, test_case in enumerate(all_test_cases):
         print(f"\nProgress: {i + 1}/{len(all_test_cases)}")
-        print(f"  Config: moe_type={test_case[0]}, kernel={test_case[1]}, model={test_case[10]}, eplb={test_case[14]}")
-        run_wideep_moe_compute(*test_case)
+        print(f"  Config: moe_type={test_case[0]}, kernel={test_case[1]}, model={test_case[10]}, eplb={test_case[13]}")
+        run_wideep_moe_compute(*test_case, perf_filename=PerfFile.WIDEEP_MOE)

--- a/collector/trtllm/registry.py
+++ b/collector/trtllm/registry.py
@@ -16,7 +16,7 @@ To add support for a new framework version:
   add a new VersionRoute at the top of the versions tuple.
 """
 
-from collector.registry_types import OpEntry, VersionRoute
+from collector.registry_types import OpEntry, PerfFile, VersionRoute
 
 REGISTRY: list[OpEntry] = [
     OpEntry(
@@ -24,17 +24,20 @@ REGISTRY: list[OpEntry] = [
         module="collector.trtllm.collect_gemm",
         get_func="get_gemm_test_cases",
         run_func="run_gemm",
+        perf_filename=PerfFile.GEMM,
     ),
     OpEntry(
         op="compute_scale",
         module="collector.trtllm.collect_computescale",
         get_func="get_computescale_test_cases",
         run_func="run_computescale",
+        perf_filename=PerfFile.COMPUTESCALE,
     ),
     OpEntry(
         op="mla_context",
         get_func="get_context_mla_test_cases",
         run_func="run_mla",
+        perf_filename=PerfFile.CONTEXT_MLA,
         versions=(
             VersionRoute("1.1.0", "collector.trtllm.collect_mla_v2"),
             VersionRoute("0.0.0", "collector.trtllm.collect_mla_v1"),
@@ -44,6 +47,7 @@ REGISTRY: list[OpEntry] = [
         op="mla_generation",
         get_func="get_generation_mla_test_cases",
         run_func="run_mla",
+        perf_filename=PerfFile.GENERATION_MLA,
         versions=(
             VersionRoute("1.1.0", "collector.trtllm.collect_mla_v2"),
             VersionRoute("0.0.0", "collector.trtllm.collect_mla_v1"),
@@ -54,29 +58,34 @@ REGISTRY: list[OpEntry] = [
         module="collector.trtllm.collect_attn",
         get_func="get_context_attention_test_cases",
         run_func="run_attention_torch",
+        perf_filename=PerfFile.CONTEXT_ATTENTION,
     ),
     OpEntry(
         op="attention_generation",
         module="collector.trtllm.collect_attn",
         get_func="get_generation_attention_test_cases",
         run_func="run_attention_torch",
+        perf_filename=PerfFile.GENERATION_ATTENTION,
     ),
     OpEntry(
         op="mla_bmm_gen_pre",
         module="collector.trtllm.collect_mla_bmm",
         get_func="get_mla_gen_pre_test_cases",
         run_func="run_mla_gen_pre",
+        perf_filename=PerfFile.MLA_BMM,
     ),
     OpEntry(
         op="mla_bmm_gen_post",
         module="collector.trtllm.collect_mla_bmm",
         get_func="get_mla_gen_post_test_cases",
         run_func="run_mla_gen_post",
+        perf_filename=PerfFile.MLA_BMM,
     ),
     OpEntry(
         op="moe",
         get_func="get_moe_test_cases",
         run_func="run_moe_torch",
+        perf_filename=PerfFile.MOE,
         versions=(
             VersionRoute("1.1.0", "collector.trtllm.collect_moe_v3"),
             VersionRoute("0.21.0", "collector.trtllm.collect_moe_v2"),
@@ -88,41 +97,48 @@ REGISTRY: list[OpEntry] = [
         module="collector.trtllm.collect_wideep_moe_compute",
         get_func="get_wideep_moe_compute_all_test_cases",
         run_func="run_wideep_moe_compute",
+        perf_filename=PerfFile.WIDEEP_MOE,
     ),
     OpEntry(
         op="mamba2",
         module="collector.trtllm.collect_mamba2",
         get_func="get_mamba2_test_cases",
         run_func="run_mamba2_torch",
+        perf_filename=PerfFile.MAMBA2,
     ),
     OpEntry(
         op="gdn",
         module="collector.trtllm.collect_gdn",
         get_func="get_gdn_test_cases",
         run_func="run_gdn_torch",
+        perf_filename=PerfFile.GDN,
     ),
     OpEntry(
         op="mla_context_module",
         module="collector.trtllm.collect_mla_module",
         get_func="get_mla_context_module_test_cases",
         run_func="run_mla_module_worker",
+        perf_filename=PerfFile.MLA_CONTEXT_MODULE,
     ),
     OpEntry(
         op="mla_generation_module",
         module="collector.trtllm.collect_mla_module",
         get_func="get_mla_generation_module_test_cases",
         run_func="run_mla_module_worker",
+        perf_filename=PerfFile.MLA_GENERATION_MODULE,
     ),
     OpEntry(
         op="dsa_context_module",
         module="collector.trtllm.collect_mla_module",
         get_func="get_dsa_context_module_test_cases",
         run_func="run_mla_module_worker",
+        perf_filename=PerfFile.DSA_CONTEXT_MODULE,
     ),
     OpEntry(
         op="dsa_generation_module",
         module="collector.trtllm.collect_mla_module",
         get_func="get_dsa_generation_module_test_cases",
         run_func="run_mla_module_worker",
+        perf_filename=PerfFile.DSA_GENERATION_MODULE,
     ),
 ]

--- a/collector/version_resolver.py
+++ b/collector/version_resolver.py
@@ -161,6 +161,7 @@ def build_collections(
                 "module": module,
                 "get_func": entry.get_func,
                 "run_func": entry.run_func,
+                "perf_filename": entry.perf_filename,
             }
         )
 

--- a/collector/vllm/collect_attn.py
+++ b/collector/vllm/collect_attn.py
@@ -75,6 +75,7 @@ def run_attention_torch(
     head_dim,
     use_fp8_kv_cache,
     is_context_phase,
+    *,
     perf_filename,
     device="cuda:0",
 ):
@@ -444,7 +445,6 @@ def get_context_attention_test_cases(if_unit_test=False):
                                 128,
                                 is_fp8_kv_cache,
                                 True,
-                                "context_attention_perf.txt",
                             ]
                         )
 
@@ -526,21 +526,22 @@ def get_generation_attention_test_cases():
                                 128,
                                 is_fp8_kv_cache,
                                 False,
-                                "generation_attention_perf.txt",
                             ]
                         )
     return test_cases
 
 
 if __name__ == "__main__":
+    from collector.registry_types import PerfFile
+
     test_cases = get_context_attention_test_cases()
     test_cases = test_cases[:10]
     for test_case in test_cases:
         print(f"Running context attention test case: {test_case}")
-        run_attention_torch(*test_case)
+        run_attention_torch(*test_case, perf_filename=PerfFile.CONTEXT_ATTENTION)
 
     test_cases = get_generation_attention_test_cases()
     test_cases = test_cases[:10]
     for test_case in test_cases:
         print(f"Running generation attention test case: {test_case}")
-        run_attention_torch(*test_case)
+        run_attention_torch(*test_case, perf_filename=PerfFile.GENERATION_ATTENTION)

--- a/collector/vllm/collect_attn_xpu.py
+++ b/collector/vllm/collect_attn_xpu.py
@@ -75,8 +75,9 @@ def run_attention_torch(
     head_dim,
     use_fp8_kv_cache,
     is_context_phase,
-    perf_filename,
     window_size=0,
+    *,
+    perf_filename,
     device="xpu:0",
 ):
     get_device_module().set_device(device)
@@ -473,7 +474,6 @@ def get_context_attention_test_cases(if_unit_test=False):
                                         head_dim,
                                         is_fp8_kv_cache,
                                         True,
-                                        "context_attention_perf.txt",
                                         window_size,
                                     ]
                                 )
@@ -560,7 +560,6 @@ def get_generation_attention_test_cases():
                                         head_dim,
                                         is_fp8_kv_cache,
                                         False,
-                                        "generation_attention_perf.txt",
                                         window_size,
                                     ]
                                 )
@@ -568,14 +567,16 @@ def get_generation_attention_test_cases():
 
 
 if __name__ == "__main__":
+    from collector.registry_types import PerfFile
+
     test_cases = get_context_attention_test_cases()
     test_cases = test_cases[:10]
     for test_case in test_cases:
         print(f"Running context attention test case: {test_case}")
-        run_attention_torch(*test_case)
+        run_attention_torch(*test_case, perf_filename=PerfFile.CONTEXT_ATTENTION)
 
     test_cases = get_generation_attention_test_cases()
     test_cases = test_cases[:10]
     for test_case in test_cases:
         print(f"Running generation attention test case: {test_case}")
-        run_attention_torch(*test_case)
+        run_attention_torch(*test_case, perf_filename=PerfFile.GENERATION_ATTENTION)

--- a/collector/vllm/collect_gdn.py
+++ b/collector/vllm/collect_gdn.py
@@ -97,7 +97,6 @@ def get_gdn_test_cases():
                     common_case.batch_size_list,
                     common_case.seq_len_list,
                     common_case.model_name,
-                    "gdn_perf.txt",
                 ]
             )
         else:
@@ -113,7 +112,6 @@ def get_gdn_test_cases():
                     common_case.batch_size_list,
                     None,  # seq_len_list not used for generation
                     common_case.model_name,
-                    "gdn_perf.txt",
                 ]
             )
 
@@ -714,6 +712,7 @@ def run_gdn_torch(
     batch_size_list: list[int],
     seq_len_list: list[int] | None,
     model_name: str,
+    *,
     perf_filename: str,
     device: str = "cuda:0",
 ):
@@ -799,6 +798,8 @@ if __name__ == "__main__":
 
     from vllm.version import __version__ as vllm_version
 
+    from collector.registry_types import PerfFile
+
     print(f"GDN Collector - vLLM {vllm_version}")
     print(f"SM Version: {get_sm_version()}")
     print(f"Device: {torch.cuda.get_device_name()}")
@@ -820,7 +821,6 @@ if __name__ == "__main__":
             batch_size_list,
             seq_len_list,
             model_name,
-            perf_filename,
         ) = test_case
 
         print(f"\n[{i + 1}/{len(test_cases)}] {model_name} - {phase}")
@@ -846,7 +846,7 @@ if __name__ == "__main__":
             batch_size_list=batch_size_list,
             seq_len_list=seq_len_list,
             model_name=model_name,
-            perf_filename=perf_filename,
+            perf_filename=PerfFile.GDN,
         )
 
     sys.exit(last_exit_code)

--- a/collector/vllm/collect_gemm.py
+++ b/collector/vllm/collect_gemm.py
@@ -77,13 +77,13 @@ def get_gemm_test_cases():
                 if sm >= 100 and (x % 4) != 0:
                     continue
 
-            test_cases.append([gemm_type, x, n, k, "gemm_perf.txt"])
+            test_cases.append([gemm_type, x, n, k])
 
     return test_cases
 
 
 @with_exit_stack
-def run_gemm(exit_stack, gemm_type, m, n, k, perf_filename, device="cuda:0"):
+def run_gemm(exit_stack, gemm_type, m, n, k, *, perf_filename, device="cuda:0"):
     # Force DeepGEMM path when available to capture the intended kernel.
     os.environ["VLLM_USE_DEEP_GEMM"] = "1"
 
@@ -237,6 +237,8 @@ def run_gemm(exit_stack, gemm_type, m, n, k, perf_filename, device="cuda:0"):
 
 
 if __name__ == "__main__":
+    from collector.registry_types import PerfFile
+
     test_cases = get_gemm_test_cases()
     for test_case in test_cases[:10]:
-        run_gemm(*test_case)
+        run_gemm(*test_case, perf_filename=PerfFile.GEMM)

--- a/collector/vllm/collect_gemm_xpu.py
+++ b/collector/vllm/collect_gemm_xpu.py
@@ -96,13 +96,13 @@ def get_gemm_test_cases():
         n = gemm_common_testcase.n
         k = gemm_common_testcase.k
         for gemm_type in gemm_list:
-            test_cases.append([gemm_type, x, n, k, "gemm_perf.txt"])
+            test_cases.append([gemm_type, x, n, k])
 
     return test_cases
 
 
 @with_exit_stack
-def run_gemm(exit_stack, gemm_type, m, n, k, perf_filename, device="xpu:0"):
+def run_gemm(exit_stack, gemm_type, m, n, k, *, perf_filename, device="xpu:0"):
     # Force DeepGEMM path when available to capture the intended kernel.
     os.environ["VLLM_USE_DEEP_GEMM"] = "1"
 
@@ -227,6 +227,8 @@ def run_gemm(exit_stack, gemm_type, m, n, k, perf_filename, device="xpu:0"):
 
 
 if __name__ == "__main__":
+    from collector.registry_types import PerfFile
+
     test_cases = get_gemm_test_cases()
     for test_case in test_cases[:10]:
-        run_gemm(*test_case)
+        run_gemm(*test_case, perf_filename=PerfFile.GEMM)

--- a/collector/vllm/collect_mla_module_v1.py
+++ b/collector/vllm/collect_mla_module_v1.py
@@ -57,6 +57,7 @@ from vllm.transformers_utils.config import _CONFIG_REGISTRY
 from vllm.version import __version__ as vllm_version
 
 from collector.helper import benchmark_with_power, get_sm_version, log_perf
+from collector.registry_types import PerfFile
 from collector.vllm.utils import (
     BatchSpec,
     create_and_prepopulate_kv_cache_mla,
@@ -163,19 +164,18 @@ def get_context_test_cases(attn_type: str):
     """Context-phase test cases.
 
     Returns list of [seq_len, batch_size, num_heads, kv_cache_dtype,
-                     compute_dtype, gemm_type, perf_filename].
+                     compute_dtype, gemm_type].
     """
     cases = []
     b_list = [1, 2, 4, 8, 16, 32, 64, 128, 256]
     s_list = [1, 16, 32, 64, 128, 256, 512, 1024, 1536, 2048, 3072, 4096, 6144, 8192, 10240, 12288, 16384, 32768]
-    base_fname = f"{attn_type}_context_module_perf.txt"
     for compute_dtype, kv_dtype, gemm_type in _get_precision_combos("context"):
         for num_heads in [128, 64, 32, 16, 8, 4, 2, 1]:
             for b in b_list:
                 for s in s_list:
                     if b * s > 131072:
                         continue
-                    cases.append([s, b, num_heads, kv_dtype, compute_dtype, gemm_type, base_fname])
+                    cases.append([s, b, num_heads, kv_dtype, compute_dtype, gemm_type])
     return cases
 
 
@@ -183,19 +183,18 @@ def get_generation_test_cases(attn_type: str):
     """Generation-phase test cases.
 
     Returns list of [kv_cache_len, batch_size, num_heads, kv_cache_dtype,
-                     compute_dtype, gemm_type, perf_filename].
+                     compute_dtype, gemm_type].
     """
     cases = []
     b_list = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024]
     s_list = [2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072]
-    base_fname = f"{attn_type}_generation_module_perf.txt"
     for compute_dtype, kv_dtype, gemm_type in _get_precision_combos("generation"):
         for num_heads in [128, 64, 32, 16, 8, 4, 2, 1]:
             for b in b_list:
                 for s in s_list:
                     if b * s > 1024 * 4096 * 2 * 2 * 2:
                         continue
-                    cases.append([s, b, num_heads, kv_dtype, compute_dtype, gemm_type, base_fname])
+                    cases.append([s, b, num_heads, kv_dtype, compute_dtype, gemm_type])
     return cases
 
 
@@ -203,14 +202,14 @@ def _build_module_test_cases(attn_type: str, mode: str):
     """Build module-level test cases for a specific attention type and phase.
 
     Output format: [seq_len, batch_size, num_heads, kv_cache_dtype,
-                    compute_dtype, gemm_type, perf_filename, model_path, attn_type]
+                    compute_dtype, gemm_type, model_path, attn_type]
     """
     base_cases = get_context_test_cases(attn_type) if mode == "context" else get_generation_test_cases(attn_type)
     model_paths = [m for m, t in SUPPORTED_MODELS.items() if t == attn_type]
     cases = []
     for model_path in model_paths:
-        for s, b, h, kv_dtype, compute_dtype, gemm_type, fname in base_cases:
-            cases.append([s, b, h, kv_dtype, compute_dtype, gemm_type, fname, model_path, attn_type])
+        for s, b, h, kv_dtype, compute_dtype, gemm_type in base_cases:
+            cases.append([s, b, h, kv_dtype, compute_dtype, gemm_type, model_path, attn_type])
     return cases
 
 
@@ -865,9 +864,10 @@ def run_mla_module_worker(
     kv_cache_dtype: str,
     compute_dtype: str,
     gemm_type: str,
-    perf_filename: str,
     model_path: str,
     attn_type: str,
+    *,
+    perf_filename: str,
     device: str = "cuda:0",
 ):
     """Worker-compatible positional wrapper used by collector/collect.py."""
@@ -955,7 +955,15 @@ def main():
             kv_dtype = args.kv_cache_dtype or "bfloat16"
             compute = args.compute_dtype or "bfloat16"
             gemm = args.gemm_type or "bfloat16"
-            fname = f"{attn_type}_{args.mode}_module_perf.txt"
+            perf_filename = (
+                PerfFile.MLA_CONTEXT_MODULE
+                if attn_type == "mla" and args.mode == "context"
+                else PerfFile.MLA_GENERATION_MODULE
+                if attn_type == "mla"
+                else PerfFile.DSA_CONTEXT_MODULE
+                if args.mode == "context"
+                else PerfFile.DSA_GENERATION_MODULE
+            )
             run_mla_module(
                 seq_len=s,
                 batch_size=b,
@@ -963,7 +971,7 @@ def main():
                 kv_cache_dtype=kv_dtype,
                 compute_dtype=compute,
                 gemm_type=gemm,
-                perf_filename=fname,
+                perf_filename=perf_filename,
                 model_path=model_path,
                 attn_type=attn_type,
                 device=args.device,
@@ -972,8 +980,10 @@ def main():
 
         if args.mode == "context":
             test_cases = get_context_test_cases(attn_type=attn_type)
+            perf_filename = PerfFile.MLA_CONTEXT_MODULE if attn_type == "mla" else PerfFile.DSA_CONTEXT_MODULE
         else:
             test_cases = get_generation_test_cases(attn_type=attn_type)
+            perf_filename = PerfFile.MLA_GENERATION_MODULE if attn_type == "mla" else PerfFile.DSA_GENERATION_MODULE
 
         if args.num_heads is not None:
             test_cases = [tc for tc in test_cases if tc[2] == args.num_heads]
@@ -989,7 +999,7 @@ def main():
 
         print(f"Running {len(test_cases)} {args.mode} {attn_type.upper()} module test cases...")
 
-        for i, (s, b, h, kv_dtype, compute, gemm, fname) in enumerate(test_cases):
+        for i, (s, b, h, kv_dtype, compute, gemm) in enumerate(test_cases):
             print(f"[{i + 1}/{len(test_cases)}]", end="")
             try:
                 run_mla_module(
@@ -999,7 +1009,7 @@ def main():
                     kv_cache_dtype=kv_dtype,
                     compute_dtype=compute,
                     gemm_type=gemm,
-                    perf_filename=fname,
+                    perf_filename=perf_filename,
                     model_path=model_path,
                     attn_type=attn_type,
                     device=args.device,

--- a/collector/vllm/collect_mla_module_v2.py
+++ b/collector/vllm/collect_mla_module_v2.py
@@ -58,6 +58,7 @@ from vllm.transformers_utils.config import _CONFIG_REGISTRY
 from vllm.version import __version__ as vllm_version
 
 from collector.helper import benchmark_with_power, get_sm_version, log_perf
+from collector.registry_types import PerfFile
 from collector.vllm.utils import (
     BatchSpec,
     create_and_prepopulate_kv_cache_mla,
@@ -179,19 +180,18 @@ def get_context_test_cases(attn_type: str):
     """Context-phase test cases.
 
     Returns list of [seq_len, batch_size, num_heads, kv_cache_dtype,
-                     compute_dtype, gemm_type, perf_filename].
+                     compute_dtype, gemm_type].
     """
     cases = []
     b_list = [1, 2, 4, 8, 16, 32, 64, 128, 256]
     s_list = [1, 16, 32, 64, 128, 256, 512, 1024, 1536, 2048, 3072, 4096, 6144, 8192, 10240, 12288, 16384, 32768]
-    base_fname = f"{attn_type}_context_module_perf.txt"
     for compute_dtype, kv_dtype, gemm_type in _get_precision_combos("context"):
         for num_heads in [128, 64, 32, 16, 8, 4, 2, 1]:
             for b in b_list:
                 for s in s_list:
                     if b * s > 131072:
                         continue
-                    cases.append([s, b, num_heads, kv_dtype, compute_dtype, gemm_type, base_fname])
+                    cases.append([s, b, num_heads, kv_dtype, compute_dtype, gemm_type])
     return cases
 
 
@@ -199,19 +199,18 @@ def get_generation_test_cases(attn_type: str):
     """Generation-phase test cases.
 
     Returns list of [kv_cache_len, batch_size, num_heads, kv_cache_dtype,
-                     compute_dtype, gemm_type, perf_filename].
+                     compute_dtype, gemm_type].
     """
     cases = []
     b_list = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024]
     s_list = [2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072]
-    base_fname = f"{attn_type}_generation_module_perf.txt"
     for compute_dtype, kv_dtype, gemm_type in _get_precision_combos("generation"):
         for num_heads in [128, 64, 32, 16, 8, 4, 2, 1]:
             for b in b_list:
                 for s in s_list:
                     if b * s > 1024 * 4096 * 2 * 2 * 2:
                         continue
-                    cases.append([s, b, num_heads, kv_dtype, compute_dtype, gemm_type, base_fname])
+                    cases.append([s, b, num_heads, kv_dtype, compute_dtype, gemm_type])
     return cases
 
 
@@ -219,14 +218,14 @@ def _build_module_test_cases(attn_type: str, mode: str):
     """Build module-level test cases for a specific attention type and phase.
 
     Output format: [seq_len, batch_size, num_heads, kv_cache_dtype,
-                    compute_dtype, gemm_type, perf_filename, model_path, attn_type]
+                    compute_dtype, gemm_type, model_path, attn_type]
     """
     base_cases = get_context_test_cases(attn_type) if mode == "context" else get_generation_test_cases(attn_type)
     model_paths = [m for m, t in SUPPORTED_MODELS.items() if t == attn_type]
     cases = []
     for model_path in model_paths:
-        for s, b, h, kv_dtype, compute_dtype, gemm_type, fname in base_cases:
-            cases.append([s, b, h, kv_dtype, compute_dtype, gemm_type, fname, model_path, attn_type])
+        for s, b, h, kv_dtype, compute_dtype, gemm_type in base_cases:
+            cases.append([s, b, h, kv_dtype, compute_dtype, gemm_type, model_path, attn_type])
     return cases
 
 
@@ -890,9 +889,10 @@ def run_mla_module_worker(
     kv_cache_dtype: str,
     compute_dtype: str,
     gemm_type: str,
-    perf_filename: str,
     model_path: str,
     attn_type: str,
+    *,
+    perf_filename: str,
     device: str = "cuda:0",
 ):
     """Worker-compatible positional wrapper used by collector/collect.py."""
@@ -980,7 +980,15 @@ def main():
             kv_dtype = args.kv_cache_dtype or "bfloat16"
             compute = args.compute_dtype or "bfloat16"
             gemm = args.gemm_type or "bfloat16"
-            fname = f"{attn_type}_{args.mode}_module_perf.txt"
+            perf_filename = (
+                PerfFile.MLA_CONTEXT_MODULE
+                if attn_type == "mla" and args.mode == "context"
+                else PerfFile.MLA_GENERATION_MODULE
+                if attn_type == "mla"
+                else PerfFile.DSA_CONTEXT_MODULE
+                if args.mode == "context"
+                else PerfFile.DSA_GENERATION_MODULE
+            )
             run_mla_module(
                 seq_len=s,
                 batch_size=b,
@@ -988,7 +996,7 @@ def main():
                 kv_cache_dtype=kv_dtype,
                 compute_dtype=compute,
                 gemm_type=gemm,
-                perf_filename=fname,
+                perf_filename=perf_filename,
                 model_path=model_path,
                 attn_type=attn_type,
                 device=args.device,
@@ -997,8 +1005,10 @@ def main():
 
         if args.mode == "context":
             test_cases = get_context_test_cases(attn_type=attn_type)
+            perf_filename = PerfFile.MLA_CONTEXT_MODULE if attn_type == "mla" else PerfFile.DSA_CONTEXT_MODULE
         else:
             test_cases = get_generation_test_cases(attn_type=attn_type)
+            perf_filename = PerfFile.MLA_GENERATION_MODULE if attn_type == "mla" else PerfFile.DSA_GENERATION_MODULE
 
         if args.num_heads is not None:
             test_cases = [tc for tc in test_cases if tc[2] == args.num_heads]
@@ -1014,7 +1024,7 @@ def main():
 
         print(f"Running {len(test_cases)} {args.mode} {attn_type.upper()} module test cases...")
 
-        for i, (s, b, h, kv_dtype, compute, gemm, fname) in enumerate(test_cases):
+        for i, (s, b, h, kv_dtype, compute, gemm) in enumerate(test_cases):
             print(f"[{i + 1}/{len(test_cases)}]", end="")
             try:
                 run_mla_module(
@@ -1024,7 +1034,7 @@ def main():
                     kv_cache_dtype=kv_dtype,
                     compute_dtype=compute,
                     gemm_type=gemm,
-                    perf_filename=fname,
+                    perf_filename=perf_filename,
                     model_path=model_path,
                     attn_type=attn_type,
                     device=args.device,

--- a/collector/vllm/collect_mla_module_v3.py
+++ b/collector/vllm/collect_mla_module_v3.py
@@ -179,19 +179,18 @@ def get_context_test_cases(attn_type: str):
     """Context-phase test cases.
 
     Returns list of [seq_len, batch_size, num_heads, kv_cache_dtype,
-                     compute_dtype, gemm_type, perf_filename].
+                     compute_dtype, gemm_type].
     """
     cases = []
     b_list = [1, 2, 4, 8, 16, 32, 64, 128, 256]
     s_list = [1, 16, 32, 64, 128, 256, 512, 1024, 1536, 2048, 3072, 4096, 6144, 8192, 10240, 12288, 16384, 32768]
-    base_fname = f"{attn_type}_context_module_perf.txt"
     for compute_dtype, kv_dtype, gemm_type in _get_precision_combos("context"):
         for num_heads in [128, 64, 32, 16, 8, 4, 2, 1]:
             for b in b_list:
                 for s in s_list:
                     if b * s > 131072:
                         continue
-                    cases.append([s, b, num_heads, kv_dtype, compute_dtype, gemm_type, base_fname])
+                    cases.append([s, b, num_heads, kv_dtype, compute_dtype, gemm_type])
     return cases
 
 
@@ -199,19 +198,18 @@ def get_generation_test_cases(attn_type: str):
     """Generation-phase test cases.
 
     Returns list of [kv_cache_len, batch_size, num_heads, kv_cache_dtype,
-                     compute_dtype, gemm_type, perf_filename].
+                     compute_dtype, gemm_type].
     """
     cases = []
     b_list = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024]
     s_list = [2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072]
-    base_fname = f"{attn_type}_generation_module_perf.txt"
     for compute_dtype, kv_dtype, gemm_type in _get_precision_combos("generation"):
         for num_heads in [128, 64, 32, 16, 8, 4, 2, 1]:
             for b in b_list:
                 for s in s_list:
                     if b * s > 1024 * 4096 * 2 * 2 * 2:
                         continue
-                    cases.append([s, b, num_heads, kv_dtype, compute_dtype, gemm_type, base_fname])
+                    cases.append([s, b, num_heads, kv_dtype, compute_dtype, gemm_type])
     return cases
 
 
@@ -219,14 +217,14 @@ def _build_module_test_cases(attn_type: str, mode: str):
     """Build module-level test cases for a specific attention type and phase.
 
     Output format: [seq_len, batch_size, num_heads, kv_cache_dtype,
-                    compute_dtype, gemm_type, perf_filename, model_path, attn_type]
+                    compute_dtype, gemm_type, model_path, attn_type]
     """
     base_cases = get_context_test_cases(attn_type) if mode == "context" else get_generation_test_cases(attn_type)
     model_paths = [m for m, t in SUPPORTED_MODELS.items() if t == attn_type]
     cases = []
     for model_path in model_paths:
-        for s, b, h, kv_dtype, compute_dtype, gemm_type, fname in base_cases:
-            cases.append([s, b, h, kv_dtype, compute_dtype, gemm_type, fname, model_path, attn_type])
+        for s, b, h, kv_dtype, compute_dtype, gemm_type in base_cases:
+            cases.append([s, b, h, kv_dtype, compute_dtype, gemm_type, model_path, attn_type])
     return cases
 
 
@@ -931,9 +929,10 @@ def run_mla_module_worker(
     kv_cache_dtype: str,
     compute_dtype: str,
     gemm_type: str,
-    perf_filename: str,
     model_path: str,
     attn_type: str,
+    *,
+    perf_filename: str,
     device: str = "cuda:0",
 ):
     """Worker-compatible positional wrapper used by collector/collect.py."""
@@ -1071,7 +1070,8 @@ def main():
 
         print(f"Running {len(test_cases)} {args.mode} {attn_type.upper()} module test cases...")
 
-        for i, (s, b, h, kv_dtype, compute, gemm, fname) in enumerate(test_cases):
+        fname = f"{attn_type}_{args.mode}_module_perf.txt"
+        for i, (s, b, h, kv_dtype, compute, gemm) in enumerate(test_cases):
             print(f"[{i + 1}/{len(test_cases)}]", end="")
             try:
                 run_mla_module(

--- a/collector/vllm/collect_mla_module_v3.py
+++ b/collector/vllm/collect_mla_module_v3.py
@@ -58,6 +58,7 @@ from vllm.transformers_utils.config import _CONFIG_REGISTRY
 from vllm.version import __version__ as vllm_version
 
 from collector.helper import benchmark_with_power, get_sm_version, log_perf
+from collector.registry_types import PerfFile
 from collector.vllm.utils import (
     BatchSpec,
     create_and_prepopulate_kv_cache_mla,
@@ -1029,6 +1030,11 @@ def main():
         print(f"Model: {model_path}  |  Attention: {attn_type.upper()}")
         print(f"{'=' * 60}")
 
+        if args.mode == "context":
+            perf_filename = PerfFile.MLA_CONTEXT_MODULE if attn_type == "mla" else PerfFile.DSA_CONTEXT_MODULE
+        else:
+            perf_filename = PerfFile.MLA_GENERATION_MODULE if attn_type == "mla" else PerfFile.DSA_GENERATION_MODULE
+
         if args.quick:
             b = args.batch_size or 4
             s = args.seq_len or 2048
@@ -1036,7 +1042,6 @@ def main():
             kv_dtype = args.kv_cache_dtype or "bfloat16"
             compute = args.compute_dtype or "bfloat16"
             gemm = args.gemm_type or "bfloat16"
-            fname = f"{attn_type}_{args.mode}_module_perf.txt"
             run_mla_module(
                 seq_len=s,
                 batch_size=b,
@@ -1044,7 +1049,7 @@ def main():
                 kv_cache_dtype=kv_dtype,
                 compute_dtype=compute,
                 gemm_type=gemm,
-                perf_filename=fname,
+                perf_filename=perf_filename,
                 model_path=model_path,
                 attn_type=attn_type,
                 device=args.device,
@@ -1069,8 +1074,6 @@ def main():
             test_cases = [tc for tc in test_cases if tc[5] == args.gemm_type]
 
         print(f"Running {len(test_cases)} {args.mode} {attn_type.upper()} module test cases...")
-
-        fname = f"{attn_type}_{args.mode}_module_perf.txt"
         for i, (s, b, h, kv_dtype, compute, gemm) in enumerate(test_cases):
             print(f"[{i + 1}/{len(test_cases)}]", end="")
             try:
@@ -1081,7 +1084,7 @@ def main():
                     kv_cache_dtype=kv_dtype,
                     compute_dtype=compute,
                     gemm_type=gemm,
-                    perf_filename=fname,
+                    perf_filename=perf_filename,
                     model_path=model_path,
                     attn_type=attn_type,
                     device=args.device,

--- a/collector/vllm/collect_moe_v1.py
+++ b/collector/vllm/collect_moe_v1.py
@@ -186,7 +186,6 @@ def get_moe_test_cases():
                     common_moe_testcase.tp,
                     common_moe_testcase.ep,
                     common_moe_testcase.model_name,
-                    "moe_perf.txt",
                     common_moe_testcase.token_expert_distribution,
                     common_moe_testcase.power_law_alpha,
                 ]
@@ -205,9 +204,10 @@ def run_moe_torch(
     moe_tp_size,
     moe_ep_size,
     model_name,
-    perf_filename,
     distributed="power_law",
     power_law_alpha=0.0,
+    *,
+    perf_filename,
     device="cuda:0",
 ):
     """Run vLLM MoE performance benchmarking"""
@@ -713,13 +713,15 @@ def run_moe_torch(
 
 
 if __name__ == "__main__":
+    from collector.registry_types import PerfFile
+
     test_cases = get_moe_test_cases()
     print(f"Total test cases: {len(test_cases)}")
 
     for test_case in test_cases[:4]:
         print(f"Running test case: {test_case}")
         try:
-            run_moe_torch(*test_case)
+            run_moe_torch(*test_case, perf_filename=PerfFile.MOE)
         except Exception as e:
             print(f"Test case failed: {test_case}")
             print(f"Error: {e}")

--- a/collector/vllm/collect_moe_v2.py
+++ b/collector/vllm/collect_moe_v2.py
@@ -163,7 +163,6 @@ def get_moe_test_cases():
                     common_moe_testcase.tp,
                     common_moe_testcase.ep,
                     common_moe_testcase.model_name,
-                    "moe_perf.txt",
                     common_moe_testcase.token_expert_distribution,
                     common_moe_testcase.power_law_alpha,
                 ]
@@ -182,9 +181,10 @@ def run_moe_torch(
     moe_tp_size,
     moe_ep_size,
     model_name,
-    perf_filename,
     distributed="power_law",
     power_law_alpha=0.0,
+    *,
+    perf_filename,
     device="cuda:0",
 ):
     """Run vLLM MoE performance benchmarking"""
@@ -648,13 +648,15 @@ def run_moe_torch(
 
 
 if __name__ == "__main__":
+    from collector.registry_types import PerfFile
+
     test_cases = get_moe_test_cases()
     print(f"Total test cases: {len(test_cases)}")
 
     for test_case in test_cases[:4]:
         print(f"Running test case: {test_case}")
         try:
-            run_moe_torch(*test_case)
+            run_moe_torch(*test_case, perf_filename=PerfFile.MOE)
         except Exception as e:
             print(f"Test case failed: {test_case}")
             print(f"Error: {e}")

--- a/collector/vllm/collect_moe_xpu.py
+++ b/collector/vllm/collect_moe_xpu.py
@@ -210,7 +210,6 @@ def get_moe_test_cases():
                     common_moe_testcase.tp,
                     common_moe_testcase.ep,
                     common_moe_testcase.model_name,
-                    "moe_perf.txt",
                     common_moe_testcase.token_expert_distribution,
                     common_moe_testcase.power_law_alpha,
                 ]
@@ -242,9 +241,10 @@ def run_moe_torch(
     moe_tp_size,
     moe_ep_size,
     model_name,
-    perf_filename,
     distributed="power_law",
     power_law_alpha=0.0,
+    *,
+    perf_filename,
     device="xpu:0",
 ):
     """Run vLLM MoE performance benchmarking"""
@@ -525,13 +525,15 @@ def create_mxfp4_weights_xpu(
 
 
 if __name__ == "__main__":
+    from collector.registry_types import PerfFile
+
     test_cases = get_moe_test_cases()
     print(f"Total test cases: {len(test_cases)}")
 
     for test_case in test_cases[:4]:
         print(f"Running test case: {test_case}")
         try:
-            run_moe_torch(*test_case)
+            run_moe_torch(*test_case, perf_filename=PerfFile.MOE)
         except Exception as e:
             print(f"Test case failed: {test_case}")
             print(f"Error: {e}")

--- a/collector/vllm/registry.py
+++ b/collector/vllm/registry.py
@@ -10,7 +10,7 @@ is <= the runtime version. To add support for a new vLLM version:
   add a new VersionRoute at the top of the versions tuple.
 """
 
-from collector.registry_types import OpEntry, VersionRoute
+from collector.registry_types import OpEntry, PerfFile, VersionRoute
 
 REGISTRY: list[OpEntry] = [
     OpEntry(
@@ -18,23 +18,27 @@ REGISTRY: list[OpEntry] = [
         module="collector.vllm.collect_gemm",
         get_func="get_gemm_test_cases",
         run_func="run_gemm",
+        perf_filename=PerfFile.GEMM,
     ),
     OpEntry(
         op="attention_context",
         module="collector.vllm.collect_attn",
         get_func="get_context_attention_test_cases",
         run_func="run_attention_torch",
+        perf_filename=PerfFile.CONTEXT_ATTENTION,
     ),
     OpEntry(
         op="attention_generation",
         module="collector.vllm.collect_attn",
         get_func="get_generation_attention_test_cases",
         run_func="run_attention_torch",
+        perf_filename=PerfFile.GENERATION_ATTENTION,
     ),
     OpEntry(
         op="moe",
         get_func="get_moe_test_cases",
         run_func="run_moe_torch",
+        perf_filename=PerfFile.MOE,
         versions=(
             VersionRoute("0.17.0", "collector.vllm.collect_moe_v2"),
             VersionRoute("0.0.0", "collector.vllm.collect_moe_v1"),
@@ -44,6 +48,7 @@ REGISTRY: list[OpEntry] = [
         op="mla_context_module",
         get_func="get_mla_context_module_test_cases",
         run_func="run_mla_module_worker",
+        perf_filename=PerfFile.MLA_CONTEXT_MODULE,
         versions=(
             VersionRoute("0.19.0", "collector.vllm.collect_mla_module_v3"),
             VersionRoute("0.17.0", "collector.vllm.collect_mla_module_v2"),
@@ -54,6 +59,7 @@ REGISTRY: list[OpEntry] = [
         op="mla_generation_module",
         get_func="get_mla_generation_module_test_cases",
         run_func="run_mla_module_worker",
+        perf_filename=PerfFile.MLA_GENERATION_MODULE,
         versions=(
             VersionRoute("0.19.0", "collector.vllm.collect_mla_module_v3"),
             VersionRoute("0.17.0", "collector.vllm.collect_mla_module_v2"),
@@ -64,6 +70,7 @@ REGISTRY: list[OpEntry] = [
         op="dsa_context_module",
         get_func="get_dsa_context_module_test_cases",
         run_func="run_mla_module_worker",
+        perf_filename=PerfFile.DSA_CONTEXT_MODULE,
         versions=(
             VersionRoute("0.19.0", "collector.vllm.collect_mla_module_v3"),
             VersionRoute("0.17.0", "collector.vllm.collect_mla_module_v2"),
@@ -74,6 +81,7 @@ REGISTRY: list[OpEntry] = [
         op="dsa_generation_module",
         get_func="get_dsa_generation_module_test_cases",
         run_func="run_mla_module_worker",
+        perf_filename=PerfFile.DSA_GENERATION_MODULE,
         versions=(
             VersionRoute("0.19.0", "collector.vllm.collect_mla_module_v3"),
             VersionRoute("0.17.0", "collector.vllm.collect_mla_module_v2"),
@@ -85,6 +93,7 @@ REGISTRY: list[OpEntry] = [
         module="collector.vllm.collect_gdn",
         get_func="get_gdn_test_cases",
         run_func="run_gdn_torch",
+        perf_filename=PerfFile.GDN,
     ),
 ]
 
@@ -94,23 +103,27 @@ REGISTRY_XPU: list[OpEntry] = [
         module="collector.vllm.collect_gemm_xpu",
         get_func="get_gemm_test_cases",
         run_func="run_gemm",
+        perf_filename=PerfFile.GEMM,
     ),
     OpEntry(
         op="attention_context",
         module="collector.vllm.collect_attn_xpu",
         get_func="get_context_attention_test_cases",
         run_func="run_attention_torch",
+        perf_filename=PerfFile.CONTEXT_ATTENTION,
     ),
     OpEntry(
         op="attention_generation",
         module="collector.vllm.collect_attn_xpu",
         get_func="get_generation_attention_test_cases",
         run_func="run_attention_torch",
+        perf_filename=PerfFile.GENERATION_ATTENTION,
     ),
     OpEntry(
         op="moe",
         module="collector.vllm.collect_moe_xpu",
         get_func="get_moe_test_cases",
         run_func="run_moe_torch",
+        perf_filename=PerfFile.MOE,
     ),
 ]

--- a/tests/unit/collector/test_version_resolver.py
+++ b/tests/unit/collector/test_version_resolver.py
@@ -11,7 +11,7 @@ from typing import ClassVar
 import pytest
 from packaging.version import Version
 
-from collector.registry_types import OpEntry, VersionRoute
+from collector.registry_types import OpEntry, PerfFile, VersionRoute
 from collector.version_resolver import (
     _check_compat,
     _normalize_version,
@@ -140,6 +140,7 @@ class TestResolveModule:
         op="moe",
         get_func="get_moe_test_cases",
         run_func="run_moe_torch",
+        perf_filename=PerfFile.MOE,
         versions=(
             VersionRoute("1.1.0", "collector.trtllm.collect_moe_v3"),
             VersionRoute("0.21.0", "collector.trtllm.collect_moe_v2"),
@@ -152,6 +153,7 @@ class TestResolveModule:
         module="collector.trtllm.collect_gemm",
         get_func="get_gemm_test_cases",
         run_func="run_gemm",
+        perf_filename=PerfFile.GEMM,
     )
 
     def test_unversioned_returns_module_directly(self):
@@ -199,11 +201,13 @@ class TestBuildCollections:
             module="collector.trtllm.collect_gemm",
             get_func="get_gemm_test_cases",
             run_func="run_gemm",
+            perf_filename=PerfFile.GEMM,
         ),
         OpEntry(
             op="moe",
             get_func="get_moe_test_cases",
             run_func="run_moe_torch",
+            perf_filename=PerfFile.MOE,
             versions=(
                 VersionRoute("1.1.0", "collector.trtllm.collect_moe_v3"),
                 VersionRoute("0.20.0", "collector.trtllm.collect_moe_v1"),
@@ -239,8 +243,12 @@ class TestBuildCollections:
     def test_output_dict_shape(self):
         colls = build_collections(self.SAMPLE_REGISTRY, "trtllm", "1.1.0", ops=["gemm"])
         c = colls[0]
-        assert set(c.keys()) == {"name", "type", "module", "get_func", "run_func"}
+        assert set(c.keys()) == {"name", "type", "module", "get_func", "run_func", "perf_filename"}
         assert c["name"] == "trtllm"
+
+    def test_perf_filename_propagated(self):
+        colls = build_collections(self.SAMPLE_REGISTRY, "trtllm", "1.1.0", ops=["gemm"])
+        assert colls[0]["perf_filename"] == PerfFile.GEMM
 
 
 # ---------------------------------------------------------------------------
@@ -252,7 +260,7 @@ class TestOpEntryValidation:
 
     def test_rejects_missing_module_and_versions(self):
         with pytest.raises(ValueError, match="must specify 'module' or 'versions'"):
-            OpEntry(op="bad", get_func="f", run_func="r")
+            OpEntry(op="bad", get_func="f", run_func="r", perf_filename="p.txt")
 
     def test_rejects_both_module_and_versions(self):
         with pytest.raises(ValueError, match="cannot specify both"):
@@ -260,23 +268,24 @@ class TestOpEntryValidation:
                 op="bad",
                 get_func="f",
                 run_func="r",
+                perf_filename="p.txt",
                 module="some.module",
                 versions=(VersionRoute("1.0.0", "other.module"),),
             )
 
     def test_accepts_module_only(self):
-        entry = OpEntry(op="ok", get_func="f", run_func="r", module="some.module")
+        entry = OpEntry(op="ok", get_func="f", run_func="r", perf_filename="p.txt", module="some.module")
         assert entry.module == "some.module"
         assert entry.versions == ()
 
     def test_accepts_versions_only(self):
         routes = (VersionRoute("1.0.0", "some.module"),)
-        entry = OpEntry(op="ok", get_func="f", run_func="r", versions=routes)
+        entry = OpEntry(op="ok", get_func="f", run_func="r", perf_filename="p.txt", versions=routes)
         assert entry.module is None
         assert entry.versions == routes
 
     def test_frozen(self):
-        entry = OpEntry(op="ok", get_func="f", run_func="r", module="m")
+        entry = OpEntry(op="ok", get_func="f", run_func="r", perf_filename="p.txt", module="m")
         with pytest.raises(AttributeError):
             entry.op = "changed"
 
@@ -313,6 +322,14 @@ class TestRegistryIntegrity:
         reg, backend = registry
         ops = [e.op for e in reg]
         assert len(ops) == len(set(ops)), f"{backend}: duplicate op names found"
+
+    def test_perf_filename_non_empty(self, registry):
+        reg, backend = registry
+        for entry in reg:
+            assert entry.perf_filename, f"{backend}/{entry.op}: perf_filename is empty"
+            assert entry.perf_filename.endswith("_perf.txt"), (
+                f"{backend}/{entry.op}: perf_filename {entry.perf_filename!r} does not follow *_perf.txt convention"
+            )
 
     # -----------------------------------------------------------------------
     # Module / function existence


### PR DESCRIPTION
Instead of hardcoding the perf filename in every collector script, factor it out into `registry_types.py`. Also, add the perf_filename to the `OpEntry` class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated performance output filename configuration into a centralized registry, enabling consistent naming across all benchmark operations and simplifying test case structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->