### PR TITLE
fix: use smaller-batch extrapolation when DeepSeek-V4 attention cubic interpolation fails

### DIFF
--- a/collector/collect.py
+++ b/collector/collect.py
@@ -1095,21 +1095,22 @@ def main():
         os.environ["COLLECTOR_MODEL_PATH"] = args.model_path
 
         # V4-Flash special-case: when the model is V4-Flash and no explicit
-        # ``--ops`` is given, scope to the V4-Flash ops only (skip generic
-        # gemm / attention / mla / ... that aren't consumed by V4's perf
-        # model).  All other models keep the default behaviour: run every
-        # op and let each get_func's ``_filter_model_config_list`` filter
-        # cases at the test-case level.
-        if args.ops is None and args.model_path == "deepseek-ai/DeepSeek-V4-Flash":
-            ops = [name for name in _all_op_names() if name.startswith("dsv4_flash_")]
+        # ``--ops`` is given, scope to the ops consumed by the V4-Flash
+        # perf model: V4 Flash attention/sparse kernels plus generic GEMM,
+        # MoE, and mHC.  All other models keep the default behaviour: run
+        # every op and let each get_func's ``_filter_model_config_list``
+        # filter cases at the test-case level.
+        if args.ops is None and args.model_path == "sgl-project/DeepSeek-V4-Flash-FP8":
+            dsv4_flash_ops = [name for name in _all_op_names() if name.startswith("dsv4_flash_")]
+            ops = dsv4_flash_ops + ["gemm", "moe", "mhc_module"]
             _dsv4_auto_expand = True
     else:
         os.environ.pop("COLLECTOR_MODEL_PATH", None)
 
     # Setup logging - debug flag is handled inside setup_logging
     if logger is None:
-        # Use short label when V4-Flash auto-expanded ops to 8 names
-        # (the joined scope would exceed Linux filename length limit).
+        # Use short label when V4-Flash auto-expanded ops to several names
+        # (the joined scope may exceed Linux filename length limit).
         if _dsv4_auto_expand:
             log_scope = ["dsv4_flash"]
         else:

--- a/collector/common_test_cases.py
+++ b/collector/common_test_cases.py
@@ -735,7 +735,7 @@ def get_common_gdn_test_cases() -> list[GdnCommonTestCase]:
 # Both backends re-export the relevant ``get_*`` functions so collect.py
 # can resolve them via getattr on each per-backend module.
 
-_DSV4_FLASH_DEFAULT_MODEL = "deepseek-ai/DeepSeek-V4-Flash"
+_DSV4_FLASH_MODEL_PATH = "sgl-project/DeepSeek-V4-Flash-FP8"
 DSV4_FLASH_ATTN_KINDS = ("csa", "hca")
 
 
@@ -747,7 +747,12 @@ def _dsv4_flash_active() -> bool:
     cases so the collector skips it.
     """
     filt = _get_model_path_filter()
-    return filt is None or filt == _DSV4_FLASH_DEFAULT_MODEL
+    return filt is None or filt == _DSV4_FLASH_MODEL_PATH
+
+
+def _dsv4_flash_model_path() -> str:
+    filt = _get_model_path_filter()
+    return filt if filt is not None else _DSV4_FLASH_MODEL_PATH
 
 
 # --- Module-level (full self_attn) sweep ---
@@ -857,6 +862,7 @@ def _build_dsv4_flash_module_test_cases(mode: str, attn_kinds=DSV4_FLASH_ATTN_KI
     """
     pairs = _dsv4_flash_module_filter_pairs(mode, _DSV4_FLASH_MODULE_BATCH_SIZES, _DSV4_FLASH_MODULE_SEQ_LENGTHS)
     bs_set = sorted({bs for bs, _ in pairs})
+    model_path = _dsv4_flash_model_path()
 
     cases: list[list] = []
     for attn_kind in attn_kinds:
@@ -871,7 +877,7 @@ def _build_dsv4_flash_module_test_cases(mode: str, attn_kinds=DSV4_FLASH_ATTN_KI
                             kv_dtype,
                             compute_dtype,
                             gemm_type,
-                            _DSV4_FLASH_DEFAULT_MODEL,
+                            model_path,
                             attn_kind,
                             None,
                         ]
@@ -990,6 +996,7 @@ def _build_dsv4_flash_sparse_test_cases(
     past_kv_list = list(past_kv_list) if past_kv_list is not None else list(_DSV4_FLASH_SPARSE_PAST_KV_LIST)
     tp_list_attn = list(tp_list_attn) if tp_list_attn is not None else list(_DSV4_FLASH_SPARSE_TP_LIST_ATTN)
     tp_list_indexer = list(tp_list_indexer) if tp_list_indexer is not None else list(_DSV4_FLASH_SPARSE_TP_LIST_INDEXER)
+    model_path = _dsv4_flash_model_path()
 
     cases = []
     for kernel in kernels:
@@ -1014,7 +1021,7 @@ def _build_dsv4_flash_sparse_test_cases(
                                 past_kv,
                                 tp_size,
                                 kernel,
-                                _DSV4_FLASH_DEFAULT_MODEL,
+                                model_path,
                             ]
                         )
     return cases
@@ -1024,7 +1031,7 @@ def _dsv4_flash_sparse_smoke_or_full(kernel: str):
     if not _dsv4_flash_active():
         return []
     if "--smoke" in sys.argv:
-        return [[1, 1024, 8192, 1, kernel, _DSV4_FLASH_DEFAULT_MODEL]]
+        return [[1, 1024, 8192, 1, kernel, _dsv4_flash_model_path()]]
     return _build_dsv4_flash_sparse_test_cases(kernels=(kernel,))
 
 

--- a/collector/sglang/collect_dsv4_flash_attn.py
+++ b/collector/sglang/collect_dsv4_flash_attn.py
@@ -31,7 +31,6 @@ import copy
 import gc
 import json
 import os
-import random
 import shutil
 import socket
 import subprocess
@@ -151,6 +150,29 @@ CLI_DEFAULT_MODEL = "deepseek-ai/DeepSeek-V4-Pro"
 _WEIGHT_SUFFIXES = (".safetensors", ".bin", ".pt", ".pth")
 
 
+_PORTS_PER_GPU = 1000
+_DSV4_FLASH_PORT_RETRIES = 5
+
+
+def _port_is_available(port: int) -> bool:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        # TCPStore may listen on any local interface; check the same address
+        # family instead of only 127.0.0.1.
+        s.bind(("0.0.0.0", port))
+        s.listen(1)
+        return True
+    except OSError:
+        return False
+    finally:
+        s.close()
+
+
+def _nccl_port_for_attempt(gpu_id: int, attempt: int) -> int:
+    """Use a deterministic, GPU-scoped TCPStore port."""
+    return 40000 + gpu_id * _PORTS_PER_GPU + attempt
+
+
 def _pick_free_port(gpu_id: int) -> int:
     """Return a free TCP port from a ``gpu_id``-scoped 1000-port range.
 
@@ -158,23 +180,15 @@ def _pick_free_port(gpu_id: int) -> int:
     rendezvous.  Up to 8 collector workers run in parallel, each pinned
     to one GPU.  Partitioning the port space by ``gpu_id`` makes
     cross-worker collision impossible: worker N's candidate set is
-    [40000 + N*1000, 40000 + N*1000 + 999], disjoint from every other
-    worker's.  The bind / close / subprocess re-bind window inside one
-    worker is harmless because no peer worker can race for the same
-    port (unrelated system services landing on our specific freed port
-    in <1ms is negligibly rare).
+    [40000 + N*1000, 40000 + N*1000 + 999].  Kept as a fallback for
+    direct/manual use; normal collect.py entrypoints pass
+    ``AIC_DSV4_FLASH_NCCL_PORT`` explicitly.
     """
-    base = 40000 + gpu_id * 1000
-    for _ in range(100):
-        port = random.randint(base, base + 999)
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        try:
-            s.bind(("127.0.0.1", port))
-        except OSError:
-            s.close()
-            continue
-        s.close()
-        return port
+    base = _nccl_port_for_attempt(gpu_id, 0)
+    for offset in range(_PORTS_PER_GPU):
+        port = _nccl_port_for_attempt(gpu_id, offset)
+        if _port_is_available(port):
+            return port
     raise RuntimeError(f"no free port in [{base}, {base + 999}] for gpu_id={gpu_id}")
 
 
