### PR TITLE
Feat/dsv4 pro attn

### DIFF
--- a/collector/common_test_cases.py
+++ b/collector/common_test_cases.py
@@ -735,24 +735,41 @@ def get_common_gdn_test_cases() -> list[GdnCommonTestCase]:
 # Both backends re-export the relevant ``get_*`` functions so collect.py
 # can resolve them via getattr on each per-backend module.
 
-_DSV4_FLASH_MODEL_PATH = "sgl-project/DeepSeek-V4-Flash-FP8"
+_DSV4_FLASH_DEFAULT_MODEL = "sgl-project/DeepSeek-V4-Flash-FP8"
+_DSV4_FLASH_MODELS = {
+    "deepseek-ai/DeepSeek-V4-Flash",
+    "sgl-project/DeepSeek-V4-Flash-FP8",
+}
+_DSV4_MODULE_MODELS = {
+    *_DSV4_FLASH_MODELS,
+    "deepseek-ai/DeepSeek-V4-Pro",
+    "sgl-project/DeepSeek-V4-Pro-FP8",
+}
 DSV4_FLASH_ATTN_KINDS = ("csa", "hca")
+
+
+def _dsv4_module_model_paths() -> list[str]:
+    """Return DSv4 attention-module models selected by COLLECTOR_MODEL_PATH."""
+    filt = _get_model_path_filter()
+    if filt is None:
+        return [_DSV4_FLASH_DEFAULT_MODEL]
+    return [filt] if filt in _DSV4_MODULE_MODELS else []
 
 
 def _dsv4_flash_active() -> bool:
     """Honour the ``--model-path`` (``COLLECTOR_MODEL_PATH``) filter.
 
-    All V4-Flash test cases are V4-Flash-only by construction.  When the
+    Sparse-kernel V4-Flash test cases are V4-Flash-only by construction. When the
     user filters to a different model, every V4-Flash op must emit zero
     cases so the collector skips it.
     """
     filt = _get_model_path_filter()
-    return filt is None or filt == _DSV4_FLASH_MODEL_PATH
+    return filt is None or filt in _DSV4_FLASH_MODELS
 
 
 def _dsv4_flash_model_path() -> str:
     filt = _get_model_path_filter()
-    return filt if filt is not None else _DSV4_FLASH_MODEL_PATH
+    return filt if filt in _DSV4_FLASH_MODELS else _DSV4_FLASH_DEFAULT_MODEL
 
 
 # --- Module-level (full self_attn) sweep ---
