### PR TITLE
refactor(collector): replace DeepSeek-specific helpers with _resolve_local_model_path() (#708)

### DIFF
--- a/collector/helper.py
+++ b/collector/helper.py
@@ -9,8 +9,10 @@ import logging
 import math
 import multiprocessing as mp
 import os
+import shutil
 import signal
 import sys
+import tempfile
 import threading
 import time
 from contextlib import contextmanager
@@ -1468,100 +1470,73 @@ def power_law_deepep_decode(num_tokens, num_experts, topk, ep, alpha):
     return num_tokens_per_expert.view(ep, experts_per_rank)[0]
 
 
-def _get_deepseek_model_path():
-    """Get DeepSeek model path, downloading config files from HuggingFace if needed.
+# AIC's cached HuggingFace model configs — avoids HF downloads in CI.
+_AIC_MODEL_CONFIG_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "src",
+    "aiconfigurator",
+    "model_configs",
+)
 
-    If DEEPSEEK_MODEL_PATH is set, use that path.
-    Otherwise, download only the necessary config files from HuggingFace.
-    This allows running the collector without downloading the full model weights.
+
+def _resolve_local_model_path(model_id: str) -> str:
+    """Resolve a model identifier to a local directory containing config files.
+
+    Resolution order:
+        1. Existing local path (absolute or relative directory) — returned as-is.
+        2. AIC's bundled configs in ``src/aiconfigurator/model_configs/``
+           (``<owner>--<name>_config.json``, with an optional ``..._hf_quant_config.json``
+           side-car). The config is copied to a fresh tempdir as ``config.json``.
+        3. HuggingFace ``hf_hub_download`` for ``config.json`` and tokenizer files.
+
+    Raises ``FileNotFoundError`` if none of the above resolves. There is no
+    hardcoded ``/deepseek-v3`` (or any other model-specific) fallback — callers
+    must supply a real ``model_id``.
     """
-    env_path = os.environ.get("DEEPSEEK_MODEL_PATH")
-    if env_path:
-        return env_path
+    if not model_id:
+        raise ValueError("_resolve_local_model_path requires a non-empty model_id")
 
-    # Download config files from HuggingFace (no model weights needed)
+    if os.path.isdir(model_id):
+        return model_id
+
+    slug = model_id.replace("/", "--")
+    cached_config = os.path.join(_AIC_MODEL_CONFIG_DIR, f"{slug}_config.json")
+    if os.path.exists(cached_config):
+        tmp_dir = tempfile.mkdtemp(prefix=f"aic_model_config_{slug}_")
+        shutil.copy(cached_config, os.path.join(tmp_dir, "config.json"))
+        quant_side_car = os.path.join(_AIC_MODEL_CONFIG_DIR, f"{slug}_hf_quant_config.json")
+        if os.path.exists(quant_side_car):
+            shutil.copy(quant_side_car, os.path.join(tmp_dir, "hf_quant_config.json"))
+        print(f"Resolved {model_id} from AIC model_configs cache: {tmp_dir}")
+        return tmp_dir
+
     try:
         from huggingface_hub import hf_hub_download
+    except ImportError as e:
+        raise FileNotFoundError(
+            f"Model '{model_id}' not found under {_AIC_MODEL_CONFIG_DIR} and "
+            "huggingface_hub is not installed — cannot download config."
+        ) from e
 
-        repo_id = "deepseek-ai/DeepSeek-V3"
-        config_files = [
-            "config.json",
-            "configuration_deepseek.py",
-            "tokenizer_config.json",
-            "tokenizer.json",
-        ]
+    config_files = ["config.json", "tokenizer_config.json", "tokenizer.json"]
+    snapshot_dir = None
+    for filename in config_files:
+        try:
+            path = hf_hub_download(repo_id=model_id, filename=filename)
+            if snapshot_dir is None:
+                snapshot_dir = os.path.dirname(path)
+        except Exception as e:
+            # tokenizer files may be optional; only config.json failure is fatal.
+            print(f"Warning: failed to download {filename} for {model_id}: {e}")
 
-        snapshot_dir = None
-        for filename in config_files:
-            try:
-                path = hf_hub_download(repo_id=repo_id, filename=filename)
-                if snapshot_dir is None:
-                    snapshot_dir = os.path.dirname(path)
-            except Exception as e:
-                print(f"Warning: Failed to download {filename}: {e}")
+    if snapshot_dir is None:
+        raise FileNotFoundError(
+            f"Model '{model_id}' not found under {_AIC_MODEL_CONFIG_DIR} and "
+            "HuggingFace download failed for all required config files."
+        )
 
-        if snapshot_dir:
-            print(f"Using DeepSeek-V3 config from HuggingFace cache: {snapshot_dir}")
-            return snapshot_dir
-    except ImportError:
-        print("Warning: huggingface_hub not installed, cannot auto-download config")
-    except Exception as e:
-        print(f"Warning: Failed to download DeepSeek-V3 config: {e}")
-
-    # Fallback to default path
-    return "/deepseek-v3"
-
-
-def _get_moe_model_path():
-    """Get MoE model path, supporting multiple MoE models (DeepSeek, Qwen3, etc.).
-
-    Checks environment variables in priority order:
-    1. MOE_MODEL_PATH - generic, for any MoE model
-    2. DEEPSEEK_MODEL_PATH - backward compatibility for DeepSeek models
-    Otherwise, download only the necessary config files from HuggingFace.
-    This allows running the collector without downloading the full model weights.
-    """
-    # Try MOE_MODEL_PATH first (generic)
-    env_path = os.environ.get("MOE_MODEL_PATH")
-    if env_path:
-        return env_path
-
-    # Backward compatibility: try DEEPSEEK_MODEL_PATH
-    env_path = os.environ.get("DEEPSEEK_MODEL_PATH")
-    if env_path:
-        return env_path
-
-    # Download config files from HuggingFace (no model weights needed)
-    try:
-        from huggingface_hub import hf_hub_download
-
-        repo_id = "deepseek-ai/DeepSeek-V3"
-        config_files = [
-            "config.json",
-            "configuration_deepseek.py",
-            "tokenizer_config.json",
-            "tokenizer.json",
-        ]
-
-        snapshot_dir = None
-        for filename in config_files:
-            try:
-                path = hf_hub_download(repo_id=repo_id, filename=filename)
-                if snapshot_dir is None:
-                    snapshot_dir = os.path.dirname(path)
-            except Exception as e:
-                print(f"Warning: Failed to download {filename}: {e}")
-
-        if snapshot_dir:
-            print(f"Using DeepSeek-V3 config from HuggingFace cache: {snapshot_dir}")
-            return snapshot_dir
-    except ImportError:
-        print("Warning: huggingface_hub not installed, cannot auto-download config")
-    except Exception as e:
-        print(f"Warning: Failed to download DeepSeek-V3 config: {e}")
-
-    # Fallback to default path
-    return "/deepseek-v3"
+    print(f"Resolved {model_id} from HuggingFace cache: {snapshot_dir}")
+    return snapshot_dir
 
 
 @functools.lru_cache(maxsize=1)

--- a/collector/helper.py
+++ b/collector/helper.py
@@ -1542,9 +1542,7 @@ def _resolve_local_model_path(model_id: str) -> str:
                 "expected a directory containing config.json"
             )
         if not os.path.exists(os.path.join(model_id, "config.json")):
-            raise FileNotFoundError(
-                f"model_id '{model_id}' is a directory but does not contain config.json"
-            )
+            raise FileNotFoundError(f"model_id '{model_id}' is a directory but does not contain config.json")
         return model_id
 
     # Step 2: AIC bundled cache.

--- a/collector/helper.py
+++ b/collector/helper.py
@@ -1479,37 +1479,82 @@ _AIC_MODEL_CONFIG_DIR = os.path.join(
 )
 
 
+def _materialize_aic_cached_config(model_id: str, slug: str, cached_config: str) -> str:
+    """Copy a bundled AIC config into a deterministic per-model tempdir.
+
+    ``auto_map`` is stripped so that ``trust_remote_code=True`` consumers
+    (e.g. SGLang's ServerArgs) do not try to import ``configuration_*.py``
+    files that AIC does not ship. A deterministic path (no random suffix,
+    no pid) lets parallel subprocesses / pytest-xdist workers converge on
+    the same directory; the JSON write is atomic via ``os.replace``.
+    """
+    tmp_dir = os.path.join(tempfile.gettempdir(), f"aic_model_config_{slug}")
+    os.makedirs(tmp_dir, exist_ok=True)
+
+    target = os.path.join(tmp_dir, "config.json")
+    if not os.path.exists(target):
+        with open(cached_config) as f:
+            config = json.load(f)
+        config.pop("auto_map", None)
+        tmp_target = f"{target}.{os.getpid()}.tmp"
+        with open(tmp_target, "w") as f:
+            json.dump(config, f)
+        os.replace(tmp_target, target)
+
+    quant_side_car = os.path.join(_AIC_MODEL_CONFIG_DIR, f"{slug}_hf_quant_config.json")
+    quant_target = os.path.join(tmp_dir, "hf_quant_config.json")
+    if os.path.exists(quant_side_car) and not os.path.exists(quant_target):
+        tmp_quant = f"{quant_target}.{os.getpid()}.tmp"
+        shutil.copy(quant_side_car, tmp_quant)
+        os.replace(tmp_quant, quant_target)
+
+    print(f"Resolved {model_id} from AIC model_configs cache: {tmp_dir}")
+    return tmp_dir
+
+
 def _resolve_local_model_path(model_id: str) -> str:
-    """Resolve a model identifier to a local directory containing config files.
+    """Resolve a model identifier to a local directory containing ``config.json``.
 
     Resolution order:
-        1. Existing local path (absolute or relative directory) — returned as-is.
+        1. Existing filesystem path. Must be a directory containing
+           ``config.json`` — a file path or a directory without ``config.json``
+           raises rather than silently falling through to HF download.
         2. AIC's bundled configs in ``src/aiconfigurator/model_configs/``
-           (``<owner>--<name>_config.json``, with an optional ``..._hf_quant_config.json``
-           side-car). The config is copied to a fresh tempdir as ``config.json``.
-        3. HuggingFace ``hf_hub_download`` for ``config.json`` and tokenizer files.
+           (``<owner>--<name>_config.json``, with an optional
+           ``..._hf_quant_config.json`` side-car).
+        3. HuggingFace ``hf_hub_download``: ``config.json`` is required
+           and downloaded first; tokenizer files are best-effort.
 
-    Raises ``FileNotFoundError`` if none of the above resolves. There is no
-    hardcoded ``/deepseek-v3`` (or any other model-specific) fallback — callers
-    must supply a real ``model_id``.
+    Raises ``FileNotFoundError`` if none of the above resolves. There is
+    no hardcoded ``/deepseek-v3`` (or any other model-specific) fallback —
+    callers must supply a real ``model_id``.
     """
     if not model_id:
         raise ValueError("_resolve_local_model_path requires a non-empty model_id")
 
-    if os.path.isdir(model_id):
+    # Step 1: existing filesystem path. Be strict about shape so a bogus
+    # MOE_MODEL_PATH (e.g. pointing at a single file) fails loudly here
+    # instead of silently triggering an HF download.
+    if os.path.exists(model_id):
+        if not os.path.isdir(model_id):
+            raise NotADirectoryError(
+                f"model_id '{model_id}' is an existing path but not a directory; "
+                "expected a directory containing config.json"
+            )
+        if not os.path.exists(os.path.join(model_id, "config.json")):
+            raise FileNotFoundError(
+                f"model_id '{model_id}' is a directory but does not contain config.json"
+            )
         return model_id
 
+    # Step 2: AIC bundled cache.
     slug = model_id.replace("/", "--")
     cached_config = os.path.join(_AIC_MODEL_CONFIG_DIR, f"{slug}_config.json")
     if os.path.exists(cached_config):
-        tmp_dir = tempfile.mkdtemp(prefix=f"aic_model_config_{slug}_")
-        shutil.copy(cached_config, os.path.join(tmp_dir, "config.json"))
-        quant_side_car = os.path.join(_AIC_MODEL_CONFIG_DIR, f"{slug}_hf_quant_config.json")
-        if os.path.exists(quant_side_car):
-            shutil.copy(quant_side_car, os.path.join(tmp_dir, "hf_quant_config.json"))
-        print(f"Resolved {model_id} from AIC model_configs cache: {tmp_dir}")
-        return tmp_dir
+        return _materialize_aic_cached_config(model_id, slug, cached_config)
 
+    # Step 3: HuggingFace download. config.json is mandatory and must
+    # succeed before we accept the resulting snapshot directory.
     try:
         from huggingface_hub import hf_hub_download
     except ImportError as e:
@@ -1518,22 +1563,21 @@ def _resolve_local_model_path(model_id: str) -> str:
             "huggingface_hub is not installed — cannot download config."
         ) from e
 
-    config_files = ["config.json", "tokenizer_config.json", "tokenizer.json"]
-    snapshot_dir = None
-    for filename in config_files:
-        try:
-            path = hf_hub_download(repo_id=model_id, filename=filename)
-            if snapshot_dir is None:
-                snapshot_dir = os.path.dirname(path)
-        except Exception as e:
-            # tokenizer files may be optional; only config.json failure is fatal.
-            print(f"Warning: failed to download {filename} for {model_id}: {e}")
-
-    if snapshot_dir is None:
+    try:
+        config_path = hf_hub_download(repo_id=model_id, filename="config.json")
+    except Exception as e:
         raise FileNotFoundError(
             f"Model '{model_id}' not found under {_AIC_MODEL_CONFIG_DIR} and "
-            "HuggingFace download failed for all required config files."
-        )
+            f"HuggingFace download of config.json failed: {e}"
+        ) from e
+    snapshot_dir = os.path.dirname(config_path)
+
+    for filename in ("tokenizer_config.json", "tokenizer.json"):
+        try:
+            hf_hub_download(repo_id=model_id, filename=filename)
+        except Exception as e:
+            # Tokenizer files are best-effort — many MoE configs ship without them.
+            print(f"Warning: failed to download {filename} for {model_id}: {e}")
 
     print(f"Resolved {model_id} from HuggingFace cache: {snapshot_dir}")
     return snapshot_dir

