### PR TITLE
feat: add --resume-retry-failed collector arg

### DIFF
--- a/collector/collect.py
+++ b/collector/collect.py
@@ -93,6 +93,7 @@ class ResumeCheckpoint:
             "run_func": run_func_name,
         }
         self._done: set[str] = set()
+        self._failed: set[str] = set()
 
         safe_name = module_name.replace("/", "_").replace(":", "_")
         self._path = Path(checkpoint_dir).expanduser().resolve() / backend / f"{safe_name}.json"
@@ -121,22 +122,47 @@ class ResumeCheckpoint:
                 )
 
         self._done = set(data.get("done", []))
-        logger.info(f"{self.module_name}: loaded {len(self._done)} completed tasks from checkpoint")
+        self._failed = set(data.get("failed", []))
+        logger.info(f"{self.module_name}: loaded checkpoint — {len(self._done)} passed, {len(self._failed)} failed")
 
     # -- public API -------------------------------------------------------
 
-    def filter_done(self, task_infos: list[dict]) -> list[dict]:
-        """Return only tasks that are not yet done."""
-        runnable = [t for t in task_infos if t["id"] not in self._done]
-        skipped = len(task_infos) - len(runnable)
-        if skipped:
-            logger.info(f"{self.module_name}: skipping {skipped} done tasks, running {len(runnable)}")
+    def filter_done(self, task_infos: list[dict], retry_failed: bool = False) -> list[dict]:
+        """Return only tasks that need to run.
+
+        By default, skips both passed and failed tasks. With retry_failed=True,
+        previously failed tasks are retried.
+        """
+        skip_set = self._done if retry_failed else (self._done | self._failed)
+        runnable = [t for t in task_infos if t["id"] not in skip_set]
+        skipped_done = sum(1 for t in task_infos if t["id"] in self._done)
+        skipped_failed = sum(1 for t in task_infos if t["id"] in self._failed)
+        retrying = sum(1 for t in runnable if t["id"] in self._failed) if retry_failed else 0
+        if skipped_done or skipped_failed or retrying:
+            parts = [f"skipping {skipped_done} passed"]
+            if retry_failed:
+                parts.append(f"retrying {retrying} previously failed")
+            else:
+                parts.append(f"skipping {skipped_failed} failed")
+            parts.append(f"running {len(runnable)}")
+            logger.info(f"{self.module_name}: {', '.join(parts)}")
         return runnable
 
-    def mark_done(self, task_id: str):
+    def mark_passed(self, task_id: str):
+        """Mark a task as successfully completed. Skipped on resume."""
         self._done.add(task_id)
+        self._failed.discard(task_id)  # if it was previously failed, it passed now
         self._dirty = True
         self.flush()
+
+    def mark_failed(self, task_id: str):
+        """Mark a task as attempted but failed. Retried on resume."""
+        self._failed.add(task_id)
+        self._dirty = True
+        self.flush()
+
+    # Keep mark_done as alias for backwards compat
+    mark_done = mark_passed
 
     def flush(self, force: bool = False):
         if not self._dirty:
@@ -145,7 +171,12 @@ class ResumeCheckpoint:
         if not force and (now - self._last_flush) < self.FLUSH_INTERVAL_SEC:
             return
 
-        data = {**self._metadata, "updated_at": datetime.now().isoformat(), "done": sorted(self._done)}
+        data = {
+            **self._metadata,
+            "updated_at": datetime.now().isoformat(),
+            "done": sorted(self._done),
+            "failed": sorted(self._failed),
+        }
         tmp_path = self._path.with_suffix(".json.tmp")
         with open(tmp_path, "w") as f:
             json.dump(data, f, indent=2)
