### PR TITLE
ci: add detailed perf parquet diffs

### DIFF
--- a/.github/workflows/comment-perf-parquet-diff.yml
+++ b/.github/workflows/comment-perf-parquet-diff.yml
@@ -82,12 +82,12 @@ jobs:
               }
 
               comment = comment.replace(
-                `Exact row-level CSVs are attached to the workflow artifact under \`${ARTIFACT_DETAIL_DIR}/\``,
-                `Exact row-level CSVs are in the ${artifactLink} artifact under \`${ARTIFACT_DETAIL_DIR}/\``
+                `Full per-file unified diffs: \`${ARTIFACT_DETAIL_DIR}/diffs/\``,
+                `Full per-file unified diffs: ${artifactLink} artifact under \`${ARTIFACT_DETAIL_DIR}/diffs/\``
               );
               comment = comment.replace(
-                `Full exact CSVs are in \`${ARTIFACT_DETAIL_DIR}/\`.`,
-                `Full exact CSVs are in the ${artifactLink} artifact under \`${ARTIFACT_DETAIL_DIR}/\`.`
+                `Exact row-level CSVs: \`${ARTIFACT_DETAIL_DIR}/\``,
+                `Exact row-level CSVs: ${artifactLink} artifact under \`${ARTIFACT_DETAIL_DIR}/\``
               );
             }
 

--- a/.github/workflows/comment-perf-parquet-diff.yml
+++ b/.github/workflows/comment-perf-parquet-diff.yml
@@ -42,6 +42,8 @@ jobs:
             const artifactDir = './artifact';
             const commentFile = path.join(artifactDir, 'comment.md');
             const COMMENT_MARKER = '<!-- perf-parquet-diff-comment -->';
+            const ARTIFACT_NAME = 'perf-parquet-diff';
+            const ARTIFACT_DETAIL_DIR = 'parquet-diff-details';
 
             if (!fs.existsSync(commentFile)) {
               console.log('Missing parquet diff artifact files, skipping comment.');
@@ -59,6 +61,36 @@ jobs:
               comment = `${COMMENT_MARKER}\n${comment}`;
             }
 
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const workflowRunId = context.payload.workflow_run.id;
+            const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+              owner,
+              repo,
+              run_id: workflowRunId,
+              per_page: 100,
+            });
+            const artifact = artifacts.find(a => a.name === ARTIFACT_NAME && !a.expired);
+            if (artifact) {
+              const artifactUrl = `https://github.com/${owner}/${repo}/actions/runs/${workflowRunId}/artifacts/${artifact.id}`;
+              const artifactLink = `[${ARTIFACT_NAME}](${artifactUrl})`;
+              const artifactSummary = `- Artifact bundle: ${artifactLink} (retained for 30 days)`;
+              const title = '## Perf Parquet Diff Report\n\n';
+
+              if (!comment.includes('Artifact bundle:') && comment.includes(title)) {
+                comment = comment.replace(title, `${title}${artifactSummary}\n\n`);
+              }
+
+              comment = comment.replace(
+                `Exact row-level CSVs are attached to the workflow artifact under \`${ARTIFACT_DETAIL_DIR}/\``,
+                `Exact row-level CSVs are in the ${artifactLink} artifact under \`${ARTIFACT_DETAIL_DIR}/\``
+              );
+              comment = comment.replace(
+                `Full exact CSVs are in \`${ARTIFACT_DETAIL_DIR}/\`.`,
+                `Full exact CSVs are in the ${artifactLink} artifact under \`${ARTIFACT_DETAIL_DIR}/\`.`
+              );
+            }
+
             const MAX_COMMENT_LENGTH = 65536;
             const TRUNCATED_SUFFIX = '\n\n*(comment truncated to fit GitHub comment limit)*';
             if (comment.length > MAX_COMMENT_LENGTH) {
@@ -66,8 +98,8 @@ jobs:
             }
 
             const allComments = await github.paginate(github.rest.issues.listComments, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
+              owner,
+              repo,
               issue_number: prNumber,
               per_page: 100,
             });
@@ -78,16 +110,16 @@ jobs:
 
             if (botComment) {
               await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
+                owner,
+                repo,
                 comment_id: botComment.id,
                 body: comment,
               });
               console.log('Updated existing parquet diff comment');
             } else {
               await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
+                owner,
+                repo,
                 issue_number: prNumber,
                 body: comment,
               });

--- a/.github/workflows/perf-parquet-diff.yml
+++ b/.github/workflows/perf-parquet-diff.yml
@@ -12,6 +12,16 @@ on:
       - 'tools/perf_database/parquet_diff.py'
       - 'tools/perf_database/parquet_textconv.py'
       - '.gitattributes'
+  workflow_dispatch:
+    inputs:
+      base-ref:
+        description: 'Base branch or ref to compare against'
+        required: true
+        default: 'main'
+      head-ref:
+        description: 'Optional head refspec to compare, for example pull/1114/head'
+        required: false
+        default: ''
 
 jobs:
   parquet-diff:
@@ -27,13 +37,18 @@ jobs:
           lfs: true
           persist-credentials: false
 
-      - name: Fetch base ref and LFS objects
+      - name: Fetch comparison refs and LFS objects
         env:
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.base-ref || github.event.pull_request.base.ref }}
+          HEAD_REFSPEC: ${{ github.event_name == 'workflow_dispatch' && inputs.head-ref || '' }}
         run: |
           git fetch --no-tags origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}"
           git lfs install
           git lfs fetch origin "refs/remotes/origin/${BASE_REF}"
+          if [ -n "${HEAD_REFSPEC}" ]; then
+            git fetch --no-tags origin "${HEAD_REFSPEC}:refs/remotes/report-head"
+            git lfs fetch origin "refs/remotes/report-head"
+          fi
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -47,9 +62,15 @@ jobs:
 
       - name: Create parquet diff report
         env:
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.base-ref || github.event.pull_request.base.ref }}
+          HEAD_REFSPEC: ${{ github.event_name == 'workflow_dispatch' && inputs.head-ref || '' }}
         run: |
-          python tools/perf_database/parquet_diff.py \
+          REPORT_SCRIPT="${RUNNER_TEMP}/parquet_diff.py"
+          cp tools/perf_database/parquet_diff.py "${REPORT_SCRIPT}"
+          if [ -n "${HEAD_REFSPEC}" ]; then
+            git checkout --detach refs/remotes/report-head
+          fi
+          python "${REPORT_SCRIPT}" \
             --base-ref "origin/${BASE_REF}" \
             --head-ref HEAD \
             --output comment.md \

--- a/.github/workflows/perf-parquet-diff.yml
+++ b/.github/workflows/perf-parquet-diff.yml
@@ -52,11 +52,14 @@ jobs:
           python tools/perf_database/parquet_diff.py \
             --base-ref "origin/${BASE_REF}" \
             --head-ref HEAD \
-            --output comment.md
+            --output comment.md \
+            --detail-dir parquet-diff-details
 
       - name: Upload parquet diff artifact bundle
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: perf-parquet-diff
-          path: comment.md
+          path: |
+            comment.md
+            parquet-diff-details
           retention-days: 30

--- a/.github/workflows/perf-parquet-diff.yml
+++ b/.github/workflows/perf-parquet-diff.yml
@@ -37,6 +37,21 @@ jobs:
           lfs: true
           persist-credentials: false
 