--- a/collector/sglang/collect_wideep_deepep_moe.py
+++ b/collector/sglang/collect_wideep_deepep_moe.py
@@ -24,13 +24,13 @@ from sglang.srt.utils import (
 )
 
 try:
-    from helper import _get_moe_model_path, log_perf, power_law_deepep_decode, power_law_deepep_prefill
+    from helper import _resolve_local_model_path, log_perf, power_law_deepep_decode, power_law_deepep_prefill
 except ModuleNotFoundError:
     import os
     import sys
 
     sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-    from helper import _get_moe_model_path, log_perf, power_law_deepep_decode, power_law_deepep_prefill
+    from helper import _resolve_local_model_path, log_perf, power_law_deepep_decode, power_law_deepep_prefill
 from importlib.metadata import version as get_version
 from math import ceil as _ceil
 
@@ -62,7 +62,16 @@ def _make_scale_tensor(num_tokens: int, hidden_size: int, device) -> torch.Tenso
     return torch.ones(num_tokens, scale_dim, device=device, dtype=torch.float32)
 
 
-MOE_MODEL_PATH = _get_moe_model_path()
+# MOE_MODEL_PATH env var selects the model to benchmark. It can be either
+# a local directory (containing config.json) or a HuggingFace model id like
+# "deepseek-ai/DeepSeek-V3" / "Qwen/Qwen3-235B-A22B". DEEPSEEK_MODEL_PATH is
+# honored for backward compatibility. Defaults to DeepSeek-V3.
+_MOE_MODEL_ID = (
+    os.environ.get("MOE_MODEL_PATH")
+    or os.environ.get("DEEPSEEK_MODEL_PATH")
+    or "deepseek-ai/DeepSeek-V3"
+)
+MOE_MODEL_PATH = _resolve_local_model_path(_MOE_MODEL_ID)
 
 
 def get_moe_prefill_test_cases(rank):

