### PR TITLE
fix: re-clamp extrapolated GEMM and GenerationAttention values to SOL floor

### DIFF
--- a/src/aiconfigurator/sdk/operations/attention.py
+++ b/src/aiconfigurator/sdk/operations/attention.py
@@ -396,6 +396,12 @@ class GenerationAttention(Operation):
 
             cls._correct_sol(database, cls._data_cache[key])
             cls._extrapolate(cls._data_cache[key])
+            # Re-clamp after extrapolation: interpolated/extrapolated grid
+            # points can land below the SOL bound. The legacy init path ran
+            # ``_correct_data()`` a second time which caught these; replicate
+            # that here so standalone ``load_data`` callers get the same
+            # physically-consistent floor.
+            cls._correct_sol(database, cls._data_cache[key])
             cls._record_load()
 
         # Bind instance attr (respect intentional test pre-overrides).

--- a/src/aiconfigurator/sdk/operations/gemm.py
+++ b/src/aiconfigurator/sdk/operations/gemm.py
@@ -141,6 +141,12 @@ class GEMM(Operation):
             # of ``GEMM.load_data`` get the legacy single-pass semantics.
             cls._correct_sol(database, gemm_loaded)
             cls._extrapolate_gemm_data(gemm_loaded)
+            # Re-clamp after extrapolation: interpolated/extrapolated grid
+            # points can land below the SOL bound. The legacy init path ran
+            # ``_correct_data()`` a second time which caught these; replicate
+            # that here so standalone ``load_data`` callers get the same
+            # physically-consistent floor.
+            cls._correct_sol(database, gemm_loaded)
 
             # All three loads + correction + extrapolation succeeded — commit
             # atomically so partially-populated cache state can never be observed.


### PR DESCRIPTION
PR #1155 removed the post-extrapolation _correct_data() call from PerfDatabase.__init__, which left extrapolated GEMM and GenerationAttention grid points below the Speed-of-Light (SOL) bound. This PR restores the second SOL correction pass after extrapolation.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced data validation in attention and matrix multiplication operations to ensure interpolated and extrapolated data points maintain consistency with expected bounds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiconfigurator/pull/1178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->