### PR TITLE
chore: Add data from auto-collector pipeline 49686248 (gb300_trtllm_1.3.0rc10)

### DIFF
--- a/src/aiconfigurator/systems/data/gb300/trtllm/1.3.0rc10/context_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/gb300/trtllm/1.3.0rc10/context_attention_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:71db839b2c804f8c8e225b56167bb1fdecdf0187e54f2db379fe6a6e48283901
-size 5382564
+oid sha256:949fea04e99964f4019237d3bf42869435b3e0eecab6f05e32d469cf046fa380
+size 7224420

--- a/src/aiconfigurator/systems/data/gb300/trtllm/1.3.0rc10/generation_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/gb300/trtllm/1.3.0rc10/generation_attention_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fc56c040365afc8724a83b2ca9b478d764accf76b4d44c6ef638d71d95fc4b89
-size 3499775
+oid sha256:fce17b892b4c9aefa0fc0c8326e5ede3fcd0418b068c57afca58deb7223a5142
+size 4838275


### PR DESCRIPTION
# Error Summary for Auto-Collector Run
## Collection summary for gb300 trtllm:1.3.0rc10
### Error summary
```
{
    "backend": "trtllm",
    "version": "1.3.0rc10",
    "timestamp": "2026-04-28T08:32:40.245208",
    "total_errors": 142,
    "errors_by_module": {
        "trtllm.attention_context": 142
    },
    "errors_by_type": {
        "AcceleratorError": 65,
        "WorkerSignalCrash": 71,
        "RuntimeError": 6
    }
}
```

