### PR TITLE
feat(sdk): warn when FallbackOp silently swallows the primary op failure

### DIFF
--- a/src/aiconfigurator/sdk/inference_summary.py
+++ b/src/aiconfigurator/sdk/inference_summary.py
@@ -59,8 +59,8 @@ class InferenceSummary:
         self._generation_latency_dict = {}  # ms
         self._context_energy_wms_dict = {}  # RENAMED from _context_power_dict, W·ms
         self._generation_energy_wms_dict = {}  # RENAMED from _generation_power_dict, W·ms
-        # Per-op data source ("silicon", "empirical", or "mixed") populated by
-        # base_backend phase helpers from PerformanceResult.source.
+        # Per-op data source ("silicon", "empirical", "fallback", or "mixed")
+        # populated by base_backend phase helpers from PerformanceResult.source.
         self._context_source_dict: dict[str, str] = {}
         self._generation_source_dict: dict[str, str] = {}
         self._is_oom = None
@@ -80,7 +80,7 @@ class InferenceSummary:
         # per-ops latency breakdown (populated by run_agg or run_disagg)
         self._per_ops_data: dict | None = None
         # per-ops data source breakdown, parallel to _per_ops_data: same key
-        # structure but values are "silicon" / "empirical" / "mixed" strings.
+        # structure but values are "silicon" / "empirical" / "fallback" / "mixed".
         self._per_ops_source: dict | None = None
 
     def set_memory_and_check_oom(

--- a/src/aiconfigurator/sdk/operations.py
+++ b/src/aiconfigurator/sdk/operations.py
@@ -1948,6 +1948,11 @@ class FallbackOp(Operation):
         self._primary = primary
         self._fallback = fallback
         self._primary_unavailable = False
+        # Exception types we've already warned about for this instance.
+        # Deduplicates per-iteration warnings during long sweeps; we still
+        # warn once per distinct failure mode so silent perf-DB gaps stay
+        # visible. See AIC-1059.
+        self._warned_exception_types: set[type] = set()
 
     def query(self, database: PerfDatabase, **kwargs) -> PerformanceResult:
         import logging as _logging
@@ -1970,13 +1975,28 @@ class FallbackOp(Operation):
             except (PerfDataNotAvailableError, KeyError, AssertionError) as e:
                 if isinstance(e, PerfDataNotAvailableError):
                     self._primary_unavailable = True
-                logger.debug(
-                    "FallbackOp '%s': primary op '%s' failed (%s: %s), using fallback ops",
-                    self._name,
-                    self._primary._name,
-                    type(e).__name__,
-                    e,
-                )
+                exc_type = type(e)
+                fallback_names = ", ".join(op._name for op in self._fallback)
+                if exc_type not in self._warned_exception_types:
+                    self._warned_exception_types.add(exc_type)
+                    logger.warning(
+                        "FallbackOp '%s': primary op '%s' failed (%s: %s); "
+                        "returning sum of fallback ops [%s]. "
+                        "Predictions for this op will be tagged source='fallback'.",
+                        self._name,
+                        self._primary._name,
+                        exc_type.__name__,
+                        e,
+                        fallback_names,
+                    )
+                else:
+                    logger.debug(
+                        "FallbackOp '%s': primary op '%s' failed (%s: %s), using fallback ops",
+                        self._name,
+                        self._primary._name,
+                        exc_type.__name__,
+                        e,
+                    )
             finally:
                 database._default_database_mode = prev_mode
                 perf_db_logger.setLevel(prev_log_level)
@@ -1987,7 +2007,11 @@ class FallbackOp(Operation):
             result = op.query(database, **kwargs)
             total_latency += float(result)
             total_energy += getattr(result, "energy", 0.0)
-        return PerformanceResult(total_latency, energy=total_energy)
+        # Tag with source="fallback" so downstream attribution (per_ops_source.json,
+        # reports) can distinguish a real prediction from a fallback-due-to-primary-
+        # failure prediction. The PerformanceResult source field propagates through
+        # arithmetic, so sums and averages will surface "fallback" or "mixed".
+        return PerformanceResult(total_latency, energy=total_energy, source="fallback")
 
     def get_weights(self, **kwargs):
         # Use primary weights if available, otherwise sum fallback weights.

--- a/src/aiconfigurator/sdk/performance_result.py
+++ b/src/aiconfigurator/sdk/performance_result.py
@@ -22,7 +22,9 @@ class PerformanceResult(float):
         - energy: watt-milliseconds (W·ms) = millijoules (mJ)
         - power: watts (W) - derived property
         - source: ``"silicon"`` (table data) | ``"empirical"`` (HYBRID-mode
-          SOL+empirical fallback) | ``"mixed"`` (sum of values from both)
+          SOL+empirical fallback) | ``"fallback"`` (FallbackOp returned the
+          summed fallback ops because the primary raised — see AIC-1059) |
+          ``"mixed"`` (sum of values from different sources)
 
     Note: 1 W·ms = 1 mJ. We use W·ms to match latency units (ms).
           To convert to Joules: divide by 1000 (J = W·s = W·ms / 1000)

