### PR TITLE
feat: Add "HW_INCOMPATIBLE" result to support matrix

### DIFF
--- a/docs/support-matrix/index.html
+++ b/docs/support-matrix/index.html
@@ -57,11 +57,16 @@ tailwind.config = {
     font-size: 0.72rem;
     font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
     line-height: 1.4;
-    white-space: pre;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    word-break: break-word;
     border-radius: 4px;
     box-shadow: 0 2px 8px rgba(0,0,0,.25);
     pointer-events: none;
-    max-width: 480px;
+    width: max-content;
+    max-width: min(480px, calc(100vw - 2rem));
+    box-sizing: border-box;
+    text-align: left;
   }
   html.dark td[data-tip]:hover::after {
     background: rgb(30 41 59);
@@ -79,6 +84,7 @@ const { useState, useEffect, useCallback, useMemo, useRef } = React;
 // ── Constants ───────────────────────────────────────────────────────
 const REPO = 'ai-dynamo/aiconfigurator';
 const CSV_PATH = 'src/aiconfigurator/systems/support_matrix.csv';
+const STATUS_HW_INCOMPATIBLE = 'HW_INCOMPATIBLE';
 const PREFERRED_DEFAULT_SYSTEM = 'b200_sxm';
 const SYSTEM_ORDER = ['b200', 'gb200', 'gb300', 'h100', 'h200', '__other__', 'a100', 'l40s'];
 
@@ -167,6 +173,7 @@ function getLatestSupportedVersion(rows, huggingfaceId, system, backend) {
 
   const versionHasFail = {};
   const versionHasPass = {};
+  const versionHasHwIncompatible = {};
   const versionErrorMsgs = {};
 
   for (const row of subset) {
@@ -188,10 +195,22 @@ function getLatestSupportedVersion(rows, huggingfaceId, system, backend) {
       }
     } else if (status === 'PASS') {
       versionHasPass[version] = true;
+    } else if (status === STATUS_HW_INCOMPATIBLE) {
+      versionHasHwIncompatible[version] = true;
+      if (errorMsg) {
+        if (version in versionErrorMsgs) {
+          const existing = versionErrorMsgs[version];
+          if (existing && existing !== errorMsg) {
+            versionErrorMsgs[version] = `${existing} | ${errorMsg}`;
+          }
+        } else {
+          versionErrorMsgs[version] = errorMsg;
+        }
+      }
     }
   }
 
-  if (!Object.keys(versionHasFail).length && !Object.keys(versionHasPass).length) {
+  if (!Object.keys(versionHasFail).length && !Object.keys(versionHasPass).length && !Object.keys(versionHasHwIncompatible).length) {
     return { version: null, isLatest: false, error: null };
   }
 
@@ -202,6 +221,9 @@ function getLatestSupportedVersion(rows, huggingfaceId, system, backend) {
   const latestVersion = testedVersions[0] || null;
   if (latestVersion && versionHasPass[latestVersion]) {
     return { version: latestVersion, isLatest: true, error: null };
+  }
+  if (latestVersion && versionHasHwIncompatible[latestVersion] && !versionHasFail[latestVersion]) {
+    return { version: STATUS_HW_INCOMPATIBLE, isLatest: false, error: versionErrorMsgs[latestVersion] || 'Hardware is incompatible with model datatype' };
   }
   if (latestVersion && versionHasFail[latestVersion]) {
     return { version: 'FAIL', isLatest: false, error: versionErrorMsgs[latestVersion] || 'No error message available' };
@@ -219,7 +241,17 @@ function getLatestSupportedVersion(rows, huggingfaceId, system, backend) {
   for (const ver of failVersions) {
     if (versionErrorMsgs[ver]) allMsgs.push(`${ver}: ${versionErrorMsgs[ver]}`);
   }
-  return { version: 'FAIL', isLatest: false, error: allMsgs.length ? allMsgs.join(' | ') : 'No error message available' };
+  if (allMsgs.length || failVersions.length) {
+    return { version: 'FAIL', isLatest: false, error: allMsgs.length ? allMsgs.join(' | ') : 'No error message available' };
+  }
+
+  const hwVersions = Object.keys(versionHasHwIncompatible)
+    .sort((a, b) => compareVersionTuples(versionSortKey(b), versionSortKey(a)));
+  const hwMsgs = [];
+  for (const ver of hwVersions) {
+    if (versionErrorMsgs[ver]) hwMsgs.push(`${ver}: ${versionErrorMsgs[ver]}`);
+  }
+  return { version: STATUS_HW_INCOMPATIBLE, isLatest: false, error: hwMsgs.length ? hwMsgs.join(' | ') : 'Hardware is incompatible with model datatype' };
 }
 
 // Aggregate per-version statuses into a single (model, backend) cell. Each
@@ -229,12 +261,21 @@ function getLatestSupportedVersion(rows, huggingfaceId, system, backend) {
 //   pass:    every tested version fully passes
 //   fail:    every tested version fully fails
 //   partial: any mix (includes per-version agg/disagg splits)
+//   hw_incompatible: latest tested version is impossible on this GPU
 //   missing: no rows tested for this (model, backend)
 function aggregateBackendCell(rows, modelId, system, backend, versions, modeFilter) {
   const passVersions = [];
   const partialVersions = [];
   const failVersions = [];
+  const hwVersions = [];
   const errors = [];
+
+  const statusFromResult = (result) => {
+    if (result.version === null) return 'missing';
+    if (result.version === 'FAIL') return 'fail';
+    if (result.version === STATUS_HW_INCOMPATIBLE) return 'hw_incompatible';
+    return 'pass';
+  };
 
   // Per-version status uses the existing agg-vs-disagg split inside
   // `getLatestSupportedVersion`, restricted to one version at a time.
@@ -243,11 +284,11 @@ function aggregateBackendCell(rows, modelId, system, backend, versions, modeFilt
     const { version: v, error } = getLatestSupportedVersion(verRows, modelId, system, backend);
     if (v === null) continue; // missing for this version
 
-    let verStatus = v === 'FAIL' ? 'fail' : 'pass';
-    let verError = v === 'FAIL' ? error : null;
+    let verStatus = statusFromResult({ version: v });
+    let verError = verStatus === 'pass' ? null : error;
 
     // Within-version agg/disagg split (only meaningful when viewing "all").
-    if (modeFilter === 'all' && verStatus === 'pass') {
+    if (modeFilter === 'all') {
       const aggRows = verRows.filter(r => r.Mode === 'agg');
       const disaggRows = verRows.filter(r => r.Mode === 'disagg');
       const aggResult = aggRows.length
@@ -256,36 +297,62 @@ function aggregateBackendCell(rows, modelId, system, backend, versions, modeFilt
       const disaggResult = disaggRows.length
         ? getLatestSupportedVersion(disaggRows, modelId, system, backend)
         : { version: null, error: null };
-      const aggPass = aggResult.version !== null && aggResult.version !== 'FAIL';
-      const disaggPass = disaggResult.version !== null && disaggResult.version !== 'FAIL';
-      if (aggPass !== disaggPass) {
+      const aggStatus = statusFromResult(aggResult);
+      const disaggStatus = statusFromResult(disaggResult);
+      const modeStatuses = [aggStatus, disaggStatus].filter(s => s !== 'missing');
+      const hasPass = modeStatuses.includes('pass');
+      const hasFail = modeStatuses.includes('fail');
+      const hasHw = modeStatuses.includes('hw_incompatible');
+
+      if (hasPass && (hasFail || hasHw || modeStatuses.length < 2)) {
         verStatus = 'partial';
-        verError = !aggPass
-          ? `[agg FAIL] ${aggResult.error || 'No error message available'}`
-          : `[disagg FAIL] ${disaggResult.error || 'No error message available'}`;
+        if (aggStatus !== 'pass') {
+          verError = `[agg ${aggStatus === 'hw_incompatible' ? STATUS_HW_INCOMPATIBLE : 'FAIL'}] ${aggResult.error || 'No error message available'}`;
+        } else {
+          verError = `[disagg ${disaggStatus === 'hw_incompatible' ? STATUS_HW_INCOMPATIBLE : 'FAIL'}] ${disaggResult.error || 'No error message available'}`;
+        }
+      } else if (!hasPass && hasFail) {
+        verStatus = 'fail';
+        verError = aggStatus === 'fail'
+          ? (aggResult.error || 'No error message available')
+          : (disaggResult.error || 'No error message available');
+      } else if (!hasPass && hasHw) {
+        verStatus = 'hw_incompatible';
+        verError = aggStatus === 'hw_incompatible'
+          ? (aggResult.error || 'Hardware is incompatible with model datatype')
+          : (disaggResult.error || 'Hardware is incompatible with model datatype');
       }
     }
 
     if (verStatus === 'pass') passVersions.push(version);
     else if (verStatus === 'partial') partialVersions.push(version);
+    else if (verStatus === 'hw_incompatible') hwVersions.push(version);
     else failVersions.push(version);
 
-    if (verError) errors.push(`[${version}] ${verError}`);
+    if (verError) {
+      if (verStatus === 'hw_incompatible') {
+        if (!errors.includes(verError)) errors.push(verError);
+      } else {
+        errors.push(`[${version}] ${verError}`);
+      }
+    }
   }
 
-  if (!passVersions.length && !partialVersions.length && !failVersions.length) {
-    return { status: 'missing', passVersions: [], partialVersions: [], failVersions: [], error: null };
+  if (!passVersions.length && !partialVersions.length && !failVersions.length && !hwVersions.length) {
+    return { status: 'missing', passVersions: [], partialVersions: [], failVersions: [], hwVersions: [], error: null };
   }
 
   // Color is driven by the **latest tested version** for this (model, backend):
   //   - latest is strictly pass               -> green
   //   - latest is fail/partial but any older  -> orange (regression)
   //   - everything failed                     -> red
+  //   - latest is hardware-incompatible       -> gray
   const sortDesc = (a, b) => compareVersionTuples(versionSortKey(b), versionSortKey(a));
-  const allTested = [...passVersions, ...partialVersions, ...failVersions].sort(sortDesc);
+  const allTested = [...passVersions, ...partialVersions, ...failVersions, ...hwVersions].sort(sortDesc);
   const newest = allTested[0];
   let status;
   if (passVersions.includes(newest)) status = 'pass';
+  else if (hwVersions.includes(newest)) status = 'hw_incompatible';
   else if (partialVersions.includes(newest)) status = 'partial';
   else if (passVersions.length || partialVersions.length) status = 'partial';
   else status = 'fail';
@@ -295,6 +362,7 @@ function aggregateBackendCell(rows, modelId, system, backend, versions, modeFilt
     passVersions: passVersions.slice().sort(sortDesc),
     partialVersions: partialVersions.slice().sort(sortDesc),
     failVersions: failVersions.slice().sort(sortDesc),
+    hwVersions: hwVersions.slice().sort(sortDesc),
     error: errors.length ? errors.join(' | ') : null,
   };
 }
@@ -680,6 +748,10 @@ function Legend() {
         <span className="inline-block w-9 h-5 rounded border border-slate-200 dark:border-slate-600 bg-red-100 dark:bg-red-950"></span>
         All versions fail (click for details)
       </div>
+      <div className="flex items-center gap-1.5">
+        <span className="inline-block w-9 h-5 rounded border border-slate-200 dark:border-slate-600 bg-slate-200 dark:bg-slate-700"></span>
+        GPU does not support model datatype
+      </div>
       <a href={buildFileIssueUrl()} target="_blank" rel="noopener"
         className="ml-auto px-3 py-1.5 bg-indigo-500 hover:bg-indigo-600 dark:bg-indigo-400 dark:hover:bg-indigo-500
                    text-white text-xs font-semibold rounded transition-colors no-underline whitespace-nowrap">
@@ -704,10 +776,10 @@ function MatrixTable({ matrixRows, columns, searchQuery, sortCol, sortAsc, showA
   // Sort by status rank first (pass < partial < fail < missing), then by
   // the concatenated version lists so rows with the same status cluster by
   // their supported-version set.
-  const STATUS_RANK = { pass: 0, partial: 1, fail: 2, missing: 3 };
+  const STATUS_RANK = { pass: 0, partial: 1, fail: 2, hw_incompatible: 3, missing: 4 };
   const cellSortKey = (c) => {
     if (!c) return '99|';
-    const versions = (c.passVersions || []).concat(c.partialVersions || [], c.failVersions || []).join(',');
+    const versions = (c.passVersions || []).concat(c.partialVersions || [], c.failVersions || [], c.hwVersions || []).join(',');
     return String(STATUS_RANK[c.status] ?? 99) + '|' + versions;
   };
 
@@ -733,6 +805,7 @@ function MatrixTable({ matrixRows, columns, searchQuery, sortCol, sortAsc, showA
       case 'pass': return 'bg-green-100 dark:bg-green-950 text-green-800 dark:text-green-300 font-medium';
       case 'partial': return 'bg-amber-100 dark:bg-amber-950 text-amber-800 dark:text-amber-300 font-medium cursor-pointer hover:brightness-95 dark:hover:brightness-125';
       case 'fail': return 'bg-red-100 dark:bg-red-950 text-red-700 dark:text-red-300 font-semibold cursor-pointer hover:brightness-95 dark:hover:brightness-125';
+      case 'hw_incompatible': return 'bg-slate-200 dark:bg-slate-700 text-slate-600 dark:text-slate-300 font-medium';
       default: return '';
     }
   };
@@ -748,16 +821,19 @@ function MatrixTable({ matrixRows, columns, searchQuery, sortCol, sortAsc, showA
     const pushPass = (v) => chips.push(<span key={`p-${v}`}>{v}</span>);
     const pushPartial = (v) => chips.push(<span key={`m-${v}`} title="Partial (agg or disagg only)">~{v}</span>);
     const pushFail = (v) => chips.push(<span key={`f-${v}`} className="line-through opacity-75">{v}</span>);
+    const pushHw = (v) => chips.push(<span key={`h-${v}`}>{v}</span>);
 
     if (showAllVersions) {
       const all = [
         ...(cell.passVersions || []).map(v => ({ version: v, status: 'pass' })),
         ...(cell.partialVersions || []).map(v => ({ version: v, status: 'partial' })),
         ...(cell.failVersions || []).map(v => ({ version: v, status: 'fail' })),
+        ...(cell.hwVersions || []).map(v => ({ version: v, status: 'hw_incompatible' })),
       ].sort((a, b) => compareVersionTuples(versionSortKey(a.version), versionSortKey(b.version)));
       all.forEach(({ version, status }) => {
         if (status === 'pass') pushPass(version);
         else if (status === 'partial') pushPartial(version);
+        else if (status === 'hw_incompatible') pushHw(version);
         else pushFail(version);
       });
     } else {
@@ -777,6 +853,8 @@ function MatrixTable({ matrixRows, columns, searchQuery, sortCol, sortAsc, showA
       } else if (cell.status === 'fail') {
         if (cell.failVersions && cell.failVersions.length) pushFail(cell.failVersions[0]);
         else if (cell.partialVersions && cell.partialVersions.length) pushPartial(cell.partialVersions[0]);
+      } else if (cell.status === 'hw_incompatible') {
+        if (cell.hwVersions && cell.hwVersions.length) pushHw(cell.hwVersions[0]);
       }
     }
     return <span className="inline-flex flex-wrap gap-x-2 gap-y-0.5 font-mono text-xs">{chips}</span>;
@@ -836,7 +914,10 @@ function MatrixTable({ matrixRows, columns, searchQuery, sortCol, sortAsc, showA
                 if (cell.passVersions && cell.passVersions.length) tooltipParts.push(`Pass: ${cell.passVersions.join(', ')}`);
                 if (cell.partialVersions && cell.partialVersions.length) tooltipParts.push(`Partial: ${cell.partialVersions.join(', ')}`);
                 if (cell.failVersions && cell.failVersions.length) tooltipParts.push(`Fail: ${cell.failVersions.join(', ')}`);
-                const tooltip = `${c.backend}\n${tooltipParts.join('\n')}`;
+                if (cell.hwVersions && cell.hwVersions.length) tooltipParts.push(`Hardware incompatible: ${cell.hwVersions.join(', ')}`);
+                const tooltip = cell.status === 'hw_incompatible'
+                  ? (cell.error || 'Hardware is incompatible with model datatype')
+                  : `${c.backend}\n${tooltipParts.join('\n')}`;
                 return (
                   <td key={c.key}
                       data-tip={tooltip}

--- a/src/aiconfigurator/sdk/common.py
+++ b/src/aiconfigurator/sdk/common.py
@@ -273,6 +273,7 @@ def check_support(
         if row["Architecture"] == architecture
         and row["System"].lower() == system.lower()
         and _matches_filters(row, backend, version)
+        and row["Status"] != "HW_INCOMPATIBLE"
     ]
 
     agg_results = [row["Status"] == "PASS" for row in arch_matches if row["Mode"] == "agg"]

--- a/src/aiconfigurator/webapp/components/support_matrix_tab.py
+++ b/src/aiconfigurator/webapp/components/support_matrix_tab.py
@@ -22,6 +22,8 @@ def parse_version(ver_str):
 # Cell colors for support matrix (used in styling and legend)
 COLOR_FAIL_BG = "#ffcccc"
 COLOR_FAIL_TEXT = "#cc0000"
+COLOR_HW_INCOMPATIBLE_BG = "#e5e7eb"
+COLOR_HW_INCOMPATIBLE_TEXT = "#475569"
 COLOR_LATEST_PASS = "#80ff80"  # Green: latest tested backend version passes
 COLOR_OLDER_PASS = "#ccffcc"  # Light green: older tested backend version passes
 
@@ -37,6 +39,9 @@ SUPPORT_MATRIX_LEGEND = (
     f'<span style="margin-right: 24px;">'
     f'<span style="background: {COLOR_FAIL_BG}; color: {COLOR_FAIL_TEXT}; padding: 2px 10px; border-radius: 4px; font-weight: bold;">FAIL</span>'
     f" test failed (click cell to see error message)</span>"
+    f'<span style="margin-right: 24px;">'
+    f'<span style="background: {COLOR_HW_INCOMPATIBLE_BG}; color: {COLOR_HW_INCOMPATIBLE_TEXT}; padding: 2px 10px; border-radius: 4px; font-weight: bold;">HW</span>'
+    f" GPU does not support model datatype</span>"
     f"</div>"
 )
 
@@ -62,9 +67,10 @@ def get_latest_supported_version(df, huggingface_id, system, backend):
         return (None, False, None)
 
     # Get all versions with their statuses and error messages
-    # For each version, track if it has any FAIL entries and collect error messages
+    # For each version, track PASS/FAIL/HW_INCOMPATIBLE entries and collect messages
     version_has_fail = {}
     version_has_pass = {}
+    version_has_hw_incompatible = {}
     version_error_msgs = {}  # Store error messages for failed versions
 
     for _, row in subset.iterrows():
@@ -96,14 +102,26 @@ def get_latest_supported_version(df, huggingface_id, system, backend):
                     version_error_msgs[version] = error_msg
         elif status == "PASS":
             version_has_pass[version] = True
+        elif status == "HW_INCOMPATIBLE":
+            version_has_hw_incompatible[version] = True
+            if error_msg:
+                if version in version_error_msgs:
+                    existing = version_error_msgs[version]
+                    if existing and existing != error_msg:
+                        version_error_msgs[version] = f"{existing} | {error_msg}"
+                else:
+                    version_error_msgs[version] = error_msg
 
-    if len(version_has_fail) == 0 and len(version_has_pass) == 0:
+    if len(version_has_fail) == 0 and len(version_has_pass) == 0 and len(version_has_hw_incompatible) == 0:
         return (None, False, None)
 
     backend_versions = df[(df["System"] == system) & (df["Backend"] == backend)]["Version"].dropna().unique()
     latest_version = max((str(version) for version in backend_versions), key=parse_version, default=None)
     if latest_version in version_has_pass:
         return (latest_version, True, None)
+    if latest_version in version_has_hw_incompatible and latest_version not in version_has_fail:
+        error_msg = version_error_msgs.get(latest_version, "Hardware is incompatible with model datatype")
+        return ("HW_INCOMPATIBLE", False, error_msg)
     if latest_version in version_has_fail:
         error_msg = version_error_msgs.get(latest_version, "No error message available")
         return ("FAIL", False, error_msg)
@@ -113,14 +131,23 @@ def get_latest_supported_version(df, huggingface_id, system, backend):
     if passing_versions:
         v = passing_versions[0]
         return (v, False, None)
-    else:
-        # No passing version exists - collect error messages from all failed versions
-        all_error_msgs = []
-        for version in sorted(version_has_fail.keys(), key=parse_version, reverse=True):
-            if version in version_error_msgs:
-                all_error_msgs.append(f"{version}: {version_error_msgs[version]}")
+    # No passing version exists - prefer real failures over hardware-incompatible rows.
+    all_error_msgs = []
+    for version in sorted(version_has_fail.keys(), key=parse_version, reverse=True):
+        if version in version_error_msgs:
+            all_error_msgs.append(f"{version}: {version_error_msgs[version]}")
+    if all_error_msgs or version_has_fail:
         error_msg = " | ".join(all_error_msgs) if all_error_msgs else "No error message available"
         return ("FAIL", False, error_msg)
+
+    hw_error_msgs = []
+    for version in sorted(version_has_hw_incompatible.keys(), key=parse_version, reverse=True):
+        if version in version_error_msgs:
+            error_msg = version_error_msgs[version]
+            if error_msg not in hw_error_msgs:
+                hw_error_msgs.append(error_msg)
+    error_msg = " | ".join(hw_error_msgs) if hw_error_msgs else "Hardware is incompatible with model datatype"
+    return ("HW_INCOMPATIBLE", False, error_msg)
 
 
 def create_system_matrix(df, system_name, mode_filter="all"):
@@ -164,7 +191,7 @@ def create_system_matrix(df, system_name, mode_filter="all"):
             else:
                 row.append(latest_version)
                 matrix_is_latest[(row_idx, col_idx)] = is_latest
-                if latest_version == "FAIL":
+                if latest_version in ("FAIL", "HW_INCOMPATIBLE"):
                     matrix_error_msgs[(row_idx, col_idx)] = error_msg
                 else:
                     matrix_error_msgs[(row_idx, col_idx)] = None
@@ -183,6 +210,11 @@ def create_system_matrix(df, system_name, mode_filter="all"):
             row_idx = row.name
             if cell_value == "FAIL":
                 styles[col_idx] = f"background-color: {COLOR_FAIL_BG}; color: {COLOR_FAIL_TEXT}; font-weight: bold;"
+            elif cell_value == "HW_INCOMPATIBLE":
+                styles[col_idx] = (
+                    f"background-color: {COLOR_HW_INCOMPATIBLE_BG}; "
+                    f"color: {COLOR_HW_INCOMPATIBLE_TEXT}; font-weight: bold;"
+                )
             elif (row_idx, col_idx - 1) in matrix_is_latest:
                 is_latest = matrix_is_latest.get((row_idx, col_idx - 1), True)
                 if not is_latest:
@@ -349,12 +381,21 @@ def create_support_matrix_tab(app_config):
                                         else:
                                             backend = ""
 
+                                        cell_value = ""
+                                        if hasattr(evt, "row_value") and evt.row_value and len(evt.row_value) > col_idx:
+                                            cell_value = str(evt.row_value[col_idx])
+
                                         # Format error message - convert escaped newlines to actual newlines
                                         formatted_msg = str(error_msg)
                                         # Replace double-escaped newlines first, then single-escaped
                                         formatted_msg = formatted_msg.replace("\\\\n", "\n").replace("\\n", "\n")
 
-                                        title = f"Error Details - {model} / {backend}"
+                                        title_prefix = (
+                                            "Hardware Incompatibility"
+                                            if cell_value == "HW_INCOMPATIBLE"
+                                            else "Error Details"
+                                        )
+                                        title = f"{title_prefix} - {model} / {backend}"
                                         # gr.Info renders HTML. Use scrollable container so long messages stay on screen.
                                         escaped_msg = html_module.escape(formatted_msg)
                                         html_message = (

--- a/tests/e2e/support_matrix/test_pr_support_matrix.py
+++ b/tests/e2e/support_matrix/test_pr_support_matrix.py
@@ -86,7 +86,7 @@ def test_pr_support_matrix(model: str, system: str, backend: str, version: str):
 
     from tools.support_matrix.support_matrix import SupportMatrix
 
-    success_dict, error_dict = SupportMatrix.run_single_test(
+    status_dict, error_dict = SupportMatrix.run_single_test(
         model=model,
         system=system,
         backend=backend,
@@ -96,9 +96,9 @@ def test_pr_support_matrix(model: str, system: str, backend: str, version: str):
 
     failures: list[str] = []
     for mode, expected in [("agg", agg_supported), ("disagg", disagg_supported)]:
-        if expected and not success_dict[mode]:
+        if expected and status_dict[mode] != "PASS":
             error_msg = error_dict[mode] or "no error message captured"
-            failures.append(f"  {mode}: expected PASS but got FAIL — {error_msg}")
+            failures.append(f"  {mode}: expected PASS but got {status_dict[mode]} — {error_msg}")
 
     if failures:
         detail = "\n".join(failures)

--- a/tests/unit/sdk/test_common.py
+++ b/tests/unit/sdk/test_common.py
@@ -186,3 +186,61 @@ class TestSupportMatrix:
         assert result.agg_supported is True
         assert result.disagg_supported is True
         assert result.exact_match is False
+
+    def test_check_support_ignores_hardware_incompatible_rows_for_architecture_fallback(self, monkeypatch):
+        """Hardware-incompatible quantized variants should not skew architecture majority voting."""
+        monkeypatch.setattr(
+            common,
+            "get_support_matrix",
+            lambda: [
+                {
+                    "HuggingFaceID": "Qwen/Qwen3-32B",
+                    "Architecture": "Qwen3ForCausalLM",
+                    "System": "a100_sxm",
+                    "Backend": "trtllm",
+                    "Version": "1.0.0",
+                    "Mode": "agg",
+                    "Status": "PASS",
+                },
+                {
+                    "HuggingFaceID": "Qwen/Qwen3-32B-FP8",
+                    "Architecture": "Qwen3ForCausalLM",
+                    "System": "a100_sxm",
+                    "Backend": "trtllm",
+                    "Version": "1.0.0",
+                    "Mode": "agg",
+                    "Status": "HW_INCOMPATIBLE",
+                },
+                {
+                    "HuggingFaceID": "Qwen/Qwen3-32B",
+                    "Architecture": "Qwen3ForCausalLM",
+                    "System": "a100_sxm",
+                    "Backend": "trtllm",
+                    "Version": "1.0.0",
+                    "Mode": "disagg",
+                    "Status": "PASS",
+                },
+                {
+                    "HuggingFaceID": "Qwen/Qwen3-32B-FP8",
+                    "Architecture": "Qwen3ForCausalLM",
+                    "System": "a100_sxm",
+                    "Backend": "trtllm",
+                    "Version": "1.0.0",
+                    "Mode": "disagg",
+                    "Status": "HW_INCOMPATIBLE",
+                },
+            ],
+        )
+
+        result = common.check_support(
+            "local-qwen-variant",
+            "a100_sxm",
+            backend="trtllm",
+            version="1.0.0",
+            architecture="Qwen3ForCausalLM",
+        )
+
+        assert result.agg_supported is True
+        assert result.disagg_supported is True
+        assert result.agg_pass_count == 1
+        assert result.agg_total_count == 1

--- a/tests/unit/support_matrix/test_compare_support_matrix.py
+++ b/tests/unit/support_matrix/test_compare_support_matrix.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from tools.support_matrix.compare_support_matrix import (
+    check_csv_sanity,
+    find_blocking_status_transitions,
+    generate_pr_description,
+)
+from tools.support_matrix.support_matrix import STATUS_FAIL, STATUS_HW_INCOMPATIBLE, STATUS_PASS
+
+pytestmark = pytest.mark.unit
+
+HEADER = ["HuggingFaceID", "Architecture", "System", "Backend", "Version", "Mode", "Status", "ErrMsg"]
+
+
+def _row(status: str, err_msg: str = "") -> list[str]:
+    return [
+        "Qwen/Qwen3-32B-FP8",
+        "Qwen3ForCausalLM",
+        "a100_sxm",
+        "trtllm",
+        "1.0.0",
+        "agg",
+        status,
+        err_msg,
+    ]
+
+
+def _changed(old_status: str, new_status: str) -> tuple:
+    return (
+        "Qwen/Qwen3-32B-FP8",
+        "Qwen3ForCausalLM",
+        "a100_sxm",
+        "trtllm",
+        "1.0.0",
+        "agg",
+        old_status,
+        new_status,
+    )
+
+
+def test_csv_sanity_accepts_hardware_incompatible_status_with_reason():
+    errors = check_csv_sanity(
+        HEADER,
+        [_row(STATUS_HW_INCOMPATIBLE, "a100_sxm (SM80) does not support FP8 required by Qwen/Qwen3-32B-FP8")],
+    )
+
+    assert errors == []
+
+
+def test_csv_sanity_requires_hardware_incompatible_reason():
+    errors = check_csv_sanity(HEADER, [_row(STATUS_HW_INCOMPATIBLE)])
+
+    assert any("must include a hardware incompatibility reason" in err for err in errors)
+
+
+def test_pass_to_hardware_incompatible_is_blocking_transition():
+    errors = find_blocking_status_transitions([_changed(STATUS_PASS, STATUS_HW_INCOMPATIBLE)])
+
+    assert len(errors) == 1
+    assert "PASS -> HW_INCOMPATIBLE" in errors[0]
+
+
+def test_hardware_incompatible_to_fail_is_blocking_transition():
+    errors = find_blocking_status_transitions([_changed(STATUS_HW_INCOMPATIBLE, STATUS_FAIL)])
+
+    assert len(errors) == 1
+    assert "HW_INCOMPATIBLE -> FAIL" in errors[0]
+
+
+def test_fail_to_hardware_incompatible_is_reported_but_not_blocking():
+    errors = find_blocking_status_transitions([_changed(STATUS_FAIL, STATUS_HW_INCOMPATIBLE)])
+    pr_description = generate_pr_description([], [], [_changed(STATUS_FAIL, STATUS_HW_INCOMPATIBLE)])
+
+    assert errors == []
+    assert "Reclassified as hardware-incompatible" in pr_description
+    assert "| Qwen/Qwen3-32B-FP8 |" in pr_description

--- a/tests/unit/support_matrix/test_hardware_incompatibility.py
+++ b/tests/unit/support_matrix/test_hardware_incompatibility.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from tools.support_matrix.support_matrix import (
+    STATUS_HW_INCOMPATIBLE,
+    STATUS_PASS,
+    SupportMatrix,
+    get_hardware_incompatibility,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _system_spec(*, sm_version: int, fp8: bool = False, fp4: bool = False) -> dict:
+    gpu = {"sm_version": sm_version}
+    if fp8:
+        gpu["fp8_tc_flops"] = 1
+    if fp4:
+        gpu["fp4_tc_flops"] = 1
+    return {"gpu": gpu}
+
+
+def test_fp8_model_is_hardware_incompatible_without_fp8_support():
+    incompatibility = get_hardware_incompatibility(
+        model="Qwen/Qwen3-32B-FP8",
+        system="a100_sxm",
+        backend="trtllm",
+        system_spec=_system_spec(sm_version=80),
+    )
+
+    assert incompatibility is not None
+    assert incompatibility.missing_datatypes == ("FP8",)
+    assert incompatibility.reason == "a100_sxm (SM80) does not support FP8 required by Qwen/Qwen3-32B-FP8"
+
+
+def test_fp8_model_is_allowed_when_system_advertises_fp8_support():
+    incompatibility = get_hardware_incompatibility(
+        model="Qwen/Qwen3-32B-FP8",
+        system="l40s",
+        backend="trtllm",
+        system_spec=_system_spec(sm_version=89, fp8=True),
+    )
+
+    assert incompatibility is None
+
+
+def test_fp8_model_is_allowed_for_b60_software_fallback_without_native_fp8_flops():
+    incompatibility = get_hardware_incompatibility(
+        model="nvidia/Llama-3.1-70B-Instruct-FP8",
+        system="b60",
+        backend="vllm",
+        system_spec={"gpu": {"bfloat16_tc_flops": 1}},
+    )
+
+    assert incompatibility is None
+
+
+def test_fp4_model_is_hardware_incompatible_without_fp4_support():
+    incompatibility = get_hardware_incompatibility(
+        model="nvidia/Qwen3-235B-A22B-NVFP4",
+        system="h100_sxm",
+        backend="trtllm",
+        system_spec=_system_spec(sm_version=90, fp8=True),
+    )
+
+    assert incompatibility is not None
+    assert incompatibility.missing_datatypes == ("FP4",)
+    assert "does not support FP4" in incompatibility.reason
+
+
+@pytest.mark.parametrize("model", ["openai/gpt-oss-20b", "openai/gpt-oss-120b"])
+def test_mxfp4_model_is_not_native_fp4_hardware_incompatible_on_hopper(model):
+    incompatibility = get_hardware_incompatibility(
+        model=model,
+        system="h100_sxm",
+        backend="trtllm",
+        system_spec=_system_spec(sm_version=90, fp8=True),
+    )
+
+    assert incompatibility is None
+
+
+def test_run_single_test_short_circuits_hardware_incompatible_model(monkeypatch):
+    def fail_run_mode(**_kwargs):
+        raise AssertionError("TaskRunner should not run for hardware-incompatible combinations")
+
+    monkeypatch.setattr(SupportMatrix, "_run_mode", staticmethod(fail_run_mode))
+
+    status_dict, error_dict = SupportMatrix.run_single_test(
+        model="Qwen/Qwen3-32B-FP8",
+        system="a100_sxm",
+        backend="trtllm",
+        version="1.0.0",
+        system_spec=_system_spec(sm_version=80),
+    )
+
+    assert status_dict == {"agg": STATUS_HW_INCOMPATIBLE, "disagg": STATUS_HW_INCOMPATIBLE}
+    assert "does not support FP8" in error_dict["agg"]
+    assert STATUS_PASS not in status_dict.values()

--- a/tools/support_matrix/compare_support_matrix.py
+++ b/tools/support_matrix/compare_support_matrix.py
@@ -29,7 +29,13 @@ _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__f
 sys.path.insert(0, os.path.join(_REPO_ROOT, "src"))
 sys.path.insert(0, _REPO_ROOT)
 
-from tools.support_matrix.support_matrix import SupportMatrix
+from tools.support_matrix.support_matrix import (
+    STATUS_FAIL,
+    STATUS_HW_INCOMPATIBLE,
+    STATUS_PASS,
+    VALID_STATUSES,
+    SupportMatrix,
+)
 
 
 def read_csv(csv_path: str) -> tuple[list[str], list[list[str]]]:
@@ -90,8 +96,12 @@ def check_csv_sanity(header: list[str], data_rows: list[list[str]]) -> list[str]
             errors.append(f"Row {i}: Invalid mode '{mode}', expected 'agg' or 'disagg'")
 
         status = row[6]
-        if status not in ["PASS", "FAIL"]:
-            errors.append(f"Row {i}: Invalid status '{status}', expected 'PASS' or 'FAIL'")
+        if status not in VALID_STATUSES:
+            errors.append(f"Row {i}: Invalid status '{status}', expected one of {sorted(VALID_STATUSES)}")
+
+        err_msg = row[7].strip() if len(row) > 7 else ""
+        if status == STATUS_HW_INCOMPATIBLE and not err_msg:
+            errors.append(f"Row {i}: {STATUS_HW_INCOMPATIBLE} rows must include a hardware incompatibility reason")
 
     return errors
 
@@ -193,6 +203,30 @@ def compare_csv_files(
     return added_rows, removed_rows, changed_rows
 
 
+def find_blocking_status_transitions(changed_rows: list[tuple]) -> list[str]:
+    """
+    Return status transitions that should block an automated support-matrix PR.
+
+    Hardware-incompatible rows are produced by deterministic preflight. A previous
+    PASS becoming hardware-incompatible, or a hardware-incompatible row becoming a
+    normal FAIL, indicates either bad metadata or a broken preflight and should be
+    investigated explicitly instead of treated as a routine support change.
+    """
+    errors = []
+    for huggingface_id, architecture, system, backend, version, mode, old_status, new_status in changed_rows:
+        if old_status == STATUS_PASS and new_status == STATUS_HW_INCOMPATIBLE:
+            errors.append(
+                "Unexpected PASS -> HW_INCOMPATIBLE transition: "
+                f"{huggingface_id} ({architecture}) {system}/{backend} v{version} {mode}"
+            )
+        elif old_status == STATUS_HW_INCOMPATIBLE and new_status == STATUS_FAIL:
+            errors.append(
+                "Unexpected HW_INCOMPATIBLE -> FAIL transition: "
+                f"{huggingface_id} ({architecture}) {system}/{backend} v{version} {mode}"
+            )
+    return errors
+
+
 def generate_pr_description(added_rows: list[tuple], removed_rows: list[tuple], changed_rows: list[tuple]) -> str:
     """
     Generate PR description markdown with tables of changes.
@@ -208,8 +242,9 @@ def generate_pr_description(added_rows: list[tuple], removed_rows: list[tuple], 
     Returns:
         Markdown formatted PR description
     """
-    regressions = [r for r in changed_rows if r[6] == "PASS" and r[7] == "FAIL"]
-    fixed = [r for r in changed_rows if r[6] == "FAIL" and r[7] == "PASS"]
+    regressions = [r for r in changed_rows if r[6] == STATUS_PASS and r[7] == STATUS_FAIL]
+    fixed = [r for r in changed_rows if r[7] == STATUS_PASS and r[6] in {STATUS_FAIL, STATUS_HW_INCOMPATIBLE}]
+    reclassified_hw = [r for r in changed_rows if r[6] == STATUS_FAIL and r[7] == STATUS_HW_INCOMPATIBLE]
 
     lines = [
         "This PR updates aiconfigurator/systems/support_matrix.csv with the following changes:",
@@ -219,7 +254,9 @@ def generate_pr_description(added_rows: list[tuple], removed_rows: list[tuple], 
         "| Category | Count |",
         "|----------|-------|",
         f"| Regressions (PASS -> FAIL) | {len(regressions)} |",
-        f"| Fixed (FAIL -> PASS) | {len(fixed)} |",
+        f"| Fixed ({STATUS_FAIL}/{STATUS_HW_INCOMPATIBLE} -> PASS) | {len(fixed)} |",
+        f"| Reclassified as hardware-incompatible ({STATUS_FAIL} -> {STATUS_HW_INCOMPATIBLE}) "
+        f"| {len(reclassified_hw)} |",
         f"| Removed rows | {len(removed_rows)} |",
         f"| Added rows | {len(added_rows)} |",
         "",
@@ -250,7 +287,7 @@ def generate_pr_description(added_rows: list[tuple], removed_rows: list[tuple], 
     lines.append("")
 
     # Fixed (FAIL -> PASS)
-    lines.append(f"### {section}. Fixed (FAIL -> PASS): {len(fixed)} rows")
+    lines.append(f"### {section}. Fixed ({STATUS_FAIL}/{STATUS_HW_INCOMPATIBLE} -> PASS): {len(fixed)} rows")
     section += 1
     if fixed:
         lines.append("")
@@ -269,6 +306,31 @@ def generate_pr_description(added_rows: list[tuple], removed_rows: list[tuple], 
     else:
         lines.append("")
         lines.append("*No fixes*")
+    lines.append("")
+
+    # Reclassified hardware incompatibilities
+    lines.append(
+        f"### {section}. Reclassified as hardware-incompatible ({STATUS_FAIL} -> {STATUS_HW_INCOMPATIBLE}): "
+        f"{len(reclassified_hw)} rows"
+    )
+    section += 1
+    if reclassified_hw:
+        lines.append("")
+        lines.append(
+            "| HuggingFaceID | Architecture | System | Backend | Version | Mode | Previous Status | New Status |"
+        )
+        lines.append(
+            "|---------------|--------------|--------|---------|---------|------|-----------------|------------|"
+        )
+        for huggingface_id, architecture, system, backend, version, mode, old_status, new_status in reclassified_hw:
+            row = (
+                f"| {huggingface_id} | {architecture} | {system} | {backend} "
+                f"| {version} | {mode} | {old_status} | {new_status} |"
+            )
+            lines.append(row)
+    else:
+        lines.append("")
+        lines.append("*No hardware-incompatible reclassifications*")
     lines.append("")
 
     # Removed rows
@@ -381,17 +443,34 @@ def main():
     print("-" * 40)
 
     added_rows, removed_rows, changed_rows = compare_csv_files(old_data_rows, new_data_rows)
+    transition_errors = find_blocking_status_transitions(changed_rows)
+    validation_errors.extend(transition_errors)
 
     print(f"Added rows: {len(added_rows)}")
     print(f"Removed rows: {len(removed_rows)}")
     print(f"Changed rows: {len(changed_rows)}")
-    print(f"  - Regressions (PASS -> FAIL): {len([r for r in changed_rows if r[6] == 'PASS' and r[7] == 'FAIL'])}")
-    print(f"  - Fixed (FAIL -> PASS): {len([r for r in changed_rows if r[6] == 'FAIL' and r[7] == 'PASS'])}")
+    print(
+        f"  - Regressions (PASS -> FAIL): "
+        f"{len([r for r in changed_rows if r[6] == STATUS_PASS and r[7] == STATUS_FAIL])}"
+    )
+    print(
+        f"  - Fixed ({STATUS_FAIL}/{STATUS_HW_INCOMPATIBLE} -> PASS): "
+        f"{len([r for r in changed_rows if r[7] == STATUS_PASS and r[6] in {STATUS_FAIL, STATUS_HW_INCOMPATIBLE}])}"
+    )
+    print(
+        f"  - Reclassified as hardware-incompatible ({STATUS_FAIL} -> {STATUS_HW_INCOMPATIBLE}): "
+        f"{len([r for r in changed_rows if r[6] == STATUS_FAIL and r[7] == STATUS_HW_INCOMPATIBLE])}"
+    )
+    if transition_errors:
+        print("Blocking status transitions:")
+        for err in transition_errors:
+            print(f"  - {err}")
 
     has_changes = len(added_rows) > 0 or len(removed_rows) > 0 or len(changed_rows) > 0
 
-    regressions = [r for r in changed_rows if r[6] == "PASS" and r[7] == "FAIL"]
-    fixed = [r for r in changed_rows if r[6] == "FAIL" and r[7] == "PASS"]
+    regressions = [r for r in changed_rows if r[6] == STATUS_PASS and r[7] == STATUS_FAIL]
+    fixed = [r for r in changed_rows if r[7] == STATUS_PASS and r[6] in {STATUS_FAIL, STATUS_HW_INCOMPATIBLE}]
+    reclassified_hw = [r for r in changed_rows if r[6] == STATUS_FAIL and r[7] == STATUS_HW_INCOMPATIBLE]
 
     # Generate output
     if args.output_diff:
@@ -403,9 +482,11 @@ def main():
             "changed_count": len(changed_rows),
             "regression_count": len(regressions),
             "fixed_count": len(fixed),
+            "reclassified_hw_incompatible_count": len(reclassified_hw),
             "added_rows": added_rows,
             "removed_rows": removed_rows,
             "changed_rows": changed_rows,
+            "blocking_status_transition_errors": transition_errors,
             "pr_description": generate_pr_description(added_rows, removed_rows, changed_rows),
         }
         with open(args.output_diff, "w") as f:

--- a/tools/support_matrix/support_matrix.py
+++ b/tools/support_matrix/support_matrix.py
@@ -23,11 +23,17 @@ from tqdm import tqdm
 
 from aiconfigurator.generator.naive import _estimate_model_weight_bytes
 from aiconfigurator.sdk import common, perf_database
+from aiconfigurator.sdk import config as sdk_config
 from aiconfigurator.sdk.models import _get_model_info
+from aiconfigurator.sdk.models.helpers import _apply_model_quant_defaults
 from aiconfigurator.sdk.task import TaskConfig, TaskRunner
 
 logger = logging.getLogger(__name__)
 
+STATUS_PASS = "PASS"
+STATUS_FAIL = "FAIL"
+STATUS_HW_INCOMPATIBLE = "HW_INCOMPATIBLE"
+VALID_STATUSES = frozenset({STATUS_PASS, STATUS_FAIL, STATUS_HW_INCOMPATIBLE})
 _BYTES_PER_PARAM = 2
 DEFAULT_ENGINE_STEP_COMPARISON_RTOL = 0.05
 DEFAULT_ENGINE_STEP_COMPARISON_ATOL = 1e-3
@@ -56,6 +62,9 @@ _FRONTIER_ENVELOPE_COLUMNS = {
     "tpot": "min",
     "request_latency": "min",
 }
+_FP8_QUANT_MODE_NAMES = frozenset({"fp8", "fp8_static", "fp8_block", "w4afp8"})
+_NATIVE_FP4_QUANT_MODE_NAMES = frozenset({"nvfp4"})
+_FP8_SOFTWARE_FALLBACK_SYSTEMS = frozenset({"b60"})
 
 
 def _combination_sort_key(combo: tuple[str, str, str, str]) -> tuple[str, str, str, str]:
@@ -76,6 +85,12 @@ class TestConstraints:
     prefix: int
     ttft: float
     tpot: float
+
+
+@dataclass(frozen=True)
+class HardwareIncompatibility:
+    missing_datatypes: tuple[str, ...]
+    reason: str
 
 
 # Tiered constraints by model size (parameter count)
@@ -110,6 +125,92 @@ def _get_test_constraints(model_path: str) -> TestConstraints:
         _DEFAULT_TIER,
     )
     return _DEFAULT_TIER
+
+
+def _enum_name(value: object | None) -> str | None:
+    if value is None:
+        return None
+    return value.name if hasattr(value, "name") else str(value)
+
+
+def _format_datatype_list(datatypes: tuple[str, ...]) -> str:
+    if len(datatypes) == 1:
+        return datatypes[0]
+    return ", ".join(datatypes[:-1]) + f" or {datatypes[-1]}"
+
+
+def _gpu_label(system: str, system_spec: dict) -> str:
+    sm_version = (system_spec.get("gpu") or {}).get("sm_version")
+    if sm_version is None:
+        return system
+    return f"{system} (SM{sm_version})"
+
+
+def _gpu_supports_datatype(system: str, system_spec: dict, datatype: str) -> bool:
+    gpu_spec = system_spec.get("gpu") or {}
+    sm_version = gpu_spec.get("sm_version")
+    if datatype == "FP8":
+        # Intel Arc Pro B60 can run FP8 PyTorch/vLLM model paths by converting
+        # FP8 to BF16. Do not model it as native FP8 throughput in b60.yaml.
+        if system.lower() in _FP8_SOFTWARE_FALLBACK_SYSTEMS:
+            return True
+        return "fp8_tc_flops" in gpu_spec or (sm_version is not None and sm_version >= 89)
+    if datatype == "FP4":
+        return "fp4_tc_flops" in gpu_spec or (sm_version is not None and sm_version >= 100)
+    return True
+
+
+def _required_datatypes_for_model(model: str, backend: str) -> tuple[str, ...]:
+    """Infer hardware datatypes required by a model's quantization metadata."""
+    model_info = dict(_get_model_info(model))
+    raw_config = model_info.get("raw_config", {}) or {}
+    architecture = model_info["architecture"]
+    model_config = sdk_config.ModelConfig(tp_size=1, moe_tp_size=1, moe_ep_size=1)
+    _apply_model_quant_defaults(model_config, raw_config, architecture, backend)
+
+    quant_mode_names = {
+        _enum_name(model_config.gemm_quant_mode),
+        _enum_name(model_config.moe_quant_mode),
+        _enum_name(model_config.kvcache_quant_mode),
+        _enum_name(model_config.fmha_quant_mode),
+    }
+    quant_mode_names.discard(None)
+
+    raw_quant_algo = str(raw_config.get("quant_algo") or "").lower()
+    raw_kv_cache_algo = str(raw_config.get("kv_cache_quant_algo") or "").lower()
+    expert_dtype = str(raw_config.get("expert_dtype") or "").lower()
+
+    required: set[str] = set()
+    if quant_mode_names & _NATIVE_FP4_QUANT_MODE_NAMES or raw_quant_algo == "nvfp4" or expert_dtype == "fp4":
+        required.add("FP4")
+    if quant_mode_names & _FP8_QUANT_MODE_NAMES or raw_quant_algo in {"fp8", "fp8_block"}:
+        required.add("FP8")
+    if raw_kv_cache_algo == "fp8":
+        required.add("FP8")
+
+    # Keep FP4 first so FP4 model failures on older GPUs read as FP4 incompatibility
+    # even when the model also uses FP8 scales or KV cache.
+    return tuple(datatype for datatype in ("FP4", "FP8") if datatype in required)
+
+
+def get_hardware_incompatibility(
+    *,
+    model: str,
+    system: str,
+    backend: str,
+    system_spec: dict,
+) -> HardwareIncompatibility | None:
+    """Return a deterministic hardware/model datatype incompatibility, if any."""
+    required_datatypes = _required_datatypes_for_model(model, backend)
+    missing = tuple(dt for dt in required_datatypes if not _gpu_supports_datatype(system, system_spec, dt))
+    if not missing:
+        return None
+
+    datatype_text = _format_datatype_list(missing)
+    return HardwareIncompatibility(
+        missing_datatypes=missing,
+        reason=f"{_gpu_label(system, system_spec)} does not support {datatype_text} required by {model}",
+    )
 
 
 @contextmanager
@@ -284,14 +385,14 @@ _worker_matrix: "SupportMatrix | None" = None
 
 def _process_combination_worker(
     combo: tuple[str, str, str, str],
-) -> list[tuple[str, str, str, str, str, str, bool, str | None]]:
+) -> list[tuple[str, str, str, str, str, str, str, str | None]]:
     """
     Run a single combination in a worker process. Uses the process-local SupportMatrix.
     Must be a module-level function for pickling by ProcessPoolExecutor.
     """
     assert _worker_matrix is not None  # this only works in linux, not in windows/macos
     model, system, backend, version = combo
-    success_dict, error_dict = _worker_matrix.run_single_test(
+    status_dict, error_dict = _worker_matrix.run_single_test(
         model=model,
         system=system,
         backend=backend,
@@ -304,8 +405,8 @@ def _process_combination_worker(
     )
     architecture = _worker_matrix.get_architecture(model)
     return [
-        (model, architecture, system, backend, version, mode, success_dict[mode], error_dict[mode])
-        for mode in success_dict
+        (model, architecture, system, backend, version, mode, status_dict[mode], error_dict[mode])
+        for mode in status_dict
     ]
 
 
@@ -437,12 +538,13 @@ class SupportMatrix:
         backend: str,
         version: str,
         *,
+        system_spec: dict | None = None,
         compare_engine_step_backends: bool = False,
         engine_step_comparison_rtol: float = DEFAULT_ENGINE_STEP_COMPARISON_RTOL,
         engine_step_comparison_atol: float = DEFAULT_ENGINE_STEP_COMPARISON_ATOL,
         engine_step_frontier_rtol: float = DEFAULT_ENGINE_STEP_FRONTIER_RTOL,
         engine_step_frontier_atol: float = DEFAULT_ENGINE_STEP_FRONTIER_ATOL,
-    ) -> tuple[dict[str, bool], dict[str, str | None]]:
+    ) -> tuple[dict[str, str], dict[str, str | None]]:
         """
         Run a single configuration test for both agg and disagg modes.
 
@@ -451,6 +553,7 @@ class SupportMatrix:
             system: System/hardware name
             backend: Backend name
             version: Backend version
+            system_spec: Optional system spec to avoid reloading the database for hardware preflight.
             compare_engine_step_backends: When True, run both Python and Rust engine-step backends.
             engine_step_comparison_rtol: Relative tolerance for Python-vs-Rust Pareto metrics.
             engine_step_comparison_atol: Absolute tolerance for Python-vs-Rust Pareto metrics.
@@ -458,13 +561,37 @@ class SupportMatrix:
             engine_step_frontier_atol: Loose absolute tolerance when frontiers choose different rows.
 
         Returns:
-            Tuple of (dict with results, dict with error messages)
-            Both dicts have keys "agg" and "disagg"
+            Tuple of (dict with statuses, dict with error messages).
+            Status values are PASS, FAIL, or HW_INCOMPATIBLE.
+            Both dicts have keys "agg" and "disagg".
         """
-        constraints = _get_test_constraints(model)
         modes_to_test = ["agg", "disagg"]
-        results = {}
+        statuses: dict[str, str] = {}
         error_messages = {}
+
+        if system_spec is None:
+            database = perf_database.get_database(system, backend, version)
+            system_spec = database.system_spec if database is not None else None
+
+        if system_spec is not None:
+            try:
+                incompatibility = get_hardware_incompatibility(
+                    model=model,
+                    system=system,
+                    backend=backend,
+                    system_spec=system_spec,
+                )
+            except Exception:
+                logger.exception("Hardware compatibility preflight failed for %s on %s/%s", model, system, backend)
+                incompatibility = None
+            if incompatibility is not None:
+                reason = _format_exception_for_csv(incompatibility.reason)
+                return (
+                    dict.fromkeys(modes_to_test, STATUS_HW_INCOMPATIBLE),
+                    dict.fromkeys(modes_to_test, reason),
+                )
+
+        constraints = _get_test_constraints(model)
 
         for mode in modes_to_test:
             try:
@@ -489,7 +616,7 @@ class SupportMatrix:
                         version,
                         mode,
                     )
-                    results[mode] = False
+                    statuses[mode] = STATUS_FAIL
                     error_messages[mode] = "Configuration returned no results, failed to catch traceback"
                     continue
 
@@ -505,7 +632,7 @@ class SupportMatrix:
                             engine_step_backend="rust",
                         )
                     if rust_pareto_df is None or rust_pareto_df.empty:
-                        results[mode] = False
+                        statuses[mode] = STATUS_FAIL
                         error_messages[mode] = "Rust engine-step backend returned no results"
                         continue
 
@@ -518,11 +645,11 @@ class SupportMatrix:
                         frontier_atol=engine_step_frontier_atol,
                     )
                     if mismatch:
-                        results[mode] = False
+                        statuses[mode] = STATUS_FAIL
                         error_messages[mode] = mismatch
                         continue
 
-                results[mode] = True
+                statuses[mode] = STATUS_PASS
                 error_messages[mode] = None
 
             except Exception as e:
@@ -535,12 +662,12 @@ class SupportMatrix:
                     mode,
                     str(e),
                 )
-                results[mode] = False
+                statuses[mode] = STATUS_FAIL
                 error_messages[mode] = traceback.format_exc()
             finally:
                 error_messages[mode] = _format_exception_for_csv(error_messages[mode])
                 perf_database.clear_database_runtime_caches(system, backend, version)
-        return results, error_messages
+        return statuses, error_messages
 
     def _run_parallel_combinations(
         self,
@@ -594,7 +721,7 @@ class SupportMatrix:
 
     def test_support_matrix(
         self, max_workers: int | None = None
-    ) -> list[tuple[str, str, str, str, str, str, bool, str | None]]:
+    ) -> list[tuple[str, str, str, str, str, str, str, str | None]]:
         """
         Test whether each combination is supported by AIC.
         Tests both agg and disagg modes for each combination and captures error messages.
@@ -609,7 +736,7 @@ class SupportMatrix:
                          Defaults to None, which uses os.cpu_count() or 1.
 
         Returns:
-            List of tuples (huggingface_id, architecture, system, backend, version, mode, success, err_msg)
+            List of tuples (huggingface_id, architecture, system, backend, version, mode, status, err_msg)
             Returns separate entries for agg and disagg modes
         """
         # Print configuration
@@ -643,7 +770,7 @@ class SupportMatrix:
 
         combinations = self.generate_combinations()
         print(f"Total combinations to test: {len(combinations)}")
-        results: list[tuple[str, str, str, str, str, str, bool, str | None]] = []
+        results: list[tuple[str, str, str, str, str, str, str, str | None]] = []
         retry_combos: set[tuple[str, str, str, str]] = set()
 
         global _worker_matrix
@@ -668,8 +795,8 @@ class SupportMatrix:
                     perf_database.unload_database(system, backend, version)
 
         # Also collect combos whose Phase 1 results had any failure
-        for model, _arch, system, backend, version, _mode, success, _err in results:
-            if not success:
+        for model, _arch, system, backend, version, _mode, status, _err in results:
+            if status == STATUS_FAIL:
                 retry_combos.add((model, system, backend, version))
 
         # -- Phase 2: sequential single-process retry of all failures --
@@ -687,7 +814,7 @@ class SupportMatrix:
                         for combo in group_iter:
                             model, system, backend, version = combo
                             try:
-                                success_dict, error_dict = self.run_single_test(
+                                status_dict, error_dict = self.run_single_test(
                                     model=model,
                                     system=system,
                                     backend=backend,
@@ -699,7 +826,7 @@ class SupportMatrix:
                                     engine_step_frontier_atol=self.engine_step_frontier_atol,
                                 )
                                 architecture = self.get_architecture(model)
-                                for mode in success_dict:
+                                for mode in status_dict:
                                     results.append(
                                         (
                                             model,
@@ -708,7 +835,7 @@ class SupportMatrix:
                                             backend,
                                             version,
                                             mode,
-                                            success_dict[mode],
+                                            status_dict[mode],
                                             error_dict[mode],
                                         )
                                     )
@@ -730,7 +857,7 @@ class SupportMatrix:
                                             backend,
                                             version,
                                             mode,
-                                            False,
+                                            STATUS_FAIL,
                                             traceback.format_exc().replace("\n", "\\n"),
                                         )
                                     )
@@ -747,11 +874,12 @@ class SupportMatrix:
 
         return results
 
-    def _print_results_summary(self, results: list[tuple[str, str, str, str, str, str, bool, str | None]]) -> None:
+    def _print_results_summary(self, results: list[tuple[str, str, str, str, str, str, str, str | None]]) -> None:
         """Print summary of test results."""
         total_tests = len(results)
-        passed = sum(1 for _, _, _, _, _, _, success, _ in results if success)
-        failed = total_tests - passed
+        passed = sum(1 for _, _, _, _, _, _, status, _ in results if status == STATUS_PASS)
+        failed = sum(1 for _, _, _, _, _, _, status, _ in results if status == STATUS_FAIL)
+        hw_incompatible = sum(1 for _, _, _, _, _, _, status, _ in results if status == STATUS_HW_INCOMPATIBLE)
 
         print("\n" + "=" * 80)
         print("Test Results Summary")
@@ -759,18 +887,22 @@ class SupportMatrix:
         print(f"Total configurations tested: {total_tests}")
         print(f"✓ Passed: {passed} ({100 * passed / total_tests:.1f}%)")
         print(f"✗ Failed: {failed} ({100 * failed / total_tests:.1f}%)")
+        print(f"⚪ Hardware incompatible: {hw_incompatible} ({100 * hw_incompatible / total_tests:.1f}%)")
         print("=" * 80)
 
         # Group results by status
         passed_configs = []
         failed_configs = []
+        hw_incompatible_configs = []
 
-        for huggingface_id, architecture, system, backend, version, mode, success, _ in results:
+        for huggingface_id, architecture, system, backend, version, mode, status, _ in results:
             config = (huggingface_id, architecture, system, backend, version, mode)
-            if success:
+            if status == STATUS_PASS:
                 passed_configs.append(config)
-            else:
+            elif status == STATUS_FAIL:
                 failed_configs.append(config)
+            elif status == STATUS_HW_INCOMPATIBLE:
+                hw_incompatible_configs.append(config)
 
         # Print passed configurations
         if passed_configs:
@@ -784,14 +916,19 @@ class SupportMatrix:
             for huggingface_id, architecture, system, backend, version, mode in sorted(failed_configs):
                 print(f"  • {huggingface_id} ({architecture}) on {system} with {backend} v{version} ({mode})")
 
+        if hw_incompatible_configs:
+            print(f"\n⚪ Hardware-Incompatible Configurations ({len(hw_incompatible_configs)}):")
+            for huggingface_id, architecture, system, backend, version, mode in sorted(hw_incompatible_configs):
+                print(f"  • {huggingface_id} ({architecture}) on {system} with {backend} v{version} ({mode})")
+
     def save_results_to_csv(
-        self, results: list[tuple[str, str, str, str, str, str, bool, str | None]], output_file: str
+        self, results: list[tuple[str, str, str, str, str, str, str, str | None]], output_file: str
     ) -> None:
         """
         Save test results to a CSV file.
 
         Args:
-            results: List of tuples (huggingface_id, architecture, system, backend, version, mode, success, err_msg)
+            results: List of tuples (huggingface_id, architecture, system, backend, version, mode, status, err_msg)
             output_file: Path to the output CSV file
         """
 
@@ -799,7 +936,8 @@ class SupportMatrix:
             writer = csv.writer(f)
             header = ["HuggingFaceID", "Architecture", "System", "Backend", "Version", "Mode", "Status", "ErrMsg"]
             writer.writerow(header)
-            for huggingface_id, architecture, system, backend, version, mode, success, err_msg in results:
-                status = "PASS" if success else "FAIL"
+            for huggingface_id, architecture, system, backend, version, mode, status, err_msg in results:
+                if status not in VALID_STATUSES:
+                    raise ValueError(f"Invalid support-matrix status: {status}")
                 writer.writerow([huggingface_id, architecture, system, backend, version, mode, status, err_msg or ""])
         print(f"\nResults saved to: {output_file}")


### PR DESCRIPTION
In the support matrix, all combinations previously resulted in "PASS" or "FAIL". In some cases, the "FAIL" is a AIC bug/shortcoming, but sometimes the model+system combination is not supported together. This PR detects if a model uses a datatype which the system does not support, and marks the support matrix result as "Hardware incompatible" rather than "FAIL". Example: DeepSeek-R1-NVFP4 + a100_sxm.

Example:
notes
1. ignore the empty cells, they're empty because I tested with only a partially-generated support matrix
2. the text spilling from the box was fixed after I took the screenshot
<img width="3366" height="1902" alt="image" src="https://github.com/user-attachments/assets/fea52a2a-7dc4-48c9-bf2d-d8055d908d56" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Support matrix now recognizes and displays hardware incompatibility status alongside pass/fail results
  * Added dedicated visual styling (gray) for hardware-incompatible configurations
  * Extended matrix legend and error details to describe hardware incompatibility scenarios

* **Bug Fixes**
  * Improved error message aggregation for incompatible hardware configurations
  * Refined fallback logic to correctly exclude incompatible rows from architecture-based evaluation

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiconfigurator/pull/1060)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->