### PR TITLE
feat: per-op silicon vs empirical attribution

### DIFF
--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -445,6 +445,33 @@ class EstimateResult:
     per_ops_data: dict | None = None
     """Per-operation latency breakdown (populated when available)."""
 
+    per_ops_source: dict | None = None
+    """Per-operation data source breakdown, parallel to ``per_ops_data``.
+
+    Same nested shape as ``per_ops_data`` (one entry per op_name in each
+    step), but values are source tags rather than latencies. Example::
+
+        {
+            "mix_step": {
+                "context_attention (scaled)": "mixed",
+                "context_full_moe":           "empirical",
+                "context_qkv_gemm":           "silicon",
+                ...
+            },
+            "genonly_step": {
+                "generation_attention": "empirical",
+                "generation_qkv_gemm":  "silicon",
+                ...
+            },
+        }
+
+    Values are ``"silicon"`` (table data), ``"empirical"`` (HYBRID-mode
+    SOL+empirical fallback), or ``"mixed"`` (a sum of values from both
+    sources). The ``scheduling`` section of ``per_ops_data`` is intentionally
+    omitted here -- those entries are scheduling math / aggregate sums, not
+    DB queries.
+    """
+
     kv_cache_warning: str | None = None
     """Warning message when batch_size exceeds KV cache capacity."""
 
@@ -906,6 +933,7 @@ def _run_agg_estimate(
         raw=result_dict,
         mode="agg",
         per_ops_data=summary.get_per_ops_data(),
+        per_ops_source=summary.get_per_ops_source(),
         kv_cache_warning=kv_warning,
     )
 

--- a/src/aiconfigurator/cli/report_and_save.py
+++ b/src/aiconfigurator/cli/report_and_save.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import logging
 import os
 import random
@@ -598,13 +599,20 @@ def save_results(
             safe_mkdir(exp_dir, exist_ok=True)
 
             # 1. Save best config dataframe
+            #    Strip the object-typed _per_ops_source column before CSV write; it is
+            #    saved as one per_ops_source.json per topN/ subdir below.
             best_config_df = best_configs.get(exp_name)  # top n configs
+            best_config_per_ops_source: list[dict | None] = []
             if best_config_df is not None:
+                if "_per_ops_source" in best_config_df.columns:
+                    best_config_per_ops_source = best_config_df["_per_ops_source"].tolist()
+                    best_config_df = best_config_df.drop(columns=["_per_ops_source"])
                 best_config_df.to_csv(os.path.join(exp_dir, "best_config_topn.csv"), index=False)
 
-            # 2. Save all pareto dataframe
+            # 2. Save all pareto dataframe (also stripped of _per_ops_source)
             if pareto_df is not None:
-                pareto_df.to_csv(os.path.join(exp_dir, "pareto.csv"), index=False)
+                pareto_csv_df = pareto_df.drop(columns=["_per_ops_source"], errors="ignore")
+                pareto_csv_df.to_csv(os.path.join(exp_dir, "pareto.csv"), index=False)
 
             # 3. Save the config for this experiment
             if backend != "auto":
@@ -748,6 +756,14 @@ def save_results(
                     safe_mkdir(top_config_dir, exist_ok=True)
                     with open(os.path.join(top_config_dir, "generator_config.yaml"), "w") as f:
                         yaml.safe_dump(cfg, f, sort_keys=False)
+
+                    # Per-op data source breakdown (silicon / empirical / mixed),
+                    # pulled from PerformanceResult.source via the InferenceSummary.
+                    # Same nested shape as per_ops_data, populated only when the row
+                    # carried it through the pareto search.
+                    if i < len(best_config_per_ops_source) and best_config_per_ops_source[i] is not None:
+                        with open(os.path.join(top_config_dir, "per_ops_source.json"), "w") as f:
+                            json.dump(best_config_per_ops_source[i], f, indent=2, sort_keys=True)
 
                     try:
                         deployment_target = getattr(args, "deployment_target", "dynamo-j2")

--- a/src/aiconfigurator/sdk/backends/base_backend.py
+++ b/src/aiconfigurator/sdk/backends/base_backend.py
@@ -42,9 +42,12 @@ class BaseBackend(ABC):
         batch_size: int,
         isl: int,
         prefix: int,
-    ) -> tuple[dict[str, float], dict[str, float]]:
+    ) -> tuple[dict[str, float], dict[str, float], dict[str, str]]:
         context_latency_dict = defaultdict(float)
         context_energy_wms_dict = defaultdict(float)
+        # Per-op data source, accumulated by merging across calls to the same op.
+        # Same-source repeated calls keep the tag; mismatched calls collapse to "mixed".
+        context_source_dict: dict[str, str] = {}
 
         effective_isl = isl - prefix
         if effective_isl <= 0:
@@ -64,8 +67,14 @@ class BaseBackend(ABC):
             )
             context_latency_dict[op._name] += float(result)
             context_energy_wms_dict[op._name] += getattr(result, "energy", 0.0)
+            new_src = getattr(result, "source", "silicon")
+            existing = context_source_dict.get(op._name)
+            if existing is None or existing == new_src:
+                context_source_dict[op._name] = new_src
+            else:
+                context_source_dict[op._name] = "mixed"
 
-        return context_latency_dict, context_energy_wms_dict
+        return context_latency_dict, context_energy_wms_dict, context_source_dict
 
     def _run_generation_phase(
         self,
@@ -77,9 +86,10 @@ class BaseBackend(ABC):
         isl: int,
         osl: int,
         stride: int,
-    ) -> tuple[dict[str, float], dict[str, float]]:
+    ) -> tuple[dict[str, float], dict[str, float], dict[str, str]]:
         generation_latency_dict = defaultdict(float)
         generation_energy_wms_dict = defaultdict(float)
+        generation_source_dict: dict[str, str] = {}
 
         batch_size = batch_size * (model._nextn + 1)
 
@@ -99,14 +109,23 @@ class BaseBackend(ABC):
                 )
                 latency_dict[op._name] += float(result)
                 energy_wms_dict[op._name] += getattr(result, "energy", 0.0)
+                new_src = getattr(result, "source", "silicon")
+                existing = generation_source_dict.get(op._name)
+                if existing is None or existing == new_src:
+                    generation_source_dict[op._name] = new_src
+                else:
+                    generation_source_dict[op._name] = "mixed"
 
             repeat_count = min(stride, osl - 1 - i)
             for op in latency_dict:
                 generation_latency_dict[op] += latency_dict[op] * repeat_count
                 generation_energy_wms_dict[op] += energy_wms_dict[op] * repeat_count
 
-        return generation_latency_dict, generation_energy_wms_dict
+        return generation_latency_dict, generation_energy_wms_dict, generation_source_dict
 
+    # TODO: refactor this 6-tuple return into a NamedTuple (or @dataclass) for
+    # readability; current call sites unpack positionally and the signature is
+    # hard to scan.
     def _run_static_breakdown(
         self,
         model: BaseModel,
@@ -115,7 +134,14 @@ class BaseBackend(ABC):
         mode: str,
         stride: int = 32,
         latency_correction_scale: float = 1.0,
-    ) -> tuple[dict[str, float], dict[str, float], dict[str, float], dict[str, float]]:
+    ) -> tuple[
+        dict[str, float],
+        dict[str, float],
+        dict[str, float],
+        dict[str, float],
+        dict[str, str],
+        dict[str, str],
+    ]:
         batch_size, beam_width, isl, osl, prefix = (
             runtime_config.batch_size,
             runtime_config.beam_width,
@@ -124,22 +150,22 @@ class BaseBackend(ABC):
             runtime_config.prefix,
         )
 
