### PR TITLE
fix: align DSA context interpolation across topk boundary

### DIFF
--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -3501,6 +3501,67 @@ class PerfDatabase:
 
             return {"latency": latency, "power": 0.0, "energy": 0.0}
 
+    def _interp_dsa_context_topk_piecewise(
+        self,
+        num_heads: int,
+        full_s: int,
+        b: int,
+        dsa_dict: dict,
+        index_topk: int | None,
+    ) -> dict | None:
+        """
+        Interpolate DSA context data without crossing the index_topk regime boundary.
+
+        DSA context uses a different kernel path when kv_len crosses index_topk:
+        <= topk can skip indexer logits/topk, while > topk enables that path.
+        A smooth interpolation from 2048 to 4096 can therefore badly
+        underestimate points just above topk. This helper only applies when
+        the exact (num_heads, batch) curve has same-regime anchors bracketing
+        the query; otherwise callers should fall back to the regular 3D
+        interpolation.
+        """
+        if index_topk is None or num_heads not in dsa_dict:
+            return None
+
+        exact_head_data = dsa_dict[num_heads]
+        curve = {
+            seq_len: batch_dict[b]
+            for seq_len, batch_dict in exact_head_data.items()
+            if isinstance(batch_dict, dict) and b in batch_dict
+        }
+        if full_s in curve:
+            value = curve[full_s]
+            if isinstance(value, dict):
+                return {
+                    "latency": self._get_value(value, "latency"),
+                    "power": self._get_value(value, "power"),
+                    "energy": self._get_value(value, "energy"),
+                }
+            return {"latency": float(value), "power": 0.0, "energy": 0.0}
+
+        if full_s <= index_topk:
+            same_regime_keys = sorted(seq_len for seq_len in curve if seq_len <= index_topk)
+        else:
+            same_regime_keys = sorted(seq_len for seq_len in curve if seq_len > index_topk)
+
+        if len(same_regime_keys) < 2 or full_s < same_regime_keys[0] or full_s > same_regime_keys[-1]:
+            return None
+
+        left, right = self._nearest_1d_point_helper(full_s, same_regime_keys)
+        left_value = curve[left]
+        right_value = curve[right]
+
+        def _interp_metric(metric: str) -> float:
+            left_metric = self._get_value(left_value, metric)
+            right_metric = self._get_value(right_value, metric)
+            return self._interp_1d([left, right], [left_metric, right_metric], full_s)
+
+        return {
+            "latency": _interp_metric("latency"),
+            "power": _interp_metric("power"),
+            "energy": _interp_metric("energy"),
+        }
+
     def _get_sample_leaf_value(self, data: dict):
         """Get a sample leaf value from nested dict to determine format."""
         current = data
@@ -6815,7 +6876,9 @@ class PerfDatabase:
                     )
                 dsa_dict = dsa_module_data[fmha_quant_mode][kvcache_quant_mode][gemm_quant_mode][architecture]
                 full_s = s + prefix
-                result = self._interp_3d(num_heads, full_s, b, dsa_dict, "cubic")
+                result = self._interp_dsa_context_topk_piecewise(num_heads, full_s, b, dsa_dict, index_topk)
+                if result is None:
+                    result = self._interp_3d(num_heads, full_s, b, dsa_dict, "cubic")
                 latency = result["latency"]
                 energy = result.get("energy", 0.0)
                 if prefix > 0:

--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import copy
 import csv
 import functools
 import importlib.resources as pkg_resources
@@ -2303,6 +2304,7 @@ class PerfDatabase:
         # Uses same dict structure as MLA so interpolation/query can be reused
         self._context_dsa_module_data = _load_op_data(PerfDataFilename.dsa_context_module)
         self._generation_dsa_module_data = _load_op_data(PerfDataFilename.dsa_generation_module)
+        self._raw_context_dsa_module_data = copy.deepcopy(self._context_dsa_module_data)
 
         # TensorRT-LLM wideep path
         if backend == "trtllm":
@@ -3501,26 +3503,27 @@ class PerfDatabase:
 
             return {"latency": latency, "power": 0.0, "energy": 0.0}
 
