### PR TITLE
fix: incorrect param name in webapp

### DIFF
--- a/src/aiconfigurator/webapp/components/profiling/sdk/config.py
+++ b/src/aiconfigurator/webapp/components/profiling/sdk/config.py
@@ -60,7 +60,7 @@ def generate_config_yaml(
         "SlaConfig": {"isl": isl, "osl": osl},
         "ServiceConfig": {
             "model_path": model_path,
-            "served_model_path": model_path,
+            "served_model_name": model_path,
             "include_frontend": True,
         },
         "ModelConfig": {


### PR DESCRIPTION
#### Overview:
Fixes following bug:
```
aiconfigurator webapp --enable-profiling
```
Then when you click "Generate Profiling Job":
```
10:40:10 [aiconfigurator] [orchestrator.py:151] [E] Error generating profiling plots
Traceback (most recent call last):
  File "/home/isherstyuk/trt_repos/aiconfigurator/src/aiconfigurator/webapp/components/profiling/core/orchestrator.py", line 124, in generate_profiling_plots
    prefill_table_data = prepare_prefill_table_data(prefill_results, model_path, system, backend, version, isl, osl)
  File "/home/isherstyuk/trt_repos/aiconfigurator/src/aiconfigurator/webapp/components/profiling/core/data_preparation.py", line 77, in prepare_prefill_table_data
    config_yaml = generate_config_yaml(
  File "/home/isherstyuk/trt_repos/aiconfigurator/src/aiconfigurator/webapp/components/profiling/sdk/config.py", line 102, in generate_config_yaml
    params = generate_config_from_input_dict(input_params, backend=backend)
  File "/home/isherstyuk/trt_repos/aiconfigurator/src/aiconfigurator/generator/aggregators.py", line 223, in generate_config_from_input_dict
    raise ValueError(f"Missing required input: {key}")
ValueError: Missing required input: ServiceConfig.served_model_name
```