### PR TITLE
chore: bump version to 0.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "aiconfigurator"
-version = "0.8.0"
+version = "0.9.0"
 authors = [
     { name = "NVIDIA Inc.", email = "sw-dl-dynamo@nvidia.com" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -19,7 +19,7 @@ resolution-markers = [
 
 [[package]]
 name = "aiconfigurator"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "bokeh" },


### PR DESCRIPTION
## Summary
- bump AIConfigurator package version from 0.8.0 to 0.9.0 in pyproject.toml
- update uv.lock editable package metadata to match

## Tests
- git diff --check
- rg -n '^version = "0\.[89]\.0"' pyproject.toml uv.lock
- /tmp/aic-version-check/bin/python -m pip install --dry-run --no-deps .

Note: uv is not installed in this environment, so uv lock --check could not be run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.9.0

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiconfigurator/pull/1051)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->