### PR TITLE
fix: derive MLA KV cache size from config and cover Kimi K2.5

### DIFF
--- a/src/aiconfigurator/sdk/backends/sglang_backend.py
+++ b/src/aiconfigurator/sdk/backends/sglang_backend.py
@@ -540,7 +540,7 @@ class SGLANGBackend(BaseBackend):
             c_dict = {1: 28, 2: 17, 4: 13, 8: 13}
             activations = 2 * num_tokens * h * c_dict[min(model.config.tp_size, 8)]
             activations = max(activations, 90 * 1024 * 1024)  # Higher minimum for SGLANG
-        elif model.model_family in ("DEEPSEEK", "DEEPSEEKV32"):
+        elif model.model_family in ("DEEPSEEK", "DEEPSEEKV32", "KIMIK25"):
             c_dict = {1: 28, 2: 17, 4: 13, 8: 13}
             activations = 2 * num_tokens * h * c_dict[min(model.config.tp_size, 8)]
             activations += (
@@ -568,11 +568,7 @@ class SGLANGBackend(BaseBackend):
         activations += sglang_overhead
 
         # ==== KV Cache calculation - SGLANG specific ====
-        if model.model_family in ("DEEPSEEK", "DEEPSEEKV32"):
-            kvcache_per_token = model._num_layers * 576
-        else:
-            num_kv_heads_per_gpu = (model._num_kv_heads + model.config.tp_size - 1) // model.config.tp_size
-            kvcache_per_token = num_kv_heads_per_gpu * model._head_size * model._num_layers * 2
+        kvcache_per_token = model.get_kvcache_elements_per_token()
 
         kvcache = (
             (batch_size * isl + batch_size * beam_width * osl)

--- a/src/aiconfigurator/sdk/backends/trtllm_backend.py
+++ b/src/aiconfigurator/sdk/backends/trtllm_backend.py
@@ -611,7 +611,7 @@ class TRTLLMBackend(BaseBackend):
             c_dict = {1: 22, 2: 13, 4: 10, 8: 10}
             activations = 2 * num_tokens * h * c_dict[min(model.config.tp_size, 8)]
             activations = max(activations, 70 * 1024 * 1024)  # minimum act
-        elif model.model_family in ("DEEPSEEK", "DEEPSEEKV32"):
+        elif model.model_family in ("DEEPSEEK", "DEEPSEEKV32", "KIMIK25"):
             c_dict = {1: 22, 2: 13, 4: 10, 8: 10}
             activations = 2 * num_tokens * h * c_dict[min(model.config.tp_size, 8)]
             # moe workspace, 128 for block scale, float for 4bytes
@@ -641,11 +641,7 @@ class TRTLLMBackend(BaseBackend):
         if model.config.nextn > 0:
             activations = activations * (model.config.nextn + 1)
 
-        if model.model_family in ("DEEPSEEK", "DEEPSEEKV32"):
-            kvcache_per_token = model._num_layers * 576
-        else:
-            num_kv_heads_per_gpu = (model._num_kv_heads + model.config.tp_size - 1) // model.config.tp_size
-            kvcache_per_token = num_kv_heads_per_gpu * model._head_size * model._num_layers * 2
+        kvcache_per_token = model.get_kvcache_elements_per_token()
         # should not be divided by pp_size as you need to hold all kvcache for stages.
         seq_tokens = max_seq_len if max_seq_len is not None else isl + beam_width * osl
         kvcache = batch_size * seq_tokens * model.config.kvcache_quant_mode.value.memory * kvcache_per_token

--- a/src/aiconfigurator/sdk/models.py
+++ b/src/aiconfigurator/sdk/models.py
@@ -604,6 +604,31 @@ class BaseModel:
         self._nextn = model_config.nextn
         self._nextn_accept_rates = model_config.nextn_accept_rates
 
+    def get_kvcache_elements_per_token(self) -> int:
+        """KV cache size per token (per GPU) summed over all layers, in elements.
+
+        Multiply by ``kvcache_quant_mode.value.memory`` (bytes/elem) for byte size.
+
+        - MLA models (DeepSeek V3/V3.2, Kimi K2/K2.5): the latent KV is shared
+          across heads and not sharded by attention TP, so the per-GPU cost is
+          ``num_layers * (kv_lora_rank + qk_rope_head_dim)``.
+        - Otherwise (GQA/MHA): ``num_kv_heads_per_gpu * head_size * num_layers * 2``.
+        """
+        if self.model_family in ("DEEPSEEK", "DEEPSEEKV32", "KIMIK25"):
+            kv_lora_rank, qk_rope_head_dim = 0, 0
+            if isinstance(self.extra_params, dict):
+                kv_lora_rank = self.extra_params.get("kv_lora_rank") or 0
+                qk_rope_head_dim = self.extra_params.get("qk_rope_head_dim") or 0
+            # Fallback to DeepSeek-V3 / Kimi K2 defaults if config didn't expose them.
+            if kv_lora_rank == 0:
+                kv_lora_rank = 512
+            if qk_rope_head_dim == 0:
+                qk_rope_head_dim = 64
+            return self._num_layers * (kv_lora_rank + qk_rope_head_dim)
+
+        num_kv_heads_per_gpu = (self._num_kv_heads + self.config.tp_size - 1) // self.config.tp_size
+        return num_kv_heads_per_gpu * self._head_size * self._num_layers * 2
+
 
 class GPTModel(BaseModel):
     """

--- a/src/aiconfigurator/sdk/utils.py
+++ b/src/aiconfigurator/sdk/utils.py
@@ -578,8 +578,18 @@ def _parse_hf_config_json(config: dict) -> dict:
         # KIMI K2.5 wraps a DeepSeek-V3-style MLA text model. Store v_head_dim so
         # DeepSeekModel can use the correct attention head size (128) for vLLM's
         # standard-attention path, instead of the generic hidden_size // n_heads = 112.
+        # kv_lora_rank + qk_rope_head_dim drive the MLA latent KV cache size.
         extra_params = {
             "v_head_dim": config.get("v_head_dim", 0),
+            "kv_lora_rank": config.get("kv_lora_rank", 0),
+            "qk_rope_head_dim": config.get("qk_rope_head_dim", 0),
+        }
+    elif architecture in {"DeepSeekForCausalLM", "DeepseekV3ForCausalLM"}:
+        # DeepSeek V3 / R1 / Kimi K2: MLA latent geometry from config so the KV
+        # cache size is data-driven instead of hardcoded.
+        extra_params = {
+            "kv_lora_rank": config.get("kv_lora_rank", 0),
+            "qk_rope_head_dim": config.get("qk_rope_head_dim", 0),
         }
     elif architecture in {"DeepseekV32ForCausalLM", "GlmMoeDsaForCausalLM"}:
         # DeepSeek-V3.2 / GLM-5 share the DSA attention pattern but have different

--- a/tests/unit/sdk/models/test_model_config.py
+++ b/tests/unit/sdk/models/test_model_config.py
@@ -130,6 +130,94 @@ class TestHFModelSupport:
         assert is_moe == is_moe_expected
 
 
+class TestKVCacheElementsPerToken:
+    """Regression tests for ``BaseModel.get_kvcache_elements_per_token``.
+
+    Guards against the bug where MLA models other than DeepSeek (notably
+    KIMIK25 / Kimi K2.5) fell through to the GQA branch in the backend
+    memory model, overestimating per-token KV cache by ~6x and capping the
+    feasible batch size in the agg sweep.
+    """
+
+    @staticmethod
+    def _build_model(hf_id: str, tp_size: int, **extra):
+        model_config = config.ModelConfig(tp_size=tp_size, pp_size=1, attention_dp_size=1, **extra)
+        return models.get_model(hf_id, model_config, backend_name="trtllm")
+
+    @pytest.mark.parametrize(
+        "hf_id,tp,moe_kw,expected_family,expected_elems",
+        [
+            # MLA path: 61 layers * (kv_lora_rank=512 + qk_rope_head_dim=64) = 35136
+            (
+                "nvidia/Kimi-K2.5-NVFP4",
+                4,
+                {"moe_tp_size": 2, "moe_ep_size": 2},
+                "KIMIK25",
+                35136,
+            ),
+            (
+                "deepseek-ai/DeepSeek-V3",
+                4,
+                {"moe_tp_size": 1, "moe_ep_size": 4},
+                "DEEPSEEK",
+                35136,
+            ),
+            (
+                "deepseek-ai/DeepSeek-V3.2",
+                4,
+                {"moe_tp_size": 1, "moe_ep_size": 4},
+                "DEEPSEEKV32",
+                35136,
+            ),
+            # GQA path: num_kv_heads_per_gpu * head_size * num_layers * 2
+            ("meta-llama/Meta-Llama-3.1-8B", 1, {}, "LLAMA", 8 * 128 * 32 * 2),
+            ("Qwen/Qwen3-32B", 4, {}, "LLAMA", 2 * 128 * 64 * 2),
+            (
+                "Qwen/Qwen3-30B-A3B",
+                4,
+                {"moe_tp_size": 1, "moe_ep_size": 4},
+                "MOE",
+                1 * 128 * 48 * 2,
+            ),
+        ],
+    )
+    def test_kvcache_elements_per_token(self, hf_id, tp, moe_kw, expected_family, expected_elems):
+        model = self._build_model(hf_id, tp, **moe_kw)
+        assert model.model_family == expected_family
+        assert model.get_kvcache_elements_per_token() == expected_elems
+
+    @pytest.mark.parametrize(
+        "hf_id",
+        [
+            "nvidia/Kimi-K2.5-NVFP4",
+            "deepseek-ai/DeepSeek-V3",
+            "deepseek-ai/DeepSeek-V3.2",
+        ],
+    )
+    def test_mla_dims_exposed_via_extra_params(self, hf_id):
+        """Parser must expose kv_lora_rank/qk_rope_head_dim so the KV cache
+        size is data-driven instead of relying on the 512/64 fallback."""
+        parsed = get_model_config_from_model_path(hf_id)
+        extra = parsed["extra_params"]
+        assert isinstance(extra, dict), f"{hf_id}: extra_params should be a dict"
+        assert extra.get("kv_lora_rank") == 512, f"{hf_id}: kv_lora_rank not extracted"
+        assert extra.get("qk_rope_head_dim") == 64, f"{hf_id}: qk_rope_head_dim not extracted"
+
+    def test_kimik25_does_not_use_gqa_branch(self):
+        """Direct regression for the original concurrency cap bug: with the
+        GQA branch, KIMIK25 would compute 16*112*61*2 = 218624 elems/token at
+        TP=4 (a ~6.2x overestimate). The MLA branch must produce 35136."""
+        model = self._build_model("nvidia/Kimi-K2.5-NVFP4", tp_size=4, moe_tp_size=2, moe_ep_size=2)
+        gqa_elems = (
+            ((model._num_kv_heads + model.config.tp_size - 1) // model.config.tp_size)
+            * model._head_size
+            * model._num_layers
+            * 2
+        )
+        assert gqa_elems != model.get_kvcache_elements_per_token()
+        assert model.get_kvcache_elements_per_token() == model._num_layers * (512 + 64)
+
+
 class TestBackendConfiguration:
     """Test backend configuration."""
 


### PR DESCRIPTION
The KV cache memory model in trtllm and sglang backends only treated DEEPSEEK / DEEPSEEKV32 as MLA. KIMIK25 (Kimi K2/K2.5) fell through to the generic GQA branch, which overestimates KV per token by ~6.2x for this architecture. On a B200 SXM with isl=8000 osl=1000 the bogus estimate trips the kv_cache budget at b=16, so the agg sweep stops at concurrency=16 even though the model can fit ~95.

Replace the hardcoded 576-element MLA constant with a single get_kvcache_elements_per_token() method on BaseModel that reads kv_lora_rank and qk_rope_head_dim from the parsed HF config (now exposed via extra_params for DeepSeek V3/R1 and Kimi K2.5; V3.2 already exposed them). Both backends call this method, so vLLM picks it up via delegation. Hardcoded 512/64 remain only as a final fallback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for KIMIK25 model family with unified memory calculations.
  * Improved KV cache memory estimation consistency across model architectures using model-specific configuration parameters.

* **Bug Fixes**
  * Fixed activation memory estimation for improved accuracy across supported model families.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->