### PR TITLE
fix: kimik2.5 default quant config in webapp

### DIFF
--- a/src/aiconfigurator/webapp/events/event_fn.py
+++ b/src/aiconfigurator/webapp/events/event_fn.py
@@ -16,6 +16,7 @@ from aiconfigurator.sdk import common, config, models, pareto_analysis
 from aiconfigurator.sdk.backends.factory import get_backend
 from aiconfigurator.sdk.inference_session import InferenceSession
 from aiconfigurator.sdk.models import check_is_moe, get_model, get_model_family
+from aiconfigurator.sdk.models.helpers import _get_model_info, _infer_quant_modes_from_raw_config
 from aiconfigurator.sdk.perf_database import get_database, get_supported_databases
 from aiconfigurator.sdk.utils import enumerate_parallel_config
 
@@ -1186,18 +1187,21 @@ class EventFn:
         supported_quant_mode = database.supported_quant_mode
 
         model_family = get_model_family(model_path)
-        if model_family not in ("DEEPSEEK", "DEEPSEEKV32", "DEEPSEEKV4"):
+        is_deepseek_fam = model_family in ("DEEPSEEK", "KIMIK25")
+        is_deepseek_v32 = model_family == "DEEPSEEKV32"
+        is_deepseek_v4 = model_family == "DEEPSEEKV4"
+        if not (is_deepseek_fam or is_deepseek_v32 or is_deepseek_v4):
             gemm_quant_mode_choices = sorted(supported_quant_mode["gemm"])
             kvcache_quant_mode_choices = sorted(supported_quant_mode["generation_attention"])
             fmha_quant_mode_choices = sorted(supported_quant_mode["context_attention"])
             moe_quant_mode_choices = sorted(supported_quant_mode["moe"])
         else:
-            if model_family == "DEEPSEEKV4":
+            if is_deepseek_v4:
                 gemm_quant_mode_choices = sorted(supported_quant_mode["gemm"])
                 kvcache_quant_mode_choices = sorted(supported_quant_mode["deepseek_v4_generation_module"])
                 fmha_quant_mode_choices = sorted(supported_quant_mode["deepseek_v4_context_module"])
                 moe_quant_mode_choices = sorted(supported_quant_mode["moe"])
-            elif model_family == "DEEPSEEKV32":
+            elif is_deepseek_v32:
                 gemm_quant_mode_choices = sorted(supported_quant_mode["gemm"])
                 kvcache_quant_mode_choices = sorted(supported_quant_mode["dsa_generation_module"])
                 fmha_quant_mode_choices = sorted(supported_quant_mode["dsa_context_module"])
@@ -1234,26 +1238,42 @@ class EventFn:
             moe_quant_mode_choices if len(moe_quant_mode_choices) > 0 else [common.MoEQuantMode.bfloat16.name]
         )
 
-        default_gemm_quant_mode = gemm_quant_mode_choices[0]
+        # Infer model-native quant modes from config.json so the UI defaults
+        # match what the CLI would use (e.g. FP8 for NVFP4 checkpoints).
+        try:
+            model_info = _get_model_info(model_path)
+            raw_config = model_info.get("raw_config", {})
+            architecture = model_info.get("architecture")
+            inferred = _infer_quant_modes_from_raw_config(raw_config, architecture)
+        except Exception:
+            inferred = {}
+
+        def _pick_default(choices, inferred_value):
+            if inferred_value is not None:
+                name = inferred_value.name if hasattr(inferred_value, "name") else str(inferred_value)
+                if name in choices:
+                    return name
+            return choices[0]
+
         return (
             gr.update(
                 choices=gemm_quant_mode_choices,
-                value=default_gemm_quant_mode,
+                value=_pick_default(gemm_quant_mode_choices, inferred.get("gemm_quant_mode")),
                 interactive=True,
             ),
             gr.update(
                 choices=kvcache_quant_mode_choices,
-                value=kvcache_quant_mode_choices[0],
+                value=_pick_default(kvcache_quant_mode_choices, inferred.get("kvcache_quant_mode")),
                 interactive=True,
             ),
             gr.update(
                 choices=fmha_quant_mode_choices,
-                value=fmha_quant_mode_choices[0],
+                value=_pick_default(fmha_quant_mode_choices, inferred.get("fmha_quant_mode")),
                 interactive=True,
             ),
             gr.update(
                 choices=moe_quant_mode_choices,
-                value=moe_quant_mode_choices[0],
+                value=_pick_default(moe_quant_mode_choices, inferred.get("moe_quant_mode")),
                 interactive=True,
             ),
         )
@@ -1304,7 +1324,7 @@ class EventFn:
     def update_model_related_components(model_path):
         # nextn, accept_rate, moe_quant_mode, moe_tp_size, moe_ep_size, dp_size, wideep
         model_family = models.get_model_family(model_path)
-        if model_family in ("DEEPSEEK", "DEEPSEEKV32", "DEEPSEEKV4", "MOE", "QWEN35"):
+        if check_is_moe(model_path):
             return (
                 gr.update(value=0, visible=True),
                 gr.update(visible=True),


### PR DESCRIPTION
#### Overview:

Fixes 2 bugs with Agg/IFB tab in webapp with Kimi K2.5 model

- moe configurations didn't show up, even though Kimi K2.5 uses MoE
- used default bf16 quantization for all layers, even though Kimi K2.5 has int4 moe weights. This caused AIC to overestimate memory usage and say the model would not fit on 8xB200


Screenshots of fixes:
<img width="1353" height="931" alt="Screenshot 2026-05-15 at 3 04 32 PM" src="https://github.com/user-attachments/assets/06a6d036-7383-413c-b4c7-26fe33feeb7c" />
<img width="1421" height="949" alt="Screenshot 2026-05-15 at 3 04 48 PM" src="https://github.com/user-attachments/assets/f65ba8d5-f375-4ab0-917c-a0e05d7d621d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Quantization mode defaults now intelligently selected based on model metadata rather than hardcoded values.

* **Bug Fixes**
  * Improved handling of DeepSeek model variants in quantization mode selection logic.
  * Enhanced visibility controls for advanced model-specific UI options based on model type detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiconfigurator/pull/1108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->