### PR TITLE
fix: add GLM-5 variant to support matrix for all GPUs

### DIFF
--- a/docs/support-matrix/index.html
+++ b/docs/support-matrix/index.html
@@ -350,7 +350,12 @@ function buildTopErrors(rows, systemName, modeFilter, topN = 10) {
 }
 
 // ── Data Fetching ───────────────────────────────────────────────────
+function isLocalPreview() {
+  return ['localhost', '127.0.0.1', '0.0.0.0'].includes(window.location.hostname);
+}
+
 function csvUrl(branch) {
+  if (isLocalPreview()) return `/${CSV_PATH}`;
   return `https://raw.githubusercontent.com/${REPO}/refs/heads/${branch}/${CSV_PATH}`;
 }
 
@@ -934,7 +939,7 @@ function App() {
 
   const [activeSystem, setActiveSystem] = useState(null);
   const [activeMode, setActiveMode] = useState('all');
-  const [searchQuery, setSearchQuery] = useState('');
+  const [searchQuery, setSearchQuery] = useState(() => new URLSearchParams(window.location.search).get('q') || '');
   const [sortCol, setSortCol] = useState(null);
   const [sortAsc, setSortAsc] = useState(true);
   const [showAllVersions, setShowAllVersions] = useState(false);
@@ -969,7 +974,7 @@ function App() {
         }
         setSortCol(null);
         setSortAsc(true);
-        setSearchQuery('');
+        setSearchQuery(new URLSearchParams(window.location.search).get('q') || '');
       })
       .catch(err => setError(err.message))
       .finally(() => setLoading(false));

--- a/src/aiconfigurator/sdk/models/deepseek_v32.py
+++ b/src/aiconfigurator/sdk/models/deepseek_v32.py
@@ -76,7 +76,7 @@ class DeepSeekV32Model(BaseModel):
         if model_info["architecture"] == "GlmMoeDsaForCausalLM" and _dsa_attention_modules_excluded_from_quant(
             model_info.get("raw_config", {})
         ):
