### PR TITLE
[AIC-937] Record collector power analysis stats

### DIFF
--- a/collector/README.md
+++ b/collector/README.md
@@ -190,13 +190,18 @@ python3 collect.py --backend trtllm --measure_power --power_test_duration_sec 2.
 
 ### Output
 When power monitoring is enabled, performance CSV files will include additional columns:
-- `power`: Average power consumption during kernel execution (Watts)
+- `power`: Time-weighted average power consumption during kernel execution (Watts)
 - `power_limit`: GPU power management limit (Watts)
+- `power_min`: Minimum observed power sample (Watts)
+- `power_max`: Maximum observed power sample (Watts)
+- `power_energy_j`: Integrated GPU energy over the measured sample window (Joules)
+- `power_duration_s`: Sample window duration (seconds)
+- `power_sample_count`: Number of NVML power samples captured
 
 **Example output:**
 ```csv
-framework,version,device,op_name,kernel_source,gemm_dtype,m,n,k,latency,power,power_limit
-TRTLLM,1.2.0,NVIDIA H200 SXM,gemm,torch_flow,bfloat16,1024,4096,4096,0.234,523.4,700.0
+framework,version,device,op_name,kernel_source,gemm_dtype,m,n,k,latency,power,power_limit,power_min,power_max,power_energy_j,power_duration_s,power_sample_count
+TRTLLM,1.2.0,NVIDIA H200 SXM,gemm,torch_flow,bfloat16,1024,4096,4096,0.234,523.4,700.0,498.1,548.8,523.4,1.0,11
 ```
 
 ### Requirements

--- a/collector/helper.py
+++ b/collector/helper.py
@@ -27,6 +27,16 @@ EXIT_CODE_RESTART = 10  # Exit code to indicate restart is needed
 _NVML_INITIALIZED = False
 _NVML_LOCK = threading.Lock()
 
