### PR TITLE
fix: generator bench script to support prefix cache

### DIFF
--- a/src/aiconfigurator/generator/config/backend_templates/benchmark/bench_run.sh.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/benchmark/bench_run.sh.j2
@@ -31,8 +31,15 @@ BENCH_ISL="${AICONFIGURATOR_BENCH_ISL:-{{ BenchConfig.isl }}}"
 BENCH_ISL_STDDEV="${AICONFIGURATOR_BENCH_ISL_STDDEV:-{{ BenchConfig.isl_stddev }}}"
 BENCH_OSL="${AICONFIGURATOR_BENCH_OSL:-{{ BenchConfig.osl }}}"
 BENCH_OSL_STDDEV="${AICONFIGURATOR_BENCH_OSL_STDDEV:-{{ BenchConfig.osl_stddev }}}"
+BENCH_PREFIX="${AICONFIGURATOR_BENCH_PREFIX:-{{ BenchConfig.prefix | default(0) }}}"
+BENCH_PREFIX_PROMPTS="${AICONFIGURATOR_BENCH_PREFIX_PROMPTS:-{{ BenchConfig.prefix_prompt_pool_size | default(1) }}}"
 BENCH_UI="simple"
 BENCH_MULTI_ROUND="${AICONFIGURATOR_BENCH_MULTI_ROUND:-20}"
+
+prefix_args=()
+if [[ "${BENCH_PREFIX}" =~ ^[0-9]+$ && "${BENCH_PREFIX}" -gt 0 ]]; then
+  prefix_args+=(--prefix-prompt-length "${BENCH_PREFIX}" --num-prefix-prompts "${BENCH_PREFIX_PROMPTS}")
+fi
 
 for concurrency in "${concurrency_array[@]}"; do
   echo "Run concurrency: $concurrency"
@@ -44,6 +51,7 @@ for concurrency in "${concurrency_array[@]}"; do
     --tokenizer "${BENCH_TOKENIZER}" \
     --isl "${BENCH_ISL}" --isl-stddev "${BENCH_ISL_STDDEV}" \
     --osl "${BENCH_OSL}" --osl-stddev "${BENCH_OSL_STDDEV}" \
+    "${prefix_args[@]}" \
     --extra-inputs ignore_eos:true \
     --extra-inputs "{\"nvext\":{\"ignore_eos\":true}}" \
     --concurrency ${concurrency} \

--- a/src/aiconfigurator/generator/config/backend_templates/benchmark/bench_run.sh.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/benchmark/bench_run.sh.j2
@@ -37,7 +37,8 @@ BENCH_UI="simple"
 BENCH_MULTI_ROUND="${AICONFIGURATOR_BENCH_MULTI_ROUND:-20}"
 
 prefix_args=()
-if [[ "${BENCH_PREFIX}" =~ ^[0-9]+$ && "${BENCH_PREFIX}" -gt 0 ]]; then
+if [[ "${BENCH_PREFIX}" =~ ^[0-9]+$ && "${BENCH_PREFIX}" -gt 0 \
+    && "${BENCH_PREFIX_PROMPTS}" =~ ^[0-9]+$ && "${BENCH_PREFIX_PROMPTS}" -gt 0 ]]; then
   prefix_args+=(--prefix-prompt-length "${BENCH_PREFIX}" --num-prefix-prompts "${BENCH_PREFIX_PROMPTS}")
 fi
 

--- a/src/aiconfigurator/generator/config/backend_templates/benchmark/k8s_bench.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/benchmark/k8s_bench.yaml.j2
@@ -55,6 +55,12 @@ spec:
               concurrency_array=({{ base_concurrency | join(' ') }})
               {% endif %}
               ARTIFACT_DIR="${BENCH_ARTIFACT_DIR:-/tmp/bench_artifacts}"
