### PR TITLE
chore: optimize error reporting when query into a partially complete custom_allreduce perf table

### DIFF
--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -3713,7 +3713,15 @@ class PerfDatabase:
                 return PerformanceResult(get_empirical(), energy=0.0)
 
             exception_msg = error_msg + " Consider using HYBRID mode."
-            logger.exception(exception_msg)
+            # PerfDataNotAvailableError is a structured signal that callers (e.g.
+            # FallbackOp, Pareto search) are expected to handle. Log it without a
+            # stack trace so successful searches that merely skip a candidate do
+            # not spam internal tracebacks. Genuinely unexpected exceptions still
+            # get the full traceback via logger.exception.
+            if isinstance(e, PerfDataNotAvailableError):
+                logger.warning(exception_msg)
+            else:
+                logger.exception(exception_msg)
             # Modify the original exception message
             if e.args:
                 e.args = (str(e.args[0]) + " " + exception_msg,) + e.args[1:]
@@ -5006,9 +5014,23 @@ class PerfDatabase:
 
                 self._custom_allreduce_data.raise_if_not_loaded()
 
-                comm_dict = self._custom_allreduce_data[quant_mode][
-                    min(tp_size, self.system_spec["node"]["num_gpus_per_node"])
-                ]["AUTO"]  # use AUTO for allreduce strategy
+                # The loader returns a 4-deep defaultdict, so chained indexing silently
+                # synthesizes empty dicts for missing (quant_mode, tp_size, strategy)
+                # combinations. Validate explicitly so upstream callers see a structured
+                # PerfDataNotAvailableError instead of an internal AssertionError from
+                # _nearest_1d_point_helper when the CSV has no rows for this bucket.
+                effective_tp = min(tp_size, self.system_spec["node"]["num_gpus_per_node"])
+                by_tp = self._custom_allreduce_data.get(quant_mode, {})
+                strategy_dict = by_tp.get(effective_tp, {})
+                comm_dict = strategy_dict.get("AUTO", {})
+                if not comm_dict:
+                    raise PerfDataNotAvailableError(
+                        f"No custom_allreduce silicon data for quant_mode={quant_mode.value.name}, "
+                        f"tp_size={effective_tp} (requested tp_size={tp_size}). "
+                        f"Available tp_sizes for this quant_mode: {sorted(by_tp.keys())}. "
+                        "Consider using HYBRID mode, or supply custom_allreduce_perf.txt rows "
+                        "covering this tp_size."
+                    )
                 size_left, size_right = self._nearest_1d_point_helper(size, list(comm_dict.keys()), inner_only=False)
                 result = self._interp_1d([size_left, size_right], [comm_dict[size_left], comm_dict[size_right]], size)
 

