### PR TITLE
docs: Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,31 @@ Before making any change under:
 
 MUST read:
 - `aiconfigurator/.claude/rules/generator-development.md`
+
+## Cursor Cloud specific instructions
+
+### Project overview
+`aiconfigurator` is a single Python package (no microservices, no databases). See `README.md` and `DEVELOPMENT.md` for full setup and usage docs.
+
+### Environment activation
+The dev virtualenv lives at `/workspace/.venv`. Activate it before any command:
+```bash
+source /workspace/.venv/bin/activate
+```
+
+### Lint / Test / Build / Run
+- **Lint:** `ruff check .` and `ruff format --check .` (config in `pyproject.toml`)
+- **Unit tests:** `pytest -m unit` (~870 tests, ~45s)
+- **PR-level tests:** `pytest -m "unit or build"` (includes a small e2e subset)
+- **CLI generate (no LFS needed):** `aiconfigurator cli generate --model-path Qwen/Qwen3-32B-FP8 --total-gpus 8 --system h200_sxm`
+- **CLI default (needs LFS data):** `aiconfigurator cli default --model Qwen/Qwen3-32B-FP8 --total-gpus 32 --system h200_sxm`
+
+### Git LFS data
+~553 performance database files under `src/aiconfigurator/systems/data/` are stored via Git LFS. Without `git lfs pull`, the CLI `default`/`exp` modes (SILICON database) and many `build`-marked e2e tests will fail. The `generate` mode and all `unit`-marked tests work without LFS data. In Cloud Agent VMs, the `github-cloud.githubusercontent.com` domain used by LFS may be blocked by egress restrictions.
+
+### Known test-environment quirks
+- 4 tests in `tests/unit/cli/test_plain_output.py` fail because the CI terminal lacks a TTY (color detection). This is not a code bug.
+- `tests/unit/sdk/test_rust_engine_step.py::test_ctypes_wrapper_calls_real_rust_core` requires the Rust toolchain (`cargo`). Skip if Rust is not installed.
+
+### Rust core (optional)
+The Rust native latency estimator at `rust/aiconfigurator-core/` is optional. Build with `cargo build --manifest-path rust/aiconfigurator-core/Cargo.toml` and set `AICONFIGURATOR_RUST_CORE_LIB` to the resulting `.so` path.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Overview:

Add development environment documentation for Cursor Cloud Agent sessions to `AGENTS.md`.

#### Details:

Documents the following for future Cloud Agent sessions:
- Virtual environment location and activation
- Lint, test, build, and run commands (with references to existing docs)
- Git LFS data requirements and known egress restrictions
- Known test-environment quirks (TTY color detection, Rust toolchain)
- Optional Rust core build instructions

#### Where should the reviewer start?

`AGENTS.md` — the new `## Cursor Cloud specific instructions` section.

#### Related Issues:

N/A — development environment setup documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ca5fe39-364c-4b91-a34b-2c9440f6ca80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ca5fe39-364c-4b91-a34b-2c9440f6ca80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated developer guidelines and agent procedures for code modifications and deployment instructions, including environment setup and testing details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiconfigurator/pull/1085)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->