### PR TITLE
fix: correct mix-step decode token count for b >= osl

### DIFF
--- a/src/aiconfigurator/sdk/backends/base_backend.py
+++ b/src/aiconfigurator/sdk/backends/base_backend.py
@@ -83,6 +83,21 @@ class BaseBackend:
         """
         return getattr(model, "_hidden_size", h)
 
+    def _mix_step_gen_tokens(self, b: int, ctx_tokens: int, isl: int, osl: int) -> int:
+        """Return the number of decode tokens per mix step for a batch of b requests.
+
+        A mix step is a forward pass that contains both prefill tokens (for requests
+        still completing their context phase) and decode tokens (for requests already
+        generating). This method encodes the engine's scheduling policy for how many
+        decode-phase requests participate alongside the prefilling request(s).
+
+        Subclasses should override to match their engine's scheduling behaviour.
+        """
+        steps_to_finish_ctx = np.ceil(isl * b / ctx_tokens)
+        if steps_to_finish_ctx >= osl:
+            return max(1, int(b // (steps_to_finish_ctx / osl)))
+        return max(1, b - int(np.ceil(ctx_tokens / isl)))
+
     def _resolve_agg_kwargs(self, kwargs: dict, isl: int, osl: int) -> dict:
         """Resolve backend-specific run_agg kwargs to defaults.
 
@@ -930,10 +945,13 @@ class BaseBackend:
         num_mix_steps = num_genonly_steps = 0
         num_mix_steps_for_tpot_calc = 0  # correction for tpot calc only
         if b > 1:
+            num_mix_gen_tokens = self._mix_step_gen_tokens(b, ctx_tokens, isl, osl)
+            assert num_mix_gen_tokens >= 1, (
+                f"num_mix_gen_tokens: {num_mix_gen_tokens}, b: {b}, ctx_tokens: {ctx_tokens}, isl: {isl}"
+            )
+            num_mix_ctx_tokens = ctx_tokens
             if steps_to_finish_ctx >= osl:
                 num_mix_steps = steps_to_finish_ctx
-                num_mix_ctx_tokens = ctx_tokens
-                num_mix_gen_tokens = max(1, b // (steps_to_finish_ctx / osl))
                 num_genonly_steps = 0
                 num_genonly_tokens = 0
                 num_mix_steps_for_tpot_calc = num_mix_steps
@@ -941,11 +959,6 @@ class BaseBackend:
                 # 3-step is an empirical correction for pipelining requests where new requests
                 # cannot be enqueued immediately after last request's exit
                 num_mix_steps = steps_to_finish_ctx
-                num_mix_ctx_tokens = ctx_tokens
-                num_mix_gen_tokens = b - np.ceil(ctx_tokens / isl)  # the error check is outside
-                assert num_mix_gen_tokens >= 1, (
-                    f"num_mix_gen_tokens: {num_mix_gen_tokens}, b: {b}, ctx_tokens: {ctx_tokens}, isl: {isl}"
-                )
                 num_genonly_steps = osl - num_mix_steps
                 num_genonly_tokens = b
                 num_mix_steps_for_tpot_calc = max(1, num_mix_steps - 3)

--- a/src/aiconfigurator/sdk/backends/vllm_backend.py
+++ b/src/aiconfigurator/sdk/backends/vllm_backend.py
@@ -3,6 +3,8 @@
 
 import logging
 
+import numpy as np
+
 from aiconfigurator.sdk import common
 from aiconfigurator.sdk.backends.base_backend import BaseBackend
 from aiconfigurator.sdk.backends.trtllm_backend import TRTLLMBackend
@@ -35,3 +37,12 @@ class VLLMBackend(BaseBackend):
     def __init__(self):
         super().__init__()
         self.name = common.BackendName.vllm
+
+    def _mix_step_gen_tokens(self, b: int, ctx_tokens: int, isl: int, osl: int) -> int:
+        # vLLM v1 scheduler sets max_num_partial_prefills=1 by default, meaning
+        # exactly one request is in partial-prefill state per forward pass.
+        # The remaining b - ceil(ctx_tokens/isl) requests are in decode phase.
+        # This applies regardless of whether steps_to_finish_ctx >= osl or not,
+        # giving a consistent formula across both scheduling regimes.
+        # Source: vllm/v1/core/sched/scheduler.py, SchedulerConfig.max_num_partial_prefills
+        return max(1, b - int(np.ceil(ctx_tokens / isl)))


### PR DESCRIPTION
Fixes #1146.

## Summary

When `steps_to_finish_ctx >= osl`, `num_mix_gen_tokens` was computed as `max(1, b // (steps_to_finish_ctx / osl)) ≈ osl` for any b, causing identical TPOT predictions for all batch sizes where `b >= osl`. At ISL=9000, OSL=30, b=32 and b=64 both predicted 238.58 ms while measured ITL was 236.8 ms and 308.8 ms respectively.

Introduces `BaseBackend._mix_step_gen_tokens(b, ctx_tokens, isl, osl)`, covering both scheduling regimes. `VLLMBackend` overrides with `b - ceil(ctx_tokens / isl)`, derived from vLLM v1's `max_num_partial_prefills=1` scheduler default (confirmed from source).

## Validation

ISL=9000, OSL=30, Qwen3-8B, H200 SXM, vLLM 0.18.0:

| b | Before | After | Measured |
|---|--------|-------|----------|
| 32 | 238.58 ms (+0.8%) | 238.90 ms (+1%) | 236.8 ms |
| 64 | 238.58 ms (+29%) | 248.76 ms (-19%) | 308.8 ms |

b=32 and b=64 now produce distinct predictions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)