### PR TITLE
ci: split build-test workflow into unit/e2e matrix jobs

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -12,9 +12,19 @@ on:
 
 jobs:
   build-and-test:
-    name: Build and Test
+    name: Build and Test (${{ matrix.suite.name }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          - name: unit
+            paths: tests/unit
+            workers: "-n 2"
+          - name: e2e
+            paths: tests/e2e
+            workers: "-n 2"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -30,9 +40,10 @@ jobs:
           docker build -f docker/Dockerfile -t aiconfigurator:test --target test .
           docker run --name aic aiconfigurator:test \
             pytest \
+            ${{ matrix.suite.paths }} \
             -m "unit or build" \
             -v --tb=short --maxfail=1 --timeout=600 \
-            -n 2 \
+            ${{ matrix.suite.workers }} \
             --md-report --md-report-verbose=1 --md-report-flavor gfm --md-report-output test_report.md
       - name: Copy test report from test Container
         if: always()


### PR DESCRIPTION
## Issue

The `Build and Test` workflow has been timing out at its 30-minute job budget on PRs that exercise the e2e support-matrix tests. The job is canceled with `##[error]The operation was canceled.` after running ~95% of the suite. No tests fail — the suite simply doesn't fit in 30 minutes.

Most recently observed on the CI run for #904: https://github.com/ai-dynamo/aiconfigurator/actions/runs/25110665068

## Root cause

`pytest` runs with `pytest-xdist -n 2`, using xdist's default `LoadScheduling`. With `N = 859` collected items, xdist computes `initial_batch = N // (4 * num_workers) = 107` and dispatches a fixed 107-item chunk to each worker before any items go through the global pending queue.

Because pytest collects directories alphabetically (`tests/e2e/` < `tests/integration/` < `tests/unit/`), items 0–106 contain virtually every `build`-marked e2e test (~73 cases across `e2e/cli/`, `e2e/support_matrix/`, `e2e/tools/`). All those slow tests get pinned to one worker by the initial dispatch, and `LoadScheduling` does **not** do work-stealing — once the global pending queue empties, an idle worker cannot pull from a busy one.

Worker activity on the failing run:

| | Worker 0 | Worker 1 |
|---|---|---|
| Unit tests run | 752 | 0 |
| E2E tests run | 0 | 65 |
| Last activity | 13:14:48 | 13:37:42 |
| Idle time | **~23 min** | 0 |

One worker finished its share in ~6 minutes; the other ran the slow e2e tests serially for the full 30 minutes and still didn't finish. The job was killed at 95% complete.

### Why this surfaced now

This pathology was latent on `main` before #904. Previously, every parametrized `test_pr_support_matrix` case was reporting as unsupported via `cli_support()` and skipping in <1s, so the e2e file effectively contributed nothing to runtime. After #904 (which expanded `sdk/perf_database.py` and `sdk/models.py`), **24 of the 36 support-matrix combos now actually run** instead of skipping:

| | `test_pr_support_matrix` PASSED | `test_pr_support_matrix` SKIPPED |
|---|---|---|
| `main` (last green: run 25078926198) | 0 | 36 |
| `dsv4` after #904 (failing run) | 24 | 12 |

Each newly-running case takes ~30–90 s; that adds ~20 minutes of real e2e wall-time. This is correct behavior — the support-matrix tests on `main` were de-facto no-ops; #904 made them do real work — but it pushed the suite past the 30-minute single-job budget.

## Intent

- Keep `pytest-xdist -n 2`. Raising it has historically OOM'd `test_validate_database` on `ubuntu-latest`.
- Keep the per-job 30-minute `timeout-minutes`.
- **No test-file changes.** Prefer a workflow-only fix so the intent is obvious in CI configuration; avoid threading `xdist_group` markers or scheduling tweaks through the test code.
- Give each half of the suite its own runner and its own 30-minute budget.

## Fix

Convert the single `build-and-test` job into a 2-entry `strategy.matrix` over `suite`:

| matrix entry | `paths` | `workers` | observed/expected wall-time |
|---|---|---|---|
| `unit` | `tests/unit` | `-n 2` | ~6 min (Worker 0's pace today) |
| `e2e`  | `tests/e2e`  | `-n 2` | ~12–15 min (parallelizes the slow e2e tests across two workers instead of pinning them all to one) |

Each matrix entry runs on a fresh `ubuntu-latest` runner with its own 30-minute `timeout-minutes`. The same `-m "unit or build"` selector and Docker build/test invocation are reused — only the path scope and worker flag are templated through matrix variables. `fail-fast: false` ensures one entry keeps running if the other fails, so we get full signal on every PR.

Diff: 1 file, +13/-2 lines (`.github/workflows/build-test.yml`).

## Caveats / follow-ups

- **Memory parallelism for `test_validate_database`.** In the previous configuration, only one xdist worker ever ran e2e tests concurrently (the other was busy with unit tests). After this split, both workers in the `e2e` job will be running e2e tests concurrently — including up to 2 simultaneous `test_validate_database` subprocesses. This is below the `-n 4` configuration that previously OOM'd, but it is a behavior change. If the e2e job OOMs on its first run, change one line to `workers: "-n 1"` for the e2e entry to fall back to serial e2e (~25 min, still under 30).
- **Branch-protection check names will change.** The required check `Build and Test` no longer exists; the new names are `Build and Test (unit)` and `Build and Test (e2e)`. Protected-branch settings will need to be updated, otherwise the rule silently passes.
- **Future levers (no test-file changes required) if e2e runtime keeps growing.** Splitting `tests/e2e/tools` into its own matrix entry with `-n 1` lets the rest of e2e stay at `-n 2`. Alternatively, `--dist=worksteal` on xdist 3.2+ enables work-stealing within a job; the only reason it isn't applied here is that it could allow 2 concurrent `test_validate_database` runs — exactly the OOM concern called out above.

## Test plan

- [x] Workflow YAML parses (`yaml.safe_load` locally).
- [ ] First post-merge run produces both `Build and Test (unit)` and `Build and Test (e2e)` checks; both finish green.
- [ ] `Build and Test (e2e)` finishes well inside 30 min (target ~15 min). If it OOMs, fall back to `workers: "-n 1"` for the e2e entry.
- [ ] Branch-protection rules updated to require the new check names instead of `Build and Test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests

* Updated test execution to run unit and end-to-end test suites as parallel variants with suite-specific configuration.
* Improved test reliability by ensuring failures in one test suite do not cancel the execution of other suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->