### PR TITLE
chore: delete the only vllm 0.14.0 perf data

### DIFF
--- a/src/aiconfigurator/systems/data/b200_sxm/vllm/0.14.0/custom_allreduce_perf.txt
+++ b/src/aiconfigurator/systems/data/b200_sxm/vllm/0.14.0/custom_allreduce_perf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:59681678d069c1484fae8fcfa1d53f9038ff46c12a5a59469fc3124b3d72c97c
-size 16400


### PR DESCRIPTION
This PR cleans up #886 leftover data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused file reference from infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->