### PR TITLE
docs: note DeepSeek-V4 SGLang image requirement

### DIFF
--- a/collector/sglang/collect_dsv4_flash_attn.py
+++ b/collector/sglang/collect_dsv4_flash_attn.py
@@ -23,6 +23,10 @@ Manual CLI use::
         --batch-sizes 1,4 --seq-lens 128,1024
 """
 
+# Requires an SGLang build with DeepSeek-V4 support. Stock lmsysorg/sglang:v*
+# images may not include the required deepseek_v4 modules; use a
+# deepseek-v4-blackwell/deepseek-v4-grace-blackwell image or matching Dynamo
+# sglang-runtime:*deepseek-v4* image.
 from __future__ import annotations
 
 import argparse

--- a/collector/sglang/collect_mhc_module.py
+++ b/collector/sglang/collect_mhc_module.py
@@ -3,6 +3,10 @@
 
 """DeepSeek-V4 mHC pre/post module collector for SGLang."""
 
+# Requires an SGLang build with DeepSeek-V4 support. Stock lmsysorg/sglang:v*
+# images may not include the required deepseek_v4 modules; use a
+# deepseek-v4-blackwell/deepseek-v4-grace-blackwell image or matching Dynamo
+# sglang-runtime:*deepseek-v4* image.
 from __future__ import annotations
 
 import argparse

--- a/collector/sglang/deepseekv4_sparse_modules.py
+++ b/collector/sglang/deepseekv4_sparse_modules.py
@@ -27,6 +27,10 @@ shared): ``isl`` carries M, ``step`` carries past_kv, ``compress_ratio``
 distinguishes CSA(=4) / HCA(=128).
 """
 
+# Requires an SGLang build with DeepSeek-V4 support. Stock lmsysorg/sglang:v*
+# images may not include the required deepseek_v4 modules; use a
+# deepseek-v4-blackwell/deepseek-v4-grace-blackwell image or matching Dynamo
+# sglang-runtime:*deepseek-v4* image.
 from __future__ import annotations
 
 import argparse


### PR DESCRIPTION
## Summary
- add per-file notes that DeepSeek-V4 SGLang collectors require a DSV4-capable SGLang image
- point away from stock lmsysorg/sglang:v* images for these collectors

## Validation
- python3 -m py_compile collector/sglang/collect_dsv4_flash_attn.py collector/sglang/deepseekv4_sparse_modules.py collector/sglang/collect_mhc_module.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarifications on runtime build and Docker image requirements for proper DeepSeek-V4 module support in the SGLang collector.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->