@@ -460,6 +474,10 @@ def _load_model_runner(
         gemm_type=gemm_type,
     )
     gpu_id = int(device.split(":")[-1]) if ":" in device else 0
+    # CUDA_VISIBLE_DEVICES remaps every child to cuda:0; keep the physical GPU
+    # id for NCCL port sharding so parallel workers do not collide.
+    port_shard = int(os.environ.get("AIC_DSV4_FLASH_PORT_SHARD", gpu_id))
+    nccl_port = int(os.environ.get("AIC_DSV4_FLASH_NCCL_PORT") or _pick_free_port(port_shard))
 
     server_args = ServerArgs(
         model_path=local_model_path,
@@ -497,7 +515,7 @@ def _load_model_runner(
         f"attn_kind={attn_kind}, backend=compressed, kv_cache_dtype={kv_cache_dtype}, "
         f"max_total_tokens={max_total_tokens}, shrink_unused_moe={shrink_unused_moe}, "
         f"disable_weight_quant={disable_weight_quant}, gemm_type={gemm_type}, "
-        f"quantization={server_args.quantization}, tp_size={tp_size}"
+        f"quantization={server_args.quantization}, tp_size={tp_size}, nccl_port={nccl_port}"
     )
 
     _set_envs_and_config(server_args)
@@ -513,7 +531,7 @@ def _load_model_runner(
             pp_size=1,
             moe_ep_rank=0,
             moe_ep_size=1,
-            nccl_port=_pick_free_port(gpu_id),
+            nccl_port=nccl_port,
             server_args=server_args,
         )
     allocator = model_runner.token_to_kv_pool_allocator
@@ -1025,6 +1043,7 @@ def _run_subprocess(
     """
     env = os.environ.copy()
     env["CUDA_VISIBLE_DEVICES"] = str(gpu_id)
+    env["AIC_DSV4_FLASH_PORT_SHARD"] = str(gpu_id)
     env.setdefault("SGLANG_APPLY_CONFIG_BACKUP", "none")
     env.setdefault("SGLANG_LOAD_FORMAT", "dummy")
     # Hard-disable DeepGEMM bulk pre-compile.  First sl in this sweep
@@ -1047,24 +1066,63 @@ def _run_subprocess(
         f")\n"
     )
 
-    proc = subprocess.Popen(
-        [sys.executable, "-c", code],
-        env=env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        cwd=os.path.dirname(os.path.abspath(__file__)),
+    # Persist subprocess output to a per-task log so we can inspect failures
+    # even when the child dies before stdout is streamed (e.g. OOM kill).
+    log_dir = os.path.join(tempfile.gettempdir(), "dsv4_flash_subproc_logs")
+    os.makedirs(log_dir, exist_ok=True)
+    log_path = os.path.join(
+        log_dir,
+        f"{attn_kind}_{mode}_bs{batch_size}_tp{tp_size}_{gemm_type}_gpu{gpu_id}.log",
     )
-    try:
-        stdout, _ = proc.communicate(timeout=3600)  # up to 1 hour per (kind, tp, gemm, bs)
-        if stdout:
-            print(stdout.decode("utf-8", errors="replace"))
-    except subprocess.TimeoutExpired:
-        proc.kill()
-        proc.wait()
-    if proc.returncode != 0:
+
+    def _run_once(nccl_port: int) -> tuple[int, str]:
+        attempt_env = env.copy()
+        attempt_env["AIC_DSV4_FLASH_NCCL_PORT"] = str(nccl_port)
+        with open(log_path, "wb") as logf:
+            proc = subprocess.Popen(
+                [sys.executable, "-c", code],
+                env=attempt_env,
+                stdout=logf,
+                stderr=subprocess.STDOUT,
+                cwd=os.path.dirname(os.path.abspath(__file__)),
+            )
+            try:
+                proc.wait(timeout=3600)  # up to 1 hour per (kind, tp, gemm, bs)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
+
+        try:
+            with open(log_path, encoding="utf-8", errors="replace") as logf:
+                log_text = logf.read()
+        except OSError:
+            log_text = ""
+
+        # Echo the log so it shows up in the parent's collector log.
+        if log_text:
+            print(log_text)
+        return proc.returncode, log_text
+
+    max_attempts = _DSV4_FLASH_PORT_RETRIES
+    for attempt in range(max_attempts):
+        nccl_port = _nccl_port_for_attempt(gpu_id, attempt)
+        returncode, log_text = _run_once(nccl_port)
+
+        if returncode == 0:
+            return
+
+        is_port_race = "EADDRINUSE" in log_text or "address already in use" in log_text
+        if is_port_race and attempt + 1 < max_attempts:
+            print(
+                f"[dsv4-collector] retrying after NCCL/TCPStore port collision "
+                f"on nccl_port={nccl_port} ({attempt + 1}/{max_attempts}); log: {log_path}"
+            )
+            continue
+
         raise RuntimeError(
             f"dsv4_flash_{attn_kind}_{mode} subprocess failed for "
-            f"(bs={batch_size}, tp={tp_size}, gemm={gemm_type}); exit={proc.returncode}"
+            f"(bs={batch_size}, tp={tp_size}, gemm={gemm_type}); "
+            f"exit={returncode}; log: {log_path}"
         )
 
 

--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -1351,20 +1351,20 @@ def _dsv4_flash_tp_from_num_heads(num_heads: int) -> int:
 
 
 def _dsv4_flash_robust_3d_lookup(self, dict_, x, y, z):
-    """V4-Flash-only 3D lookup: try exact, then cubic, then linear.
+    """V4-Flash-only 3D lookup: exact, cubic, then sampled-batch fallback.
 
     Generic ``_interp_3d`` raises ``QhullError`` when the point cloud has
     a degenerate axis (e.g. our V4-Flash sweep caps b=1 at s=8192, so the
-    b axis is flat near that query point).  Cubic crashes instead of
-    gracefully degrading.  This helper:
+    b axis is flat near that query point).  This helper:
 
       1. Try an exact ``dict[x][y][z]`` lookup — handles the common case
          of querying at a measured bench point.
-      2. Fall back to cubic 3D interp.
-      3. Fall back to linear 3D interp (different qhull tolerances; less
-         likely to fail on near-degenerate inputs).
+      2. Try the existing cubic interpolation path.
+      3. If interpolation fails, use the largest sampled batch no larger than
+         the query batch, interpolate/extrapolate along sequence length, and
+         scale by batch.
 
-    Caller swallows lower-level exceptions if all three paths fail.
+    Caller swallows lower-level exceptions if all paths fail.
     """
     # Use .get() chain instead of [] indexing: dict_ may be a (nested)
     # defaultdict, so [] reads would create spurious empty branches that
@@ -1374,10 +1374,51 @@ def _dsv4_flash_robust_3d_lookup(self, dict_, x, y, z):
     exact = level2.get(z) if isinstance(level2, dict) else None
     if isinstance(exact, dict) and "latency" in exact:
         return exact
+
+    def _finite_result(result):
+        if not isinstance(result, dict):
+            return False
+        value = result.get("latency")
+        return value is not None and bool(np.all(np.isfinite(np.asarray(value))))
+
     try:
-        return self._interp_3d(x, y, z, dict_, "cubic")
+        result = self._interp_3d(x, y, z, dict_, "cubic")
+        if _finite_result(result):
+            return result
     except Exception:
-        return self._interp_3d(x, y, z, dict_, "linear")
+        pass
+
+    # Fallback: real V4-Flash data is sampled at batches like 1/2/4/8.
+    # Prefer the largest batch <= query batch that covers the sequence length
+    # (interpolation along s). Only extrapolate along s if none covers it.
+    sub = dict_.get(x) if isinstance(dict_, dict) else None
+    if isinstance(sub, dict):
+        batch_points = sorted({b for sd in sub.values() if isinstance(sd, dict) for b in sd if b <= z}, reverse=True)
+
+        def _lookup_at_batch(bp, *, allow_extrapolate: bool):
+            if y in sub and bp in sub[y]:
+                return sub[y][bp]
+            ss = sorted(s for s, sd in sub.items() if isinstance(sd, dict) and bp in sd)
+            if len(ss) < 2:
+                return None
+            if not allow_extrapolate and not (ss[0] <= y <= ss[-1]):
+                return None
+            sl, sr = self._nearest_1d_point_helper(y, ss, inner_only=not allow_extrapolate)
+            return self._interp_1d([sl, sr], [sub[sl][bp], sub[sr][bp]], y)
+
+        for allow_extrapolate in (False, True):
+            for bp in batch_points:
+                try:
+                    leaf = _lookup_at_batch(bp, allow_extrapolate=allow_extrapolate)
+                    if leaf is None:
+                        continue
+                    result = {f: leaf.get(f, 0.0) * z / bp for f in ("latency", "power", "energy")}
+                    if _finite_result(result):
+                        return result
+                except Exception:
+                    continue
+
+    raise ValueError(f"V4-Flash robust lookup failed (tp={x}, s={y}, b={z})")
 
 
 def load_context_dsv4_flash_kind_module_data(file_path: str):
@@ -7615,6 +7656,7 @@ class PerfDatabase:
         Strategy:
           1. Exact (bs, isl, past_kv, tp) hit  → return latency
           2. (bs, isl) miss but past_kv hit    → 2D interp on (isl, bs)
+             with sampled-batch fallback if 2D interp fails
           3. past_kv miss                       → linear interp along past_kv,
              with (isl, bs) interpolated at each bracketing past_kv
         Returns None if the kernel CSV is not loaded.
@@ -7645,11 +7687,55 @@ class PerfDatabase:
                 return None
             isl_dict = per_tp_dict[past_val]
             if isl in isl_dict and bs in isl_dict[isl]:
-                return isl_dict[isl][bs]["latency"]
+                latency = isl_dict[isl][bs]["latency"]
+                if latency is not None and bool(np.all(np.isfinite(np.asarray(latency)))):
+                    return latency
             try:
-                return self._interp_2d_linear(isl, bs, isl_dict)["latency"]
+                latency = self._interp_2d_linear(isl, bs, isl_dict)["latency"]
+                if latency is not None and bool(np.all(np.isfinite(np.asarray(latency)))):
+                    return latency
             except Exception:
-                return None
+                pass
+
+            # Sparse kernels are sampled on the same batch grid as module data.
+            # If 2D interpolation fails because a larger batch lacks this isl
+            # range, fall back to the largest batch <= query batch, interpolate
+            # along isl, and scale by batch.
+            batch_points = sorted(
+                {b for isl_data in isl_dict.values() if isinstance(isl_data, dict) for b in isl_data if b <= bs},
+                reverse=True,
+            )
+
+            def _lookup_at_batch(bp, *, allow_extrapolate: bool):
+                if isl in isl_dict and bp in isl_dict[isl]:
+                    return isl_dict[isl][bp]
+                isl_points = sorted(
+                    s for s, isl_data in isl_dict.items() if isinstance(isl_data, dict) and bp in isl_data
+                )
+                if len(isl_points) < 2:
+                    return None
+                if not allow_extrapolate and not (isl_points[0] <= isl <= isl_points[-1]):
+                    return None
+                left, right = self._nearest_1d_point_helper(isl, isl_points, inner_only=not allow_extrapolate)
+                latency = self._interp_1d(
+                    [left, right],
+                    [isl_dict[left][bp].get("latency"), isl_dict[right][bp].get("latency")],
+                    isl,
+                )
+                return {"latency": latency}
+
+            for allow_extrapolate in (False, True):
+                for bp in batch_points:
+                    try:
+                        leaf = _lookup_at_batch(bp, allow_extrapolate=allow_extrapolate)
+                        if leaf is None:
+                            continue
+                        latency = leaf.get("latency") * bs / bp
+                        if latency is not None and bool(np.all(np.isfinite(np.asarray(latency)))):
+                            return latency
+                    except Exception:
+                        continue
+            return None
 
         direct = _at_past(past_kv)
         if direct is not None:
@@ -7898,7 +7984,13 @@ class PerfDatabase:
                     tp_size=head_axis,
                     architecture=architecture,
                 )
-            use_kernel_delta = t_with is not None and t_without is not None
+                if t_with is None or t_without is None:
+                    raise PerfDataNotAvailableError(
+                        f"DeepSeek-V4 {kernel} sparse-kernel correction data not available for "
+                        f"{b=}, {s=}, {prefix=}, {head_axis=}, {architecture=}. "
+                        "Cannot query prefix context attention in SILICON mode without kernel delta."
+                    )
+            use_kernel_delta = kernel is not None
             lookup_s = s if use_kernel_delta else s + prefix
 
             result = None
@@ -7916,9 +8008,10 @@ class PerfDatabase:
                     head_axis, lookup_s, b, raw_dict, index_topk * compress_ratio
                 )
             if result is None:
