### PR TITLE
chore: Add data from auto-collector pipeline 49856094 (gb300_vllm_0.19.0)

### DIFF
--- a/src/aiconfigurator/systems/data/gb300/vllm/0.19.0/moe_perf.txt
+++ b/src/aiconfigurator/systems/data/gb300/vllm/0.19.0/moe_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a87601a11ca985a2ebfcc684dd1c856a1d90327bc974ad67bbbbe72bcdc0530e
-size 4714850
+oid sha256:b18be15ea9bbbc5efbb3292128c47e45256ac687c0952c12f34d5e8cd86444e0
+size 5280132


### PR DESCRIPTION
# Error Summary for Auto-Collector Run
## Collection summary for gb300 vllm:0.19.0
### Error summary
```
{
    "backend": "vllm",
    "version": "0.19.0",
    "timestamp": "2026-04-29T23:15:41.055852",
    "total_errors": 408,
    "errors_by_module": {
        "vllm.moe": 408
    },
    "errors_by_type": {
        "RuntimeError": 360,
        "AssertionError": 48
    }
}
```