-    def _interp_dsa_context_topk_piecewise(
+    def _interp_dsa_context_topk_piecewise_from_raw(
         self,
         num_heads: int,
         full_s: int,
         b: int,
-        dsa_dict: dict,
+        dsa_dict: dict | None,
         index_topk: int | None,
     ) -> dict | None:
         """
-        Interpolate DSA context data without crossing the index_topk regime boundary.
+        Interpolate raw DSA context data without crossing the index_topk regime boundary.
 
         DSA context uses a different kernel path when kv_len crosses index_topk:
         <= topk can skip indexer logits/topk, while > topk enables that path.
         A smooth interpolation from 2048 to 4096 can therefore badly
         underestimate points just above topk. This helper only applies when
-        the exact (num_heads, batch) curve has same-regime anchors bracketing
-        the query; otherwise callers should fall back to the regular 3D
-        interpolation.
+        the exact raw (num_heads, batch) curve has at least two same-regime
+        anchors. Points just above index_topk use the first two right-regime
+        anchors for same-regime extrapolation instead of falling back to cubic
+        interpolation across the topk boundary.
         """
-        if index_topk is None or num_heads not in dsa_dict:
+        if index_topk is None or dsa_dict is None or num_heads not in dsa_dict:
             return None
 
         exact_head_data = dsa_dict[num_heads]
@@ -3544,10 +3547,17 @@ class PerfDatabase:
         else:
             same_regime_keys = sorted(seq_len for seq_len in curve if seq_len > index_topk)
 
-        if len(same_regime_keys) < 2 or full_s < same_regime_keys[0] or full_s > same_regime_keys[-1]:
+        if len(same_regime_keys) < 2:
             return None
 
-        left, right = self._nearest_1d_point_helper(full_s, same_regime_keys)
+        if full_s < same_regime_keys[0]:
+            if full_s <= index_topk:
+                return None
+            left, right = same_regime_keys[0], same_regime_keys[1]
+        elif full_s > same_regime_keys[-1]:
+            return None
+        else:
+            left, right = self._nearest_1d_point_helper(full_s, same_regime_keys)
         left_value = curve[left]
         right_value = curve[right]
 
@@ -6876,7 +6886,15 @@ class PerfDatabase:
                     )
                 dsa_dict = dsa_module_data[fmha_quant_mode][kvcache_quant_mode][gemm_quant_mode][architecture]
                 full_s = s + prefix
-                result = self._interp_dsa_context_topk_piecewise(num_heads, full_s, b, dsa_dict, index_topk)
+                raw_dsa_dict = None
+                raw_dsa_module_data = getattr(self, "_raw_context_dsa_module_data", None)
+                if raw_dsa_module_data is not None and getattr(raw_dsa_module_data, "loaded", True):
+                    raw_dsa_dict = raw_dsa_module_data[fmha_quant_mode][kvcache_quant_mode][gemm_quant_mode][
+                        architecture
+                    ]
+                result = self._interp_dsa_context_topk_piecewise_from_raw(
+                    num_heads, full_s, b, raw_dsa_dict, index_topk
+                )
                 if result is None:
                     result = self._interp_3d(num_heads, full_s, b, dsa_dict, "cubic")
                 latency = result["latency"]

--- a/tests/unit/sdk/database/test_dsa_module.py
+++ b/tests/unit/sdk/database/test_dsa_module.py
@@ -6,8 +6,25 @@ import math
 import pytest
 
 from aiconfigurator.sdk import common
+from aiconfigurator.sdk.perf_database import DEFAULT_DSA_ARCHITECTURE, LoadedOpData
 
 pytestmark = pytest.mark.unit
+
+
+def _dsa_value(latency: float) -> dict[str, float]:
+    return {"latency": latency, "power": 10.0, "energy": latency * 10.0}
+
+
+def _context_dsa_data(dsa_dict: dict) -> dict:
+    return {
+        common.FMHAQuantMode.bfloat16: {
+            common.KVCacheQuantMode.bfloat16: {
+                common.GEMMQuantMode.bfloat16: {
+                    DEFAULT_DSA_ARCHITECTURE: dsa_dict,
+                },
+            },
+        },
+    }
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -17,6 +34,105 @@ pytestmark = pytest.mark.unit
 
 class TestContextDSAModule:
     """Tests for query_context_dsa_module."""
