### PR TITLE
fix: keep FP8 FMHA for DeepSeek V3 and Kimi

### DIFF
--- a/src/aiconfigurator/sdk/models/helpers.py
+++ b/src/aiconfigurator/sdk/models/helpers.py
@@ -149,13 +149,6 @@ def _apply_model_quant_defaults(
     if applied:
         logger.debug("Using model-provided quantization defaults: %s", ", ".join(applied))
 
-    # FIXME: temporary workaround for Deepseek V3 fp8 fmha quant mode, only bfloat16+fp8kvcache is supported
-    if (
-        architecture in ("DeepseekV3ForCausalLM", "KimiK25ForConditionalGeneration")
-        and model_config.fmha_quant_mode == common.FMHAQuantMode.fp8
-    ):
-        model_config.fmha_quant_mode = common.FMHAQuantMode.bfloat16
-
     # DSA module (DeepSeek-V3.2 / GLM-5): DSA perf tables only have bfloat16 FMHA currently.
     if (
         architecture in ("DeepseekV32ForCausalLM", "GlmMoeDsaForCausalLM")

--- a/src/aiconfigurator/sdk/task.py
+++ b/src/aiconfigurator/sdk/task.py
@@ -1058,6 +1058,7 @@ class TaskConfig:
         def _validate_worker_config(
             wc: object, *, validate_context: bool, validate_generation: bool, worker_name: str
         ) -> None:
+            explicit_fmha_mode = _get_cfg_value(wc, "fmha_quant_mode") is not None
             _resolve_model_quant_modes(wc, worker_name)
             supported, system_name, backend_version = _load_worker_supported_quant_modes(wc)
             gemm_mode = _to_name(_get_cfg_value(wc, "gemm_quant_mode"))
@@ -1076,6 +1077,24 @@ class TaskConfig:
 
             if validate_context:
                 fmha_mode = _to_name(_get_cfg_value(wc, "fmha_quant_mode"))
+                context_modes = supported.get(context_attn_key, []) or []
+                if (
+                    not explicit_fmha_mode
+                    and model_architecture in ("DeepseekV3ForCausalLM", "KimiK25ForConditionalGeneration")
+                    and fmha_mode == common.FMHAQuantMode.fp8.name
+                    and context_modes
+                    and common.FMHAQuantMode.fp8.name not in context_modes
+                    and common.FMHAQuantMode.bfloat16.name in context_modes
+                ):
+                    wc["fmha_quant_mode"] = common.FMHAQuantMode.bfloat16
+                    fmha_mode = common.FMHAQuantMode.bfloat16.name
+                    logger.info(
+                        "Using bfloat16 FMHA for %s because %s/%s %s data does not support fp8",
+                        worker_name,
+                        system_name,
+                        self.backend_name,
+                        context_attn_key,
+                    )
                 _supported_or_raise(context_attn_key, fmha_mode, supported, system_name, backend_version)
 
             if validate_generation:

--- a/tests/unit/sdk/models/test_model_config.py
+++ b/tests/unit/sdk/models/test_model_config.py
@@ -534,6 +534,43 @@ class TestQuantizationModes:
         assert "bfloat16" in mode_names
         assert "fp8" in mode_names
 
+    @pytest.mark.parametrize(
+        "hf_id,backend_name",
+        [
+            ("deepseek-ai/DeepSeek-V3", "trtllm"),
+            ("deepseek-ai/DeepSeek-V3", "sglang"),
+            ("nvidia/Kimi-K2.5-NVFP4", "trtllm"),
+            ("nvidia/Kimi-K2.5-NVFP4", "sglang"),
+        ],
+    )
+    def test_deepseek_v3_and_kimi_keep_fp8_fmha_for_supported_backends(self, hf_id, backend_name):
+        model_info = get_model_config_from_model_path(hf_id)
+        model_config = config.ModelConfig()
+
+        models._apply_model_quant_defaults(
+            model_config,
+            model_info["raw_config"],
+            model_info["architecture"],
+            backend_name,
+        )
+
+        assert model_config.kvcache_quant_mode == common.KVCacheQuantMode.fp8
+        assert model_config.fmha_quant_mode == common.FMHAQuantMode.fp8
+
+    def test_vllm_still_uses_bfloat16_fmha_tables_for_quantized_models(self):
+        model_info = get_model_config_from_model_path("deepseek-ai/DeepSeek-V3")
+        model_config = config.ModelConfig()
+
+        models._apply_model_quant_defaults(
+            model_config,
+            model_info["raw_config"],
+            model_info["architecture"],
+            "vllm",
+        )
+
+        assert model_config.kvcache_quant_mode == common.KVCacheQuantMode.fp8
+        assert model_config.fmha_quant_mode == common.FMHAQuantMode.bfloat16
+
 
 class TestMOEModelFP8BlockQuantizationValidation:
     """Test MOEModel._validate_fp8_block_quantized_moe_config() method."""

--- a/tests/unit/sdk/task/test_task.py
+++ b/tests/unit/sdk/task/test_task.py
@@ -606,12 +606,47 @@ def test_taskconfig_quant_merge_deepseek_fmha_fallback(monkeypatch):
     monkeypatch.setattr(task_module, "get_database", fake_get_database)
     monkeypatch.setattr(task_module, "get_model_config_from_model_path", fake_model_info)
 
-    TaskConfig(
+    task = TaskConfig(
         serving_mode="agg",
         model_path="deepseek-ai/DeepSeek-V3",
         system_name="h200_sxm",
         backend_name="trtllm",
     )
+
+    assert _enum_name(task.config.worker_config.fmha_quant_mode) == "bfloat16"
+
+
+def test_taskconfig_quant_merge_preserves_explicit_deepseek_fmha(monkeypatch):
+    class FakeDatabase:
+        def __init__(self):
+            self.system_spec = {"gpu": {"sm_version": 90}}
+            self.supported_quant_mode = {
+                "gemm": ["fp8"],
+                "moe": ["fp8"],
+                "context_mla": ["bfloat16"],
+                "generation_mla": ["fp8"],
+            }
+
+    def fake_get_database(system, backend, version, database_mode=None):
+        return FakeDatabase()
+
+    def fake_model_info(_path):
+        return {
+            "raw_config": {"quant_algo": "fp8", "quant_dynamic": True},
+            "architecture": "DeepseekV3ForCausalLM",
+        }
+
+    monkeypatch.setattr(task_module, "get_database", fake_get_database)
+    monkeypatch.setattr(task_module, "get_model_config_from_model_path", fake_model_info)
+
+    with pytest.raises(ValueError, match=r"Unsupported context_mla quant mode 'fp8'"):
+        TaskConfig(
+            serving_mode="agg",
+            model_path="deepseek-ai/DeepSeek-V3",
+            system_name="h200_sxm",
+            backend_name="trtllm",
+            profiles=["fp8"],
+        )
 
 
 def test_taskrunner_runs_agg_and_disagg():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Overview:

Remove the stale DeepSeek V3 / Kimi workaround that globally forced inferred FP8 FMHA back to BF16. The PR keeps FP8 FMHA when the selected backend/system data supports it, while preserving support-matrix compatibility for existing databases that only have BF16 MLA context rows.

#### Details:

- Keep model-level inferred FP8 FMHA for DeepSeek V3-family and Kimi K2.5 on TRT-LLM and SGLang.
- Preserve existing BF16 FMHA fallbacks for vLLM, DSA/GLM, and DeepSeek V4 table coverage.
- Add a TaskConfig support-data fallback for inferred-only FP8 FMHA: if the selected MLA context support data has BF16 but not FP8, use BF16 for that task before support validation.
- Preserve explicit user requests for FP8 FMHA. If a user passes an explicit FP8 profile/config and the selected support data does not support it, validation still raises.
- Add regression tests for DSv3/Kimi FP8 FMHA inference, vLLM behavior, support-aware fallback, and explicit FP8 rejection.

#### Where should the reviewer start?

- `src/aiconfigurator/sdk/models/helpers.py`
- `src/aiconfigurator/sdk/task.py`
- `tests/unit/sdk/models/test_model_config.py`
- `tests/unit/sdk/task/test_task.py`

#### Support-matrix validation:

- CI e2e support-matrix smoke path passed as part of `Build and Test (e2e)`.
- Accuracy regression testing passed with no MAPE regression reported.
- Local targeted regression tests passed: `7 passed`.
- Local high-risk TaskConfig checks confirmed existing TRT-LLM support-matrix paths still resolve to `fmha=bfloat16`, `kvcache=fp8` when context MLA data lacks FP8:
  - `deepseek-ai/DeepSeek-V3` on `h200_sxm/trtllm/1.2.0rc5`
  - `nvidia/DeepSeek-V3.1-NVFP4` on `b200_sxm/trtllm/1.3.0rc10`
- Full support-matrix regeneration was not run locally; the PR checks plus targeted construction/unit checks cover the regression mechanism introduced by this change.

#### Tests:

- `python3 -m pytest tests/unit/sdk/models/test_model_config.py::TestQuantizationModes::test_deepseek_v3_and_kimi_keep_fp8_fmha_for_supported_backends tests/unit/sdk/models/test_model_config.py::TestQuantizationModes::test_vllm_still_uses_bfloat16_fmha_tables_for_quantized_models tests/unit/sdk/task/test_task.py::test_taskconfig_quant_merge_deepseek_fmha_fallback tests/unit/sdk/task/test_task.py::test_taskconfig_quant_merge_preserves_explicit_deepseek_fmha -q`
- CI: `Build and Test (unit)` passed
- CI: `Build and Test (e2e)` passed
- CI: `AIC Accuracy Regression Testing` passed
- CI: `Lint and Format (Ruff)` passed
- CI: `Lint and Format (ESLint)` passed

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to Slack discussion about DeepSeek/Kimi FP8 FMHA quantization defaults
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://nvidia.slack.com/archives/C096945HE8M/p1778786901952149?thread_ts=1778786901.952149&cid=C096945HE8M)

<div><a href="https://cursor.com/agents/bc-842db750-7e56-52cf-b282-94db90a9556f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-842db750-7e56-52cf-b282-94db90a9556f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved quantization mode handling for DeepSeek and related models to ensure compatible configurations.
  * Enhanced validation logic to automatically adjust unsupported quantization settings.

* **Tests**
  * Added unit tests validating quantization defaults for specific model architectures and backends.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiconfigurator/pull/1087)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->