@@ -862,50 +879,42 @@ def _build_dsv4_flash_module_test_cases(mode: str, attn_kinds=DSV4_FLASH_ATTN_KI
     """
     pairs = _dsv4_flash_module_filter_pairs(mode, _DSV4_FLASH_MODULE_BATCH_SIZES, _DSV4_FLASH_MODULE_SEQ_LENGTHS)
     bs_set = sorted({bs for bs, _ in pairs})
-    model_path = _dsv4_flash_model_path()
 
     cases: list[list] = []
-    for attn_kind in attn_kinds:
-        for compute_dtype, kv_dtype, gemm_type in _dsv4_flash_module_precision_combos(mode):
-            for tp_size in _DSV4_FLASH_MODULE_TP_SIZES:
-                for bs in bs_set:
-                    cases.append(
-                        [
-                            0,
-                            bs,
-                            tp_size,
-                            kv_dtype,
-                            compute_dtype,
-                            gemm_type,
-                            model_path,
-                            attn_kind,
-                            None,
-                        ]
-                    )
+    for model_path in _dsv4_module_model_paths():
+        for attn_kind in attn_kinds:
+            for compute_dtype, kv_dtype, gemm_type in _dsv4_flash_module_precision_combos(mode):
+                for tp_size in _DSV4_FLASH_MODULE_TP_SIZES:
+                    for bs in bs_set:
+                        cases.append(
+                            [
+                                0,
+                                bs,
+                                tp_size,
+                                kv_dtype,
+                                compute_dtype,
+                                gemm_type,
+                                model_path,
+                                attn_kind,
+                                None,
+                            ]
+                        )
     return cases
 
 
 def get_dsv4_flash_csa_context_test_cases():
-    if not _dsv4_flash_active():
-        return []
     return _build_dsv4_flash_module_test_cases("context", ("csa",))
 
 
 def get_dsv4_flash_hca_context_test_cases():
-    if not _dsv4_flash_active():
-        return []
     return _build_dsv4_flash_module_test_cases("context", ("hca",))
 
 
 def get_dsv4_flash_csa_generation_test_cases():
-    if not _dsv4_flash_active():
-        return []
     return _build_dsv4_flash_module_test_cases("generation", ("csa",))
 
 
 def get_dsv4_flash_hca_generation_test_cases():
-    if not _dsv4_flash_active():
-        return []
     return _build_dsv4_flash_module_test_cases("generation", ("hca",))
 
 

--- a/collector/sglang/collect_dsv4_flash_attn.py
+++ b/collector/sglang/collect_dsv4_flash_attn.py
@@ -152,6 +152,12 @@ ATTN_KIND_TO_COMPRESS_RATIO = {
 
 CLI_DEFAULT_MODEL = "deepseek-ai/DeepSeek-V4-Pro"
 _WEIGHT_SUFFIXES = (".safetensors", ".bin", ".pt", ".pth")
+_AIC_MODEL_CONFIG_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "src",
+    "aiconfigurator",
+    "model_configs",
+)
 
 
 _PORTS_PER_GPU = 1000
@@ -199,6 +205,27 @@ def _pick_free_port(gpu_id: int) -> int:
 def _kv_dtype_db_to_sglang(kv_dtype_db: str) -> str:
     """Map perf-database kv dtype string to SGLang's ServerArgs value."""
     return {"bfloat16": "bfloat16", "fp8": "fp8_e4m3"}[kv_dtype_db]
+
+
+def _cfg_get(cfg, key: str):
+    if cfg is None:
+        return None
+    if isinstance(cfg, dict):
+        return cfg.get(key)
+    return getattr(cfg, key, None)
+
+
+def _native_num_attention_heads(model_runner, attention_module) -> int:
+    for cfg in (
+        _cfg_get(model_runner, "model_config"),
+        _cfg_get(_cfg_get(model_runner, "model_config"), "hf_config"),
+        _cfg_get(_cfg_get(model_runner, "model"), "config"),
+        _cfg_get(attention_module, "config"),
+    ):
+        value = _cfg_get(cfg, "num_attention_heads")
+        if value is not None:
+            return int(value)
+    return NATIVE_HEADS
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -271,6 +298,15 @@ def _download_non_weight_model_files(model_id: str) -> tuple[str, dict]:
     return os.path.dirname(config_file), config
 
 
+def _read_packaged_model_config(model_id: str) -> dict:
+    cfg_fname = model_id.replace("/", "--") + "_config.json"
+    config_file = os.path.join(_AIC_MODEL_CONFIG_DIR, cfg_fname)
+    if not os.path.isfile(config_file):
+        raise FileNotFoundError(f"AIC packaged config not found for model_id={model_id!r}: expected {config_file}")
+    with open(config_file) as f:
+        return json.load(f)
+
+
 def _resolve_model_path(
     model_path: str,
     *,
@@ -306,6 +342,9 @@ def _resolve_model_path(
         src_dir = model_path
         with open(os.path.join(src_dir, "config.json")) as f:
             config = json.load(f)
+    elif os.environ.get("SGLANG_LOAD_FORMAT", "dummy") == "dummy":
+        src_dir = None
+        config = _read_packaged_model_config(model_path)
     else:
         src_dir, config = _download_non_weight_model_files(model_path)
 
@@ -365,7 +404,8 @@ def _resolve_model_path(
         f"aic_dsv4_{attn_kind}_{model_path.replace('/', '_')}_{os.getpid()}",
     )
     os.makedirs(tmp_dir, exist_ok=True)
-    _copy_non_weight_files(src_dir, tmp_dir)
+    if src_dir is not None:
+        _copy_non_weight_files(src_dir, tmp_dir)
     with open(os.path.join(tmp_dir, "config.json"), "w") as f:
         json.dump(config, f)
     return tmp_dir
@@ -850,6 +890,7 @@ def _log_result(
     perf_filename_prefix: str = "dsv4",
     gemm_type: str = "bfloat16",
     tp_size: int = 1,
+    num_heads: int = NATIVE_HEADS,
 ) -> None:
     # V4-Flash output layout: ONE CSV per (attn_kind, mode) — 3 kinds x 2
     # modes = 6 files total, regardless of how many (tp_size, gemm_type)
@@ -873,7 +914,7 @@ def _log_result(
                 "mla_dtype": "bfloat16",
                 "kv_cache_dtype": kv_cache_dtype,
                 "gemm_type": gemm_type,
-                "num_heads": NATIVE_HEADS,
+                "num_heads": num_heads,
                 "batch_size": batch_size,
                 "isl": seq_len if is_prefill else 1,
                 "tp_size": tp_size,
@@ -936,6 +977,7 @@ def run_dsv4_mla_module(
     )
 
     attention_module = model_runner.model.model.layers[layer_id].self_attn
+    native_num_heads = _native_num_attention_heads(model_runner, attention_module)
     actual_ratio = getattr(attention_module, "compress_ratio", None)
     if actual_ratio != compress_ratio:
         raise RuntimeError(f"target layer compress_ratio mismatch: expected {compress_ratio}, got {actual_ratio}")
@@ -995,6 +1037,7 @@ def run_dsv4_mla_module(
                         perf_filename_prefix=perf_filename_prefix,
                         gemm_type=gemm_type,
                         tp_size=tp_size,
+                        num_heads=native_num_heads,
                     )
                     stats.update(
                         {
@@ -1036,6 +1079,8 @@ def _run_subprocess(
     batch_size: int,
     output_path: str,
     gpu_id: int,
+    seq_lens: Iterable[int] | None = None,
+    allow_unfiltered_shapes: bool = False,
     gemm_type: str = "bfloat16",
     tp_size: int = 1,
 ):
@@ -1064,6 +1109,8 @@ def _run_subprocess(
         f'    model_path="{model_path}",\n'
         f'    kv_cache_dtype="{kv_cache_dtype_sglang}",\n'
         f"    batch_size={batch_size},\n"
+        f"    seq_lens={list(seq_lens) if seq_lens is not None else None!r},\n"
+        f"    allow_unfiltered_shapes={allow_unfiltered_shapes!r},\n"
         f'    output_path="{output_path}",\n'
         f'    gemm_type="{gemm_type}",\n'
         f"    tp_size={tp_size!r},\n"
@@ -1137,6 +1184,8 @@ def _subprocess_entry(
     model_path: str,
     kv_cache_dtype: str,
     batch_size: int,
+    seq_lens: Iterable[int] | None = None,
+    allow_unfiltered_shapes: bool = False,
     output_path: str,
     gemm_type: str = "bfloat16",
     tp_size: int = 1,
@@ -1147,7 +1196,14 @@ def _subprocess_entry(
     forward reuses the same allocator without re-init.
     """
     bs_grid, sl_grid = _expand_grid()
-    pairs = _filter_pairs(mode, [batch_size], sl_grid)
+    del bs_grid
+    if seq_lens is not None:
+        sl_grid = list(seq_lens)
+    pairs = (
+        [(batch_size, sl) for sl in sl_grid]
+        if allow_unfiltered_shapes
+        else _filter_pairs(mode, [batch_size], sl_grid)
+    )
     if not pairs:
         print(f"[dsv4-flash] no valid sl values for mode={mode}, bs={batch_size}")
         return
@@ -1289,6 +1345,14 @@ def _build_arg_parser() -> argparse.ArgumentParser:
             "h_q=64 (V4 zero-pads), so any TP power-of-2 in [1, 32] is valid."
         ),
     )
+    parser.add_argument(
+        "--allow-unfiltered-shapes",
+        action="store_true",
+        help=(
+            "Run the explicitly provided --batch-sizes/--seq-lens without the default safety cap. "
+            "Intended only for targeted boundary backfill after validating the shape."
+        ),
+    )
     return parser
 
 
@@ -1304,7 +1368,11 @@ def main() -> None:
     else:
         _, seq_lens = _expand_grid()
 
-    pairs = _filter_pairs(args.mode, batch_sizes, seq_lens)
+    pairs = (
+        [(bs, sl) for bs in batch_sizes for sl in seq_lens]
+        if args.allow_unfiltered_shapes
+        else _filter_pairs(args.mode, batch_sizes, seq_lens)
+    )
     _bs_grid = sorted({bs for bs, _ in pairs})
     kinds = [args.attn_kind] if args.attn_kind else list(ATTN_KINDS)
     tp_sizes = _parse_int_list(args.tp_sizes)
@@ -1331,6 +1399,8 @@ def main() -> None:
                         batch_size=bs,
                         output_path=output_path,
                         gpu_id=gpu_id,
+                        seq_lens=seq_lens,
+                        allow_unfiltered_shapes=args.allow_unfiltered_shapes,
                         gemm_type=args.gemm_type,
                         tp_size=tp_size,
                     )

--- a/src/aiconfigurator/sdk/backends/sglang_backend.py
+++ b/src/aiconfigurator/sdk/backends/sglang_backend.py
@@ -549,6 +549,13 @@ class SGLANGBackend(BaseBackend):
         weights /= model.config.pp_size
 
         h = model._num_heads * model._head_size
+        if model.model_family == "DEEPSEEKV4":
+            # DeepSeek-V4 decouples the residual/MoE hidden width from the
+            # attention-internal Q/O expansion. The coarse activation model
+            # below describes resident hidden/workspace tensors, so using
+            # num_heads * head_size would incorrectly apply the 65K-wide
+            # attention temporary dimension to MoE and residual activations.
+            h = getattr(model, "_hidden_size", h)
         if num_tokens == 0:
             num_tokens = (isl - prefix) * batch_size
 

--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -1378,11 +1378,17 @@ def _dsv4_normalize_dtype(name: str) -> str:
 # When sglang eventually adds real V4 head sharding, drop this special-case
 # and the generic ``local_heads`` axis will work directly.
 DSV4_FLASH_NATIVE_HEADS = 64
+DSV4_PRO_NATIVE_HEADS = 128
+DSV4_NATIVE_HEADS_BY_HIDDEN_SIZE = {
+    4096: DSV4_FLASH_NATIVE_HEADS,
+    7168: DSV4_PRO_NATIVE_HEADS,
+}
 
 
-def _dsv4_flash_tp_from_num_heads(num_heads: int) -> int:
+def _dsv4_flash_tp_from_num_heads(num_heads: int, hidden_size: int | None = None) -> int:
     """Recover ``tp_size`` from the model layer's ``local_heads`` value."""
-    return max(1, DSV4_FLASH_NATIVE_HEADS // max(num_heads, 1))
+    native_heads = DSV4_NATIVE_HEADS_BY_HIDDEN_SIZE.get(int(hidden_size or 0), DSV4_FLASH_NATIVE_HEADS)
+    return max(1, native_heads // max(num_heads, 1))
 
 
 def _dsv4_flash_robust_3d_lookup(self, dict_, x, y, z, *, batch_axis: str = "z"):
@@ -8045,7 +8051,9 @@ class PerfDatabase:
             # the actual tp_size for the lookup).  Other architectures are
             # unaffected; this branch only fires for DeepseekV4ForCausalLM.
             head_axis = (
-                _dsv4_flash_tp_from_num_heads(num_heads) if architecture == "DeepseekV4ForCausalLM" else num_heads
+                _dsv4_flash_tp_from_num_heads(num_heads, hidden_size=hidden_size)
+                if architecture == "DeepseekV4ForCausalLM"
+                else num_heads
             )
 
             # Pick correction strategy up-front because it changes the lookup
@@ -8233,7 +8241,9 @@ class PerfDatabase:
             # V4-Flash special-case: data keyed by ``tp_size`` (heads aren't
             # actually sharded — see note at top of file).
             head_axis = (
-                _dsv4_flash_tp_from_num_heads(num_heads) if architecture == "DeepseekV4ForCausalLM" else num_heads
+                _dsv4_flash_tp_from_num_heads(num_heads, hidden_size=hidden_size)
+                if architecture == "DeepseekV4ForCausalLM"
+                else num_heads
             )
             # V4-Flash generation data is keyed as [tp_size][batch][s_total].
             result = (

--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -1369,8 +1369,9 @@ def _dsv4_normalize_dtype(name: str) -> str:
 # see ``deepseek_v4.py:847``).  The kernel sees the same h_q on every rank.
 #
 # Rather than touch that generic math, the V4 path special-cases here:
-#   * The loader stores data keyed by ``tp_size`` (the column that actually
-#     differentiates rows for V4-Flash; see ``load_*_dsv4_flash_*`` below).
+#   * The loader stores data keyed by native head count, then by ``tp_size``
+#     (the column that differentiates rows within a model size; see
+#     ``load_*_dsv4_flash_*`` below).
 #   * The query helper recovers ``tp_size`` from the incoming ``num_heads``
 #     argument as ``DSV4_FLASH_NATIVE_HEADS // num_heads`` and uses that
 #     for the data lookup.
@@ -1385,9 +1386,23 @@ DSV4_NATIVE_HEADS_BY_HIDDEN_SIZE = {
 }
 
 
+def _dsv4_native_heads_from_hidden_size(hidden_size: int | None = None) -> int:
+    return DSV4_NATIVE_HEADS_BY_HIDDEN_SIZE.get(int(hidden_size or 0), DSV4_FLASH_NATIVE_HEADS)
+
+
+def _dsv4_native_heads_from_row(row: dict[str, str]) -> int:
+    try:
+        native_heads = int(row.get("num_heads") or 0)
+        if native_heads > 0:
+            return native_heads
+    except (TypeError, ValueError):
+        pass
+    return DSV4_PRO_NATIVE_HEADS if "pro" in row.get("model", "").lower() else DSV4_FLASH_NATIVE_HEADS
+
+
 def _dsv4_flash_tp_from_num_heads(num_heads: int, hidden_size: int | None = None) -> int:
     """Recover ``tp_size`` from the model layer's ``local_heads`` value."""
-    native_heads = DSV4_NATIVE_HEADS_BY_HIDDEN_SIZE.get(int(hidden_size or 0), DSV4_FLASH_NATIVE_HEADS)
+    native_heads = _dsv4_native_heads_from_hidden_size(hidden_size)
     return max(1, native_heads // max(num_heads, 1))
 
 
@@ -1502,13 +1517,15 @@ def _dsv4_flash_robust_3d_lookup(self, dict_, x, y, z, *, batch_axis: str = "z")
 def load_context_dsv4_flash_kind_module_data(file_path: str):
     """Load ONE V4-Flash context CSV (single attn_kind / compress_ratio).
 
-    Returns an 8-level nested dict:
-        data[fmha_quant][kv_quant][gemm_quant][arch][compress_ratio]
-            [tp_size][s][b] = {"latency": ms, "power": W, "energy": J}
+    Returns a 9-level nested dict:
+        data[fmha_quant][kv_quant][gemm_quant][arch][native_heads]
+            [compress_ratio][tp_size][s][b] = {"latency": ms, "power": W, "energy": J}
 
     ``tp_size`` is the data axis (V4-Flash doesn't shard heads — see top-of-
     file note + ``_dsv4_flash_tp_from_num_heads``).  Query side recovers
-    tp_size from the ``num_heads`` argument the model layer passes.
+    tp_size from the ``num_heads`` argument the model layer passes.  ``native_heads``
+    keeps Flash (64 heads) and Pro (128 heads) data separate when both use the
+    same architecture string and tp-size axis.
 
     Multiple files (csa/hca/swa) merge cleanly because compress_ratio is
     the differentiating leaf dimension.
@@ -1517,13 +1534,13 @@ def load_context_dsv4_flash_kind_module_data(file_path: str):
         logger.debug(f"DSV4-Flash module data file {file_path} not found.")
         return None
 
-    # 8-level nesting: fmha → kv → gemm → arch → cr → local_heads → s → b
+    # 9-level nesting: fmha → kv → gemm → arch → native_heads → cr → tp → s → b
     def _make_nested(depth: int):
         if depth == 0:
             return defaultdict()
         return defaultdict(lambda d=depth: _make_nested(d - 1))
 
-    data = _make_nested(7)
+    data = _make_nested(8)
 
     with open(file_path, encoding="utf-8") as f:
         rows = list(csv.DictReader(f))
@@ -1536,6 +1553,7 @@ def load_context_dsv4_flash_kind_module_data(file_path: str):
             b = int(row["batch_size"])
             s = int(row["isl"])
             tp_size = int(row.get("tp_size", 1))
+            native_heads = _dsv4_native_heads_from_row(row)
             cr = int(row["compress_ratio"])
             latency = float(row["latency"])
         except (TypeError, ValueError, KeyError):
@@ -1550,7 +1568,7 @@ def load_context_dsv4_flash_kind_module_data(file_path: str):
         # V4-Flash: TP doesn't shard heads (h_q=64 on every rank), so the
         # row-distinguishing axis is ``tp_size`` itself.  Query side recovers
         # this via ``_dsv4_flash_tp_from_num_heads``.  See top-of-file note.
-        data[fmha_mode][kv_dtype][gemm_mode][arch][cr][tp_size][s][b] = {
+        data[fmha_mode][kv_dtype][gemm_mode][arch][native_heads][cr][tp_size][s][b] = {
             "latency": latency,
             "power": power,
             "energy": power * latency,
@@ -1563,7 +1581,7 @@ def load_generation_dsv4_flash_kind_module_data(file_path: str):
 
     Generation lookup uses absolute KV length ``s_total = isl + step`` (decode
     is q_len=1 with past_kv = step).  Dict shape:
-        data[kv_quant][gemm_quant][arch][compress_ratio]
+        data[kv_quant][gemm_quant][arch][native_heads][compress_ratio]
             [tp_size][b][s_total]
 
     ``tp_size`` is the data axis; query side recovers it from the model layer's
@@ -1573,13 +1591,13 @@ def load_generation_dsv4_flash_kind_module_data(file_path: str):
         logger.debug(f"DSV4-Flash module data file {file_path} not found.")
         return None
 
-    # 7-level nesting: kv → gemm → arch → cr → tp_size → b → s_total
+    # 8-level nesting: kv → gemm → arch → native_heads → cr → tp_size → b → s_total
     def _make_nested(depth: int):
         if depth == 0:
             return defaultdict()
         return defaultdict(lambda d=depth: _make_nested(d - 1))
 
-    data = _make_nested(6)
+    data = _make_nested(7)
 
     with open(file_path, encoding="utf-8") as f:
         rows = list(csv.DictReader(f))
@@ -1592,6 +1610,7 @@ def load_generation_dsv4_flash_kind_module_data(file_path: str):
             b = int(row["batch_size"])
             s_total = int(row["isl"]) + int(row["step"])
             tp_size = int(row.get("tp_size", 1))
+            native_heads = _dsv4_native_heads_from_row(row)
             cr = int(row["compress_ratio"])
             latency = float(row["latency"])
         except (TypeError, ValueError, KeyError):
@@ -1606,7 +1625,7 @@ def load_generation_dsv4_flash_kind_module_data(file_path: str):
         # at the top of the file.  Generation convention puts ``b`` before
         # ``s_total`` (matches existing ``_interp_3d(num_heads, b, s, ...)``
         # call order in ``query_generation_*``).
-        data[kv_dtype][gemm_mode][arch][cr][tp_size][b][s_total] = {
+        data[kv_dtype][gemm_mode][arch][native_heads][cr][tp_size][b][s_total] = {
             "latency": latency,
             "power": power,
             "energy": power * latency,
@@ -8044,7 +8063,20 @@ class PerfDatabase:
                     f"DeepSeek-V4 context attention module data not loaded for system='{self.system}', "
                     f"backend='{self.backend}', version='{self.version}'."
                 )
-            deepseek_v4_dict = data[fmha_quant_mode][kvcache_quant_mode][gemm_quant_mode][architecture][compress_ratio]
+            native_heads = (
+                _dsv4_native_heads_from_hidden_size(hidden_size)
+                if architecture == "DeepseekV4ForCausalLM"
+                else num_heads
+            )
+            try:
+                deepseek_v4_dict = data[fmha_quant_mode][kvcache_quant_mode][gemm_quant_mode][architecture][
+                    native_heads
+                ][compress_ratio]
+            except KeyError as exc:
+                raise PerfDataNotAvailableError(
+                    "DeepSeek-V4 context attention module data not available for "
+                    f"{native_heads=}, {hidden_size=}, {compress_ratio=}, {architecture=}."
+                ) from exc
             # V4-Flash special-case: data is keyed by ``tp_size`` (sglang
             # never splits attention heads, so the "post-TP local_heads"
             # value the model layer passes here is just a label — recover
@@ -8099,8 +8131,8 @@ class PerfDatabase:
                 if raw_data is not None and getattr(raw_data, "loaded", True):
                     try:
                         raw_dict = raw_data[fmha_quant_mode][kvcache_quant_mode][gemm_quant_mode][architecture][
-                            compress_ratio
-                        ]
+                            native_heads
+                        ][compress_ratio]
                     except KeyError:
                         raw_dict = None
                 result = self._interp_context_topk_piecewise_from_raw(
@@ -8237,7 +8269,20 @@ class PerfDatabase:
                     f"DeepSeek-V4 generation attention module data not loaded for system='{self.system}', "
                     f"backend='{self.backend}', version='{self.version}'."
                 )
-            deepseek_v4_dict = data[kvcache_quant_mode][gemm_quant_mode][architecture][compress_ratio]
+            native_heads = (
+                _dsv4_native_heads_from_hidden_size(hidden_size)
+                if architecture == "DeepseekV4ForCausalLM"
+                else num_heads
+            )
+            try:
+                deepseek_v4_dict = data[kvcache_quant_mode][gemm_quant_mode][architecture][native_heads][
+                    compress_ratio
+                ]
+            except KeyError as exc:
+                raise PerfDataNotAvailableError(
+                    "DeepSeek-V4 generation attention module data not available for "
+                    f"{native_heads=}, {hidden_size=}, {compress_ratio=}, {architecture=}."
+                ) from exc
             # V4-Flash special-case: data keyed by ``tp_size`` (heads aren't
             # actually sharded — see note at top of file).
             head_axis = (

--- a/src/aiconfigurator/systems/data/gb200/sglang/0.5.10/dsv4_flash_csa_context_module_perf.txt
+++ b/src/aiconfigurator/systems/data/gb200/sglang/0.5.10/dsv4_flash_csa_context_module_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1effb88d51efbe404d43ef4ceea7d42c4de5c2312f95a6968e637b99b5964d5
+size 69275

--- a/src/aiconfigurator/systems/data/gb200/sglang/0.5.10/dsv4_flash_csa_generation_module_perf.txt
+++ b/src/aiconfigurator/systems/data/gb200/sglang/0.5.10/dsv4_flash_csa_generation_module_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66750f5e17242ab45e9d619b68e8a320541814c855a3fae53a7989930a1da3f0
+size 152047

--- a/src/aiconfigurator/systems/data/gb200/sglang/0.5.10/dsv4_flash_hca_context_module_perf.txt
+++ b/src/aiconfigurator/systems/data/gb200/sglang/0.5.10/dsv4_flash_hca_context_module_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2294ab2f5b9019cea39f48a8d23456ab1107aeee65734e574c843aff8ee601ca
+size 70035

--- a/src/aiconfigurator/systems/data/gb200/sglang/0.5.10/dsv4_flash_hca_generation_module_perf.txt
+++ b/src/aiconfigurator/systems/data/gb200/sglang/0.5.10/dsv4_flash_hca_generation_module_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f058842fddb515e97878730f2516b78e8d8a96d43c14497dd323ebebdf486451
+size 153679

--- a/src/aiconfigurator/systems/data/gb200/sglang/0.5.10/mhc_module_perf.txt
+++ b/src/aiconfigurator/systems/data/gb200/sglang/0.5.10/mhc_module_perf.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4b74788de93cb70b397eff104729a09042ae05f73923266a535779a6d09993a
+size 6283

--- a/tests/unit/sdk/database/test_deepseek_v4_module.py
+++ b/tests/unit/sdk/database/test_deepseek_v4_module.py
@@ -13,6 +13,8 @@ from aiconfigurator.sdk.config import RuntimeConfig
 from aiconfigurator.sdk.inference_summary import InferenceSummary
 from aiconfigurator.sdk.models import get_model
 from aiconfigurator.sdk.perf_database import (
+    DSV4_FLASH_NATIVE_HEADS,
+    DSV4_PRO_NATIVE_HEADS,
     LoadedOpData,
     PerfDataNotAvailableError,
     _dsv4_flash_robust_3d_lookup,
@@ -51,13 +53,17 @@ def _deepseek_v4_value(latency: float) -> dict[str, float]:
     return {"latency": latency, "power": 10.0, "energy": latency * 10.0}
 
 
-def _context_deepseek_v4_data(compress_ratio: int, attn_dict: dict) -> dict:
+def _context_deepseek_v4_data(
+    compress_ratio: int, attn_dict: dict, native_heads: int = DSV4_FLASH_NATIVE_HEADS
+) -> dict:
     return {
         common.FMHAQuantMode.bfloat16: {
             common.KVCacheQuantMode.fp8: {
                 common.GEMMQuantMode.fp8_block: {
                     "DeepseekV4ForCausalLM": {
-                        compress_ratio: attn_dict,
+                        native_heads: {
+                            compress_ratio: attn_dict,
+                        },
                     },
                 },
             },
@@ -65,12 +71,16 @@ def _context_deepseek_v4_data(compress_ratio: int, attn_dict: dict) -> dict:
     }
 
 
-def _generation_deepseek_v4_data(compress_ratio: int, attn_dict: dict) -> dict:
+def _generation_deepseek_v4_data(
+    compress_ratio: int, attn_dict: dict, native_heads: int = DSV4_FLASH_NATIVE_HEADS
+) -> dict:
     return {
         common.KVCacheQuantMode.fp8: {
             common.GEMMQuantMode.fp8_block: {
                 "DeepseekV4ForCausalLM": {
-                    compress_ratio: attn_dict,
+                    native_heads: {
+                        compress_ratio: attn_dict,
+                    },
                 },
             },
         },
@@ -283,6 +293,93 @@ class TestDeepSeekV4AttentionModule:
         expected = 0.20 + (0.50 - 0.20) * (1 - 2) / (5 - 2)
         assert float(result) == pytest.approx(expected)
         assert result.energy == pytest.approx(expected * 10.0)
+
+    def test_context_silicon_does_not_reuse_pro_module_rows_for_flash(self, mutable_comprehensive_perf_db):
+        db = mutable_comprehensive_perf_db
+        pro_grid = {
+            1: {
+                8192: {
+                    1: _deepseek_v4_value(6.0),
+                },
+            },
+        }
+        db._context_deepseek_v4_attention_module_data = LoadedOpData(
+            _context_deepseek_v4_data(4, pro_grid, native_heads=DSV4_PRO_NATIVE_HEADS),
+            common.PerfDataFilename.deepseek_v4_context_module,
+            "mock_dsv4_pro_context_module_tp1",
+        )
+        db._raw_context_deepseek_v4_attention_module_data = LoadedOpData(
+            _context_deepseek_v4_data(4, pro_grid, native_heads=DSV4_PRO_NATIVE_HEADS),
+            common.PerfDataFilename.deepseek_v4_context_module,
+            "mock_raw_dsv4_pro_context_module_tp1",
+        )
+
+        pro_result = db.query_context_deepseek_v4_attention_module(
+            **{
+                **_deepseek_v4_attn_kwargs(4),
+                "b": 1,
+                "s": 8192,
+                "num_heads": DSV4_PRO_NATIVE_HEADS,
+                "hidden_size": 7168,
+            },
+            database_mode=common.DatabaseMode.SILICON,
+        )
+        assert float(pro_result) == pytest.approx(6.0)
+
+        with pytest.raises(PerfDataNotAvailableError):
+            db.query_context_deepseek_v4_attention_module(
+                **{
+                    **_deepseek_v4_attn_kwargs(4),
+                    "b": 1,
+                    "s": 8192,
+                    "num_heads": DSV4_FLASH_NATIVE_HEADS,
+                    "hidden_size": 4096,
+                },
+                database_mode=common.DatabaseMode.SILICON,
+            )
+
+    def test_generation_silicon_does_not_reuse_pro_module_rows_for_flash(self, mutable_comprehensive_perf_db):
+        db = mutable_comprehensive_perf_db
+        pro_grid = {
+            1: {
+                1: {
+                    8192: _deepseek_v4_value(0.7),
+                },
+            },
+        }
+        db._generation_deepseek_v4_attention_module_data = LoadedOpData(
+            _generation_deepseek_v4_data(4, pro_grid, native_heads=DSV4_PRO_NATIVE_HEADS),
+            common.PerfDataFilename.deepseek_v4_generation_module,
+            "mock_dsv4_pro_generation_module_tp1",
+        )
+
+        pro_kwargs = _deepseek_v4_attn_kwargs(4)
+        pro_kwargs.pop("prefix")
+        pro_result = db.query_generation_deepseek_v4_attention_module(
+            **{
+                **pro_kwargs,
+                "b": 1,
+                "s": 8192,
+                "num_heads": DSV4_PRO_NATIVE_HEADS,
+                "hidden_size": 7168,
+            },
+            database_mode=common.DatabaseMode.SILICON,
+        )
+        assert float(pro_result) == pytest.approx(0.7)
+
+        flash_kwargs = _deepseek_v4_attn_kwargs(4)
+        flash_kwargs.pop("prefix")
+        with pytest.raises(PerfDataNotAvailableError):
+            db.query_generation_deepseek_v4_attention_module(
+                **{
+                    **flash_kwargs,
+                    "b": 1,
+                    "s": 8192,
+                    "num_heads": DSV4_FLASH_NATIVE_HEADS,
+                    "hidden_size": 4096,
+                },
+                database_mode=common.DatabaseMode.SILICON,
+            )
 
     def test_csa_topk_changes_attention_workload(self, comprehensive_perf_db):
         base = _deepseek_v4_attn_kwargs(4)

--- a/tests/unit/sdk/database/test_deepseek_v4_module.py
+++ b/tests/unit/sdk/database/test_deepseek_v4_module.py
@@ -7,8 +7,10 @@ import pytest
 
 from aiconfigurator.sdk import common, config
 from aiconfigurator.sdk import operations as ops
+from aiconfigurator.sdk.backends.sglang_backend import SGLANGBackend
 from aiconfigurator.sdk.backends.trtllm_backend import TRTLLMBackend
 from aiconfigurator.sdk.config import RuntimeConfig
+from aiconfigurator.sdk.inference_summary import InferenceSummary
 from aiconfigurator.sdk.models import get_model
 from aiconfigurator.sdk.perf_database import (
     LoadedOpData,
@@ -28,7 +30,7 @@ def _deepseek_v4_attn_kwargs(compress_ratio: int) -> dict:
         "s": 256,
         "prefix": 0,
         "num_heads": 16,
-        "hidden_size": 7168,
+        "hidden_size": 4096,
         "q_lora_rank": 1536,
         "o_lora_rank": 1024,
         "head_dim": 512,
@@ -561,3 +563,39 @@ def test_deepseek_v4_static_sol_and_hybrid_run_end_to_end(mutable_comprehensive_
         summary = backend.run_static(model, db, runtime, mode="static", stride=1)
         assert sum(summary.get_context_latency_dict().values()) > 0
         assert sum(summary.get_generation_latency_dict().values()) > 0
+
+
+def test_sglang_deepseek_v4_pro_prefill_memory_uses_hidden_size(mutable_comprehensive_perf_db):
+    db = mutable_comprehensive_perf_db
+    db.system_spec["gpu"]["mem_capacity"] = 198674743296  # GB200 189471 MiB
+    db.system_spec["misc"]["nccl_mem"] = {1: 0, 2: 358612992, 4: 411041792, 8: 411041792}
+    db.system_spec["misc"]["other_mem"] = 3758096384
+
+    model_config = config.ModelConfig(
+        tp_size=1,
+        pp_size=1,
+        attention_dp_size=8,
+        moe_tp_size=1,
+        moe_ep_size=8,
+        gemm_quant_mode=common.GEMMQuantMode.fp8_block,
+        moe_quant_mode=common.MoEQuantMode.w4a8_mxfp4_mxfp8,
+        kvcache_quant_mode=common.KVCacheQuantMode.fp8,
+        fmha_quant_mode=common.FMHAQuantMode.bfloat16,
+        comm_quant_mode=common.CommQuantMode.half,
+        nextn=0,
+    )
+    model = get_model("deepseek-ai/DeepSeek-V4-Pro", model_config, backend_name="sglang")
+
+    memory = SGLANGBackend()._get_memory_usage(
+        model,
+        db,
+        batch_size=1,
+        beam_width=1,
+        isl=8192,
+        osl=1024,
+    )
+
+    assert memory["activations"] == pytest.approx(8.05)
+    summary = InferenceSummary(RuntimeConfig(isl=8192, osl=1024))
+    summary.set_memory_and_check_oom(memory, db.system_spec["gpu"]["mem_capacity"])
+    assert not summary.check_oom()

--- a/tests/unit/sdk/database/test_dsv4_flash_sparse.py
+++ b/tests/unit/sdk/database/test_dsv4_flash_sparse.py
@@ -22,6 +22,7 @@ import pytest
 from aiconfigurator.sdk import common
 from aiconfigurator.sdk.perf_database import (
     DSV4_FLASH_NATIVE_HEADS,
+    DSV4_PRO_NATIVE_HEADS,
     LoadedOpData,
     _deep_merge_dsv4_dicts,
     _dsv4_flash_robust_3d_lookup,
@@ -46,21 +47,42 @@ _CTX_HEADER = (
 _SPARSE_HEADER = _CTX_HEADER  # same column layout
 
 
-def _ctx_row(*, attn_kind: str, cr: int, bs: int, isl: int, tp: int, gemm: str = "fp8_block", lat: float = 1.0) -> str:
+def _ctx_row(
+    *,
+    attn_kind: str,
+    cr: int,
+    bs: int,
+    isl: int,
+    tp: int,
+    gemm: str = "fp8_block",
+    lat: float = 1.0,
+    model: str = "deepseek-ai/DeepSeek-V4-Flash",
+    native_heads: int = DSV4_FLASH_NATIVE_HEADS,
+) -> str:
     return (
         f"SGLang,test,NVIDIA H20-3e,dsv4_flash_{attn_kind}_context_module,"
-        "compressed_flashmla,deepseek-ai/DeepSeek-V4-Flash,DeepseekV4ForCausalLM,"
-        f"bfloat16,fp8_e4m3,{gemm},64,{bs},{isl},{tp},0,{cr},{lat:.4f}"
+        f"compressed_flashmla,{model},DeepseekV4ForCausalLM,"
+        f"bfloat16,fp8_e4m3,{gemm},{native_heads},{bs},{isl},{tp},0,{cr},{lat:.4f}"
     )
 
 
 def _gen_row(
-    *, attn_kind: str, cr: int, bs: int, isl: int, step: int, tp: int, gemm: str = "fp8_block", lat: float = 0.1
+    *,
+    attn_kind: str,
+    cr: int,
+    bs: int,
+    isl: int,
+    step: int,
+    tp: int,
+    gemm: str = "fp8_block",
+    lat: float = 0.1,
+    model: str = "deepseek-ai/DeepSeek-V4-Flash",
+    native_heads: int = DSV4_FLASH_NATIVE_HEADS,
 ) -> str:
     return (
         f"SGLang,test,NVIDIA H20-3e,dsv4_flash_{attn_kind}_generation_module,"
-        "compressed_flashmla,deepseek-ai/DeepSeek-V4-Flash,DeepseekV4ForCausalLM,"
-        f"bfloat16,fp8_e4m3,{gemm},64,{bs},{isl},{tp},{step},{cr},{lat:.4f}"
+        f"compressed_flashmla,{model},DeepseekV4ForCausalLM,"
+        f"bfloat16,fp8_e4m3,{gemm},{native_heads},{bs},{isl},{tp},{step},{cr},{lat:.4f}"
     )
 
 
@@ -153,22 +175,36 @@ def test_load_dsv4_flash_sparse_kernel_data_missing_returns_none(tmp_path):
 # ───────────────────────────────────────────────────────────────────────
 
 
-def test_load_context_dsv4_flash_kind_module_data_keys_by_tp(tmp_path):
-    """Context loader must key the inner cube by ``tp_size``, not ``num_heads``."""
+def test_load_context_dsv4_flash_kind_module_data_keys_by_native_heads_and_tp(tmp_path):
+    """Context loader must separate model size before keying by tp_size."""
     rows = [
         _ctx_row(attn_kind="csa", cr=4, bs=1, isl=8192, tp=1, lat=18.0),
         _ctx_row(attn_kind="csa", cr=4, bs=1, isl=8192, tp=2, lat=14.0),
         _ctx_row(attn_kind="csa", cr=4, bs=1, isl=8192, tp=4, lat=11.5),
         _ctx_row(attn_kind="csa", cr=4, bs=1, isl=8192, tp=8, lat=10.5),
+        _ctx_row(
+            attn_kind="csa",
+            cr=4,
+            bs=1,
+            isl=8192,
+            tp=1,
+            lat=6.0,
+            model="deepseek-ai/DeepSeek-V4-Pro",
+            native_heads=DSV4_PRO_NATIVE_HEADS,
+        ),
     ]
     path = _write_csv(tmp_path / "csa_ctx.txt", _CTX_HEADER, rows)
     data = load_context_dsv4_flash_kind_module_data(path)
     arch = "DeepseekV4ForCausalLM"
-    sub = data[common.FMHAQuantMode.bfloat16][common.KVCacheQuantMode.fp8][common.GEMMQuantMode.fp8_block][arch][4]
+    by_native_heads = data[common.FMHAQuantMode.bfloat16][common.KVCacheQuantMode.fp8][
+        common.GEMMQuantMode.fp8_block
+    ][arch]
+    sub = by_native_heads[DSV4_FLASH_NATIVE_HEADS][4]
     # keys at the 6th level are tp_size {1, 2, 4, 8}
     assert set(sub.keys()) == {1, 2, 4, 8}
     # axis order continues [tp][s][b]
     assert sub[8][8192][1]["latency"] == pytest.approx(10.5)
+    assert by_native_heads[DSV4_PRO_NATIVE_HEADS][4][1][8192][1]["latency"] == pytest.approx(6.0)
     # TP variation must be preserved (smaller TP slower; projections 1/N sharded)
     assert sub[1][8192][1]["latency"] > sub[8][8192][1]["latency"]
 
@@ -188,7 +224,7 @@ def test_load_generation_dsv4_flash_kind_module_data_b_before_s(tmp_path):
     path = _write_csv(tmp_path / "csa_gen.txt", _CTX_HEADER, rows)
     data = load_generation_dsv4_flash_kind_module_data(path)
     arch = "DeepseekV4ForCausalLM"
-    sub = data[common.KVCacheQuantMode.fp8][common.GEMMQuantMode.fp8_block][arch][4]
+    sub = data[common.KVCacheQuantMode.fp8][common.GEMMQuantMode.fp8_block][arch][DSV4_FLASH_NATIVE_HEADS][4]
     # axis order [tp][b][s_total] — b comes before s_total
     s_total_short = 1 + 1023  # isl + step
     s_total_long = 1 + 8191

--- a/tests/unit/sdk/database/test_dsv4_flash_sparse.py
+++ b/tests/unit/sdk/database/test_dsv4_flash_sparse.py
@@ -99,6 +99,14 @@ def test_dsv4_flash_tp_from_num_heads_edge_cases():
     assert DSV4_FLASH_NATIVE_HEADS == 64
 
 
+@pytest.mark.parametrize(
+    "num_heads,expected_tp",
+    [(128, 1), (64, 2), (32, 4), (16, 8)],
+)
+def test_dsv4_pro_tp_from_num_heads_uses_pro_hidden_size(num_heads, expected_tp):
+    assert _dsv4_flash_tp_from_num_heads(num_heads, hidden_size=7168) == expected_tp
+
+
 # ───────────────────────────────────────────────────────────────────────
 # Loader: sparse-kernel CSV
 # ───────────────────────────────────────────────────────────────────────
@@ -535,6 +543,19 @@ def test_dsv4_flash_test_cases_active_under_v4_filter(monkeypatch):
     assert {c[6] for c in cases} == {model_path}
     # all cases for this op are CSA
     assert {c[7] for c in cases} == {"csa"}
+
+
+def test_dsv4_module_test_cases_active_under_v4_pro_filter(monkeypatch):
+    monkeypatch.setenv("COLLECTOR_MODEL_PATH", "deepseek-ai/DeepSeek-V4-Pro")
+    from collector.common_test_cases import (
+        get_dsv4_flash_csa_context_test_cases,
+        get_dsv4_flash_paged_mqa_logits_test_cases,
+    )
+
+    cases = get_dsv4_flash_csa_context_test_cases()
+    assert len(cases) > 0
+    assert {c[6] for c in cases} == {"deepseek-ai/DeepSeek-V4-Pro"}
+    assert get_dsv4_flash_paged_mqa_logits_test_cases() == []
 
 
 def test_dsv4_flash_sparse_test_cases_only_indexer_tp1(monkeypatch):


### PR DESCRIPTION
#### Overview:

  Adds DeepSeek-V4 Pro attention support for SGLang/GB200 by separating the attention
  collector, perf data, database lookup, and memory-model changes from the MegaMoE
  branch.

  #### Details:

  - Enables DSv4 module-level attention collection for DeepSeek-V4 Pro while keeping
  sparse V4-Flash kernel cases Flash-only.
  - Updates the SGLang DSv4 attention collector to use packaged model configs in dummy-
  load mode, log the model's native attention-head count, and support explicit shape
  backfills.
  - Adds GB200 SGLang DSv4 CSA/HCA context/generation attention module data and mHC
  module data.
  - Keys DSv4 attention module perf rows by native head count so Flash and Pro data do
  not share the same `tp_size` lookup axis.
  - Uses hidden size to map DSv4 Flash to 64 native heads and DSv4 Pro to 128 native
  heads during lookup.
  - Fixes SGLang DeepSeek-V4 Pro prefill memory estimation to use residual hidden size
  instead of the attention-internal Q/O expansion width.
  - Adds unit coverage for Pro head-count mapping, V4-Pro collector case selection,
  Flash/Pro perf-row isolation, and Pro memory sizing.

  #### Where should the reviewer start?

  - `collector/common_test_cases.py`
  - `collector/sglang/collect_dsv4_flash_attn.py`
  - `src/aiconfigurator/sdk/perf_database.py`
  - `src/aiconfigurator/sdk/backends/sglang_backend.py`
  - `tests/unit/sdk/database/test_dsv4_flash_sparse.py`
  - `tests/unit/sdk/database/test_deepseek_v4_module.py`

  #### Validation:

  - `PYTHONPATH=src pytest -q tests/unit/sdk/database/test_dsv4_flash_sparse.py tests/
  unit/sdk/database/test_deepseek_v4_module.py`
    - 67 passed
  - `PYTHONPATH=src pytest -q tests/unit/sdk/database/test_data_loaders.py`
    - 31 passed
  - `PYTHONPATH=src pytest -q tests/unit/sdk/database --ignore=tests/unit/sdk/database/
  test_moe_dispatch.py`
    - 301 passed
  - GB200 cluster smoke:
    - `deepseek-ai/DeepSeek-V4-Pro`
    - SGLang `0.5.10rc0`
    - CSA context module
    - output row recorded `num_heads=128`