--- a/tests/unit/sdk/database/test_fallback_op.py
+++ b/tests/unit/sdk/database/test_fallback_op.py
@@ -206,6 +206,117 @@ class TestFallbackOp:
 
         assert perf_logger.level == original_level
 
+    def test_fallback_result_tagged_with_source_fallback(self):
+        """Result returned via fallback path is tagged source='fallback' (AIC-1059)."""
+        mock_db = _make_mock_db()
+        primary = _make_failing_op(PerfDataNotAvailableError)
+        fallback_1 = _make_mock_op(5.0, 50.0)
+
+        op = FallbackOp("test", primary=primary, fallback=[fallback_1])
+        result = op.query(mock_db, batch_size=4)
+
+        assert result.source == "fallback"
+
+    def test_primary_success_preserves_source(self):
+        """When primary succeeds, its source tag is preserved (not overwritten)."""
+        mock_db = _make_mock_db()
+        primary = MagicMock()
+        primary._name = "primary"
+        primary.query.return_value = PerformanceResult(10.0, energy=100.0, source="silicon")
+        fallback_1 = _make_mock_op(5.0, 50.0)
+
+        op = FallbackOp("test", primary=primary, fallback=[fallback_1])
+        result = op.query(mock_db, batch_size=4)
+
+        assert result.source == "silicon"
+
+    def test_warning_logged_on_first_fallback(self, caplog):
+        """First time primary fails, FallbackOp emits a WARNING (AIC-1059)."""
+        import logging
+
+        mock_db = _make_mock_db()
+        primary = _make_failing_op(PerfDataNotAvailableError, "missing module data")
+        primary._name = "context_mla_module"
+        fallback_1 = _make_mock_op(5.0, 50.0)
+        fallback_1._name = "context_attention"
+
+        op = FallbackOp("context_mla_block", primary=primary, fallback=[fallback_1])
+
+        with caplog.at_level(logging.WARNING, logger="aiconfigurator.sdk.operations"):
+            op.query(mock_db, batch_size=4)
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        msg = warnings[0].getMessage()
+        assert "context_mla_block" in msg
+        assert "context_mla_module" in msg
+        assert "PerfDataNotAvailableError" in msg
+        assert "context_attention" in msg  # fallback op listed
+        assert "missing module data" in msg
+
+    def test_warning_deduplicated_per_exception_type(self, caplog):
+        """Repeated failures with the same exception type warn ONCE, then debug-log.
+
+        FallbackOp is queried many times during a sweep. Spamming WARNING on
+        every iteration would drown out other diagnostics. We warn once per
+        (instance, exception type), then drop to DEBUG.
+        """
+        import logging
+
+        mock_db = _make_mock_db()
+        # Use KeyError so the primary is retried on every call (not latched off).
+        primary = _make_failing_op(KeyError, "fp8_block")
+        fallback_1 = _make_mock_op(5.0, 50.0)
+
+        op = FallbackOp("test", primary=primary, fallback=[fallback_1])
+
+        with caplog.at_level(logging.WARNING, logger="aiconfigurator.sdk.operations"):
+            for _ in range(10):
+                op.query(mock_db, batch_size=4)
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1, f"expected 1 warning, got {len(warnings)}"
+
+    def test_warning_emitted_per_exception_type(self, caplog):
+        """Different exception types each get their own warning."""
+        import logging
+
+        mock_db = _make_mock_db()
+        # Cycle through different exception types across calls.
+        primary = MagicMock()
+        primary._name = "primary"
+        primary.query.side_effect = [
+            KeyError("missing key"),
+            AssertionError("empty data"),
+            KeyError("missing key again"),
+        ]
+        fallback_1 = _make_mock_op(5.0, 50.0)
+
+        op = FallbackOp("test", primary=primary, fallback=[fallback_1])
+
+        with caplog.at_level(logging.WARNING, logger="aiconfigurator.sdk.operations"):
+            for _ in range(3):
+                op.query(mock_db, batch_size=4)
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        # First KeyError + first AssertionError -> 2 warnings; second KeyError dedup'd.
+        assert len(warnings) == 2
+
+    def test_no_warning_when_primary_succeeds(self, caplog):
+        """No warning is emitted on the happy path."""
+        import logging
+
+        mock_db = _make_mock_db()
+        primary = _make_mock_op(10.0, 100.0)
+        fallback_1 = _make_mock_op(5.0, 50.0)
+
+        op = FallbackOp("test", primary=primary, fallback=[fallback_1])
+
+        with caplog.at_level(logging.WARNING, logger="aiconfigurator.sdk.operations"):
+            op.query(mock_db, batch_size=4)
+
+        assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
+
 
 class TestMLAModule:
     """Test cases for MLAModule class."""


