### PR TITLE
chore: Add data from auto-collector pipeline 50677732 (b300_sxm_vllm_0.19.0)

### DIFF
--- a/src/aiconfigurator/systems/data/b300_sxm/vllm/0.19.0/dsa_context_module_perf.txt
+++ b/src/aiconfigurator/systems/data/b300_sxm/vllm/0.19.0/dsa_context_module_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f511ec19dbca6fa508fc973369a25131e882aff6e23a6752cb73d237157363d
+size 4941459

--- a/src/aiconfigurator/systems/data/b300_sxm/vllm/0.19.0/dsa_generation_module_perf.txt
+++ b/src/aiconfigurator/systems/data/b300_sxm/vllm/0.19.0/dsa_generation_module_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5360bdd5213ccf492fd2d3aee5e9801e4a9dd72f2d89bef697dd24a612e89f8
+size 2644788

--- a/src/aiconfigurator/systems/data/b300_sxm/vllm/0.19.0/mla_context_module_perf.txt
+++ b/src/aiconfigurator/systems/data/b300_sxm/vllm/0.19.0/mla_context_module_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:270247cd76e05cf329feee92b0c317e46fb830bbc546a249c1eaf7c008620d2a
+size 2597230

--- a/src/aiconfigurator/systems/data/b300_sxm/vllm/0.19.0/mla_generation_module_perf.txt
+++ b/src/aiconfigurator/systems/data/b300_sxm/vllm/0.19.0/mla_generation_module_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51adab20e0f41c5e62bc76ed20b749d06b93d8243a3280eea7b0676d87ea3126
+size 2715458


### PR DESCRIPTION
# Add b300_sxm DSV32/GLM-5 perf data (vllm 0.19.0)

## Tracking

Part of [AIC-1018](https://linear.app/nvidia/issue/AIC-1018/add-missing-data-entries-to-heal-dsv32glm5-support-matrix) — *"Add missing data entries to heal dsv32/GLM5 support matrix"* (Urgent, AIC 0.9.0).

## What this adds

Four perf files for `b300_sxm` × `vllm 0.19.0` × DSV32-family ops:

```
src/aiconfigurator/systems/data/b300_sxm/vllm/0.19.0/dsa_context_module_perf.txt
src/aiconfigurator/systems/data/b300_sxm/vllm/0.19.0/dsa_generation_module_perf.txt
src/aiconfigurator/systems/data/b300_sxm/vllm/0.19.0/mla_context_module_perf.txt
src/aiconfigurator/systems/data/b300_sxm/vllm/0.19.0/mla_generation_module_perf.txt
```

Both DSV32 (`DeepseekV32ForCausalLM`) and GLM-5 (`GlmMoeDsaForCausalLM`) rows are emitted in the `dsa_*` files (per `collector/vllm/collect_mla_module_v3.py`'s `SUPPORTED_MODELS`), so this single PR covers both architectures' silicon-mode lookups for DSA on b300_sxm.

## Provenance

Collected by [aic-auto-collector pipeline 50677732](https://gitlab-master.nvidia.com/dl/ai-dynamo/aic-auto-collector/-/pipelines/50677732), running off branch `fix/vllm-fa3-scheduler-metadata` — i.e., the collector branch from #1004 which fixes the FA3 `scheduler_metadata` shape mismatch on Hopper. b300_sxm doesn't trigger that bug (Blackwell uses non-FA3 attention), so this data would be identical on `main`; including the trail anyway since the same branch will produce h100/h200/gb200/gb300 data next.

## Quality

```
total_errors: 0
errors_by_module: {}
errors_by_type:   {}
```

All 4 ops completed cleanly across the three chained slurm allocations the run took (~10.5h wall time, well under any threshold; multiple-allocation chaining was a transient artifact of the dlcluster wall, not a quality concern).

## Impact

Closes the missing-data gap for **b300_sxm + vllm 0.19** in the DSV32 and GLM-5 rows of `support_matrix.csv`. Both should flip from FAIL (`PerfDataNotAvailableError: dsa_context_module_perf.txt does not exist`) to PASS once this lands. h100_sxm / h200_sxm / gb200 / gb300 collections are in flight; they'll arrive as separate per-system data PRs.
