### PR TITLE
fix: llm-d output improvements

### DIFF
--- a/src/aiconfigurator/generator/config/backend_templates/sglang/llm-d-values.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/sglang/llm-d-values.yaml.j2
@@ -22,12 +22,8 @@ modelArtifacts:
     llm-d.ai/model: {{ served_name | replace('-', '_') | replace('/', '_') }}
   uri: {{ model_uri }}
   size: {{ llmd_config.model_cache_size | default('100Gi') }}
-  # hf_token should be the name of a K8s Secret containing the HF token
-  {% if service_config.hf_token -%}
-  authSecretName: {{ service_config.hf_token }}
-  {% else -%}
-  authSecretName: ""
-  {% endif -%}
+  # Name of a K8s Secret containing HF_TOKEN. Set via --generator-set LlmdConfig.hf_token_secret=<secret-name>
+  authSecretName: {{ llmd_config.hf_token_secret | default('') }}
   mountPath: {{ llmd_config.model_mount_path | default('/model-cache') }}
 
 # Accelerator configuration

--- a/src/aiconfigurator/generator/config/backend_templates/sglang/llm-d-values.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/sglang/llm-d-values.yaml.j2
@@ -69,9 +69,9 @@ decode:
         - {{ model_name }}
         - --served-model-name
         - {{ served_name }}
-        {%- for arg in agg_cli_args_list | default([]) %}
+        {% for arg in agg_cli_args_list | default([]) %}
         - {{ arg | tojson }}
-        {%- endfor %}
+        {% endfor %}
       env: []
       ports:
         - containerPort: 8200
@@ -125,9 +125,9 @@ decode:
         - {{ model_name }}
         - --served-model-name
         - {{ served_name }}
-        {%- for arg in decode_cli_args_list | default([]) %}
+        {% for arg in decode_cli_args_list | default([]) %}
         - {{ arg | tojson }}
-        {%- endfor %}
+        {% endfor %}
       env: []
       ports:
         - containerPort: 8200
@@ -173,9 +173,9 @@ prefill:
         - {{ model_name }}
         - --served-model-name
         - {{ served_name }}
-        {%- for arg in prefill_cli_args_list | default([]) %}
+        {% for arg in prefill_cli_args_list | default([]) %}
         - {{ arg | tojson }}
-        {%- endfor %}
+        {% endfor %}
       env: []
       ports:
         - containerPort: 8000

--- a/src/aiconfigurator/generator/config/backend_templates/vllm/llm-d-values.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/vllm/llm-d-values.yaml.j2
@@ -22,12 +22,8 @@ modelArtifacts:
     llm-d.ai/model: {{ served_name | replace('-', '_') | replace('/', '_') }}
   uri: {{ model_uri }}
   size: {{ llmd_config.model_cache_size | default('100Gi') }}
-  # hf_token should be the name of a K8s Secret containing the HF token
-  {% if service_config.hf_token -%}
-  authSecretName: {{ service_config.hf_token }}
-  {% else -%}
-  authSecretName: ""
-  {% endif -%}
+  # Name of a K8s Secret containing HF_TOKEN. Set via --generator-set LlmdConfig.hf_token_secret=<secret-name>
+  authSecretName: {{ llmd_config.hf_token_secret | default('') }}
   mountPath: {{ llmd_config.model_mount_path | default('/model-cache') }}
 
 # Accelerator configuration

--- a/src/aiconfigurator/generator/config/backend_templates/vllm/llm-d-values.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/vllm/llm-d-values.yaml.j2
@@ -58,6 +58,7 @@ decode:
 
   containers:
     - name: vllm
+      # AIC predicted with vllm {{ backend_version | default('latest') }} — pin image tag to match for reproducibility
       image: {{ llmd_config.vllm_image | default('vllm/vllm-openai:latest') }}
       modelCommand: vllmServe
       args:
@@ -114,6 +115,7 @@ decode:
 
   containers:
     - name: vllm
+      # AIC predicted with vllm {{ backend_version | default('latest') }} — pin image tag to match for reproducibility
       image: {{ llmd_config.vllm_image | default('vllm/vllm-openai:latest') }}
       modelCommand: vllmServe
       args:
@@ -162,6 +164,7 @@ prefill:
 
   containers:
     - name: vllm
+      # AIC predicted with vllm {{ backend_version | default('latest') }} — pin image tag to match for reproducibility
       image: {{ llmd_config.vllm_image | default('vllm/vllm-openai:latest') }}
       modelCommand: vllmServe
       args:

--- a/src/aiconfigurator/generator/config/backend_templates/vllm/llm-d-values.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/vllm/llm-d-values.yaml.j2
@@ -69,9 +69,9 @@ decode:
         - {{ model_name }}
         - --served-model-name
         - {{ served_name }}
-        {%- for arg in agg_cli_args_list | default([]) %}
+        {% for arg in agg_cli_args_list | default([]) %}
         - {{ arg | tojson }}
-        {%- endfor %}
+        {% endfor %}
       env: []
       ports:
         - containerPort: 8200
@@ -125,9 +125,9 @@ decode:
         - {{ model_name }}
         - --served-model-name
         - {{ served_name }}
-        {%- for arg in decode_cli_args_list | default([]) %}
+        {% for arg in decode_cli_args_list | default([]) %}
         - {{ arg | tojson }}
-        {%- endfor %}
+        {% endfor %}
       env: []
       ports:
         - containerPort: 8200
