### PR TITLE
chore: Add data from auto-collector pipeline 49856094 (gb200_vllm_0.19.0)

### DIFF
--- a/src/aiconfigurator/systems/data/gb200/vllm/0.19.0/moe_perf.txt
+++ b/src/aiconfigurator/systems/data/gb200/vllm/0.19.0/moe_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7793ec2e519bddfe54a57a0d8d0a90f76f0c25e6e614ce600bcf9c146e5ee2ea
-size 4714993
+oid sha256:78fba7576c7eb0a6bc76981e70f309ec59f909a69fc826e72f17c03f0ad1e18e
+size 5279864


### PR DESCRIPTION
# Error Summary for Auto-Collector Run
## Collection summary for gb200 vllm:0.19.0
### Error summary
```
{
    "backend": "vllm",
    "version": "0.19.0",
    "timestamp": "2026-04-29T23:14:10.000316",
    "total_errors": 408,
    "errors_by_module": {
        "vllm.moe": 408
    },
    "errors_by_type": {
        "RuntimeError": 360,
        "AssertionError": 48
    }
}
```

