### PR TITLE
docs: order support matrix systems by priority

### DIFF
--- a/docs/support-matrix/index.html
+++ b/docs/support-matrix/index.html
@@ -56,7 +56,19 @@ const SUPPORT_MATRIX_INDEX_PATH = `${SUPPORT_MATRIX_PATH}/index.json`;
 const LEGACY_CSV_PATH = 'src/aiconfigurator/systems/support_matrix.csv';
 const STATUS_HW_INCOMPATIBLE = 'HW_INCOMPATIBLE';
 const PREFERRED_DEFAULT_SYSTEM = 'b200_sxm';
-const SYSTEM_ORDER = ['b200', 'gb200', 'gb300', 'h100', 'h200', '__other__', 'a100', 'l40s'];
+const SYSTEM_ORDER = [
+  'b200',
+  'gb200',
+  'b300',
+  'gb300',
+  'rtx_pro_6000',
+  'h200',
+  'h100',
+  'l40s',
+  'a100',
+  'b60',
+  '__other__',
+];
 
 function isFrameworkUnsupported(error) {
   if (!error) return false;

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -1617,7 +1617,7 @@ def _run_support_matrix_mode(args):
         architecture = None
 
     matrix = common.get_support_matrix()
-    systems = sorted(common.SupportedSystems) if args.system == "all" else [args.system]
+    systems = common.sort_support_matrix_systems(common.SupportedSystems) if args.system == "all" else [args.system]
     backends = [b.value for b in common.BackendName] if args.backend == "all" else [args.backend]
     existing_combos = {(row["System"].lower(), row["Backend"].lower()) for row in matrix}
 

--- a/src/aiconfigurator/sdk/common.py
+++ b/src/aiconfigurator/sdk/common.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import csv
+import json
 from collections import namedtuple
 from dataclasses import dataclass
 from enum import Enum
@@ -19,6 +20,34 @@ def parse_support_matrix_version(version: str | None) -> Version | None:
         return Version(version)
     except InvalidVersion:
         return None
+
+
+SupportMatrixSystemOrder = (
+    "b200",
+    "gb200",
+    "b300",
+    "gb300",
+    "rtx_pro_6000",
+    "h200",
+    "h100",
+    "l40s",
+    "a100",
+    "b60",
+)
+
+
+def get_support_matrix_system_sort_key(system: str) -> tuple[int, str]:
+    """Sort support-matrix systems by product priority, then by name."""
+    normalized_system = system.lower()
+    for index, prefix in enumerate(SupportMatrixSystemOrder):
+        if normalized_system.startswith(prefix):
+            return index, normalized_system
+    return len(SupportMatrixSystemOrder), normalized_system
+
+
+def sort_support_matrix_systems(systems):
+    """Return systems in the preferred support-matrix display order."""
+    return sorted(systems, key=get_support_matrix_system_sort_key)
 
 
 @dataclass(frozen=True)
@@ -242,9 +271,25 @@ def _iter_support_matrix_resources():
     split_matrix_resource = systems_resource / "support_matrix"
 
     if split_matrix_resource.is_dir():
+        csv_resources = {
+            resource.name: resource for resource in split_matrix_resource.iterdir() if resource.name.endswith(".csv")
+        }
+        index_resource = split_matrix_resource / "index.json"
+        if index_resource.is_file():
+            try:
+                index_data = json.loads(index_resource.read_text())
+                ordered_files = index_data.get("files", []) if isinstance(index_data, dict) else []
+            except (OSError, json.JSONDecodeError):
+                ordered_files = []
+
+            for file_name in ordered_files:
+                resource = csv_resources.pop(file_name, None)
+                if resource is not None:
+                    yield resource
+
         yield from sorted(
-            (resource for resource in split_matrix_resource.iterdir() if resource.name.endswith(".csv")),
-            key=lambda resource: resource.name,
+            csv_resources.values(),
+            key=lambda resource: get_support_matrix_system_sort_key(resource.name.removesuffix(".csv")),
         )
         return
 

--- a/src/aiconfigurator/systems/support_matrix/index.json
+++ b/src/aiconfigurator/systems/support_matrix/index.json
@@ -1,14 +1,14 @@
 {
   "files": [
-    "a100_sxm.csv",
     "b200_sxm.csv",
-    "b300_sxm.csv",
-    "b60.csv",
     "gb200.csv",
+    "b300_sxm.csv",
     "gb300.csv",
-    "h100_sxm.csv",
+    "rtx_pro_6000_server.csv",
     "h200_sxm.csv",
+    "h100_sxm.csv",
     "l40s.csv",
-    "rtx_pro_6000_server.csv"
+    "a100_sxm.csv",
+    "b60.csv"
   ]
 }

--- a/src/aiconfigurator/webapp/components/support_matrix_tab.py
+++ b/src/aiconfigurator/webapp/components/support_matrix_tab.py
@@ -312,7 +312,7 @@ def create_support_matrix_tab(app_config):
 
         # Load data
         initial_df = load_support_matrix_data()
-        unique_systems = sorted(initial_df["System"].unique())
+        unique_systems = common.sort_support_matrix_systems(initial_df["System"].unique())
 
         # Mode filter
         mode_filter = gr.Dropdown(

--- a/tests/unit/sdk/test_common.py
+++ b/tests/unit/sdk/test_common.py
@@ -8,6 +8,7 @@ Tests supported systems, model families, and other common configurations.
 """
 
 import csv
+import json
 from collections import Counter
 from pathlib import Path
 
@@ -70,6 +71,34 @@ class TestSupportedSystems:
         """Cloud/colo PCIe systems should be available for naive and SOL-style estimates."""
         assert {"h100_pcie", "a100_pcie", "l4", "a30"}.issubset(common.SupportedSystems)
 
+    def test_support_matrix_systems_sort_by_display_priority(self):
+        """Support matrix systems should sort by product priority before name."""
+        systems = [
+            "b60",
+            "a100_sxm",
+            "gb300",
+            "h100_sxm",
+            "l40s",
+            "b200_sxm",
+            "rtx_pro_6000_server",
+            "gb200",
+            "h200_sxm",
+            "b300_sxm",
+        ]
+
+        assert common.sort_support_matrix_systems(systems) == [
+            "b200_sxm",
+            "gb200",
+            "b300_sxm",
+            "gb300",
+            "rtx_pro_6000_server",
+            "h200_sxm",
+            "h100_sxm",
+            "l40s",
+            "a100_sxm",
+            "b60",
+        ]
+
 
 class TestSupportMatrix:
     """Test support matrix functionality."""
@@ -101,6 +130,29 @@ class TestSupportMatrix:
             with csv_path.open(newline="") as f:
                 systems = {row["System"] for row in csv.DictReader(f)}
             assert systems == {csv_path.stem}
+
+    def test_support_matrix_index_uses_display_order(self):
+        """The static support-matrix manifest should keep the preferred system order."""
+        repo_root = _find_repo_root(Path(__file__))
+        index_path = repo_root / "src" / "aiconfigurator" / "systems" / "support_matrix" / "index.json"
+
+        with index_path.open() as f:
+            files = json.load(f)["files"]
+
+        systems = [Path(file_name).stem for file_name in files]
+        assert systems == [
+            "b200_sxm",
+            "gb200",
+            "b300_sxm",
+            "gb300",
+            "rtx_pro_6000_server",
+            "h200_sxm",
+            "h100_sxm",
+            "l40s",
+            "a100_sxm",
+            "b60",
+        ]
+        assert systems == common.sort_support_matrix_systems(systems)
 
     @pytest.mark.parametrize(
         "model,system,backend,version,architecture,expected_agg,expected_disagg",

--- a/tests/unit/support_matrix/test_support_matrix_order.py
+++ b/tests/unit/support_matrix/test_support_matrix_order.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+import pytest
+
+from tools.support_matrix.support_matrix import STATUS_PASS, SupportMatrix
+
+pytestmark = pytest.mark.unit
+
+
+def _result(system: str) -> tuple[str, str, str, str, str, str, str, None]:
+    """Build a minimal passing support-matrix result row for a system."""
+    return ("test/model", "TestArchitecture", system, "trtllm", "1.0.0", "agg", STATUS_PASS, None)
+
+
+def test_save_results_to_csv_writes_manifest_in_display_order(tmp_path):
+    """Split support-matrix output should preserve product-priority file order."""
+    results = [
+        _result("b60"),
+        _result("a100_sxm"),
+        _result("l40s"),
+        _result("h100_sxm"),
+        _result("h200_sxm"),
+        _result("rtx_pro_6000_server"),
+        _result("gb300"),
+        _result("b300_sxm"),
+        _result("gb200"),
+        _result("b200_sxm"),
+    ]
+
+    support_matrix = SupportMatrix.__new__(SupportMatrix)
+    support_matrix.save_results_to_csv(results, str(tmp_path))
+
+    with (tmp_path / "index.json").open() as f:
+        manifest = json.load(f)
+
+    assert manifest["files"] == [
+        "b200_sxm.csv",
+        "gb200.csv",
+        "b300_sxm.csv",
+        "gb300.csv",
+        "rtx_pro_6000_server.csv",
+        "h200_sxm.csv",
+        "h100_sxm.csv",
+        "l40s.csv",
+        "a100_sxm.csv",
+        "b60.csv",
+    ]

--- a/tools/support_matrix/support_matrix.py
+++ b/tools/support_matrix/support_matrix.py
@@ -69,9 +69,9 @@ _NATIVE_FP4_QUANT_MODE_NAMES = frozenset({"nvfp4"})
 _FP8_SOFTWARE_FALLBACK_SYSTEMS = frozenset({"b60"})
 
 
-def _combination_sort_key(combo: tuple[str, str, str, str]) -> tuple[str, str, str, str]:
+def _combination_sort_key(combo: tuple[str, str, str, str]) -> tuple[tuple[int, str], str, str, str]:
     model, system, backend, version = combo
-    return system, backend, version, model
+    return common.get_support_matrix_system_sort_key(system), backend, version, model
 
 
 def _combination_group_key(combo: tuple[str, str, str, str]) -> tuple[str, str, str]:
@@ -460,7 +460,7 @@ class SupportMatrix:
         """
         Iterate over all combinations of hardware, and inference backend, version.
         """
-        for hardware in sorted(self.get_systems()):
+        for hardware in common.sort_support_matrix_systems(self.get_systems()):
             hardware_databases = self.databases.get(hardware, {})
             for backend in sorted(self.get_backends()):
                 for version in sorted(hardware_databases.get(backend, [])):
@@ -956,7 +956,10 @@ class SupportMatrix:
         for stale_csv in output_path.glob("*.csv"):
             stale_csv.unlink()
 
-        sorted_results = sorted(results, key=lambda x: (x[2], x[0], x[1], x[3], x[4], x[5]))
+        sorted_results = sorted(
+            results,
+            key=lambda x: (common.get_support_matrix_system_sort_key(x[2]), x[0], x[1], x[3], x[4], x[5]),
+        )
         grouped_results = {
             system: list(system_results) for system, system_results in groupby(sorted_results, key=lambda x: x[2])
         }


### PR DESCRIPTION
#### Overview:

Updates the AIC support matrix system ordering to prioritize Blackwell systems first, then RTX Pro 6000, Hopper, L40S, A100, and B60.

#### Details:

- Adds a shared support-matrix system sort order in `common.py`.
- Applies the order to the static docs page, webapp tabs, CLI matrix mode, generated combinations, and generated `index.json` manifests.
- Reorders the checked-in support matrix manifest to match.
- Adds unit coverage for the preferred order and manifest generation.

#### Where should the reviewer start?

`src/aiconfigurator/sdk/common.py` and `docs/support-matrix/index.html`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- N/A

#### Testing:

- `uv run --extra dev pytest tests/unit/sdk/test_common.py tests/unit/support_matrix`
- `uv run --extra dev ruff check src/aiconfigurator/sdk/common.py tools/support_matrix/support_matrix.py src/aiconfigurator/webapp/components/support_matrix_tab.py src/aiconfigurator/cli/main.py tests/unit/sdk/test_common.py tests/unit/support_matrix/test_support_matrix_order.py`
- `uv run --extra dev ruff format --check src/aiconfigurator/sdk/common.py tools/support_matrix/support_matrix.py src/aiconfigurator/webapp/components/support_matrix_tab.py src/aiconfigurator/cli/main.py tests/unit/sdk/test_common.py tests/unit/support_matrix/test_support_matrix_order.py`

<img width="1440" height="1200" alt="image" src="https://github.com/user-attachments/assets/eda53f0c-8c83-4718-8358-46f23ab72267" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reordered system display in the support matrix to follow a prioritized product-based order and include additional system prefixes.
  * Support-matrix generation and UI tabs now use the new prioritized ordering.

* **Tests**
  * Added unit tests ensuring support-matrix files and rendered tabs follow the new display priority ordering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiconfigurator/pull/1174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->