### PR TITLE
chore: Add data from auto-collector pipeline 49686248 (gb200_trtllm_1.3.0rc10)

### DIFF
--- a/src/aiconfigurator/systems/data/gb200/trtllm/1.3.0rc10/context_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/gb200/trtllm/1.3.0rc10/context_attention_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5ee143461b195f17a0b72246a050275868fc066b05d5d93d3ba7f65217eec6b1
-size 5381212
+oid sha256:74fe261d4255f1b6a8fa13743860e3887e8cdf38e3e4285aa89be7fc6c43da6c
+size 7222069

--- a/src/aiconfigurator/systems/data/gb200/trtllm/1.3.0rc10/generation_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/gb200/trtllm/1.3.0rc10/generation_attention_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5ce8304db956c7ece873fb75ad4f1f361bb4960a0ad60e48b89164b1f4390ed8
-size 3499823
+oid sha256:9b45d73abe7375f1215864868d23a2d5a4d44b29affd425a3f6a85c498f0e6f3
+size 4838236


### PR DESCRIPTION
# Error Summary for Auto-Collector Run
## Collection summary for gb200 trtllm:1.3.0rc10
### Error summary
```
{
    "backend": "trtllm",
    "version": "1.3.0rc10",
    "timestamp": "2026-04-28T08:34:58.287099",
    "total_errors": 144,
    "errors_by_module": {
        "trtllm.attention_context": 144
    },
    "errors_by_type": {
        "AcceleratorError": 63,
        "WorkerSignalCrash": 72,
        "RuntimeError": 9
    }
}
```