+
+    def test_topk_piecewise_from_raw_handles_both_boundary_sides(self, stub_perf_db):
+        raw_dsa_dict = {
+            32: {
+                1024: {1: _dsa_value(10.0)},
+                2048: {1: _dsa_value(20.0)},
+                3072: {1: _dsa_value(80.0)},
+                4096: {1: _dsa_value(100.0)},
+            }
+        }
+
+        below = stub_perf_db._interp_dsa_context_topk_piecewise_from_raw(32, 2047, 1, raw_dsa_dict, 2048)
+        above = stub_perf_db._interp_dsa_context_topk_piecewise_from_raw(32, 2049, 1, raw_dsa_dict, 2048)
+
+        assert below is not None
+        assert above is not None
+        assert below["latency"] == pytest.approx(10.0 + (20.0 - 10.0) / 1024.0 * (2047 - 1024))
+        assert above["latency"] == pytest.approx(80.0 + (100.0 - 80.0) / 1024.0 * (2049 - 3072))
+        assert above["latency"] > raw_dsa_dict[32][2048][1]["latency"]
+
+    def test_topk_plus_one_uses_raw_piecewise_instead_of_cubic_fallback(self, stub_perf_db, monkeypatch):
+        raw_dsa_dict = {
+            32: {
+                2048: {1: _dsa_value(20.0)},
+                3072: {1: _dsa_value(80.0)},
+                4096: {1: _dsa_value(100.0)},
+            }
+        }
+        extrapolated_dsa_dict = {
+            32: {
+                2048: {1: _dsa_value(20.0)},
+                2049: {1: _dsa_value(21.0)},
+                3072: {1: _dsa_value(80.0)},
+                4096: {1: _dsa_value(100.0)},
+            }
+        }
+        stub_perf_db._raw_context_dsa_module_data = LoadedOpData(
+            _context_dsa_data(raw_dsa_dict), common.PerfDataFilename.dsa_context_module, "raw"
+        )
+        stub_perf_db._context_dsa_module_data = LoadedOpData(
+            _context_dsa_data(extrapolated_dsa_dict), common.PerfDataFilename.dsa_context_module, "extrapolated"
+        )
+
+        def fail_interp_3d(*args, **kwargs):
+            raise AssertionError("_interp_3d should not be used for topk + 1 when raw right-regime anchors exist")
+
+        monkeypatch.setattr(stub_perf_db, "_interp_3d", fail_interp_3d)
+
+        result = stub_perf_db.query_context_dsa_module(
+            b=1,
+            s=2049,
+            prefix=0,
+            num_heads=32,
+            index_topk=2048,
+            kvcache_quant_mode=common.KVCacheQuantMode.bfloat16,
+            fmha_quant_mode=common.FMHAQuantMode.bfloat16,
+            gemm_quant_mode=common.GEMMQuantMode.bfloat16,
+            database_mode=common.DatabaseMode.SILICON,
+        )
+
+        assert float(result) == pytest.approx(80.0 + (100.0 - 80.0) / 1024.0 * (2049 - 3072))
+        assert result.energy == pytest.approx((80.0 + (100.0 - 80.0) / 1024.0 * (2049 - 3072)) * 10.0)
+
+    def test_topk_piecewise_falls_back_when_raw_same_regime_anchors_are_unavailable(self, stub_perf_db, monkeypatch):
+        raw_dsa_dict = {
+            32: {
+                2048: {1: _dsa_value(20.0)},
+                4096: {1: _dsa_value(100.0)},
+            }
+        }
+        stub_perf_db._raw_context_dsa_module_data = LoadedOpData(
+            _context_dsa_data(raw_dsa_dict), common.PerfDataFilename.dsa_context_module, "raw"
+        )
+        stub_perf_db._context_dsa_module_data = LoadedOpData(
+            _context_dsa_data(raw_dsa_dict), common.PerfDataFilename.dsa_context_module, "extrapolated"
+        )
+        cubic_calls = []
+
+        def fake_interp_3d(*args, **kwargs):
+            cubic_calls.append((args, kwargs))
+            return {"latency": 123.0, "power": 0.0, "energy": 456.0}
+
+        monkeypatch.setattr(stub_perf_db, "_interp_3d", fake_interp_3d)
+
+        result = stub_perf_db.query_context_dsa_module(
+            b=1,
+            s=2049,
+            prefix=0,
+            num_heads=32,
+            index_topk=2048,
+            kvcache_quant_mode=common.KVCacheQuantMode.bfloat16,
+            fmha_quant_mode=common.FMHAQuantMode.bfloat16,
+            gemm_quant_mode=common.GEMMQuantMode.bfloat16,
+            database_mode=common.DatabaseMode.SILICON,
+        )
+
+        assert float(result) == pytest.approx(123.0)
+        assert result.energy == pytest.approx(456.0)
+        assert len(cubic_calls) == 1
 
     def test_sol_returns_positive(self, comprehensive_perf_db):
         result = comprehensive_perf_db.query_context_dsa_module(


### PR DESCRIPTION
#### Overview:

  Fix DSA context-module silicon interpolation so it does not interpolate across the `index_topk` regime boundary.

  DSA context uses different kernel behavior when the total KV length is `<= index_topk` versus `> index_topk`. The previous cubic 3D
  interpolation could blend data points across that boundary and underestimate cases just above topk.

  #### Details:

  - Added a DSA-specific context interpolation helper in `PerfDatabase`.
  - The helper uses an exact `(num_heads, batch_size)` curve when available.
  - It only interpolates between sequence-length anchors within the same `index_topk` regime.
  - If exact head/batch data or same-regime anchors are unavailable, it falls back to the previous `_interp_3d(..., "cubic")` path.
  - Scope is limited to DSA context-module `SILICON` / `HYBRID` queries.
  - It does not affect DSA generation/decode, regular attention, MLA, MoE, GEMM, comm ops, or `SOL` / `EMPIRICAL` modes.

  #### Where should the reviewer start?

  - `src/aiconfigurator/sdk/perf_database.py`
    - `_interp_dsa_context_topk_piecewise`
    - `query_context_dsa_module`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced accuracy of performance metric calculations (latency, power, energy) for DSA contexts through an improved interpolation methodology that intelligently selects optimal reference points for more precise estimates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->