### PR TITLE
fix: filter invalid benchmark concurrencies

### DIFF
--- a/src/aiconfigurator/generator/config/backend_templates/benchmark/bench_run.sh.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/benchmark/bench_run.sh.j2
@@ -9,7 +9,7 @@ set -euo pipefail
 {% set combined = base_concurrency + [eff_low, eff, eff_high] %}
 {% set ns = namespace(seen=[]) %}
 {% for c in combined %}
-{% if c not in ns.seen %}
+{% if c >= 1 and c not in ns.seen %}
 {% set ns.seen = ns.seen + [c] %}
 {% endif %}
 {% endfor %}

--- a/src/aiconfigurator/generator/config/backend_templates/benchmark/k8s_bench.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/benchmark/k8s_bench.yaml.j2
@@ -46,7 +46,7 @@ spec:
               {% set combined = base_concurrency + [eff_low, eff, eff_high] %}
               {% set ns = namespace(seen=[]) %}
               {% for c in combined %}
-              {% if c not in ns.seen %}
+              {% if c >= 1 and c not in ns.seen %}
               {% set ns.seen = ns.seen + [c] %}
               {% endif %}
               {% endfor %}

--- a/tests/unit/generator/test_benchmark_templates.py
+++ b/tests/unit/generator/test_benchmark_templates.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for shared benchmark templates."""
+
+from pathlib import Path
+
+import pytest
+from jinja2 import Environment, FileSystemLoader
+
+_TEMPLATE_DIR = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "aiconfigurator"
+    / "generator"
+    / "config"
+    / "backend_templates"
+    / "benchmark"
+)
+
+
+@pytest.fixture(scope="module")
+def benchmark_env():
+    return Environment(
+        loader=FileSystemLoader(str(_TEMPLATE_DIR)),
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
+
+
+def _render(template_name: str, env: Environment, **ctx) -> str:
+    return env.get_template(template_name).render(**ctx).strip()
+
+
+def _base_context() -> dict:
+    return {
+        "BenchConfig": {
+            "estimated_concurrency": 1,
+            "model": "test/model",
+            "endpoint_type": "chat",
+            "endpoint_url": "http://bench.example:8000",
+            "tokenizer": "test/tokenizer",
+            "isl": 1000,
+            "isl_stddev": 0,
+            "osl": 100,
+            "osl_stddev": 0,
+            "ui": "simple",
+            "name": "test-benchmark",
+            "image": "python:3.12-slim",
+            "profile_start_timeout": 400,
+        },
+        "ServiceConfig": {"head_node_ip": "127.0.0.1", "port": 8000},
+        "K8sConfig": {"k8s_namespace": "default"},
+    }
+
+
+@pytest.mark.unit
+class TestBenchmarkTemplates:
+    def test_bench_run_filters_zero_concurrency(self, benchmark_env):
+        rendered = _render("bench_run.sh.j2", benchmark_env, **_base_context())
+        assert "concurrency_array=(0" not in rendered
+        assert "concurrency_array=(1 2 8 16 32 64 128)" in rendered
+
+    def test_k8s_bench_filters_zero_concurrency(self, benchmark_env):
+        rendered = _render("k8s_bench.yaml.j2", benchmark_env, **_base_context())
+        assert "concurrency_array=(0" not in rendered
+        assert "concurrency_array=(1 2 8 16 32 64 128)" in rendered


### PR DESCRIPTION
### Overview:
Fix the benchmark template edge case where `estimated_concurrency=1` causes the rendered concurrency list to include `0`.

### Details:
This PR updates both shared benchmark generation paths:
- `src/aiconfigurator/generator/config/backend_templates/benchmark/bench_run.sh.j2`
- `src/aiconfigurator/generator/config/backend_templates/benchmark/k8s_bench.yaml.j2`

The templates previously computed:
- `eff_low = int(estimated_concurrency * 0.95)`

When `estimated_concurrency` was 1, `eff_low` became 0, which caused the generated `concurrency_array` to include an invalid value and made `aiperf profile` fail validation.

The fix filters out non-positive concurrency values when deduplicating the generated list.

This PR also adds a regression test:
- `tests/unit/generator/test_benchmark_templates.py`

### Where should the reviewer start?
Please start with:
- `src/aiconfigurator/generator/config/backend_templates/benchmark/bench_run.sh.j2`
- `src/aiconfigurator/generator/config/backend_templates/benchmark/k8s_bench.yaml.j2`

Then review:
- `tests/unit/generator/test_benchmark_templates.py`

### Related Issues:
- Relates to benchmark generation producing `concurrency_array=(0 1 2 8 16 32 64 128)` when `estimated_concurrency=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Benchmark configuration templates now properly filter out computed concurrency values below 1, preventing invalid or zero concurrency settings from being included in generated configurations.

* **Tests**
  * Added new tests to validate benchmark template rendering, confirming that invalid concurrency values are excluded while preserving expected valid settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->