### PR TITLE
fix: support latent-MoE (moe_latent_size) to fix OOM false-positive

### DIFF
--- a/src/aiconfigurator/sdk/common.py
+++ b/src/aiconfigurator/sdk/common.py
@@ -60,6 +60,9 @@ class NemotronHConfig:
         n_groups (int): Number of groups for Mamba2
         chunk_size (int): Chunk size for Mamba2 chunked scan
         moe_shared_expert_intermediate_size (int): Intermediate size for shared expert
+        moe_latent_size (int): Latent dim for routed-expert projections (0 disables
+            latent compression and routed experts run on hidden_size directly).
+            Used by latent-MoE variants like Nemotron-3-Super.
     """
 
     hybrid_override_pattern: str
@@ -70,6 +73,7 @@ class NemotronHConfig:
     n_groups: int
     chunk_size: int
     moe_shared_expert_intermediate_size: int = 0  # Optional: 0 for non-MoE NemotronH models
+    moe_latent_size: int = 0  # Optional: 0 means routed experts use hidden_size directly
 
 
 @dataclass(frozen=True)

--- a/src/aiconfigurator/sdk/models/nemotron_h.py
+++ b/src/aiconfigurator/sdk/models/nemotron_h.py
@@ -300,13 +300,12 @@ class NemotronHModel(BaseModel):
                         False,
                         quant_mode=moe_quant_mode,
                     ),
-                    # TRT-LLM does allreduce after combining routed + shared outputs when TP>1
-                    ops.CustomAllReduce("context_moe_ar", count, h, tp_size),
                 ]
             )
             if cfg.moe_latent_size > 0:
-                # fc2_latent_proj (latent -> h) runs after expert combine, before
-                # adding the shared-expert output. Modeled as a row-parallel GEMM.
+                # fc2_latent_proj (latent -> h) runs after expert combine,
+                # before the post-MoE allreduce. Modeled as a row-parallel GEMM
+                # whose partial sums are aggregated by the following AllReduce.
                 self.context_ops.append(
                     ops.GEMM(
                         "context_fc2_latent_proj_gemm",
@@ -317,6 +316,8 @@ class NemotronHModel(BaseModel):
                         low_precision_input=True,
                     )
                 )
+            # TRT-LLM does allreduce after combining routed + shared outputs when TP>1
+            self.context_ops.append(ops.CustomAllReduce("context_moe_ar", count, h, tp_size))
 
         # MLP layers (-) - not present in Nemotron-3 Nano but in NemotronH model
         if layer_counts["-"] > 0:
@@ -588,13 +589,12 @@ class NemotronHModel(BaseModel):
                         False,
                         quant_mode=moe_quant_mode,
                     ),
-                    # TRT-LLM does allreduce after combining routed + shared outputs when TP>1
-                    ops.CustomAllReduce("generation_moe_ar", count, h, tp_size),
                 ]
             )
             if cfg.moe_latent_size > 0:
-                # fc2_latent_proj (latent -> h) runs after expert combine, before
-                # adding the shared-expert output. Modeled as a row-parallel GEMM.
+                # fc2_latent_proj (latent -> h) runs after expert combine,
+                # before the post-MoE allreduce. Modeled as a row-parallel GEMM
+                # whose partial sums are aggregated by the following AllReduce.
                 self.generation_ops.append(
                     ops.GEMM(
                         "generation_fc2_latent_proj_gemm",
@@ -605,6 +605,8 @@ class NemotronHModel(BaseModel):
                         low_precision_input=True,
                     )
                 )
+            # TRT-LLM does allreduce after combining routed + shared outputs when TP>1
+            self.generation_ops.append(ops.CustomAllReduce("generation_moe_ar", count, h, tp_size))
 
         # MLP layers (-)
         if layer_counts["-"] > 0:

--- a/src/aiconfigurator/sdk/models/nemotron_h.py
+++ b/src/aiconfigurator/sdk/models/nemotron_h.py
@@ -199,6 +199,10 @@ class NemotronHModel(BaseModel):
         # MoE layers (E)
         if layer_counts["E"] > 0:
             count = layer_counts["E"]
+            # Latent-MoE (e.g. Nemotron-3-Super): experts run on a compressed
+            # `moe_latent_size` projection of hidden_states. Shared expert and the
+            # router still operate on hidden_size.
+            moe_h = cfg.moe_latent_size if cfg.moe_latent_size > 0 else h
             # Pre-norm for MoE
             self.context_ops.append(ops.ElementWise("context_moe_norm", count, 2 * h, 2 * h, 0.8))
 
@@ -244,12 +248,24 @@ class NemotronHModel(BaseModel):
             )
 
             # MoE dispatch and compute
+            # When latent-MoE is active, fc1_latent_proj (h -> latent) runs before
+            # dispatch, so dispatch/experts/combine all communicate in latent dim.
+            if cfg.moe_latent_size > 0:
+                self.context_ops.append(
+                    ops.GEMM(
+                        "context_fc1_latent_proj_gemm",
+                        count,
+                        cfg.moe_latent_size // tp_size,
+                        h,
+                        gemm_quant_mode,
+                    )
+                )
             self.context_ops.extend(
                 [
                     ops.MoEDispatch(
                         "context_moe_pre_dispatch",
                         count,
-                        h,
+                        moe_h,
                         self._topk,
                         self._num_experts,
                         moe_tp_size,
@@ -261,7 +277,7 @@ class NemotronHModel(BaseModel):
                     ops.MoE(
                         "context_moe",
                         count,
-                        h,
+                        moe_h,
                         self._moe_inter_size,
                         self._topk,
                         self._num_experts,
@@ -275,7 +291,7 @@ class NemotronHModel(BaseModel):
                     ops.MoEDispatch(
                         "context_moe_post_dispatch",
                         count,
-                        h,
+                        moe_h,
                         self._topk,
                         self._num_experts,
                         moe_tp_size,
@@ -288,6 +304,19 @@ class NemotronHModel(BaseModel):
                     ops.CustomAllReduce("context_moe_ar", count, h, tp_size),
                 ]
             )
+            if cfg.moe_latent_size > 0:
+                # fc2_latent_proj (latent -> h) runs after expert combine, before
+                # adding the shared-expert output. Modeled as a row-parallel GEMM.
+                self.context_ops.append(
+                    ops.GEMM(
+                        "context_fc2_latent_proj_gemm",
+                        count,
+                        h,
+                        cfg.moe_latent_size // tp_size,
+                        gemm_quant_mode,
+                        low_precision_input=True,
+                    )
+                )
 
         # MLP layers (-) - not present in Nemotron-3 Nano but in NemotronH model
         if layer_counts["-"] > 0:
@@ -458,6 +487,10 @@ class NemotronHModel(BaseModel):
         # MoE layers (E)
         if layer_counts["E"] > 0:
             count = layer_counts["E"]
+            # Latent-MoE (e.g. Nemotron-3-Super): experts run on a compressed
+            # `moe_latent_size` projection of hidden_states. Shared expert and the
+            # router still operate on hidden_size.
+            moe_h = cfg.moe_latent_size if cfg.moe_latent_size > 0 else h
             # Pre-norm for MoE
             self.generation_ops.append(ops.ElementWise("generation_moe_norm", count, 2 * h, 2 * h, 0.8))
 
@@ -503,12 +536,24 @@ class NemotronHModel(BaseModel):
             )
 
             # MoE dispatch and compute
+            # When latent-MoE is active, fc1_latent_proj (h -> latent) runs before
+            # dispatch, so dispatch/experts/combine all communicate in latent dim.
+            if cfg.moe_latent_size > 0:
+                self.generation_ops.append(
+                    ops.GEMM(
+                        "generation_fc1_latent_proj_gemm",
+                        count,
+                        cfg.moe_latent_size // tp_size,
+                        h,
+                        gemm_quant_mode,
+                    )
+                )
             self.generation_ops.extend(
                 [
                     ops.MoEDispatch(
                         "generation_moe_pre_dispatch",
                         count,
-                        h,
+                        moe_h,
                         self._topk,
                         self._num_experts,
                         moe_tp_size,
@@ -520,7 +565,7 @@ class NemotronHModel(BaseModel):
                     ops.MoE(
                         "generation_moe",
                         count,
-                        h,
+                        moe_h,
                         self._moe_inter_size,
                         self._topk,
                         self._num_experts,
@@ -534,7 +579,7 @@ class NemotronHModel(BaseModel):
                     ops.MoEDispatch(
                         "generation_moe_post_dispatch",
                         count,
-                        h,
+                        moe_h,
                         self._topk,
                         self._num_experts,
                         moe_tp_size,
@@ -547,6 +592,19 @@ class NemotronHModel(BaseModel):
                     ops.CustomAllReduce("generation_moe_ar", count, h, tp_size),
                 ]
             )
+            if cfg.moe_latent_size > 0:
+                # fc2_latent_proj (latent -> h) runs after expert combine, before
+                # adding the shared-expert output. Modeled as a row-parallel GEMM.
+                self.generation_ops.append(
+                    ops.GEMM(
+                        "generation_fc2_latent_proj_gemm",
+                        count,
+                        h,
+                        cfg.moe_latent_size // tp_size,
+                        gemm_quant_mode,
+                        low_precision_input=True,
+                    )
+                )
 
         # MLP layers (-)
         if layer_counts["-"] > 0:

--- a/src/aiconfigurator/sdk/utils.py
+++ b/src/aiconfigurator/sdk/utils.py
@@ -566,6 +566,9 @@ def _parse_hf_config_json(config: dict) -> dict:
             chunk_size=config["chunk_size"],
             # Optional: 0 for non-MoE NemotronH models (e.g., Nemotron-H-56B)
             moe_shared_expert_intermediate_size=config.get("moe_shared_expert_intermediate_size", 0),
+            # Optional: latent compression dim for routed experts (Nemotron-3-Super).
+            # HF config uses None to mean "no compression"; map to 0 here.
+            moe_latent_size=config.get("moe_latent_size") or 0,
         )
         logger.info(
             f"NemotronH hybrid config: pattern={extra_params.hybrid_override_pattern}, "


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->


Nemotron-3-Super-120B-A12B uses latent-MoE: hidden_states are projected from hidden_size (4096) down to moe_latent_size (1024) via fc1_latent_proj before routing, experts run on the 1024-dim latent, then fc2_latent_proj projects back to hidden_size. The shared expert and router still operate on hidden_size.

Previously NemotronHModel ignored moe_latent_size and fed hidden_size as the expert input dim, inflating routed-expert weights by hidden/latent = 4x. For the 120B-A12B-BF16 model this produced ~902 GB of weights instead of ~225 GB, so every parallel config up to 8 GPUs failed the OOM check and pareto_analysis raised:

  RuntimeError: No results found: the model does not fit in GPU memory
  for any parallel configuration.

#### Details:

<!-- Describe the changes made in this PR. -->

Changes:
- common.NemotronHConfig: add moe_latent_size (default 0 = no latent compression, preserves behavior for Nemotron-H-56B / Nemotron-3-Nano).
- utils._parse_hf_config_json: parse moe_latent_size from HF config (HF uses None for no compression; mapped to 0).
- models.nemotron_h: when moe_latent_size > 0, route the MoE op and pre/post MoEDispatch through the latent dim, and add fc1/fc2 latent projection GEMMs (column-/row-parallel). Shared expert, router, and the post-MoE allreduce stay on hidden_size, matching the HF modeling code.

Verified the original failing command now produces a full pareto frontier (best: disagg @ 1044 tokens/s/gpu on 16xH100). All 14 nemotron-related unit tests pass.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new configuration option, moe_latent_size. Default 0 preserves prior behavior; values >0 enable an optional latent-MoE pathway that compresses the routed-expert communication into a smaller latent dimension.
  * The latent-MoE behavior applies to both context (prefill) and generation (decoding) pipelines. Missing or unspecified values are treated as 0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiconfigurator/pull/1143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->