### PR TITLE
docs: add row numbers to support matrix

### DIFF
--- a/docs/support-matrix/index.html
+++ b/docs/support-matrix/index.html
@@ -761,6 +761,10 @@ function MatrixTable({ matrixRows, columns, searchQuery, sortCol, sortAsc, showA
       <table className="w-full text-sm border-collapse">
         <thead>
           <tr>
+            <th className="bg-slate-50 dark:bg-slate-800 sticky top-0 z-10 px-3 py-2 text-right font-bold
+                  border-b-2 border-slate-200 dark:border-slate-600 whitespace-nowrap w-14 text-slate-500 dark:text-slate-400">
+              No.
+            </th>
             <th onClick={() => onSort('model')}
                 className={`bg-slate-50 dark:bg-slate-800 sticky top-0 z-10 px-3 py-2 text-left font-bold
                   border-b-2 border-slate-200 dark:border-slate-600 cursor-pointer select-none whitespace-nowrap
@@ -784,8 +788,11 @@ function MatrixTable({ matrixRows, columns, searchQuery, sortCol, sortAsc, showA
           </tr>
         </thead>
         <tbody>
-          {filtered.map(row => (
+          {filtered.map((row, index) => (
             <tr key={row.model} className="hover:bg-slate-50/50 dark:hover:bg-slate-800/50 transition-colors">
+              <td className="px-3 py-2 border-b border-slate-200 dark:border-slate-700 text-right text-slate-500 dark:text-slate-400 tabular-nums w-14">
+                {index + 1}
+              </td>
               <td className="px-3 py-2 border-b border-slate-200 dark:border-slate-700 font-medium max-w-xs overflow-hidden text-ellipsis whitespace-nowrap"
                   title={row.model}>
                 {row.model}


### PR DESCRIPTION
#### Overview:

Adds a leftmost `No.` column to the support matrix table so visible rows are easy to reference.

<img width="1679" height="1192" alt="Screenshot 2026-05-13 at 10 36 19" src="https://github.com/user-attachments/assets/19a68dd5-b743-4bc0-ab82-293e39ff35b0" />


#### Details:

- Adds a non-sortable `No.` header before the HuggingFace ID column.
- Numbers rows from the current filtered and sorted table order.
- Keeps the column narrow and right-aligned with tabular numerals.

#### Where should the reviewer start?

- `docs/support-matrix/index.html`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- N/A

#### Verification:

- `git diff --check`
- Served local preview at `http://127.0.0.1:7861/support-matrix/` and confirmed the `No.` column is present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Enhanced the support matrix table with a new numbered column. The table now displays sequential row numbers in a dedicated left column, with proper formatting and alignment applied. This improvement simplifies navigation and helps users more efficiently reference and identify specific entries within the support matrix documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiconfigurator/pull/1065)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->