### PR TITLE
refactor: remove hard-coded `target_version`

### DIFF
--- a/docs/support-matrix/index.html
+++ b/docs/support-matrix/index.html
@@ -79,7 +79,6 @@ const { useState, useEffect, useCallback, useMemo, useRef } = React;
 // ── Constants ───────────────────────────────────────────────────────
 const REPO = 'ai-dynamo/aiconfigurator';
 const CSV_PATH = 'src/aiconfigurator/systems/support_matrix.csv';
-const TARGET_VERSIONS = { vllm: '0.14.0', sglang: '0.5.9', trtllm: '1.2.0rc6' };
 const PREFERRED_DEFAULT_SYSTEM = 'b200_sxm';
 const SYSTEM_ORDER = ['b200', 'gb200', 'gb300', 'h100', 'h200', '__other__', 'a100', 'l40s'];
 
@@ -132,16 +131,6 @@ function parseVersionTuple(verStr) {
   return [...parts, PHASE_ORDER.release, 0, 0, 0];
 }
 
-function versionGe(a, b) {
-  const ta = parseVersionTuple(a);
-  const tb = parseVersionTuple(b);
-  for (let i = 0; i < 7; i++) {
-    if (ta[i] > tb[i]) return true;
-    if (ta[i] < tb[i]) return false;
-  }
-  return true;
-}
-
 function versionSortKey(verStr) {
   return parseVersionTuple(verStr);
 }
