### PR TITLE
chore: Add data from auto-collector pipeline 49903029 (gb200_vllm_0.19.0)

### DIFF
--- a/src/aiconfigurator/systems/data/gb200/vllm/0.19.0/moe_perf.txt
+++ b/src/aiconfigurator/systems/data/gb200/vllm/0.19.0/moe_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:78fba7576c7eb0a6bc76981e70f309ec59f909a69fc826e72f17c03f0ad1e18e
-size 5279864
+oid sha256:c599e0db4a0797056ac37aadf0200bd82697ce0ea7b07a790e4b630141140804
+size 6396442


### PR DESCRIPTION
# Error Summary for Auto-Collector Run
## Collection summary for gb200 vllm:0.19.0
### Error summary
```
{
    "backend": "vllm",
    "version": "0.19.0",
    "timestamp": "2026-04-30T10:36:23.250466",
    "total_errors": 48,
    "errors_by_module": {
        "vllm.moe": 48
    },
    "errors_by_type": {
        "AssertionError": 48
    }
}
```

