### PR TITLE
fix: incorrect param name in webapp (cherry-pick to release/0.9.0)

### DIFF
--- a/src/aiconfigurator/webapp/components/profiling/sdk/config.py
+++ b/src/aiconfigurator/webapp/components/profiling/sdk/config.py
@@ -60,7 +60,7 @@ def generate_config_yaml(
         "SlaConfig": {"isl": isl, "osl": osl},
         "ServiceConfig": {
             "model_path": model_path,
-            "served_model_path": model_path,
+            "served_model_name": model_path,
             "include_frontend": True,
         },
         "ModelConfig": {


### PR DESCRIPTION
Cherry-pick https://github.com/ai-dynamo/aiconfigurator/pull/1097 to release branch