### PR TITLE
chore: bump aiconfigurator-core to 0.9.0 and enable cargo-deny (cherry-pick #1082)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,6 +11,22 @@ on:
       - synchronize
 
 jobs:
+  cargo-deny:
+    name: Cargo Deny
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install and run cargo-deny
+        working-directory: rust/aiconfigurator-core
+        # Default log level (warn) surfaces "license inferred from file" notes
+        # so any crate that may need a [[licenses.clarify]] entry is named.
+        # --show-stats prints a per-license usage summary at the end.
+        run: |
+          cargo-deny --version || cargo install cargo-deny@0.19.0
+          cargo-deny --all-features check --show-stats licenses bans
+
   build-and-test:
     name: Build and Test (${{ matrix.suite.name }})
     runs-on: ubuntu-latest

--- a/rust/aiconfigurator-core/Cargo.lock
+++ b/rust/aiconfigurator-core/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "aiconfigurator-core"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "csv",
  "serde",

--- a/rust/aiconfigurator-core/Cargo.toml
+++ b/rust/aiconfigurator-core/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "aiconfigurator-core"
-version = "0.1.0"
+version = "0.9.0"
 edition = "2021"
 description = "Rust-native core latency estimator for AIConfigurator"
 license = "Apache-2.0"

--- a/rust/aiconfigurator-core/deny.toml
+++ b/rust/aiconfigurator-core/deny.toml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# cargo-deny plugin for linting dependencies
+# https://github.com/EmbarkStudios/cargo-deny/blob/main/deny.template.toml
+
+[licenses]
+confidence-threshold = 0.93
+allow = [
+    "MIT-0",
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "ISC",
+    "0BSD",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "OpenSSL",
+    "Unicode-3.0",
+    "BSL-1.0",
+    "MPL-2.0",
+    "CDLA-Permissive-2.0",
+    "Zlib",
+    "NCSA",
+    "LGPL-3.0",
+    "LGPL-3.0-only",
+    "CC0-1.0",
+    "Unicode-DFS-2016",
+    "WTFPL"
+]
+
+[bans]
+deny = [
+    # Ensure we don't depend on openssl
+    { name = "native-tls" },
+    { name = "openssl-sys" },
+]


### PR DESCRIPTION
## Summary

- Cherry-pick of #1082 (commit cbb16e32) from `main` onto `release/0.9.0`.
- Bumps `aiconfigurator-core` to 0.9.0 and enables `cargo-deny`.

Closes OPS-6337

## Test plan

- [ ] CI passes on `release/0.9.0` base

🤖 Generated with [Claude Code](https://claude.com/claude-code)