### PR TITLE
chore: Add data from auto-collector pipeline 49903029 (gb300_vllm_0.19.0)

### DIFF
--- a/src/aiconfigurator/systems/data/gb300/vllm/0.19.0/moe_perf.txt
+++ b/src/aiconfigurator/systems/data/gb300/vllm/0.19.0/moe_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b18be15ea9bbbc5efbb3292128c47e45256ac687c0952c12f34d5e8cd86444e0
-size 5280132
+oid sha256:4a074c0a849e08c72636dee67be3e3aca87c8538e761b5f7d1eed3882d1d2c52
+size 6396549


### PR DESCRIPTION
# Error Summary for Auto-Collector Run
## Collection summary for gb300 vllm:0.19.0
### Error summary
```
{
    "backend": "vllm",
    "version": "0.19.0",
    "timestamp": "2026-04-30T10:36:13.480140",
    "total_errors": 48,
    "errors_by_module": {
        "vllm.moe": 48
    },
    "errors_by_type": {
        "AssertionError": 48
    }
}
```

