### PR TITLE
feat(rust): estimate_kv_cache KV-cache memory API

### DIFF
--- a/rust/aiconfigurator-core/docs/phase-1.5-capacity-followup.md
+++ b/rust/aiconfigurator-core/docs/phase-1.5-capacity-followup.md
@@ -1,0 +1,86 @@
+# Phase 1.5 Capacity API — deferred Dynamo wrapper (follow-up)
+
+**Status:** the in-repo surface is complete (K1–K3). The Dynamo-side rewrite is
+a separate, downstream PR in the `ai-dynamo/dynamo` repo and is intentionally
+NOT done here.
+
+## What landed in-repo (K1–K3)
+
+The KV-cache capacity API (Issue
+[#1159](https://github.com/ai-dynamo/aiconfigurator/issues/1159)) is fully
+implemented inside `aiconfigurator`:
+
+- **Python source of truth** `aiconfigurator.sdk.memory.estimate_kv_cache(...)`
+  — `src/aiconfigurator/sdk/memory.py`. Owns the COMPLETE estimate: fraction +
+  tolerance validation, the native `BaseBackend._get_memory_usage` breakdown
+  path, the naive HF-config fallback, AND the `tolerance_adjusted` margin. Flat
+  kwargs in, a `dict` out (`total_*`, `source`, `memory_breakdown`,
+  `tolerance_adjusted`).
+- **Rust top-level fn** `aiconfigurator_core::estimate_kv_cache(req)` —
+  `rust/aiconfigurator-core/src/memory.rs`. A **pure** PyO3 forwarder for
+  embedded callers (the Dynamo Mocker): it crosses into Python once to call the
+  function above (forwarding `tolerance_fraction`) and rebuilds a
+  `KvCacheEstimate` from the returned dict, with no math of its own. It is NOT
+  exposed as a `#[pyfunction]` — there is no `aiconfigurator_core.estimate_kv_cache`
+  Python surface; in-repo Python callers use the `sdk.memory` function directly.
+- **AIC-Python convenience** `aiconfigurator.sdk.memory.estimate_num_gpu_blocks(
+  ..., scheduler_block_size)` — calls `estimate_kv_cache` directly (in-process,
+  no Rust hop) and returns `floor(total_kv_size_tokens / scheduler_block_size)`,
+  using the tolerance-adjusted token count when `tolerance_fraction` is set, else
+  the raw count. This is the in-repo reference for the conversion the Dynamo shim
+  will mirror, and it is exercised end-to-end against a real perf DB by the
+  integration test (`tests/integration/test_memory_estimation.py`).
+
+### Coverage
+
+- **Python estimate** (logic, incl. the tolerance math that moved out of Rust):
+  `tests/unit/sdk/test_memory_estimation.py` (synthetic breakdowns + naive
+  fallback) and the native path end-to-end in
+  `tests/integration/test_memory_estimation.py` (real perf DB). Neither is a
+  Python-vs-Rust parity test -- there is no independent Rust implementation, since
+  the Rust `estimate_kv_cache` forwards to this same Python code.
+- **Rust forwarder round-trip** (`fetch_python_estimate` forwarding
+  `tolerance_fraction` -> `estimate_from_dict` parsing `tolerance_adjusted` back):
+  `rust/aiconfigurator-core/tests/memory_round_trip.rs`, an enforced end-to-end
+  test against a real perf DB. The Python emit side and the Rust parse side share
+  the same dict keys (`tolerance_fraction` / `total_kv_size_bytes` /
+  `total_kv_size_tokens`), so a drift on either end fails this test.
+
+### Deferred: share the budget formula with the OOM check ([#1208])
+
+`sdk/memory.py` exposes `kv_cache_budget_bytes(...)` as the single KV-cache budget
+formula (used by `estimate_kv_cache`). `InferenceSummary._check_and_set_kv_cache_oom`
+in the config sweep still carries its own copy of the same math. Wiring the OOM
+check onto `kv_cache_budget_bytes` (and reconciling the `reserved`/tolerance
+handling) is tracked in [#1208] — kept out of this PR so the sweep's OOM path is
+not perturbed by the Mocker-facing capacity work.
+
+[#1208]: https://github.com/ai-dynamo/aiconfigurator/issues/1208
+
+## The deferred Dynamo wrapper (downstream PR, NOT in this repo)
+
+Dynamo's `dynamo._internal.aic.estimate_num_gpu_blocks(...)` (today: Python
+`backend._get_memory_usage` + a per-backend KV-budget formula) should be
+rewritten as a thin wrapper that:
+
+1. Calls the estimate — for the fully Rust-embedded Mocker path, the top-level
+   Rust `aiconfigurator_core::estimate_kv_cache(req)` (one PyO3 hop into the
+   Python source of truth); a pure-Python caller calls
+   `aiconfigurator.sdk.memory.estimate_kv_cache(...)` directly. (There is no
+   `aiconfigurator_core.estimate_kv_cache` `#[pyfunction]` — it was removed as a
+   redundant surface.)
+2. Applies `num_gpu_blocks_per_rank = floor(total_kv_size_tokens /
+   scheduler_block_size)` locally — exactly what
+   `aiconfigurator.sdk.memory.estimate_num_gpu_blocks` does in-repo.
+
+This change lives in `ai-dynamo/dynamo`
+(`lib/bindings/python/src/dynamo/_internal/aic.py` and/or
+`lib/bindings/python/rust/llm/aic_callback.rs`) and is out of scope for the
+`aiconfigurator` repo. The `estimate_num_gpu_blocks` signature on the Dynamo
+side stays frozen (see the "AIC ↔ Dynamo Mocker handshake" section of
+`phase-1.5-execution-plan.md`, surface **H3**); only its body is replaced.
+
+**The in-repo surface is ready for it:** the Rust `estimate_kv_cache(req)`
+forwarder (for the embedded Mocker) plus the AIC `estimate_num_gpu_blocks` helper
+give the downstream PR both a callable entry point and a reference implementation
+of the floor conversion to match.

--- a/rust/aiconfigurator-core/docs/phase-1.5-execution-plan.md
+++ b/rust/aiconfigurator-core/docs/phase-1.5-execution-plan.md
@@ -589,8 +589,28 @@ let num_gpu_blocks_per_rank = estimate.total_kv_size_tokens / scheduler_block_si
 ```
 
 `dynamo._internal.aic.estimate_num_gpu_blocks()` becomes a thin
-Python wrapper that calls `estimate_kv_cache` via PyO3 and applies
-the same conversion.
+Python wrapper that calls `estimate_kv_cache` and applies the same
+conversion. **As of K3 that Dynamo-side rewrite is a DEFERRED
+downstream PR in the `ai-dynamo/dynamo` repo** (it is NOT done in
+`aiconfigurator`). K3 ships the in-repo surface it consumes: the Rust
+`aiconfigurator_core::estimate_kv_cache(req)` forwarder (for the
+embedded Mocker) plus the AIC-side reference
+`aiconfigurator.sdk.memory.estimate_num_gpu_blocks` helper (the same
+`floor(tokens / scheduler_block_size)` conversion). See
+`phase-1.5-capacity-followup.md`.
+
+> **Post-K3 design change.** The capacity API moved out of `sdk/engine.py` into
+> a dedicated `sdk/memory.py`. The redundant Python-callable
+> `aiconfigurator_core.estimate_kv_cache` `#[pyfunction]` was dropped, and the
+> tolerance validation + `tolerance_adjusted` margin moved out of Rust into the
+> Python `sdk.memory.estimate_kv_cache` (the single source of truth). The Rust
+> `estimate_kv_cache(req)` is now a pure forwarder; `estimate_num_gpu_blocks`
+> calls the Python estimate directly (no Rust hop). The naive fallback reuses the
+> SDK's existing HF-config loaders + `_parse_hf_config_json` (with a raw-key read
+> for unsupported architectures) and its reservation fraction is a caller arg
+> (`naive_kv_reservation`, default 0.80). The illustrative Rust snippet above uses
+> the raw token count; a tolerance-aware Mocker reads
+> `tolerance_adjusted.total_kv_size_tokens` when a tolerance is set.
 
 ## The crux: OpSpec wire format
 
@@ -656,7 +676,7 @@ audit table that gates E1.
 | **E8** | Perf gate | Benchmark `engine.run_static` / `engine.run_agg` against Phase 1's ctypes path on the smoke set. Exit criterion: **≥3× p50 speedup** on small-graph families that today regress below 1× (MiniMax-M2.5 gen, NemotronNas gen, DSv3.2 ctx) by eliminating the per-call Python op-walking. Big-graph families stay at or above Phase 1 speedup. Numbers land in `parity_tests/benchmarks.md`. | **GATE** |
 | **K1** | `estimate_kv_cache` native path | Top-level Rust function in `src/capacity.rs`. **PyO3 → Python `BaseBackend._get_memory_usage`** for the breakdown, then Rust math. Returns `KvCacheEstimate` with `EstimateSource::Native` and a populated `MemoryBreakdown`. Validates `KvCacheMemoryFraction` against `engine.backend` (TRT-LLM ↔ `OfFree`; vLLM / SGLang ↔ `OfTotal`). | unit |
 | **K2** | `estimate_kv_cache` naive fallback | **Pure Rust** — no PyO3 hop. HF-config parsing for KV bytes per token (MLA-aware via `kv_lora_rank + qk_rope_head_dim`), 80%-of-post-weight reservation, `allow_hf_config_download` honoured. Returns `EstimateSource::NaiveFallback` with `memory_breakdown: None`. | unit |
-| **K3** | Tolerance + Dynamo replacement | `tolerance_adjusted` field populated when `tolerance_fraction` is set. Rewrite `dynamo._internal.aic.estimate_num_gpu_blocks` as a thin PyO3 wrapper that calls `estimate_kv_cache` and applies `floor(total_kv_size_tokens / scheduler_block_size)` locally. | integration |
+| **K3** | Tolerance + capacity surface | `tolerance_adjusted` field populated when `tolerance_fraction` is set (native AND naive; `BadConfig` if `t ∉ [0,1)`). Tolerance validation and margin handling live in Python `aiconfigurator.sdk.memory.estimate_kv_cache` (the single source of truth); Rust `aiconfigurator_core::estimate_kv_cache` is a pure forwarder with no math of its own (the earlier `#[pyfunction]` re-export was dropped as redundant — see the "Post-K3 design change" note above). Add the AIC-side reference `aiconfigurator.sdk.memory.estimate_num_gpu_blocks` helper (`floor(total_kv_size_tokens / scheduler_block_size)`). The Dynamo-side rewrite of `dynamo._internal.aic.estimate_num_gpu_blocks` into a thin wrapper over this surface is a **DEFERRED downstream PR** in `ai-dynamo/dynamo` (out of scope here); documented in `phase-1.5-capacity-followup.md`. | integration |
 
 ## Commit dependencies
 

--- a/rust/aiconfigurator-core/src/lib.rs
+++ b/rust/aiconfigurator-core/src/lib.rs
@@ -23,6 +23,7 @@ mod common;
 mod config;
 pub mod engine;
 mod fpm;
+pub mod memory;
 mod operators;
 mod perf_database;
 mod session;
@@ -43,6 +44,13 @@ pub use fpm::{
 // `engine/runtime.rs`) keep resolving after the types moved into `fpm`.
 pub(crate) use fpm::validate_forward_pass_metrics;
 pub use fpm::{ForwardPassMetrics, QueuedRequestMetrics, ScheduledRequestMetrics, FPM_VERSION};
+// KV-cache memory API. Top-level surface, not a method on
+// `AicEngine`: estimation runs once at startup, separate from the latency path.
+pub use memory::{
+    estimate_kv_cache, EstimateSource, KvCacheEstimate, KvCacheEstimateAdjusted,
+    KvCacheEstimateError, KvCacheEstimateOptions, KvCacheEstimateRequest, KvCacheMemoryFraction,
+    MemoryBreakdown,
+};
 // PyO3 bindings. `AicEngine` is the Python -> Rust hot-path pyclass;
 // `build_aic_engine` is the Rust -> Python -> Rust embedded build entry point
 // for callers in OTHER crates (the Dynamo Mocker,

--- a/rust/aiconfigurator-core/src/memory.rs
+++ b/rust/aiconfigurator-core/src/memory.rs
@@ -1,0 +1,436 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! KV-cache memory estimation.
+//!
+//! [`estimate_kv_cache`] is a top-level crate function (NOT a method on
+//! `AicEngine`): estimation runs once at startup, uses overlapping but not
+//! identical inputs to `build_aic_engine`, and is a separate concern from
+//! latency prediction. The Dynamo Mocker is the primary external consumer; it
+//! calls this once and derives `num_gpu_blocks_per_rank` from
+//! `total_kv_size_tokens`.
+//!
+//! ## Rust is a pure forwarder; the estimate is computed in Python
+//!
+//! This mirrors how `build_aic_engine` forwards to the Python `compile_engine`:
+//! ALL of the work -- fraction + tolerance validation, HF-config parsing, the
+//! AIC backend memory model, the OfFree/OfTotal budget math, the naive heuristic
+//! fallback, AND the tolerance margin -- lives in
+//! `aiconfigurator.sdk.memory.estimate_kv_cache`. The Rust side:
+//!
+//! 1. crosses into Python once (`with_gil → import → call estimate_kv_cache →
+//!    extract dict`), forwarding `tolerance_fraction` through;
+//! 2. rebuilds a [`KvCacheEstimate`] from that dict (including
+//!    `tolerance_adjusted`), with no math of its own.
+//!
+//! The two budget formulas (TRT-LLM free-fraction vs vLLM/SGLang total-fraction),
+//! the naive fallback, and the tolerance margin all live on the Python side; see
+//! the docstring of `aiconfigurator.sdk.memory.estimate_kv_cache`. The
+//! [`KvCacheMemoryFraction`] enum still encodes the backend↔fraction XOR so the
+//! request shape is unambiguous; the variant is validated against
+//! `engine.backend` in Python.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{BackendKind, EngineConfig};
+
+/// KV-cache memory request. `engine` reuses the modularised [`EngineConfig`];
+/// the remaining fields describe the runtime sizing budget.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct KvCacheEstimateRequest {
+    pub engine: EngineConfig,
+    pub max_num_tokens: u32,
+    pub max_batch_size: u32,
+    pub kv_cache_memory_fraction: KvCacheMemoryFraction,
+    /// Override for unknown SKUs; when `Some`, it wins over the SystemSpec
+    /// capacity reported by the native path.
+    pub gpu_memory_capacity_bytes_override: Option<u64>,
+    /// `None` = raw estimate only; `Some(0.05)` = 5% safety margin.
+    pub tolerance_fraction: Option<f64>,
+    pub options: KvCacheEstimateOptions,
+}
+
+/// Backend-tagged memory fraction. The variant encodes the XOR between
+/// TRT-LLM's free-fraction and vLLM/SGLang's total-fraction semantics; the
+/// Python `estimate_kv_cache` validates it against `engine.backend` and returns
+/// an error (mapped to [`KvCacheEstimateError::IncompatibleMemoryFraction`]) if
+/// mismatched.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
+pub enum KvCacheMemoryFraction {
+    /// Fraction of TOTAL GPU memory. Compatible with vLLM
+    /// (`gpu_memory_utilization`) and SGLang (`mem_fraction_static`).
+    OfTotal(f64),
+    /// Fraction of FREE (post-non-KV) GPU memory. Compatible with TRT-LLM
+    /// (`free_gpu_memory_fraction`).
+    OfFree(f64),
+}
+
+impl KvCacheMemoryFraction {
+    /// `(kind, value)` pair for the flat Python call. `kind` is the wire string
+    /// the Python `estimate_kv_cache` expects (`"of_total"` / `"of_free"`).
+    fn to_wire(self) -> (&'static str, f64) {
+        match self {
+            Self::OfTotal(f) => ("of_total", f),
+            Self::OfFree(f) => ("of_free", f),
+        }
+    }
+}
+
+/// Default for [`KvCacheEstimateOptions::naive_kv_reservation`] so a JSON request
+/// from an embedded caller (the Mocker) that omits this newer field still
+/// deserializes (to the same 0.80 the Python side defaults to).
+fn default_naive_kv_reservation() -> f64 {
+    0.80
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
+pub struct KvCacheEstimateOptions {
+    pub allow_naive_fallback: bool,
+    pub allow_hf_config_download: bool,
+    /// Fraction of post-weight memory the naive fallback reserves for KV
+    /// (default `0.80`). Ignored on the native path. Exposed so the Mocker can
+    /// tune the crude fallback budget.
+    #[serde(default = "default_naive_kv_reservation")]
+    pub naive_kv_reservation: f64,
+}
+
+/// KV-cache memory estimate.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct KvCacheEstimate {
+    pub total_gpu_capacity_bytes: u64,
+    pub total_kv_size_bytes: u64,
+    pub kv_size_per_token_bytes: u64,
+    pub total_kv_size_tokens: u64,
+    pub source: EstimateSource,
+    /// `Some` on the native path; `None` on the naive fallback.
+    pub memory_breakdown: Option<MemoryBreakdown>,
+    /// `Some` iff `tolerance_fraction` set; `None` for the raw estimate.
+    pub tolerance_adjusted: Option<KvCacheEstimateAdjusted>,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum EstimateSource {
+    /// AIC's full backend memory model used.
+    Native,
+    /// Post-weight reservation heuristic (`naive_kv_reservation`, default 80%).
+    NaiveFallback,
+}
+
+/// Non-KV memory components, in bytes. Maps AIC's `_get_memory_usage` dict:
+/// `weights → weights`, `activations → activations`, `others →
+/// runtime_overhead`, `nccl → comm_overhead`.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MemoryBreakdown {
+    pub weights_bytes: u64,
+    pub activations_bytes: u64,
+    pub runtime_overhead_bytes: u64,
+    pub comm_overhead_bytes: u64,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
+pub struct KvCacheEstimateAdjusted {
+    pub tolerance_fraction: f64,
+    pub total_kv_size_bytes: u64,
+    pub total_kv_size_tokens: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum KvCacheEstimateError {
+    Unsupported {
+        model: String,
+        backend: BackendKind,
+        gpu_sku: String,
+        reason: String,
+    },
+    InsufficientModelMetadata {
+        missing_fields: Vec<String>,
+    },
+    NoKvBudget {
+        total_gpu_capacity_bytes: u64,
+        non_kv_bytes: u64,
+    },
+    IncompatibleMemoryFraction {
+        backend: BackendKind,
+        variant_kind: &'static str,
+    },
+    BadConfig {
+        field: String,
+        reason: String,
+    },
+    HfConfigFetchFailed {
+        hf_id: String,
+        source: String,
+    },
+}
+
+impl std::fmt::Display for KvCacheEstimateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unsupported {
+                model,
+                backend,
+                gpu_sku,
+                reason,
+            } => write!(
+                f,
+                "unsupported model/backend/GPU for KV-cache estimation: model={model}, \
+                 backend={backend:?}, gpu_sku={gpu_sku}: {reason}"
+            ),
+            Self::InsufficientModelMetadata { missing_fields } => {
+                write!(
+                    f,
+                    "insufficient model metadata; missing: {missing_fields:?}"
+                )
+            }
+            Self::NoKvBudget {
+                total_gpu_capacity_bytes,
+                non_kv_bytes,
+            } => write!(
+                f,
+                "no KV budget: non-KV memory ({non_kv_bytes} bytes) meets/exceeds the \
+                 KV-cache memory limit (capacity={total_gpu_capacity_bytes} bytes)"
+            ),
+            Self::IncompatibleMemoryFraction {
+                backend,
+                variant_kind,
+            } => write!(
+                f,
+                "incompatible memory fraction: backend {backend:?} does not accept \
+                 KvCacheMemoryFraction::{variant_kind}"
+            ),
+            Self::BadConfig { field, reason } => {
+                write!(f, "bad memory config field {field:?}: {reason}")
+            }
+            Self::HfConfigFetchFailed { hf_id, source } => {
+                write!(f, "HF config fetch failed for {hf_id:?}: {source}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for KvCacheEstimateError {}
+
+/// Estimate KV-cache memory (raw estimate + optional tolerance margin).
+///
+/// Pure forwarder: crosses into Python once to compute the COMPLETE estimate. The
+/// Python `aiconfigurator.sdk.memory.estimate_kv_cache` does the backend↔fraction
+/// and tolerance validation, the native AIC memory breakdown + budget math, the
+/// naive heuristic fallback, AND the tolerance margin (`tolerance_adjusted`); the
+/// Rust side rebuilds a [`KvCacheEstimate`] from the returned dict with no math
+/// of its own.
+///
+/// Errors from the Python side (unsupported model/backend, incompatible memory
+/// fraction, out-of-range tolerance, no KV budget, HF config fetch failure) cross
+/// the PyO3 boundary as a `ValueError` whose message carries the failure detail
+/// and are surfaced here as [`KvCacheEstimateError::Unsupported`] with that
+/// message.
+pub fn estimate_kv_cache(
+    req: KvCacheEstimateRequest,
+) -> Result<KvCacheEstimate, KvCacheEstimateError> {
+    fetch_python_estimate(&req)
+}
+
+/// Cross into Python once to compute the complete estimate.
+///
+/// Mirrors the `build_aic_engine` → `compile_engine` forwarder shape: `with_gil
+/// → import aiconfigurator.sdk.memory → call estimate_kv_cache(...) → extract
+/// the returned dict`. `tolerance_fraction` is forwarded; the Python fn applies
+/// the tolerance and returns `tolerance_adjusted` in the dict.
+fn fetch_python_estimate(
+    req: &KvCacheEstimateRequest,
+) -> Result<KvCacheEstimate, KvCacheEstimateError> {
+    use pyo3::prelude::*;
+    use pyo3::types::PyDict;
+
+    let engine = &req.engine;
+    let parallel = &engine.parallel;
+    let quant = &engine.quantization;
+    let nextn = engine
+        .speculative
+        .as_ref()
+        .and_then(|s| s.nextn)
+        .unwrap_or(0);
+    let nextn_accept_rates = engine
+        .speculative
+        .as_ref()
+        .and_then(|s| s.nextn_accept_rates.clone());
+    let (fraction_kind, fraction_value) = req.kv_cache_memory_fraction.to_wire();
+
+    Python::with_gil(|py| -> PyResult<KvCacheEstimate> {
+        let engine_mod = py.import("aiconfigurator.sdk.memory")?;
+        let kwargs = PyDict::new(py);
+        kwargs.set_item("backend_version", engine.backend_version.as_deref())?;
+        kwargs.set_item("max_num_tokens", req.max_num_tokens)?;
+        kwargs.set_item("max_batch_size", req.max_batch_size)?;
+        kwargs.set_item("memory_fraction_kind", fraction_kind)?;
+        kwargs.set_item("memory_fraction_value", fraction_value)?;
+        kwargs.set_item("tp_size", parallel.tp_size)?;
+        kwargs.set_item("pp_size", parallel.pp_size)?;
+        kwargs.set_item("attention_dp_size", parallel.attention_dp_size.unwrap_or(1))?;
+        kwargs.set_item("moe_tp_size", parallel.moe_tp_size)?;
+        kwargs.set_item("moe_ep_size", parallel.moe_ep_size)?;
+        kwargs.set_item(
+            "gemm_quant_mode",
+            quant.weight_dtype.as_ref().map(dtype_str),
+        )?;
+        kwargs.set_item("moe_quant_mode", quant.moe_dtype.as_ref().map(dtype_str))?;
+        kwargs.set_item(
+            "kvcache_quant_mode",
+            quant.kv_cache_dtype.as_ref().map(dtype_str),
+        )?;
+        kwargs.set_item(
+            "fmha_quant_mode",
+            quant.activation_dtype.as_ref().map(dtype_str),
+        )?;
+        // `comm_quant_mode` is intentionally NOT forwarded: the comm/NCCL
+        // overhead comes from `system_spec` (`nccl_mem` / `other_mem`), not the
+        // comm quant mode, so it does not affect the non-KV breakdown.
+        kwargs.set_item("nextn", nextn)?;
+        kwargs.set_item("nextn_accept_rates", nextn_accept_rates)?;
+        kwargs.set_item(
+            "systems_path",
+            engine.systems_path.as_deref().and_then(|p| p.to_str()),
+        )?;
+        kwargs.set_item(
+            "gpu_memory_capacity_bytes_override",
+            req.gpu_memory_capacity_bytes_override,
+        )?;
+        kwargs.set_item("tolerance_fraction", req.tolerance_fraction)?;
+        kwargs.set_item("naive_kv_reservation", req.options.naive_kv_reservation)?;
+        kwargs.set_item("allow_naive_fallback", req.options.allow_naive_fallback)?;
+        kwargs.set_item(
+            "allow_hf_config_download",
+            req.options.allow_hf_config_download,
+        )?;
+
+        let out = engine_mod.call_method(
+            "estimate_kv_cache",
+            (
+                engine.model_name.as_str(),
+                engine.system_name.as_str(),
+                engine.backend.as_str(),
+            ),
+            Some(&kwargs),
+        )?;
+
+        estimate_from_dict(&out)
+    })
+    // PyErr → KvCacheEstimateError inline (keeps the error enum self-contained).
+    // The Python side raises a ValueError whose message already carries the
+    // specific failure detail; surface it as Unsupported so the (deferred)
+    // Mocker fallback decision still keys on the same variant it did before.
+    .map_err(|e| KvCacheEstimateError::Unsupported {
+        model: engine.model_name.clone(),
+        backend: engine.backend.clone(),
+        gpu_sku: engine.system_name.clone(),
+        reason: format!("estimate_kv_cache: {e}"),
+    })
+}
+
+/// Rebuild a [`KvCacheEstimate`] from the Python `estimate_kv_cache` dict.
+/// The dict carries every struct field (`total_*`, `kv_size_per_token_bytes`,
+/// `source`, `memory_breakdown`, and `tolerance_adjusted`); the Python fn applies
+/// the tolerance, so `tolerance_adjusted` is a nested dict iff
+/// `tolerance_fraction` was set, `None` otherwise.
+fn estimate_from_dict(
+    out: &pyo3::Bound<'_, pyo3::types::PyAny>,
+) -> pyo3::PyResult<KvCacheEstimate> {
+    use pyo3::exceptions::PyValueError;
+    use pyo3::types::PyAnyMethods;
+
+    let u64_at = |k: &str| -> pyo3::PyResult<u64> { out.get_item(k)?.extract::<u64>() };
+
+    let source = match out.get_item("source")?.extract::<String>()?.as_str() {
+        "native" => EstimateSource::Native,
+        "naive_fallback" => EstimateSource::NaiveFallback,
+        other => {
+            return Err(PyValueError::new_err(format!(
+                "estimate_kv_cache returned unknown source {other:?}"
+            )))
+        }
+    };
+
+    let breakdown_item = out.get_item("memory_breakdown")?;
+    let memory_breakdown = if breakdown_item.is_none() {
+        None
+    } else {
+        let get = |k: &str| -> pyo3::PyResult<u64> { breakdown_item.get_item(k)?.extract::<u64>() };
+        Some(MemoryBreakdown {
+            weights_bytes: get("weights_bytes")?,
+            activations_bytes: get("activations_bytes")?,
+            runtime_overhead_bytes: get("runtime_overhead_bytes")?,
+            comm_overhead_bytes: get("comm_overhead_bytes")?,
+        })
+    };
+
+    // The Python fn applies the tolerance, so `tolerance_adjusted` is a nested
+    // dict iff `tolerance_fraction` was set (keys mirror the Python emit side:
+    // `tolerance_fraction` / `total_kv_size_bytes` / `total_kv_size_tokens`).
+    let adjusted_item = out.get_item("tolerance_adjusted")?;
+    let tolerance_adjusted = if adjusted_item.is_none() {
+        None
+    } else {
+        Some(KvCacheEstimateAdjusted {
+            tolerance_fraction: adjusted_item.get_item("tolerance_fraction")?.extract::<f64>()?,
+            total_kv_size_bytes: adjusted_item.get_item("total_kv_size_bytes")?.extract::<u64>()?,
+            total_kv_size_tokens: adjusted_item.get_item("total_kv_size_tokens")?.extract::<u64>()?,
+        })
+    };
+
+    Ok(KvCacheEstimate {
+        total_gpu_capacity_bytes: u64_at("total_gpu_capacity_bytes")?,
+        total_kv_size_bytes: u64_at("total_kv_size_bytes")?,
+        kv_size_per_token_bytes: u64_at("kv_size_per_token_bytes")?,
+        total_kv_size_tokens: u64_at("total_kv_size_tokens")?,
+        source,
+        memory_breakdown,
+        tolerance_adjusted,
+    })
+}
+
+/// Map a [`crate::DataType`] to the snake_case quant-mode string the Python
+/// `_build_model_config` accepts (the serde `rename` already produces these).
+fn dtype_str(dt: &crate::DataType) -> &'static str {
+    use crate::DataType::*;
+    match dt {
+        Bfloat16 => "bfloat16",
+        Float16 => "float16",
+        Fp8 => "fp8",
+        Fp8Static => "fp8_static",
+        Fp8Block => "fp8_block",
+        Nvfp4 => "nvfp4",
+        Int8 => "int8",
+        Int4 => "int4",
+        W4afp8 => "w4afp8",
+        W4a16Mxfp4 => "w4a16_mxfp4",
+        W4a8Mxfp4Mxfp8 => "w4a8_mxfp4_mxfp8",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Tolerance validation + application and the native/naive budget math now
+    // live entirely in Python (`aiconfigurator.sdk.memory.estimate_kv_cache`),
+    // exercised by `tests/unit/sdk/test_memory_estimation.py` and the integration
+    // parity test. The Rust side is a pure forwarder; the only pure-Rust unit
+    // left here is the memory-fraction wire mapping. The dict round-trip
+    // (`fetch_python_estimate` → `estimate_from_dict`, including the
+    // `tolerance_adjusted` parse) is covered end-to-end by the Mocker consumer;
+    // see `docs/phase-1.5-capacity-followup.md` for that coverage note.
+
+    /// The memory fraction must cross to Python as the wire `(kind, value)` pair
+    /// the Python `estimate_kv_cache` expects.
+    #[test]
+    fn memory_fraction_to_wire() {
+        assert_eq!(
+            KvCacheMemoryFraction::OfFree(0.9).to_wire(),
+            ("of_free", 0.9)
+        );
+        assert_eq!(
+            KvCacheMemoryFraction::OfTotal(0.85).to_wire(),
+            ("of_total", 0.85)
+        );
+    }
+}

--- a/rust/aiconfigurator-core/src/py.rs
+++ b/rust/aiconfigurator-core/src/py.rs
@@ -32,7 +32,9 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
 use crate::common::error::AicError;
-use crate::engine::runtime::{Engine, RuntimeConfig, StaticMode, StaticResult, DEFAULT_STATIC_STRIDE};
+use crate::engine::runtime::{
+    Engine, RuntimeConfig, StaticMode, StaticResult, DEFAULT_STATIC_STRIDE,
+};
 use crate::{DataType, EngineConfig, ENGINE_CONFIG_SCHEMA_VERSION};
 
 /// Trivial smoke export: returns the engine-config schema version so callers
@@ -201,7 +203,13 @@ impl AicEngine {
     /// `mode=Context` (osl is irrelevant for the context phase, so it is fixed
     /// at 1). Returns the total ms (== context_ms in this mode).
     #[pyo3(signature = (bs, isl, prefix=0))]
-    fn predict_prefill_latency(&self, py: Python<'_>, bs: u32, isl: u32, prefix: u32) -> PyResult<f64> {
+    fn predict_prefill_latency(
+        &self,
+        py: Python<'_>,
+        bs: u32,
+        isl: u32,
+        prefix: u32,
+    ) -> PyResult<f64> {
         py.allow_threads(|| self.inner.predict_prefill_latency(bs, isl, prefix))
             .map_err(aic_to_py)
     }
@@ -229,8 +237,11 @@ impl AicEngine {
         osl: u32,
         prefix: u32,
     ) -> PyResult<f64> {
-        py.allow_threads(|| self.inner.mixed_step_latency(ctx_tokens, gen_tokens, isl, osl, prefix))
-            .map_err(aic_to_py)
+        py.allow_threads(|| {
+            self.inner
+                .mixed_step_latency(ctx_tokens, gen_tokens, isl, osl, prefix)
+        })
+        .map_err(aic_to_py)
     }
 
     /// One generation-only engine-step latency in ms. Binds
@@ -373,7 +384,11 @@ fn compile_engine_from_flat(
         kwargs.set_item("kv_block_size", kv_block_size)?;
         kwargs.set_item("systems_path", systems_path)?;
         engine_mod
-            .call_method("compile_engine", (model_path, system, backend), Some(&kwargs))?
+            .call_method(
+                "compile_engine",
+                (model_path, system, backend),
+                Some(&kwargs),
+            )?
             .extract::<Vec<u8>>()
     })
     // PyErr → AicError inline (keeps error.rs pyo3-free). A `compile_engine`
@@ -553,8 +568,7 @@ impl PyForwardPassPerfModel {
         let config: EngineConfig = serde_json::from_str(config_json)
             .map_err(|e| PyValueError::new_err(format!("invalid engine config JSON: {e}")))?;
         let options = parse_fpm_options(options_json)?;
-        let inner =
-            crate::ForwardPassPerfModel::from_native(config, options).map_err(aic_to_py)?;
+        let inner = crate::ForwardPassPerfModel::from_native(config, options).map_err(aic_to_py)?;
         Ok(Self { inner })
     }
 
@@ -657,9 +671,7 @@ mod tests {
     use crate::common::enums::{FmhaQuantMode, GemmQuantMode, KvCacheQuantMode};
     use crate::engine::spec::EngineSpec;
     use crate::operators::op::Op;
-    use crate::operators::{
-        ContextAttentionOp, ElementwiseOp, GemmOp, GenerationAttentionOp,
-    };
+    use crate::operators::{ContextAttentionOp, ElementwiseOp, GemmOp, GenerationAttentionOp};
     use crate::{BackendKind, EngineConfig, ParallelMapping, QuantizationConfig};
 
     fn systems_root() -> PathBuf {
@@ -783,7 +795,18 @@ mod tests {
             .unwrap();
         // Positional order: (bs, beam, isl, osl, prefix, seq_corr, gen_seq_corr, mode, stride).
         let (ctx, gen, total) = Python::with_gil(|py| {
-            aic.run_static(py, 1, 1, 1024, 8, 0, 1.0, 1.0, "static", DEFAULT_STATIC_STRIDE)
+            aic.run_static(
+                py,
+                1,
+                1,
+                1024,
+                8,
+                0,
+                1.0,
+                1.0,
+                "static",
+                DEFAULT_STATIC_STRIDE,
+            )
         })
         .unwrap();
         assert!((ctx - raw_static.context_ms).abs() < 1e-12);
@@ -836,12 +859,14 @@ mod tests {
 
         // Positional order: (bs, beam, isl, osl, prefix, seq_corr, gen_seq_corr, mode, stride).
         Python::with_gil(|py| {
-            let ctx_only =
-                aic.run_static(py, 1, 1, 1024, 8, 0, 1.0, 1.0, "static_ctx", 32).unwrap();
+            let ctx_only = aic
+                .run_static(py, 1, 1, 1024, 8, 0, 1.0, 1.0, "static_ctx", 32)
+                .unwrap();
             assert!(ctx_only.0 > 0.0 && ctx_only.1 == 0.0);
 
-            let gen_only =
-                aic.run_static(py, 1, 1, 1024, 8, 0, 1.0, 1.0, "static_gen", 32).unwrap();
+            let gen_only = aic
+                .run_static(py, 1, 1, 1024, 8, 0, 1.0, 1.0, "static_gen", 32)
+                .unwrap();
             assert!(gen_only.0 == 0.0 && gen_only.1 > 0.0);
 
             assert!(aic

--- a/rust/aiconfigurator-core/tests/memory_round_trip.rs
+++ b/rust/aiconfigurator-core/tests/memory_round_trip.rs
@@ -1,0 +1,177 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end KV-cache capacity round-trip.
+//!
+//! Drives the full Rust → Python → Rust capacity path: calls the top-level
+//! [`aiconfigurator_core::estimate_kv_cache`] (the **pure forwarder** the Dynamo
+//! Mocker uses) for a real fixture model. That crosses into Python once to run
+//! `aiconfigurator.sdk.memory.estimate_kv_cache` (which owns the budget math AND
+//! the tolerance margin) and rebuilds a [`aiconfigurator_core::KvCacheEstimate`]
+//! from the returned dict.
+//!
+//! ## Why this test exists
+//!
+//! Removing the `aiconfigurator_core.estimate_kv_cache` `#[pyfunction]` removed
+//! the only in-repo path that exercised the Rust `fetch_python_estimate`
+//! (forwarding `tolerance_fraction`) and `estimate_from_dict` (parsing
+//! `tolerance_adjusted`). This test restores that coverage: a typo in a forwarded
+//! kwarg name or a parsed dict key fails here instead of first surfacing in the
+//! deferred downstream Mocker PR. It mirrors `embedded_round_trip.rs`, the sibling
+//! `build_aic_engine` round-trip.
+//!
+//! ## Run requirements
+//!
+//! Same as `embedded_round_trip.rs`: an embedded Python interpreter that can
+//! import `aiconfigurator.sdk.memory` (which imports the maturin-built
+//! `aiconfigurator_core`), plus the perf DB (LFS) for the native SystemSpec
+//! capacity. Run after
+//! `uv run maturin develop -m rust/aiconfigurator-core/Cargo.toml --release`:
+//! ```text
+//! AIC_REQUIRE_EMBEDDED_ROUND_TRIP=1 \
+//!   PYTHONPATH="$PWD/.venv/lib/python3.12/site-packages:$PWD/src" \
+//!   cargo test -p aiconfigurator-core --test memory_round_trip -- --nocapture
+//! ```
+//!
+//! ## Honest skip vs. enforced run
+//!
+//! On a bare `cargo test` the Python imports are usually unavailable, so the
+//! test prints a visible `SKIP` and returns (it does NOT read as coverage).
+//! `AIC_REQUIRE_EMBEDDED_ROUND_TRIP=1` makes an import failure a HARD failure so
+//! the test cannot false-pass. The estimate itself additionally needs the perf
+//! DB; when that is absent the call errors and the test skips with a message
+//! (matching the Python integration test in `tests/integration/test_memory_estimation.py`).
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use aiconfigurator_core::{
+    estimate_kv_cache, BackendKind, EngineConfig, EstimateSource, KvCacheEstimateOptions,
+    KvCacheEstimateRequest, KvCacheMemoryFraction, ParallelMapping, QuantizationConfig,
+    ENGINE_CONFIG_SCHEMA_VERSION,
+};
+use pyo3::prelude::*;
+
+const TEST_MODEL: &str = "Qwen/Qwen3-32B";
+const TOLERANCE: f64 = 0.05;
+
+fn systems_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../src/aiconfigurator/systems")
+}
+
+/// Soft-skip guard: true only when the embedded interpreter can import
+/// `aiconfigurator.sdk.memory` (which transitively imports the maturin-built
+/// `aiconfigurator_core`).
+fn python_memory_importable() -> bool {
+    Python::with_gil(|py| match py.import("aiconfigurator.sdk.memory") {
+        Ok(_) => true,
+        Err(e) => {
+            let exe: String = py
+                .import("sys")
+                .and_then(|s| s.getattr("executable"))
+                .and_then(|x| x.extract())
+                .unwrap_or_default();
+            eprintln!("memory_round_trip: import failed (sys.executable={exe}): {e}");
+            false
+        }
+    })
+}
+
+/// TRT-LLM native request for the fixture model. `tolerance_fraction` is the
+/// only field that varies between the two calls under test.
+fn request(tolerance_fraction: Option<f64>) -> KvCacheEstimateRequest {
+    KvCacheEstimateRequest {
+        engine: EngineConfig {
+            schema_version: ENGINE_CONFIG_SCHEMA_VERSION,
+            model_name: TEST_MODEL.to_string(),
+            system_name: "h200_sxm".to_string(),
+            systems_path: systems_root().to_str().map(PathBuf::from),
+            backend: BackendKind::Trtllm,
+            backend_version: Some("1.3.0rc10".to_string()),
+            kv_block_size: None,
+            parallel: ParallelMapping {
+                tp_size: 1,
+                pp_size: 1,
+                attention_dp_size: Some(1),
+                moe_tp_size: None,
+                moe_ep_size: None,
+            },
+            quantization: QuantizationConfig {
+                weight_dtype: None,
+                moe_dtype: None,
+                activation_dtype: None,
+                kv_cache_dtype: None,
+            },
+            speculative: None,
+            extra: BTreeMap::new(),
+        },
+        max_num_tokens: 8192,
+        max_batch_size: 256,
+        kv_cache_memory_fraction: KvCacheMemoryFraction::OfFree(0.9),
+        gpu_memory_capacity_bytes_override: None,
+        tolerance_fraction,
+        options: KvCacheEstimateOptions {
+            allow_naive_fallback: false,
+            allow_hf_config_download: false,
+            naive_kv_reservation: 0.80,
+        },
+    }
+}
+
+#[test]
+fn memory_round_trip_forwards_tolerance_and_parses_adjusted() {
+    let required = std::env::var_os("AIC_REQUIRE_EMBEDDED_ROUND_TRIP").is_some();
+    if !python_memory_importable() {
+        assert!(
+            !required,
+            "memory_round_trip: AIC_REQUIRE_EMBEDDED_ROUND_TRIP is set but \
+             `aiconfigurator.sdk.memory` is not importable — run after \
+             `maturin develop` with PYTHONPATH including the venv site-packages + src."
+        );
+        eprintln!(
+            "memory_round_trip: SKIP — `aiconfigurator.sdk.memory` not importable. \
+             Set AIC_REQUIRE_EMBEDDED_ROUND_TRIP=1 + PYTHONPATH to enforce."
+        );
+        return;
+    }
+
+    // Raw estimate (no tolerance forwarded). The native path needs the perf DB;
+    // when it is absent the Python side raises the "unsupported model/backend/GPU"
+    // ValueError (native build could not run), which we tolerate as a skip — same
+    // as the Python integration test. ANY other error (a forwarder kwarg typo, a
+    // dict-parse regression, budget math) must fail the test rather than hide.
+    let raw = match estimate_kv_cache(request(None)) {
+        Ok(est) => est,
+        Err(e) if e.to_string().contains("unsupported model/backend/GPU for KV-cache estimation") => {
+            eprintln!("memory_round_trip: SKIP — native estimate unavailable (perf DB?): {e}");
+            return;
+        }
+        Err(e) => panic!("memory_round_trip: native estimate failed unexpectedly (not a missing-fixture error): {e}"),
+    };
+
+    // `estimate_from_dict` parsed the scalar fields and the breakdown; with no
+    // tolerance forwarded, `tolerance_adjusted` must be None.
+    assert_eq!(raw.source, EstimateSource::Native);
+    assert!(raw.total_kv_size_bytes > 0 && raw.kv_size_per_token_bytes > 0);
+    assert!(raw.memory_breakdown.is_some());
+    assert!(raw.tolerance_adjusted.is_none());
+
+    // Tolerance forwarded: `fetch_python_estimate` must pass `tolerance_fraction`
+    // through, and `estimate_from_dict` must parse the `tolerance_adjusted` dict.
+    let adjusted = estimate_kv_cache(request(Some(TOLERANCE)))
+        .expect("tolerance estimate must succeed once the raw one did");
+    let adj = adjusted
+        .tolerance_adjusted
+        .expect("tolerance forwarded -> tolerance_adjusted must be Some");
+
+    assert_eq!(adj.tolerance_fraction, TOLERANCE);
+    // Same formula the deleted Rust `apply_tolerance` used, now computed Python-side.
+    let expected_bytes = (raw.total_kv_size_bytes as f64 * (1.0 - TOLERANCE)) as u64;
+    assert_eq!(adj.total_kv_size_bytes, expected_bytes);
+    assert_eq!(
+        adj.total_kv_size_tokens,
+        expected_bytes / raw.kv_size_per_token_bytes
+    );
+    // The raw fields are unchanged when a tolerance is applied.
+    assert_eq!(adjusted.total_kv_size_bytes, raw.total_kv_size_bytes);
+}

--- a/src/aiconfigurator/sdk/memory.py
+++ b/src/aiconfigurator/sdk/memory.py
@@ -1,0 +1,1051 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""KV-cache capacity estimation.
+
+The single source of truth for the rank-local KV-cache capacity estimate. The
+Rust ``aiconfigurator_core::memory::estimate_kv_cache`` is a pure forwarder that
+calls :func:`estimate_kv_cache` here and rebuilds its result, so all of the
+math -- fraction + tolerance validation, the native AIC memory model, the naive
+fallback, and the tolerance margin -- lives in this module.
+
+Two estimators, each built then asked to ``estimate()``:
+
+- **Native** (:class:`KVCacheEstimator`): ``from_request`` reuses AIC's full
+  backend memory model (``BaseBackend._get_memory_usage`` plus the model's
+  MLA-aware per-token KV size), then ``estimate`` does the OfFree (TRT-LLM,
+  fraction of FREE memory) / OfTotal (vLLM/SGLang, fraction of TOTAL memory)
+  budget math.
+- **Naive fallback** (:class:`NaiveKVCacheEstimator`): for models/backends AIC
+  cannot build natively, ``from_model_path`` parses the HF ``config.json``
+  (reusing the SDK's existing loaders +
+  :func:`~aiconfigurator.sdk.utils._parse_hf_config_json`) and ``estimate``
+  reserves a fraction (default 80%) of post-weight memory for KV. It handles
+  standard K/V and MLA/compressed-latent attention separately, auto-selects
+  hybrid sliding-window vs linear KV growth, and RAISES when the config lacks the
+  metadata to compute the weights or the per-token KV size (rather than guessing
+  with a placeholder).
+
+The budget math is factored into :func:`kv_cache_budget_bytes` so the deferred
+consolidation of ``InferenceSummary._check_and_set_kv_cache_oom`` onto a single
+formula is a small follow-up (tracked in #1208). See
+``docs/phase-1.5-capacity-followup.md``.
+"""
+
+from __future__ import annotations
+
+import enum
+import math
+import os
+from collections.abc import Callable
+from typing import Any
+
+from aiconfigurator.cli.api import _apply_nextn, _build_model_config
+from aiconfigurator.sdk import perf_database
+from aiconfigurator.sdk.backends.factory import get_backend
+from aiconfigurator.sdk.common import DefaultHFModels
+from aiconfigurator.sdk.models import get_model
+from aiconfigurator.sdk.utils import (
+    _download_hf_config,
+    _load_local_config,
+    _load_pre_downloaded_hf_config,
+    _parse_hf_config_json,
+)
+
+_ONE_GIB = 1 << 30
+
+# A KV byte-budget -> token-count inverse. Every estimation path produces one of
+# these (native: the model's ``get_kvcache_max_tokens``; naive:
+# ``NaiveKVCacheEstimator.get_kvcache_max_tokens``; the linear
+# ``_linear_tokens_from_bytes`` is the default for constant-per-token growth), so
+# the raw and tolerance-adjusted token counts invert the same curve through a
+# single, uniform type.
+TokensFromBytes = Callable[[float], int]
+
+# Default fraction of post-weight memory reserved for KV in the naive fallback
+# (exposed as the ``naive_kv_reservation`` arg so callers can tune it).
+_DEFAULT_NAIVE_KV_RESERVATION = 0.80
+
+# Backend -> the memory-fraction kind that backend accepts. TRT-LLM applies the
+# fraction to FREE memory (`free_gpu_memory_fraction`); vLLM/SGLang apply it to
+# TOTAL memory (`gpu_memory_utilization` / `mem_fraction_static`).
+_BACKEND_FRACTION_KIND = {
+    "trtllm": "of_free",
+    "vllm": "of_total",
+    "sglang": "of_total",
+}
+
+
+# --------------------------------------------------------------------------- #
+# Validation (runs before any model build, so bad inputs fail cheaply).
+# --------------------------------------------------------------------------- #
+
+
+def _validate_memory_fraction(backend: str, memory_fraction_kind: str, memory_fraction_value: float) -> None:
+    """Validate the ``memory_fraction_kind`` against the backend, then the range.
+
+    Runs FIRST in :func:`estimate_kv_cache`, before any model build, so a wrong
+    kind or out-of-range value fails deterministically without touching the perf
+    database. ``of_free`` is TRT-LLM only; ``of_total`` is vLLM / SGLang.
+    """
+    expected = _BACKEND_FRACTION_KIND.get(backend)
+    if expected is None:
+        raise ValueError(f"unknown backend {backend!r} for KV-cache estimation")
+    if memory_fraction_kind != expected:
+        raise ValueError(
+            f"incompatible memory fraction: backend {backend!r} does not accept "
+            f"memory_fraction_kind {memory_fraction_kind!r} (expected {expected!r})"
+        )
+    f = float(memory_fraction_value)
+    if not (math.isfinite(f) and 0.0 <= f <= 1.0):
+        raise ValueError(f"kv_cache_memory_fraction must be finite and in [0, 1], got {f}")
+
+
+def _validate_naive_reservation(naive_kv_reservation: float) -> None:
+    """Validate the naive-fallback KV reservation fraction.
+
+    Must be finite and in ``[0, 1]``. Runs FIRST in :func:`estimate_kv_cache`
+    (before any model build), alongside the other fail-fast validators, so a bad
+    value is rejected deterministically even on the native path where the
+    fraction is never used.
+    """
+    r = float(naive_kv_reservation)
+    if not (math.isfinite(r) and 0.0 <= r <= 1.0):
+        raise ValueError(f"naive_kv_reservation must be finite and in [0, 1], got {naive_kv_reservation}")
+
+
+def _validate_tolerance(tolerance_fraction: float | None) -> None:
+    """Validate the optional KV-cache safety-margin ``tolerance_fraction``.
+
+    Must be finite and in the half-open interval ``[0, 1)`` (``t = 1.0`` would
+    reserve the entire budget). Runs FIRST in :func:`estimate_kv_cache`, before
+    the expensive breakdown, so a bad value fails cheaply and deterministically.
+    """
+    if tolerance_fraction is None:
+        return
+    t = float(tolerance_fraction)
+    if not (math.isfinite(t) and 0.0 <= t < 1.0):
+        raise ValueError(f"tolerance_fraction must be finite and in [0, 1), got {tolerance_fraction}")
+
+
+# --------------------------------------------------------------------------- #
+# Shared budget math.
+#
+# The single formula both the estimate and (in a follow-up PR) the sweep's
+# `InferenceSummary._check_and_set_kv_cache_oom` should use. The OOM check folds
+# `reserved` (block-allocator overhead) and `tolerance` into the fraction
+# multiplicatively; the estimate passes `reserved=tolerance=0` here and applies
+# its tolerance separately via `_apply_tolerance` (so `tolerance_adjusted` stays
+# a distinct field). Unit-agnostic: pass capacity/non_kv in the same unit.
+# TODO(#1208): point `_check_and_set_kv_cache_oom` at this helper.
+# --------------------------------------------------------------------------- #
+
+
+def kv_cache_budget_bytes(
+    *,
+    capacity: float,
+    non_kv: float,
+    fraction: float,
+    of_free: bool,
+    reserved: float = 0.0,
+    tolerance: float = 0.0,
+) -> float:
+    """KV-cache budget for one rank.
+
+    ``of_free`` (TRT-LLM) applies the fraction to the FREE pool
+    ``(capacity - non_kv)``; otherwise (vLLM/SGLang ``of_total``) it applies the
+    fraction to TOTAL memory then subtracts ``non_kv``. ``reserved`` and
+    ``tolerance`` shrink the fraction multiplicatively (both default to a no-op).
+    """
+    scale = (1.0 - reserved) * (1.0 - tolerance)
+    if of_free:
+        return (capacity - non_kv) * fraction * scale
+    return capacity * fraction * scale - non_kv
+
+
+def _linear_tokens_from_bytes(per_token_bytes: float) -> TokensFromBytes:
+    """The linear-growth inverse ``floor(budget / per_token)`` as a callable.
+
+    The default :data:`TokensFromBytes` for models with a constant per-token KV
+    size (MHA / GQA / MLA), where token capacity scales linearly with the budget.
+    Hybrid / compressed-attention paths supply their own non-linear inverse
+    instead.
+    """
+
+    def tokens_from_bytes(budget_bytes: float) -> int:
+        budget = float(budget_bytes)
+        if budget <= 0.0 or per_token_bytes <= 0.0:
+            return 0
+        return int(budget // per_token_bytes)
+
+    return tokens_from_bytes
+
+
+def _apply_tolerance(estimate: dict[str, Any], tolerance_fraction: float | None) -> dict[str, Any]:
+    """Populate ``tolerance_adjusted`` on a finished raw estimate (in place).
+
+    ``adj_bytes = floor(total_kv_size_bytes * (1 - t))`` (a ``t`` of 0.05 keeps
+    95% of raw, reserving a 5% safety margin); ``adj_tokens`` is the token count
+    that fits in ``adj_bytes``, derived through the estimate's
+    ``tokens_from_kv_bytes`` inverse -- the SAME callable used for the raw count,
+    so the raw and adjusted counts follow the same KV curve. When
+    ``tolerance_fraction`` is ``None``, ``tolerance_adjusted`` stays ``None`` (raw
+    only).
+
+    The emitted dict keys (``tolerance_fraction`` / ``total_kv_size_bytes`` /
+    ``total_kv_size_tokens``) match what the Rust ``estimate_from_dict`` parses
+    back, so the numbers are identical across the PyO3 boundary.
+    """
+    if tolerance_fraction is None:
+        return estimate
+    t = float(tolerance_fraction)
+    raw_bytes = int(estimate["total_kv_size_bytes"])
+    adj_bytes = math.floor(raw_bytes * (1.0 - t))
+    tokens_from_bytes: TokensFromBytes = estimate["tokens_from_kv_bytes"]
+    adj_tokens = int(tokens_from_bytes(adj_bytes))
+    estimate["tolerance_adjusted"] = {
+        "tolerance_fraction": t,
+        "total_kv_size_bytes": adj_bytes,
+        "total_kv_size_tokens": adj_tokens,
+    }
+    return estimate
+
+
+# --------------------------------------------------------------------------- #
+# Native path: AIC's full backend memory model.
+#
+# `KVCacheEstimator` builds the model + backend + perf DB (the part that fails
+# for models AIC cannot model -> the caller falls back to NaiveKVCacheEstimator),
+# computes the `BaseBackend._get_memory_usage` breakdown + per-token KV byte size
+# + capacity, then sizes the rank-local KV budget via the OfFree (TRT-LLM) /
+# OfTotal (vLLM/SGLang) formula. Mirrors NaiveKVCacheEstimator: build via
+# from_request(...), then estimate().
+#
+# Everything is in BYTES (not GiB) so no downstream unit scaling is needed:
+# `_get_memory_usage` returns GiB, so the breakdown components are multiplied by
+# 1 GiB; `get_kvcache_bytes_per_sequence(1)` is already bytes;
+# `system_spec["gpu"]["mem_capacity"]` is already bytes.
+# --------------------------------------------------------------------------- #
+
+
+class KVCacheEstimator:
+    """Native KV-cache estimator: AIC's full backend memory model.
+
+    :meth:`from_request` builds the model / backend / perf DB and the non-KV
+    memory breakdown -- the part that raises for models AIC cannot build, which is
+    the signal for the caller to fall back to :class:`NaiveKVCacheEstimator`.
+    :meth:`estimate` then does the pure OfFree (TRT-LLM) / OfTotal (vLLM/SGLang)
+    budget math, whose ``ValueError``\\ s (no KV budget, zero per-token) propagate
+    rather than triggering the fallback.
+    """
+
+    def __init__(self, breakdown: dict[str, Any]):
+        self._breakdown = breakdown
+
+    @classmethod
+    def from_request(
+        cls,
+        model_path: str,
+        system: str,
+        backend: str,
+        backend_version: str | None = None,
+        *,
+        max_num_tokens: int,
+        max_batch_size: int,
+        tp_size: int = 1,
+        pp_size: int = 1,
+        attention_dp_size: int = 1,
+        moe_tp_size: int | None = None,
+        moe_ep_size: int | None = None,
+        gemm_quant_mode: str | None = None,
+        moe_quant_mode: str | None = None,
+        kvcache_quant_mode: str | None = None,
+        fmha_quant_mode: str | None = None,
+        comm_quant_mode: str | None = None,
+        nextn: int = 0,
+        nextn_accept_rates: list[float] | None = None,
+        systems_path: str | None = None,
+    ) -> KVCacheEstimator:
+        """Build the model/backend/perf-DB and the non-KV memory breakdown.
+
+        Reuses the exact AIC machinery the latency path uses: ``_build_model_config``
+        + ``_apply_nextn`` (so speculative/MTP requests scale activation memory) +
+        ``get_model`` (quant inferred inside ``get_model``), ``get_backend``, and
+        ``perf_database.get_database``. Calls ``BaseBackend._get_memory_usage`` with
+        ``num_tokens = max_num_tokens`` (so activations track
+        ``BuildConfig.max_num_tokens`` the way TRT-LLM's
+        ``_memory_usage_kwargs_for_agg`` does); ``isl``/``osl``/``max_seq_len`` only
+        feed the discarded ``kvcache`` key, so they are set to a neutral ``1``. Note
+        ``max_batch_size`` does NOT affect non-KV memory (activations use
+        ``num_tokens``, KV is recomputed per token), but it is accepted to mirror the
+        request shape.
+
+        Raises when AIC cannot build the model/backend or the perf DB is missing --
+        the signal for the caller to fall back to the naive estimator.
+        """
+        resolved_moe_tp = moe_tp_size if moe_tp_size is not None else 1
+        resolved_moe_ep = moe_ep_size if moe_ep_size is not None else 1
+        model_config = _build_model_config(
+            tp_size=tp_size,
+            pp_size=pp_size,
+            attention_dp_size=attention_dp_size,
+            moe_tp_size=resolved_moe_tp,
+            moe_ep_size=resolved_moe_ep,
+            gemm_quant_mode=gemm_quant_mode,
+            kvcache_quant_mode=kvcache_quant_mode,
+            fmha_quant_mode=fmha_quant_mode,
+            moe_quant_mode=moe_quant_mode,
+            comm_quant_mode=comm_quant_mode,
+        )
+        # Apply nextn/MTP onto the config BEFORE get_model: _get_memory_usage reads
+        # model.config.nextn to scale activation memory for speculative decoding, so
+        # skipping this would size non-KV memory as if nextn=0 and overstate the KV
+        # budget. Mirrors the agg/disagg/static estimate paths in cli.api.
+        _apply_nextn(model_config, nextn, nextn_accept_rates)
+        model = get_model(model_path, model_config, backend)
+        backend_obj = get_backend(backend)
+        database = perf_database.get_database(system, backend, backend_version)
+
+        # num_tokens = max_num_tokens -> activations track BuildConfig.max_num_tokens
+        # (TRT-LLM `_memory_usage_kwargs_for_agg`). With num_tokens > 0 passed
+        # explicitly, isl/osl/max_seq_len only feed the discarded `kvcache` key.
+        memory = backend_obj._get_memory_usage(
+            model,
+            database,
+            batch_size=int(max_batch_size),
+            beam_width=1,
+            isl=1,
+            osl=1,
+            num_tokens=int(max_num_tokens),
+            prefix=0,
+            max_seq_len=1,
+        )
+
+        weights_bytes = float(memory["weights"]) * _ONE_GIB
+        activations_bytes = float(memory["activations"]) * _ONE_GIB
+        runtime_overhead_bytes = float(memory["others"]) * _ONE_GIB
+        comm_overhead_bytes = float(memory["nccl"]) * _ONE_GIB
+        non_kv_bytes = weights_bytes + activations_bytes + runtime_overhead_bytes + comm_overhead_bytes
+
+        return cls(
+            {
+                "weights_bytes": weights_bytes,
+                "activations_bytes": activations_bytes,
+                "runtime_overhead_bytes": runtime_overhead_bytes,
+                "comm_overhead_bytes": comm_overhead_bytes,
+                "non_kv_bytes": non_kv_bytes,
+                "kv_size_per_token_bytes": float(model.get_kvcache_bytes_per_sequence(1)),
+                "gpu_memory_capacity_bytes": float(database.system_spec["gpu"]["mem_capacity"]),
+                # Model's byte-budget -> token-count inverse (KV-curve aware).
+                "tokens_from_kv_bytes": model.get_kvcache_max_tokens,
+            }
+        )
+
+    @property
+    def breakdown(self) -> dict[str, Any]:
+        """The non-KV memory breakdown (BYTE quantities + the ``tokens_from_kv_bytes``
+        inverse) computed by :meth:`from_request`."""
+        return self._breakdown
+
+    def estimate(
+        self,
+        *,
+        is_of_free: bool,
+        fraction: float,
+        gpu_memory_capacity_bytes_override: int | None,
+    ) -> dict[str, Any]:
+        """Size the rank-local KV budget from the breakdown (raw estimate dict)."""
+        return self._estimate_from_breakdown(
+            self._breakdown,
+            is_of_free=is_of_free,
+            fraction=fraction,
+            gpu_memory_capacity_bytes_override=gpu_memory_capacity_bytes_override,
+        )
+
+    @staticmethod
+    def _estimate_from_breakdown(
+        breakdown: dict[str, Any],
+        *,
+        is_of_free: bool,
+        fraction: float,
+        gpu_memory_capacity_bytes_override: int | None,
+    ) -> dict[str, Any]:
+        """Native budget math over a breakdown dict (pure; no model build).
+
+        Uses the shared :func:`kv_cache_budget_bytes` (``reserved=tolerance=0``;
+        tolerance is applied separately by :func:`_apply_tolerance`). Floors to whole
+        bytes/tokens. The token count comes from the breakdown's
+        ``tokens_from_kv_bytes`` inverse (the model's KV-curve-aware
+        ``get_kvcache_max_tokens``), so hybrid / sliding-window models do not get
+        capacity extrapolated from the ``seq_len=1`` slope; when absent (e.g. a
+        synthetic breakdown) it defaults to the linear
+        :func:`_linear_tokens_from_bytes`. Raises ``ValueError`` for a non-positive
+        per-token KV size or budget (these propagate; they do NOT trigger the naive
+        fallback, which only fires when the breakdown itself cannot be built).
+        """
+        kv_per_token = float(breakdown["kv_size_per_token_bytes"])
+        if not (math.isfinite(kv_per_token) and kv_per_token > 0.0):
+            raise ValueError("insufficient model metadata; missing: kv_size_per_token_bytes")
+
+        if gpu_memory_capacity_bytes_override is not None:
+            capacity = float(gpu_memory_capacity_bytes_override)
+        else:
+            capacity = float(breakdown["gpu_memory_capacity_bytes"])
+        if not (math.isfinite(capacity) and capacity > 0.0):
+            raise ValueError(f"GPU capacity must be finite and positive, got {capacity}")
+
+        non_kv = float(breakdown["non_kv_bytes"])
+        total_kv_size_bytes_f = kv_cache_budget_bytes(
+            capacity=capacity, non_kv=non_kv, fraction=fraction, of_free=is_of_free
+        )
+
+        if total_kv_size_bytes_f <= 0.0:
+            raise ValueError(
+                f"no KV budget: non-KV memory ({int(max(non_kv, 0.0))} bytes) meets/exceeds the "
+                f"KV-cache memory limit (capacity={int(max(capacity, 0.0))} bytes)"
+            )
+
+        tokens_from_bytes: TokensFromBytes = breakdown.get("tokens_from_kv_bytes") or _linear_tokens_from_bytes(
+            kv_per_token
+        )
+        total_kv_size_tokens = int(tokens_from_bytes(total_kv_size_bytes_f))
+
+        return {
+            "total_gpu_capacity_bytes": int(max(capacity, 0.0)),
+            "total_kv_size_bytes": math.floor(total_kv_size_bytes_f),
+            "kv_size_per_token_bytes": math.floor(kv_per_token),
+            "total_kv_size_tokens": total_kv_size_tokens,
+            # Carried so _apply_tolerance derives adjusted tokens the same way;
+            # stripped by estimate_kv_cache before returning.
+            "tokens_from_kv_bytes": tokens_from_bytes,
+            "source": "native",
+            "memory_breakdown": {
+                "weights_bytes": int(max(float(breakdown["weights_bytes"]), 0.0)),
+                "activations_bytes": int(max(float(breakdown["activations_bytes"]), 0.0)),
+                "runtime_overhead_bytes": int(max(float(breakdown["runtime_overhead_bytes"]), 0.0)),
+                "comm_overhead_bytes": int(max(float(breakdown["comm_overhead_bytes"]), 0.0)),
+            },
+            "tolerance_adjusted": None,
+        }
+
+
+# --------------------------------------------------------------------------- #
+# Naive fallback: NaiveKVCacheEstimator (HF-config-only) + reserve a fraction of
+# post-weight memory.
+#
+# The estimator reuses the SDK's config loaders + `_parse_hf_config_json`, which
+# REJECTS architectures AIC does not support -- exactly the fallback's target --
+# so a supported arch (perf DB missing) uses the normalized parse, while an
+# unsupported arch reads the raw config keys directly. Both feed one geometry dict
+# that drives the per-token KV, weight, and token-capacity math.
+# --------------------------------------------------------------------------- #
+
+
+class NaiveKVCacheMode(enum.Enum):
+    """Which KV-growth model :class:`NaiveKVCacheEstimator` inverts."""
+
+    LINEAR = "linear"  # constant bytes/token (MHA/GQA/MLA, or an unknown layout)
+    HYBRID = "hybrid"  # SWA layers cap at the window; global layers keep growing
+
+
+class NaiveKVCacheEstimator:
+    """Config-only KV-cache estimator for models AIC cannot build natively.
+
+    Owns the HF-``config.json``-derived geometry and the byte<->token math the
+    native backend memory model would otherwise provide, and mirrors the native
+    :meth:`~aiconfigurator.sdk.models.base.Model.get_kvcache_max_tokens` surface so
+    the naive fallback plugs into the same :data:`TokensFromBytes` pipeline.
+    Handles standard K/V and MLA attention, and (via :class:`NaiveKVCacheMode`)
+    hybrid sliding-window vs linear KV growth.
+
+    The static ``_load_config`` / ``_dtype_bytes`` / ``_swa_layout`` / ``_geometry``
+    helpers turn an HF config into the geometry dict; :meth:`from_model_path` wires
+    them together. The instance methods compute the per-token / weight byte sizes
+    and the token-capacity inverse from that geometry.
+    """
+
+    def __init__(self, geometry: dict, *, dtype_bytes: int, tp_size: int, pp_size: int):
+        self.geometry = geometry
+        self.dtype_bytes = int(dtype_bytes)
+        self.tp_size = int(tp_size)
+        self.pp_size = int(pp_size)
+
+    @classmethod
+    def from_model_path(
+        cls, model_path: str, *, tp_size: int, pp_size: int, allow_hf_config_download: bool
+    ) -> NaiveKVCacheEstimator:
+        """Build from an HF ``config.json`` (local dir / pre-cached / optional download).
+
+        Supported architectures go through the normalized parse (which also unwraps
+        multimodal); unsupported architectures -- the fallback's real target -- read
+        the raw config keys directly. Raises ``ValueError`` when no config can be
+        obtained offline.
+        """
+        hf_config = cls._load_config(model_path, allow_hf_config_download)
+        if hf_config is None:
+            raise ValueError(
+                f"insufficient model metadata: no HF config for {model_path!r} (not a local "
+                "directory / not pre-cached, and HF download is disabled)"
+            )
+        try:
+            parsed = _parse_hf_config_json(hf_config)  # supported arch -> normalized parse
+        except Exception:
+            parsed = None  # unsupported arch (the fallback's target) -> raw-key read
+        return cls(
+            cls._geometry(hf_config, parsed),
+            dtype_bytes=cls._dtype_bytes(hf_config),
+            tp_size=tp_size,
+            pp_size=pp_size,
+        )
+
+    # ----------------------------- config -> geometry ----------------------------- #
+
+    @staticmethod
+    def _load_config(model_path: str, allow_hf_config_download: bool) -> dict | None:
+        """Load a raw HF ``config.json`` dict, or ``None`` when unavailable offline.
+
+        Reuses the SDK loaders: a local directory -> the pre-downloaded
+        ``model_configs`` cache -> an HF download (ONLY when
+        ``allow_hf_config_download`` is set). Returns ``None`` when no config can be
+        obtained without downloading; :meth:`from_model_path` raises in that case.
+        """
+        if os.path.isdir(model_path):
+            return _load_local_config(model_path)
+        if model_path in DefaultHFModels:
+            return _load_pre_downloaded_hf_config(model_path)
+        if allow_hf_config_download:
+            return _download_hf_config(model_path)
+        return None
+
+    @staticmethod
+    def _dtype_bytes(hf_config: dict) -> int:
+        """dtype byte width from ``torch_dtype``/``dtype``. Defaults to 2 (bf16)."""
+        dtype_str = (hf_config.get("torch_dtype") or hf_config.get("dtype") or "").lower()
+        if dtype_str in ("float32", "fp32"):
+            return 4
+        if dtype_str in ("bfloat16", "float16", "bf16", "fp16", "half"):
+            return 2
+        if "fp8" in dtype_str or "float8" in dtype_str or "int8" in dtype_str:
+            return 1
+        return 2
+
+    @staticmethod
+    def _swa_layout(hf_config: dict) -> tuple[int | None, int | None, int | None]:
+        """Sliding-window size + (SWA, global) layer counts from an HF config.
+
+        Returns ``(sliding_window, num_swa_layers, num_global_layers)`` for a hybrid
+        sliding-window model, or ``(None, None, None)`` when the layout cannot be
+        pinned down (so the estimator stays on its linear per-token mode). Two
+        signals are recognized, in order:
+
+        - ``layer_types`` (Gemma-3/4-style explicit per-layer list): count the
+          ``sliding_*`` entries vs the rest.
+        - ``sliding_window`` + ``sliding_window_pattern`` (an integer ``P``): the
+          Gemma convention of one global layer every ``P`` layers, the rest sliding.
+
+        A bare ``sliding_window`` with no per-layer signal is left unresolved -- the
+        split is too model-specific to guess, and linear is the safe default.
+        """
+        sliding_window = hf_config.get("sliding_window") or hf_config.get("sliding_window_size")
+        layer_types = hf_config.get("layer_types")
+        if isinstance(layer_types, list) and layer_types:
+            num_swa = sum(1 for t in layer_types if "sliding" in str(t).lower())
+            return sliding_window, num_swa, len(layer_types) - num_swa
+
+        num_layers = hf_config.get("num_hidden_layers")
+        pattern = hf_config.get("sliding_window_pattern")
+        if sliding_window and num_layers and pattern and int(pattern) > 0:
+            num_global = int(num_layers) // int(pattern)
+            return int(sliding_window), int(num_layers) - num_global, num_global
+
+        return None, None, None
+
+    @classmethod
+    def _geometry(cls, hf_config: dict, parsed: dict | None) -> dict:
+        """Normalized attention/FFN scalars the byte formulas consume.
+
+        From :func:`~aiconfigurator.sdk.utils._parse_hf_config_json` output when the
+        architecture is supported (``parsed`` not ``None``), else from the HF config
+        keys directly (unsupported architecture). Missing values stay ``None`` /
+        ``0`` so the formulas can fail closed.
+        """
+        if parsed is not None:
+            extra = parsed.get("extra_params")
+            if isinstance(extra, dict):
+                kv_lora = extra.get("kv_lora_rank")
+                qk_rope = extra.get("qk_rope_head_dim")
+            else:
+                # Some supported archs carry a dataclass extra_params (e.g. NemotronH,
+                # Gemma4Mix, DeepSeek-V4); read MLA latent fields by attribute when
+                # present. Archs whose latent geometry is NOT a simple
+                # (kv_lora_rank + qk_rope_head_dim) sum -- notably DeepSeek-V4's sparse
+                # attention -- expose neither and fall through to the standard branch,
+                # a rough approximation acceptable for this naive fallback.
+                kv_lora = getattr(extra, "kv_lora_rank", None)
+                qk_rope = getattr(extra, "qk_rope_head_dim", None)
+            return {
+                "layers": parsed.get("layers"),
+                "num_kv_heads": parsed.get("n_kv") or parsed.get("n"),
+                "head_dim": parsed.get("d"),
+                "kv_lora_rank": kv_lora,
+                "qk_rope_head_dim": qk_rope,
+                "vocab": parsed.get("vocab"),
+                "hidden": parsed.get("hidden_size"),
+                "inter": parsed.get("inter_size"),
+                "num_experts": parsed.get("num_experts") or 0,
+                "moe_inter": parsed.get("moe_inter_size") or 0,
+                # Supported (native-capable) archs do not take the naive path, so the
+                # sliding-window split is only mined from the HF config (below).
+                "sliding_window": None,
+                "num_swa_layers": None,
+                "num_global_layers": None,
+            }
+
+        hidden = hf_config.get("hidden_size")
+        heads = hf_config.get("num_attention_heads")
+        head_dim = hf_config.get("head_dim") or hf_config.get("attention_head_dim")
+        if head_dim is None and hidden and heads:
+            head_dim = int(hidden) // int(heads)
+        sliding_window, num_swa_layers, num_global_layers = cls._swa_layout(hf_config)
+        return {
+            "layers": hf_config.get("num_hidden_layers"),
+            "num_kv_heads": hf_config.get("num_key_value_heads") or heads,
+            "head_dim": head_dim,
+            "kv_lora_rank": hf_config.get("kv_lora_rank"),
+            "qk_rope_head_dim": hf_config.get("qk_rope_head_dim"),
+            "vocab": hf_config.get("vocab_size"),
+            "hidden": hidden,
+            "inter": hf_config.get("intermediate_size"),
+            "num_experts": hf_config.get("n_routed_experts") or hf_config.get("num_local_experts") or 0,
+            "moe_inter": hf_config.get("moe_intermediate_size") or hf_config.get("intermediate_size") or 0,
+            "sliding_window": sliding_window,
+            "num_swa_layers": num_swa_layers,
+            "num_global_layers": num_global_layers,
+        }
+
+    # --------------------------- geometry -> byte sizes --------------------------- #
+
+    def kv_bytes_per_token(self) -> int | None:
+        """Per-token KV byte size (the ``seq_len=1`` rate), MLA-aware, or ``None``.
+
+        Standard K/V and MLA/compressed-latent attention are handled separately
+        (MLA stores one shared latent cache per layer, not per-head K and V):
+
+        - MLA (``kv_lora_rank`` present): ``layers * (kv_lora_rank + qk_rope_head_dim)
+          * dtype_bytes`` (the latent is shared across heads, NOT sharded by TP).
+          Fails closed (``None``) when ``qk_rope_head_dim`` is absent so the caller
+          raises rather than guessing the latent width.
+        - Standard (GQA/MHA): ``2 * ceil(num_kv_heads / tp) * head_dim * layers *
+          dtype_bytes``.
+        """
+        geom = self.geometry
+        layers = geom.get("layers")
+        if not layers:
+            return None
+
+        kv_lora = geom.get("kv_lora_rank")
+        if kv_lora:
+            qk_rope = geom.get("qk_rope_head_dim")
+            if not qk_rope:
+                # MLA but latent width unclear -> fail closed (None; the caller raises).
+                return None
+            return int(layers) * (int(kv_lora) + int(qk_rope)) * self.dtype_bytes
+
+        num_kv_heads = geom.get("num_kv_heads")
+        head_dim = geom.get("head_dim")
+        if not num_kv_heads or not head_dim:
+            return None
+        kv_heads_per_rank = -(-int(num_kv_heads) // max(self.tp_size, 1))  # ceil division
+        return 2 * kv_heads_per_rank * int(head_dim) * int(layers) * self.dtype_bytes
+
+    def weight_bytes(self) -> int | None:
+        """Rough per-rank weight estimate (bytes) from the geometry, or ``None``.
+
+        Coarse param count (embeddings + per-layer attention + dense/MoE FFN), times
+        dtype bytes, divided by TP*PP. NOT calibrated; for models AIC cannot fully
+        model. Attention-DP replicates rather than shards, so it does NOT divide
+        here. ``hidden_size`` / ``num_hidden_layers`` / ``vocab_size`` /
+        ``intermediate_size`` are all required: returns ``None`` (the caller raises)
+        when any is missing, rather than fabricating a placeholder.
+        """
+        geom = self.geometry
+        hidden = geom.get("hidden")
+        layers = geom.get("layers")
+        vocab = geom.get("vocab")
+        inter = geom.get("inter")
+        if not hidden or not layers or not vocab or not inter:
+            return None
+        hidden = int(hidden)
+        layers = int(layers)
+        vocab = int(vocab)
+        inter = int(inter)
+
+        # Embeddings: input + (untied) output projection ~ 2 * vocab * hidden.
+        embed_params = 2 * vocab * hidden
+        # Per-layer attention q/k/v/o ~ 4 * hidden**2.
+        attn_params_per_layer = 4 * hidden * hidden
+
+        n_experts = int(geom.get("num_experts") or 0)
+        if n_experts > 0:
+            moe_inter = int(geom.get("moe_inter") or inter)
+            ffn_params_per_layer = n_experts * 3 * hidden * moe_inter
+        else:
+            ffn_params_per_layer = 3 * hidden * inter
+
+        total_params = embed_params + layers * (attn_params_per_layer + ffn_params_per_layer)
+        divisor = max(self.tp_size, 1) * max(self.pp_size, 1)
+        return (total_params * self.dtype_bytes) // max(divisor, 1)
+
+    # --------------------------- byte budget -> tokens ---------------------------- #
+
+    @property
+    def mode(self) -> NaiveKVCacheMode:
+        """HYBRID when the config exposes a usable sliding-window layout, else LINEAR."""
+        return NaiveKVCacheMode.HYBRID if self._hybrid_tokens_from_bytes() is not None else NaiveKVCacheMode.LINEAR
+
+    def get_kvcache_max_tokens(self, kv_budget_bytes: float, mode: NaiveKVCacheMode | None = None) -> int:
+        """KV byte budget -> token capacity, mirroring ``Model.get_kvcache_max_tokens``.
+
+        ``mode`` defaults to :attr:`mode` (auto: HYBRID when a sliding-window layout
+        is known, else LINEAR); pass it explicitly to force one. HYBRID caps the SWA
+        layers at the window while global layers keep growing; LINEAR floor-divides
+        the budget by the per-token size. An explicit HYBRID with no usable layout
+        falls back to LINEAR rather than raising.
+        """
+        hybrid = self._hybrid_tokens_from_bytes()
+        use_hybrid = mode is NaiveKVCacheMode.HYBRID or (mode is None and hybrid is not None)
+        if use_hybrid and hybrid is not None:
+            return hybrid(kv_budget_bytes)
+        return _linear_tokens_from_bytes(float(self.kv_bytes_per_token() or 0.0))(kv_budget_bytes)
+
+    def estimate(self, *, capacity: int | None, naive_kv_reservation: float) -> dict[str, Any]:
+        """Conservative naive estimate: reserve ``naive_kv_reservation`` of post-weight memory.
+
+        The naive counterpart to :meth:`KVCacheEstimator.estimate`. ``capacity`` is
+        the per-rank GPU memory (the ``gpu_memory_capacity_bytes_override`` the caller
+        must supply, since the native SystemSpec capacity is unavailable when this
+        path runs). Does NOT honor the requested ``memory_fraction`` -- the
+        post-weight reservation is the crude budget. The estimator auto-selects
+        HYBRID (window-capped) vs LINEAR from the config, so hybrid sliding-window
+        models do not get capacity extrapolated from the (larger) ``seq_len=1`` rate.
+        RAISES ``ValueError`` when ``capacity`` is missing or the config lacks the
+        metadata to estimate the weights / per-token KV (rather than guessing with a
+        placeholder constant).
+        """
+        if not (capacity and int(capacity) > 0):
+            raise ValueError(
+                "naive fallback requires gpu_memory_capacity_bytes_override (the native "
+                "path failed, so SystemSpec capacity is unavailable)"
+            )
+        capacity_bytes = float(capacity)
+
+        kv_per_token = self.kv_bytes_per_token()
+        if kv_per_token is None or not (math.isfinite(kv_per_token) and kv_per_token > 0.0):
+            raise ValueError(
+                "insufficient model metadata; missing: per-token KV geometry "
+                "(num_hidden_layers + num_key_value_heads/head_dim, or the MLA latent dims)"
+            )
+        weight_bytes = self.weight_bytes()
+        if weight_bytes is None:
+            raise ValueError(
+                "insufficient model metadata; missing: weight-estimate fields "
+                "(hidden_size, num_hidden_layers, vocab_size, intermediate_size)"
+            )
+        kv_per_token = float(kv_per_token)
+        weight_bytes = float(weight_bytes)
+
+        post_weight = max(capacity_bytes - weight_bytes, 0.0)
+        total_kv_size_bytes_f = post_weight * float(naive_kv_reservation)
+        if total_kv_size_bytes_f <= 0.0:
+            raise ValueError(
+                f"no KV budget: non-KV memory ({int(max(weight_bytes, 0.0))} bytes) meets/exceeds the "
+                f"KV-cache memory limit (capacity={int(max(capacity_bytes, 0.0))} bytes)"
+            )
+
+        return {
+            "total_gpu_capacity_bytes": int(max(capacity_bytes, 0.0)),
+            "total_kv_size_bytes": math.floor(total_kv_size_bytes_f),
+            "kv_size_per_token_bytes": math.floor(kv_per_token),
+            "total_kv_size_tokens": self.get_kvcache_max_tokens(total_kv_size_bytes_f),
+            # Carried so _apply_tolerance derives adjusted tokens the same way;
+            # stripped by estimate_kv_cache before returning.
+            "tokens_from_kv_bytes": self.get_kvcache_max_tokens,
+            "source": "naive_fallback",
+            "memory_breakdown": None,
+            "tolerance_adjusted": None,
+        }
+
+    def _hybrid_tokens_from_bytes(self) -> TokensFromBytes | None:
+        """Piecewise sliding-window inverse closure, or ``None`` when not hybrid.
+
+        For a STANDARD-attention model with a known sliding-window layout: caps the
+        SWA layers at the window while the global layers keep growing, so capacity
+        is not extrapolated from the (larger) ``seq_len=1`` rate. ``None`` (caller
+        stays LINEAR) for non-hybrid models, MLA hybrids (latent cache; out of scope
+        for this simple heuristic), or incomplete geometry. Deliberately coarse: it
+        assumes one head geometry across both layer types.
+        """
+        geom = self.geometry
+        if geom.get("kv_lora_rank"):  # MLA latent cache: piecewise split N/A here
+            return None
+        window = geom.get("sliding_window")
+        num_swa = geom.get("num_swa_layers")
+        num_global = geom.get("num_global_layers")
+        head_dim = geom.get("head_dim")
+        num_kv_heads = geom.get("num_kv_heads")
+        if not window or not num_swa or num_global is None or not head_dim or not num_kv_heads:
+            return None
+
+        window = int(window)
+        kv_heads_per_rank = -(-int(num_kv_heads) // max(self.tp_size, 1))  # ceil division
+        per_layer = 2 * kv_heads_per_rank * int(head_dim) * self.dtype_bytes
+        swa_const = int(num_swa) * per_layer  # bytes/token for the window-capped layers
+        global_const = int(num_global) * per_layer  # bytes/token for the growing layers
+
+        def tokens_from_bytes(budget_bytes: float) -> int:
+            budget = float(budget_bytes)
+            if budget <= 0.0:
+                return 0
+            within_window_rate = swa_const + global_const  # every layer grows up to the window
+            bytes_at_window = within_window_rate * window
+            if budget <= bytes_at_window:
+                return int(budget // within_window_rate) if within_window_rate > 0 else 0
+            if global_const <= 0:  # all layers capped -> KV can't grow past the window
+                return window
+            return window + int((budget - bytes_at_window) // global_const)
+
+        return tokens_from_bytes
+
+
+# --------------------------------------------------------------------------- #
+# Public entry points.
+# --------------------------------------------------------------------------- #
+
+
+def estimate_kv_cache(
+    model_path: str,
+    system: str,
+    backend: str,
+    backend_version: str | None = None,
+    *,
+    max_num_tokens: int,
+    max_batch_size: int,
+    memory_fraction_kind: str,
+    memory_fraction_value: float,
+    tp_size: int = 1,
+    pp_size: int = 1,
+    attention_dp_size: int = 1,
+    moe_tp_size: int | None = None,
+    moe_ep_size: int | None = None,
+    gemm_quant_mode: str | None = None,
+    moe_quant_mode: str | None = None,
+    kvcache_quant_mode: str | None = None,
+    fmha_quant_mode: str | None = None,
+    comm_quant_mode: str | None = None,
+    nextn: int = 0,
+    nextn_accept_rates: list[float] | None = None,
+    systems_path: str | None = None,
+    gpu_memory_capacity_bytes_override: int | None = None,
+    tolerance_fraction: float | None = None,
+    naive_kv_reservation: float = _DEFAULT_NAIVE_KV_RESERVATION,
+    allow_naive_fallback: bool = False,
+    allow_hf_config_download: bool = False,
+) -> dict[str, Any]:
+    """Compute the KV-cache memory estimate (raw + optional tolerance margin).
+
+    This is the complete implementation: fraction + tolerance validation, the
+    native/naive budget math, AND the tolerance margin. The Rust
+    ``aiconfigurator_core::memory::estimate_kv_cache`` is a pure forwarder that
+    calls this function and rebuilds its result, so this is the single source of
+    truth for the estimate.
+
+    Native path: :meth:`KVCacheEstimator.from_request` builds AIC's full backend
+    memory model and :meth:`KVCacheEstimator.estimate` does the OfFree (TRT-LLM) /
+    OfTotal (vLLM/SGLang) budget math. Naive fallback: when the native model build
+    is unsupported (``from_request`` raises) AND ``allow_naive_fallback`` is set,
+    :meth:`NaiveKVCacheEstimator.estimate` parses the HF ``config.json`` and
+    reserves ``naive_kv_reservation`` of post-weight memory for KV; this requires
+    ``gpu_memory_capacity_bytes_override``.
+
+    Args:
+        memory_fraction_kind: ``"of_total"`` (vLLM / SGLang) or ``"of_free"``
+            (TRT-LLM); validated against ``backend`` BEFORE any model build.
+        memory_fraction_value: the fraction in ``[0, 1]``.
+        gpu_memory_capacity_bytes_override: when set, wins over the SystemSpec
+            capacity on the native path; REQUIRED on the naive fallback.
+        tolerance_fraction: optional safety margin in ``[0, 1)``; when set,
+            ``tolerance_adjusted`` is populated with ``floor(raw * (1 - t))``
+            bytes and the recomputed token count. ``None`` -> raw estimate only.
+        naive_kv_reservation: fraction of post-weight memory the naive fallback
+            reserves for KV (default ``0.80``). Ignored on the native path.
+        allow_naive_fallback: fall back to the naive heuristic when the native
+            model build is unsupported (default off -> the error propagates).
+        allow_hf_config_download: allow the naive fallback to download a
+            ``config.json`` from HuggingFace when it is not local / pre-cached.
+
+    Returns:
+        A flat dict with ``total_gpu_capacity_bytes``, ``total_kv_size_bytes``,
+        ``kv_size_per_token_bytes``, ``total_kv_size_tokens``, ``source``
+        (``"native"`` | ``"naive_fallback"``), ``memory_breakdown`` (dict on the
+        native path, ``None`` on the fallback), and ``tolerance_adjusted`` (a dict
+        when ``tolerance_fraction`` is set, else ``None``).
+
+    Raises:
+        ValueError: incompatible / out-of-range memory fraction, out-of-range
+            tolerance, no KV budget, insufficient model metadata, or (with the
+            fallback off) an unsupported model/backend.
+    """
+    _validate_memory_fraction(backend, memory_fraction_kind, memory_fraction_value)
+    _validate_tolerance(tolerance_fraction)
+    _validate_naive_reservation(naive_kv_reservation)
+    fraction = float(memory_fraction_value)
+    is_of_free = memory_fraction_kind == "of_free"
+
+    try:
+        native = KVCacheEstimator.from_request(
+            model_path,
+            system,
+            backend,
+            backend_version,
+            max_num_tokens=int(max_num_tokens),
+            max_batch_size=int(max_batch_size),
+            tp_size=int(tp_size),
+            pp_size=int(pp_size),
+            attention_dp_size=int(attention_dp_size),
+            moe_tp_size=moe_tp_size,
+            moe_ep_size=moe_ep_size,
+            gemm_quant_mode=gemm_quant_mode,
+            moe_quant_mode=moe_quant_mode,
+            kvcache_quant_mode=kvcache_quant_mode,
+            fmha_quant_mode=fmha_quant_mode,
+            comm_quant_mode=comm_quant_mode,
+            nextn=int(nextn),
+            nextn_accept_rates=nextn_accept_rates,
+            systems_path=systems_path,
+        )
+    except Exception as exc:  # native model build unsupported (model/backend/perf DB)
+        if not allow_naive_fallback:
+            raise ValueError(
+                f"unsupported model/backend/GPU for KV-cache estimation: "
+                f"model={model_path}, backend={backend}, gpu_sku={system}: {exc}"
+            ) from exc
+        estimate = NaiveKVCacheEstimator.from_model_path(
+            model_path,
+            tp_size=int(tp_size),
+            pp_size=int(pp_size),
+            allow_hf_config_download=allow_hf_config_download,
+        ).estimate(
+            capacity=gpu_memory_capacity_bytes_override,
+            naive_kv_reservation=float(naive_kv_reservation),
+        )
+    else:
+        # Native model built: budget-math failures (no KV budget, zero per-token)
+        # propagate; they do NOT trigger the naive fallback.
+        estimate = native.estimate(
+            is_of_free=is_of_free,
+            fraction=fraction,
+            gpu_memory_capacity_bytes_override=gpu_memory_capacity_bytes_override,
+        )
+
+    # Apply the tolerance margin (no-op when `tolerance_fraction` is None),
+    # identically for the native and naive estimates. _apply_tolerance reads the
+    # carried `tokens_from_kv_bytes` inverse; strip it afterwards so the result is
+    # the flat, serializable dict the Rust forwarder parses.
+    _apply_tolerance(estimate, tolerance_fraction)
+    estimate.pop("tokens_from_kv_bytes", None)
+    return estimate
+
+
+def estimate_num_gpu_blocks(
+    model_path: str,
+    system: str,
+    backend: str,
+    backend_version: str | None = None,
+    *,
+    scheduler_block_size: int,
+    max_num_tokens: int,
+    max_batch_size: int,
+    memory_fraction_kind: str,
+    memory_fraction_value: float,
+    tp_size: int = 1,
+    pp_size: int = 1,
+    attention_dp_size: int = 1,
+    moe_tp_size: int | None = None,
+    moe_ep_size: int | None = None,
+    gemm_quant_mode: str | None = None,
+    moe_quant_mode: str | None = None,
+    kvcache_quant_mode: str | None = None,
+    fmha_quant_mode: str | None = None,
+    comm_quant_mode: str | None = None,
+    nextn: int = 0,
+    nextn_accept_rates: list[float] | None = None,
+    systems_path: str | None = None,
+    gpu_memory_capacity_bytes_override: int | None = None,
+    tolerance_fraction: float | None = None,
+    naive_kv_reservation: float = _DEFAULT_NAIVE_KV_RESERVATION,
+    allow_naive_fallback: bool = False,
+    allow_hf_config_download: bool = False,
+) -> int:
+    """Convert the KV-cache token capacity to a scheduler block count.
+
+    Thin convenience over :func:`estimate_kv_cache`: computes the per-rank
+    KV-cache token capacity and returns ``floor(total_kv_size_tokens /
+    scheduler_block_size)``, using the tolerance-adjusted token count when
+    ``tolerance_fraction`` is set (the raw count otherwise).
+
+    Args:
+        scheduler_block_size: KV block size the scheduler allocates in (tokens).
+        memory_fraction_kind: ``"of_total"`` (vLLM / SGLang) or ``"of_free"``
+            (TRT-LLM); validated against ``backend``.
+        memory_fraction_value: the fraction in ``[0, 1]``.
+        (remaining kwargs mirror :func:`estimate_kv_cache`.)
+
+    Returns:
+        ``floor(total_kv_size_tokens / scheduler_block_size)``, using the
+        tolerance-adjusted tokens when ``tolerance_fraction`` is set.
+
+    Raises:
+        ValueError: propagated from :func:`estimate_kv_cache` (unsupported
+            model/backend, incompatible memory fraction, out-of-range tolerance,
+            no KV budget, etc.).
+    """
+    block_size = int(scheduler_block_size)
+    if block_size <= 0 or block_size != scheduler_block_size:
+        raise ValueError(f"scheduler_block_size must be a positive integer, got {scheduler_block_size!r}")
+
+    estimate = estimate_kv_cache(
+        model_path,
+        system,
+        backend,
+        backend_version=backend_version,
+        max_num_tokens=int(max_num_tokens),
+        max_batch_size=int(max_batch_size),
+        memory_fraction_kind=memory_fraction_kind,
+        memory_fraction_value=float(memory_fraction_value),
+        tp_size=int(tp_size),
+        pp_size=int(pp_size),
+        attention_dp_size=int(attention_dp_size),
+        moe_tp_size=moe_tp_size,
+        moe_ep_size=moe_ep_size,
+        gemm_quant_mode=gemm_quant_mode,
+        moe_quant_mode=moe_quant_mode,
+        kvcache_quant_mode=kvcache_quant_mode,
+        fmha_quant_mode=fmha_quant_mode,
+        comm_quant_mode=comm_quant_mode,
+        nextn=int(nextn),
+        nextn_accept_rates=nextn_accept_rates,
+        systems_path=systems_path,
+        gpu_memory_capacity_bytes_override=gpu_memory_capacity_bytes_override,
+        tolerance_fraction=tolerance_fraction,
+        naive_kv_reservation=float(naive_kv_reservation),
+        allow_naive_fallback=allow_naive_fallback,
+        allow_hf_config_download=allow_hf_config_download,
+    )
+
+    adjusted = estimate.get("tolerance_adjusted")
+    if adjusted is not None:
+        tokens = int(adjusted["total_kv_size_tokens"])
+    else:
+        tokens = int(estimate["total_kv_size_tokens"])
+
+    return tokens // block_size

--- a/src/aiconfigurator/sdk/models/base.py
+++ b/src/aiconfigurator/sdk/models/base.py
@@ -158,3 +158,64 @@ class BaseModel:
         """KV cache bytes for one sequence on one GPU."""
         seq_len = max(0, seq_len)
         return seq_len * self.config.kvcache_quant_mode.value.memory * self.get_kvcache_elements_per_token()
+
+    def get_kvcache_max_tokens(self, kv_budget_bytes: float) -> int:
+        """Largest single-sequence length whose KV cache fits in ``kv_budget_bytes``.
+
+        The capacity-sizing inverse of :meth:`get_kvcache_bytes_per_sequence`. The
+        base model's KV grows linearly -- a constant number of bytes per token --
+        so the inverse is exact floor-division by that per-token size.
+
+        Models whose KV growth is non-linear -- hybrid sliding-window attention
+        (SWA layers cap at the window while global layers keep growing) or
+        compressed / sparse attention (the per-token rate drops past a window, plus
+        fixed decode-state buffers) -- override :meth:`get_kvcache_bytes_per_sequence`
+        and also override this method (delegating to
+        :meth:`_binary_search_kvcache_max_tokens`) so capacity follows their true piecewise
+        curve instead of extrapolating the ``seq_len=1`` slope.
+        """
+        budget = float(kv_budget_bytes)
+        per_token = self.get_kvcache_bytes_per_sequence(1)
+        if budget <= 0.0 or per_token <= 0.0:
+            return 0
+        return int(budget // per_token)
+
+    def _binary_search_kvcache_max_tokens(self, kv_budget_bytes: float) -> int:
+        """Monotonic-search inverse of :meth:`get_kvcache_bytes_per_sequence`.
+
+        For non-linear-growth models, where a single per-token constant cannot
+        describe the curve, so :meth:`get_kvcache_max_tokens` cannot floor-divide.
+        ``get_kvcache_bytes_per_sequence`` is monotonic non-decreasing, so this
+        doubles the trial length until its KV exceeds the budget, then binary
+        searches for the largest length that still fits.
+        """
+        budget = float(kv_budget_bytes)
+        if budget <= 0.0:
+            return 0
+
+        # The equal-size guard handles a model whose KV stops growing with length
+        # (a cache fully capped by its window): once doubling the length leaves the
+        # KV size unchanged it has saturated, every longer length fits too, and the
+        # budget would never be exceeded -- so the loop would not otherwise stop.
+        hi, hi_bytes = 1, self.get_kvcache_bytes_per_sequence(1)
+        if hi_bytes <= 0.0:
+            return 0
+        while hi_bytes <= budget:
+            nxt = hi * 2
+            nxt_bytes = self.get_kvcache_bytes_per_sequence(nxt)
+            if nxt_bytes == hi_bytes:
+                # KV saturated (a fully window-capped cache): memory never binds, so
+                # the real limit is the model's context length. Fall back to the
+                # current step only when the context length is unknown.
+                return int(self._context_length) if self._context_length > 0 else nxt
+            hi, hi_bytes = nxt, nxt_bytes
+
+        # bytes(hi // 2) <= budget < bytes(hi); binary search the boundary.
+        lo = hi // 2
+        while lo + 1 < hi:
+            mid = (lo + hi) // 2
+            if self.get_kvcache_bytes_per_sequence(mid) <= budget:
+                lo = mid
+            else:
+                hi = mid
+        return lo

--- a/src/aiconfigurator/sdk/models/deepseek_v4.py
+++ b/src/aiconfigurator/sdk/models/deepseek_v4.py
@@ -346,3 +346,7 @@ class DeepSeekV4Model(BaseModel):
                     # CSA has a second FP4 indexer compressor with its own decode state.
                     total += 2 * ratio * 2 * deepseek_v4_cfg.index_head_dim * 4
         return total
+
+    def get_kvcache_max_tokens(self, kv_budget_bytes: float) -> int:
+        """Capacity inverse over the window-capped + compressed KV curve (non-linear)."""
+        return self._binary_search_kvcache_max_tokens(kv_budget_bytes)

--- a/src/aiconfigurator/sdk/models/gemma4.py
+++ b/src/aiconfigurator/sdk/models/gemma4.py
@@ -423,3 +423,9 @@ class Gemma4MixModel(BaseModel):
         swa_bytes = num_swa * swa_kv_per_gpu * cfg.swa_head_dim * 2 * bytes_per_elem * swa_seq
         global_bytes = num_global * global_kv_per_gpu * cfg.global_head_dim * 2 * bytes_per_elem * seq_len
         return float(swa_bytes + global_bytes)
+
+    def get_kvcache_max_tokens(self, kv_budget_bytes: float) -> int:
+        """Capacity inverse over the window-capped KV curve (non-linear past the window)."""
+        if not self._gemma4_config:
+            return super().get_kvcache_max_tokens(kv_budget_bytes)
+        return self._binary_search_kvcache_max_tokens(kv_budget_bytes)

--- a/src/aiconfigurator_core/__init__.py
+++ b/src/aiconfigurator_core/__init__.py
@@ -10,7 +10,7 @@ exports the compiled-engine pyclass ``AicEngine``
 (``from_spec`` / ``run_static`` / ``predict_prefill_latency`` /
 ``predict_decode_latency`` / ``mixed_step_latency`` / ``decode_step_latency``),
 the op-transfer ``#[pyfunction]`` ``engine_spec_bincode_from_json`` (JSON
-``EngineSpec`` -> bincode bytes, the Python -> Rust op-transfer wire), plus the
+``EngineSpec`` -> bincode bytes, the Python -> Rust op-transfer wire), and the
 build smoke check ``_build_smoke``.
 
 It also exports the forward-pass perf model pyclass
@@ -18,9 +18,10 @@ It also exports the forward-pass perf model pyclass
 tuned/fallback forward-pass latency model with online correction, regression
 fallback, and diagnostics.
 
-``build_aic_engine`` is intentionally NOT re-exported: it is a Rust-only entry
-point for embedded callers (e.g. the Dynamo Mocker), not part of the Python
-surface.
+KV-cache capacity estimation is not exported here: it is computed in Python
+(``aiconfigurator.sdk.memory``), and the Rust
+``aiconfigurator_core::memory::estimate_kv_cache`` is a Rust-only forwarder for
+embedded callers (e.g. the Dynamo Mocker), like ``build_aic_engine``.
 """
 
 from ._aiconfigurator_core import (

--- a/tests/integration/test_memory_estimation.py
+++ b/tests/integration/test_memory_estimation.py
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration: ``aiconfigurator.sdk.memory`` capacity estimate over a REAL perf DB.
+
+Exercises the NATIVE path end-to-end (the full ``_get_memory_usage`` backend
+memory model + the OfFree/OfTotal budget math), which the unit tests in
+``tests/unit/sdk/test_memory_estimation.py`` only cover with a synthetic
+breakdown. This is NOT a Python-vs-Rust parity test: the Rust
+``estimate_kv_cache`` is a pure forwarder into this same Python code, so there is
+no independent Rust implementation to compare against -- that round-trip is
+covered separately by ``rust/aiconfigurator-core/tests/memory_round_trip.rs``.
+
+Native cases (Qwen3-32B on h200_sxm, TRT-LLM OfFree and vLLM OfTotal), asserting:
+
+- the returned dict carries the expected fields and a ``source`` string;
+- ``tolerance_adjusted`` appears iff ``tolerance_fraction`` is passed, with bytes
+  == ``floor(raw * (1 - t))`` at ``t = 0.05``;
+- ``estimate_num_gpu_blocks`` returns ``floor(total_kv_size_tokens /
+  scheduler_block_size)``, using the tolerance-adjusted token count when set.
+
+Requires the perf DB (LFS) for the SystemSpec capacity used by the native path,
+plus ``aiconfigurator_core`` importable (transitively, via ``sdk.memory``).
+Soft-skips when the import or the native breakdown is unavailable (e.g. no
+``git lfs pull``) so bare runs stay green.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+# `sdk.memory` (transitively) needs the compiled `aiconfigurator_core` extension,
+# so it must be importable; skip rather than error when it is not built.
+memory = pytest.importorskip("aiconfigurator.sdk.memory")
+
+
+# (model, system, backend, backend_version, memory_fraction_kind) — the
+# native cases. h200_sxm perf DB supplies the SystemSpec capacity.
+NATIVE_CASES = [
+    ("Qwen/Qwen3-32B", "h200_sxm", "trtllm", "1.3.0rc10", "of_free"),
+    ("Qwen/Qwen3-32B", "h200_sxm", "vllm", "0.19.0", "of_total"),
+]
+
+_FRACTION = 0.9
+_BLOCK_SIZE = 64
+_TOLERANCE = 0.05
+
+
+def _skip_if_fixture_unavailable(exc: ValueError) -> None:
+    """Skip ONLY when the native build could not run because the fixture is absent.
+
+    With ``allow_naive_fallback=False`` a missing perf DB / model surfaces as the
+    ``"unsupported model/backend/GPU"`` ValueError. Any OTHER ValueError (budget
+    math, dict shape, a real native-path regression) is re-raised so it fails the
+    test instead of hiding behind an unconditional skip.
+    """
+    if "unsupported model/backend/GPU" in str(exc):
+        pytest.skip(f"native breakdown unavailable (perf DB / model?): {exc}")
+    raise exc
+
+
+def _estimate(case, *, tolerance_fraction=None):
+    model, system, backend, version, kind = case
+    return memory.estimate_kv_cache(
+        model,
+        system,
+        backend,
+        backend_version=version,
+        max_num_tokens=8192,
+        max_batch_size=256,
+        memory_fraction_kind=kind,
+        memory_fraction_value=_FRACTION,
+        tp_size=1,
+        pp_size=1,
+        attention_dp_size=1,
+        tolerance_fraction=tolerance_fraction,
+        allow_naive_fallback=False,
+        allow_hf_config_download=False,
+    )
+
+
+def test_estimate_kv_cache_validates_before_breakdown():
+    """Fraction + tolerance validation raise ValueError without touching the perf DB.
+
+    Both cases fail in the up-front validation (no model / perf DB needed), so
+    this runs deterministically in a bare environment:
+      - incompatible memory fraction (TRT-LLM rejects ``of_total``);
+      - out-of-range tolerance (``t = 1.5``).
+    """
+    with pytest.raises(ValueError, match="incompatible memory fraction"):
+        memory.estimate_kv_cache(
+            "Qwen/Qwen3-32B",
+            "h200_sxm",
+            "trtllm",
+            max_num_tokens=8192,
+            max_batch_size=256,
+            memory_fraction_kind="of_total",  # TRT-LLM requires of_free.
+            memory_fraction_value=0.9,
+        )
+
+    with pytest.raises(ValueError, match="tolerance_fraction"):
+        memory.estimate_kv_cache(
+            "Qwen/Qwen3-32B",
+            "h200_sxm",
+            "trtllm",
+            max_num_tokens=8192,
+            max_batch_size=256,
+            memory_fraction_kind="of_free",
+            memory_fraction_value=0.9,
+            tolerance_fraction=1.5,  # out of [0, 1).
+        )
+
+
+@pytest.mark.parametrize("case", NATIVE_CASES, ids=lambda c: f"{c[2]}-{c[4]}")
+def test_estimate_kv_cache_native_dict_shape(case):
+    """The dict has the expected fields; tolerance_adjusted is None without a tolerance."""
+    try:
+        est = _estimate(case)
+    except ValueError as exc:
+        _skip_if_fixture_unavailable(exc)
+
+    # Required scalar fields.
+    for key in (
+        "total_gpu_capacity_bytes",
+        "total_kv_size_bytes",
+        "kv_size_per_token_bytes",
+        "total_kv_size_tokens",
+    ):
+        assert key in est and isinstance(est[key], int) and est[key] > 0
+
+    assert est["source"] == "native"
+    # Native populates the breakdown; the four components are present.
+    mb = est["memory_breakdown"]
+    assert mb is not None
+    for key in (
+        "weights_bytes",
+        "activations_bytes",
+        "runtime_overhead_bytes",
+        "comm_overhead_bytes",
+    ):
+        assert key in mb
+
+    # No tolerance passed -> tolerance_adjusted absent.
+    assert est["tolerance_adjusted"] is None
+
+
+@pytest.mark.parametrize("case", NATIVE_CASES, ids=lambda c: f"{c[2]}-{c[4]}")
+def test_estimate_kv_cache_tolerance_applied(case):
+    """tolerance_fraction=0.05 -> tolerance_adjusted set, bytes == floor(raw * 0.95)."""
+    try:
+        raw = _estimate(case)
+        adj_est = _estimate(case, tolerance_fraction=_TOLERANCE)
+    except ValueError as exc:
+        _skip_if_fixture_unavailable(exc)
+
+    adjusted = adj_est["tolerance_adjusted"]
+    assert adjusted is not None
+    assert adjusted["tolerance_fraction"] == pytest.approx(_TOLERANCE)
+
+    # adj bytes = floor(raw bytes * 0.95); tokens recomputed by floor-divide.
+    expected_bytes = int(raw["total_kv_size_bytes"] * (1.0 - _TOLERANCE))
+    assert adjusted["total_kv_size_bytes"] == expected_bytes
+    assert adjusted["total_kv_size_tokens"] == expected_bytes // raw["kv_size_per_token_bytes"]
+    # The raw fields are unchanged between the two calls.
+    assert adj_est["total_kv_size_bytes"] == raw["total_kv_size_bytes"]
+
+
+@pytest.mark.parametrize("case", NATIVE_CASES, ids=lambda c: f"{c[2]}-{c[4]}")
+def test_estimate_num_gpu_blocks_floor_conversion(case):
+    """The AIC helper returns floor(tokens / block_size); tolerance picks adjusted tokens."""
+    model, system, backend, version, kind = case
+    common = dict(
+        backend_version=version,
+        scheduler_block_size=_BLOCK_SIZE,
+        max_num_tokens=8192,
+        max_batch_size=256,
+        memory_fraction_kind=kind,
+        memory_fraction_value=_FRACTION,
+        tp_size=1,
+        pp_size=1,
+        attention_dp_size=1,
+    )
+
+    try:
+        raw_est = _estimate(case)
+        blocks_raw = memory.estimate_num_gpu_blocks(model, system, backend, **common)
+        blocks_tol = memory.estimate_num_gpu_blocks(model, system, backend, tolerance_fraction=_TOLERANCE, **common)
+    except ValueError as exc:
+        _skip_if_fixture_unavailable(exc)
+
+    # Raw path: floor(raw tokens / block_size).
+    assert blocks_raw == raw_est["total_kv_size_tokens"] // _BLOCK_SIZE
+
+    # Tolerance path: floor(adjusted tokens / block_size), which is <= raw blocks.
+    adj_est = _estimate(case, tolerance_fraction=_TOLERANCE)
+    adj_tokens = adj_est["tolerance_adjusted"]["total_kv_size_tokens"]
+    assert blocks_tol == adj_tokens // _BLOCK_SIZE
+    assert blocks_tol <= blocks_raw
+    assert math.floor(adj_tokens / _BLOCK_SIZE) == blocks_tol

--- a/tests/unit/sdk/models/test_model_config.py
+++ b/tests/unit/sdk/models/test_model_config.py
@@ -760,6 +760,66 @@ class TestKVCacheElementsPerToken:
         assert model.get_kvcache_elements_per_token() == model._num_layers * (512 + 64)
 
 
+class TestGetKvcacheMaxTokens:
+    """``Model.get_kvcache_max_tokens`` -- the capacity-sizing inverse of
+    ``get_kvcache_bytes_per_sequence``.
+
+    Linear-growth models (GQA / MLA) must invert to exact floor-division by the
+    per-token size; non-linear models (DeepSeek-V4's window-capped + compressed
+    attention) must follow the true piecewise curve via the monotonic search,
+    which also fits strictly more tokens than the seq_len=1 extrapolation.
+    """
+
+    @staticmethod
+    def _build_model(hf_id: str, tp_size: int, **extra):
+        model_config = config.ModelConfig(tp_size=tp_size, pp_size=1, attention_dp_size=1, **extra)
+        return models.get_model(hf_id, model_config, backend_name="trtllm")
+
+    @pytest.mark.parametrize(
+        "hf_id,tp,moe_kw",
+        [
+            ("meta-llama/Meta-Llama-3.1-8B", 1, {}),  # GQA, linear
+            ("Qwen/Qwen3-32B", 4, {}),  # GQA, linear
+            ("deepseek-ai/DeepSeek-V3.2", 4, {"moe_tp_size": 1, "moe_ep_size": 4}),  # MLA, linear
+        ],
+    )
+    def test_linear_models_invert_to_floor_division(self, hf_id, tp, moe_kw):
+        model = self._build_model(hf_id, tp, **moe_kw)
+        per_token = model.get_kvcache_bytes_per_sequence(1)
+        for seq_len in (1, 137, 4096, 200_000):
+            budget = model.get_kvcache_bytes_per_sequence(seq_len)
+            assert model.get_kvcache_max_tokens(budget) == int(budget // per_token) == seq_len
+
+    def test_zero_or_sub_token_budget_returns_zero(self):
+        model = self._build_model("Qwen/Qwen3-32B", 4)
+        assert model.get_kvcache_max_tokens(0) == 0
+        assert model.get_kvcache_max_tokens(model.get_kvcache_bytes_per_sequence(1) - 1) == 0
+
+    def test_deepseek_v4_inverts_nonlinear_curve(self):
+        """DeepSeek-V4 caps local attention at its window and compresses past it
+        (plus fixed decode-state buffers), so its KV growth is non-linear; the
+        inverse follows that curve and beats the seq_len=1 extrapolation."""
+        model_config = config.ModelConfig(
+            tp_size=8,
+            moe_tp_size=1,
+            moe_ep_size=8,
+            attention_dp_size=1,
+            nextn=1,
+            nextn_accept_rates=[0.85, 0.3, 0.0, 0.0, 0.0],
+        )
+        model = models.get_model("sgl-project/DeepSeek-V4-Pro-FP8", model_config, backend_name="trtllm")
+        window = model.extra_params.sliding_window
+        budget = model.get_kvcache_bytes_per_sequence(window * 8)  # well past the window
+        tokens = model.get_kvcache_max_tokens(budget)
+        # Exact monotonic inverse: `tokens` fits, `tokens + 1` does not.
+        assert model.get_kvcache_bytes_per_sequence(tokens) <= budget
+        assert model.get_kvcache_bytes_per_sequence(tokens + 1) > budget
+        # The seq_len=1 slope (inflated by the fixed buffers + uncapped local KV)
+        # under-counts capacity; the curve-aware inverse fits more.
+        per_token = model.get_kvcache_bytes_per_sequence(1)
+        assert tokens > int(budget // per_token)
+
+
 class TestBackendConfiguration:
     """Test backend configuration."""
 

--- a/tests/unit/sdk/test_memory_estimation.py
+++ b/tests/unit/sdk/test_memory_estimation.py
@@ -1,0 +1,726 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the pure-Python KV-cache memory estimate in ``sdk.memory``.
+
+Exercises the naive-fallback math (MLA-aware per-token KV, rough weight estimate,
+80%-of-post-weight reservation, default constants) and the OfFree/OfTotal native
+budget formulas. ``sdk.memory`` imports the compiled ``aiconfigurator_core``
+extension at module top, so these tests are skipped (``pytest.importorskip``)
+when it is not built. The native budget math is tested with a synthetic breakdown
+(no perf DB / model build), and the routing in ``estimate_kv_cache`` is driven by
+monkeypatching ``KVCacheEstimator.from_request`` (to raise -> fallback, or to
+return a ``KVCacheEstimator`` carrying a synthetic breakdown).
+
+The fixture-derived magic numbers (DeepSeek-V3 -> 70_272 bytes/token, Llama-3.1-70B
+-> 327_680) match the values the prior Rust naive tests asserted, so this is a
+checkable parity assertion for the port.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+# ``sdk.memory`` imports the compiled ``aiconfigurator_core`` extension at module
+# top, so these pure-Python tests require it to be importable. Skip them when it
+# is not built rather than stubbing ``sys.modules`` — a stub would leak to other
+# test modules in the same xdist worker and break tests that use the real
+# extension (e.g. the FPM pyclass).
+pytest.importorskip("aiconfigurator_core")
+
+from aiconfigurator.sdk import memory
+
+_GIB = 1 << 30
+
+
+# --------------------------------------------------------------------------- #
+# Memory-fraction validation (runs before any model build).
+# --------------------------------------------------------------------------- #
+
+
+def test_fraction_validation_rejects_wrong_kind_per_backend():
+    with pytest.raises(ValueError, match="incompatible memory fraction"):
+        memory._validate_memory_fraction("trtllm", "of_total", 0.9)
+    with pytest.raises(ValueError, match="incompatible memory fraction"):
+        memory._validate_memory_fraction("vllm", "of_free", 0.9)
+    with pytest.raises(ValueError, match="incompatible memory fraction"):
+        memory._validate_memory_fraction("sglang", "of_free", 0.9)
+    # Correct pairings pass.
+    memory._validate_memory_fraction("trtllm", "of_free", 0.9)
+    memory._validate_memory_fraction("vllm", "of_total", 0.85)
+    memory._validate_memory_fraction("sglang", "of_total", 0.85)
+
+
+def test_fraction_validation_rejects_out_of_range():
+    with pytest.raises(ValueError):
+        memory._validate_memory_fraction("trtllm", "of_free", 1.5)
+    with pytest.raises(ValueError):
+        memory._validate_memory_fraction("vllm", "of_total", -0.1)
+
+
+def test_naive_reservation_validation_rejects_out_of_range():
+    # Boundaries are valid; finite values outside [0, 1] (and non-finite) are not.
+    memory._validate_naive_reservation(0.0)
+    memory._validate_naive_reservation(1.0)
+    memory._validate_naive_reservation(0.8)
+    for bad in (-0.1, 1.5, float("nan"), float("inf")):
+        with pytest.raises(ValueError, match="naive_kv_reservation"):
+            memory._validate_naive_reservation(bad)
+
+
+def test_estimate_num_gpu_blocks_rejects_non_positive_or_non_integer_block_size():
+    # Caught up front (before any model build), so no perf DB / fixture is needed.
+    # A positive non-integer (e.g. 0.5 -> int() == 0) must be rejected rather than
+    # reaching the floor-divide and raising ZeroDivisionError.
+    common = dict(
+        max_num_tokens=8192,
+        max_batch_size=256,
+        memory_fraction_kind="of_free",
+        memory_fraction_value=0.9,
+    )
+    for bad in (0, -1, 0.5, 1.5):
+        with pytest.raises(ValueError, match="scheduler_block_size"):
+            memory.estimate_num_gpu_blocks(
+                "Qwen/Qwen3-32B",
+                "h200_sxm",
+                "trtllm",
+                scheduler_block_size=bad,
+                **common,
+            )
+
+
+# --------------------------------------------------------------------------- #
+# Native budget math: OfFree (TRT-LLM) and OfTotal (vLLM/SGLang).
+# --------------------------------------------------------------------------- #
+
+
+def _breakdown(non_kv: float, kv_per_token: float, capacity: float) -> dict[str, float]:
+    return {
+        "weights_bytes": non_kv * 0.7,
+        "activations_bytes": non_kv * 0.2,
+        "runtime_overhead_bytes": non_kv * 0.07,
+        "comm_overhead_bytes": non_kv * 0.03,
+        "non_kv_bytes": non_kv,
+        "kv_size_per_token_bytes": kv_per_token,
+        "gpu_memory_capacity_bytes": capacity,
+    }
+
+
+def _native_estimate(breakdown, **kwargs):
+    """Run the native budget math over a (synthetic) breakdown via KVCacheEstimator."""
+    return memory.KVCacheEstimator(breakdown).estimate(**kwargs)
+
+
+def _naive_estimate(
+    model_path,
+    *,
+    tp_size=1,
+    pp_size=1,
+    gpu_memory_capacity_bytes_override,
+    naive_kv_reservation,
+    allow_hf_config_download=False,
+):
+    """Build a NaiveKVCacheEstimator and run its estimate (mirrors the old helper)."""
+    return memory.NaiveKVCacheEstimator.from_model_path(
+        model_path, tp_size=tp_size, pp_size=pp_size, allow_hf_config_download=allow_hf_config_download
+    ).estimate(capacity=gpu_memory_capacity_bytes_override, naive_kv_reservation=naive_kv_reservation)
+
+
+def test_of_free_budget_formula():
+    capacity, non_kv, kv_per_token, f = 141.0 * _GIB, 60.0 * _GIB, 327_680.0, 0.9
+    out = _native_estimate(
+        _breakdown(non_kv, kv_per_token, capacity),
+        is_of_free=True,
+        fraction=f,
+        gpu_memory_capacity_bytes_override=None,
+    )
+    ref_kv = (capacity - non_kv) * f
+    assert out["total_kv_size_bytes"] == int(ref_kv)
+    assert out["total_kv_size_tokens"] == int(ref_kv / kv_per_token)
+    assert out["source"] == "native"
+    assert out["memory_breakdown"] is not None
+
+
+def test_of_total_budget_formula_differs_from_of_free():
+    capacity, non_kv, kv_per_token, f = 180.0 * _GIB, 70.0 * _GIB, 131_072.0, 0.9
+    bd = _breakdown(non_kv, kv_per_token, capacity)
+    of_total = _native_estimate(bd, is_of_free=False, fraction=f, gpu_memory_capacity_bytes_override=None)
+    of_free = _native_estimate(bd, is_of_free=True, fraction=f, gpu_memory_capacity_bytes_override=None)
+    assert of_total["total_kv_size_bytes"] == int(capacity * f - non_kv)
+    # OfFree gives a strictly larger budget for f < 1 (the whole point of the split).
+    assert of_free["total_kv_size_bytes"] > of_total["total_kv_size_bytes"]
+
+
+def test_native_no_kv_budget_raises():
+    capacity, non_kv = 100.0 * _GIB, 95.0 * _GIB
+    with pytest.raises(ValueError, match="no KV budget"):
+        _native_estimate(
+            _breakdown(non_kv, 100_000.0, capacity),
+            is_of_free=False,
+            fraction=0.9,
+            gpu_memory_capacity_bytes_override=None,
+        )
+
+
+def test_native_zero_per_token_raises():
+    with pytest.raises(ValueError, match="kv_size_per_token_bytes"):
+        _native_estimate(
+            _breakdown(10.0 * _GIB, 0.0, 100.0 * _GIB),
+            is_of_free=True,
+            fraction=0.9,
+            gpu_memory_capacity_bytes_override=None,
+        )
+
+
+def test_breakdown_applies_nextn_to_model_config(monkeypatch):
+    # KVCacheEstimator.from_request must push nextn/MTP onto the ModelConfig before
+    # get_model, so _get_memory_usage scales activation memory for speculative
+    # decoding instead of treating the request as nextn=0.
+    captured = {}
+
+    def _fake_get_model(model_path, model_config, backend):
+        captured["nextn"] = model_config.nextn
+        captured["rates"] = model_config.nextn_accept_rates
+
+        class _StubModel:
+            def get_kvcache_bytes_per_sequence(self, seq_len):
+                return 100.0 * seq_len
+
+            def get_kvcache_max_tokens(self, budget):
+                return int(budget // 100)
+
+        return _StubModel()
+
+    class _StubBackend:
+        def _get_memory_usage(self, *a, **k):
+            return {"weights": 1.0, "activations": 1.0, "others": 1.0, "nccl": 1.0, "kvcache": 0.0}
+
+    class _StubDB:
+        def __init__(self):
+            self.system_spec = {"gpu": {"mem_capacity": 100 * _GIB}}
+
+    monkeypatch.setattr(memory, "get_model", _fake_get_model)
+    monkeypatch.setattr(memory, "get_backend", lambda backend: _StubBackend())
+    monkeypatch.setattr(memory.perf_database, "get_database", lambda *a, **k: _StubDB())
+
+    memory.KVCacheEstimator.from_request(
+        "Qwen/Qwen3-32B",
+        "h200_sxm",
+        "trtllm",
+        max_num_tokens=8192,
+        max_batch_size=256,
+        nextn=2,
+    )
+    assert captured["nextn"] == 2
+    # No explicit rates -> the project-wide MTP default is applied.
+    assert captured["rates"] == [0.85, 0.3, 0.0, 0.0, 0.0]
+
+
+def test_native_capacity_override_wins():
+    capacity, non_kv, kv_per_token, f = 141.0 * _GIB, 60.0 * _GIB, 327_680.0, 0.9
+    override = 200 * _GIB
+    out = _native_estimate(
+        _breakdown(non_kv, kv_per_token, capacity),
+        is_of_free=True,
+        fraction=f,
+        gpu_memory_capacity_bytes_override=override,
+    )
+    assert out["total_gpu_capacity_bytes"] == override
+    assert out["total_kv_size_bytes"] == int((override - non_kv) * f)
+
+
+# --------------------------------------------------------------------------- #
+# NaiveKVCacheEstimator: per-token KV (standard GQA/MHA vs MLA), weight estimate,
+# config->geometry parsing, sliding-window detection, and the byte-budget ->
+# token-count inverse with auto LINEAR/HYBRID mode selection.
+# --------------------------------------------------------------------------- #
+
+
+def _estimator(geometry, *, dtype_bytes=2, tp_size=1, pp_size=1):
+    return memory.NaiveKVCacheEstimator(geometry, dtype_bytes=dtype_bytes, tp_size=tp_size, pp_size=pp_size)
+
+
+def test_naive_kv_per_token_mla():
+    # DeepSeek-V3-style: layers=61, kv_lora_rank=512, qk_rope_head_dim=64, bf16:
+    #   61 * (512 + 64) * 2 = 70_272 bytes/token. The latent is NOT sharded by TP.
+    geom = {"layers": 61, "kv_lora_rank": 512, "qk_rope_head_dim": 64}
+    assert _estimator(geom, tp_size=1).kv_bytes_per_token() == 70_272
+    assert _estimator(geom, tp_size=8).kv_bytes_per_token() == 70_272
+
+
+def test_naive_kv_per_token_mla_fails_closed_without_latent_width():
+    # MLA detected (kv_lora_rank present) but qk_rope_head_dim missing -> the
+    # cached latent width is unclear, so fail closed (None -> caller raises) rather
+    # than guessing the latent width.
+    assert _estimator({"layers": 61, "kv_lora_rank": 512}).kv_bytes_per_token() is None
+
+
+def test_naive_kv_per_token_standard():
+    # Llama-3.1-70B-style: layers=80, num_kv_heads=8, head_dim=128, bf16:
+    #   TP=1: 2 * 8 * 128 * 80 * 2 = 327_680.
+    geom = {"layers": 80, "num_kv_heads": 8, "head_dim": 128}
+    assert _estimator(geom, tp_size=1).kv_bytes_per_token() == 327_680
+    # TP=4: kv_heads_per_rank = ceil(8/4) = 2 -> quarter.
+    assert _estimator(geom, tp_size=4).kv_bytes_per_token() == 2 * 2 * 128 * 80 * 2
+    # TP=16: kv_heads_per_rank = ceil(8/16) = 1.
+    assert _estimator(geom, tp_size=16).kv_bytes_per_token() == 2 * 1 * 128 * 80 * 2
+
+
+def test_naive_geometry_from_raw_unsupported_arch():
+    # Unsupported architecture -> raw-key extraction (parsed=None). head_dim is
+    # derived from hidden_size / num_attention_heads when absent.
+    hf_config = {
+        "num_hidden_layers": 32,
+        "num_attention_heads": 32,
+        "num_key_value_heads": 8,
+        "hidden_size": 4096,
+        "vocab_size": 128_000,
+        "intermediate_size": 11_008,
+    }
+    geom = memory.NaiveKVCacheEstimator._geometry(hf_config, None)
+    assert geom["head_dim"] == 4096 // 32  # 128
+    # Standard branch: 2 * ceil(8/2) * 128 * 32 * 2 (bf16).
+    assert _estimator(geom, tp_size=2).kv_bytes_per_token() == 2 * 4 * 128 * 32 * 2
+    assert _estimator(geom).weight_bytes() is not None
+    # vocab / intermediate_size are required: drop either and the weight is None.
+    assert _estimator({**geom, "vocab": None}).weight_bytes() is None
+    assert _estimator({**geom, "inter": None}).weight_bytes() is None
+
+
+def test_naive_kv_per_token_empty_geometry_is_none():
+    assert _estimator({}).kv_bytes_per_token() is None
+    assert _estimator({}).weight_bytes() is None
+
+
+def test_dtype_bytes():
+    dtype_bytes = memory.NaiveKVCacheEstimator._dtype_bytes
+    assert dtype_bytes({"torch_dtype": "bfloat16"}) == 2
+    assert dtype_bytes({"torch_dtype": "float32"}) == 4
+    assert dtype_bytes({"torch_dtype": "fp8_e4m3"}) == 1
+    assert dtype_bytes({}) == 2  # default bf16
+
+
+# --------------------------------------------------------------------------- #
+# NaiveKVCacheEstimator hybrid sliding-window support: layer-layout detection +
+# the piecewise byte-budget -> token-count inverse, so the fallback does not
+# assume linear KV growth for SWA models.
+# --------------------------------------------------------------------------- #
+
+
+def test_naive_swa_layout_from_layer_types():
+    # Explicit per-layer list (Gemma-3/4 style): count sliding vs the rest.
+    hf_config = {"sliding_window": 1024, "layer_types": ["sliding_attention"] * 5 + ["full_attention"]}
+    assert memory.NaiveKVCacheEstimator._swa_layout(hf_config) == (1024, 5, 1)
+
+
+def test_naive_swa_layout_from_pattern():
+    # sliding_window + sliding_window_pattern=6: one global layer every 6 layers.
+    hf_config = {"sliding_window": 4096, "num_hidden_layers": 30, "sliding_window_pattern": 6}
+    assert memory.NaiveKVCacheEstimator._swa_layout(hf_config) == (4096, 25, 5)
+
+
+def test_naive_swa_layout_unresolved_returns_none():
+    # A bare window with no per-layer signal is too model-specific to split.
+    assert memory.NaiveKVCacheEstimator._swa_layout({"sliding_window": 4096}) == (None, None, None)
+    assert memory.NaiveKVCacheEstimator._swa_layout({}) == (None, None, None)
+
+
+def test_naive_hybrid_mode_caps_swa_past_window():
+    # 25 SWA + 5 global layers, window 1024, 8 KV heads, head_dim 128, bf16, tp=1.
+    geom = {
+        "sliding_window": 1024,
+        "num_swa_layers": 25,
+        "num_global_layers": 5,
+        "num_kv_heads": 8,
+        "head_dim": 128,
+    }
+    est = _estimator(geom)
+    assert est.mode is memory.NaiveKVCacheMode.HYBRID
+    hybrid = memory.NaiveKVCacheMode.HYBRID
+    per_layer = 2 * 8 * 128 * 2  # 4096
+    rate = (25 + 5) * per_layer  # every layer grows up to the window
+    global_const = 5 * per_layer
+    assert est.get_kvcache_max_tokens(rate * 512, mode=hybrid) == 512  # within the window: linear
+    assert est.get_kvcache_max_tokens(rate * 1024, mode=hybrid) == 1024  # at the boundary
+    # Past the window only the 5 global layers grow.
+    budget = rate * 1024 + global_const * 3
+    assert est.get_kvcache_max_tokens(budget, mode=hybrid) == 1027
+    # mode auto-resolves to HYBRID here, so it gives the same answer as forcing it.
+    assert est.get_kvcache_max_tokens(budget) == 1027
+    # Beats the linear seq_len=1 extrapolation, which over-charges the SWA layers.
+    assert est.get_kvcache_max_tokens(budget, mode=hybrid) > budget // rate
+
+
+def test_naive_mode_linear_for_standard_and_mla():
+    # No sliding-window layout -> LINEAR.
+    assert _estimator({"num_kv_heads": 8, "head_dim": 128}).mode is memory.NaiveKVCacheMode.LINEAR
+    # MLA latent cache is out of scope for the hybrid heuristic -> LINEAR.
+    mla_hybrid = {
+        "sliding_window": 1024,
+        "num_swa_layers": 5,
+        "num_global_layers": 1,
+        "kv_lora_rank": 512,
+        "num_kv_heads": 8,
+        "head_dim": 128,
+    }
+    assert _estimator(mla_hybrid).mode is memory.NaiveKVCacheMode.LINEAR
+
+
+# --------------------------------------------------------------------------- #
+# Naive fallback end-to-end (post-weight reservation + defaults), driven through
+# the SDK's existing config loaders + `_parse_hf_config_json` (cached fixtures).
+# --------------------------------------------------------------------------- #
+
+
+# A synthetic config for an architecture AIC does not support, carrying the full
+# geometry the naive weight + KV formulas require.
+_RAW_UNSUPPORTED = {
+    "architectures": ["FooBarForCausalLM"],
+    "num_hidden_layers": 48,
+    "num_attention_heads": 32,
+    "num_key_value_heads": 8,
+    "hidden_size": 4096,
+    "vocab_size": 128_000,
+    "intermediate_size": 14_336,
+    "torch_dtype": "bfloat16",
+}
+
+
+def test_naive_fallback_mla_fixture():
+    # `deepseek-ai/DeepSeek-V3` is cached in model_configs (DefaultHFModels), so
+    # `NaiveKVCacheEstimator._load_config` loads it without a download; the
+    # supported arch goes through `_parse_hf_config_json` -> 70_272 bytes/token.
+    capacity = 180 * _GIB
+    out = _naive_estimate(
+        "deepseek-ai/DeepSeek-V3",
+        tp_size=16,
+        pp_size=1,
+        gpu_memory_capacity_bytes_override=capacity,
+        naive_kv_reservation=memory._DEFAULT_NAIVE_KV_RESERVATION,
+        allow_hf_config_download=False,
+    )
+    assert out["source"] == "naive_fallback"
+    assert out["memory_breakdown"] is None
+    assert out["kv_size_per_token_bytes"] == 70_272  # config-driven MLA latent
+
+
+def test_naive_fallback_unsupported_arch_uses_raw_read(monkeypatch):
+    # Unsupported architecture: `_parse_hf_config_json` raises, so the estimator
+    # falls to the raw-key read. This drives the real parser (FooBar arch is not in
+    # ARCHITECTURE_TO_MODEL_FAMILY) through the except branch into
+    # `NaiveKVCacheEstimator._geometry(hf_config, None)`.
+    monkeypatch.setattr(memory.NaiveKVCacheEstimator, "_load_config", lambda *a, **k: dict(_RAW_UNSUPPORTED))
+    out = _naive_estimate(
+        "foo/bar-unknown-arch",
+        tp_size=1,
+        pp_size=1,
+        gpu_memory_capacity_bytes_override=200 * _GIB,
+        naive_kv_reservation=memory._DEFAULT_NAIVE_KV_RESERVATION,
+        allow_hf_config_download=False,
+    )
+    assert out["source"] == "naive_fallback"
+    # Raw-read standard branch: layers=48, n_kv=8, head_dim=4096/32=128, bf16.
+    assert out["kv_size_per_token_bytes"] == 2 * 8 * 128 * 48 * 2  # 196608
+
+
+def test_naive_fallback_raises_without_config():
+    # HF id that is neither local nor pre-cached, with download disabled -> no
+    # config -> raise rather than guess with a placeholder constant.
+    with pytest.raises(ValueError, match="insufficient model metadata"):
+        _naive_estimate(
+            "definitely/not-a-real-model-xyz",
+            tp_size=1,
+            pp_size=1,
+            gpu_memory_capacity_bytes_override=200 * _GIB,
+            naive_kv_reservation=memory._DEFAULT_NAIVE_KV_RESERVATION,
+            allow_hf_config_download=False,
+        )
+
+
+def test_naive_fallback_raises_on_missing_weight_metadata(monkeypatch):
+    # Config present but lacking weight-estimate fields (no vocab_size /
+    # intermediate_size) -> raise rather than fabricate a placeholder weight.
+    raw = {k: v for k, v in _RAW_UNSUPPORTED.items() if k not in ("vocab_size", "intermediate_size")}
+    monkeypatch.setattr(memory.NaiveKVCacheEstimator, "_load_config", lambda *a, **k: raw)
+    with pytest.raises(ValueError, match="weight-estimate fields"):
+        _naive_estimate(
+            "foo/bar-unknown-arch",
+            tp_size=1,
+            pp_size=1,
+            gpu_memory_capacity_bytes_override=200 * _GIB,
+            naive_kv_reservation=memory._DEFAULT_NAIVE_KV_RESERVATION,
+            allow_hf_config_download=False,
+        )
+
+
+def test_naive_fallback_honors_reservation_param(monkeypatch):
+    # The reservation fraction is caller-adjustable (default 0.80); a 0.5 reserve
+    # halves the post-weight KV budget. Uses a full synthetic config so the weight
+    # estimate is available (no placeholder fallback any more).
+    capacity = 200 * _GIB
+    monkeypatch.setattr(memory.NaiveKVCacheEstimator, "_load_config", lambda *a, **k: dict(_RAW_UNSUPPORTED))
+    weight = float(
+        memory.NaiveKVCacheEstimator(
+            memory.NaiveKVCacheEstimator._geometry(dict(_RAW_UNSUPPORTED), None),
+            dtype_bytes=memory.NaiveKVCacheEstimator._dtype_bytes(_RAW_UNSUPPORTED),
+            tp_size=1,
+            pp_size=1,
+        ).weight_bytes()
+    )
+    post_weight = capacity - weight
+    out = _naive_estimate(
+        "foo/bar-unknown-arch",
+        tp_size=1,
+        pp_size=1,
+        gpu_memory_capacity_bytes_override=capacity,
+        naive_kv_reservation=0.5,
+        allow_hf_config_download=False,
+    )
+    assert out["total_kv_size_bytes"] == int(post_weight * 0.5)
+
+
+def test_naive_fallback_requires_capacity_override():
+    # Use a cached model so from_model_path succeeds; the capacity check inside
+    # .estimate() is what must raise.
+    with pytest.raises(ValueError, match="gpu_memory_capacity_bytes_override"):
+        _naive_estimate(
+            "deepseek-ai/DeepSeek-V3",
+            tp_size=1,
+            pp_size=1,
+            gpu_memory_capacity_bytes_override=None,
+            naive_kv_reservation=memory._DEFAULT_NAIVE_KV_RESERVATION,
+            allow_hf_config_download=False,
+        )
+
+
+# An unsupported hybrid sliding-window config: 25 SWA + 5 global layers, window
+# 1024. The naive fallback should cap the SWA layers at the window rather than
+# extrapolate the seq_len=1 per-token rate forever.
+_RAW_HYBRID = {
+    "architectures": ["FooSwaForCausalLM"],
+    "num_hidden_layers": 30,
+    "num_attention_heads": 16,
+    "num_key_value_heads": 8,
+    "head_dim": 128,
+    "hidden_size": 2048,
+    "vocab_size": 256_000,
+    "intermediate_size": 8192,
+    "sliding_window": 1024,
+    "layer_types": (["sliding_attention"] * 5 + ["full_attention"]) * 5,
+    "torch_dtype": "bfloat16",
+}
+
+
+def test_naive_fallback_hybrid_beats_linear_capacity(monkeypatch):
+    # With a large budget the token count runs well past the window, so the
+    # window-capped curve fits strictly more tokens than dividing by the full
+    # per-token rate would. kv_size_per_token_bytes (the reported seq=1 rate) is
+    # unchanged -- only the capacity inversion is curve-aware.
+    monkeypatch.setattr(memory.NaiveKVCacheEstimator, "_load_config", lambda *a, **k: dict(_RAW_HYBRID))
+    out = _naive_estimate(
+        "foo/swa-unknown-arch",
+        tp_size=1,
+        pp_size=1,
+        gpu_memory_capacity_bytes_override=200 * _GIB,
+        naive_kv_reservation=memory._DEFAULT_NAIVE_KV_RESERVATION,
+        allow_hf_config_download=False,
+    )
+    assert out["source"] == "naive_fallback"
+    linear_tokens = out["total_kv_size_bytes"] // out["kv_size_per_token_bytes"]
+    assert out["total_kv_size_tokens"] > linear_tokens
+
+
+# --------------------------------------------------------------------------- #
+# estimate_kv_cache: routing between native and naive fallback.
+# --------------------------------------------------------------------------- #
+
+
+def test_estimate_kv_cache_falls_back_when_breakdown_raises(monkeypatch):
+    def _boom(*args, **kwargs):
+        raise RuntimeError("perf DB not available")
+
+    monkeypatch.setattr(memory.KVCacheEstimator, "from_request", classmethod(_boom))
+    monkeypatch.setattr(memory.NaiveKVCacheEstimator, "_load_config", lambda *a, **k: dict(_RAW_UNSUPPORTED))
+    out = memory.estimate_kv_cache(
+        "foo/bar-unknown-arch",
+        "h200_sxm",
+        "trtllm",
+        max_num_tokens=8192,
+        max_batch_size=256,
+        memory_fraction_kind="of_free",
+        memory_fraction_value=0.9,
+        gpu_memory_capacity_bytes_override=200 * _GIB,
+        allow_naive_fallback=True,
+    )
+    assert out["source"] == "naive_fallback"
+    assert out["tolerance_adjusted"] is None
+
+
+def test_estimate_kv_cache_propagates_when_fallback_disabled(monkeypatch):
+    def _boom(*args, **kwargs):
+        raise RuntimeError("perf DB not available")
+
+    monkeypatch.setattr(memory.KVCacheEstimator, "from_request", classmethod(_boom))
+    with pytest.raises(ValueError, match="unsupported model/backend/GPU"):
+        memory.estimate_kv_cache(
+            "definitely/not-a-real-model-xyz",
+            "h200_sxm",
+            "trtllm",
+            max_num_tokens=8192,
+            max_batch_size=256,
+            memory_fraction_kind="of_free",
+            memory_fraction_value=0.9,
+            gpu_memory_capacity_bytes_override=200 * _GIB,
+            allow_naive_fallback=False,
+        )
+
+
+def test_estimate_kv_cache_rejects_bad_fraction_before_breakdown(monkeypatch):
+    # Fraction validation must run before any breakdown attempt: a TRT-LLM +
+    # of_total request fails even though the breakdown would also have raised.
+    called = {"n": 0}
+
+    def _spy(*args, **kwargs):
+        called["n"] += 1
+        raise RuntimeError("should not be reached")
+
+    monkeypatch.setattr(memory.KVCacheEstimator, "from_request", classmethod(_spy))
+    with pytest.raises(ValueError, match="incompatible memory fraction"):
+        memory.estimate_kv_cache(
+            "Qwen/Qwen3-32B",
+            "h200_sxm",
+            "trtllm",
+            max_num_tokens=8192,
+            max_batch_size=256,
+            memory_fraction_kind="of_total",
+            memory_fraction_value=0.9,
+            allow_naive_fallback=True,
+        )
+    assert called["n"] == 0
+
+
+def test_estimate_kv_cache_native_uses_synthetic_breakdown(monkeypatch):
+    bd = _breakdown(60.0 * _GIB, 327_680.0, 141.0 * _GIB)
+    monkeypatch.setattr(memory.KVCacheEstimator, "from_request", classmethod(lambda cls, *a, **k: cls(bd)))
+    out = memory.estimate_kv_cache(
+        "Qwen/Qwen3-32B",
+        "h200_sxm",
+        "trtllm",
+        max_num_tokens=8192,
+        max_batch_size=256,
+        memory_fraction_kind="of_free",
+        memory_fraction_value=0.9,
+    )
+    assert out["source"] == "native"
+    assert out["total_kv_size_bytes"] == int((141.0 * _GIB - 60.0 * _GIB) * 0.9)
+    assert out["tolerance_adjusted"] is None
+    # The internal KV-curve inverse callable must not leak into the result dict
+    # (it would not survive the PyO3 boundary).
+    assert "tokens_from_kv_bytes" not in out
+
+
+# --------------------------------------------------------------------------- #
+# tolerance_fraction: validation (up front) + application (native & naive).
+#
+# This math moved out of Rust `apply_tolerance` into the Python
+# `estimate_kv_cache`; the assertions reproduce the formula the Rust tests
+# previously asserted (`adj_bytes = floor(raw * (1 - t))`, tokens floor-divided),
+# so this is the parity guarantee that the port preserves the old numbers.
+# --------------------------------------------------------------------------- #
+
+
+def test_tolerance_applied_to_native_estimate(monkeypatch):
+    bd = _breakdown(60.0 * _GIB, 327_680.0, 141.0 * _GIB)
+    monkeypatch.setattr(memory.KVCacheEstimator, "from_request", classmethod(lambda cls, *a, **k: cls(bd)))
+    out = memory.estimate_kv_cache(
+        "Qwen/Qwen3-32B",
+        "h200_sxm",
+        "trtllm",
+        max_num_tokens=8192,
+        max_batch_size=256,
+        memory_fraction_kind="of_free",
+        memory_fraction_value=0.9,
+        tolerance_fraction=0.05,
+    )
+    adj = out["tolerance_adjusted"]
+    assert adj is not None
+    assert adj["tolerance_fraction"] == pytest.approx(0.05)
+    # adj bytes = floor(raw * 0.95); tokens recomputed by floor-divide.
+    expected_bytes = int(out["total_kv_size_bytes"] * 0.95)
+    assert adj["total_kv_size_bytes"] == expected_bytes
+    assert adj["total_kv_size_tokens"] == expected_bytes // out["kv_size_per_token_bytes"]
+    # Raw fields are left untouched.
+    assert out["total_kv_size_bytes"] == int((141.0 * _GIB - 60.0 * _GIB) * 0.9)
+
+
+def test_tolerance_applied_to_naive_fallback(monkeypatch):
+    def _boom(*args, **kwargs):
+        raise RuntimeError("perf DB not available")
+
+    monkeypatch.setattr(memory.KVCacheEstimator, "from_request", classmethod(_boom))
+    monkeypatch.setattr(memory.NaiveKVCacheEstimator, "_load_config", lambda *a, **k: dict(_RAW_UNSUPPORTED))
+    out = memory.estimate_kv_cache(
+        "foo/bar-unknown-arch",
+        "h200_sxm",
+        "trtllm",
+        max_num_tokens=8192,
+        max_batch_size=256,
+        memory_fraction_kind="of_free",
+        memory_fraction_value=0.9,
+        gpu_memory_capacity_bytes_override=200 * _GIB,
+        tolerance_fraction=0.05,
+        allow_naive_fallback=True,
+    )
+    assert out["source"] == "naive_fallback"
+    adj = out["tolerance_adjusted"]
+    assert adj is not None
+    expected_bytes = int(out["total_kv_size_bytes"] * 0.95)
+    assert adj["total_kv_size_bytes"] == expected_bytes
+    assert adj["total_kv_size_tokens"] == expected_bytes // out["kv_size_per_token_bytes"]
+
+
+def test_tolerance_out_of_range_rejected_before_breakdown(monkeypatch):
+    # Tolerance validation must run before any breakdown attempt: a bad tolerance
+    # fails even though the breakdown would have succeeded (spy never called).
+    called = {"n": 0}
+
+    def _spy(*args, **kwargs):
+        called["n"] += 1
+        raise RuntimeError("should not be reached")
+
+    monkeypatch.setattr(memory.KVCacheEstimator, "from_request", classmethod(_spy))
+    for bad in (1.0, 1.5, -0.1, float("nan")):
+        with pytest.raises(ValueError, match="tolerance_fraction"):
+            memory.estimate_kv_cache(
+                "Qwen/Qwen3-32B",
+                "h200_sxm",
+                "trtllm",
+                max_num_tokens=8192,
+                max_batch_size=256,
+                memory_fraction_kind="of_free",
+                memory_fraction_value=0.9,
+                tolerance_fraction=bad,
+                allow_naive_fallback=True,
+            )
+    assert called["n"] == 0
+
+
+def test_tolerance_zero_is_noop_margin(monkeypatch):
+    # t = 0.0 is accepted (half-open [0, 1)): adjusted bytes == raw bytes.
+    bd = _breakdown(60.0 * _GIB, 327_680.0, 141.0 * _GIB)
+    monkeypatch.setattr(memory.KVCacheEstimator, "from_request", classmethod(lambda cls, *a, **k: cls(bd)))
+    out = memory.estimate_kv_cache(
+        "Qwen/Qwen3-32B",
+        "h200_sxm",
+        "trtllm",
+        max_num_tokens=8192,
+        max_batch_size=256,
+        memory_fraction_kind="of_free",
+        memory_fraction_value=0.9,
+        tolerance_fraction=0.0,
+    )
+    adj = out["tolerance_adjusted"]
+    assert adj is not None
+    assert adj["total_kv_size_bytes"] == out["total_kv_size_bytes"]

--- a/tests/unit/sdk/test_utils.py
+++ b/tests/unit/sdk/test_utils.py
@@ -692,6 +692,42 @@ class TestGemma4MixModelBuilder:
         expected = 25 * 1024 * 1024 + 5 * 2048 * seq_len
         assert model.get_kvcache_bytes_per_sequence(seq_len) == expected
 
+    def test_get_kvcache_max_tokens_follows_window_capped_curve(self):
+        """The capacity inverse caps SWA layers at the window instead of using the
+        (larger) seq_len=1 slope, so it fits far more tokens past the window."""
+        model = self._make_model(self._make_model_config())
+        budget = model.get_kvcache_bytes_per_sequence(65536)  # >> 1024 window
+        tokens = model.get_kvcache_max_tokens(budget)
+        # Exact monotonic inverse: `tokens` fits, one more token does not.
+        assert tokens == 65536
+        assert model.get_kvcache_bytes_per_sequence(tokens) <= budget
+        assert model.get_kvcache_bytes_per_sequence(tokens + 1) > budget
+        # The seq_len=1 extrapolation under-counts: SWA layers are charged forever.
+        per_token = model.get_kvcache_bytes_per_sequence(1)
+        assert tokens > int(budget // per_token)
+
+    def test_get_kvcache_max_tokens_linear_below_window(self):
+        """Below the window every layer still grows, so the inverse is plain
+        floor-division by the per-token size."""
+        model = self._make_model(self._make_model_config())
+        per_token = model.get_kvcache_bytes_per_sequence(1)
+        budget = model.get_kvcache_bytes_per_sequence(512)  # < 1024 window
+        assert model.get_kvcache_max_tokens(budget) == int(budget // per_token) == 512
+
+    def test_get_kvcache_max_tokens_saturated_caps_at_context_length(self):
+        """A fully window-capped cache (all SWA, no global layers) saturates: KV
+        stops growing past the window, so memory never binds and capacity is
+        bounded by the model context length -- not an arbitrary doubling step."""
+        # No full_attention layer -> every layer caps at the 1024 window.
+        model = self._make_model(self._make_model_config(), layer_types=["sliding_attention"] * 6)
+        # KV is flat past the window: confirm we are actually in the saturated regime.
+        assert model.get_kvcache_bytes_per_sequence(2048) == model.get_kvcache_bytes_per_sequence(1024)
+        saturated = model.get_kvcache_bytes_per_sequence(model._context_length)
+        # Any budget at/above the saturated size returns the context length, and is
+        # stable across wildly different (large) budgets rather than tracking 2^k.
+        assert model.get_kvcache_max_tokens(saturated) == model._context_length == 262144
+        assert model.get_kvcache_max_tokens(saturated * 1000) == model._context_length
+
     def test_set_gemma4_config_rejects_wrong_type(self):
         """Passing a HybridMoEConfig (or any non-Gemma4MixConfig) raises."""
         model = Gemma4MixModel(


### PR DESCRIPTION
#### Overview:

Top-level KV-cache memory (capacity) estimation in the core, separate from latency prediction. Called once per session (e.g. by the Dynamo Mocker) to size `num_gpu_blocks`. The complete estimate lives in Python (`sdk/memory.py`, the single source of truth); the Rust entry point is a **pure** PyO3 forwarder with no math of its own.

> **Stacked on #1200** — review/merge that PR first; this PR's diff is only the capacity commit on top.

#### Details (file map):

```text
src/aiconfigurator/sdk/memory.py        NEW — single source of truth. Two estimators, each built then
                                          asked to .estimate(): KVCacheEstimator (native: AIC model +
                                          backend + perf DB, OfFree/OfTotal budget) and NaiveKVCacheEstimator
                                          (naive: HF-config-only, reserves a fraction of post-weight memory,
                                          standard K/V vs MLA split, fail-closed). estimate_kv_cache
                                          validates + routes native↔naive + applies the tolerance margin;
                                          estimate_num_gpu_blocks (floor helper); shared kv_cache_budget_bytes.
                                          bytes->tokens follows the model's true KV curve
                                          (get_kvcache_max_tokens), so hybrid SWA / compressed models aren't
                                          extrapolated from the seq_len=1 rate; nextn/MTP applied before the
                                          model build. engine.py untouched.

src/aiconfigurator/sdk/models/          Model.get_kvcache_max_tokens — capacity-sizing inverse of
  base.py / gemma4.py /                   get_kvcache_bytes_per_sequence. Base is exact floor-division for
  deepseek_v4.py                          linear KV (MHA/GQA/MLA); Gemma 4 (SWA) and DeepSeek-V4
                                          (window-capped + compressed) override it to invert their
                                          piecewise curve via a monotonic binary search.

rust/aiconfigurator-core/
├── src/memory.rs                       PURE PyO3 forwarder to sdk.memory; owns KvCacheEstimate* result
│                                         types. No tolerance math (moved to Python): forwards
│                                         tolerance_fraction, parses tolerance_adjusted back.
├── src/py.rs                           drops the estimate_kv_cache #[pyfunction] (redundant Python surface)
├── src/lib.rs                          re-export the memory API at the crate root
├── tests/memory_round_trip.rs          Rust round-trip: forwarder end-to-end (tolerance fwd + parse)
└── docs/phase-1.5-*.md                 design / follow-up notes (capacity-followup, execution-plan)

src/aiconfigurator_core/__init__.py     drops the estimate_kv_cache export
tests/unit/sdk/test_memory_estimation.py     pure-Python unit tests (budget formulas; standard/MLA/
                                          fail-closed per-token; naive fallback incl. unsupported arch +
                                          hybrid sliding-window; nextn applied to the model config)
tests/unit/sdk/models/test_model_config.py   get_kvcache_max_tokens: linear floor-division + DeepSeek-V4 curve
tests/unit/sdk/test_utils.py                  get_kvcache_max_tokens: Gemma 4 window-capped curve
tests/integration/test_memory_estimation.py  native path end-to-end vs a real perf DB
```

- **compat**: drops the `aiconfigurator_core.estimate_kv_cache` `#[pyfunction]` and its `__init__.py` export — in-repo Python callers use `sdk.memory` directly; the Rust fn is for embedded callers (the Mocker).

#### Rust caller usage (the Mocker):

`aiconfigurator_core::estimate_kv_cache(req)` is a plain `pub fn` (not a `#[pyfunction]`), like `build_aic_engine`. The crate links libpython; the call acquires the GIL internally and imports `aiconfigurator.sdk.memory`, so the caller just needs `aiconfigurator` importable in the embedded interpreter (no GIL handling on the caller side).

```rust
use aiconfigurator_core::{
    estimate_kv_cache, BackendKind, EngineConfig, KvCacheEstimateOptions,
    KvCacheEstimateRequest, KvCacheMemoryFraction, ParallelMapping, QuantizationConfig,
    ENGINE_CONFIG_SCHEMA_VERSION,
};

let est = estimate_kv_cache(KvCacheEstimateRequest {
    engine: EngineConfig {
        schema_version: ENGINE_CONFIG_SCHEMA_VERSION,
        model_name: "Qwen/Qwen3-32B".into(),
        system_name: "h200_sxm".into(),
        systems_path: None,                  // None -> bundled systems data
        backend: BackendKind::Trtllm,
        backend_version: Some("1.3.0rc10".into()),
        kv_block_size: None,
        parallel: ParallelMapping {
            tp_size: 2, pp_size: 1, attention_dp_size: Some(1),
            moe_tp_size: None, moe_ep_size: None,
        },
        quantization: QuantizationConfig {   // None -> inferred from the HF config
            weight_dtype: None, moe_dtype: None,
            activation_dtype: None, kv_cache_dtype: None,
        },
        speculative: None,
        extra: Default::default(),
    },
    max_num_tokens: 8192,
    max_batch_size: 256,
    // TRT-LLM -> OfFree(free_gpu_memory_fraction); vLLM/SGLang -> OfTotal.
    kv_cache_memory_fraction: KvCacheMemoryFraction::OfFree(0.9),
    gpu_memory_capacity_bytes_override: None,  // Some(bytes) for unknown SKUs / required by the naive fallback
    tolerance_fraction: Some(0.05),            // None -> raw estimate only
    options: KvCacheEstimateOptions {
        allow_naive_fallback: true,
        allow_hf_config_download: false,
        naive_kv_reservation: 0.80,            // post-weight reserve on the naive path
    },
})?;

// Result is rank-local. Convert to scheduler blocks with the scheduler's own block size,
// preferring the tolerance-adjusted token count when a tolerance was requested:
let tokens = est.tolerance_adjusted.as_ref()
    .map(|a| a.total_kv_size_tokens)
    .unwrap_or(est.total_kv_size_tokens);
let num_gpu_blocks_per_rank = tokens / scheduler_block_size;
// est.source: Native | NaiveFallback;  est.memory_breakdown: Some(..) native, None on fallback.
```

#### Where should the reviewer start?

`src/aiconfigurator/sdk/memory.py` (the logic) → `rust/aiconfigurator-core/src/memory.rs` (the forwarder)

#### Related Issues:

- Relates to #1159
- Follow-up (deferred OOM-check consolidation onto `kv_cache_budget_bytes`): #1208



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * KV-cache GPU capacity estimation with native and fallback strategies
  * Tolerance-adjusted capacity and conversion to scheduler block counts
  * Detailed memory breakdown and max-sequence-length computation

* **Documentation**
  * Phase 1.5 execution plan and capacity API design docs updated

* **Tests**
  * New unit and integration tests validating estimation math and end-to-end parity
<!-- end of auto-generated comment: release notes by coderabbit.ai -->