--- a/collector/sglang/collect_wideep_deepep_moe.py
+++ b/collector/sglang/collect_wideep_deepep_moe.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+import functools
 import json
 import logging
 import os
@@ -67,7 +68,18 @@ def _make_scale_tensor(num_tokens: int, hidden_size: int, device) -> torch.Tenso
 # "deepseek-ai/DeepSeek-V3" / "Qwen/Qwen3-235B-A22B". DEEPSEEK_MODEL_PATH is
 # honored for backward compatibility. Defaults to DeepSeek-V3.
 _MOE_MODEL_ID = os.environ.get("MOE_MODEL_PATH") or os.environ.get("DEEPSEEK_MODEL_PATH") or "deepseek-ai/DeepSeek-V3"
-MOE_MODEL_PATH = _resolve_local_model_path(_MOE_MODEL_ID)
+
+
+@functools.lru_cache(maxsize=1)
+def _get_moe_model_path() -> str:
+    """Resolve MOE_MODEL_PATH lazily so that ``collect.py``'s registry import
+    of this module does not trigger tempdir / JSON I/O on every invocation.
+
+    Cached for the lifetime of the process; subprocess workers each get a
+    fresh interpreter and re-resolve on first call (which converges on the
+    same deterministic tempdir built by ``helper._resolve_local_model_path``).
+    """
+    return _resolve_local_model_path(_MOE_MODEL_ID)
 
 
 def get_moe_prefill_test_cases(rank):