### PR DESCRIPTION
#### Overview:

Make `FallbackOp` visible: log a WARNING when it silently picks the fallback because the primary raised, and tag the result with `source="fallback"` so per-ops attribution shows it.

#### Before / after on Kimi K2.5 NVFP4 on B200 (the config that motivated this fix):

`cli_estimate(model="nvidia/Kimi-K2.5-NVFP4", system="b200_sxm", backend="trtllm", ...)` — the MLA module table is present but has no NVFP4 GEMM-quant rows, so `FallbackOp.primary` (MLAModule) raises `AssertionError: values is None or empty` and the fallback chain (GEMM + MLABmm + GenerationMLA + ...) is summed instead.

**Before:** silent. `TTFT=135.06ms TPOT=22.21ms` with no signal that the MLA attention component was modelled by the fallback path.

**After:** one WARNING per `FallbackOp` instance per exception type (dedup'd across the 1024-iter generation loop):

```
WARNING aiconfigurator.sdk.operations | FallbackOp 'context_mla_block':
  primary op 'context_mla_module' failed (AssertionError: values is None
  or empty ... gemm_quant_mode=nvfp4 ...); returning sum of fallback ops
  [context_downscale_gemm, context_q_b_proj_gemm, context_kv_b_proj_gemm,
  context_attention, context_proj_gemm]. Predictions for this op will be
  tagged source='fallback'.

WARNING aiconfigurator.sdk.operations | FallbackOp 'generation_mla_block':
  primary op 'generation_mla_module' failed (AssertionError: values is
  None or empty ... gemm_quant_mode=nvfp4 ...); returning sum of fallback
  ops [generation_downscale_gemm, generation_q_b_proj_gemm,
  generation_bmm_pre, generation_attention, generation_bmm_post,
  generation_proj_gemm]. Predictions for this op will be tagged
  source='fallback'.
```

#### Details:

- **WARNING on swallow**: includes op name, primary name, exception type+message, and the fallback op list.
- **Dedup**: per-instance `set[exception_type]` — first occurrence is WARNING, subsequent are DEBUG, so sweeps don't spam.
- **Source tag**: fallback `PerformanceResult` gets `source="fallback"`; propagates through existing `_merge_source` into `per_ops_source.json`.

#### Where should the reviewer start?

`src/aiconfigurator/sdk/operations.py` (`FallbackOp.query`).

#### Related Issues:

- Closes AIC-1059
- Would have caught AIC-1057 immediately