### PR TITLE
chore: add generator template and tests for Dynamo 1.2.0 backends

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -30,6 +30,32 @@ jobs:
         uses: actions/checkout@v4
         with:
           lfs: true
+          fetch-depth: 0
+      - name: Detect generator golden changes
+        id: generator-golden-changes
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base_sha="${{ github.event.pull_request.base.sha }}"
+          else
+            base_sha="${{ github.event.before }}"
+          fi
+          head_sha="${{ github.sha }}"
+
+          if [ -z "${base_sha}" ] || [[ "${base_sha}" =~ ^0+$ ]]; then
+            base_sha="$(git rev-list --max-parents=0 HEAD)"
+          fi
+
+          changed_files="$(git diff --name-only "${base_sha}" "${head_sha}")"
+          echo "Changed files:"
+          printf '%s\n' "${changed_files}"
+
+          if printf '%s\n' "${changed_files}" | grep -Eq '^(src/aiconfigurator/generator/|tests/golden/generator/)'; then
+            echo "run_golden=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "run_golden=false" >> "${GITHUB_OUTPUT}"
+          fi
       - name: Git LFS Pull
         run: git lfs pull
       - name: Print runner resources
@@ -40,11 +66,18 @@ jobs:
         run: |
           docker build -f docker/Dockerfile -t aiconfigurator:build --target build .
       - name: Run tests in container
+        shell: bash
         run: |
+          test_paths=(${{ matrix.suite.paths }})
+          if [ "${{ matrix.suite.name }}" = "unit" ] && [ "${{ steps.generator-golden-changes.outputs.run_golden }}" = "true" ]; then
+            test_paths+=(tests/golden/generator)
+          fi
+          echo "Running pytest paths: ${test_paths[*]}"
+
           docker build -f docker/Dockerfile -t aiconfigurator:test --target test .
           docker run --name aic aiconfigurator:test \
             pytest \
-            ${{ matrix.suite.paths }} \
+            "${test_paths[@]}" \
             -m "unit or build" \
             -v --tb=short --maxfail=1 --timeout=600 \
             ${{ matrix.suite.workers }} \

--- a/docs/cli_user_guide.md
+++ b/docs/cli_user_guide.md
@@ -439,7 +439,7 @@ The backend (`--backend trtllm/vllm/sglang`) and deployment target are orthogona
 
 **Generator Dynamo version** (applies to Dynamo deployments only)
 - Use `--generator-dynamo-version 0.7.1` to select the Dynamo release. This affects both the generated backend config version and the default K8s image tag.
