### PR TITLE
[codex] Add targeted collector selection

### DIFF
--- a/collector/README.md
+++ b/collector/README.md
@@ -171,6 +171,31 @@ python3 collect.py --backend sglang --smoke
 python3 collect.py --backend trtllm --ops moe --smoke
 ```
 
+## Targeted Support-Matrix Healing
+
+Use `--target-spec` when a support-matrix heal only needs a few missing data points instead of a smoke sample or the full generated collector space. The spec keeps desired data points and GPU-specific exceptions in separate sections:
+
+```bash
+python3 collect.py \
+  --backend sglang \
+  --ops gdn \
+  --target-spec targeted_collection.example.json \
+  --target-gpu b200_sxm \
+  --target-model Qwen/Qwen3.5-27B
+```
+
+`data_points` entries are allowlist selectors. `gpu_exceptions` entries remove matching cases after the allowlist is applied. Selectors support:
+- `backend` / `framework`: `sglang`, `trtllm`, or `vllm`
+- `op` / `operation`: registry op name such as `gdn`, `moe`, or `mhc_module`
+- `models` / `model`: model metadata used with `--target-model`
+- `gpus` / `gpu`: GPU keys such as `b200_sxm`
+- `match`: exact generated-case fields. For list-shaped cases, use string indexes like `"0"` or `"9"`; for dataclass/dict cases, use field names.
+- `contains`: values that must appear somewhere in the generated case
+- `case_ids` / `task_ids`: exact task IDs, using the same stable ID format as resume checkpoints
+- `id_contains`: substrings that must appear in the stable task ID
+
+When a target spec has `data_points`, only selected entries run. When it has no `data_points`, all generated cases remain eligible and only `gpu_exceptions` are applied. `--target-mode full` is available for callers that want to aggregate all data points in the spec while still applying GPU exceptions.
+
 ## Power Monitoring (Optional)
 
 The collector supports GPU power monitoring during kernel execution using NVML. This feature is optional and disabled by default.

--- a/collector/collect.py
+++ b/collector/collect.py
@@ -759,6 +759,10 @@ def collect_ops(
     shuffle_seed: int = 42,
     backend: str = "unknown",
     resume_options: dict | None = None,
+    target_spec=None,
+    target_gpu: str | None = None,
+    target_models: list[str] | None = None,
+    target_mode: str = "targeted",
 ) -> list[dict]:
     """Run collection for a list of resolved collection entries.
 
@@ -781,6 +785,22 @@ def collect_ops(
 
     for collection in collections:
         try:
+            if target_spec is not None:
+                from collector.targeted_collection import TargetContext
+
+                context = TargetContext(
+                    backend=backend,
+                    op=collection["type"],
+                    target_gpu=target_gpu,
+                    target_models=tuple(target_models or ()),
+                    mode=target_mode,
+                )
+                if not target_spec.collection_selected(context):
+                    logger.info(
+                        f"Target spec skipped {collection['name']}.{collection['type']}: no selected data points"
+                    )
+                    continue
+
             module_name = collection["module"]
             get_module = __import__(module_name, fromlist=[collection["get_func"]])
             run_module = __import__(module_name, fromlist=[collection["run_func"]])
@@ -807,10 +827,35 @@ def collect_ops(
 
             get_func = getattr(get_module, collection["get_func"])
             run_func = getattr(run_module, collection["run_func"])
+            run_func_name = getattr(run_func, "__name__", None) or getattr(run_func, "func", run_func).__name__
             run_func = functools.partial(run_func, perf_filename=collection["perf_filename"])
 
-            def get_func_with_limit(get_func=get_func):
+            def get_func_with_limit(get_func=get_func, collection=collection, run_func_name=run_func_name):
                 cases = get_func()
+                if target_spec is not None:
+                    from collector.targeted_collection import TargetContext
+
+                    context = TargetContext(
+                        backend=backend,
+                        op=collection["type"],
+                        target_gpu=target_gpu,
+                        target_models=tuple(target_models or ()),
+                        mode=target_mode,
+                    )
+                    full_name = f"{collection['name']}.{collection['type']}"
+                    result = target_spec.filter_cases(
+                        cases,
+                        context,
+                        task_id_factory=lambda case: create_test_case_id(case, run_func_name, full_name),
+                    )
+                    logger.info(
+                        "Target spec filtered "
+                        f"{full_name}: {result.original_count} generated, "
+                        f"{result.selected_count} selected, "
+                        f"{result.skipped_by_exception} GPU exceptions, "
+                        f"{len(result.cases)} runnable"
+                    )
+                    cases = result.cases
                 if shuffle:
                     rng = random.Random(shuffle_seed)
                     rng.shuffle(cases)
@@ -849,6 +894,10 @@ def collect_sglang(
     limit: int | None = None,
     shuffle: bool = False,
     resume_options: dict | None = None,
+    target_spec=None,
+    target_gpu: str | None = None,
+    target_models: list[str] | None = None,
+    target_mode: str = "targeted",
 ):
     """Collect performance data for SGLang with enhanced error tracking"""
     from collector.sglang.registry import REGISTRY
@@ -874,6 +923,10 @@ def collect_sglang(
         shuffle=shuffle,
         backend="sglang",
         resume_options=resume_options,
+        target_spec=target_spec,
+        target_gpu=target_gpu,
+        target_models=target_models,
+        target_mode=target_mode,
     )
 
     generate_collection_summary(all_errors, "sglang", version)
@@ -885,6 +938,10 @@ def collect_vllm(
     limit: int | None = None,
     shuffle: bool = False,
     resume_options: dict | None = None,
+    target_spec=None,
+    target_gpu: str | None = None,
+    target_models: list[str] | None = None,
+    target_mode: str = "targeted",
 ):
     """Collect performance data for vLLM"""
     from collector.version_resolver import build_collections
@@ -906,7 +963,17 @@ def collect_vllm(
 
     collections = build_collections(REGISTRY, "vllm", version, ops, logger=logger)
     all_errors = collect_ops(
-        num_processes, collections, version, limit=limit, shuffle=shuffle, backend="vllm", resume_options=resume_options
+        num_processes,
+        collections,
+        version,
+        limit=limit,
+        shuffle=shuffle,
+        backend="vllm",
+        resume_options=resume_options,
+        target_spec=target_spec,
+        target_gpu=target_gpu,
+        target_models=target_models,
+        target_mode=target_mode,
     )
 
     generate_collection_summary(all_errors, "vllm", version)
@@ -918,6 +985,10 @@ def collect_trtllm(
     limit: int | None = None,
     shuffle: bool = False,
     resume_options: dict | None = None,
+    target_spec=None,
+    target_gpu: str | None = None,
+    target_models: list[str] | None = None,
+    target_mode: str = "targeted",
 ):
     """Collect performance data for TensorRT LLM with enhanced error tracking"""
     from collector.trtllm.registry import REGISTRY
@@ -949,6 +1020,10 @@ def collect_trtllm(
         shuffle=shuffle,
         backend="trtllm",
         resume_options=resume_options,
+        target_spec=target_spec,
+        target_gpu=target_gpu,
+        target_models=target_models,
+        target_mode=target_mode,
     )
 
     generate_collection_summary(all_errors, "trtllm", version)
@@ -1082,6 +1157,32 @@ def main():
         "Default: collect all models.",
     )
     parser.add_argument(
+        "--target-spec",
+        type=str,
+        default=None,
+        help="JSON/YAML file with data_points and gpu_exceptions for targeted support-matrix healing.",
+    )
+    parser.add_argument(
+        "--target-gpu",
+        type=str,
+        default=None,
+        help="GPU key for targeted collection and GPU exception matching (e.g. b200_sxm).",
+    )
+    parser.add_argument(
+        "--target-model",
+        action="append",
+        default=None,
+        help="Model key for targeted collection. Can be repeated. A single target model also activates "
+        "the existing model-path generator filter.",
+    )
+    parser.add_argument(
+        "--target-mode",
+        choices=["targeted", "full"],
+        default="targeted",
+        help="With --target-spec, 'targeted' runs selected data points; 'full' aggregates all spec data points. "
+        "Both modes apply matching GPU exceptions.",
+    )
+    parser.add_argument(
         "--profile",
         action="store_true",
         help="Profile the collector run and save output ",
@@ -1089,16 +1190,37 @@ def main():
     args = parser.parse_args()
     ops = args.ops
     _dsv4_auto_expand = False
+    target_spec = None
 
+    if args.target_spec:
+        from collector.targeted_collection import load_target_collection_spec
+
+        try:
+            target_spec = load_target_collection_spec(args.target_spec)
+        except (TypeError, ValueError) as e:
+            parser.error(str(e))
+
+    target_models = list(args.target_model or [])
     if args.model_path:
+        if target_models and any(model != args.model_path for model in target_models):
+            parser.error("--model-path and --target-model must refer to the same model when both are provided")
+        if args.model_path not in target_models:
+            target_models.append(args.model_path)
+
+    if target_models:
         from collector.common_test_cases import get_all_model_names
 
         all_models = get_all_model_names()
-        if args.model_path not in all_models:
+        unknown_models = [model for model in target_models if model not in all_models]
+        if unknown_models:
             parser.error(
-                f"Model '{args.model_path}' not found. Available models:\n" + "\n".join(f"  - {m}" for m in all_models)
+                f"Unknown target model(s): {', '.join(unknown_models)}. Available models:\n"
+                + "\n".join(f"  - {m}" for m in all_models)
             )
-        os.environ["COLLECTOR_MODEL_PATH"] = args.model_path
+        if len(target_models) == 1:
+            os.environ["COLLECTOR_MODEL_PATH"] = target_models[0]
+        else:
+            os.environ.pop("COLLECTOR_MODEL_PATH", None)
 
         # V4-Flash special-case: when the model is V4-Flash and no explicit
         # ``--ops`` is given, scope to the ops consumed by the V4-Flash
@@ -1106,7 +1228,7 @@ def main():
         # MoE, and mHC.  All other models keep the default behaviour: run
         # every op and let each get_func's ``_filter_model_config_list``
         # filter cases at the test-case level.
-        if args.ops is None and args.model_path == "sgl-project/DeepSeek-V4-Flash-FP8":
+        if args.ops is None and len(target_models) == 1 and target_models[0] == "sgl-project/DeepSeek-V4-Flash-FP8":
             dsv4_flash_ops = [name for name in _all_op_names() if name.startswith("dsv4_flash_")]
             ops = dsv4_flash_ops + ["gemm", "moe", "mhc_module"]
             _dsv4_auto_expand = True
@@ -1126,10 +1248,17 @@ def main():
         # Update log level if debug flag changed
         setup_logging(debug=args.debug)
 
-    if args.model_path:
-        logger.info(f"Model filter active: collecting only for '{args.model_path}'")
+    if target_models:
+        logger.info(f"Model filter active: collecting only for {target_models}")
         if ops and args.ops is None:
             logger.info(f"  expanded to model-specific ops: {ops}")
+    if target_spec is not None:
+        logger.info(
+            "Target spec active: "
+            f"{len(target_spec.data_points)} data points, "
+            f"{len(target_spec.gpu_exceptions)} GPU exceptions, "
+            f"mode={args.target_mode}, gpu={args.target_gpu or 'all'}"
+        )
 
     resume_options = {
         "resume": args.resume,
@@ -1189,11 +1318,41 @@ def main():
     # Use profiling context manager
     with ProfilerContext(args.backend, enabled=args.profile):
         if args.backend == "trtllm":
-            collect_trtllm(num_processes, ops, limit=limit, shuffle=shuffle, resume_options=resume_options)
+            collect_trtllm(
+                num_processes,
+                ops,
+                limit=limit,
+                shuffle=shuffle,
+                resume_options=resume_options,
+                target_spec=target_spec,
+                target_gpu=args.target_gpu,
+                target_models=target_models,
+                target_mode=args.target_mode,
+            )
         elif args.backend == "sglang":
-            collect_sglang(num_processes, ops, limit=limit, shuffle=shuffle, resume_options=resume_options)
+            collect_sglang(
+                num_processes,
+                ops,
+                limit=limit,
+                shuffle=shuffle,
+                resume_options=resume_options,
+                target_spec=target_spec,
+                target_gpu=args.target_gpu,
+                target_models=target_models,
+                target_mode=args.target_mode,
+            )
         elif args.backend == "vllm":
-            collect_vllm(num_processes, ops, limit=limit, shuffle=shuffle, resume_options=resume_options)
+            collect_vllm(
+                num_processes,
+                ops,
+                limit=limit,
+                shuffle=shuffle,
+                resume_options=resume_options,
+                target_spec=target_spec,
+                target_gpu=args.target_gpu,
+                target_models=target_models,
+                target_mode=args.target_mode,
+            )
 
 
 if __name__ == "__main__":

--- a/collector/targeted_collection.example.json
+++ b/collector/targeted_collection.example.json
@@ -1,0 +1,39 @@
+{
+  "data_points": [
+    {
+      "name": "Qwen3.5 27B GDN context rows on B200",
+      "backend": "sglang",
+      "op": "gdn",
+      "models": ["Qwen/Qwen3.5-27B"],
+      "gpus": ["b200_sxm"],
+      "match": {
+        "0": "context",
+        "1": 5120,
+        "9": "Qwen/Qwen3.5-27B"
+      }
+    },
+    {
+      "name": "DeepSeek V4 Flash mHC module rows",
+      "backend": "sglang",
+      "op": "mhc_module",
+      "models": ["deepseek-ai/DeepSeek-V4-Flash"],
+      "gpus": ["b200_sxm", "b300_sxm"],
+      "contains": ["deepseek-ai/DeepSeek-V4-Flash"]
+    }
+  ],
+  "gpu_exceptions": [
+    {
+      "name": "Skip B200 GDN generation row while the kernel is blocked",
+      "backend": "sglang",
+      "op": "gdn",
+      "gpus": ["b200_sxm"],
+      "models": ["Qwen/Qwen3.5-27B"],
+      "match": {
+        "0": "generation",
+        "1": 5120,
+        "9": "Qwen/Qwen3.5-27B"
+      },
+      "reason": "Known unsupported generation row on this GPU"
+    }
+  ]
+}

--- a/collector/targeted_collection.py
+++ b/collector/targeted_collection.py
@@ -1,0 +1,297 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Targeted collector selection for support-matrix healing.
+
+The collector historically had two practical modes: sample a few generated
+cases with ``--smoke`` or run the full generated case list.  Support-matrix
+healing often needs a narrower third path: run the few generated cases that
+represent missing rows for one GPU/model, while keeping GPU-specific skips
+separate from the desired data-point set.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+_MISSING = object()
+_SUPPORTED_MODES = {"targeted", "full"}
+
+
+@dataclass(frozen=True, slots=True)
+class TargetContext:
+    """Runtime scope used when applying a target collection spec."""
+
+    backend: str
+    op: str
+    target_gpu: str | None = None
+    target_models: tuple[str, ...] = ()
+    mode: str = "targeted"
+
+    def __post_init__(self):
+        if self.mode not in _SUPPORTED_MODES:
+            raise ValueError(f"Unsupported target mode {self.mode!r}; expected one of {sorted(_SUPPORTED_MODES)}")
+
+
+@dataclass(frozen=True, slots=True)
+class TargetSelector:
+    """One data-point or GPU-exception selector from a target spec."""
+
+    name: str = ""
+    backend: str | None = None
+    op: str | None = None
+    models: tuple[str, ...] = ()
+    gpus: tuple[str, ...] = ()
+    match: Mapping[str, Any] = field(default_factory=dict)
+    contains: tuple[Any, ...] = ()
+    case_ids: tuple[str, ...] = ()
+    id_contains: tuple[str, ...] = ()
+    reason: str = ""
+
+    def matches_scope(self, context: TargetContext, *, require_target_gpu: bool = False) -> bool:
+        if self.backend and self.backend != context.backend:
+            return False
+        if self.op and self.op != context.op:
+            return False
+        if self.gpus:
+            if context.target_gpu is None:
+                return not require_target_gpu
+            if context.target_gpu not in self.gpus:
+                return False
+        return not (context.target_models and self.models and not set(context.target_models).intersection(self.models))
+
+    def matches_case(self, case: Any, task_id: str, context: TargetContext) -> bool:
+        if self.case_ids and task_id not in self.case_ids:
+            return False
+        if self.id_contains and not all(needle in task_id for needle in self.id_contains):
+            return False
+        if not _matches_models(case, self.models or context.target_models):
+            return False
+        for key, expected in self.match.items():
+            actual = _lookup(case, str(key))
+            if actual is _MISSING or not _value_matches(actual, expected):
+                return False
+        flattened = tuple(_flatten(case))
+        for needle in self.contains:
+            if not any(_value_matches(value, needle) or str(needle) in str(value) for value in flattened):
+                return False
+        return True
+
+
+@dataclass(frozen=True, slots=True)
+class TargetFilterResult:
+    cases: list[Any]
+    original_count: int
+    selected_count: int
+    skipped_by_exception: int
+
+
+@dataclass(frozen=True, slots=True)
+class TargetCollectionSpec:
+    """Parsed target collection spec.
+
+    ``data_points`` is the allowlist for desired collection work. If it is
+    empty, all generated cases remain eligible and only ``gpu_exceptions`` are
+    applied.  This lets a GPU exception file be used without forcing a
+    allowlist-style targeted run.
+    """
+
+    data_points: tuple[TargetSelector, ...] = ()
+    gpu_exceptions: tuple[TargetSelector, ...] = ()
+
+    def collection_selected(self, context: TargetContext) -> bool:
+        if not self.data_points:
+            return True
+        return any(selector.matches_scope(context) for selector in self.data_points)
+
+    def filter_cases(
+        self,
+        cases: Sequence[Any],
+        context: TargetContext,
+        task_id_factory: Callable[[Any], str],
+    ) -> TargetFilterResult:
+        original = list(cases)
+        data_points = [selector for selector in self.data_points if selector.matches_scope(context)]
+        exceptions = [
+            selector
+            for selector in self.gpu_exceptions
+            if selector.matches_scope(context, require_target_gpu=bool(selector.gpus))
+        ]
+
+        if data_points:
+            selected = [
+                case
+                for case in original
+                if any(selector.matches_case(case, task_id_factory(case), context) for selector in data_points)
+            ]
+        elif self.data_points:
+            selected = []
+        else:
+            selected = original
+
+        filtered = []
+        skipped_by_exception = 0
+        for case in selected:
+            task_id = task_id_factory(case)
+            if any(selector.matches_case(case, task_id, context) for selector in exceptions):
+                skipped_by_exception += 1
+                continue
+            filtered.append(case)
+
+        return TargetFilterResult(
+            cases=filtered,
+            original_count=len(original),
+            selected_count=len(selected),
+            skipped_by_exception=skipped_by_exception,
+        )
+
+
+def load_target_collection_spec(path: str | Path) -> TargetCollectionSpec:
+    """Load a target collection spec from JSON or YAML."""
+    spec_path = Path(path).expanduser()
+    if not spec_path.exists():
+        raise ValueError(f"Target collection spec does not exist: {spec_path}")
+
+    if spec_path.suffix.lower() in {".yaml", ".yml"}:
+        try:
+            import yaml
+        except ImportError as e:
+            raise ValueError("YAML target specs require PyYAML; use JSON or install pyyaml") from e
+        with open(spec_path) as f:
+            raw = yaml.safe_load(f)
+    else:
+        with open(spec_path) as f:
+            raw = json.load(f)
+
+    if not isinstance(raw, Mapping):
+        raise TypeError("Target collection spec must be a mapping with data_points and/or gpu_exceptions")
+
+    data_points = tuple(
+        _selector_from_raw(item, section="data_points", index=i)
+        for i, item in enumerate(_as_list(raw.get("data_points", [])))
+    )
+    gpu_exceptions = tuple(
+        _selector_from_raw(item, section="gpu_exceptions", index=i)
+        for i, item in enumerate(_as_list(raw.get("gpu_exceptions", raw.get("exceptions", []))))
+    )
+    return TargetCollectionSpec(data_points=data_points, gpu_exceptions=gpu_exceptions)
+
+
+def _selector_from_raw(raw: Any, *, section: str, index: int) -> TargetSelector:
+    if not isinstance(raw, Mapping):
+        raise TypeError(f"{section}[{index}] must be a mapping")
+
+    backend = _optional_str(raw.get("backend", raw.get("framework")))
+    op = _optional_str(raw.get("op", raw.get("operation")))
+    match = raw.get("match", raw.get("case_match", {}))
+    if not isinstance(match, Mapping):
+        raise TypeError(f"{section}[{index}].match must be a mapping")
+
+    return TargetSelector(
+        name=str(raw.get("name", "")),
+        backend=backend,
+        op=op,
+        models=tuple(str(item) for item in _as_list(raw.get("models", raw.get("model", [])))),
+        gpus=tuple(str(item) for item in _as_list(raw.get("gpus", raw.get("gpu", [])))),
+        match=dict(match),
+        contains=tuple(_as_list(raw.get("contains", raw.get("case_contains", [])))),
+        case_ids=tuple(str(item) for item in _as_list(raw.get("case_ids", raw.get("task_ids", [])))),
+        id_contains=tuple(str(item) for item in _as_list(raw.get("id_contains", []))),
+        reason=str(raw.get("reason", "")),
+    )
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    return [value]
+
+
+def _lookup(value: Any, path: str) -> Any:
+    current = value
+    for part in path.split("."):
+        current = _lookup_one(current, part)
+        if current is _MISSING:
+            return _MISSING
+    return current
+
+
+def _lookup_one(value: Any, key: str) -> Any:
+    if dataclasses.is_dataclass(value):
+        return getattr(value, key, _MISSING)
+    if isinstance(value, Mapping):
+        if key in value:
+            return value[key]
+        if key.isdigit() and int(key) in value:
+            return value[int(key)]
+        return _MISSING
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        if not key.isdigit():
+            return _MISSING
+        index = int(key)
+        if index >= len(value):
+            return _MISSING
+        return value[index]
+    return getattr(value, key, _MISSING)
+
+
+def _flatten(value: Any):
+    if dataclasses.is_dataclass(value):
+        yield from _flatten(dataclasses.asdict(value))
+    elif isinstance(value, Mapping):
+        for item in value.values():
+            yield from _flatten(item)
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        for item in value:
+            yield from _flatten(item)
+    else:
+        yield value
+
+
+def _value_matches(actual: Any, expected: Any) -> bool:
+    if isinstance(expected, Sequence) and not isinstance(expected, (str, bytes, bytearray)):
+        if isinstance(actual, Sequence) and not isinstance(actual, (str, bytes, bytearray)):
+            return list(actual) == list(expected)
+        return any(_value_matches(actual, item) for item in expected)
+    return actual == expected or str(actual) == str(expected)
+
+
+def _matches_models(case: Any, models: tuple[str, ...]) -> bool:
+    if not models:
+        return True
+
+    values = {str(value) for value in _flatten(case)}
+    if values.intersection(models):
+        return True
+
+    known_models = _known_model_names()
+    if values.intersection(known_models):
+        return False
+
+    # Some generated cases, such as GEMM, represent model-derived dimensions
+    # but do not carry the model name. Let explicit case predicates decide.
+    return not (any("/" in value for value in values) and any("/" in model for model in models))
+
+
+def _known_model_names() -> set[str]:
+    try:
+        from collector.common_test_cases import get_all_model_names
+    except Exception:
+        return set()
+    return set(get_all_model_names())

--- a/tests/unit/collector/test_targeted_collection.py
+++ b/tests/unit/collector/test_targeted_collection.py
@@ -1,0 +1,172 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from dataclasses import dataclass
+
+import pytest
+
+from collector.targeted_collection import (
+    TargetCollectionSpec,
+    TargetContext,
+    TargetSelector,
+    load_target_collection_spec,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _task_id(case):
+    return f"sglang.gdn:run_gdn:{case}"
+
+
+def test_filters_data_points_by_model_gpu_and_case_fields():
+    spec = TargetCollectionSpec(
+        data_points=(
+            TargetSelector(
+                backend="sglang",
+                op="gdn",
+                models=("Qwen/Qwen3.5-27B",),
+                gpus=("b200_sxm",),
+                match={"0": "context", "1": 5120, "9": "Qwen/Qwen3.5-27B"},
+            ),
+        )
+    )
+    cases = [
+        ["context", 5120, 4, 16, 128, 48, 128, [1, 2], [128], "Qwen/Qwen3.5-27B"],
+        ["generation", 5120, 4, 16, 128, 48, 128, [1, 2], None, "Qwen/Qwen3.5-27B"],
+        ["context", 4096, 4, 16, 128, 32, 128, [1, 2], [128], "Qwen/Qwen3.5-9B"],
+    ]
+
+    result = spec.filter_cases(
+        cases,
+        TargetContext(
+            backend="sglang",
+            op="gdn",
+            target_gpu="b200_sxm",
+            target_models=("Qwen/Qwen3.5-27B",),
+        ),
+        _task_id,
+    )
+
+    assert result.cases == [cases[0]]
+    assert result.original_count == 3
+    assert result.selected_count == 1
+    assert result.skipped_by_exception == 0
+
+
+def test_gpu_exception_removes_matching_case_only_for_matching_gpu():
+    spec = TargetCollectionSpec(
+        data_points=(TargetSelector(backend="sglang", op="gdn", contains=("Qwen/Qwen3.5-27B",)),),
+        gpu_exceptions=(
+            TargetSelector(
+                backend="sglang",
+                op="gdn",
+                gpus=("b200_sxm",),
+                match={"0": "generation", "9": "Qwen/Qwen3.5-27B"},
+            ),
+        ),
+    )
+    cases = [
+        ["context", 5120, 4, 16, 128, 48, 128, [1], [128], "Qwen/Qwen3.5-27B"],
+        ["generation", 5120, 4, 16, 128, 48, 128, [1], None, "Qwen/Qwen3.5-27B"],
+    ]
+
+    b200_result = spec.filter_cases(
+        cases,
+        TargetContext(backend="sglang", op="gdn", target_gpu="b200_sxm"),
+        _task_id,
+    )
+    h100_result = spec.filter_cases(
+        cases,
+        TargetContext(backend="sglang", op="gdn", target_gpu="h100_sxm"),
+        _task_id,
+    )
+    no_gpu_result = spec.filter_cases(
+        cases,
+        TargetContext(backend="sglang", op="gdn"),
+        _task_id,
+    )
+
+    assert b200_result.cases == [cases[0]]
+    assert b200_result.skipped_by_exception == 1
+    assert h100_result.cases == cases
+    assert h100_result.skipped_by_exception == 0
+    assert no_gpu_result.cases == cases
+    assert no_gpu_result.skipped_by_exception == 0
+
+
+def test_case_id_selector_matches_exact_task_id():
+    cases = [["a"], ["b"]]
+    spec = TargetCollectionSpec(data_points=(TargetSelector(case_ids=("id:1",)),))
+
+    result = spec.filter_cases(
+        cases,
+        TargetContext(backend="sglang", op="gdn"),
+        task_id_factory=lambda case: "id:1" if case == ["b"] else "id:0",
+    )
+
+    assert result.cases == [["b"]]
+
+
+def test_named_fields_work_for_dataclass_cases():
+    @dataclass
+    class FakeCase:
+        phase: str
+        d_model: int
+        model_name: str
+
+    cases = [
+        FakeCase("context", 5120, "Qwen/Qwen3.5-27B"),
+        FakeCase("context", 4096, "Qwen/Qwen3.5-9B"),
+    ]
+    spec = TargetCollectionSpec(
+        data_points=(
+            TargetSelector(
+                backend="sglang",
+                op="gdn",
+                models=("Qwen/Qwen3.5-27B",),
+                match={"phase": "context", "d_model": 5120},
+            ),
+        )
+    )
+
+    result = spec.filter_cases(cases, TargetContext(backend="sglang", op="gdn"), _task_id)
+
+    assert result.cases == [cases[0]]
+
+
+def test_load_target_collection_spec_accepts_aliases(tmp_path):
+    spec_path = tmp_path / "target_spec.json"
+    spec_path.write_text(
+        json.dumps(
+            {
+                "data_points": [
+                    {
+                        "framework": "sglang",
+                        "operation": "gdn",
+                        "model": "Qwen/Qwen3.5-27B",
+                        "gpu": "b200_sxm",
+                        "case_match": {"0": "context"},
+                    }
+                ],
+                "exceptions": [
+                    {
+                        "framework": "sglang",
+                        "operation": "gdn",
+                        "gpu": "b200_sxm",
+                        "id_contains": "generation",
+                    }
+                ],
+            }
+        )
+    )
+
+    spec = load_target_collection_spec(spec_path)
+
+    assert spec.data_points[0].backend == "sglang"
+    assert spec.data_points[0].op == "gdn"
+    assert spec.data_points[0].models == ("Qwen/Qwen3.5-27B",)
+    assert spec.data_points[0].gpus == ("b200_sxm",)
+    assert spec.data_points[0].match == {"0": "context"}
+    assert spec.gpu_exceptions[0].id_contains == ("generation",)


### PR DESCRIPTION
## Summary

Adds a targeted support-matrix healing path for collector runs so a healer can run specific generated data points for a GPU/model instead of choosing only between smoke mode and full collection.

## Changes

- Add `collector.targeted_collection` for JSON/YAML target specs with separate `data_points` and `gpu_exceptions` sections.
- Wire `collect.py` with `--target-spec`, `--target-gpu`, `--target-model`, and `--target-mode`.
- Add a sample target spec and collector README guidance.
- Add unit coverage for selector parsing, model/GPU scoping, generated-case matching, exact task IDs, and GPU-specific exceptions.

## Validation

- `uvx ruff check collector/targeted_collection.py collector/collect.py tests/unit/collector/test_targeted_collection.py`
- `uvx ruff format --check collector/targeted_collection.py collector/collect.py tests/unit/collector/test_targeted_collection.py`
- `uv run --with pytest pytest tests/unit/collector/test_targeted_collection.py -q`
- `uv run --with pytest pytest tests/unit/collector/test_parallel_run.py -q`
- `python3 -m py_compile collector/targeted_collection.py collector/collect.py tests/unit/collector/test_targeted_collection.py`
- `git diff --check`