### PR TITLE
ci: Revert test timeout and speed up unit tests 5x

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -14,7 +14,7 @@ jobs:
   build-and-test:
     name: Build and Test (${{ matrix.suite.name }})
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -32,6 +32,10 @@ jobs:
           lfs: true
       - name: Git LFS Pull
         run: git lfs pull
+      - name: Print runner resources
+        run: |
+          echo "CPU cores: $(nproc)"
+          free -h
       - name: Build wheel in container
         run: |
           docker build -f docker/Dockerfile -t aiconfigurator:build --target build .

--- a/tests/unit/sdk/database/conftest.py
+++ b/tests/unit/sdk/database/conftest.py
@@ -12,6 +12,50 @@ import yaml
 from aiconfigurator.sdk import common
 from aiconfigurator.sdk.perf_database import PerfDatabase
 
+# ---------------------------------------------------------------------------
+# Single source of truth: every loader function that PerfDatabase.__init__
+# can call via its internal _load_op_data / func_map.
+#
+# Mapping: function_name -> default stub return value.
+#   * Most loaders return None when the perf file is absent.
+#   * load_moe_data is special: it returns a *tuple* of two dicts.
+#   * load_nccl_data covers both nccl and oneccl keys in func_map.
+#
+# When PerfDatabase adds a new loader, add a line here.  Both
+# _patch_all_loaders_and_yaml() and _get_comprehensive_db_singleton()
+# derive their patch lists from this dict, so they cannot drift.
+# ---------------------------------------------------------------------------
+_LOADER_STUBS: dict[str, object] = {
+    "load_gemm_data": None,
+    "load_context_attention_data": None,
+    "load_generation_attention_data": None,
+    "load_moe_data": (None, None),  # returns tuple
+    "load_custom_allreduce_data": None,
+    "load_nccl_data": None,  # also used for oneccl
+    "load_context_mla_data": None,
+    "load_generation_mla_data": None,
+    "load_mla_bmm_data": None,
+    "load_mamba2_data": None,
+    "load_gdn_data": None,
+    "load_compute_scale_data": None,
+    "load_scale_matrix_data": None,
+    "load_wideep_context_moe_data": None,
+    "load_wideep_generation_moe_data": None,
+    "load_wideep_context_mla_data": None,
+    "load_wideep_generation_mla_data": None,
+    "load_wideep_deepep_normal_data": None,
+    "load_wideep_deepep_ll_data": None,
+    "load_wideep_moe_compute_data": None,
+    "load_trtllm_alltoall_data": None,
+    "load_context_mla_module_data": None,
+    "load_generation_mla_module_data": None,
+    "load_context_dsa_module_data": None,
+    "load_generation_dsa_module_data": None,
+    "load_deepseek_v4_mhc_module_data": None,
+    "load_context_deepseek_v4_attention_module_data": None,
+    "load_generation_deepseek_v4_attention_module_data": None,
+}
+
 
 def _patch_all_loaders_and_yaml(monkeypatch) -> None:
     """
@@ -67,7 +111,6 @@ def _patch_all_loaders_and_yaml(monkeypatch) -> None:
             },
         }
     }
-    monkeypatch.setattr("aiconfigurator.sdk.perf_database.load_gemm_data", lambda path: dummy_gemm_data)
 
     # Patch load_custom_allreduce_data to return proper structure.
     # Structure: { 'bfloat16': { 2: { 'AUTO': { 1024:  5.0 } } } }
@@ -78,29 +121,17 @@ def _patch_all_loaders_and_yaml(monkeypatch) -> None:
             8: {"AUTO": {1024: 15.0, 2048: 30.0}},
         }
     }
-    monkeypatch.setattr(
-        "aiconfigurator.sdk.perf_database.load_custom_allreduce_data",
-        lambda path: dummy_custom_allreduce_data,
-    )
 
-    # load_moe_data needs to return 2 dicts
-    monkeypatch.setattr("aiconfigurator.sdk.perf_database.load_moe_data", lambda path: ({}, {}))
+    # Per-loader overrides for stub_perf_db (most stay at the default from _LOADER_STUBS)
+    overrides = {
+        "load_gemm_data": dummy_gemm_data,
+        "load_custom_allreduce_data": dummy_custom_allreduce_data,
+        "load_moe_data": ({}, {}),
+    }
 
-    # Patch every other loader to return an empty dict (or None for optional loaders)
-    for loader_name in [
-        "load_context_attention_data",
-        "load_generation_attention_data",
-        "load_context_mla_data",
-        "load_generation_mla_data",
-        "load_mla_bmm_data",
-        "load_nccl_data",
-    ]:
-        monkeypatch.setattr(f"aiconfigurator.sdk.perf_database.{loader_name}", lambda path: {})
-    for loader_name in [
-        "load_context_dsa_module_data",
-        "load_generation_dsa_module_data",
-    ]:
-        monkeypatch.setattr(f"aiconfigurator.sdk.perf_database.{loader_name}", lambda path: None)
+    for name, default_value in _LOADER_STUBS.items():
+        ret = overrides.get(name, default_value)
+        monkeypatch.setattr(f"aiconfigurator.sdk.perf_database.{name}", lambda path, _r=ret: _r)
 
 
 @pytest.fixture
@@ -300,36 +331,26 @@ def _get_comprehensive_db_singleton() -> PerfDatabase:
     with open(yaml_file, "w") as f:
         yaml.dump(system_spec, f)
 
-    # Use unittest.mock.patch (not monkeypatch) so we can call this outside a fixture
+    # Use unittest.mock.patch (not monkeypatch) so we can call this outside a fixture.
+    # Per-loader overrides — anything not listed here falls through to
+    # the default in _LOADER_STUBS (None for most, (None, None) for moe).
+    overrides = {
+        "load_gemm_data": cached["gemm_data"],
+        "load_context_attention_data": cached["context_attention_data"],
+        "load_generation_attention_data": cached["generation_attention_data"],
+        "load_moe_data": (cached["moe_data"], cached["moe_data"]),
+        "load_custom_allreduce_data": cached["custom_allreduce_data"],
+        "load_nccl_data": cached["nccl_data"],
+        "load_context_mla_data": cached["context_mla_data"],
+        "load_generation_mla_data": cached["generation_mla_data"],
+        "load_mla_bmm_data": cached["mla_bmm_data"],
+    }
     patches = [
         patch("yaml.load", side_effect=lambda stream, Loader=None: system_spec),  # noqa: N803
-        patch("aiconfigurator.sdk.perf_database.load_gemm_data", return_value=cached["gemm_data"]),
-        patch(
-            "aiconfigurator.sdk.perf_database.load_context_attention_data",
-            return_value=cached["context_attention_data"],
-        ),
-        patch(
-            "aiconfigurator.sdk.perf_database.load_generation_attention_data",
-            return_value=cached["generation_attention_data"],
-        ),
-        patch(
-            "aiconfigurator.sdk.perf_database.load_custom_allreduce_data",
-            return_value=cached["custom_allreduce_data"],
-        ),
-        patch(
-            "aiconfigurator.sdk.perf_database.load_moe_data",
-            return_value=(cached["moe_data"], cached["moe_data"]),
-        ),
-        patch("aiconfigurator.sdk.perf_database.load_context_mla_data", return_value=cached["context_mla_data"]),
-        patch(
-            "aiconfigurator.sdk.perf_database.load_generation_mla_data",
-            return_value=cached["generation_mla_data"],
-        ),
-        patch("aiconfigurator.sdk.perf_database.load_mla_bmm_data", return_value=cached["mla_bmm_data"]),
-        patch("aiconfigurator.sdk.perf_database.load_nccl_data", return_value=cached["nccl_data"]),
-        patch("aiconfigurator.sdk.perf_database.load_context_dsa_module_data", return_value=None),
-        patch("aiconfigurator.sdk.perf_database.load_generation_dsa_module_data", return_value=None),
     ]
+    for name, default_value in _LOADER_STUBS.items():
+        ret = overrides.get(name, default_value)
+        patches.append(patch(f"aiconfigurator.sdk.perf_database.{name}", return_value=ret))
 
     for p in patches:
         p.start()

--- a/tests/unit/sdk/database/conftest.py
+++ b/tests/unit/sdk/database/conftest.py
@@ -1,7 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+import tempfile
 from collections import defaultdict
+from unittest.mock import patch
 
 import pytest
 import yaml
@@ -119,13 +122,9 @@ def stub_perf_db(tmp_path, monkeypatch):
     return PerfDatabase(system, backend, version, systems_dir)
 
 
-@pytest.fixture
-def comprehensive_perf_db(tmp_path, monkeypatch):
-    """
-    Create a PerfDatabase with comprehensive test data for all query methods.
-    """
-    # System spec with all required fields
-    dummy_system_spec = {
+def _build_comprehensive_test_data():
+    """Build all the dummy data dicts for comprehensive_perf_db."""
+    system_spec = {
         "data_dir": "data",
         "misc": {"nccl_version": "v1"},
         "gpu": {
@@ -142,15 +141,8 @@ def comprehensive_perf_db(tmp_path, monkeypatch):
         },
     }
 
-    # Create the yaml file
-    yaml_file = tmp_path / "test_system.yaml"
-    with open(yaml_file, "w") as f:
-        yaml.dump(dummy_system_spec, f)
-
-    monkeypatch.setattr("yaml.load", lambda stream, Loader=None: dummy_system_spec)  # noqa: N803
-
     # Comprehensive GEMM data with energy
-    dummy_gemm_data = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict())))
+    gemm_data = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict())))
     for quant_mode in [common.GEMMQuantMode.bfloat16, common.GEMMQuantMode.fp8]:
         for m in [1, 2, 4, 8, 16, 32, 64, 128, 256]:
             for n in [128, 256, 512, 1024]:
@@ -158,14 +150,14 @@ def comprehensive_perf_db(tmp_path, monkeypatch):
                     latency = 0.1 + m * 0.001 + n * 0.0001 + k * 0.00001
                     power = 5.0 + m * 0.01  # Dummy power value
                     energy = power * latency
-                    dummy_gemm_data[quant_mode][m][n][k] = {
+                    gemm_data[quant_mode][m][n][k] = {
                         "latency": latency,
                         "power": power,
                         "energy": energy,
                     }
 
     # Context attention data
-    dummy_context_attention_data = defaultdict(
+    context_attention_data = defaultdict(
         lambda: defaultdict(
             lambda: defaultdict(
                 lambda: defaultdict(
@@ -182,12 +174,12 @@ def comprehensive_perf_db(tmp_path, monkeypatch):
                         for n in [4, 8, 16, 32]:
                             for s in [16, 32, 64, 128, 256]:
                                 for b in [1, 2, 4, 8]:
-                                    dummy_context_attention_data[quant_mode][kv_cache_dtype][kv_n][head_size][
-                                        window_size
-                                    ][n][s][b] = 0.01 * (n * s * b) / 1000.0
+                                    context_attention_data[quant_mode][kv_cache_dtype][kv_n][head_size][window_size][n][
+                                        s
+                                    ][b] = 0.01 * (n * s * b) / 1000.0
 
     # Generation attention data
-    dummy_generation_attention_data = defaultdict(
+    generation_attention_data = defaultdict(
         lambda: defaultdict(
             lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict()))))
         )
@@ -201,12 +193,12 @@ def comprehensive_perf_db(tmp_path, monkeypatch):
                         if kv_n <= n:
                             for b in [1, 2, 4, 8, 16]:
                                 for s in [1, 16, 32, 64, 128, 256, 512, 1024]:
-                                    dummy_generation_attention_data[kv_cache_dtype][kv_n][head_size][window_size][n][b][
-                                        s
-                                    ] = 0.001 * (n * b * s) / 1000.0
+                                    generation_attention_data[kv_cache_dtype][kv_n][head_size][window_size][n][b][s] = (
+                                        0.001 * (n * b * s) / 1000.0
+                                    )
 
     # MoE data
-    dummy_moe_data = defaultdict(
+    moe_data = defaultdict(
         lambda: defaultdict(
             lambda: defaultdict(
                 lambda: defaultdict(
@@ -226,12 +218,12 @@ def comprehensive_perf_db(tmp_path, monkeypatch):
                             for moe_tp in [1, 2]:
                                 for moe_ep in [1, 2]:
                                     for num_tokens in [1, 2, 4, 8, 16, 32]:
-                                        dummy_moe_data[quant_mode][workload][topk][num_experts][hidden_size][
-                                            inter_size
-                                        ][moe_tp][moe_ep][num_tokens] = 0.1 * num_tokens
+                                        moe_data[quant_mode][workload][topk][num_experts][hidden_size][inter_size][
+                                            moe_tp
+                                        ][moe_ep][num_tokens] = 0.1 * num_tokens
 
     # Context MLA data
-    dummy_context_mla_data = defaultdict(
+    context_mla_data = defaultdict(
         lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict()))))
     )
     for quant_mode in [common.FMHAQuantMode.bfloat16]:
@@ -239,73 +231,150 @@ def comprehensive_perf_db(tmp_path, monkeypatch):
             for num_heads in [16, 32, 64, 128]:
                 for s in [16, 32, 64, 128]:
                     for b in [1, 2, 4, 8]:
-                        dummy_context_mla_data[quant_mode][kv_cache_dtype][num_heads][s][b] = 0.0001 * s * b * num_heads
+                        context_mla_data[quant_mode][kv_cache_dtype][num_heads][s][b] = 0.0001 * s * b * num_heads
 
     # Generation MLA data
-    dummy_generation_mla_data = defaultdict(
+    generation_mla_data = defaultdict(
         lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict())))
     )
     for kv_cache_dtype in [common.KVCacheQuantMode.bfloat16]:
         for num_heads in [16, 32, 64, 128]:
             for b in [1, 2, 4, 8]:
                 for s in [1, 16, 32, 64, 128]:
-                    dummy_generation_mla_data[kv_cache_dtype][num_heads][b][s] = 0.00001 * b * s * num_heads
+                    generation_mla_data[kv_cache_dtype][num_heads][b][s] = 0.00001 * b * s * num_heads
 
     # MLA BMM data
-    dummy_mla_bmm_data = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict())))
+    mla_bmm_data = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict())))
     for quant_mode in [common.GEMMQuantMode.bfloat16, common.GEMMQuantMode.fp8]:
         for op_name in ["mla_gen_pre", "mla_gen_post"]:
             for num_heads in [1, 2, 4, 8]:
                 for num_tokens in [1, 2, 4, 8, 16, 32]:
-                    dummy_mla_bmm_data[quant_mode][op_name][num_heads][num_tokens] = 0.01 * num_heads * num_tokens
+                    mla_bmm_data[quant_mode][op_name][num_heads][num_tokens] = 0.01 * num_heads * num_tokens
 
     # Custom allreduce data
-    dummy_custom_allreduce_data = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict())))
+    custom_allreduce_data = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict())))
     for dtype in [common.CommQuantMode.half]:
         for tp_size in [1, 2, 4, 8]:
             for strategy in ["AUTO"]:
                 for msg_size in [512, 1024, 2048, 4096, 8192]:
-                    dummy_custom_allreduce_data[dtype][tp_size][strategy][msg_size] = 0.001 * msg_size * tp_size
+                    custom_allreduce_data[dtype][tp_size][strategy][msg_size] = 0.001 * msg_size * tp_size
 
     # NCCL data
-    dummy_nccl_data = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict())))
+    nccl_data = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict())))
     for dtype in [common.CommQuantMode.half, common.CommQuantMode.int8]:  # Use enum objects as keys
         for operation in ["all_gather", "alltoall", "reduce_scatter"]:
             for num_gpus in [1, 2, 4, 8]:
                 for msg_size in [512, 1024, 2048, 4096]:
-                    dummy_nccl_data[dtype][operation][num_gpus][msg_size] = 0.001 * msg_size * num_gpus
+                    nccl_data[dtype][operation][num_gpus][msg_size] = 0.001 * msg_size * num_gpus
 
-    # Apply all patches
-    monkeypatch.setattr("aiconfigurator.sdk.perf_database.load_gemm_data", lambda path: dummy_gemm_data)
-    monkeypatch.setattr(
-        "aiconfigurator.sdk.perf_database.load_context_attention_data",
-        lambda path: dummy_context_attention_data,
-    )
-    monkeypatch.setattr(
-        "aiconfigurator.sdk.perf_database.load_generation_attention_data",
-        lambda path: dummy_generation_attention_data,
-    )
-    monkeypatch.setattr(
-        "aiconfigurator.sdk.perf_database.load_custom_allreduce_data",
-        lambda path: dummy_custom_allreduce_data,
-    )
-    monkeypatch.setattr(
-        "aiconfigurator.sdk.perf_database.load_moe_data",
-        lambda path: (dummy_moe_data, dummy_moe_data),
-    )
-    monkeypatch.setattr(
-        "aiconfigurator.sdk.perf_database.load_context_mla_data",
-        lambda path: dummy_context_mla_data,
-    )
-    monkeypatch.setattr(
-        "aiconfigurator.sdk.perf_database.load_generation_mla_data",
-        lambda path: dummy_generation_mla_data,
-    )
-    monkeypatch.setattr("aiconfigurator.sdk.perf_database.load_mla_bmm_data", lambda path: dummy_mla_bmm_data)
-    monkeypatch.setattr("aiconfigurator.sdk.perf_database.load_nccl_data", lambda path: dummy_nccl_data)
+    return {
+        "system_spec": system_spec,
+        "gemm_data": gemm_data,
+        "context_attention_data": context_attention_data,
+        "generation_attention_data": generation_attention_data,
+        "moe_data": moe_data,
+        "context_mla_data": context_mla_data,
+        "generation_mla_data": generation_mla_data,
+        "mla_bmm_data": mla_bmm_data,
+        "custom_allreduce_data": custom_allreduce_data,
+        "nccl_data": nccl_data,
+    }
 
-    # DSA module-level attention data (same dict structure as MLA)
-    monkeypatch.setattr("aiconfigurator.sdk.perf_database.load_context_dsa_module_data", lambda path: None)
-    monkeypatch.setattr("aiconfigurator.sdk.perf_database.load_generation_dsa_module_data", lambda path: None)
 
-    return PerfDatabase("test_system", "trtllm", "v1", str(tmp_path))
+# Module-level singleton: the PerfDatabase is built once (including the expensive
+# _correct_data + _extrapolate_data_grid passes in __init__) and reused by ALL tests.
+#
+# *** THIS OBJECT IS SHARED — DO NOT MUTATE IT IN TESTS. ***
+#
+# If a test must modify the db (e.g. to test _correct_data), it MUST save the
+# original value before the mutation and restore it in a try/finally block.
+_comprehensive_db_singleton: PerfDatabase | None = None
+
+
+def _get_comprehensive_db_singleton() -> PerfDatabase:
+    """Build and cache a fully-initialized PerfDatabase singleton."""
+    global _comprehensive_db_singleton
+    if _comprehensive_db_singleton is not None:
+        return _comprehensive_db_singleton
+
+    cached = _build_comprehensive_test_data()
+    system_spec = cached["system_spec"]
+
+    tmp_dir = tempfile.mkdtemp()
+    yaml_file = os.path.join(tmp_dir, "test_system.yaml")
+    with open(yaml_file, "w") as f:
+        yaml.dump(system_spec, f)
+
+    # Use unittest.mock.patch (not monkeypatch) so we can call this outside a fixture
+    patches = [
+        patch("yaml.load", side_effect=lambda stream, Loader=None: system_spec),  # noqa: N803
+        patch("aiconfigurator.sdk.perf_database.load_gemm_data", return_value=cached["gemm_data"]),
+        patch(
+            "aiconfigurator.sdk.perf_database.load_context_attention_data",
+            return_value=cached["context_attention_data"],
+        ),
+        patch(
+            "aiconfigurator.sdk.perf_database.load_generation_attention_data",
+            return_value=cached["generation_attention_data"],
+        ),
+        patch(
+            "aiconfigurator.sdk.perf_database.load_custom_allreduce_data",
+            return_value=cached["custom_allreduce_data"],
+        ),
+        patch(
+            "aiconfigurator.sdk.perf_database.load_moe_data",
+            return_value=(cached["moe_data"], cached["moe_data"]),
+        ),
+        patch("aiconfigurator.sdk.perf_database.load_context_mla_data", return_value=cached["context_mla_data"]),
+        patch(
+            "aiconfigurator.sdk.perf_database.load_generation_mla_data",
+            return_value=cached["generation_mla_data"],
+        ),
+        patch("aiconfigurator.sdk.perf_database.load_mla_bmm_data", return_value=cached["mla_bmm_data"]),
+        patch("aiconfigurator.sdk.perf_database.load_nccl_data", return_value=cached["nccl_data"]),
+        patch("aiconfigurator.sdk.perf_database.load_context_dsa_module_data", return_value=None),
+        patch("aiconfigurator.sdk.perf_database.load_generation_dsa_module_data", return_value=None),
+    ]
+
+    for p in patches:
+        p.start()
+    try:
+        _comprehensive_db_singleton = PerfDatabase("test_system", "trtllm", "v1", tmp_dir)
+    finally:
+        for p in patches:
+            p.stop()
+
+    return _comprehensive_db_singleton
+
+
+@pytest.fixture
+def comprehensive_perf_db():
+    """
+    Return a **shared, read-only** PerfDatabase with comprehensive test data.
+
+    This is a singleton — the same object is returned to every test.
+    This avoids the expensive __init__ (data loading + correction + extrapolation)
+    that previously ran per-test and dominated the test suite runtime.
+
+    DO NOT mutate the returned object. If a test needs to modify the db,
+    use the ``mutable_comprehensive_perf_db`` fixture instead.
+    """
+    return _get_comprehensive_db_singleton()
+
+
+@pytest.fixture
+def mutable_comprehensive_perf_db():
+    """
+    Return an independent deep copy of the comprehensive PerfDatabase.
+
+    Use this instead of ``comprehensive_perf_db`` when the test needs to mutate
+    the database (e.g. replacing data dicts, modifying system_spec, calling
+    _correct_data). Each invocation returns a fresh copy so mutations cannot
+    leak between tests.
+
+    Slower than the shared fixture (~100ms for deepcopy) but much faster than
+    re-running PerfDatabase.__init__ from scratch.
+    """
+    import copy
+
+    return copy.deepcopy(_get_comprehensive_db_singleton())

--- a/tests/unit/sdk/database/conftest.py
+++ b/tests/unit/sdk/database/conftest.py
@@ -124,7 +124,7 @@ def stub_perf_db(tmp_path, monkeypatch):
 
 def _build_comprehensive_test_data():
     """Build all the dummy data dicts for comprehensive_perf_db."""
-    system_spec = {
+    dummy_system_spec = {
         "data_dir": "data",
         "misc": {"nccl_version": "v1"},
         "gpu": {
@@ -142,7 +142,7 @@ def _build_comprehensive_test_data():
     }
 
     # Comprehensive GEMM data with energy
-    gemm_data = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict())))
+    dummy_gemm_data = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict())))
     for quant_mode in [common.GEMMQuantMode.bfloat16, common.GEMMQuantMode.fp8]:
         for m in [1, 2, 4, 8, 16, 32, 64, 128, 256]:
             for n in [128, 256, 512, 1024]:
@@ -150,14 +150,14 @@ def _build_comprehensive_test_data():
                     latency = 0.1 + m * 0.001 + n * 0.0001 + k * 0.00001
                     power = 5.0 + m * 0.01  # Dummy power value
                     energy = power * latency
-                    gemm_data[quant_mode][m][n][k] = {
+                    dummy_gemm_data[quant_mode][m][n][k] = {
                         "latency": latency,
                         "power": power,
                         "energy": energy,
                     }
 
     # Context attention data
-    context_attention_data = defaultdict(
+    dummy_context_attention_data = defaultdict(
         lambda: defaultdict(
             lambda: defaultdict(
                 lambda: defaultdict(
@@ -174,12 +174,12 @@ def _build_comprehensive_test_data():
                         for n in [4, 8, 16, 32]:
                             for s in [16, 32, 64, 128, 256]:
                                 for b in [1, 2, 4, 8]:
-                                    context_attention_data[quant_mode][kv_cache_dtype][kv_n][head_size][window_size][n][
-                                        s
-                                    ][b] = 0.01 * (n * s * b) / 1000.0
+                                    dummy_context_attention_data[quant_mode][kv_cache_dtype][kv_n][head_size][
+                                        window_size
+                                    ][n][s][b] = 0.01 * (n * s * b) / 1000.0
 
     # Generation attention data
-    generation_attention_data = defaultdict(
+    dummy_generation_attention_data = defaultdict(
         lambda: defaultdict(
             lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict()))))
         )
@@ -193,12 +193,12 @@ def _build_comprehensive_test_data():
                         if kv_n <= n:
                             for b in [1, 2, 4, 8, 16]:
                                 for s in [1, 16, 32, 64, 128, 256, 512, 1024]:
-                                    generation_attention_data[kv_cache_dtype][kv_n][head_size][window_size][n][b][s] = (
-                                        0.001 * (n * b * s) / 1000.0
-                                    )
+                                    dummy_generation_attention_data[kv_cache_dtype][kv_n][head_size][window_size][n][b][
+                                        s
+                                    ] = 0.001 * (n * b * s) / 1000.0
 
     # MoE data
-    moe_data = defaultdict(
+    dummy_moe_data = defaultdict(
         lambda: defaultdict(
             lambda: defaultdict(
                 lambda: defaultdict(
@@ -218,12 +218,12 @@ def _build_comprehensive_test_data():
                             for moe_tp in [1, 2]:
                                 for moe_ep in [1, 2]:
                                     for num_tokens in [1, 2, 4, 8, 16, 32]:
-                                        moe_data[quant_mode][workload][topk][num_experts][hidden_size][inter_size][
-                                            moe_tp
-                                        ][moe_ep][num_tokens] = 0.1 * num_tokens
+                                        dummy_moe_data[quant_mode][workload][topk][num_experts][hidden_size][
+                                            inter_size
+                                        ][moe_tp][moe_ep][num_tokens] = 0.1 * num_tokens
 
     # Context MLA data
-    context_mla_data = defaultdict(
+    dummy_context_mla_data = defaultdict(
         lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict()))))
     )
     for quant_mode in [common.FMHAQuantMode.bfloat16]:
@@ -231,53 +231,53 @@ def _build_comprehensive_test_data():
             for num_heads in [16, 32, 64, 128]:
                 for s in [16, 32, 64, 128]:
                     for b in [1, 2, 4, 8]:
-                        context_mla_data[quant_mode][kv_cache_dtype][num_heads][s][b] = 0.0001 * s * b * num_heads
+                        dummy_context_mla_data[quant_mode][kv_cache_dtype][num_heads][s][b] = 0.0001 * s * b * num_heads
 
     # Generation MLA data
-    generation_mla_data = defaultdict(
+    dummy_generation_mla_data = defaultdict(
         lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict())))
     )
     for kv_cache_dtype in [common.KVCacheQuantMode.bfloat16]:
         for num_heads in [16, 32, 64, 128]:
             for b in [1, 2, 4, 8]:
                 for s in [1, 16, 32, 64, 128]:
-                    generation_mla_data[kv_cache_dtype][num_heads][b][s] = 0.00001 * b * s * num_heads
+                    dummy_generation_mla_data[kv_cache_dtype][num_heads][b][s] = 0.00001 * b * s * num_heads
 
     # MLA BMM data
-    mla_bmm_data = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict())))
+    dummy_mla_bmm_data = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict())))
     for quant_mode in [common.GEMMQuantMode.bfloat16, common.GEMMQuantMode.fp8]:
         for op_name in ["mla_gen_pre", "mla_gen_post"]:
             for num_heads in [1, 2, 4, 8]:
                 for num_tokens in [1, 2, 4, 8, 16, 32]:
-                    mla_bmm_data[quant_mode][op_name][num_heads][num_tokens] = 0.01 * num_heads * num_tokens
+                    dummy_mla_bmm_data[quant_mode][op_name][num_heads][num_tokens] = 0.01 * num_heads * num_tokens
 
     # Custom allreduce data
-    custom_allreduce_data = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict())))
+    dummy_custom_allreduce_data = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict())))
     for dtype in [common.CommQuantMode.half]:
         for tp_size in [1, 2, 4, 8]:
             for strategy in ["AUTO"]:
                 for msg_size in [512, 1024, 2048, 4096, 8192]:
-                    custom_allreduce_data[dtype][tp_size][strategy][msg_size] = 0.001 * msg_size * tp_size
+                    dummy_custom_allreduce_data[dtype][tp_size][strategy][msg_size] = 0.001 * msg_size * tp_size
 
     # NCCL data
-    nccl_data = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict())))
+    dummy_nccl_data = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict())))
     for dtype in [common.CommQuantMode.half, common.CommQuantMode.int8]:  # Use enum objects as keys
         for operation in ["all_gather", "alltoall", "reduce_scatter"]:
             for num_gpus in [1, 2, 4, 8]:
                 for msg_size in [512, 1024, 2048, 4096]:
-                    nccl_data[dtype][operation][num_gpus][msg_size] = 0.001 * msg_size * num_gpus
+                    dummy_nccl_data[dtype][operation][num_gpus][msg_size] = 0.001 * msg_size * num_gpus
 
     return {
-        "system_spec": system_spec,
-        "gemm_data": gemm_data,
-        "context_attention_data": context_attention_data,
-        "generation_attention_data": generation_attention_data,
-        "moe_data": moe_data,
-        "context_mla_data": context_mla_data,
-        "generation_mla_data": generation_mla_data,
-        "mla_bmm_data": mla_bmm_data,
-        "custom_allreduce_data": custom_allreduce_data,
-        "nccl_data": nccl_data,
+        "system_spec": dummy_system_spec,
+        "gemm_data": dummy_gemm_data,
+        "context_attention_data": dummy_context_attention_data,
+        "generation_attention_data": dummy_generation_attention_data,
+        "moe_data": dummy_moe_data,
+        "context_mla_data": dummy_context_mla_data,
+        "generation_mla_data": dummy_generation_mla_data,
+        "mla_bmm_data": dummy_mla_bmm_data,
+        "custom_allreduce_data": dummy_custom_allreduce_data,
+        "nccl_data": dummy_nccl_data,
     }
 
 

--- a/tests/unit/sdk/database/conftest.py
+++ b/tests/unit/sdk/database/conftest.py
@@ -283,11 +283,6 @@ def _build_comprehensive_test_data():
 
 # Module-level singleton: the PerfDatabase is built once (including the expensive
 # _correct_data + _extrapolate_data_grid passes in __init__) and reused by ALL tests.
-#
-# *** THIS OBJECT IS SHARED — DO NOT MUTATE IT IN TESTS. ***
-#
-# If a test must modify the db (e.g. to test _correct_data), it MUST save the
-# original value before the mutation and restore it in a try/finally block.
 _comprehensive_db_singleton: PerfDatabase | None = None
 
 
@@ -372,7 +367,7 @@ def mutable_comprehensive_perf_db():
     _correct_data). Each invocation returns a fresh copy so mutations cannot
     leak between tests.
 
-    Slower than the shared fixture (~100ms for deepcopy) but much faster than
+    Slower than the shared fixture (~1s for deepcopy) but much faster than
     re-running PerfDatabase.__init__ from scratch.
     """
     import copy

