### PR TITLE
feat: deepseekv4 mhc collect and query

### DIFF
--- a/collector/common_test_cases.py
+++ b/collector/common_test_cases.py
@@ -84,6 +84,17 @@ _MLA_MODULE_MODEL_NAMES: list[str] = [
     "zai-org/GLM-5",
 ]
 
+# MHC (DeepSeek-V4 Hash-Compressed attention) module:
+# [hidden_size, hc_mult, model_name]
+# Only AIC-cached model_configs/<id>_config.json are usable; both sgl-project
+# FP8 and deepseek-ai non-FP8 namespaces point at the same pre/post kernels.
+_MHC_MODEL_CONFIGS: list[list] = [
+    [4096, 4, "deepseek-ai/DeepSeek-V4-Flash"],
+    [7168, 4, "deepseek-ai/DeepSeek-V4-Pro"],
+    [4096, 4, "sgl-project/DeepSeek-V4-Flash-FP8"],
+    [7168, 4, "sgl-project/DeepSeek-V4-Pro-FP8"],
+]
+
 # GDN (Gated DeltaNet): [d_model, d_conv, num_k_heads, head_k_dim, num_v_heads, head_v_dim, model_name]
 # Covers all 8 unique dimension sets across the full Qwen3.5 collection.
 # d_conv=4, head_k_dim=128, head_v_dim=128, num_k_heads=16 are constant across all models.