-        context_latency_dict, context_energy_wms_dict = {}, {}
-        generation_latency_dict, generation_energy_wms_dict = {}, {}
+        context_latency_dict, context_energy_wms_dict, context_source_dict = {}, {}, {}
+        generation_latency_dict, generation_energy_wms_dict, generation_source_dict = {}, {}, {}
 
         if mode == "static_ctx":
-            context_latency_dict, context_energy_wms_dict = self._run_context_phase(
+            context_latency_dict, context_energy_wms_dict, context_source_dict = self._run_context_phase(
                 model, database, runtime_config, batch_size, isl, prefix
             )
         elif mode == "static_gen":
-            generation_latency_dict, generation_energy_wms_dict = self._run_generation_phase(
+            generation_latency_dict, generation_energy_wms_dict, generation_source_dict = self._run_generation_phase(
                 model, database, runtime_config, batch_size, beam_width, isl, osl, stride
             )
         else:
-            context_latency_dict, context_energy_wms_dict = self._run_context_phase(
+            context_latency_dict, context_energy_wms_dict, context_source_dict = self._run_context_phase(
                 model, database, runtime_config, batch_size, isl, prefix
             )
-            generation_latency_dict, generation_energy_wms_dict = self._run_generation_phase(
+            generation_latency_dict, generation_energy_wms_dict, generation_source_dict = self._run_generation_phase(
                 model, database, runtime_config, batch_size, beam_width, isl, osl, stride
             )
 
@@ -157,6 +183,8 @@ class BaseBackend(ABC):
             context_energy_wms_dict,
             generation_latency_dict,
             generation_energy_wms_dict,
+            context_source_dict,
+            generation_source_dict,
         )
 
     def run_static_latency_only(
@@ -178,6 +206,8 @@ class BaseBackend(ABC):
             context_latency_dict,
             _,
             generation_latency_dict,
+            _,
+            _,
             _,
         ) = self._run_static_breakdown(model, database, runtime_config, mode, stride, latency_correction_scale)
         return sum(context_latency_dict.values()) + sum(generation_latency_dict.values())
@@ -220,6 +250,8 @@ class BaseBackend(ABC):
             context_energy_wms_dict,
             generation_latency_dict,
             generation_energy_wms_dict,
+            context_source_dict,
+            generation_source_dict,
         ) = self._run_static_breakdown(model, database, runtime_config, mode, stride, latency_correction_scale)
 
         if mode == "static_ctx":
@@ -337,6 +369,8 @@ class BaseBackend(ABC):
         summary.set_generation_latency_dict(generation_latency_dict)
         summary.set_context_energy_wms_dict(context_energy_wms_dict)  # UPDATED: explicit units
         summary.set_generation_energy_wms_dict(generation_energy_wms_dict)  # UPDATED: explicit units
+        summary.set_context_source_dict(context_source_dict)
+        summary.set_generation_source_dict(generation_source_dict)
         summary.set_context_power_avg(context_power_avg)
         summary.set_generation_power_avg(generation_power_avg)
         summary.set_e2e_power_avg(e2e_power_avg)

--- a/src/aiconfigurator/sdk/backends/sglang_backend.py
+++ b/src/aiconfigurator/sdk/backends/sglang_backend.py
@@ -80,8 +80,9 @@ class SGLANGBackend(BaseBackend):
                 num_genonly_tokens = 1
                 num_mix_steps_for_tpot_calc = 0
 
-            # Per-ops latency collection
+            # Per-ops latency collection (and parallel data-source breakdown).
             per_ops_data = {}
+            per_ops_source = {}
 
             # FIXME, fix for DS. DS has different ops for attn in ctx and gen.
             def _get_mix_step_latency(
@@ -117,14 +118,17 @@ class SGLANGBackend(BaseBackend):
                 )
                 latency_dict = summary.get_context_latency_dict()
                 energy_wms_dict = summary.get_context_energy_wms_dict()
+                source_dict = summary.get_context_source_dict()
                 non_attention_latency_ms = 0.0
                 non_attention_energy_wms = 0.0
                 mix_non_attn_ops = {}
+                mix_non_attn_sources = {}
                 for layer_name, latency in latency_dict.items():
                     if layer_name != "context_attention":
                         non_attention_latency_ms += latency
                         non_attention_energy_wms += energy_wms_dict.get(layer_name, 0.0)
                         mix_non_attn_ops[layer_name] = latency
+                        mix_non_attn_sources[layer_name] = source_dict.get(layer_name, "silicon")
 
                 # second pass to get ctx attn, split full isl over
                 # num_steps(=np.ceil(isl/ctx_tokens))
@@ -146,6 +150,7 @@ class SGLANGBackend(BaseBackend):
                 )
                 latency_dict = summary.get_context_latency_dict()
                 energy_wms_dict = summary.get_context_energy_wms_dict()
+                ctx_attn_source = summary.get_context_source_dict().get("context_attention", "silicon")
                 scale_factor = np.ceil(isl / ctx_tokens)
                 ctx_attention_latency_ms = latency_dict["context_attention"] / scale_factor
                 ctx_attention_energy_wms = energy_wms_dict.get("context_attention", 0.0) / scale_factor
@@ -169,15 +174,22 @@ class SGLANGBackend(BaseBackend):
                     energy_wms_dict = summary.get_generation_energy_wms_dict()
                     gen_attention_latency_ms = latency_dict["generation_attention"]
                     gen_attention_energy_wms = energy_wms_dict.get("generation_attention", 0.0)
+                    gen_attn_source = summary.get_generation_source_dict().get("generation_attention", "silicon")
                 else:
                     gen_attention_latency_ms = 0.0
                     gen_attention_energy_wms = 0.0
+                    gen_attn_source = "silicon"
 
                 # Collect per-op breakdown for mix step
                 per_ops_data["mix_step"] = {
                     **mix_non_attn_ops,
                     "context_attention (scaled)": ctx_attention_latency_ms,
                     "generation_attention": gen_attention_latency_ms,
+                }
+                per_ops_source["mix_step"] = {
+                    **mix_non_attn_sources,
+                    "context_attention (scaled)": ctx_attn_source,
+                    "generation_attention": gen_attn_source,
                 }
 
                 # Combine all components (simple addition)
@@ -212,15 +224,19 @@ class SGLANGBackend(BaseBackend):
                 )
                 latency_dict = summary.get_generation_latency_dict()
                 energy_wms_dict = summary.get_generation_energy_wms_dict()
+                source_dict = summary.get_generation_source_dict()
                 genonly_step_latency_ms = 0.0
                 genonly_step_energy_wms = 0.0
                 genonly_ops = {}
+                genonly_sources = {}
                 for layer_name, latency in latency_dict.items():
                     genonly_step_latency_ms += latency
                     genonly_step_energy_wms += energy_wms_dict.get(layer_name, 0.0)
                     genonly_ops[layer_name] = latency
+                    genonly_sources[layer_name] = source_dict.get(layer_name, "silicon")
 
                 per_ops_data["genonly_step"] = genonly_ops
+                per_ops_source["genonly_step"] = genonly_sources
 
                 return genonly_step_latency_ms, genonly_step_energy_wms
 
@@ -379,7 +395,12 @@ class SGLANGBackend(BaseBackend):
                 "mix_step_latency_ms": float(mix_step_latency_ms),
                 "genonly_step_latency_ms": float(genonly_step_latency_ms),
             }
+            # Scheduling counters are not silicon-DB queries -- tag as silicon.
+            # scheduling entries (num_*_steps, *_step_latency_ms) are scheduling math
+            # / aggregate sums, not DB queries -- no per-op source applies. Skip them
+            # in per_ops_source; per_ops_data still carries the values themselves.
             summary.set_per_ops_data(per_ops_data)