@@ -974,7 +986,7 @@ def run_moe_benchmark(num_experts, gpu_id, output_path=None):
 
     server_port = 30000 + gpu_id * 100
     server_args = ServerArgs(
-        model_path=MOE_MODEL_PATH,
+        model_path=_get_moe_model_path(),
         dtype="auto",
         device="cuda",
         load_format="dummy",
@@ -1082,7 +1094,7 @@ if __name__ == "__main__":
     parser.add_argument("--output-path", default=None, help="Output directory for perf files")
     args = parser.parse_args()
 
-    print(f"Model path: {MOE_MODEL_PATH}")
+    print(f"Model path: {_get_moe_model_path()}")
 
     # Run all MOE test cases
     for test_case in get_wideep_moe_test_cases():

--- a/collector/sglang/collect_wideep_deepep_moe.py
+++ b/collector/sglang/collect_wideep_deepep_moe.py
@@ -66,11 +66,7 @@ def _make_scale_tensor(num_tokens: int, hidden_size: int, device) -> torch.Tenso
 # a local directory (containing config.json) or a HuggingFace model id like
 # "deepseek-ai/DeepSeek-V3" / "Qwen/Qwen3-235B-A22B". DEEPSEEK_MODEL_PATH is
 # honored for backward compatibility. Defaults to DeepSeek-V3.
-_MOE_MODEL_ID = (
-    os.environ.get("MOE_MODEL_PATH")
-    or os.environ.get("DEEPSEEK_MODEL_PATH")
-    or "deepseek-ai/DeepSeek-V3"
-)
+_MOE_MODEL_ID = os.environ.get("MOE_MODEL_PATH") or os.environ.get("DEEPSEEK_MODEL_PATH") or "deepseek-ai/DeepSeek-V3"
 MOE_MODEL_PATH = _resolve_local_model_path(_MOE_MODEL_ID)
 
 

--- a/tests/unit/collector/sglang/test_collect_mla_module.py
+++ b/tests/unit/collector/sglang/test_collect_mla_module.py
@@ -16,7 +16,6 @@ def _mock_helper_imports(monkeypatch):
     fake_helper.get_sm_version = lambda: 90  # default Hopper
     fake_helper.log_perf = lambda **kw: None
     fake_helper.benchmark_with_power = lambda **kw: None
-    fake_helper._get_deepseek_model_path = lambda: "/fake"
     monkeypatch.setitem(__import__("sys").modules, "helper", fake_helper)
 
 

--- a/tests/unit/collector/test_helper_resolve_model_path.py
+++ b/tests/unit/collector/test_helper_resolve_model_path.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ``collector.helper._resolve_local_model_path``."""
+
+import json
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+# Ensure ``collector/`` is importable since collector ships as a top-level package
+# of loose scripts (not installed via pyproject).
+_COLLECTOR_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "..", "collector")
+sys.path.insert(0, os.path.abspath(_COLLECTOR_DIR))
+
+from helper import _resolve_local_model_path
+
+
+class TestResolveLocalModelPath:
+    def test_local_directory_passthrough(self, tmp_path):
+        # An existing directory must be returned unchanged.
+        (tmp_path / "config.json").write_text("{}")
+        result = _resolve_local_model_path(str(tmp_path))
+        assert result == str(tmp_path)
+
+    def test_aic_cache_hit(self, tmp_path, monkeypatch):
+        # Point the helper at a synthetic AIC model_configs cache.
+        cache_dir = tmp_path / "model_configs"
+        cache_dir.mkdir()
+        slug = "fake-org--fake-model"
+        (cache_dir / f"{slug}_config.json").write_text(json.dumps({"model_type": "fake"}))
+
+        monkeypatch.setattr("helper._AIC_MODEL_CONFIG_DIR", str(cache_dir))
+
+        result = _resolve_local_model_path("fake-org/fake-model")
+        assert os.path.isdir(result)
+        with open(os.path.join(result, "config.json")) as f:
+            assert json.load(f) == {"model_type": "fake"}
+        # No hf_quant_config side-car was provided, so none should appear.
+        assert not os.path.exists(os.path.join(result, "hf_quant_config.json"))
+
+    def test_aic_cache_hit_with_quant_side_car(self, tmp_path, monkeypatch):
+        cache_dir = tmp_path / "model_configs"
+        cache_dir.mkdir()
+        slug = "fake-org--fake-fp8"
+        (cache_dir / f"{slug}_config.json").write_text(json.dumps({"model_type": "fake"}))
+        (cache_dir / f"{slug}_hf_quant_config.json").write_text(json.dumps({"quant": "fp8"}))
+
+        monkeypatch.setattr("helper._AIC_MODEL_CONFIG_DIR", str(cache_dir))
+
+        result = _resolve_local_model_path("fake-org/fake-fp8")
+        with open(os.path.join(result, "hf_quant_config.json")) as f:
+            assert json.load(f) == {"quant": "fp8"}
+
+    def test_hf_fallback_invoked_when_not_cached(self, tmp_path, monkeypatch):
+        # Empty AIC cache forces the HF download branch.
+        empty_cache = tmp_path / "empty"
+        empty_cache.mkdir()
+        monkeypatch.setattr("helper._AIC_MODEL_CONFIG_DIR", str(empty_cache))
+
+        hf_dir = tmp_path / "hf"
+        hf_dir.mkdir()
+        (hf_dir / "config.json").write_text("{}")
+
+        def fake_hf_hub_download(repo_id, filename):
+            # config.json succeeds, tokenizer files are missing — typical for many MoE models.
+            target = hf_dir / filename
+            if filename == "config.json":
+                return str(target)
+            raise FileNotFoundError(filename)
+
+        fake_hub = type(sys)("huggingface_hub")
+        fake_hub.hf_hub_download = fake_hf_hub_download
+        with patch.dict(sys.modules, {"huggingface_hub": fake_hub}):
+            result = _resolve_local_model_path("any-org/any-model")
+        assert result == str(hf_dir)
+
+    def test_no_hardcoded_deepseek_fallback(self, tmp_path, monkeypatch):
+        # When the model is not cached AND HF download fails entirely, the helper
+        # must raise — there must be no implicit "/deepseek-v3" or similar fallback.
+        monkeypatch.setattr("helper._AIC_MODEL_CONFIG_DIR", str(tmp_path / "nope"))
+
+        fake_hub = type(sys)("huggingface_hub")
+        fake_hub.hf_hub_download = lambda **kw: (_ for _ in ()).throw(RuntimeError("offline"))
+        # Accept positional or keyword call signatures.
+        def _raise(*a, **kw):
+            raise RuntimeError("offline")
+        fake_hub.hf_hub_download = _raise
+
+        with patch.dict(sys.modules, {"huggingface_hub": fake_hub}), pytest.raises(FileNotFoundError):
+            _resolve_local_model_path("unknown-org/unknown-model")
+
+    def test_empty_model_id_rejected(self):
+        with pytest.raises(ValueError):
+            _resolve_local_model_path("")

--- a/tests/unit/collector/test_helper_resolve_model_path.py
+++ b/tests/unit/collector/test_helper_resolve_model_path.py
@@ -18,15 +18,37 @@ sys.path.insert(0, os.path.abspath(_COLLECTOR_DIR))
 from helper import _resolve_local_model_path
 
 
+@pytest.fixture
+def isolated_tmp(tmp_path, monkeypatch):
+    """Redirect tempfile.gettempdir() so the helper's deterministic per-slug
+    cache lives under pytest's tmp_path and is auto-cleaned between tests."""
+    tmp_root = tmp_path / "tmpdir"
+    tmp_root.mkdir()
+    monkeypatch.setattr("helper.tempfile.gettempdir", lambda: str(tmp_root))
+    return tmp_root
+
+
 class TestResolveLocalModelPath:
     def test_local_directory_passthrough(self, tmp_path):
-        # An existing directory must be returned unchanged.
         (tmp_path / "config.json").write_text("{}")
         result = _resolve_local_model_path(str(tmp_path))
         assert result == str(tmp_path)
 
-    def test_aic_cache_hit(self, tmp_path, monkeypatch):
-        # Point the helper at a synthetic AIC model_configs cache.
+    def test_local_path_is_file_rejected(self, tmp_path):
+        # A MOE_MODEL_PATH pointing at a file (not a directory) must fail loudly
+        # rather than silently falling through to an HF download attempt.
+        f = tmp_path / "config.json"
+        f.write_text("{}")
+        with pytest.raises(NotADirectoryError):
+            _resolve_local_model_path(str(f))
+
+    def test_local_dir_missing_config_rejected(self, tmp_path):
+        # An existing directory without config.json must fail at the helper
+        # rather than deferring to SGLang startup.
+        with pytest.raises(FileNotFoundError):
+            _resolve_local_model_path(str(tmp_path))
+
+    def test_aic_cache_hit(self, isolated_tmp, tmp_path, monkeypatch):
         cache_dir = tmp_path / "model_configs"
         cache_dir.mkdir()
         slug = "fake-org--fake-model"
@@ -38,10 +60,35 @@ class TestResolveLocalModelPath:
         assert os.path.isdir(result)
         with open(os.path.join(result, "config.json")) as f:
             assert json.load(f) == {"model_type": "fake"}
-        # No hf_quant_config side-car was provided, so none should appear.
         assert not os.path.exists(os.path.join(result, "hf_quant_config.json"))
 
-    def test_aic_cache_hit_with_quant_side_car(self, tmp_path, monkeypatch):
+    def test_aic_cache_strips_auto_map(self, isolated_tmp, tmp_path, monkeypatch):
+        # auto_map references .py files that AIC does not ship; with
+        # trust_remote_code=True, transformers would try to import them and
+        # crash. The helper must strip auto_map when materializing the cache.
+        cache_dir = tmp_path / "model_configs"
+        cache_dir.mkdir()
+        slug = "fake-org--fake-with-automap"
+        (cache_dir / f"{slug}_config.json").write_text(
+            json.dumps(
+                {
+                    "model_type": "fake",
+                    "auto_map": {
+                        "AutoConfig": "configuration_fake.FakeConfig",
+                        "AutoModel": "modeling_fake.FakeModel",
+                    },
+                }
+            )
+        )
+        monkeypatch.setattr("helper._AIC_MODEL_CONFIG_DIR", str(cache_dir))
+
+        result = _resolve_local_model_path("fake-org/fake-with-automap")
+        with open(os.path.join(result, "config.json")) as f:
+            materialized = json.load(f)
+        assert "auto_map" not in materialized
+        assert materialized["model_type"] == "fake"
+
+    def test_aic_cache_hit_with_quant_side_car(self, isolated_tmp, tmp_path, monkeypatch):
         cache_dir = tmp_path / "model_configs"
         cache_dir.mkdir()
         slug = "fake-org--fake-fp8"
@@ -54,8 +101,21 @@ class TestResolveLocalModelPath:
         with open(os.path.join(result, "hf_quant_config.json")) as f:
             assert json.load(f) == {"quant": "fp8"}
 
+    def test_aic_cache_is_deterministic_across_calls(self, isolated_tmp, tmp_path, monkeypatch):
+        # Two calls with the same model_id must converge on the same tempdir
+        # so parallel subprocesses (wideep collector spawns one per GPU) don't
+        # each create their own divergent copy.
+        cache_dir = tmp_path / "model_configs"
+        cache_dir.mkdir()
+        slug = "fake-org--deterministic"
+        (cache_dir / f"{slug}_config.json").write_text(json.dumps({"model_type": "fake"}))
+        monkeypatch.setattr("helper._AIC_MODEL_CONFIG_DIR", str(cache_dir))
+
+        first = _resolve_local_model_path("fake-org/deterministic")
+        second = _resolve_local_model_path("fake-org/deterministic")
+        assert first == second
+
     def test_hf_fallback_invoked_when_not_cached(self, tmp_path, monkeypatch):
-        # Empty AIC cache forces the HF download branch.
         empty_cache = tmp_path / "empty"
         empty_cache.mkdir()
         monkeypatch.setattr("helper._AIC_MODEL_CONFIG_DIR", str(empty_cache))
@@ -65,7 +125,7 @@ class TestResolveLocalModelPath:
         (hf_dir / "config.json").write_text("{}")
 
         def fake_hf_hub_download(repo_id, filename):
-            # config.json succeeds, tokenizer files are missing — typical for many MoE models.
+            # config.json succeeds; tokenizer files are missing — typical for MoE models.
             target = hf_dir / filename
             if filename == "config.json":
                 return str(target)
@@ -77,16 +137,29 @@ class TestResolveLocalModelPath:
             result = _resolve_local_model_path("any-org/any-model")
         assert result == str(hf_dir)
 
-    def test_no_hardcoded_deepseek_fallback(self, tmp_path, monkeypatch):
-        # When the model is not cached AND HF download fails entirely, the helper
-        # must raise — there must be no implicit "/deepseek-v3" or similar fallback.
-        monkeypatch.setattr("helper._AIC_MODEL_CONFIG_DIR", str(tmp_path / "nope"))
+    def test_hf_fallback_raises_if_config_json_missing(self, tmp_path, monkeypatch):
+        # If config.json itself fails to download we must raise, even if a
+        # tokenizer file happens to land first. The pre-fix code would have
+        # returned a snapshot dir without config.json.
+        empty_cache = tmp_path / "empty"
+        empty_cache.mkdir()
+        monkeypatch.setattr("helper._AIC_MODEL_CONFIG_DIR", str(empty_cache))
+
+        def fake_hf_hub_download(repo_id, filename):
+            raise RuntimeError(f"network down ({filename})")
 
         fake_hub = type(sys)("huggingface_hub")
-        fake_hub.hf_hub_download = lambda **kw: (_ for _ in ()).throw(RuntimeError("offline"))
-        # Accept positional or keyword call signatures.
+        fake_hub.hf_hub_download = fake_hf_hub_download
+        with patch.dict(sys.modules, {"huggingface_hub": fake_hub}), pytest.raises(FileNotFoundError):
+            _resolve_local_model_path("any-org/any-model")
+
+    def test_no_hardcoded_deepseek_fallback(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("helper._AIC_MODEL_CONFIG_DIR", str(tmp_path / "nope"))
+
         def _raise(*a, **kw):
             raise RuntimeError("offline")
+
+        fake_hub = type(sys)("huggingface_hub")
         fake_hub.hf_hub_download = _raise
 
         with patch.dict(sys.modules, {"huggingface_hub": fake_hub}), pytest.raises(FileNotFoundError):


### PR DESCRIPTION
## Summary

Closes #708. Removes the DeepSeek-specific fallback chain that `_get_moe_model_path()` and `_get_deepseek_model_path()` left behind after PR #684 added generic SGLang MoE collection. Both helpers hardcoded `deepseek-ai/DeepSeek-V3` as the HF repo, `configuration_deepseek.py` as a required file, and `/deepseek-v3` as the final fallback path — so generic MoE collection (Qwen, MiniMax, etc.) silently resolved the wrong config/tokenizer whenever `MOE_MODEL_PATH` was unset.

- Adds `helper._resolve_local_model_path(model_id)` with resolution order: existing local directory passthrough → AIC bundled `src/aiconfigurator/model_configs/<slug>_config.json` (+ optional `..._hf_quant_config.json` side-car copied into a tempdir) → `hf_hub_download` of `config.json` and tokenizer files. Raises `FileNotFoundError` if none resolve — no hardcoded `/deepseek-v3` fallback.
- Deletes `_get_deepseek_model_path()` and `_get_moe_model_path()` from `collector/helper.py`.
- Updates the only caller, `collector/sglang/collect_wideep_deepep_moe.py`, to derive a model id from `MOE_MODEL_PATH` (with `DEEPSEEK_MODEL_PATH` honored for backward compatibility) and delegate to the new helper.
- Drops the stale `_get_deepseek_model_path` mock from `tests/unit/collector/sglang/test_collect_mla_module.py` — the module never imported it.
- Adds `tests/unit/collector/test_helper_resolve_model_path.py` covering: local-path passthrough, AIC cache hit, AIC cache + quant side-car, HF fallback (mocked), failure path (no implicit fallback), empty model id rejected.

## Notes

- `collect_mla_module.py` already has its own sglang-specific `_resolve_local_model_path()` that does extra `model_type`/`architectures` rewriting for DSA + GLM-5. That helper is left untouched — its concerns are SGLang AutoConfig compatibility, not generic config resolution, and it is independent of the helpers being removed here.
- Behavior of `MOE_MODEL_PATH` env var is unchanged: when it points at an existing local directory, the value is passed through; when it looks like a HuggingFace id, it goes through the cache → HF resolution path.
- `DEEPSEEK_MODEL_PATH` retains its previous role as a legacy fallback env var in the wideep collector so existing CI configs do not break.

## Test plan

- [x] `pytest tests/unit/collector/test_helper_resolve_model_path.py -v` — 6 new tests pass
- [x] `pytest tests/unit/collector/ --ignore=tests/unit/collector/sglang/test_collect_mla_module.py -q` — 111 passed, 1 skipped, no regressions
- [x] Confirmed the 31 pre-existing failures in `test_collect_mla_module.py` reproduce on `upstream/main` without this change (they are unrelated)
- [x] `ruff check` clean on all touched files
- [x] Smoke test: `_resolve_local_model_path("deepseek-ai/DeepSeek-V3")` resolves from the bundled `model_configs/` cache without network access

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved model configuration resolution to support local directories, bundled cached configs, and Hugging Face Hub downloads in a unified approach.
  * Simplified model path handling with cleaner environment variable defaults and removed hardcoded model-specific fallback paths.

* **Tests**
  * Added comprehensive tests for model path resolution logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiconfigurator/pull/1122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->