### PR TITLE
fix(interpolation): preserve energy in interp_1d and grid extrapolation

### DIFF
--- a/src/aiconfigurator/sdk/interpolation.py
+++ b/src/aiconfigurator/sdk/interpolation.py
@@ -158,35 +158,35 @@ def extract_latency_and_energy_3d(data: dict) -> tuple[dict, dict]:
 
 
 def interp_1d(x: list[int], y: list, value: int):
-    """Linear interpolation in 1-D. Handles both float and dict leaf values."""
+    """Linear interpolation in 1-D. Handles both float and dict leaf values.
+
+    When the leaves are dicts, every numeric metric present in BOTH endpoints
+    is interpolated (e.g. ``latency``, ``power``, ``energy``). Dropping
+    ``energy`` here used to zero out every extrapolated grid point and made
+    the SDK power model return 0 W for any GEMM shape that wasn't an exact
+    collection point.
+    """
     x0, x1 = x
     y0, y1 = y
 
+    def _interp_scalar(v0, v1):
+        a, b = v0, v1
+        if (x0 - x1) * (a - b) < 0 and (value - x0) * (value - x1) > 0:
+            b = a
+        if a == b:
+            return a
+        return a + (b - a) / (x1 - x0) * (value - x0)
+
     if isinstance(y0, dict) and isinstance(y1, dict):
-        lat0, lat1 = y0["latency"], y1["latency"]
-        pow0, pow1 = y0["power"], y1["power"]
+        result = {}
+        for key in y0.keys() & y1.keys():
+            v0 = y0[key]
+            v1 = y1[key]
+            if isinstance(v0, (int, float)) and isinstance(v1, (int, float)):
+                result[key] = _interp_scalar(v0, v1)
+        return result
 
-        if (x0 - x1) * (lat0 - lat1) < 0 and (value - x0) * (value - x1) > 0:
-            lat1 = lat0
-        if lat0 == lat1:
-            lat_result = lat0
-        else:
-            lat_result = lat0 + (lat1 - lat0) / (x1 - x0) * (value - x0)
-
-        if (x0 - x1) * (pow0 - pow1) < 0 and (value - x0) * (value - x1) > 0:
-            pow1 = pow0
-        if pow0 == pow1:
-            pow_result = pow0
-        else:
-            pow_result = pow0 + (pow1 - pow0) / (x1 - x0) * (value - x0)
-
-        return {"latency": lat_result, "power": pow_result}
-
-    if (x0 - x1) * (y0 - y1) < 0 and (value - x0) * (value - x1) > 0:
-        y1 = y0
-    if y0 == y1:
-        return y0
-    return y0 + (y1 - y0) / (x1 - x0) * (value - x0)
+    return _interp_scalar(y0, y1)
 
 
 # ---------------------------------------------------------------------------
