### PR TITLE
fix: improve support matrix table visualization

### DIFF
--- a/docs/support-matrix/index.html
+++ b/docs/support-matrix/index.html
@@ -60,7 +60,7 @@ const SYSTEM_ORDER = ['b200', 'gb200', 'gb300', 'h100', 'h200', '__other__', 'a1
 
 function isFrameworkUnsupported(error) {
   if (!error) return false;
-  return /Unsupported [A-Za-z0-9_ -]*quant mode/.test(String(error));
+  return /\bUnsupported\s+[A-Za-z0-9_ -]*quant mode\b/i.test(String(error));
 }
 
 function isHardwareUnsupported(error) {
@@ -271,7 +271,9 @@ function aggregateBackendCell(rows, modelId, system, backend, versions, modeFilt
 
   const statusFromResult = (result) => {
     if (result.version === null) return 'missing';
-    if (result.version === 'FAIL') return 'fail';
+    if (result.version === 'FAIL') {
+      return isFrameworkUnsupported(result.error) ? 'framework_unsupported' : 'fail';
+    }
     if (result.version === STATUS_HW_INCOMPATIBLE) return unsupportedStatusFromError(result.error);
     return 'pass';
   };
@@ -857,7 +859,7 @@ function MatrixTable({ matrixRows, columns, searchQuery, sortCol, sortAsc, showA
     const gap = 8;
     const viewportWidth = window.innerWidth || document.documentElement.clientWidth;
     const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
-    const width = Math.min(520, Math.max(240, viewportWidth - margin * 2));
+    const width = Math.min(520, Math.max(0, viewportWidth - margin * 2));
     const maxLeft = Math.max(margin, viewportWidth - width - margin);
     const left = Math.min(
       Math.max(rect.left + rect.width / 2 - width / 2, margin),

--- a/docs/support-matrix/index.html
+++ b/docs/support-matrix/index.html
@@ -36,42 +36,10 @@ tailwind.config = {
   /* Body/backgrounds are full-bleed. Each bar (header / controls / tabs)
      and the main panel wrap their children in `max-w-[1600px] mx-auto` so
      content is centered at 1600px while the colored bar extends edge-to-edge. */
-  /* Instant (no-delay) tooltip for table cells. Uses `data-tip` so the
-     browser's native `title` delay does not kick in. */
-  td[data-tip] { position: relative; }
-  /* Orange/red cells use `hover:brightness-95` which creates a CSS filter
-     stacking context. Without lifting the hovered cell itself, the
-     tooltip's z-index is trapped inside that context and gets painted
-     under the next sibling <td>. Promoting the cell on hover escapes that. */
-  td[data-tip]:hover { z-index: 20; }
-  td[data-tip]:hover::after {
-    content: attr(data-tip);
-    position: absolute;
-    left: 50%;
-    top: 100%;
-    transform: translate(-50%, 6px);
-    z-index: 1000;
-    padding: 0.4rem 0.6rem;
-    background: rgb(15 23 42);
-    color: rgb(241 245 249);
-    font-size: 0.72rem;
-    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-    line-height: 1.4;
+  .matrix-tooltip {
     white-space: pre-wrap;
     overflow-wrap: anywhere;
     word-break: break-word;
-    border-radius: 4px;
-    box-shadow: 0 2px 8px rgba(0,0,0,.25);
-    pointer-events: none;
-    width: max-content;
-    max-width: min(480px, calc(100vw - 2rem));
-    box-sizing: border-box;
-    text-align: left;
-  }
-  html.dark td[data-tip]:hover::after {
-    background: rgb(30 41 59);
-    color: rgb(241 245 249);
-    box-shadow: 0 2px 8px rgba(0,0,0,.5);
   }
 </style>
 </head>
@@ -89,6 +57,31 @@ const LEGACY_CSV_PATH = 'src/aiconfigurator/systems/support_matrix.csv';
 const STATUS_HW_INCOMPATIBLE = 'HW_INCOMPATIBLE';
 const PREFERRED_DEFAULT_SYSTEM = 'b200_sxm';
 const SYSTEM_ORDER = ['b200', 'gb200', 'gb300', 'h100', 'h200', '__other__', 'a100', 'l40s'];
+
+function isFrameworkUnsupported(error) {
+  if (!error) return false;
+  return /Unsupported [A-Za-z0-9_ -]*quant mode/.test(String(error));
+}
+
+function isHardwareUnsupported(error) {
+  if (!error) return true;
+  const text = String(error).toLowerCase();
+  if (text.includes('gpu does not support') || text.includes('hardware is incompatible')) return true;
+  if (/\bdoes not support\b.*\brequired by\b/.test(text)) return true;
+  return text.includes('does not support model datatype') || text.includes('does not support model dtype');
+}
+
+function unsupportedStatusFromError(error) {
+  if (isFrameworkUnsupported(error)) return 'framework_unsupported';
+  if (isHardwareUnsupported(error)) return 'hw_incompatible';
+  return 'fail';
+}
+
+function statusDisplayLabel(status) {
+  if (status === 'hw_incompatible') return STATUS_HW_INCOMPATIBLE;
+  if (status === 'framework_unsupported') return 'FRAMEWORK_UNSUPPORTED';
+  return 'FAIL';
+}
 
 function sortSystems(systems) {
   return [...systems].sort((a, b) => {
@@ -260,22 +253,26 @@ function getLatestSupportedVersion(rows, huggingfaceId, system, backend) {
 // cell records which versions pass, partially pass, or fail so the UI can
 // show "pass on v1.0, fail on v1.1" instead of a single PASS/FAIL flag.
 // Overall status:
-//   pass:    every tested version fully passes
+//   pass:    every tested framework version fully passes
+//   latest_pass_with_older_issues: latest framework version passes, older versions have issues
+//   older_pass_only: latest framework version does not pass, but an older version does
 //   fail:    every tested version fully fails
 //   partial: any mix (includes per-version agg/disagg splits)
 //   hw_incompatible: latest tested version is impossible on this GPU
+//   framework_unsupported: framework/version does not support required model feature
 //   missing: no rows tested for this (model, backend)
 function aggregateBackendCell(rows, modelId, system, backend, versions, modeFilter) {
   const passVersions = [];
   const partialVersions = [];
   const failVersions = [];
   const hwVersions = [];
-  const errors = [];
+  const frameworkUnsupportedVersions = [];
+  const errorEntries = [];
 
   const statusFromResult = (result) => {
     if (result.version === null) return 'missing';
     if (result.version === 'FAIL') return 'fail';
-    if (result.version === STATUS_HW_INCOMPATIBLE) return 'hw_incompatible';
+    if (result.version === STATUS_HW_INCOMPATIBLE) return unsupportedStatusFromError(result.error);
     return 'pass';
   };
 
@@ -286,7 +283,7 @@ function aggregateBackendCell(rows, modelId, system, backend, versions, modeFilt
     const { version: v, error } = getLatestSupportedVersion(verRows, modelId, system, backend);
     if (v === null) continue; // missing for this version
 
-    let verStatus = statusFromResult({ version: v });
+    let verStatus = statusFromResult({ version: v, error });
     let verError = verStatus === 'pass' ? null : error;
 
     // Within-version agg/disagg split (only meaningful when viewing "all").
@@ -305,19 +302,25 @@ function aggregateBackendCell(rows, modelId, system, backend, versions, modeFilt
       const hasPass = modeStatuses.includes('pass');
       const hasFail = modeStatuses.includes('fail');
       const hasHw = modeStatuses.includes('hw_incompatible');
+      const hasFrameworkUnsupported = modeStatuses.includes('framework_unsupported');
 
-      if (hasPass && (hasFail || hasHw || modeStatuses.length < 2)) {
+      if (hasPass && (hasFail || hasHw || hasFrameworkUnsupported || modeStatuses.length < 2)) {
         verStatus = 'partial';
         if (aggStatus !== 'pass') {
-          verError = `[agg ${aggStatus === 'hw_incompatible' ? STATUS_HW_INCOMPATIBLE : 'FAIL'}] ${aggResult.error || 'No error message available'}`;
+          verError = `[agg ${statusDisplayLabel(aggStatus)}] ${aggResult.error || 'No error message available'}`;
         } else {
-          verError = `[disagg ${disaggStatus === 'hw_incompatible' ? STATUS_HW_INCOMPATIBLE : 'FAIL'}] ${disaggResult.error || 'No error message available'}`;
+          verError = `[disagg ${statusDisplayLabel(disaggStatus)}] ${disaggResult.error || 'No error message available'}`;
         }
       } else if (!hasPass && hasFail) {
         verStatus = 'fail';
         verError = aggStatus === 'fail'
           ? (aggResult.error || 'No error message available')
           : (disaggResult.error || 'No error message available');
+      } else if (!hasPass && hasFrameworkUnsupported) {
+        verStatus = 'framework_unsupported';
+        verError = aggStatus === 'framework_unsupported'
+          ? (aggResult.error || 'Framework version does not support required model feature')
+          : (disaggResult.error || 'Framework version does not support required model feature');
       } else if (!hasPass && hasHw) {
         verStatus = 'hw_incompatible';
         verError = aggStatus === 'hw_incompatible'
@@ -328,35 +331,57 @@ function aggregateBackendCell(rows, modelId, system, backend, versions, modeFilt
 
     if (verStatus === 'pass') passVersions.push(version);
     else if (verStatus === 'partial') partialVersions.push(version);
+    else if (verStatus === 'framework_unsupported') frameworkUnsupportedVersions.push(version);
     else if (verStatus === 'hw_incompatible') hwVersions.push(version);
     else failVersions.push(version);
 
     if (verError) {
-      if (verStatus === 'hw_incompatible') {
-        if (!errors.includes(verError)) errors.push(verError);
-      } else {
-        errors.push(`[${version}] ${verError}`);
-      }
+      errorEntries.push({ version, message: `[${version}] ${verError}` });
     }
   }
 
-  if (!passVersions.length && !partialVersions.length && !failVersions.length && !hwVersions.length) {
-    return { status: 'missing', passVersions: [], partialVersions: [], failVersions: [], hwVersions: [], error: null };
+  if (!passVersions.length && !partialVersions.length && !failVersions.length && !hwVersions.length && !frameworkUnsupportedVersions.length) {
+    return {
+      status: 'missing',
+      passVersions: [],
+      partialVersions: [],
+      failVersions: [],
+      frameworkUnsupportedVersions: [],
+      hwVersions: [],
+      error: null,
+    };
   }
 
   // Color is driven by the **latest tested version** for this (model, backend):
-  //   - latest is strictly pass               -> green
-  //   - latest is fail/partial but any older  -> orange (regression)
+  //   - every tested version fully passes     -> dark green
+  //   - latest passes but older versions have issues -> light green
+  //   - only an older version passes          -> blue
+  //   - latest has partial support only       -> orange
   //   - everything failed                     -> red
+  //   - latest is framework-unsupported       -> violet
   //   - latest is hardware-incompatible       -> gray
   const sortDesc = (a, b) => compareVersionTuples(versionSortKey(b), versionSortKey(a));
-  const allTested = [...passVersions, ...partialVersions, ...failVersions, ...hwVersions].sort(sortDesc);
+  const allTested = [
+    ...passVersions,
+    ...partialVersions,
+    ...failVersions,
+    ...frameworkUnsupportedVersions,
+    ...hwVersions,
+  ].sort(sortDesc);
   const newest = allTested[0];
   let status;
-  if (passVersions.includes(newest)) status = 'pass';
+  if (passVersions.includes(newest)) {
+    status = passVersions.length === allTested.length
+      ? 'pass'
+      : 'latest_pass_with_older_issues';
+  }
+  else if (passVersions.length) {
+    status = 'older_pass_only';
+  }
+  else if (frameworkUnsupportedVersions.includes(newest)) status = 'framework_unsupported';
   else if (hwVersions.includes(newest)) status = 'hw_incompatible';
   else if (partialVersions.includes(newest)) status = 'partial';
-  else if (passVersions.length || partialVersions.length) status = 'partial';
+  else if (partialVersions.length) status = 'partial';
   else status = 'fail';
 
   return {
@@ -364,8 +389,15 @@ function aggregateBackendCell(rows, modelId, system, backend, versions, modeFilt
     passVersions: passVersions.slice().sort(sortDesc),
     partialVersions: partialVersions.slice().sort(sortDesc),
     failVersions: failVersions.slice().sort(sortDesc),
+    frameworkUnsupportedVersions: frameworkUnsupportedVersions.slice().sort(sortDesc),
     hwVersions: hwVersions.slice().sort(sortDesc),
-    error: errors.length ? errors.join(' | ') : null,
+    error: errorEntries.length
+      ? errorEntries
+        .slice()
+        .sort((a, b) => compareVersionTuples(versionSortKey(b.version), versionSortKey(a.version)))
+        .map(e => e.message)
+        .join('\n')
+      : null,
   };
 }
 
@@ -425,7 +457,7 @@ function isLocalPreview() {
 }
 
 function rawUrl(branch, path) {
-  if (isLocalPreview()) return `/${path}`;
+  if (isLocalPreview()) return `/${path}?localPreviewTs=${Date.now()}`;
   return `https://raw.githubusercontent.com/${REPO}/refs/heads/${branch}/${path}`;
 }
 
@@ -502,7 +534,7 @@ async function fetchBranchList() {
 }
 
 async function fetchOneCsv(branch, path) {
-  const res = await fetch(rawUrl(branch, path));
+  const res = await fetch(rawUrl(branch, path), { cache: isLocalPreview() ? 'no-store' : 'default' });
   if (!res.ok) throw new Error(`Failed to fetch CSV (HTTP ${res.status}) from branch "${branch}"`);
   const text = await res.text();
   // Support generated updates that mix historical CRLF rows with LF rows.
@@ -512,7 +544,7 @@ async function fetchOneCsv(branch, path) {
 }
 
 async function fetchCsv(branch) {
-  const indexRes = await fetch(rawUrl(branch, SUPPORT_MATRIX_INDEX_PATH));
+  const indexRes = await fetch(rawUrl(branch, SUPPORT_MATRIX_INDEX_PATH), { cache: isLocalPreview() ? 'no-store' : 'default' });
   if (!indexRes.ok) {
     return fetchOneCsv(branch, LEGACY_CSV_PATH);
   }
@@ -757,19 +789,31 @@ function Legend() {
     <div className="flex flex-wrap gap-4 items-center mb-4 text-sm text-slate-500 dark:text-slate-400">
       <span className="font-semibold">Legend:</span>
       <div className="flex items-center gap-1.5">
-        <span className="inline-block w-9 h-5 rounded border border-slate-200 dark:border-slate-600 bg-green-100 dark:bg-green-950"></span>
-        Latest version passes
+        <span className="inline-block w-9 h-5 rounded border border-slate-200 dark:border-slate-600 bg-green-300 dark:bg-green-900"></span>
+        All framework versions supported
       </div>
       <div className="flex items-center gap-1.5">
-        <span className="inline-block w-9 h-5 rounded border border-slate-200 dark:border-slate-600 bg-amber-100 dark:bg-amber-950"></span>
-        Regression (latest fails, older passes) or partial coverage in latest version (agg or disagg only) (<span className="line-through opacity-75 font-mono">struck</span>&nbsp;= fails)
+        <span className="inline-block w-9 h-5 rounded border border-slate-200 dark:border-slate-600 bg-green-200 dark:bg-green-950"></span>
+        Latest framework version supported, older version has issues (<span className="font-mono">F</span>&nbsp;= framework unsupported, <span className="font-mono">!</span>&nbsp;= hardware-incompatible)
       </div>
       <div className="flex items-center gap-1.5">
-        <span className="inline-block w-9 h-5 rounded border border-slate-200 dark:border-slate-600 bg-red-100 dark:bg-red-950"></span>
+        <span className="inline-block w-9 h-5 rounded border border-slate-200 dark:border-slate-600 bg-sky-200 dark:bg-sky-950"></span>
+        Only older framework version supported; latest does not pass
+      </div>
+      <div className="flex items-center gap-1.5">
+        <span className="inline-block w-9 h-5 rounded border border-slate-200 dark:border-slate-600 bg-amber-200 dark:bg-amber-950"></span>
+        Partial coverage in latest version (agg or disagg only) (<span className="line-through opacity-75 font-mono">struck</span>&nbsp;= fails)
+      </div>
+      <div className="flex items-center gap-1.5">
+        <span className="inline-block w-9 h-5 rounded border border-slate-200 dark:border-slate-600 bg-red-200 dark:bg-red-950"></span>
         All versions fail (click for details)
       </div>
       <div className="flex items-center gap-1.5">
-        <span className="inline-block w-9 h-5 rounded border border-slate-200 dark:border-slate-600 bg-slate-200 dark:bg-slate-700"></span>
+        <span className="inline-block w-9 h-5 rounded border border-slate-200 dark:border-slate-600 bg-violet-200 dark:bg-violet-950"></span>
+        Framework version does not support required model feature
+      </div>
+      <div className="flex items-center gap-1.5">
+        <span className="inline-block w-9 h-5 rounded border border-slate-200 dark:border-slate-600 bg-slate-300 dark:bg-slate-700"></span>
         GPU does not support model datatype
       </div>
       <a href={buildFileIssueUrl()} target="_blank" rel="noopener"
@@ -786,20 +830,91 @@ function SortArrow({ col, sortCol, sortAsc }) {
   return <span className="ml-1 text-[0.65rem]">{sortAsc ? '\u25B2' : '\u25BC'}</span>;
 }
 
+function FloatingTooltip({ tip }) {
+  if (!tip) return null;
+  return (
+    <div
+      className="matrix-tooltip fixed z-[2000] pointer-events-none rounded bg-slate-900 dark:bg-slate-800
+                 px-2.5 py-2 text-[0.72rem] leading-snug font-mono text-slate-100 shadow-lg overflow-auto"
+      style={tip.style}
+    >
+      {tip.text}
+    </div>
+  );
+}
+
 function MatrixTable({ matrixRows, columns, searchQuery, sortCol, sortAsc, showAllVersions, onSort, onCellClick }) {
+  const [hoverTip, setHoverTip] = useState(null);
+  const rowNumberColumnWidth = 56;
+  const modelColumnWidth = 360;
+  const backendColumnWidth = 184;
+  const tableMinWidth = rowNumberColumnWidth + modelColumnWidth + columns.length * backendColumnWidth;
+
+  const showTooltip = useCallback((event, text, placement = 'bottom') => {
+    if (!text) return;
+    const rect = event.currentTarget.getBoundingClientRect();
+    const margin = 12;
+    const gap = 8;
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
+    const width = Math.min(520, Math.max(240, viewportWidth - margin * 2));
+    const maxLeft = Math.max(margin, viewportWidth - width - margin);
+    const left = Math.min(
+      Math.max(rect.left + rect.width / 2 - width / 2, margin),
+      maxLeft,
+    );
+    const availableAbove = rect.top - margin - gap;
+    const availableBelow = viewportHeight - rect.bottom - margin - gap;
+    const useAbove = placement === 'top'
+      ? availableAbove >= 96 || availableAbove >= availableBelow
+      : availableBelow < 120 && availableAbove > availableBelow;
+    const maxHeight = Math.max(96, Math.min(420, useAbove ? availableAbove : availableBelow));
+    const style = {
+      left: `${left}px`,
+      width: `${width}px`,
+      maxHeight: `${maxHeight}px`,
+    };
+    if (useAbove) style.bottom = `${Math.max(margin, viewportHeight - rect.top + gap)}px`;
+    else style.top = `${Math.max(margin, Math.min(rect.bottom + gap, viewportHeight - margin - maxHeight))}px`;
+    setHoverTip({ text, style });
+  }, []);
+
+  const hideTooltip = useCallback(() => setHoverTip(null), []);
+  const tooltipHandlers = (text, placement) => ({
+    onMouseEnter: (event) => showTooltip(event, text, placement),
+    onMouseLeave: hideTooltip,
+    onFocus: (event) => showTooltip(event, text, placement),
+    onBlur: hideTooltip,
+  });
+
   let filtered = matrixRows;
   if (searchQuery) {
     const q = searchQuery.toLowerCase();
     filtered = matrixRows.filter(r => r.model.toLowerCase().includes(q));
   }
 
-  // Sort by status rank first (pass < partial < fail < missing), then by
+  // Sort by status rank first (all-pass < latest-pass < older-pass-only <
+  // partial < fail < framework-unsupported < hardware-incompatible < missing), then by
   // the concatenated version lists so rows with the same status cluster by
   // their supported-version set.
-  const STATUS_RANK = { pass: 0, partial: 1, fail: 2, hw_incompatible: 3, missing: 4 };
+  const STATUS_RANK = {
+    pass: 0,
+    latest_pass_with_older_issues: 1,
+    older_pass_only: 2,
+    partial: 3,
+    fail: 4,
+    framework_unsupported: 5,
+    hw_incompatible: 6,
+    missing: 7,
+  };
   const cellSortKey = (c) => {
     if (!c) return '99|';
-    const versions = (c.passVersions || []).concat(c.partialVersions || [], c.failVersions || [], c.hwVersions || []).join(',');
+    const versions = (c.passVersions || []).concat(
+      c.partialVersions || [],
+      c.failVersions || [],
+      c.frameworkUnsupportedVersions || [],
+      c.hwVersions || [],
+    ).join(',');
     return String(STATUS_RANK[c.status] ?? 99) + '|' + versions;
   };
 
@@ -822,10 +937,13 @@ function MatrixTable({ matrixRows, columns, searchQuery, sortCol, sortAsc, showA
 
   const cellClass = (status) => {
     switch (status) {
-      case 'pass': return 'bg-green-100 dark:bg-green-950 text-green-800 dark:text-green-300 font-medium';
-      case 'partial': return 'bg-amber-100 dark:bg-amber-950 text-amber-800 dark:text-amber-300 font-medium cursor-pointer hover:brightness-95 dark:hover:brightness-125';
-      case 'fail': return 'bg-red-100 dark:bg-red-950 text-red-700 dark:text-red-300 font-semibold cursor-pointer hover:brightness-95 dark:hover:brightness-125';
-      case 'hw_incompatible': return 'bg-slate-200 dark:bg-slate-700 text-slate-600 dark:text-slate-300 font-medium';
+      case 'pass': return 'bg-green-300 dark:bg-green-900 text-green-950 dark:text-white font-semibold';
+      case 'latest_pass_with_older_issues': return 'bg-green-200 dark:bg-green-950 text-green-900 dark:text-green-300 font-medium cursor-pointer hover:brightness-95 dark:hover:brightness-125';
+      case 'older_pass_only': return 'bg-sky-200 dark:bg-sky-950 text-sky-900 dark:text-sky-300 font-medium cursor-pointer hover:brightness-95 dark:hover:brightness-125';
+      case 'partial': return 'bg-amber-200 dark:bg-amber-950 text-amber-900 dark:text-amber-300 font-medium cursor-pointer hover:brightness-95 dark:hover:brightness-125';
+      case 'fail': return 'bg-red-200 dark:bg-red-950 text-red-800 dark:text-red-300 font-semibold cursor-pointer hover:brightness-95 dark:hover:brightness-125';
+      case 'framework_unsupported': return 'bg-violet-200 dark:bg-violet-950 text-violet-900 dark:text-violet-300 font-medium cursor-pointer hover:brightness-95 dark:hover:brightness-125';
+      case 'hw_incompatible': return 'bg-slate-300 dark:bg-slate-700 text-slate-700 dark:text-slate-300 font-medium cursor-pointer hover:brightness-95 dark:hover:brightness-125';
       default: return '';
     }
   };
@@ -841,25 +959,31 @@ function MatrixTable({ matrixRows, columns, searchQuery, sortCol, sortAsc, showA
     const pushPass = (v) => chips.push(<span key={`p-${v}`}>{v}</span>);
     const pushPartial = (v) => chips.push(<span key={`m-${v}`} title="Partial (agg or disagg only)">~{v}</span>);
     const pushFail = (v) => chips.push(<span key={`f-${v}`} className="line-through opacity-75">{v}</span>);
-    const pushHw = (v) => chips.push(<span key={`h-${v}`}>{v}</span>);
+    const pushFrameworkUnsupported = (v) => chips.push(<span key={`u-${v}`} title="Framework unsupported" className="opacity-80">F{v}</span>);
+    const pushHw = (v) => chips.push(<span key={`h-${v}`} title="Hardware incompatible" className="opacity-80">!{v}</span>);
 
     if (showAllVersions) {
       const all = [
         ...(cell.passVersions || []).map(v => ({ version: v, status: 'pass' })),
         ...(cell.partialVersions || []).map(v => ({ version: v, status: 'partial' })),
         ...(cell.failVersions || []).map(v => ({ version: v, status: 'fail' })),
+        ...(cell.frameworkUnsupportedVersions || []).map(v => ({ version: v, status: 'framework_unsupported' })),
         ...(cell.hwVersions || []).map(v => ({ version: v, status: 'hw_incompatible' })),
       ].sort((a, b) => compareVersionTuples(versionSortKey(a.version), versionSortKey(b.version)));
       all.forEach(({ version, status }) => {
         if (status === 'pass') pushPass(version);
         else if (status === 'partial') pushPartial(version);
+        else if (status === 'framework_unsupported') pushFrameworkUnsupported(version);
         else if (status === 'hw_incompatible') pushHw(version);
         else pushFail(version);
       });
     } else {
       // Each per-status list is already newest-first (sorted in aggregateBackendCell).
       // Pick whichever bucket the overall status points at.
-      if (cell.status === 'pass' && cell.passVersions && cell.passVersions.length) {
+      if (
+        (cell.status === 'pass' || cell.status === 'latest_pass_with_older_issues' || cell.status === 'older_pass_only')
+        && cell.passVersions && cell.passVersions.length
+      ) {
         pushPass(cell.passVersions[0]);
       } else if (cell.status === 'partial') {
         const brokenVersions = [
@@ -873,6 +997,10 @@ function MatrixTable({ matrixRows, columns, searchQuery, sortCol, sortAsc, showA
       } else if (cell.status === 'fail') {
         if (cell.failVersions && cell.failVersions.length) pushFail(cell.failVersions[0]);
         else if (cell.partialVersions && cell.partialVersions.length) pushPartial(cell.partialVersions[0]);
+      } else if (cell.status === 'framework_unsupported') {
+        if (cell.frameworkUnsupportedVersions && cell.frameworkUnsupportedVersions.length) {
+          pushFrameworkUnsupported(cell.frameworkUnsupportedVersions[0]);
+        }
       } else if (cell.status === 'hw_incompatible') {
         if (cell.hwVersions && cell.hwVersions.length) pushHw(cell.hwVersions[0]);
       }
@@ -881,12 +1009,20 @@ function MatrixTable({ matrixRows, columns, searchQuery, sortCol, sortAsc, showA
   };
 
   return (
-    <div className="overflow-x-auto mb-6 rounded-lg border border-slate-200 dark:border-slate-700 scrollbar-thin">
-      <table className="w-full text-sm border-collapse">
+    <React.Fragment>
+    <div className="overflow-x-auto mb-6 rounded-lg border border-slate-200 dark:border-slate-700 scrollbar-thin" onScroll={hideTooltip}>
+      <table className="w-full text-sm border-collapse table-fixed" style={{ minWidth: `${tableMinWidth}px` }}>
+        <colgroup>
+          <col style={{ width: `${rowNumberColumnWidth}px` }} />
+          <col style={{ width: `${modelColumnWidth}px` }} />
+          {columns.map(c => (
+            <col key={c.key} style={{ width: `${backendColumnWidth}px` }} />
+          ))}
+        </colgroup>
         <thead>
           <tr>
             <th className="bg-slate-50 dark:bg-slate-800 sticky top-0 z-10 px-3 py-2 text-right font-bold
-                  border-b-2 border-slate-200 dark:border-slate-600 whitespace-nowrap w-14 text-slate-500 dark:text-slate-400">
+                  border-b-2 border-slate-200 dark:border-slate-600 whitespace-nowrap text-slate-500 dark:text-slate-400">
               No.
             </th>
             <th onClick={() => onSort('model')}
@@ -899,22 +1035,26 @@ function MatrixTable({ matrixRows, columns, searchQuery, sortCol, sortAsc, showA
             {columns.map(c => (
               <th key={c.key} onClick={() => onSort(c.key)}
                   className={`bg-slate-50 dark:bg-slate-800 sticky top-0 z-10 px-3 py-2 text-left font-bold
-                    border-b-2 border-slate-200 dark:border-slate-600 cursor-pointer select-none whitespace-nowrap
+                    border-b-2 border-slate-200 dark:border-slate-600 cursor-pointer select-none
                     hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors
                     ${sortCol === c.key ? 'text-indigo-600 dark:text-indigo-400' : ''}`}>
-                {c.backend}
-                {c.versions.length > 1 && (
-                  <small className="font-normal text-slate-400 ml-1">({c.versions.join(', ')})</small>
-                )}
-                <SortArrow col={c.key} sortCol={sortCol} sortAsc={sortAsc} />
+                <div className="flex items-start gap-1 min-w-0">
+                  <span className="shrink-0">{c.backend}</span>
+                  {c.versions.length > 1 && (
+                    <small className="font-normal text-slate-400 truncate min-w-0">({c.versions.join(', ')})</small>
+                  )}
+                  <span className="shrink-0"><SortArrow col={c.key} sortCol={sortCol} sortAsc={sortAsc} /></span>
+                </div>
               </th>
             ))}
           </tr>
         </thead>
         <tbody>
-          {filtered.map((row, index) => (
+          {filtered.map((row, index) => {
+            const tipPlacement = index >= Math.max(filtered.length - 6, 0) ? 'top' : 'bottom';
+            return (
             <tr key={row.model} className="hover:bg-slate-50/50 dark:hover:bg-slate-800/50 transition-colors">
-              <td className="px-3 py-2 border-b border-slate-200 dark:border-slate-700 text-right text-slate-500 dark:text-slate-400 tabular-nums w-14">
+              <td className="px-3 py-2 border-b border-slate-200 dark:border-slate-700 text-right text-slate-500 dark:text-slate-400 tabular-nums">
                 {index + 1}
               </td>
               <td className="px-3 py-2 border-b border-slate-200 dark:border-slate-700 font-medium max-w-xs overflow-hidden text-ellipsis whitespace-nowrap"
@@ -924,9 +1064,21 @@ function MatrixTable({ matrixRows, columns, searchQuery, sortCol, sortAsc, showA
               {columns.map(c => {
                 const cell = row.cells[c.key];
                 if (!cell || cell.status === 'missing') {
-                  return <td key={c.key} data-tip={`${c.backend}: not tested`} className="px-3 py-2 border-b border-slate-200 dark:border-slate-700 text-slate-400">&mdash;</td>;
+                  const displayTooltip = `${c.backend}: not tested`;
+                  return (
+                    <td key={c.key}
+                        {...tooltipHandlers(displayTooltip, tipPlacement)}
+                        aria-label={displayTooltip}
+                        className="px-3 py-2 border-b border-slate-200 dark:border-slate-700 text-slate-400">
+                      &mdash;
+                    </td>
+                  );
                 }
-                const clickable = cell.status === 'fail' || cell.status === 'partial';
+                const clickable = Boolean(cell.error) && (
+                  cell.status === 'fail' || cell.status === 'partial' ||
+                  cell.status === 'framework_unsupported' || cell.status === 'hw_incompatible' ||
+                  cell.status === 'latest_pass_with_older_issues' || cell.status === 'older_pass_only'
+                );
                 // Native browser tooltip with the full version breakdown so the
                 // user can always inspect all versions regardless of the
                 // "Show all versions" toggle.
@@ -934,24 +1086,44 @@ function MatrixTable({ matrixRows, columns, searchQuery, sortCol, sortAsc, showA
                 if (cell.passVersions && cell.passVersions.length) tooltipParts.push(`Pass: ${cell.passVersions.join(', ')}`);
                 if (cell.partialVersions && cell.partialVersions.length) tooltipParts.push(`Partial: ${cell.partialVersions.join(', ')}`);
                 if (cell.failVersions && cell.failVersions.length) tooltipParts.push(`Fail: ${cell.failVersions.join(', ')}`);
+                if (cell.frameworkUnsupportedVersions && cell.frameworkUnsupportedVersions.length) tooltipParts.push(`Framework unsupported: ${cell.frameworkUnsupportedVersions.join(', ')}`);
                 if (cell.hwVersions && cell.hwVersions.length) tooltipParts.push(`Hardware incompatible: ${cell.hwVersions.join(', ')}`);
-                const tooltip = cell.status === 'hw_incompatible'
-                  ? (cell.error || 'Hardware is incompatible with model datatype')
-                  : `${c.backend}\n${tooltipParts.join('\n')}`;
+                const tooltip = cell.status === 'framework_unsupported'
+                  ? (cell.error || 'Framework version does not support required model feature')
+                  : cell.status === 'hw_incompatible'
+                    ? (cell.error || 'Hardware is incompatible with model datatype')
+                    : `${c.backend}\n${tooltipParts.join('\n')}`;
+                const displayTooltip = clickable ? `${tooltip}\n\nClick to keep this open and copy it.` : tooltip;
                 return (
                   <td key={c.key}
-                      data-tip={tooltip}
-                      onClick={clickable ? () => onCellClick(row.model, c.backend, cell.error) : undefined}
+                      {...tooltipHandlers(displayTooltip, tipPlacement)}
+                      onClick={clickable ? () => {
+                        hideTooltip();
+                        onCellClick(row.model, c.backend, cell.error);
+                      } : undefined}
+                      onKeyDown={clickable ? (e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          hideTooltip();
+                          onCellClick(row.model, c.backend, cell.error);
+                        }
+                      } : undefined}
+                      role={clickable ? 'button' : undefined}
+                      tabIndex={clickable ? 0 : undefined}
+                      aria-label={clickable ? `Open error details for ${row.model} on ${c.backend}` : undefined}
                       className={`px-3 py-2 border-b border-slate-200 dark:border-slate-700 ${cellClass(cell.status)}`}>
                     {renderChips(cell)}
                   </td>
                 );
               })}
             </tr>
-          ))}
+          );
+          })}
         </tbody>
       </table>
     </div>
+    <FloatingTooltip tip={hoverTip} />
+    </React.Fragment>
   );
 }
 
@@ -994,15 +1166,49 @@ function TopErrors({ errors }) {
 }
 
 function ErrorModal({ model, system, backend, error, onClose }) {
+  const [copied, setCopied] = useState(false);
   if (!error) return null;
   const formatted = error.replace(/\\\\n/g, '\n').replace(/\\n/g, '\n');
   const issueUrl = buildCallForFixUrl(model, system, backend, formatted);
+  const copyError = () => {
+    const copyWithTextarea = () => {
+      const textarea = document.createElement('textarea');
+      textarea.value = formatted;
+      textarea.style.position = 'fixed';
+      textarea.style.left = '-9999px';
+      document.body.appendChild(textarea);
+      textarea.focus();
+      textarea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textarea);
+    };
+    const done = () => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1400);
+    };
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(formatted)
+        .then(done)
+        .catch(() => {
+          copyWithTextarea();
+          done();
+        });
+      return;
+    }
+    copyWithTextarea();
+    done();
+  };
   return (
     <div className="fixed inset-0 bg-black/50 z-[1000] flex items-center justify-center p-6" onClick={onClose}>
       <div className="bg-white dark:bg-slate-800 rounded-lg max-w-3xl w-full max-h-[85vh] flex flex-col shadow-2xl"
            onClick={e => e.stopPropagation()}>
         <div className="flex items-center gap-3 px-5 py-4 border-b border-slate-200 dark:border-slate-700 shrink-0">
           <h3 className="flex-1 text-base font-bold">Error Details &mdash; {model} / {backend}</h3>
+          <button onClick={copyError}
+            className="px-3 py-1.5 bg-slate-100 hover:bg-slate-200 dark:bg-slate-700 dark:hover:bg-slate-600
+                       text-slate-700 dark:text-slate-200 text-xs font-semibold rounded transition-colors whitespace-nowrap">
+            {copied ? 'Copied' : 'Copy'}
+          </button>
           <a href={issueUrl} target="_blank" rel="noopener"
             className="px-3 py-1.5 bg-indigo-500 hover:bg-indigo-600 dark:bg-indigo-400 dark:hover:bg-indigo-500
                        text-white text-xs font-semibold rounded transition-colors no-underline whitespace-nowrap">


### PR DESCRIPTION
## Summary
- target `main` directly; this PR contains only `docs/support-matrix/index.html`
- classify framework-unsupported support-matrix failures separately from hardware-incompatible failures
- add clearer status colors for all-pass, latest-pass, older-pass-only, partial, framework-unsupported, and hardware-incompatible cells
- replace fragile table-cell hover text with a fixed tooltip and copyable error-detail flow
- show per-framework-version failure messages on separate lines with latest versions first

## Visual Before / After
Captured on `b200_sxm` with no model search filter so the broader model table is visible.

**Before (`main`)**

![Before support matrix visualization](https://raw.githubusercontent.com/ai-dynamo/aiconfigurator/codex-pr1124-visual-assets/docs/support-matrix/assets/pr1124-before-all-models.png)

**After (this PR)**

![After support matrix visualization](https://raw.githubusercontent.com/ai-dynamo/aiconfigurator/codex-pr1124-visual-assets/docs/support-matrix/assets/pr1124-after-all-models.png)

## Validation
- `git diff --check origin/main...HEAD`
- `gh pr diff 1124 --repo ai-dynamo/aiconfigurator --name-only` shows only `docs/support-matrix/index.html`
- generated before/after screenshots locally with local React/Babel/PapaParse/Tailwind assets against the same support-matrix data