-- If `--generator-dynamo-version` is not provided, the default is the first entry in `backend_version_matrix.yaml` (currently `1.0.0`).
+- If `--generator-dynamo-version` is not provided, the default is the first entry in `backend_version_matrix.yaml` (currently `1.2.0`).
 - If `--generated-config-version` is provided, it overrides the generated backend version, but the default K8s image tag still follows the selected Dynamo version mapping.
 
 Use `--generator-config path/to/file.yaml` to provide ServiceConfig/K8sConfig/DynConfig/WorkerConfig/Workers.<role> sections, or add inline overrides via `--generator-set KEY=VALUE`. Examples:

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.3.0rc14.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.3.0rc14.yaml.j2
@@ -1,0 +1,56 @@
+backend: pytorch
+
+{% if is_moe is defined %}  # is_moe from sdk
+moe_expert_parallel_size: {{ moe_expert_parallel_size }}
+moe_tensor_parallel_size: {{ moe_tensor_parallel_size }}
+
+moe_config:
+    backend: {{ moe_config.backend | default('CUTLASS') }} # MOE backend to use (CUTLASS, CUTEDSL, WIDEEP, TRTLLM, VANILLA)
+    {% if moe_config.load_balancer is defined %}  # Configuration for MoE load balancing
+    load_balancer: {{ moe_config.load_balancer }} # moe load balancer
+    {% endif %}
+{% endif %}
+
+tensor_parallel_size: {{ tensor_parallel_size }}
+pipeline_parallel_size: {{ pipeline_parallel_size }}
+enable_attention_dp: {{ enable_attention_dp | default(false) }}
+enable_chunked_prefill: {{ enable_chunked_prefill | default(false) }}
+
+{% set _max_seq_len = max_seq_len | default(none) %}
+
+max_batch_size: {{ max_batch_size }}
+max_num_tokens: {{ max_num_tokens }}
+{% if _max_seq_len is not none and _max_seq_len != '' %}
+max_seq_len: {{ _max_seq_len }}
+{% endif %}
+
+kv_cache_config:
+  free_gpu_memory_fraction: {{ kv_cache_config.free_gpu_memory_fraction | default(0.80) }}  # Fraction of GPU memory usable for KV-cache
+  dtype: {{ kv_cache_config.dtype | default('auto') }}
+  {% if kv_cache_config.tokens_per_block is defined %}
+  tokens_per_block: {{ kv_cache_config.tokens_per_block }}
+  {% endif %}
+  enable_block_reuse: {{ kv_cache_config.enable_block_reuse | default(false) }}
+
+{% if cache_transceiver_config.max_tokens_in_buffer is defined %}
+cache_transceiver_config:
+  backend: {{ cache_transceiver_config.backend | default('DEFAULT') }} # The communication backend type to use for the cache transceiver ("DEFAULT","UCX","NIXL","MPI")
+  max_tokens_in_buffer: {{ cache_transceiver_config.max_tokens_in_buffer }}
+{% endif %}
+
+cuda_graph_config:
+  enable_padding: {{ cuda_graph_config.enable_padding | default(false) }} # Pad CUDA graph
+  batch_sizes: [{% for s in cuda_graph_config.batch_sizes
+                               | default([1,2,4,8,16,32,64,128,256]) -%}
+                    {{- s }}{{ ',' if not loop.last else '' }} {%- endfor %}]
+
+disable_overlap_scheduler: {{ disable_overlap_scheduler | default(true) }}
+print_iter_log: {{ print_iter_log | default(false) }}
+
+{% if speculative_config.decoding_type is defined %}  # speculative decoding
+speculative_config:
+  decoding_type: {{ speculative_config.decoding_type }}
+  {% if speculative_config.decoding_type == 'MTP' %}
+  num_nextn_predict_layers: {{ num_nextn_predict_layers }}
+  {% endif %}
+{% endif %}

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.3.0rc14.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/extra_engine_args.1.3.0rc14.yaml.j2
@@ -50,7 +50,7 @@ print_iter_log: {{ print_iter_log | default(false) }}
 {% if speculative_config.decoding_type is defined %}  # speculative decoding
 speculative_config:
   decoding_type: {{ speculative_config.decoding_type }}
-  {% if speculative_config.decoding_type == 'MTP' %}
-  num_nextn_predict_layers: {{ num_nextn_predict_layers }}
+  {% if speculative_config.decoding_type == 'MTP' and speculative_config.num_nextn_predict_layers is defined %}
+  num_nextn_predict_layers: {{ speculative_config.num_nextn_predict_layers }}
   {% endif %}
 {% endif %}

