### PR TITLE
fix: handle missing DSA module data as unavailable perf data

### DIFF
--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -7124,6 +7124,16 @@ class PerfDatabase:
             emp_latency = get_empirical(b, s, prefix, num_heads, kvcache_quant_mode, fmha_quant_mode)
             return PerformanceResult(emp_latency, energy=0.0)
         else:
+
+            def missing_context_dsa_error() -> PerfDataNotAvailableError:
+                return PerfDataNotAvailableError(
+                    f"Context DSA module data not available for system='{self.system}', "
+                    f"backend='{self.backend}', version='{self.version}', architecture='{architecture}', "
+                    f"fmha_quant_mode={fmha_quant_mode}, kvcache_quant_mode={kvcache_quant_mode}, "
+                    f"gemm_quant_mode={gemm_quant_mode}, num_heads={num_heads}, s={s}, prefix={prefix}, b={b}. "
+                    "Missing silicon data for the requested lookup."
+                )
+
             try:
                 dsa_module_data = getattr(self, "_context_dsa_module_data", None)
                 if dsa_module_data is None:
@@ -7131,21 +7141,30 @@ class PerfDatabase:
                         f"Context DSA module perf data not loaded for system='{self.system}', "
                         f"backend='{self.backend}', version='{self.version}'."
                     )
-                dsa_dict = dsa_module_data[fmha_quant_mode][kvcache_quant_mode][gemm_quant_mode][architecture]
+                try:
+                    dsa_dict = dsa_module_data[fmha_quant_mode][kvcache_quant_mode][gemm_quant_mode][architecture]
+                except (KeyError, TypeError) as exc:
+                    raise missing_context_dsa_error() from exc
                 full_s = s + prefix
                 raw_dsa_dict = None
                 raw_dsa_module_data = getattr(self, "_raw_context_dsa_module_data", None)
                 if raw_dsa_module_data is not None and getattr(raw_dsa_module_data, "loaded", True):
-                    raw_dsa_dict = raw_dsa_module_data[fmha_quant_mode][kvcache_quant_mode][gemm_quant_mode][
-                        architecture
-                    ]
-                result = self._interp_dsa_context_topk_piecewise_from_raw(
-                    num_heads, full_s, b, raw_dsa_dict, index_topk
-                )
-                if result is None:
-                    result = self._interp_3d(num_heads, full_s, b, dsa_dict, "cubic")
-                latency = result["latency"]
-                energy = result.get("energy", 0.0)
+                    try:
+                        raw_dsa_dict = raw_dsa_module_data[fmha_quant_mode][kvcache_quant_mode][gemm_quant_mode][
+                            architecture
+                        ]
+                    except (KeyError, TypeError):
+                        raw_dsa_dict = None
+                try:
+                    result = self._interp_dsa_context_topk_piecewise_from_raw(
+                        num_heads, full_s, b, raw_dsa_dict, index_topk
+                    )
+                    if result is None:
+                        result = self._interp_3d(num_heads, full_s, b, dsa_dict, "cubic")
+                    latency = result["latency"]
+                    energy = result.get("energy", 0.0)
+                except (KeyError, TypeError, ValueError, AssertionError) as exc:
+                    raise missing_context_dsa_error() from exc
                 if prefix > 0:
                     base_sol = get_sol(b, full_s, 0, num_heads, kvcache_quant_mode, fmha_quant_mode)[0]
                     target_sol = get_sol(b, s, prefix, num_heads, kvcache_quant_mode, fmha_quant_mode)[0]
@@ -7297,6 +7316,16 @@ class PerfDatabase:
             emp_latency = get_empirical(b, s, num_heads, kv_cache_dtype)
             return PerformanceResult(emp_latency, energy=0.0)
         else:
+
+            def missing_generation_dsa_error() -> PerfDataNotAvailableError:
+                return PerfDataNotAvailableError(
+                    f"Generation DSA module data not available for system='{self.system}', "
+                    f"backend='{self.backend}', version='{self.version}', architecture='{architecture}', "
+                    f"kv_cache_dtype={kv_cache_dtype}, gemm_quant_mode={gemm_quant_mode}, "
+                    f"num_heads={num_heads}, s={s}, b={b}. "
+                    "Missing silicon data for the requested lookup."
+                )
+
             try:
                 dsa_module_data = getattr(self, "_generation_dsa_module_data", None)
                 if dsa_module_data is None:
@@ -7304,10 +7333,13 @@ class PerfDatabase:
                         f"Generation DSA module perf data not loaded for system='{self.system}', "
                         f"backend='{self.backend}', version='{self.version}'."
                     )
-                dsa_dict = dsa_module_data[kv_cache_dtype][gemm_quant_mode][architecture]
-                result = self._interp_3d(num_heads, b, s, dsa_dict, "cubic")
-                latency = result["latency"]
-                energy = result.get("energy", 0.0)
+                try:
+                    dsa_dict = dsa_module_data[kv_cache_dtype][gemm_quant_mode][architecture]
+                    result = self._interp_3d(num_heads, b, s, dsa_dict, "cubic")
+                    latency = result["latency"]
+                    energy = result.get("energy", 0.0)
+                except (KeyError, TypeError, ValueError, AssertionError) as exc:
+                    raise missing_generation_dsa_error() from exc
                 return PerformanceResult(latency, energy=energy)
             except Exception:
                 if database_mode == common.DatabaseMode.HYBRID:

