### PR TITLE
fix(ci): resolve PR number for fork PRs in accuracy regression comment

### DIFF
--- a/.github/workflows/accuracy-regression-comment.yml
+++ b/.github/workflows/accuracy-regression-comment.yml
@@ -56,7 +56,13 @@ jobs:
             INPUT_DIR="comment-inputs/accuracy-regression-comment-inputs"
           fi
 
-          : "${PR_NUMBER:?workflow_run payload did not include a PR number}"
+          # workflow_run.pull_requests is empty for PRs from forks; fall back to
+          # the pr-number.txt saved in the artifact by the triggering workflow.
+          if [ -z "${PR_NUMBER}" ] && [ -f "${INPUT_DIR}/pr-number.txt" ]; then
+            PR_NUMBER="$(tr -d '[:space:]' < "${INPUT_DIR}/pr-number.txt")"
+          fi
+
+          : "${PR_NUMBER:?could not determine PR number from workflow_run payload or artifact}"
 
           echo "input_dir=${INPUT_DIR}" >> "$GITHUB_OUTPUT"
           echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/accuracy-regression-testing.yml
+++ b/.github/workflows/accuracy-regression-testing.yml
@@ -133,6 +133,7 @@ jobs:
           mkdir -p accuracy-regression-comment-inputs
           printf '%s\n' "${OLD_REF}" > accuracy-regression-comment-inputs/old-ref.txt
           printf '%s\n' "${ARTIFACT_URL}" > accuracy-regression-comment-inputs/artifact-url.txt
+          printf '%s\n' "${{ github.event.pull_request.number }}" > accuracy-regression-comment-inputs/pr-number.txt
           cp tools/accuracy_regression_testing/results/comparison_summary.csv accuracy-regression-comment-inputs/ 2>/dev/null || true
           cp tools/accuracy_regression_testing/results/comparison_plot.png accuracy-regression-comment-inputs/ 2>/dev/null || true
 


### PR DESCRIPTION
## Problem

The `Comment Accuracy Regression Testing` workflow fails for PRs opened from forks with:

```
PR_NUMBER: workflow_run payload did not include a PR number
```

`github.event.workflow_run.pull_requests` is empty when the triggering `workflow_run` originates from a fork PR (as opposed to a branch on the upstream repo). This is a known GitHub limitation for security reasons — fork PR workflows run with restricted permissions and the `pull_requests` context is not propagated to the `workflow_run` event.

This means the comment workflow works for contributors with direct upstream access but silently fails for all external contributors opening PRs from forks.

## Fix

Save the PR number to the artifact in the triggering workflow (`accuracy-regression-testing.yml`) where `github.event.pull_request.number` is available. The comment workflow reads it as a fallback when `pull_requests[0].number` is empty.

This is the standard pattern recommended by GitHub for cross-fork `workflow_run` comment workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow robustness so PRs from forks are handled correctly when the PR number is missing from the event payload.
  * Persisted the PR number into regression test artifacts so downstream steps can reliably reference the target PR for comments and comparisons.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiconfigurator/pull/1154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->