### PR TITLE
fix: deep-ep failure should not block e2e workflow

### DIFF
--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -819,9 +819,15 @@ def build_default_task_configs(
         if backend_name == "sglang" and not enable_wideep and is_moe_model:
             deepep_kwargs = dict(agg_kwargs)
             deepep_kwargs["moe_backend"] = "deepep_moe"
-            deepep_task = TaskConfig(serving_mode="agg", **deepep_kwargs)
-            deepep_name = f"agg_{backend_name}_deepep" if backend == "auto" else "agg_deepep"
-            task_configs[deepep_name] = deepep_task
+            try:
+                deepep_task = TaskConfig(serving_mode="agg", **deepep_kwargs)
+            except ValueError as exc:
+                if "Unsupported wideep_" not in str(exc):
+                    raise
+                logger.info("Skipping SGLang DeepEP agg sweep: %s", exc)
+            else:
+                deepep_name = f"agg_{backend_name}_deepep" if backend == "auto" else "agg_deepep"
+                task_configs[deepep_name] = deepep_task
 
         if total_gpus < 2:
             logger.warning("Skipping disagg since it requires at least 2 GPUs.")
@@ -841,10 +847,15 @@ def build_default_task_configs(
         if backend_name == "sglang" and not enable_wideep and is_moe_model:
             deepep_disagg_kwargs = dict(disagg_kwargs)
             deepep_disagg_kwargs["moe_backend"] = "deepep_moe"
-            deepep_disagg_task = TaskConfig(serving_mode="disagg", **deepep_disagg_kwargs)
-            deepep_name = f"disagg_{backend_name}_deepep" if backend == "auto" else "disagg_deepep"
-            task_configs[deepep_name] = deepep_disagg_task
-
+            try:
+                deepep_disagg_task = TaskConfig(serving_mode="disagg", **deepep_disagg_kwargs)
+            except ValueError as exc:
+                if "Unsupported wideep_" not in str(exc):
+                    raise
+                logger.info("Skipping SGLang DeepEP disagg sweep: %s", exc)
+            else:
+                deepep_name = f"disagg_{backend_name}_deepep" if backend == "auto" else "disagg_deepep"
+                task_configs[deepep_name] = deepep_disagg_task
     return task_configs
 
 

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -23,7 +23,7 @@ from aiconfigurator.generator.api import (
 from aiconfigurator.logging_utils import setup_logging
 from aiconfigurator.sdk import common, perf_database
 from aiconfigurator.sdk.models import check_is_moe
-from aiconfigurator.sdk.task import TaskConfig, TaskRunner
+from aiconfigurator.sdk.task import TaskConfig, TaskRunner, UnsupportedWideepConfigError
 from aiconfigurator.sdk.utils import ListFlowDumper, get_model_config_from_model_path
 
 logger = logging.getLogger(__name__)
@@ -821,9 +821,7 @@ def build_default_task_configs(
             deepep_kwargs["moe_backend"] = "deepep_moe"
             try:
                 deepep_task = TaskConfig(serving_mode="agg", **deepep_kwargs)
-            except ValueError as exc:
-                if "Unsupported wideep_" not in str(exc):
-                    raise
+            except UnsupportedWideepConfigError as exc:
                 logger.info("Skipping SGLang DeepEP agg sweep: %s", exc)
             else:
                 deepep_name = f"agg_{backend_name}_deepep" if backend == "auto" else "agg_deepep"
@@ -849,9 +847,7 @@ def build_default_task_configs(
             deepep_disagg_kwargs["moe_backend"] = "deepep_moe"
             try:
                 deepep_disagg_task = TaskConfig(serving_mode="disagg", **deepep_disagg_kwargs)
-            except ValueError as exc:
-                if "Unsupported wideep_" not in str(exc):
-                    raise
+            except UnsupportedWideepConfigError as exc:
                 logger.info("Skipping SGLang DeepEP disagg sweep: %s", exc)
             else:
                 deepep_name = f"disagg_{backend_name}_deepep" if backend == "auto" else "disagg_deepep"

--- a/src/aiconfigurator/sdk/task.py
+++ b/src/aiconfigurator/sdk/task.py
@@ -24,6 +24,11 @@ logger = logging.getLogger(__name__)
 DEFAULT_PREFILL_LATENCY_CORRECTION_SCALE = 1.1
 DEFAULT_DECODE_LATENCY_CORRECTION_SCALE = 1.08
 
+
+class UnsupportedWideepConfigError(ValueError):
+    """Raised when a requested WideEP configuration is not supported by perf data."""
+
+
 _DEEPSEEK_V4_NATIVE_FP4_TO_FP8_MODEL = {
     "deepseek-ai/DeepSeek-V4-Flash": "sgl-project/DeepSeek-V4-Flash-FP8",
     "deepseek-ai/DeepSeek-V4-Pro": "sgl-project/DeepSeek-V4-Pro-FP8",
@@ -907,7 +912,8 @@ class TaskConfig:
                 return
             supported_modes = supported.get(op, []) or []
             if supported_modes and mode_name not in supported_modes:
-                raise ValueError(
+                exc_type = UnsupportedWideepConfigError if op.startswith("wideep_") else ValueError
+                raise exc_type(
                     f"Unsupported {op} quant mode '{mode_name}' for system='{self.system_name}', "
                     f"backend='{self.backend_name}', version='{self.backend_version}'. "
                     f"Supported {op} modes: {sorted(supported_modes)}"


### PR DESCRIPTION
# Overview

Fixes default SGLang MoE runs for models whose regular MoE quant mode is supported but DeepEP/WideEP data is not.

RFR: Author of #684 @changhuaixin & reviewer of #684 @Arsene12358 

## Detailed Bug Trigger

In default mode, AIConfigurator auto-adds SGLang DeepEP agg/disagg sweeps for MoE models. For `moonshotai/Kimi-K2.5`, the model resolves to `int4_wo`, which is present in regular `moe_perf.txt` but not in `wideep_context_moe_perf.txt` / `wideep_generation_moe_perf.txt`. This caused the default CLI flow to fail during optional DeepEP task construction before regular SGLang agg/disagg could run.

This change keeps the existing DeepEP auto-sweep behavior, but treats unsupported wideep_* quant-mode validation errors as a reason to skip only the optional DeepEP variant. Other validation errors are still raised. Explicit --enable-wideep behavior is unchanged.

# Example
The following command was failed but fixed:
```bash
aiconfigurator cli default --model moonshotai/Kimi-K2.5 --total-gpus 32 --backend sglang --system h100_sxm
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for SGLang task configuration generation with Mixture of Experts models. Unsupported configuration variants are now gracefully skipped instead of causing failures, improving stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->