-                # V4-Flash uses a robust lookup (exact → cubic → linear) to
-                # avoid qhull crashes on the caps-driven flat b axis.  Generic
-                # ``_interp_3d`` is left untouched for other architectures.
+                # V4-Flash uses a robust lookup (exact -> cubic ->
+                # sampled-batch fallback) to avoid qhull crashes on the
+                # caps-driven flat b axis. Generic ``_interp_3d`` is left
+                # untouched for other architectures.
                 result = (
                     _dsv4_flash_robust_3d_lookup(self, deepseek_v4_dict, head_axis, lookup_s, b)
                     if architecture == "DeepseekV4ForCausalLM"
@@ -8051,8 +8144,8 @@ class PerfDatabase:
             head_axis = (
                 _dsv4_flash_tp_from_num_heads(num_heads) if architecture == "DeepseekV4ForCausalLM" else num_heads
             )
-            # V4-Flash robust lookup (exact → cubic → linear) — see helper
-            # docstring; generic ``_interp_3d`` left untouched for others.
+            # V4-Flash robust lookup (exact -> cubic -> sampled-batch
+            # fallback); generic ``_interp_3d`` left untouched for others.
             result = (
                 _dsv4_flash_robust_3d_lookup(self, deepseek_v4_dict, head_axis, b, s)
                 if architecture == "DeepseekV4ForCausalLM"

--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -7692,10 +7692,9 @@ class PerfDatabase:
 
         Strategy:
           1. Exact (bs, isl, past_kv, tp) hit  → return latency
-          2. (bs, isl) miss but past_kv hit    → 2D interp on (isl, bs)
-             with sampled-batch fallback if 2D interp fails
-          3. past_kv miss                       → linear interp along past_kv,
-             with (isl, bs) interpolated at each bracketing past_kv
+          2. Cubic 3D interpolation on (past_kv, isl, bs) within the fixed tp slice
+          3. If cubic fails, use the largest sampled batch no larger than the query
+             batch that covers isl, interpolate on (past_kv, isl), then scale by batch.
         Returns None if the kernel CSV is not loaded.
         """
         all_data = getattr(self, "_dsv4_flash_sparse_kernel_data", None)
@@ -7719,36 +7718,61 @@ class PerfDatabase:
         if not per_tp_dict:
             return None
 
-        def _at_past(past_val):
-            if past_val not in per_tp_dict:
+        def _finite_latency(value):
+            return value is not None and bool(np.all(np.isfinite(np.asarray(value))))
+
+        if past_kv in per_tp_dict and isl in per_tp_dict[past_kv] and bs in per_tp_dict[past_kv][isl]:
+            latency = per_tp_dict[past_kv][isl][bs]["latency"]
+            if _finite_latency(latency):
+                return float(np.asarray(latency))
+
+        try:
+            result = self._interp_3d(past_kv, isl, bs, per_tp_dict, "cubic")
+            latency = result.get("latency") if isinstance(result, dict) else None
+            if _finite_latency(latency):
+                return float(np.asarray(latency))
+        except Exception:
+            pass
+
+        batch_points = sorted(
+            {
+                sampled_b
+                for isl_dict in per_tp_dict.values()
+                if isinstance(isl_dict, dict)
+                for isl_data in isl_dict.values()
+                if isinstance(isl_data, dict)
+                for sampled_b in isl_data
+                if sampled_b <= bs
+            },
+            reverse=True,
+        )
+
+        def _lookup_at_batch(bp, *, allow_extrapolate: bool):
+            batch_slice = defaultdict(dict)
+            for sampled_past, isl_dict in per_tp_dict.items():
+                if not isinstance(isl_dict, dict):
+                    continue
+                for sampled_isl, isl_data in isl_dict.items():
+                    if isinstance(isl_data, dict) and bp in isl_data:
+                        batch_slice[sampled_past][sampled_isl] = isl_data[bp]
+
+            if not batch_slice:
                 return None
-            isl_dict = per_tp_dict[past_val]
-            if isl in isl_dict and bs in isl_dict[isl]:
-                latency = isl_dict[isl][bs]["latency"]
-                if latency is not None and bool(np.all(np.isfinite(np.asarray(latency)))):
-                    return latency
+
             try:
-                latency = self._interp_2d_linear(isl, bs, isl_dict)["latency"]
-                if latency is not None and bool(np.all(np.isfinite(np.asarray(latency)))):
+                latency = self._interp_2d_linear(past_kv, isl, batch_slice)["latency"]
+                if _finite_latency(latency):
                     return latency
             except Exception:
                 pass
 
-            # Sparse kernels are sampled on the same batch grid as module data.
-            # If 2D interpolation fails because a larger batch lacks this isl
-            # range, fall back to the largest batch <= query batch, interpolate
-            # along isl, and scale by batch.
-            batch_points = sorted(
-                {b for isl_data in isl_dict.values() if isinstance(isl_data, dict) for b in isl_data if b <= bs},
-                reverse=True,
-            )
-
-            def _lookup_at_batch(bp, *, allow_extrapolate: bool):
-                if isl in isl_dict and bp in isl_dict[isl]:
-                    return isl_dict[isl][bp]
-                isl_points = sorted(
-                    s for s, isl_data in isl_dict.items() if isinstance(isl_data, dict) and bp in isl_data
-                )
+            def _lookup_isl_at_past(sampled_past):
+                isl_dict = batch_slice.get(sampled_past)
+                if not isinstance(isl_dict, dict):
+                    return None
+                if isl in isl_dict:
+                    return isl_dict[isl].get("latency")
+                isl_points = sorted(s for s, leaf in isl_dict.items() if isinstance(leaf, dict) and "latency" in leaf)
                 if len(isl_points) < 2:
                     return None
                 if not allow_extrapolate and not (isl_points[0] <= isl <= isl_points[-1]):
@@ -7756,44 +7780,39 @@ class PerfDatabase:
                 left, right = self._nearest_1d_point_helper(isl, isl_points, inner_only=not allow_extrapolate)
                 latency = self._interp_1d(
                     [left, right],
-                    [isl_dict[left][bp].get("latency"), isl_dict[right][bp].get("latency")],
+                    [isl_dict[left].get("latency"), isl_dict[right].get("latency")],
                     isl,
                 )
-                return {"latency": latency}
+                return latency
 
-            for allow_extrapolate in (False, True):
-                for bp in batch_points:
-                    try:
-                        leaf = _lookup_at_batch(bp, allow_extrapolate=allow_extrapolate)
-                        if leaf is None:
-                            continue
-                        latency = leaf.get("latency") * bs / bp
-                        if latency is not None and bool(np.all(np.isfinite(np.asarray(latency)))):
-                            return latency
-                    except Exception:
+            if past_kv in batch_slice:
+                return _lookup_isl_at_past(past_kv)
+
+            past_points = sorted(
+                sampled_past for sampled_past in batch_slice if _lookup_isl_at_past(sampled_past) is not None
+            )
+            if len(past_points) < 2:
+                return None
+            if not allow_extrapolate and not (past_points[0] <= past_kv <= past_points[-1]):
+                return None
+            left, right = self._nearest_1d_point_helper(past_kv, past_points, inner_only=not allow_extrapolate)
+            left_latency = _lookup_isl_at_past(left)
+            right_latency = _lookup_isl_at_past(right)
+            if left_latency is None or right_latency is None:
+                return None
+            return self._interp_1d([left, right], [left_latency, right_latency], past_kv)
+
+        for allow_extrapolate in (False, True):
+            for bp in batch_points:
+                try:
+                    latency = _lookup_at_batch(bp, allow_extrapolate=allow_extrapolate)
+                    if latency is None:
                         continue
-            return None
-
-        direct = _at_past(past_kv)
-        if direct is not None:
-            return direct
-
-        past_keys = sorted(per_tp_dict.keys())
-        if not past_keys:
-            return None
-        if past_kv <= past_keys[0]:
-            return _at_past(past_keys[0])
-        if past_kv >= past_keys[-1]:
-            return _at_past(past_keys[-1])
-        for i in range(len(past_keys) - 1):
-            lo, hi = past_keys[i], past_keys[i + 1]
-            if lo <= past_kv <= hi:
-                lat_lo = _at_past(lo)
-                lat_hi = _at_past(hi)
-                if lat_lo is None or lat_hi is None:
-                    return None
-                t = (past_kv - lo) / max(1, hi - lo)
-                return lat_lo + t * (lat_hi - lat_lo)
+                    latency = latency * bs / bp
+                    if _finite_latency(latency):
+                        return latency
+                except Exception:
+                    continue
         return None
 
     def _deepseek_v4_attention_sol(

--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -1350,7 +1350,7 @@ def _dsv4_flash_tp_from_num_heads(num_heads: int) -> int:
     return max(1, DSV4_FLASH_NATIVE_HEADS // max(num_heads, 1))
 
 
-def _dsv4_flash_robust_3d_lookup(self, dict_, x, y, z):
+def _dsv4_flash_robust_3d_lookup(self, dict_, x, y, z, *, batch_axis: str = "z"):
     """V4-Flash-only 3D lookup: exact, cubic, then sampled-batch fallback.
 
     Generic ``_interp_3d`` raises ``QhullError`` when the point cloud has
@@ -1362,10 +1362,14 @@ def _dsv4_flash_robust_3d_lookup(self, dict_, x, y, z):
       2. Try the existing cubic interpolation path.
       3. If interpolation fails, use the largest sampled batch no larger than
          the query batch, interpolate/extrapolate along sequence length, and
-         scale by batch.
+         scale by batch. ``batch_axis`` selects whether fallback treats ``y``
+         or ``z`` as the batch axis.
 
     Caller swallows lower-level exceptions if all paths fail.
     """
+    if batch_axis not in ("y", "z"):
+        raise ValueError(f"unsupported V4-Flash fallback {batch_axis=}; expected 'y' or 'z'")
+
     # Use .get() chain instead of [] indexing: dict_ may be a (nested)
     # defaultdict, so [] reads would create spurious empty branches that
     # later poison _interp_3d's grid traversal.
@@ -1393,31 +1397,64 @@ def _dsv4_flash_robust_3d_lookup(self, dict_, x, y, z):
     # (interpolation along s). Only extrapolate along s if none covers it.
     sub = dict_.get(x) if isinstance(dict_, dict) else None
     if isinstance(sub, dict):
-        batch_points = sorted({b for sd in sub.values() if isinstance(sd, dict) for b in sd if b <= z}, reverse=True)
+        query_s, query_b = (z, y) if batch_axis == "y" else (y, z)
+
+        def _batch_points():
+            if batch_axis == "y":
+                return sorted(
+                    (bp for bp, sd in sub.items() if isinstance(sd, dict) and bp <= query_b),
+                    reverse=True,
+                )
+            return sorted(
+                {bp for sd in sub.values() if isinstance(sd, dict) for bp in sd if bp <= query_b},
+                reverse=True,
+            )
+
+        def _leaf_at(s, b):
+            first_key, second_key = (b, s) if batch_axis == "y" else (s, b)
+            level = sub.get(first_key)
+            return level.get(second_key) if isinstance(level, dict) else None
+
+        def _seq_points_at_batch(b):
+            if batch_axis == "y":
+                level = sub.get(b)
+                return sorted(level.keys()) if isinstance(level, dict) else []
+            return sorted(s for s, sd in sub.items() if isinstance(sd, dict) and b in sd)
 
         def _lookup_at_batch(bp, *, allow_extrapolate: bool):
-            if y in sub and bp in sub[y]:
-                return sub[y][bp]
-            ss = sorted(s for s, sd in sub.items() if isinstance(sd, dict) and bp in sd)
+            exact_at_batch = _leaf_at(query_s, bp)
+            if exact_at_batch is not None:
+                return exact_at_batch
+            ss = _seq_points_at_batch(bp)
             if len(ss) < 2:
                 return None
-            if not allow_extrapolate and not (ss[0] <= y <= ss[-1]):
+            if not allow_extrapolate and not (ss[0] <= query_s <= ss[-1]):
                 return None
-            sl, sr = self._nearest_1d_point_helper(y, ss, inner_only=not allow_extrapolate)
-            return self._interp_1d([sl, sr], [sub[sl][bp], sub[sr][bp]], y)
+            sl, sr = self._nearest_1d_point_helper(query_s, ss, inner_only=not allow_extrapolate)
+            left = _leaf_at(sl, bp)
+            right = _leaf_at(sr, bp)
+            if not isinstance(left, dict) or not isinstance(right, dict):
+                return None
+            return {
+                field: self._interp_1d([sl, sr], [left.get(field, 0.0), right.get(field, 0.0)], query_s)
+                for field in ("latency", "power", "energy")
+            }
 
+        batch_points = _batch_points()
         for allow_extrapolate in (False, True):
             for bp in batch_points:
                 try:
                     leaf = _lookup_at_batch(bp, allow_extrapolate=allow_extrapolate)
                     if leaf is None:
                         continue
-                    result = {f: leaf.get(f, 0.0) * z / bp for f in ("latency", "power", "energy")}
+                    result = {f: leaf.get(f, 0.0) * query_b / bp for f in ("latency", "power", "energy")}
                     if _finite_result(result):
                         return result
                 except Exception:
                     continue
 
+    if batch_axis == "y":
+        raise ValueError(f"V4-Flash robust lookup failed (tp={x}, b={y}, s={z})")
     raise ValueError(f"V4-Flash robust lookup failed (tp={x}, s={y}, b={z})")
 
 
@@ -1486,16 +1523,16 @@ def load_generation_dsv4_flash_kind_module_data(file_path: str):
     Generation lookup uses absolute KV length ``s_total = isl + step`` (decode
     is q_len=1 with past_kv = step).  Dict shape:
         data[kv_quant][gemm_quant][arch][compress_ratio]
-            [local_heads][s_total][b]
+            [tp_size][b][s_total]
 
-    ``local_heads = NATIVE_HEADS // tp_size`` matches the post-TP head count
-    the model layer passes as ``num_heads`` (see context loader docstring).
+    ``tp_size`` is the data axis; query side recovers it from the model layer's
+    local-head ``num_heads`` value (see top-of-file V4-Flash note).
     """
     if not os.path.exists(file_path):
         logger.debug(f"DSV4-Flash module data file {file_path} not found.")
         return None
 
-    # 7-level nesting: kv → gemm → arch → cr → local_heads → s_total → b
+    # 7-level nesting: kv → gemm → arch → cr → tp_size → b → s_total
     def _make_nested(depth: int):
         if depth == 0:
             return defaultdict()
@@ -8144,10 +8181,9 @@ class PerfDatabase:
             head_axis = (
                 _dsv4_flash_tp_from_num_heads(num_heads) if architecture == "DeepseekV4ForCausalLM" else num_heads
             )
-            # V4-Flash robust lookup (exact -> cubic -> sampled-batch
-            # fallback); generic ``_interp_3d`` left untouched for others.
+            # V4-Flash generation data is keyed as [tp_size][batch][s_total].
             result = (
-                _dsv4_flash_robust_3d_lookup(self, deepseek_v4_dict, head_axis, b, s)
+                _dsv4_flash_robust_3d_lookup(self, deepseek_v4_dict, head_axis, b, s, batch_axis="y")
                 if architecture == "DeepseekV4ForCausalLM"
                 else self._interp_3d(head_axis, b, s, deepseek_v4_dict, "cubic")
             )

--- a/tests/unit/sdk/database/test_deepseek_v4_module.py
+++ b/tests/unit/sdk/database/test_deepseek_v4_module.py
@@ -63,6 +63,18 @@ def _context_deepseek_v4_data(compress_ratio: int, attn_dict: dict) -> dict:
     }
 
 
+def _generation_deepseek_v4_data(compress_ratio: int, attn_dict: dict) -> dict:
+    return {
+        common.KVCacheQuantMode.fp8: {
+            common.GEMMQuantMode.fp8_block: {
+                "DeepseekV4ForCausalLM": {
+                    compress_ratio: attn_dict,
+                },
+            },
+        },
+    }
+
+
 def _dsv4_flash_sampled_batch_caps_grid() -> dict:
     """Mock the real V4-Flash sampled shape: b=1/2/4/8 with shrinking max s."""
     return {
@@ -84,6 +96,22 @@ def _dsv4_flash_sampled_batch_caps_grid() -> dict:
             },
             8192: {
                 1: _deepseek_v4_value(4.00),
+            },
+        }
+    }
+
+
+def _dsv4_flash_generation_sampled_grid() -> dict:
+    """Generation shape is [tp][b][s_total]; collector's minimum s_total is 2."""
+    return {
+        8: {
+            1: {
+                2: _deepseek_v4_value(0.20),
+                5: _deepseek_v4_value(0.50),
+            },
+            2: {
+                2: _deepseek_v4_value(0.40),
+                5: _deepseek_v4_value(1.00),
             },
         }
     }
