### PR TITLE
ci: accelerate accuracy regression testing

### DIFF
--- a/tools/accuracy_regression_testing/predict_silicon_sample.py
+++ b/tools/accuracy_regression_testing/predict_silicon_sample.py
@@ -15,11 +15,18 @@ AGG_FIELDS = ("batch_size", *PARALLEL_FIELDS)
 DISAGG_FIELDS = tuple(
     f"{stage}_{field}" for stage in ("prefill", "decode") for field in (*PARALLEL_FIELDS, "batch_size", "num_workers")
 )
+REQUIRED_DISAGG_FIELDS = ("prefill_batch_size", "prefill_num_workers", "decode_batch_size", "decode_num_workers")
+EstimateArgs = dict[str, str | int | None]
+EstimateCacheKey = tuple[tuple[str, str | int | None], ...]
+_ESTIMATE_CACHE: dict[EstimateCacheKey, tuple[float, float] | Exception] = {}
+_MISSING_DATABASE_VERSIONS: set[tuple[str, str, str]] = set()
+_CACHE_HITS = 0
+_CACHE_MISSES = 0
 
 
-def _estimate(row: dict[str, str]) -> tuple[float, float]:
+def _estimate_args(row: dict[str, str]) -> EstimateArgs:
     fields = AGG_FIELDS if row["mode"] == "agg" else DISAGG_FIELDS
-    args = dict(
+    return dict(
         model_path=row["model_path"],
         system_name=row["system"],
         mode=row["mode"],
@@ -32,6 +39,27 @@ def _estimate(row: dict[str, str]) -> tuple[float, float]:
         **{field: int(row[field]) for field in fields if row.get(field)},
     )
 
+
+def _estimate_cache_key(args: EstimateArgs) -> EstimateCacheKey:
+    return tuple(sorted(args.items()))
+
+
+def _run_estimate(args: EstimateArgs, row_id: str) -> tuple[float, float]:
+    if args["mode"] == "disagg":
+        for field in REQUIRED_DISAGG_FIELDS:
+            if args.get(field) is None:
+                raise ValueError(f"{field} is required for disagg mode.")
+
+    database_version = args["backend_version"]
+    if database_version is not None:
+        missing_database_key = (
+            str(args["system_name"]),
+            str(args["backend_name"]),
+            str(database_version),
+        )
+        if missing_database_key in _MISSING_DATABASE_VERSIONS:
+            args["backend_version"] = None
+
     def run_estimate() -> tuple[float, float]:
         with redirect_stdout(sys.stderr):
             result = cli_estimate(**args)
@@ -42,13 +70,41 @@ def _estimate(row: dict[str, str]) -> tuple[float, float]:
     except ValueError as e:
         if args["backend_version"] is None or "Failed to load perf database" not in str(e):
             raise
+        _MISSING_DATABASE_VERSIONS.add(
+            (
+                str(args["system_name"]),
+                str(args["backend_name"]),
+                str(args["backend_version"]),
+            )
+        )
         print(
-            f"{row.get('id', '<unknown>')}: missing database version {args['backend_version']}; "
-            "retrying with AIC default database version",
+            f"{row_id}: missing database version {args['backend_version']}; retrying with AIC default database version",
             file=sys.stderr,
         )
         args["backend_version"] = None
         return run_estimate()
+
+
+def _estimate(row: dict[str, str]) -> tuple[float, float]:
+    global _CACHE_HITS, _CACHE_MISSES
+
+    args = _estimate_args(row)
+    cache_key = _estimate_cache_key(args)
+    cached = _ESTIMATE_CACHE.get(cache_key)
+    if cached is not None:
+        _CACHE_HITS += 1
+        if isinstance(cached, Exception):
+            raise cached
+        return cached
+
+    _CACHE_MISSES += 1
+    try:
+        result = _run_estimate(args, row.get("id", "<unknown>"))
+    except Exception as e:
+        _ESTIMATE_CACHE[cache_key] = e
+        raise
+    _ESTIMATE_CACHE[cache_key] = result
+    return result
 
 
 def main() -> None:
@@ -69,6 +125,7 @@ def main() -> None:
                 print(f"{row.get('id', '<unknown>')}: {e}", file=sys.stderr)
                 row[ttft_col] = row[tpot_col] = ""
             writer.writerow(row)
+    print(f"prediction cache: {_CACHE_HITS} hits, {_CACHE_MISSES} misses", file=sys.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
This PR speeds up the AIC accuracy regression workflow by avoiding repeated estimator work for identical silicon sample configurations.

## Why
The accuracy workflow runs `predict_silicon_sample.py` over the full silicon sample for both the incoming and base revisions. Many rows resolve to the same estimator arguments or the same validation/fallback outcome, so the script was repeatedly paying for duplicate `cli_estimate` calls.

## Changes
- memoize prediction results by exact estimator arguments
- memoize repeated estimator exceptions so duplicate invalid configurations are cheap
- preflight incomplete disaggregated rows before calling `cli_estimate`
- cache missing database-version fallback decisions before retrying with AIC defaults
- emit `prediction cache: <hits> hits, <misses> misses` to stderr for visibility

## Benchmark
Full-sample local benchmark on `src/aiconfigurator/systems/silicon_sample.csv` (5,221 rows), comparing the `origin/main` script against this PR's script on the same machine:

| Script | Time |
| --- | ---: |
| `origin/main` | 446.53s |
| this PR | 382.65s |

That is 63.88s saved per prediction pass, a 14.3% wall-clock reduction (1.17x faster). The accuracy workflow runs both new and old prediction passes, so the expected workflow-level savings is roughly 2m08s per run on this machine.

The PR script reported `prediction cache: 1816 hits, 3405 misses`, reducing `cli_estimate` calls by 34.8% per pass. The benchmark CSV output matched the `origin/main` output.

## Validation
- `uv run --extra dev ruff check tools/accuracy_regression_testing/predict_silicon_sample.py`
- `uv run --extra dev ruff format --check tools/accuracy_regression_testing/predict_silicon_sample.py`
- `uv run python -m py_compile tools/accuracy_regression_testing/predict_silicon_sample.py`
- GitHub Actions are green on this PR, including AIC Accuracy Regression Testing