+POWER_STATS_FIELDS = [
+    "power",
+    "power_limit",
+    "power_min",
+    "power_max",
+    "power_energy_j",
+    "power_duration_s",
+    "power_sample_count",
+]
+
 
 def _parse_bool_env(env_var: str, default: bool = False) -> bool:
     """
@@ -63,6 +73,56 @@ def _ensure_nvml_initialized():
                 logging.getLogger(__name__).warning(f"Failed to initialize NVML: {e}")
                 return False
         return _NVML_INITIALIZED
+
+
+def summarize_power_samples(
+    samples: list[tuple[float, int | float]],
+    power_limit_mw: int | float | None = None,
+) -> dict | None:
+    """Summarize NVML power samples.
+
+    Args:
+        samples: ``(timestamp_s, power_mw)`` samples from NVML.
+        power_limit_mw: Optional NVML power-management limit in milliwatts.
+
+    Returns:
+        Power stats compatible with collector perf CSV rows, or ``None`` when
+        no samples are available.
+    """
+    if not samples:
+        return None
+
+    samples = sorted((float(ts), float(power_mw)) for ts, power_mw in samples)
+    power_values_w = [power_mw / 1000.0 for _, power_mw in samples]
+
+    start_s = samples[0][0]
+    end_s = samples[-1][0]
+    duration_s = max(0.0, end_s - start_s)
+
+    energy_j = 0.0
+    if len(samples) >= 2:
+        for (left_ts, left_power_mw), (right_ts, right_power_mw) in zip(samples, samples[1:]):
+            delta_s = right_ts - left_ts
+            if delta_s <= 0:
+                continue
+            left_power_w = left_power_mw / 1000.0
+            right_power_w = right_power_mw / 1000.0
+            energy_j += ((left_power_w + right_power_w) / 2.0) * delta_s
+
+    if duration_s > 0:
+        average_power_w = energy_j / duration_s
+    else:
+        average_power_w = float(np.mean(power_values_w))
+
+    return {
+        "power": float(average_power_w),
+        "power_limit": float(power_limit_mw / 1000.0) if power_limit_mw else None,
+        "power_min": float(min(power_values_w)),
+        "power_max": float(max(power_values_w)),
+        "power_energy_j": float(energy_j),
+        "power_duration_s": float(duration_s),
+        "power_sample_count": len(samples),
+    }
 
 
 class PowerMonitor:
@@ -134,14 +194,9 @@ class PowerMonitor:
         with self._lock:
             if not self._samples:
                 return None
-            power_values_w = [p_mw / 1000.0 for _, p_mw in self._samples]
+            samples = list(self._samples)
 
-        import numpy as np
-
-        return {
-            "power": float(np.mean(power_values_w)),
-            "power_limit": float(self._power_limit_mw / 1000.0) if self._power_limit_mw else None,
-        }
+        return summarize_power_samples(samples, power_limit_mw=self._power_limit_mw)
 
     def _monitoring_loop(self):
         """Background thread function that samples power every 100ms."""
@@ -685,7 +740,7 @@ def log_perf(
                 fieldnames += list(item_list[0].keys())
             # Add power_stats keys if present
             if power_stats:
-                for key in ["power", "power_limit"]:
+                for key in POWER_STATS_FIELDS:
                     if key not in fieldnames:
                         fieldnames.append(key)
 
@@ -698,7 +753,7 @@ def log_perf(
                 row = base_data | item
                 # Add power_stats values if present
                 if power_stats:
-                    for key in ["power", "power_limit"]:
+                    for key in POWER_STATS_FIELDS:
                         row[key] = power_stats.get(key, "")
                 writer.writerow(row)
 

--- a/tests/unit/collector/test_power_stats.py
+++ b/tests/unit/collector/test_power_stats.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import csv
+import sys
+from pathlib import Path
+
+import pytest
+
+_COLLECTOR_DIR = str(Path(__file__).resolve().parents[3] / "collector")
+if _COLLECTOR_DIR not in sys.path:
+    sys.path.insert(0, _COLLECTOR_DIR)
+
+from helper import log_perf, summarize_power_samples
+
+
+def test_summarize_power_samples_integrates_energy_with_trapezoids():
+    stats = summarize_power_samples(
+        [
+            (2.0, 100_000),
+            (0.0, 100_000),
+            (1.0, 200_000),
+        ],
+        power_limit_mw=700_000,
+    )
+
+    assert stats == {
+        "power": 150.0,
+        "power_limit": 700.0,
+        "power_min": 100.0,
+        "power_max": 200.0,
+        "power_energy_j": 300.0,
+        "power_duration_s": 2.0,
+        "power_sample_count": 3,
+    }
+
+
+def test_summarize_power_samples_uses_arithmetic_mean_without_duration():
+    stats = summarize_power_samples([(10.0, 125_000)])
+
+    assert stats["power"] == 125.0
+    assert stats["power_limit"] is None
+    assert stats["power_min"] == 125.0
+    assert stats["power_max"] == 125.0
+    assert stats["power_energy_j"] == 0.0
+    assert stats["power_duration_s"] == 0.0
+    assert stats["power_sample_count"] == 1
+
+
+def test_summarize_power_samples_empty_returns_none():
+    assert summarize_power_samples([]) is None
+
+
+def test_log_perf_writes_power_analysis_fields(tmp_path):
+    perf_path = tmp_path / "perf.csv"
+    log_perf(
+        item_list=[{"latency": 3.5}],
+        framework="vllm",
+        version="0.19.0",
+        device_name="H100",
+        op_name="gemm",
+        kernel_source="triton",
+        perf_filename=str(perf_path),
+        power_stats={
+            "power": 150.0,
+            "power_limit": 700.0,
+            "power_min": 100.0,
+            "power_max": 200.0,
+            "power_energy_j": 300.0,
+            "power_duration_s": 2.0,
+            "power_sample_count": 3,
+        },
+    )
+
+    with perf_path.open() as f:
+        rows = list(csv.DictReader(f))
+
+    assert rows == [
+        {
+            "framework": "vllm",
+            "version": "0.19.0",
+            "device": "H100",
+            "op_name": "gemm",
+            "kernel_source": "triton",
+            "latency": "3.5",
+            "power": "150.0",
+            "power_limit": "700.0",
+            "power_min": "100.0",
+            "power_max": "200.0",
+            "power_energy_j": "300.0",
+            "power_duration_s": "2.0",
+            "power_sample_count": "3",
+        }
+    ]
+
+
+@pytest.mark.parametrize("power_stats", [None, {}])
+def test_log_perf_preserves_legacy_columns_without_power_stats(tmp_path, power_stats):
+    perf_path = tmp_path / "perf.csv"
+    log_perf(
+        item_list=[{"latency": 3.5}],
+        framework="vllm",
+        version="0.19.0",
+        device_name="H100",
+        op_name="gemm",
+        kernel_source="triton",
+        perf_filename=str(perf_path),
+        power_stats=power_stats,
+    )
+
+    with perf_path.open() as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert reader.fieldnames == [
+        "framework",
+        "version",
+        "device",
+        "op_name",
+        "kernel_source",
+        "latency",
+    ]
+    assert rows[0]["latency"] == "3.5"


### PR DESCRIPTION
## Summary
- extend collector power monitoring with min/peak power, sample count, sample duration, and integrated energy
- keep the existing `power` and `power_limit` columns for backward compatibility
- document the expanded power CSV fields

## Linear
- Project: https://linear.app/nvidia/project/feature-power-analysis-1eb278fd0bec
- Implements corrected AIC slice for AIC-937 and AIC-938
- Supersedes the mistakenly opened Dynamo draft PR: https://github.com/ai-dynamo/dynamo/pull/9244

## Tests
- `/tmp/dynamo-power-pytest-venv/bin/python -m pytest tests/unit/collector/test_power_stats.py -q` (`6 passed`)
- `python3 -m py_compile collector/helper.py tests/unit/collector/test_power_stats.py`
- `git diff --check origin/main...HEAD`