@@ -216,6 +244,43 @@ class TestDeepSeekV4AttentionModule:
         )
 
         assert next_step[1] > current[1]
+
+    def test_generation_robust_lookup_extrapolates_query_below_min_sampled_s_total(self, mutable_comprehensive_perf_db):
+        """Regression: query s_total=1 is below the collector's sampled s_total=2."""
+        db = mutable_comprehensive_perf_db
+        mock_grid = _dsv4_flash_generation_sampled_grid()
+
+        result = _dsv4_flash_robust_3d_lookup(db, mock_grid, 8, 1, 1, batch_axis="y")
+
+        expected = 0.20 + (0.50 - 0.20) * (1 - 2) / (5 - 2)
+        assert math.isclose(result["latency"], expected, rel_tol=1e-6)
+        assert math.isclose(result["energy"], expected * 10.0, rel_tol=1e-6)
+
+    def test_generation_silicon_extrapolates_query_below_min_sampled_s_total(self, mutable_comprehensive_perf_db):
+        """Full-query regression for generated query b=1, s_total=1, tp=8."""
+        db = mutable_comprehensive_perf_db
+        mock_grid = _dsv4_flash_generation_sampled_grid()
+        db._generation_deepseek_v4_attention_module_data = LoadedOpData(
+            _generation_deepseek_v4_data(4, mock_grid),
+            common.PerfDataFilename.deepseek_v4_generation_module,
+            "mock_dsv4_flash_generation_module_tp8",
+        )
+        kwargs = _deepseek_v4_attn_kwargs(4)
+        kwargs.pop("prefix")
+
+        result = db.query_generation_deepseek_v4_attention_module(
+            **{
+                **kwargs,
+                "b": 1,
+                "s": 1,
+                "num_heads": 8,
+            },
+            database_mode=common.DatabaseMode.SILICON,
+        )
+
+        expected = 0.20 + (0.50 - 0.20) * (1 - 2) / (5 - 2)
+        assert float(result) == pytest.approx(expected)
+        assert result.energy == pytest.approx(expected * 10.0)
 
     def test_csa_topk_changes_attention_workload(self, comprehensive_perf_db):
         base = _deepseek_v4_attn_kwargs(4)