+            summary.set_per_ops_source(per_ops_source)
 
             # caching
             self._agg_cache[isl][osl][b][ctx_tokens] = summary
@@ -440,6 +461,7 @@ class SGLANGBackend(BaseBackend):
 
         results_df = pd.DataFrame(columns=common.ColumnsAgg)
         results_dict_list = []
+        results_per_ops_source: list[dict | None] = []  # aligned with results_dict_list
         capped_b = []
         all_oom = True
         for b in b_list:
@@ -480,9 +502,14 @@ class SGLANGBackend(BaseBackend):
                 result_dict = summary.get_result_dict()
                 if result_dict and result_dict["tpot"] <= tpot and result_dict["ttft"] <= ttft:
                     results_dict_list.append(result_dict)
+                    results_per_ops_source.append(summary.get_per_ops_source())
 
         if results_dict_list:
             results_df = pd.DataFrame(results_dict_list, columns=common.ColumnsAgg).round(3)
+            # Carry per-row per_ops_source as an object column, sorted/truncated alongside the
+            # standard columns. report_and_save.py strips this before writing best_config_topn.csv
+            # and emits one per_ops_source.json per topN/ subdir.
+            results_df["_per_ops_source"] = results_per_ops_source
 
         sorted_results_df = results_df.sort_values(by="seq/s", ascending=False).round(3)
         if top_k > 0:

--- a/src/aiconfigurator/sdk/backends/trtllm_backend.py
+++ b/src/aiconfigurator/sdk/backends/trtllm_backend.py
@@ -123,8 +123,9 @@ class TRTLLMBackend(BaseBackend):
                 num_genonly_tokens = 1
                 num_mix_steps_for_tpot_calc = 0
 
-            # Per-ops latency collection
+            # Per-ops latency collection (and parallel data-source breakdown).
             per_ops_data = {}
+            per_ops_source = {}
 
             # FIXME, fix for DS. DS has different ops for attn in ctx and gen.
             def _get_mix_step_latency(
@@ -160,14 +161,17 @@ class TRTLLMBackend(BaseBackend):
                 )
                 latency_dict = summary.get_context_latency_dict()
                 energy_wms_dict = summary.get_context_energy_wms_dict()  # CHANGED from get_context_power_dict()
+                source_dict = summary.get_context_source_dict()
                 non_attention_latency_ms = 0.0
                 non_attention_energy_wms = 0.0  # RENAMED from non_attention_power_weighted
                 mix_non_attn_ops = {}
+                mix_non_attn_sources = {}
                 for layer_name, latency in latency_dict.items():
                     if layer_name != "context_attention":
                         non_attention_latency_ms += latency
                         non_attention_energy_wms += energy_wms_dict.get(layer_name, 0.0)  # SIMPLIFIED
                         mix_non_attn_ops[layer_name] = latency
+                        mix_non_attn_sources[layer_name] = source_dict.get(layer_name, "silicon")
 
                 # second pass to get ctx attn, split full isl over
                 # num_steps(=np.ceil(isl/ctx_tokens))
@@ -189,6 +193,7 @@ class TRTLLMBackend(BaseBackend):
                 )
                 latency_dict = summary.get_context_latency_dict()
                 energy_wms_dict = summary.get_context_energy_wms_dict()
+                ctx_attn_source = summary.get_context_source_dict().get("context_attention", "silicon")
                 scale_factor = np.ceil(isl / ctx_tokens)
                 ctx_attention_latency_ms = latency_dict["context_attention"] / scale_factor
                 ctx_attention_energy_wms = energy_wms_dict.get("context_attention", 0.0) / scale_factor  # CHANGED
@@ -196,6 +201,7 @@ class TRTLLMBackend(BaseBackend):
                 # third pass to get generation attn. use isl+osl//2 for avg generation attn latency.
                 gen_attention_latency_ms = 0.0
                 gen_attention_energy_wms = 0.0  # RENAMED from gen_attention_power_weighted
+                gen_attn_source = "silicon"
                 if gen_tokens > 0:
                     num_tokens = gen_tokens
                     summary = self.run_static(
@@ -214,12 +220,18 @@ class TRTLLMBackend(BaseBackend):
                     energy_wms_dict = summary.get_generation_energy_wms_dict()
                     gen_attention_latency_ms = latency_dict["generation_attention"]
                     gen_attention_energy_wms = energy_wms_dict.get("generation_attention", 0.0)  # CHANGED
+                    gen_attn_source = summary.get_generation_source_dict().get("generation_attention", "silicon")
 
                 # Collect per-op breakdown for mix step
                 per_ops_data["mix_step"] = {
                     **mix_non_attn_ops,
                     "context_attention (scaled)": ctx_attention_latency_ms,
                     "generation_attention": gen_attention_latency_ms,
+                }
+                per_ops_source["mix_step"] = {
+                    **mix_non_attn_sources,
+                    "context_attention (scaled)": ctx_attn_source,
+                    "generation_attention": gen_attn_source,
                 }
 
                 # Combine all components (simple addition)
@@ -254,15 +266,19 @@ class TRTLLMBackend(BaseBackend):
                 )
                 latency_dict = summary.get_generation_latency_dict()
                 energy_wms_dict = summary.get_generation_energy_wms_dict()  # CHANGED
+                source_dict = summary.get_generation_source_dict()
                 genonly_step_latency_ms = 0.0
                 genonly_step_energy_wms = 0.0  # RENAMED from genonly_power_weighted
                 genonly_ops = {}
+                genonly_sources = {}
                 for layer_name, latency in latency_dict.items():
                     genonly_step_latency_ms += latency
                     genonly_step_energy_wms += energy_wms_dict.get(layer_name, 0.0)  # SIMPLIFIED
                     genonly_ops[layer_name] = latency
+                    genonly_sources[layer_name] = source_dict.get(layer_name, "silicon")
 
                 per_ops_data["genonly_step"] = genonly_ops
+                per_ops_source["genonly_step"] = genonly_sources
 
                 return genonly_step_latency_ms, genonly_step_energy_wms
 
@@ -440,7 +456,11 @@ class TRTLLMBackend(BaseBackend):
                 "mix_step_latency_ms": float(mix_step_latency_ms),
                 "genonly_step_latency_ms": float(genonly_step_latency_ms),
             }
+            # scheduling entries (num_*_steps, *_step_latency_ms) are scheduling math
+            # / aggregate sums, not DB queries -- no per-op source applies. Skip them
+            # in per_ops_source; per_ops_data still carries the values themselves.
             summary.set_per_ops_data(per_ops_data)
+            summary.set_per_ops_source(per_ops_source)
 
             # caching
             self._agg_cache[isl][osl][b][ctx_tokens][max_seq_len][max_num_tokens][free_gpu_memory_fraction] = summary
@@ -514,6 +534,7 @@ class TRTLLMBackend(BaseBackend):
 
         results_df = pd.DataFrame(columns=common.ColumnsAgg)
         results_dict_list = []
+        results_per_ops_source: list[dict | None] = []
         capped_b = []
         all_oom = True
         for b in b_list:
@@ -556,9 +577,12 @@ class TRTLLMBackend(BaseBackend):
                 result_dict = summary.get_result_dict()
                 if result_dict and result_dict["tpot"] <= tpot and result_dict["ttft"] <= ttft:
                     results_dict_list.append(result_dict)
+                    results_per_ops_source.append(summary.get_per_ops_source())
 
         if results_dict_list:
             results_df = pd.DataFrame(results_dict_list, columns=common.ColumnsAgg).round(3)
