### PR TITLE
fix: handle AIConfigurator 0.9.0 RC0 NVBugs (cherry-pick #1076)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -55,8 +55,8 @@ RUN WHL=$(ls -d /wheelhouse/*) && \
     rm -rf /wheelhouse
 
 COPY rust/ /workspace/rust/
-RUN cargo build --manifest-path /workspace/rust/aiconfigurator-core/Cargo.toml
-ENV AICONFIGURATOR_RUST_CORE_LIB=/workspace/rust/aiconfigurator-core/target/debug/libaiconfigurator_core.so
+RUN cargo build --release --manifest-path /workspace/rust/aiconfigurator-core/Cargo.toml
+ENV AICONFIGURATOR_RUST_CORE_LIB=/workspace/rust/aiconfigurator-core/target/release/libaiconfigurator_core.so
 
 COPY pytest.ini /workspace/
 COPY tests/ /workspace/tests/

--- a/rust/aiconfigurator-core/README.md
+++ b/rust/aiconfigurator-core/README.md
@@ -25,6 +25,7 @@ let estimator = create_engine_step_estimator(EngineConfig {
     moe_ep_size: None,
     attention_dp_size: None,
     weight_dtype: Some(DataType::Bfloat16),
+    moe_dtype: None,
     activation_dtype: Some(DataType::Bfloat16),
     kv_cache_dtype: Some(DataType::Bfloat16),
     kv_block_size: None,

--- a/rust/aiconfigurator-core/src/lib.rs
+++ b/rust/aiconfigurator-core/src/lib.rs
@@ -48,6 +48,8 @@ pub struct EngineConfig {
     pub attention_dp_size: Option<u32>,
 
     pub weight_dtype: Option<DataType>,
+    #[serde(default)]
+    pub moe_dtype: Option<DataType>,
     pub activation_dtype: Option<DataType>,
     pub kv_cache_dtype: Option<DataType>,
 
@@ -80,14 +82,28 @@ impl BackendKind {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum DataType {
+    #[serde(rename = "bfloat16")]
     Bfloat16,
+    #[serde(rename = "float16")]
     Float16,
+    #[serde(rename = "fp8")]
     Fp8,
+    #[serde(rename = "fp8_static")]
     Fp8Static,
+    #[serde(rename = "fp8_block")]
     Fp8Block,
+    #[serde(rename = "nvfp4")]
     Nvfp4,
+    #[serde(rename = "int8")]
     Int8,
+    #[serde(rename = "int4")]
     Int4,
+    #[serde(rename = "w4afp8")]
+    W4afp8,
+    #[serde(rename = "w4a16_mxfp4")]
+    W4a16Mxfp4,
+    #[serde(rename = "w4a8_mxfp4_mxfp8")]
+    W4a8Mxfp4Mxfp8,
 }
 
 impl DataType {
@@ -99,7 +115,7 @@ impl DataType {
             Self::Fp8Block => "fp8_block",
             Self::Nvfp4 => "nvfp4",
             Self::Int8 => "int8_wo",
-            Self::Int4 => "int4_wo",
+            Self::Int4 | Self::W4afp8 | Self::W4a16Mxfp4 | Self::W4a8Mxfp4Mxfp8 => "int4_wo",
         }
     }
 
@@ -126,6 +142,9 @@ impl DataType {
             Self::Nvfp4 => "nvfp4",
             Self::Int8 => "int8_wo",
             Self::Int4 => "int4_wo",
+            Self::W4afp8 => "w4afp8",
+            Self::W4a16Mxfp4 => "w4a16_mxfp4",
+            Self::W4a8Mxfp4Mxfp8 => "w4a8_mxfp4_mxfp8",
         }
     }
 }
@@ -376,6 +395,18 @@ impl EngineStepEstimator {
         let proj_k = model.num_attention_heads * model.head_dim / tp;
         let ffn1_out = 2 * model.intermediate_size / tp;
         let ffn2_k = model.intermediate_size / tp;
+        let hidden = model.hidden_size;
+        let dense_tokens_u64 = u64::from(dense_tokens);
+
+        if model.uses_moe() {
+            return self.model_moe_non_attention_latency_ms(
+                dense_tokens,
+                moe_tokens,
+                logits_batch,
+                qkv_out,
+                proj_k,
+            );
+        }
 
         let dense_ffn = self
             .perf
@@ -383,23 +414,6 @@ impl EngineStepEstimator {
             + self
                 .perf
                 .query_gemm(quant, dense_tokens, model.hidden_size, ffn2_k)?;
-        let ffn = if model.uses_moe() {
-            self.perf
-                .query_moe(
-                    self.moe_quant_name(),
-                    moe_tokens.max(1),
-                    model.hidden_size,
-                    model.moe_intermediate_size.max(model.intermediate_size),
-                    model.top_k.max(1),
-                    model.num_experts.max(1),
-                    self.config.moe_tp_size.unwrap_or(tp).max(1),
-                    self.config.moe_ep_size.unwrap_or(1).max(1),
-                    "uniform",
-                )
-                .unwrap_or(dense_ffn)
-        } else {
-            dense_ffn
-        };
 
         let per_layer = self
             .perf
@@ -407,7 +421,7 @@ impl EngineStepEstimator {
             + self
                 .perf
                 .query_gemm(quant, dense_tokens, model.hidden_size, proj_k)?
-            + ffn;
+            + dense_ffn;
 
         let logits = if logits_batch > 0 {
             self.perf
@@ -421,8 +435,113 @@ impl EngineStepEstimator {
         } else {
             0.0
         };
+        let non_gemm = self.memory_op_latency_ms(dense_tokens_u64, hidden)
+            + layers
+                * (self.elementwise_latency_ms(dense_tokens_u64, 2 * hidden, 2 * hidden)
+                    + self.elementwise_latency_ms(dense_tokens_u64, 2 * hidden, 2 * hidden)
+                    + self.elementwise_latency_ms(dense_tokens_u64, ffn1_out, ffn2_k))
+            + self.custom_allreduce_latency_ms(1.0, dense_tokens_u64, hidden)
+            + self.custom_allreduce_latency_ms(layers, dense_tokens_u64, hidden)
+            + self.custom_allreduce_latency_ms(layers, dense_tokens_u64, hidden)
+            + self.p2p_latency_ms(layers, dense_tokens_u64, hidden);
 
-        Ok(per_layer * layers + logits)
+        Ok(per_layer * layers + logits + non_gemm)
+    }
+
+    fn model_moe_non_attention_latency_ms(
+        &self,
+        dense_tokens: u32,
+        moe_tokens: u32,
+        logits_batch: u32,
+        qkv_out: u32,
+        proj_k: u32,
+    ) -> Result<f64, AicError> {
+        let tp = self.config.tp_size.max(1);
+        let model = &self.model;
+        let layers = model.num_hidden_layers as f64;
+        let quant = self.gemm_quant_name();
+        let hidden = model.hidden_size;
+        let dense_tokens_u64 = u64::from(dense_tokens);
+        let moe_tp = self.config.moe_tp_size.unwrap_or(tp).max(1);
+        let moe_ep = self.config.moe_ep_size.unwrap_or(1).max(1);
+        let attention_dp = self.config.attention_dp_size.unwrap_or(1);
+
+        let dense_ffn =
+            self.perf.query_gemm(
+                quant,
+                dense_tokens,
+                2 * model.intermediate_size / tp,
+                hidden,
+            )? + self
+                .perf
+                .query_gemm(quant, dense_tokens, hidden, model.intermediate_size / tp)?;
+        let router = self.perf.query_gemm(
+            DataType::Bfloat16.gemm_quant_name(),
+            dense_tokens,
+            model.num_experts.max(1),
+            hidden,
+        )?;
+        let moe = self
+            .perf
+            .query_moe(
+                self.moe_quant_name(),
+                moe_tokens.max(1),
+                hidden,
+                model.moe_intermediate_size.max(1),
+                model.top_k.max(1),
+                model.num_experts.max(1),
+                moe_tp,
+                moe_ep,
+                &self.moe_workload_distribution(),
+            )
+            .unwrap_or(dense_ffn);
+        let dispatch_pre = self.moe_dispatch_latency_ms(
+            dense_tokens_u64,
+            hidden,
+            moe_tp,
+            moe_ep,
+            attention_dp,
+            true,
+        )?;
+        let dispatch_post = self.moe_dispatch_latency_ms(
+            dense_tokens_u64,
+            hidden,
+            moe_tp,
+            moe_ep,
+            attention_dp,
+            false,
+        )?;
+        let shared_expert =
+            self.shared_expert_latency_ms(dense_tokens, dense_tokens_u64, hidden)?;
+
+        let per_layer = self.perf.query_gemm(quant, dense_tokens, qkv_out, hidden)?
+            + self.perf.query_gemm(quant, dense_tokens, hidden, proj_k)?
+            + router
+            + dispatch_pre
+            + moe
+            + dispatch_post
+            + shared_expert;
+
+        let logits = if logits_batch > 0 {
+            self.perf
+                .query_gemm(
+                    self.logits_gemm_quant_name(),
+                    logits_batch,
+                    model.vocab_size / tp,
+                    hidden,
+                )
+                .unwrap_or(0.0)
+        } else {
+            0.0
+        };
+        let non_gemm = self.memory_op_latency_ms(dense_tokens_u64, hidden)
+            + layers
+                * (self.elementwise_latency_ms(dense_tokens_u64, 2 * hidden, 2 * hidden)
+                    + self.elementwise_latency_ms(dense_tokens_u64, 2 * hidden, 2 * hidden))
+            + self.custom_allreduce_latency_ms(1.0, dense_tokens_u64, hidden)
+            + self.p2p_latency_ms(layers, dense_tokens_u64, hidden);
+
+        Ok(per_layer * layers + logits + non_gemm)
     }
 
     fn model_prefill_attention_latency_ms(
@@ -541,7 +660,12 @@ impl EngineStepEstimator {
     }
 
     fn moe_quant_name(&self) -> &'static str {
-        match self.config.weight_dtype.as_ref() {
+        match self
+            .config
+            .moe_dtype
+            .as_ref()
+            .or(self.config.weight_dtype.as_ref())
+        {
             Some(dtype) => dtype.moe_quant_name(),
             None => DataType::Bfloat16.moe_quant_name(),
         }
@@ -551,6 +675,118 @@ impl EngineStepEstimator {
         // Match the Python op graph: logits/LM-head GEMM stays BF16 even when
         // transformer layer GEMMs use quantized kernels.
         DataType::Bfloat16.gemm_quant_name()
+    }
+
+    fn memory_op_latency_ms(&self, tokens: u64, dim: u32) -> f64 {
+        self.perf
+            .query_mem_op(tokens.saturating_mul(u64::from(dim)).saturating_mul(2))
+    }
+
+    fn elementwise_latency_ms(&self, tokens: u64, dim_in: u32, dim_out: u32) -> f64 {
+        let bytes = tokens
+            .saturating_mul(u64::from(dim_in).saturating_add(u64::from(dim_out)))
+            .saturating_mul(2);
+        self.perf.query_mem_op(bytes)
+    }
+
+    fn custom_allreduce_latency_ms(&self, scale_factor: f64, tokens: u64, hidden: u32) -> f64 {
+        if self.config.tp_size <= 1 {
+            return 0.0;
+        }
+        let size = tokens.saturating_mul(u64::from(hidden));
+        self.perf.query_custom_allreduce(self.config.tp_size, size) * scale_factor
+    }
+
+    fn moe_dispatch_latency_ms(
+        &self,
+        tokens: u64,
+        hidden: u32,
+        moe_tp: u32,
+        moe_ep: u32,
+        attention_dp: u32,
+        pre_dispatch: bool,
+    ) -> Result<f64, AicError> {
+        let num_gpus = moe_tp.saturating_mul(moe_ep).max(1);
+        if attention_dp == 0 || attention_dp > num_gpus || num_gpus % attention_dp != 0 {
+            return Err(AicError::InvalidEngineConfig(format!(
+                "invalid MoE dispatch topology: moe_tp ({moe_tp}) * moe_ep ({moe_ep}) must be divisible by attention_dp_size ({attention_dp})"
+            )));
+        }
+        let attention_tp = num_gpus / attention_dp;
+        if matches!(self.config.backend, BackendKind::Sglang)
+            && attention_tp > 1
+            && attention_dp > 1
+        {
+            return Err(AicError::InvalidEngineConfig(
+                "SGLang non-DeepEP MoE dispatch does not support attention TP > 1 and attention DP > 1 together"
+                    .to_string(),
+            ));
+        }
+        let volume = tokens.saturating_mul(u64::from(hidden));
+        if attention_tp > 1 {
+            Ok(self.perf.query_custom_allreduce(num_gpus, volume))
+        } else if attention_dp > 1 {
+            let operation = if pre_dispatch {
+                "all_gather"
+            } else {
+                "reduce_scatter"
+            };
+            Ok(self.perf.query_nccl(
+                "half",
+                num_gpus,
+                operation,
+                volume.saturating_mul(u64::from(attention_dp)),
+            ))
+        } else {
+            Ok(0.0)
+        }
+    }
+
+    fn shared_expert_latency_ms(
+        &self,
+        dense_tokens: u32,
+        dense_tokens_u64: u64,
+        hidden: u32,
+    ) -> Result<f64, AicError> {
+        let shared_intermediate = self.model.shared_expert_intermediate_size;
+        if shared_intermediate == 0 {
+            return Ok(0.0);
+        }
+        let tp = self.config.tp_size.max(1);
+        let shared_per_tp = shared_intermediate / tp;
+        Ok(self
+            .perf
+            .query_gemm(self.gemm_quant_name(), dense_tokens, shared_per_tp, hidden)?
+            + self.elementwise_latency_ms(dense_tokens_u64, shared_per_tp, shared_per_tp)
+            + self
+                .perf
+                .query_gemm(self.gemm_quant_name(), dense_tokens, hidden, shared_per_tp)?)
+    }
+
+    fn moe_workload_distribution(&self) -> String {
+        let distribution = self
+            .config
+            .extra
+            .get("moe_workload_distribution")
+            .or_else(|| self.config.extra.get("workload_distribution"))
+            .map(String::as_str)
+            .unwrap_or("power_law");
+        if distribution != "power_law" {
+            return distribution.to_string();
+        }
+        let alpha = match self.model.family {
+            ModelFamily::Moe | ModelFamily::Qwen35 => "1.2",
+            _ => "1.01",
+        };
+        format!("power_law_{alpha}")
+    }
+
+    fn p2p_latency_ms(&self, scale_factor: f64, tokens: u64, hidden: u32) -> f64 {
+        if self.config.pp_size <= 1 || scale_factor == 0.0 {
+            return 0.0;
+        }
+        let bytes = tokens.saturating_mul(u64::from(hidden)).saturating_mul(2);
+        self.perf.query_p2p(bytes) * scale_factor
     }
 }
 

--- a/rust/aiconfigurator-core/src/model.rs
+++ b/rust/aiconfigurator-core/src/model.rs
@@ -38,6 +38,7 @@ pub struct ModelSpec {
     pub top_k: u32,
     pub num_experts: u32,
     pub moe_intermediate_size: u32,
+    pub shared_expert_intermediate_size: u32,
 }
 
 impl ModelSpec {
@@ -112,6 +113,14 @@ impl ModelSpec {
             .unwrap_or(0);
         let moe_intermediate_size =
             optional_u32(model_value, "moe_intermediate_size", path)?.unwrap_or(intermediate_size);
+        let shared_expert_intermediate_size =
+            optional_u32(model_value, "shared_expert_intermediate_size", path)?
+                .or(optional_u32(
+                    model_value,
+                    "moe_shared_expert_intermediate_size",
+                    path,
+                )?)
+                .unwrap_or(0);
 
         Ok(Self {
             architecture,
@@ -127,6 +136,7 @@ impl ModelSpec {
             top_k,
             num_experts,
             moe_intermediate_size,
+            shared_expert_intermediate_size,
         })
     }
 }

--- a/rust/aiconfigurator-core/src/perf.rs
+++ b/rust/aiconfigurator-core/src/perf.rs
@@ -12,11 +12,20 @@ use csv::StringRecord;
 
 use crate::AicError;
 
+// Prefer exact MoE distribution matches; uniform is a cheap fallback, while
+// mismatched shaped distributions should be selected only when closer overall.
+const DIST_PENALTY_SAME: f64 = 0.0;
+const DIST_PENALTY_UNIFORM: f64 = 0.05;
+const DIST_PENALTY_OTHER: f64 = 0.25;
+
 #[derive(Clone, Debug)]
 pub(crate) struct PerfDatabase {
+    system: SystemSpec,
     gemm: Vec<GemmPoint>,
     context_attention: Vec<ContextAttentionPoint>,
     generation_attention: Vec<GenerationAttentionPoint>,
+    custom_allreduce: Vec<CustomAllReducePoint>,
+    nccl: Vec<NcclPoint>,
     moe: Vec<MoePoint>,
     context_mla: Vec<ContextMlaPoint>,
     generation_mla: Vec<GenerationMlaPoint>,
@@ -28,6 +37,8 @@ struct QueryCache {
     gemm: HashMap<(String, u32, u32, u32), f64>,
     context_attention: HashMap<(String, String, u32, u32, u32, u32, u32, u32), f64>,
     generation_attention: HashMap<(String, u32, u32, u32, u32, u32), f64>,
+    custom_allreduce: HashMap<(u32, u64), f64>,
+    nccl: HashMap<(String, String, u32, u64), f64>,
     moe: HashMap<(String, u32, u32, u32, u32, u32, u32, u32, String), Option<f64>>,
     context_mla: HashMap<(String, String, u32, u32, u32), Option<f64>>,
     generation_mla: HashMap<(String, u32, u32, u32), Option<f64>>,
@@ -41,21 +52,30 @@ impl PerfDatabase {
         backend_version: Option<&str>,
     ) -> Result<Self, AicError> {
         let system_path = systems_root.join(format!("{system_name}.yaml"));
-        let data_dir = read_data_dir(&system_path)?;
-        let backend_root = systems_root.join(data_dir).join(backend);
+        let system = read_system_spec(&system_path)?;
+        let backend_root = systems_root.join(&system.data_dir).join(backend);
         let version_path = resolve_backend_version(&backend_root, backend_version)?;
 
         let gemm_path = version_path.join("gemm_perf.txt");
         let context_attention_path = version_path.join("context_attention_perf.txt");
         let generation_attention_path = version_path.join("generation_attention_perf.txt");
+        let custom_allreduce_path = version_path.join("custom_allreduce_perf.txt");
+        let nccl_path = systems_root
+            .join(&system.data_dir)
+            .join("nccl")
+            .join(&system.nccl_version)
+            .join("nccl_perf.txt");
         let moe_path = version_path.join("moe_perf.txt");
         let context_mla_path = version_path.join("context_mla_perf.txt");
         let generation_mla_path = version_path.join("generation_mla_perf.txt");
 
         Ok(Self {
+            system,
             gemm: load_gemm_points(&gemm_path)?,
             context_attention: load_context_attention_points(&context_attention_path)?,
             generation_attention: load_generation_attention_points(&generation_attention_path)?,
+            custom_allreduce: load_optional_custom_allreduce_points(&custom_allreduce_path)?,
+            nccl: load_optional_nccl_points(&nccl_path)?,
             moe: load_optional_moe_points(&moe_path)?,
             context_mla: load_optional_context_mla_points(&context_mla_path)?,
             generation_mla: load_optional_generation_mla_points(&generation_mla_path)?,
@@ -69,6 +89,31 @@ impl PerfDatabase {
             if let Some(latency) = cache.gemm.get(&key) {
                 return Ok(*latency);
             }
+        }
+
+        let mut same_shape_points = Vec::new();
+        let mut same_quant_points = Vec::new();
+        for point in self
+            .gemm
+            .iter()
+            .filter(|point| point.quant == quant && point.n == n && point.k == k)
+        {
+            same_shape_points.push((point.m, point.latency_ms));
+        }
+        for point in self.gemm.iter().filter(|point| point.quant == quant) {
+            same_quant_points.push((point.m, point.n, point.k, point.latency_ms));
+        }
+        if let Some(latency) = interpolate_1d_latency(&same_shape_points, m) {
+            if let Ok(mut cache) = self.query_cache.lock() {
+                cache.gemm.insert(key, latency);
+            }
+            return Ok(latency);
+        }
+        if let Some(latency) = interpolate_3d_latency(&same_quant_points, m, n, k) {
+            if let Ok(mut cache) = self.query_cache.lock() {
+                cache.gemm.insert(key, latency);
+            }
+            return Ok(latency);
         }
 
         let mut best: Option<(f64, f64)> = None;
@@ -120,6 +165,9 @@ impl PerfDatabase {
 
         let full_sequence_tokens = sequence_tokens.saturating_add(prefix_tokens);
         let query_kv_heads = normalized_kv_heads(num_heads, num_kv_heads);
+        let mut same_heads_points = Vec::new();
+        let mut same_shape_batch_points = Vec::new();
+        let mut same_shape_sequence_points = Vec::new();
         let mut best: Option<(f64, f64)> = None;
 
         for point in self.context_attention.iter().filter(|point| {
@@ -129,6 +177,15 @@ impl PerfDatabase {
                 && point.head_dim == head_dim
                 && point.window_size == 0
         }) {
+            if point.num_heads == num_heads {
+                same_heads_points.push((point.sequence_tokens, point.batch_size, point.latency_ms));
+            }
+            if point.num_heads == num_heads && point.sequence_tokens == full_sequence_tokens {
+                same_shape_batch_points.push((point.batch_size, point.latency_ms));
+            }
+            if point.num_heads == num_heads && point.batch_size == batch_size {
+                same_shape_sequence_points.push((point.sequence_tokens, point.latency_ms));
+            }
             let score = relative_distance(point.batch_size, batch_size)
                 + relative_distance(point.sequence_tokens, full_sequence_tokens)
                 + relative_distance(point.num_heads, num_heads);
@@ -137,7 +194,11 @@ impl PerfDatabase {
             }
         }
 
-        let latency = best.map(|(_, latency)| latency).ok_or_else(|| {
+        let latency = interpolate_2d_latency(&same_heads_points, full_sequence_tokens, batch_size)
+            .or_else(|| interpolate_1d_latency(&same_shape_batch_points, batch_size))
+            .or_else(|| interpolate_1d_latency(&same_shape_sequence_points, full_sequence_tokens))
+            .or_else(|| best.map(|(_, latency)| latency))
+            .ok_or_else(|| {
             AicError::PerfDatabase(format!(
                 "no context-attention perf point for fmha_quant={fmha_quant}, kv_cache_quant={kv_cache_quant}, b={batch_size}, s={full_sequence_tokens}, prefix={prefix_tokens}, n={num_heads}, n_kv={num_kv_heads}, head_dim={head_dim}"
             ))
@@ -180,6 +241,9 @@ impl PerfDatabase {
         }
 
         let query_kv_heads = normalized_kv_heads(num_heads, num_kv_heads);
+        let mut same_heads_points = Vec::new();
+        let mut same_shape_batch_points = Vec::new();
+        let mut same_shape_sequence_points = Vec::new();
         let mut best: Option<(f64, f64)> = None;
 
         for point in self.generation_attention.iter().filter(|point| {
@@ -188,6 +252,15 @@ impl PerfDatabase {
                 && point.head_dim == head_dim
                 && point.window_size == 0
         }) {
+            if point.num_heads == num_heads {
+                same_heads_points.push((point.batch_size, point.sequence_tokens, point.latency_ms));
+            }
+            if point.num_heads == num_heads && point.sequence_tokens == sequence_tokens {
+                same_shape_batch_points.push((point.batch_size, point.latency_ms));
+            }
+            if point.num_heads == num_heads && point.batch_size == batch_size {
+                same_shape_sequence_points.push((point.sequence_tokens, point.latency_ms));
+            }
             let score = relative_distance(point.batch_size, batch_size)
                 + relative_distance(point.sequence_tokens, sequence_tokens)
                 + relative_distance(point.num_heads, num_heads);
@@ -196,7 +269,13 @@ impl PerfDatabase {
             }
         }
 
-        let latency = best.map(|(_, latency)| latency).ok_or_else(|| {
+        let sampled_latency =
+            average_generation_attention_latency(&same_heads_points, batch_size, sequence_tokens);
+        let latency = sampled_latency
+            .or_else(|| interpolate_1d_latency(&same_shape_batch_points, batch_size))
+            .or_else(|| interpolate_1d_latency(&same_shape_sequence_points, sequence_tokens))
+            .or_else(|| best.map(|(_, latency)| latency))
+            .ok_or_else(|| {
             AicError::PerfDatabase(format!(
                 "no generation-attention perf point for kv_cache_quant={kv_cache_quant}, b={batch_size}, s={sequence_tokens}, n={num_heads}, n_kv={num_kv_heads}, head_dim={head_dim}"
             ))
@@ -205,6 +284,154 @@ impl PerfDatabase {
             cache.generation_attention.insert(key, latency);
         }
         Ok(latency)
+    }
+
+    pub(crate) fn query_mem_op(&self, mem_bytes: u64) -> f64 {
+        (mem_bytes as f64 / (self.system.mem_bw * self.system.mem_bw_empirical_scaling_factor)
+            + self.system.mem_empirical_constant_latency)
+            * 1000.0
+    }
+
+    pub(crate) fn query_p2p(&self, message_bytes: u64) -> f64 {
+        (message_bytes as f64 / self.system.inter_node_bw + self.system.p2p_latency) * 1000.0
+    }
+
+    pub(crate) fn query_custom_allreduce(&self, tp_size: u32, size: u64) -> f64 {
+        if tp_size <= 1 {
+            return 0.0;
+        }
+        let key = (tp_size, size);
+        if let Ok(cache) = self.query_cache.lock() {
+            if let Some(latency) = cache.custom_allreduce.get(&key) {
+                return *latency;
+            }
+        }
+
+        let effective_tp = tp_size.min(self.system.num_gpus_per_node.max(1));
+        let mut points = Vec::new();
+        for point in self
+            .custom_allreduce
+            .iter()
+            .filter(|point| point.tp_size == effective_tp)
+        {
+            points.push((point.message_size, point.latency_ms));
+        }
+        let latency = interpolate_1d_latency_u64(&points, size)
+            .map(|latency| {
+                self.scale_collective_latency_for_gpu_count(latency, effective_tp, tp_size)
+            })
+            .unwrap_or_else(|| self.custom_allreduce_empirical(tp_size, size));
+        if let Ok(mut cache) = self.query_cache.lock() {
+            cache.custom_allreduce.insert(key, latency);
+        }
+        latency
+    }
+
+    pub(crate) fn query_nccl(&self, quant: &str, num_gpus: u32, operation: &str, size: u64) -> f64 {
+        if num_gpus <= 1 {
+            return 0.0;
+        }
+        let key = (quant.to_string(), operation.to_string(), num_gpus, size);
+        if let Ok(cache) = self.query_cache.lock() {
+            if let Some(latency) = cache.nccl.get(&key) {
+                return *latency;
+            }
+        }
+
+        let mut available_gpu_counts = self
+            .nccl
+            .iter()
+            .filter(|point| point.quant == quant && point.operation == operation)
+            .map(|point| point.num_gpus)
+            .collect::<Vec<_>>();
+        available_gpu_counts.sort_unstable();
+        available_gpu_counts.dedup();
+        let effective_gpus = available_gpu_counts
+            .iter()
+            .copied()
+            .filter(|count| *count <= num_gpus)
+            .max()
+            .or_else(|| available_gpu_counts.first().copied());
+
+        let latency = effective_gpus
+            .and_then(|effective_gpus| {
+                let mut points = Vec::new();
+                for point in self.nccl.iter().filter(|point| {
+                    point.quant == quant
+                        && point.operation == operation
+                        && point.num_gpus == effective_gpus
+                }) {
+                    points.push((point.message_size, point.latency_ms));
+                }
+                interpolate_1d_latency_u64(&points, size).map(|latency| {
+                    if num_gpus > effective_gpus && effective_gpus > 1 {
+                        let max_bw = self.p2p_bandwidth(effective_gpus);
+                        let target_bw = self.p2p_bandwidth(num_gpus);
+                        latency
+                            * collective_gpu_count_scale(effective_gpus, num_gpus)
+                            * (max_bw / target_bw)
+                    } else {
+                        latency
+                    }
+                })
+            })
+            .unwrap_or_else(|| self.nccl_empirical(quant, num_gpus, operation, size));
+        if let Ok(mut cache) = self.query_cache.lock() {
+            cache.nccl.insert(key, latency);
+        }
+        latency
+    }
+
+    fn custom_allreduce_empirical(&self, tp_size: u32, size: u64) -> f64 {
+        if tp_size <= 1 {
+            return 0.0;
+        }
+        let tp = f64::from(tp_size);
+        let p2p_bw = if tp_size <= self.system.num_gpus_per_node {
+            self.system.intra_node_bw
+        } else {
+            self.system.inter_node_bw
+        };
+        let sol_ms = 2.0 * size as f64 * 2.0 / tp * (tp - 1.0) / p2p_bw * 1000.0;
+        sol_ms / 0.8
+    }
+
+    fn nccl_empirical(&self, quant: &str, num_gpus: u32, operation: &str, size: u64) -> f64 {
+        let dtype_bytes = match quant {
+            "fp8" | "fp8_block" | "int8" => 1.0,
+            "nvfp4" | "fp4" => 0.5,
+            _ => 2.0,
+        };
+        let multiplier = if operation == "all_reduce" { 2.0 } else { 1.0 };
+        let sol_ms = multiplier * dtype_bytes * size as f64 * f64::from(num_gpus.saturating_sub(1))
+            / f64::from(num_gpus.max(1))
+            / self.p2p_bandwidth(num_gpus)
+            * 1000.0;
+        sol_ms / 0.8
+    }
+
+    fn p2p_bandwidth(&self, num_gpus: u32) -> f64 {
+        if num_gpus <= self.system.num_gpus_per_node {
+            self.system.intra_node_bw
+        } else {
+            self.system.inter_node_bw
+        }
+    }
+
+    fn scale_collective_latency_for_gpu_count(
+        &self,
+        latency: f64,
+        measured_gpus: u32,
+        requested_gpus: u32,
+    ) -> f64 {
+        if requested_gpus <= measured_gpus || measured_gpus <= 1 {
+            return latency;
+        }
+        let measured_bw = self.p2p_bandwidth(measured_gpus);
+        let requested_bw = self.p2p_bandwidth(requested_gpus);
+        latency
+            * collective_gpu_count_scale(measured_gpus, requested_gpus)
+            * (measured_bw / requested_bw)
     }
 
     pub(crate) fn query_moe(
@@ -236,14 +463,24 @@ impl PerfDatabase {
             }
         }
 
+        let requested_distribution_available = self
+            .moe
+            .iter()
+            .any(|point| point.quant == quant && point.distribution == distribution);
+        let used_distribution = if requested_distribution_available {
+            distribution
+        } else {
+            "uniform"
+        };
+        let mut same_shape_points = Vec::new();
         let mut best: Option<(f64, f64)> = None;
         for point in self.moe.iter().filter(|point| point.quant == quant) {
-            let distribution_penalty = if point.distribution == distribution {
-                0.0
+            let distribution_penalty = if point.distribution == used_distribution {
+                DIST_PENALTY_SAME
             } else if point.distribution == "uniform" {
-                0.05
+                DIST_PENALTY_UNIFORM
             } else {
-                0.25
+                DIST_PENALTY_OTHER
             };
             let score = distribution_penalty
                 + relative_distance(point.num_tokens, num_tokens)
@@ -256,8 +493,19 @@ impl PerfDatabase {
             if best.map_or(true, |(best_score, _)| score < best_score) {
                 best = Some((score, point.latency_ms));
             }
+            if point.distribution == used_distribution
+                && point.hidden_size == hidden_size
+                && point.inter_size == inter_size
+                && point.top_k == top_k
+                && point.num_experts == num_experts
+                && point.moe_tp_size == moe_tp_size
+                && point.moe_ep_size == moe_ep_size
+            {
+                same_shape_points.push((point.num_tokens, point.latency_ms));
+            }
         }
-        let latency = best.map(|(_, latency)| latency);
+        let latency = interpolate_1d_latency(&same_shape_points, num_tokens)
+            .or_else(|| best.map(|(_, latency)| latency));
         if let Ok(mut cache) = self.query_cache.lock() {
             cache.moe.insert(key, latency);
         }
@@ -410,25 +658,177 @@ struct GenerationMlaPoint {
     latency_ms: f64,
 }
 
-fn read_data_dir(system_path: &Path) -> Result<PathBuf, AicError> {
+#[derive(Clone, Debug)]
+struct CustomAllReducePoint {
+    tp_size: u32,
+    message_size: u64,
+    latency_ms: f64,
+}
+
+#[derive(Clone, Debug)]
+struct NcclPoint {
+    quant: String,
+    operation: String,
+    num_gpus: u32,
+    message_size: u64,
+    latency_ms: f64,
+}
+
+#[derive(Clone, Debug)]
+struct SystemSpec {
+    data_dir: PathBuf,
+    nccl_version: String,
+    mem_bw: f64,
+    mem_bw_empirical_scaling_factor: f64,
+    mem_empirical_constant_latency: f64,
+    num_gpus_per_node: u32,
+    inter_node_bw: f64,
+    intra_node_bw: f64,
+    p2p_latency: f64,
+}
+
+fn read_system_spec(system_path: &Path) -> Result<SystemSpec, AicError> {
     let text = fs::read_to_string(system_path).map_err(|source| AicError::Io {
         path: system_path.to_path_buf(),
         source,
     })?;
+    let mut data_dir = None;
+    let mut nccl_version = None;
+    let mut section = "";
+    let mut mem_bw = None;
+    let mut mem_bw_empirical_scaling_factor = None;
+    let mut mem_empirical_constant_latency = None;
+    let mut num_gpus_per_node = None;
+    let mut inter_node_bw = None;
+    let mut intra_node_bw = None;
+    let mut p2p_latency = None;
+
     for line in text.lines() {
-        let line = line.split('#').next().unwrap_or("").trim();
-        let Some(value) = line.strip_prefix("data_dir:") else {
+        let raw = line.split('#').next().unwrap_or("");
+        let line = raw.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if !raw.starts_with(' ') && line.ends_with(':') {
+            section = line.trim_end_matches(':');
+            continue;
+        }
+        if let Some(value) = line.strip_prefix("data_dir:") {
+            data_dir = Some(PathBuf::from(clean_yaml_scalar(value)));
+            continue;
+        }
+        let Some((name, value)) = line.split_once(':') else {
             continue;
         };
-        let value = value.trim().trim_matches('"').trim_matches('\'');
-        if !value.is_empty() {
-            return Ok(PathBuf::from(value));
+        let value = clean_yaml_scalar(value);
+        match (section, name.trim()) {
+            ("gpu", "mem_bw") => {
+                mem_bw = Some(parse_required_yaml_f64(system_path, "gpu.mem_bw", &value)?)
+            }
+            ("gpu", "mem_bw_empirical_scaling_factor") => {
+                mem_bw_empirical_scaling_factor = parse_yaml_f64(&value)
+            }
+            ("gpu", "mem_empirical_constant_latency") => {
+                mem_empirical_constant_latency = parse_yaml_f64(&value)
+            }
+            ("node", "num_gpus_per_node") => {
+                num_gpus_per_node = Some(parse_required_yaml_u32(
+                    system_path,
+                    "node.num_gpus_per_node",
+                    &value,
+                )?)
+            }
+            ("node", "inter_node_bw") => {
+                inter_node_bw = Some(parse_required_yaml_f64(
+                    system_path,
+                    "node.inter_node_bw",
+                    &value,
+                )?)
+            }
+            ("node", "intra_node_bw") => {
+                intra_node_bw = Some(parse_required_yaml_f64(
+                    system_path,
+                    "node.intra_node_bw",
+                    &value,
+                )?)
+            }
+            ("node", "p2p_latency") => p2p_latency = parse_yaml_f64(&value),
+            ("misc", "nccl_version") => nccl_version = Some(value),
+            _ => {}
         }
     }
-    Err(AicError::PerfDatabase(format!(
-        "missing data_dir in system file {}",
+    Ok(SystemSpec {
+        data_dir: data_dir.ok_or_else(|| {
+            AicError::PerfDatabase(format!(
+                "missing data_dir in system file {}",
+                system_path.display()
+            ))
+        })?,
+        nccl_version: nccl_version.unwrap_or_default(),
+        mem_bw: require_system_field(system_path, "gpu.mem_bw", mem_bw)?,
+        mem_bw_empirical_scaling_factor: mem_bw_empirical_scaling_factor.unwrap_or(1.0),
+        mem_empirical_constant_latency: mem_empirical_constant_latency.unwrap_or(0.0),
+        num_gpus_per_node: require_system_field(
+            system_path,
+            "node.num_gpus_per_node",
+            num_gpus_per_node,
+        )?,
+        inter_node_bw: require_system_field(system_path, "node.inter_node_bw", inter_node_bw)?,
+        intra_node_bw: require_system_field(system_path, "node.intra_node_bw", intra_node_bw)?,
+        p2p_latency: p2p_latency.unwrap_or(0.0),
+    })
+}
+
+fn clean_yaml_scalar(value: &str) -> String {
+    value
+        .trim()
+        .trim_matches('"')
+        .trim_matches('\'')
+        .to_string()
+}
+
+fn parse_yaml_f64(value: &str) -> Option<f64> {
+    value.split_whitespace().next()?.parse::<f64>().ok()
+}
+
+fn parse_required_yaml_f64(system_path: &Path, field: &str, value: &str) -> Result<f64, AicError> {
+    value
+        .split_whitespace()
+        .next()
+        .ok_or_else(|| missing_system_field_error(system_path, field))?
+        .parse::<f64>()
+        .map_err(|_| invalid_system_field_error(system_path, field, value))
+}
+
+fn parse_required_yaml_u32(system_path: &Path, field: &str, value: &str) -> Result<u32, AicError> {
+    value
+        .split_whitespace()
+        .next()
+        .ok_or_else(|| missing_system_field_error(system_path, field))?
+        .parse::<u32>()
+        .map_err(|_| invalid_system_field_error(system_path, field, value))
+}
+
+fn require_system_field<T>(
+    system_path: &Path,
+    field: &str,
+    value: Option<T>,
+) -> Result<T, AicError> {
+    value.ok_or_else(|| missing_system_field_error(system_path, field))
+}
+
+fn missing_system_field_error(system_path: &Path, field: &str) -> AicError {
+    AicError::PerfDatabase(format!(
+        "missing {field} in system file {}",
         system_path.display()
-    )))
+    ))
+}
+
+fn invalid_system_field_error(system_path: &Path, field: &str, value: &str) -> AicError {
+    AicError::PerfDatabase(format!(
+        "invalid {field} value {value:?} in system file {}",
+        system_path.display()
+    ))
 }
 
 fn resolve_backend_version(
@@ -510,6 +910,207 @@ fn version_number_runs(version: &str) -> Vec<u64> {
         numbers.push(number);
     }
     numbers
+}
+
+fn interpolate_1d_latency(points: &[(u32, f64)], query: u32) -> Option<f64> {
+    if points.is_empty() {
+        return None;
+    }
+
+    let mut sorted = points.to_vec();
+    sorted.sort_by_key(|(x, _)| *x);
+    sorted.dedup_by_key(|(x, _)| *x);
+
+    if let Some((_, latency)) = sorted.iter().find(|(x, _)| *x == query) {
+        return Some(*latency);
+    }
+    if sorted.len() < 2 {
+        return None;
+    }
+
+    let (left, right) = if query < sorted[0].0 {
+        (sorted[0], sorted[1])
+    } else if query > sorted[sorted.len() - 1].0 {
+        (sorted[sorted.len() - 2], sorted[sorted.len() - 1])
+    } else {
+        let mut bracket = None;
+        for window in sorted.windows(2) {
+            if query >= window[0].0 && query <= window[1].0 {
+                bracket = Some((window[0], window[1]));
+                break;
+            }
+        }
+        bracket?
+    };
+
+    let (x0, y0) = (f64::from(left.0), left.1);
+    let (x1, mut y1) = (f64::from(right.0), right.1);
+    let x = f64::from(query);
+
+    if x0 == x1 {
+        return Some(y0);
+    }
+    // When extrapolating with a negative measured slope, flatten the line to
+    // avoid nonsensical latency estimates; keep this in sync with the u64 path.
+    if (x0 - x1) * (y0 - y1) < 0.0 && (x - x0) * (x - x1) > 0.0 {
+        y1 = y0;
+    }
+    Some(y0 + (y1 - y0) / (x1 - x0) * (x - x0))
+}
+
+fn interpolate_1d_latency_u64(points: &[(u64, f64)], query: u64) -> Option<f64> {
+    if points.is_empty() {
+        return None;
+    }
+
+    let mut sorted = points.to_vec();
+    sorted.sort_by_key(|(x, _)| *x);
+    sorted.dedup_by_key(|(x, _)| *x);
+
+    if let Some((_, latency)) = sorted.iter().find(|(x, _)| *x == query) {
+        return Some(*latency);
+    }
+    if sorted.len() < 2 {
+        return None;
+    }
+
+    let (left, right) = if query < sorted[0].0 {
+        (sorted[0], sorted[1])
+    } else if query > sorted[sorted.len() - 1].0 {
+        (sorted[sorted.len() - 2], sorted[sorted.len() - 1])
+    } else {
+        let mut bracket = None;
+        for window in sorted.windows(2) {
+            if query >= window[0].0 && query <= window[1].0 {
+                bracket = Some((window[0], window[1]));
+                break;
+            }
+        }
+        bracket?
+    };
+
+    let (x0, y0) = (left.0 as f64, left.1);
+    let (x1, mut y1) = (right.0 as f64, right.1);
+    let x = query as f64;
+
+    if x0 == x1 {
+        return Some(y0);
+    }
+    // Same negative-slope extrapolation guard used by interpolate_1d_latency.
+    if (x0 - x1) * (y0 - y1) < 0.0 && (x - x0) * (x - x1) > 0.0 {
+        y1 = y0;
+    }
+    Some(y0 + (y1 - y0) / (x1 - x0) * (x - x0))
+}
+
+fn interpolate_2d_latency(points: &[(u32, u32, f64)], query_x: u32, query_y: u32) -> Option<f64> {
+    if points.is_empty() {
+        return None;
+    }
+    let mut xs = points.iter().map(|(x, _, _)| *x).collect::<Vec<_>>();
+    xs.sort_unstable();
+    xs.dedup();
+    let (x_left, x_right) = axis_pair(&xs, query_x)?;
+
+    let left_points = points
+        .iter()
+        .filter(|(x, _, _)| *x == x_left)
+        .map(|(_, y, latency)| (*y, *latency))
+        .collect::<Vec<_>>();
+    let left_latency = interpolate_1d_latency(&left_points, query_y)?;
+
+    if x_left == x_right {
+        return Some(left_latency);
+    }
+
+    let right_points = points
+        .iter()
+        .filter(|(x, _, _)| *x == x_right)
+        .map(|(_, y, latency)| (*y, *latency))
+        .collect::<Vec<_>>();
+    let right_latency = interpolate_1d_latency(&right_points, query_y)?;
+    interpolate_1d_latency(&[(x_left, left_latency), (x_right, right_latency)], query_x)
+}
+
+fn interpolate_3d_latency(
+    points: &[(u32, u32, u32, f64)],
+    query_x: u32,
+    query_y: u32,
+    query_z: u32,
+) -> Option<f64> {
+    if points.is_empty() {
+        return None;
+    }
+    let mut xs = points.iter().map(|(x, _, _, _)| *x).collect::<Vec<_>>();
+    xs.sort_unstable();
+    xs.dedup();
+    let (x_left, x_right) = axis_pair(&xs, query_x)?;
+
+    let left_points = points
+        .iter()
+        .filter(|(x, _, _, _)| *x == x_left)
+        .map(|(_, y, z, latency)| (*y, *z, *latency))
+        .collect::<Vec<_>>();
+    let left_latency = interpolate_2d_latency(&left_points, query_y, query_z)?;
+
+    if x_left == x_right {
+        return Some(left_latency);
+    }
+
+    let right_points = points
+        .iter()
+        .filter(|(x, _, _, _)| *x == x_right)
+        .map(|(_, y, z, latency)| (*y, *z, *latency))
+        .collect::<Vec<_>>();
+    let right_latency = interpolate_2d_latency(&right_points, query_y, query_z)?;
+    interpolate_1d_latency(&[(x_left, left_latency), (x_right, right_latency)], query_x)
+}
+
+fn axis_pair(sorted: &[u32], query: u32) -> Option<(u32, u32)> {
+    if sorted.is_empty() {
+        return None;
+    }
+    if sorted.contains(&query) {
+        return Some((query, query));
+    }
+    if sorted.len() < 2 {
+        return None;
+    }
+    if query < sorted[0] {
+        return Some((sorted[0], sorted[1]));
+    }
+    if query > sorted[sorted.len() - 1] {
+        return Some((sorted[sorted.len() - 2], sorted[sorted.len() - 1]));
+    }
+    for window in sorted.windows(2) {
+        if query >= window[0] && query <= window[1] {
+            return Some((window[0], window[1]));
+        }
+    }
+    None
+}
+
+fn average_generation_attention_latency(
+    points: &[(u32, u32, f64)],
+    batch_size: u32,
+    sequence_tokens: u32,
+) -> Option<f64> {
+    let s_min = (sequence_tokens.saturating_mul(9) / 10).max(1);
+    let s_max = sequence_tokens.saturating_mul(11) / 10;
+    let mut sum = 0.0;
+    for i in 0..5_u32 {
+        let sample = s_min + (s_max.saturating_sub(s_min)) * i / 4;
+        sum += interpolate_2d_latency(points, batch_size, sample)?;
+    }
+    Some(sum / 5.0)
+}
+
+fn collective_gpu_count_scale(measured_gpus: u32, requested_gpus: u32) -> f64 {
+    if measured_gpus <= 1 || requested_gpus <= 1 {
+        return 1.0;
+    }
+    (f64::from(requested_gpus - 1) / f64::from(requested_gpus))
+        * (f64::from(measured_gpus) / f64::from(measured_gpus - 1))
 }
 
 fn load_gemm_points(path: &Path) -> Result<Vec<GemmPoint>, AicError> {
@@ -635,6 +1236,76 @@ fn load_generation_attention_points(
             "no generation-attention rows loaded from {}",
             path.display()
         )));
+    }
+    Ok(points)
+}
+
+fn load_optional_custom_allreduce_points(
+    path: &Path,
+) -> Result<Vec<CustomAllReducePoint>, AicError> {
+    if !path.is_file() || is_lfs_pointer(path)? {
+        return Ok(Vec::new());
+    }
+    let mut reader = csv::ReaderBuilder::new()
+        .trim(csv::Trim::All)
+        .from_path(path)
+        .map_err(|source| AicError::Csv {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    let headers = header_map(reader.headers().map_err(|source| AicError::Csv {
+        path: path.to_path_buf(),
+        source,
+    })?);
+    let is_b60 = path.to_string_lossy().contains("b60");
+    let mut points = Vec::new();
+    for record in reader.records() {
+        let record = record.map_err(|source| AicError::Csv {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        let kernel_source = optional_field(&record, &headers, "kernel_source").unwrap_or("");
+        let backend = optional_field(&record, &headers, "backend").unwrap_or("");
+        if !is_b60 && (kernel_source.ends_with("_eager") || backend.ends_with("_eager")) {
+            continue;
+        }
+        points.push(CustomAllReducePoint {
+            tp_size: parse_u32(&record, &headers, "num_gpus", path)?,
+            message_size: parse_u64(&record, &headers, "message_size", path)?,
+            latency_ms: parse_f64(&record, &headers, "latency", path)?,
+        });
+    }
+    Ok(points)
+}
+
+fn load_optional_nccl_points(path: &Path) -> Result<Vec<NcclPoint>, AicError> {
+    if !path.is_file() || is_lfs_pointer(path)? {
+        return Ok(Vec::new());
+    }
+    let mut reader = csv::ReaderBuilder::new()
+        .trim(csv::Trim::All)
+        .from_path(path)
+        .map_err(|source| AicError::Csv {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    let headers = header_map(reader.headers().map_err(|source| AicError::Csv {
+        path: path.to_path_buf(),
+        source,
+    })?);
+    let mut points = Vec::new();
+    for record in reader.records() {
+        let record = record.map_err(|source| AicError::Csv {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        points.push(NcclPoint {
+            quant: required_field(&record, &headers, "nccl_dtype", path)?.to_string(),
+            operation: required_field(&record, &headers, "op_name", path)?.to_string(),
+            num_gpus: parse_u32(&record, &headers, "num_gpus", path)?,
+            message_size: parse_u64(&record, &headers, "message_size", path)?,
+            latency_ms: parse_f64(&record, &headers, "latency", path)?,
+        });
     }
     Ok(points)
 }
@@ -802,6 +1473,15 @@ fn required_field<'a>(
     })
 }
 
+fn optional_field<'a>(
+    record: &'a StringRecord,
+    headers: &HashMap<String, usize>,
+    name: &str,
+) -> Option<&'a str> {
+    let idx = headers.get(name)?;
+    record.get(*idx)
+}
+
 fn parse_u32(
     record: &StringRecord,
     headers: &HashMap<String, usize>,
@@ -812,6 +1492,21 @@ fn parse_u32(
     raw.parse::<u32>().map_err(|source| {
         AicError::PerfDatabase(format!(
             "invalid u32 value '{raw}' for column '{name}' in {}: {source}",
+            path.display()
+        ))
+    })
+}
+
+fn parse_u64(
+    record: &StringRecord,
+    headers: &HashMap<String, usize>,
+    name: &str,
+    path: &Path,
+) -> Result<u64, AicError> {
+    let raw = required_field(record, headers, name, path)?;
+    raw.parse::<u64>().map_err(|source| {
+        AicError::PerfDatabase(format!(
+            "invalid u64 value '{raw}' for column '{name}' in {}: {source}",
             path.display()
         ))
     })

--- a/rust/aiconfigurator-core/tests/engine_step.rs
+++ b/rust/aiconfigurator-core/tests/engine_step.rs
@@ -80,6 +80,471 @@ bfloat16,4,160,32,0.5\n",
 }
 
 #[test]
+fn gemm_queries_extrapolate_token_dimension_for_matching_shape() {
+    let fixture = Fixture::new();
+    fs::write(
+        fixture.perf_dir().join("gemm_perf.txt"),
+        "gemm_dtype,m,n,k,latency\n\
+bfloat16,20,64,32,1.0\n\
+bfloat16,20,32,32,2.0\n\
+bfloat16,20,128,32,3.0\n\
+bfloat16,20,32,64,4.0\n\
+bfloat16,40,64,32,2.0\n\
+bfloat16,40,32,32,4.0\n\
+bfloat16,40,128,32,6.0\n\
+bfloat16,40,32,64,8.0\n\
+bfloat16,1,160,32,0.0\n",
+    )
+    .unwrap();
+    fs::write(
+        fixture.perf_dir().join("context_attention_perf.txt"),
+        "attn_dtype,kv_cache_dtype,batch_size,isl,num_heads,num_key_value_heads,head_dim,latency\n\
+bfloat16,bfloat16,1,60,4,2,8,0.0\n",
+    )
+    .unwrap();
+    let estimator = fixture.estimator();
+    let metrics = ForwardPassMetrics {
+        scheduled_requests: ScheduledRequestMetrics {
+            num_prefill_requests: 1,
+            sum_prefill_tokens: 60,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let latency = estimator.forward_pass_time_ms(&[metrics]).unwrap();
+
+    assert_close(latency, 60.0);
+}
+
+#[test]
+fn moe_queries_extrapolate_token_dimension_for_matching_shape() {
+    let fixture = Fixture::new_moe();
+    let estimator = fixture.estimator_with_config(moe_engine_config());
+    let metrics = ForwardPassMetrics {
+        scheduled_requests: ScheduledRequestMetrics {
+            num_prefill_requests: 1,
+            sum_prefill_tokens: 60,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let latency = estimator.forward_pass_time_ms(&[metrics]).unwrap();
+
+    assert_close(latency, 56.0);
+}
+
+#[test]
+fn moe_defaults_to_power_law_distribution_when_available() {
+    let fixture = Fixture::new_moe();
+    fs::write(
+        fixture.perf_dir().join("gemm_perf.txt"),
+        "gemm_dtype,m,n,k,latency\n\
+bfloat16,60,64,32,0.0\n\
+bfloat16,60,32,32,0.0\n\
+bfloat16,60,128,32,0.0\n\
+bfloat16,60,32,64,0.0\n\
+bfloat16,60,4,32,0.0\n\
+bfloat16,1,160,32,0.0\n",
+    )
+    .unwrap();
+    fs::write(
+        fixture.perf_dir().join("moe_perf.txt"),
+        "moe_dtype,num_tokens,hidden_size,inter_size,topk,num_experts,moe_tp_size,moe_ep_size,distribution,latency\n\
+bfloat16,60,32,64,2,4,1,1,uniform,1.0\n\
+bfloat16,60,32,64,2,4,1,1,power_law_1.2,7.0\n",
+    )
+    .unwrap();
+    let estimator = fixture.estimator_with_config(moe_engine_config());
+    let metrics = ForwardPassMetrics {
+        scheduled_requests: ScheduledRequestMetrics {
+            num_prefill_requests: 1,
+            sum_prefill_tokens: 60,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let latency = estimator.forward_pass_time_ms(&[metrics]).unwrap();
+
+    assert_close(latency, 14.0);
+}
+
+#[test]
+fn moe_dtype_selects_moe_specific_perf_rows() {
+    let fixture = Fixture::new_moe();
+    fs::write(
+        fixture.perf_dir().join("gemm_perf.txt"),
+        "gemm_dtype,m,n,k,latency\n\
+bfloat16,60,64,32,0.0\n\
+bfloat16,60,32,32,0.0\n\
+bfloat16,60,128,32,0.0\n\
+bfloat16,60,32,64,0.0\n\
+bfloat16,60,4,32,0.0\n\
+bfloat16,1,160,32,0.0\n",
+    )
+    .unwrap();
+    fs::write(
+        fixture.perf_dir().join("moe_perf.txt"),
+        "moe_dtype,num_tokens,hidden_size,inter_size,topk,num_experts,moe_tp_size,moe_ep_size,distribution,latency\n\
+bfloat16,60,32,64,2,4,1,1,power_law_1.2,1.0\n\
+w4a16_mxfp4,60,32,64,2,4,1,1,power_law_1.2,7.0\n",
+    )
+    .unwrap();
+    let mut config = moe_engine_config();
+    config.moe_dtype = Some(DataType::W4a16Mxfp4);
+    let estimator = fixture.estimator_with_config(config);
+    let metrics = ForwardPassMetrics {
+        scheduled_requests: ScheduledRequestMetrics {
+            num_prefill_requests: 1,
+            sum_prefill_tokens: 60,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let latency = estimator.forward_pass_time_ms(&[metrics]).unwrap();
+
+    assert_close(latency, 14.0);
+}
+
+#[test]
+fn moe_non_attention_includes_router_and_dispatch_costs() {
+    let fixture = Fixture::new_moe();
+    fs::write(
+        fixture.perf_dir().join("gemm_perf.txt"),
+        "gemm_dtype,m,n,k,latency\n\
+bfloat16,60,64,32,1.0\n\
+bfloat16,60,32,32,2.0\n\
+bfloat16,60,128,32,0.0\n\
+bfloat16,60,32,64,0.0\n\
+bfloat16,60,4,32,3.0\n\
+bfloat16,1,160,32,0.0\n",
+    )
+    .unwrap();
+    fs::write(
+        fixture.perf_dir().join("moe_perf.txt"),
+        "moe_dtype,num_tokens,hidden_size,inter_size,topk,num_experts,moe_tp_size,moe_ep_size,distribution,latency\n\
+bfloat16,120,32,64,2,4,1,2,power_law_1.2,5.0\n",
+    )
+    .unwrap();
+    let nccl_root = fixture.systems_root().join("data/test_sxm/nccl/1.0.0");
+    fs::create_dir_all(&nccl_root).unwrap();
+    fs::write(
+        nccl_root.join("nccl_perf.txt"),
+        "op_name,nccl_dtype,num_gpus,message_size,latency\n\
+all_gather,half,2,3840,7.0\n\
+reduce_scatter,half,2,3840,11.0\n",
+    )
+    .unwrap();
+    let mut config = moe_engine_config();
+    config.moe_ep_size = Some(2);
+    config.attention_dp_size = Some(2);
+    let estimator = fixture.estimator_with_config(config);
+    let metrics = ForwardPassMetrics {
+        scheduled_requests: ScheduledRequestMetrics {
+            num_prefill_requests: 1,
+            sum_prefill_tokens: 60,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let latency = estimator
+        .forward_pass_time_ms(&[metrics.clone(), metrics])
+        .unwrap();
+
+    assert_close(latency, 58.0);
+}
+
+#[test]
+fn moe_dispatch_rejects_invalid_attention_dp_topology() {
+    let fixture = Fixture::new_moe();
+    let mut config = moe_engine_config();
+    config.moe_ep_size = Some(1);
+    config.attention_dp_size = Some(2);
+    let estimator = fixture.estimator_with_config(config);
+    let metrics = ForwardPassMetrics {
+        scheduled_requests: ScheduledRequestMetrics {
+            num_prefill_requests: 1,
+            sum_prefill_tokens: 60,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let err = estimator.forward_pass_time_ms(&[metrics]).unwrap_err();
+
+    assert!(err.to_string().contains("invalid MoE dispatch topology"));
+}
+
+#[test]
+fn moe_non_attention_includes_shared_expert_costs() {
+    let fixture = Fixture::new_moe();
+    fs::write(
+        fixture.model_configs_root().join("Test--Moe_config.json"),
+        r#"{
+  "architectures": ["Qwen2MoeForCausalLM"],
+  "model_type": "qwen2_moe",
+  "num_hidden_layers": 2,
+  "num_attention_heads": 4,
+  "num_key_value_heads": 2,
+  "head_dim": 8,
+  "hidden_size": 32,
+  "intermediate_size": 64,
+  "vocab_size": 160,
+  "num_experts_per_tok": 2,
+  "num_experts": 4,
+  "moe_intermediate_size": 64,
+  "shared_expert_intermediate_size": 96
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        fixture.perf_dir().join("gemm_perf.txt"),
+        "gemm_dtype,m,n,k,latency\n\
+bfloat16,60,64,32,0.0\n\
+bfloat16,60,32,32,0.0\n\
+bfloat16,60,128,32,0.0\n\
+bfloat16,60,32,64,0.0\n\
+bfloat16,60,4,32,0.0\n\
+bfloat16,60,96,32,4.0\n\
+bfloat16,60,32,96,6.0\n\
+bfloat16,1,160,32,0.0\n",
+    )
+    .unwrap();
+    fs::write(
+        fixture.perf_dir().join("moe_perf.txt"),
+        "moe_dtype,num_tokens,hidden_size,inter_size,topk,num_experts,moe_tp_size,moe_ep_size,distribution,latency\n\
+bfloat16,60,32,64,2,4,1,1,power_law_1.2,0.0\n",
+    )
+    .unwrap();
+    let estimator = fixture.estimator_with_config(moe_engine_config());
+    let metrics = ForwardPassMetrics {
+        scheduled_requests: ScheduledRequestMetrics {
+            num_prefill_requests: 1,
+            sum_prefill_tokens: 60,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let latency = estimator.forward_pass_time_ms(&[metrics]).unwrap();
+
+    assert_close(latency, 20.0);
+}
+
+#[test]
+fn context_attention_queries_extrapolate_batch_for_matching_shape() {
+    let fixture = Fixture::new();
+    fs::write(
+        fixture.perf_dir().join("gemm_perf.txt"),
+        "gemm_dtype,m,n,k,latency\n\
+bfloat16,30,64,32,0.0\n\
+bfloat16,30,32,32,0.0\n\
+bfloat16,30,128,32,0.0\n\
+bfloat16,30,32,64,0.0\n\
+bfloat16,3,160,32,0.0\n",
+    )
+    .unwrap();
+    fs::write(
+        fixture.perf_dir().join("context_attention_perf.txt"),
+        "attn_dtype,kv_cache_dtype,batch_size,isl,num_heads,num_key_value_heads,head_dim,latency\n\
+bfloat16,bfloat16,1,10,4,2,8,5.0\n\
+bfloat16,bfloat16,2,10,4,2,8,10.0\n",
+    )
+    .unwrap();
+    let estimator = fixture.estimator();
+    let metrics = ForwardPassMetrics {
+        scheduled_requests: ScheduledRequestMetrics {
+            num_prefill_requests: 3,
+            sum_prefill_tokens: 30,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let latency = estimator.forward_pass_time_ms(&[metrics]).unwrap();
+
+    assert_close(latency, 30.0);
+}
+
+#[test]
+fn generation_attention_queries_extrapolate_batch_for_matching_shape() {
+    let fixture = Fixture::new();
+    fs::write(
+        fixture.perf_dir().join("gemm_perf.txt"),
+        "gemm_dtype,m,n,k,latency\n\
+bfloat16,3,64,32,0.0\n\
+bfloat16,3,32,32,0.0\n\
+bfloat16,3,128,32,0.0\n\
+bfloat16,3,32,64,0.0\n\
+bfloat16,3,160,32,0.0\n",
+    )
+    .unwrap();
+    fs::write(
+        fixture.perf_dir().join("generation_attention_perf.txt"),
+        "attn_dtype,kv_cache_dtype,batch_size,isl,num_heads,num_key_value_heads,head_dim,step,latency\n\
+bfloat16,bfloat16,1,15,4,2,8,1,2.0\n\
+bfloat16,bfloat16,2,15,4,2,8,1,4.0\n",
+    )
+    .unwrap();
+    let estimator = fixture.estimator();
+    let metrics = ForwardPassMetrics {
+        scheduled_requests: ScheduledRequestMetrics {
+            num_decode_requests: 3,
+            sum_decode_kv_tokens: 45,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let latency = estimator.forward_pass_time_ms(&[metrics]).unwrap();
+
+    assert_close(latency, 12.0);
+}
+
+#[test]
+fn gemm_queries_interpolate_matrix_shape_for_matching_tokens() {
+    let fixture = Fixture::new();
+    fs::write(
+        fixture.perf_dir().join("gemm_perf.txt"),
+        "gemm_dtype,m,n,k,latency\n\
+bfloat16,60,64,32,0.0\n\
+bfloat16,60,32,32,0.0\n\
+bfloat16,60,32,64,0.0\n\
+bfloat16,1,160,32,0.0\n\
+bfloat16,60,64,16,4.0\n\
+bfloat16,60,64,48,6.0\n\
+bfloat16,60,192,16,8.0\n\
+bfloat16,60,192,48,10.0\n",
+    )
+    .unwrap();
+    fs::write(
+        fixture.perf_dir().join("context_attention_perf.txt"),
+        "attn_dtype,kv_cache_dtype,batch_size,isl,num_heads,num_key_value_heads,head_dim,latency\n\
+bfloat16,bfloat16,1,60,4,2,8,0.0\n",
+    )
+    .unwrap();
+    let estimator = fixture.estimator();
+    let metrics = ForwardPassMetrics {
+        scheduled_requests: ScheduledRequestMetrics {
+            num_prefill_requests: 1,
+            sum_prefill_tokens: 60,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let latency = estimator.forward_pass_time_ms(&[metrics]).unwrap();
+
+    assert_close(latency, 9.0);
+}
+
+#[test]
+fn non_attention_includes_custom_allreduce_ops() {
+    let fixture = Fixture::new();
+    fs::write(
+        fixture.perf_dir().join("gemm_perf.txt"),
+        "gemm_dtype,m,n,k,latency\n\
+bfloat16,10,32,32,0.0\n\
+bfloat16,10,32,16,0.0\n\
+bfloat16,10,64,32,0.0\n\
+bfloat16,1,80,32,0.0\n",
+    )
+    .unwrap();
+    fs::write(
+        fixture.perf_dir().join("context_attention_perf.txt"),
+        "attn_dtype,kv_cache_dtype,batch_size,isl,num_heads,num_key_value_heads,head_dim,latency\n\
+bfloat16,bfloat16,1,10,2,1,8,0.0\n",
+    )
+    .unwrap();
+    fs::write(
+        fixture.perf_dir().join("custom_allreduce_perf.txt"),
+        "allreduce_dtype,num_gpus,message_size,latency,kernel_source,backend\n\
+bfloat16,2,320,1.0,vLLM_custom_graph,vllm_graph\n",
+    )
+    .unwrap();
+    let estimator = fixture.estimator_with_config(EngineConfig {
+        tp_size: 2,
+        ..engine_config()
+    });
+    let metrics = ForwardPassMetrics {
+        scheduled_requests: ScheduledRequestMetrics {
+            num_prefill_requests: 1,
+            sum_prefill_tokens: 10,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let latency = estimator.forward_pass_time_ms(&[metrics]).unwrap();
+
+    assert_close(latency, 5.0);
+}
+
+#[test]
+fn custom_allreduce_scales_node_local_perf_for_multi_node_tp() {
+    let fixture = Fixture::new();
+    fs::write(
+        fixture.systems_root().join("test_sxm.yaml"),
+        "data_dir: data/test_sxm\n\
+gpu:\n\
+  mem_bw: 1000000000000000000000000000000\n\
+  mem_bw_empirical_scaling_factor: 1.0\n\
+  mem_empirical_constant_latency: 0.0\n\
+node:\n\
+  num_gpus_per_node: 2\n\
+  inter_node_bw: 50\n\
+  intra_node_bw: 100\n\
+  p2p_latency: 0.0\n\
+misc:\n\
+  nccl_version: '1.0.0'\n",
+    )
+    .unwrap();
+    fs::write(
+        fixture.perf_dir().join("gemm_perf.txt"),
+        "gemm_dtype,m,n,k,latency\n\
+bfloat16,10,24,32,0.0\n\
+bfloat16,10,32,8,0.0\n\
+bfloat16,10,32,32,0.0\n\
+bfloat16,10,32,16,0.0\n\
+bfloat16,1,40,32,0.0\n",
+    )
+    .unwrap();
+    fs::write(
+        fixture.perf_dir().join("context_attention_perf.txt"),
+        "attn_dtype,kv_cache_dtype,batch_size,isl,num_heads,num_key_value_heads,head_dim,latency\n\
+bfloat16,bfloat16,1,10,1,1,8,0.0\n",
+    )
+    .unwrap();
+    fs::write(
+        fixture.perf_dir().join("custom_allreduce_perf.txt"),
+        "allreduce_dtype,num_gpus,message_size,latency,kernel_source,backend\n\
+bfloat16,2,320,1.0,vLLM_custom_graph,vllm_graph\n",
+    )
+    .unwrap();
+    let estimator = fixture.estimator_with_config(EngineConfig {
+        tp_size: 4,
+        ..engine_config()
+    });
+    let metrics = ForwardPassMetrics {
+        scheduled_requests: ScheduledRequestMetrics {
+            num_prefill_requests: 1,
+            sum_prefill_tokens: 10,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let latency = estimator.forward_pass_time_ms(&[metrics]).unwrap();
+
+    assert_close(latency, 15.0);
+}
+
+#[test]
 fn attention_dp_rank_metrics_use_max_rank_attention_workload() {
     let fixture = Fixture::new();
     fs::write(
@@ -200,6 +665,37 @@ fn git_lfs_pointer_is_reported() {
 }
 
 #[test]
+fn missing_required_system_perf_field_is_reported() {
+    let fixture = Fixture::new();
+    fs::write(
+        fixture.systems_root().join("test_sxm.yaml"),
+        "data_dir: data/test_sxm\n\
+gpu:\n\
+  mem_bw_empirical_scaling_factor: 1.0\n\
+  mem_empirical_constant_latency: 0.0\n\
+node:\n\
+  num_gpus_per_node: 8\n\
+  inter_node_bw: 1000000000000\n\
+  intra_node_bw: 1000000000000\n\
+  p2p_latency: 0.0\n\
+misc:\n\
+  nccl_version: '1.0.0'\n",
+    )
+    .unwrap();
+
+    let err = EngineStepEstimator::from_config_with_roots(
+        engine_config(),
+        fixture.systems_root(),
+        fixture.model_configs_root(),
+    )
+    .unwrap_err()
+    .to_string();
+
+    assert!(err.contains("missing gpu.mem_bw"));
+    assert!(err.contains("test_sxm.yaml"));
+}
+
+#[test]
 fn long_prefill_prefix_rescale_avoids_u32_overflow() {
     let fixture = Fixture::new();
     fs::write(
@@ -288,7 +784,18 @@ impl Fixture {
         fs::create_dir_all(&model_configs_root).unwrap();
         fs::write(
             systems_root.join("test_sxm.yaml"),
-            "data_dir: data/test_sxm\n",
+            "data_dir: data/test_sxm\n\
+gpu:\n\
+  mem_bw: 1000000000000000000000000000000\n\
+  mem_bw_empirical_scaling_factor: 1.0\n\
+  mem_empirical_constant_latency: 0.0\n\
+node:\n\
+  num_gpus_per_node: 8\n\
+  inter_node_bw: 1000000000000000000000000000000\n\
+  intra_node_bw: 1000000000000000000000000000000\n\
+  p2p_latency: 0.0\n\
+misc:\n\
+  nccl_version: '1.0.0'\n",
         )
         .unwrap();
         fs::write(
@@ -337,6 +844,54 @@ bfloat16,bfloat16,2,16,4,2,8,1,0.7\n",
         Self { _temp: temp, root }
     }
 
+    fn new_moe() -> Self {
+        let fixture = Self::new();
+        fs::write(
+            fixture.model_configs_root().join("Test--Moe_config.json"),
+            r#"{
+  "architectures": ["Qwen2MoeForCausalLM"],
+  "model_type": "qwen2_moe",
+  "num_hidden_layers": 2,
+  "num_attention_heads": 4,
+  "num_key_value_heads": 2,
+  "head_dim": 8,
+  "hidden_size": 32,
+  "intermediate_size": 64,
+  "vocab_size": 160,
+  "num_experts_per_tok": 2,
+  "num_experts": 4,
+  "moe_intermediate_size": 64
+}
+"#,
+        )
+        .unwrap();
+        fs::write(
+            fixture.perf_dir().join("gemm_perf.txt"),
+            "gemm_dtype,m,n,k,latency\n\
+bfloat16,60,64,32,1.0\n\
+bfloat16,60,32,32,2.0\n\
+bfloat16,60,128,32,100.0\n\
+bfloat16,60,32,64,100.0\n\
+bfloat16,60,4,32,0.0\n\
+bfloat16,1,160,32,0.0\n",
+        )
+        .unwrap();
+        fs::write(
+            fixture.perf_dir().join("context_attention_perf.txt"),
+            "attn_dtype,kv_cache_dtype,batch_size,isl,num_heads,num_key_value_heads,head_dim,latency\n\
+bfloat16,bfloat16,1,60,4,2,8,0.0\n",
+        )
+        .unwrap();
+        fs::write(
+            fixture.perf_dir().join("moe_perf.txt"),
+            "moe_dtype,num_tokens,hidden_size,inter_size,topk,num_experts,moe_tp_size,moe_ep_size,distribution,latency\n\
+bfloat16,20,32,64,2,4,1,1,uniform,5.0\n\
+bfloat16,40,32,64,2,4,1,1,uniform,15.0\n",
+        )
+        .unwrap();
+        fixture
+    }
+
     fn systems_root(&self) -> PathBuf {
         self.root.join("systems")
     }
@@ -354,8 +909,12 @@ bfloat16,bfloat16,2,16,4,2,8,1,0.7\n",
     }
 
     fn estimator(&self) -> EngineStepEstimator {
+        self.estimator_with_config(engine_config())
+    }
+
+    fn estimator_with_config(&self, config: EngineConfig) -> EngineStepEstimator {
         EngineStepEstimator::from_config_with_roots(
-            engine_config(),
+            config,
             self.systems_root(),
             self.model_configs_root(),
         )
@@ -388,10 +947,20 @@ fn engine_config() -> EngineConfig {
         moe_ep_size: None,
         attention_dp_size: None,
         weight_dtype: Some(DataType::Bfloat16),
+        moe_dtype: None,
         activation_dtype: Some(DataType::Bfloat16),
         kv_cache_dtype: Some(DataType::Bfloat16),
         kv_block_size: None,
         extra: BTreeMap::new(),
+    }
+}
+
+fn moe_engine_config() -> EngineConfig {
+    EngineConfig {
+        model_name: "Test/Moe".to_string(),
+        moe_tp_size: Some(1),
+        moe_ep_size: Some(1),
+        ..engine_config()
     }
 }
 

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -23,6 +23,7 @@ from aiconfigurator.generator.api import (
 )
 from aiconfigurator.logging_utils import setup_logging
 from aiconfigurator.sdk import common, perf_database
+from aiconfigurator.sdk.errors import NoFeasibleConfigError
 from aiconfigurator.sdk.models import check_is_moe
 from aiconfigurator.sdk.task import TaskConfig, TaskRunner, UnsupportedWideepConfigError
 from aiconfigurator.sdk.utils import ListFlowDumper, get_model_config_from_model_path
@@ -684,6 +685,55 @@ def _get_backend_data_path(system_name: str, backend_name: str, backend_version:
     return None
 
 
+_SGLANG_DEEPEP_REQUIRED_FILES = (
+    common.PerfDataFilename.wideep_deepep_normal.value,
+    common.PerfDataFilename.wideep_deepep_ll.value,
+)
+
+
+def _sglang_deepep_perf_data_skip_reason(
+    system_name: str,
+    decode_system_name: str | None,
+    backend_version: str | None,
+) -> str | None:
+    """Return a concise skip reason when optional SGLang DeepEP data is absent."""
+    missing_paths: list[str] = []
+    missing_versions: list[str] = []
+
+    systems_to_check = [system_name]
+    if decode_system_name and decode_system_name != system_name:
+        systems_to_check.append(decode_system_name)
+
+    for system_to_check in systems_to_check:
+        resolved_version = backend_version or perf_database.get_latest_database_version(
+            system=system_to_check,
+            backend=common.BackendName.sglang.value,
+        )
+        if resolved_version is None:
+            missing_versions.append(f"{system_to_check}/{common.BackendName.sglang.value}")
+            continue
+
+        data_path = _get_backend_data_path(system_to_check, common.BackendName.sglang.value, resolved_version)
+        if data_path is None:
+            missing_paths.extend(
+                f"{system_to_check}/{common.BackendName.sglang.value}/{resolved_version}/{filename}"
+                for filename in _SGLANG_DEEPEP_REQUIRED_FILES
+            )
+            continue
+
+        missing_paths.extend(
+            os.path.join(data_path, filename)
+            for filename in _SGLANG_DEEPEP_REQUIRED_FILES
+            if not os.path.isfile(os.path.join(data_path, filename))
+        )
+
+    if missing_versions:
+        return "no database version available for " + ", ".join(missing_versions)
+    if missing_paths:
+        return "missing required DeepEP perf data: " + ", ".join(missing_paths)
+    return None
+
+
 def _ensure_backend_version_available(system_name: str, backend_name: str, backend_version: str | None = None) -> None:
     """
     Validate that the backend is supported for the given system and version.
@@ -936,15 +986,19 @@ def build_default_task_configs(
 
         # For SGLang MoE without --enable-wideep, also sweep DeepEP intra-node
         if backend_name == "sglang" and not enable_wideep and is_moe_model:
-            deepep_kwargs = dict(agg_kwargs)
-            deepep_kwargs["moe_backend"] = "deepep_moe"
-            try:
-                deepep_task = TaskConfig(serving_mode="agg", **deepep_kwargs)
-            except UnsupportedWideepConfigError as exc:
-                logger.info("Skipping SGLang DeepEP agg sweep: %s", exc)
+            skip_reason = _sglang_deepep_perf_data_skip_reason(system, None, backend_version)
+            if skip_reason:
+                logger.info("Skipping SGLang DeepEP agg sweep: %s", skip_reason)
             else:
-                deepep_name = f"agg_{backend_name}_deepep" if backend == "auto" else "agg_deepep"
-                task_configs[deepep_name] = deepep_task
+                deepep_kwargs = dict(agg_kwargs)
+                deepep_kwargs["moe_backend"] = "deepep_moe"
+                try:
+                    deepep_task = TaskConfig(serving_mode="agg", **deepep_kwargs)
+                except UnsupportedWideepConfigError as exc:
+                    logger.info("Skipping SGLang DeepEP agg sweep: %s", exc)
+                else:
+                    deepep_name = f"agg_{backend_name}_deepep" if backend == "auto" else "agg_deepep"
+                    task_configs[deepep_name] = deepep_task
 
         if total_gpus < 2:
             logger.warning("Skipping disagg since it requires at least 2 GPUs.")
@@ -962,15 +1016,19 @@ def build_default_task_configs(
 
         # For SGLang MoE without --enable-wideep, also sweep DeepEP intra-node
         if backend_name == "sglang" and not enable_wideep and is_moe_model:
-            deepep_disagg_kwargs = dict(disagg_kwargs)
-            deepep_disagg_kwargs["moe_backend"] = "deepep_moe"
-            try:
-                deepep_disagg_task = TaskConfig(serving_mode="disagg", **deepep_disagg_kwargs)
-            except UnsupportedWideepConfigError as exc:
-                logger.info("Skipping SGLang DeepEP disagg sweep: %s", exc)
+            skip_reason = _sglang_deepep_perf_data_skip_reason(system, decode_system, backend_version)
+            if skip_reason:
+                logger.info("Skipping SGLang DeepEP disagg sweep: %s", skip_reason)
             else:
-                deepep_name = f"disagg_{backend_name}_deepep" if backend == "auto" else "disagg_deepep"
-                task_configs[deepep_name] = deepep_disagg_task
+                deepep_disagg_kwargs = dict(disagg_kwargs)
+                deepep_disagg_kwargs["moe_backend"] = "deepep_moe"
+                try:
+                    deepep_disagg_task = TaskConfig(serving_mode="disagg", **deepep_disagg_kwargs)
+                except UnsupportedWideepConfigError as exc:
+                    logger.info("Skipping SGLang DeepEP disagg sweep: %s", exc)
+                else:
+                    deepep_name = f"disagg_{backend_name}_deepep" if backend == "auto" else "disagg_deepep"
+                    task_configs[deepep_name] = deepep_disagg_task
     return task_configs
 
 
@@ -1217,8 +1275,15 @@ def _execute_task_configs(
                 )
                 logger.warning(msg)
                 failure_messages.append(msg)
+        except NoFeasibleConfigError as exc:
+            msg = f"Experiment {exp_name} found no SLA-feasible configuration: {exc}"
+            logger.warning(msg)
+            failure_messages.append(msg)
         except Exception as exc:
-            logger.exception("Error running experiment %s", exp_name)
+            if perf_database.has_perf_data_not_available_cause(exc):
+                logger.log(logging.ERROR, "Error running experiment %s: %s", exp_name, exc)
+            else:
+                logger.exception("Error running experiment %s", exp_name)
             failure_messages.append(f"Experiment {exp_name} failed: {exc}")
 
     if len(results) < 1:

--- a/src/aiconfigurator/sdk/errors.py
+++ b/src/aiconfigurator/sdk/errors.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared SDK exception types."""
+
+
+class NoFeasibleConfigError(RuntimeError):
+    """Raised when no configuration satisfies user-provided SLA constraints."""

--- a/src/aiconfigurator/sdk/inference_session.py
+++ b/src/aiconfigurator/sdk/inference_session.py
@@ -10,6 +10,7 @@ import pandas as pd
 
 from aiconfigurator.sdk import common, config, models, perf_database
 from aiconfigurator.sdk.backends.base_backend import BaseBackend
+from aiconfigurator.sdk.errors import NoFeasibleConfigError
 from aiconfigurator.sdk.inference_summary import InferenceSummary
 from aiconfigurator.sdk.picking import (
     _AUTOSCALE_TTFT_CORRECTION_FACTOR,
@@ -439,7 +440,7 @@ class DisaggInferenceSession:
                     "configuration. Try increasing --total-gpus, using a quantized model, or "
                     "using a system with more VRAM per GPU."
                 )
-            raise RuntimeError(
+            raise NoFeasibleConfigError(
                 "No results found for any parallel configuration. No configuration satisfied the "
                 "TTFT/TPOT or request-latency constraints. Try relaxing --ttft, --tpot, or "
                 "--request_latency (e.g., higher ttft/tpot or higher request_latency)."

--- a/src/aiconfigurator/sdk/pareto_analysis.py
+++ b/src/aiconfigurator/sdk/pareto_analysis.py
@@ -14,6 +14,7 @@ from aiconfigurator.logging_utils import use_plain_cli_output
 from aiconfigurator.sdk import config
 from aiconfigurator.sdk.backends.factory import get_backend
 from aiconfigurator.sdk.common import ColumnsAgg
+from aiconfigurator.sdk.errors import NoFeasibleConfigError
 from aiconfigurator.sdk.inference_session import DisaggInferenceSession, InferenceSession
 from aiconfigurator.sdk.models import get_model
 from aiconfigurator.sdk.perf_database import PerfDatabase
@@ -173,7 +174,7 @@ def agg_pareto(
                 "parallel configurations. Try reducing --batch-size, increasing "
                 "--free-gpu-memory-fraction, or using a system with more VRAM per GPU."
             )
-        raise RuntimeError(
+        raise NoFeasibleConfigError(
             "No results found for any parallel configuration. No configuration satisfied the "
             "TTFT/TPOT or request-latency constraints. Try relaxing --ttft, --tpot, or "
             "--request_latency (e.g., higher ttft/tpot or higher request_latency)."

--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -90,6 +90,24 @@ class PerfDataNotAvailableError(RuntimeError):
     """Raised when required performance data is missing or unsupported for a requested mode."""
 
 
+def has_perf_data_not_available_cause(error: BaseException) -> bool:
+    """Return True when an exception or chained cause is a structured perf-data miss."""
+    seen: set[int] = set()
+    stack: list[BaseException] = [error]
+    while stack:
+        current = stack.pop()
+        if id(current) in seen:
+            continue
+        if isinstance(current, PerfDataNotAvailableError):
+            return True
+        seen.add(id(current))
+        if current.__cause__ is not None:
+            stack.append(current.__cause__)
+        if current.__context__ is not None:
+            stack.append(current.__context__)
+    return False
+
+
 @functools.cache
 def _load_op_kernel_source_manifest_entries(systems_root: str) -> dict[str, tuple[dict, ...]]:
     """Load `<systems_root>/op_kernel_source_manifest.yaml` and group entries by op_file.
@@ -3760,6 +3778,36 @@ class PerfDatabase:
         """Thin wrapper — delegates to ``interpolation.interp_dsa_context_topk_piecewise_from_raw``."""
         return interpolation.interp_dsa_context_topk_piecewise_from_raw(num_heads, full_s, b, dsa_dict, index_topk)
 
+    @staticmethod
+    def _is_dsa_interpolation_miss(error: Exception) -> bool:
+        message = str(error)
+        return isinstance(error, ValueError) and (
+            "x is not equal to the only value in the list" in message
+            or "x is less than the smallest value in the list" in message
+            or "x is greater than the largest value in the list" in message
+        )
+
+    @staticmethod
+    def _format_dsa_unavailable_message(
+        phase: str,
+        error: Exception,
+        *,
+        b: int,
+        s: int,
+        num_heads: int,
+        architecture: str,
+        index_n_heads: int,
+        index_head_dim: int,
+        index_topk: int,
+        prefix: int | None = None,
+    ) -> str:
+        prefix_part = "" if prefix is None else f", prefix={prefix}"
+        return (
+            f"{phase} DSA module perf data unavailable for candidate "
+            f"b={b}, s={s}{prefix_part}, num_heads={num_heads}, architecture={architecture}, "
+            f"index_n_heads={index_n_heads}, index_head_dim={index_head_dim}, index_topk={index_topk}: {error}"
+        )
+
     def _get_sample_leaf_value(self, data: dict):
         """Thin wrapper — delegates to ``interpolation.get_sample_leaf_value``."""
         return interpolation.get_sample_leaf_value(data)
@@ -6928,7 +6976,7 @@ class PerfDatabase:
                     latency *= correction
                     energy *= correction
                 return PerformanceResult(latency, energy=energy)
-            except Exception:
+            except Exception as e:
                 if database_mode == common.DatabaseMode.HYBRID:
                     logger.debug(
                         f"Failed to query context DSA module for {b=}, {s=}, {prefix=}, {num_heads=}, "
@@ -6936,6 +6984,24 @@ class PerfDatabase:
                     )
                     latency = get_empirical(b, s, prefix, num_heads, kvcache_quant_mode, fmha_quant_mode)
                     return PerformanceResult(latency, energy=0.0)
+                if isinstance(e, PerfDataNotAvailableError):
+                    logger.warning(str(e))
+                    raise
+                if self._is_dsa_interpolation_miss(e):
+                    message = self._format_dsa_unavailable_message(
+                        "Context",
+                        e,
+                        b=b,
+                        s=s,
+                        prefix=prefix,
+                        num_heads=num_heads,
+                        architecture=architecture,
+                        index_n_heads=index_n_heads,
+                        index_head_dim=index_head_dim,
+                        index_topk=index_topk,
+                    )
+                    logger.warning(message)
+                    raise PerfDataNotAvailableError(message) from None
                 else:
                     logger.exception(
                         f"Failed to query context DSA module for {b=}, {s=}, {prefix=}, {num_heads=}, "
@@ -7084,7 +7150,7 @@ class PerfDatabase:
                 latency = result["latency"]
                 energy = result.get("energy", 0.0)
                 return PerformanceResult(latency, energy=energy)
-            except Exception:
+            except Exception as e:
                 if database_mode == common.DatabaseMode.HYBRID:
                     logger.debug(
                         f"Failed to query generation DSA module for {b=}, {s=}, {num_heads=}, "
@@ -7092,6 +7158,23 @@ class PerfDatabase:
                     )
                     latency = get_empirical(b, s, num_heads, kv_cache_dtype)
                     return PerformanceResult(latency, energy=0.0)
+                if isinstance(e, PerfDataNotAvailableError):
+                    logger.warning(str(e))
+                    raise
+                if self._is_dsa_interpolation_miss(e):
+                    message = self._format_dsa_unavailable_message(
+                        "Generation",
+                        e,
+                        b=b,
+                        s=s,
+                        num_heads=num_heads,
+                        architecture=architecture,
+                        index_n_heads=index_n_heads,
+                        index_head_dim=index_head_dim,
+                        index_topk=index_topk,
+                    )
+                    logger.warning(message)
+                    raise PerfDataNotAvailableError(message) from None
                 else:
                     logger.exception(
                         f"Failed to query generation DSA module for {b=}, {s=}, {num_heads=}, "

--- a/src/aiconfigurator/sdk/rust_engine_step.py
+++ b/src/aiconfigurator/sdk/rust_engine_step.py
@@ -218,6 +218,7 @@ def _engine_config_json(model: Any, database: Any) -> str:
         "moe_ep_size": _optional_int(getattr(model_config, "moe_ep_size", None)),
         "attention_dp_size": _optional_int(getattr(model_config, "attention_dp_size", None)),
         "weight_dtype": _quant_to_dtype(getattr(model_config, "gemm_quant_mode", None)),
+        "moe_dtype": _moe_quant_to_dtype(getattr(model_config, "moe_quant_mode", None)),
         "activation_dtype": _quant_to_dtype(getattr(model_config, "fmha_quant_mode", None)),
         "kv_cache_dtype": _quant_to_dtype(getattr(model_config, "kvcache_quant_mode", None)),
         "kv_block_size": None,
@@ -250,16 +251,13 @@ def _decode_metrics(*, batch_size: int, context_length: int) -> dict[str, Any]:
 
 @cache
 def _load_library(autobuild: bool) -> ctypes.CDLL:
-    if autobuild and not os.environ.get(RUST_CORE_LIB_ENV):
+    library_path = _find_library(include_debug=not autobuild)
+    if library_path is None and autobuild:
         library_path = _build_rust_core()
-    else:
-        library_path = _find_library()
-        if library_path is None and autobuild:
-            library_path = _build_rust_core()
     if library_path is None:
         raise RustCoreUnavailableError(
             "Rust core shared library not found. Build it with "
-            "`cargo build --manifest-path rust/aiconfigurator-core/Cargo.toml`, "
+            "`cargo build --release --manifest-path rust/aiconfigurator-core/Cargo.toml`, "
             f"set {RUST_CORE_LIB_ENV}, or set {RUST_CORE_AUTOBUILD_ENV}=1."
         )
 
@@ -279,7 +277,7 @@ def _load_library(autobuild: bool) -> ctypes.CDLL:
     return lib
 
 
-def _find_library() -> Path | None:
+def _find_library(*, include_debug: bool = True) -> Path | None:
     explicit = os.environ.get(RUST_CORE_LIB_ENV)
     if explicit:
         path = Path(explicit)
@@ -291,10 +289,9 @@ def _find_library() -> Path | None:
     if crate_root is None:
         return None
     lib_name = _library_name()
-    candidates = [
-        crate_root / "target" / "release" / lib_name,
-        crate_root / "target" / "debug" / lib_name,
-    ]
+    candidates = [crate_root / "target" / "release" / lib_name]
+    if include_debug:
+        candidates.append(crate_root / "target" / "debug" / lib_name)
     return next((path for path in candidates if path.is_file()), None)
 
 
@@ -306,10 +303,10 @@ def _build_rust_core() -> Path:
         raise RustCoreUnavailableError("cargo is not available on PATH")
 
     subprocess.run(
-        ["cargo", "build", "--manifest-path", str(crate_root / "Cargo.toml")],
+        ["cargo", "build", "--release", "--manifest-path", str(crate_root / "Cargo.toml")],
         check=True,
     )
-    library_path = crate_root / "target" / "debug" / _library_name()
+    library_path = crate_root / "target" / "release" / _library_name()
     if not library_path.is_file():
         raise RustCoreUnavailableError(f"cargo build completed but did not produce {library_path}")
     return library_path
@@ -386,6 +383,18 @@ def _quant_to_dtype(value: Any) -> str | None:
     if name in {"int4", "int4_wo", "w4afp8", "w4a16_mxfp4", "w4a8_mxfp4_mxfp8"}:
         return "int4"
     return None
+
+
+def _moe_quant_to_dtype(value: Any) -> str | None:
+    if value is None:
+        return None
+    name = getattr(value, "name", str(value)).lower()
+    value_name = getattr(getattr(value, "value", None), "name", None)
+    if value_name:
+        name = value_name.lower()
+    if name in {"w4afp8", "w4a16_mxfp4", "w4a8_mxfp4_mxfp8"}:
+        return name
+    return _quant_to_dtype(value)
 
 
 def _configure_default_data_roots() -> None:

--- a/src/aiconfigurator/sdk/task.py
+++ b/src/aiconfigurator/sdk/task.py
@@ -15,9 +15,14 @@ import yaml
 from munch import DefaultMunch, Munch
 
 from aiconfigurator.sdk import common, config
+from aiconfigurator.sdk.errors import NoFeasibleConfigError
 from aiconfigurator.sdk.models import _apply_model_quant_defaults, check_is_moe, get_model_family
 from aiconfigurator.sdk.pareto_analysis import get_pareto_front
-from aiconfigurator.sdk.perf_database import get_database, get_latest_database_version
+from aiconfigurator.sdk.perf_database import (
+    get_database,
+    get_latest_database_version,
+    has_perf_data_not_available_cause,
+)
 from aiconfigurator.sdk.utils import ListFlowDumper, enumerate_parallel_config, get_model_config_from_model_path
 
 logger = logging.getLogger(__name__)
@@ -1567,12 +1572,30 @@ class TaskRunner:
                 result = self.run_disagg(task_config.config, autoscale=autoscale)
             else:
                 raise ValueError(f"Invalid serving mode: {serving_mode}")
-        except Exception:
-            logger.exception(
-                "Error running pareto analysis for %s in %s mode",
+        except NoFeasibleConfigError as exc:
+            logger.warning(
+                "No feasible configuration found for %s in %s mode: %s",
                 task_config.task_name,
                 serving_mode,
+                exc,
             )
+            result = None
+            raise
+        except Exception as exc:
+            if has_perf_data_not_available_cause(exc):
+                logger.log(
+                    logging.ERROR,
+                    "Error running pareto analysis for %s in %s mode: %s",
+                    task_config.task_name,
+                    serving_mode,
+                    exc,
+                )
+            else:
+                logger.exception(
+                    "Error running pareto analysis for %s in %s mode",
+                    task_config.task_name,
+                    serving_mode,
+                )
             result = None
             raise
 

--- a/tests/unit/cli/test_cli_workflow.py
+++ b/tests/unit/cli/test_cli_workflow.py
@@ -9,12 +9,19 @@ while keeping heavy computation mocked out.
 """
 
 import argparse
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from aiconfigurator.cli.main import build_default_task_configs, build_experiment_task_configs, configure_parser
+from aiconfigurator.cli.main import (
+    _execute_task_configs,
+    build_default_task_configs,
+    build_experiment_task_configs,
+    configure_parser,
+)
 from aiconfigurator.cli.main import main as cli_main
+from aiconfigurator.sdk.errors import NoFeasibleConfigError
 
 pytestmark = pytest.mark.unit
 
@@ -183,6 +190,28 @@ class TestCLIIntegration:
         )
         assert args.database_mode == database_mode
 
+    @patch("aiconfigurator.cli.main.TaskRunner")
+    def test_execute_task_configs_no_feasible_config_logs_without_traceback(
+        self,
+        mock_task_runner_class,
+        caplog,
+    ):
+        """Strict-SLA no-match should produce a controlled report, not a traceback."""
+        mock_runner = mock_task_runner_class.return_value
+        mock_runner.run.side_effect = NoFeasibleConfigError("No configuration satisfied the TTFT/TPOT constraints.")
+        mock_task_config = MagicMock(name="TaskConfig")
+        mock_task_config.to_yaml.return_value = "serving_mode: agg"
+        mock_task_config.database_mode = None
+
+        with caplog.at_level(logging.WARNING), pytest.raises(SystemExit) as exc_info:
+            _execute_task_configs({"agg": mock_task_config}, mode="default", strict_sla=True)
+
+        assert exc_info.value.code == 1
+        assert "Experiment agg found no SLA-feasible configuration" in caplog.text
+        assert "No successful experiment runs to compare." in caplog.text
+        assert "Traceback" not in caplog.text
+        assert all(record.exc_info is None for record in caplog.records)
+
     @patch("aiconfigurator.cli.main._execute_task_configs")
     @patch("aiconfigurator.cli.main.build_experiment_task_configs")
     def test_cli_exp_mode_with_database_mode_in_yaml(self, mock_build_exp, mock_execute, tmp_path):
@@ -279,6 +308,60 @@ class TestBuildDefaultTaskConfigs:
         assert "disagg" in result
         # TaskConfig should be called twice (agg + disagg)
         assert mock_task_config.call_count == 2
+
+    @patch("aiconfigurator.cli.main.check_is_moe", return_value=True)
+    @patch("aiconfigurator.cli.main.TaskConfig")
+    def test_skips_optional_sglang_deepep_when_perf_data_missing(
+        self,
+        mock_task_config,
+        _mock_check_is_moe,
+        tmp_path,
+        caplog,
+    ):
+        """Optional SGLang DeepEP sweeps should not be scheduled without DeepEP op data."""
+        mock_task_config.return_value = MagicMock(name="MockTaskConfig")
+        caplog.set_level(logging.INFO, logger="aiconfigurator.cli.main")
+
+        with patch("aiconfigurator.cli.main._get_backend_data_path", return_value=str(tmp_path)):
+            result = build_default_task_configs(
+                model_path="deepseek-ai/DeepSeek-R1",
+                total_gpus=8,
+                system="b200_sxm",
+                backend="sglang",
+                backend_version="0.5.10",
+                database_mode="HYBRID",
+            )
+
+        assert set(result) == {"agg", "disagg"}
+        assert mock_task_config.call_count == 2
+        assert "Skipping SGLang DeepEP agg sweep" in caplog.text
+        assert "Skipping SGLang DeepEP disagg sweep" in caplog.text
+        assert "wideep_deepep_normal_perf.txt" in caplog.text
+
+    @patch("aiconfigurator.cli.main.check_is_moe", return_value=True)
+    @patch("aiconfigurator.cli.main.TaskConfig")
+    def test_includes_optional_sglang_deepep_when_perf_data_exists(
+        self,
+        mock_task_config,
+        _mock_check_is_moe,
+        tmp_path,
+    ):
+        """SGLang DeepEP sweeps remain available when required DeepEP op data exists."""
+        mock_task_config.return_value = MagicMock(name="MockTaskConfig")
+        for filename in ("wideep_deepep_normal_perf.txt", "wideep_deepep_ll_perf.txt"):
+            (tmp_path / filename).write_text("header\n", encoding="utf-8")
+
+        with patch("aiconfigurator.cli.main._get_backend_data_path", return_value=str(tmp_path)):
+            result = build_default_task_configs(
+                model_path="deepseek-ai/DeepSeek-R1",
+                total_gpus=8,
+                system="h100_sxm",
+                backend="sglang",
+                backend_version="0.5.6.post2",
+            )
+
+        assert set(result) == {"agg", "agg_deepep", "disagg", "disagg_deepep"}
+        assert mock_task_config.call_count == 4
 
 
 class TestBuildExperimentTaskConfigs:

--- a/tests/unit/sdk/database/test_dsa_module.py
+++ b/tests/unit/sdk/database/test_dsa_module.py
@@ -1,12 +1,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 import math
 
 import pytest
 
 from aiconfigurator.sdk import common
-from aiconfigurator.sdk.perf_database import DEFAULT_DSA_ARCHITECTURE, LoadedOpData
+from aiconfigurator.sdk.perf_database import DEFAULT_DSA_ARCHITECTURE, LoadedOpData, PerfDataNotAvailableError
 
 pytestmark = pytest.mark.unit
 
@@ -22,6 +23,16 @@ def _context_dsa_data(dsa_dict: dict) -> dict:
                 common.GEMMQuantMode.bfloat16: {
                     DEFAULT_DSA_ARCHITECTURE: dsa_dict,
                 },
+            },
+        },
+    }
+
+
+def _generation_dsa_data(dsa_dict: dict) -> dict:
+    return {
+        common.KVCacheQuantMode.bfloat16: {
+            common.GEMMQuantMode.bfloat16: {
+                DEFAULT_DSA_ARCHITECTURE: dsa_dict,
             },
         },
     }
@@ -133,6 +144,29 @@ class TestContextDSAModule:
         assert float(result) == pytest.approx(123.0)
         assert result.energy == pytest.approx(456.0)
         assert len(cubic_calls) == 1
+
+    def test_unsupported_silicon_candidate_logs_warning_without_traceback(self, stub_perf_db, caplog):
+        dsa_dict = {64: {4000: {1: _dsa_value(10.0)}}}
+        stub_perf_db._context_dsa_module_data = LoadedOpData(
+            _context_dsa_data(dsa_dict), common.PerfDataFilename.dsa_context_module, "single-head"
+        )
+
+        caplog.set_level(logging.WARNING, logger="aiconfigurator.sdk.perf_database")
+        with pytest.raises(PerfDataNotAvailableError, match="Context DSA module perf data unavailable"):
+            stub_perf_db.query_context_dsa_module(
+                b=1,
+                s=4000,
+                prefix=0,
+                num_heads=32,
+                index_topk=2048,
+                kvcache_quant_mode=common.KVCacheQuantMode.bfloat16,
+                fmha_quant_mode=common.FMHAQuantMode.bfloat16,
+                gemm_quant_mode=common.GEMMQuantMode.bfloat16,
+                database_mode=common.DatabaseMode.SILICON,
+            )
+
+        assert any("Context DSA module perf data unavailable" in record.getMessage() for record in caplog.records)
+        assert all(record.exc_info is None for record in caplog.records)
 
     def test_sol_returns_positive(self, comprehensive_perf_db):
         result = comprehensive_perf_db.query_context_dsa_module(
@@ -270,6 +304,27 @@ class TestContextDSAModule:
 
 class TestGenerationDSAModule:
     """Tests for query_generation_dsa_module."""
+
+    def test_unsupported_silicon_candidate_logs_warning_without_traceback(self, stub_perf_db, caplog):
+        dsa_dict = {64: {1: {4000: _dsa_value(10.0)}}}
+        stub_perf_db._generation_dsa_module_data = LoadedOpData(
+            _generation_dsa_data(dsa_dict), common.PerfDataFilename.dsa_generation_module, "single-head"
+        )
+
+        caplog.set_level(logging.WARNING, logger="aiconfigurator.sdk.perf_database")
+        with pytest.raises(PerfDataNotAvailableError, match="Generation DSA module perf data unavailable"):
+            stub_perf_db.query_generation_dsa_module(
+                b=1,
+                s=4000,
+                num_heads=32,
+                index_topk=2048,
+                kv_cache_dtype=common.KVCacheQuantMode.bfloat16,
+                gemm_quant_mode=common.GEMMQuantMode.bfloat16,
+                database_mode=common.DatabaseMode.SILICON,
+            )
+
+        assert any("Generation DSA module perf data unavailable" in record.getMessage() for record in caplog.records)
+        assert all(record.exc_info is None for record in caplog.records)
 
     def test_sol_returns_positive(self, comprehensive_perf_db):
         result = comprehensive_perf_db.query_generation_dsa_module(

--- a/tests/unit/sdk/database/test_perf_database_errors.py
+++ b/tests/unit/sdk/database/test_perf_database_errors.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from aiconfigurator.sdk.perf_database import (
+    PerfDataNotAvailableError,
+    has_perf_data_not_available_cause,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_perf_data_cause_detection_traverses_cause_and_context() -> None:
+    error = RuntimeError("outer")
+    error.__cause__ = RuntimeError("explicit cause")
+    error.__context__ = PerfDataNotAvailableError("missing perf data")
+
+    assert has_perf_data_not_available_cause(error)
+
+
+def test_perf_data_cause_detection_avoids_cycles() -> None:
+    error = RuntimeError("outer")
+    nested = RuntimeError("nested")
+    error.__cause__ = nested
+    nested.__context__ = error
+
+    assert not has_perf_data_not_available_cause(error)

--- a/tests/unit/sdk/task/test_task.py
+++ b/tests/unit/sdk/task/test_task.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 import pathlib
 import sys
 from types import SimpleNamespace
@@ -30,6 +31,7 @@ if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 
 import aiconfigurator.sdk.task as task_module
+from aiconfigurator.sdk.errors import NoFeasibleConfigError
 from aiconfigurator.sdk.task import TaskConfig, TaskRunner
 
 
@@ -87,6 +89,25 @@ def test_taskconfig_agg_default():
     assert _enum_name(cfg.worker_config.gemm_quant_mode) == "bfloat16"
     assert cfg.worker_config.num_gpu_per_worker == [1, 2, 4, 8]
     assert cfg.applied_layers == ["base-common", "agg-defaults"]
+
+
+def test_taskrunner_no_feasible_config_logs_without_traceback(monkeypatch, caplog):
+    """Expected strict-SLA no-match failures should not emit traceback records."""
+
+    def raise_no_feasible(**kwargs):
+        raise NoFeasibleConfigError("No configuration satisfied the TTFT/TPOT constraints.")
+
+    pa_stub = sys.modules["aiconfigurator.sdk.pareto_analysis"]
+    monkeypatch.setattr(pa_stub, "agg_pareto", raise_no_feasible)
+
+    task = TaskConfig(serving_mode="agg", model_path="Qwen/Qwen3-32B", system_name="h200_sxm")
+
+    with caplog.at_level(logging.WARNING), pytest.raises(NoFeasibleConfigError):
+        TaskRunner().run(task)
+
+    assert "No feasible configuration found" in caplog.text
+    assert "Traceback" not in caplog.text
+    assert all(record.exc_info is None for record in caplog.records)
 
 
 def test_taskconfig_disagg_default():

--- a/tests/unit/sdk/test_rust_engine_step.py
+++ b/tests/unit/sdk/test_rust_engine_step.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 import shutil
 from types import SimpleNamespace
 
@@ -20,6 +21,51 @@ def test_should_use_rust_engine_step_supports_runtime_config_and_env(monkeypatch
     assert rust_engine_step.should_use_rust_engine_step(RuntimeConfig())
     assert rust_engine_step.should_use_rust_engine_step(RuntimeConfig(engine_step_backend="rust"))
     assert not rust_engine_step.should_use_rust_engine_step(RuntimeConfig(engine_step_backend="python"))
+
+
+def test_autobuild_uses_release_profile(tmp_path, monkeypatch) -> None:
+    crate_root = tmp_path / "rust" / "aiconfigurator-core"
+    crate_root.mkdir(parents=True)
+    (crate_root / "Cargo.toml").write_text('[package]\nname = "aiconfigurator-core"\nversion = "0.0.0"\n')
+
+    monkeypatch.setattr(rust_engine_step, "_crate_root", lambda: crate_root)
+    monkeypatch.setattr(rust_engine_step.shutil, "which", lambda name: "/usr/bin/cargo")
+
+    commands = []
+
+    def fake_run(command, check):
+        commands.append(command)
+        library_path = crate_root / "target" / "release" / rust_engine_step._library_name()
+        library_path.parent.mkdir(parents=True)
+        library_path.touch()
+
+    monkeypatch.setattr(rust_engine_step.subprocess, "run", fake_run)
+
+    library_path = rust_engine_step._build_rust_core()
+
+    assert library_path == crate_root / "target" / "release" / rust_engine_step._library_name()
+    assert commands == [
+        [
+            "cargo",
+            "build",
+            "--release",
+            "--manifest-path",
+            str(crate_root / "Cargo.toml"),
+        ]
+    ]
+
+
+def test_find_library_can_ignore_debug_artifacts(tmp_path, monkeypatch) -> None:
+    crate_root = tmp_path / "rust" / "aiconfigurator-core"
+    debug_library_path = crate_root / "target" / "debug" / rust_engine_step._library_name()
+    debug_library_path.parent.mkdir(parents=True)
+    debug_library_path.touch()
+
+    monkeypatch.delenv("AICONFIGURATOR_RUST_CORE_LIB", raising=False)
+    monkeypatch.setattr(rust_engine_step, "_crate_root", lambda: crate_root)
+
+    assert rust_engine_step._find_library(include_debug=False) is None
+    assert rust_engine_step._find_library(include_debug=True) == debug_library_path
 
 
 def test_static_latency_breakdown_maps_runtime_config_to_fpm(monkeypatch) -> None:
@@ -143,6 +189,30 @@ def test_mixed_and_decode_helpers_map_to_fpm(monkeypatch) -> None:
     }
 
 
+def test_engine_config_json_preserves_moe_specific_quant_mode() -> None:
+    model = SimpleNamespace(
+        model_path="Test/Moe",
+        architecture="GptOssForCausalLM",
+        config=ModelConfig(
+            tp_size=1,
+            pp_size=1,
+            attention_dp_size=1,
+            moe_tp_size=1,
+            moe_ep_size=1,
+            gemm_quant_mode=common.GEMMQuantMode.bfloat16,
+            moe_quant_mode=common.MoEQuantMode.w4a16_mxfp4,
+            kvcache_quant_mode=common.KVCacheQuantMode.bfloat16,
+            fmha_quant_mode=common.FMHAQuantMode.bfloat16,
+        ),
+    )
+    database = SimpleNamespace(system="test_sxm", backend="vllm", version="1.0.0")
+
+    config = json.loads(rust_engine_step._engine_config_json(model, database))
+
+    assert config["weight_dtype"] == "bfloat16"
+    assert config["moe_dtype"] == "w4a16_mxfp4"
+
+
 @pytest.mark.skipif(shutil.which("cargo") is None, reason="cargo is required to build the Rust core shared library")
 def test_ctypes_wrapper_calls_real_rust_core(tmp_path, monkeypatch) -> None:
     systems_root = tmp_path / "systems"
@@ -151,7 +221,18 @@ def test_ctypes_wrapper_calls_real_rust_core(tmp_path, monkeypatch) -> None:
     data_root.mkdir(parents=True)
     model_configs_root.mkdir()
 
-    (systems_root / "test_sxm.yaml").write_text("data_dir: data/test_sxm\n")
+    (systems_root / "test_sxm.yaml").write_text(
+        "data_dir: data/test_sxm\n"
+        "gpu:\n"
+        "  mem_bw: 1000000000000000000000000000000\n"
+        "  mem_bw_empirical_scaling_factor: 1.0\n"
+        "  mem_empirical_constant_latency: 0.0\n"
+        "node:\n"
+        "  num_gpus_per_node: 8\n"
+        "  inter_node_bw: 1000000000000000000000000000000\n"
+        "  intra_node_bw: 1000000000000000000000000000000\n"
+        "  p2p_latency: 0.0\n"
+    )
     (model_configs_root / "Test--Dense_config.json").write_text(
         """{
   "architectures": ["LlamaForCausalLM"],

--- a/tools/support_matrix/support_matrix.py
+++ b/tools/support_matrix/support_matrix.py
@@ -527,7 +527,7 @@ class SupportMatrix:
                 results[mode] = False
                 error_messages[mode] = traceback.format_exc()
             finally:
-                error_messages[mode] = _format_exception_for_csv(error_messages[mode])
+                error_messages[mode] = _format_exception_for_csv(error_messages.get(mode))
         return results, error_messages
 
     def test_support_matrix(


### PR DESCRIPTION
## Summary
- Cherry-picks #1076 onto release/0.9.0 via source commit ed084c1607dc0f6eaa4d156ec806555e1e25e983.
- Resolves release-branch conflicts in DSA tests and support matrix handling.
- Preserves the release/0.9.0 DSA unavailable-message wording in the backported tests.

## Testing
- cargo fmt --manifest-path rust/aiconfigurator-core/Cargo.toml -- --check
- cargo test --manifest-path rust/aiconfigurator-core/Cargo.toml
- /tmp/aic-pr1076-venv/bin/ruff check src/aiconfigurator/cli/main.py src/aiconfigurator/sdk/errors.py src/aiconfigurator/sdk/inference_session.py src/aiconfigurator/sdk/pareto_analysis.py src/aiconfigurator/sdk/perf_database.py src/aiconfigurator/sdk/rust_engine_step.py src/aiconfigurator/sdk/task.py tests/unit/cli/test_cli_workflow.py tests/unit/sdk/database/test_dsa_module.py tests/unit/sdk/database/test_perf_database_errors.py tests/unit/sdk/task/test_task.py tests/unit/sdk/test_rust_engine_step.py tools/support_matrix/support_matrix.py
- PYTHONPATH=src /tmp/aic-pr1076-venv/bin/pytest tests/unit/sdk/test_rust_engine_step.py tests/unit/sdk/database/test_perf_database_errors.py tests/unit/sdk/database/test_dsa_module.py tests/unit/sdk/task/test_task.py tests/unit/cli/test_cli_workflow.py => 88 passed