-            extra_params["dsa_gemm_quant_mode"] = common.GEMMQuantMode.bfloat16
+            extra_params.setdefault("dsa_gemm_quant_mode", common.GEMMQuantMode.bfloat16)
 
         if backend_name == "sglang" and model_config.enable_wideep:
             logger.debug(

--- a/src/aiconfigurator/sdk/models/deepseek_v32.py
+++ b/src/aiconfigurator/sdk/models/deepseek_v32.py
@@ -13,6 +13,38 @@ from aiconfigurator.sdk.models.helpers import calc_expectation
 logger = logging.getLogger(__name__)
 
 
+def _dsa_attention_modules_excluded_from_quant(raw_config: dict) -> bool:
+    """Return whether a GLM/DSA checkpoint keeps DSA attention projections unquantized."""
+    quant_config = raw_config.get("quantization_config")
+    quant_config = quant_config if isinstance(quant_config, dict) else {}
+
+    hf_quant_config = raw_config.get("hf_quant_config")
+    hf_quant_config = hf_quant_config if isinstance(hf_quant_config, dict) else {}
+    hf_quant = hf_quant_config.get("quantization")
+    hf_quant = hf_quant if isinstance(hf_quant, dict) else {}
+
+    patterns = [
+        *list(quant_config.get("modules_to_not_convert") or []),
+        *list(quant_config.get("exclude_modules") or []),
+        *list(hf_quant.get("exclude_modules") or []),
+    ]
+    dsa_projection_markers = (
+        "self_attn.q_a_proj",
+        "self_attn.q_b_proj",
+        "self_attn.kv_a_proj",
+        "self_attn.kv_a_proj_with_mqa",
+        "self_attn.kv_b_proj",
+        "self_attn.o_proj",
+    )
+    return any(any(marker in str(pattern) for marker in dsa_projection_markers) for pattern in patterns)
+
+
+def _dsa_gemm_quant_mode(extra_params: object, fallback: common.GEMMQuantMode) -> common.GEMMQuantMode:
+    if isinstance(extra_params, dict):
+        return extra_params.get("dsa_gemm_quant_mode", fallback)
+    return fallback
+
+
 @register_model("DEEPSEEKV32")
 class DeepSeekV32Model(BaseModel):
     """
@@ -40,7 +72,11 @@ class DeepSeekV32Model(BaseModel):
             model_info["context"],
             model_config,
         )
-        extra_params = model_info["extra_params"]
+        extra_params = dict(model_info["extra_params"])
+        if model_info["architecture"] == "GlmMoeDsaForCausalLM" and _dsa_attention_modules_excluded_from_quant(
+            model_info.get("raw_config", {})
+        ):
+            extra_params["dsa_gemm_quant_mode"] = common.GEMMQuantMode.bfloat16
 
         if backend_name == "sglang" and model_config.enable_wideep:
             logger.debug(
@@ -88,6 +124,7 @@ class DeepSeekV32Model(BaseModel):
         moe_quant_mode = self.config.moe_quant_mode
         kvcache_quant_mode = self.config.kvcache_quant_mode
         fmha_quant_mode = self.config.fmha_quant_mode
+        dsa_gemm_quant_mode = _dsa_gemm_quant_mode(self.extra_params, gemm_quant_mode)
         workload_distribution = (
             self.config.workload_distribution + f"_{self._power_law_alpha}"
             if self.config.workload_distribution == "power_law"
@@ -105,7 +142,7 @@ class DeepSeekV32Model(BaseModel):
                     local_heads,
                     kvcache_quant_mode,
                     fmha_quant_mode,
-                    gemm_quant_mode,
+                    dsa_gemm_quant_mode,
                     architecture=self.architecture,
                 ),
                 ops.ElementWise("context_add_norm_2", self._num_layers, 2 * h, 2 * h, 0.8),
@@ -199,7 +236,7 @@ class DeepSeekV32Model(BaseModel):
                     self._num_layers * self._mtp_scale_factor,
                     local_heads,
                     kvcache_quant_mode,
-                    gemm_quant_mode,
+                    dsa_gemm_quant_mode,
                     architecture=self.architecture,
                 ),
                 ops.ElementWise(
@@ -354,6 +391,7 @@ class TrtllmWideEPDeepSeekV32Model(BaseModel):
         moe_quant_mode = self.config.moe_quant_mode
         kvcache_quant_mode = self.config.kvcache_quant_mode
         fmha_quant_mode = self.config.fmha_quant_mode
+        dsa_gemm_quant_mode = _dsa_gemm_quant_mode(self.extra_params, gemm_quant_mode)
 
         eplb_enabled = self.config.enable_eplb
         if self.config.workload_distribution == "power_law":
@@ -404,7 +442,7 @@ class TrtllmWideEPDeepSeekV32Model(BaseModel):
                     local_heads,
                     kvcache_quant_mode,
                     fmha_quant_mode,
-                    gemm_quant_mode,
+                    dsa_gemm_quant_mode,
                     architecture=self.architecture,
                 ),
                 ops.ElementWise("context_add_norm_2", self._num_layers, 2 * h, 2 * h, 0.8),
@@ -495,7 +533,7 @@ class TrtllmWideEPDeepSeekV32Model(BaseModel):
                     generation_scale,
                     local_heads,
                     kvcache_quant_mode,
-                    gemm_quant_mode,
+                    dsa_gemm_quant_mode,
                     architecture=self.architecture,
                 ),
                 ops.ElementWise("generation_add_norm_2", generation_scale, 2 * h, 2 * h, 0.8),
@@ -600,6 +638,7 @@ class WideEPDeepSeekV32Model(BaseModel):
         moe_quant_mode = self.config.moe_quant_mode
         kvcache_quant_mode = self.config.kvcache_quant_mode
         fmha_quant_mode = self.config.fmha_quant_mode
+        dsa_gemm_quant_mode = _dsa_gemm_quant_mode(self.extra_params, gemm_quant_mode)
         moe_backend = self.config.moe_backend
         sms = self.config.sms
 
@@ -639,7 +678,7 @@ class WideEPDeepSeekV32Model(BaseModel):
                     local_heads,
                     kvcache_quant_mode,
                     fmha_quant_mode,
-                    gemm_quant_mode,
+                    dsa_gemm_quant_mode,
                     architecture=self.architecture,
                 ),
                 *(
@@ -723,7 +762,7 @@ class WideEPDeepSeekV32Model(BaseModel):
                     generation_scale,
                     local_heads,
                     kvcache_quant_mode,
-                    gemm_quant_mode,
+                    dsa_gemm_quant_mode,
                     architecture=self.architecture,
                 ),
                 ops.GEMM(

--- a/tests/unit/sdk/models/test_model_config.py
+++ b/tests/unit/sdk/models/test_model_config.py
@@ -359,6 +359,18 @@ class TestHFModelSupport:
         assert model_config.moe_quant_mode == expected_moe_quant
         assert model_config.fmha_quant_mode == common.FMHAQuantMode.bfloat16
 
+    def test_glm5_nvfp4_dsa_attention_uses_unquantized_projection_tables(self):
+        model_config = config.ModelConfig(tp_size=1, moe_tp_size=1, moe_ep_size=1)
+        model = get_model("nvidia/GLM-5-NVFP4", model_config, backend_name="sglang")
+
+        context_dsa = next(op for op in model.context_ops if op._name == "context_attention")
+        generation_dsa = next(op for op in model.generation_ops if op._name == "generation_attention")
+
+        assert model_config.gemm_quant_mode == common.GEMMQuantMode.nvfp4
+        assert model_config.moe_quant_mode == common.MoEQuantMode.nvfp4
+        assert context_dsa._gemm_quant_mode == common.GEMMQuantMode.bfloat16
+        assert generation_dsa._gemm_quant_mode == common.GEMMQuantMode.bfloat16
+
     @pytest.mark.parametrize(
         "model_path,replacement",
         [

--- a/tests/unit/sdk/test_common.py
+++ b/tests/unit/sdk/test_common.py
@@ -104,6 +104,25 @@ class TestSupportMatrix:
         assert agg is expected_agg
         assert disagg is expected_disagg
 
+    @pytest.mark.parametrize(
+        "model,backend,version,expected_agg,expected_disagg",
+        [
+            ("zai-org/GLM-5-FP8", "sglang", "0.5.10", True, True),
+            ("zai-org/GLM-5-FP8", "trtllm", "1.3.0rc10", False, False),
+            ("nvidia/GLM-5-NVFP4", "sglang", "0.5.10", True, True),
+            ("nvidia/GLM-5-NVFP4", "vllm", "0.19.0", True, True),
+        ],
+    )
+    def test_check_support_uses_exact_glm5_b200_variant_rows(
+        self, model, backend, version, expected_agg, expected_disagg
+    ):
+        """GLM-5 quantized variants should not inherit BF16 support results."""
+        result = common.check_support(model, "b200_sxm", backend, version, "GlmMoeDsaForCausalLM")
+
+        assert result.agg_supported is expected_agg
+        assert result.disagg_supported is expected_disagg
+        assert result.exact_match is True
+
     def test_check_support_matches_architecture_fallback_case_insensitively(self, monkeypatch):
         """Test system/backend case normalization for architecture-based fallback."""
         monkeypatch.setattr(

--- a/tests/unit/sdk/test_common.py
+++ b/tests/unit/sdk/test_common.py
@@ -104,6 +104,25 @@ class TestSupportMatrix:
         assert agg is expected_agg
         assert disagg is expected_disagg
 
+    @pytest.mark.parametrize(
+        "model,backend,version,expected_agg,expected_disagg",
+        [
+            ("zai-org/GLM-5-FP8", "sglang", "0.5.10", True, True),
+            ("zai-org/GLM-5-FP8", "trtllm", "1.3.0rc10", False, False),
+            ("nvidia/GLM-5-NVFP4", "sglang", "0.5.10", False, False),
+            ("nvidia/GLM-5-NVFP4", "vllm", "0.19.0", True, True),
+        ],
+    )
+    def test_check_support_uses_exact_glm5_b200_variant_rows(
+        self, model, backend, version, expected_agg, expected_disagg
+    ):
+        """GLM-5 quantized variants should not inherit BF16 support results."""
+        result = common.check_support(model, "b200_sxm", backend, version, "GlmMoeDsaForCausalLM")
+
+        assert result.agg_supported is expected_agg
+        assert result.disagg_supported is expected_disagg
+        assert result.exact_match is True
+
     def test_check_support_matches_architecture_fallback_case_insensitively(self, monkeypatch):
         """Test system/backend case normalization for architecture-based fallback."""
         monkeypatch.setattr(

--- a/tests/unit/sdk/test_common.py
+++ b/tests/unit/sdk/test_common.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import pytest
 
-from aiconfigurator.sdk import common
+from aiconfigurator.sdk import common, perf_database
 
 pytestmark = pytest.mark.unit
 
@@ -122,6 +122,27 @@ class TestSupportMatrix:
         assert result.agg_supported is expected_agg
         assert result.disagg_supported is expected_disagg
         assert result.exact_match is True
+
+    def test_glm5_quantized_variants_cover_all_database_combinations(self):
+        """GLM-5 quantized variants should have exact rows for every support-matrix target."""
+        supported_databases = perf_database.get_supported_databases()
+        expected_keys = {
+            (system, backend, version, mode)
+            for system, backend_versions in supported_databases.items()
+            for backend, versions in backend_versions.items()
+            for version in versions
+            for mode in ("agg", "disagg")
+        }
+
+        matrix = common.get_support_matrix()
+        for model in ("zai-org/GLM-5-FP8", "nvidia/GLM-5-NVFP4"):
+            model_keys = {
+                (row["System"], row["Backend"], row["Version"], row["Mode"])
+                for row in matrix
+                if row["HuggingFaceID"] == model
+            }
+
+            assert model_keys == expected_keys
 
     def test_check_support_matches_architecture_fallback_case_insensitively(self, monkeypatch):
         """Test system/backend case normalization for architecture-based fallback."""

--- a/tests/unit/sdk/test_common.py
+++ b/tests/unit/sdk/test_common.py
@@ -7,6 +7,7 @@ Unit tests for common SDK configurations.
 Tests supported systems, model families, and other common configurations.
 """
 
+from collections import Counter
 from pathlib import Path
 
 import pytest
@@ -136,13 +137,16 @@ class TestSupportMatrix:
 
         matrix = common.get_support_matrix()
         for model in ("zai-org/GLM-5-FP8", "nvidia/GLM-5-NVFP4"):
-            model_keys = {
-                (row["System"], row["Backend"], row["Version"], row["Mode"])
-                for row in matrix
-                if row["HuggingFaceID"] == model
-            }
+            model_rows = [row for row in matrix if row["HuggingFaceID"] == model]
+            model_key_counts = Counter(
+                (row["System"], row["Backend"], row["Version"], row["Mode"]) for row in model_rows
+            )
+            model_keys = set(model_key_counts)
 
             assert model_keys == expected_keys
+            assert all(count == 1 for count in model_key_counts.values()), (
+                f"{model} has duplicate support-matrix rows for one or more keys"
+            )
 
     def test_check_support_matches_architecture_fallback_case_insensitively(self, monkeypatch):
         """Test system/backend case normalization for architecture-based fallback."""


### PR DESCRIPTION
## Summary
- add exact support-matrix rows for `zai-org/GLM-5-FP8` and `nvidia/GLM-5-NVFP4` across every GPU/backend/version target currently present in the matrix
- fix `nvidia/GLM-5-NVFP4` on B200 + SGLang 0.5.10 by keeping GLM-5 DSA attention lookup on BF16 tables when those DSA projection modules are excluded from NVFP4 quantization
- improve the static support-matrix page with shareable `?q=` search deep links on both GitHub Pages and local previews
- make localhost previews load the local repo CSV so reviewers can verify unmerged support-matrix changes before deployment

## New Support Matrix
<img width="711" height="661" alt="image" src="https://github.com/user-attachments/assets/35316806-0772-4525-8dd8-f200c1681be4" />


## Why
The support check uses exact model/system/backend/version rows first, then falls back to architecture-level majority. The matrix only had plain `zai-org/GLM-5` rows, so quantized variants could inherit BF16 GLM-5 failures instead of showing their own support state on the public support matrix.

This PR adds explicit GLM-5 variant rows for all supported GPU systems currently represented by the support database: `a100_sxm`, `b200_sxm`, `b300_sxm`, `b60`, `gb200`, `gb300`, `h100_sxm`, `h200_sxm`, `l40s`, and `rtx_pro_6000_server`.

The `nvidia/GLM-5-NVFP4` SGLang 0.5.10 B200 failure came from DSA attention perf lookup using NVFP4 GEMM mode even though the raw config excludes the DSA/self-attention projection modules from quantization. In that case the model GEMM/MoE paths remain NVFP4, but DSA context/generation modules need BF16 perf tables.

The localhost CSV fallback is not needed for production behavior. It is only there so `http://127.0.0.1:7860/support-matrix/` shows the checked-out branch's CSV instead of fetching `main` from GitHub raw. The `?q=` support applies on deployed GitHub Pages too, so links like `/support-matrix/?q=GLM-5` open directly filtered.

## Local Preview
- `http://127.0.0.1:7860/support-matrix/?q=GLM-5`
- Served CSV sanity check: `3872` total rows
- `zai-org/GLM-5-FP8`: `88` rows across all 10 GPU systems
- `nvidia/GLM-5-NVFP4`: `88` rows across all 10 GPU systems
- Coverage check against `perf_database.get_supported_databases()`: `0` missing keys, `0` extra keys per GLM-5 variant

## Validation
- `.venv/bin/python -m pytest tests/unit/sdk/test_common.py tests/unit/sdk/models/test_model_config.py::TestHFModelSupport::test_glm5_quantized_cached_config_uses_deepseek_v32_family tests/unit/sdk/models/test_model_config.py::TestHFModelSupport::test_glm5_nvfp4_dsa_attention_uses_unquantized_projection_tables -q` (`18 passed, 1 warning`)
- `git diff --check`
- PapaParse sanity check: `3872` rows, `0` errors, `nvidia/GLM-5-NVFP4` B200 SGLang 0.5.10 is `agg:PASS/disagg:PASS`
- `SupportMatrix.run_single_test('nvidia/GLM-5-NVFP4', 'b200_sxm', 'sglang', '0.5.10')` -> `{'agg': True, 'disagg': True}`