### PR TITLE
fix: update sglang dsa module collection cases

### DIFF
--- a/collector/cases/base_ops/mla_module.yaml
+++ b/collector/cases/base_ops/mla_module.yaml
@@ -74,6 +74,24 @@ common_case_values:
         kv_cache_dtype: fp8
         gemm_type: bfloat16
         min_sm: 90
+    generation_sequence_lengths:
+      - 1
+      - 4
+      - 8
+      - 16
+      - 32
+      - 64
+      - 128
+      - 256
+      - 512
+      - 1024
+      - 2048
+      - 4096
+      - 8192
+      - 16384
+      - 32768
+      - 65536
+      - 131072
     context:
       max_tokens: 131072
       large_sequence_min: 8192

--- a/collector/sglang/collect_mla_module.py
+++ b/collector/sglang/collect_mla_module.py
@@ -397,8 +397,8 @@ def get_generation_test_cases(attn_type: str):
     cases = []
     for compute_dtype, kv_dtype, gemm_type in _get_precision_combos("generation"):
         for num_heads in sweep.inner_sweep_head_counts:
-            for batch_size in sweep.batch_sizes:
-                for seq_len in sweep.sequence_lengths:
+            for batch_size in sweep.generation_batch_sizes:
+                for seq_len in sweep.generation_sequence_lengths:
                     if batch_size * seq_len > sweep.generation_max_tokens:
                         continue
                     if (
@@ -1826,10 +1826,12 @@ def run_mla_module(
         base_cases = [(bs, seq_len, ip) for bs, seq_len, ip in base_cases if bs == batch_size_filter]
     if is_prefill and attn_type == "dsa":
         prefix_lens = get_mla_module_sweep_spec("sglang").context_prefix_lengths
+        # Run prefix as the outer loop so a late long-prefix illegal access does
+        # not discard all larger-ISL rows for the current batch-size subprocess.
         cases = [
             (bs, seq_len, ip, prefix_len)
-            for bs, seq_len, ip in base_cases
             for prefix_len in prefix_lens
+            for bs, seq_len, ip in base_cases
             if _dsa_context_prefix_shape_is_valid(bs, seq_len, prefix_len)
         ]
     else:


### PR DESCRIPTION
#### Overview:

  Fix SGLang DSA module collection coverage for GLM5-style long context/decode shapes.

  #### Details:

  - Add SGLang-specific generation/decode sequence lengths up to 131072 tokens for MLA/DSA module collection.
  - Use `generation_batch_sizes` and `generation_sequence_lengths` when generating SGLang generation/decode MLA module cases.
  - Reorder DSA context collection so prefix length is the outer loop, preventing one long-prefix failure from dropping valid larger-ISL rows in the same batch subprocess.

  #### Where should the reviewer start?

  - `collector/sglang/collect_mla_module.py`
  - `collector/cases/base_ops/mla_module.yaml`

  #### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

  - Relates to GLM5 SGLang DSA module collection coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended generation sequence length testing range to cover larger sequences (1–131,072 tokens)
  * Modified generation benchmark test case generation to use dedicated generation parameters separately from prefill parameters
  * Adjusted test case execution ordering for generation benchmarks

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiconfigurator/pull/1160?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->