+            # Carry per-row per_ops_source as an object column (stripped before CSV write).
+            results_df["_per_ops_source"] = results_per_ops_source
 
         sorted_results_df = results_df.sort_values(by="seq/s", ascending=False).round(3)
         if top_k > 0:

--- a/src/aiconfigurator/sdk/backends/vllm_backend.py
+++ b/src/aiconfigurator/sdk/backends/vllm_backend.py
@@ -82,8 +82,9 @@ class VLLMBackend(BaseBackend):
                 num_genonly_tokens = 1
                 num_mix_steps_for_tpot_calc = 0
 
-            # Per-ops latency collection
+            # Per-ops latency collection (and parallel data-source breakdown).
             per_ops_data = {}
+            per_ops_source = {}
 
             # FIXME, fix for DS. DS has different ops for attn in ctx and gen.
             def _get_mix_step_latency(
@@ -119,14 +120,17 @@ class VLLMBackend(BaseBackend):
                 )
                 latency_dict = summary.get_context_latency_dict()
                 energy_wms_dict = summary.get_context_energy_wms_dict()
+                source_dict = summary.get_context_source_dict()
                 non_attention_latency_ms = 0.0
                 non_attention_energy_wms = 0.0
                 mix_non_attn_ops = {}
+                mix_non_attn_sources = {}
                 for layer_name, latency in latency_dict.items():
                     if layer_name != "context_attention":
                         non_attention_latency_ms += latency
                         non_attention_energy_wms += energy_wms_dict.get(layer_name, 0.0)
                         mix_non_attn_ops[layer_name] = latency
+                        mix_non_attn_sources[layer_name] = source_dict.get(layer_name, "silicon")
 
                 # second pass to get ctx attn, split full isl over
                 # num_steps(=np.ceil(isl/ctx_tokens))
@@ -148,6 +152,7 @@ class VLLMBackend(BaseBackend):
                 )
                 latency_dict = summary.get_context_latency_dict()
                 energy_wms_dict = summary.get_context_energy_wms_dict()
+                ctx_attn_source = summary.get_context_source_dict().get("context_attention", "silicon")
                 scale_factor = np.ceil(isl / ctx_tokens)
                 ctx_attention_latency_ms = latency_dict["context_attention"] / scale_factor
                 ctx_attention_energy_wms = energy_wms_dict.get("context_attention", 0.0) / scale_factor
@@ -155,6 +160,7 @@ class VLLMBackend(BaseBackend):
                 # third pass to get generation attn. use isl+osl//2 for avg generation attn latency.
                 gen_attention_latency_ms = 0.0
                 gen_attention_energy_wms = 0.0
+                gen_attn_source = "silicon"
                 if gen_tokens > 0:
                     num_tokens = gen_tokens
                     summary = self.run_static(
@@ -173,12 +179,18 @@ class VLLMBackend(BaseBackend):
                     energy_wms_dict = summary.get_generation_energy_wms_dict()
                     gen_attention_latency_ms = latency_dict["generation_attention"]
                     gen_attention_energy_wms = energy_wms_dict.get("generation_attention", 0.0)
+                    gen_attn_source = summary.get_generation_source_dict().get("generation_attention", "silicon")
 
                 # Collect per-op breakdown for mix step
                 per_ops_data["mix_step"] = {
                     **mix_non_attn_ops,
                     "context_attention (scaled)": ctx_attention_latency_ms,
                     "generation_attention": gen_attention_latency_ms,
+                }
+                per_ops_source["mix_step"] = {
+                    **mix_non_attn_sources,
+                    "context_attention (scaled)": ctx_attn_source,
+                    "generation_attention": gen_attn_source,
                 }
 
                 # Combine all components (simple addition)
@@ -213,15 +225,19 @@ class VLLMBackend(BaseBackend):
                 )
                 latency_dict = summary.get_generation_latency_dict()
                 energy_wms_dict = summary.get_generation_energy_wms_dict()
+                source_dict = summary.get_generation_source_dict()
                 genonly_step_latency_ms = 0.0
                 genonly_step_energy_wms = 0.0
                 genonly_ops = {}
+                genonly_sources = {}
                 for layer_name, latency in latency_dict.items():
                     genonly_step_latency_ms += latency
                     genonly_step_energy_wms += energy_wms_dict.get(layer_name, 0.0)
                     genonly_ops[layer_name] = latency
+                    genonly_sources[layer_name] = source_dict.get(layer_name, "silicon")
 
                 per_ops_data["genonly_step"] = genonly_ops
+                per_ops_source["genonly_step"] = genonly_sources
 
                 return genonly_step_latency_ms, genonly_step_energy_wms
 
@@ -380,7 +396,11 @@ class VLLMBackend(BaseBackend):
                 "mix_step_latency_ms": float(mix_step_latency_ms),
                 "genonly_step_latency_ms": float(genonly_step_latency_ms),
             }
+            # scheduling entries (num_*_steps, *_step_latency_ms) are scheduling math
+            # / aggregate sums, not DB queries -- no per-op source applies. Skip them
+            # in per_ops_source; per_ops_data still carries the values themselves.
             summary.set_per_ops_data(per_ops_data)
+            summary.set_per_ops_source(per_ops_source)
 
             # caching
             self._agg_cache[isl][osl][b][ctx_tokens] = summary
@@ -441,6 +461,7 @@ class VLLMBackend(BaseBackend):
 
         results_df = pd.DataFrame(columns=common.ColumnsAgg)
         results_dict_list = []
+        results_per_ops_source: list[dict | None] = []
         capped_b = []
         all_oom = True
         for b in b_list:
@@ -481,9 +502,12 @@ class VLLMBackend(BaseBackend):
                 result_dict = summary.get_result_dict()
                 if result_dict and result_dict["tpot"] <= tpot and result_dict["ttft"] <= ttft:
                     results_dict_list.append(result_dict)
+                    results_per_ops_source.append(summary.get_per_ops_source())
 
         if results_dict_list:
             results_df = pd.DataFrame(results_dict_list, columns=common.ColumnsAgg).round(3)
+            # Carry per-row per_ops_source as an object column (stripped before CSV write).
+            results_df["_per_ops_source"] = results_per_ops_source
 
         sorted_results_df = results_df.sort_values(by="seq/s", ascending=False).round(3)
         if top_k > 0:

--- a/src/aiconfigurator/sdk/inference_summary.py
+++ b/src/aiconfigurator/sdk/inference_summary.py
@@ -59,6 +59,10 @@ class InferenceSummary:
         self._generation_latency_dict = {}  # ms
         self._context_energy_wms_dict = {}  # RENAMED from _context_power_dict, W·ms
         self._generation_energy_wms_dict = {}  # RENAMED from _generation_power_dict, W·ms
+        # Per-op data source ("silicon", "empirical", or "mixed") populated by
+        # base_backend phase helpers from PerformanceResult.source.
+        self._context_source_dict: dict[str, str] = {}
+        self._generation_source_dict: dict[str, str] = {}
         self._is_oom = None
         self._is_kv_cache_oom = False
 
@@ -75,6 +79,9 @@ class InferenceSummary:
 
         # per-ops latency breakdown (populated by run_agg or run_disagg)
         self._per_ops_data: dict | None = None
