### PR TITLE
fix: lower latency floor in trtllm allreduce collector

### DIFF
--- a/collector/collect_all_reduce.py
+++ b/collector/collect_all_reduce.py
@@ -115,6 +115,12 @@ def benchmark_trtllm_allreduce(
     power_min_duration: float = 1.0,
 ):
     """Benchmark TensorRT-LLM AllReduce implementation"""
+    # Disable the autotuner so that the strategy lookup table (selectImplementation)
+    # is used directly.  Without this, tunable_allreduce may override the strategy
+    # to NCCL symmetric, which is significantly slower than the Lamport custom
+    # allreduce kernels used during actual inference.
+    os.environ["TLLM_DISABLE_ALLREDUCE_AUTOTUNE"] = "1"
+
     trtllm_mods = import_trtllm()
     tllm = trtllm_mods["tllm"]
 

--- a/src/aiconfigurator/systems/data/b300_sxm/trtllm/1.3.0rc10/custom_allreduce_perf.txt
+++ b/src/aiconfigurator/systems/data/b300_sxm/trtllm/1.3.0rc10/custom_allreduce_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:24bf6b487e3b43021331b3519c6dbe6b6a24dce3188a5d980d68f64bc51ac090
-size 21050
+oid sha256:c7b1c2289037176409b262bd21179c853abff44d17bf90d85a22bb6b95138ad1
+size 7107

--- a/src/aiconfigurator/systems/data/gb200/trtllm/1.3.0rc10/custom_allreduce_perf.txt
+++ b/src/aiconfigurator/systems/data/gb200/trtllm/1.3.0rc10/custom_allreduce_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fc51131852c5b1368ef5d0071ae0b96b85967c336ab767eb91d40d1fa514f602
-size 21763
+oid sha256:d907e2ccb3aed66d08ec8c7bef6f8068883b99674105fec241a93ae9507fa3af
+size 4447

--- a/src/aiconfigurator/systems/data/gb300/trtllm/1.3.0rc10/custom_allreduce_perf.txt
+++ b/src/aiconfigurator/systems/data/gb300/trtllm/1.3.0rc10/custom_allreduce_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:29c3fd3bf746c23fb214f4526ea9d8e327e7e3e6249c9696635415383b525eda
-size 17440
+oid sha256:aaedab8250b3b40a4db74628ed9bd480cf1376df720059fb26ce3ce9c835b015
+size 4454

--- a/src/aiconfigurator/systems/data/h100_sxm/trtllm/1.3.0rc10/custom_allreduce_perf.txt
+++ b/src/aiconfigurator/systems/data/h100_sxm/trtllm/1.3.0rc10/custom_allreduce_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e22d6d817a2219d056f28bda65232050251bdb7ff801a17b6c9b4e56c3818631
-size 14338
+oid sha256:85853d2ff3ef0b12ca7a51f351312eb310d3318b4bd0c1ce27e4d0832287780a
+size 7249

--- a/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.3.0rc10/custom_allreduce_perf.txt
+++ b/src/aiconfigurator/systems/data/h200_sxm/trtllm/1.3.0rc10/custom_allreduce_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9b558ad828d5b03937cd9a8a7beb237a306a967bc122c4ba4f2a5975ab953558
-size 12971
+oid sha256:99c2458dc9db260d8e89ea098327fbd225dca3e6ddf4b786c1e44de7497e5a4e
+size 6564


### PR DESCRIPTION
I discovered that TRTLLM allreduce in our DB had a latency floor of ~0.015 ms per operation. Doesn't sound like a lot, but it adds up. Consider a single forward pass in a model with 64 transformer blocks. with 2 allreduce per block, that's an extra ~2ms of error.

New vs old latency floor:

<img width="3131" height="1728" alt="image" src="https://github.com/user-attachments/assets/c426ea72-b483-472b-9a41-14ca7b38aeac" />