### PR TITLE
fix(enumerate): accept total_gpus to cap candidates and size min-fit floor

### DIFF
--- a/src/aiconfigurator/generator/enumerate.py
+++ b/src/aiconfigurator/generator/enumerate.py
@@ -350,6 +350,7 @@ def enumerate_profiling_configs(
     enable_wideep: bool = False,
     backend_version: str | None = None,
     num_gpus_per_node: int | None = None,
+    total_gpus: int | None = None,
     k8s_pvc_name: str | None = None,
     k8s_pvc_mount_path: str = "/workspace/model_cache",
     k8s_model_path_in_pvc: str | None = None,
@@ -385,6 +386,10 @@ def enumerate_profiling_configs(
         backend_version: Optional backend database version.
         num_gpus_per_node: GPUs per physical node.  If ``None`` it is
             read from the system config YAML.
+        total_gpus: Total GPU budget for the deployment (e.g. 32 for a
+            4-node H100 cluster).  Used to cap the enumerated search space
+            and to compute the memory-fit minimum for MoE wide-EP sweeps.
+            When ``None``, defaults to ``num_gpus_per_node`` (single node).
         k8s_pvc_name: PVC claim name for model cache.  When set, the
             generated DGDs will mount this PVC.
         k8s_pvc_mount_path: Where the PVC is mounted inside the container.
@@ -454,11 +459,16 @@ def enumerate_profiling_configs(
     # ------------------------------------------------------------------
     # 2. Memory-based minimum GPUs per engine
     # ------------------------------------------------------------------
+    # For MoE wide-EP, engines can span multiple nodes (DEP/TEP shard weights
+    # across all GPUs), so the memory-fit floor is not capped at a single node.
+    # Otherwise (dense, or MoE intra-node) the floor stays within a node.
+    effective_total_gpus = total_gpus if total_gpus is not None else num_gpus_per_node
     min_gpus = _calculate_min_tp(
         model_weight_bytes=model_weight_bytes,
         vram_per_gpu=vram_per_gpu,
         gpus_per_node=num_gpus_per_node,
-        total_gpus=num_gpus_per_node,  # cap at single node for min calculation
+        total_gpus=effective_total_gpus,
+        allow_multi_node=is_moe and enable_wideep,
     )
     logger.info("Minimum GPUs per engine (memory fit): %d", min_gpus)
 
@@ -481,6 +491,13 @@ def enumerate_profiling_configs(
         # Dense models (and MoE non-wideEP): cap at num_gpus_per_node
         prefill_max_gpus = num_gpus_per_node
         decode_max_gpus = num_gpus_per_node
+
+    # Never enumerate beyond the deployment's GPU budget.  The parallel-list
+    # builder does not know the cluster size, so a 64-GPU candidate can show
+    # up on a 32-GPU system without this cap.
+    if total_gpus is not None:
+        prefill_max_gpus = min(prefill_max_gpus, total_gpus)
+        decode_max_gpus = min(decode_max_gpus, total_gpus)
 
     logger.info(
         "Parallel lists: is_moe=%s, enable_wideep=%s, min_gpus=%d, "

--- a/src/aiconfigurator/generator/naive.py
+++ b/src/aiconfigurator/generator/naive.py
@@ -218,6 +218,7 @@ def _calculate_min_tp(
     vram_per_gpu: int,
     gpus_per_node: int,
     total_gpus: int,
+    allow_multi_node: bool = False,
 ) -> int:
     """
     Calculate the minimum TP size that fits the model in memory.
@@ -229,9 +230,13 @@ def _calculate_min_tp(
         vram_per_gpu: VRAM per GPU in bytes.
         gpus_per_node: Number of GPUs per node.
         total_gpus: Total GPUs available.
+        allow_multi_node: When True, do not cap the result at ``gpus_per_node``.
+            Use for MoE wide-EP sweeps where an engine can span nodes; the
+            result is still capped at ``total_gpus``.
 
     Returns:
-        Minimum TP size (power of 2, capped at gpus_per_node and total_gpus).
+        Minimum TP size (power of 2). Capped at ``min(gpus_per_node, total_gpus)``
+        by default, or at ``total_gpus`` when ``allow_multi_node=True``.
     """
     # Required VRAM per model copy
     required_vram = model_weight_bytes * _MEMORY_MULTIPLIER
@@ -246,17 +251,18 @@ def _calculate_min_tp(
     while tp < min_tp:
         tp *= 2
 
-    # Cap at gpus_per_node (to stay within a single node) and total_gpus
-    max_tp = min(gpus_per_node, total_gpus)
+    # Cap at gpus_per_node (single-node constraint) unless multi-node is allowed.
+    max_tp = total_gpus if allow_multi_node else min(gpus_per_node, total_gpus)
 
-    # Warn if the model requires more GPUs than available in a single node
+    # Warn if the model requires more GPUs than available.
     if tp > max_tp:
         logger.warning(
             f"Model requires TP={tp} to fit in memory, but max TP is {max_tp} "
-            f"(gpus_per_node={gpus_per_node}, total_gpus={total_gpus}). "
+            f"(gpus_per_node={gpus_per_node}, total_gpus={total_gpus}, "
+            f"allow_multi_node={allow_multi_node}). "
             f"The model may not fit! Consider using PP or other parallelism "
             f"strategies to fit across more than one node, or use a system "
-            f"with more GPUs per node."
+            f"with more GPUs."
         )
         tp = max_tp
 

--- a/tests/unit/generator/test_naive.py
+++ b/tests/unit/generator/test_naive.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import pytest
 
 from aiconfigurator.generator.naive import (
+    _calculate_min_tp,
     _estimate_model_weight_bytes,
     _sanitize_rfc1123,
     build_naive_generator_params,
@@ -173,6 +174,57 @@ class TestEstimateModelWeightBytesFailsOnMissingModel:
                 system_name="h200_sxm",
                 backend_name="vllm",
             )
+
+
+@pytest.mark.unit
+class TestCalculateMinTp:
+    """Verify _calculate_min_tp memory-fit floor, including multi-node sweeps."""
+
+    # H100: 80 GiB per GPU.  DeepSeek R1 FP8: ~671 GiB of weights.
+    _H100_VRAM = 80 * 1024**3
+    _R1_FP8_WEIGHTS = 671 * 1024**3
+
+    def test_single_node_caps_at_gpus_per_node(self):
+        """Dense default: min_tp capped at gpus_per_node even if model is larger."""
+        tp = _calculate_min_tp(
+            model_weight_bytes=self._R1_FP8_WEIGHTS,
+            vram_per_gpu=self._H100_VRAM,
+            gpus_per_node=8,
+            total_gpus=32,
+        )
+        assert tp == 8  # capped at node even though model wants more
+
+    def test_multi_node_allows_crossing_node_boundary(self):
+        """MoE wide-EP: min_tp can span nodes, floored to power-of-2 fit."""
+        tp = _calculate_min_tp(
+            model_weight_bytes=self._R1_FP8_WEIGHTS,
+            vram_per_gpu=self._H100_VRAM,
+            gpus_per_node=8,
+            total_gpus=32,
+            allow_multi_node=True,
+        )
+        # 1.5 * 671 / 80 = ~12.6 -> 13 -> round to 16
+        assert tp == 16
+
+    def test_multi_node_capped_by_total_gpus(self):
+        """Even in multi-node mode, result cannot exceed total_gpus budget."""
+        tp = _calculate_min_tp(
+            model_weight_bytes=self._R1_FP8_WEIGHTS,
+            vram_per_gpu=self._H100_VRAM,
+            gpus_per_node=8,
+            total_gpus=8,
+            allow_multi_node=True,
+        )
+        assert tp == 8  # clamped to budget
+
+    def test_small_model_fits_on_one_gpu(self):
+        tp = _calculate_min_tp(
+            model_weight_bytes=10 * 1024**3,
+            vram_per_gpu=self._H100_VRAM,
+            gpus_per_node=8,
+            total_gpus=8,
+        )
+        assert tp == 1
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

`enumerate_profiling_configs` had no knowledge of the deployment's total GPU budget. Two consequences:

- **64-GPU candidate on a 32-GPU cluster.** For MoE wide-EP, `decode_max_gpus` was `max(num_gpu_per_worker)` = 64, so a 32-GPU system could be handed a decode config that can't possibly schedule.
- **OOM candidates not pruned.** `_calculate_min_tp` was called with `total_gpus=num_gpus_per_node`, capping the memory-fit floor at a single node. For DeepSeek R1 FP8 on 32 H100s, 8-GPU wide-EP candidates passed the floor (floor=8, capped) but OOM'd on deploy — they should have been filtered since R1 needs ≥16 GPUs to hold weights.

## Changes

- `enumerate_profiling_configs` gets a new optional `total_gpus: int | None` parameter. When provided, it caps `prefill_max_gpus` / `decode_max_gpus` by the real budget and feeds the real budget into the memory-fit floor.
- `_calculate_min_tp` gets `allow_multi_node: bool = False`. When enabled (passed from enumerate when `is_moe and enable_wideep`), the floor can span nodes, still bounded by `total_gpus`. Dense and intra-node MoE paths keep the single-node cap.
- 4 new `_calculate_min_tp` unit tests covering R1-sized weights on 8x80 GiB H100 nodes, with and without multi-node.

Backward compatible: callers that don't pass `total_gpus` see identical behavior.

## Test plan

- [x] Existing generator unit tests pass (`pytest tests/unit/generator/`)
- [x] Existing SDK utils/task tests pass (`pytest tests/unit/sdk/test_utils.py tests/unit/sdk/task/`)
- [x] New `TestCalculateMinTp` cases pass (single-node cap, multi-node crosses node, multi-node bounded by budget, small-model base case)
- [x] `pre-commit run` on changed files
- [ ] Downstream Dynamo PR (forthcoming) threads `total_gpus` from `thorough.py` into this call; once both land, the R1-on-32-H100 candidate set drops the 8-GPU OOM and 64-GPU impossible configs

## Related

Paired with a Dynamo-side PR that passes `total_gpus` from `components/src/dynamo/profiler/thorough.py` into this function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional total GPU budget parameter to configuration enumeration, allowing the system to cap the search space and generate configurations that fit within specified GPU allocations.

* **Tests**
  * Added comprehensive test coverage for tensor-parallel minimum calculations across single-node and multi-node deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->