@@ -363,6 +428,7 @@ class TestDeepSeekV4AttentionModule:
         b4_at_avg_isl = 6.00 + (8.00 - 6.00) * (avg_isl - 1024) / (2048 - 1024)
         expected = b4_at_avg_isl * 5 / 4
         assert math.isclose(result["latency"], expected, rel_tol=1e-6)
+        assert math.isclose(result["energy"], expected * 10.0, rel_tol=1e-6)
 
     def test_robust_3d_lookup_uses_b1_for_bs1_short_single_attn_shape(self, mutable_comprehensive_perf_db):
         """Regression: bs=1 has no smaller batch, so use b=1 along the s axis."""

--- a/tests/unit/sdk/database/test_deepseek_v4_module.py
+++ b/tests/unit/sdk/database/test_deepseek_v4_module.py
@@ -12,6 +12,8 @@ from aiconfigurator.sdk.config import RuntimeConfig
 from aiconfigurator.sdk.models import get_model
 from aiconfigurator.sdk.perf_database import (
     LoadedOpData,
+    PerfDataNotAvailableError,
+    _dsv4_flash_robust_3d_lookup,
     load_context_deepseek_v4_attention_module_data,
     load_generation_deepseek_v4_attention_module_data,
     load_mhc_module_data,
@@ -58,6 +60,47 @@ def _context_deepseek_v4_data(compress_ratio: int, attn_dict: dict) -> dict:
                 },
             },
         },