--- a/tests/unit/sdk/database/test_custom_allreduce_empty_bucket.py
+++ b/tests/unit/sdk/database/test_custom_allreduce_empty_bucket.py
@@ -1,0 +1,184 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Regression tests for NVBUG-6095486.
+
+In SILICON mode, query_custom_allreduce must raise a structured
+PerfDataNotAvailableError when the loaded custom_allreduce data does not
+contain a bucket for the requested (quant_mode, tp_size, strategy) tuple.
+Previously it leaked an internal AssertionError from _nearest_1d_point_helper,
+which upper layers could not distinguish from real invariant failures.
+
+Additionally, _query_silicon_or_hybrid must not dump a full stack trace for
+this expected-but-unavailable case — that traceback noise during otherwise
+successful Pareto searches was the user-facing symptom of the bug.
+"""
+
+import logging
+import math
+from collections import defaultdict
+
+import pytest
+import yaml
+
+from aiconfigurator.sdk import common
+from aiconfigurator.sdk.perf_database import PerfDatabase, PerfDataNotAvailableError
+
+
+def _make_defaultdict_custom_allreduce(tp_sizes):
+    """
+    Build a custom_allreduce dataset in the same 4-deep defaultdict shape
+    that load_custom_allreduce_data produces, containing entries only for
+    the requested tp_sizes under CommQuantMode.half / strategy "AUTO".
+    """
+    data = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict())))
+    for tp in tp_sizes:
+        for msg_size in [1024, 2048, 4096]:
+            latency = 0.001 * msg_size * tp
+            data[common.CommQuantMode.half][tp]["AUTO"][msg_size] = {
+                "latency": latency,
+                "power": 0.0,
+                "energy": 0.0,
+            }
+    return data
+
+
+@pytest.fixture
+def _db_factory(tmp_path, monkeypatch):
+    """
+    PerfDatabase factory whose custom_allreduce dataset is injected per call.
+    """
+    dummy_spec = {
+        "data_dir": "data",
+        "misc": {"nccl_version": "v1"},
+        "gpu": {
+            "float16_tc_flops": 1_000.0,
+            "mem_bw": 100.0,
+            "mem_empirical_constant_latency": 1.0,
+        },
+        "node": {
+            "inter_node_bw": 100.0,
+            "intra_node_bw": 100.0,
+            "num_gpus_per_node": 8,
+            "p2p_latency": 0.000001,
+        },
+    }
+    monkeypatch.setattr(yaml, "load", lambda stream, Loader=None: dummy_spec)  # noqa: N803
+
+    def _factory(custom_allreduce_data):
+        monkeypatch.setattr(
+            "aiconfigurator.sdk.perf_database.load_custom_allreduce_data",
+            lambda path: custom_allreduce_data,
+        )
+        # Minimal stubs for other loaders — we only exercise custom_allreduce.
+        monkeypatch.setattr("aiconfigurator.sdk.perf_database.load_gemm_data", lambda p: {})
+        monkeypatch.setattr("aiconfigurator.sdk.perf_database.load_context_attention_data", lambda p: {})
+        monkeypatch.setattr("aiconfigurator.sdk.perf_database.load_generation_attention_data", lambda p: {})
+        monkeypatch.setattr("aiconfigurator.sdk.perf_database.load_moe_data", lambda p: ({}, {}))
+        monkeypatch.setattr("aiconfigurator.sdk.perf_database.load_nccl_data", lambda p: {})
+        monkeypatch.setattr("aiconfigurator.sdk.perf_database.load_context_mla_data", lambda p: {})
+        monkeypatch.setattr("aiconfigurator.sdk.perf_database.load_generation_mla_data", lambda p: {})
+        monkeypatch.setattr("aiconfigurator.sdk.perf_database.load_mla_bmm_data", lambda p: {})
+        monkeypatch.setattr("aiconfigurator.sdk.perf_database.load_context_dsa_module_data", lambda p: None)
+        monkeypatch.setattr("aiconfigurator.sdk.perf_database.load_generation_dsa_module_data", lambda p: None)
+
+        yaml_file = tmp_path / "sys.yaml"
+        yaml_file.write_text("dummy: data")
+        return PerfDatabase("sys", "backend", "v1", str(tmp_path))
+
+    return _factory
+
+
+class TestCustomAllreduceEmptyBucket:
+    """SILICON mode must surface empty custom_allreduce buckets as structured errors."""
+
+    def test_silicon_raises_structured_error_when_tp_bucket_missing(self, _db_factory):
+        """
+        Reproduces NVBUG-6095486: CSV has tp_size in {2, 4} only; a tp_size=8
+        query must raise PerfDataNotAvailableError, not leak AssertionError
+        from _nearest_1d_point_helper.
+        """
+        data = _make_defaultdict_custom_allreduce(tp_sizes=[2, 4])
+        db = _db_factory(data)
+
+        with pytest.raises(PerfDataNotAvailableError) as excinfo:
+            db.query_custom_allreduce(
+                common.CommQuantMode.half,
+                tp_size=8,
+                size=6291456,
+                database_mode=common.DatabaseMode.SILICON,
+            )
+
+        msg = str(excinfo.value)
+        assert "tp_size" in msg
+        assert "HYBRID" in msg, "error message should point users at the HYBRID workaround"
+
+    def test_silicon_raises_structured_error_when_quant_mode_missing(self, _db_factory):
+        """Empty dataset (no quant_mode entries) must raise PerfDataNotAvailableError."""
+        data = _make_defaultdict_custom_allreduce(tp_sizes=[])
+        db = _db_factory(data)
+
+        with pytest.raises(PerfDataNotAvailableError):
+            db.query_custom_allreduce(
+                common.CommQuantMode.half,
+                tp_size=4,
+                size=1024,
+                database_mode=common.DatabaseMode.SILICON,
+            )
+
+    def test_hybrid_falls_back_to_empirical_when_tp_bucket_missing(self, _db_factory):
+        """HYBRID mode must keep falling back cleanly on the same condition."""
+        data = _make_defaultdict_custom_allreduce(tp_sizes=[2, 4])
+        db = _db_factory(data)
+
+        result = db.query_custom_allreduce(
+            common.CommQuantMode.half,
+            tp_size=8,
+            size=6291456,
+            database_mode=common.DatabaseMode.HYBRID,
+        )
+        assert float(result) > 0, "HYBRID empirical fallback should yield positive latency"
+
+    def test_silicon_available_bucket_still_works(self, _db_factory):
+        """Sanity check: a tp_size that IS present still returns the interpolated value."""
+        data = _make_defaultdict_custom_allreduce(tp_sizes=[2, 4])
+        db = _db_factory(data)
+
+        result = db.query_custom_allreduce(
+            common.CommQuantMode.half,
+            tp_size=4,
+            size=2048,
+            database_mode=common.DatabaseMode.SILICON,
+        )
+        expected = 0.001 * 2048 * 4
+        assert math.isclose(float(result), expected, rel_tol=1e-6)
+
+    def test_silicon_missing_bucket_does_not_log_traceback(self, _db_factory, caplog):
+        """
+        Bullet 1 of NVBUG-6095486: successful searches that merely skip a
+        candidate must not spam internal tracebacks. When the structured
+        PerfDataNotAvailableError is raised, _query_silicon_or_hybrid must
+        not emit an ERROR-level log record with exc_info attached.
+        """
+        data = _make_defaultdict_custom_allreduce(tp_sizes=[2, 4])
+        db = _db_factory(data)
+
+        caplog.set_level(logging.DEBUG, logger="aiconfigurator.sdk.perf_database")
+        with pytest.raises(PerfDataNotAvailableError):
+            db.query_custom_allreduce(
+                common.CommQuantMode.half,
+                tp_size=8,
+                size=6291456,
+                database_mode=common.DatabaseMode.SILICON,
+            )
+
+        records_with_traceback = [
+            r
+            for r in caplog.records
+            if r.name == "aiconfigurator.sdk.perf_database" and r.levelno >= logging.ERROR and r.exc_info is not None
+        ]
+        assert not records_with_traceback, (
+            "PerfDataNotAvailableError is a structured signal — it must not be logged "
+            f"via logger.exception. Got: {[r.getMessage() for r in records_with_traceback]}"
+        )


### PR DESCRIPTION
## Summary

In SILICON mode, `PerfDatabase.query_custom_allreduce(...)` leaked an internal
`AssertionError: values is None or empty` whenever the loaded
`custom_allreduce_perf.txt` had no rows for the requested `(quant_mode, tp_size)`
bucket. Because the leaked exception was an invariant failure from an internal
helper (`_nearest_1d_point_helper`), upstream Pareto search could not
distinguish it from a genuine bug and users saw two symptoms:

- noisy internal tracebacks during otherwise successful candidate sweeps
- hard Pareto failures with a cryptic `RuntimeError: ... values is None or empty`
  when the search space was narrow

This change makes the query path emit a structured, actionable
`PerfDataNotAvailableError` for the empty-bucket case and quiets the
corresponding log record so successful searches no longer spam tracebacks.

## Root cause

`load_custom_allreduce_data` returns a 4-deep `defaultdict`
(`perf_database.py:386`). The SILICON branch of `query_custom_allreduce`
walked that structure with chained indexing:

```python
comm_dict = self._custom_allreduce_data[quant_mode][
    min(tp_size, num_gpus_per_node)
]["AUTO"]
```

For any `(quant_mode, tp_size)` pair not present in the CSV, the defaultdict
silently synthesized empty nested dicts at each missing level. `comm_dict`
ended up empty, so `list(comm_dict.keys())` was `[]`, tripping the guard
assertion inside `_nearest_1d_point_helper`. The bug was not in the helper —
it was that `query_custom_allreduce` never validated the bucket before
handing it to the helper.

`raise_if_not_loaded()` already covers the "CSV file is missing entirely"
case, but had no signal for "file loaded but contains a subset of tp_sizes".

Reproduced on `b200_sxm / vllm / 0.14.0` (CSV rows cover `tp_size ∈ {2, 4}`
only) with `tp_size=8, size=6291456` — matches the stack trace in the report.

## Changes

`src/aiconfigurator/sdk/perf_database.py` (+26 / −4):

1. **`query_custom_allreduce.get_silicon`** (around line 5007): after
   `raise_if_not_loaded()`, walk `(quant_mode, effective_tp, "AUTO")` with
   `.get(..., {})` so the defaultdict no longer silently synthesizes empty
   buckets at lookup sites. When the final dict is empty, raise
   `PerfDataNotAvailableError` with a message that names the missing
   `tp_size`, enumerates the `tp_size`s actually present for the requested
   `quant_mode`, and points users at the HYBRID-mode workaround.

2. **`_query_silicon_or_hybrid`** (around line 3716): in the SILICON
   re-raise branch, emit `logger.warning(...)` (no stack trace) when the
   wrapped exception is `PerfDataNotAvailableError`. Unexpected exceptions
   still hit `logger.exception(...)` so genuine bugs stay visible. This
   removes the traceback noise that Pareto sweeps produced when individual
   candidates were skipped.

## Behavior after the fix

On `b200_sxm / vllm / 0.14.0`, `tp_size=8`:

- **SILICON** → `PerfDataNotAvailableError: No custom_allreduce silicon data
  for quant_mode=half, tp_size=8 (requested tp_size=8). Available tp_sizes
  for this quant_mode: [2, 4]. Consider using HYBRID mode, or supply
  custom_allreduce_perf.txt rows covering this tp_size.`
  Logged as a single `WARNING` line; no traceback.
- **HYBRID** → clean empirical fallback (unchanged behavior, same latency).
- **SILICON, `tp_size=4`** → unchanged; returns the interpolated silicon
  latency as before.

Upstream error surface:

- `FallbackOp.query` (operations.py:1736) already treats
  `PerfDataNotAvailableError`, `KeyError`, and `AssertionError` as
  "primary unavailable". It continues to work without changes — the fix just
  replaces a same-semantics-different-type exception.
- `pareto_analysis.agg_pareto`'s "No results found ... Showing last
  exception: ..." now embeds the new structured message, so users on narrow
  searches see a clear perf-data-availability error instead of an internal
  invariant message.

## Scope

Fix is intentionally narrow to `query_custom_allreduce`. The same
defaultdict-empty-bucket pattern exists in several other `query_*` methods
in `perf_database.py` (shared via the common `*_data[key][…]["AUTO"]`
idiom). Those are out of scope for this PR — they can be hardened
individually as bugs are filed, so each change stays reviewable against its
own reproducer.

## Test plan

Added `tests/unit/sdk/database/test_custom_allreduce_empty_bucket.py`
(5 cases):

- [x] SILICON + `tp_size=8` bucket missing → raises `PerfDataNotAvailableError`
      (regression test for the original `AssertionError` leak)
- [x] SILICON + empty dataset (`quant_mode` missing entirely) →
      raises `PerfDataNotAvailableError`
- [x] HYBRID + same empty-bucket condition → clean empirical fallback
      (positive latency, no exception)
- [x] SILICON + populated `tp_size=4` bucket → unchanged interpolated value
- [x] SILICON + empty bucket → no `ERROR`-level log record with `exc_info`
      attached (verifies bullet 1 of the bug report: no tracebacks during
      successful searches that merely skip a candidate)

Verified locally:

- All 5 new tests pass on the fix; the first one reproduces the original
  `AssertionError: values is None or empty` exactly when run against `main`.
- Full `tests/unit/sdk/database/`: 243 passed. 7 pre-existing failures in
  `test_moe_dispatch.py` (`TestEnableAlltoallConditions`,
  `TestSm100AlltoallPath`) reproduce identically on `main` and are
  unrelated to this change.
- Real-data repro on `b200_sxm / vllm / 0.14.0` confirms the structured
  SILICON error message, the quiet log record, and the unchanged HYBRID and
  `tp_size=4` paths described above.

## Backport

Bug was filed against `release/0.8.0` at `5a6a115`. Consider cherry-picking
this commit onto `release/0.8.0` after merge if users on that line are
hitting the hard-failure case.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error logging: missing performance data now generates warnings without stack traces, while genuine errors continue with full diagnostics.
  * Improved data validation to detect unavailable performance data buckets early and provide clearer diagnostic messages.

* **Tests**
  * Added regression test coverage for performance data availability scenarios across operational modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->