### PR TITLE
feat: add support for Phi3ForCausalLM architecture

### DIFF
--- a/src/aiconfigurator/sdk/common.py
+++ b/src/aiconfigurator/sdk/common.py
@@ -517,6 +517,7 @@ ARCHITECTURE_TO_MODEL_FAMILY = {
     "LlamaForCausalLM": "LLAMA",
     "Qwen2ForCausalLM": "LLAMA",
     "Qwen3ForCausalLM": "LLAMA",
+    "Phi3ForCausalLM": "LLAMA",
     "Qwen3VLForConditionalGeneration": "QWEN3VL",
     "Qwen3VLMoeForConditionalGeneration": "QWEN3VL_MOE",
     "MiMoForCausalLM": "LLAMA",


### PR DESCRIPTION

#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Map Phi3ForCausalLM to the LLAMA model family.
Phi-3 is a dense Llama-like architecture (GQA, RMSNorm, SwiGLU MLP), so the existing LLAMA family handles it without further changes. This enables aiconfigurator to estimate performance for Phi-3/Phi-4 family models (microsoft/phi-4, Phi-4-mini-instruct, Phi-3-mini/medium-4k/128k-instruct, Phi-3.5-mini-instruct).

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended model support: The system now recognizes and automatically classifies Phi3 models from HuggingFace as part of the LLAMA model family. This enhancement improves overall compatibility with an expanding ecosystem of language models, enabling users to seamlessly work with a broader range of supported model architectures and configurations across various use cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiconfigurator/pull/1144?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->