### PR TITLE
chore: Add data from auto-collector pipeline 50731506 (h100_sxm_vllm_0.19.0)

### DIFF
--- a/src/aiconfigurator/systems/data/h100_sxm/vllm/0.19.0/dsa_generation_module_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/vllm/0.19.0/dsa_generation_module_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ee78dcc0d23cd3a409ab9b395ffa0c323445d6b537953747a9483ca8ef83776
+size 1770524


### PR DESCRIPTION
# Error Summary for Auto-Collector Run
## Collection summary for h100_sxm vllm:0.19.0
### Error summary
```
{
    "backend": "vllm",
    "version": "0.19.0",
    "timestamp": "2026-05-09T00:25:05.956774",
    "total_errors": 192,
    "errors_by_module": {
        "vllm.dsa_generation_module": 192
    },
    "errors_by_type": {
        "OutOfMemoryError": 192
    }
}
```

