### PR TITLE
feat: add --inclusive-tpot output flag

### DIFF
--- a/docs/cli_user_guide.md
+++ b/docs/cli_user_guide.md
@@ -18,6 +18,7 @@ the corresponding flag is not specified:
 | TTFT (Time to First Token) | 2000 ms | `--ttft` | Max acceptable time to first token |
 | TPOT (Time per Output Token) | 30 ms | `--tpot` | Max acceptable time per output token |
 | Strict SLA | off | `--strict-sla` | Pre-filter Pareto frontier to only SLA-compliant configs |
+| Inclusive TPOT | off | `--inclusive-tpot` | Report TPOT inclusive of TTFT |
 | Backend | trtllm | `--backend` | Inference backend used for estimation |
 | Prefix Cache Length | 0 | `--prefix` | Prefix cache length for KV reuse |
 | Database Mode | SILICON | `--database-mode` | Source of performance data |
@@ -568,6 +569,12 @@ disagg Top Configurations: (Sorted by tokens/s/gpu)
 ********************************************************************************
 2025-12-01 23:36:41,892 - aiconfigurator.cli.main - INFO - All experiments completed in 1.92 seconds
 ```
+
+#### Inclusive TPOT reporting (`--inclusive-tpot`)
+
+AIC's TPOT metric is the inter-token latency during the decode phase — it does not include TTFT. Pass `--inclusive-tpot` to report TPOT as `(ttft + tpot × (osl − 1)) / osl`, which spreads the TTFT cost across all output tokens. This matches the end-to-end per-token latency reported by GuideLLM and other benchmarking tools, making predicted values directly comparable to benchmark measurements.
+
+The flag only affects terminal output and saved CSV — SLA filtering always uses inter-token latency.
 
 #### Strict SLA filtering (`--strict-sla`)
 

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -272,6 +272,15 @@ def _add_default_mode_arguments(parser):
         default=None,
         help="Optional end-to-end request latency target (ms). Enables request-latency optimization mode.",
     )
+    parser.add_argument(
+        "--inclusive-tpot",
+        action="store_true",
+        default=False,
+        help=(
+            "Report TPOT as (ttft + tpot * (osl - 1)) / osl, spreading TTFT cost across all output tokens. "
+            "Affects terminal output and saved CSV only; SLA filtering always uses inter-token latency."
+        ),
+    )
     parser.add_argument("--prefix", type=int, default=0, help="Prefix cache length. Default to 0.")
     parser.add_argument(
         "--nextn",
@@ -328,6 +337,15 @@ def _add_experiments_mode_arguments(parser):
         type=str,
         required=True,
         help="Path to a YAML file containing experiment definitions.",
+    )
+    parser.add_argument(
+        "--inclusive-tpot",
+        action="store_true",
+        default=False,
+        help=(
+            "Report TPOT as (ttft + tpot * (osl - 1)) / osl, spreading TTFT cost across all output tokens. "
+            "Affects terminal output and saved CSV only; SLA filtering always uses inter-token latency."
+        ),
     )
 
 
@@ -1372,6 +1390,7 @@ def _execute_task_configs(
     target_concurrency: float | None = None,
     max_total_gpus: int | None = None,
     strict_sla: bool = False,
+    inclusive_tpot: bool = False,
 ) -> tuple[str, dict[str, pd.DataFrame], dict[str, pd.DataFrame], dict[str, float], dict[str, dict[str, float]]]:
     """
     Execute task configs and return the chosen experiment, best configs, results, best
@@ -1388,6 +1407,8 @@ def _execute_task_configs(
         max_total_gpus: Optional upper bound on total GPUs for load-match.
         strict_sla: When True, enforce both TTFT and TPOT SLA constraints
             during picking.
+        inclusive_tpot: When True, replace TPOT in terminal and CSV output
+            with (ttft + tpot * (osl - 1)) / osl.
 
     Returns:
         tuple:
@@ -1497,6 +1518,7 @@ def _execute_task_configs(
         top_n=top_n,
         target_request_rate=target_request_rate,
         target_concurrency=target_concurrency,
+        inclusive_tpot=inclusive_tpot,
     )
 
     end_time = time.time()
@@ -2012,6 +2034,8 @@ def main(args):
     execute_kwargs: dict = {}
     if getattr(args, "strict_sla", False):
         execute_kwargs["strict_sla"] = True
+    if getattr(args, "inclusive_tpot", False):
+        execute_kwargs["inclusive_tpot"] = True
     _, best_configs, pareto_fronts, _, _ = _execute_task_configs(
         task_configs,
         args.mode,

--- a/src/aiconfigurator/cli/report_and_save.py
+++ b/src/aiconfigurator/cli/report_and_save.py
@@ -28,6 +28,18 @@ from aiconfigurator.sdk.utils import safe_mkdir
 logger = logging.getLogger(__name__)
 
 
+def _apply_inclusive_tpot(df: pd.DataFrame) -> pd.DataFrame:
+    """Return a copy of df with tpot replaced by inclusive semantics.
+
+    inclusive tpot = (ttft + tpot * (osl - 1)) / osl
+    Applied to output copies only — never to internal computation DataFrames.
+    """
+    if "ttft" in df.columns:
+        df = df.copy()
+        df["tpot"] = (df["ttft"] + df["tpot"] * (df["osl"] - 1)) / df["osl"]
+    return df
+
+
 def _check_power_data_available(best_configs: dict[str, pd.DataFrame], threshold: float = 0.9) -> bool:
     """
     Check if power data is available and meaningful across configurations.
@@ -284,8 +296,20 @@ def log_final_summary(
     top_n: int = 5,
     target_request_rate: float | None = None,
     target_concurrency: float | None = None,
+    inclusive_tpot: bool = False,
 ):
     """Log final summary of configuration results"""
+    # display_* copies carry inclusive TPOT for printed values only.
+    # The originals are kept for _plot_worker_setup_table which does TPOT filtering.
+    if inclusive_tpot:
+        display_best_configs = {k: _apply_inclusive_tpot(v) for k, v in best_configs.items()}
+        display_pareto_fronts = {
+            k: _apply_inclusive_tpot(v) if v is not None else None for k, v in pareto_fronts.items()
+        }
+    else:
+        display_best_configs = best_configs
+        display_pareto_fronts = pareto_fronts
+
     load_match = target_request_rate is not None or target_concurrency is not None
 
     # Consolidate and format results into a summary box for clear presentation
@@ -357,7 +381,7 @@ def log_final_summary(
 
     # ============================= overall summary
     summary_box.append("  Overall Best Configuration:")
-    best_config_df = best_configs[chosen_exp]
+    best_config_df = display_best_configs[chosen_exp]
     best_throughput = best_throughputs[chosen_exp]
 
     summary_box.append(f"    - Best Throughput: {best_throughput * chosen_task_config.total_gpus:,.2f} tokens/s")
@@ -375,13 +399,13 @@ def log_final_summary(
 
     # ============================= pareto frontier
     pareto_plot_buf = ""
-    if len(pareto_fronts) <= 10:  # avoid overly crowded plots
+    if len(display_pareto_fronts) <= 10:  # avoid overly crowded plots
         summary_box.append("  Pareto Frontier:")
         target_x_axis = "tokens/s/user"
         if pareto_x_axis:
             target_x_axis = pareto_x_axis.get(chosen_exp, target_x_axis)
         series_payload = []
-        for name, df in pareto_fronts.items():
+        for name, df in display_pareto_fronts.items():
             if df is None or df.empty:
                 continue
             series_axis = pareto_x_axis.get(name, target_x_axis) if pareto_x_axis else target_x_axis
@@ -472,6 +496,16 @@ def save_results(
     backend: str | None = None,
 ):
     """Save the results to a directory."""
+    # display_* copies carry inclusive TPOT for CSV/plot output only.
+    # Originals are kept for artifact generation (task_config_to_generator_config).
+    if getattr(args, "inclusive_tpot", False):
+        display_best_configs = {k: _apply_inclusive_tpot(v) for k, v in best_configs.items()}
+        display_pareto_fronts = {
+            k: _apply_inclusive_tpot(v) if v is not None else None for k, v in pareto_fronts.items()
+        }
+    else:
+        display_best_configs = best_configs
+        display_pareto_fronts = pareto_fronts
 
     first_exp_name = list(task_configs.keys())[0]
     first_task = task_configs[first_exp_name]
@@ -546,7 +580,7 @@ def save_results(
         ]
         color_idx = 0
 
-        for exp_name, pareto_df in pareto_fronts.items():
+        for exp_name, pareto_df in display_pareto_fronts.items():
             if pareto_df is None or pareto_df.empty:
                 continue
             if pareto_axis.get(exp_name, global_x_axis) != global_x_axis:
@@ -595,14 +629,14 @@ def save_results(
         plt.close()
 
         # Save each experiment's results in its own subdirectory
-        for exp_name, pareto_df in pareto_fronts.items():
+        for exp_name, pareto_df in display_pareto_fronts.items():
             exp_dir = os.path.join(safe_result_dir, exp_name)
             safe_mkdir(exp_dir, exist_ok=True)
 
-            # 1. Save best config dataframe
+            # 1. Save best config dataframe (display copy carries inclusive TPOT if flag set)
             #    Strip the object-typed _per_ops_source column before CSV write; it is
             #    saved as one per_ops_source.json per topN/ subdir below.
-            best_config_df = best_configs.get(exp_name)  # top n configs
+            best_config_df = display_best_configs.get(exp_name)  # top n configs
             best_config_per_ops_source: list[dict | None] = []
             if best_config_df is not None:
                 if "_per_ops_source" in best_config_df.columns:
@@ -733,8 +767,10 @@ def save_results(
                         f.write(exp_task_config.to_yaml())
 
             # 4. Save the generated config for this experiment, sub-directory for each best config
-            if best_config_df is not None:
-                for i, (idx, result_df) in enumerate(best_config_df.iterrows()):
+            # Use original (non-display) data so --inclusive-tpot does not affect deployment artifacts.
+            artifact_config_df = best_configs.get(exp_name)
+            if artifact_config_df is not None:
+                for i, (idx, result_df) in enumerate(artifact_config_df.iterrows()):
                     # For multi-backend mode, get the task_config for this row's backend
                     if backend == "auto" and "backend" in result_df:
                         row_backend = result_df["backend"]

--- a/tests/unit/cli/test_argument_parsing.py
+++ b/tests/unit/cli/test_argument_parsing.py
@@ -117,8 +117,19 @@ class TestCLIArgumentParsing:
         assert args.ttft == 2000.0
         assert args.tpot == 30.0
         assert args.request_latency is None
+        assert args.inclusive_tpot is False
         assert args.prefix == 0
         assert args.engine_step_backend is None
+
+    def test_inclusive_tpot_default_false_in_exp_mode(self, cli_parser, mock_exp_yaml_path):
+        """--inclusive-tpot defaults to False in exp mode."""
+        args = cli_parser.parse_args(["exp", "--yaml-path", str(mock_exp_yaml_path)])
+        assert args.inclusive_tpot is False
+
+    def test_inclusive_tpot_enabled_in_exp_mode(self, cli_parser, mock_exp_yaml_path):
+        """--inclusive-tpot can be set in exp mode."""
+        args = cli_parser.parse_args(["exp", "--yaml-path", str(mock_exp_yaml_path), "--inclusive-tpot"])
+        assert args.inclusive_tpot is True
 
     def test_debug_mode_flag(self, cli_parser):
         """Test that debug mode can be enabled."""

--- a/tests/unit/cli/test_cli_workflow.py
+++ b/tests/unit/cli/test_cli_workflow.py
@@ -12,6 +12,7 @@ import argparse
 import logging
 from unittest.mock import MagicMock, patch
 
+import pandas as pd
 import pytest
 
 from aiconfigurator.cli.main import (
@@ -21,6 +22,7 @@ from aiconfigurator.cli.main import (
     configure_parser,
 )
 from aiconfigurator.cli.main import main as cli_main
+from aiconfigurator.cli.report_and_save import _apply_inclusive_tpot
 from aiconfigurator.sdk.errors import NoFeasibleConfigError
 
 pytestmark = pytest.mark.unit
@@ -394,3 +396,38 @@ class TestBuildExperimentTaskConfigs:
         assert set(kwargs_by_backend) == {"rust", "python"}
         assert kwargs_by_backend["rust"]["model_path"] == "Qwen/Qwen3-32B"
         assert kwargs_by_backend["python"]["model_path"] == "Qwen/Qwen3-32B"
+
+
+class TestInclusiveTpot:
+    """Unit tests for _apply_inclusive_tpot output transformation."""
+
+    def _make_df(self, ttft, tpot, osl):
+        return pd.DataFrame([{"ttft": ttft, "tpot": tpot, "osl": osl}])
+
+    def test_formula(self):
+        df = self._make_df(ttft=500.0, tpot=20.0, osl=30)
+        result = _apply_inclusive_tpot(df)
+        expected = (500.0 + 20.0 * 29) / 30
+        assert abs(result["tpot"].iloc[0] - expected) < 1e-9
+
+    def test_does_not_mutate_input(self):
+        df = self._make_df(ttft=500.0, tpot=20.0, osl=30)
+        original_tpot = df["tpot"].iloc[0]
+        _apply_inclusive_tpot(df)
+        assert df["tpot"].iloc[0] == original_tpot
+
+    def test_ttft_unchanged(self):
+        df = self._make_df(ttft=500.0, tpot=20.0, osl=30)
+        result = _apply_inclusive_tpot(df)
+        assert result["ttft"].iloc[0] == 500.0
+
+    def test_missing_columns_is_noop(self):
+        df = pd.DataFrame([{"tpot": 20.0, "osl": 30}])  # no ttft column
+        result = _apply_inclusive_tpot(df)
+        assert result["tpot"].iloc[0] == 20.0
+
+    def test_osl_one_equals_ttft(self):
+        # osl=1: zero decode tokens, inclusive TPOT collapses to TTFT/1 = TTFT
+        df = self._make_df(ttft=500.0, tpot=20.0, osl=1)
+        result = _apply_inclusive_tpot(df)
+        assert abs(result["tpot"].iloc[0] - 500.0) < 1e-9


### PR DESCRIPTION
## Summary

AIC's TPOT metric is inter-token latency (decode phase only). This PR adds `--inclusive-tpot`, a flag that reports TPOT as `(ttft + tpot * (osl - 1)) / osl` at output time, spreading TTFT cost across all output tokens. This matches the end-to-end per-token latency definition used by GuideLLM and other benchmarking tools, making predicted values directly comparable to benchmark measurements.

- Transformation applied to terminal output and saved CSV only — internal DataFrames, SLA filtering, and pareto computation are unaffected
- Available in `default` and `exp` modes
- The `estimate` subcommand has a separate single-point output path reading scalar attributes directly and is not affected by this flag
- The Python SDK (`cli_default`/`cli_exp`) does not expose the flag; SDK callers receive raw DataFrames and can apply the formula themselves if needed

## Changes

- `src/aiconfigurator/cli/main.py` — add `--inclusive-tpot` to `default` and `exp` subparsers; thread `inclusive_tpot` through `_execute_task_configs`
- `src/aiconfigurator/cli/report_and_save.py` — add `_apply_inclusive_tpot` helper; apply at entry of `log_final_summary` and `save_results`
- `docs/cli_user_guide.md` — document flag in defaults table and add section near `--strict-sla`
- `tests/unit/cli/test_cli_workflow.py` — unit tests for formula correctness, no-mutation, TTFT unchanged, missing columns, and osl=1 boundary case
- `tests/unit/cli/test_argument_parsing.py` — assert default is False

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI flag to optionally report per-output-token latency by distributing startup time across tokens.

* **Documentation**
  * User guide updated with flag details and examples of reporting behavior.

* **Behavioral Notes**
  * Terminal output, CSV exports, and Pareto plots show inclusive TPOT when enabled; SLA filtering, worker setup, and deployment artifacts continue to use the original inter-token metric.

* **Tests**
  * Unit tests added/updated to cover flag parsing and inclusive TPOT computation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiconfigurator/pull/1141?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->