### PR TITLE
fix: select support matrix versions semantically

### DIFF
--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -11,7 +11,6 @@ from typing import Any
 
 import pandas as pd
 import yaml
-from packaging.version import InvalidVersion, Version
 
 from aiconfigurator import __version__
 from aiconfigurator.cli.report_and_save import log_final_summary, save_results
@@ -30,16 +29,6 @@ from aiconfigurator.sdk.utils import ListFlowDumper, get_model_config_from_model
 logger = logging.getLogger(__name__)
 
 
-def _parse_support_matrix_version(version: str | None) -> Version | None:
-    """Parse backend versions so 0.5.10 sorts after 0.5.9."""
-    if not version:
-        return None
-    try:
-        return Version(version)
-    except InvalidVersion:
-        return None
-
-
 def _latest_support_matrix_version(
     matrix: list[dict[str, str]],
     system: str,
@@ -47,7 +36,15 @@ def _latest_support_matrix_version(
     model: str | None = None,
     architecture: str | None = None,
 ) -> str | None:
-    rows = [row for row in matrix if row["System"] == system and row["Backend"] == backend]
+    """Pick the highest PEP 440 version for the relevant support-matrix rows.
+
+    Matches system and backend case-insensitively. When a model is provided,
+    exact-model rows win, then architecture rows. If neither model nor
+    architecture matches, return None instead of selecting an unrelated row.
+    """
+    rows = [
+        row for row in matrix if row["System"].lower() == system.lower() and row["Backend"].lower() == backend.lower()
+    ]
 
     if model:
         exact_rows = [row for row in rows if row["HuggingFaceID"].lower() == model.lower()]
@@ -57,11 +54,28 @@ def _latest_support_matrix_version(
             architecture_rows = [row for row in rows if row["Architecture"] == architecture]
             if architecture_rows:
                 rows = architecture_rows
+            else:
+                logger.debug(
+                    "No support-matrix rows match model=%s or architecture=%s for system=%s backend=%s",
+                    model,
+                    architecture,
+                    system,
+                    backend,
+                )
+                return None
+        else:
+            logger.debug(
+                "No exact support-matrix rows match model=%s for system=%s backend=%s and no architecture was provided",
+                model,
+                system,
+                backend,
+            )
+            return None
 
     versions = [
         (version, parsed)
         for version in {row["Version"] for row in rows}
-        if (parsed := _parse_support_matrix_version(version))
+        if (parsed := common.parse_support_matrix_version(version))
     ]
     if not versions:
         return None
@@ -1262,14 +1276,14 @@ def _run_support_matrix_mode(args):
     matrix = common.get_support_matrix()
     systems = sorted(common.SupportedSystems) if args.system == "all" else [args.system]
     backends = [b.value for b in common.BackendName] if args.backend == "all" else [args.backend]
-    existing_combos = {(row["System"], row["Backend"]) for row in matrix}
+    existing_combos = {(row["System"].lower(), row["Backend"].lower()) for row in matrix}
 
     results: dict[tuple[str, str], common.SupportResult | None] = {}
     has_inferred = False
 
     for system in systems:
         for be in backends:
-            if (system, be) not in existing_combos:
+            if (system.lower(), be.lower()) not in existing_combos:
                 results[(system, be)] = None
                 continue
 
@@ -1358,6 +1372,15 @@ def _run_support_mode(args):
     if not version:
         matrix = common.get_support_matrix()
         version = _latest_support_matrix_version(matrix, system, backend, model=model, architecture=architecture)
+        if version is None:
+            logger.info(
+                "No valid support-matrix backend version found for model=%s system=%s backend=%s",
+                model,
+                system,
+                backend,
+            )
+            print("\nNo valid support-matrix backend version found for this model/system/backend combination.\n")
+            return
 
     logger.info("Checking support for model=%s, system=%s, backend=%s, version=%s", model, system, backend, version)
 

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import pandas as pd
 import yaml
+from packaging.version import InvalidVersion, Version
 
 from aiconfigurator import __version__
 from aiconfigurator.cli.report_and_save import log_final_summary, save_results
@@ -27,6 +28,44 @@ from aiconfigurator.sdk.task import TaskConfig, TaskRunner
 from aiconfigurator.sdk.utils import ListFlowDumper, get_model_config_from_model_path
 
 logger = logging.getLogger(__name__)
+
+
+def _parse_support_matrix_version(version: str | None) -> Version | None:
+    """Parse backend versions so 0.5.10 sorts after 0.5.9."""
+    if not version:
+        return None
+    try:
+        return Version(version)
+    except InvalidVersion:
+        return None
+
+
+def _latest_support_matrix_version(
+    matrix: list[dict[str, str]],
+    system: str,
+    backend: str,
+    model: str | None = None,
+    architecture: str | None = None,
+) -> str | None:
+    rows = [row for row in matrix if row["System"] == system and row["Backend"] == backend]
+
+    if model:
+        exact_rows = [row for row in rows if row["HuggingFaceID"].lower() == model.lower()]
+        if exact_rows:
+            rows = exact_rows
+        elif architecture:
+            architecture_rows = [row for row in rows if row["Architecture"] == architecture]
+            if architecture_rows:
+                rows = architecture_rows
+
+    versions = [
+        (version, parsed)
+        for version in {row["Version"] for row in rows}
+        if (parsed := _parse_support_matrix_version(version))
+    ]
+    if not versions:
+        return None
+    return max(versions, key=lambda version: version[1])[0]
 
 
 def _build_common_cli_parser() -> argparse.ArgumentParser:
@@ -1237,14 +1276,10 @@ def _run_support_matrix_mode(args):
             if version_filter:
                 version = version_filter
             else:
-                versions = sorted(
-                    {r["Version"] for r in matrix if r["System"] == system and r["Backend"] == be},
-                    reverse=True,
-                )
-                if not versions:
+                version = _latest_support_matrix_version(matrix, system, be, model=model, architecture=architecture)
+                if version is None:
                     results[(system, be)] = None
                     continue
-                version = versions[0]
 
             result = common.check_support(
                 model=model, system=system, backend=be, version=version, architecture=architecture
@@ -1312,21 +1347,19 @@ def _run_support_mode(args):
     backend = args.backend
     version = args.backend_version
 
-    # If no version specified, find the latest version in the support matrix
-    if not version:
-        matrix = common.get_support_matrix()
-        versions_for_combo = [row["Version"] for row in matrix if row["System"] == system and row["Backend"] == backend]
-        if versions_for_combo:
-            version = sorted(set(versions_for_combo), reverse=True)[0]
-
-    logger.info("Checking support for model=%s, system=%s, backend=%s, version=%s", model, system, backend, version)
-
     # Resolve architecture for better check
     try:
         model_info = get_model_config_from_model_path(model)
         architecture = model_info["architecture"]
     except Exception:
         architecture = None
+
+    # If no version specified, find the latest model-relevant version in the support matrix
+    if not version:
+        matrix = common.get_support_matrix()
+        version = _latest_support_matrix_version(matrix, system, backend, model=model, architecture=architecture)
+
+    logger.info("Checking support for model=%s, system=%s, backend=%s, version=%s", model, system, backend, version)
 
     result = common.check_support(
         model=model, system=system, backend=backend, version=version, architecture=architecture

--- a/src/aiconfigurator/sdk/common.py
+++ b/src/aiconfigurator/sdk/common.py
@@ -8,6 +8,18 @@ from enum import Enum
 from functools import cache
 from importlib import resources as pkg_resources
 
+from packaging.version import InvalidVersion, Version
+
+
+def parse_support_matrix_version(version: str | None) -> Version | None:
+    """Parse a support-matrix backend version as PEP 440, or return None."""
+    if not version:
+        return None
+    try:
+        return Version(version)
+    except InvalidVersion:
+        return None
+
 
 @dataclass(frozen=True)
 class BlockConfig:
@@ -226,7 +238,7 @@ def check_support(
     matrix = get_support_matrix()
 
     def _matches_filters(row: dict, backend: str | None, version: str | None) -> bool:
-        if backend and row["Backend"] != backend:
+        if backend and row["Backend"].lower() != backend.lower():
             return False
         return not (version and row["Version"] != version)
 
@@ -240,7 +252,7 @@ def check_support(
     ]
 
     # Resolve architecture from matrix if model is found anywhere
-    matrix_arch = next((row["Architecture"] for row in matrix if row["HuggingFaceID"] == model), None)
+    matrix_arch = next((row["Architecture"] for row in matrix if row["HuggingFaceID"].lower() == model.lower()), None)
 
     if exact_matches:
         return SupportResult(
@@ -258,7 +270,9 @@ def check_support(
     arch_matches = [
         row
         for row in matrix
-        if row["Architecture"] == architecture and row["System"] == system and _matches_filters(row, backend, version)
+        if row["Architecture"] == architecture
+        and row["System"].lower() == system.lower()
+        and _matches_filters(row, backend, version)
     ]
 
     agg_results = [row["Status"] == "PASS" for row in arch_matches if row["Mode"] == "agg"]

--- a/src/aiconfigurator/webapp/components/support_matrix_tab.py
+++ b/src/aiconfigurator/webapp/components/support_matrix_tab.py
@@ -6,7 +6,7 @@ import re
 
 import gradio as gr
 import pandas as pd
-from packaging.version import InvalidVersion, Version
+from packaging.version import Version
 
 from aiconfigurator.sdk import common
 
@@ -16,12 +16,7 @@ def parse_version(ver_str):
     Parse version string into comparable Version (PEP 440).
     Invalid or empty strings return Version("0.0.0") so they sort first.
     """
-    if not ver_str:
-        return Version("0.0.0")
-    try:
-        return Version(ver_str)
-    except InvalidVersion:
-        return Version("0.0.0")
+    return common.parse_support_matrix_version(ver_str) or Version("0.0.0")
 
 
 # Cell colors for support matrix (used in styling and legend)

--- a/tests/unit/cli/test_support_matrix_version.py
+++ b/tests/unit/cli/test_support_matrix_version.py
@@ -1,9 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from types import SimpleNamespace
+
 import pytest
 
-from aiconfigurator.cli.main import _latest_support_matrix_version
+from aiconfigurator.cli.main import _latest_support_matrix_version, _run_support_mode
 
 pytestmark = pytest.mark.unit
 
@@ -49,6 +51,12 @@ def test_latest_support_matrix_version_selects_latest_valid_version(versions, ex
     matrix = [_row(version=version) for version in versions]
 
     assert _latest_support_matrix_version(matrix, "b200_sxm", "sglang", model="model") == expected_version
+
+
+def test_latest_support_matrix_version_matches_system_and_backend_case_insensitively():
+    matrix = [_row(version="0.5.10")]
+
+    assert _latest_support_matrix_version(matrix, "B200_SXM", "SGLang", model="model") == "0.5.10"
 
 
 @pytest.mark.parametrize(
@@ -113,3 +121,48 @@ def test_latest_support_matrix_version_scopes_rows_by_model_or_architecture(
         )
         == expected_version
     )
+
+
+def test_latest_support_matrix_version_does_not_fall_back_to_unrelated_rows():
+    matrix = [
+        _row(model="Qwen/Qwen3-32B", architecture="Qwen3ForCausalLM", version="0.5.9"),
+        _row(model="zai-org/GLM-5-FP8", architecture="GlmMoeDsaForCausalLM", version="0.5.10"),
+    ]
+
+    assert (
+        _latest_support_matrix_version(
+            matrix,
+            "b200_sxm",
+            "sglang",
+            model="local-unknown-model",
+            architecture="UnknownArchitecture",
+        )
+        is None
+    )
+
+
+def test_run_support_mode_stops_when_auto_version_is_unavailable(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "aiconfigurator.cli.main.get_model_config_from_model_path",
+        lambda _model: {"architecture": "UnknownArchitecture"},
+    )
+    monkeypatch.setattr(
+        "aiconfigurator.cli.main.common.get_support_matrix",
+        lambda: [_row(model="Qwen/Qwen3-32B", architecture="Qwen3ForCausalLM", version="0.5.10")],
+    )
+
+    def fail_check_support(*_args, **_kwargs):
+        raise AssertionError("check_support should not run without an auto-selected version")
+
+    monkeypatch.setattr("aiconfigurator.cli.main.common.check_support", fail_check_support)
+
+    _run_support_mode(
+        SimpleNamespace(
+            backend="sglang",
+            backend_version=None,
+            model_path="local-unknown-model",
+            system="b200_sxm",
+        )
+    )
+
+    assert "No valid support-matrix backend version found" in capsys.readouterr().out

--- a/tests/unit/cli/test_support_matrix_version.py
+++ b/tests/unit/cli/test_support_matrix_version.py
@@ -8,131 +8,87 @@ from aiconfigurator.cli.main import _latest_support_matrix_version
 pytestmark = pytest.mark.unit
 
 
-def test_latest_support_matrix_version_uses_semantic_sorting():
-    matrix = [
-        {
-            "HuggingFaceID": "model",
-            "Architecture": "Arch",
-            "System": "b200_sxm",
-            "Backend": "sglang",
-            "Version": "0.5.9",
-        },
-        {
-            "HuggingFaceID": "model",
-            "Architecture": "Arch",
-            "System": "b200_sxm",
-            "Backend": "sglang",
-            "Version": "0.5.10",
-        },
-    ]
-
-    assert _latest_support_matrix_version(matrix, "b200_sxm", "sglang", model="model") == "0.5.10"
+def _row(
+    *,
+    model: str = "model",
+    architecture: str = "Arch",
+    system: str = "b200_sxm",
+    backend: str = "sglang",
+    version: str,
+) -> dict[str, str]:
+    return {
+        "HuggingFaceID": model,
+        "Architecture": architecture,
+        "System": system,
+        "Backend": backend,
+        "Version": version,
+    }
 
 
-def test_latest_support_matrix_version_ignores_invalid_versions():
-    matrix = [
-        {
-            "HuggingFaceID": "model",
-            "Architecture": "Arch",
-            "System": "b200_sxm",
-            "Backend": "sglang",
-            "Version": "",
-        },
-        {
-            "HuggingFaceID": "model",
-            "Architecture": "Arch",
-            "System": "b200_sxm",
-            "Backend": "sglang",
-            "Version": "bad-version",
-        },
-        {
-            "HuggingFaceID": "model",
-            "Architecture": "Arch",
-            "System": "b200_sxm",
-            "Backend": "sglang",
-            "Version": "0.5.10",
-        },
-    ]
+@pytest.mark.parametrize(
+    ("matrix", "kwargs", "expected"),
+    [
+        pytest.param(
+            [_row(version="0.5.9"), _row(version="0.5.10")],
+            {},
+            "0.5.10",
+            id="semantic-version-sort",
+        ),
+        pytest.param(
+            [_row(version=""), _row(version="bad-version"), _row(version="0.5.10")],
+            {},
+            "0.5.10",
+            id="ignore-invalid-versions",
+        ),
+        pytest.param(
+            [_row(version=""), _row(version="bad-version")],
+            {},
+            None,
+            id="no-valid-versions",
+        ),
+        pytest.param(
+            [
+                _row(
+                    model="Qwen/Qwen3-32B",
+                    architecture="Qwen3ForCausalLM",
+                    system="b300_sxm",
+                    version="0.5.9",
+                ),
+                _row(
+                    model="zai-org/GLM-5",
+                    architecture="GlmMoeDsaForCausalLM",
+                    system="b300_sxm",
+                    version="0.5.10",
+                ),
+            ],
+            {
+                "system": "b300_sxm",
+                "model": "Qwen/Qwen3-32B",
+                "architecture": "Qwen3ForCausalLM",
+            },
+            "0.5.9",
+            id="prefer-exact-model",
+        ),
+        pytest.param(
+            [
+                _row(
+                    model="deepseek-ai/DeepSeek-V3.2",
+                    architecture="GlmMoeDsaForCausalLM",
+                    version="0.5.9",
+                ),
+                _row(
+                    model="zai-org/GLM-5-FP8",
+                    architecture="GlmMoeDsaForCausalLM",
+                    version="0.5.10",
+                ),
+            ],
+            {"model": "local-glm5-variant", "architecture": "GlmMoeDsaForCausalLM"},
+            "0.5.10",
+            id="architecture-fallback",
+        ),
+    ],
+)
+def test_latest_support_matrix_version(matrix, kwargs, expected):
+    options = {"system": "b200_sxm", "backend": "sglang", "model": "model"} | kwargs
 
-    assert _latest_support_matrix_version(matrix, "b200_sxm", "sglang", model="model") == "0.5.10"
-
-
-def test_latest_support_matrix_version_returns_none_without_valid_versions():
-    matrix = [
-        {
-            "HuggingFaceID": "model",
-            "Architecture": "Arch",
-            "System": "b200_sxm",
-            "Backend": "sglang",
-            "Version": "",
-        },
-        {
-            "HuggingFaceID": "model",
-            "Architecture": "Arch",
-            "System": "b200_sxm",
-            "Backend": "sglang",
-            "Version": "bad-version",
-        },
-    ]
-
-    assert _latest_support_matrix_version(matrix, "b200_sxm", "sglang", model="model") is None
-
-
-def test_latest_support_matrix_version_prefers_exact_model_rows():
-    matrix = [
-        {
-            "HuggingFaceID": "Qwen/Qwen3-32B",
-            "Architecture": "Qwen3ForCausalLM",
-            "System": "b300_sxm",
-            "Backend": "sglang",
-            "Version": "0.5.9",
-        },
-        {
-            "HuggingFaceID": "zai-org/GLM-5",
-            "Architecture": "GlmMoeDsaForCausalLM",
-            "System": "b300_sxm",
-            "Backend": "sglang",
-            "Version": "0.5.10",
-        },
-    ]
-
-    assert (
-        _latest_support_matrix_version(
-            matrix,
-            "b300_sxm",
-            "sglang",
-            model="Qwen/Qwen3-32B",
-            architecture="Qwen3ForCausalLM",
-        )
-        == "0.5.9"
-    )
-
-
-def test_latest_support_matrix_version_uses_architecture_when_exact_rows_are_missing():
-    matrix = [
-        {
-            "HuggingFaceID": "deepseek-ai/DeepSeek-V3.2",
-            "Architecture": "GlmMoeDsaForCausalLM",
-            "System": "b200_sxm",
-            "Backend": "sglang",
-            "Version": "0.5.9",
-        },
-        {
-            "HuggingFaceID": "zai-org/GLM-5-FP8",
-            "Architecture": "GlmMoeDsaForCausalLM",
-            "System": "b200_sxm",
-            "Backend": "sglang",
-            "Version": "0.5.10",
-        },
-    ]
-
-    assert (
-        _latest_support_matrix_version(
-            matrix,
-            "b200_sxm",
-            "sglang",
-            model="local-glm5-variant",
-            architecture="GlmMoeDsaForCausalLM",
-        )
-        == "0.5.10"
-    )
+    assert _latest_support_matrix_version(matrix, **options) == expected

--- a/tests/unit/cli/test_support_matrix_version.py
+++ b/tests/unit/cli/test_support_matrix_version.py
@@ -26,26 +26,34 @@ def _row(
 
 
 @pytest.mark.parametrize(
-    ("matrix", "kwargs", "expected"),
+    ("versions", "expected_version"),
     [
         pytest.param(
-            [_row(version="0.5.9"), _row(version="0.5.10")],
-            {},
+            ["0.5.9", "0.5.10"],
             "0.5.10",
             id="semantic-version-sort",
         ),
         pytest.param(
-            [_row(version=""), _row(version="bad-version"), _row(version="0.5.10")],
-            {},
+            ["", "bad-version", "0.5.10"],
             "0.5.10",
             id="ignore-invalid-versions",
         ),
         pytest.param(
-            [_row(version=""), _row(version="bad-version")],
-            {},
+            ["", "bad-version"],
             None,
             id="no-valid-versions",
         ),
+    ],
+)
+def test_latest_support_matrix_version_selects_latest_valid_version(versions, expected_version):
+    matrix = [_row(version=version) for version in versions]
+
+    assert _latest_support_matrix_version(matrix, "b200_sxm", "sglang", model="model") == expected_version
+
+
+@pytest.mark.parametrize(
+    ("matrix", "system", "model", "architecture", "expected_version"),
+    [
         pytest.param(
             [
                 _row(
@@ -61,11 +69,9 @@ def _row(
                     version="0.5.10",
                 ),
             ],
-            {
-                "system": "b300_sxm",
-                "model": "Qwen/Qwen3-32B",
-                "architecture": "Qwen3ForCausalLM",
-            },
+            "b300_sxm",
+            "Qwen/Qwen3-32B",
+            "Qwen3ForCausalLM",
             "0.5.9",
             id="prefer-exact-model",
         ),
@@ -82,13 +88,28 @@ def _row(
                     version="0.5.10",
                 ),
             ],
-            {"model": "local-glm5-variant", "architecture": "GlmMoeDsaForCausalLM"},
+            "b200_sxm",
+            "local-glm5-variant",
+            "GlmMoeDsaForCausalLM",
             "0.5.10",
             id="architecture-fallback",
         ),
     ],
 )
-def test_latest_support_matrix_version(matrix, kwargs, expected):
-    options = {"system": "b200_sxm", "backend": "sglang", "model": "model"} | kwargs
-
-    assert _latest_support_matrix_version(matrix, **options) == expected
+def test_latest_support_matrix_version_scopes_rows_by_model_or_architecture(
+    matrix,
+    system,
+    model,
+    architecture,
+    expected_version,
+):
+    assert (
+        _latest_support_matrix_version(
+            matrix,
+            system,
+            "sglang",
+            model=model,
+            architecture=architecture,
+        )
+        == expected_version
+    )

--- a/tests/unit/cli/test_support_matrix_version.py
+++ b/tests/unit/cli/test_support_matrix_version.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from aiconfigurator.cli.main import _latest_support_matrix_version
+
+pytestmark = pytest.mark.unit
+
+
+def test_latest_support_matrix_version_uses_semantic_sorting():
+    matrix = [
+        {
+            "HuggingFaceID": "model",
+            "Architecture": "Arch",
+            "System": "b200_sxm",
+            "Backend": "sglang",
+            "Version": "0.5.9",
+        },
+        {
+            "HuggingFaceID": "model",
+            "Architecture": "Arch",
+            "System": "b200_sxm",
+            "Backend": "sglang",
+            "Version": "0.5.10",
+        },
+    ]
+
+    assert _latest_support_matrix_version(matrix, "b200_sxm", "sglang", model="model") == "0.5.10"
+
+
+def test_latest_support_matrix_version_ignores_invalid_versions():
+    matrix = [
+        {
+            "HuggingFaceID": "model",
+            "Architecture": "Arch",
+            "System": "b200_sxm",
+            "Backend": "sglang",
+            "Version": "",
+        },
+        {
+            "HuggingFaceID": "model",
+            "Architecture": "Arch",
+            "System": "b200_sxm",
+            "Backend": "sglang",
+            "Version": "bad-version",
+        },
+        {
+            "HuggingFaceID": "model",
+            "Architecture": "Arch",
+            "System": "b200_sxm",
+            "Backend": "sglang",
+            "Version": "0.5.10",
+        },
+    ]
+
+    assert _latest_support_matrix_version(matrix, "b200_sxm", "sglang", model="model") == "0.5.10"
+
+
+def test_latest_support_matrix_version_returns_none_without_valid_versions():
+    matrix = [
+        {
+            "HuggingFaceID": "model",
+            "Architecture": "Arch",
+            "System": "b200_sxm",
+            "Backend": "sglang",
+            "Version": "",
+        },
+        {
+            "HuggingFaceID": "model",
+            "Architecture": "Arch",
+            "System": "b200_sxm",
+            "Backend": "sglang",
+            "Version": "bad-version",
+        },
+    ]
+
+    assert _latest_support_matrix_version(matrix, "b200_sxm", "sglang", model="model") is None
+
+
+def test_latest_support_matrix_version_prefers_exact_model_rows():
+    matrix = [
+        {
+            "HuggingFaceID": "Qwen/Qwen3-32B",
+            "Architecture": "Qwen3ForCausalLM",
+            "System": "b300_sxm",
+            "Backend": "sglang",
+            "Version": "0.5.9",
+        },
+        {
+            "HuggingFaceID": "zai-org/GLM-5",
+            "Architecture": "GlmMoeDsaForCausalLM",
+            "System": "b300_sxm",
+            "Backend": "sglang",
+            "Version": "0.5.10",
+        },
+    ]
+
+    assert (
+        _latest_support_matrix_version(
+            matrix,
+            "b300_sxm",
+            "sglang",
+            model="Qwen/Qwen3-32B",
+            architecture="Qwen3ForCausalLM",
+        )
+        == "0.5.9"
+    )
+
+
+def test_latest_support_matrix_version_uses_architecture_when_exact_rows_are_missing():
+    matrix = [
+        {
+            "HuggingFaceID": "deepseek-ai/DeepSeek-V3.2",
+            "Architecture": "GlmMoeDsaForCausalLM",
+            "System": "b200_sxm",
+            "Backend": "sglang",
+            "Version": "0.5.9",
+        },
+        {
+            "HuggingFaceID": "zai-org/GLM-5-FP8",
+            "Architecture": "GlmMoeDsaForCausalLM",
+            "System": "b200_sxm",
+            "Backend": "sglang",
+            "Version": "0.5.10",
+        },
+    ]
+
+    assert (
+        _latest_support_matrix_version(
+            matrix,
+            "b200_sxm",
+            "sglang",
+            model="local-glm5-variant",
+            architecture="GlmMoeDsaForCausalLM",
+        )
+        == "0.5.10"
+    )

--- a/tests/unit/sdk/test_common.py
+++ b/tests/unit/sdk/test_common.py
@@ -99,3 +99,42 @@ class TestSupportMatrix:
         agg, disagg = common.check_support(model, system, backend, version, architecture)
         assert agg is expected_agg
         assert disagg is expected_disagg
+
+    def test_check_support_matches_architecture_fallback_case_insensitively(self, monkeypatch):
+        """Test system/backend case normalization for architecture-based fallback."""
+        monkeypatch.setattr(
+            common,
+            "get_support_matrix",
+            lambda: [
+                {
+                    "HuggingFaceID": "Qwen/Qwen3-32B",
+                    "Architecture": "Qwen3ForCausalLM",
+                    "System": "b200_sxm",
+                    "Backend": "sglang",
+                    "Version": "0.5.10",
+                    "Mode": "agg",
+                    "Status": "PASS",
+                },
+                {
+                    "HuggingFaceID": "Qwen/Qwen3-32B",
+                    "Architecture": "Qwen3ForCausalLM",
+                    "System": "b200_sxm",
+                    "Backend": "sglang",
+                    "Version": "0.5.10",
+                    "Mode": "disagg",
+                    "Status": "PASS",
+                },
+            ],
+        )
+
+        result = common.check_support(
+            "local-qwen-variant",
+            "B200_SXM",
+            backend="SGLang",
+            version="0.5.10",
+            architecture="Qwen3ForCausalLM",
+        )
+
+        assert result.agg_supported is True
+        assert result.disagg_supported is True
+        assert result.exact_match is False


### PR DESCRIPTION
## Summary
- Select support-matrix backend versions with semantic version parsing so `0.5.10` sorts after `0.5.9`.
- Prefer exact model rows before architecture fallback when auto-selecting a support-matrix version.
- Ignore empty/invalid version strings and return `None` when no valid version is available.

## Impact
This improves `aiconfigurator cli support` preflight accuracy when users omit `--backend-version`, especially for branches that contain model-specific newer rows. It does not change `cli default`/`TaskRunner` backend resolution; that path already uses `get_latest_database_version()` from the perf DB layer.

## Tests
- `python3 -m py_compile src/aiconfigurator/cli/main.py tests/unit/cli/test_support_matrix_version.py`
- Manual helper behavior checks for `0.5.10 > 0.5.9` and invalid-version handling

Note: local `pytest`/`ruff` entry points are not installed in this checkout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed support matrix matching to perform case-insensitive comparisons for system and backend values.
  * Improved architecture detection through model-based lookup.

* **New Features**
  * Added automatic version selection from support matrix when no explicit version is provided.

* **Tests**
  * Added comprehensive test coverage for version selection logic and architecture fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->