--- a/src/aiconfigurator/generator/config/backend_templates/vllm/cli_args.0.20.1.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/vllm/cli_args.0.20.1.j2
@@ -1,0 +1,28 @@
+{%- set args = [] -%}
+{%- if vllm['tensor-parallel-size'] is defined -%}{%- set _ = args.append('--tensor-parallel-size "' ~ vllm['tensor-parallel-size'] ~ '"') -%}{%- endif -%}
+{%- if vllm['pipeline-parallel-size'] is defined -%}{%- set _ = args.append('--pipeline-parallel-size "' ~ vllm['pipeline-parallel-size'] ~ '"') -%}{%- endif -%}
+{%- if vllm['data-parallel-size'] is defined -%}{%- set _ = args.append('--data-parallel-size "' ~ vllm['data-parallel-size'] ~ '"') -%}{%- endif -%}
+{%- if vllm['enable-expert-parallel'] -%}{%- set _ = args.append('--enable-expert-parallel') -%}{%- endif -%}
+{%- if vllm['block-size'] is defined -%}{%- set _ = args.append('--block-size "' ~ vllm['block-size'] ~ '"') -%}{%- endif -%}
+{%- if vllm['kv-cache-dtype'] is defined -%}{%- set _ = args.append('--kv-cache-dtype "' ~ vllm['kv-cache-dtype'] ~ '"') -%}{%- endif -%}
+{%- if vllm['max-model-len'] is defined -%}{%- set _ = args.append('--max-model-len "' ~ vllm['max-model-len'] ~ '"') -%}{%- endif -%}
+{%- if vllm['max-num-seqs'] is defined -%}{%- set _ = args.append('--max-num-seqs "' ~ vllm['max-num-seqs'] ~ '"') -%}{%- endif -%}
+{%- if vllm['max-num-batched-tokens'] is defined -%}{%- set _ = args.append('--max-num-batched-tokens ' ~ vllm['max-num-batched-tokens']) -%}{%- endif -%}
+{%- if vllm['skip-tokenizer-init'] -%}{%- set _ = args.append('--skip-tokenizer-init') -%}{%- endif -%}
+{%- if vllm['trust-remote-code'] -%}{%- set _ = args.append('--trust-remote-code') -%}{%- endif -%}
+{%- if vllm['enforce-eager'] -%}{%- set _ = args.append('--enforce-eager') -%}{%- endif -%}
+{%- if vllm['cudagraph-capture-sizes'] is defined -%}{%- set _ = args.append('--cudagraph-capture-sizes ' ~ (vllm['cudagraph-capture-sizes'] | join(' '))) -%}{%- endif -%}
+
+
+{%- if vllm['no-enable-prefix-caching'] -%}{%- set _ = args.append('--no-enable-prefix-caching') -%}{%- endif -%}
+{%- set spec_cfg = namespace(value={}) -%}
+{%- if speculative_config.method is defined and speculative_config.method -%}
+    {%- set _ = spec_cfg.value.update({'method': speculative_config.method}) -%}
+{%- endif -%}
+{%- if speculative_config.num_speculative_tokens is defined and speculative_config.num_speculative_tokens is not none -%}
+    {%- set _ = spec_cfg.value.update({'num_speculative_tokens': speculative_config.num_speculative_tokens}) -%}
+{%- endif -%}
+{%- if spec_cfg.value -%}
+    {%- set _ = args.append('--speculative-config \'' ~ (spec_cfg.value | tojson) ~ '\'') -%}
+{%- endif -%}
+{{ args | join(' ') }}

--- a/src/aiconfigurator/generator/config/backend_version_matrix.yaml
+++ b/src/aiconfigurator/generator/config/backend_version_matrix.yaml
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 matrix:
+  1.2.0:
+    vllm: "0.20.1"
+    sglang: "0.5.10.post1"
+    trtllm: "1.3.0rc14"
   1.1.0:
     vllm: "0.19.0"
     sglang: "0.5.10.post1"

