### PR TITLE
test(sdk/database): force in-parent loading in get_all_databases tests

### DIFF
--- a/tests/unit/sdk/database/test_data_loaders.py
+++ b/tests/unit/sdk/database/test_data_loaders.py
@@ -121,7 +121,10 @@ def test_get_all_databases(tmp_path, monkeypatch):
         data_subdir = systems_dir / data / backend.value / version
         data_subdir.mkdir(parents=True)
 
-    database_dict = get_all_databases(systems_paths=str(systems_dir))
+    # max_workers=1 keeps loading in-parent so the DummyPerfDatabase monkeypatch
+    # is honored. The ProcessPoolExecutor path re-imports the module in workers
+    # and would bypass the patch.
+    database_dict = get_all_databases(systems_paths=str(systems_dir), max_workers=1)
 
     assert isinstance(database_dict["testsys_0"][BackendName.trtllm.value]["v1"], DummyPerfDatabase)
     assert isinstance(database_dict["testsys_0"][BackendName.trtllm.value]["v2"], DummyPerfDatabase)
@@ -203,7 +206,12 @@ def test_get_all_databases_system_config_conflict(tmp_path, monkeypatch, caplog)
     (systems_root_b / "data_b" / "vllm" / "v0").mkdir(parents=True)
 
     databases_cache.clear()
-    database_dict = get_all_databases(systems_paths=[str(systems_root_a), str(systems_root_b)])
+    # max_workers=1 keeps loading in-parent so the DummyPerfDatabase monkeypatch
+    # is honored. The ProcessPoolExecutor path re-imports the module in workers
+    # and would bypass the patch.
+    database_dict = get_all_databases(
+        systems_paths=[str(systems_root_a), str(systems_root_b)], max_workers=1
+    )
 
     assert "trtllm" in database_dict[system]
     assert "vllm" in database_dict[system]
@@ -227,7 +235,12 @@ def test_get_all_databases_conflicting_backend_version_keeps_first(tmp_path, mon
     (systems_root_b / "data_b" / "trtllm" / "v1").mkdir(parents=True)
 
     databases_cache.clear()
-    database_dict = get_all_databases(systems_paths=[str(systems_root_a), str(systems_root_b)])
+    # max_workers=1 keeps loading in-parent so the DummyPerfDatabase monkeypatch
+    # is honored. The ProcessPoolExecutor path re-imports the module in workers
+    # and would bypass the patch.
+    database_dict = get_all_databases(
+        systems_paths=[str(systems_root_a), str(systems_root_b)], max_workers=1
+    )
     db = database_dict[system]["trtllm"]["v1"]
     assert db.systems_root == str(systems_root_a)
     assert any("Database 'h100/trtllm/v1' already loaded from" in record.message for record in caplog.records)

--- a/tests/unit/sdk/database/test_data_loaders.py
+++ b/tests/unit/sdk/database/test_data_loaders.py
@@ -209,9 +209,7 @@ def test_get_all_databases_system_config_conflict(tmp_path, monkeypatch, caplog)
     # max_workers=1 keeps loading in-parent so the DummyPerfDatabase monkeypatch
     # is honored. The ProcessPoolExecutor path re-imports the module in workers
     # and would bypass the patch.
-    database_dict = get_all_databases(
-        systems_paths=[str(systems_root_a), str(systems_root_b)], max_workers=1
-    )
+    database_dict = get_all_databases(systems_paths=[str(systems_root_a), str(systems_root_b)], max_workers=1)
 
     assert "trtllm" in database_dict[system]
     assert "vllm" in database_dict[system]
@@ -238,9 +236,7 @@ def test_get_all_databases_conflicting_backend_version_keeps_first(tmp_path, mon
     # max_workers=1 keeps loading in-parent so the DummyPerfDatabase monkeypatch
     # is honored. The ProcessPoolExecutor path re-imports the module in workers
     # and would bypass the patch.
-    database_dict = get_all_databases(
-        systems_paths=[str(systems_root_a), str(systems_root_b)], max_workers=1
-    )
+    database_dict = get_all_databases(systems_paths=[str(systems_root_a), str(systems_root_b)], max_workers=1)
     db = database_dict[system]["trtllm"]["v1"]
     assert db.systems_root == str(systems_root_a)
     assert any("Database 'h100/trtllm/v1' already loaded from" in record.message for record in caplog.records)


### PR DESCRIPTION
#### Overview:

Fix two pre-existing failures in `tests/unit/sdk/database/test_data_loaders.py` introduced by PR #1061 (the `ProcessPoolExecutor` parallelization in `get_all_databases`). Test-only change; no production code is touched.

#### Details:

PR #1061 ("convert defaultdicts to dicts after database loads") parallelized `get_all_databases()` via a `ProcessPoolExecutor`. The affected tests use:

```python
monkeypatch.setattr("aiconfigurator.sdk.perf_database.PerfDatabase", DummyPerfDatabase)
```

to swap in a dummy that doesn't try to load real CSV files. Worker processes re-import `aiconfigurator.sdk.perf_database` from scratch, so the monkeypatch installed in the *parent* test process is **not visible** to the workers. The workers therefore construct the real `PerfDatabase` against the test fixture's empty CSVs, which fails silently and is reported as `get_database returned None`, leaving the returned `database_dict` empty.

Concretely, this broke two tests on `main`:

- `test_get_all_databases` → `KeyError: 'v1'` (no databases stored under any `(system, backend, version)` key).
- `test_get_all_databases_system_config_conflict` → `AssertionError: assert 'trtllm' in defaultdict(...)` for the same reason.

A third related test, `test_get_all_databases_conflicting_backend_version_keeps_first`, currently passes only by accident: dedup leaves a single database ref, which causes `get_all_databases` to auto-select its sequential, in-parent code path (`max_workers <= 1`), where the monkeypatch is honored.

#### Fix:

Pass `max_workers=1` to `get_all_databases()` in all three call sites in this test file. This forces the sequential in-parent path so the monkeypatched `PerfDatabase` is used. A short inline comment documents the requirement so the intent isn't lost the next time someone refactors `get_all_databases`.

This change does not weaken coverage of the parallel path in production — it just keeps the unit tests on the only code path that can honor `monkeypatch.setattr` of a module-level binding.

#### Where should the reviewer start?

- `tests/unit/sdk/database/test_data_loaders.py` — the three `get_all_databases(... max_workers=1)` call sites in:
  - `test_get_all_databases`
  - `test_get_all_databases_system_config_conflict`
  - `test_get_all_databases_conflicting_backend_version_keeps_first`

#### Verification:

- Before this PR: `pytest tests/unit/sdk/database/test_data_loaders.py` → 30 passed, 2 failed (the two listed above).
- With this PR:  `pytest tests/unit/sdk/database/test_data_loaders.py` → **32 passed**.
- Full suite: `pytest tests/unit/sdk/database` (excluding `test_moe_dispatch.py` which needs `torch`) → **297 passed**.

#### Related Issues:

- Relates to #1061 (the change that introduced the regression).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated unit tests for database loading functionality to ensure proper test execution behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiconfigurator/pull/1069)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->