@@ -173,9 +173,9 @@ prefill:
         - {{ model_name }}
         - --served-model-name
         - {{ served_name }}
-        {%- for arg in prefill_cli_args_list | default([]) %}
+        {% for arg in prefill_cli_args_list | default([]) %}
         - {{ arg | tojson }}
-        {%- endfor %}
+        {% endfor %}
       env: []
       ports:
         - containerPort: 8000

--- a/src/aiconfigurator/generator/config/deployment_config.yaml
+++ b/src/aiconfigurator/generator/config/deployment_config.yaml
@@ -193,6 +193,9 @@ inputs:
     default: "'simple'"
 
   # LlmdConfig - llm-d specific configuration
+  - key: LlmdConfig.hf_token_secret
+    required: false
+    default: ""
   - key: LlmdConfig.vllm_image
     required: false
     default: "vllm/vllm-openai:latest"

--- a/tests/unit/generator/test_llmd_deployment.py
+++ b/tests/unit/generator/test_llmd_deployment.py
@@ -255,6 +255,54 @@ def test_llmd_sglang_default_image():
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("backend", ["vllm", "sglang"])
+def test_llmd_hf_token_secret(backend):
+    """Test that hf_token_secret renders as authSecretName for both backends."""
+    params = {
+        "ServiceConfig": {
+            "model_path": "meta-llama/Llama-3.1-8B",
+            "served_model_name": "llama-3.1-8b",
+            "port": 8000,
+        },
+        "DynConfig": {"mode": "agg"},
+        "LlmdConfig": {"hf_token_secret": "my-hf-secret"},
+        "WorkerConfig": {"agg_workers": 1, "agg_gpus_per_worker": 1},
+        "params": {"agg": {"gpus_per_worker": 1}},
+        "agg_tensor_parallel_size": 1,
+        "agg_data_parallel_size": 1,
+        "agg_cli_args_list": [],
+    }
+
+    artifacts = render_backend_templates(param_values=params, backend=backend, deployment_target="llm-d")
+    values_content = artifacts["llm-d-values.yaml"]
+    assert "authSecretName: my-hf-secret" in values_content
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("backend", ["vllm", "sglang"])
+def test_llmd_hf_token_secret_default_empty(backend):
+    """Test that authSecretName defaults to empty when hf_token_secret is not set."""
+    params = {
+        "ServiceConfig": {
+            "model_path": "meta-llama/Llama-3.1-8B",
+            "port": 8000,
+        },
+        "DynConfig": {"mode": "agg"},
+        "LlmdConfig": {},
+        "WorkerConfig": {"agg_workers": 1, "agg_gpus_per_worker": 1},
+        "params": {"agg": {"gpus_per_worker": 1}},
+        "agg_tensor_parallel_size": 1,
+        "agg_data_parallel_size": 1,
+        "agg_cli_args_list": [],
+    }
+
+    artifacts = render_backend_templates(param_values=params, backend=backend, deployment_target="llm-d")
+    values_content = artifacts["llm-d-values.yaml"]
+    assert "authSecretName:" in values_content
+    assert "authSecretName: my-hf-secret" not in values_content
+
+
+@pytest.mark.unit
 def test_dynamo_deployment_still_works():
     """Test that Dynamo deployment target still works (default behavior)."""
     params = {


### PR DESCRIPTION
Overview:

This PR improves the llm-d output from the generator: fixes whitespace corruption in generated args lists, adds a proper hf_token_secret parameter for K8s auth secret configuration, and adds backend version comments to vLLM container image fields.

Details:

- Fix args list whitespace stripping (sglang/llm-d-values.yaml.j2, vllm/llm-d-values.yaml.j2): The {%- / -%} strip-whitespace Jinja2 modifiers were used on for/endfor tags wrapping the args list entries. This caused all list items to be rendered on a single line without proper YAML indentation, producing invalid K8s manifests. Changed to {% / %} (no whitespace stripping) across all three worker sections (agg, decode, prefill) in both backend templates.
- Add LlmdConfig.hf_token_secret parameter (deployment_config.yaml, vllm/llm-d-values.yaml.j2): The vLLM llm-d template previously referenced service_config.hf_token for the authSecretName field, but that field is a token value, not a K8s secret name. Introduced LlmdConfig.hf_token_secret as a dedicated optional parameter (settable via --generator-set LlmdConfig.hf_token_secret=<secret-name>) and wired it to authSecretName. Updated the inline comment to reflect the new parameter.
- Add backend version comment above image field (vllm/llm-d-values.yaml.j2): Added a comment above each image: field in all three worker sections noting the vLLM version AIC used when predicting the configuration, prompting users to pin the image tag for reproducibility. 

Where should the reviewer start?

- src/aiconfigurator/generator/config/backend_templates/vllm/llm-d-values.yaml.j2 — contains all
three changes; review the authSecretName block replacement and the for-loop whitespace fix closely
- src/aiconfigurator/generator/config/deployment_config.yaml — the new LlmdConfig.hf_token_secret
schema entry
- src/aiconfigurator/generator/config/backend_templates/sglang/llm-d-values.yaml.j2 — same whitespace
fix applied here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new `hf_token_secret` configuration option, enabling users to securely provision Hugging Face tokens through secret-based methods.

* **Configuration Enhancements**
  * Updated backend configuration to properly source Hugging Face credentials from the newly available secret field, improving flexibility and security in token management across supported backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->