### PR TITLE
fix: when no parato exists, should not fail the workflow

### DIFF
--- a/src/aiconfigurator/cli/report_and_save.py
+++ b/src/aiconfigurator/cli/report_and_save.py
@@ -276,7 +276,7 @@ def log_final_summary(
     chosen_exp: str,
     best_throughputs: dict[str, float],
     best_configs: dict[str, pd.DataFrame],
-    pareto_fronts: dict[str, pd.DataFrame],
+    pareto_fronts: dict[str, pd.DataFrame | None],
     task_configs: dict[str, TaskConfig],
     mode: str,
     pareto_x_axis: dict[str, str] | None = None,
@@ -464,7 +464,7 @@ def log_final_summary(
 def save_results(
     args,
     best_configs: dict[str, pd.DataFrame],
-    pareto_fronts: dict[str, pd.DataFrame],
+    pareto_fronts: dict[str, pd.DataFrame | None],
     task_configs: dict[str, TaskConfig],
     save_dir: str,
     generated_backend_version: str | None = None,
@@ -546,9 +546,9 @@ def save_results(
         color_idx = 0
 
         for exp_name, pareto_df in pareto_fronts.items():
-            if pareto_axis.get(exp_name, global_x_axis) != global_x_axis:
+            if pareto_df is None or pareto_df.empty:
                 continue
-            if pareto_df.empty:
+            if pareto_axis.get(exp_name, global_x_axis) != global_x_axis:
                 continue
 
             # Check if this is multi-backend mode (pareto_df has "backend" column)


### PR DESCRIPTION
# Description

When no parato is generated, the `--save-dir` should not fail.

# Example of Failure

When `--total-gpus` is not enough, disagg more failed to generate config, which may be expected.

```
cli default --model Qwen/Qwen3.5-397B-A17B --system b200_sxm --backend sglang --isl 8196 --osl 1024 --total-gpus 32 --save-dir results

Traceback (most recent call last):
  File "/Users/harrli/projects/aiconfigurator/src/aiconfigurator/cli/report_and_save.py", line 551, in save_results
    if pareto_df.empty:
       ^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'empty'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced handling of missing or unavailable Pareto front data during result logging and saving operations to prevent errors when Pareto analysis information is not available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->