+              BENCH_PREFIX="${AICONFIGURATOR_BENCH_PREFIX:-{{ BenchConfig.prefix | default(0) }}}"
+              BENCH_PREFIX_PROMPTS="${AICONFIGURATOR_BENCH_PREFIX_PROMPTS:-{{ BenchConfig.prefix_prompt_pool_size | default(1) }}}"
+              prefix_args=()
+              if [[ "${BENCH_PREFIX}" =~ ^[0-9]+$ && "${BENCH_PREFIX}" -gt 0 ]]; then
+                prefix_args+=(--prefix-prompt-length "${BENCH_PREFIX}" --num-prefix-prompts "${BENCH_PREFIX_PROMPTS}")
+              fi
               for concurrency in "${concurrency_array[@]}"; do
                 echo "Run concurrency: $concurrency"
                 aiperf profile \
@@ -65,6 +71,7 @@ spec:
                   --tokenizer {{ BenchConfig.tokenizer }} \
                   --isl {{ BenchConfig.isl }} --isl-stddev {{ BenchConfig.isl_stddev }} \
                   --osl {{ BenchConfig.osl }} --osl-stddev {{ BenchConfig.osl_stddev }} \
+                  "${prefix_args[@]}" \
                   --extra-inputs ignore_eos:true \
                   --extra-inputs "{\"nvext\":{\"ignore_eos\":true}}" \
                   --concurrency ${concurrency} \

--- a/src/aiconfigurator/generator/config/backend_templates/benchmark/k8s_bench.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/benchmark/k8s_bench.yaml.j2
@@ -58,7 +58,8 @@ spec:
               BENCH_PREFIX="${AICONFIGURATOR_BENCH_PREFIX:-{{ BenchConfig.prefix | default(0) }}}"
               BENCH_PREFIX_PROMPTS="${AICONFIGURATOR_BENCH_PREFIX_PROMPTS:-{{ BenchConfig.prefix_prompt_pool_size | default(1) }}}"
               prefix_args=()
-              if [[ "${BENCH_PREFIX}" =~ ^[0-9]+$ && "${BENCH_PREFIX}" -gt 0 ]]; then
+              if [[ "${BENCH_PREFIX}" =~ ^[0-9]+$ && "${BENCH_PREFIX}" -gt 0 \
+                  && "${BENCH_PREFIX_PROMPTS}" =~ ^[0-9]+$ && "${BENCH_PREFIX_PROMPTS}" -gt 0 ]]; then
                 prefix_args+=(--prefix-prompt-length "${BENCH_PREFIX}" --num-prefix-prompts "${BENCH_PREFIX_PROMPTS}")
               fi
               for concurrency in "${concurrency_array[@]}"; do

--- a/src/aiconfigurator/generator/config/backend_templates/sglang/k8s_deploy.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/sglang/k8s_deploy.yaml.j2
@@ -64,6 +64,9 @@
               {% elif role == 'decode' %}
               args+=(--disaggregation-mode decode)
               {% endif %}
