### PR TITLE
fix: handle missing silicon perf data as typed errors

### DIFF
--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -27,6 +27,7 @@ databases_cache = defaultdict(lambda: defaultdict(lambda: defaultdict()))
 logger = logging.getLogger(__name__)
 
 _SYSTEMS_PATHS: list[str] = [os.fspath(pkg_resources.files("aiconfigurator") / "systems")]
+_MISSING_SILICON_DATA_EXCEPTIONS = (KeyError, IndexError)
 
 
 def _normalize_systems_paths(raw_paths: str | Iterable[str] | None) -> list[str]:
@@ -3985,6 +3986,12 @@ class PerfDatabase:
             # get the full traceback via logger.exception.
             if isinstance(e, PerfDataNotAvailableError):
                 logger.warning(exception_msg)
+            elif isinstance(e, _MISSING_SILICON_DATA_EXCEPTIONS):
+                missing_data_error = PerfDataNotAvailableError(
+                    f"{exception_msg} Missing silicon data surfaced as {type(e).__name__}: {e}"
+                )
+                logger.warning(str(missing_data_error))
+                raise missing_data_error from e
             else:
                 logger.exception(exception_msg)
             # Modify the original exception message
@@ -5615,6 +5622,24 @@ class PerfDatabase:
 
             return PerformanceResult(est_latency, energy=est_energy)
 
+        def _require_moe_token_points(
+            moe_dict: dict,
+            query_tokens: int,
+            used_workload_distribution: str,
+        ) -> list[int]:
+            token_points = sorted(moe_dict.keys())
+            if token_points:
+                return token_points
+
+            raise PerfDataNotAvailableError(
+                "No MoE silicon data points for requested shape. "
+                f"system='{self.system}', backend='{self.backend}', version='{self.version}', "
+                f"num_tokens={query_tokens}, hidden_size={hidden_size}, inter_size={inter_size}, "
+                f"topk={topk}, num_experts={num_experts}, moe_tp_size={moe_tp_size}, "
+                f"moe_ep_size={moe_ep_size}, quant_mode={quant_mode}, "
+                f"workload_distribution='{used_workload_distribution}'."
+            )
+
         if database_mode is None:
             database_mode = self._default_database_mode
         if database_mode == common.DatabaseMode.SOL:
@@ -5678,7 +5703,11 @@ class PerfDatabase:
                     moe_dict = moe_data[quant_mode][used_workload_distribution][topk][num_experts][hidden_size][
                         inter_size
                     ][moe_tp_size][moe_ep_size]
