### PR TITLE
fix: skip sparse L40S vLLM 0.22.0 database

### DIFF
--- a/src/aiconfigurator/systems/data/l40s/vllm/0.22.0/INCOMPLETE.txt
+++ b/src/aiconfigurator/systems/data/l40s/vllm/0.22.0/INCOMPLETE.txt
@@ -1,0 +1,4 @@
+L40S vLLM 0.22.0 data is intentionally excluded from supported database discovery.
+The available generation attention data is too sparse for the sanity-check workload
+and can fail interpolation, so keep using the older L40S vLLM database until this
+version is recollected with sufficient coverage.

--- a/tests/unit/sdk/database/test_database_helpers.py
+++ b/tests/unit/sdk/database/test_database_helpers.py
@@ -93,6 +93,17 @@ def test_get_supported_databases_basic(temp_systems_dir: Path, perf_database):
     assert result["h200"]["trtllm"] == ["1.2.0", "1.3.0rc2"]
 
 
+def test_get_supported_databases_skips_incomplete_versions(temp_systems_dir: Path, perf_database):
+    setup_mock_filesystem(temp_systems_dir, {"h100": {"vllm": ["0.14.0", "0.22.0"]}})
+    incomplete_path = temp_systems_dir / "data_h100" / "vllm" / "0.22.0" / "INCOMPLETE.txt"
+    incomplete_path.write_text("not enough profiling coverage\n", encoding="utf-8")
+
+    result = perf_database.get_supported_databases(str(temp_systems_dir))
+
+    assert result["h100"]["vllm"] == ["0.14.0"]
+    assert perf_database.get_latest_database_version("h100", "vllm", systems_paths=str(temp_systems_dir)) == "0.14.0"
+
+
 def test_get_supported_databases_empty_dir(temp_systems_dir: Path, perf_database):
     result = perf_database.get_supported_databases(str(temp_systems_dir))
     # defaultdict, but empty


### PR DESCRIPTION
## Summary

Temporary fix for the CI failures introduced by #1158. The L40S vLLM 0.22.0 data added there is too sparse — the support-matrix healer is purely model-driven, so some interpolation-required generation-attention points were never collected, and downstream PRs fail when the sanity checks hit them.

- Mark `l40s/vllm/0.22.0` as incomplete via `INCOMPLETE.txt` so `get_supported_databases` skips it during database discovery. CI sanity checks keep using L40S vLLM 0.14.0 until 0.22.0 is recollected with sufficient generation-attention coverage.
- Add unit coverage (`test_get_supported_databases_skips_incomplete_versions`) confirming incomplete versions are excluded from discovery and from `get_latest_database_version`.

This PR is intentionally minimal to unblock CI quickly. The `validate_database.ipynb` coverage preflight (`sanity_coverage.py` + its tests) that was previously on this branch is deferred to a follow-up PR.

## Verification

- `uv run --extra dev pytest tests/unit/sdk/database/test_database_helpers.py -q` → 21 passed
