### PR TITLE
fix: Infer moe_tp and moe_ep when only 1 is provided

### DIFF
--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -23,6 +23,7 @@ from aiconfigurator.cli.main import (
     build_experiment_task_configs,
 )
 from aiconfigurator.cli.report_and_save import save_results
+from aiconfigurator.sdk.config import ModelConfig
 from aiconfigurator.sdk.models import check_is_moe
 from aiconfigurator.sdk.task import (
     DEFAULT_DECODE_LATENCY_CORRECTION_SCALE,
@@ -557,26 +558,19 @@ def _resolve_moe_parallelism(
 ) -> tuple[int, int]:
     """Resolve and validate MoE parallelism widths, returning (moe_tp_size, moe_ep_size).
 
-    For dense (non-MoE) models the width constraint is not enforced because
-    MoE parallelism has no effect on the computation.
+    For dense (non-MoE) models, MoE parallelism has no effect on the
+    computation, so leave the fields as provided.
     """
-    if moe_tp_size is None and moe_ep_size is None:
-        moe_tp_size = tp_size
-        moe_ep_size = attention_dp_size
-    elif moe_tp_size is None:
-        moe_tp_size = tp_size * attention_dp_size // moe_ep_size
-    elif moe_ep_size is None:
-        moe_ep_size = tp_size * attention_dp_size // moe_tp_size
+    if model_path is not None and not check_is_moe(model_path):
+        return moe_tp_size, moe_ep_size
 
-    attn_width = tp_size * attention_dp_size
-    moe_width = moe_tp_size * moe_ep_size
-    if attn_width != moe_width and (model_path is None or check_is_moe(model_path)):
-        raise ValueError(
-            f"Parallelism width mismatch: tp_size({tp_size}) * attention_dp_size({attention_dp_size}) = {attn_width}, "
-            f"but moe_tp_size({moe_tp_size}) * moe_ep_size({moe_ep_size}) = {moe_width}. "
-            f"These must be equal."
-        )
-    return moe_tp_size, moe_ep_size
+    cfg = ModelConfig(
+        tp_size=tp_size,
+        attention_dp_size=attention_dp_size,
+        moe_tp_size=moe_tp_size,
+        moe_ep_size=moe_ep_size,
+    )
+    return cfg.resolve_moe_parallelism()
 
 
 def _build_model_config(

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -677,8 +677,12 @@ def cli_estimate(
             prefill/decode TP when their specific args are omitted.
         pp_size: Pipeline parallelism size. Default is 1.
         attention_dp_size: Attention data parallelism size. Default is 1.
-        moe_tp_size: MoE tensor parallelism size. Default is None (auto).
-        moe_ep_size: MoE expert parallelism size. Default is None (auto).
+        moe_tp_size: MoE tensor parallelism size. At least one of ``moe_tp_size``
+            or ``moe_ep_size`` is required for MoE models; the missing dimension
+            is inferred when possible.
+        moe_ep_size: MoE expert parallelism size. At least one of ``moe_tp_size``
+            or ``moe_ep_size`` is required for MoE models; the missing dimension
+            is inferred when possible.
         gemm_quant_mode: GEMM quantization mode. Default is None (auto-inferred).
         kvcache_quant_mode: KV cache quantization mode. Default is None (auto-inferred).
         fmha_quant_mode: FMHA quantization mode. Default is None (auto-inferred).

--- a/src/aiconfigurator/sdk/config.py
+++ b/src/aiconfigurator/sdk/config.py
@@ -42,8 +42,8 @@ class ModelConfig:
         For MoE models, the attention width must match the expert width:
         ``tp_size * attention_dp_size == moe_tp_size * moe_ep_size``. If one
         MoE dimension is missing, infer it from the other. If both are missing,
-        keep the common default shape of ``moe_tp_size=tp_size`` and
-        ``moe_ep_size=attention_dp_size``.
+        raise an error so callers do not silently get an MoE layout they did
+        not request.
         """
 
         def _validate_positive(name: str, value: int) -> None:
@@ -57,8 +57,7 @@ class ModelConfig:
         moe_tp_size = self.moe_tp_size
         moe_ep_size = self.moe_ep_size
         if moe_tp_size is None and moe_ep_size is None:
-            moe_tp_size = self.tp_size
-            moe_ep_size = self.attention_dp_size
+            raise ValueError("At least one of moe_tp_size or moe_ep_size must be set for MoE models.")
         elif moe_tp_size is None:
             _validate_positive("moe_ep_size", moe_ep_size)
             if attn_width % moe_ep_size != 0:
@@ -81,6 +80,7 @@ class ModelConfig:
         _validate_positive("moe_tp_size", moe_tp_size)
         _validate_positive("moe_ep_size", moe_ep_size)
 
+        # TODO: enforce moe_tp_size == 1 when enable_wideep is set.
         moe_width = moe_tp_size * moe_ep_size
         if attn_width != moe_width:
             raise ValueError(

--- a/src/aiconfigurator/sdk/config.py
+++ b/src/aiconfigurator/sdk/config.py
@@ -36,6 +36,64 @@ class ModelConfig:
     enable_eplb: bool = False  # Expert Parallel Load Balancing
     wideep_num_slots: int = None  # EPLB num_slots, defaults to num_experts if None
 
+    def resolve_moe_parallelism(self) -> tuple[int, int]:
+        """Resolve and validate MoE parallelism dimensions in-place.
+
+        For MoE models, the attention width must match the expert width:
+        ``tp_size * attention_dp_size == moe_tp_size * moe_ep_size``. If one
+        MoE dimension is missing, infer it from the other. If both are missing,
+        keep the common default shape of ``moe_tp_size=tp_size`` and
+        ``moe_ep_size=attention_dp_size``.
+        """
+
+        def _validate_positive(name: str, value: int) -> None:
+            if value <= 0:
+                raise ValueError(f"{name} must be positive, got {value}.")
+
+        _validate_positive("tp_size", self.tp_size)
+        _validate_positive("attention_dp_size", self.attention_dp_size)
+
+        attn_width = self.tp_size * self.attention_dp_size
+        moe_tp_size = self.moe_tp_size
+        moe_ep_size = self.moe_ep_size
+        if moe_tp_size is None and moe_ep_size is None:
+            moe_tp_size = self.tp_size
+            moe_ep_size = self.attention_dp_size
+        elif moe_tp_size is None:
+            _validate_positive("moe_ep_size", moe_ep_size)
+            if attn_width % moe_ep_size != 0:
+                raise ValueError(
+                    f"Cannot infer moe_tp_size: tp_size({self.tp_size}) * "
+                    f"attention_dp_size({self.attention_dp_size}) = {attn_width} is not "
+                    f"divisible by moe_ep_size({moe_ep_size})."
+                )
+            moe_tp_size = attn_width // moe_ep_size
+        elif moe_ep_size is None:
+            _validate_positive("moe_tp_size", moe_tp_size)
+            if attn_width % moe_tp_size != 0:
+                raise ValueError(
+                    f"Cannot infer moe_ep_size: tp_size({self.tp_size}) * "
+                    f"attention_dp_size({self.attention_dp_size}) = {attn_width} is not "
+                    f"divisible by moe_tp_size({moe_tp_size})."
+                )
+            moe_ep_size = attn_width // moe_tp_size
+
+        _validate_positive("moe_tp_size", moe_tp_size)
+        _validate_positive("moe_ep_size", moe_ep_size)
+
+        moe_width = moe_tp_size * moe_ep_size
+        if attn_width != moe_width:
+            raise ValueError(
+                f"Parallelism width mismatch: tp_size({self.tp_size}) * "
+                f"attention_dp_size({self.attention_dp_size}) = {attn_width}, but "
+                f"moe_tp_size({moe_tp_size}) * moe_ep_size({moe_ep_size}) = "
+                f"{moe_width}. These must be equal."
+            )
+
+        self.moe_tp_size = moe_tp_size
+        self.moe_ep_size = moe_ep_size
+        return self.moe_tp_size, self.moe_ep_size
+
 
 @dataclass
 class RuntimeConfig:

--- a/src/aiconfigurator/sdk/models/__init__.py
+++ b/src/aiconfigurator/sdk/models/__init__.py
@@ -69,6 +69,8 @@ def get_model(
     model_family = _architecture_to_model_family(architecture)
 
     _apply_model_quant_defaults(model_config, raw_config, architecture, backend_name)
+    if check_is_moe(model_path, model_info=model_info):
+        model_config.resolve_moe_parallelism()
 
     if model_config.overwrite_num_layers > 0:
         model_info["layers"] = model_config.overwrite_num_layers

--- a/src/aiconfigurator/sdk/models/helpers.py
+++ b/src/aiconfigurator/sdk/models/helpers.py
@@ -23,6 +23,8 @@ from aiconfigurator.sdk.utils import (
 
 logger = logging.getLogger(__name__)
 
+_MOE_MODEL_FAMILIES = {"MOE", "DEEPSEEK", "DEEPSEEKV32", "DEEPSEEKV4", "KIMIK25", "HYBRIDMOE"}
+
 
 @cache
 def _get_model_info(model_path: str) -> dict:
@@ -196,22 +198,22 @@ def get_model_family(model_path: str) -> str:
     return _architecture_to_model_family(architecture)
 
 
-def check_is_moe(model_path: str) -> bool:
+def check_is_moe(model_path: str, model_info: dict | None = None) -> bool:
     """
     Check if the model is a MoE model.
 
     For NEMOTRONH models, checks if 'E' (MoE layer) is in hybrid_override_pattern..
     E.g., Nemotron_H is not an MoE model, but Nemotron_3 is an MoE model.
     """
-    family = get_model_family(model_path)
-    if family in ("MOE", "DEEPSEEK", "DEEPSEEKV32", "DEEPSEEKV4", "KIMIK25", "HYBRIDMOE"):
+    if model_info is None:
+        model_info = _get_model_info(model_path)
+    family = _architecture_to_model_family(model_info["architecture"])
+    if family in _MOE_MODEL_FAMILIES:
         return True
     if family == "QWEN35":
-        model_info = _get_model_info(model_path)
         extra_params = model_info.get("extra_params")
         return isinstance(extra_params, common.Qwen35Config) and extra_params.num_experts > 0
     if family == "NEMOTRONH":
-        model_info = _get_model_info(model_path)
         extra_params = model_info.get("extra_params")
         if extra_params is None or not hasattr(extra_params, "hybrid_override_pattern"):
             logger.warning(f"NEMOTRONH model {model_path} missing hybrid_override_pattern, defaulting is_moe=False")

--- a/tests/unit/sdk/models/test_model_config.py
+++ b/tests/unit/sdk/models/test_model_config.py
@@ -90,6 +90,92 @@ class TestSupportedModels:
         assert is_moe == is_moe_expected
 
 
+class TestMOEParallelismResolution:
+    """Regression tests for SDK-side MoE parallelism defaults."""
+
+    def test_missing_moe_tp_size_is_inferred_for_minimax_nvfp4(self):
+        model_config = config.ModelConfig(
+            tp_size=1,
+            attention_dp_size=1,
+            moe_tp_size=None,
+            moe_ep_size=1,
+        )
+
+        model = get_model("nvidia/MiniMax-M2.7-NVFP4", model_config, backend_name="vllm")
+
+        assert model.model_family == "MOE"
+        assert model_config.moe_tp_size == 1
+        assert model_config.moe_ep_size == 1
+
+    def test_both_missing_moe_parallelism_defaults_to_attention_width(self):
+        model_config = config.ModelConfig(
+            tp_size=4,
+            attention_dp_size=2,
+            moe_tp_size=None,
+            moe_ep_size=None,
+        )
+
+        get_model("Qwen/Qwen3-235B-A22B", model_config, backend_name="trtllm")
+
+        assert model_config.moe_tp_size == 4
+        assert model_config.moe_ep_size == 2
+
+    @pytest.mark.parametrize(
+        "tp_size,attention_dp_size,moe_tp_size,moe_ep_size,expected_moe_tp_size,expected_moe_ep_size",
+        [
+            (4, 2, None, 2, 4, 2),
+            (4, 2, 2, None, 2, 4),
+            (2, 4, None, 4, 2, 4),
+            (2, 4, 1, None, 1, 8),
+        ],
+    )
+    def test_partial_moe_parallelism_is_inferred_for_nontrivial_widths(
+        self,
+        tp_size,
+        attention_dp_size,
+        moe_tp_size,
+        moe_ep_size,
+        expected_moe_tp_size,
+        expected_moe_ep_size,
+    ):
+        model_config = config.ModelConfig(
+            tp_size=tp_size,
+            attention_dp_size=attention_dp_size,
+            moe_tp_size=moe_tp_size,
+            moe_ep_size=moe_ep_size,
+        )
+
+        get_model("Qwen/Qwen3-235B-A22B", model_config, backend_name="trtllm")
+
+        assert model_config.moe_tp_size == expected_moe_tp_size
+        assert model_config.moe_ep_size == expected_moe_ep_size
+
+    def test_uninferrable_moe_parallelism_raises_clear_error(self):
+        model_config = config.ModelConfig(
+            tp_size=3,
+            attention_dp_size=1,
+            moe_tp_size=None,
+            moe_ep_size=2,
+        )
+
+        with pytest.raises(ValueError, match="Cannot infer moe_tp_size"):
+            get_model("Qwen/Qwen3-235B-A22B", model_config, backend_name="trtllm")
+
+    def test_dense_model_does_not_resolve_moe_parallelism(self):
+        model_config = config.ModelConfig(
+            tp_size=1,
+            attention_dp_size=1,
+            moe_tp_size=None,
+            moe_ep_size=None,
+        )
+
+        model = get_model("Qwen/Qwen3-32B", model_config, backend_name="trtllm")
+
+        assert model.model_family == "LLAMA"
+        assert model_config.moe_tp_size is None
+        assert model_config.moe_ep_size is None
+
+
 class TestHFModelSupport:
     """Test HuggingFace model ID support."""
 

--- a/tests/unit/sdk/models/test_model_config.py
+++ b/tests/unit/sdk/models/test_model_config.py
@@ -107,7 +107,7 @@ class TestMOEParallelismResolution:
         assert model_config.moe_tp_size == 1
         assert model_config.moe_ep_size == 1
 
-    def test_both_missing_moe_parallelism_defaults_to_attention_width(self):
+    def test_both_missing_moe_parallelism_raises_clear_error(self):
         model_config = config.ModelConfig(
             tp_size=4,
             attention_dp_size=2,
@@ -115,10 +115,8 @@ class TestMOEParallelismResolution:
             moe_ep_size=None,
         )
 
-        get_model("Qwen/Qwen3-235B-A22B", model_config, backend_name="trtllm")
-
-        assert model_config.moe_tp_size == 4
-        assert model_config.moe_ep_size == 2
+        with pytest.raises(ValueError, match="At least one of moe_tp_size or moe_ep_size must be set"):
+            get_model("Qwen/Qwen3-235B-A22B", model_config, backend_name="trtllm")
 
     @pytest.mark.parametrize(
         "tp_size,attention_dp_size,moe_tp_size,moe_ep_size,expected_moe_tp_size,expected_moe_ep_size",


### PR DESCRIPTION
Fixes https://github.com/ai-dynamo/dynamo/issues/9398

When `moe_ep_size` is provided but `moe_tp_size` is not, `moe_tp_size` defaulted to `None` which caused a crash. This PR sets `moe_tp_size` and `moe_ep_size` to an int for MoE models.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * MoE model parallelism configuration validation now occurs earlier in the initialization process with clearer error messages for invalid setups.
  * Missing MoE parallelism dimensions are automatically inferred when possible with improved consistency.

* **Tests**
  * Added comprehensive test coverage for MoE parallelism resolution and validation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiconfigurator/pull/1074)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->