### PR TITLE
fix: size DSv4 MoE workspace by hidden width

### DIFF
--- a/src/aiconfigurator/sdk/backends/sglang_backend.py
+++ b/src/aiconfigurator/sdk/backends/sglang_backend.py
@@ -549,6 +549,10 @@ class SGLANGBackend(BaseBackend):
         weights /= model.config.pp_size
 
         h = model._num_heads * model._head_size
+        # MoE block-scale workspace is routed-token payload, so its feature
+        # width is the residual hidden size. For most models this equals
+        # num_heads * head_size; DeepSeek-V4's attention expansion is wider.
+        moe_workspace_h = getattr(model, "_hidden_size", h)
         if num_tokens == 0:
             num_tokens = (isl - prefix) * batch_size
 
@@ -572,7 +576,7 @@ class SGLANGBackend(BaseBackend):
             activations = 2 * num_tokens * h * c_dict[min(model.config.tp_size, 8)]
             activations += (
                 num_tokens
-                * h
+                * moe_workspace_h
                 * model.config.attention_dp_size
                 * model._num_experts
                 * model._topk

--- a/tests/unit/sdk/database/test_deepseek_v4_module.py
+++ b/tests/unit/sdk/database/test_deepseek_v4_module.py
@@ -7,6 +7,7 @@ import pytest
 
 from aiconfigurator.sdk import common, config
 from aiconfigurator.sdk import operations as ops
+from aiconfigurator.sdk.backends.sglang_backend import SGLANGBackend
 from aiconfigurator.sdk.backends.trtllm_backend import TRTLLMBackend
 from aiconfigurator.sdk.config import RuntimeConfig
 from aiconfigurator.sdk.models import get_model
@@ -561,3 +562,66 @@ def test_deepseek_v4_static_sol_and_hybrid_run_end_to_end(mutable_comprehensive_
         summary = backend.run_static(model, db, runtime, mode="static", stride=1)
         assert sum(summary.get_context_latency_dict().values()) > 0
         assert sum(summary.get_generation_latency_dict().values()) > 0
+
+
+def test_sglang_deepseek_v4_pro_moe_workspace_uses_residual_hidden_size(mutable_comprehensive_perf_db):
+    db = mutable_comprehensive_perf_db
+    db.system_spec["gpu"]["mem_capacity"] = 198674743296  # GB200 189471 MiB
+    db.system_spec["misc"]["nccl_mem"] = {1: 0, 2: 358612992, 4: 411041792, 8: 411041792}
+    db.system_spec["misc"]["other_mem"] = 3758096384
+
+    model_config = config.ModelConfig(
+        tp_size=1,
+        pp_size=1,
+        attention_dp_size=8,
+        moe_tp_size=1,
+        moe_ep_size=8,
+        gemm_quant_mode=common.GEMMQuantMode.fp8_block,
+        moe_quant_mode=common.MoEQuantMode.w4a8_mxfp4_mxfp8,
+        kvcache_quant_mode=common.KVCacheQuantMode.fp8,
+        fmha_quant_mode=common.FMHAQuantMode.bfloat16,
+        comm_quant_mode=common.CommQuantMode.half,
+        nextn=0,
+    )
+    model = get_model("deepseek-ai/DeepSeek-V4-Pro", model_config, backend_name="sglang")
+
+    memory = SGLANGBackend()._get_memory_usage(
+        model,
+        db,
+        batch_size=1,
+        beam_width=1,
+        isl=8192,
+        osl=1024,
+    )
+
+    num_tokens = 8192
+    attention_width = model._num_heads * model._head_size
+    residual_width = model._hidden_size
+    tp_activation_factor = 28
+    attention_workspace = 2 * num_tokens * attention_width * tp_activation_factor
+    moe_scale_workspace = (
+        num_tokens
+        * residual_width
+        * model.config.attention_dp_size
+        * model._num_experts
+        * model._topk
+        / model.config.moe_ep_size
+        / 128
+        * 4
+    )
+    expected_activation_gib = (attention_workspace + moe_scale_workspace) * 1.15 / (1 << 30)
+
+    assert memory["activations"] == pytest.approx(expected_activation_gib)
+
+    old_moe_scale_workspace = (
+        num_tokens
+        * attention_width
+        * model.config.attention_dp_size
+        * model._num_experts
+        * model._topk
+        / model.config.moe_ep_size
+        / 128
+        * 4
+    )
+    old_activation_gib = (attention_workspace + old_moe_scale_workspace) * 1.15 / (1 << 30)
+    assert memory["activations"] < old_activation_gib


### PR DESCRIPTION
 #### Overview:

  Fix SGLang DeepSeek-V4 memory estimation so MoE block-scale workspace is sized by the residual hidden width instead of the
  attention-expanded width.

  #### Details:

  - Keeps the broad SGLang activation estimate using `num_heads * head_dim`, preserving the attention workspace scale.
  - Uses `_hidden_size` only for the DeepSeek-V4 MoE block-scale workspace term.
  - Adds a regression test for DeepSeek-V4-Pro memory estimation to ensure the MoE workspace term does not reuse the attention-
  expanded width.

  #### Where should the reviewer start?

  - `src/aiconfigurator/sdk/backends/sglang_backend.py`
  - `tests/unit/sdk/database/test_deepseek_v4_module.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved memory usage calculation accuracy for DeepSeek V4 models with mixture-of-experts configurations.

* **Tests**
  * Added regression test to verify correct memory estimation for DeepSeek V4 Pro models.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiconfigurator/pull/1055)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->