### PR TITLE
docs: fix typos, broken link, and missing cd

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ apt-get install git-lfs  # (Linux)
 
 # 2. Clone the repo
 git clone https://github.com/ai-dynamo/aiconfigurator.git
+cd aiconfigurator
 git lfs pull
 
 # 3. Create and activate a virtual environment

--- a/docs/advanced_tuning.md
+++ b/docs/advanced_tuning.md
@@ -2,14 +2,14 @@
 In aiconfigurator, the inference framework and serving modeling is relatively complicated compared with the most simplified CLI entrypoint.  
 For example, behind the command,
 ```bash
-  aiconfigurator cli default --model-path Qwen/Qwen3-32B-FP8 --total-gpus 512 --system h200_sxm
+aiconfigurator cli default --model-path Qwen/Qwen3-32B-FP8 --total-gpus 512 --system h200_sxm
 ```
 We hide a lot of default settings of the execution. Such as the quantization of each component, the matrix multiply, attention, moe, etc. We  
 also hide the parallel config for how we search possible combinations.  
 
 The optional params of cli contains the definition of ISL, OSL, TTFT and TPOT while we don't cover these params mentioned above. In CLI, We auto populate all these stuff for `default` mode and allow users to modify in `exp` mode. Since webapp follows the same logic, we take CLI as an example,
 ```bash
-  aiconfigurator cli exp --yaml-path example.yaml
+aiconfigurator cli exp --yaml-path example.yaml
 ```
 The example.yaml is defined [here](../src/aiconfigurator/cli/example.yaml).  
 Let's take a look at example.yaml
@@ -132,7 +132,7 @@ Explicit quantization in `profiles` or the YAML `config` overrides those default
 This is the most complicated part of the search space definition.  
 First, `num_gpu_per_worker` is trying to define how many gpus in a worker, the searched result will do exact match.
 Then, we define options for different components, tp for attention module, pp for transformer layer. Specifically for MoE, dp for attention data parallel, 
-moe_tp for moe tensor parallel and moe_ep for moe expert paralell.  
+moe_tp for moe tensor parallel and moe_ep for moe expert parallel.  
 Here's the pseudo code about how we enumerate valid configs based on the various list definitions,
 ```python
     for config in space[tp x pp x dp x moe_tp x moe_ep]:

--- a/docs/cli_user_guide.md
+++ b/docs/cli_user_guide.md
@@ -842,7 +842,7 @@ We defined two experiments. `exp_h200_h200` uses h200 for both prefill and decod
 **Note**: You can also compare different backends by setting different `backend_name` values (trtllm, vllm, sglang) in your experiments.
 
 2. use a specific quantization  
-The example [yaml](../src/aiconfigurator/cli/exps/qwen3_32b_disagg_pertensor.yaml)
+The example [yaml](../src/aiconfigurator/cli/exps/qwen3_32b_pertensor.yaml)
 ```yaml
 exps:
   - exp_agg

--- a/docs/dynamo_deployment_guide.md
+++ b/docs/dynamo_deployment_guide.md
@@ -74,7 +74,7 @@ predicted by aiconfigurator. E.g., [1 2 4 8 ... target_concurrency]
 Compare the result at target_concurrency with `TTFT, TPOT, tokens/s/gpu and previous baseline you have`
 
 > In order to reduce the impact of first batch of requests, we use `concurrency * 10` as `num_requests`
-> In order to aovid undefined cache hit rate when benchmarking with random data, we delebrately disable 
+> In order to avoid undefined cache hit rate when benchmarking with random data, we deliberately disable 
 cache reuse to make it fair.
 
 ## Step-by-step Manual Deployment

--- a/src/aiconfigurator/webapp/README.md
+++ b/src/aiconfigurator/webapp/README.md
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 # Run
 After install aiconfigurator
 ```bash
- aiconfigurator webapp --server-name 0.0.0.0 --server-port 7860
+aiconfigurator webapp --server-name 0.0.0.0 --server-port 7860
 ```
 
 Optional: override system YAML/data search paths:


### PR DESCRIPTION
Misc docs cleanup removing leading spaces (doesn't register in bash history) and missing commands like `cd` into the repo, + typos

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified build and installation instructions for source builds
  * Fixed spelling errors and formatting inconsistencies across guides
  * Updated CLI example references to correct configuration files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->