--- a/tests/unit/sdk/database/test_dsa_module.py
+++ b/tests/unit/sdk/database/test_dsa_module.py
@@ -6,7 +6,7 @@ import math
 import pytest
 
 from aiconfigurator.sdk import common
-from aiconfigurator.sdk.perf_database import DEFAULT_DSA_ARCHITECTURE, LoadedOpData
+from aiconfigurator.sdk.perf_database import DEFAULT_DSA_ARCHITECTURE, LoadedOpData, PerfDataNotAvailableError
 
 pytestmark = pytest.mark.unit
 
@@ -27,6 +27,16 @@ def _context_dsa_data(dsa_dict: dict) -> dict:
     }
 
 
+def _generation_dsa_data(dsa_dict: dict) -> dict:
+    return {
+        common.KVCacheQuantMode.bfloat16: {
+            common.GEMMQuantMode.bfloat16: {
+                DEFAULT_DSA_ARCHITECTURE: dsa_dict,
+            },
+        },
+    }
+
+
 # ═══════════════════════════════════════════════════════════════════════
 # Context DSA Module
 # ═══════════════════════════════════════════════════════════════════════
@@ -34,6 +44,25 @@ def _context_dsa_data(dsa_dict: dict) -> dict:
 
 class TestContextDSAModule:
     """Tests for query_context_dsa_module."""
+
+    def test_missing_architecture_raises_perf_data_not_available(self, stub_perf_db):
+        dsa_dict = {32: {256: {1: _dsa_value(10.0)}}}
+        stub_perf_db._context_dsa_module_data = LoadedOpData(
+            _context_dsa_data(dsa_dict), common.PerfDataFilename.dsa_context_module, "extrapolated"
+        )
+
+        with pytest.raises(PerfDataNotAvailableError, match="Context DSA module data not available"):
+            stub_perf_db.query_context_dsa_module(
+                b=1,
+                s=256,
+                prefix=0,
+                num_heads=32,
+                kvcache_quant_mode=common.KVCacheQuantMode.bfloat16,
+                fmha_quant_mode=common.FMHAQuantMode.bfloat16,
+                gemm_quant_mode=common.GEMMQuantMode.bfloat16,
+                database_mode=common.DatabaseMode.SILICON,
+                architecture="GlmMoeDsaForCausalLM",
+            )
 
     def test_topk_piecewise_from_raw_handles_both_boundary_sides(self, stub_perf_db):
         raw_dsa_dict = {
@@ -270,6 +299,23 @@ class TestContextDSAModule:
 
 class TestGenerationDSAModule:
     """Tests for query_generation_dsa_module."""
+
+    def test_missing_architecture_raises_perf_data_not_available(self, stub_perf_db):
+        dsa_dict = {32: {1: {256: _dsa_value(10.0)}}}
+        stub_perf_db._generation_dsa_module_data = LoadedOpData(
+            _generation_dsa_data(dsa_dict), common.PerfDataFilename.dsa_generation_module, "extrapolated"
+        )
+
+        with pytest.raises(PerfDataNotAvailableError, match="Generation DSA module data not available"):
+            stub_perf_db.query_generation_dsa_module(
+                b=1,
+                s=256,
+                num_heads=32,
+                kv_cache_dtype=common.KVCacheQuantMode.bfloat16,
+                gemm_quant_mode=common.GEMMQuantMode.bfloat16,
+                database_mode=common.DatabaseMode.SILICON,
+                architecture="GlmMoeDsaForCausalLM",
+            )
 
     def test_sol_returns_positive(self, comprehensive_perf_db):
         result = comprehensive_perf_db.query_generation_dsa_module(


### PR DESCRIPTION
Automated AIC support matrix CPU-heal follow-up for `b300_sxm` from healing job `heal-010daa4732d6`.

This PR does **not** claim a verified support-matrix coverage increase yet. The CPU-only pass found a real AIC robustness issue: some DSA module lookups can miss silicon data for a requested architecture or lookup point and currently fall through lower-level errors. This change converts those cases into typed `PerfDataNotAvailableError`s with enough context for support-matrix generation to classify the cell cleanly instead of treating it as an unexpected failure.

Changes:
- Guard context DSA module architecture/raw-data/interpolation lookups and raise typed missing-perf-data errors.
- Guard generation DSA module lookups the same way.
- Add unit coverage for missing DSA architecture cases.

Verification:
- GitHub CI before the title/signoff update: unit, e2e, accuracy, Ruff, ESLint, cargo-deny, and copyright checks passed.
- Local targeted check: `uv run --with pytest pytest tests/unit/sdk/database/test_dsa_module.py tests/unit/sdk/test_utils.py -q` passed before narrowing this PR wording.

Remaining support-matrix work:
- `b300_sxm` coverage in the recorded healer run stayed at 248 passed / 66 failed / 62 unhealable, so GPU-backed collection/healing is still needed for actual coverage movement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * DSA module queries now provide structured error messages when data is unavailable, including detailed lookup context.
  * Improved error reporting for missing architecture data in context and generation modules.

* **Tests**
  * Added test coverage for missing architecture scenarios in DSA module queries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiconfigurator/pull/1104)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->