+              {% if enable_router %}
+              args+=(--kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:{{ ServiceConfig.sglang_kv_event_port | default(5557, true) }}"}')
+              {% endif %}
               exec python3 -m dynamo.sglang "${args[@]}"
 {%- endmacro %}
 

--- a/src/aiconfigurator/generator/config/backend_templates/sglang/run.sh.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/sglang/run.sh.j2
@@ -17,9 +17,13 @@ PREFILL_SYSTEM_PORT_BASE=${PREFILL_SYSTEM_PORT_BASE:-8082}
 DECODE_SYSTEM_PORT_BASE=${DECODE_SYSTEM_PORT_BASE:-$((PREFILL_SYSTEM_PORT_BASE + PREFILL_WORKERS))}
 
 {% set mode = DynConfig.mode | default('disagg') %}
+{% set enable_router = DynConfig.enable_router | default(false) %}
+{% if enable_router %}
+SGLANG_KV_EVENT_PORT_BASE=${SGLANG_KV_EVENT_PORT_BASE:-{{ ServiceConfig.sglang_kv_event_port | default(5557, true) }}}
+{% endif %}
 {% if ServiceConfig.include_frontend %}
 OTEL_SERVICE_NAME=dynamo-frontend \
-python3 -m dynamo.frontend --http-port "{{ ServiceConfig.port }}" 2>&1 | sed "s/^/[Frontend] /" &
+python3 -m dynamo.frontend {% if enable_router %}--router-mode kv {% endif %}--http-port "{{ ServiceConfig.port }}" 2>&1 | sed "s/^/[Frontend] /" &
 {% endif %}
 
 {% if mode == 'agg' %}
@@ -35,6 +39,9 @@ for ((w=0; w<AGG_WORKERS; w++)); do
   if (( AGG_WORKERS > 1 )); then
     WORKER_NAME="${WORKER_NAME}-${WORKER_IDX}"
   fi
+  {% if enable_router %}
+  EVENT_PORT=$(( SGLANG_KV_EVENT_PORT_BASE + w ))
+  {% endif %}
   ( CUDA_VISIBLE_DEVICES=$GPU_LIST \
   OTEL_SERVICE_NAME="${WORKER_NAME}" \
   DYN_SYSTEM_PORT="${SYSTEM_PORT}" \
@@ -43,6 +50,9 @@ for ((w=0; w<AGG_WORKERS; w++)); do
     --served-model-name "$SERVED_MODEL_NAME" \
     {{ agg_cli_args }} \
     --host "0.0.0.0" \
+    {% if enable_router %}
+    --kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${EVENT_PORT}\"}" \
+    {% endif %}
     --enable-metrics 2>&1 | sed "s/^/[Worker $w] /" ) &
 done
 wait
@@ -58,6 +68,9 @@ for ((w=0; w<PREFILL_WORKERS; w++)); do
   if (( PREFILL_WORKERS > 1 )); then
     WORKER_NAME="${WORKER_NAME}-${WORKER_IDX}"
   fi
+  {% if enable_router %}
+  EVENT_PORT=$(( SGLANG_KV_EVENT_PORT_BASE + w ))
+  {% endif %}
   ( CUDA_VISIBLE_DEVICES=$GPU_LIST \
   OTEL_SERVICE_NAME="${WORKER_NAME}" \
   DYN_SYSTEM_PORT="${SYSTEM_PORT}" \
@@ -66,6 +79,9 @@ for ((w=0; w<PREFILL_WORKERS; w++)); do
       --served-model-name "$SERVED_MODEL_NAME" \
       {{ prefill_cli_args }} --disaggregation-mode prefill \
       --host "0.0.0.0" \
+      {% if enable_router %}
+      --kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${EVENT_PORT}\"}" \
+      {% endif %}
       --enable-metrics 2>&1 | sed "s/^/[Prefill $w] /" ) &
 done
 {% endif %}
@@ -82,6 +98,9 @@ for ((w=0; w<DECODE_WORKERS; w++)); do
   if (( DECODE_WORKERS > 1 )); then
     WORKER_NAME="${WORKER_NAME}-${WORKER_IDX}"
   fi
+  {% if enable_router %}
+  EVENT_PORT=$(( SGLANG_KV_EVENT_PORT_BASE + PREFILL_WORKERS + w ))
+  {% endif %}
   ( CUDA_VISIBLE_DEVICES=$GPU_LIST \
   OTEL_SERVICE_NAME="${WORKER_NAME}" \
   DYN_SYSTEM_PORT="${SYSTEM_PORT}" \
@@ -90,6 +109,9 @@ for ((w=0; w<DECODE_WORKERS; w++)); do
       --served-model-name "$SERVED_MODEL_NAME" \
       {{ decode_cli_args }} --disaggregation-mode decode \
       --host "0.0.0.0" \
+      {% if enable_router %}
+      --kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${EVENT_PORT}\"}" \
+      {% endif %}
       --enable-metrics 2>&1 | sed "s/^/[Decode $w] /" ) &
 done
 {% endif %}

--- a/src/aiconfigurator/generator/config/backend_templates/vllm/k8s_deploy.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/vllm/k8s_deploy.yaml.j2
@@ -8,6 +8,7 @@
 {%- set k8s_use_model_cache = (model_cache_input != '') -%}
 {%- set k8s_model_cache_pvc = (model_cache_input if k8s_use_model_cache else 'model-cache') -%}
 {%- set k8s_model_cache_mount = '/workspace/model_cache' -%}
+{%- set enable_router = DynConfig.enable_router | default(false) -%}
 
 {%- macro render_worker(component_name, role, replicas, gpu, cli_args_list) -%}
     {%- set parsed_args = cli_args_list | default([]) -%}
@@ -62,6 +63,10 @@
             {% for arg in parsed_args %}
             - {{ arg | tojson }}
             {% endfor %}
+            {% if enable_router %}
+            - --kv-events-config
+            - '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:{{ ServiceConfig.dyn_vllm_kv_event_port | default(20081, true) }}","enable_kv_cache_events":true}'
+            {% endif %}
             {% if role == 'prefill' %}
             - --is-prefill-worker
             - --kv-transfer-config
@@ -82,17 +87,6 @@ spec:
   services:
     Frontend:
       envFromSecret: hf-token-secret
-      {% if K8sConfig.k8s_hf_home or K8sConfig.k8s_etcd_endpoints %}
-      envs:
-        {% if K8sConfig.k8s_etcd_endpoints %}
-        - name: ETCD_ENDPOINTS
-          value: {{ K8sConfig.k8s_etcd_endpoints }}
-        {% endif %}
-        {% if K8sConfig.k8s_hf_home %}
-        - name: HF_HOME
-          value: {{ K8sConfig.k8s_hf_home }}
-        {% endif %}
-      {% endif %}
       componentType: frontend
       replicas: {{ frontend_replicas | default(1) }}
       extraPodSpec:
@@ -103,6 +97,21 @@ spec:
         mainContainer:
           image: {{ K8sConfig.k8s_image }}
           imagePullPolicy: IfNotPresent
+      {% if enable_router or K8sConfig.k8s_hf_home or K8sConfig.k8s_etcd_endpoints %}
+      envs:
+        {% if K8sConfig.k8s_etcd_endpoints %}
+        - name: ETCD_ENDPOINTS
+          value: {{ K8sConfig.k8s_etcd_endpoints }}
+        {% endif %}
+        {% if enable_router %}
+        - name: DYN_ROUTER_MODE
+          value: kv
+        {% endif %}
+        {% if K8sConfig.k8s_hf_home %}
+        - name: HF_HOME
+          value: {{ K8sConfig.k8s_hf_home }}
+        {% endif %}
+      {% endif %}
 
     {% if DynConfig.mode | default('disagg') == 'agg' %}
 {{ render_worker(

--- a/src/aiconfigurator/generator/config/deployment_config.yaml
+++ b/src/aiconfigurator/generator/config/deployment_config.yaml
@@ -41,6 +41,10 @@ inputs:
     required: false
     default: 20097
     backends: ["vllm"]
+  - key: ServiceConfig.sglang_kv_event_port
+    required: false
+    default: 5557
+    backends: ["sglang"]
 
   # Generator-level defaults
   - key: generator_dynamo_version
@@ -180,6 +184,11 @@ inputs:
   - key: BenchConfig.osl_stddev
     required: false
     default: 0
+  - key: BenchConfig.prefix
+    required: false
+  - key: BenchConfig.prefix_prompt_pool_size
+    required: false
+    default: 1
   - key: BenchConfig.concurrency
     required: false
     default: "[1, 2, 4, 8, 32, 64, 128, 256]"

--- a/src/aiconfigurator/generator/rendering/engine.py
+++ b/src/aiconfigurator/generator/rendering/engine.py
@@ -827,7 +827,14 @@ def prepare_template_context(param_values: dict[str, Any], backend: str) -> dict
     if isinstance(bench_config, dict):
         bench_context = dict(bench_config)
         if bench_context.get("prefix") is None:
-            bench_context["prefix"] = model_config.get("prefix") or service_config.get("prefix") or 0
+            model_prefix = model_config.get("prefix")
+            service_prefix = service_config.get("prefix")
+            if model_prefix is not None:
+                bench_context["prefix"] = model_prefix
+            elif service_prefix is not None:
+                bench_context["prefix"] = service_prefix
+            else:
+                bench_context["prefix"] = 0
         if bench_context.get("prefix_prompt_pool_size") is None:
             bench_context["prefix_prompt_pool_size"] = 1
         context["BenchConfig"] = bench_context

--- a/src/aiconfigurator/generator/rendering/engine.py
+++ b/src/aiconfigurator/generator/rendering/engine.py
@@ -392,6 +392,11 @@ def render_backend_templates(
         _set_nested("cuda_graph_config", "batch_sizes", "cuda_graph_batch_sizes")
         _set_nested("cache_transceiver_config", "max_tokens_in_buffer", "cache_transceiver_max_tokens_in_buffer")
 
+        if wc.get("disable_prefix_cache") is False:
+            kv_cache_config = dict(wc.get("kv_cache_config") or {})
+            kv_cache_config.setdefault("enable_block_reuse", True)
+            wc["kv_cache_config"] = kv_cache_config
+
         if wc.get("cache_transceiver_config"):
             cache_transceiver_config = dict(wc["cache_transceiver_config"])
             cache_transceiver_config.setdefault("backend", "DEFAULT")
@@ -736,7 +741,10 @@ def prepare_template_context(param_values: dict[str, Any], backend: str) -> dict
     context = {}
 
     # Extract ModelConfig (is_moe, nextn, etc.)
-    model_config = param_values.get("ModelConfig", {})
+    model_config = param_values.get("ModelConfig") or {}
+    if not isinstance(model_config, dict):
+        model_config = {}
+    context["ModelConfig"] = dict(model_config)
     if model_config.get("is_moe"):
         context["is_moe"] = model_config["is_moe"]
 
@@ -817,7 +825,12 @@ def prepare_template_context(param_values: dict[str, Any], backend: str) -> dict
         context["SlaConfig"] = dict(sla_config)
     bench_config = param_values.get("BenchConfig", {}) or {}
     if isinstance(bench_config, dict):
-        context["BenchConfig"] = dict(bench_config)
+        bench_context = dict(bench_config)
+        if bench_context.get("prefix") is None:
+            bench_context["prefix"] = model_config.get("prefix") or service_config.get("prefix") or 0
+        if bench_context.get("prefix_prompt_pool_size") is None:
+            bench_context["prefix_prompt_pool_size"] = 1
+        context["BenchConfig"] = bench_context
 
     # Load backend_config_mapping.yaml to understand parameter mappings
     mapping_data = load_yaml_mapping(_BACKEND_MAPPING_FILE)

--- a/tests/golden/generator/test_release_1_2_0_backend_contracts.py
+++ b/tests/golden/generator/test_release_1_2_0_backend_contracts.py
@@ -278,6 +278,24 @@ def test_vllm_0_20_1_cli_args_golden_contract():
     assert speculative == {"method": "mtp", "num_speculative_tokens": 2}
 
 
+def test_vllm_0_20_1_k8s_router_contract():
+    k8s = yaml.safe_load(_render("vllm")["k8s_deploy.yaml"])
+    services = k8s["spec"]["services"]
+
+    frontend_env = {item["name"]: item["value"] for item in services["Frontend"]["envs"]}
+    assert frontend_env["DYN_ROUTER_MODE"] == "kv"
+
+    worker_args = services["VllmWorker"]["extraPodSpec"]["mainContainer"]["args"]
+    assert "--kv-events-config" in worker_args
+    kv_events = json.loads(_value_after(worker_args, "--kv-events-config"))
+    assert kv_events == {
+        "publisher": "zmq",
+        "topic": "kv-events",
+        "endpoint": "tcp://*:20081",
+        "enable_kv_cache_events": True,
+    }
+
+
 def test_sglang_0_5_11_cli_args_golden_contract():
     tokens = _split_cli(_render("sglang")["cli_args_agg"])
     flags = _flag_set(tokens)
@@ -295,6 +313,29 @@ def test_sglang_0_5_11_cli_args_golden_contract():
     assert _value_after(tokens, "--speculative-num-steps") == "2"
     assert "--disable-cuda-graph" in flags
     assert "--moe-dense-tp-size" not in flags
+
+
+def test_sglang_0_5_11_k8s_router_contract():
+    k8s = yaml.safe_load(_render("sglang")["k8s_deploy.yaml"])
+    services = k8s["spec"]["services"]
+
+    frontend_env = {item["name"]: item["value"] for item in services["Frontend"]["envs"]}
+    assert frontend_env["DYN_ROUTER_MODE"] == "kv"
+
+    worker_script = services["SGLangWorker"]["extraPodSpec"]["mainContainer"]["args"][0]
+    assert "--kv-events-config" in worker_script
+    assert '"publisher":"zmq"' in worker_script
+    assert '"topic":"kv-events"' in worker_script
+    assert '"endpoint":"tcp://*:5557"' in worker_script
+
+
+def test_sglang_0_5_11_run_router_contract():
+    run_sh = _render("sglang")["run_0.sh"]
+
+    assert "SGLANG_KV_EVENT_PORT_BASE=${SGLANG_KV_EVENT_PORT_BASE:-5557}" in run_sh
+    assert "python3 -m dynamo.frontend --router-mode kv --http-port" in run_sh
+    assert "--kv-events-config" in run_sh
+    assert "tcp://*:${EVENT_PORT}" in run_sh
 
 
 def test_sglang_0_5_11_optional_cli_args_golden_contract():
@@ -359,9 +400,19 @@ def test_trtllm_1_3_0rc14_extra_engine_args_golden_contract():
     assert engine_args["kv_cache_config"]["free_gpu_memory_fraction"] == 0.82
     assert engine_args["kv_cache_config"]["dtype"] == "auto"
     assert engine_args["kv_cache_config"]["tokens_per_block"] == 32
+    assert engine_args["kv_cache_config"]["enable_block_reuse"] is True
     assert engine_args["cuda_graph_config"]["enable_padding"] is True
     assert engine_args["cuda_graph_config"]["batch_sizes"][-1] == 72
     assert engine_args["speculative_config"] == {
         "decoding_type": "MTP",
         "num_nextn_predict_layers": 2,
     }
+
+
+def test_benchmark_prefix_defaults_from_model_config():
+    bench = _render("trtllm")["bench_run.sh"]
+
+    assert 'BENCH_PREFIX="${AICONFIGURATOR_BENCH_PREFIX:-1024}"' in bench
+    assert 'BENCH_PREFIX_PROMPTS="${AICONFIGURATOR_BENCH_PREFIX_PROMPTS:-1}"' in bench
+    assert "--prefix-prompt-length" in bench
+    assert "--num-prefix-prompts" in bench

--- a/tests/unit/generator/test_benchmark_templates.py
+++ b/tests/unit/generator/test_benchmark_templates.py
@@ -65,3 +65,33 @@ class TestBenchmarkTemplates:
         rendered = _render("k8s_bench.yaml.j2", benchmark_env, **_base_context())
         assert "concurrency_array=(0" not in rendered
         assert "concurrency_array=(1 2 8 16 32 64 128)" in rendered
+
+    def test_bench_run_emits_prefix_prompt_args_when_configured(self, benchmark_env):
+        context = _base_context()
+        context["BenchConfig"]["prefix"] = 512
+        context["BenchConfig"]["prefix_prompt_pool_size"] = 3
+
+        rendered = _render("bench_run.sh.j2", benchmark_env, **context)
+
+        prefix_arg_line = (
+            'prefix_args+=(--prefix-prompt-length "${BENCH_PREFIX}" --num-prefix-prompts "${BENCH_PREFIX_PROMPTS}")'
+        )
+        assert 'BENCH_PREFIX="${AICONFIGURATOR_BENCH_PREFIX:-512}"' in rendered
+        assert 'BENCH_PREFIX_PROMPTS="${AICONFIGURATOR_BENCH_PREFIX_PROMPTS:-3}"' in rendered
+        assert prefix_arg_line in rendered
+        assert '"${prefix_args[@]}" \\' in rendered
+
+    def test_k8s_bench_emits_prefix_prompt_args_when_configured(self, benchmark_env):
+        context = _base_context()
+        context["BenchConfig"]["prefix"] = 512
+        context["BenchConfig"]["prefix_prompt_pool_size"] = 3
+
+        rendered = _render("k8s_bench.yaml.j2", benchmark_env, **context)
+
+        prefix_arg_line = (
+            'prefix_args+=(--prefix-prompt-length "${BENCH_PREFIX}" --num-prefix-prompts "${BENCH_PREFIX_PROMPTS}")'
+        )
+        assert 'BENCH_PREFIX="${AICONFIGURATOR_BENCH_PREFIX:-512}"' in rendered
+        assert 'BENCH_PREFIX_PROMPTS="${AICONFIGURATOR_BENCH_PREFIX_PROMPTS:-3}"' in rendered
+        assert prefix_arg_line in rendered
+        assert '"${prefix_args[@]}" \\' in rendered

--- a/tests/unit/generator/test_benchmark_templates.py
+++ b/tests/unit/generator/test_benchmark_templates.py
@@ -78,6 +78,8 @@ class TestBenchmarkTemplates:
         )
         assert 'BENCH_PREFIX="${AICONFIGURATOR_BENCH_PREFIX:-512}"' in rendered
         assert 'BENCH_PREFIX_PROMPTS="${AICONFIGURATOR_BENCH_PREFIX_PROMPTS:-3}"' in rendered
+        assert '"${BENCH_PREFIX_PROMPTS}" =~ ^[0-9]+$' in rendered
+        assert '"${BENCH_PREFIX_PROMPTS}" -gt 0' in rendered
         assert prefix_arg_line in rendered
         assert '"${prefix_args[@]}" \\' in rendered
 
@@ -93,5 +95,7 @@ class TestBenchmarkTemplates:
         )
         assert 'BENCH_PREFIX="${AICONFIGURATOR_BENCH_PREFIX:-512}"' in rendered
         assert 'BENCH_PREFIX_PROMPTS="${AICONFIGURATOR_BENCH_PREFIX_PROMPTS:-3}"' in rendered
+        assert '"${BENCH_PREFIX_PROMPTS}" =~ ^[0-9]+$' in rendered
+        assert '"${BENCH_PREFIX_PROMPTS}" -gt 0' in rendered
         assert prefix_arg_line in rendered
         assert '"${prefix_args[@]}" \\' in rendered

--- a/tests/unit/generator/test_naive.py
+++ b/tests/unit/generator/test_naive.py
@@ -341,3 +341,18 @@ class TestRenderingNameFallback:
         }
         ctx = prepare_template_context(params, "vllm")
         assert ctx["frontend_replicas"] == 0
+
+    def test_benchmark_prefix_preserves_explicit_model_zero(self):
+        from aiconfigurator.generator.rendering.engine import prepare_template_context
+
+        params = {
+            "K8sConfig": {"name_prefix": "test"},
+            "ServiceConfig": {"model_path": "test", "prefix": 1024},
+            "ModelConfig": {"prefix": 0},
+            "BenchConfig": {},
+            "DynConfig": {"mode": "agg"},
+            "params": {"agg": {}},
+            "WorkerConfig": {},
+        }
+        ctx = prepare_template_context(params, "vllm")
+        assert ctx["BenchConfig"]["prefix"] == 0


### PR DESCRIPTION
#### Overview:

Generator benchmark artifacts now pass aiperf prefix prompt arguments when ModelConfig.prefix or BenchConfig.prefix is set, allowing server prefix caches to be exercised during generated bench runs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added router mode with KV event streaming for SGLang and vLLM backends (optional)
  * Added optional benchmark prefix prompt configuration with conditional activation
  * Made model/deployment config handling more robust to malformed/missing values

* **Tests**
  * Added comprehensive golden and unit tests for router mode and benchmark prefix behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiconfigurator/pull/1078)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->