### PR TITLE
fix: sync support matrix search query

### DIFF
--- a/docs/support-matrix/index.html
+++ b/docs/support-matrix/index.html
@@ -359,6 +359,27 @@ function csvUrl(branch) {
   return `https://raw.githubusercontent.com/${REPO}/refs/heads/${branch}/${CSV_PATH}`;
 }
 
+function readSearchQuery() {
+  return new URLSearchParams(window.location.search).get('q') || '';
+}
+
+function writeSearchQuery(query) {
+  const params = new URLSearchParams(window.location.search);
+  const normalized = query.trim();
+  if (normalized) {
+    params.set('q', normalized);
+  } else {
+    params.delete('q');
+  }
+
+  const nextSearch = params.toString();
+  const nextUrl = `${window.location.pathname}${nextSearch ? `?${nextSearch}` : ''}${window.location.hash}`;
+  const currentUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+  if (nextUrl !== currentUrl) {
+    window.history.replaceState(null, '', nextUrl);
+  }
+}
+
 const HARDCODED_RELEASE_BRANCHES = [
   'release/0.8.0',
   'release/0.7.0',
@@ -946,7 +967,7 @@ function App() {
 
   const [activeSystem, setActiveSystem] = useState(null);
   const [activeMode, setActiveMode] = useState('all');
-  const [searchQuery, setSearchQuery] = useState(() => new URLSearchParams(window.location.search).get('q') || '');
+  const [searchQuery, setSearchQuery] = useState(readSearchQuery);
   const [sortCol, setSortCol] = useState(null);
   const [sortAsc, setSortAsc] = useState(true);
   const [showAllVersions, setShowAllVersions] = useState(false);
@@ -981,7 +1002,7 @@ function App() {
         }
         setSortCol(null);
         setSortAsc(true);
-        setSearchQuery(new URLSearchParams(window.location.search).get('q') || '');
+        setSearchQuery(readSearchQuery());
       })
       .catch(err => setError(err.message))
       .finally(() => setLoading(false));
@@ -1021,6 +1042,17 @@ function App() {
     if (branchName !== branch) loadCsv(branchName);
   }, [branch, loadCsv]);
 
+  const handleSetSearchQuery = useCallback((query) => {
+    setSearchQuery(query);
+    writeSearchQuery(query);
+  }, []);
+
+  useEffect(() => {
+    const handler = () => setSearchQuery(readSearchQuery());
+    window.addEventListener('popstate', handler);
+    return () => window.removeEventListener('popstate', handler);
+  }, []);
+
   useEffect(() => {
     const handler = (e) => { if (e.key === 'Escape') setModal(null); };
     document.addEventListener('keydown', handler);
@@ -1043,7 +1075,7 @@ function App() {
         <>
           <Controls
             activeMode={activeMode} onSetMode={(m) => { setActiveMode(m); setSortCol(null); setSortAsc(true); }}
-            searchQuery={searchQuery} onSetSearch={setSearchQuery}
+            searchQuery={searchQuery} onSetSearch={handleSetSearchQuery}
             totalPass={totalPass} totalFail={totalFail}
             showAllVersions={showAllVersions} onToggleShowAllVersions={setShowAllVersions}
           />


### PR DESCRIPTION
## Summary
- Add small helpers for reading and writing the support matrix `q` URL parameter
- Keep the search field and browser URL synchronized as users type
- Re-read `q` after CSV reloads and browser navigation so deployed links like `/support-matrix/?q=GLM` are stable

## Testing
- `git diff --check`
- `curl -sS http://127.0.0.1:7860/support-matrix/?q=GLM` returns the patched support matrix page

Local preview: http://127.0.0.1:7860/support-matrix/?q=GLM