### PR TITLE
chore: Add data from auto-collector pipeline 49898847 (gb200_vllm_0.19.0)

### DIFF
--- a/src/aiconfigurator/systems/data/gb200/vllm/0.19.0/moe_perf.txt
+++ b/src/aiconfigurator/systems/data/gb200/vllm/0.19.0/moe_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:78fba7576c7eb0a6bc76981e70f309ec59f909a69fc826e72f17c03f0ad1e18e
-size 5279864
+oid sha256:79fde59b6a800c7cb11433a3699fe5c24a759259eee2e4df541598afc41ce944
+size 5279592


### PR DESCRIPTION
# Error Summary for Auto-Collector Run
## Collection summary for gb200 vllm:0.19.0
### Error summary
```
{
    "backend": "vllm",
    "version": "0.19.0",
    "timestamp": "2026-04-30T09:30:16.555414",
    "total_errors": 408,
    "errors_by_module": {
        "vllm.moe": 408
    },
    "errors_by_type": {
        "RuntimeError": 360,
        "AssertionError": 48
    }
}
```