+    }
+
+
+def _dsv4_flash_sampled_batch_caps_grid() -> dict:
+    """Mock the real V4-Flash sampled shape: b=1/2/4/8 with shrinking max s."""
+    return {
+        8: {
+            1024: {
+                1: _deepseek_v4_value(1.00),
+                2: _deepseek_v4_value(3.00),
+                4: _deepseek_v4_value(6.00),
+                8: _deepseek_v4_value(12.00),
+            },
+            2048: {
+                1: _deepseek_v4_value(2.00),
+                2: _deepseek_v4_value(4.80),
+                4: _deepseek_v4_value(8.00),
+            },
+            4096: {
+                1: _deepseek_v4_value(3.00),
+                2: _deepseek_v4_value(5.80),
+            },
+            8192: {
+                1: _deepseek_v4_value(4.00),
+            },
+        }
+    }
+
+
+def _dsv4_flash_sparse_kernel_grid(lat_without_prefix: float = 0.02, lat_with_prefix: float = 0.05) -> dict:
+    return {
+        "DeepseekV4ForCausalLM": {
+            1: {
+                0: {
+                    54.0: {1: {"latency": lat_without_prefix}},
+                },
+                2816.0: {
+                    54.0: {1: {"latency": lat_with_prefix}},
+                },
+            }
+        }
     }
 
 
@@ -291,6 +334,143 @@ class TestDeepSeekV4AttentionModule:
         )
         assert fp8[1] < bf16[1]
         assert fp8[2] < bf16[2]
+
+    def test_robust_3d_lookup_uses_b2_when_b3_s2682_is_missing(self, mutable_comprehensive_perf_db):
+        """Regression: b=3, s=2682 uses b=2 because b=4 only reaches s=2048."""
+        db = mutable_comprehensive_perf_db
+        mock_grid = _dsv4_flash_sampled_batch_caps_grid()
+
+        result = _dsv4_flash_robust_3d_lookup(db, mock_grid, 8, 2682, 3)
+        b2_at_2682 = 4.80 + (5.80 - 4.80) * (2682 - 2048) / (4096 - 2048)
+        expected = b2_at_2682 * 3 / 2
+        assert math.isclose(result["latency"], expected, rel_tol=1e-6)
+
+    def test_robust_3d_lookup_uses_b4_for_bs5_real_mixed_batch_shape(self, mutable_comprehensive_perf_db):
+        """Regression: real bs=5 mixed-prefix request uses b=4 at avg_isl=1565.2."""
+        db = mutable_comprehensive_perf_db
+        reqs = [(1266, 1792), (1292, 1280), (1251, 1792), (2225, 1280), (1792, 1792)]
+        avg_isl = sum(isl for isl, _ in reqs) / len(reqs)
+        avg_past_kv = sum(past_kv for _, past_kv in reqs) / len(reqs)
+        bs = len(reqs)
+
+        assert bs == 5
+        assert avg_isl == pytest.approx(1565.2)
+        assert avg_past_kv == pytest.approx(1587.2)
+
+        mock_grid = _dsv4_flash_sampled_batch_caps_grid()
+        result = _dsv4_flash_robust_3d_lookup(db, mock_grid, 8, avg_isl, bs)
+
+        b4_at_avg_isl = 6.00 + (8.00 - 6.00) * (avg_isl - 1024) / (2048 - 1024)
+        expected = b4_at_avg_isl * 5 / 4
+        assert math.isclose(result["latency"], expected, rel_tol=1e-6)
+
+    def test_robust_3d_lookup_uses_b1_for_bs1_short_single_attn_shape(self, mutable_comprehensive_perf_db):
+        """Regression: bs=1 has no smaller batch, so use b=1 along the s axis."""
+        db = mutable_comprehensive_perf_db
+        reqs = [(54, 2816)]
+        avg_isl = sum(isl for isl, _ in reqs) / len(reqs)
+        avg_past_kv = sum(past_kv for _, past_kv in reqs) / len(reqs)
+        bs = len(reqs)
+
+        assert bs == 1
+        assert avg_isl == pytest.approx(54.0)
+        assert avg_past_kv == pytest.approx(2816.0)
+
+        mock_grid = _dsv4_flash_sampled_batch_caps_grid()
+        result = _dsv4_flash_robust_3d_lookup(db, mock_grid, 8, avg_isl, bs)
+
+        b1_at_avg_isl = 1.00 + (2.00 - 1.00) * (avg_isl - 1024) / (2048 - 1024)
+        assert math.isclose(result["latency"], b1_at_avg_isl, rel_tol=1e-6)
+
+    def test_context_silicon_handles_bs1_s54_prefix2816_single_attn_module(self, mutable_comprehensive_perf_db):
+        """Full-query regression for the single bs=1, isl=54, prefix=2816 attention module."""
+        db = mutable_comprehensive_perf_db
+        module_grid = _dsv4_flash_sampled_batch_caps_grid()
+        db._context_deepseek_v4_attention_module_data = LoadedOpData(
+            _context_deepseek_v4_data(4, module_grid),
+            common.PerfDataFilename.deepseek_v4_context_module,
+            "mock_dsv4_flash_context_module_tp8",
+        )
+        db._raw_context_deepseek_v4_attention_module_data = LoadedOpData(
+            _context_deepseek_v4_data(4, module_grid),
+            common.PerfDataFilename.deepseek_v4_context_module,
+            "mock_raw_dsv4_flash_context_module_tp8",
+        )
+        sparse_grid = _dsv4_flash_sparse_kernel_grid()
+        db._dsv4_flash_sparse_kernel_data = {
+            "paged_mqa_logits": LoadedOpData(
+                sparse_grid,
+                common.PerfDataFilename.dsv4_flash_paged_mqa_logits_module,
+                "mock_dsv4_flash_paged_mqa_logits_module",
+            ),
+        }
+
+        result = db.query_context_deepseek_v4_attention_module(
+            **{
+                **_deepseek_v4_attn_kwargs(4),
+                "b": 1,
+                "s": 54,
+                "prefix": 2816,
+                "num_heads": 8,
+            },
+            database_mode=common.DatabaseMode.SILICON,
+        )
+
+        assert float(result) > 0
+        assert result.energy >= 0
+
+    def test_context_silicon_errors_when_prefix_sparse_kernel_delta_missing(self, mutable_comprehensive_perf_db):
+        """Prefix CSA needs paged_mqa_logits delta; do not silently query s+prefix."""
+        db = mutable_comprehensive_perf_db
+        module_grid = _dsv4_flash_sampled_batch_caps_grid()
+        db._context_deepseek_v4_attention_module_data = LoadedOpData(
+            _context_deepseek_v4_data(4, module_grid),
+            common.PerfDataFilename.deepseek_v4_context_module,
+            "mock_dsv4_flash_context_module_tp8",
+        )
+
+        with pytest.raises(PerfDataNotAvailableError, match="paged_mqa_logits sparse-kernel correction"):
+            db.query_context_deepseek_v4_attention_module(
+                **{
+                    **_deepseek_v4_attn_kwargs(4),
+                    "b": 1,
+                    "s": 54,
+                    "prefix": 2816,
+                    "num_heads": 8,
+                },
+                database_mode=common.DatabaseMode.SILICON,
+            )
+
+    def test_context_silicon_handles_b3_s2682_prefix0_num_heads8_from_sampled_batches(
+        self, mutable_comprehensive_perf_db
+    ):
+        """Full-query regression for sampled b=2/b=4 data and query b=3."""
+        db = mutable_comprehensive_perf_db
+        module_grid = _dsv4_flash_sampled_batch_caps_grid()
+        db._context_deepseek_v4_attention_module_data = LoadedOpData(
+            _context_deepseek_v4_data(4, module_grid),
+            common.PerfDataFilename.deepseek_v4_context_module,
+            "mock_dsv4_flash_context_module_tp8",
+        )
+        db._raw_context_deepseek_v4_attention_module_data = LoadedOpData(
+            _context_deepseek_v4_data(4, module_grid),
+            common.PerfDataFilename.deepseek_v4_context_module,
+            "mock_raw_dsv4_flash_context_module_tp8",
+        )
+
+        result = db.query_context_deepseek_v4_attention_module(
+            **{
+                **_deepseek_v4_attn_kwargs(4),
+                "b": 3,
+                "s": 2682,
+                "prefix": 0,
+                "num_heads": 8,
+            },
+            database_mode=common.DatabaseMode.SILICON,
+        )
+
+        assert float(result) > 0
+        assert result.energy >= 0
 
 
 def test_deepseek_v4_static_sol_and_hybrid_run_end_to_end(mutable_comprehensive_perf_db):