+        # per-ops data source breakdown, parallel to _per_ops_data: same key
+        # structure but values are "silicon" / "empirical" / "mixed" strings.
+        self._per_ops_source: dict | None = None
 
     def set_memory_and_check_oom(
         self,
@@ -361,6 +368,30 @@ class InferenceSummary:
     def get_per_ops_data(self) -> dict | None:
         """Get per-operation latency breakdown data (populated by run_agg)."""
         return self._per_ops_data
+
+    def set_per_ops_source(self, per_ops_source: dict) -> None:
+        """Set per-operation data-source breakdown ("silicon"/"empirical"/"mixed")."""
+        self._per_ops_source = per_ops_source
+
+    def get_per_ops_source(self) -> dict | None:
+        """Get per-operation data-source breakdown, parallel to per_ops_data."""
+        return self._per_ops_source
+
+    def set_context_source_dict(self, context_source_dict: dict) -> None:
+        """Set the per-op data source dict for the context (prefill) phase."""
+        self._context_source_dict = context_source_dict
+
+    def get_context_source_dict(self) -> dict:
+        """Get the per-op data source dict for the context (prefill) phase."""
+        return self._context_source_dict
+
+    def set_generation_source_dict(self, generation_source_dict: dict) -> None:
+        """Set the per-op data source dict for the generation (decode) phase."""
+        self._generation_source_dict = generation_source_dict
+
+    def get_generation_source_dict(self) -> dict:
+        """Get the per-op data source dict for the generation (decode) phase."""
+        return self._generation_source_dict
 
     def set_result_dict(self, result_dict: dict) -> None:
         """

--- a/src/aiconfigurator/sdk/operations.py
+++ b/src/aiconfigurator/sdk/operations.py
@@ -56,7 +56,11 @@ class CustomAllReduce(Operation):
         size = kwargs.get("x") * self._h
 
         result = database.query_custom_allreduce(common.CommQuantMode.half, self._tp_size, size)
-        return PerformanceResult(float(result) * self._scale_factor, energy=result.energy * self._scale_factor)
+        return PerformanceResult(
+            float(result) * self._scale_factor,
+            energy=result.energy * self._scale_factor,
+            source=getattr(result, "source", "silicon"),
+        )
 
     def get_weights(self, **kwargs):
         return self._weights * self._scale_factor
@@ -84,7 +88,11 @@ class P2P(Operation):
         p2p_bytes = size * 2
 
         result = database.query_p2p(p2p_bytes)
-        return PerformanceResult(float(result) * self._scale_factor, energy=result.energy * self._scale_factor)
+        return PerformanceResult(
+            float(result) * self._scale_factor,
+            energy=result.energy * self._scale_factor,
+            source=getattr(result, "source", "silicon"),
+        )
 
     def get_weights(self, **kwargs):
         return self._weights * self._scale_factor
@@ -116,7 +124,11 @@ class NCCL(Operation):
         message_size = kwargs.get("x") * self._num_elements_per_token
 
         result = database.query_nccl(self._comm_quant_mode, self._num_gpus, self._nccl_op, message_size)
-        return PerformanceResult(float(result) * self._scale_factor, energy=result.energy * self._scale_factor)
+        return PerformanceResult(
+            float(result) * self._scale_factor,
+            energy=result.energy * self._scale_factor,
+            source=getattr(result, "source", "silicon"),
+        )
 
     def get_weights(self, **kwargs):
         return self._weights * self._scale_factor
@@ -167,16 +179,23 @@ class GEMM(Operation):
         result = database.query_gemm(x, self._n, self._k, quant_mode)
         latency = float(result)
         energy = result.energy
+        source = getattr(result, "source", "silicon")
 
         # Adjust for fp8_static: subtract compute_scale overhead, only fix for trtllm now
         if is_fp8_static:
             compute_scale_result = database.query_compute_scale(x, self._k, quant_mode)
             latency -= float(compute_scale_result)
             energy -= compute_scale_result.energy
+            sub_src = getattr(compute_scale_result, "source", "silicon")
+            if sub_src != source:
+                source = "mixed"
             if self._low_precision_input:
                 scale_matrix_result = database.query_scale_matrix(x, self._k, quant_mode)
                 latency -= float(scale_matrix_result)
                 energy -= scale_matrix_result.energy
+                sub_src = getattr(scale_matrix_result, "source", "silicon")
+                if sub_src != source:
+                    source = "mixed"
 
         # Ensure non-negative latency and energy
         latency_clamped = max(0.0, latency)
@@ -201,6 +220,7 @@ class GEMM(Operation):
         return PerformanceResult(
             latency=latency * self._scale_factor,
             energy=energy * self._scale_factor,
+            source=source,
         )
 
     def get_weights(self, **kwargs):
@@ -317,7 +337,11 @@ class TrtLLMWideEPMoE(Operation):
             workload_distribution=self._workload_distribution,
         )
 
-        return PerformanceResult(float(result) * self._scale_factor, energy=result.energy * self._scale_factor)
+        return PerformanceResult(
+            float(result) * self._scale_factor,
+            energy=result.energy * self._scale_factor,
+            source=getattr(result, "source", "silicon"),
+        )
 
     def get_weights(self, **kwargs):
         """Get the weight memory size for this MoE layer."""
@@ -522,7 +546,11 @@ class MoE(Operation):
             enable_eplb=self._enable_eplb,
         )
 
-        return PerformanceResult(float(result) * self._scale_factor, energy=result.energy * self._scale_factor)
+        return PerformanceResult(
+            float(result) * self._scale_factor,
+            energy=result.energy * self._scale_factor,
+            source=getattr(result, "source", "silicon"),
+        )
 
     def get_weights(self, **kwargs):
         return self._weights * self._scale_factor
@@ -901,7 +929,11 @@ class ContextAttention(Operation):
         if seq_imbalance_correction_scale != 1.0:
             result = result * seq_imbalance_correction_scale
 
-        return PerformanceResult(float(result) * self._scale_factor, energy=result.energy * self._scale_factor)
+        return PerformanceResult(
+            float(result) * self._scale_factor,
+            energy=result.energy * self._scale_factor,
+            source=getattr(result, "source", "silicon"),
+        )
 
     def get_weights(self, **kwargs):
         return self._weights * self._scale_factor
@@ -960,7 +992,11 @@ class GenerationAttention(Operation):
         )
         if gen_seq_imbalance_correction_scale != 1.0:
             result = result * gen_seq_imbalance_correction_scale
-        return PerformanceResult(float(result) * self._scale_factor, energy=result.energy * self._scale_factor)
+        return PerformanceResult(
+            float(result) * self._scale_factor,
+            energy=result.energy * self._scale_factor,
+            source=getattr(result, "source", "silicon"),
+        )
 
     def get_weights(self, **kwargs):
         return self._weights * self._scale_factor
@@ -1001,7 +1037,11 @@ class ContextMLA(Operation):
             kvcache_quant_mode=self._kvcache_quant_mode,
             fmha_quant_mode=self._fmha_quant_mode,
         )
-        return PerformanceResult(float(result) * self._scale_factor, energy=result.energy * self._scale_factor)
+        return PerformanceResult(
+            float(result) * self._scale_factor,
+            energy=result.energy * self._scale_factor,
+            source=getattr(result, "source", "silicon"),
+        )
 
     def get_weights(self, **kwargs):
         return self._weights * self._scale_factor
@@ -1035,7 +1075,11 @@ class GenerationMLA(Operation):
         s = kwargs.get("s")
 
         result = database.query_generation_mla(batch_size, s, self._num_heads, self._kv_cache_dtype)
-        return PerformanceResult(float(result) * self._scale_factor, energy=result.energy * self._scale_factor)
+        return PerformanceResult(
+            float(result) * self._scale_factor,
+            energy=result.energy * self._scale_factor,
+            source=getattr(result, "source", "silicon"),
+        )
 
     def get_weights(self, **kwargs):
         return self._weights * self._scale_factor
@@ -1069,7 +1113,11 @@ class MLABmm(Operation):
         batch_size = kwargs.get("batch_size")
 
         result = database.query_mla_bmm(batch_size, self._num_heads, self._quant_mode, self._if_pre)
-        return PerformanceResult(float(result) * self._scale_factor, energy=result.energy * self._scale_factor)
+        return PerformanceResult(
+            float(result) * self._scale_factor,
+            energy=result.energy * self._scale_factor,
+            source=getattr(result, "source", "silicon"),
+        )
 
     def get_weights(self, **kwargs):
         return self._weights * self._scale_factor
@@ -1102,7 +1150,11 @@ class Embedding(Operation):
         d2d_bytes = x * self._column_size * 2
 
         result = database.query_mem_op(d2d_bytes)
-        return PerformanceResult(float(result) * self._scale_factor, energy=result.energy * self._scale_factor)
+        return PerformanceResult(
+            float(result) * self._scale_factor,
+            energy=result.energy * self._scale_factor,
+            source=getattr(result, "source", "silicon"),
+        )
 
     def get_weights(self, **kwargs):
         return self._weights * self._scale_factor
@@ -1139,7 +1191,11 @@ class ElementWise(Operation):
         write_bytes = x * self._dim_out * 2
 
         result = database.query_mem_op(read_bytes + write_bytes)
-        return PerformanceResult(float(result) * self._scale_factor, energy=result.energy * self._scale_factor)
+        return PerformanceResult(
+            float(result) * self._scale_factor,
+            energy=result.energy * self._scale_factor,
+            source=getattr(result, "source", "silicon"),
+        )
 
     def get_weights(self, **kwargs):
         return self._weights * self._scale_factor
@@ -1180,7 +1236,11 @@ class WideEPGenerationMLA(Operation):
             self._fmha_quant_mode,
             self._attn_backend,
         )
-        return PerformanceResult(float(result) * self._scale_factor, energy=result.energy * self._scale_factor)
+        return PerformanceResult(
+            float(result) * self._scale_factor,
+            energy=result.energy * self._scale_factor,
+            source=getattr(result, "source", "silicon"),
+        )
 
     def get_weights(self, **kwargs):
         return self._weights * self._scale_factor
@@ -1223,7 +1283,11 @@ class WideEPContextMLA(Operation):
             fmha_quant_mode=self._fmha_quant_mode,
             attention_backend=self._attn_backend,
         )
-        return PerformanceResult(float(result) * self._scale_factor, energy=result.energy * self._scale_factor)
+        return PerformanceResult(
+            float(result) * self._scale_factor,
+            energy=result.energy * self._scale_factor,
+            source=getattr(result, "source", "silicon"),
+        )
 
     def get_weights(self, **kwargs):
         return self._weights * self._scale_factor

--- a/src/aiconfigurator/sdk/pareto_analysis.py
+++ b/src/aiconfigurator/sdk/pareto_analysis.py
@@ -151,7 +151,10 @@ def agg_pareto(
             continue
 
     if not results_df.empty:
-        results_df = results_df.drop_duplicates(ignore_index=True)
+        # Dedupe on numeric/identifier columns only; _per_ops_source holds dicts
+        # which are unhashable and would break drop_duplicates with default subset.
+        dedupe_cols = [c for c in results_df.columns if c != "_per_ops_source"]
+        results_df = results_df.drop_duplicates(subset=dedupe_cols, ignore_index=True)
         results_df = results_df.sort_values(by="tokens/s/gpu", ascending=False).reset_index(drop=True)
     else:
         if exceptions:

--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -4146,7 +4146,7 @@ class PerfDatabase:
             if database_mode == common.DatabaseMode.HYBRID:
                 debug_msg = error_msg + " Will try empirical mode."
                 logger.debug(debug_msg)
-                return PerformanceResult(get_empirical(), energy=0.0)
+                return PerformanceResult(get_empirical(), energy=0.0, source="empirical")
 
             exception_msg = error_msg + " Consider using HYBRID mode."
             # PerfDataNotAvailableError is a structured signal that callers (e.g.

--- a/src/aiconfigurator/sdk/performance_result.py
+++ b/src/aiconfigurator/sdk/performance_result.py
@@ -2,16 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-PerformanceResult class for backward-compatible latency+energy tracking.
+PerformanceResult class for backward-compatible latency+energy+source tracking.
 """
 
 
 class PerformanceResult(float):
     """
-    Float-like class that stores both latency and energy.
+    Float-like class that stores latency, energy, and a data-source tag.
 
     Behaves exactly like a float for backward compatibility, but stores energy
-    instead of power internally. Power is derived as energy / latency.
+    instead of power internally. Power is derived as energy / latency. A
+    ``source`` tag records whether the value came from silicon table data or
+    an empirical fallback, and is propagated through arithmetic.
 
     Supports all arithmetic and comparison operations for full float compatibility.
 
@@ -19,43 +21,59 @@ class PerformanceResult(float):
         - latency: milliseconds (ms)
         - energy: watt-milliseconds (W·ms) = millijoules (mJ)
         - power: watts (W) - derived property
+        - source: ``"silicon"`` (table data) | ``"empirical"`` (HYBRID-mode
+          SOL+empirical fallback) | ``"mixed"`` (sum of values from both)
 
     Note: 1 W·ms = 1 mJ. We use W·ms to match latency units (ms).
           To convert to Joules: divide by 1000 (J = W·s = W·ms / 1000)
 
+    Source propagation:
+        - ``__add__``: sources merged (same -> same; mismatch -> ``"mixed"``)
+        - ``__mul__`` / ``__rmul__`` / ``__truediv__``: scalar operand has no
+          provenance, so the left operand's source is preserved unchanged.
+        - ``__abs__``: source preserved.
+
     Example:
-        result = PerformanceResult(10.5, energy=3675.0)  # 10.5ms latency, 3675 W·ms energy
+        result = PerformanceResult(10.5, energy=3675.0, source="silicon")
         print(result)           # 10.5 (acts like float)
         print(result.energy)    # 3675.0 (energy in W·ms = 3.675 J)
         print(result.power)     # 350.0 (derived: 3675.0 / 10.5 = 350W)
+        print(result.source)    # "silicon"
 
         # Comparisons work correctly
         if result > 10.0:  # Uses __gt__
             print("Latency exceeds threshold")
 
-        # Aggregation with sum()
+        # Aggregation with sum() preserves energy and merges sources
         results = [result1, result2, result3]
         total = sum(results)  # __radd__ handles sum() start value
         print(total.energy)   # Energy is preserved
+        print(total.source)   # "silicon" if all were silicon, else "mixed"
 
         # Sorting works based on latency
         sorted_results = sorted(results)
     """
 
     # Note: We don't use __slots__ here because float subclasses cannot define __slots__
+    # TODO: add type hints to the remaining methods of this class. Only the
+    # scalar arithmetic operators (__mul__/__rmul__/__truediv__/__rtruediv__)
+    # are currently annotated.
 
-    def __new__(cls, latency, energy=0.0):
+    def __new__(cls, latency, energy=0.0, source="silicon"):
         """
         Create a new PerformanceResult.
 
         Args:
             latency: The latency value in milliseconds (acts as the float value)
             energy: The energy value in watt-milliseconds (W·ms)
+            source: Where this measurement came from --  "silicon" (table data),
+                "empirical" (SOL+empirical fallback in HYBRID mode), or "mixed"
+                (sum of values from different sources).
         """
         instance = float.__new__(cls, latency)
         return instance
 
-    def __init__(self, latency, energy=0.0):
+    def __init__(self, latency, energy=0.0, source="silicon"):
         """
         Initialize the PerformanceResult.
 
@@ -63,8 +81,10 @@ class PerformanceResult(float):
             latency: The latency value in milliseconds
             energy: The energy value in watt-milliseconds (W·ms)
                    Note: 1 W·ms = 1 millijoule (mJ)
+            source: Data source tag (see __new__).
         """
         self.energy = energy  # W·ms (watt-milliseconds)
+        self.source = source
 
     @property
     def power(self):
@@ -87,14 +107,23 @@ class PerformanceResult(float):
         """String representation showing latency, energy, and derived power."""
         return f"PerformanceResult(latency={float(self)}, energy={self.energy}, power={self.power})"
 
+    @staticmethod
+    def _merge_source(a: str, b: str) -> str:
+        """Combine source tags during arithmetic. Same -> same; mismatch -> 'mixed'."""
+        return a if a == b else "mixed"
+
     def __add__(self, other):
         """Add two PerformanceResults or a PerformanceResult and a number."""
         if isinstance(other, PerformanceResult):
-            # Add latencies and energies (both are additive!)
-            return PerformanceResult(float(self) + float(other), energy=self.energy + other.energy)
+            # Add latencies and energies (both are additive!) and merge sources.
+            return PerformanceResult(
+                float(self) + float(other),
+                energy=self.energy + other.energy,
+                source=self._merge_source(self.source, other.source),
+            )
         else:
-            # Add to latency only, keep same energy
-            return PerformanceResult(float(self) + other, energy=self.energy)
+            # Add to latency only, keep same energy and source.
+            return PerformanceResult(float(self) + other, energy=self.energy, source=self.source)
 
     def __radd__(self, other):
         """Right addition for sum() support.
@@ -107,23 +136,20 @@ class PerformanceResult(float):
             return self
         return self.__add__(other)
 
-    def __mul__(self, other):
-        """Multiply PerformanceResult by a scalar."""
-        # Scale both latency and energy
-        return PerformanceResult(float(self) * other, energy=self.energy * other)
+    def __mul__(self, other: int | float) -> "PerformanceResult":
+        """Multiply PerformanceResult by a scalar; preserve source."""
+        return PerformanceResult(float(self) * other, energy=self.energy * other, source=self.source)
 
-    def __rmul__(self, other):
+    def __rmul__(self, other: int | float) -> "PerformanceResult":
         """Right multiplication."""
         return self.__mul__(other)
 
-    def __truediv__(self, other):
-        """Divide PerformanceResult by a scalar."""
-        # Scale both latency and energy
-        return PerformanceResult(float(self) / other, energy=self.energy / other)
+    def __truediv__(self, other: int | float) -> "PerformanceResult":
+        """Divide PerformanceResult by a scalar; preserve source."""
+        return PerformanceResult(float(self) / other, energy=self.energy / other, source=self.source)
 
-    def __rtruediv__(self, other):
-        """Right division: other / self."""
-        # Return plain float when dividing by PerformanceResult
+    def __rtruediv__(self, other: int | float) -> float:
+        """Right division: other / self. Returns plain float (no source on scalar)."""
         return other / float(self)
 
     # Comparison operators (CRITICAL - Python doesn't auto-infer from float inheritance)
@@ -159,7 +185,7 @@ class PerformanceResult(float):
 
     def __abs__(self):
         """Absolute value of latency and energy."""
-        return PerformanceResult(abs(float(self)), energy=abs(self.energy))
+        return PerformanceResult(abs(float(self)), energy=abs(self.energy), source=self.source)
 
     def __hash__(self):
         """Hash based on latency and energy for use in sets/dicts."""

--- a/tests/unit/sdk/test_performance_result.py
+++ b/tests/unit/sdk/test_performance_result.py
@@ -1,0 +1,231 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for PerformanceResult: latency, energy, and source tag propagation.
+
+Covers the new ``source`` attribute introduced in the per-op silicon vs
+empirical attribution feature -- default value, _merge_source helper, and
+propagation through ``+``, ``*``, ``/``, ``abs()``.
+"""
+
+import pytest
+
+from aiconfigurator.sdk.performance_result import PerformanceResult
+
+
+def pr(latency, energy=0.0, source="silicon"):
+    """Convenience constructor with explicit defaults."""
+    return PerformanceResult(latency, energy=energy, source=source)
+
+
+# -------------------------------------------------------------------------
+# Construction & defaults
+# -------------------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_default_source_is_silicon(self):
+        r = PerformanceResult(10.0)
+        assert r.source == "silicon"
+
+    def test_explicit_source_empirical(self):
+        r = pr(10.0, source="empirical")
+        assert r.source == "empirical"
+
+    def test_explicit_source_mixed(self):
+        r = pr(10.0, source="mixed")
+        assert r.source == "mixed"
+
+    def test_float_value_is_latency(self):
+        r = pr(7.5, energy=100.0)
+        assert float(r) == 7.5
+
+    def test_energy_stored(self):
+        r = pr(5.0, energy=250.0)
+        assert r.energy == 250.0
+
+
+# -------------------------------------------------------------------------
+# _merge_source
+# -------------------------------------------------------------------------
+
+
+class TestMergeSource:
+    @pytest.mark.parametrize("src", ["silicon", "empirical", "mixed"])
+    def test_same_source_preserved(self, src):
+        assert PerformanceResult._merge_source(src, src) == src
+
+    @pytest.mark.parametrize(
+        "a,b",
+        [
+            ("silicon", "empirical"),
+            ("empirical", "silicon"),
+            ("silicon", "mixed"),
+            ("mixed", "empirical"),
+        ],
+    )
+    def test_different_sources_become_mixed(self, a, b):
+        assert PerformanceResult._merge_source(a, b) == "mixed"
+
+
+# -------------------------------------------------------------------------
+# __add__: PerformanceResult + PerformanceResult
+# -------------------------------------------------------------------------
+
+
+class TestAddPerformanceResult:
+    def test_latency_summed(self):
+        result = pr(3.0) + pr(4.0)
+        assert float(result) == pytest.approx(7.0)
+
+    def test_energy_summed(self):
+        result = pr(3.0, energy=100.0) + pr(4.0, energy=200.0)
+        assert result.energy == pytest.approx(300.0)
+
+    def test_same_source_preserved(self):
+        result = pr(1.0, source="silicon") + pr(2.0, source="silicon")
+        assert result.source == "silicon"
+
+    def test_same_empirical_preserved(self):
+        result = pr(1.0, source="empirical") + pr(2.0, source="empirical")
+        assert result.source == "empirical"
+
+    def test_different_sources_become_mixed(self):
+        result = pr(1.0, source="silicon") + pr(2.0, source="empirical")
+        assert result.source == "mixed"
+
+    def test_result_is_performance_result(self):
+        result = pr(1.0) + pr(2.0)
+        assert isinstance(result, PerformanceResult)
+
+
+# -------------------------------------------------------------------------
+# __add__: PerformanceResult + scalar
+# -------------------------------------------------------------------------
+
+
+class TestAddScalar:
+    def test_latency_updated(self):
+        result = pr(5.0) + 3.0
+        assert float(result) == pytest.approx(8.0)
+
+    def test_energy_preserved(self):
+        result = pr(5.0, energy=150.0) + 3.0
+        assert result.energy == pytest.approx(150.0)
+
+    def test_source_preserved(self):
+        result = pr(5.0, source="empirical") + 3.0
+        assert result.source == "empirical"
+
+
+# -------------------------------------------------------------------------
+# __radd__: sum() support
+# -------------------------------------------------------------------------
+
+
+class TestRadd:
+    def test_sum_latency(self):
+        results = [pr(1.0), pr(2.0), pr(3.0)]
+        total = sum(results)
+        assert float(total) == pytest.approx(6.0)
+
+    def test_sum_energy(self):
+        results = [pr(1.0, energy=10.0), pr(2.0, energy=20.0), pr(3.0, energy=30.0)]
+        total = sum(results)
+        assert total.energy == pytest.approx(60.0)
+
+    def test_sum_same_source_preserved(self):
+        results = [pr(1.0, source="empirical")] * 3
+        total = sum(results)
+        assert total.source == "empirical"
+
+    def test_sum_mixed_sources_become_mixed(self):
+        results = [pr(1.0, source="silicon"), pr(2.0, source="empirical")]
+        total = sum(results)
+        assert total.source == "mixed"
+
+
+# -------------------------------------------------------------------------
+# __mul__ / __rmul__
+# -------------------------------------------------------------------------
+
+
+class TestMul:
+    def test_latency_scaled(self):
+        result = pr(4.0) * 2
+        assert float(result) == pytest.approx(8.0)
+
+    def test_energy_scaled(self):
+        result = pr(4.0, energy=100.0) * 2
+        assert result.energy == pytest.approx(200.0)
+
+    def test_source_preserved(self):
+        result = pr(4.0, source="empirical") * 2
+        assert result.source == "empirical"
+
+    def test_rmul_equivalent(self):
+        r = pr(4.0, energy=100.0, source="empirical")
+        assert float(2 * r) == float(r * 2)
+        assert (2 * r).energy == (r * 2).energy
+        assert (2 * r).source == (r * 2).source
+
+
+# -------------------------------------------------------------------------
+# __truediv__ / __rtruediv__
+# -------------------------------------------------------------------------
+
+
+class TestDiv:
+    def test_latency_divided(self):
+        result = pr(8.0) / 2
+        assert float(result) == pytest.approx(4.0)
+
+    def test_energy_divided(self):
+        result = pr(8.0, energy=200.0) / 2
+        assert result.energy == pytest.approx(100.0)
+
+    def test_source_preserved(self):
+        result = pr(8.0, source="empirical") / 2
+        assert result.source == "empirical"
+
+    def test_rtruediv_returns_plain_float(self):
+        r = pr(4.0)
+        result = 8.0 / r
+        assert isinstance(result, float)
+        assert not isinstance(result, PerformanceResult)
+        assert result == pytest.approx(2.0)
+
+
+# -------------------------------------------------------------------------
+# __abs__
+# -------------------------------------------------------------------------
+
+
+class TestAbs:
+    def test_negative_latency(self):
+        result = abs(pr(-5.0, energy=-100.0, source="empirical"))
+        assert float(result) == pytest.approx(5.0)
+
+    def test_negative_energy(self):
+        result = abs(pr(-5.0, energy=-100.0))
+        assert result.energy == pytest.approx(100.0)
+
+    def test_source_preserved(self):
+        result = abs(pr(-5.0, source="empirical"))
+        assert result.source == "empirical"
+
+
+# -------------------------------------------------------------------------
+# power property
+# -------------------------------------------------------------------------
+
+
+class TestPower:
+    def test_normal_power(self):
+        r = pr(10.0, energy=3500.0)
+        assert r.power == pytest.approx(350.0)
+
+    def test_zero_latency_returns_zero(self):
+        r = pr(0.0, energy=100.0)
+        assert r.power == 0.0


### PR DESCRIPTION
From Claude:

In HYBRID mode, callers cannot tell which ops fell back from silicon table data to SOL+empirical estimates. This adds a `source` tag to `PerformanceResult` and surfaces it as `EstimateResult.per_ops_source` — same shape as `per_ops_data`, values are `"silicon"`, `"empirical"`, or `"mixed"` (a sum of values from different sources).

## Changes (~120 LOC, 9 files)

- `sdk/performance_result.py` — new `source` attribute, propagated through `__add__` (merge mismatched sources to `"mixed"`), `__mul__`, `__truediv__`, `__abs__`.
- `sdk/perf_database.py` — `_query_silicon_or_hybrid` tags every returned `PerformanceResult`: `"silicon"` on the table-data path, `"empirical"` on the HYBRID fallback path.
- `sdk/operations.py` — each `Operation` subclass's `query()` reads `getattr(result, "source", "silicon")` and threads it into the returned `PerformanceResult`. `GEMM` merges sub-query sources for the `fp8_static` `compute_scale` / `scale_matrix` adjustments.
- `sdk/inference_summary.py` — new `_per_ops_source` dict and `_context_source_dict` / `_generation_source_dict`, with setter/getter pairs paralleling the existing latency dicts.
- `sdk/backends/base_backend.py` — `_run_context_phase` / `_run_generation_phase` accumulate per-op source from results and return source dicts; `_run_static_breakdown` propagates them onto the summary.
- `sdk/backends/{sglang,vllm,trtllm}_backend.py` — build `per_ops_source` parallel to `per_ops_data` from the inner static-run summaries; call `summary.set_per_ops_source(...)`.
- `cli/api.py` — new `EstimateResult.per_ops_source` field, populated from `summary.get_per_ops_source()`.

## Persisting in `cli exp` top-N artifacts

The per-op source breakdown is now also saved when running the full pareto search, not just `cli_estimate`. Each top-N config dir gets a `per_ops_source.json` next to `generator_config.yaml`, with the same nested shape as `EstimateResult.per_ops_source`. The data flows as an object-typed `_per_ops_source` column on the search DataFrame (one entry per row), threaded through `find_best_agg_result_under_constraints` in all three backends, deduped via `drop_duplicates(subset=...)` to handle the unhashable column, and stripped before CSV write so existing schemas (`best_config_topn.csv`, `pareto.csv`) are unchanged. ~30 LOC across 5 files. Disagg path not yet covered.

## Example output (Qwen3.5-397B-A17B-FP8 / H200 / TRT-LLM top-1)

```python
result.per_ops_source["genonly_step"] == {
    "generation_attention": "empirical",
    "generation_full_moe":  "empirical",
    "generation_gdn_moe":   "empirical",
    # ... 28 silicon ops
}
```

The `context_attention (scaled)` entry is correctly tagged `"mixed"` because the backend issues two scaled context-attention sub-queries (full ISL + chunked batch) that hit cells with different sources.

## Compatibility

- Numerics unchanged: all 12 search/estimate pairs verified across 4 models × 3 backends produce identical `tpot`, `ttft`, `tokens/s/gpu`, `tokens/s/user`, `memory`.
- `PerformanceResult.source` defaults to `"silicon"` — additive change.
- CSV schemas (`best_config_topn.csv`, `pareto.csv`) unchanged.
- No metaclass, no `ContextVar`, no global state. Explicit data flow.

## Tested

| Model / SKU | Empirical ops (top-1) |
|---|---|
| Kimi K2.5 NVFP4 / B200 (3 backends) | 0% |
| Qwen3.5-397B-A17B FP8 / H200 | 7 ops (attention + MoEs) |
| DeepSeek V3.1 NVFP4 / B200 | 0% |
| MiniMax-M2.5 NVFP4 / B200 | 0% |

## Example `per_ops_source.json` (abbreviated)

`top1/per_ops_source.json` for the same Qwen3.5 / H200 / TRT-LLM run:

```jsonc
{
  "genonly_step": {
    "generation_attention":              "empirical",
    "generation_full_moe":               "empirical",
    "generation_gdn_moe":                "empirical",
    "generation_qkv_gemm":               "silicon",
    "generation_proj_gemm":              "silicon",
    "generation_logits_gemm":            "silicon",
    // ... 26 more silicon ops
  },
  "mix_step": {
    "context_attention (scaled)":        "mixed",
    "context_full_moe":                  "empirical",
    "context_gdn_moe":                   "empirical",
    "generation_attention":              "empirical",
    "context_qkv_gemm":                  "silicon",
    "context_proj_gemm":                 "silicon",
    // ... 26 more silicon ops
  }
}
```
