### PR TITLE
fix: adapt XPU collector scripts for vllm-xpu >=0.20 compatibility

### DIFF
--- a/collector/vllm/collect_gemm_xpu.py
+++ b/collector/vllm/collect_gemm_xpu.py
@@ -21,7 +21,7 @@ from vllm.version import __version__ as vllm_version
 
 from collector.common_test_cases import GemmCommonTestCase
 from collector.helper import benchmark_with_power, get_device_module, log_perf
-from collector.vllm.utils import setup_distributed, with_exit_stack
+from collector.vllm.utils import create_vllm_config, setup_distributed, with_exit_stack
 
 FP8_BLOCK_SHAPE = (128, 128)
 
@@ -186,7 +186,16 @@ def run_gemm(exit_stack, gemm_type, m, n, k, *, perf_filename, device="xpu:0"):
 
         return gemm
 
-    exit_stack.enter_context(set_current_vllm_config(VllmConfig()))
+    # vLLM >=0.20 requires model_config.dtype in VllmConfig for FP8 layers;
+    # fall back to bare VllmConfig() for older versions where the vLLM config
+    # APIs used by create_vllm_config() may be incompatible.
+    try:
+        model = os.path.join(os.path.dirname(__file__), "fake_hf_model")
+        vllm_config = create_vllm_config(model_name=model, dtype=dtype)
+    except Exception as exc:
+        print(f"create_vllm_config failed, falling back to VllmConfig(): {exc}")
+        vllm_config = VllmConfig()
+    exit_stack.enter_context(set_current_vllm_config(vllm_config))
 
     outside_loop_count = 6
     op_list = []

--- a/collector/vllm/collect_moe_xpu.py
+++ b/collector/vllm/collect_moe_xpu.py
@@ -276,23 +276,52 @@ def run_moe_torch(
         w13_scales = w2_scales = None
         w13_bias = w2_bias = None
 
-        # Create weight tensors in xpu_fused_moe layout
-        # w1: [num_experts, 2 * inter_size, hidden_size]
-        # w2: [num_experts, hidden_size, inter_size]
-        w1 = torch.randn(
-            local_num_experts,
-            2 * local_inter_size,
-            hidden_size,
-            dtype=torch.bfloat16,
-            device=device,
-        )
-        w2 = torch.randn(
-            local_num_experts,
-            hidden_size,
-            local_inter_size,
-            dtype=torch.bfloat16,
-            device=device,
-        )
+        # Create weight tensors in xpu_fused_moe layout.
+        # The expected layout depends on the vllm_xpu_kernels version:
+        #   vllm-xpu >=0.20: [E, K, N] — inter_size = w13.shape[-1] // 2
+        #   vllm-xpu <0.20:  [E, N, K] — inter_size = w13.shape[-2] // 2
+        # Detect by inspecting how xpu_fused_moe derives inter_size.
+        import inspect as inspect_src
+
+        try:
+            moe_src = inspect_src.getsource(xpu_fused_moe)
+            use_kn_layout = "inter_size = list(w13.shape)[-1]" in moe_src
+        except (OSError, TypeError) as exc:
+            print(f"inspect.getsource(xpu_fused_moe) failed, defaulting to [E,N,K] layout: {exc}")
+            use_kn_layout = False
+
+        if use_kn_layout:
+            # [E, K, N] layout (vllm-xpu >=0.20)
+            w1 = torch.randn(
+                local_num_experts,
+                hidden_size,
+                2 * local_inter_size,
+                dtype=torch.bfloat16,
+                device=device,
+            )
+            w2 = torch.randn(
+                local_num_experts,
+                local_inter_size,
+                hidden_size,
+                dtype=torch.bfloat16,
+                device=device,
+            )
+        else:
+            # [E, N, K] layout (vllm-xpu <0.20)
+            w1 = torch.randn(
+                local_num_experts,
+                2 * local_inter_size,
+                hidden_size,
+                dtype=torch.bfloat16,
+                device=device,
+            )
+            w2 = torch.randn(
+                local_num_experts,
+                hidden_size,
+                local_inter_size,
+                dtype=torch.bfloat16,
+                device=device,
+            )
 
         if is_fp8:
             w1, w13_scales = quantize_fp8_per_expert(w1)
@@ -366,6 +395,7 @@ def run_moe_torch(
                             n_experts_per_token=topk,
                             activation=activation_name,
                             num_experts=local_num_experts,
+                            ep_size=moe_ep_size,
                             is_mxfp4=True,
                         )
                     else:
@@ -382,6 +412,7 @@ def run_moe_torch(
                             n_experts_per_token=topk,
                             activation=activation_name,
                             num_experts=local_num_experts,
+                            ep_size=moe_ep_size,
                             is_fp8=is_fp8,
                         )
             else:
@@ -399,6 +430,7 @@ def run_moe_torch(
                         n_experts_per_token=topk,
                         activation=activation_name,
                         num_experts=local_num_experts,
+                        ep_size=moe_ep_size,
                         is_mxfp4=True,
                     )
                 else:
@@ -415,6 +447,7 @@ def run_moe_torch(
                         n_experts_per_token=topk,
                         activation=activation_name,
                         num_experts=local_num_experts,
+                        ep_size=moe_ep_size,
                         is_fp8=is_fp8,
                     )
 


### PR DESCRIPTION
- collect_moe_xpu: detect weight layout change ([E,N,K] vs [E,K,N])
  by inspecting xpu_fused_moe source at runtime
- collect_gemm_xpu: use create_vllm_config with model dtype for FP8
  layers required by vLLM >=0.20, with fallback for older versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected missing parameter in computation calls to ensure proper execution.
  * Resolved compatibility issues across varying hardware configurations.

* **Improvements**
  * Enhanced configuration initialization with improved error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiconfigurator/pull/1077)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->