### PR TITLE
fix: derive support matrix target versions

### DIFF
--- a/docs/support-matrix/index.html
+++ b/docs/support-matrix/index.html
@@ -44,7 +44,6 @@ const { useState, useEffect, useCallback, useMemo, useRef } = React;
 // ── Constants ───────────────────────────────────────────────────────
 const REPO = 'ai-dynamo/aiconfigurator';
 const CSV_PATH = 'src/aiconfigurator/systems/support_matrix.csv';
-const TARGET_VERSIONS = { vllm: '0.14.0', sglang: '0.5.9', trtllm: '1.2.0rc6' };
 const PREFERRED_DEFAULT_SYSTEM = 'b200_sxm';
 const SYSTEM_ORDER = ['b200', 'gb200', 'gb300', 'h100', 'h200', '__other__', 'a100', 'l40s'];
 
@@ -118,6 +117,21 @@ function compareVersionTuples(a, b) {
   return 0;
 }
 
+function buildTargetVersions(rows) {
+  const versionsByBackend = {};
+  for (const row of rows) {
+    if (!row.Backend || !row.Version) continue;
+    if (!versionsByBackend[row.Backend]) versionsByBackend[row.Backend] = new Set();
+    versionsByBackend[row.Backend].add(row.Version);
+  }
+  return Object.fromEntries(
+    Object.entries(versionsByBackend).map(([backend, versions]) => [
+      backend,
+      [...versions].sort((a, b) => compareVersionTuples(versionSortKey(b), versionSortKey(a)))[0],
+    ])
+  );
+}
+
 // ── Error Signature Extraction ──────────────────────────────────────
 function extractErrorSignature(errMsg) {
   if (!errMsg) return 'No error message';
@@ -135,7 +149,7 @@ function extractErrorSignature(errMsg) {
 }
 
 // ── Matrix Building Logic ───────────────────────────────────────────
-function getLatestSupportedVersion(rows, huggingfaceId, system, backend) {
+function getLatestSupportedVersion(rows, huggingfaceId, system, backend, targetVersions) {
   const subset = rows.filter(r =>
     r.HuggingFaceID === huggingfaceId && r.System === system && r.Backend === backend
   );
@@ -171,7 +185,7 @@ function getLatestSupportedVersion(rows, huggingfaceId, system, backend) {
     return { version: null, atTarget: false, error: null };
   }
 
-  const targetVer = TARGET_VERSIONS[backend] || null;
+  const targetVer = targetVersions[backend] || null;
   const atOrAboveTarget = (ver) => targetVer === null || versionGe(ver, targetVer);
 
   if (targetVer !== null) {
@@ -198,7 +212,7 @@ function getLatestSupportedVersion(rows, huggingfaceId, system, backend) {
   return { version: 'FAIL', atTarget: false, error: allMsgs.length ? allMsgs.join(' | ') : 'No error message available' };
 }
 
-function buildMatrixForMode(rows, systemName, modeFilter) {
+function buildMatrixForMode(rows, systemName, modeFilter, targetVersions) {
   let subset = rows.filter(r => r.System === systemName);
   if (modeFilter !== 'all') subset = subset.filter(r => r.Mode === modeFilter);
   if (!subset.length) return { matrixRows: [], backends: [] };
@@ -209,7 +223,9 @@ function buildMatrixForMode(rows, systemName, modeFilter) {
   const matrixRows = models.map(model => {
     const cells = {};
     for (const backend of backends) {
-      const { version, atTarget, error } = getLatestSupportedVersion(subset, model, systemName, backend);
+      const { version, atTarget, error } = getLatestSupportedVersion(
+        subset, model, systemName, backend, targetVersions
+      );
       let status = 'pass';
       if (version === null || version === 'FAIL') status = 'fail';
 
@@ -218,10 +234,10 @@ function buildMatrixForMode(rows, systemName, modeFilter) {
         const aggRows = subset.filter(r => r.Mode === 'agg');
         const disaggRows = subset.filter(r => r.Mode === 'disagg');
         const aggResult = aggRows.length
-          ? getLatestSupportedVersion(aggRows, model, systemName, backend)
+          ? getLatestSupportedVersion(aggRows, model, systemName, backend, targetVersions)
           : { version: null, atTarget: false, error: null };
         const disaggResult = disaggRows.length
-          ? getLatestSupportedVersion(disaggRows, model, systemName, backend)
+          ? getLatestSupportedVersion(disaggRows, model, systemName, backend, targetVersions)
           : { version: null, atTarget: false, error: null };
         const aggPass = aggResult.version !== null && aggResult.version !== 'FAIL';
         const disaggPass = disaggResult.version !== null && disaggResult.version !== 'FAIL';
@@ -567,7 +583,7 @@ function SortArrow({ col, sortCol, sortAsc }) {
   return <span className="ml-1 text-[0.65rem]">{sortAsc ? '\u25B2' : '\u25BC'}</span>;
 }
 
-function MatrixTable({ matrixRows, backends, searchQuery, sortCol, sortAsc, onSort, onCellClick }) {
+function MatrixTable({ matrixRows, backends, targetVersions, searchQuery, sortCol, sortAsc, onSort, onCellClick }) {
   let filtered = matrixRows;
   if (searchQuery) {
     const q = searchQuery.toLowerCase();
@@ -621,8 +637,8 @@ function MatrixTable({ matrixRows, backends, searchQuery, sortCol, sortAsc, onSo
                     hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors
                     ${sortCol === b ? 'text-indigo-600 dark:text-indigo-400' : ''}`}>
                 {b}
-                {TARGET_VERSIONS[b] && (
-                  <small className="font-normal text-slate-400 ml-1">(target: {TARGET_VERSIONS[b]})</small>
+                {targetVersions[b] && (
+                  <small className="font-normal text-slate-400 ml-1">(target: {targetVersions[b]})</small>
                 )}
                 <SortArrow col={b} sortCol={sortCol} sortAsc={sortAsc} />
               </th>
@@ -815,9 +831,16 @@ function App() {
   const totalPass = useMemo(() => csvRows.filter(r => r.Status === 'PASS').length, [csvRows]);
   const totalFail = useMemo(() => csvRows.filter(r => r.Status === 'FAIL').length, [csvRows]);
 
+  const targetVersions = useMemo(
+    () => activeSystem ? buildTargetVersions(csvRows.filter(r => r.System === activeSystem)) : {},
+    [csvRows, activeSystem]
+  );
+
   const { matrixRows, backends } = useMemo(
-    () => activeSystem ? buildMatrixForMode(csvRows, activeSystem, activeMode) : { matrixRows: [], backends: [] },
-    [csvRows, activeSystem, activeMode]
+    () => activeSystem
+      ? buildMatrixForMode(csvRows, activeSystem, activeMode, targetVersions)
+      : { matrixRows: [], backends: [] },
+    [csvRows, activeSystem, activeMode, targetVersions]
   );
 
   const topErrors = useMemo(
@@ -872,7 +895,7 @@ function App() {
           <div className="p-6 max-w-full">
             <Legend />
             <MatrixTable
-              matrixRows={matrixRows} backends={backends}
+              matrixRows={matrixRows} backends={backends} targetVersions={targetVersions}
               searchQuery={searchQuery} sortCol={sortCol} sortAsc={sortAsc}
               onSort={handleSort}
               onCellClick={(model, backend, err) => setModal({ model, system: activeSystem, backend, error: err })}

--- a/tests/unit/support_matrix/test_generate_static_page.py
+++ b/tests/unit/support_matrix/test_generate_static_page.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+from pathlib import Path
+
+_MODULE_PATH = Path(__file__).parents[3] / "tools" / "support_matrix" / "generate_static_page.py"
+_SPEC = importlib.util.spec_from_file_location("generate_static_page", _MODULE_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+generate_static_page = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(generate_static_page)
+
+build_full_data = generate_static_page.build_full_data
+build_target_versions = generate_static_page.build_target_versions
+
+
+def _row(model, system, backend, version, mode="agg", status="PASS"):
+    return {
+        "HuggingFaceID": model,
+        "Architecture": "ExampleForCausalLM",
+        "System": system,
+        "Backend": backend,
+        "Version": version,
+        "Mode": mode,
+        "Status": status,
+        "ErrMsg": "",
+    }
+
+
+def test_target_versions_are_derived_from_latest_tested_backend_versions():
+    rows = [
+        _row("model-a", "b200_sxm", "vllm", "0.14.0"),
+        _row("model-a", "b200_sxm", "vllm", "0.19.0"),
+        _row("model-a", "b200_sxm", "trtllm", "1.2.0rc5"),
+        _row("model-a", "b200_sxm", "trtllm", "1.3.0rc10"),
+        _row("model-a", "b200_sxm", "sglang", "0.5.9"),
+        _row("model-a", "b200_sxm", "sglang", "0.5.10"),
+    ]
+
+    assert build_target_versions(rows) == {
+        "sglang": "0.5.10",
+        "trtllm": "1.3.0rc10",
+        "vllm": "0.19.0",
+    }
+
+
+def test_full_page_data_uses_derived_target_versions():
+    rows = [
+        _row("model-a", "a100_sxm", "vllm", "0.14.0", "agg"),
+        _row("model-a", "a100_sxm", "vllm", "0.14.0", "disagg"),
+        _row("model-a", "b200_sxm", "vllm", "0.14.0", "agg"),
+        _row("model-a", "b200_sxm", "vllm", "0.14.0", "disagg"),
+        _row("model-a", "b200_sxm", "vllm", "0.19.0", "agg"),
+        _row("model-a", "b200_sxm", "vllm", "0.19.0", "disagg"),
+    ]
+
+    data = build_full_data(rows)
+
+    assert data["target_versions"] == {"vllm": "0.19.0"}
+    assert data["systems"]["a100_sxm"]["target_versions"] == {"vllm": "0.14.0"}
+    assert data["systems"]["b200_sxm"]["target_versions"] == {"vllm": "0.19.0"}
+    assert data["systems"]["b200_sxm"]["matrix"]["all"][0]["cells"]["vllm"]["version"] == "0.19.0"

--- a/tools/support_matrix/generate_static_page.py
+++ b/tools/support_matrix/generate_static_page.py
@@ -26,13 +26,6 @@ from datetime import datetime, timezone
 _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
-TARGET_VERSIONS = {
-    "vllm": "0.14.0",
-    "sglang": "0.5.9",
-    "trtllm": "1.2.0rc6",
-}
-
-
 _PHASE_ORDER = {"dev": 0, "a": 1, "b": 2, "rc": 3, "release": 4, "post": 5}
 
 
@@ -123,7 +116,23 @@ def load_csv(csv_path):
         return list(csv.DictReader(f))
 
 
-def get_latest_supported_version(rows, huggingface_id, system, backend):
+def build_target_versions(rows):
+    """Return the latest tested version for each backend in the support matrix."""
+    versions_by_backend = {}
+    for row in rows:
+        backend = row.get("Backend")
+        version = row.get("Version")
+        if not backend or not version:
+            continue
+        versions_by_backend.setdefault(backend, set()).add(version)
+
+    return {
+        backend: sorted(versions, key=_version_sort_key, reverse=True)[0]
+        for backend, versions in sorted(versions_by_backend.items())
+    }
+
+
+def get_latest_supported_version(rows, huggingface_id, system, backend, target_versions):
     """
     Determine the latest supported version for a (model, system, backend) tuple.
     Ported from support_matrix_tab.py but operates on plain dicts.
@@ -160,7 +169,7 @@ def get_latest_supported_version(rows, huggingface_id, system, backend):
     if not version_has_fail and not version_has_pass:
         return (None, False, None)
 
-    target_ver = TARGET_VERSIONS.get(backend)
+    target_ver = target_versions.get(backend)
 
     def at_or_above_target(ver_str):
         if target_ver is None:
@@ -186,7 +195,7 @@ def get_latest_supported_version(rows, huggingface_id, system, backend):
     return ("FAIL", False, " | ".join(all_msgs) if all_msgs else "No error message available")
 
 
-def build_matrix_for_mode(rows, system_name, mode_filter):
+def build_matrix_for_mode(rows, system_name, mode_filter, target_versions):
     """
     Build the matrix data for a single (system, mode) combination.
     Returns a list of row dicts and a list of backend names.
@@ -204,7 +213,9 @@ def build_matrix_for_mode(rows, system_name, mode_filter):
     for model in models:
         cells = {}
         for backend in backends:
-            version, at_target, error_msg = get_latest_supported_version(subset, model, system_name, backend)
+            version, at_target, error_msg = get_latest_supported_version(
+                subset, model, system_name, backend, target_versions
+            )
 
             # For "all" mode, determine if support is partial (one mode passes, other fails)
             status = "pass"
@@ -216,12 +227,12 @@ def build_matrix_for_mode(rows, system_name, mode_filter):
                 agg_rows = [r for r in subset if r["Mode"] == "agg"]
                 disagg_rows = [r for r in subset if r["Mode"] == "disagg"]
                 agg_ver, _, agg_err = (
-                    get_latest_supported_version(agg_rows, model, system_name, backend)
+                    get_latest_supported_version(agg_rows, model, system_name, backend, target_versions)
                     if agg_rows
                     else (None, False, None)
                 )
                 disagg_ver, _, disagg_err = (
-                    get_latest_supported_version(disagg_rows, model, system_name, backend)
+                    get_latest_supported_version(disagg_rows, model, system_name, backend, target_versions)
                     if disagg_rows
                     else (None, False, None)
                 )
@@ -262,12 +273,20 @@ def build_full_data(rows):
     """Build the complete data structure for all systems and modes."""
     systems_set = sorted(set(r["System"] for r in rows))
     modes = ["all", "agg", "disagg"]
+    target_versions = build_target_versions(rows)
 
     systems_data = {}
     for system in systems_set:
-        system_entry = {"matrix": {}, "top_errors": {}, "backends": []}
+        system_rows = [r for r in rows if r["System"] == system]
+        system_target_versions = build_target_versions(system_rows)
+        system_entry = {
+            "matrix": {},
+            "top_errors": {},
+            "backends": [],
+            "target_versions": system_target_versions,
+        }
         for mode in modes:
-            matrix_rows, backends = build_matrix_for_mode(rows, system, mode)
+            matrix_rows, backends = build_matrix_for_mode(rows, system, mode, system_target_versions)
             system_entry["matrix"][mode] = matrix_rows
             system_entry["top_errors"][mode] = build_top_errors(rows, system, mode)
             if mode == "all" and backends:
@@ -279,7 +298,7 @@ def build_full_data(rows):
 
     return {
         "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "target_versions": TARGET_VERSIONS,
+        "target_versions": target_versions,
         "summary": {"total_rows": len(rows), "pass": total_pass, "fail": total_fail},
         "systems": systems_data,
     }

--- a/tools/support_matrix/static_page_template.html
+++ b/tools/support_matrix/static_page_template.html
@@ -381,8 +381,9 @@ function renderTable(system) {
   var html = '<div class="table-wrap"><table class="matrix">';
   html += '<thead><tr>';
   html += '<th data-sort="model" class="' + (state.sortCol === 'model' ? 'sorted' : '') + '">HuggingFace ID ' + arrow('model') + '</th>';
+  var targetVersions = info.target_versions || DATA.target_versions || {};
   backends.forEach(function(b) {
-    var target = DATA.target_versions[b] ? ' <small style="font-weight:400;color:var(--text-muted)">(target: ' + escHtml(DATA.target_versions[b]) + ')</small>' : '';
+    var target = targetVersions[b] ? ' <small style="font-weight:400;color:var(--text-muted)">(target: ' + escHtml(targetVersions[b]) + ')</small>' : '';
     html += '<th data-sort="' + b + '" class="' + (state.sortCol === b ? 'sorted' : '') + '">' + escHtml(b) + target + ' ' + arrow(b) + '</th>';
   });
   html += '</tr></thead><tbody>';


### PR DESCRIPTION

<img width="1661" height="775" alt="image" src="https://github.com/user-attachments/assets/9853219f-ed3c-4bb3-b9fc-d9d0a8aa9cee" />


## Summary
- derive support-matrix target versions from the CSV instead of hardcoding backend constants
- store target versions per system so each tab displays the latest tested backend version for that system
- update the static template and checked-in support-matrix page to read the derived targets

## Verification
- python3 -m py_compile tools/support_matrix/generate_static_page.py tests/unit/support_matrix/test_generate_static_page.py
- manual execution of the new unit test functions
- generated /tmp/support-matrix-test.html and confirmed b200_sxm targets are sglang 0.5.10, trtllm 1.3.0rc10, vllm 0.19.0

Note: pytest is not installed in this local environment, so I could not run the pytest command directly here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support matrix target versions are now dynamically computed from test data for each backend, automatically updating matrix table headers to display the latest tested version instead of using predefined static values

* **Tests**
  * Added comprehensive unit tests validating the target version computation logic and matrix generation with dynamically calculated target versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->