@@ -282,6 +313,7 @@ def worker(
     lock,
     error_queue=None,
     done_tasks=None,
+    failed_tasks=None,
     module_name="unknown",
     current_task_ids=None,
     consumed_sentinel=None,
@@ -331,6 +363,13 @@ def worker(
             worker_logger.debug(f"Starting task {task_id}")
             func(*task, device=device)
             worker_logger.debug(f"Completed task {task_id}")
+
+            # Mark done ONLY on success — failed tasks should be retried on resume
+            if done_tasks is not None:
+                try:
+                    done_tasks[task_id] = True
+                except Exception:
+                    pass
         except Exception as e:
             # Build comprehensive error info
             error_info = {
@@ -349,6 +388,13 @@ def worker(
                 error_queue.put(error_info)
 
             worker_logger.exception(f"Task {task_id} failed")
+
+            # Track failed task for checkpoint
+            if failed_tasks is not None:
+                try:
+                    failed_tasks[task_id] = True
+                except Exception:
+                    pass
 
             # Force flush logs before any potential exit
             for handler in worker_logger.handlers:
@@ -374,16 +420,6 @@ def worker(
                 # which we don't want (error already reported above).
                 exit(0)
         finally:
-            # All three writes below use synchronous manager RPCs, so they
-            # are guaranteed to complete before the worker picks up the next
-            # task.  This means even if the *next* task kills the process
-            # via signal, the bookkeeping for *this* task is already safe.
-            if done_tasks is not None:
-                try:
-                    done_tasks[task_id] = True
-                except Exception:
-                    pass
-
             with lock:
                 progress_value.value += 1
             if current_task_ids is not None:
@@ -428,7 +464,8 @@ def parallel_run(tasks, func, num_processes, module_name="unknown", resume_optio
 
     if resume_options and resume_options.get("resume"):
         resume_tracker.load_existing()
-        task_infos = resume_tracker.filter_done(raw_task_infos)
+        retry_failed = resume_options.get("retry_failed", False)
+        task_infos = resume_tracker.filter_done(raw_task_infos, retry_failed=retry_failed)
     else:
         task_infos = raw_task_infos
 
@@ -457,6 +494,7 @@ def parallel_run(tasks, func, num_processes, module_name="unknown", resume_optio
     # task.  Unlike mp.Queue (async feeder thread) this cannot be lost when
     # a worker is killed by a signal on a subsequent task.
     done_tasks = manager.dict()
+    failed_tasks = manager.dict()
 
     def start_process(device_id):
         p = mp.Process(
@@ -469,6 +507,7 @@ def parallel_run(tasks, func, num_processes, module_name="unknown", resume_optio
                 lock,
                 error_queue,
                 done_tasks,
+                failed_tasks,
                 module_name,
                 current_task_ids,
                 consumed_sentinel,
@@ -510,9 +549,15 @@ def parallel_run(tasks, func, num_processes, module_name="unknown", resume_optio
 
     def sync_done_to_checkpoint():
         for task_id in list(done_tasks.keys()):
-            resume_tracker.mark_done(task_id)
+            resume_tracker.mark_passed(task_id)
             try:
                 del done_tasks[task_id]
+            except KeyError:
+                pass
+        for task_id in list(failed_tasks.keys()):
+            resume_tracker.mark_failed(task_id)
+            try:
+                del failed_tasks[task_id]
             except KeyError:
                 pass
 
@@ -548,8 +593,9 @@ def parallel_run(tasks, func, num_processes, module_name="unknown", resume_optio
 
                 try:
                     func(*task_params, device=device)
-                    resume_tracker.mark_done(task_id)
+                    resume_tracker.mark_passed(task_id)
                 except Exception as e:
+                    resume_tracker.mark_failed(task_id)
                     error_info = {
                         "module": module_name,
                         "device_id": 0,
@@ -621,7 +667,11 @@ def parallel_run(tasks, func, num_processes, module_name="unknown", resume_optio
                         pbar.set_postfix({"errors": len(errors)})
                         last_error_count = len(errors)
                         if active_task_id is not None:
-                            resume_tracker.mark_done(active_task_id)
+                            # Mark as failed so it's retried on resume
+                            try:
+                                failed_tasks[active_task_id] = True
+                            except Exception:
+                                pass
                             current_task_ids[i] = None
                             with lock:
                                 progress_value.value += 1
@@ -974,7 +1024,12 @@ def main():
     parser.add_argument(
         "--resume",
         action="store_true",
-        help="Resume collection from checkpoint, skipping already-attempted tasks",
+        help="Resume collection from checkpoint, skipping passed and failed tasks",
+    )
+    parser.add_argument(
+        "--resume-retry-failed",
+        action="store_true",
+        help="When resuming, retry previously failed tasks instead of skipping them",
     )
     parser.add_argument(
         "--checkpoint-dir",
@@ -1036,9 +1091,13 @@ def main():
     resume_options = {
         "resume": args.resume,
         "checkpoint_dir": args.checkpoint_dir,
+        "retry_failed": args.resume_retry_failed,
     }
     if args.resume:
-        logger.info(f"Resume enabled: dir={Path(args.checkpoint_dir).expanduser()}")
+        logger.info(
+            f"Resume enabled: dir={Path(args.checkpoint_dir).expanduser()}"
+            + (" (retrying previously failed tasks)" if args.resume_retry_failed else "")
+        )
 
     # Determine number of processes (0 = sequential mode for profiling)
     if args.profile:

--- a/collector/collect.py
+++ b/collector/collect.py
@@ -1029,7 +1029,7 @@ def main():
     parser.add_argument(
         "--resume-retry-failed",
         action="store_true",
-        help="When resuming, retry previously failed tasks instead of skipping them",
+        help="When resuming, retry previously failed tasks instead of skipping them. Requires --resume.",
     )
     parser.add_argument(
         "--checkpoint-dir",
@@ -1093,6 +1093,8 @@ def main():
         "checkpoint_dir": args.checkpoint_dir,
         "retry_failed": args.resume_retry_failed,
     }
+    if args.resume_retry_failed and not args.resume:
+        parser.error("--resume-retry-failed requires --resume")
     if args.resume:
         logger.info(
             f"Resume enabled: dir={Path(args.checkpoint_dir).expanduser()}"

--- a/collector/collect.py
+++ b/collector/collect.py
@@ -370,6 +370,21 @@ def worker(
                     done_tasks[task_id] = True
                 except Exception:
                     pass
+            # Clear task ID on success so crash handler knows it completed
+            if current_task_ids is not None:
+                current_task_ids[device_id] = None
+        except SystemExit as e:
+            # EXIT_CODE_RESTART: task completed successfully, worker exits to free GPU memory
+            # (e.g., MOE collectors call sys.exit(EXIT_CODE_RESTART) after finishing)
+            if e.code == EXIT_CODE_RESTART:
+                if done_tasks is not None:
+                    try:
+                        done_tasks[task_id] = True
+                    except Exception:
+                        pass
+                if current_task_ids is not None:
+                    current_task_ids[device_id] = None
+            raise  # re-raise so the worker actually exits
         except Exception as e:
             # Build comprehensive error info
             error_info = {
@@ -395,6 +410,9 @@ def worker(
                     failed_tasks[task_id] = True
                 except Exception:
                     pass
+            # Clear task ID so crash handler knows it was handled
+            if current_task_ids is not None:
+                current_task_ids[device_id] = None
 
             # Force flush logs before any potential exit
             for handler in worker_logger.handlers:
@@ -422,8 +440,6 @@ def worker(
         finally:
             with lock:
                 progress_value.value += 1
-            if current_task_ids is not None:
-                current_task_ids[device_id] = None
 
             # Periodic memory cleanup to reduce fragmentation
             if progress_value.value % 100 == 0:
@@ -660,21 +676,22 @@ def parallel_run(tasks, func, num_processes, module_name="unknown", resume_optio
                             f"errors: {len(process_stats[i]['errors'])})"
                         )
 
+                    # Mark active task as failed if the process died while running it
+                    if active_task_id is not None and active_task_id not in done_tasks:
+                        try:
+                            failed_tasks[active_task_id] = True
+                        except Exception:
+                            pass
+                        current_task_ids[i] = None
+                        with lock:
+                            progress_value.value += 1
+
                     crash_error = create_process_exit_error(i, exit_code)
                     if crash_error:
                         errors.append(crash_error)
                         process_stats[i]["errors"].append("process_exit")
                         pbar.set_postfix({"errors": len(errors)})
                         last_error_count = len(errors)
-                        if active_task_id is not None:
-                            # Mark as failed so it's retried on resume
-                            try:
-                                failed_tasks[active_task_id] = True
-                            except Exception:
-                                pass
-                            current_task_ids[i] = None
-                            with lock:
-                                progress_value.value += 1
 
                     if process_stats[i]["restarts"] > 8192:
                         logger.error(f"Process {i} exceeded restart limit, not restarting")

--- a/tests/unit/collector/test_parallel_run.py
+++ b/tests/unit/collector/test_parallel_run.py
@@ -118,20 +118,31 @@ def _checkpoint_path(tmp_path, module_name, backend="unknown"):
     return tmp_path / ".checkpoint" / backend / f"{safe_name}.json"
 
 
-def _load_done_ids(tmp_path, module_name, backend="unknown"):
+def _load_checkpoint_data(tmp_path, module_name, backend="unknown"):
     checkpoint = _checkpoint_path(tmp_path, module_name, backend=backend)
     assert checkpoint.exists(), f"checkpoint not found: {checkpoint}"
     with checkpoint.open() as f:
-        data = json.load(f)
+        return json.load(f)
+
+
+def _load_done_ids(tmp_path, module_name, backend="unknown"):
+    data = _load_checkpoint_data(tmp_path, module_name, backend=backend)
     return set(data.get("done", []))
+
+
+def _load_failed_ids(tmp_path, module_name, backend="unknown"):
+    data = _load_checkpoint_data(tmp_path, module_name, backend=backend)
+    return set(data.get("failed", []))
 
 
 def _assert_all_tasks_attempted(tasks, tmp_path, module_name):
     expected = {task["id"] for task in tasks}
-    actual = _load_done_ids(tmp_path, module_name)
-    missing = expected - actual
-    extra = actual - expected
-    assert actual == expected, f"done mismatch: missing={missing}, extra={extra}"
+    done = _load_done_ids(tmp_path, module_name)
+    failed = _load_failed_ids(tmp_path, module_name)
+    attempted = done | failed
+    missing = expected - attempted
+    extra = attempted - expected
+    assert attempted == expected, f"attempted mismatch: missing={missing}, extra={extra}"
 
 
 def _run_and_assert_all_done(tasks, num_processes, tmp_path, module_name):
@@ -164,10 +175,12 @@ class TestNormalCompletion:
     def test_two_workers(self, tmp_path):
         tasks = _tasks(8)
         assert _run_and_assert_all_done(tasks, 2, tmp_path, module_name="normal_two_workers") == []
+        assert _load_failed_ids(tmp_path, "normal_two_workers") == set()
 
     def test_single_worker(self, tmp_path):
         tasks = _tasks(4)
         assert _run_and_assert_all_done(tasks, 1, tmp_path, module_name="normal_single_worker") == []
+        assert _load_failed_ids(tmp_path, "normal_single_worker") == set()
 
 
 class TestExitCodeRestart:
@@ -204,6 +217,8 @@ class TestTaskExceptions:
         tasks = _tasks([(f"t{i}", "error") for i in range(4)])
         errors = _run_and_assert_all_done(tasks, 2, tmp_path, module_name="all_fail")
         assert len([e for e in errors if e.get("error_type") == "ValueError"]) == 4
+        assert _load_done_ids(tmp_path, "all_fail") == set()
+        assert _load_failed_ids(tmp_path, "all_fail") == {f"t{i}" for i in range(4)}
 
     def test_mixed_success_and_fail(self, tmp_path):
         tasks = _tasks(
@@ -217,6 +232,8 @@ class TestTaskExceptions:
         )
         errors = _run_and_assert_all_done(tasks, 2, tmp_path, module_name="mixed_success_fail")
         assert len([e for e in errors if e.get("error_type") == "ValueError"]) == 2
+        assert _load_done_ids(tmp_path, "mixed_success_fail") == {"a", "c", "e"}
+        assert _load_failed_ids(tmp_path, "mixed_success_fail") == {"b", "d"}
 
 
 class TestMixedFailureModes:
@@ -238,6 +255,10 @@ class TestMixedFailureModes:
         errors = _run_and_assert_all_done(tasks, 2, tmp_path, module_name="restart_and_exception")
         assert len([e for e in errors if e.get("error_type") == "ValueError"]) == 2
         assert _crash_errors(errors) == []
+        done = _load_done_ids(tmp_path, "restart_and_exception")
+        failed = _load_failed_ids(tmp_path, "restart_and_exception")
+        assert {"a", "b", "d", "e", "g", "h"} == done  # normal + exit_restart = passed
+        assert {"c", "f"} == failed  # error = failed
 
 
 class TestSentinelBalance:
@@ -280,7 +301,7 @@ class TestSentinelBalance:
 class TestSignalCrashRecovery:
     """Fatal signal exits should be accounted for exactly once."""
 
-    def test_sigabrt_tasks_are_marked_done(self, tmp_path):
+    def test_sigabrt_tasks_are_tracked(self, tmp_path):
         tasks = _tasks(
             [
                 ("a", "normal"),
@@ -292,6 +313,10 @@ class TestSignalCrashRecovery:
         )
         errors = _run_and_assert_all_done(tasks, 2, tmp_path, module_name="sigabrt_done")
         assert len([e for e in errors if e.get("error_type") == "WorkerSignalCrash"]) >= 2
+        done = _load_done_ids(tmp_path, "sigabrt_done")
+        failed = _load_failed_ids(tmp_path, "sigabrt_done")
+        assert {"a", "c", "e"} == done
+        assert {"b", "d"} == failed
 
     def test_sigabrt_and_restart_mix(self, tmp_path):
         tasks = _tasks(
@@ -306,3 +331,7 @@ class TestSignalCrashRecovery:
         )
         errors = _run_and_assert_all_done(tasks, 2, tmp_path, module_name="sigabrt_restart_mix")
         assert len([e for e in errors if e.get("error_type") == "WorkerSignalCrash"]) >= 2
+        done = _load_done_ids(tmp_path, "sigabrt_restart_mix")
+        failed = _load_failed_ids(tmp_path, "sigabrt_restart_mix")
+        assert {"b", "c", "e", "f"} == done  # exit_restart + normal = passed
+        assert {"a", "d"} == failed  # sigabrt = failed


### PR DESCRIPTION
Previously, failed cases were marked "done" in collector checkpoints. Now, they are marked as "failed" instead. When `--resume` is used, the default behavior is the same as before (skip all cases that were run before - passed or failed). Add a new option `--resume-retry-failed` which can be used together with `--resume`, and it will retry previously failed testcases.

Default resume behavior (skip previously failed cases) is useful for when you are trying to collect all data points without modifying collector code.

New behavior (`--resume-retry-failed`) is useful for when you are iterating on fixing bugs in the collector code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--resume-retry-failed` option to retry previously failed tasks when resuming a collection.

* **Improvements**
  * Enhanced task status tracking to distinguish between successful and failed task outcomes in checkpoint data.
  * Improved resume logic to better manage task state persistence and recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->