### PR TITLE
fix: handle missing MoE and DSA perf data

### DIFF
--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -5553,6 +5553,51 @@ class PerfDatabase:
             scale_factor = 0.4
             return latency / scale_factor
 
+        def _raise_missing_moe_perf(
+            *,
+            source: str,
+            used_workload_distribution: str | None,
+            reason: str,
+            cause: Exception | None = None,
+        ) -> None:
+            distribution = used_workload_distribution or workload_distribution
+            exc = PerfDataNotAvailableError(
+                "MoE perf data not available for requested shape. "
+                f"system='{self.system}', backend='{self.backend}', version='{self.version}', "
+                f"source='{source}', num_tokens={num_tokens}, hidden_size={hidden_size}, "
+                f"inter_size={inter_size}, topk={topk}, num_experts={num_experts}, "
+                f"moe_tp_size={moe_tp_size}, moe_ep_size={moe_ep_size}, "
+                f"quant_mode='{quant_mode.name}', requested_distribution='{workload_distribution}', "
+                f"used_distribution='{distribution}', reason='{reason}'."
+            )
+            if cause is None:
+                raise exc
+            raise exc from cause
+
+        def _lookup_moe_token_table(moe_data: LoadedOpData, *, source: str) -> tuple[str, dict]:
+            used_workload_distribution: str | None = None
+            try:
+                quant_data = moe_data[quant_mode]
+                used_workload_distribution = workload_distribution if workload_distribution in quant_data else "uniform"
+                moe_dict = quant_data[used_workload_distribution][topk][num_experts][hidden_size][inter_size][
+                    moe_tp_size
+                ][moe_ep_size]
+            except KeyError as exc:
+                missing_key = exc.args[0] if exc.args else "<unknown>"
+                _raise_missing_moe_perf(
+                    source=source,
+                    used_workload_distribution=used_workload_distribution,
+                    reason=f"missing key {missing_key!r}",
+                    cause=exc,
+                )
+            if not moe_dict:
+                _raise_missing_moe_perf(
+                    source=source,
+                    used_workload_distribution=used_workload_distribution,
+                    reason="no token points for shape",
+                )
+            return used_workload_distribution, moe_dict
+
         def _estimate_overflow_with_last_token_util(
             query_tokens: int,
             moe_dict: dict,
@@ -5672,12 +5717,10 @@ class PerfDatabase:
 
                     moe_data.raise_if_not_loaded()
 
-                    used_workload_distribution = (
-                        workload_distribution if workload_distribution in moe_data[quant_mode] else "uniform"
+                    used_workload_distribution, moe_dict = _lookup_moe_token_table(
+                        moe_data,
+                        source="sglang_wideep_moe" if moe_backend == "deepep_moe" else "sglang_moe",
                     )
-                    moe_dict = moe_data[quant_mode][used_workload_distribution][topk][num_experts][hidden_size][
-                        inter_size
-                    ][moe_tp_size][moe_ep_size]
                     token_points = sorted(moe_dict.keys())
                     if num_tokens_corrected > token_points[-1]:
                         return _estimate_overflow_with_last_token_util(
@@ -5725,42 +5768,25 @@ class PerfDatabase:
                         and is_gated
                     ):
                         try:
-                            used_workload_distribution = (
-                                workload_distribution
-                                if workload_distribution in self._moe_low_latency_data[quant_mode]
-                                else "uniform"
+                            used_workload_distribution, moe_dict = _lookup_moe_token_table(
+                                self._moe_low_latency_data,
+                                source="trtllm_moe_low_latency",
                             )
-                            moe_dict = self._moe_low_latency_data[quant_mode][used_workload_distribution][topk][
-                                num_experts
-                            ][hidden_size][inter_size][moe_tp_size][moe_ep_size]
-                            if not moe_dict:
-                                # Shape not present in low-latency table (nested defaultdict returned
-                                # an empty dict instead of raising KeyError). Fall back to regular data.
-                                raise KeyError(
-                                    f"No low-latency data for nvfp4 shape "
-                                    f"[{hidden_size}, {inter_size}, {topk}, {num_experts}]"
-                                )
                             logger.debug(
                                 f"Using low-latency kernel for nvfp4 moe "
                                 f"{workload_distribution} {topk} {num_experts} {hidden_size} "
                                 f"{inter_size} {moe_tp_size} {moe_ep_size}."
                             )
-                        except:
-                            used_workload_distribution = (
-                                workload_distribution
-                                if workload_distribution in self._moe_data[quant_mode]
-                                else "uniform"
+                        except PerfDataNotAvailableError:
+                            used_workload_distribution, moe_dict = _lookup_moe_token_table(
+                                self._moe_data,
+                                source="trtllm_moe",
                             )
-                            moe_dict = self._moe_data[quant_mode][used_workload_distribution][topk][num_experts][
-                                hidden_size
-                            ][inter_size][moe_tp_size][moe_ep_size]
                     else:
-                        used_workload_distribution = (
-                            workload_distribution if workload_distribution in self._moe_data[quant_mode] else "uniform"
+                        used_workload_distribution, moe_dict = _lookup_moe_token_table(
+                            self._moe_data,
+                            source="trtllm_moe",
                         )
-                        moe_dict = self._moe_data[quant_mode][used_workload_distribution][topk][num_experts][
-                            hidden_size
-                        ][inter_size][moe_tp_size][moe_ep_size]
                     token_points = sorted(moe_dict.keys())
                     if num_tokens > token_points[-1]:
                         return _estimate_overflow_with_last_token_util(
@@ -5794,12 +5820,10 @@ class PerfDatabase:
                     return PerformanceResult(lat, energy=energy)
                 elif self.backend == common.BackendName.vllm.value:
                     self._moe_data.raise_if_not_loaded()
-                    used_workload_distribution = (
-                        workload_distribution if workload_distribution in self._moe_data[quant_mode] else "uniform"
+                    used_workload_distribution, moe_dict = _lookup_moe_token_table(
+                        self._moe_data,
+                        source="vllm_moe",
                     )
-                    moe_dict = self._moe_data[quant_mode][used_workload_distribution][topk][num_experts][hidden_size][
-                        inter_size
-                    ][moe_tp_size][moe_ep_size]
                     token_points = sorted(moe_dict.keys())
                     if num_tokens > token_points[-1]:
                         return _estimate_overflow_with_last_token_util(
@@ -7046,6 +7070,20 @@ class PerfDatabase:
             emp_latency = get_empirical(b, s, prefix, num_heads, kvcache_quant_mode, fmha_quant_mode)
             return PerformanceResult(emp_latency, energy=0.0)
         else:
+
+            def _raise_missing_context_dsa_perf(reason: str, cause: Exception | None = None) -> None:
+                exc = PerfDataNotAvailableError(
+                    "Context DSA module perf data not available for requested shape. "
+                    f"system='{self.system}', backend='{self.backend}', version='{self.version}', "
+                    f"b={b}, s={s}, prefix={prefix}, num_heads={num_heads}, "
+                    f"index_n_heads={index_n_heads}, index_head_dim={index_head_dim}, index_topk={index_topk}, "
+                    f"kvcache_quant_mode='{kvcache_quant_mode.name}', fmha_quant_mode='{fmha_quant_mode.name}', "
+                    f"gemm_quant_mode='{gemm_quant_mode.name}', architecture='{architecture}', reason='{reason}'."
+                )
+                if cause is None:
+                    raise exc
+                raise exc from cause
+
             try:
                 dsa_module_data = getattr(self, "_context_dsa_module_data", None)
                 if dsa_module_data is None:
@@ -7053,19 +7091,23 @@ class PerfDatabase:
                         f"Context DSA module perf data not loaded for system='{self.system}', "
                         f"backend='{self.backend}', version='{self.version}'."
                     )
-                dsa_dict = dsa_module_data[fmha_quant_mode][kvcache_quant_mode][gemm_quant_mode][architecture]
-                full_s = s + prefix
-                raw_dsa_dict = None
-                raw_dsa_module_data = getattr(self, "_raw_context_dsa_module_data", None)
-                if raw_dsa_module_data is not None and getattr(raw_dsa_module_data, "loaded", True):
-                    raw_dsa_dict = raw_dsa_module_data[fmha_quant_mode][kvcache_quant_mode][gemm_quant_mode][
-                        architecture
-                    ]
-                result = self._interp_dsa_context_topk_piecewise_from_raw(
-                    num_heads, full_s, b, raw_dsa_dict, index_topk
-                )
-                if result is None:
-                    result = self._interp_3d(num_heads, full_s, b, dsa_dict, "cubic")
+                try:
+                    dsa_dict = dsa_module_data[fmha_quant_mode][kvcache_quant_mode][gemm_quant_mode][architecture]
+                    full_s = s + prefix
+                    raw_dsa_dict = None
+                    raw_dsa_module_data = getattr(self, "_raw_context_dsa_module_data", None)
+                    if raw_dsa_module_data is not None and getattr(raw_dsa_module_data, "loaded", True):
+                        raw_dsa_dict = raw_dsa_module_data[fmha_quant_mode][kvcache_quant_mode][gemm_quant_mode][
+                            architecture
+                        ]
+                    result = self._interp_dsa_context_topk_piecewise_from_raw(
+                        num_heads, full_s, b, raw_dsa_dict, index_topk
+                    )
+                    if result is None:
+                        result = self._interp_3d(num_heads, full_s, b, dsa_dict, "cubic")
+                except (AssertionError, KeyError, IndexError, TypeError) as exc:
+                    missing_key = exc.args[0] if isinstance(exc, KeyError) and exc.args else str(exc)
+                    _raise_missing_context_dsa_perf(f"missing key or interpolation point {missing_key!r}", exc)
                 latency = result["latency"]
                 energy = result.get("energy", 0.0)
                 if prefix > 0:
@@ -7075,7 +7117,7 @@ class PerfDatabase:
                     latency *= correction
                     energy *= correction
                 return PerformanceResult(latency, energy=energy)
-            except Exception:
+            except Exception as exc:
                 if database_mode == common.DatabaseMode.HYBRID:
                     logger.debug(
                         f"Failed to query context DSA module for {b=}, {s=}, {prefix=}, {num_heads=}, "
@@ -7084,7 +7126,8 @@ class PerfDatabase:
                     latency = get_empirical(b, s, prefix, num_heads, kvcache_quant_mode, fmha_quant_mode)
                     return PerformanceResult(latency, energy=0.0)
                 else:
-                    logger.exception(
+                    log = logger.warning if isinstance(exc, PerfDataNotAvailableError) else logger.exception
+                    log(
                         f"Failed to query context DSA module for {b=}, {s=}, {prefix=}, {num_heads=}, "
                         f"{index_n_heads=}, {index_head_dim=}, {index_topk=}, "
                         f"{kvcache_quant_mode=}, {fmha_quant_mode=}, {database_mode=}."
@@ -7219,6 +7262,20 @@ class PerfDatabase:
             emp_latency = get_empirical(b, s, num_heads, kv_cache_dtype)
             return PerformanceResult(emp_latency, energy=0.0)
         else:
+
+            def _raise_missing_generation_dsa_perf(reason: str, cause: Exception | None = None) -> None:
+                exc = PerfDataNotAvailableError(
+                    "Generation DSA module perf data not available for requested shape. "
+                    f"system='{self.system}', backend='{self.backend}', version='{self.version}', "
+                    f"b={b}, s={s}, num_heads={num_heads}, index_n_heads={index_n_heads}, "
+                    f"index_head_dim={index_head_dim}, index_topk={index_topk}, "
+                    f"kv_cache_dtype='{kv_cache_dtype.name}', gemm_quant_mode='{gemm_quant_mode.name}', "
+                    f"architecture='{architecture}', reason='{reason}'."
+                )
+                if cause is None:
+                    raise exc
+                raise exc from cause
+
             try:
                 dsa_module_data = getattr(self, "_generation_dsa_module_data", None)
                 if dsa_module_data is None:
@@ -7226,12 +7283,16 @@ class PerfDatabase:
                         f"Generation DSA module perf data not loaded for system='{self.system}', "
                         f"backend='{self.backend}', version='{self.version}'."
                     )
-                dsa_dict = dsa_module_data[kv_cache_dtype][gemm_quant_mode][architecture]
-                result = self._interp_3d(num_heads, b, s, dsa_dict, "cubic")
+                try:
+                    dsa_dict = dsa_module_data[kv_cache_dtype][gemm_quant_mode][architecture]
+                    result = self._interp_3d(num_heads, b, s, dsa_dict, "cubic")
+                except (AssertionError, KeyError, IndexError, TypeError) as exc:
+                    missing_key = exc.args[0] if isinstance(exc, KeyError) and exc.args else str(exc)
+                    _raise_missing_generation_dsa_perf(f"missing key or interpolation point {missing_key!r}", exc)
                 latency = result["latency"]
                 energy = result.get("energy", 0.0)
                 return PerformanceResult(latency, energy=energy)
-            except Exception:
+            except Exception as exc:
                 if database_mode == common.DatabaseMode.HYBRID:
                     logger.debug(
                         f"Failed to query generation DSA module for {b=}, {s=}, {num_heads=}, "
@@ -7240,7 +7301,8 @@ class PerfDatabase:
                     latency = get_empirical(b, s, num_heads, kv_cache_dtype)
                     return PerformanceResult(latency, energy=0.0)
                 else:
-                    logger.exception(
+                    log = logger.warning if isinstance(exc, PerfDataNotAvailableError) else logger.exception
+                    log(
                         f"Failed to query generation DSA module for {b=}, {s=}, {num_heads=}, "
                         f"{index_n_heads=}, {index_head_dim=}, {index_topk=}, "
                         f"{kv_cache_dtype=}, {database_mode=}."

--- a/tests/unit/sdk/database/test_base_queries.py
+++ b/tests/unit/sdk/database/test_base_queries.py
@@ -6,7 +6,7 @@ import math
 import pytest
 
 from aiconfigurator.sdk import common
-from aiconfigurator.sdk.perf_database import LoadedOpData
+from aiconfigurator.sdk.perf_database import LoadedOpData, PerfDataNotAvailableError
 
 # Import PerfDatabase and its dependencies
 
@@ -155,6 +155,89 @@ def test_query_trtllm_alltoall_normalizes_fp8_block_lookup(stub_perf_db):
     )
 
     assert math.isclose(float(result), 3.0)
+
+
+def test_query_moe_empty_token_table_reports_missing_perf(stub_perf_db):
+    """
+    Missing MoE shape leaves should report a structured data gap, not a raw
+    list-index or dictionary-key failure.
+    """
+    stub_perf_db.backend = common.BackendName.sglang.value
+    stub_perf_db._moe_data = LoadedOpData(
+        {
+            common.MoEQuantMode.bfloat16: {
+                "uniform": {
+                    1: {
+                        8: {
+                            2048: {
+                                4096: {
+                                    1: {
+                                        1: {},
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        common.PerfDataFilename.moe,
+        "dummy_moe_perf.txt",
+    )
+
+    with pytest.raises(PerfDataNotAvailableError, match=r"hidden_size=2048.*no token points"):
+        stub_perf_db.query_moe(
+            num_tokens=128,
+            hidden_size=2048,
+            inter_size=4096,
+            topk=1,
+            num_experts=8,
+            moe_tp_size=1,
+            moe_ep_size=1,
+            quant_mode=common.MoEQuantMode.bfloat16,
+            workload_distribution="power_law_1.2",
+            database_mode=common.DatabaseMode.SILICON,
+        )
+
+
+def test_query_moe_missing_shape_key_reports_missing_perf(stub_perf_db):
+    """Missing MoE shape keys should not leak raw KeyError text."""
+    stub_perf_db.backend = common.BackendName.trtllm.value
+    stub_perf_db._moe_data = LoadedOpData(
+        {
+            common.MoEQuantMode.bfloat16: {
+                "uniform": {
+                    1: {
+                        8: {
+                            1024: {
+                                4096: {
+                                    1: {
+                                        1: {128: {"latency": 1.0, "power": 0.0, "energy": 0.0}},
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        common.PerfDataFilename.moe,
+        "dummy_moe_perf.txt",
+    )
+
+    with pytest.raises(PerfDataNotAvailableError, match=r"hidden_size=2048.*missing key 2048"):
+        stub_perf_db.query_moe(
+            num_tokens=128,
+            hidden_size=2048,
+            inter_size=4096,
+            topk=1,
+            num_experts=8,
+            moe_tp_size=1,
+            moe_ep_size=1,
+            quant_mode=common.MoEQuantMode.bfloat16,
+            workload_distribution="power_law_1.2",
+            database_mode=common.DatabaseMode.SILICON,
+        )
 
 
 def test_query_custom_allreduce_database_mode_calculation(stub_perf_db):

--- a/tests/unit/sdk/database/test_dsa_module.py
+++ b/tests/unit/sdk/database/test_dsa_module.py
@@ -6,7 +6,7 @@ import math
 import pytest
 
 from aiconfigurator.sdk import common
-from aiconfigurator.sdk.perf_database import DEFAULT_DSA_ARCHITECTURE, LoadedOpData
+from aiconfigurator.sdk.perf_database import DEFAULT_DSA_ARCHITECTURE, LoadedOpData, PerfDataNotAvailableError
 
 pytestmark = pytest.mark.unit
 
@@ -236,6 +236,29 @@ class TestContextDSAModule:
         )
         assert float(result) > 0
 
+    def test_missing_architecture_reports_missing_perf(self, stub_perf_db):
+        stub_perf_db._context_dsa_module_data = LoadedOpData(
+            _context_dsa_data({32: {1024: {1: _dsa_value(1.0)}}}),
+            common.PerfDataFilename.dsa_context_module,
+            "dummy_context_dsa_module_perf.txt",
+        )
+
+        with pytest.raises(
+            PerfDataNotAvailableError,
+            match=r"Context DSA module perf data not available.*architecture='unprofiled_arch'",
+        ):
+            stub_perf_db.query_context_dsa_module(
+                b=1,
+                s=1024,
+                prefix=0,
+                num_heads=32,
+                kvcache_quant_mode=common.KVCacheQuantMode.bfloat16,
+                fmha_quant_mode=common.FMHAQuantMode.bfloat16,
+                gemm_quant_mode=common.GEMMQuantMode.bfloat16,
+                architecture="unprofiled_arch",
+                database_mode=common.DatabaseMode.SILICON,
+            )
+
     def test_different_index_params_change_sol(self, comprehensive_perf_db):
         """Different index_topk should yield different SOL estimates."""
         r1 = comprehensive_perf_db.query_context_dsa_module(
@@ -356,3 +379,30 @@ class TestGenerationDSAModule:
             database_mode=common.DatabaseMode.HYBRID,
         )
         assert float(result) > 0
+
+    def test_missing_architecture_reports_missing_perf(self, stub_perf_db):
+        stub_perf_db._generation_dsa_module_data = LoadedOpData(
+            {
+                common.KVCacheQuantMode.bfloat16: {
+                    common.GEMMQuantMode.bfloat16: {
+                        DEFAULT_DSA_ARCHITECTURE: {32: {1: {1024: _dsa_value(1.0)}}},
+                    },
+                },
+            },
+            common.PerfDataFilename.dsa_generation_module,
+            "dummy_generation_dsa_module_perf.txt",
+        )
+
+        with pytest.raises(
+            PerfDataNotAvailableError,
+            match=r"Generation DSA module perf data not available.*architecture='unprofiled_arch'",
+        ):
+            stub_perf_db.query_generation_dsa_module(
+                b=1,
+                s=1024,
+                num_heads=32,
+                kv_cache_dtype=common.KVCacheQuantMode.bfloat16,
+                gemm_quant_mode=common.GEMMQuantMode.bfloat16,
+                architecture="unprofiled_arch",
+                database_mode=common.DatabaseMode.SILICON,
+            )


### PR DESCRIPTION
Automated AIC support matrix healing for `rtx_pro_6000_server`.

- Healing job: `heal-41e4b8de83df`
- Phase: `finalization`
- Target branch: `main`

Summary:
- CPU-only fixes recovered the four deterministic cells that could be healed locally.
- Final healer matrix: `282` rows, `114 PASS`, `0 FAIL`, `168 UNHEALABLE`.
- The remaining `46` failures were finalized as `UNHEALABLE` with per-cell evidence in `support_matrices/rtx_pro_6000_server.csv` and final evidence at `healing_runs/evidence/heal-41e4b8de83df__rtx_pro_6000_server__finalization.json`.
- Remaining unhealable categories: `20` missing/empty MoE perf, `12` missing DSA context module perf, `8` missing NCCL perf, `6` no valid parallel configuration.
- Single-node GPU recollection was blocked by no usable local/Brev/collector RTX PRO 6000 Server node.
- Two-node recollection was attempted through auto-collector pipeline `51431082` / child `51431114`, but all framework jobs failed before collection because Slurm rejected `rtxpro6000_ci --gres=gpu:2`.

Verification:
- `uv run --with pytest pytest tests/unit/sdk/database/test_database_helpers.py` -> `19 passed`
- Healer repo: `uv run --with pytest pytest tests/test_support_matrix_csv.py` -> `4 passed`
- Path-scoped diff check passed for the finalized RTX matrix, job JSON, and finalization evidence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when performance profiling data is missing or unavailable, providing clearer diagnostics and additional context to help troubleshoot issues.
  * Enhanced error handling to better distinguish scenarios where data is missing from other unexpected failures.

* **Tests**
  * Added new unit tests validating proper error handling for unavailable performance data and unsupported configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiconfigurator/pull/1098)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->