+      - name: Validate workflow_dispatch inputs
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          BASE_REF: ${{ inputs.base-ref }}
+          HEAD_REFSPEC: ${{ inputs.head-ref }}
+        run: |
+          if [[ ! "${BASE_REF}" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+            echo "base-ref contains unsupported characters"
+            exit 1
+          fi
+          if [[ -n "${HEAD_REFSPEC}" && ! "${HEAD_REFSPEC}" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+            echo "head-ref contains unsupported characters"
+            exit 1
+          fi
+
       - name: Fetch comparison refs and LFS objects
         env:
           BASE_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.base-ref || github.event.pull_request.base.ref }}

--- a/docs/perf_database/parquet-review.md
+++ b/docs/perf_database/parquet-review.md
@@ -22,10 +22,15 @@ For PR review summaries, run:
 uv run python tools/perf_database/parquet_diff.py \
   --base-ref origin/main \
   --head-ref HEAD \
-  --output parquet-diff.md
+  --output parquet-diff.md \
+  --detail-dir parquet-diff-details
 ```
 
 The summary checks row counts, column names, and Arrow table content hashes.
 When a PR replaces `*_perf.txt` with `*.parquet`, the tool compares the new
 parquet file against the base branch's legacy text file. A GitHub workflow also
-uploads and comments this report on PRs that touch perf data.
+uploads and comments this report on PRs that touch perf data. The artifact
+bundle includes `parquet-diff-details/changed-files.csv` plus full unified diffs
+for every changed perf data file under `parquet-diff-details/diffs/`; row-level
+CSV details are also included when the tool can classify added, removed, or
+modified rows.

--- a/docs/perf_database/parquet-review.md
+++ b/docs/perf_database/parquet-review.md
@@ -30,7 +30,7 @@ The summary checks row counts, column names, and Arrow table content hashes.
 When a PR replaces `*_perf.txt` with `*.parquet`, the tool compares the new
 parquet file against the base branch's legacy text file. A GitHub workflow also
 uploads and comments this report on PRs that touch perf data. The artifact
-bundle includes `parquet-diff-details/changed-files.csv` plus full unified diffs
-for every changed perf data file under `parquet-diff-details/diffs/`; row-level
-CSV details are also included when the tool can classify added, removed, or
-modified rows.
+bundle includes `parquet-diff-details/changed-files.csv`, full unified diffs for
+every changed perf data file under `parquet-diff-details/diffs/`, and
+`parquet-diff-details/summary.csv` with row-level CSV details when the tool can
+classify added, removed, or modified rows.

--- a/tests/unit/tools/test_parquet_diff.py
+++ b/tests/unit/tools/test_parquet_diff.py
@@ -185,7 +185,13 @@ def test_full_row_delta_preserves_original_nested_values(parquet_diff_module):
 def test_full_diff_artifacts_include_every_changed_perf_file(parquet_diff_module, tmp_path, monkeypatch):
     entries = [
         parquet_diff_module.DiffEntry("M", "src/aiconfigurator/systems/data/h100/gemm_perf.parquet"),
+        parquet_diff_module.DiffEntry("A", "src/aiconfigurator/systems/data/h100/new_perf.parquet"),
         parquet_diff_module.DiffEntry("D", "src/aiconfigurator/systems/data/h100/moe_perf.txt"),
+        parquet_diff_module.DiffEntry(
+            "R100",
+            "src/aiconfigurator/systems/data/h100/nccl_perf.parquet",
+            old_path="src/aiconfigurator/systems/data/h100/comm_perf.parquet",
+        ),
     ]
     file_lines = {
         ("base", "src/aiconfigurator/systems/data/h100/gemm_perf.parquet"): [
@@ -196,9 +202,21 @@ def test_full_diff_artifacts_include_every_changed_perf_file(parquet_diff_module
             "framework,latency",
             "vllm,1.5",
         ],
+        ("head", "src/aiconfigurator/systems/data/h100/new_perf.parquet"): [
+            "framework,latency",
+            "trtllm,3.0",
+        ],
         ("base", "src/aiconfigurator/systems/data/h100/moe_perf.txt"): [
             "framework,latency",
             "sglang,2.0",
+        ],
+        ("base", "src/aiconfigurator/systems/data/h100/comm_perf.parquet"): [
+            "framework,bandwidth",
+            "nccl,900",
+        ],
+        ("head", "src/aiconfigurator/systems/data/h100/nccl_perf.parquet"): [
+            "framework,bandwidth",
+            "nccl,950",
         ],
     }
 
@@ -215,10 +233,17 @@ def test_full_diff_artifacts_include_every_changed_perf_file(parquet_diff_module
 
     assert [artifact.diff_file for artifact in artifacts] == [
         "diffs/src/aiconfigurator/systems/data/h100/gemm_perf.parquet.diff",
+        "diffs/src/aiconfigurator/systems/data/h100/new_perf.parquet.diff",
         "diffs/src/aiconfigurator/systems/data/h100/moe_perf.txt.diff",
+        "diffs/src/aiconfigurator/systems/data/h100/nccl_perf.parquet.diff",
     ]
     assert "+vllm,1.5" in (tmp_path / artifacts[0].diff_file).read_text()
-    assert "-sglang,2.0" in (tmp_path / artifacts[1].diff_file).read_text()
+    assert "+trtllm,3.0" in (tmp_path / artifacts[1].diff_file).read_text()
+    assert "-sglang,2.0" in (tmp_path / artifacts[2].diff_file).read_text()
+    assert "comm_perf.parquet" in (tmp_path / artifacts[3].diff_file).read_text()
+    assert "nccl_perf.parquet" in (tmp_path / artifacts[3].diff_file).read_text()
+    assert "-nccl,900" in (tmp_path / artifacts[3].diff_file).read_text()
+    assert "+nccl,950" in (tmp_path / artifacts[3].diff_file).read_text()
 
     with (tmp_path / "changed-files.csv").open(newline="") as f:
         manifest_rows = list(csv.DictReader(f))
@@ -231,10 +256,22 @@ def test_full_diff_artifacts_include_every_changed_perf_file(parquet_diff_module
             "full_diff_file": "diffs/src/aiconfigurator/systems/data/h100/gemm_perf.parquet.diff",
         },
         {
+            "status": "A",
+            "file": "src/aiconfigurator/systems/data/h100/new_perf.parquet",
+            "old_file": "",
+            "full_diff_file": "diffs/src/aiconfigurator/systems/data/h100/new_perf.parquet.diff",
+        },
+        {
             "status": "D",
             "file": "src/aiconfigurator/systems/data/h100/moe_perf.txt",
             "old_file": "",
             "full_diff_file": "diffs/src/aiconfigurator/systems/data/h100/moe_perf.txt.diff",
+        },
+        {
+            "status": "R100",
+            "file": "src/aiconfigurator/systems/data/h100/nccl_perf.parquet",
+            "old_file": "src/aiconfigurator/systems/data/h100/comm_perf.parquet",
+            "full_diff_file": "diffs/src/aiconfigurator/systems/data/h100/nccl_perf.parquet.diff",
         },
     ]
 
@@ -257,7 +294,8 @@ def test_report_includes_row_level_counts(parquet_diff_module):
             modified_rows=1,
             detail_files={"added": "gemm.added.csv", "removed": "gemm.removed.csv", "modified": "gemm.modified.csv"},
             detail_previews={
-                "modified": "framework,gemm_dtype,m,n,k,latency__base,latency__head\nvllm,fp8,1,16,16,1.0,1.5"
+                "added": "framework,gemm_dtype,m,n,k,latency\nvllm,fp8,4,16,16,4.0",
+                "modified": "framework,gemm_dtype,m,n,k,latency__base,latency__head\nvllm,fp8,1,16,16,1.0,1.5",
             },
         ),
     )
@@ -284,3 +322,7 @@ def test_report_includes_row_level_counts(parquet_diff_module):
     assert "| M | src/aiconfigurator/systems/data/h100/vllm/0.19.0/gemm_perf.parquet |" not in report
     assert "Full per-file unified diffs: `parquet-diff-details/diffs/` (1 file)" in report
     assert "Exact row-level CSVs: `parquet-diff-details/` (listed in `summary.csv`)" in report
+    assert "**added rows** - full CSV: `parquet-diff-details/gemm.added.csv`" in report
+    assert "vllm,fp8,4,16,16,4.0" in report
+    assert "**modified rows** - full CSV: `parquet-diff-details/gemm.modified.csv`" in report
+    assert "vllm,fp8,1,16,16,1.0,1.5" in report

--- a/tests/unit/tools/test_parquet_diff.py
+++ b/tests/unit/tools/test_parquet_diff.py
@@ -142,6 +142,63 @@ def test_row_diff_pairs_duplicate_keys_within_key(parquet_diff_module, tmp_path)
     assert row_diff.note == "duplicate keys; unmatched rows paired within key"
 
 
+def test_full_diff_artifacts_include_every_changed_perf_file(parquet_diff_module, tmp_path, monkeypatch):
+    entries = [
+        parquet_diff_module.DiffEntry("M", "src/aiconfigurator/systems/data/h100/gemm_perf.parquet"),
+        parquet_diff_module.DiffEntry("D", "src/aiconfigurator/systems/data/h100/moe_perf.txt"),
+    ]
+    file_lines = {
+        ("base", "src/aiconfigurator/systems/data/h100/gemm_perf.parquet"): [
+            "framework,latency",
+            "vllm,1.0",
+        ],
+        ("head", "src/aiconfigurator/systems/data/h100/gemm_perf.parquet"): [
+            "framework,latency",
+            "vllm,1.5",
+        ],
+        ("base", "src/aiconfigurator/systems/data/h100/moe_perf.txt"): [
+            "framework,latency",
+            "sglang,2.0",
+        ],
+    }
+
+    monkeypatch.setattr(parquet_diff_module, "_git_file_exists", lambda ref, path: (ref, path) in file_lines)
+    monkeypatch.setattr(parquet_diff_module, "_file_text_lines", lambda ref, path: file_lines[(ref, path)])
+
+    artifacts = parquet_diff_module._write_full_diff_artifacts(
+        detail_dir=tmp_path,
+        base_ref="base",
+        head_ref="head",
+        entries=entries,
+    )
+    parquet_diff_module._write_diff_manifest(tmp_path, artifacts)
+
+    assert [artifact.diff_file for artifact in artifacts] == [
+        "diffs/src/aiconfigurator/systems/data/h100/gemm_perf.parquet.diff",
+        "diffs/src/aiconfigurator/systems/data/h100/moe_perf.txt.diff",
+    ]
+    assert "+vllm,1.5" in (tmp_path / artifacts[0].diff_file).read_text()
+    assert "-sglang,2.0" in (tmp_path / artifacts[1].diff_file).read_text()
+
+    with (tmp_path / "changed-files.csv").open(newline="") as f:
+        manifest_rows = list(csv.DictReader(f))
+
+    assert manifest_rows == [
+        {
+            "status": "M",
+            "file": "src/aiconfigurator/systems/data/h100/gemm_perf.parquet",
+            "old_file": "",
+            "full_diff_file": "diffs/src/aiconfigurator/systems/data/h100/gemm_perf.parquet.diff",
+        },
+        {
+            "status": "D",
+            "file": "src/aiconfigurator/systems/data/h100/moe_perf.txt",
+            "old_file": "",
+            "full_diff_file": "diffs/src/aiconfigurator/systems/data/h100/moe_perf.txt.diff",
+        },
+    ]
+
+
 def test_report_includes_row_level_counts(parquet_diff_module):
     comparison = parquet_diff_module.Comparison(
         path="src/aiconfigurator/systems/data/h100/vllm/0.19.0/gemm_perf.parquet",
@@ -171,10 +228,19 @@ def test_report_includes_row_level_counts(parquet_diff_module):
         entries=[parquet_diff_module.DiffEntry("M", comparison.path)],
         comparisons=[comparison],
         legacy_perf_changes=[],
+        full_diff_artifacts=[
+            parquet_diff_module.FullDiffArtifact(
+                status="M",
+                path=comparison.path,
+                old_path=None,
+                diff_file="diffs/src/aiconfigurator/systems/data/h100/vllm/0.19.0/gemm_perf.parquet.diff",
+            )
+        ],
     )
 
     assert "- Row-level changes: +1 / -1 / ~1" in report
-    assert "| M | src/aiconfigurator/systems/data/h100/vllm/0.19.0/gemm_perf.parquet | 3 | 3 | 1 | 1 | 1 |" in report
-    assert "Exact row-level CSVs are attached" in report
-    assert "### Per-File Row Diff Preview" in report
-    assert "latency__base,latency__head" in report
+    assert "- Full per-file diff artifacts: 1 file under `parquet-diff-details/diffs/`" in report
+    assert "### Other Parquet Changes" not in report
+    assert "| M | src/aiconfigurator/systems/data/h100/vllm/0.19.0/gemm_perf.parquet |" not in report
+    assert "Full per-file unified diffs: `parquet-diff-details/diffs/` (1 file)" in report
+    assert "Exact row-level CSVs: `parquet-diff-details/` (listed in `summary.csv`)" in report

--- a/tests/unit/tools/test_parquet_diff.py
+++ b/tests/unit/tools/test_parquet_diff.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import csv
 import importlib.util
+import math
 import sys
 from pathlib import Path
 
@@ -140,6 +141,45 @@ def test_row_diff_pairs_duplicate_keys_within_key(parquet_diff_module, tmp_path)
     assert row_diff.removed_rows == 0
     assert row_diff.modified_rows == 1
     assert row_diff.note == "duplicate keys; unmatched rows paired within key"
+
+
+def test_measurement_only_columns_use_full_row_delta(parquet_diff_module, tmp_path):
+    base = _snapshot(parquet_diff_module, "latency_perf.parquet", [{"latency": 1.0}, {"latency": 2.0}])
+    head = _snapshot(parquet_diff_module, "latency_perf.parquet", [{"latency": 2.0}, {"latency": 3.0}])
+
+    row_diff = parquet_diff_module._diff_snapshots(
+        "src/aiconfigurator/systems/data/h100/vllm/0.19.0/latency_perf.parquet",
+        base,
+        head,
+        detail_dir=tmp_path,
+    )
+
+    assert row_diff.key_columns == []
+    assert row_diff.added_rows == 1
+    assert row_diff.removed_rows == 1
+    assert row_diff.modified_rows == 0
+    assert row_diff.note == "unavailable keys; exact full-row add/remove diff used"
+
+
+def test_full_row_delta_preserves_original_nested_values(parquet_diff_module):
+    row = {"latency": float("nan"), "power": {"rails": ["gpu", "soc"]}}
+
+    added_rows, removed_rows = parquet_diff_module._counter_rows_delta(
+        base_rows=[],
+        head_rows=[row],
+        columns=["latency", "power"],
+    )
+    unmatched_rows = parquet_diff_module._unmatched_full_rows(
+        [row],
+        matched_rows=parquet_diff_module.Counter(),
+        columns=["latency", "power"],
+    )
+
+    assert removed_rows == []
+    assert added_rows[0] is row
+    assert unmatched_rows[0] is row
+    assert math.isnan(added_rows[0]["latency"])
+    assert isinstance(added_rows[0]["power"], dict)
 
 
 def test_full_diff_artifacts_include_every_changed_perf_file(parquet_diff_module, tmp_path, monkeypatch):

--- a/tests/unit/tools/test_parquet_diff.py
+++ b/tests/unit/tools/test_parquet_diff.py
@@ -3,10 +3,12 @@
 
 from __future__ import annotations
 
+import csv
 import importlib.util
 import sys
 from pathlib import Path
 
+import pyarrow as pa
 import pytest
 
 pytestmark = pytest.mark.unit
@@ -21,6 +23,10 @@ def parquet_diff_module():
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
+
+
+def _snapshot(parquet_diff_module, path: str, rows: list[dict[str, object]]):
+    return parquet_diff_module.Snapshot(path=path, table=pa.Table.from_pylist(rows))
 
 
 def test_legacy_perf_policy_flags_added_and_modified_text_files(parquet_diff_module):
@@ -54,3 +60,116 @@ def test_legacy_perf_policy_allows_text_file_deletions(parquet_diff_module):
     assert legacy_changes == []
     assert not parquet_diff_module.should_fail_strict([], legacy_changes)
     assert "- Legacy `*_perf.txt` files added or modified: 0" in report
+
+
+def test_row_diff_writes_added_removed_and_modified_artifacts(parquet_diff_module, tmp_path):
+    base = _snapshot(
+        parquet_diff_module,
+        "gemm_perf.parquet",
+        [
+            {"framework": "vllm", "gemm_dtype": "fp8", "m": 1, "n": 16, "k": 16, "latency": 1.0},
+            {"framework": "vllm", "gemm_dtype": "fp8", "m": 2, "n": 16, "k": 16, "latency": 2.0},
+            {"framework": "vllm", "gemm_dtype": "fp8", "m": 3, "n": 16, "k": 16, "latency": 3.0},
+        ],
+    )
+    head = _snapshot(
+        parquet_diff_module,
+        "gemm_perf.parquet",
+        [
+            {"framework": "vllm", "gemm_dtype": "fp8", "m": 1, "n": 16, "k": 16, "latency": 1.5},
+            {"framework": "vllm", "gemm_dtype": "fp8", "m": 2, "n": 16, "k": 16, "latency": 2.0},
+            {"framework": "vllm", "gemm_dtype": "fp8", "m": 4, "n": 16, "k": 16, "latency": 4.0},
+        ],
+    )
+
+    row_diff = parquet_diff_module._diff_snapshots(
+        "src/aiconfigurator/systems/data/h100/vllm/0.19.0/gemm_perf.parquet",
+        base,
+        head,
+        detail_dir=tmp_path,
+    )
+
+    assert row_diff.added_rows == 1
+    assert row_diff.removed_rows == 1
+    assert row_diff.modified_rows == 1
+    assert set(row_diff.detail_files) == {"added", "removed", "modified"}
+
+    modified_path = tmp_path / row_diff.detail_files["modified"]
+    with modified_path.open(newline="") as f:
+        modified_rows = list(csv.DictReader(f))
+
+    assert modified_rows == [
+        {
+            "framework": "vllm",
+            "gemm_dtype": "fp8",
+            "m": "1",
+            "n": "16",
+            "k": "16",
+            "latency__base": "1.0",
+            "latency__head": "1.5",
+        }
+    ]
+
+
+def test_row_diff_pairs_duplicate_keys_within_key(parquet_diff_module, tmp_path):
+    base = _snapshot(
+        parquet_diff_module,
+        "moe_perf.parquet",
+        [
+            {"framework": "sglang", "moe_dtype": "fp8", "num_tokens": 1, "latency": 1.0},
+            {"framework": "sglang", "moe_dtype": "fp8", "num_tokens": 1, "latency": 1.1},
+        ],
+    )
+    head = _snapshot(
+        parquet_diff_module,
+        "moe_perf.parquet",
+        [
+            {"framework": "sglang", "moe_dtype": "fp8", "num_tokens": 1, "latency": 1.0},
+            {"framework": "sglang", "moe_dtype": "fp8", "num_tokens": 1, "latency": 1.2},
+        ],
+    )
+
+    row_diff = parquet_diff_module._diff_snapshots(
+        "src/aiconfigurator/systems/data/h100/sglang/0.5.10/moe_perf.parquet",
+        base,
+        head,
+        detail_dir=tmp_path,
+    )
+
+    assert row_diff.added_rows == 0
+    assert row_diff.removed_rows == 0
+    assert row_diff.modified_rows == 1
+    assert row_diff.note == "duplicate keys; unmatched rows paired within key"
+
+
+def test_report_includes_row_level_counts(parquet_diff_module):
+    comparison = parquet_diff_module.Comparison(
+        path="src/aiconfigurator/systems/data/h100/vllm/0.19.0/gemm_perf.parquet",
+        base_path="src/aiconfigurator/systems/data/h100/vllm/0.19.0/gemm_perf.parquet",
+        status="M",
+        base_rows=3,
+        head_rows=3,
+        columns_match=True,
+        content_match=False,
+        base_hash="aaa",
+        head_hash="bbb",
+        row_diff=parquet_diff_module.RowDiff(
+            key_columns=["framework", "gemm_dtype", "m", "n", "k"],
+            added_rows=1,
+            removed_rows=1,
+            modified_rows=1,
+            detail_files={"added": "gemm.added.csv", "removed": "gemm.removed.csv", "modified": "gemm.modified.csv"},
+        ),
+    )
+
+    report = parquet_diff_module.render_report(
+        base_ref="origin/main",
+        head_ref="HEAD",
+        entries=[parquet_diff_module.DiffEntry("M", comparison.path)],
+        comparisons=[comparison],
+        legacy_perf_changes=[],
+    )
+
+    assert "- Row-level changes: +1 / -1 / ~1" in report
+    assert "| M | src/aiconfigurator/systems/data/h100/vllm/0.19.0/gemm_perf.parquet | 3 | 3 | 1 | 1 | 1 |" in report
+    assert "Exact row-level CSVs are attached" in report

--- a/tests/unit/tools/test_parquet_diff.py
+++ b/tests/unit/tools/test_parquet_diff.py
@@ -159,6 +159,9 @@ def test_report_includes_row_level_counts(parquet_diff_module):
             removed_rows=1,
             modified_rows=1,
             detail_files={"added": "gemm.added.csv", "removed": "gemm.removed.csv", "modified": "gemm.modified.csv"},
+            detail_previews={
+                "modified": "framework,gemm_dtype,m,n,k,latency__base,latency__head\nvllm,fp8,1,16,16,1.0,1.5"
+            },
         ),
     )
 
@@ -173,3 +176,5 @@ def test_report_includes_row_level_counts(parquet_diff_module):
     assert "- Row-level changes: +1 / -1 / ~1" in report
     assert "| M | src/aiconfigurator/systems/data/h100/vllm/0.19.0/gemm_perf.parquet | 3 | 3 | 1 | 1 | 1 |" in report
     assert "Exact row-level CSVs are attached" in report
+    assert "### Per-File Row Diff Preview" in report
+    assert "latency__base,latency__head" in report

--- a/tools/perf_database/parquet_diff.py
+++ b/tools/perf_database/parquet_diff.py
@@ -932,6 +932,8 @@ def render_report(
             lines.append(f"\n...and {len(legacy_perf_changes) - 50} more legacy text perf changes.")
         lines.append("")
 
+    lines.extend(_render_inline_diff_previews(comparisons))
+
     has_row_detail_files = any(c.row_diff and c.row_diff.detail_files for c in comparisons)
     if full_diff_artifacts is not None or has_row_detail_files:
         lines.extend(["### Artifact Contents", ""])

--- a/tools/perf_database/parquet_diff.py
+++ b/tools/perf_database/parquet_diff.py
@@ -7,12 +7,13 @@ from __future__ import annotations
 import argparse
 import csv
 import hashlib
+import io
 import json
 import math
 import subprocess
 import sys
 from collections import Counter, defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import pyarrow as pa
@@ -23,6 +24,8 @@ PERF_DATA_PREFIX = "src/aiconfigurator/systems/data"
 COMMENT_MARKER = "<!-- perf-parquet-diff-comment -->"
 LFS_POINTER_PREFIX = b"version https://git-lfs.github.com/spec/v1\n"
 DEFAULT_DETAIL_DIR = "parquet-diff-details"
+INLINE_PREVIEW_ROWS = 3
+MAX_INLINE_PREVIEW_CHARS = 45_000
 MEASUREMENT_COLUMNS = frozenset(
     {
         "latency",
@@ -80,6 +83,7 @@ class RowDiff:
     modified_rows: int
     detail_files: dict[str, str]
     note: str | None = None
+    detail_previews: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass
@@ -210,6 +214,15 @@ def _csv_value(value: object) -> object:
     return value
 
 
+def _rows_to_csv_text(rows: list[dict[str, object]], columns: list[str], *, limit: int | None = None) -> str:
+    output = io.StringIO()
+    writer = csv.DictWriter(output, fieldnames=columns, lineterminator="\n")
+    writer.writeheader()
+    for row in rows[:limit]:
+        writer.writerow({column: _csv_value(row.get(column)) for column in columns})
+    return output.getvalue().rstrip()
+
+
 def _write_rows_csv(path: Path, rows: list[dict[str, object]], columns: list[str]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", newline="") as f:
@@ -219,6 +232,43 @@ def _write_rows_csv(path: Path, rows: list[dict[str, object]], columns: list[str
             writer.writerow({column: _csv_value(row.get(column)) for column in columns})
 
 
+def _modified_csv_rows(
+    modified_rows: list[tuple[dict[str, object], dict[str, object]]],
+    *,
+    key_columns: list[str],
+    compare_columns: list[str],
+) -> tuple[list[str], list[dict[str, object]]]:
+    changed_columns = [
+        column
+        for column in compare_columns
+        if any(_freeze_value(base.get(column)) != _freeze_value(head.get(column)) for base, head in modified_rows)
+    ]
+    fieldnames = key_columns + [field for column in changed_columns for field in (f"{column}__base", f"{column}__head")]
+    rows: list[dict[str, object]] = []
+    for base, head in modified_rows:
+        row: dict[str, object] = {column: _csv_value(head.get(column)) for column in key_columns}
+        for column in changed_columns:
+            row[f"{column}__base"] = _csv_value(base.get(column))
+            row[f"{column}__head"] = _csv_value(head.get(column))
+        rows.append(row)
+    return fieldnames, rows
+
+
+def _modified_rows_to_csv_text(
+    modified_rows: list[tuple[dict[str, object], dict[str, object]]],
+    *,
+    key_columns: list[str],
+    compare_columns: list[str],
+    limit: int | None = None,
+) -> str:
+    fieldnames, rows = _modified_csv_rows(
+        modified_rows,
+        key_columns=key_columns,
+        compare_columns=compare_columns,
+    )
+    return _rows_to_csv_text(rows, fieldnames, limit=limit)
+
+
 def _write_modified_csv(
     path: Path,
     modified_rows: list[tuple[dict[str, object], dict[str, object]]],
@@ -226,23 +276,17 @@ def _write_modified_csv(
     key_columns: list[str],
     compare_columns: list[str],
 ) -> None:
-    changed_columns = [
-        column
-        for column in compare_columns
-        if any(_freeze_value(base.get(column)) != _freeze_value(head.get(column)) for base, head in modified_rows)
-    ]
-    fieldnames = key_columns + [field for column in changed_columns for field in (f"{column}__base", f"{column}__head")]
+    fieldnames, rows = _modified_csv_rows(
+        modified_rows,
+        key_columns=key_columns,
+        compare_columns=compare_columns,
+    )
 
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", newline="") as f:
         writer = csv.DictWriter(f, fieldnames=fieldnames, lineterminator="\n")
         writer.writeheader()
-        for base, head in modified_rows:
-            row: dict[str, object] = {column: _csv_value(head.get(column)) for column in key_columns}
-            for column in changed_columns:
-                row[f"{column}__base"] = _csv_value(base.get(column))
-                row[f"{column}__head"] = _csv_value(head.get(column))
-            writer.writerow(row)
+        writer.writerows(rows)
 
 
 def _detail_output_path(detail_dir: Path, parquet_path: str, kind: str) -> tuple[Path, str]:
@@ -379,9 +423,11 @@ def _diff_snapshots(
     columns = _merge_columns(base_columns, head_columns)
     key_columns = _select_key_columns(base_columns or head_columns, head_columns or base_columns)
     detail_files: dict[str, str] = {}
+    detail_previews: dict[str, str] = {}
 
     if base_snapshot is None:
         head_rows = sorted(_row_dicts(head_snapshot.table), key=lambda row: _sort_key(row, columns))
+        detail_previews["added"] = _rows_to_csv_text(head_rows, columns, limit=INLINE_PREVIEW_ROWS)
         detail_file = _write_detail_rows(
             detail_dir=detail_dir,
             parquet_path=parquet_path,
@@ -391,10 +437,11 @@ def _diff_snapshots(
         )
         if detail_file:
             detail_files["added"] = detail_file
-        return RowDiff(key_columns, len(head_rows), 0, 0, detail_files)
+        return RowDiff(key_columns, len(head_rows), 0, 0, detail_files, detail_previews=detail_previews)
 
     if head_snapshot is None:
         base_rows = sorted(_row_dicts(base_snapshot.table), key=lambda row: _sort_key(row, columns))
+        detail_previews["removed"] = _rows_to_csv_text(base_rows, columns, limit=INLINE_PREVIEW_ROWS)
         detail_file = _write_detail_rows(
             detail_dir=detail_dir,
             parquet_path=parquet_path,
@@ -404,7 +451,7 @@ def _diff_snapshots(
         )
         if detail_file:
             detail_files["removed"] = detail_file
-        return RowDiff(key_columns, 0, len(base_rows), 0, detail_files)
+        return RowDiff(key_columns, 0, len(base_rows), 0, detail_files, detail_previews=detail_previews)
 
     base_rows = _row_dicts(base_snapshot.table)
     head_rows = _row_dicts(head_snapshot.table)
@@ -413,6 +460,8 @@ def _diff_snapshots(
         added_rows = sorted(added_rows, key=lambda row: _sort_key(row, columns))
         removed_rows = sorted(removed_rows, key=lambda row: _sort_key(row, columns))
         for kind, rows in (("added", added_rows), ("removed", removed_rows)):
+            if rows:
+                detail_previews[kind] = _rows_to_csv_text(rows, columns, limit=INLINE_PREVIEW_ROWS)
             detail_file = _write_detail_rows(
                 detail_dir=detail_dir,
                 parquet_path=parquet_path,
@@ -429,6 +478,7 @@ def _diff_snapshots(
             0,
             detail_files,
             note="unavailable keys; exact full-row add/remove diff used",
+            detail_previews=detail_previews,
         )
 
     duplicate_keys = _has_duplicate_keys(base_rows, key_columns) or _has_duplicate_keys(head_rows, key_columns)
@@ -440,6 +490,8 @@ def _diff_snapshots(
             columns=columns,
         )
         for kind, rows in (("added", added_rows), ("removed", removed_rows)):
+            if rows:
+                detail_previews[kind] = _rows_to_csv_text(rows, columns, limit=INLINE_PREVIEW_ROWS)
             detail_file = _write_detail_rows(
                 detail_dir=detail_dir,
                 parquet_path=parquet_path,
@@ -458,6 +510,13 @@ def _diff_snapshots(
             key_columns=key_columns,
             compare_columns=compare_columns,
         )
+        if modified_rows:
+            detail_previews["modified"] = _modified_rows_to_csv_text(
+                modified_rows,
+                key_columns=key_columns,
+                compare_columns=compare_columns,
+                limit=INLINE_PREVIEW_ROWS,
+            )
         if detail_file:
             detail_files["modified"] = detail_file
 
@@ -468,6 +527,7 @@ def _diff_snapshots(
             len(modified_rows),
             detail_files,
             note="duplicate keys; unmatched rows paired within key",
+            detail_previews=detail_previews,
         )
 
     base_by_key = {_row_key(row, key_columns): row for row in base_rows}
@@ -484,6 +544,8 @@ def _diff_snapshots(
     ]
 
     for kind, rows in (("added", added_rows), ("removed", removed_rows)):
+        if rows:
+            detail_previews[kind] = _rows_to_csv_text(rows, columns, limit=INLINE_PREVIEW_ROWS)
         detail_file = _write_detail_rows(
             detail_dir=detail_dir,
             parquet_path=parquet_path,
@@ -502,10 +564,24 @@ def _diff_snapshots(
         key_columns=key_columns,
         compare_columns=compare_columns,
     )
+    if modified_rows:
+        detail_previews["modified"] = _modified_rows_to_csv_text(
+            modified_rows,
+            key_columns=key_columns,
+            compare_columns=compare_columns,
+            limit=INLINE_PREVIEW_ROWS,
+        )
     if detail_file:
         detail_files["modified"] = detail_file
 
-    return RowDiff(key_columns, len(added_rows), len(removed_rows), len(modified_rows), detail_files)
+    return RowDiff(
+        key_columns,
+        len(added_rows),
+        len(removed_rows),
+        len(modified_rows),
+        detail_files,
+        detail_previews=detail_previews,
+    )
 
 
 def _write_detail_summary(detail_dir: Path, comparisons: list[Comparison]) -> None:
@@ -595,6 +671,57 @@ def _render_table(rows: list[list[object]]) -> list[str]:
     for row in rows[1:]:
         out.append("| " + " | ".join(str(value) for value in row) + " |")
     return out
+
+
+def _render_inline_diff_previews(comparisons: list[Comparison]) -> list[str]:
+    preview_lines = [
+        "### Per-File Row Diff Preview",
+        "",
+        f"Showing the first {INLINE_PREVIEW_ROWS} rows per diff kind for each changed parquet file. "
+        f"Full exact CSVs are in `{DEFAULT_DETAIL_DIR}/`.",
+        "",
+    ]
+    budget_used = 0
+    rendered = 0
+    for comparison in comparisons:
+        row_diff = comparison.row_diff
+        if not row_diff or not row_diff.detail_previews:
+            continue
+
+        section = [
+            f"<details><summary>{comparison.path}</summary>",
+            "",
+            f"- Rows: +{row_diff.added_rows} / -{row_diff.removed_rows} / ~{row_diff.modified_rows}",
+            f"- Key columns: `{', '.join(row_diff.key_columns)}`" if row_diff.key_columns else "- Key columns: n/a",
+        ]
+        if row_diff.note:
+            section.append(f"- Note: {row_diff.note}")
+        section.append("")
+
+        for kind, preview in row_diff.detail_previews.items():
+            detail_file = row_diff.detail_files.get(kind)
+            if detail_file:
+                section.append(f"**{kind} rows** - full CSV: `{DEFAULT_DETAIL_DIR}/{detail_file}`")
+            else:
+                section.append(f"**{kind} rows**")
+            section.extend(["", "```csv", preview, "```", ""])
+        section.extend(["</details>", ""])
+
+        section_text = "\n".join(section)
+        if budget_used + len(section_text) > MAX_INLINE_PREVIEW_CHARS:
+            remaining = len([c for c in comparisons if c.row_diff and c.row_diff.detail_previews]) - rendered
+            preview_lines.append(
+                f"...inline previews truncated after {rendered} files to keep the PR comment readable; "
+                f"{remaining} more files are available in `{DEFAULT_DETAIL_DIR}/`."
+            )
+            preview_lines.append("")
+            break
+
+        preview_lines.append(section_text)
+        budget_used += len(section_text)
+        rendered += 1
+
+    return preview_lines if rendered else []
 
 
 def render_report(
@@ -701,6 +828,7 @@ def render_report(
                 "with filenames matching `<source>.{added,removed,modified}.csv`."
             )
             lines.append("")
+            lines.extend(_render_inline_diff_previews(interesting))
 
     if converted and not converted_bad and not legacy_perf_changes:
         lines.append("All detected CSV-to-parquet conversions preserve column names and Arrow table content.")

--- a/tools/perf_database/parquet_diff.py
+++ b/tools/perf_database/parquet_diff.py
@@ -13,7 +13,7 @@ import json
 import math
 import subprocess
 import sys
-from collections import Counter, defaultdict
+from collections import Counter, defaultdict, deque
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -191,7 +191,7 @@ def _merge_columns(*column_lists: list[str]) -> list[str]:
 def _select_key_columns(base_columns: list[str], head_columns: list[str]) -> list[str]:
     common_columns = [column for column in base_columns if column in head_columns]
     key_columns = [column for column in common_columns if column not in MEASUREMENT_COLUMNS]
-    return key_columns or common_columns
+    return key_columns
 
 
 def _freeze_value(value: object) -> object:
@@ -435,17 +435,28 @@ def _counter_rows_delta(
 ) -> tuple[list[dict[str, object]], list[dict[str, object]]]:
     base_counter = Counter(_row_key(row, columns) for row in base_rows)
     head_counter = Counter(_row_key(row, columns) for row in head_rows)
+    base_by_key = _rows_by_key(base_rows, columns)
+    head_by_key = _rows_by_key(head_rows, columns)
     added_rows: list[dict[str, object]] = []
     removed_rows: list[dict[str, object]] = []
-    for key, count in (head_counter - base_counter).items():
-        added_rows.extend(dict(zip(columns, key, strict=True)) for _ in range(count))
-    for key, count in (base_counter - head_counter).items():
-        removed_rows.extend(dict(zip(columns, key, strict=True)) for _ in range(count))
-    return added_rows, removed_rows
+    for key, count in sorted((head_counter - base_counter).items(), key=lambda item: repr(item[0])):
+        added_rows.extend(head_by_key[key].popleft() for _ in range(count))
+    for key, count in sorted((base_counter - head_counter).items(), key=lambda item: repr(item[0])):
+        removed_rows.extend(base_by_key[key].popleft() for _ in range(count))
+    return (
+        sorted(added_rows, key=lambda row: _sort_key(row, columns)),
+        sorted(removed_rows, key=lambda row: _sort_key(row, columns)),
+    )
 
 
-def _dict_from_key(columns: list[str], key: tuple[object, ...]) -> dict[str, object]:
-    return dict(zip(columns, key, strict=True))
+def _rows_by_key(
+    rows: list[dict[str, object]],
+    columns: list[str],
+) -> defaultdict[tuple[object, ...], deque[dict[str, object]]]:
+    rows_by_key: defaultdict[tuple[object, ...], deque[dict[str, object]]] = defaultdict(deque)
+    for row in sorted(rows, key=lambda item: _sort_key(item, columns)):
+        rows_by_key[_row_key(row, columns)].append(row)
+    return rows_by_key
 
 
 def _unmatched_full_rows(
@@ -456,9 +467,10 @@ def _unmatched_full_rows(
 ) -> list[dict[str, object]]:
     counter = Counter(_row_key(row, columns) for row in rows)
     unmatched = counter - matched_rows
+    rows_by_key = _rows_by_key(rows, columns)
     result: list[dict[str, object]] = []
-    for key, count in unmatched.items():
-        result.extend(_dict_from_key(columns, key) for _ in range(count))
+    for key, count in sorted(unmatched.items(), key=lambda item: repr(item[0])):
+        result.extend(rows_by_key[key].popleft() for _ in range(count))
     return sorted(result, key=lambda row: _sort_key(row, columns))
 
 

--- a/tools/perf_database/parquet_diff.py
+++ b/tools/perf_database/parquet_diff.py
@@ -5,9 +5,13 @@
 from __future__ import annotations
 
 import argparse
+import csv
 import hashlib
+import json
+import math
 import subprocess
 import sys
+from collections import Counter, defaultdict
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -18,6 +22,25 @@ import pyarrow.parquet as pq
 PERF_DATA_PREFIX = "src/aiconfigurator/systems/data"
 COMMENT_MARKER = "<!-- perf-parquet-diff-comment -->"
 LFS_POINTER_PREFIX = b"version https://git-lfs.github.com/spec/v1\n"
+DEFAULT_DETAIL_DIR = "parquet-diff-details"
+MEASUREMENT_COLUMNS = frozenset(
+    {
+        "latency",
+        "power",
+        "energy",
+        "avg_ms",
+        "dispatch_avg_t_us",
+        "dispatch_bandwidth_gbps",
+        "dispatch_notify_us",
+        "dispatch_sms",
+        "dispatch_transmit_us",
+        "combine_avg_t_us",
+        "combine_bandwidth_gbps",
+        "combine_notify_us",
+        "combine_sms",
+        "combine_transmit_us",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -50,6 +73,16 @@ class Snapshot:
 
 
 @dataclass
+class RowDiff:
+    key_columns: list[str]
+    added_rows: int
+    removed_rows: int
+    modified_rows: int
+    detail_files: dict[str, str]
+    note: str | None = None
+
+
+@dataclass
 class Comparison:
     path: str
     base_path: str | None
@@ -60,6 +93,7 @@ class Comparison:
     content_match: bool | None
     base_hash: str | None
     head_hash: str | None
+    row_diff: RowDiff | None
 
 
 def _git(args: list[str], *, input_data: bytes | None = None, check: bool = True) -> subprocess.CompletedProcess:
@@ -125,11 +159,399 @@ def _hash_table(table: pa.Table) -> str:
     return hashlib.sha256(sink.getvalue().to_pybytes()).hexdigest()[:16]
 
 
+def _row_dicts(table: pa.Table) -> list[dict[str, object]]:
+    return table.combine_chunks().to_pylist()
+
+
+def _merge_columns(*column_lists: list[str]) -> list[str]:
+    columns: list[str] = []
+    seen: set[str] = set()
+    for column_list in column_lists:
+        for column in column_list:
+            if column not in seen:
+                columns.append(column)
+                seen.add(column)
+    return columns
+
+
+def _select_key_columns(base_columns: list[str], head_columns: list[str]) -> list[str]:
+    common_columns = [column for column in base_columns if column in head_columns]
+    key_columns = [column for column in common_columns if column not in MEASUREMENT_COLUMNS]
+    return key_columns or common_columns
+
+
+def _freeze_value(value: object) -> object:
+    if isinstance(value, float) and math.isnan(value):
+        return ("__nan__",)
+    if isinstance(value, dict):
+        return tuple(sorted((key, _freeze_value(item)) for key, item in value.items()))
+    if isinstance(value, list | tuple):
+        return tuple(_freeze_value(item) for item in value)
+    return value
+
+
+def _row_key(row: dict[str, object], columns: list[str]) -> tuple[object, ...]:
+    return tuple(_freeze_value(row.get(column)) for column in columns)
+
+
+def _sort_key(row: dict[str, object], columns: list[str]) -> tuple[str, ...]:
+    return tuple(repr(_freeze_value(row.get(column))) for column in columns)
+
+
+def _rows_equal(base_row: dict[str, object], head_row: dict[str, object], columns: list[str]) -> bool:
+    return all(_freeze_value(base_row.get(column)) == _freeze_value(head_row.get(column)) for column in columns)
+
+
+def _csv_value(value: object) -> object:
+    if value is None:
+        return ""
+    if isinstance(value, dict | list | tuple):
+        return json.dumps(value, sort_keys=True)
+    return value
+
+
+def _write_rows_csv(path: Path, rows: list[dict[str, object]], columns: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=columns, lineterminator="\n")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({column: _csv_value(row.get(column)) for column in columns})
+
+
+def _write_modified_csv(
+    path: Path,
+    modified_rows: list[tuple[dict[str, object], dict[str, object]]],
+    *,
+    key_columns: list[str],
+    compare_columns: list[str],
+) -> None:
+    changed_columns = [
+        column
+        for column in compare_columns
+        if any(_freeze_value(base.get(column)) != _freeze_value(head.get(column)) for base, head in modified_rows)
+    ]
+    fieldnames = key_columns + [field for column in changed_columns for field in (f"{column}__base", f"{column}__head")]
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames, lineterminator="\n")
+        writer.writeheader()
+        for base, head in modified_rows:
+            row: dict[str, object] = {column: _csv_value(head.get(column)) for column in key_columns}
+            for column in changed_columns:
+                row[f"{column}__base"] = _csv_value(base.get(column))
+                row[f"{column}__head"] = _csv_value(head.get(column))
+            writer.writerow(row)
+
+
+def _detail_output_path(detail_dir: Path, parquet_path: str, kind: str) -> tuple[Path, str]:
+    relative_path = Path(f"{parquet_path}.{kind}.csv")
+    return detail_dir / relative_path, relative_path.as_posix()
+
+
+def _write_detail_rows(
+    *,
+    detail_dir: Path | None,
+    parquet_path: str,
+    kind: str,
+    rows: list[dict[str, object]],
+    columns: list[str],
+) -> str | None:
+    if not detail_dir or not rows:
+        return None
+    output_path, relative_path = _detail_output_path(detail_dir, parquet_path, kind)
+    _write_rows_csv(output_path, rows, columns)
+    return relative_path
+
+
+def _write_detail_modified_rows(
+    *,
+    detail_dir: Path | None,
+    parquet_path: str,
+    modified_rows: list[tuple[dict[str, object], dict[str, object]]],
+    key_columns: list[str],
+    compare_columns: list[str],
+) -> str | None:
+    if not detail_dir or not modified_rows:
+        return None
+    output_path, relative_path = _detail_output_path(detail_dir, parquet_path, "modified")
+    _write_modified_csv(output_path, modified_rows, key_columns=key_columns, compare_columns=compare_columns)
+    return relative_path
+
+
+def _has_duplicate_keys(rows: list[dict[str, object]], key_columns: list[str]) -> bool:
+    counts = Counter(_row_key(row, key_columns) for row in rows)
+    return any(count > 1 for count in counts.values())
+
+
+def _counter_rows_delta(
+    *,
+    base_rows: list[dict[str, object]],
+    head_rows: list[dict[str, object]],
+    columns: list[str],
+) -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+    base_counter = Counter(_row_key(row, columns) for row in base_rows)
+    head_counter = Counter(_row_key(row, columns) for row in head_rows)
+    added_rows: list[dict[str, object]] = []
+    removed_rows: list[dict[str, object]] = []
+    for key, count in (head_counter - base_counter).items():
+        added_rows.extend(dict(zip(columns, key, strict=True)) for _ in range(count))
+    for key, count in (base_counter - head_counter).items():
+        removed_rows.extend(dict(zip(columns, key, strict=True)) for _ in range(count))
+    return added_rows, removed_rows
+
+
+def _dict_from_key(columns: list[str], key: tuple[object, ...]) -> dict[str, object]:
+    return dict(zip(columns, key, strict=True))
+
+
+def _unmatched_full_rows(
+    rows: list[dict[str, object]],
+    *,
+    matched_rows: Counter[tuple[object, ...]],
+    columns: list[str],
+) -> list[dict[str, object]]:
+    counter = Counter(_row_key(row, columns) for row in rows)
+    unmatched = counter - matched_rows
+    result: list[dict[str, object]] = []
+    for key, count in unmatched.items():
+        result.extend(_dict_from_key(columns, key) for _ in range(count))
+    return sorted(result, key=lambda row: _sort_key(row, columns))
+
+
+def _diff_rows_with_duplicate_keys(
+    *,
+    base_rows: list[dict[str, object]],
+    head_rows: list[dict[str, object]],
+    key_columns: list[str],
+    columns: list[str],
+) -> tuple[list[dict[str, object]], list[dict[str, object]], list[tuple[dict[str, object], dict[str, object]]]]:
+    base_groups: dict[tuple[object, ...], list[dict[str, object]]] = defaultdict(list)
+    head_groups: dict[tuple[object, ...], list[dict[str, object]]] = defaultdict(list)
+    for row in base_rows:
+        base_groups[_row_key(row, key_columns)].append(row)
+    for row in head_rows:
+        head_groups[_row_key(row, key_columns)].append(row)
+
+    added_rows: list[dict[str, object]] = []
+    removed_rows: list[dict[str, object]] = []
+    modified_rows: list[tuple[dict[str, object], dict[str, object]]] = []
+
+    for key in sorted(set(base_groups) | set(head_groups), key=repr):
+        base_group = base_groups.get(key, [])
+        head_group = head_groups.get(key, [])
+        if not base_group:
+            added_rows.extend(head_group)
+            continue
+        if not head_group:
+            removed_rows.extend(base_group)
+            continue
+
+        matched_rows = Counter(_row_key(row, columns) for row in base_group) & Counter(
+            _row_key(row, columns) for row in head_group
+        )
+        unmatched_base = _unmatched_full_rows(base_group, matched_rows=matched_rows, columns=columns)
+        unmatched_head = _unmatched_full_rows(head_group, matched_rows=matched_rows, columns=columns)
+        pair_count = min(len(unmatched_base), len(unmatched_head))
+        modified_rows.extend(zip(unmatched_base[:pair_count], unmatched_head[:pair_count], strict=True))
+        removed_rows.extend(unmatched_base[pair_count:])
+        added_rows.extend(unmatched_head[pair_count:])
+
+    added_rows = sorted(added_rows, key=lambda row: _sort_key(row, columns))
+    removed_rows = sorted(removed_rows, key=lambda row: _sort_key(row, columns))
+    modified_rows = sorted(modified_rows, key=lambda pair: _sort_key(pair[1], columns))
+    return added_rows, removed_rows, modified_rows
+
+
+def _diff_snapshots(
+    parquet_path: str,
+    base_snapshot: Snapshot | None,
+    head_snapshot: Snapshot | None,
+    *,
+    detail_dir: Path | None,
+) -> RowDiff | None:
+    if base_snapshot is None and head_snapshot is None:
+        return None
+
+    base_columns = base_snapshot.columns if base_snapshot else []
+    head_columns = head_snapshot.columns if head_snapshot else []
+    columns = _merge_columns(base_columns, head_columns)
+    key_columns = _select_key_columns(base_columns or head_columns, head_columns or base_columns)
+    detail_files: dict[str, str] = {}
+
+    if base_snapshot is None:
+        head_rows = sorted(_row_dicts(head_snapshot.table), key=lambda row: _sort_key(row, columns))
+        detail_file = _write_detail_rows(
+            detail_dir=detail_dir,
+            parquet_path=parquet_path,
+            kind="added",
+            rows=head_rows,
+            columns=columns,
+        )
+        if detail_file:
+            detail_files["added"] = detail_file
+        return RowDiff(key_columns, len(head_rows), 0, 0, detail_files)
+
+    if head_snapshot is None:
+        base_rows = sorted(_row_dicts(base_snapshot.table), key=lambda row: _sort_key(row, columns))
+        detail_file = _write_detail_rows(
+            detail_dir=detail_dir,
+            parquet_path=parquet_path,
+            kind="removed",
+            rows=base_rows,
+            columns=columns,
+        )
+        if detail_file:
+            detail_files["removed"] = detail_file
+        return RowDiff(key_columns, 0, len(base_rows), 0, detail_files)
+
+    base_rows = _row_dicts(base_snapshot.table)
+    head_rows = _row_dicts(head_snapshot.table)
+    if not key_columns:
+        added_rows, removed_rows = _counter_rows_delta(base_rows=base_rows, head_rows=head_rows, columns=columns)
+        added_rows = sorted(added_rows, key=lambda row: _sort_key(row, columns))
+        removed_rows = sorted(removed_rows, key=lambda row: _sort_key(row, columns))
+        for kind, rows in (("added", added_rows), ("removed", removed_rows)):
+            detail_file = _write_detail_rows(
+                detail_dir=detail_dir,
+                parquet_path=parquet_path,
+                kind=kind,
+                rows=rows,
+                columns=columns,
+            )
+            if detail_file:
+                detail_files[kind] = detail_file
+        return RowDiff(
+            key_columns,
+            len(added_rows),
+            len(removed_rows),
+            0,
+            detail_files,
+            note="unavailable keys; exact full-row add/remove diff used",
+        )
+
+    duplicate_keys = _has_duplicate_keys(base_rows, key_columns) or _has_duplicate_keys(head_rows, key_columns)
+    if duplicate_keys:
+        added_rows, removed_rows, modified_rows = _diff_rows_with_duplicate_keys(
+            base_rows=base_rows,
+            head_rows=head_rows,
+            key_columns=key_columns,
+            columns=columns,
+        )
+        for kind, rows in (("added", added_rows), ("removed", removed_rows)):
+            detail_file = _write_detail_rows(
+                detail_dir=detail_dir,
+                parquet_path=parquet_path,
+                kind=kind,
+                rows=rows,
+                columns=columns,
+            )
+            if detail_file:
+                detail_files[kind] = detail_file
+
+        compare_columns = [column for column in columns if column not in key_columns]
+        detail_file = _write_detail_modified_rows(
+            detail_dir=detail_dir,
+            parquet_path=parquet_path,
+            modified_rows=modified_rows,
+            key_columns=key_columns,
+            compare_columns=compare_columns,
+        )
+        if detail_file:
+            detail_files["modified"] = detail_file
+
+        return RowDiff(
+            key_columns,
+            len(added_rows),
+            len(removed_rows),
+            len(modified_rows),
+            detail_files,
+            note="duplicate keys; unmatched rows paired within key",
+        )
+
+    base_by_key = {_row_key(row, key_columns): row for row in base_rows}
+    head_by_key = {_row_key(row, key_columns): row for row in head_rows}
+    added_keys = sorted(set(head_by_key) - set(base_by_key), key=repr)
+    removed_keys = sorted(set(base_by_key) - set(head_by_key), key=repr)
+    common_keys = sorted(set(base_by_key) & set(head_by_key), key=repr)
+    added_rows = [head_by_key[key] for key in added_keys]
+    removed_rows = [base_by_key[key] for key in removed_keys]
+    modified_rows = [
+        (base_by_key[key], head_by_key[key])
+        for key in common_keys
+        if not _rows_equal(base_by_key[key], head_by_key[key], columns)
+    ]
+
+    for kind, rows in (("added", added_rows), ("removed", removed_rows)):
+        detail_file = _write_detail_rows(
+            detail_dir=detail_dir,
+            parquet_path=parquet_path,
+            kind=kind,
+            rows=rows,
+            columns=columns,
+        )
+        if detail_file:
+            detail_files[kind] = detail_file
+
+    compare_columns = [column for column in columns if column not in key_columns]
+    detail_file = _write_detail_modified_rows(
+        detail_dir=detail_dir,
+        parquet_path=parquet_path,
+        modified_rows=modified_rows,
+        key_columns=key_columns,
+        compare_columns=compare_columns,
+    )
+    if detail_file:
+        detail_files["modified"] = detail_file
+
+    return RowDiff(key_columns, len(added_rows), len(removed_rows), len(modified_rows), detail_files)
+
+
+def _write_detail_summary(detail_dir: Path, comparisons: list[Comparison]) -> None:
+    rows: list[dict[str, object]] = []
+    for comparison in comparisons:
+        row_diff = comparison.row_diff
+        if row_diff is None:
+            continue
+        rows.append(
+            {
+                "file": comparison.path,
+                "status": comparison.status,
+                "base_rows": comparison.base_rows,
+                "head_rows": comparison.head_rows,
+                "added_rows": row_diff.added_rows,
+                "removed_rows": row_diff.removed_rows,
+                "modified_rows": row_diff.modified_rows,
+                "key_columns": ",".join(row_diff.key_columns),
+                "detail_files": ",".join(row_diff.detail_files.values()),
+                "note": row_diff.note or "",
+            }
+        )
+    if rows:
+        _write_rows_csv(
+            detail_dir / "summary.csv",
+            rows,
+            [
+                "file",
+                "status",
+                "base_rows",
+                "head_rows",
+                "added_rows",
+                "removed_rows",
+                "modified_rows",
+                "key_columns",
+                "detail_files",
+                "note",
+            ],
+        )
+
+
 def _legacy_txt_path(path: str) -> str:
     return f"{path[: -len('.parquet')]}.txt"
 
 
-def _compare(base_ref: str, head_ref: str, entry: DiffEntry) -> Comparison:
+def _compare(base_ref: str, head_ref: str, entry: DiffEntry, detail_dir: Path | None = None) -> Comparison:
     head_snapshot = None if entry.status.startswith("D") else _read_snapshot(head_ref, entry.path)
 
     base_path: str | None = entry.old_path or entry.path
@@ -144,6 +566,8 @@ def _compare(base_ref: str, head_ref: str, entry: DiffEntry) -> Comparison:
     if base_path is not None and _git_file_exists(base_ref, base_path):
         base_snapshot = _read_snapshot(base_ref, base_path)
 
+    row_diff = _diff_snapshots(entry.path, base_snapshot, head_snapshot, detail_dir=detail_dir)
+
     return Comparison(
         path=entry.path,
         base_path=base_path,
@@ -156,6 +580,7 @@ def _compare(base_ref: str, head_ref: str, entry: DiffEntry) -> Comparison:
         else None,
         base_hash=base_snapshot.content_hash if base_snapshot else None,
         head_hash=head_snapshot.content_hash if head_snapshot else None,
+        row_diff=row_diff,
     )
 
 
@@ -188,6 +613,10 @@ def render_report(
         c for c in comparisons if c.base_path and c.base_path.endswith(".parquet") and not c.status.startswith("D")
     ]
     deleted = [c for c in comparisons if c.status.startswith("D")]
+    row_diffs = [c.row_diff for c in comparisons if c.row_diff]
+    added_rows = sum(row_diff.added_rows for row_diff in row_diffs)
+    removed_rows = sum(row_diff.removed_rows for row_diff in row_diffs)
+    modified_rows = sum(row_diff.modified_rows for row_diff in row_diffs)
 
     lines = [
         COMMENT_MARKER,
@@ -202,6 +631,7 @@ def render_report(
         f"- Modified or renamed parquet files: {len(modified)}",
         f"- Deleted parquet files: {len(deleted)}",
         f"- Legacy `*_perf.txt` files added or modified: {len(legacy_perf_changes)}",
+        f"- Row-level changes: +{added_rows} / -{removed_rows} / ~{modified_rows}",
         "",
     ]
 
@@ -240,17 +670,37 @@ def render_report(
     interesting = [c for c in added + modified + deleted if c not in converted_bad]
     if interesting:
         lines.extend(["### Other Parquet Changes", ""])
-        rows = [["Status", "File", "Base rows", "Head rows", "Content"]]
+        rows = [["Status", "File", "Base rows", "Head rows", "Rows +", "Rows -", "Rows ~", "Details"]]
         for item in interesting[:75]:
-            if item.content_match is None:
-                content = "n/a"
-            else:
-                content = "match" if item.content_match else f"{item.base_hash} -> {item.head_hash}"
-            rows.append([item.status, item.path, item.base_rows, item.head_rows, content])
+            row_diff = item.row_diff
+            if row_diff is None:
+                rows.append([item.status, item.path, item.base_rows, item.head_rows, "n/a", "n/a", "n/a", "n/a"])
+                continue
+            detail_kinds = ", ".join(row_diff.detail_files.keys()) or "none"
+            if row_diff.note:
+                detail_kinds = f"{detail_kinds}; {row_diff.note}"
+            rows.append(
+                [
+                    item.status,
+                    item.path,
+                    item.base_rows,
+                    item.head_rows,
+                    row_diff.added_rows,
+                    row_diff.removed_rows,
+                    row_diff.modified_rows,
+                    detail_kinds,
+                ]
+            )
         lines.extend(_render_table(rows))
         if len(interesting) > 75:
             lines.append(f"\n...and {len(interesting) - 75} more parquet changes.")
         lines.append("")
+        if any(item.row_diff and item.row_diff.detail_files for item in interesting):
+            lines.append(
+                f"Exact row-level CSVs are attached to the workflow artifact under `{DEFAULT_DETAIL_DIR}/` "
+                "with filenames matching `<source>.{added,removed,modified}.csv`."
+            )
+            lines.append("")
 
     if converted and not converted_bad and not legacy_perf_changes:
         lines.append("All detected CSV-to-parquet conversions preserve column names and Arrow table content.")
@@ -278,13 +728,23 @@ def main() -> int:
     parser.add_argument("--head-ref", default="HEAD")
     parser.add_argument("--path-prefix", default=PERF_DATA_PREFIX)
     parser.add_argument("--output", type=Path, default=None)
+    parser.add_argument(
+        "--detail-dir",
+        type=Path,
+        default=None,
+        help="Directory for exact row-level CSV artifacts.",
+    )
     parser.add_argument("--no-strict", action="store_true", help="Do not fail on conversion mismatches.")
     args = parser.parse_args()
 
     entries = _parse_diff(args.base_ref, args.head_ref, args.path_prefix)
     parquet_entries = [entry for entry in entries if entry.path.endswith(".parquet")]
     legacy_perf_changes = find_legacy_perf_changes(entries)
-    comparisons = [_compare(args.base_ref, args.head_ref, entry) for entry in parquet_entries]
+    comparisons = [
+        _compare(args.base_ref, args.head_ref, entry, detail_dir=args.detail_dir) for entry in parquet_entries
+    ]
+    if args.detail_dir:
+        _write_detail_summary(args.detail_dir, comparisons)
     report = render_report(
         base_ref=args.base_ref,
         head_ref=args.head_ref,

--- a/tools/perf_database/parquet_diff.py
+++ b/tools/perf_database/parquet_diff.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+import difflib
 import hashlib
 import io
 import json
@@ -24,6 +25,7 @@ PERF_DATA_PREFIX = "src/aiconfigurator/systems/data"
 COMMENT_MARKER = "<!-- perf-parquet-diff-comment -->"
 LFS_POINTER_PREFIX = b"version https://git-lfs.github.com/spec/v1\n"
 DEFAULT_DETAIL_DIR = "parquet-diff-details"
+FULL_DIFF_SUBDIR = "diffs"
 INLINE_PREVIEW_ROWS = 3
 MAX_INLINE_PREVIEW_CHARS = 45_000
 MEASUREMENT_COLUMNS = frozenset(
@@ -51,6 +53,14 @@ class DiffEntry:
     status: str
     path: str
     old_path: str | None = None
+
+
+@dataclass(frozen=True)
+class FullDiffArtifact:
+    status: str
+    path: str
+    old_path: str | None
+    diff_file: str
 
 
 @dataclass
@@ -289,6 +299,49 @@ def _write_modified_csv(
         writer.writerows(rows)
 
 
+def _ensure_trailing_newline(text: str) -> str:
+    if text and not text.endswith("\n"):
+        return f"{text}\n"
+    return text
+
+
+def _file_text_lines(ref: str, path: str) -> list[str]:
+    data = _read_git_file(ref, path)
+    suffix = Path(path).suffix.lower()
+    if suffix == ".parquet":
+        table = pq.read_table(pa.BufferReader(data))
+        text = _rows_to_csv_text(_row_dicts(table), table.schema.names)
+    else:
+        text = data.decode("utf-8", errors="replace")
+    return _ensure_trailing_newline(text).splitlines()
+
+
+def _render_file_diff(
+    *,
+    status: str,
+    base_path: str | None,
+    head_path: str | None,
+    base_lines: list[str],
+    head_lines: list[str],
+) -> str:
+    fromfile = f"a/{base_path}" if base_path else "/dev/null"
+    tofile = f"b/{head_path}" if head_path else "/dev/null"
+    diff = "\n".join(
+        difflib.unified_diff(
+            base_lines,
+            head_lines,
+            fromfile=fromfile,
+            tofile=tofile,
+            lineterm="",
+        )
+    )
+    if diff:
+        return f"{diff}\n"
+
+    path = head_path or base_path or "unknown"
+    return f"# {status} {path}\n# No content changes after perf text conversion.\n"
+
+
 def _detail_output_path(detail_dir: Path, parquet_path: str, kind: str) -> tuple[Path, str]:
     relative_path = Path(f"{parquet_path}.{kind}.csv")
     return detail_dir / relative_path, relative_path.as_posix()
@@ -322,6 +375,51 @@ def _write_detail_modified_rows(
     output_path, relative_path = _detail_output_path(detail_dir, parquet_path, "modified")
     _write_modified_csv(output_path, modified_rows, key_columns=key_columns, compare_columns=compare_columns)
     return relative_path
+
+
+def _full_diff_output_path(detail_dir: Path, entry: DiffEntry) -> tuple[Path, str]:
+    relative_path = Path(FULL_DIFF_SUBDIR) / f"{entry.path}.diff"
+    return detail_dir / relative_path, relative_path.as_posix()
+
+
+def _write_full_diff_artifacts(
+    *,
+    detail_dir: Path,
+    base_ref: str,
+    head_ref: str,
+    entries: list[DiffEntry],
+) -> list[FullDiffArtifact]:
+    artifacts: list[FullDiffArtifact] = []
+    for entry in entries:
+        base_path = None if entry.status.startswith("A") else entry.old_path or entry.path
+        head_path = None if entry.status.startswith("D") else entry.path
+        if base_path and not _git_file_exists(base_ref, base_path):
+            base_path = None
+        if head_path and not _git_file_exists(head_ref, head_path):
+            head_path = None
+
+        base_lines = _file_text_lines(base_ref, base_path) if base_path else []
+        head_lines = _file_text_lines(head_ref, head_path) if head_path else []
+        output_path, relative_path = _full_diff_output_path(detail_dir, entry)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(
+            _render_file_diff(
+                status=entry.status,
+                base_path=base_path,
+                head_path=head_path,
+                base_lines=base_lines,
+                head_lines=head_lines,
+            )
+        )
+        artifacts.append(
+            FullDiffArtifact(
+                status=entry.status,
+                path=entry.path,
+                old_path=entry.old_path,
+                diff_file=relative_path,
+            )
+        )
+    return artifacts
 
 
 def _has_duplicate_keys(rows: list[dict[str, object]], key_columns: list[str]) -> bool:
@@ -584,7 +682,26 @@ def _diff_snapshots(
     )
 
 
-def _write_detail_summary(detail_dir: Path, comparisons: list[Comparison]) -> None:
+def _write_diff_manifest(detail_dir: Path, full_diff_artifacts: list[FullDiffArtifact]) -> None:
+    rows = [
+        {
+            "status": artifact.status,
+            "file": artifact.path,
+            "old_file": artifact.old_path or "",
+            "full_diff_file": artifact.diff_file,
+        }
+        for artifact in full_diff_artifacts
+    ]
+    if rows:
+        _write_rows_csv(detail_dir / "changed-files.csv", rows, ["status", "file", "old_file", "full_diff_file"])
+
+
+def _write_detail_summary(
+    detail_dir: Path,
+    comparisons: list[Comparison],
+    full_diff_artifacts: list[FullDiffArtifact] | None = None,
+) -> None:
+    full_diff_files = {artifact.path: artifact.diff_file for artifact in full_diff_artifacts or []}
     rows: list[dict[str, object]] = []
     for comparison in comparisons:
         row_diff = comparison.row_diff
@@ -601,6 +718,7 @@ def _write_detail_summary(detail_dir: Path, comparisons: list[Comparison]) -> No
                 "modified_rows": row_diff.modified_rows,
                 "key_columns": ",".join(row_diff.key_columns),
                 "detail_files": ",".join(row_diff.detail_files.values()),
+                "full_diff_file": full_diff_files.get(comparison.path, ""),
                 "note": row_diff.note or "",
             }
         )
@@ -618,6 +736,7 @@ def _write_detail_summary(detail_dir: Path, comparisons: list[Comparison]) -> No
                 "modified_rows",
                 "key_columns",
                 "detail_files",
+                "full_diff_file",
                 "note",
             ],
         )
@@ -731,6 +850,7 @@ def render_report(
     entries: list[DiffEntry],
     comparisons: list[Comparison],
     legacy_perf_changes: list[DiffEntry],
+    full_diff_artifacts: list[FullDiffArtifact] | None = None,
 ) -> str:
     converted = [c for c in comparisons if c.base_path and c.base_path.endswith(".txt")]
     converted_ok = [c for c in converted if c.columns_match and c.content_match]
@@ -759,8 +879,14 @@ def render_report(
         f"- Deleted parquet files: {len(deleted)}",
         f"- Legacy `*_perf.txt` files added or modified: {len(legacy_perf_changes)}",
         f"- Row-level changes: +{added_rows} / -{removed_rows} / ~{modified_rows}",
-        "",
     ]
+    if full_diff_artifacts is not None:
+        diff_artifact_label = "file" if len(full_diff_artifacts) == 1 else "files"
+        lines.append(
+            f"- Full per-file diff artifacts: {len(full_diff_artifacts)} {diff_artifact_label} under "
+            f"`{DEFAULT_DETAIL_DIR}/{FULL_DIFF_SUBDIR}/`"
+        )
+    lines.append("")
 
     if not entries:
         lines.append("No perf data changes found.")
@@ -794,41 +920,18 @@ def render_report(
             lines.append(f"\n...and {len(legacy_perf_changes) - 50} more legacy text perf changes.")
         lines.append("")
 
-    interesting = [c for c in added + modified + deleted if c not in converted_bad]
-    if interesting:
-        lines.extend(["### Other Parquet Changes", ""])
-        rows = [["Status", "File", "Base rows", "Head rows", "Rows +", "Rows -", "Rows ~", "Details"]]
-        for item in interesting[:75]:
-            row_diff = item.row_diff
-            if row_diff is None:
-                rows.append([item.status, item.path, item.base_rows, item.head_rows, "n/a", "n/a", "n/a", "n/a"])
-                continue
-            detail_kinds = ", ".join(row_diff.detail_files.keys()) or "none"
-            if row_diff.note:
-                detail_kinds = f"{detail_kinds}; {row_diff.note}"
-            rows.append(
-                [
-                    item.status,
-                    item.path,
-                    item.base_rows,
-                    item.head_rows,
-                    row_diff.added_rows,
-                    row_diff.removed_rows,
-                    row_diff.modified_rows,
-                    detail_kinds,
-                ]
-            )
-        lines.extend(_render_table(rows))
-        if len(interesting) > 75:
-            lines.append(f"\n...and {len(interesting) - 75} more parquet changes.")
-        lines.append("")
-        if any(item.row_diff and item.row_diff.detail_files for item in interesting):
+    has_row_detail_files = any(c.row_diff and c.row_diff.detail_files for c in comparisons)
+    if full_diff_artifacts is not None or has_row_detail_files:
+        lines.extend(["### Artifact Contents", ""])
+        if full_diff_artifacts is not None:
+            diff_artifact_label = "file" if len(full_diff_artifacts) == 1 else "files"
             lines.append(
-                f"Exact row-level CSVs are attached to the workflow artifact under `{DEFAULT_DETAIL_DIR}/` "
-                "with filenames matching `<source>.{added,removed,modified}.csv`."
+                f"- Full per-file unified diffs: `{DEFAULT_DETAIL_DIR}/{FULL_DIFF_SUBDIR}/` "
+                f"({len(full_diff_artifacts)} {diff_artifact_label})"
             )
-            lines.append("")
-            lines.extend(_render_inline_diff_previews(interesting))
+        if has_row_detail_files:
+            lines.append(f"- Exact row-level CSVs: `{DEFAULT_DETAIL_DIR}/` (listed in `summary.csv`)")
+        lines.append("")
 
     if converted and not converted_bad and not legacy_perf_changes:
         lines.append("All detected CSV-to-parquet conversions preserve column names and Arrow table content.")
@@ -860,7 +963,7 @@ def main() -> int:
         "--detail-dir",
         type=Path,
         default=None,
-        help="Directory for exact row-level CSV artifacts.",
+        help="Directory for full diff and exact row-level CSV artifacts.",
     )
     parser.add_argument("--no-strict", action="store_true", help="Do not fail on conversion mismatches.")
     args = parser.parse_args()
@@ -871,14 +974,23 @@ def main() -> int:
     comparisons = [
         _compare(args.base_ref, args.head_ref, entry, detail_dir=args.detail_dir) for entry in parquet_entries
     ]
+    full_diff_artifacts = None
     if args.detail_dir:
-        _write_detail_summary(args.detail_dir, comparisons)
+        full_diff_artifacts = _write_full_diff_artifacts(
+            detail_dir=args.detail_dir,
+            base_ref=args.base_ref,
+            head_ref=args.head_ref,
+            entries=entries,
+        )
+        _write_diff_manifest(args.detail_dir, full_diff_artifacts)
+        _write_detail_summary(args.detail_dir, comparisons, full_diff_artifacts)
     report = render_report(
         base_ref=args.base_ref,
         head_ref=args.head_ref,
         entries=entries,
         comparisons=comparisons,
         legacy_perf_changes=legacy_perf_changes,
+        full_diff_artifacts=full_diff_artifacts,
     )
 
     if args.output:


### PR DESCRIPTION
## Summary

- generate row-level perf parquet diffs for added, removed, and modified rows
- upload the full review bundle: `comment.md`, `parquet-diff-details/changed-files.csv`, `parquet-diff-details/summary.csv`, exact row CSVs, and full per-file unified diffs under `parquet-diff-details/diffs/`
- keep the PR comment compact with totals, inline row previews, and links into the artifact bundle instead of duplicating the normal PR file diff
- support manual workflow dispatch with explicit base/head refs so the report workflow can be smoke-tested against another PR, such as PR #1114

## Notes

The row matcher treats non-measurement columns as the logical perf key and reports measurement changes as modified rows. When a table has duplicate logical keys, unmatched rows are paired deterministically within each key so repeated perf samples show up as modified rows instead of noisy whole-table remove/add churn.

The report no longer includes the old `Other Parquet Changes` section. Full per-file diffs now live in the uploaded artifact, where reviewers can inspect every changed perf data file without bloating the PR comment.

## Validation

- `uv run pytest tests/unit/tools/test_parquet_diff.py`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `git diff --check`
- CI on `95c396db`: CodeRabbit, DCO, parquet-diff, Ruff, ESLint, copyright, unit, e2e, Cargo Deny, and PR title checks passed; accuracy regression was still running when this description was updated.
- Smoke-tested the generated report against PR #1114 with the manual workflow; artifact bundle: https://github.com/ai-dynamo/aiconfigurator/actions/runs/26847997281/artifacts/7369840583


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Row-level performance diffs with per-file CSV artifacts, truncated inline CSV previews, and aggregated added/removed/modified row totals.

* **CI**
  * Workflows support manual dispatch, fetch base/head refs, and upload both the summary report and detailed row-diff artifacts; PR comments now include links to the artifact bundle.

* **Tests**
  * New unit tests validating row-level diffs, duplicate-key pairing, artifact generation, and report/CSV previews.

* **Documentation**
  * PR-review docs updated with new report arguments and artifact expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->