@@ -174,7 +163,7 @@ function getLatestSupportedVersion(rows, huggingfaceId, system, backend) {
   const subset = rows.filter(r =>
     r.HuggingFaceID === huggingfaceId && r.System === system && r.Backend === backend
   );
-  if (!subset.length) return { version: null, atTarget: false, error: null };
+  if (!subset.length) return { version: null, isLatest: false, error: null };
 
   const versionHasFail = {};
   const versionHasPass = {};
@@ -203,25 +192,25 @@ function getLatestSupportedVersion(rows, huggingfaceId, system, backend) {
   }
 
   if (!Object.keys(versionHasFail).length && !Object.keys(versionHasPass).length) {
-    return { version: null, atTarget: false, error: null };
+    return { version: null, isLatest: false, error: null };
   }
 
-  const targetVer = TARGET_VERSIONS[backend] || null;
-  const atOrAboveTarget = (ver) => targetVer === null || versionGe(ver, targetVer);
-
-  if (targetVer !== null) {
-    if (versionHasPass[targetVer]) {
-      return { version: targetVer, atTarget: atOrAboveTarget(targetVer), error: null };
-    }
-    if (versionHasFail[targetVer]) {
-      return { version: 'FAIL', atTarget: false, error: versionErrorMsgs[targetVer] || 'No error message available' };
-    }
+  const testedVersions = [...new Set(rows
+    .filter(r => r.System === system && r.Backend === backend && r.Version)
+    .map(r => r.Version))]
+    .sort((a, b) => compareVersionTuples(versionSortKey(b), versionSortKey(a)));
+  const latestVersion = testedVersions[0] || null;
+  if (latestVersion && versionHasPass[latestVersion]) {
+    return { version: latestVersion, isLatest: true, error: null };
+  }
+  if (latestVersion && versionHasFail[latestVersion]) {
+    return { version: 'FAIL', isLatest: false, error: versionErrorMsgs[latestVersion] || 'No error message available' };
   }
 
   const passing = Object.keys(versionHasPass)
     .sort((a, b) => compareVersionTuples(versionSortKey(b), versionSortKey(a)));
   if (passing.length) {
-    return { version: passing[0], atTarget: atOrAboveTarget(passing[0]), error: null };
+    return { version: passing[0], isLatest: false, error: null };
   }
 
   const allMsgs = [];
@@ -230,7 +219,7 @@ function getLatestSupportedVersion(rows, huggingfaceId, system, backend) {
   for (const ver of failVersions) {
     if (versionErrorMsgs[ver]) allMsgs.push(`${ver}: ${versionErrorMsgs[ver]}`);
   }
-  return { version: 'FAIL', atTarget: false, error: allMsgs.length ? allMsgs.join(' | ') : 'No error message available' };
+  return { version: 'FAIL', isLatest: false, error: allMsgs.length ? allMsgs.join(' | ') : 'No error message available' };
 }
 
 // Aggregate per-version statuses into a single (model, backend) cell. Each

--- a/src/aiconfigurator/webapp/components/support_matrix_tab.py
+++ b/src/aiconfigurator/webapp/components/support_matrix_tab.py
@@ -22,43 +22,37 @@ def parse_version(ver_str):
 # Cell colors for support matrix (used in styling and legend)
 COLOR_FAIL_BG = "#ffcccc"
 COLOR_FAIL_TEXT = "#cc0000"
-COLOR_AT_OR_ABOVE_MIN = "#80ff80"  # Green: version at or above target
-COLOR_BELOW_MIN = "#ccffcc"  # Light green: version below target
+COLOR_LATEST_PASS = "#80ff80"  # Green: latest tested backend version passes
+COLOR_OLDER_PASS = "#ccffcc"  # Light green: older tested backend version passes
 
 SUPPORT_MATRIX_LEGEND = (
     f'<div style="margin-bottom: 10px; font-size: 0.95em;">'
     f"<strong>Legend:</strong>"
     f'<span style="margin-left: 8px; margin-right: 24px;">'
-    f'<span style="background: {COLOR_AT_OR_ABOVE_MIN}; padding: 2px 10px; border-radius: 4px; margin-right: 8px;">Green</span>'
-    f"at or above target version</span>"
+    f'<span style="background: {COLOR_LATEST_PASS}; padding: 2px 10px; border-radius: 4px; margin-right: 8px;">Green</span>'
+    f"latest tested version passes</span>"
     f'<span style="margin-right: 24px;">'
-    f'<span style="background: {COLOR_BELOW_MIN}; padding: 2px 10px; border-radius: 4px; margin-right: 8px;">Light green</span>'
-    f"below target version</span>"
+    f'<span style="background: {COLOR_OLDER_PASS}; padding: 2px 10px; border-radius: 4px; margin-right: 8px;">Light green</span>'
+    f"older tested version passes</span>"
     f'<span style="margin-right: 24px;">'
     f'<span style="background: {COLOR_FAIL_BG}; color: {COLOR_FAIL_TEXT}; padding: 2px 10px; border-radius: 4px; font-weight: bold;">FAIL</span>'
     f" test failed (click cell to see error message)</span>"
     f"</div>"
 )
 
-# Hard-coded target version per backend (used for "target" check and as minimum for green)
-TARGET_VERSIONS = {
-    "vllm": "0.14.0",
-    "sglang": "0.5.9",
-    "trtllm": "1.2.0rc6",
-}
-
 
 def get_latest_supported_version(df, huggingface_id, system, backend):
     """
     Get the latest version status for a given HuggingFace ID and system combination.
-    Uses hard-coded latest versions. If the latest version fails, returns "FAIL".
+    Uses the latest backend version present in the filtered matrix data. If that
+    latest version fails for the model/system/backend combination, returns "FAIL".
 
     Returns:
         tuple: (version, is_latest, error_msg) where:
             - version: Latest version string if latest version passes, "FAIL" if latest version fails,
                        None if no data exists
-            - is_latest: True if the returned version is at or above the hard-coded minimum (green),
-                         False if below (light green). Ignored when version is "FAIL".
+            - is_latest: True if the returned version is the latest tested version (green),
+                         False if an older passing version is shown (light green). Ignored when version is "FAIL".
             - error_msg: Error message if version fails, None otherwise
     """
     # Filter for this specific combination (both PASS and FAIL)
@@ -106,29 +100,19 @@ def get_latest_supported_version(df, huggingface_id, system, backend):
     if len(version_has_fail) == 0 and len(version_has_pass) == 0:
         return (None, False, None)
 
-    min_ver = TARGET_VERSIONS.get(backend)
+    backend_versions = df[(df["System"] == system) & (df["Backend"] == backend)]["Version"].dropna().unique()
+    latest_version = max((str(version) for version in backend_versions), key=parse_version, default=None)
+    if latest_version in version_has_pass:
+        return (latest_version, True, None)
+    if latest_version in version_has_fail:
+        error_msg = version_error_msgs.get(latest_version, "No error message available")
+        return ("FAIL", False, error_msg)
 
-    def at_or_above_min(ver_str):
-        if min_ver is None:
-            return True
-        try:
-            return parse_version(ver_str) >= parse_version(min_ver)
-        except Exception:
-            return False
-
-    latest_version = min_ver
-    if latest_version is not None:
-        if latest_version in version_has_pass:
-            return (latest_version, at_or_above_min(latest_version), None)
-        if latest_version in version_has_fail:
-            error_msg = version_error_msgs.get(latest_version, "No error message available")
-            return ("FAIL", False, error_msg)
-
-    # Hard-coded latest not in data or no min set - find the latest passing version
+    # Latest backend version is not tested for this model; show the newest passing version.
     passing_versions = sorted(version_has_pass.keys(), key=parse_version, reverse=True)
     if passing_versions:
         v = passing_versions[0]
-        return (v, at_or_above_min(v), None)
+        return (v, False, None)
     else:
         # No passing version exists - collect error messages from all failed versions
         all_error_msgs = []
@@ -202,9 +186,9 @@ def create_system_matrix(df, system_name, mode_filter="all"):
             elif (row_idx, col_idx - 1) in matrix_is_latest:
                 is_latest = matrix_is_latest.get((row_idx, col_idx - 1), True)
                 if not is_latest:
-                    styles[col_idx] = f"background-color: {COLOR_BELOW_MIN};"
+                    styles[col_idx] = f"background-color: {COLOR_OLDER_PASS};"
                 else:
-                    styles[col_idx] = f"background-color: {COLOR_AT_OR_ABOVE_MIN};"
+                    styles[col_idx] = f"background-color: {COLOR_LATEST_PASS};"
         return styles
 
     # Apply styling using pandas Styler


### PR DESCRIPTION
This commit removes the hard coded TARGET_VERSIONS for support matrix web-pages, and always use the latest supported version as our original "target_version".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Support matrix now displays the latest tested backend version status with updated visual indicators and legend, showing whether the newest version passes or fails instead of comparing against fixed target versions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiconfigurator/pull/1052)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->