### PR TITLE
ci: slightly faster e2e tests

### DIFF
--- a/tests/e2e/support_matrix/test_pr_support_matrix.py
+++ b/tests/e2e/support_matrix/test_pr_support_matrix.py
@@ -78,8 +78,7 @@ def test_pr_support_matrix(model: str, system: str, backend: str, version: str):
 
     from tools.support_matrix.support_matrix import SupportMatrix
 
-    sm = SupportMatrix()
-    success_dict, error_dict = sm.run_single_test(
+    success_dict, error_dict = SupportMatrix.run_single_test(
         model=model,
         system=system,
         backend=backend,

--- a/tools/support_matrix/support_matrix.py
+++ b/tools/support_matrix/support_matrix.py
@@ -155,8 +155,8 @@ class SupportMatrix:
         combinations = list(self.__get_model_and_hardware_and_backend_combinations())
         return combinations
 
+    @staticmethod
     def run_single_test(
-        self,
         model: str,
         system: str,
         backend: str,


### PR DESCRIPTION
#### Overview:

Make `SupportMatrix.run_single_test` a staticmethod to avoid calling `load_databases` which is expensive. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test fixtures to improve database test isolation and reusability.
  * Updated multiple test cases to use optimized fixture setup.

* **Chores**
  * Reduced CI build-and-test job timeout from 60 to 30 minutes.
  * Added system resource diagnostics output to CI workflow for better visibility into runner performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->