### PR TITLE
chore: bump aiconfigurator-core to 0.9.0 and enable cargo-deny

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,6 +11,21 @@ on:
       - synchronize
 
 jobs:
+  cargo-deny:
+    name: Cargo Deny
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny@0.19.0
+      - name: Run cargo-deny
+        working-directory: rust/aiconfigurator-core
+        run: cargo-deny -L error --all-features check licenses bans
+
   build-and-test:
     name: Build and Test (${{ matrix.suite.name }})
     runs-on: ubuntu-latest

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -24,7 +24,10 @@ jobs:
           tool: cargo-deny@0.19.0
       - name: Run cargo-deny
         working-directory: rust/aiconfigurator-core
-        run: cargo-deny -L error --all-features check licenses bans
+        # Default log level (warn) surfaces "license inferred from file" notes
+        # so any crate that may need a [[licenses.clarify]] entry is named.
+        # --show-stats prints a per-license usage summary at the end.
+        run: cargo-deny --all-features check --show-stats licenses bans
 
   build-and-test:
     name: Build and Test (${{ matrix.suite.name }})

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -18,21 +18,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Install cargo-deny
-        env:
-          CARGO_DENY_VERSION: "0.19.0"
-        run: |
-          set -euo pipefail
-          tarball="cargo-deny-${CARGO_DENY_VERSION}-x86_64-unknown-linux-musl.tar.gz"
-          url="https://github.com/EmbarkStudios/cargo-deny/releases/download/${CARGO_DENY_VERSION}/${tarball}"
-          curl --proto '=https' --tlsv1.2 -sSfL "${url}" | tar -xz --strip-components=1 -C /usr/local/bin "${tarball%.tar.gz}/cargo-deny"
-          cargo-deny --version
-      - name: Run cargo-deny
+      - name: Install and run cargo-deny
         working-directory: rust/aiconfigurator-core
         # Default log level (warn) surfaces "license inferred from file" notes
         # so any crate that may need a [[licenses.clarify]] entry is named.
         # --show-stats prints a per-license usage summary at the end.
-        run: cargo-deny --all-features check --show-stats licenses bans
+        run: |
+          cargo-deny --version || cargo install cargo-deny@0.19.0
+          cargo-deny --all-features check --show-stats licenses bans
 
   build-and-test:
     name: Build and Test (${{ matrix.suite.name }})

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,9 +19,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install cargo-deny
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-deny@0.19.0
+        env:
+          CARGO_DENY_VERSION: "0.19.0"
+        run: |
+          set -euo pipefail
+          tarball="cargo-deny-${CARGO_DENY_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          url="https://github.com/EmbarkStudios/cargo-deny/releases/download/${CARGO_DENY_VERSION}/${tarball}"
+          curl --proto '=https' --tlsv1.2 -sSfL "${url}" | tar -xz --strip-components=1 -C /usr/local/bin "${tarball%.tar.gz}/cargo-deny"
+          cargo-deny --version
       - name: Run cargo-deny
         working-directory: rust/aiconfigurator-core
         # Default log level (warn) surfaces "license inferred from file" notes

--- a/rust/aiconfigurator-core/Cargo.lock
+++ b/rust/aiconfigurator-core/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "aiconfigurator-core"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "csv",
  "serde",

--- a/rust/aiconfigurator-core/Cargo.toml
+++ b/rust/aiconfigurator-core/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "aiconfigurator-core"
-version = "0.1.0"
+version = "0.9.0"
 edition = "2021"
 description = "Rust-native core latency estimator for AIConfigurator"
 license = "Apache-2.0"

--- a/rust/aiconfigurator-core/deny.toml
+++ b/rust/aiconfigurator-core/deny.toml
@@ -29,14 +29,6 @@ allow = [
     "WTFPL"
 ]
 
-[[licenses.clarify]]
-
-name = "ring"
-expression = "MIT AND ISC AND OpenSSL"
-license-files = [
-    { path = "LICENSE", hash = 0xbd0eed23 }
-]
-
 [bans]
 deny = [
     # Ensure we don't depend on openssl

--- a/rust/aiconfigurator-core/deny.toml
+++ b/rust/aiconfigurator-core/deny.toml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# cargo-deny plugin for linting dependencies
+# https://github.com/EmbarkStudios/cargo-deny/blob/main/deny.template.toml
+
+[licenses]
+confidence-threshold = 0.93
+allow = [
+    "MIT-0",
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "ISC",
+    "0BSD",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "OpenSSL",
+    "Unicode-3.0",
+    "BSL-1.0",
+    "MPL-2.0",
+    "CDLA-Permissive-2.0",
+    "Zlib",
+    "NCSA",
+    "LGPL-3.0",
+    "LGPL-3.0-only",
+    "CC0-1.0",
+    "Unicode-DFS-2016",
+    "WTFPL"
+]
+
+[[licenses.clarify]]
+
+name = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 }
+]
+
+[bans]
+deny = [
+    # Ensure we don't depend on openssl
+    { name = "native-tls" },
+    { name = "openssl-sys" },
+]


### PR DESCRIPTION
## Summary

* Bumps the Rust `aiconfigurator-core` crate from `0.1.0` to `0.9.0` so it tracks the Python package version (`pyproject.toml`).
* Adds `rust/aiconfigurator-core/deny.toml` with the same license allowlist and bans (`native-tls`, `openssl-sys`) used by the sibling dynamo repo.
* Adds a new `cargo-deny` job to `.github/workflows/build-test.yml`. It runs in parallel with `build-and-test` (no `needs:`), uses `taiki-e/install-action@v2` to fetch a prebuilt `cargo-deny@0.19.0`, and invokes it with the same flags as dynamo: `cargo-deny -L error --all-features check licenses bans`.

A `cargo-deny` failure surfaces as a red check but does not cancel the Python build/test jobs.

Relates to [OPS-6337](https://linear.app/nvidia/issue/OPS-6337/update-the-version-of-aiconfigurator-core-and-set-up-rust-standards).

## Test plan

- [ ] CI: `Cargo Deny` job runs on this PR and passes against the current dep tree (`csv`, `serde`, `serde_json`, `thiserror`, `tempfile`).
- [ ] CI: `Build and Test (unit)` and `Build and Test (e2e)` jobs still run in parallel and remain unaffected.
- [ ] Local: `cd rust/aiconfigurator-core && cargo build` succeeds at v0.9.0 (verified locally).
- [ ] Local: `cargo-deny -L error --all-features check licenses bans` passes locally (requires `cargo install cargo-deny@0.19.0`).

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 0.9.0
  * Enhanced continuous integration pipeline with automated dependency compliance checks

[![Review Change Stack](https://uploads.linear.app/4b55b3e6-cef7-4cb1-9342-85566ca665d9/4bef96e2-9228-40e0-b38b-e33780e6ba4d/602e98e5-95f1-4148-a03b-281235c5df73?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzRiNTViM2U2LWNlZjctNGNiMS05MzQyLTg1NTY2Y2E2NjVkOS80YmVmOTZlMi05MjI4LTQwZTAtYjM4Yi1lMzM3ODBlNmJhNGQvNjAyZTk4ZTUtOTVmMS00MTQ4LWEwM2ItMjgxMjM1YzVkZjczIiwiaWF0IjoxNzc4ODA4MDMwLCJleHAiOjE4MTAzNzg1OTB9.gv0Zdf1PVUPeh9nj9c-Wcaq7iU1Gr9vg78_W0NRsmTk)](<https://app.coderabbit.ai/change-stack/ai-dynamo/aiconfigurator/pull/1082>)