--- a/tests/unit/sdk/database/test_dsv4_flash_sparse.py
+++ b/tests/unit/sdk/database/test_dsv4_flash_sparse.py
@@ -236,6 +236,8 @@ def test_robust_3d_lookup_exact_match_short_circuits():
 
 def _make_sparse_db_with_paged_mqa(tmp_path, *, lat_at_past0: float, lat_at_past8192: float):
     """Helper: build a minimal PerfDatabase carrying paged_mqa_logits at tp=1."""
+    from aiconfigurator.sdk.perf_database import PerfDatabase
+
     rows = [
         _sparse_row(kernel="paged_mqa_logits", bs=1, isl=8192, past_kv=0, tp=1, cr=4, lat=lat_at_past0),
         _sparse_row(kernel="paged_mqa_logits", bs=1, isl=8192, past_kv=8192, tp=1, cr=4, lat=lat_at_past8192),
@@ -248,6 +250,8 @@ def _make_sparse_db_with_paged_mqa(tmp_path, *, lat_at_past0: float, lat_at_past
         _dsv4_flash_sparse_kernel_data: ClassVar[dict] = {
             "paged_mqa_logits": LoadedOpData(data, None, path),
         }
+        _interp_1d = PerfDatabase._interp_1d
+        _nearest_1d_point_helper = PerfDatabase._nearest_1d_point_helper
 
     return _DB()
 
@@ -355,6 +359,44 @@ def test_lookup_sparse_kernel_past_kv_linear_interp(tmp_path):
     assert val == pytest.approx(0.2, rel=1e-3)
 
 
+def test_lookup_sparse_kernel_uses_cubic_3d_before_fallback():
+    from aiconfigurator.sdk.perf_database import PerfDatabase
+
+    calls = []
+
+    class _DB:
+        _dsv4_flash_sparse_kernel_data: ClassVar[dict] = {
+            "paged_mqa_logits": LoadedOpData(
+                {
+                    "DeepseekV4ForCausalLM": {
+                        1: {
+                            0: {1024: {1: _sparse_value(1.0)}},
+                            4096: {2048: {2: _sparse_value(4.0)}},
+                        }
+                    }
+                },
+                None,
+                "mock_paged_mqa_logits",
+            ),
+        }
+
+        def _interp_3d(self, x, y, z, data, method):
+            calls.append((x, y, z, method))
+            return {"latency": 7.0}
+
+    val = PerfDatabase._lookup_dsv4_flash_sparse_kernel(
+        _DB(),
+        kernel="paged_mqa_logits",
+        bs=2,
+        isl=1536,
+        past_kv=2048,
+        tp_size=1,
+    )
+
+    assert val == pytest.approx(7.0)
+    assert calls == [(2048, 1536, 2, "cubic")]
+
+
 def test_lookup_sparse_kernel_uses_b2_when_bs3_s2682_is_missing():
     from aiconfigurator.sdk.perf_database import PerfDatabase
 
@@ -370,6 +412,23 @@ def test_lookup_sparse_kernel_uses_b2_when_bs3_s2682_is_missing():
 
     b2_at_2682 = 4.80 + (5.80 - 4.80) * (2682 - 2048) / (4096 - 2048)
     assert val == pytest.approx(b2_at_2682 * 3 / 2)
+
+
+def test_lookup_sparse_kernel_uses_largest_batch_that_covers_isl():
+    from aiconfigurator.sdk.perf_database import PerfDatabase
+
+    db = _make_sparse_db_from_grid({0: _sparse_sampled_batch_caps_grid()})
+    val = PerfDatabase._lookup_dsv4_flash_sparse_kernel(
+        db,
+        kernel="paged_mqa_logits",
+        bs=5,
+        isl=2682,
+        past_kv=0,
+        tp_size=1,
+    )
+
+    b2_at_2682 = 4.80 + (5.80 - 4.80) * (2682 - 2048) / (4096 - 2048)
+    assert val == pytest.approx(b2_at_2682 * 5 / 2)
 
 
 def test_lookup_sparse_kernel_uses_b4_when_bs5_s1565_is_missing():

--- a/tests/unit/sdk/database/test_dsv4_flash_sparse.py
+++ b/tests/unit/sdk/database/test_dsv4_flash_sparse.py
@@ -229,23 +229,6 @@ def test_robust_3d_lookup_exact_match_short_circuits():
     assert result["latency"] == pytest.approx(11.7)
 
 
-def test_robust_3d_lookup_falls_back_to_linear_when_cubic_fails():
-    """Cubic raise (QhullError on degenerate point cloud) → linear path runs."""
-    calls = []
-
-    class _Stub:
-        def _interp_3d(self, x, y, z, d, method):
-            calls.append(method)
-            if method == "cubic":
-                raise RuntimeError("QH6154 simulated qhull failure")
-            return {"latency": 4.94, "energy": 0.0}
-
-    # Empty data → exact lookup misses
-    result = _dsv4_flash_robust_3d_lookup(_Stub(), {}, 8, 8192, 1)
-    assert calls == ["cubic", "linear"]
-    assert result["latency"] == pytest.approx(4.94)
-
-
 # ───────────────────────────────────────────────────────────────────────
 # _lookup_dsv4_flash_sparse_kernel — tp fallback + past_kv interp
 # ───────────────────────────────────────────────────────────────────────
@@ -265,6 +248,52 @@ def _make_sparse_db_with_paged_mqa(tmp_path, *, lat_at_past0: float, lat_at_past
         _dsv4_flash_sparse_kernel_data: ClassVar[dict] = {
             "paged_mqa_logits": LoadedOpData(data, None, path),
         }
+
+    return _DB()
+
+
+def _sparse_value(latency: float) -> dict[str, float]:
+    return {"latency": latency}
+
+
+def _sparse_sampled_batch_caps_grid(*, offset: float = 0.0) -> dict:
+    """Mock sparse-kernel data with real V4-Flash batch caps."""
+    return {
+        1024: {
+            1: _sparse_value(offset + 1.00),
+            2: _sparse_value(offset + 3.00),
+            4: _sparse_value(offset + 6.00),
+            8: _sparse_value(offset + 12.00),
+        },
+        2048: {
+            1: _sparse_value(offset + 2.00),
+            2: _sparse_value(offset + 4.80),
+            4: _sparse_value(offset + 8.00),
+        },
+        4096: {
+            1: _sparse_value(offset + 3.00),
+            2: _sparse_value(offset + 5.80),
+        },
+        8192: {
+            1: _sparse_value(offset + 4.00),
+        },
+    }
+
+
+def _make_sparse_db_from_grid(per_tp_dict: dict):
+    from aiconfigurator.sdk.perf_database import PerfDatabase
+
+    class _DB:
+        _dsv4_flash_sparse_kernel_data: ClassVar[dict] = {
+            "paged_mqa_logits": LoadedOpData(
+                {"DeepseekV4ForCausalLM": {1: per_tp_dict}},
+                None,
+                "mock_paged_mqa_logits",
+            ),
+        }
+        _interp_2d_linear = PerfDatabase._interp_2d_linear
+        _interp_1d = PerfDatabase._interp_1d
+        _nearest_1d_point_helper = PerfDatabase._nearest_1d_point_helper
 
     return _DB()
 
@@ -326,6 +355,66 @@ def test_lookup_sparse_kernel_past_kv_linear_interp(tmp_path):
     assert val == pytest.approx(0.2, rel=1e-3)
 
 
+def test_lookup_sparse_kernel_uses_b2_when_bs3_s2682_is_missing():
+    from aiconfigurator.sdk.perf_database import PerfDatabase
+
+    db = _make_sparse_db_from_grid({0: _sparse_sampled_batch_caps_grid()})
+    val = PerfDatabase._lookup_dsv4_flash_sparse_kernel(
+        db,
+        kernel="paged_mqa_logits",
+        bs=3,
+        isl=2682,
+        past_kv=0,
+        tp_size=1,
+    )
+
+    b2_at_2682 = 4.80 + (5.80 - 4.80) * (2682 - 2048) / (4096 - 2048)
+    assert val == pytest.approx(b2_at_2682 * 3 / 2)
+
+
+def test_lookup_sparse_kernel_uses_b4_when_bs5_s1565_is_missing():
+    from aiconfigurator.sdk.perf_database import PerfDatabase
+
+    isl = 1565.2
+    db = _make_sparse_db_from_grid({0: _sparse_sampled_batch_caps_grid()})
+    val = PerfDatabase._lookup_dsv4_flash_sparse_kernel(
+        db,
+        kernel="paged_mqa_logits",
+        bs=5,
+        isl=isl,
+        past_kv=0,
+        tp_size=1,
+    )
+
+    b4_at_isl = 6.00 + (8.00 - 6.00) * (isl - 1024) / (2048 - 1024)
+    assert val == pytest.approx(b4_at_isl * 5 / 4)
+
+
+def test_lookup_sparse_kernel_interpolates_past_kv_after_batch_fallback():
+    from aiconfigurator.sdk.perf_database import PerfDatabase
+
+    isl = 1565.2
+    db = _make_sparse_db_from_grid(
+        {
+            0: _sparse_sampled_batch_caps_grid(offset=0.0),
+            4096: _sparse_sampled_batch_caps_grid(offset=4.0),
+        }
+    )
+    val = PerfDatabase._lookup_dsv4_flash_sparse_kernel(
+        db,
+        kernel="paged_mqa_logits",
+        bs=5,
+        isl=isl,
+        past_kv=2048,
+        tp_size=1,
+    )
+
+    b4_at_isl = 6.00 + (8.00 - 6.00) * (isl - 1024) / (2048 - 1024)
+    at_past_0 = b4_at_isl * 5 / 4
+    at_past_4096 = (b4_at_isl + 4.0) * 5 / 4
+    assert val == pytest.approx((at_past_0 + at_past_4096) / 2)
+
+
 def test_lookup_sparse_kernel_missing_returns_none():
     """Missing dict / kernel name → None (caller uses SOL ratio fallback)."""
     from aiconfigurator.sdk.perf_database import PerfDatabase
@@ -377,20 +466,21 @@ def test_dsv4_flash_test_cases_skipped_under_other_model(monkeypatch):
 
 
 def test_dsv4_flash_test_cases_active_under_v4_filter(monkeypatch):
-    monkeypatch.setenv("COLLECTOR_MODEL_PATH", "deepseek-ai/DeepSeek-V4-Flash")
+    model_path = "sgl-project/DeepSeek-V4-Flash-FP8"
+    monkeypatch.setenv("COLLECTOR_MODEL_PATH", model_path)
     from collector.common_test_cases import get_dsv4_flash_csa_context_test_cases
 
     cases = get_dsv4_flash_csa_context_test_cases()
     assert len(cases) > 0
-    # all cases reference the V4-Flash model name
-    assert {c[6] for c in cases} == {"deepseek-ai/DeepSeek-V4-Flash"}
+    # all cases use the caller-provided V4-Flash model path
+    assert {c[6] for c in cases} == {model_path}
     # all cases for this op are CSA
     assert {c[7] for c in cases} == {"csa"}
 
 
 def test_dsv4_flash_sparse_test_cases_only_indexer_tp1(monkeypatch):
     """Sweep is fixed at tp=[1] (kernel is TP-invariant)."""
-    monkeypatch.setenv("COLLECTOR_MODEL_PATH", "deepseek-ai/DeepSeek-V4-Flash")
+    monkeypatch.setenv("COLLECTOR_MODEL_PATH", "sgl-project/DeepSeek-V4-Flash-FP8")
     from collector.common_test_cases import (
         get_dsv4_flash_hca_attn_test_cases,
         get_dsv4_flash_paged_mqa_logits_test_cases,


### PR DESCRIPTION
#### Overview:

  Two fixes for DeepSeek-V4-Flash in AIC: (1) make mixed-batch context-attention                                                                                                                                                                    
  queries robust when the requested `(bs, isl)` falls outside the captured perf
  grid; (2) point the collector's V4-Flash default at the FP8 quant variant we                                                                                                                                                                      
  actually run on Hopper (H20), so the `deepseek-ai/DeepSeek-V4-Flash` logical                                                                                                                                                                      
  name no longer (silently) triggers any data collection on its own.                                                                                                                                                                                
                                                                                                                                                                                                                                                    
  #### Details:                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                    
  **1. Smaller-batch fallback in `_dsv4_flash_robust_3d_lookup`**                                                                                                                                                                                   
     (`src/aiconfigurator/sdk/perf_database.py`)
                                                                                                                                                                                                                                                    
  V4-Flash sweeps only b ∈ {1, 2, 4, 8, ..., 1024} and the grid is trapezoidal:
  larger b -> smaller max captured s. A query for an unsampled batch (e.g. bs=3                                                                                                                                                                     
  from a 3-request prefill batch with avg_isl=2670) hits a region where both                                                                                                                                                                        
  cubic and linear 3D interp return NaN (or raise on degenerate point clouds),                                                                                                                                                                      
  leaving the caller without a value.                                                                                                                                                                                                               
                                                                                                                                                                                                                                                    
  The robust lookup now adds a final fallback: pick the largest captured b' < z,                                                                                                                                                                    
  1D-interpolate along s at b' if exact y is missing, and linearly scale the                                                                                                                                                                        
  leaf by z/b'. FlashMLA varlen attention work scales near-linearly with batch                                                                                                                                                                      
  at fixed seq_len, so this is a physically reasonable extrapolation.                                                                                                                                                                               
                                                                                                                                                                                                                                                    
  **2. Collector V4-Flash default → sgl-project FP8**                                                                                                                                                                                               
     (`collector/common_test_cases.py`, `collector/collect.py`)                                                                                                                                                                                     
   
  `_DSV4_FLASH_DEFAULT_MODEL` and `collect.py`'s auto-expand trigger both move                                                                                                                                                                      
  from `deepseek-ai/DeepSeek-V4-Flash` (native MXFP4, Hopper unsupported) to                                                                                                                                                                        
  `sgl-project/DeepSeek-V4-Flash-FP8` (FP8 block quant, the variant we run).                                                                                                                                                                        
  After this change `--model-path deepseek-ai/DeepSeek-V4-Flash` is a no-op for                                                                                                                                                                     
  dsv4_flash_* collection — that name will be wired up later, separately.                                                                                                                                                                           
                                                                                                                                                                                                                                                    
  #### Where should the reviewer start?                                                                                                                                                                                                             
                                                                                                                                                                                                                                                    
  - `src/aiconfigurator/sdk/perf_database.py` — the fallback logic in
    `_dsv4_flash_robust_3d_lookup`. The hot-path early return for cubic/linear                                                                                                                                                                      
    is unchanged; only the previously-thrown failure case now extrapolates.                                                                                                                                                                         
  - `tests/unit/sdk/database/test_deepseek_v4_module.py` — two new tests                                                                                                                                                                            
    document the fallback contract (interp-along-s + scale-by-batch, plus the                                                                                                                                                                       
    trapezoidal case where the closest b' has no anchor at the query s).                                                                                                                                                                            
  - The two collector-side one-liners are mechanical.    

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated V4-Flash model configuration for improved system compatibility.
  * Enhanced performance lookup with robust fallback strategies for better edge case handling.

* **Tests**
  * Added comprehensive test coverage for V4-Flash performance lookup edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->