### PR TITLE
fix: support SGLang MoEDispatch attention TPxDP

### DIFF
--- a/src/aiconfigurator/sdk/operations.py
+++ b/src/aiconfigurator/sdk/operations.py
@@ -796,13 +796,24 @@ class MoEDispatch(Operation):
                         hidden_size=self._hidden_size,
                     )
             else:
-                assert self._attention_tp_size == 1 or self._attention_dp_size == 1, (
-                    "We don't enable the path for non-wideep SGLang to support TP>1 and DP>1 for attn simultaneously"
-                )
-                # TODO: support TP+DP
                 logger.debug("MoEDispatch: In SGLang non-DeepEP execution path")
+                combined_attention_tpdp = self._attention_tp_size > 1 and self._attention_dp_size > 1
                 if self._pre_dispatch:
-                    if self._attention_tp_size > 1:  # tp>1, use allreduce
+                    if combined_attention_tpdp:
+                        # Matches SGLang DP attention: shard across attention TP, then gather across the full TP world.
+                        comm_latency = database.query_nccl(
+                            common.CommQuantMode.half,
+                            self._attention_tp_size,
+                            "reduce_scatter",
+                            volume,
+                        )
+                        comm_latency += database.query_nccl(
+                            common.CommQuantMode.half,
+                            self.num_gpus,
+                            "all_gather",
+                            volume * self._attention_dp_size,
+                        )
+                    elif self._attention_tp_size > 1:  # tp>1, use allreduce
                         # to do: custom allreduce
                         comm_latency = database.query_custom_allreduce(common.CommQuantMode.half, self.num_gpus, volume)
                     elif self._attention_dp_size > 1:
@@ -815,7 +826,21 @@ class MoEDispatch(Operation):
                     else:
                         comm_latency = 0
                 else:
-                    if self._attention_tp_size > 1:  # tp>1, use allreduce
+                    if combined_attention_tpdp:
+                        # Reverse path: reduce-scatter across the full TP world, then rebuild each attention TP group.
+                        comm_latency = database.query_nccl(
+                            common.CommQuantMode.half,
+                            self.num_gpus,
+                            "reduce_scatter",
+                            volume * self._attention_dp_size,
+                        )
+                        comm_latency += database.query_nccl(
+                            common.CommQuantMode.half,
+                            self._attention_tp_size,
+                            "all_gather",
+                            volume,
+                        )
+                    elif self._attention_tp_size > 1:  # tp>1, use allreduce
                         # to do: custom allreduce
                         comm_latency = database.query_custom_allreduce(common.CommQuantMode.half, self.num_gpus, volume)
                     elif self._attention_dp_size > 1:

--- a/tests/unit/sdk/database/test_moe_dispatch.py
+++ b/tests/unit/sdk/database/test_moe_dispatch.py
@@ -3,7 +3,7 @@
 
 """Unit tests for MoEDispatch communication logic across SM versions."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pytest
 import torch
@@ -19,10 +19,10 @@ pytestmark = pytest.mark.unit
 # ---------------------------------------------------------------------------
 
 
-def _make_mock_db(sm_version=100, num_gpus_per_node=8):
-    """Create a mock database configured as trtllm backend."""
+def _make_mock_db(sm_version=100, num_gpus_per_node=8, backend="trtllm"):
+    """Create a mock database configured for MoEDispatch tests."""
     db = MagicMock()
-    db.backend = "trtllm"
+    db.backend = backend
     db.system_spec = {
         "gpu": {"sm_version": sm_version},
         "node": {"num_gpus_per_node": num_gpus_per_node},
@@ -430,6 +430,59 @@ class TestSmLt100NoAlltoall:
         )
         dispatch.query(db, x=16)
         db.query_trtllm_alltoall.assert_not_called()
+
+
+@pytest.mark.skipif(torch.xpu.is_available(), reason="skip for xpu")
+class TestSGLangNonDeepEPAttentionTpDp:
+    """Test SGLang non-DeepEP combined attention TPxDP communication."""
+
+    def test_pre_dispatch_uses_reduce_scatter_then_all_gather(self):
+        db = _make_mock_db(sm_version=90, backend="sglang")
+        db.query_nccl.side_effect = [PerformanceResult(2.0), PerformanceResult(3.0)]
+        dispatch = _make_dispatch(
+            moe_tp_size=4,
+            moe_ep_size=2,
+            attention_dp_size=2,
+            pre_dispatch=True,
+            hidden_size=1024,
+        )
+
+        result = dispatch.query(db, x=16)
+
+        volume = 16 * 1024
+        assert float(result) == 5.0
+        assert db.query_nccl.call_count == 2
+        db.query_nccl.assert_has_calls(
+            [
+                call(common.CommQuantMode.half, 4, "reduce_scatter", volume),
+                call(common.CommQuantMode.half, 8, "all_gather", volume * 2),
+            ]
+        )
+        db.query_custom_allreduce.assert_not_called()
+
+    def test_post_dispatch_uses_reduce_scatter_then_all_gather(self):
+        db = _make_mock_db(sm_version=90, backend="sglang")
+        db.query_nccl.side_effect = [PerformanceResult(2.0), PerformanceResult(3.0)]
+        dispatch = _make_dispatch(
+            moe_tp_size=4,
+            moe_ep_size=2,
+            attention_dp_size=2,
+            pre_dispatch=False,
+            hidden_size=1024,
+        )
+
+        result = dispatch.query(db, x=16)
+
+        volume = 16 * 1024
+        assert float(result) == 5.0
+        assert db.query_nccl.call_count == 2
+        db.query_nccl.assert_has_calls(
+            [
+                call(common.CommQuantMode.half, 8, "reduce_scatter", volume * 2),
+                call(common.CommQuantMode.half, 4, "all_gather", volume),
+            ]
+        )
+        db.query_custom_allreduce.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Remove the SGLang non-DeepEP MoEDispatch assertion that rejected simultaneous `attention_tp_size > 1` and `attention_dp_size > 1`.
- Model SGLang's combined attention TPxDP communication as the runtime's two-step DP attention flow:
  - pre-dispatch: `reduce_scatter` across attention TP, then `all_gather` across the full TP world
  - post-dispatch: `reduce_scatter` across the full TP world, then `all_gather` across attention TP
- Add targeted MoEDispatch unit coverage for pre/post combined TPxDP collectives.

Reference runtime code: https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/layers/dp_attention.py#L498-L515 and https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/layers/dp_attention.py#L572-L580

## Linear
- Project: https://linear.app/nvidia/project/framework-sglang-non-deepep-moedispatch-tpxdp-9a696565e1e8/overview
- Issue: https://linear.app/nvidia/issue/AIC-1097/support-sglang-non-deepep-attention-tpxdp-in-moedispatch

## Verification
- `python3 -m py_compile src/aiconfigurator/sdk/operations.py tests/unit/sdk/database/test_moe_dispatch.py`
- `git diff --check`
- line-length scan for the touched files
- isolated SGLang TPxDP execution harness with a stubbed perf DB

Could not run the full pytest target in this checkout because local test dependencies are missing: `uv` is not installed, `python` is not present, and `python3` lacks `pytest`, `torch`, and `numpy`.