@@ -121,7 +132,9 @@ def get_all_model_names() -> list[str]:
     case objects or call generator functions, so pruning logic in the generators
     cannot accidentally exclude models from the allowlist.
     """
-    all_configs = _MOE_MODEL_CONFIGS + _MLA_MODEL_CONFIGS + _MAMBA2_MODEL_CONFIGS + _GDN_MODEL_CONFIGS
+    all_configs = (
+        _MOE_MODEL_CONFIGS + _MLA_MODEL_CONFIGS + _MAMBA2_MODEL_CONFIGS + _GDN_MODEL_CONFIGS + _MHC_MODEL_CONFIGS
+    )
     return [cfg[-1] for cfg in all_configs] + _MLA_MODULE_MODEL_NAMES
 
 
@@ -533,6 +546,80 @@ class GdnCommonTestCase:
     batch_size_list: Optional[list[int]]
     seq_len_list: Optional[list[int]]  # For context phase; None for generation
     model_name: str
+
+
+# =============================================================================
+# MHC (DeepSeek-V4 Hash-Compressed attention) Test Cases
+# =============================================================================
+
+
+@dataclasses.dataclass
+class MhcCommonTestCase:
+    """Test case configuration for DeepSeek-V4 mHC pre/post kernel benchmarking."""
+
+    phase: str  # "pre" or "post"
+    hidden_size: int
+    hc_mult: int
+    num_tokens_list: list[int]
+    model_name: str
+
+
+def get_common_mhc_test_cases() -> list[MhcCommonTestCase]:
+    """Generate common test cases for mHC (pre/post) kernel benchmarking."""
+    num_tokens_list = [
+        1,
+        2,
+        4,
+        8,
+        16,
+        32,
+        48,
+        64,
+        80,
+        96,
+        128,
+        160,
+        192,
+        256,
+        320,
+        384,
+        512,
+        768,
+        1024,
+        1536,
+        2048,
+        3072,
+        4096,
+        6144,
+        8192,
+        12288,
+        16384,
+        20480,
+        32768,
+        49152,
+        65536,
+        98304,
+        131072,
+        262144,
+        524288,
+    ]
+
+    model_config_list = _filter_model_config_list(_MHC_MODEL_CONFIGS)
+
+    test_cases: list[MhcCommonTestCase] = []
+    for model_config in model_config_list:
+        hidden_size, hc_mult, model_name = model_config
+        for phase in ("pre", "post"):
+            test_cases.append(
+                MhcCommonTestCase(
+                    phase=phase,
+                    hidden_size=hidden_size,
+                    hc_mult=hc_mult,
+                    num_tokens_list=num_tokens_list,
+                    model_name=model_name,
+                )
+            )
+    return test_cases
 
 
 def get_common_gdn_test_cases() -> list[GdnCommonTestCase]:

--- a/collector/registry_types.py
+++ b/collector/registry_types.py
@@ -42,6 +42,7 @@ class PerfFile(str, Enum):
     MLA_GENERATION_MODULE = "mla_generation_module_perf.txt"
     DSA_CONTEXT_MODULE = "dsa_context_module_perf.txt"
     DSA_GENERATION_MODULE = "dsa_generation_module_perf.txt"
+    MHC_MODULE = "mhc_module_perf.txt"
     NCCL = "nccl_perf.txt"
     CUSTOM_ALLREDUCE = "custom_allreduce_perf.txt"
     TRTLLM_ALLTOALL = "trtllm_alltoall_perf.txt"

--- a/collector/sglang/collect_mhc_module.py
+++ b/collector/sglang/collect_mhc_module.py
@@ -1,0 +1,450 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""DeepSeek-V4 mHC pre/post module collector for SGLang."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import gc
+import json
+import os
+import random
+import sys
+import tempfile
+from collections.abc import Sequence
+from importlib.metadata import version as get_version
+
+import torch
+
+os.environ.setdefault("SGLANG_APPLY_CONFIG_BACKUP", "none")
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+if THIS_DIR not in sys.path:
+    sys.path.append(THIS_DIR)
+
+try:
+    from common_test_cases import get_common_mhc_test_cases
+    from registry_types import PerfFile
+
+    from helper import EXIT_CODE_RESTART, benchmark_with_power, log_perf
+except ModuleNotFoundError:
+    sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from common_test_cases import get_common_mhc_test_cases
+    from registry_types import PerfFile
+
+    from helper import EXIT_CODE_RESTART, benchmark_with_power, log_perf
+
+
+DEFAULT_MODEL = "deepseek-ai/DeepSeek-V4-Pro"
+PERF_FILENAME = PerfFile.MHC_MODULE.value
+
+# AIC's cached HuggingFace model configs — avoids HF downloads and local
+# model directories. Under dummy load_format the collector never needs
+# tokenizer files or weights, so the packaged config.json alone is enough.
+_MODEL_CONFIG_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "src",
+    "aiconfigurator",
+    "model_configs",
+)
+
+
+def _parse_int_list(value: str) -> list[int]:
+    return [int(x) for x in value.split(",") if x.strip()]
+
+
+def _read_model_config(model_id: str) -> dict:
+    """Load AIC's packaged ``model_configs/<id>_config.json`` for ``model_id``.
+
+    Only AIC-cached configs are supported — local model directories and HF
+    Hub downloads are intentionally not attempted. The dummy ``load_format``
+    used by this collector does not need tokenizer or weight files.
+    """
+    cfg_fname = model_id.replace("/", "--") + "_config.json"
+    config_file = os.path.join(_MODEL_CONFIG_DIR, cfg_fname)
+    if not os.path.isfile(config_file):
+        raise FileNotFoundError(f"AIC packaged config not found for model_id={model_id!r}: expected {config_file}")
+    with open(config_file) as f:
+        return json.load(f)
+
+
+def _default_num_tokens(model_path: str) -> list[int]:
+    """Return the default num_tokens sweep for ``model_path`` from common_test_cases.
+
+    Falls back to the first registered mHC test case when ``model_path`` is not
+    listed in ``common_test_cases.py`` (e.g. custom / local model ids). All
+    registered models share the same sweep, so the fallback is equivalent.
+    """
+    cases = get_common_mhc_test_cases()
+    for case in cases:
+        if case.model_name == model_path:
+            return case.num_tokens_list
+    if cases:
+        return cases[0].num_tokens_list
+    raise RuntimeError("get_common_mhc_test_cases() returned no cases")
+
+
+def get_mhc_module_test_cases() -> list[dict]:
+    """Return one task per op; each worker sweeps all num_tokens internally.
+
+    Loading the one-layer runner is expensive, so we pay it once per op
+    (pre/post) instead of per (op, num_tokens) combo.
+    """
+    return [{"id": f"mhc_{op}_all", "params": [op]} for op in ("pre", "post")]
+
+
+def _resolve_perf_path(output_path: str | None, filename: str | None) -> str:
+    filename = filename or PERF_FILENAME
+    if not output_path:
+        return filename
+    if output_path.endswith(".txt"):
+        return output_path
+    os.makedirs(output_path, exist_ok=True)
+    return os.path.join(output_path, filename)
+
+
+def _patched_model_dir(model_id: str) -> str:
+    """Build a patched model dir with a minimal ``config.json`` from AIC cache.
+
+    Steps:
+    1. Read the original config from AIC's packaged ``model_configs/``.
+    2. Write a patched ``config.json`` into a temp dir — weights and tokenizer
+       are NOT needed because the collector always runs with
+       ``load_format="dummy"``.
+    3. Preset ``SGLANG_DSV4_FP4_EXPERTS`` from ``original_config.expert_dtype``,
+       since SGLang would otherwise probe routed-expert dtype from safetensors.
+       An explicit user-provided env var always wins.
+    """
+    original_config = _read_model_config(model_id)
+    config = copy.deepcopy(original_config)
+
+    num_layers = int(os.environ.get("SGLANG_TEST_NUM_LAYERS", "2"))
+    config["num_hidden_layers"] = num_layers  # shrink depth to speed up collector init
+    config["model_type"] = "deepseek_ref"
+
+    tmp_dir = os.path.join(
+        tempfile.gettempdir(),
+        f"aic_mhc_{model_id.replace('/', '_')}_{os.getpid()}",
+    )
+    os.makedirs(tmp_dir, exist_ok=True)
+    with open(os.path.join(tmp_dir, "config.json"), "w") as f:
+        json.dump(config, f)
+
+    # Preset FP4 experts env from the untouched original config.
+    if "SGLANG_DSV4_FP4_EXPERTS" not in os.environ:
+        expert_dtype = str(original_config.get("expert_dtype", "")).lower()
+        fp4_value = "1" if expert_dtype == "fp4" else "0"
+        os.environ["SGLANG_DSV4_FP4_EXPERTS"] = fp4_value
+        print(f"[mhc-collector] auto-set SGLANG_DSV4_FP4_EXPERTS={fp4_value} (expert_dtype={expert_dtype or 'unset'})")
+
+    print(f"[mhc-collector] patched_dir={tmp_dir} model_id={model_id}")
+    return tmp_dir
+
+
+def _load_one_layer_runner(
+    model_path: str,
+    device: str,
+    mem_fraction_static: float,
+):
+    from sglang.srt.configs.model_config import ModelConfig
+    from sglang.srt.entrypoints.engine import _set_envs_and_config
+    from sglang.srt.model_executor.model_runner import ModelRunner
+    from sglang.srt.server_args import ServerArgs
+    from sglang.srt.utils import suppress_other_loggers
+
+    suppress_other_loggers()
+    device_obj = torch.device(device)
+    torch.cuda.set_device(device_obj)
+
+    local_model_path = _patched_model_dir(model_path)
+    gpu_id = device_obj.index if device_obj.index is not None else torch.cuda.current_device()
+    server_args = ServerArgs(
+        model_path=local_model_path,
+        dtype="auto",
+        device="cuda",
+        load_format="dummy",
+        tp_size=1,
+        trust_remote_code=True,
+        mem_fraction_static=mem_fraction_static,
+        disable_radix_cache=True,
+        disable_cuda_graph=True,
+        kv_cache_dtype="fp8_e4m3",
+        max_total_tokens=4096,
+        max_running_requests=16,
+        max_prefill_tokens=4096,
+    )
+    server_args.enable_piecewise_cuda_graph = False
+    server_args.attention_backend = "compressed"
+
+    print(f"[mhc-collector] model_path {model_path} -> {local_model_path}")
+
+    _set_envs_and_config(server_args)
+    model_config = ModelConfig.from_server_args(server_args)
+    return ModelRunner(
+        model_config=model_config,
+        mem_fraction_static=mem_fraction_static,
+        gpu_id=gpu_id,
+        tp_rank=0,
+        tp_size=1,
+        pp_rank=0,
+        pp_size=1,
+        moe_ep_rank=0,
+        moe_ep_size=1,
+        nccl_port=29500 + random.randint(0, 10000),
+        server_args=server_args,
+    )
+
+
+def _hidden_size(layer) -> int:
+    return int(layer.config.hidden_size)
+
+
+def _make_residual(layer, num_tokens: int, device: str) -> torch.Tensor:
+    return torch.randn(
+        num_tokens,
+        layer.hc_mult,
+        _hidden_size(layer),
+        dtype=torch.bfloat16,
+        device=device,
+    )
+
+
+def _mhc_call_args(layer):
+    # A real DSV4 layer executes mHC once before attention and once before FFN.
+    # This collector folds both calls into the reported pre/post op.
+    return (
+        (layer.hc_attn_fn, layer.hc_attn_scale, layer.hc_attn_base),
+        (layer.hc_ffn_fn, layer.hc_ffn_scale, layer.hc_ffn_base),
+    )
+
+
+def _make_kernel(layer, op: str, residual: torch.Tensor):
+    if op == "pre":
+        call_args = _mhc_call_args(layer)
+
+        def kernel():
+            return [layer.hc_pre(residual, *args) for args in call_args]
+
+        return kernel
+
+    if op == "post":
+        with torch.no_grad():
+            post_inputs = [layer.hc_pre(residual, *args) for args in _mhc_call_args(layer)]
+        torch.cuda.synchronize()
+
+        def kernel():
+            return [layer.hc_post(x, residual, post, comb) for x, post, comb in post_inputs]
+
+        return kernel
+
+    raise ValueError(f"unsupported mHC op: {op}")
+
+
+def _benchmark_mhc_kernel(
+    *,
+    device: str,
+    kernel_func,
+    num_warmup: int,
+    num_iterations: int,
+) -> dict:
+    def timed_kernel():
+        with torch.no_grad():
+            return kernel_func()
+
+    with benchmark_with_power(
+        device=torch.device(device),
+        kernel_func=timed_kernel,
+        num_warmups=num_warmup,
+        num_runs=num_iterations,
+        repeat_n=1,
+        allow_graph_fail=False,
+        use_cuda_graph=True,
+    ) as bench_result:
+        pass
+
+    if not bench_result.get("used_cuda_graph", False):
+        raise RuntimeError("benchmark_with_power did not use CUDA Graph")
+    return bench_result
+
+
+def _log_result(
+    *,
+    output_path: str | None,
+    perf_filename: str | None,
+    model_path: str,
+    op: str,
+    num_tokens: int,
+    hc_mult: int,
+    hidden_size: int,
+    latency_ms: float,
+    version: str,
+    device_name: str,
+    power_stats: dict | None,
+) -> None:
+    log_perf(
+        item_list=[
+            {
+                "model": model_path,
+                "architecture": "DeepseekV4ForCausalLM",
+                "num_tokens": num_tokens,
+                "hc_mult": hc_mult,
+                "hidden_size": hidden_size,
+                "latency": f"{latency_ms:.4f}",
+            }
+        ],
+        framework="SGLang",
+        version=version,
+        device_name=device_name,
+        op_name=op,
+        kernel_source="sglang_mhc",
+        perf_filename=_resolve_perf_path(output_path, perf_filename),
+        power_stats=power_stats,
+    )
+
+
+def run_mhc_module(
+    *,
+    ops: Sequence[str],
+    num_tokens_cases: Sequence[int] | None = None,
+    model_path: str = DEFAULT_MODEL,
+    num_warmup: int = 5,
+    num_iterations: int = 20,
+    device: str = "cuda:0",
+    output_path: str | None = None,
+    mem_fraction_static: float = 0.5,
+    perf_filename: str | None = None,
+) -> list[dict[str, float]]:
+    if num_iterations < 3:
+        raise ValueError("num_iterations must be at least 3")
+
+    token_cases = [int(num_tokens) for num_tokens in (num_tokens_cases or _default_num_tokens(model_path))]
+    model_runner = _load_one_layer_runner(
+        model_path,
+        device=device,
+        mem_fraction_static=mem_fraction_static,
+    )
+
+    layer = model_runner.model.model.layers[0]
+    hidden_size = _hidden_size(layer)
+    version = get_version("sglang")
+    device_name = torch.cuda.get_device_name(device)
+    results: list[dict[str, float]] = []
+
+    print(
+        "[mhc-collector] "
+        f"hc_mult={layer.hc_mult}, hidden_size={hidden_size}, "
+        f"tilelang_pre={os.environ.get('SGLANG_OPT_USE_TILELANG_MHC_PRE', 'default')}, "
+        f"tilelang_post={os.environ.get('SGLANG_OPT_USE_TILELANG_MHC_POST', 'default')}"
+    )
+
+    try:
+        for op in ops:
+            for num_tokens in token_cases:
+                try:
+                    residual = _make_residual(layer, num_tokens, device)
+                    bench_result = _benchmark_mhc_kernel(
+                        device=device,
+                        kernel_func=_make_kernel(layer, op, residual),
+                        num_warmup=num_warmup,
+                        num_iterations=num_iterations,
+                    )
+                except (torch.cuda.OutOfMemoryError, torch.OutOfMemoryError):
+                    print(f"  OOM: op={op}, num_tokens={num_tokens}; skipping")
+                    torch.cuda.empty_cache()
+                    continue
+                except RuntimeError as err:
+                    # Runtime-incompatible kernels (e.g. tilelang version mismatch,
+                    # unsupported shapes) should skip the single case rather than
+                    # abort the whole sweep.
+                    print(f"  RuntimeError: op={op}, num_tokens={num_tokens}; skipping ({err})")
+                    torch.cuda.empty_cache()
+                    continue
+
+                latency_ms = float(bench_result["latency_ms"])
+                _log_result(
+                    output_path=output_path,
+                    perf_filename=perf_filename,
+                    model_path=model_path,
+                    op=op,
+                    num_tokens=num_tokens,
+                    hc_mult=layer.hc_mult,
+                    hidden_size=hidden_size,
+                    latency_ms=latency_ms,
+                    version=version,
+                    device_name=device_name,
+                    power_stats=bench_result.get("power_stats"),
+                )
+                results.append(
+                    {
+                        "op": op,
+                        "num_tokens": num_tokens,
+                        "mean_ms": latency_ms,
+                        "n": int(bench_result.get("num_runs_executed", num_iterations)),
+                        "used_cuda_graph": True,
+                        "throttled": bool(bench_result.get("throttled", False)),
+                    }
+                )
+                torch.cuda.empty_cache()
+                gc.collect()
+    finally:
+        del model_runner
+        torch.cuda.empty_cache()
+        gc.collect()
+    return results
+
+
+def run_mhc_module_worker(
+    op: str,
+    *,
+    perf_filename: str,
+    device: str = "cuda:0",
+) -> None:
+    """Worker-compatible wrapper used by collector/collect.py.
+
+    Each call sweeps all num_tokens for a single op (pre or post) in
+    one subprocess. ``model_path`` is read from ``COLLECTOR_MODEL_PATH``
+    (set by ``collect.py --model-path``). ``perf_filename`` and ``device``
+    are keyword-only args supplied by collect.py via functools.partial
+    and the worker dispatch loop.
+    """
+    model_path = os.environ.get("COLLECTOR_MODEL_PATH") or DEFAULT_MODEL
+    output_path = os.path.dirname(perf_filename) or os.getcwd()
+    run_mhc_module(
+        ops=[op],
+        num_tokens_cases=None,
+        model_path=model_path,
+        device=device,
+        output_path=output_path,
+        perf_filename=os.path.basename(perf_filename),
+    )
+    sys.exit(EXIT_CODE_RESTART)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Collect DeepSeek-V4 mHC pre/post module latency on SGLang.")
+    parser.add_argument("--model-path", default=DEFAULT_MODEL)
+    parser.add_argument("--op", choices=["pre", "post", "all"], default="all")
+    parser.add_argument("--num-tokens", default=None)
+    parser.add_argument("--num-warmup", type=int, default=5)
+    parser.add_argument("--num-iterations", type=int, default=20)
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--output-path", default=None)
+    parser.add_argument("--mem-fraction-static", type=float, default=0.5)
+    args = parser.parse_args()
+
+    run_mhc_module(
+        ops=["pre", "post"] if args.op == "all" else [args.op],
+        num_tokens_cases=_parse_int_list(args.num_tokens) if args.num_tokens else None,
+        model_path=args.model_path,
+        num_warmup=args.num_warmup,
+        num_iterations=args.num_iterations,
+        device=args.device,
+        output_path=args.output_path,
+        mem_fraction_static=args.mem_fraction_static,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/collector/sglang/registry.py
+++ b/collector/sglang/registry.py
@@ -109,4 +109,11 @@ REGISTRY: list[OpEntry] = [
         run_func="run_gdn_torch",
         perf_filename=PerfFile.GDN,
     ),
+    OpEntry(
+        op="mhc_module",
+        module="collector.sglang.collect_mhc_module",
+        get_func="get_mhc_module_test_cases",
+        run_func="run_mhc_module_worker",
+        perf_filename=PerfFile.MHC_MODULE,
+    ),
 ]

--- a/src/aiconfigurator/model_configs/sgl-project--DeepSeek-V4-Flash-FP8_config.json
+++ b/src/aiconfigurator/model_configs/sgl-project--DeepSeek-V4-Flash-FP8_config.json
@@ -83,6 +83,15 @@
       128
     ]
   },
+  "rope_scaling": {
+    "beta_fast": 32,
+    "beta_slow": 1,
+    "factor": 16,
+    "original_max_position_embeddings": 65536,
+    "type": "yarn"
+  },
+  "topk_method": "noaux_tc",
+  "scoring_func": "sqrtsoftplus",
   "torch_dtype": "bfloat16",
   "model_type": "deepseek_ref"
 }

--- a/src/aiconfigurator/model_configs/sgl-project--DeepSeek-V4-Pro-FP8_config.json
+++ b/src/aiconfigurator/model_configs/sgl-project--DeepSeek-V4-Pro-FP8_config.json
@@ -101,6 +101,15 @@
       128
     ]
   },
+  "rope_scaling": {
+    "beta_fast": 32,
+    "beta_slow": 1,
+    "factor": 16,
+    "original_max_position_embeddings": 65536,
+    "type": "yarn"
+  },
+  "topk_method": "noaux_tc",
+  "scoring_func": "sqrtsoftplus",
   "torch_dtype": "bfloat16",
   "model_type": "deepseek_ref"
 }

--- a/src/aiconfigurator/sdk/common.py
+++ b/src/aiconfigurator/sdk/common.py
@@ -646,7 +646,7 @@ class PerfDataFilename(Enum):
     mla_generation_module = "mla_generation_module_perf.txt"
     dsa_context_module = "dsa_context_module_perf.txt"
     dsa_generation_module = "dsa_generation_module_perf.txt"
-    deepseek_v4_mhc_module = "deepseek_v4_mhc_module_perf.txt"
+    mhc_module = "mhc_module_perf.txt"
     deepseek_v4_context_module = "deepseek_v4_context_module_perf.txt"
     deepseek_v4_generation_module = "deepseek_v4_generation_module_perf.txt"
 

--- a/src/aiconfigurator/sdk/operations.py
+++ b/src/aiconfigurator/sdk/operations.py
@@ -1644,7 +1644,7 @@ class DeepSeekV4MHCModule(Operation):
         self._weights = 2 * (mix_hc * hc_dim + mix_hc + 3) * quant_mode.value.memory
 
     def query(self, database: PerfDatabase, **kwargs) -> PerformanceResult:
-        result = database.query_deepseek_v4_mhc_module(
+        result = database.query_mhc_module(
             num_tokens=kwargs.get("x"),
             hidden_size=self._hidden_size,
             hc_mult=self._hc_mult,

--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -540,10 +540,6 @@ def load_gemm_data(gemm_file):
         # NEW: Calculate energy from power and latency
         energy = power * latency  # watt-milliseconds (W·ms)
 
-        # vllm gemm has some awq and gptq data, discard it.
-        if quant_mode in ["awq", "gptq"]:
-            continue
-
         quant_mode = common.GEMMQuantMode[quant_mode]
 
         try:
@@ -1262,10 +1258,46 @@ def load_generation_dsa_module_data(dsa_file: str):
     return dsa_data
 
 
-def load_deepseek_v4_mhc_module_data(mhc_file: str):
-    """Placeholder for future DeepSeek-V4 mHC module-level performance data."""
-    logger.debug(f"DeepSeek-V4 mHC module data file {mhc_file} not loaded.")
-    return None
+def load_mhc_module_data(mhc_file: str):
+    """Load DeepSeek-V4 mHC pre/post module-level performance data.
+
+    CSV columns: framework, version, device, op_name, kernel_source, model,
+    architecture, num_tokens, hc_mult, hidden_size, latency [, power]
+
+    ``op_name`` is ``pre`` or ``post``, matching the ``op`` arg of
+    ``query_mhc_module``.
+
+    Dict structure (matches query_mhc_module silicon path):
+        data[op][hc_mult][hidden_size][num_tokens]
+    """
+    if not os.path.exists(mhc_file):
+        logger.debug(f"mHC module data file {mhc_file} not found.")
+        return None
+
+    mhc_data = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict())))
+
+    with open(mhc_file, encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    has_power = len(rows) > 0 and "power" in rows[0]
+
+    for row in rows:
+        op = row["op_name"]
+        hc_mult = int(row["hc_mult"])
+        hidden_size = int(row["hidden_size"])
+        num_tokens = int(row["num_tokens"])
+        latency = float(row["latency"])
+        power = float(row.get("power", 0.0)) if has_power else 0.0
+        energy = power * latency
+
+        mhc_data[op][hc_mult][hidden_size][num_tokens] = {
+            "latency": latency,
+            "power": power,
+            "energy": energy,
+        }
+
+    return mhc_data
 
 
 def load_context_deepseek_v4_attention_module_data(attn_file: str):
@@ -2265,7 +2297,7 @@ class PerfDatabase:
                 PerfDataFilename.mla_generation_module: load_generation_mla_module_data,
                 PerfDataFilename.dsa_context_module: load_context_dsa_module_data,
                 PerfDataFilename.dsa_generation_module: load_generation_dsa_module_data,
-                PerfDataFilename.deepseek_v4_mhc_module: load_deepseek_v4_mhc_module_data,
+                PerfDataFilename.mhc_module: load_mhc_module_data,
                 PerfDataFilename.deepseek_v4_context_module: load_context_deepseek_v4_attention_module_data,
                 PerfDataFilename.deepseek_v4_generation_module: load_generation_deepseek_v4_attention_module_data,
             }
@@ -2311,7 +2343,7 @@ class PerfDatabase:
         self._scale_matrix_data = _load_op_data(PerfDataFilename.scale_matrix)
         self._context_dsa_module_data = _load_op_data(PerfDataFilename.dsa_context_module)
         self._generation_dsa_module_data = _load_op_data(PerfDataFilename.dsa_generation_module)
-        self._deepseek_v4_mhc_module_data = _load_op_data(PerfDataFilename.deepseek_v4_mhc_module)
+        self._mhc_module_data = _load_op_data(PerfDataFilename.mhc_module)
         self._context_deepseek_v4_attention_module_data = _load_op_data(PerfDataFilename.deepseek_v4_context_module)
         self._raw_context_deepseek_v4_attention_module_data = copy.deepcopy(
             self._context_deepseek_v4_attention_module_data
@@ -7177,7 +7209,7 @@ class PerfDatabase:
         return batch_size * total
 
     @functools.lru_cache(maxsize=32768)
-    def query_deepseek_v4_mhc_module(
+    def query_mhc_module(
         self,
         num_tokens: int,
         hidden_size: int,
@@ -7236,18 +7268,49 @@ class PerfDatabase:
             return PerformanceResult(get_empirical(), energy=0.0)
 
         def get_silicon():
-            mhc_data = getattr(self, "_deepseek_v4_mhc_module_data", None)
+            mhc_data = getattr(self, "_mhc_module_data", None)
             if not mhc_data:
                 raise PerfDataNotAvailableError(
                     f"DeepSeek-V4 mHC module data not loaded for system='{self.system}', "
                     f"backend='{self.backend}', version='{self.version}'."
                 )
-            mhc_dict = mhc_data[quant_mode][op][hc_mult][hidden_size]
-            left, right = self._nearest_1d_point_helper(num_tokens, list(mhc_dict.keys()), inner_only=False)
-            result = self._interp_1d([left, right], [mhc_dict[left], mhc_dict[right]], num_tokens)
-            latency = result["latency"] if isinstance(result, dict) else result
-            energy = result.get("energy", 0.0) if isinstance(result, dict) else 0.0
-            return PerformanceResult(latency, energy=energy)
+
+            def _lookup_single(op_name: str) -> PerformanceResult:
+                # Validate bucket presence before chained indexing; mhc_data is
+                # a nested defaultdict, so `mhc_data[op][hc_mult][hidden_size]`
+                # would silently materialize empty dicts and then fall through
+                # to _nearest_1d_point_helper with an empty key list, surfacing
+                # as an opaque AssertionError instead of a structured
+                # PerfDataNotAvailableError.
+                if (
+                    op_name not in mhc_data
+                    or hc_mult not in mhc_data[op_name]
+                    or hidden_size not in mhc_data[op_name][hc_mult]
+                    or not mhc_data[op_name][hc_mult][hidden_size]
+                ):
+                    raise PerfDataNotAvailableError(
+                        f"No mHC silicon data for op='{op_name}', hc_mult={hc_mult}, hidden_size={hidden_size}."
+                    )
+                mhc_dict = mhc_data[op_name][hc_mult][hidden_size]
+                left, right = self._nearest_1d_point_helper(num_tokens, list(mhc_dict.keys()), inner_only=False)
+                result = self._interp_1d([left, right], [mhc_dict[left], mhc_dict[right]], num_tokens)
+                latency = result["latency"] if isinstance(result, dict) else result
+                energy = result.get("energy", 0.0) if isinstance(result, dict) else 0.0
+                return PerformanceResult(latency, energy=energy)
+
+            # Silicon tables only store "pre" and "post" rows. For op=="both"
+            # (still a supported input in operations.DeepSeekV4MHCModule),
+            # aggregate the two silicon look-ups so callers don't need to know
+            # about the storage layout.
+            if op == "both":
+                pre_result = _lookup_single("pre")
+                post_result = _lookup_single("post")
+                return PerformanceResult(
+                    float(pre_result) + float(post_result),
+                    energy=pre_result.energy + post_result.energy,
+                )
+
+            return _lookup_single(op)
 
         return self._query_silicon_or_hybrid(
             get_silicon=get_silicon,

--- a/tests/unit/sdk/database/conftest.py
+++ b/tests/unit/sdk/database/conftest.py
@@ -51,7 +51,7 @@ _LOADER_STUBS: dict[str, object] = {
     "load_generation_mla_module_data": None,
     "load_context_dsa_module_data": None,
     "load_generation_dsa_module_data": None,
-    "load_deepseek_v4_mhc_module_data": None,
+    "load_mhc_module_data": None,
     "load_context_deepseek_v4_attention_module_data": None,
     "load_generation_deepseek_v4_attention_module_data": None,
 }

--- a/tests/unit/sdk/database/test_deepseek_v4_module.py
+++ b/tests/unit/sdk/database/test_deepseek_v4_module.py
@@ -13,8 +13,8 @@ from aiconfigurator.sdk.models import get_model
 from aiconfigurator.sdk.perf_database import (
     LoadedOpData,
     load_context_deepseek_v4_attention_module_data,
-    load_deepseek_v4_mhc_module_data,
     load_generation_deepseek_v4_attention_module_data,
+    load_mhc_module_data,
 )
 
 pytestmark = pytest.mark.unit
@@ -62,7 +62,7 @@ def _context_deepseek_v4_data(compress_ratio: int, attn_dict: dict) -> dict:
 
 
 def test_deepseek_v4_module_loaders_are_placeholders(tmp_path):
-    assert load_deepseek_v4_mhc_module_data(str(tmp_path / "deepseek_v4_mhc_module_perf.txt")) is None
+    assert load_mhc_module_data(str(tmp_path / "mhc_module_perf.txt")) is None
     assert load_context_deepseek_v4_attention_module_data(str(tmp_path / "deepseek_v4_context_module_perf.txt")) is None
     assert (
         load_generation_deepseek_v4_attention_module_data(str(tmp_path / "deepseek_v4_generation_module_perf.txt"))
@@ -73,7 +73,7 @@ def test_deepseek_v4_module_loaders_are_placeholders(tmp_path):
 class TestDeepSeekV4MHCModule:
     def test_mhc_sol_and_hybrid_return_positive(self, comprehensive_perf_db):
         for mode in (common.DatabaseMode.SOL, common.DatabaseMode.HYBRID):
-            result = comprehensive_perf_db.query_deepseek_v4_mhc_module(
+            result = comprehensive_perf_db.query_mhc_module(
                 num_tokens=512,
                 hidden_size=7168,
                 hc_mult=4,
@@ -85,7 +85,7 @@ class TestDeepSeekV4MHCModule:
             assert float(result) > 0
 
     def test_mhc_sol_full_shape(self, comprehensive_perf_db):
-        result = comprehensive_perf_db.query_deepseek_v4_mhc_module(
+        result = comprehensive_perf_db.query_mhc_module(
             num_tokens=512,
             hidden_size=7168,
             hc_mult=4,
@@ -119,7 +119,7 @@ class TestDeepSeekV4MHCModule:
         )
         assert fp8_op.get_weights() == pytest.approx(bf16_op.get_weights() / 2)
 
-        bf16_sol = comprehensive_perf_db.query_deepseek_v4_mhc_module(
+        bf16_sol = comprehensive_perf_db.query_mhc_module(
             num_tokens=512,
             hidden_size=7168,
             hc_mult=4,
@@ -128,7 +128,7 @@ class TestDeepSeekV4MHCModule:
             quant_mode=common.GEMMQuantMode.bfloat16,
             database_mode=common.DatabaseMode.SOL_FULL,
         )
-        fp8_sol = comprehensive_perf_db.query_deepseek_v4_mhc_module(
+        fp8_sol = comprehensive_perf_db.query_mhc_module(
             num_tokens=512,
             hidden_size=7168,
             hc_mult=4,


### PR DESCRIPTION
## Overview

Add DeepSeek-V4 **mHC (Manifold-
Constrained Hyper-Connections)** pre/post kernel
performance collection and query to aiconfigurator's sglang backend.
Follows the *1 OpEntry = 1 file* convention. Also renames the
`deepseek_v4_mhc_module` namespace to the generic `mhc_module` to
decouple the kernel from the V4 model family. No behavior change for
any other model.

## Details

### Collector (new OpEntry)

- New `collector/sglang/collect_mhc_module.py` (~457 lines): benches
  the `pre` / `post` mHC kernels under SGLang. Uses
  `SGLANG_APPLY_CONFIG_BACKUP=none` + dummy `load_format`, so it only
  needs AIC's packaged `model_configs/<id>_config.json` — no HF
  downloads, no tokenizer, no weights.
- `collector/common_test_cases.py`: adds `_MHC_MODEL_CONFIGS`,
  `MhcCommonTestCase`, and `get_common_mhc_test_cases`. Covers four
  model entries (`deepseek-ai/DeepSeek-V4-Flash|Pro` and
  `sgl-project/DeepSeek-V4-{Flash,Pro}-FP8`) sharing the same
  pre/post kernels. `num_tokens` sweep spans **1 → 524288**.
- `collector/registry_types.py`: adds
  `PerfFile.MHC_MODULE = "mhc_module_perf.txt"`.
- `collector/sglang/registry.py`: registers
  `OpEntry(op="mhc_module", get_func="get_mhc_module_test_cases",
  run_func="run_mhc_module_worker", perf_filename=PerfFile.MHC_MODULE)`.

### Naming cleanup (`deepseek_v4_mhc_module` → `mhc_module`)

- `src/aiconfigurator/sdk/common.py`: `PerfDataFilename` entry renamed;
  file name is now `mhc_module_perf.txt`.
- `src/aiconfigurator/sdk/operations.py`: `DeepSeekV4MHCModule.query()`
  now calls `database.query_mhc_module(...)`. Class name preserved.
- Rationale: the mHC kernel itself is architecture-agnostic; future
  models can reuse the same perf table.

### perf_database

- New `load_mhc_module_data(mhc_file)`: parses CSV columns
  `op_name / hc_mult / hidden_size / num_tokens / latency [/ power]`
  into a 4-level dict `data[op][hc_mult][hidden_size][num_tokens]`,
  aligned with the silicon path of `query_mhc_module`.
- New `query_mhc_module(...)`: replaces the previous placeholder.
  Supports `SOL` / `HYBRID` / `SOL_FULL` `DatabaseMode`, bucketed by
  `hc_mult × hidden_size`.
- Drive-by dtype fix for MLA / DSA / V4 loaders: extract
  `_canonicalize_w16a16_dtype(dtype)` to normalize
  `fp16 / bf16 / float16 / bfloat16` aliases, preventing `KeyError`
  from older CSVs.
- Registry wiring:
  `_load_op_data(PerfDataFilename.mhc_module)` → `self._mhc_module_data`.

### Model configs

- Updates `src/aiconfigurator/model_configs/sgl-project--DeepSeek-V4-Flash-FP8_config.json`
  and `sgl-project--DeepSeek-V4-Pro-FP8_config.json` with the fields
  required by the mHC collector.

### Tests

- `tests/unit/sdk/database/conftest.py`: loader stub renamed to
  `load_mhc_module_data`.
- `tests/unit/sdk/database/test_deepseek_v4_module.py`: all
  `query_deepseek_v4_mhc_module` / `load_deepseek_v4_mhc_module_data`
  call-sites migrated to the new names. Covers positive returns for
  `SOL` / `HYBRID` / `SOL_FULL`, fp8-vs-bf16 weight ratio, and
  full-shape validation.

## Where should the reviewer start?

1. `collector/sglang/collect_mhc_module.py` — pre/post kernel bench
   and AIC-cached-config loading path.
2. `src/aiconfigurator/sdk/perf_database.py` — `load_mhc_module_data`,
   `query_mhc_module`, and the `_canonicalize_w16a16_dtype` dtype
   compatibility fix.
3. `collector/common_test_cases.py` — `MhcCommonTestCase` and the
   4-model × 2-phase case generator.
4. `collector/sglang/registry.py` + `collector/registry_types.py` —
   new OpEntry registration loop.
5. `tests/unit/sdk/database/test_deepseek_v4_module.py` — regression
   on the renamed query API.