### PR TITLE
fix: handle NaN values in Pareto selection

### DIFF
--- a/src/aiconfigurator/sdk/pareto_analysis.py
+++ b/src/aiconfigurator/sdk/pareto_analysis.py
@@ -338,9 +338,19 @@ def get_pareto_front(
         maximize_x: Treat larger values on x axis as better if True, else minimize.
         maximize_y: Treat larger values on y axis as better if True, else minimize.
     """
-    if df is None or df.empty:
+    if df is None:
         return pd.DataFrame()
-    df = df.sort_values(by=x_col)
+    if df.empty:
+        return df.iloc[0:0].copy()
+    if x_col not in df.columns or y_col not in df.columns:
+        return pd.DataFrame(columns=[x_col, y_col])
+
+    working = df[[x_col, y_col]].replace([np.inf, -np.inf], np.nan)
+    valid_mask = working.notna().all(axis=1)
+    if not valid_mask.any():
+        return df.iloc[0:0].copy()
+
+    df = df.loc[valid_mask].sort_values(by=x_col)
 
     def is_pareto(costs: np.ndarray) -> np.ndarray:
         is_better = np.ones(costs.shape[0], dtype=bool)
@@ -545,8 +555,24 @@ def _get_best_configs_under_constraint(
         * candidate_configs["num_total_gpus"]
         / total_gpus
     )
+    candidate_configs.replace([np.inf, -np.inf], np.nan, inplace=True)
+    finite_value_cols = [constraint_col, "tokens/s/gpu_cluster"]
+    invalid_value_mask = candidate_configs[finite_value_cols].isna().any(axis=1)
+    if invalid_value_mask.any():
+        logger.info(
+            "Dropping %d Pareto configs with non-finite %s or tokens/s/gpu_cluster values.",
+            int(invalid_value_mask.sum()),
+            constraint_col,
+        )
+        candidate_configs = candidate_configs.loc[~invalid_value_mask].copy()
+
+    if candidate_configs.empty:
+        return pd.DataFrame()
+
     if group_by is not None and group_by in candidate_configs.columns:
-        top_indexes = candidate_configs.groupby(group_by)["tokens/s/gpu_cluster"].idxmax()
+        top_indexes = candidate_configs.groupby(group_by)["tokens/s/gpu_cluster"].idxmax().dropna()
+        if top_indexes.empty:
+            return pd.DataFrame()
         candidate_configs = candidate_configs.loc[top_indexes]
 
     if candidate_configs["_sla_exceeded"].all():

--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -3735,7 +3735,10 @@ class PerfDatabase:
         """
         Validate the value
         """
-        if value < 0.0:
+        value_array = np.asarray(value)
+        if not np.all(np.isfinite(value_array)):
+            raise ValueError(f"Non-finite value detected {value}")
+        if np.any(value_array < 0.0):
             logger.debug(f"Negative value detected {value}, pass")
         return value
 

--- a/tests/unit/sdk/database/test_interpolation.py
+++ b/tests/unit/sdk/database/test_interpolation.py
@@ -77,6 +77,12 @@ class TestInterpolationMethods:
             assert result == -5.0
             assert "Negative value detected" in caplog.text
 
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+    def test_validate_rejects_non_finite_values(self, comprehensive_perf_db, value):
+        """Non-finite interpolation results should fail instead of propagating."""
+        with pytest.raises(ValueError, match="Non-finite value detected"):
+            comprehensive_perf_db._validate(value)
+
     def test_interp_1d(self, comprehensive_perf_db):
         """Test 1D interpolation."""
         # Linear interpolation

--- a/tests/unit/sdk/picking/test_pareto_sla_filtering.py
+++ b/tests/unit/sdk/picking/test_pareto_sla_filtering.py
@@ -15,7 +15,9 @@ import pandas as pd
 import pytest
 
 from aiconfigurator.sdk.pareto_analysis import (
+    get_best_configs_under_request_latency_constraint,
     get_best_configs_under_tpot_constraint,
+    get_pareto_front,
 )
 from aiconfigurator.sdk.picking import pick_default
 
@@ -107,6 +109,70 @@ class TestTpotConstraintFiltering:
         # Should return something (fallback), sorted by closest to target
         assert not result.empty
         assert result.iloc[0]["tpot"] == 20.0, "Fallback should return the config closest to the SLA target"
+
+    def test_grouped_selection_drops_all_nan_throughput_groups(self):
+        """Grouped idxmax must not crash when all candidate throughputs are NaN."""
+        df = _make_pareto_df(
+            [
+                {
+                    "request_latency": 1000.0,
+                    "tokens/s/gpu": float("nan"),
+                    "num_total_gpus": 1,
+                    "parallel": "tp1_pp1_dp1",
+                },
+                {
+                    "request_latency": 900.0,
+                    "tokens/s/gpu": float("nan"),
+                    "num_total_gpus": 2,
+                    "parallel": "tp2_pp1_dp1",
+                },
+            ]
+        )
+
+        result = get_best_configs_under_request_latency_constraint(
+            total_gpus=8,
+            pareto_df=df,
+            target_request_latency=1200.0,
+            top_n=5,
+            group_by="parallel",
+        )
+
+        assert result.empty
+
+
+class TestParetoFrontFiltering:
+    """Invalid metric rows should not participate in Pareto ranking."""
+
+    def test_get_pareto_front_ignores_non_finite_points(self):
+        """NaN and infinity rows are filtered before Pareto ranking."""
+        df = _make_pareto_df(
+            [
+                {"tokens/s/user": float("nan"), "tokens/s/gpu": 1000.0},
+                {"tokens/s/user": 100.0, "tokens/s/gpu": float("nan")},
+                {"tokens/s/user": float("inf"), "tokens/s/gpu": 900.0},
+                {"tokens/s/user": 150.0, "tokens/s/gpu": float("-inf")},
+                {"tokens/s/user": 200.0, "tokens/s/gpu": 800.0},
+            ]
+        )
+
+        result = get_pareto_front(df, "tokens/s/user", "tokens/s/gpu")
+
+        assert len(result) == 1
+        assert result.iloc[0]["tokens/s/user"] == 200.0
+
+    def test_get_pareto_front_preserves_schema_when_all_points_are_invalid(self):
+        """All-invalid inputs return empty results with the original schema."""
+        df = _make_pareto_df(
+            [
+                {"tokens/s/user": float("nan"), "tokens/s/gpu": 1000.0},
+                {"tokens/s/user": 100.0, "tokens/s/gpu": float("inf")},
+            ]
+        )
+
+        result = get_pareto_front(df, "tokens/s/user", "tokens/s/gpu")
+
+        assert result.empty
+        assert list(result.columns) == list(df.columns)
 
 
 class TestStrictSlaFiltering:


### PR DESCRIPTION
## Summary
- filter NaN/inf Pareto axis values before frontier computation
- drop non-finite best-config candidates before grouped idxmax selection
- add regression coverage for the all-NaN grouped idxmax crash

Linear: https://linear.app/nvidia/issue/DYN-2796/ga-vdr-fix-aic-profiler-nan-handling-crash-in-pareto-analysis

## Repro
Before the fix, with pandas 2.2.3, all-NaN throughput groups produce NaN idxmax labels and crash:

```text
idxmax result: [nan, nan]
KeyError: "None of [Index([nan, nan], dtype='float64')] are in the [index]"
```

After the fix, the same input returns an empty DataFrame instead of raising.

## Testing
- `/tmp/aic-nan-repro-venv/bin/python - <<'PY' ...` -> `empty: True`
- `PYTHONPATH=src /tmp/aic-nan-repro-venv/bin/python -m pytest -q tests/unit/sdk/picking/test_pareto_sla_filtering.py::TestTpotConstraintFiltering::test_grouped_selection_drops_all_nan_throughput_groups tests/unit/sdk/picking/test_pareto_sla_filtering.py::TestParetoFrontFiltering::test_get_pareto_front_ignores_non_finite_points` -> 2 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced data validation in Pareto analysis to filter out invalid numerical values (infinity, NaN) and verify required input columns exist.
  * Improved constraint-based candidate selection logic to properly exclude invalid data points from results.

* **Tests**
  * Added comprehensive test coverage for edge cases involving invalid data values in Pareto analysis and constraint filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->