--- a/tests/unit/sdk/database/test_attention.py
+++ b/tests/unit/sdk/database/test_attention.py
@@ -315,28 +315,29 @@ class TestGenerationMLA:
         assert math.isclose(sol_time, max(sol_math, sol_mem), rel_tol=1e-6)
 
 
-def test_default_database_mode(comprehensive_perf_db):
+def test_default_database_mode(mutable_comprehensive_perf_db):
     """Test setting and getting default database mode, and that query cache is cleared when default mode is changed."""
+    db = mutable_comprehensive_perf_db
     # Initially should be SILICON
-    assert comprehensive_perf_db.get_default_database_mode() == common.DatabaseMode.SILICON
+    assert db.get_default_database_mode() == common.DatabaseMode.SILICON
 
-    non_sol_result = comprehensive_perf_db.query_context_attention(
+    non_sol_result = db.query_context_attention(
         1, 32, 0, 8, 4, common.KVCacheQuantMode.bfloat16, common.FMHAQuantMode.bfloat16
     )
-    assert comprehensive_perf_db.query_context_attention.cache_info().currsize >= 1
+    assert db.query_context_attention.cache_info().currsize >= 1
 
     # Set to SOL mode
-    comprehensive_perf_db.set_default_database_mode(common.DatabaseMode.SOL)
-    assert comprehensive_perf_db.get_default_database_mode() == common.DatabaseMode.SOL
+    db.set_default_database_mode(common.DatabaseMode.SOL)
+    assert db.get_default_database_mode() == common.DatabaseMode.SOL
     # Cache should be cleared
-    assert comprehensive_perf_db.query_context_attention.cache_info().currsize == 0
+    assert db.query_context_attention.cache_info().currsize == 0
 
     # Query should use default mode when not specified
-    sol_result = comprehensive_perf_db.query_context_attention(
+    sol_result = db.query_context_attention(
         1, 32, 0, 8, 4, common.KVCacheQuantMode.bfloat16, common.FMHAQuantMode.bfloat16
     )
 
-    cache_info = comprehensive_perf_db.query_context_attention.cache_info()
+    cache_info = db.query_context_attention.cache_info()
     assert cache_info.misses == 1
     assert cache_info.hits == 0
     assert cache_info.currsize == 1

--- a/tests/unit/sdk/database/test_base_queries.py
+++ b/tests/unit/sdk/database/test_base_queries.py
@@ -92,16 +92,17 @@ def test_query_gemm_interpolates_only_on_m_when_nk_match(comprehensive_perf_db, 
     assert calls["value"] == m
 
 
-def test_query_gemm_fast_paths_support_legacy_scalar_leaves(comprehensive_perf_db, monkeypatch):
+def test_query_gemm_fast_paths_support_legacy_scalar_leaves(mutable_comprehensive_perf_db):
     """Fast GEMM paths should support legacy scalar-leaf tables."""
+    db = mutable_comprehensive_perf_db
     quant_mode = common.GEMMQuantMode.bfloat16
-    comprehensive_perf_db._gemm_data[quant_mode] = {
+    db._gemm_data[quant_mode] = {
         8: {128: {128: 0.5}},
         16: {128: {128: 0.9}},
     }
 
-    exact = comprehensive_perf_db.query_gemm(8, 128, 128, quant_mode, database_mode=common.DatabaseMode.SILICON)
-    interp = comprehensive_perf_db.query_gemm(12, 128, 128, quant_mode, database_mode=common.DatabaseMode.SILICON)
+    exact = db.query_gemm(8, 128, 128, quant_mode, database_mode=common.DatabaseMode.SILICON)
+    interp = db.query_gemm(12, 128, 128, quant_mode, database_mode=common.DatabaseMode.SILICON)
 
     assert math.isclose(float(exact), 0.5)
     assert math.isclose(float(interp), 0.7)

--- a/tests/unit/sdk/database/test_deepseek_v4_module.py
+++ b/tests/unit/sdk/database/test_deepseek_v4_module.py
@@ -186,7 +186,8 @@ class TestDeepSeekV4AttentionModule:
         )
         assert high_topk > low_topk
 
-    def test_csa_context_uses_raw_piecewise_around_compressed_topk_boundary(self, comprehensive_perf_db, monkeypatch):
+    def test_csa_context_uses_raw_piecewise_around_compressed_topk_boundary(self, mutable_comprehensive_perf_db):
+        db = mutable_comprehensive_perf_db
         raw_attn_dict = {
             16: {
                 4096: {2: _deepseek_v4_value(20.0)},
@@ -202,33 +203,22 @@ class TestDeepSeekV4AttentionModule:
                 12288: {2: _deepseek_v4_value(100.0)},
             }
         }
-        # Save and restore — comprehensive_perf_db is shared across all tests
-        monkeypatch.setattr(
-            comprehensive_perf_db,
-            "_raw_context_deepseek_v4_attention_module_data",
-            LoadedOpData(
-                _context_deepseek_v4_data(4, raw_attn_dict),
-                common.PerfDataFilename.deepseek_v4_context_module,
-                "raw",
-            ),
+        db._raw_context_deepseek_v4_attention_module_data = LoadedOpData(
+            _context_deepseek_v4_data(4, raw_attn_dict), common.PerfDataFilename.deepseek_v4_context_module, "raw"
         )
-        monkeypatch.setattr(
-            comprehensive_perf_db,
-            "_context_deepseek_v4_attention_module_data",
-            LoadedOpData(
-                _context_deepseek_v4_data(4, extrapolated_attn_dict),
-                common.PerfDataFilename.deepseek_v4_context_module,
-                "extrapolated",
-            ),
+        db._context_deepseek_v4_attention_module_data = LoadedOpData(
+            _context_deepseek_v4_data(4, extrapolated_attn_dict),
+            common.PerfDataFilename.deepseek_v4_context_module,
+            "extrapolated",
         )
 
         def fail_interp_3d(*args, **kwargs):
             raise AssertionError("_interp_3d should not be used when raw same-regime CSA anchors exist")
 
-        monkeypatch.setattr(comprehensive_perf_db, "_interp_3d", fail_interp_3d)
+        db._interp_3d = fail_interp_3d
 
         base = _deepseek_v4_attn_kwargs(4)
-        result = comprehensive_perf_db.query_context_deepseek_v4_attention_module(
+        result = db.query_context_deepseek_v4_attention_module(
             **{**base, "s": 4097, "prefix": 0},
             database_mode=common.DatabaseMode.SILICON,
         )

--- a/tests/unit/sdk/database/test_deepseek_v4_module.py
+++ b/tests/unit/sdk/database/test_deepseek_v4_module.py
@@ -202,13 +202,24 @@ class TestDeepSeekV4AttentionModule:
                 12288: {2: _deepseek_v4_value(100.0)},
             }
         }
-        comprehensive_perf_db._raw_context_deepseek_v4_attention_module_data = LoadedOpData(
-            _context_deepseek_v4_data(4, raw_attn_dict), common.PerfDataFilename.deepseek_v4_context_module, "raw"
+        # Save and restore — comprehensive_perf_db is shared across all tests
+        monkeypatch.setattr(
+            comprehensive_perf_db,
+            "_raw_context_deepseek_v4_attention_module_data",
+            LoadedOpData(
+                _context_deepseek_v4_data(4, raw_attn_dict),
+                common.PerfDataFilename.deepseek_v4_context_module,
+                "raw",
+            ),
         )
-        comprehensive_perf_db._context_deepseek_v4_attention_module_data = LoadedOpData(
-            _context_deepseek_v4_data(4, extrapolated_attn_dict),
-            common.PerfDataFilename.deepseek_v4_context_module,
-            "extrapolated",
+        monkeypatch.setattr(
+            comprehensive_perf_db,
+            "_context_deepseek_v4_attention_module_data",
+            LoadedOpData(
+                _context_deepseek_v4_data(4, extrapolated_attn_dict),
+                common.PerfDataFilename.deepseek_v4_context_module,
+                "extrapolated",
+            ),
         )
 
         def fail_interp_3d(*args, **kwargs):
@@ -290,10 +301,11 @@ class TestDeepSeekV4AttentionModule:
         assert fp8[2] < bf16[2]
 
 
-def test_deepseek_v4_static_sol_and_hybrid_run_end_to_end(comprehensive_perf_db):
-    comprehensive_perf_db.system_spec["gpu"]["mem_capacity"] = 288400343040
-    comprehensive_perf_db.system_spec["misc"]["nccl_mem"] = {1: 0, 2: 0, 4: 0, 8: 0}
-    comprehensive_perf_db.system_spec["misc"]["other_mem"] = 0
+def test_deepseek_v4_static_sol_and_hybrid_run_end_to_end(mutable_comprehensive_perf_db):
+    db = mutable_comprehensive_perf_db
+    db.system_spec["gpu"]["mem_capacity"] = 288400343040
+    db.system_spec["misc"]["nccl_mem"] = {1: 0, 2: 0, 4: 0, 8: 0}
+    db.system_spec["misc"]["other_mem"] = 0
     model_config = config.ModelConfig(
         tp_size=1,
         moe_tp_size=1,
@@ -307,7 +319,7 @@ def test_deepseek_v4_static_sol_and_hybrid_run_end_to_end(comprehensive_perf_db)
     runtime = RuntimeConfig(batch_size=1, beam_width=1, isl=128, osl=4, prefix=0)
 
     for mode in (common.DatabaseMode.SOL, common.DatabaseMode.HYBRID):
-        comprehensive_perf_db.set_default_database_mode(mode)
-        summary = backend.run_static(model, comprehensive_perf_db, runtime, mode="static", stride=1)
+        db.set_default_database_mode(mode)
+        summary = backend.run_static(model, db, runtime, mode="static", stride=1)
         assert sum(summary.get_context_latency_dict().values()) > 0
         assert sum(summary.get_generation_latency_dict().values()) > 0

--- a/tests/unit/sdk/database/test_fp8_static.py
+++ b/tests/unit/sdk/database/test_fp8_static.py
@@ -27,66 +27,70 @@ def test_query_gemm_fp8_static_reuses_fp8_table(comprehensive_perf_db):
     assert static_result.energy == pytest.approx(fp8_result.energy)
 
 
-def test_query_compute_scale_fp8_static_reuses_fp8_table(comprehensive_perf_db):
+def test_query_compute_scale_fp8_static_reuses_fp8_table(mutable_comprehensive_perf_db):
+    db = mutable_comprehensive_perf_db
     # Provide enough points for 2D interpolation (>=2 keys in each axis).
-    compute_scale_data_dict = {
-        common.GEMMQuantMode.fp8: {
-            64: {
-                256: {"latency": 1.0, "energy": 10.0},
-                512: {"latency": 2.0, "energy": 20.0},
-            },
-            128: {
-                256: {"latency": 1.5, "energy": 15.0},
-                512: {"latency": 2.5, "energy": 25.0},
-            },
-        }
-    }
-    comprehensive_perf_db._compute_scale_data = LoadedOpData(
-        compute_scale_data_dict, common.PerfDataFilename.compute_scale, "dummy_path"
+    db._compute_scale_data = LoadedOpData(
+        {
+            common.GEMMQuantMode.fp8: {
+                64: {
+                    256: {"latency": 1.0, "energy": 10.0},
+                    512: {"latency": 2.0, "energy": 20.0},
+                },
+                128: {
+                    256: {"latency": 1.5, "energy": 15.0},
+                    512: {"latency": 2.5, "energy": 25.0},
+                },
+            }
+        },
+        common.PerfDataFilename.compute_scale,
+        "dummy_path",
     )
 
     # Query an interior point so we avoid any boundary corner cases.
     m, k = 96, 384
-    fp8_result = comprehensive_perf_db.query_compute_scale(m, k, common.GEMMQuantMode.fp8)
-    static_result = comprehensive_perf_db.query_compute_scale(m, k, common.GEMMQuantMode.fp8_static)
+    fp8_result = db.query_compute_scale(m, k, common.GEMMQuantMode.fp8)
+    static_result = db.query_compute_scale(m, k, common.GEMMQuantMode.fp8_static)
 
     assert float(static_result) == pytest.approx(float(fp8_result))
     assert static_result.energy == pytest.approx(fp8_result.energy)
 
     # Out-of-range m should be clamped to the table range (avoid hard failure in SILICON mode).
-    clamped = comprehensive_perf_db.query_compute_scale(10_000, k, common.GEMMQuantMode.fp8_static)
-    fp8_max_m = comprehensive_perf_db.query_compute_scale(128, k, common.GEMMQuantMode.fp8)
+    clamped = db.query_compute_scale(10_000, k, common.GEMMQuantMode.fp8_static)
+    fp8_max_m = db.query_compute_scale(128, k, common.GEMMQuantMode.fp8)
     assert float(clamped) == pytest.approx(float(fp8_max_m))
     assert clamped.energy == pytest.approx(fp8_max_m.energy)
 
 
-def test_query_scale_matrix_fp8_static_reuses_fp8_table(comprehensive_perf_db):
-    scale_matrix_data_dict = {
-        common.GEMMQuantMode.fp8: {
-            64: {
-                256: {"latency": 3.0, "energy": 30.0},
-                512: {"latency": 4.0, "energy": 40.0},
-            },
-            128: {
-                256: {"latency": 3.5, "energy": 35.0},
-                512: {"latency": 4.5, "energy": 45.0},
-            },
-        }
-    }
-    comprehensive_perf_db._scale_matrix_data = LoadedOpData(
-        scale_matrix_data_dict, common.PerfDataFilename.scale_matrix, "dummy_path"
+def test_query_scale_matrix_fp8_static_reuses_fp8_table(mutable_comprehensive_perf_db):
+    db = mutable_comprehensive_perf_db
+    db._scale_matrix_data = LoadedOpData(
+        {
+            common.GEMMQuantMode.fp8: {
+                64: {
+                    256: {"latency": 3.0, "energy": 30.0},
+                    512: {"latency": 4.0, "energy": 40.0},
+                },
+                128: {
+                    256: {"latency": 3.5, "energy": 35.0},
+                    512: {"latency": 4.5, "energy": 45.0},
+                },
+            }
+        },
+        common.PerfDataFilename.scale_matrix,
+        "dummy_path",
     )
 
     m, k = 96, 384
-    fp8_result = comprehensive_perf_db.query_scale_matrix(m, k, common.GEMMQuantMode.fp8)
-    static_result = comprehensive_perf_db.query_scale_matrix(m, k, common.GEMMQuantMode.fp8_static)
+    fp8_result = db.query_scale_matrix(m, k, common.GEMMQuantMode.fp8)
+    static_result = db.query_scale_matrix(m, k, common.GEMMQuantMode.fp8_static)
 
     assert float(static_result) == pytest.approx(float(fp8_result))
     assert static_result.energy == pytest.approx(fp8_result.energy)
 
     # Out-of-range m should be clamped to the table range (avoid hard failure in SILICON mode).
-    clamped = comprehensive_perf_db.query_scale_matrix(10_000, k, common.GEMMQuantMode.fp8_static)
-    fp8_max_m = comprehensive_perf_db.query_scale_matrix(128, k, common.GEMMQuantMode.fp8)
+    clamped = db.query_scale_matrix(10_000, k, common.GEMMQuantMode.fp8_static)
+    fp8_max_m = db.query_scale_matrix(128, k, common.GEMMQuantMode.fp8)
     assert float(clamped) == pytest.approx(float(fp8_max_m))
     assert clamped.energy == pytest.approx(fp8_max_m.energy)
 

--- a/tests/unit/sdk/database/test_fp8_static.py
+++ b/tests/unit/sdk/database/test_fp8_static.py
@@ -30,22 +30,19 @@ def test_query_gemm_fp8_static_reuses_fp8_table(comprehensive_perf_db):
 def test_query_compute_scale_fp8_static_reuses_fp8_table(mutable_comprehensive_perf_db):
     db = mutable_comprehensive_perf_db
     # Provide enough points for 2D interpolation (>=2 keys in each axis).
-    db._compute_scale_data = LoadedOpData(
-        {
-            common.GEMMQuantMode.fp8: {
-                64: {
-                    256: {"latency": 1.0, "energy": 10.0},
-                    512: {"latency": 2.0, "energy": 20.0},
-                },
-                128: {
-                    256: {"latency": 1.5, "energy": 15.0},
-                    512: {"latency": 2.5, "energy": 25.0},
-                },
-            }
-        },
-        common.PerfDataFilename.compute_scale,
-        "dummy_path",
-    )
+    compute_scale_data_dict = {
+        common.GEMMQuantMode.fp8: {
+            64: {
+                256: {"latency": 1.0, "energy": 10.0},
+                512: {"latency": 2.0, "energy": 20.0},
+            },
+            128: {
+                256: {"latency": 1.5, "energy": 15.0},
+                512: {"latency": 2.5, "energy": 25.0},
+            },
+        }
+    }
+    db._compute_scale_data = LoadedOpData(compute_scale_data_dict, common.PerfDataFilename.compute_scale, "dummy_path")
 
     # Query an interior point so we avoid any boundary corner cases.
     m, k = 96, 384
@@ -64,22 +61,19 @@ def test_query_compute_scale_fp8_static_reuses_fp8_table(mutable_comprehensive_p
 
 def test_query_scale_matrix_fp8_static_reuses_fp8_table(mutable_comprehensive_perf_db):
     db = mutable_comprehensive_perf_db
-    db._scale_matrix_data = LoadedOpData(
-        {
-            common.GEMMQuantMode.fp8: {
-                64: {
-                    256: {"latency": 3.0, "energy": 30.0},
-                    512: {"latency": 4.0, "energy": 40.0},
-                },
-                128: {
-                    256: {"latency": 3.5, "energy": 35.0},
-                    512: {"latency": 4.5, "energy": 45.0},
-                },
-            }
-        },
-        common.PerfDataFilename.scale_matrix,
-        "dummy_path",
-    )
+    scale_matrix_data_dict = {
+        common.GEMMQuantMode.fp8: {
+            64: {
+                256: {"latency": 3.0, "energy": 30.0},
+                512: {"latency": 4.0, "energy": 40.0},
+            },
+            128: {
+                256: {"latency": 3.5, "energy": 35.0},
+                512: {"latency": 4.5, "energy": 45.0},
+            },
+        }
+    }
+    db._scale_matrix_data = LoadedOpData(scale_matrix_data_dict, common.PerfDataFilename.scale_matrix, "dummy_path")
 
     m, k = 96, 384
     fp8_result = db.query_scale_matrix(m, k, common.GEMMQuantMode.fp8)

--- a/tests/unit/sdk/database/test_interpolation.py
+++ b/tests/unit/sdk/database/test_interpolation.py
@@ -298,47 +298,48 @@ class TestExtrapolateDataGrid:
 class TestCorrectData:
     """Test cases for _correct_data method."""
 
-    def test_correct_gemm_data(self, comprehensive_perf_db, caplog):
+    def test_correct_gemm_data(self, mutable_comprehensive_perf_db, caplog):
         """Test that _correct_data adjusts GEMM data based on SOL."""
-        # Manually set a GEMM value that's too optimistic (lower than SOL)
+        db = mutable_comprehensive_perf_db
         quant_mode = common.GEMMQuantMode.bfloat16
         m, n, k = 64, 128, 256
 
         # Calculate what SOL should be
-        sol_value = comprehensive_perf_db.query_gemm(m, n, k, quant_mode, database_mode=common.DatabaseMode.SOL)
+        sol_value = db.query_gemm(m, n, k, quant_mode, database_mode=common.DatabaseMode.SOL)
 
         # Set an artificially low value
-        comprehensive_perf_db._gemm_data[quant_mode][m][n][k] = sol_value * 0.5
+        db._gemm_data[quant_mode][m][n][k] = sol_value * 0.5
 
         # Run correction
         with caplog.at_level("DEBUG"):
-            comprehensive_perf_db._correct_data()
+            db._correct_data()
 
         # Check that the value was corrected
-        assert comprehensive_perf_db._gemm_data[quant_mode][m][n][k] >= sol_value
+        assert db._gemm_data[quant_mode][m][n][k] >= sol_value
         assert f"sol {sol_value} > perf_db" in caplog.text or "gemm quant" in caplog.text
 
-    def test_correct_generation_attention_data(self, comprehensive_perf_db, caplog):
+    def test_correct_generation_attention_data(self, mutable_comprehensive_perf_db, caplog):
         """Test that _correct_data adjusts generation attention data."""
+        db = mutable_comprehensive_perf_db
         kv_cache_quant_mode = common.KVCacheQuantMode.bfloat16
         n_kv = 0  # MHA case
         n, b, s = 16, 4, 64
 
         # Calculate SOL
-        sol_value = comprehensive_perf_db.query_generation_attention(
+        sol_value = db.query_generation_attention(
             b, s, n, n, kv_cache_quant_mode, database_mode=common.DatabaseMode.SOL
         )
 
         # Set an artificially low value
-        comprehensive_perf_db._generation_attention_data[kv_cache_quant_mode][n_kv][128][0][n][b][s] = sol_value * 0.5
+        gen_data = db._generation_attention_data[kv_cache_quant_mode][n_kv][128][0][n][b]
+        gen_data[s] = sol_value * 0.5
 
         # Run correction
         with caplog.at_level("DEBUG"):
-            comprehensive_perf_db._correct_data()
+            db._correct_data()
 
         # Check that the value was corrected
-        corrected_value = comprehensive_perf_db._generation_attention_data[kv_cache_quant_mode][n_kv][128][0][n][b][s]
-        assert corrected_value >= sol_value
+        assert gen_data[s] >= sol_value
 
 
 class TestUpdateSupportMatrix:

--- a/tests/unit/sdk/database/test_interpolation.py
+++ b/tests/unit/sdk/database/test_interpolation.py
@@ -300,6 +300,7 @@ class TestCorrectData:
 
     def test_correct_gemm_data(self, mutable_comprehensive_perf_db, caplog):
         """Test that _correct_data adjusts GEMM data based on SOL."""
+        # Manually set a GEMM value that's too optimistic (lower than SOL)
         db = mutable_comprehensive_perf_db
         quant_mode = common.GEMMQuantMode.bfloat16
         m, n, k = 64, 128, 256
@@ -331,15 +332,15 @@ class TestCorrectData:
         )
 
         # Set an artificially low value
-        gen_data = db._generation_attention_data[kv_cache_quant_mode][n_kv][128][0][n][b]
-        gen_data[s] = sol_value * 0.5
+        db._generation_attention_data[kv_cache_quant_mode][n_kv][128][0][n][b][s] = sol_value * 0.5
 
         # Run correction
         with caplog.at_level("DEBUG"):
             db._correct_data()
 
         # Check that the value was corrected
-        assert gen_data[s] >= sol_value
+        corrected_value = db._generation_attention_data[kv_cache_quant_mode][n_kv][128][0][n][b][s]
+        assert corrected_value >= sol_value
 
 
 class TestUpdateSupportMatrix:

--- a/tests/unit/sdk/database/test_loaded_op_data.py
+++ b/tests/unit/sdk/database/test_loaded_op_data.py
@@ -176,21 +176,20 @@ class TestLoadedOpDataIntegration:
         db = mutable_comprehensive_perf_db
         # Provide enough points for 2D interpolation (>=2 keys in each axis).
         # This is similar to what we do in test_fp8_static.py
+        compute_scale_data_dict = {
+            common.GEMMQuantMode.fp8: {
+                64: {
+                    256: {"latency": 1.0, "energy": 10.0},
+                    512: {"latency": 2.0, "energy": 20.0},
+                },
+                128: {
+                    256: {"latency": 1.5, "energy": 15.0},
+                    512: {"latency": 2.5, "energy": 25.0},
+                },
+            }
+        }
         db._compute_scale_data = LoadedOpData(
-            {
-                common.GEMMQuantMode.fp8: {
-                    64: {
-                        256: {"latency": 1.0, "energy": 10.0},
-                        512: {"latency": 2.0, "energy": 20.0},
-                    },
-                    128: {
-                        256: {"latency": 1.5, "energy": 15.0},
-                        512: {"latency": 2.5, "energy": 25.0},
-                    },
-                }
-            },
-            common.PerfDataFilename.compute_scale,
-            "dummy_path",
+            compute_scale_data_dict, common.PerfDataFilename.compute_scale, "dummy_path"
         )
 
         # Query should work - test exact match

--- a/tests/unit/sdk/database/test_loaded_op_data.py
+++ b/tests/unit/sdk/database/test_loaded_op_data.py
@@ -171,36 +171,39 @@ class TestLoadedOpDataRaiseIfNotLoaded:
 class TestLoadedOpDataIntegration:
     """Test LoadedOpData integration scenarios."""
 
-    def test_used_in_perf_database_query(self, comprehensive_perf_db):
+    def test_used_in_perf_database_query(self, mutable_comprehensive_perf_db):
         """Test that LoadedOpData works when used in PerfDatabase queries."""
+        db = mutable_comprehensive_perf_db
         # Provide enough points for 2D interpolation (>=2 keys in each axis).
         # This is similar to what we do in test_fp8_static.py
-        compute_scale_data_dict = {
-            common.GEMMQuantMode.fp8: {
-                64: {
-                    256: {"latency": 1.0, "energy": 10.0},
-                    512: {"latency": 2.0, "energy": 20.0},
-                },
-                128: {
-                    256: {"latency": 1.5, "energy": 15.0},
-                    512: {"latency": 2.5, "energy": 25.0},
-                },
-            }
-        }
-        comprehensive_perf_db._compute_scale_data = LoadedOpData(
-            compute_scale_data_dict, common.PerfDataFilename.compute_scale, "dummy_path"
+        db._compute_scale_data = LoadedOpData(
+            {
+                common.GEMMQuantMode.fp8: {
+                    64: {
+                        256: {"latency": 1.0, "energy": 10.0},
+                        512: {"latency": 2.0, "energy": 20.0},
+                    },
+                    128: {
+                        256: {"latency": 1.5, "energy": 15.0},
+                        512: {"latency": 2.5, "energy": 25.0},
+                    },
+                }
+            },
+            common.PerfDataFilename.compute_scale,
+            "dummy_path",
         )
 
         # Query should work - test exact match
-        result = comprehensive_perf_db.query_compute_scale(64, 256, common.GEMMQuantMode.fp8)
+        result = db.query_compute_scale(64, 256, common.GEMMQuantMode.fp8)
         assert float(result) == pytest.approx(1.0)
         assert result.energy == pytest.approx(10.0)
 
-    def test_error_when_querying_unloaded_data(self, comprehensive_perf_db, tmp_path):
+    def test_error_when_querying_unloaded_data(self, mutable_comprehensive_perf_db, tmp_path):
         """Test that querying unloaded data raises appropriate error."""
+        db = mutable_comprehensive_perf_db
         filepath = str(tmp_path / "nonexistent.txt")
-        comprehensive_perf_db._compute_scale_data = LoadedOpData(None, common.PerfDataFilename.compute_scale, filepath)
+        db._compute_scale_data = LoadedOpData(None, common.PerfDataFilename.compute_scale, filepath)
 
         # Query should raise error in SILICON mode
         with pytest.raises(PerfDataNotAvailableError):
-            comprehensive_perf_db.query_compute_scale(64, 256, common.GEMMQuantMode.fp8)
+            db.query_compute_scale(64, 256, common.GEMMQuantMode.fp8)


### PR DESCRIPTION
#### Overview:
Revert increased test timeout, it was already fixed by this PR: https://github.com/ai-dynamo/aiconfigurator/pull/928

Speedup unit tests from 5m (run serially) to 55s. Reuse same PerfDatabase object instead of creating a new one for each test. saves 2s per test which adds up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized CI/CD build job timeout from 60 to 30 minutes
  * Added runner resource diagnostics output to CI workflow for monitoring system capacity

* **Tests**
  * Improved test suite performance through cached database fixtures, reducing redundant initialization overhead across test modules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->