### PR TITLE
feat(collector/sglang): support MiniMax-M2 family in WideEP DeepEP MoE collector

### DIFF
--- a/collector/sglang/collect_wideep_deepep_moe.py
+++ b/collector/sglang/collect_wideep_deepep_moe.py
@@ -736,28 +736,71 @@ def run_moe(
         original_model_config = ModelConfig.from_server_args(server_args)
         original_hf_config = original_model_config.hf_config
         model_hidden_size = original_hf_config.hidden_size
-        model_inter_size = getattr(original_hf_config, "moe_intermediate_size", 2048)
-        model_total_experts = getattr(original_hf_config, "n_routed_experts", None) or getattr(
-            original_hf_config, "num_experts", 256
+        # Per-expert MLP intermediate size. The HF field name varies:
+        #   moe_intermediate_size  - DeepSeek-V3, Qwen3-MoE, GPT-OSS
+        #   intermediate_size      - MiniMax-M2 (Mixtral-style; no separate dense MLP)
+        # Probe in priority order; raise if neither is present rather than silently
+        # falling back to a wrong default (2048 was DeepSeek-shaped).
+        model_inter_size = getattr(original_hf_config, "moe_intermediate_size", None)
+        if model_inter_size is None:
+            model_inter_size = getattr(original_hf_config, "intermediate_size", None)
+        if model_inter_size is None:
+            raise AttributeError(
+                f"Could not find MoE intermediate size on hf_config "
+                f"({type(original_hf_config).__name__}); tried "
+                "moe_intermediate_size / intermediate_size."
+            )
+        # Total expert count. The HF field name varies:
+        #   n_routed_experts   - DeepSeek-V3
+        #   num_experts        - Qwen3-MoE, GPT-OSS
+        #   num_local_experts  - MiniMax-M2 (Mixtral-style)
+        model_total_experts = (
+            getattr(original_hf_config, "n_routed_experts", None)
+            or getattr(original_hf_config, "num_experts", None)
+            or getattr(original_hf_config, "num_local_experts", None)
         )
+        if model_total_experts is None:
+            raise AttributeError(
+                f"Could not find expert count on hf_config "
+                f"({type(original_hf_config).__name__}); tried "
+                "n_routed_experts / num_experts / num_local_experts."
+            )
         rank_print(
             f"Original model config: hidden_size={model_hidden_size}, "
             f"inter_size={model_inter_size}, total_experts={model_total_experts}"
         )
 
-        # Now apply override to load model with reduced experts
-        # Support both DeepSeek-V3 (n_routed_experts) and Qwen3 (num_experts)
+        # Now apply override to load model with reduced experts.
+        # The HF expert-count field varies across model families; override
+        # all known names so this works for DeepSeek / Qwen / MiniMax.
         server_args.json_model_override_args = json.dumps(
             {
                 "num_hidden_layers": 4,
-                "n_routed_experts": num_experts,
-                "num_experts": num_experts,
+                "n_routed_experts": num_experts,  # DeepSeek-V3
+                "num_experts": num_experts,  # Qwen3-MoE, GPT-OSS
+                "num_local_experts": num_experts,  # MiniMax-M2 (Mixtral-style)
             }
         )
 
         model_runner = load_model_with_dummy_weights(server_args, port_args, tp_rank)
 
-        moe_layer = model_runner.model.model.layers[test_layer].mlp
+        # MoE submodule attribute name differs across sglang models:
+        #   .mlp                 - DeepSeek-V2/V3, Qwen2/3-MoE, GPT-OSS
+        #   .block_sparse_moe    - MiniMax-M2 (HF Mixtral-style), Mixtral
+        decoder_layer = model_runner.model.model.layers[test_layer]
+        moe_layer = None
+        for attr in ("mlp", "block_sparse_moe"):
+            candidate = getattr(decoder_layer, attr, None)
+            # Skip non-MoE MLP layers (DeepSeek's first few layers are dense).
+            if candidate is not None and (hasattr(candidate, "experts") or hasattr(candidate, "n_routed_experts")):
+                moe_layer = candidate
+                break
+        if moe_layer is None:
+            raise AttributeError(
+                f"Could not find MoE submodule on {type(decoder_layer).__name__}; "
+                "tried .mlp / .block_sparse_moe. "
+                "Add the attribute name used by this model to the probe list."
+            )
         # Supports DeepSeek-V3 and Qwen3 MoE
         if hasattr(moe_layer, "config") and hasattr(moe_layer.config, "n_routed_experts"):
             # DeepSeek-V3 style

--- a/collector/sglang/collect_wideep_deepep_moe.py
+++ b/collector/sglang/collect_wideep_deepep_moe.py
@@ -815,8 +815,22 @@ def run_moe(
             # Direct attribute (deepep mode)
             actual_num_experts = moe_layer.num_experts
         else:
-            # Fall back to model_config
-            actual_num_experts = model_runner.model_config.hf_config.num_experts
+            # Fall back to hf_config; probe the same three field names as the
+            # pre-load probe at the top of this function, since the loaded
+            # config has had all three overridden to the simulated count.
+            hf_config = model_runner.model_config.hf_config
+            actual_num_experts = (
+                getattr(hf_config, "n_routed_experts", None)
+                or getattr(hf_config, "num_experts", None)
+                or getattr(hf_config, "num_local_experts", None)
+            )
+            if actual_num_experts is None:
+                raise AttributeError(
+                    f"Could not determine expert count from {type(moe_layer).__name__} "
+                    "or hf_config; tried .config.n_routed_experts / "
+                    ".experts.num_experts / .num_experts on the MoE layer and "
+                    "n_routed_experts / num_experts / num_local_experts on hf_config."
+                )
 
         rank_print(f"Loaded model with {actual_num_experts} local experts (simulating {model_total_experts} total)")
 

--- a/collector/sglang/collect_wideep_deepep_moe.py
+++ b/collector/sglang/collect_wideep_deepep_moe.py
@@ -791,8 +791,11 @@ def run_moe(
         moe_layer = None
         for attr in ("mlp", "block_sparse_moe"):
             candidate = getattr(decoder_layer, attr, None)
-            # Skip non-MoE MLP layers (DeepSeek's first few layers are dense).
-            if candidate is not None and (hasattr(candidate, "experts") or hasattr(candidate, "n_routed_experts")):
+            # Require an `experts` submodule whose `run_moe_core` is callable: this
+            # is what the benchmark actually invokes below, and it filters out
+            # non-MoE MLP layers (e.g. DeepSeek's leading dense layers).
+            experts = getattr(candidate, "experts", None) if candidate is not None else None
+            if experts is not None and callable(getattr(experts, "run_moe_core", None)):
                 moe_layer = candidate
                 break
         if moe_layer is None:


### PR DESCRIPTION
MiniMax-M2 (MiniMaxM2ForCausalLM, e.g. MiniMaxAI/MiniMax-M2.5) uses Mixtral-style HF config field names and sglang submodule attribute names that differ from the DeepSeek-V3 / Qwen3-MoE / GPT-OSS families the collector currently supports, so today it either raises AttributeError or silently falls back to DeepSeek-shaped defaults (inter=2048, num_experts=256) and produces perf tables that do not reflect the actual MiniMax-M2 MoE shape (inter=1536, 256 experts).

In collector/sglang/collect_wideep_deepep_moe.py run_moe():

- Probe per-expert MLP intermediate size as moe_intermediate_size (DeepSeek-V3 / Qwen3-MoE / GPT-OSS), then intermediate_size (MiniMax-M2, Mixtral-style; no separate dense MLP). Raise a descriptive AttributeError if neither is present instead of using the previous silent default of 2048.
- Probe total expert count across n_routed_experts (DeepSeek-V3), num_experts (Qwen3-MoE, GPT-OSS), num_local_experts (MiniMax-M2). Raise on miss, same as above.
- Include num_local_experts in json_model_override_args so MiniMax-M2 also receives the reduced-expert override during dummy-weight load.
- Resolve the MoE submodule on the decoder layer by trying .mlp (DeepSeek-V2/V3, Qwen2/3-MoE, GPT-OSS) then .block_sparse_moe (MiniMax-M2, Mixtral), accepting the attribute only if it exposes experts / n_routed_experts (which skips DeepSeek's leading dense MLP layers).

Existing DeepSeek / Qwen / GPT-OSS code paths are unchanged: the new probes are strictly additive and preserve the previous lookup order.

#### Overview:

 Extend the SGLang WideEP DeepEP MoE collector (`collector/sglang/collect_wideep_deepep_moe.py`) so it can profile the MiniMax-M2 family (`MiniMaxM2ForCausalLM`, e.g. `MiniMaxAI/MiniMax-M2.5`) in addition to the
  already-supported DeepSeek-V3 / Qwen3-MoE / GPT-OSS.

  Today the collector hard-codes HuggingFace config field names and the sglang MoE submodule attribute name, both of which differ in MiniMax-M2:

  | Probe                              | DeepSeek-V3            | Qwen3-MoE / GPT-OSS     | MiniMax-M2              |
  |---                                 |---                     |---                      |---                      |
  | per-expert MLP intermediate size   | `moe_intermediate_size`| `moe_intermediate_size` | `intermediate_size`     |
  | routed expert count                | `n_routed_experts`     | `num_experts`           | `num_local_experts`     |
  | MoE submodule on decoder layer     | `.mlp`                 | `.mlp`                  | `.block_sparse_moe`     |

  Without this PR the collector either raises `AttributeError` on MiniMax-M2 when probing `.mlp`, or silently falls back to DeepSeek-shaped defaults (`inter=2048`, expert count `256`) when the HF config probes miss — producing perf tables that do not reflect the actual MiniMax-M2 MoE shape (`inter=1536`, 256 experts).

#### Details:

In `collector/sglang/collect_wideep_deepep_moe.py`, inside `run_moe()`:

  1. Probe `moe_intermediate_size` first, fall back to `intermediate_size` for Mixtral-style models without a dense MLP (MiniMax-M2). Raise a descriptive `AttributeError` on miss instead of using `2048` as a silent
  default.
  2. Probe expert count across `n_routed_experts` / `num_experts` / `num_local_experts`. Same descriptive raise on miss.
  3. Include `num_local_experts` in `json_model_override_args` so MiniMax-M2 also receives the reduced-expert override during dummy-weight load.
  4. Resolve the MoE submodule by trying `.mlp` then `.block_sparse_moe`, accepting the attribute only if it exposes `experts` / `n_routed_experts` (skips DeepSeek's leading dense MLP layers).

  Existing DeepSeek / Qwen / GPT-OSS code paths are unchanged — the new probes are strictly additive and preserve the previous lookup order. 

#### Where should the reviewer start?

  - `collector/sglang/collect_wideep_deepep_moe.py` — the `run_moe()` function around HF-config probing, `json_model_override_args` construction, and the MoE submodule lookup.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced MoE model configuration detection with more robust parameter discovery and fallback mechanisms.
  * Expanded support for additional MoE model architectures through generalized layer identification.
  * Improved error handling with actionable guidance for unsupported model configurations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiconfigurator/pull/1039)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->