### PR TITLE
feat: deepseekv4 moe

### DIFF
--- a/collector/common_test_cases.py
+++ b/collector/common_test_cases.py
@@ -31,6 +31,10 @@ def _filter_model_config_list(model_config_list: list[list]) -> list[list]:
 _WIDEEP_MOE_MODEL_NAMES: set[str] = {
     "deepseek-ai/DeepSeek-V3",
     "deepseek-ai/DeepSeek-V3.2",
+    "deepseek-ai/DeepSeek-V4-Flash",
+    "deepseek-ai/DeepSeek-V4-Pro",
+    "sgl-project/DeepSeek-V4-Flash-FP8",
+    "sgl-project/DeepSeek-V4-Pro-FP8",
     "zai-org/GLM-5",
     "MiniMaxAI/MiniMax-M2.5",
     "moonshotai/Kimi-K2-Instruct",
@@ -52,6 +56,10 @@ _MOE_MODEL_CONFIGS: list[list] = [
     [4096, 14336, 2, 8, "mistralai/Mixtral-8x7B-v0.1"],  # mixtral_8x7b
     [6144, 16384, 2, 8, "mistralai/Mixtral-8x22B-v0.1"],  # mixtral_8x22b
     [7168, 2048, 8, 256, "deepseek-ai/DeepSeek-V3"],  # deepseekv3, will have 1 shared expert, dsv32
+    [4096, 2048, 6, 256, "deepseek-ai/DeepSeek-V4-Flash"],  # deepseekv4, 1 shared expert
+    [7168, 3072, 6, 384, "deepseek-ai/DeepSeek-V4-Pro"],  # deepseekv4, 1 shared expert
+    [4096, 2048, 6, 256, "sgl-project/DeepSeek-V4-Flash-FP8"],  # deepseekv4, 1 shared expert
+    [7168, 3072, 6, 384, "sgl-project/DeepSeek-V4-Pro-FP8"],  # deepseekv4, 1 shared expert
     [6144, 2048, 8, 256, "zai-org/GLM-5"],  # glm-5 (DEEPSEEKV32 family, different hidden_size)
     [2048, 768, 8, 128, "Qwen/Qwen3-30B-A3B"],  # qwen3-moe, 30b-a3b
     [4096, 1536, 8, 128, "Qwen/Qwen3-235B-A22B"],  # qwen3-moe, 235b-a22b

--- a/collector/sglang/collect_moe.py
+++ b/collector/sglang/collect_moe.py
@@ -26,6 +26,7 @@ from sglang.srt.layers.moe.fused_moe_triton.fused_moe_triton_config import (
     get_default_config,
     get_moe_configs,
 )
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
 from sglang.srt.layers.moe.topk import StandardTopKOutput, TopKConfig, select_experts
 from sglang.srt.utils import is_hip
 
@@ -149,6 +150,11 @@ def get_moe_test_cases():
             ):
                 continue
 
+            swiglu_limit = None
+            # DeepSeek-V4 uses swiglu_limit=10
+            if "DeepSeek-V4" in common_moe_testcase.model_name:
+                swiglu_limit = 10
+
             test_cases.append(
                 [
                     moe_type,
@@ -162,6 +168,7 @@ def get_moe_test_cases():
                     common_moe_testcase.model_name,
                     common_moe_testcase.token_expert_distribution,
                     common_moe_testcase.power_law_alpha,
+                    swiglu_limit,
                 ]
             )
 
@@ -195,6 +202,7 @@ def benchmark_config(
     distributed: str = "power_law",
     power_law_alpha: float = 0,
     workloads: list["Rank0Workload"] | None = None,
+    swiglu_limit: float | None = None,
 ) -> float:
     device = torch.device("cuda")
     if workloads is not None:
@@ -508,11 +516,15 @@ def benchmark_config(
                 )
 
             with override_config(config):
+                moe_runner_config = MoeRunnerConfig(
+                    swiglu_limit=swiglu_limit,
+                )
                 fused_moe(
                     current_hidden_states,
                     w1,
                     w2,
                     current_topk_output,
+                    moe_runner_config=moe_runner_config,
                     use_fp8_w8a8=use_fp8_w8a8,
                     use_int8_w8a8=use_int8_w8a8,
                     use_int8_w8a16=use_int8_w8a16,
@@ -563,6 +575,7 @@ def benchmark(
     distributed: str = "power_law",
     power_law_alpha: float = 0,
     workloads: list["Rank0Workload"] | None = None,
+    swiglu_limit: float | None = None,
 ) -> tuple[dict[str, int], float]:
     torch.cuda.manual_seed_all(0)
     benchmark_num_tokens = (
@@ -589,6 +602,7 @@ def benchmark(
             distributed=distributed,
             power_law_alpha=power_law_alpha,
             workloads=workloads,
+            swiglu_limit=swiglu_limit,
         )
         return kernel_time, power_stats
 
@@ -633,6 +647,7 @@ def benchmark(
         distributed=distributed,
         power_law_alpha=power_law_alpha,
         workloads=workloads,
+        swiglu_limit=swiglu_limit,
     )
     return kernel_time, power_stats
 
@@ -712,6 +727,7 @@ def run_moe_torch(
     model_name,
     distributed="power_law",
     power_law_alpha=0,
+    swiglu_limit=None,
     *,
     perf_filename,
     device="cuda:0",
@@ -770,6 +786,7 @@ def run_moe_torch(
             distributed=distributed,
             power_law_alpha=power_law_alpha,
             workloads=rank0_workloads,
+            swiglu_limit=swiglu_limit,
         )
     else:
         latency, power_stats = benchmark(
@@ -787,6 +804,7 @@ def run_moe_torch(
             block_shape=block_shape,
             distributed=distributed,
             power_law_alpha=power_law_alpha,
+            swiglu_limit=swiglu_limit,
         )
 
     log_perf(


### PR DESCRIPTION
#### Overview:

Add DeepSeek-V4 MoE model support (Flash / Pro, BF16 & FP8 variants) to the performance data collector, including the required `swiglu_limit` parameter for the V4 architecture.

#### Details:

1. **Model registration** (`collector/common_test_cases.py`):
   - Added 4 DeepSeek-V4 models to `_WIDEEP_MOE_MODEL_NAMES` for wide-EP dispatch.
   - Added corresponding entries in `_MOE_MODEL_CONFIGS` with V4 architecture parameters:
     - V4-Flash: hidden=4096, intermediate=2048, top_k=6, num_experts=256
     - V4-Pro: hidden=7168, intermediate=3072, top_k=6, num_experts=384

2. **`swiglu_limit` plumbing** (`collector/sglang/collect_moe.py`):
   - DeepSeek-V4 uses `swiglu_limit=10`; auto-detected by model name in `get_moe_test_cases()`.
   - Propagated `swiglu_limit` through the full call chain: `get_moe_test_cases` → `run_moe_torch` → `benchmark` → `benchmark_config`.
   - Constructed `MoeRunnerConfig(swiglu_limit=swiglu_limit)` and passed it to the `fused_moe()` kernel invocation.
#### Where should the reviewer start?

- `collector/common_test_cases.py` — new model entries and architecture configs
- `collector/sglang/collect_moe.py` — `swiglu_limit` parameter threading and `MoeRunnerConfig` integration in `benchmark_config()`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: DeepSeek-V4 MoE performance data collection support


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for four new DeepSeek-V4 model variants (Flash, Pro, and FP8-quantized versions).
  * Enhanced MoE benchmark configuration with improved optimization parameter handling.

* **Chores**
  * Extended MoE model configurations and allowlists to support the new model variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->