-                    token_points = sorted(moe_dict.keys())
+                    token_points = _require_moe_token_points(
+                        moe_dict,
+                        num_tokens_corrected,
+                        used_workload_distribution,
+                    )
                     if num_tokens_corrected > token_points[-1]:
                         return _estimate_overflow_with_last_token_util(
                             num_tokens_corrected,
@@ -5761,7 +5790,7 @@ class PerfDatabase:
                         moe_dict = self._moe_data[quant_mode][used_workload_distribution][topk][num_experts][
                             hidden_size
                         ][inter_size][moe_tp_size][moe_ep_size]
-                    token_points = sorted(moe_dict.keys())
+                    token_points = _require_moe_token_points(moe_dict, num_tokens, used_workload_distribution)
                     if num_tokens > token_points[-1]:
                         return _estimate_overflow_with_last_token_util(
                             num_tokens,
@@ -5800,7 +5829,7 @@ class PerfDatabase:
                     moe_dict = self._moe_data[quant_mode][used_workload_distribution][topk][num_experts][hidden_size][
                         inter_size
                     ][moe_tp_size][moe_ep_size]
-                    token_points = sorted(moe_dict.keys())
+                    token_points = _require_moe_token_points(moe_dict, num_tokens, used_workload_distribution)
                     if num_tokens > token_points[-1]:
                         return _estimate_overflow_with_last_token_util(
                             num_tokens,

--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -3988,7 +3988,7 @@ class PerfDatabase:
                 logger.warning(exception_msg)
             elif isinstance(e, _MISSING_SILICON_DATA_EXCEPTIONS):
                 missing_data_error = PerfDataNotAvailableError(
-                    f"{exception_msg} Missing silicon data surfaced as {type(e).__name__}: {e}"
+                    f"{exception_msg} Missing silicon data for the requested lookup."
                 )
                 logger.warning(str(missing_data_error))
                 raise missing_data_error from e

--- a/tests/unit/sdk/database/test_moe_mla.py
+++ b/tests/unit/sdk/database/test_moe_mla.py
@@ -6,6 +6,7 @@ import math
 import pytest
 
 from aiconfigurator.sdk import common
+from aiconfigurator.sdk.perf_database import PerfDataNotAvailableError
 from aiconfigurator.sdk.performance_result import PerformanceResult
 
 pytestmark = pytest.mark.unit
@@ -239,6 +240,53 @@ class TestMoE:
             max_stored
         ]
         assert math.isclose(float(result), expected, rel_tol=1e-6)
+
+    def test_query_moe_vllm_missing_bucket_raises_structured_error(self, mutable_comprehensive_perf_db):
+        """Missing MoE token buckets must not leak raw IndexError/KeyError in SILICON mode."""
+        db = mutable_comprehensive_perf_db
+        db.backend = common.BackendName.vllm.value
+
+        with pytest.raises(PerfDataNotAvailableError) as exc_info:
+            db.query_moe(
+                22,
+                2048,
+                8192,
+                2,
+                8,
+                1,
+                3,
+                common.MoEQuantMode.bfloat16,
+                "uniform",
+                database_mode=common.DatabaseMode.SILICON,
+            )
+
+        message = str(exc_info.value)
+        assert "No MoE silicon data points" in message
+        assert "Consider using HYBRID mode" in message
+        assert "IndexError" not in message
+        assert "KeyError" not in message
+
+    def test_query_moe_vllm_missing_bucket_hybrid_falls_back(self, mutable_comprehensive_perf_db):
+        """HYBRID mode keeps the existing empirical fallback for missing MoE silicon data."""
+        db = mutable_comprehensive_perf_db
+        db.backend = common.BackendName.vllm.value
+
+        result = db.query_moe(
+            22,
+            2048,
+            8192,
+            2,
+            8,
+            1,
+            3,
+            common.MoEQuantMode.bfloat16,
+            "uniform",
+            database_mode=common.DatabaseMode.HYBRID,
+        )
+
+        assert isinstance(result, PerformanceResult)
+        assert result.source == "empirical"
+        assert float(result) > 0
 
 
 class TestMLABMM:

--- a/tests/unit/sdk/database/test_moe_mla.py
+++ b/tests/unit/sdk/database/test_moe_mla.py
@@ -245,6 +245,7 @@ class TestMoE:
         """Missing MoE token buckets must not leak raw IndexError/KeyError in SILICON mode."""
         db = mutable_comprehensive_perf_db
         db.backend = common.BackendName.vllm.value
+        db._moe_data[common.MoEQuantMode.bfloat16]["uniform"][2][8][2048][8192][1][3] = {}
 
         with pytest.raises(PerfDataNotAvailableError) as exc_info:
             db.query_moe(
@@ -266,10 +267,36 @@ class TestMoE:
         assert "IndexError" not in message
         assert "KeyError" not in message
 
+    def test_query_moe_vllm_missing_dimension_wraps_keyerror(self, mutable_comprehensive_perf_db):
+        """Missing MoE shape dimensions must also be converted to typed missing-data errors."""
+        db = mutable_comprehensive_perf_db
+        db.backend = common.BackendName.vllm.value
+
+        with pytest.raises(PerfDataNotAvailableError) as exc_info:
+            db.query_moe(
+                22,
+                2048,
+                8192,
+                2,
+                8,
+                1,
+                3,
+                common.MoEQuantMode.bfloat16,
+                "uniform",
+                database_mode=common.DatabaseMode.SILICON,
+            )
+
+        message = str(exc_info.value)
+        assert "Missing silicon data for the requested lookup" in message
+        assert "Consider using HYBRID mode" in message
+        assert "KeyError" not in message
+        assert "IndexError" not in message
+
     def test_query_moe_vllm_missing_bucket_hybrid_falls_back(self, mutable_comprehensive_perf_db):
         """HYBRID mode keeps the existing empirical fallback for missing MoE silicon data."""
         db = mutable_comprehensive_perf_db
         db.backend = common.BackendName.vllm.value
+        db._moe_data[common.MoEQuantMode.bfloat16]["uniform"][2][8][2048][8192][1][3] = {}
 
         result = db.query_moe(
             22,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Overview:

Convert missing silicon perf-data lookups into structured `PerfDataNotAvailableError` failures so callers can recover instead of seeing raw language exceptions.

#### Details:

- Wrap raw `KeyError`/`IndexError` from silicon lookups at `_query_silicon_or_hybrid` as `PerfDataNotAvailableError`.
- Add an explicit MoE empty-token-bucket guard before indexing token points.
- Add regression coverage for missing vLLM MoE buckets, missing MoE shape dimensions, and HYBRID fallback behavior.

#### Where should the reviewer start?

- `src/aiconfigurator/sdk/perf_database.py`
- `tests/unit/sdk/database/test_moe_mla.py`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #1081
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://nvidia.slack.com/archives/C096945HE8M/p1778780616280839?thread_ts=1778780616.280839&cid=C096945HE8M)

<div><a href="https://cursor.com/agents/bc-166730a6-9d59-5a87-87fe-0d336f06e77d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-166730a6-9d59-5a87-87fe-0d336f06e77d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when MoE performance data is unavailable, providing clear user-facing error messages
  * Enhanced fallback behavior to empirical results in hybrid mode when MoE lookup data is missing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiconfigurator/pull/1084)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->