@@ -523,25 +523,20 @@ def extrapolate_data_grid(
                     y_right_value = data_dict[x][y_right][z]
                     assert y_right_value is not None, "y_right_value cannot be None"
                     if sqrt_y_value:
-                        if isinstance(y_left_value, dict):
-                            y_left_value = {
-                                "latency": math.sqrt(y_left_value["latency"]),
-                                "power": math.sqrt(y_left_value["power"]) if y_left_value["power"] > 0 else 0.0,
-                            }
-                            y_right_value = {
-                                "latency": math.sqrt(y_right_value["latency"]),
-                                "power": math.sqrt(y_right_value["power"]) if y_right_value["power"] > 0 else 0.0,
-                            }
-                        else:
-                            y_left_value = math.sqrt(y_left_value)
-                            y_right_value = math.sqrt(y_right_value)
+                        def _sqrt_leaf(v):
+                            if isinstance(v, dict):
+                                return {
+                                    key: (math.sqrt(metric) if isinstance(metric, (int, float)) and metric > 0 else 0.0)
+                                    for key, metric in v.items()
+                                }
+                            return math.sqrt(v) if v > 0 else 0.0
+
+                        y_left_value = _sqrt_leaf(y_left_value)
+                        y_right_value = _sqrt_leaf(y_right_value)
                     value = interp_1d([y_left, y_right], [y_left_value, y_right_value], y)
                     if sqrt_y_value:
                         if isinstance(value, dict):
-                            value = {
-                                "latency": value["latency"] * value["latency"],
-                                "power": value["power"] * value["power"],
-                            }
+                            value = {key: metric * metric for key, metric in value.items()}
                         else:
                             value = value * value
 

--- a/src/aiconfigurator/sdk/interpolation.py
+++ b/src/aiconfigurator/sdk/interpolation.py
@@ -523,6 +523,7 @@ def extrapolate_data_grid(
                     y_right_value = data_dict[x][y_right][z]
                     assert y_right_value is not None, "y_right_value cannot be None"
                     if sqrt_y_value:
+
                         def _sqrt_leaf(v):
                             if isinstance(v, dict):
                                 return {

--- a/tests/unit/sdk/database/test_interpolation.py
+++ b/tests/unit/sdk/database/test_interpolation.py
@@ -120,7 +120,7 @@ class TestInterpolationMethods:
         ]
 
         # Midpoint: every metric should interpolate linearly.
-        mid = comprehensive_perf_db._interp_1d(x, y, 15)
+        mid = interpolation.interp_1d(x, y, 15)
         assert isinstance(mid, dict)
         assert mid["latency"] == pytest.approx(2.0)
         assert mid["power"] == pytest.approx(500.0)
@@ -129,13 +129,13 @@ class TestInterpolationMethods:
         )
 
         # Endpoints
-        left = comprehensive_perf_db._interp_1d(x, y, 10)
+        left = interpolation.interp_1d(x, y, 10)
         assert left["energy"] == pytest.approx(400.0)
-        right = comprehensive_perf_db._interp_1d(x, y, 20)
+        right = interpolation.interp_1d(x, y, 20)
         assert right["energy"] == pytest.approx(1800.0)
 
         # Extrapolation also preserves energy.
-        far = comprehensive_perf_db._interp_1d(x, y, 25)
+        far = interpolation.interp_1d(x, y, 25)
         assert far["energy"] == pytest.approx(2500.0)
 
     def test_bilinear_interpolation(self, comprehensive_perf_db):
@@ -333,7 +333,7 @@ class TestExtrapolateDataGrid:
         target_x_list = [10, 15, 20]
         target_y_list = [30, 35, 40]
         target_z_list = [50, 55, 60]
-        comprehensive_perf_db._extrapolate_data_grid(data_dict, target_x_list, target_y_list, target_z_list)
+        interpolation.extrapolate_data_grid(data_dict, target_x_list, target_y_list, target_z_list)
 
         # Every newly created cell must have a positive energy field.
         new_cells = [

--- a/tests/unit/sdk/database/test_interpolation.py
+++ b/tests/unit/sdk/database/test_interpolation.py
@@ -104,6 +104,41 @@ class TestInterpolationMethods:
         result = interpolation.interp_1d(x, y, 25)
         assert result == 250.0
 
+    def test_interp_1d_preserves_energy_dict_leaves(self, comprehensive_perf_db):
+        """Regression test for the power-feature interp bug.
+
+        Per-op data leaves carry latency/power/energy. `interp_1d` used to
+        return only {"latency", "power"}, silently dropping `energy`.
+        After `_extrapolate_data_grid` filled the grid, every extrapolated
+        cell had energy=0 -> the SDK reported 0 W for any GEMM shape near
+        an extrapolated point. This test guards against regression.
+        """
+        x = [10, 20]
+        y = [
+            {"latency": 1.0, "power": 400.0, "energy": 400.0},
+            {"latency": 3.0, "power": 600.0, "energy": 1800.0},
+        ]
+
+        # Midpoint: every metric should interpolate linearly.
+        mid = comprehensive_perf_db._interp_1d(x, y, 15)
+        assert isinstance(mid, dict)
+        assert mid["latency"] == pytest.approx(2.0)
+        assert mid["power"] == pytest.approx(500.0)
+        assert mid["energy"] == pytest.approx(1100.0), (
+            "Energy must not be dropped during 1D interpolation -- regression "
+            "of the H200 vLLM bfloat16 zero-power bug."
+        )
+
+        # Endpoints
+        left = comprehensive_perf_db._interp_1d(x, y, 10)
+        assert left["energy"] == pytest.approx(400.0)
+        right = comprehensive_perf_db._interp_1d(x, y, 20)
+        assert right["energy"] == pytest.approx(1800.0)
+
+        # Extrapolation also preserves energy.
+        far = comprehensive_perf_db._interp_1d(x, y, 25)
+        assert far["energy"] == pytest.approx(2500.0)
+
     def test_bilinear_interpolation(self, comprehensive_perf_db):
         """Test bilinear interpolation."""
         # Create a simple 2x2 grid
@@ -273,6 +308,48 @@ class TestExtrapolateDataGrid:
             interpolation.extrapolate_data_grid(data_dict, target_x_list, target_y_list, target_z_list)
             # Should warn about insufficient data
             assert "only one data point" in caplog.text
+
+    def test_extrapolate_data_grid_preserves_energy_dict_leaves(self, comprehensive_perf_db):
+        """Regression test: extrapolated grid cells must carry energy too.
+
+        Before the fix, `_extrapolate_data_grid` filled in new cells via
+        `interp_1d` on dict leaves and quietly dropped the `energy` field.
+        That produced grid points with valid latency but `energy=0`, which
+        was the root cause of the H200 vLLM bfloat16 zero-power bug
+        (see PR153 power-validation docs, section 10.8.8).
+        """
+        data_dict = defaultdict(lambda: defaultdict(lambda: defaultdict()))
+        # 2x2x2 cube of dict-leaf data with non-trivial energy.
+        for x in [10, 20]:
+            for y in [30, 40]:
+                for z in [50, 60]:
+                    lat = (x + y + z) / 10.0
+                    power = 100.0 + x + y + z
+                    data_dict[x][y][z] = {
+                        "latency": lat,
+                        "power": power,
+                        "energy": lat * power,
+                    }
+
+        target_x_list = [10, 15, 20]
+        target_y_list = [30, 35, 40]
+        target_z_list = [50, 55, 60]
+        comprehensive_perf_db._extrapolate_data_grid(
+            data_dict, target_x_list, target_y_list, target_z_list
+        )
+
+        # Every newly created cell must have a positive energy field.
+        new_cells = [
+            data_dict[10][30][55],
+            data_dict[10][35][50],
+            data_dict[15][30][50],
+            data_dict[15][35][55],
+            data_dict[20][35][60],
+        ]
+        for cell in new_cells:
+            assert isinstance(cell, dict), f"expected dict leaf, got {type(cell)}"
+            assert "energy" in cell, f"energy field missing from extrapolated cell: {cell}"
+            assert cell["energy"] > 0, f"extrapolated cell has zero energy: {cell}"
 
     def test_extrapolate_data_grid_boundary_extension(self, comprehensive_perf_db):
         """Test extrapolation beyond original data boundaries."""

--- a/tests/unit/sdk/database/test_interpolation.py
+++ b/tests/unit/sdk/database/test_interpolation.py
@@ -125,8 +125,7 @@ class TestInterpolationMethods:
         assert mid["latency"] == pytest.approx(2.0)
         assert mid["power"] == pytest.approx(500.0)
         assert mid["energy"] == pytest.approx(1100.0), (
-            "Energy must not be dropped during 1D interpolation -- regression "
-            "of the H200 vLLM bfloat16 zero-power bug."
+            "Energy must not be dropped during 1D interpolation -- regression of the H200 vLLM bfloat16 zero-power bug."
         )
 
         # Endpoints
@@ -334,9 +333,7 @@ class TestExtrapolateDataGrid:
         target_x_list = [10, 15, 20]
         target_y_list = [30, 35, 40]
         target_z_list = [50, 55, 60]
-        comprehensive_perf_db._extrapolate_data_grid(
-            data_dict, target_x_list, target_y_list, target_z_list
-        )
+        comprehensive_perf_db._extrapolate_data_grid(data_dict, target_x_list, target_y_list, target_z_list)
 
         # Every newly created cell must have a positive energy field.
         new_cells = [


### PR DESCRIPTION
#### Overview:

Fix the PR153 power-estimation feature so that `energy` (W·ms) is preserved through all interpolation paths. Two paths in `src/aiconfigurator/sdk/interpolation.py` only operated on `latency` and `power` when the leaf was a dict and silently dropped `energy`, which caused downstream `KeyError: 'energy'` failures or — more insidiously — power values of `0 W` for any GEMM/attention shape that landed on an extrapolated grid point.

#### Details:

PR153 (per-GPU average-power estimation) added an `energy` key alongside `latency` and `power` in the dict leaves of the perf database. Two places didn't get the memo:

1. `interp_1d()` — for dict leaves it hard-coded extracting `latency` and `power` and returned a dict containing only those two keys. Any caller that later looked up `energy` either crashed with `KeyError` or, after recent defensive cleanups, fell back to `energy = 0.0`.
2. `_extrapolate_data_grid()` `sqrt_y_value` branch — applied the sqrt/square transform to a hard-coded subset of keys, so newly materialized extrapolated grid cells lacked an `energy` entry.

This PR rewrites both paths to be generic over numeric keys in dict leaves: every `(int|float)` value present in both endpoint dicts is interpolated/transformed independently, so `energy` is preserved and any future metric (e.g., `tgp_w`, `sm_clock_mhz`) is handled automatically.

Two regression tests are added in `tests/unit/sdk/database/test_interpolation.py`:

- `test_interp_1d_preserves_energy_dict_leaves` — asserts `interp_1d` returns a dict containing `energy` for midpoint, endpoint, and extrapolated values, and that the interpolated energy matches the expected linear interpolation of the two endpoint energies.
- `test_extrapolate_data_grid_preserves_energy_dict_leaves` — builds a sparse 2D grid with `energy` leaves and asserts the newly materialized cells produced by extrapolation contain a non-zero `energy` value.

Both tests reproduce the original symptom on a worktree where the interpolation fix is reverted (`KeyError: 'energy'` from `interp_1d`; missing-key assertion from the grid path) and pass with this change.

End-to-end validation reproduced the documented PR153 power-estimation sweeps locally on the H200:

- vLLM 0.19.1 bfloat16 overlay (§10.8.8) — non-zero `power_w` restored.
- TRT-LLM 1.3.0rc2 FP8 overlay (§10.8.2) — non-zero `power_w` restored.
- Stock latency-only sweeps (§10.8.7, §10.12.3) — unchanged, as expected.

#### Where should the reviewer start?

- `src/aiconfigurator/sdk/interpolation.py` — the two changed functions, `interp_1d` and `_extrapolate_data_grid`. Focus on:
  - The new `_interp_scalar` helper closure inside `interp_1d` and the `for key in y0.keys() & y1.keys():` loop that replaces the hard-coded latency/power extraction.
  - The generalization of the `sqrt_y_value` branch in `_extrapolate_data_grid` to iterate over numeric keys in dict leaves.
- `tests/unit/sdk/database/test_interpolation.py` — the two new regression tests, which document the invariants this PR enforces.

#### Verification:

- `pytest tests/unit/sdk/database/test_interpolation.py` — 21 / 21 passed.
- `pytest tests/unit/sdk/database` (excluding `test_moe_dispatch.py` which needs `torch`) — 297 / 297 passed.

#### Related Issues:

- Relates to PR153 (power-estimation feature).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Interpolation and extrapolation now consistently preserve all numeric metric fields (e.g., energy) for both scalar and dict-formatted data, and retain prior sign-crossing protection to avoid spurious sign flips.

* **Tests**
  * Added regression tests that verify metric preservation and correct interpolation/extrapolation behavior across 1D and multi-dimensional grid scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiconfigurator/pull/1068?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->