### PR TITLE
fix: heal B200 SGLang 0.5.10 support matrix

### DIFF
--- a/collector/sglang/collect_attn.py
+++ b/collector/sglang/collect_attn.py
@@ -155,7 +155,7 @@ def get_context_attention_test_cases():
     s_list = [1, 16, 32, 64, 128, 256, 512, 1024, 1536, 2048, 3072, 4096, 6144, 8192, 10240, 12288, 16384, 262144]
     n_list = [1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 64, 96]
     n_kv_list = [0, 1, 2, 4, 8]
-    head_dim_list = [128, 256]
+    head_dim_list = [128, 192, 256]
 
     # FP8 attention requires SM90+ (Hopper)
     sm_version = get_sm_version()
@@ -209,7 +209,7 @@ def get_generation_attention_test_cases():
     n_list = [1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 64]
     n_list_xqa = [1, 2, 4, 8, 16, 32, 64, 96, 128]
     n_kv_list = [1, 2, 4, 8]
-    head_dim_list = [128, 256]
+    head_dim_list = [128, 192, 256]
 
     # MHA
     max_bsn = 8192 * 1024
@@ -292,6 +292,7 @@ def run_attention_torch(
     use_fp8_kv_cache,
     use_fp8_context_fmha,
     is_context_phase,
+    window_size=0,
     *,
     perf_filename,
     device="cuda:0",
@@ -313,6 +314,7 @@ def run_attention_torch(
         head_dim=head_dim,
     )
     model_runner.kv_cache_dtype = kvtype
+    model_runner.sliding_window_size = window_size if window_size > 0 else None
 
     total_len = input_len if is_context_phase else input_len + 1
     req_to_token_pool, token_matrix = create_req_to_token_pool(
@@ -342,9 +344,11 @@ def run_attention_torch(
     model_runner.token_to_kv_pool = kv_pool
 
     sm_version = get_sm_version()
-    if sm_version >= 110:
+    use_triton_attention = sm_version >= 110 or (sm_version >= 100 and head_dim == 192)
+    if use_triton_attention:
         # SM120+ (workstation Blackwell): TRTLLM prefill (TllmGenFmhaRunner) is unsupported;
-        # FA3 is not compiled for SM120. Use Triton JIT-compiled backend instead.
+        # FA3 is not compiled for SM120. B200/SM100 TRTLLM also lacks head-dim 192
+        # kernels, which MiMo-style models need. Use Triton JIT-compiled backend instead.
         from sglang.srt.layers.attention.triton_backend import TritonAttnBackend
 
         attn_backend = TritonAttnBackend(model_runner)
@@ -373,6 +377,7 @@ def run_attention_torch(
         num_kv_heads=num_key_value_heads,
         layer_id=0,
     ).to(torch_device)
+    layer.sliding_window_size = window_size if window_size > 0 else None
 
     seqlen_q = input_len if is_context_phase else 1
     q = torch.randn(
@@ -530,6 +535,7 @@ def run_attention_torch(
                 "attn_dtype": "fp8" if use_fp8_context_fmha else "bfloat16",
                 "kv_cache_dtype": "fp8" if use_fp8_kv_cache else "bfloat16",
                 "step": step,
+                "window_size": window_size,
                 "latency": latency,
             }
         ],

--- a/src/aiconfigurator/systems/data/b200_sxm/sglang/0.5.10/context_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/b200_sxm/sglang/0.5.10/context_attention_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:405d7a369dc93875d2ed31d5bb05a12c6ecf6af1bfd43cc72132d300e0d61b57
-size 3655360
+oid sha256:a43c373f24961d5998503ae672e99e149ef55d066ee471a88b849f7dfe516f2e
+size 3893491

--- a/src/aiconfigurator/systems/data/b200_sxm/sglang/0.5.10/generation_attention_perf.txt
+++ b/src/aiconfigurator/systems/data/b200_sxm/sglang/0.5.10/generation_attention_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7f1ae0e1ff78a474a29edec208beed670d8562f9eae25b97bb921bf9e4d744a6
-size 2230682
+oid sha256:89596ce700fa1e1ecedc548576a52c01c9ae860cf0b7bb670f38f671b934eb36
+size 2438585

--- a/src/aiconfigurator/systems/data/b200_sxm/sglang/0.5.10/moe_perf.txt
+++ b/src/aiconfigurator/systems/data/b200_sxm/sglang/0.5.10/moe_perf.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e001aa340d6da4547ac2824e9e22ab730c4fb189dca488308584a490a188150d
-size 14144689
+oid sha256:502cdcec9dd0d352d1634a5df25fd42add57e2b8117eb445da0598c8f75bd4e1
+size 14145671


### PR DESCRIPTION
## Summary
- add B200 SGLang 0.5.10 perf data that heals six previously failing model families
- add SGLang attention collector support for head_dim=192 and sliding-window logging
- route B200/SM100 head_dim=192 attention collection through Triton because TRTLLM lacks those kernels

## Healed support-matrix rows
All of these now pass both `agg` and `disagg` on `b200_sxm`, `sglang`, `0.5.10`:
- `Qwen/Qwen3.5-35B-A3B`
- `meta-llama/Llama-4-Maverick-17B-128E-Instruct`
- `meta-llama/Llama-4-Scout-17B-16E-Instruct`
- `nvidia/nemotron-ultra-rl-050826`
- `sgl-project/DeepSeek-V4-Flash-FP8`
- `XiaomiMiMo/MiMo-V2-Flash`

## Verification
- Live B200 debug node on latest AIC main, SGLang `0.5.10`, `lmsysorg/sglang:v0.5.10-cu130`: `SupportMatrix.run_single_test(...)` returned `PASS` for both modes for the six models above.
- Local branch verification after fetching required B200/NCCL LFS data: `PYTHONPATH=src uv run python` invoking `SupportMatrix.run_single_test(...)` returned `PASS` for both modes for the six models above.
- `uvx ruff format collector/sglang/collect_attn.py --check`
- `uvx ruff check collector/sglang/collect_attn.py`