--- a/src/aiconfigurator/generator/rendering/engine.py
+++ b/src/aiconfigurator/generator/rendering/engine.py
@@ -267,24 +267,45 @@ def render_backend_templates(
                 _remove_key_and_nested(bk)
         return wc
 
+    def _populate_trtllm_nested_engine_config(wc: dict[str, Any]) -> None:
+        def _set_nested(config_name: str, nested_key: str, source_key: str) -> None:
+            source_value = wc.get(source_key)
+            if source_value is None:
+                return
+            config = dict(wc.get(config_name) or {})
+            if nested_key not in config or config.get(nested_key) is None:
+                config[nested_key] = source_value
+            wc[config_name] = config
+
+        _set_nested("kv_cache_config", "free_gpu_memory_fraction", "kv_cache_free_gpu_memory_fraction")
+        _set_nested("kv_cache_config", "dtype", "kv_cache_dtype")
+        _set_nested("kv_cache_config", "tokens_per_block", "tokens_per_block")
+        _set_nested("cuda_graph_config", "enable_padding", "cuda_graph_enable_padding")
+        _set_nested("cuda_graph_config", "batch_sizes", "cuda_graph_batch_sizes")
+        _set_nested("cache_transceiver_config", "max_tokens_in_buffer", "cache_transceiver_max_tokens_in_buffer")
+
+        if wc.get("cache_transceiver_config"):
+            cache_transceiver_config = dict(wc["cache_transceiver_config"])
+            cache_transceiver_config.setdefault("backend", "DEFAULT")
+            wc["cache_transceiver_config"] = cache_transceiver_config
+
+        decoding_type = wc.get("speculative_decoding_type")
+        num_nextn_predict_layers = wc.get("num_nextn_predict_layers")
+        if decoding_type is not None or num_nextn_predict_layers is not None:
+            speculative_config = dict(wc.get("speculative_config") or {})
+            if decoding_type is not None:
+                speculative_config.setdefault("decoding_type", decoding_type)
+            if num_nextn_predict_layers is not None:
+                speculative_config.setdefault("num_nextn_predict_layers", num_nextn_predict_layers)
+            wc["speculative_config"] = speculative_config
+
     if engine_template_file is not None:
         try:
             eng_tmpl = env.get_template(engine_template_file.name)
             for worker in worker_plan:
                 wc = make_worker_context(context, worker, param_keys, mapping_data)
-                # Populate cache_transceiver_config for trtllm so extra_engine_args emits it
-                # (template expects cache_transceiver_config.max_tokens_in_buffer; rule sets
-                # cache_transceiver_max_tokens_in_buffer scalar only)
                 if backend == "trtllm":
-                    mtib = wc.get("cache_transceiver_max_tokens_in_buffer")
-                    if mtib is not None and (
-                        not wc.get("cache_transceiver_config")
-                        or not wc["cache_transceiver_config"].get("max_tokens_in_buffer")
-                    ):
-                        ctc = dict(wc.get("cache_transceiver_config") or {})
-                        ctc.setdefault("max_tokens_in_buffer", mtib)
-                        ctc.setdefault("backend", "DEFAULT")
-                        wc["cache_transceiver_config"] = ctc
+                    _populate_trtllm_nested_engine_config(wc)
                 rendered = eng_tmpl.render(**wc)
                 if worker == "agg":
                     out_name = "extra_engine_args_agg.yaml"

--- a/src/aiconfigurator/generator/rule_plugin/benchmark/sglang.rule
+++ b/src/aiconfigurator/generator/rule_plugin/benchmark/sglang.rule
@@ -30,4 +30,4 @@ when (ModelConfig.prefix or 0) > 0:
     
 when (ModelConfig.nextn or 0) > 0:
     speculative_decoding_type = "NEXTN"
-    speculative_num_steps = ModelConfig.nextn
+    num_nextn_predict_layers = ModelConfig.nextn

--- a/src/aiconfigurator/generator/rule_plugin/sglang.rule
+++ b/src/aiconfigurator/generator/rule_plugin/sglang.rule
@@ -32,4 +32,4 @@ when (ModelConfig.prefix or 0) > 0:
 
 when (ModelConfig.nextn or 0) > 0:
     speculative_decoding_type = "NEXTN"
-    speculative_num_steps = ModelConfig.nextn
+    num_nextn_predict_layers = ModelConfig.nextn

--- a/tests/golden/generator/test_release_1_2_0_backend_contracts.py
+++ b/tests/golden/generator/test_release_1_2_0_backend_contracts.py
@@ -1,0 +1,292 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Lightweight generator golden contracts for the Dynamo 1.2.0 backend set."""
+
+from __future__ import annotations
+
+import copy
+import json
+import shlex
+import subprocess
+from functools import cache
+from pathlib import Path
+
+import pytest
+import yaml
+
+from aiconfigurator.generator.api import generate_backend_artifacts
+from aiconfigurator.generator.utils import resolve_backend_version_for_dynamo
+
+pytestmark = pytest.mark.unit
+
+_DYNAMO_VERSION = "1.2.0"
+_BACKEND_VERSIONS = {
+    "vllm": "0.20.1",
+    "sglang": "0.5.10.post1",
+    "trtllm": "1.3.0rc14",
+}
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_WORKSPACE_ROOT = _REPO_ROOT.parent
+
+_BACKEND_SOURCES = {
+    ("vllm", "0.20.1"): ("vllm", "v0.20.1", "vllm/engine/arg_utils.py"),
+    ("sglang", "0.5.10.post1"): ("sglang", "v0.5.10.post1", "python/sglang/srt/server_args.py"),
+    ("trtllm", "1.3.0rc14"): ("TensorRT-LLM", "v1.3.0rc14", "tensorrt_llm/llmapi/llm_args.py"),
+}
+
+_ALLOWED_CLI_FLAGS = {
+    "vllm": {
+        "--tensor-parallel-size",
+        "--pipeline-parallel-size",
+        "--data-parallel-size",
+        "--enable-expert-parallel",
+        "--block-size",
+        "--kv-cache-dtype",
+        "--max-model-len",
+        "--max-num-seqs",
+        "--max-num-batched-tokens",
+        "--skip-tokenizer-init",
+        "--trust-remote-code",
+        "--enforce-eager",
+        "--cudagraph-capture-sizes",
+        "--no-enable-prefix-caching",
+        "--speculative-config",
+    },
+    "sglang": {
+        "--tensor-parallel-size",
+        "--pipeline-parallel-size",
+        "--data-parallel-size",
+        "--page-size",
+        "--kv-cache-dtype",
+        "--max-prefill-tokens",
+        "--enable-mixed-chunk",
+        "--context-length",
+        "--max-running-requests",
+        "--skip-tokenizer-init",
+        "--trust-remote-code",
+        "--enable-dp-attention",
+        "--expert-parallel-size",
+        "--moe-dense-tp-size",
+        "--disable-cuda-graph",
+        "--cuda-graph-bs",
+        "--speculative-algorithm",
+        "--speculative-num-steps",
+        "--disable-cuda-graph-padding",
+        "--cuda-graph-max-bs",
+        "--disaggregation-transfer-backend",
+    },
+}
+
+_TRTLLM_TOP_LEVEL_KEYS = {
+    "backend",
+    "moe_expert_parallel_size",
+    "moe_tensor_parallel_size",
+    "moe_config",
+    "tensor_parallel_size",
+    "pipeline_parallel_size",
+    "enable_attention_dp",
+    "enable_chunked_prefill",
+    "max_batch_size",
+    "max_num_tokens",
+    "max_seq_len",
+    "kv_cache_config",
+    "cache_transceiver_config",
+    "cuda_graph_config",
+    "disable_overlap_scheduler",
+    "print_iter_log",
+    "speculative_config",
+}
+
+_TRTLLM_NESTED_KEYS = {
+    "kv_cache_config": {"free_gpu_memory_fraction", "dtype", "tokens_per_block", "enable_block_reuse"},
+    "cache_transceiver_config": {"backend", "max_tokens_in_buffer"},
+    "cuda_graph_config": {"enable_padding", "batch_sizes"},
+    "speculative_config": {"decoding_type", "num_nextn_predict_layers"},
+}
+
+_GOLDEN_PARAMS = {
+    "ServiceConfig": {
+        "model_path": "Qwen/Qwen3-32B-FP8",
+        "served_model_path": "Qwen/Qwen3-32B-FP8",
+        "served_model_name": "qwen3-golden",
+        "include_frontend": True,
+    },
+    "K8sConfig": {
+        "name_prefix": "golden",
+        "k8s_image": "nvcr.io/nvidia/ai-dynamo/runtime:test",
+        "k8s_namespace": "default",
+    },
+    "DynConfig": {"mode": "agg"},
+    "WorkerConfig": {
+        "agg_workers": 1,
+        "agg_gpus_per_worker": 1,
+        "prefill_workers": 0,
+        "decode_workers": 0,
+    },
+    "NodeConfig": {"num_gpus_per_node": 8},
+    "SlaConfig": {"isl": 2048, "osl": 512},
+    "ModelConfig": {"is_moe": True, "prefix": 1024, "nextn": 2},
+    "BenchConfig": {},
+    "params": {
+        "agg": {
+            "tensor_parallel_size": 1,
+            "pipeline_parallel_size": 1,
+            "data_parallel_size": 1,
+            "moe_tensor_parallel_size": 2,
+            "moe_expert_parallel_size": 4,
+            "max_batch_size": 64,
+            "max_num_tokens": 4096,
+            "max_seq_len": 4096,
+            "kv_cache_dtype": "bfloat16",
+            "kv_cache_free_gpu_memory_fraction": 0.82,
+            "tokens_per_block": 32,
+            "enable_chunked_prefill": False,
+            "skip_tokenizer_init": True,
+            "trust_remote_code": True,
+            "disable_cuda_graph": True,
+        }
+    },
+}
+
+
+@cache
+def _backend_source(backend: str, version: str) -> str:
+    source_ref = _BACKEND_SOURCES.get((backend, version))
+    if source_ref is None:
+        return ""
+    repo_name, ref, source_path = source_ref
+    repo_path = _WORKSPACE_ROOT / "third_party" / repo_name
+    if not (repo_path / ".git").exists():
+        return ""
+    result = subprocess.run(
+        ["git", "-C", str(repo_path), "show", f"{ref}:{source_path}"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout if result.returncode == 0 else ""
+
+
+def _render(backend: str) -> dict[str, str]:
+    return generate_backend_artifacts(
+        copy.deepcopy(_GOLDEN_PARAMS),
+        backend,
+        backend_version=_BACKEND_VERSIONS[backend],
+        deployment_target="dynamo-j2",
+    )
+
+
+def _split_cli(cli: str) -> list[str]:
+    return shlex.split(cli)
+
+
+def _flag_set(tokens: list[str]) -> set[str]:
+    return {token for token in tokens if token.startswith("--")}
+
+
+def _value_after(tokens: list[str], flag: str) -> str:
+    idx = tokens.index(flag)
+    assert idx + 1 < len(tokens), f"{flag} is missing a value"
+    return tokens[idx + 1]
+
+
+def _assert_generated_flags_are_known(backend: str, version: str, flags: set[str]) -> None:
+    unexpected = flags - _ALLOWED_CLI_FLAGS[backend]
+    assert not unexpected
+
+    source = _backend_source(backend, version)
+    if not source:
+        return
+
+    for flag in flags:
+        if flag == "--no-enable-prefix-caching":
+            assert "--enable-prefix-caching" in source
+        else:
+            assert flag in source
+
+
+def _assert_trtllm_engine_keys_are_known(engine_args: dict[str, object]) -> None:
+    unexpected = set(engine_args) - _TRTLLM_TOP_LEVEL_KEYS
+    assert not unexpected
+
+    source = _backend_source("trtllm", _BACKEND_VERSIONS["trtllm"])
+    if not source:
+        return
+
+    for key in engine_args:
+        assert key in source
+
+    for group, allowed_keys in _TRTLLM_NESTED_KEYS.items():
+        nested = engine_args.get(group)
+        if not isinstance(nested, dict):
+            continue
+        unexpected_nested = set(nested) - allowed_keys
+        assert not unexpected_nested
+        for key in nested:
+            assert key in source
+
+
+def test_release_1_2_0_backend_version_matrix():
+    for backend, version in _BACKEND_VERSIONS.items():
+        assert resolve_backend_version_for_dynamo(_DYNAMO_VERSION, backend) == version
+
+
+def test_vllm_0_20_1_cli_args_golden_contract():
+    tokens = _split_cli(_render("vllm")["cli_args_agg"])
+    flags = _flag_set(tokens)
+
+    _assert_generated_flags_are_known("vllm", _BACKEND_VERSIONS["vllm"], flags)
+    assert _value_after(tokens, "--tensor-parallel-size") == "8"
+    assert _value_after(tokens, "--data-parallel-size") == "1"
+    assert _value_after(tokens, "--kv-cache-dtype") == "auto"
+    assert _value_after(tokens, "--max-num-batched-tokens") == "4060"
+    assert "--enable-expert-parallel" in flags
+    assert "--enforce-eager" in flags
+    assert "--no-enable-prefix-caching" not in flags
+
+    speculative = json.loads(_value_after(tokens, "--speculative-config"))
+    assert speculative == {"method": "mtp", "num_speculative_tokens": 2}
+
+
+def test_sglang_0_5_10_post1_cli_args_golden_contract():
+    tokens = _split_cli(_render("sglang")["cli_args_agg"])
+    flags = _flag_set(tokens)
+
+    _assert_generated_flags_are_known("sglang", _BACKEND_VERSIONS["sglang"], flags)
+    assert _value_after(tokens, "--tensor-parallel-size") == "8"
+    assert _value_after(tokens, "--expert-parallel-size") == "4"
+    assert _value_after(tokens, "--kv-cache-dtype") == "auto"
+    assert _value_after(tokens, "--max-prefill-tokens") == "3548"
+    assert _value_after(tokens, "--context-length") == "4096"
+    assert _value_after(tokens, "--max-running-requests") == "512"
+    assert _value_after(tokens, "--speculative-algorithm") == "NEXTN"
+    assert _value_after(tokens, "--speculative-num-steps") == "2"
+    assert "--disable-cuda-graph" in flags
+    assert "--moe-dense-tp-size" not in flags
+
+
+def test_trtllm_1_3_0rc14_extra_engine_args_golden_contract():
+    artifacts = _render("trtllm")
+    engine_args = yaml.safe_load(artifacts["extra_engine_args_agg.yaml"])
+
+    _assert_trtllm_engine_keys_are_known(engine_args)
+    assert engine_args["backend"] == "pytorch"
+    assert engine_args["tensor_parallel_size"] == 8
+    assert engine_args["pipeline_parallel_size"] == 1
+    assert engine_args["moe_expert_parallel_size"] == 4
+    assert engine_args["moe_tensor_parallel_size"] == 2
+    assert engine_args["max_batch_size"] == 64
+    assert engine_args["max_num_tokens"] == 2624
+    assert engine_args["max_seq_len"] == 4096
+
+    assert engine_args["kv_cache_config"]["free_gpu_memory_fraction"] == 0.82
+    assert engine_args["kv_cache_config"]["dtype"] == "auto"
+    assert engine_args["kv_cache_config"]["tokens_per_block"] == 32
+    assert engine_args["cuda_graph_config"]["enable_padding"] is True
+    assert engine_args["cuda_graph_config"]["batch_sizes"][-1] == 72
+    assert engine_args["speculative_config"] == {
+        "decoding_type": "MTP",
+        "num_nextn_predict_layers": 2,
+    }

--- a/tests/golden/generator/test_release_1_2_0_backend_contracts.py
+++ b/tests/golden/generator/test_release_1_2_0_backend_contracts.py
@@ -160,12 +160,16 @@ def _backend_source(backend: str, version: str) -> str:
     repo_path = _WORKSPACE_ROOT / "third_party" / repo_name
     if not (repo_path / ".git").exists():
         return ""
-    result = subprocess.run(
-        ["git", "-C", str(repo_path), "show", f"{ref}:{source_path}"],
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_path), "show", f"{ref}:{source_path}"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired as exc:
+        pytest.fail(f"Timed out reading {backend} {version} source from {repo_path}: {exc}")
     return result.stdout if result.returncode == 0 else ""
 
 


### PR DESCRIPTION
#### Overview:

- Add Dynamo 1.2.0 backend version mapping for vLLM 0.20.1, SGLang 0.5.10.post1, and TensorRT-LLM 1.3.0rc14.
- Add lightweight generator tests for backend CLI args and TRT-LLM extra engine args.
- Populate TRT-LLM nested extra engine config fields from computed scalar values before rendering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for backend version 1.2.0 with vLLM 0.20.1, SGLang 0.5.10.post1, and TRT-LLM 1.3.0rc14.
  * Enhanced configuration support for TRT-LLM engine arguments and vLLM CLI parameters.

* **Documentation**
  * Updated CLI User Guide: default generator version now defaults to 1.2.0.

* **Tests**
  * Added comprehensive golden test contracts validating backend configurations for version 1.2.0.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiconfigurator/pull/1050)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->