### PR TITLE
fix: resolve symlinks in safe_mkdir allowed path prefixes

### DIFF
--- a/src/aiconfigurator/sdk/utils.py
+++ b/src/aiconfigurator/sdk/utils.py
@@ -286,9 +286,9 @@ def safe_mkdir(target_path: str, exist_ok: bool = True) -> Path:
         allowed_prefixes = [
             current_dir,
             Path.home(),
-            Path("/tmp"),
+            Path("/tmp").resolve(),
             Path("/workspace"),
-            Path("/var/tmp"),
+            Path("/var/tmp").resolve(),
             Path(tempfile.gettempdir()).resolve(),
         ]
 

--- a/src/aiconfigurator/sdk/utils.py
+++ b/src/aiconfigurator/sdk/utils.py
@@ -285,9 +285,9 @@ def safe_mkdir(target_path: str, exist_ok: bool = True) -> Path:
         current_dir = Path.cwd().resolve()
         allowed_prefixes = [
             current_dir,
-            Path.home(),
+            Path.home().resolve(),
             Path("/tmp").resolve(),
-            Path("/workspace"),
+            Path("/workspace").resolve(),
             Path("/var/tmp").resolve(),
             Path(tempfile.gettempdir()).resolve(),
         ]


### PR DESCRIPTION
## Overview

Fix safe_mkdir rejecting valid /tmp and /var/tmp paths on macOS due to unresolved symlinks.

## Details

On macOS, /tmp and /var/tmp are symlinks to /private/tmp and /private/var/tmp. safe_mkdir resolves the user input path but compared it against unresolved allowed prefixes, causing ValueError: Path is outside allowed locations when using --save-dir /tmp/output.

The fix adds .resolve() to the /tmp and /var/tmp entries in the allowed prefixes list so both sides of the comparison use canonical paths.

## Test plan

- [x] Verified aiconfigurator cli default --save-dir /tmp/output succeeds on macOS (previously failed)
- [ ] Verify no regression on Linux (where /tmp is not a symlink)
