### PR TITLE
fix: DSV4-Pro topk correlation, fix moe kernel path

### DIFF
--- a/collector/case_generator.py
+++ b/collector/case_generator.py
@@ -164,16 +164,26 @@ def _expand_model_case_entry(raw_value: object, *, field_name: str) -> list[dict
 def _model_case_values(op_name: str, *, apply_model_filter: bool = True) -> list[dict]:
     values = []
     for data in _load_model_cases_data():
+        # Carry the model file's architecture onto every expanded case dict so
+        # downstream model-family checks use config-derived metadata (the
+        # architecture in the cases YAML mirrors config.json's
+        # ``architectures[0]``) rather than fragile model_name string patterns.
+        arch = data.get("architecture")
         op_values = data.get("model_case_values", {}).get(op_name, [])
         if op_values is None:
             continue
         if isinstance(op_values, dict):
-            values.extend(_expand_model_case_entry(op_values, field_name=f"model_case_values.{op_name}"))
-            continue
-        if not isinstance(op_values, list):
+            expanded = _expand_model_case_entry(op_values, field_name=f"model_case_values.{op_name}")
+        elif isinstance(op_values, list):
+            expanded = []
+            for index, item in enumerate(op_values):
+                expanded.extend(_expand_model_case_entry(item, field_name=f"model_case_values.{op_name}[{index}]"))
+        else:
             raise TypeError(f"model_case_values.{op_name} must be a list or mapping")
-        for index, item in enumerate(op_values):
-            values.extend(_expand_model_case_entry(item, field_name=f"model_case_values.{op_name}[{index}]"))
+        for value in expanded:
+            if arch is not None:
+                value.setdefault("architecture", arch)
+            values.append(value)
 
     model_path = _get_model_path_filter() if apply_model_filter else None
     if model_path:
@@ -525,6 +535,7 @@ class MoeCommonTestCase:
     model_name: str
     token_expert_distribution: str
     power_law_alpha: Optional[float]
+    architecture: str = ""  # config-derived (cases-YAML architecture); for model-family checks
 
 
 @dataclasses.dataclass(frozen=True)
@@ -892,6 +903,7 @@ def get_moe_backend_test_cases(backend: str) -> list[MoeCommonTestCase]:
                     model_name=model_name,
                     token_expert_distribution=token_distribution,
                     power_law_alpha=power_law_alpha,
+                    architecture=str(model_config.get("architecture") or ""),
                 )
             )
     return test_cases
@@ -954,6 +966,7 @@ def get_common_moe_test_cases():
                 model_name=model_name,
                 token_expert_distribution=token_distribution,
                 power_law_alpha=power_law_alpha,
+                architecture=str(model_config.get("architecture") or ""),
             )
         )
 

--- a/collector/case_generator.py
+++ b/collector/case_generator.py
@@ -14,7 +14,6 @@ import dataclasses
 import functools
 import itertools
 import os
-import sys
 from pathlib import Path
 from typing import Optional
 
@@ -1683,6 +1682,18 @@ def get_dsv4_hca_generation_test_cases():
     return _build_dsv4_module_test_cases("generation", ("hca",))
 
 
+def get_dsv4_topk_calib_test_cases():
+    """One case per model (the topk DELTA calibration is just another member of
+    the sparse-op family — same ``[model_path, kernel]`` shape as paged_mqa /
+    csa_attn / hca_attn, dispatched through ``run_dsv4_sparse_kernel_worker``).
+
+    The grid matches the CSA module data 1:1: the worker reads the
+    already-collected ``dsv4_csa_*_module_perf.txt`` and benches exactly those
+    ``(prefix, isl, batch_size)`` shapes — no separate grid is generated here.
+    """
+    return [[model_path, "topk"] for model_path in _selected_dsv4_models()]
+
+
 DSV4_SPARSE_KERNELS = ("paged_mqa_logits", "hca_attn")
 
 
@@ -1736,20 +1747,24 @@ def _build_dsv4_sparse_test_cases(
     return cases
 
 
-def _dsv4_sparse_smoke_or_full(kernel: str):
-    if "--smoke" in sys.argv:
-        return [[1, 1024, 8192, 1, kernel, model_path] for model_path in _selected_dsv4_models()]
-    return _build_dsv4_sparse_test_cases(kernels=(kernel,))
-
-
 def get_dsv4_paged_mqa_logits_test_cases():
-    """paged_mqa_logits sparse-kernel sweep (CSA indexer scoring)."""
-    return _dsv4_sparse_smoke_or_full("paged_mqa_logits")
+    """One case per model. The worker derives shapes from the CSA module CSV
+    (paged_mqa_logits is the CSA indexer scoring sub-kernel), 1:1 with the
+    csa-module rows — no separate sparse sweep grid."""
+    return [[model_path, "paged_mqa_logits"] for model_path in _selected_dsv4_models()]
 
 
 def get_dsv4_hca_attn_test_cases():
-    """hca_attn sparse-kernel sweep (HCA c128 sparse FMLA)."""
-    return _dsv4_sparse_smoke_or_full("hca_attn")
+    """One case per model. The worker derives shapes from the HCA module CSV
+    (hca_attn is the HCA c128 FMLA sub-kernel), 1:1 with the hca-module rows."""
+    return [[model_path, "hca_attn"] for model_path in _selected_dsv4_models()]
+
+
+def get_dsv4_csa_attn_test_cases():
+    """One case per model. The worker derives shapes from the CSA module CSV
+    (csa_attn is the CSA sparse FMLA over the topk-selected c4 positions),
+    1:1 with the csa-module rows — same source as paged_mqa_logits/topk."""
+    return [[model_path, "csa_attn"] for model_path in _selected_dsv4_models()]
 
 
 # Backward-compatible names for older PR comments/tests while the registry and
@@ -1784,7 +1799,6 @@ _dsv4_flash_module_precision_combos = _dsv4_module_precision_combos
 _dsv4_flash_module_filter_pairs = _dsv4_module_filter_pairs
 _build_dsv4_flash_module_test_cases = _build_dsv4_module_test_cases
 _build_dsv4_flash_sparse_test_cases = _build_dsv4_sparse_test_cases
-_dsv4_flash_sparse_smoke_or_full = _dsv4_sparse_smoke_or_full
 get_dsv4_flash_csa_context_test_cases = get_dsv4_csa_context_test_cases
 get_dsv4_flash_hca_context_test_cases = get_dsv4_hca_context_test_cases
 get_dsv4_flash_csa_generation_test_cases = get_dsv4_csa_generation_test_cases

--- a/collector/cases/models/DeepseekV4ForCausalLM_cases.yaml
+++ b/collector/cases/models/DeepseekV4ForCausalLM_cases.yaml
@@ -206,12 +206,24 @@ framework_specific_op_cases:
       cases: all
     dsv4_hca_generation_module:
       cases: all
+    # topK DELTA calibration: one case per model. The worker reads the
+    # already-collected dsv4_csa_*_module_perf.txt in the output dir and benches
+    # exactly those (prefix, isl, batch_size) shapes, so it must run AFTER the
+    # CSA module ops (guaranteed by registry order: topk_calib is registered
+    # after the csa module entries).
+    dsv4_csa_topk_calib:
+      cases: all
     # These kernel-level cases are kept as auxiliary data for future
     # prefix/past_kv correction.  Current DeepSeek-V4 SGLang modeling uses the
     # full CSA/HCA attention-module rows above as the primary path.
     dsv4_paged_mqa_logits_module:
       cases: all
     dsv4_hca_attn_module:
+      cases: all
+    # CSA sparse FMLA over the topk-selected c4 positions. Same source as
+    # paged_mqa_logits/topk_calib (reads dsv4_csa_*_module_perf.txt), so it must
+    # run AFTER the CSA module ops (guaranteed by registry order).
+    dsv4_csa_attn_module:
       cases: all
     mhc_module:
       cases: all

--- a/collector/collect.py
+++ b/collector/collect.py
@@ -1137,6 +1137,15 @@ def collect_sglang(
 
     os.environ["FLASHINFER_LOG_LEVEL"] = "ERROR"
 
+    # DSV4-Pro mhc-pre fast path: the DeepGEMM tf32 prenorm + TileLang fused
+    # kernels must have these names present in os.environ at worker-spawn time,
+    # otherwise mhc-pre collects ~53% slow and diverges from the reference
+    # dataset. Both default to True in environ.py, but the effect is triggered
+    # by presence in the process env (consumed downstream in the JIT path), not
+    # just by .get(). setdefault so an explicit caller value still wins.
+    os.environ.setdefault("SGLANG_OPT_DEEPGEMM_HC_PRENORM", "1")
+    os.environ.setdefault("SGLANG_OPT_USE_TILELANG_MHC_PRE", "1")
+
     try:
         from importlib.metadata import version as get_version
 

--- a/collector/registry_types.py
+++ b/collector/registry_types.py
@@ -51,10 +51,14 @@ class PerfFile(str, Enum):
     DSV4_CSA_GENERATION_MODULE = "dsv4_csa_generation_module_perf.txt"
     DSV4_HCA_GENERATION_MODULE = "dsv4_hca_generation_module_perf.txt"
     # DeepSeek-V4 sparse-kernel data — bench-collected (paged_mqa_logits +
-    # hca_attn).  topk_512 + csa_attn are modeled analytically in
-    # perf_database — no CSV is collected for them.
+    # hca_attn + csa_attn), each 1:1 with its owning CSA/HCA module rows.
     DSV4_PAGED_MQA_LOGITS_MODULE = "dsv4_paged_mqa_logits_module_perf.txt"
     DSV4_HCA_ATTN_MODULE = "dsv4_hca_attn_module_perf.txt"
+    DSV4_CSA_ATTN_MODULE = "dsv4_csa_attn_module_perf.txt"
+    # DeepSeek-V4 CSA topk_512 degenerate-vs-representative DELTA calibration
+    # (flat vs top_last scores).  Consumed by perf_database's
+    # _load_dsv4_topk_calib / _dsv4_csa_topk_latency_delta_ms.
+    DSV4_CSA_TOPK_CALIB = "dsv4_csa_topk_calib_perf.txt"
     DSV4_MEGAMOE_MODULE = "dsv4_megamoe_module_perf.txt"
     NCCL = "nccl_perf.txt"
     CUSTOM_ALLREDUCE = "custom_allreduce_perf.txt"

--- a/collector/sglang/collect_dsv4_attn.py
+++ b/collector/sglang/collect_dsv4_attn.py
@@ -72,6 +72,10 @@ try:
         kv_pool_capacity_tokens as _kv_pool_capacity_tokens,
     )
     from collector.sglang.runtime_limits import (
+        kv_pool_page_size as _kv_pool_page_size,
+    )
+    from collector.sglang.runtime_limits import (
+        required_kv_alloc_tokens,
         required_kv_tokens,
         required_prefill_extend_tokens,
     )
@@ -89,6 +93,10 @@ except ModuleNotFoundError:
         kv_pool_capacity_tokens as _kv_pool_capacity_tokens,
     )
     from runtime_limits import (
+        kv_pool_page_size as _kv_pool_page_size,
+    )
+    from runtime_limits import (
+        required_kv_alloc_tokens,
         required_kv_tokens,
         required_prefill_extend_tokens,
     )
@@ -217,6 +225,16 @@ _WEIGHT_SUFFIXES = (".safetensors", ".bin", ".pt", ".pth")
 
 _PORTS_PER_GPU = 1000
 _DSV4_PORT_RETRIES = 5
+
+
+def _canonical_dsv4_model_id(model_path: str) -> str:
+    normalized = str(model_path).rstrip("/")
+    basename = normalized.rsplit("/", 1)[-1]
+    if basename == "DeepSeek-V4-Pro":
+        return "deepseek-ai/DeepSeek-V4-Pro"
+    if basename == "DeepSeek-V4-Flash":
+        return "deepseek-ai/DeepSeek-V4-Flash"
+    return str(model_path)
 
 
 def _port_is_available(port: int) -> bool:
@@ -514,12 +532,11 @@ def _load_model_runner(
     num_layers: int,
     kv_cache_dtype: str,
     device: str,
-    mem_fraction_static: float,
-    max_total_tokens: int | None,
     shrink_unused_moe: bool,
     disable_weight_quant: bool,
     gemm_type: str = "bfloat16",
     tp_size: int = 1,
+    max_total_tokens: int | None = None,
 ):
     from sglang.srt.configs.model_config import ModelConfig
     from sglang.srt.entrypoints.engine import _set_envs_and_config
@@ -543,6 +560,21 @@ def _load_model_runner(
     # id for NCCL port sharding so parallel workers do not collide.
     port_shard = int(os.environ.get("AIC_DSV4_PORT_SHARD", gpu_id))
     nccl_port = int(os.environ.get("AIC_DSV4_NCCL_PORT") or _pick_free_port(port_shard))
+    # Mirror collect_mla_module.py's "grab sglang's own defaults, only override
+    # what is strictly needed" approach: construct ServerArgs and let its
+    # ``__post_init__`` derive the runtime-sizing knobs from sglang's own logic.
+    # Do NOT pass collector-derived values for mem_fraction_static,
+    # chunked_prefill_size, or max_prefill_tokens -- leaving them unset means:
+    #   * mem_fraction_static=None -> derived from GPU memory in __post_init__
+    #   * chunked_prefill_size=None -> derived from GPU memory
+    #   * max_prefill_tokens         -> sglang default (16384)
+    # The ONE sizing knob we DO pass is ``max_total_tokens``, computed by the
+    # caller from the actual swept (bs, sl, prefix) cases via required_kv_tokens
+    # (+~5% headroom).  This caps the KV pool to what the sweep needs instead of
+    # letting sglang fill all of GPU memory, exactly like collect_mla_module.py.
+    # The derived KV pool is still honored downstream by the
+    # ``_kv_pool_capacity_tokens`` SKIP path, so over-large shapes are skipped
+    # rather than hardcoded around.
 
     server_args = ServerArgs(
         model_path=local_model_path,
@@ -551,23 +583,26 @@ def _load_model_runner(
         load_format=os.environ.get("SGLANG_LOAD_FORMAT", "dummy"),
         tp_size=1,
         trust_remote_code=True,
-        mem_fraction_static=mem_fraction_static,
         disable_radix_cache=True,
         # The module benchmark below captures its own CUDA Graph and fails if
         # capture is not possible.  Keep SGLang's serving-level graph runner off
         # so it does not add unrelated full-model graph state to this collector.
         disable_cuda_graph=True,
         kv_cache_dtype=kv_cache_dtype,
-        max_total_tokens=max_total_tokens,
         # The bench sweep includes batch_size up to 1024 (collector's
         # ``_BATCH_SIZES``).  sglang's ``alloc_req_slots`` exposes
         # ``available_size = max_running_requests - 1`` (one slot is
         # reserved internally), so a bs=1024 cell with
         # ``max_running_requests=1024`` raises
         # ``alloc_req_slots runs out of memory: available=1023, num_reqs=1024``.
-        # Bump to 1100 for headroom over the largest tested bs.
+        # Bump to 1100 for headroom over the largest tested bs.  This is the
+        # only sizing knob the collector must override (per-cell request slots
+        # for the bs sweep); all memory/token knobs come from sglang.
         max_running_requests=1100,
-        max_prefill_tokens=max(max_total_tokens or 4096, 2048),
+        # Case-sized KV pool cap from the caller (None -> sglang default sizing).
+        # mem_fraction_static / chunked_prefill_size stay unset -> derived by
+        # ServerArgs.__post_init__ from sglang.
+        max_total_tokens=max_total_tokens,
     )
     # gemm_type controls projection GEMM dispatch.  "fp8_block" → DeepGEMM
     # (matches production V4-Flash-FP8); anything else → cuBLASLt bf16.
@@ -578,7 +613,11 @@ def _load_model_runner(
     print(
         f"[dsv4-collector] model_path {model_path} -> {local_model_path}; "
         f"attn_kind={attn_kind}, backend=dsv4, kv_cache_dtype={kv_cache_dtype}, "
-        f"max_total_tokens={max_total_tokens}, shrink_unused_moe={shrink_unused_moe}, "
+        f"mem_fraction_static={server_args.mem_fraction_static} (sglang-derived), "
+        f"chunked_prefill_size={server_args.chunked_prefill_size} (sglang-derived), "
+        f"max_prefill_tokens={server_args.max_prefill_tokens} (sglang-derived), "
+        f"max_total_tokens={server_args.max_total_tokens} (case-sized), "
+        f"shrink_unused_moe={shrink_unused_moe}, "
         f"disable_weight_quant={disable_weight_quant}, gemm_type={gemm_type}, "
         f"quantization={server_args.quantization}, tp_size={tp_size}, nccl_port={nccl_port}"
     )
@@ -588,7 +627,8 @@ def _load_model_runner(
     with _tp_load_model_patch(tp_size):
         model_runner = ModelRunner(
             model_config=model_config,
-            mem_fraction_static=mem_fraction_static,
+            # Use sglang's own __post_init__-derived value, not a collector knob.
+            mem_fraction_static=server_args.mem_fraction_static,
             gpu_id=gpu_id,
             tp_rank=0,
             tp_size=1,
@@ -599,6 +639,47 @@ def _load_model_runner(
             nccl_port=nccl_port,
             server_args=server_args,
         )
+    # --- AIC proper init (env-gated) -------------------------------------
+    # Dummy load uses uniform(-1e-3, 1e-3) (sglang initialize_dummy_weights).
+    # Those tiny weights make the C4 indexer's q.k logits land in the fp16
+    # subnormal range (<6.1e-5). extract_coarse_bin casts scores to fp16
+    # first, so subnormal logits collapse into very few coarse bins -> the
+    # topK threshold bin holds hundreds of ties (num_equal >> 64) -> Small
+    # path takes its O(n^2) block tie-break -> topk_short_transform is huge
+    # and non-representative vs a trained checkpoint.
+    # Re-init projection weights with a normal of larger scale so logits keep
+    # full fp16 precision (spread). norm/scale params are forced to 1.0 to
+    # avoid scaling activations back down (norm) or producing inf on fp8
+    # dequant (scale). Only safe because the collector runs num_layers==1.
+    _proper = os.environ.get("AIC_DSV4_PROPER_INIT", "")
+    if _proper and _proper != "0":
+        _std = float(os.environ.get("AIC_DSV4_PROPER_INIT_STD", "0.05"))
+        torch.manual_seed(1234)
+        _n_normal = _n_norm = _n_scale = 0
+        with torch.no_grad():
+            for _name, _p in model_runner.model.state_dict().items():
+                if not torch.is_floating_point(_p):
+                    continue
+                _lname = _name.lower()
+                if "scale" in _lname:
+                    _p.fill_(1.0)
+                    _n_scale += 1
+                elif "norm" in _lname:
+                    _p.fill_(1.0)
+                    _n_norm += 1
+                elif torch.finfo(_p.dtype).bits < 16:
+                    _tmp = torch.empty_like(_p, dtype=torch.float16).normal_(0.0, _std)
+                    _p.copy_(_tmp.to(_p.dtype))
+                    _n_normal += 1
+                else:
+                    _p.normal_(0.0, _std)
+                    _n_normal += 1
+        print(
+            f"[dsv4-collector] AIC_DSV4_PROPER_INIT std={_std}: "
+            f"normal={_n_normal} norm->1={_n_norm} scale->1={_n_scale}",
+            flush=True,
+        )
+
     allocator = model_runner.token_to_kv_pool_allocator
     pool_parts = []
     for name in (
@@ -826,6 +907,7 @@ def _log_result(
     gemm_type: str = "bfloat16",
     tp_size: int = 1,
     step: int | None = None,
+    num_heads: int | None = None,
 ) -> None:
     # V4-Flash output layout: ONE CSV per (attn_kind, mode) — 3 kinds x 2
     # modes = 6 files total, regardless of how many (tp_size, gemm_type)
@@ -845,12 +927,12 @@ def _log_result(
     log_perf(
         item_list=[
             {
-                "model": model_path,
+                "model": _canonical_dsv4_model_id(model_path),
                 "architecture": "DeepseekV4ForCausalLM",
                 "mla_dtype": "bfloat16",
                 "kv_cache_dtype": kv_cache_dtype,
                 "gemm_type": gemm_type,
-                "num_heads": max(1, NATIVE_HEADS // tp_size),
+                "num_heads": num_heads if num_heads is not None else max(1, NATIVE_HEADS // tp_size),
                 "batch_size": batch_size,
                 "isl": seq_len if is_prefill else 1,
                 "tp_size": tp_size,
@@ -886,8 +968,6 @@ def run_dsv4_mla_module(
     graph_repeat: int = 1,
     device: str = "cuda:0",
     output_path: str | None = None,
-    mem_fraction_static: float = 0.5,
-    max_total_tokens: int | None = 4096,
     shrink_unused_moe: bool = True,
     disable_weight_quant: bool = True,
     perf_filename_prefix: str = "dsv4",
@@ -896,6 +976,7 @@ def run_dsv4_mla_module(
     prefix_len: int = 0,
     prefix_lens: Iterable[int] | None = None,
     seq_lens_by_prefix: dict[int, list[int]] | None = None,
+    max_total_tokens: int | None = None,
 ) -> list[dict[str, float]]:
     is_prefill = mode == "context"
     if prefix_lens is None:
@@ -916,18 +997,19 @@ def run_dsv4_mla_module(
         num_layers=max(num_layers, layer_id + 1),
         kv_cache_dtype=kv_cache_dtype,
         device=device,
-        mem_fraction_static=mem_fraction_static,
-        max_total_tokens=max_total_tokens,
         shrink_unused_moe=shrink_unused_moe,
         disable_weight_quant=disable_weight_quant,
         gemm_type=gemm_type,
         tp_size=tp_size,
+        max_total_tokens=max_total_tokens,
     )
 
     attention_module = model_runner.model.model.layers[layer_id].self_attn
     actual_ratio = getattr(attention_module, "compress_ratio", None)
     if actual_ratio != compress_ratio:
         raise RuntimeError(f"target layer compress_ratio mismatch: expected {compress_ratio}, got {actual_ratio}")
+    native_attention_heads = int(getattr(attention_module, "n_heads", NATIVE_HEADS))
+    local_attention_heads = max(1, native_attention_heads // tp_size)
 
     print(
         f"[dsv4-collector] layer={layer_id}, attn_kind={attn_kind}, "
@@ -942,7 +1024,22 @@ def run_dsv4_mla_module(
     try:
         default_seq_lens = list(seq_lens)
         kv_capacity = _kv_pool_capacity_tokens(model_runner)
+        kv_page_size = _kv_pool_page_size(model_runner)
         runtime_chunk = _runtime_chunk_size(model_runner) if is_prefill else None
+        if is_prefill and runtime_chunk is not None:
+            # FlashMLA's get_decoding_sched_meta kernel allocates dynamic shared
+            # memory proportional to the forward's query-token count b (it does
+            # cudaFuncSetAttribute(MaxDynamicSharedMemorySize, 4*(b*5+1))). For a
+            # DSV4 context module forward, b == fresh_tokens (bs*seq_len). SGLang's
+            # derived chunked_prefill_size can exceed what the device's per-block
+            # shared memory can hold (e.g. 16384 > the ~11.6k that a 227KB optin
+            # cap allows), so cudaFuncSetAttribute returns invalid argument and the
+            # subprocess crashes. Cap the effective prefill chunk to the smaller of
+            # SGLang's chunk and the sched-meta shared-memory limit (read from the
+            # device, not hardcoded).
+            _smem_optin = torch.cuda.get_device_properties(torch.cuda.current_device()).shared_memory_per_block_optin
+            _sched_meta_max_b = (_smem_optin // 4 - 1) // 5
+            runtime_chunk = min(runtime_chunk, _sched_meta_max_b)
         for cur_prefix in prefix_values:
             seq_lens_for_prefix = (
                 seq_lens_by_prefix.get(cur_prefix, default_seq_lens)
@@ -974,6 +1071,27 @@ def run_dsv4_mla_module(
                         )
                         skipped_shapes.append((batch_size, seq_len, cur_prefix, "KVPoolCapacity"))
                         continue
+                    # Paged alloc_extend over-estimate: each request rounds its KV
+                    # span up to a page and reserves one extra page (bs*page_size),
+                    # so large-bs cases pass the naive capacity check above yet still
+                    # fail alloc_extend with "Prefill out of memory". Skip them here
+                    # instead of letting the forward raise (read page_size at runtime;
+                    # this is a no-op for page_size==1 token allocators).
+                    alloc_tokens = required_kv_alloc_tokens(
+                        batch_size,
+                        seq_len,
+                        cur_prefix,
+                        kv_page_size,
+                        is_prefill=is_prefill,
+                    )
+                    if kv_capacity is not None and alloc_tokens > kv_capacity:
+                        print(
+                            f"[SKIP] dsv4-flash {sweep_label} bs={batch_size} sl={seq_len} "
+                            f"prefix={cur_prefix}: alloc_tokens={alloc_tokens} (page_size="
+                            f"{kv_page_size}) exceeds KV pool capacity={kv_capacity}"
+                        )
+                        skipped_shapes.append((batch_size, seq_len, cur_prefix, "KVPoolAllocPaged"))
+                        continue
                     print(f"\n{mode}: batch_size={batch_size}, seq_len={seq_len}, prefix_len={cur_prefix}")
                     try:
                         forward_batch = _build_forward_batch(
@@ -992,12 +1110,23 @@ def run_dsv4_mla_module(
                             prefix_len=cur_prefix,
                         )
 
-                        def kernel_func():
-                            return attention_module(
-                                x=hidden_states,
-                                positions=positions,
-                                forward_batch=forward_batch,
+                        def kernel_func(model_runner=model_runner):
+                            # e958 sglang DeepSeek-V4 forward reads the attn backend
+                            # from the global forward context (get_attn_backend), so
+                            # enter sglang's default forward_context around the call.
+                            # (model_runner bound as a default arg to make the closure
+                            # explicit for static analysis.)
+                            from sglang.srt.model_executor.forward_context import (
+                                ForwardContext,
+                                forward_context,
                             )
+
+                            with forward_context(ForwardContext(attn_backend=model_runner.attn_backend)):
+                                return attention_module(
+                                    x=hidden_states,
+                                    positions=positions,
+                                    forward_batch=forward_batch,
+                                )
 
                         stats = _bench_cuda_events(
                             kernel_func,
@@ -1029,6 +1158,7 @@ def run_dsv4_mla_module(
                             gemm_type=gemm_type,
                             tp_size=tp_size,
                             step=cur_prefix if is_prefill else None,
+                            num_heads=local_attention_heads,
                         )
                         stats.update(
                             {
@@ -1086,6 +1216,21 @@ def run_dsv4_mla_module(
             f"{len(skipped_shapes) + len(results)} shapes failed: {skipped_str}"
         )
     if not results:
+        # Distinguish "nothing fits on this GPU/TP config" (every shape pre-skipped
+        # for a known capacity limit) from a genuine all-crash. The former is a
+        # legitimate empty result — the parent must NOT count it as an op error
+        # (otherwise large-bs sweeps where every shape exceeds KV capacity, e.g.
+        # bs512/1024 generation, are reported as failures even though they were
+        # cleanly skipped). Only raise when a real runtime failure occurred.
+        _capacity_skip_reasons = {"ChunkedPrefillSize", "KVPoolCapacity", "KVPoolAllocPaged"}
+        _reasons = {r for _, _, _, r in skipped_shapes}
+        if skipped_shapes and _reasons <= _capacity_skip_reasons:
+            print(
+                f"[WARN] dsv4-flash {sweep_label}: all {len(skipped_shapes)} shapes "
+                f"skipped for capacity reasons {sorted(_reasons)}; no rows collected "
+                "(clean skip, not a failure)"
+            )
+            return results
         raise RuntimeError(f"dsv4-flash {sweep_label}: all shapes failed")
     return results
 
@@ -1249,10 +1394,24 @@ def _subprocess_entry(
         print(f"[dsv4-flash] no valid prefix/sl values for mode={mode}, bs={batch_size}")
         return
 
-    # The shape filter caps bs * (sl + prefix) at 1M.  Allocate 16x because
-    # DSV4 compressed/SWA sub-pools are carved from the full KV pool.
-    GLOBAL_MAX_PAIR = 1024 * 1024  # noqa: N806
-    max_total_tokens = GLOBAL_MAX_PAIR * 16
+    # mem_fraction_static stays sglang-derived (see _load_model_runner).  Size
+    # max_total_tokens to THIS worker's actual swept (bs, sl, prefix) set rather
+    # than leaving it None (sglang would then size the KV pool to fill all GPU
+    # memory) or hardcoding a global cap.  Mirrors collect_mla_module.py: take
+    # max(required_kv_tokens(...)) over the cases this subprocess will run and
+    # add ~5% headroom (>=1024).  Shapes still exceeding the resulting pool are
+    # skipped via the ``_kv_pool_capacity_tokens`` SKIP path.
+    is_prefill = mode == "context"
+    swept_kv = [
+        required_kv_tokens(batch_size, sl, cur_prefix, is_prefill=is_prefill)
+        for cur_prefix, sls in seq_lens_by_prefix.items()
+        for sl in sls
+    ]
+    max_total_tokens = None
+    if swept_kv:
+        max_total_tokens = max(swept_kv)
+        if max_total_tokens > 0:
+            max_total_tokens += max(1024, max_total_tokens // 20)
 
     run_dsv4_mla_module(
         model_path=model_path,
@@ -1263,13 +1422,12 @@ def _subprocess_entry(
         kv_cache_dtype=kv_cache_dtype,
         device="cuda:0",
         output_path=output_path,
-        mem_fraction_static=0.7,
-        max_total_tokens=max_total_tokens,
         perf_filename_prefix="dsv4",
         gemm_type=gemm_type,
         tp_size=tp_size,
         prefix_lens=seq_lens_by_prefix.keys(),
         seq_lens_by_prefix=seq_lens_by_prefix,
+        max_total_tokens=max_total_tokens,
     )
 
 

--- a/collector/sglang/collect_moe.py
+++ b/collector/sglang/collect_moe.py
@@ -592,22 +592,39 @@ def get_moe_test_cases():
             if "DeepSeek-V4" in common_moe_testcase.model_name:
                 swiglu_limit = 10
 
-            test_cases.append(
-                [
-                    moe_type,
-                    num_tokens,
-                    common_moe_testcase.hidden_size,
-                    common_moe_testcase.inter_size,
-                    common_moe_testcase.topk,
-                    common_moe_testcase.num_experts,
-                    common_moe_testcase.tp,
-                    common_moe_testcase.ep,
-                    common_moe_testcase.model_name,
-                    common_moe_testcase.token_expert_distribution,
-                    common_moe_testcase.power_law_alpha,
-                    swiglu_limit,
-                ]
-            )
+            base_case = [
+                moe_type,
+                num_tokens,
+                common_moe_testcase.hidden_size,
+                common_moe_testcase.inter_size,
+                common_moe_testcase.topk,
+                common_moe_testcase.num_experts,
+                common_moe_testcase.tp,
+                common_moe_testcase.ep,
+                common_moe_testcase.model_name,
+                common_moe_testcase.token_expert_distribution,
+                common_moe_testcase.power_law_alpha,
+                swiglu_limit,
+                "",  # moe_backend: "" = default (CuteDSL for w4a8_mxfp4_mxfp8)
+            ]
+            test_cases.append(base_case)
+
+            # DeepSeek-V4 production runs the trtllm-gen MXFP4xMXFP8 MoE kernel,
+            # NOT CuteDSL. Collect that kernel too (same w4a8_mxfp4_mxfp8 dtype,
+            # kernel_source=sglang_mxfp4_flashinfer_trtllm_moe). Single-rank
+            # (ep==1) synthetic case, matching the trtllm routed-moe bench path.
+            # Restrict to tp<=8: the trtllm-gen kernel asserts on the tiny
+            # per-rank intermediate sizes produced at tp16/32 (and the reference
+            # trtllm grid only covers tp 1/2/4/8 too).
+            if (
+                is_native_dsv4
+                and moe_type == "w4a8_mxfp4_mxfp8"
+                and common_moe_testcase.ep == 1
+                and common_moe_testcase.tp <= 8
+            ):
+                trtllm_case = list(base_case)
+                trtllm_case[-1] = "trtllm_mxfp4"
+                test_cases.append(trtllm_case)
 
     return test_cases
 
@@ -634,6 +651,7 @@ def benchmark_config(
     use_int8_w8a16: bool,
     use_nvfp4: bool = False,
     use_trtllm_bf16_fp4: bool = False,
+    use_trtllm_mxfp4: bool = False,
     use_int4_w4a16: bool = False,
     use_mxfp4_w4a16: bool = False,
     use_mxfp4_w4a8: bool = False,
@@ -890,6 +908,131 @@ def benchmark_config(
                 routing_method_type=1,
                 do_finalize=True,
                 activation_type=activation_type,
+                output=output,
+                tune_max_num_tokens=tune_max_num_tokens,
+            )
+
+    elif use_trtllm_mxfp4 and workloads is None:
+        # DeepSeek-V4 production MoE path on Blackwell: MXFP4 weights (E2M1,
+        # block-32 E8M0 scales) x MXFP8 (E4M3) activations through the trtllm-gen
+        # routed kernel. Mirrors sglang Mxfp4FlashinferTrtllmMoEMethod
+        # (mxfp4_flashinfer_trtllm_moe.py): weights are int8 (hidden//2 packed),
+        # scales are block-32 cast to e8m0 then shuffled with shuffle_matrix_a /
+        # shuffle_matrix_sf_a (epilogue_tile_m=128), activations quantized with
+        # mxfp8_quantize. This is a DIFFERENT kernel from CuteDSL
+        # (sglang_flashinfer_cutedsl_moe) which the plain w4a8_mxfp4_mxfp8 uses.
+        from flashinfer import mxfp8_quantize, shuffle_matrix_a, shuffle_matrix_sf_a
+        from flashinfer.fused_moe import trtllm_fp4_block_scale_routed_moe
+        from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
+            _pack_topk_for_flashinfer_routed,
+        )
+
+        if hidden_size % 32 != 0 or (shard_intermediate_size // 2) % 32 != 0:
+            raise ValueError(
+                "TRTLLM MXFP4 MoE requires hidden and intermediate dims divisible by 32, "
+                f"got hidden_size={hidden_size}, intermediate_size={shard_intermediate_size // 2}"
+            )
+
+        fp4_block_k = 32
+        epilogue_tile_m = 128
+        intermediate_size = shard_intermediate_size // 2
+        x = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device)
+        router_logits_list = (
+            gating_output
+            if isinstance(gating_output, list)
+            else [gating_output[i] for i in range(gating_output.shape[0])]
+        )
+
+        # Dummy MXFP4 expert weights (E2M1 packed -> hidden//2) + block-32 scales.
+        w13 = torch.randint(
+            0,
+            256,
+            (num_experts, shard_intermediate_size, hidden_size // 2),
+            dtype=torch.uint8,
+            device=device,
+        )
+        w2 = torch.randint(
+            0,
+            256,
+            (num_experts, hidden_size, intermediate_size // 2),
+            dtype=torch.uint8,
+            device=device,
+        )
+        w13_scale = torch.ones(
+            (num_experts, shard_intermediate_size, hidden_size // fp4_block_k),
+            dtype=torch.float32,
+            device=device,
+        ).to(torch.float8_e8m0fnu)
+        w2_scale = torch.ones(
+            (num_experts, hidden_size, intermediate_size // fp4_block_k),
+            dtype=torch.float32,
+            device=device,
+        ).to(torch.float8_e8m0fnu)
+
+        # Shuffle weights/scales into the trtllm-gen kernel layout (matches
+        # mxfp4_flashinfer_trtllm_moe.process_weights_after_loading non-official path).
+        g1w, g1s, g2w, g2s = [], [], [], []
+        for e in range(num_experts):
+            g1w.append(shuffle_matrix_a(w13[e].view(torch.uint8), epilogue_tile_m))
+            g1s.append(shuffle_matrix_sf_a(w13_scale[e].view(torch.uint8), epilogue_tile_m))
+            g2w.append(shuffle_matrix_a(w2[e].view(torch.uint8), epilogue_tile_m))
+            g2s.append(shuffle_matrix_sf_a(w2_scale[e].view(torch.uint8), epilogue_tile_m))
+        w13 = torch.stack(g1w)
+        w13_scale = torch.stack(g1s).view(torch.float8_e4m3fn).reshape(num_experts, shard_intermediate_size, -1)
+        w2 = torch.stack(g2w)
+        w2_scale = torch.stack(g2s).view(torch.float8_e4m3fn).reshape(num_experts, hidden_size, -1)
+
+        output = torch.empty(num_tokens, hidden_size, dtype=torch.bfloat16, device=device)
+        scale_ones = torch.ones(num_experts, dtype=torch.float32, device=device)
+        tune_max_num_tokens = max(1, 1 << (num_tokens - 1).bit_length())
+        topk_config = TopKConfig(
+            top_k=topk,
+            renormalize=True,
+            scoring_func="sigmoid",
+            routed_scaling_factor=1.0,
+        )
+        packed_topk_list = []
+        for logits in router_logits_list:
+            topk_output = select_experts(x, logits, topk_config)
+            packed_topk_list.append(
+                _pack_topk_for_flashinfer_routed(
+                    topk_output.topk_ids,
+                    topk_output.topk_weights,
+                )
+            )
+        torch.cuda.synchronize()
+
+        def run_op(i):
+            x_quant, x_scale = mxfp8_quantize(x, False, alignment=hidden_size)
+            x_scale = x_scale.view(torch.float8_e4m3fn).reshape(*x.shape[:-1], -1)
+            packed_topk = packed_topk_list[i % len(packed_topk_list)]
+            trtllm_fp4_block_scale_routed_moe(
+                topk_ids=packed_topk,
+                routing_bias=None,
+                hidden_states=x_quant,
+                hidden_states_scale=x_scale,
+                gemm1_weights=w13,
+                gemm1_weights_scale=w13_scale,
+                gemm1_bias=None,
+                gemm1_alpha=None,
+                gemm1_beta=None,
+                gemm1_clamp_limit=None,
+                gemm2_weights=w2,
+                gemm2_weights_scale=w2_scale,
+                gemm2_bias=None,
+                output1_scale_scalar=scale_ones,
+                output1_scale_gate_scalar=scale_ones,
+                output2_scale_scalar=scale_ones,
+                num_experts=num_experts,
+                top_k=packed_topk.shape[1],
+                n_group=1,
+                topk_group=1,
+                intermediate_size=intermediate_size,
+                local_expert_offset=0,
+                local_num_experts=num_experts,
+                routed_scaling_factor=1.0,
+                routing_method_type=1,
+                do_finalize=True,
                 output=output,
                 tune_max_num_tokens=tune_max_num_tokens,
             )
@@ -1203,6 +1346,7 @@ def benchmark(
     use_int8_w8a16: bool,
     use_nvfp4: bool = False,
     use_trtllm_bf16_fp4: bool = False,
+    use_trtllm_mxfp4: bool = False,
     use_int4_w4a16: bool = False,
     use_mxfp4_w4a16: bool = False,
     use_mxfp4_w4a8: bool = False,
@@ -1222,8 +1366,8 @@ def benchmark(
     use_mxfp4_moe = use_mxfp4_w4a16 or use_mxfp4_w4a8
 
     if use_nvfp4 or use_mxfp4_moe or (use_int4_w4a16 and _HAS_MARLIN_MOE):
-        # nvfp4 uses flashinfer cutedsl backend; int4_w4a16 uses Marlin CUDA
-        # kernels — neither needs Triton tuning configs.
+        # nvfp4 uses flashinfer cutedsl backend; mxfp4 (incl. DSV4 trtllm-gen)
+        # uses flashinfer; int4_w4a16 uses Marlin CUDA — none need Triton tuning.
         kernel_time, power_stats = benchmark_config(
             None,
             benchmark_num_tokens,
@@ -1237,6 +1381,7 @@ def benchmark(
             use_int8_w8a16,
             use_nvfp4,
             use_trtllm_bf16_fp4,
+            use_trtllm_mxfp4,
             use_int4_w4a16,
             use_mxfp4_w4a16,
             use_mxfp4_w4a8,
@@ -1287,6 +1432,7 @@ def benchmark(
         use_int8_w8a8,
         use_int8_w8a16,
         use_nvfp4,
+        False,
         False,
         use_int4_w4a16,
         use_mxfp4_w4a16,
@@ -1379,6 +1525,7 @@ def run_moe_torch(
     distributed="power_law",
     power_law_alpha=0,
     swiglu_limit=None,
+    moe_backend="",
     *,
     perf_filename,
     device="cuda:0",
@@ -1404,7 +1551,10 @@ def run_moe_torch(
     use_mxfp4_w4a16 = moe_type == "w4a16_mxfp4"
     use_mxfp4_w4a8 = moe_type == "w4a8_mxfp4_mxfp8"
     use_mxfp4_moe = use_mxfp4_w4a16 or use_mxfp4_w4a8
-    use_nvfp4_kernel = moe_type in ("nvfp4", "w4a8_mxfp4_mxfp8")
+    # DeepSeek-V4 production runs the trtllm-gen MXFP4xMXFP8 MoE kernel
+    # (moe_backend="trtllm_mxfp4"); the plain w4a8_mxfp4_mxfp8 stays on CuteDSL.
+    use_trtllm_mxfp4 = moe_backend == "trtllm_mxfp4"
+    use_nvfp4_kernel = moe_type in ("nvfp4", "w4a8_mxfp4_mxfp8") and not use_trtllm_mxfp4
     use_trtllm_bf16_fp4 = moe_type == "nvfp4" and moe_ep_size == 1
     # int4_wo uses block_shape=[0, group_size] for grouped scales (group_size=128)
     if use_int4_w4a16:
@@ -1442,6 +1592,7 @@ def run_moe_torch(
             False,
             use_nvfp4=use_nvfp4_kernel,
             use_trtllm_bf16_fp4=use_trtllm_bf16_fp4,
+            use_trtllm_mxfp4=use_trtllm_mxfp4,
             use_int4_w4a16=use_int4_w4a16,
             use_mxfp4_w4a16=False,
             use_mxfp4_w4a8=False,
@@ -1467,6 +1618,7 @@ def run_moe_torch(
             False,
             use_nvfp4=use_nvfp4_kernel,
             use_trtllm_bf16_fp4=use_trtllm_bf16_fp4,
+            use_trtllm_mxfp4=use_trtllm_mxfp4,
             use_int4_w4a16=use_int4_w4a16,
             use_mxfp4_w4a16=use_mxfp4_w4a16,
             use_mxfp4_w4a8=use_mxfp4_w4a8,
@@ -1499,7 +1651,9 @@ def run_moe_torch(
         device_name=torch.cuda.get_device_name(device),
         op_name="moe",
         kernel_source=(
-            "sglang_flashinfer_trtllm_bf16_fp4_moe"
+            "sglang_mxfp4_flashinfer_trtllm_moe"
+            if use_trtllm_mxfp4
+            else "sglang_flashinfer_trtllm_bf16_fp4_moe"
             if use_trtllm_bf16_fp4
             else "sglang_flashinfer_cutedsl_moe"
             if use_nvfp4_kernel

--- a/collector/sglang/collect_moe.py
+++ b/collector/sglang/collect_moe.py
@@ -205,7 +205,10 @@ def get_moe_test_cases():
         for moe_type, num_tokens in itertools.product(model_moe_list, num_tokens_list):
             if not moe_model_allows_quantization("sglang", model_name, moe_type):
                 continue
-            is_native_dsv4 = model_name.startswith("deepseek-ai/DeepSeek-V4-")
+            # Native DeepSeek-V4 detection by config-derived architecture (not a
+            # model_name string pattern), so aliased/FP8 variants like
+            # sgl-project/DeepSeek-V4-Pro-FP8 are still recognized.
+            is_native_dsv4 = common_moe_testcase.architecture == "DeepseekV4ForCausalLM"
             if is_native_dsv4 and moe_type == "w4a8_mxfp4_mxfp8" and num_tokens > 8192:
                 # DeepSeek-V4 FP4 experts are only exercised up to the SGLang
                 # prefill chunk size. Larger synthetic masked-CuteDSL cases
@@ -1541,6 +1544,13 @@ def run_moe_torch(
         "int4_wo",
         "w4a16_mxfp4",
     ], "only support moe type = fp8_block, bfloat16, nvfp4, int4_wo, w4a16_mxfp4, or w4a8_mxfp4_mxfp8"
+    # Only w4a8_mxfp4_mxfp8 consumes the trtllm-gen backend; reject other combos
+    # up-front so we never benchmark one kernel while log_perf tags the row as
+    # kernel_source="sglang_mxfp4_flashinfer_trtllm_moe".
+    if moe_backend == "trtllm_mxfp4" and moe_type != "w4a8_mxfp4_mxfp8":
+        raise ValueError(
+            f"moe_backend='trtllm_mxfp4' is only valid with moe_type='w4a8_mxfp4_mxfp8', got moe_type={moe_type!r}"
+        )
     assert inter_size % moe_tp_size == 0, "inter_size % moe_tp_size must be 0"
     assert num_experts % moe_ep_size == 0, "num_experts must be divisible by moe_ep_size"
 

--- a/collector/sglang/deepseekv4_sparse_modules.py
+++ b/collector/sglang/deepseekv4_sparse_modules.py
@@ -523,8 +523,12 @@ def _build_flash_mla_inputs(
 
     Layout = MODEL1_FP8Sparse (DSV4 NSA): d_qk=512 with 584-byte fp8 cache.
     """
-    full_s = M + past_kv
     M_per_req = M // batch_size if batch_size > 1 else M  # noqa: N806
+    # Per-request sequence length: each of the ``batch_size`` requests has
+    # ``M_per_req`` new query tokens over ``past_kv`` prefix (NOT the flattened
+    # total M), so cache_seqlens / indices mirror the owning module
+    # (prefix, isl, bs) row 1:1 instead of one giant bs*isl request.
+    full_s = M_per_req + past_kv
     K_per_query = max(min(K_per_query, full_s), 1)  # noqa: N806
 
     # Q: (batch, M_per_req, n_local_heads, FMLA_D_QK=512) bf16
@@ -585,8 +589,8 @@ def _bench_flash_mla_sparse(
 
     # rank-local head count (what the upstream projection actually produces)
     n_local_heads = max(1, native_heads // tp_size)
-    _full_s = M + past_kv
     M_per_req = M // batch_size if batch_size > 1 else M  # noqa: N806
+    _full_s = M_per_req + past_kv  # per-request sequence length (bs requests, M_per_req new tokens each)
 
     # Build main K cache + ``q_local`` (per-rank Q at n_local_heads)
     q_local, k_cache_main, _, _, cache_seqlens = _build_flash_mla_inputs(
@@ -766,12 +770,18 @@ def _bench_sparse_kernel_shape(kernel, prefix, isl, bs, sc, device):
     perf_database consumes (flat.latency - top_last.latency)."""
     M = bs * isl  # noqa: N806
     if kernel in _FMLA_K_PER_QUERY:
+        # FMLA mirrors the module row 1:1: bs requests, each isl new query tokens
+        # over `prefix` past_kv. Pass batch_size=bs (so M_per_req=isl) and base
+        # K_per_query on the PER-REQUEST sequence length (isl+prefix), not the
+        # flattened total (bs*isl+prefix).
+        full_s = isl + prefix
         lat = _bench_flash_mla_sparse(
             M,
             prefix,
-            K_per_query=_FMLA_K_PER_QUERY[kernel](M + prefix, sc),
+            K_per_query=_FMLA_K_PER_QUERY[kernel](full_s, sc),
             native_heads=sc.num_attention_heads,
             sliding_window=sc.sliding_window,
+            batch_size=bs,
             device=device,
         )["latency_ms"]
         return [(None, lat)]
@@ -812,8 +822,10 @@ def run_dsv4_sparse_kernel_worker(
 
     csv_files = KERNEL_TO_MODULE_CSVS[kernel]
     # TP-independent: dedup to unique (prefix, isl, bs) — one bench, one row per
-    # shape (tp-agnostic), no per-tp expansion.
-    shapes = _read_module_shapes(output_dir, csv_files)
+    # shape (tp-agnostic), no per-tp expansion. Filter to THIS model: the module
+    # CSV is consolidated across every model collected to this (system, backend,
+    # version), so unioning all rows would mirror other models' shapes.
+    shapes = _read_module_shapes(output_dir, csv_files, model_path)
     if not shapes:
         print(
             f"[dsv4-sparse {kernel}] no module CSV ({'/'.join(csv_files)}) in {output_dir}; "
@@ -932,15 +944,23 @@ def get_dsv4_topk_calib_test_cases():
     return _impl()
 
 
-def _read_module_shapes(data_dir: str, csv_files) -> list[tuple[int, int, int]]:
+def _read_module_shapes(data_dir: str, csv_files, model_path: str | None = None) -> list[tuple[int, int, int]]:
     """Unique ``(prefix, isl, bs)`` shape keys from the already-collected module
     CSVs (the SINGLE input source: every sparse sub-kernel derives its shapes
     from the module it belongs to). ``step`` is the prefix/past_kv length; the
     sparse kernels are TP-independent so ``tp_size`` is dropped (one shape per
     unique prefix/isl/bs). Order preserved, deduped.
+
+    ``collect_dsv4_attn`` writes ONE consolidated ``*_module_perf`` file per
+    (system, backend, version) holding rows for every model collected there, so
+    rows are filtered to ``model_path`` before deduping — otherwise a sparse
+    worker would mirror another model's shapes and break the same-source 1:1
+    contract (writing those shapes under the wrong model). ``model_path=None``
+    keeps every row (no filter).
     """
     import csv
 
+    want_model = None if not model_path else str(model_path).rstrip("/")
     shapes: list[tuple[int, int, int]] = []
     seen: set[tuple[int, int, int]] = set()
     for fname in csv_files:
@@ -949,6 +969,8 @@ def _read_module_shapes(data_dir: str, csv_files) -> list[tuple[int, int, int]]:
             continue
         with open(path, newline="") as f:
             for row in csv.DictReader(f):
+                if want_model is not None and str(row.get("model", "")).rstrip("/") != want_model:
+                    continue
                 try:
                     key = (int(float(row.get("step", 0) or 0)), int(row["isl"]), int(row["batch_size"]))
                 except (KeyError, ValueError, TypeError):

--- a/collector/sglang/deepseekv4_sparse_modules.py
+++ b/collector/sglang/deepseekv4_sparse_modules.py
@@ -3,33 +3,31 @@
 
 """DeepSeek-V4 sparse-attention kernel-level collector for SGLang.
 
-DeepSeek-V4's default AIC path uses prefix-aware full CSA/HCA attention-module
-rows.  This collector is intentionally kept as auxiliary data for future
-prefix/past_kv correction and residual analysis, not as the primary modeling
-path.
+Collects the DeepSeek-V4 NSA sparse-attention sub-kernels at the kernel level.
+DeepSeek-V4's primary AIC path uses prefix-aware full CSA/HCA attention-module
+rows; paged_mqa_logits / csa_attn / hca_attn here are supporting kernel-level
+data for prefix/past_kv correction and residual analysis, while the topk_calib
+DELTA is actively consumed by perf_database's topK correction.
 
-Benchmarks the two past_kv-sensitive kernels that bench accurately at the
-kernel level (paged_mqa_logits + hca_attn).  Inputs match upstream layouts
-(DeepGEMM ``test_attention.py`` for the indexer GEMM, FlashMLA
-``MODEL1_FP8Sparse`` quant for the FMLA kernel).
+The four sub-kernels form ONE sparse-op family — the CSA/HCA sparse path in
+order — all collected, none modeled analytically:
 
-Kernels:
+    1. ``deep_gemm.fp8_paged_mqa_logits``      CSA indexer scoring
+    2. ``topk_transform`` (topk_512/_1024)     CSA selection — flat-vs-top_last
+                                               DELTA calib (flat_ms/top_last_ms)
+    3. ``flash_mla_with_kvcache`` (csa_attn)   CSA sparse FMLA over the
+                                               topk-selected c4 positions
+    4. ``flash_mla_with_kvcache`` (hca_attn)   HCA c128 sparse FMLA
 
-    1. ``deep_gemm.fp8_paged_mqa_logits``       (CSA indexer scoring)
-    2. ``flash_mla.flash_mla_with_kvcache`` HCA  (HCA c128 sparse FMLA)
+Inputs are SAME-SOURCE: every sub-kernel derives its ``(prefix, isl, bs[, tp])``
+shapes STRICTLY 1:1 from the CSA/HCA attention-module CSV it belongs to
+(paged_mqa / topk / csa_attn ← CSA module; hca_attn ← HCA module) — no separate
+sweep grid — benched at upstream layouts (DeepGEMM ``test_attention.py`` for the
+indexer GEMM, FlashMLA ``MODEL1_FP8Sparse`` quant for the FMLA kernel).
 
-(``topk_512`` and ``csa_attn`` are modeled analytically in perf_database —
-see KERNELS comment.)
-
-Sweep dims (defaults):
-
-    M        : new query tokens (mirrors current prefill ctx sweep)  # noqa: N803,N806
-               [1, 8, 64, 256, 1024, 4096, 8192]
-    past_kv  : 0 → ~1M     [0, 1024, 4096, 16384, 65536, 262144, 1048575-8192]
-
-CSV schema matches existing aic dsv4 module CSVs (so loaders can be
-shared): ``isl`` carries M, ``step`` carries past_kv, ``compress_ratio``
-distinguishes CSA(=4) / HCA(=128).
+CSV schema matches existing aic dsv4 module CSVs (so loaders can be shared):
+``isl`` carries M, ``step`` carries past_kv, ``compress_ratio`` distinguishes
+CSA(=4) / HCA(=128).
 """
 
 # Requires an SGLang build with DeepSeek-V4 support. Stock lmsysorg/sglang:v*
@@ -38,7 +36,7 @@ distinguishes CSA(=4) / HCA(=128).
 # sglang-runtime:*deepseek-v4* image.
 from __future__ import annotations
 
-import argparse
+import functools
 import importlib.util
 import json
 import os
@@ -46,6 +44,7 @@ import sys
 import traceback
 from collections.abc import Callable
 from pathlib import Path
+from types import SimpleNamespace
 
 import torch
 
@@ -58,50 +57,10 @@ except ModuleNotFoundError:
 # Re-export test case generators from the centralized case generator
 # module so collect.py's registry can resolve them via getattr on this module.
 try:
-    from collector.case_generator import (
-        _DSV4_DEFAULT_MODELS,
-    )
-    from collector.case_generator import (
-        _DSV4_SPARSE_BS_LIST as DEFAULT_BS_LIST,
-    )
-    from collector.case_generator import (
-        _DSV4_SPARSE_ISL_LIST as DEFAULT_ISL_LIST,
-    )
-    from collector.case_generator import (
-        _DSV4_SPARSE_PAST_KV_LIST as DEFAULT_PAST_KV_LIST,
-    )
-    from collector.case_generator import (
-        _DSV4_SPARSE_TP_LIST_ATTN as DEFAULT_TP_LIST_ATTN,
-    )
-    from collector.case_generator import (
-        DSV4_SPARSE_KERNELS as KERNELS,
-    )
-    from collector.case_generator import (
-        _build_dsv4_sparse_test_cases as _build_sparse_test_cases,
-    )
+    from collector.case_generator import _DSV4_DEFAULT_MODELS
 except ModuleNotFoundError:
     sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-    from case_generator import (
-        _DSV4_DEFAULT_MODELS,
-    )
-    from case_generator import (
-        _DSV4_SPARSE_BS_LIST as DEFAULT_BS_LIST,
-    )
-    from case_generator import (
-        _DSV4_SPARSE_ISL_LIST as DEFAULT_ISL_LIST,
-    )
-    from case_generator import (
-        _DSV4_SPARSE_PAST_KV_LIST as DEFAULT_PAST_KV_LIST,
-    )
-    from case_generator import (
-        _DSV4_SPARSE_TP_LIST_ATTN as DEFAULT_TP_LIST_ATTN,
-    )
-    from case_generator import (
-        DSV4_SPARSE_KERNELS as KERNELS,
-    )
-    from case_generator import (
-        _build_dsv4_sparse_test_cases as _build_sparse_test_cases,
-    )
+    from case_generator import _DSV4_DEFAULT_MODELS
 
 
 def get_dsv4_paged_mqa_logits_test_cases():
@@ -120,22 +79,26 @@ def get_dsv4_hca_attn_test_cases():
     return _impl()
 
 
+def get_dsv4_csa_attn_test_cases():
+    from collector.case_generator import get_dsv4_csa_attn_test_cases as _impl
+
+    if not _dsv4_sparse_kernel_supported("csa_attn"):
+        return []
+    return _impl()
+
+
 get_dsv4_flash_paged_mqa_logits_test_cases = get_dsv4_paged_mqa_logits_test_cases
 get_dsv4_flash_hca_attn_test_cases = get_dsv4_hca_attn_test_cases
 
 
 __all__ = [
-    "DEFAULT_BS_LIST",
-    "DEFAULT_ISL_LIST",
     "DEFAULT_MODEL",
-    "DEFAULT_PAST_KV_LIST",
-    "DEFAULT_TP_LIST_ATTN",
-    "KERNELS",
-    "_build_sparse_test_cases",
+    "get_dsv4_csa_attn_test_cases",
     "get_dsv4_flash_hca_attn_test_cases",
     "get_dsv4_flash_paged_mqa_logits_test_cases",
     "get_dsv4_hca_attn_test_cases",
     "get_dsv4_paged_mqa_logits_test_cases",
+    "get_dsv4_topk_calib_test_cases",
     "run_dsv4_sparse_kernel_worker",
 ]
 
@@ -144,26 +107,107 @@ DEFAULT_MODEL = _DSV4_DEFAULT_MODELS[0]
 MODEL_CONFIGS_DIR = Path(__file__).resolve().parents[2] / "src" / "aiconfigurator" / "model_configs"
 
 # ═══════════════════════════════════════════════════════════════════════
-# DeepSeek-V4 sparse architectural constants
+# Model config (single source for all DSV4 model-specific shapes)
 # ═══════════════════════════════════════════════════════════════════════
 
-# Main attention (DSV4 NSA -- MODEL1_FP8Sparse layout)
-V_HEAD_DIM = 512
 
-# FlashMLA d_qk for DSV4 NSA = 512 (NOT 576).  Layout MODEL1_FP8Sparse:
-#   d_nope=448, d_rope=64, tile_size=64, num_tiles=7
-# bytes_per_token = 448 + 64*2 + 7 + 1 = 584 (with 1 pad)
-FMLA_D_QK = 512
-FMLA_D_NOPE = 448
-FMLA_D_ROPE = 64
+def _dsv4_model_config(model_path: str) -> dict:
+    """Load a DSV4 model config json — the single source of model shapes.
+
+    Accepts a local model directory (``<dir>/config.json``) or an HF-style id
+    resolved under ``MODEL_CONFIGS_DIR``. Hard error if absent; these values
+    MUST NOT be guessed/defaulted.
+    """
+    if model_path and os.path.isdir(model_path):
+        path = Path(model_path) / "config.json"
+    else:
+        path = MODEL_CONFIGS_DIR / ((model_path or "").replace("/", "--") + "_config.json")
+    if not path.is_file():
+        raise FileNotFoundError(f"DSV4 model config not found at {path} for {model_path!r}")
+    return json.loads(path.read_text())
+
+
+def _dsv4_cfg_int(cfg: dict, field: str) -> int:
+    """Required int field from a loaded config (hard error if missing/empty)."""
+    if cfg.get(field) in (None, ""):
+        raise KeyError(f"{field} missing in DSV4 model config")
+    return int(cfg[field])
+
+
+@functools.cache
+def _dsv4_sparse_config(model_path: str) -> SimpleNamespace:
+    """All sparse-attention kernel shapes, extracted from the model config the
+    SAME way sglang's MQALayer / C4Indexer ``__init__`` read them
+    (models/deepseek_v4.py) — the single source for every sparse-kernel shape,
+    no scattered reads or magic numbers.
+
+    NSA compress-ratio layer types are exactly {0, 4, 128} (sglang asserts this
+    and selects the CSA/indexer path with the literal ``compress_ratio == 4``);
+    the topk / paged-mqa indexer is that c4 path, so ``csa_compress_ratio`` is 4
+    by architecture (validated against the config, not min()/heuristic).
+    ``page_size`` and the fp8 quant tile are kernel-layout invariants (not in the
+    config) and remain module constants below.
+    """
+    cfg = _dsv4_model_config(model_path)
+    compress = {int(r) for r in (cfg.get("compress_ratios") or [])}
+    if not compress <= {0, 4, 128}:
+        raise ValueError(
+            f"unexpected compress_ratios {sorted(compress)} for {model_path!r}; "
+            "DSV4 NSA expects a subset of {0, 4, 128}"
+        )
+    if 4 not in compress:
+        raise KeyError(f"no CSA layer (compress_ratio=4) in config for {model_path!r}; got {sorted(compress)}")
+    head_dim = _dsv4_cfg_int(cfg, "head_dim")
+    rope = _dsv4_cfg_int(cfg, "qk_rope_head_dim")
+    return SimpleNamespace(
+        head_dim=head_dim,  # FlashMLA d_qk / V_HEAD_DIM (512)
+        d_rope=rope,  # FlashMLA d_rope (64)
+        d_nope=head_dim - rope,  # FlashMLA d_nope (448)
+        num_attention_heads=_dsv4_cfg_int(cfg, "num_attention_heads"),
+        index_n_heads=_dsv4_cfg_int(cfg, "index_n_heads"),
+        index_head_dim=_dsv4_cfg_int(cfg, "index_head_dim"),
+        index_topk=_dsv4_cfg_int(cfg, "index_topk"),  # V4-Pro=1024, V4-Flash=512
+        csa_compress_ratio=4,  # sglang: compress_ratio == 4 is the CSA/indexer path
+        sliding_window=_dsv4_cfg_int(cfg, "sliding_window"),  # HCA SWA window (128)
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# DeepSeek-V4 sparse architectural constants
+# ═══════════════════════════════════════════════════════════════════════
+# Shape fields below are identical across DSV4 variants (Flash/Pro), so the
+# default model config is authoritative; read them via the sparse config.
+_DEFAULT_SC = _dsv4_sparse_config(DEFAULT_MODEL)
+V_HEAD_DIM = _DEFAULT_SC.head_dim  # 512
+FMLA_D_QK = V_HEAD_DIM  # FlashMLA d_qk == head_dim (NOT 576)
+FMLA_D_ROPE = _DEFAULT_SC.d_rope  # 64
+FMLA_D_NOPE = _DEFAULT_SC.d_nope  # 448
+
+# Kernel-layout invariants — NOT in the model config. The FlashMLA
+# MODEL1_FP8Sparse fp8 quant tile size and the deep_gemm / FlashMLA paged block
+# size are hardcoded in the kernels themselves (deep_gemm blocksize 64;
+# flashmla_backend.PAGE_SIZE = 64), so they are fixed constants here.
+# bytes_per_token = d_nope + d_rope*2 + num_tiles + 1 pad = 448 + 128 + 7 + 1 = 584
 FMLA_TILE_SIZE = 64
-FMLA_NUM_TILES = 7
-
-# Page sizes
-PAGE_SIZE_C4 = 64  # paged_mqa_logits block_kv
-PAGE_SIZE_FULL = 64  # FlashMLA paged block_size
+FMLA_NUM_TILES = FMLA_D_NOPE // FMLA_TILE_SIZE  # 448 / 64 = 7
 
 DEFAULT_ARCHITECTURE = "DeepseekV4ForCausalLM"
+
+
+@functools.lru_cache(maxsize=1)
+def _dsv4_kv_page_size() -> int:
+    """DSV4 KV-pool paged block size — single source from sglang.
+
+    The deep_gemm indexer (paged_mqa_logits block_kv) and FlashMLA paged
+    attention share ONE KV-pool page size: sglang's DSA indexer asserts
+    get_token_to_kv_pool().page_size == 64 and FlashMLA uses the same value
+    (flashmla_backend.PAGE_SIZE). Imported lazily — flashmla_backend pulls in
+    the whole MLA attention backend, which must not run at collector
+    module-import time.
+    """
+    from sglang.srt.layers.attention.flashmla_backend import PAGE_SIZE
+
+    return int(PAGE_SIZE)
 
 
 def _device_num_sms(device: str | torch.device) -> int:
@@ -172,49 +216,70 @@ def _device_num_sms(device: str | torch.device) -> int:
     return torch.cuda.get_device_properties(device).multi_processor_count
 
 
-# Two kernels are benched at the kernel level:
-#   - paged_mqa_logits: CSA indexer scoring (TP-independent, accurate)
-#   - hca_attn:       HCA's flash_mla over c128 cache (TP-independent, accurate)
+# The DSV4 sparse-op family — all four collected by ONE worker
+# (run_dsv4_sparse_kernel_worker), all driven by the KERNEL_* maps below, all
+# same-source (shapes read 1:1 from the CSA/HCA attention-module CSV they belong
+# to), all writing the SAME row schema (one ``latency`` per row):
+#   - paged_mqa_logits: CSA indexer scoring (deep_gemm)            -> 1 row/shape
+#   - topk:           CSA selection — benched under two score
+#                     distributions, emitted as TWO rows/shape
+#                     (score_mode=flat | top_last); perf_database
+#                     takes DELTA = flat.latency - top_last.latency -> 2 rows/shape
+#   - csa_attn:       CSA's flash_mla over the topk-selected c4
+#                     positions (K_per_query = min(index_topk, full_s//4))
+#   - hca_attn:       HCA's flash_mla over c128 cache.
 #                     (production DSV4 at TP>1 also runs FlashMLA with
 #                      the native h_q — sglang pads Q to full native heads,
 #                      then slices output back; see deepseek_v4.py:847.  So
 #                      TP=1 data is valid for any deployment TP.)
-#
-# Two kernels are modeled ANALYTICALLY in perf_database (NOT benched):
-#   - topk_512: pure memory-IO scan over fp32 logits (per-token causal).
-#     Bench at random / chained logits gives Δ off by 60%; AIC IO formula
-#     with eff≈0.1 gives Δ off by only ~8%.  Modeled as
-#         Δ_bytes(M, past_kv) = M * past_kv   (causal-scan additional bytes)
-#         Δ_time              = Δ_bytes / (mem_bw * 0.1) * 1000  (ms)
-#   - csa_attn: cache scatter pattern of topk-selected indices is impossible
-#     to reproduce with sequential indices in a kernel-level bench.
 KERNEL_TO_OP_NAME = {
     "paged_mqa_logits": "dsv4_paged_mqa_logits_module",
+    "topk": "dsv4_csa_topk_calib",
     "hca_attn": "dsv4_hca_attn_module",
+    "csa_attn": "dsv4_csa_attn_module",
 }
 
 KERNEL_TO_KERNEL_SOURCE = {
     "paged_mqa_logits": "deep_gemm.fp8_paged_mqa_logits",
+    "topk": "topk_transform_v2",
     "hca_attn": "flash_mla_with_kvcache",
+    "csa_attn": "flash_mla_with_kvcache",
 }
 
-# compress_ratio: 4 for indexer kernel, 128 for HCA's c128 attn
+# compress_ratio: 4 for the CSA c4 path (indexer/topk/csa_attn), 128 for HCA c128.
 KERNEL_TO_COMPRESS_RATIO = {
     "paged_mqa_logits": 4,
+    "topk": 4,
     "hca_attn": 128,
+    "csa_attn": 4,
 }
 
-KERNEL_TO_DEFAULT_FILENAME = {
-    "paged_mqa_logits": "dsv4_paged_mqa_logits_module_perf.txt",
-    "hca_attn": "dsv4_hca_attn_module_perf.txt",
+# Single input source: each sparse sub-kernel derives its (prefix, isl, bs[, tp])
+# shapes from the module it belongs to (paged_mqa/topk/csa_attn are CSA-module
+# sub-kernels; hca_attn is the HCA-module FMLA). The worker reads these
+# already-collected module CSVs at runtime — registry order runs the modules
+# first — instead of a separate sparse sweep grid.
+_CSA_MODULE_CSVS = ("dsv4_csa_context_module_perf.txt", "dsv4_csa_generation_module_perf.txt")
+_HCA_MODULE_CSVS = ("dsv4_hca_context_module_perf.txt", "dsv4_hca_generation_module_perf.txt")
+KERNEL_TO_MODULE_CSVS = {
+    "paged_mqa_logits": _CSA_MODULE_CSVS,
+    "topk": _CSA_MODULE_CSVS,
+    "hca_attn": _HCA_MODULE_CSVS,
+    "csa_attn": _CSA_MODULE_CSVS,
 }
+# ALL four sparse kernels are TP-independent — the indexer/FMLA latency does not
+# change with tp (the module's per-tp rows differ only by the attention module's
+# comms/sharding, not the sparse sub-kernel). So each is benched ONCE per unique
+# (prefix, isl, bs) module shape and written one row per shape (tp_size=1),
+# matching how the SDK consumes them (keyed by shape, not tp) — no per-tp
+# expansion. (topk additionally emits two score_mode rows per shape.)
 
 
 def _dsv4_sparse_kernel_supported(kernel: str) -> bool:
     """Return True when the active runtime can execute a DSV4 sparse kernel."""
     if os.environ.get("COLLECTOR_FORCE_DSV4_SPARSE") == "1":
         return True
-    if kernel == "hca_attn":
+    if kernel in ("hca_attn", "csa_attn"):
         return importlib.util.find_spec("flash_mla") is not None
     if kernel == "paged_mqa_logits":
         if importlib.util.find_spec("deep_gemm") is None:
@@ -238,14 +303,18 @@ def _bench_cuda_graph(
     num_warmup: int = 5,
     num_iterations: int = 20,
     graph_repeat: int = 4,
+    allow_graph_fail: bool = False,
     device: str = "cuda:0",
 ) -> dict:
-    """Benchmark a kernel via AIC's benchmark_with_power helper.
+    """Benchmark a kernel via AIC's benchmark_with_power helper (the single
+    bench path for all DSV4 sparse kernels).
 
     benchmark_with_power handles warmup, CUDA-Graph capture/replay, optional
-    power sampling, and graph-private-pool teardown. Capture failure is a
-    hard error: ``allow_graph_fail=False`` and ``used_cuda_graph`` is
-    checked explicitly. Returns ``{"latency_ms", "power_stats"}``.
+    power sampling, and graph-private-pool teardown. With ``allow_graph_fail``
+    False, CUDA-graph capture is mandatory (used_cuda_graph is asserted); set it
+    True for kernels whose graph capture may fall back to eager (e.g. the JIT
+    topk_transform whose host-side planning is done outside the timed region).
+    Returns ``{"latency_ms", "power_stats"}``.
     """
     if num_iterations < 3:
         raise ValueError("num_iterations must be at least 3")
@@ -262,11 +331,11 @@ def _bench_cuda_graph(
         num_warmups=num_warmup,
         num_runs=num_iterations,
         repeat_n=graph_repeat,
-        allow_graph_fail=False,
+        allow_graph_fail=allow_graph_fail,
     ) as result:
         pass
 
-    if not result.get("used_cuda_graph", False):
+    if not allow_graph_fail and not result.get("used_cuda_graph", False):
         raise RuntimeError("benchmark_with_power did not use CUDA Graph")
 
     return {
@@ -357,6 +426,19 @@ def _quantize_k_cache_model1(k_bf16: torch.Tensor) -> torch.Tensor:
     )
 
 
+def _expand_block_table(num_blocks: int, batch_size: int, device) -> torch.Tensor:
+    """Block list [0..num_blocks) replicated to (batch_size, num_blocks) int32.
+    All requests share the same physical blocks (KV cache is shared in-bench)."""
+    row = torch.arange(num_blocks, dtype=torch.int32, device=device)
+    return row.unsqueeze(0).expand(batch_size, num_blocks).contiguous()
+
+
+def _expand_indices(k: int, batch_size: int, m: int, device) -> torch.Tensor:
+    """Sequential KV indices [0..k) replicated to (batch_size, m, k) int32."""
+    base = torch.arange(k, dtype=torch.int32, device=device)
+    return base.view(1, 1, k).expand(batch_size, m, k).contiguous()
+
+
 # ═══════════════════════════════════════════════════════════════════════
 # Kernel 1: deep_gemm.fp8_paged_mqa_logits
 # ═══════════════════════════════════════════════════════════════════════
@@ -385,7 +467,7 @@ def _bench_paged_mqa_logits(
     del batch_size  # ignored — we treat each new token as its own batch entry
     full_s = M + past_kv
     full_c4 = max(1, full_s // 4)
-    block_kv = PAGE_SIZE_C4
+    block_kv = _dsv4_kv_page_size()
 
     b = M
     next_n = 1
@@ -413,8 +495,7 @@ def _bench_paged_mqa_logits(
     context_lens = causal_c4.view(b, next_n)
 
     # All requests reuse the same block list [0..blocks_per_req-1]
-    block_table = torch.arange(blocks_per_req, dtype=torch.int32, device=device)
-    block_table = block_table.unsqueeze(0).expand(b, blocks_per_req).contiguous()
+    block_table = _expand_block_table(blocks_per_req, b, device)
 
     schedule_meta = get_paged_mqa_logits_metadata(context_lens, block_kv, _device_num_sms(device))
 
@@ -450,16 +531,14 @@ def _build_flash_mla_inputs(
     q = torch.randn(batch_size, M_per_req, n_local_heads, FMLA_D_QK, dtype=torch.bfloat16, device=device)
 
     # K cache: SHARED across batch entries to avoid b-fold blowup.
-    blocks_per_req = (full_s + PAGE_SIZE_FULL - 1) // PAGE_SIZE_FULL
-    k_bf16 = torch.randn(blocks_per_req, PAGE_SIZE_FULL, 1, FMLA_D_QK, dtype=torch.bfloat16, device=device)
+    blocks_per_req = (full_s + _dsv4_kv_page_size() - 1) // _dsv4_kv_page_size()
+    k_bf16 = torch.randn(blocks_per_req, _dsv4_kv_page_size(), 1, FMLA_D_QK, dtype=torch.bfloat16, device=device)
     k_cache = _quantize_k_cache_model1(k_bf16)
 
-    block_table = torch.arange(blocks_per_req, dtype=torch.int32, device=device)
-    block_table = block_table.unsqueeze(0).expand(batch_size, blocks_per_req).contiguous()
+    block_table = _expand_block_table(blocks_per_req, batch_size, device)
 
     # indices_in_kvcache: (batch, M_per_req, K_per_query) int32 — first K_per_query positions per Q
-    base = torch.arange(K_per_query, dtype=torch.int32, device=device)
-    indices = base.view(1, 1, K_per_query).expand(batch_size, M_per_req, K_per_query).contiguous()
+    indices = _expand_indices(K_per_query, batch_size, M_per_req, device)
 
     # Pad indices to multiple of 64 (FlashMLA assertion)
     if K_per_query % 64 != 0:
@@ -483,6 +562,7 @@ def _bench_flash_mla_sparse(
     *,
     K_per_query: int,  # noqa: N803
     native_heads: int,
+    sliding_window: int,
     batch_size: int = 1,
     tp_size: int = 1,
     device: str = "cuda:0",
@@ -528,18 +608,17 @@ def _bench_flash_mla_sparse(
 
     # Kernel always sees full h_q.
     n_local_heads = native_heads
-    swa_window = 128
-    swa_indices = torch.arange(swa_window, dtype=torch.int32, device=device)
-    swa_indices = swa_indices.view(1, 1, swa_window).expand(batch_size, M_per_req, swa_window).contiguous()
+    swa_window = sliding_window
+    swa_indices = _expand_indices(swa_window, batch_size, M_per_req, device)
     swa_topk_lengths = torch.full((batch_size,), swa_window, dtype=torch.int32, device=device)
 
     # Build extra K cache (c128 or c4) + extra indices
-    extra_blocks = (K_per_query + PAGE_SIZE_FULL - 1) // PAGE_SIZE_FULL
-    extra_k_bf16 = torch.randn(max(1, extra_blocks), PAGE_SIZE_FULL, 1, FMLA_D_QK, dtype=torch.bfloat16, device=device)
+    _pg = _dsv4_kv_page_size()
+    extra_blocks = (K_per_query + _pg - 1) // _pg
+    extra_k_bf16 = torch.randn(max(1, extra_blocks), _pg, 1, FMLA_D_QK, dtype=torch.bfloat16, device=device)
     extra_k_cache = _quantize_k_cache_model1(extra_k_bf16)
     extra_K = max(64, ((K_per_query + 63) // 64) * 64)  # noqa: N806
-    extra_base = torch.arange(extra_K, dtype=torch.int32, device=device)
-    extra_indices = extra_base.view(1, 1, extra_K).expand(batch_size, M_per_req, extra_K).contiguous()
+    extra_indices = _expand_indices(extra_K, batch_size, M_per_req, device)
     extra_topk_lengths = torch.full((batch_size,), K_per_query, dtype=torch.int32, device=device)
 
     sched_meta, _ = get_mla_metadata(
@@ -577,32 +656,15 @@ def _bench_flash_mla_sparse(
     return _bench_cuda_graph(kernel_fn, device=device)
 
 
-def _bench_hca_attn(
-    M: int,  # noqa: N803
-    past_kv: int,
-    *,
-    native_heads: int,
-    batch_size: int = 1,
-    tp_size: int = 1,
-    device: str = "cuda:0",
-) -> float:
-    """HCA: each Q attends to all c128 positions (no topk cap)."""
-    full_s = M + past_kv
-    K_per_query = max(1, full_s // 128)  # noqa: N806
-    return _bench_flash_mla_sparse(
-        M,
-        past_kv,
-        K_per_query=K_per_query,
-        native_heads=native_heads,
-        batch_size=batch_size,
-        tp_size=tp_size,
-        device=device,
-    )
-
-
-_BENCH_FN = {
-    "paged_mqa_logits": _bench_paged_mqa_logits,
-    "hca_attn": _bench_hca_attn,
+# HCA and CSA are the SAME FlashMLA kernel (``_bench_flash_mla_sparse``) — they
+# differ only in how many KV positions each query attends to:
+#   - hca_attn: all c128 positions               -> full_s // 128
+#   - csa_attn: the topk-selected c4 positions    -> min(index_topk, full_s // 4)
+# (csa uses the same sequential-index approximation as hca; the real topk
+# scatter pattern is not reproducible in a kernel-level bench.)
+_FMLA_K_PER_QUERY = {
+    "hca_attn": lambda full_s, sc: max(1, full_s // 128),
+    "csa_attn": lambda full_s, sc: max(1, min(sc.index_topk, full_s // 4)),
 }
 
 
@@ -612,8 +674,9 @@ _BENCH_FN = {
 
 
 def _make_perf_filename(kernel: str, output_path: str) -> str:
+    # Default filename derives directly from the op name (op_name + "_perf.txt").
     if os.path.isdir(output_path) or not output_path.endswith(".txt"):
-        return os.path.join(output_path, KERNEL_TO_DEFAULT_FILENAME[kernel])
+        return os.path.join(output_path, f"{KERNEL_TO_OP_NAME[kernel]}_perf.txt")
     return output_path
 
 
@@ -630,31 +693,36 @@ def _write_row(
     device_name: str,
     model_path: str = DEFAULT_MODEL,
     architecture: str = DEFAULT_ARCHITECTURE,
+    score_mode: str | None = None,
     power_stats: dict | None = None,
 ) -> None:
     os.makedirs(os.path.dirname(os.path.abspath(perf_filename)) or ".", exist_ok=True)
 
-    mla_dtype = "bfloat16" if kernel == "hca_attn" else "fp8_e4m3"
+    mla_dtype = "bfloat16" if kernel in ("hca_attn", "csa_attn") else "fp8_e4m3"
     kv_cache_dtype = "fp8_e4m3"
     gemm_type = "fp8_block"
 
+    item = {
+        "model": model_path,
+        "architecture": architecture,
+        "mla_dtype": mla_dtype,
+        "kv_cache_dtype": kv_cache_dtype,
+        "gemm_type": gemm_type,
+        "num_heads": native_heads,
+        "batch_size": bs,
+        "isl": isl,
+        "tp_size": tp_size,
+        "step": past_kv,
+        "compress_ratio": KERNEL_TO_COMPRESS_RATIO[kernel],
+        "latency": f"{latency_ms:.6f}",
+    }
+    # topk emits two rows per shape (flat vs top_last); the discriminator column
+    # is only present for topk so the single-latency kernels keep their schema.
+    if score_mode is not None:
+        item["score_mode"] = score_mode
+
     log_perf(
-        item_list=[
-            {
-                "model": model_path,
-                "architecture": architecture,
-                "mla_dtype": mla_dtype,
-                "kv_cache_dtype": kv_cache_dtype,
-                "gemm_type": gemm_type,
-                "num_heads": native_heads,
-                "batch_size": bs,
-                "isl": isl,
-                "tp_size": tp_size,
-                "step": past_kv,
-                "compress_ratio": KERNEL_TO_COMPRESS_RATIO[kernel],
-                "latency": f"{latency_ms:.6f}",
-            }
-        ],
+        item_list=[item],
         framework="SGLang",
         version="kernel-level",
         device_name=device_name,
@@ -666,160 +734,245 @@ def _write_row(
 
 
 # ═══════════════════════════════════════════════════════════════════════
-# Worker
+# Worker (invoked by collect.py via the registry; test-case generators live in
+# case_generator.py so all collectors share one sweep-grid definition).
 # ═══════════════════════════════════════════════════════════════════════
-# Test cases (``get_dsv4_{paged_mqa_logits,hca_attn}_test_cases`` and
-# ``_build_sparse_test_cases``) are imported from ``dsv4_test_cases``
-# at the top of this module — kept central so both collectors share the
-# same sweep grid definitions.
+
+
+def _guarded_bench(bench_fn: Callable[[], object], label: str):
+    """Run a per-shape bench, returning its result or ``None`` on OOM / any
+    error (logged, with a CUDA cache flush), so a single bad shape skips rather
+    than aborting the whole op."""
+    try:
+        return bench_fn()
+    except torch.cuda.OutOfMemoryError:
+        print(f"  OOM at {label}; skipping shape")
+        torch.cuda.empty_cache()
+        return None
+    except Exception:
+        traceback.print_exc()
+        print(f"  failed at {label}; skipping shape")
+        torch.cuda.empty_cache()
+        return None
+
+
+def _bench_sparse_kernel_shape(kernel, prefix, isl, bs, sc, device):
+    """Bench one module ``(prefix, isl, bs)`` shape; return a list of
+    ``(score_mode, latency_ms)`` rows. TP-independent (paged_mqa flattens bs→b=M;
+    FMLA pads to full native heads), so this is computed once per shape.
+
+    Single-latency kernels return one ``(None, latency)``; topk returns the
+    flat-vs-representative pair ``[("flat", …), ("top_last", …)]`` whose DELTA
+    perf_database consumes (flat.latency - top_last.latency)."""
+    M = bs * isl  # noqa: N806
+    if kernel in _FMLA_K_PER_QUERY:
+        lat = _bench_flash_mla_sparse(
+            M,
+            prefix,
+            K_per_query=_FMLA_K_PER_QUERY[kernel](M + prefix, sc),
+            native_heads=sc.num_attention_heads,
+            sliding_window=sc.sliding_window,
+            device=device,
+        )["latency_ms"]
+        return [(None, lat)]
+    if kernel == "topk":
+        return _bench_topk_shape(prefix, isl, bs, sc, device)
+    # paged_mqa_logits: bs flattened to b=M, next_n=1
+    lat = _bench_paged_mqa_logits(
+        M,
+        prefix,
+        index_n_heads=sc.index_n_heads,
+        index_head_dim=sc.index_head_dim,
+        device=device,
+    )["latency_ms"]
+    return [(None, lat)]
 
 
 def run_dsv4_sparse_kernel_worker(
-    bs: int,
-    isl: int,
-    past_kv: int,
-    tp_size: int,
-    kernel: str,
     model_path: str,
+    kernel: str,
     *,
     perf_filename: str,
     device: str = "cuda:0",
 ):
-    """Worker invoked by collect.py.
+    """Single worker for the whole DSV4 sparse-op family (invoked by collect.py,
+    one case per model from get_func).
 
-    Tuple positional args come from get_func; ``perf_filename`` is bound by
-    collect.py via functools.partial.
-
-    Internal mapping to bench functions:
-      - paged_mqa_logits : M = bs x isl  (work depends only on total new
-        tokens; ``b=M, next_n=1`` workaround for SM90 smem limit on next_n)
-      - hca_attn         : pass batch_size=bs and M=bsxisl directly
-        (``_build_flash_mla_inputs`` derives M_per_req=isl).
-    """
-    if kernel not in _BENCH_FN:
-        raise ValueError(f"unknown kernel={kernel}; expected one of {list(_BENCH_FN)}")
-    if os.path.isdir(model_path):
-        config_path = Path(model_path) / "config.json"
-    else:
-        config_path = MODEL_CONFIGS_DIR / f"{model_path.replace('/', '--')}_config.json"
-    with open(config_path, encoding="utf-8") as f:
-        model_config = json.load(f)
-    native_heads = int(model_config["num_attention_heads"])
-    index_n_heads = int(model_config["index_n_heads"])
-    index_head_dim = int(model_config["index_head_dim"])
-
-    # The OpEntry binds a single ``perf_filename`` (placeholder
-    # ``dsv4_sparse_module_perf.txt``) but we collect TWO kernels in
-    # one op — always derive the directory from the bound path and dispatch
-    # to ``dsv4_{kernel}_module_perf.txt`` per the case's ``kernel``.
+    Reads the kernel's owning module CSV(s) — paged_mqa_logits/topk/csa_attn ←
+    CSA, hca_attn ← HCA — dedups to the unique ``(prefix, isl, bs)`` module shapes
+    (the kernels are TP-independent), and benches each once.
+    ``_bench_sparse_kernel_shape`` returns one or more ``(score_mode, latency)``
+    rows per shape — one for the single-latency kernels, two for topk (flat +
+    top_last) — each written as one row (tp_size=1)."""
+    if kernel not in KERNEL_TO_OP_NAME:
+        raise ValueError(f"unknown kernel={kernel}; expected one of {list(KERNEL_TO_OP_NAME)}")
+    sc = _dsv4_sparse_config(model_path)
     output_dir = os.path.dirname(perf_filename) or os.getcwd()
     perf_path = _make_perf_filename(kernel, output_dir)
 
-    M = bs * isl  # noqa: N806
-    print(f"[dsv4-sparse {kernel}] bs={bs} isl={isl} past_kv={past_kv} tp={tp_size} (M={M}) → {perf_path}")
-
-    bench_fn = _BENCH_FN[kernel]
-    if kernel == "hca_attn":
-        kwargs = dict(batch_size=bs, tp_size=tp_size, native_heads=native_heads, device=device)
-    else:
-        # paged_mqa_logits: bs at kernel level is flattened to b=M, next_n=1
-        kwargs = dict(
-            batch_size=1,
-            index_n_heads=index_n_heads,
-            index_head_dim=index_head_dim,
-            device=device,
+    csv_files = KERNEL_TO_MODULE_CSVS[kernel]
+    # TP-independent: dedup to unique (prefix, isl, bs) — one bench, one row per
+    # shape (tp-agnostic), no per-tp expansion.
+    shapes = _read_module_shapes(output_dir, csv_files)
+    if not shapes:
+        print(
+            f"[dsv4-sparse {kernel}] no module CSV ({'/'.join(csv_files)}) in {output_dir}; "
+            "collect the owning csa/hca module first. Skipping."
         )
-
-    try:
-        bench_result = bench_fn(M, past_kv, **kwargs)
-    except torch.cuda.OutOfMemoryError:
-        print(f"  OOM at bs={bs} isl={isl} past_kv={past_kv}; skipping")
-        torch.cuda.empty_cache()
         return
-    except Exception:
-        traceback.print_exc()
-        print(f"  failed at bs={bs} isl={isl} past_kv={past_kv}")
-        torch.cuda.empty_cache()
-        raise
 
-    latency_ms = float(bench_result["latency_ms"])
-    power_stats = bench_result.get("power_stats")
     device_name = torch.cuda.get_device_name(device)
-    _write_row(
-        perf_path,
-        kernel=kernel,
-        bs=bs,
-        isl=isl,
-        past_kv=past_kv,
-        tp_size=tp_size,
-        native_heads=native_heads,
-        latency_ms=latency_ms,
-        device_name=device_name,
-        model_path=model_path,
-        power_stats=power_stats,
-    )
-    power_str = f", power={power_stats['power']:.1f}W" if power_stats and power_stats.get("power") is not None else ""
-    print(f"  latency={latency_ms:.4f} ms{power_str}")
-
-
-# ═══════════════════════════════════════════════════════════════════════
-# CLI
-# ═══════════════════════════════════════════════════════════════════════
-
-
-def _parse_int_list(value: str) -> list[int]:
-    return [int(x) for x in value.split(",") if x.strip()]
-
-
-def _build_arg_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Collect DeepSeek-V4 sparse-attention kernel-level latency.")
-    parser.add_argument("--kernel", default="all", help=f"comma-separated subset of {KERNELS} (or 'all')")
-    parser.add_argument("--bs-list", type=_parse_int_list, default=DEFAULT_BS_LIST)
-    parser.add_argument("--isl-list", type=_parse_int_list, default=DEFAULT_ISL_LIST)
-    parser.add_argument("--past-kv-list", type=_parse_int_list, default=DEFAULT_PAST_KV_LIST)
-    parser.add_argument(
-        "--tp-list-attn", type=_parse_int_list, default=DEFAULT_TP_LIST_ATTN, help="TP sizes for hca_attn"
-    )
-    parser.add_argument("--output-path", default=os.getcwd())
-    parser.add_argument("--device", default="cuda:0")
-    parser.add_argument("--model-path", default=DEFAULT_MODEL)
-    return parser
-
-
-def main():
-    args = _build_arg_parser().parse_args()
-    os.environ["COLLECTOR_MODEL_PATH"] = args.model_path
-
-    if args.kernel == "all":
-        kernels = list(KERNELS)
-    else:
-        kernels = [k.strip() for k in args.kernel.split(",") if k.strip()]
-        for k in kernels:
-            if k not in KERNELS:
-                raise SystemExit(f"unknown kernel '{k}'; expected one of {KERNELS}")
-
-    cases = _build_sparse_test_cases(
-        kernels=kernels,
-        bs_list=args.bs_list,
-        isl_list=args.isl_list,
-        past_kv_list=args.past_kv_list,
-        tp_list_attn=args.tp_list_attn,
-    )
-    print(f"Running {len(cases)} sparse-kernel test cases on {args.device}")
-    for case in cases:
-        bs, isl, past_kv, tp, kernel, model_path = case
-        perf_path = _make_perf_filename(kernel, args.output_path)
-        run_dsv4_sparse_kernel_worker(
-            bs,
-            isl,
-            past_kv,
-            tp,
-            kernel,
-            model_path,
-            perf_filename=perf_path,
-            device=args.device,
+    print(f"[dsv4-sparse {kernel}] {len(shapes)} module shapes -> {perf_path}")
+    n_ok = 0
+    for prefix, isl, bs in shapes:
+        # Every module shape is benched (strict 1:1); tiny shapes run fine
+        # (K/window clamp to full_s) and a shape that OOMs is skipped by
+        # _guarded_bench rather than pre-filtered.
+        results = _guarded_bench(
+            lambda: _bench_sparse_kernel_shape(kernel, prefix, isl, bs, sc, device),
+            f"bs={bs} isl={isl} past_kv={prefix}",
         )
+        if results is None:
+            continue
+        n_ok += 1
+        for score_mode, latency_ms in results:
+            _write_row(
+                perf_path,
+                kernel=kernel,
+                bs=bs,
+                isl=isl,
+                past_kv=prefix,
+                tp_size=1,
+                native_heads=sc.num_attention_heads,
+                latency_ms=latency_ms,
+                device_name=device_name,
+                model_path=model_path,
+                score_mode=score_mode,
+            )
+    print(f"  {kernel}: benched {n_ok}/{len(shapes)} unique shapes")
 
 
-if __name__ == "__main__":
-    main()
+# ═══════════════════════════════════════════════════════════════════════
+# topk_512 indexer DELTA calibration (kernels, fed by the shared worker above)
+# ═══════════════════════════════════════════════════════════════════════
+# The CSA indexer's topk kernel needs a CALIBRATION rather than a single latency:
+# the CSA module CSV already contains the topK time measured on DEGENERATE scores
+# (dummy weights -> near-constant logits -> the small O(n^2) tie-break path).
+# ``_bench_topk_shape`` benches topk_transform under FLAT (worst-case degenerate)
+# and TOP_LAST (representative: largest scores at the causal tail) distributions
+# and returns the two as ``(score_mode, latency)`` rows; the shared worker writes
+# them like any other sparse-kernel rows, and perf_database applies
+# DELTA = flat.latency - top_last.latency to swap the degenerate cost for a
+# representative one at query time (see _load_dsv4_topk_calib).
+#
+# topK is CSA-only (compress_ratio=4) and, like the other sparse kernels,
+# TP-independent (per-token causal scan): one (flat, top_last) pair per shape.
+
+
+def _dsv4_topk_kernel_supported() -> bool:
+    """True when the SGLang build exposes the sm_100 topk_512 indexer kernel."""
+    if os.environ.get("COLLECTOR_FORCE_DSV4_SPARSE") == "1":
+        return True
+    try:
+        # find_spec raises (not returns None) when a PARENT package is absent.
+        return importlib.util.find_spec("sglang.jit_kernel.dsv4.topk") is not None
+    except ModuleNotFoundError:
+        return False
+
+
+def _make_topk_scores(mode: str, rows: int, seq: int, device: str, generator, topk_k: int) -> torch.Tensor:
+    # score_stride must be a multiple of 4 (kernel TMA 16B alignment); allocate
+    # padded width and let the kernel read [:, :seq].
+    pad = ((seq + 3) // 4) * 4
+    if mode == "flat":
+        return torch.zeros(rows, pad, device=device)
+    if mode == "top_last":
+        s = -5.0 + 0.05 * torch.randn(rows, pad, device=device, generator=generator)
+        s[:, seq - topk_k : seq] = 5.0 + torch.randn(rows, topk_k, device=device, generator=generator)
+        return s.contiguous()
+    raise ValueError(f"unknown topk score mode: {mode}")
+
+
+def _bench_topk_512(rows: int, c4_len: int, mode: str, device: str, topk_k: int) -> float:
+    """Time one topk_transform shape via the shared ``_bench_cuda_graph`` path
+    (same bench helper as paged_mqa_logits/hca_attn).
+
+    The topk_transform kernel runs inside sglang's decode CUDA graph in
+    production, so we capture under CUDA graph too — but with
+    ``allow_graph_fail=True`` (eager fallback) since this JIT kernel's capture is
+    less robust. Host-side planning (``plan_topk_v2``) is done ONCE outside the
+    timed region — only the kernel is captured/timed.
+    """
+    from sglang.jit_kernel.dsv4.topk import plan_topk_v2, topk_transform_512_v2
+
+    generator = torch.Generator(device=device)
+    generator.manual_seed(1234)
+    seq_lens = torch.full((rows,), c4_len, dtype=torch.int32, device=device)
+    meta = plan_topk_v2(seq_lens, 0)
+    torch.cuda.synchronize(device)
+    pages = (c4_len + _dsv4_kv_page_size() - 1) // _dsv4_kv_page_size()
+    page_table = torch.arange(pages, dtype=torch.int32, device=device).unsqueeze(0).repeat(rows, 1)
+    scores = _make_topk_scores(mode, rows, c4_len, device, generator, topk_k=topk_k)
+    out = torch.empty((rows, topk_k), dtype=torch.int32, device=device)
+
+    def kernel_func():
+        topk_transform_512_v2(scores, seq_lens, page_table, out, _dsv4_kv_page_size(), meta)
+
+    return _bench_cuda_graph(kernel_func, allow_graph_fail=True, device=device)["latency_ms"]
+
+
+def get_dsv4_topk_calib_test_cases():
+    """topk_512 DELTA calibration cases (gated on kernel availability)."""
+    try:
+        from collector.case_generator import get_dsv4_topk_calib_test_cases as _impl
+    except ModuleNotFoundError:
+        from case_generator import get_dsv4_topk_calib_test_cases as _impl
+    if not _dsv4_topk_kernel_supported():
+        return []
+    return _impl()
+
+
+def _read_module_shapes(data_dir: str, csv_files) -> list[tuple[int, int, int]]:
+    """Unique ``(prefix, isl, bs)`` shape keys from the already-collected module
+    CSVs (the SINGLE input source: every sparse sub-kernel derives its shapes
+    from the module it belongs to). ``step`` is the prefix/past_kv length; the
+    sparse kernels are TP-independent so ``tp_size`` is dropped (one shape per
+    unique prefix/isl/bs). Order preserved, deduped.
+    """
+    import csv
+
+    shapes: list[tuple[int, int, int]] = []
+    seen: set[tuple[int, int, int]] = set()
+    for fname in csv_files:
+        path = os.path.join(data_dir, fname)
+        if not os.path.isfile(path):
+            continue
+        with open(path, newline="") as f:
+            for row in csv.DictReader(f):
+                try:
+                    key = (int(float(row.get("step", 0) or 0)), int(row["isl"]), int(row["batch_size"]))
+                except (KeyError, ValueError, TypeError):
+                    continue
+                if key not in seen:
+                    seen.add(key)
+                    shapes.append(key)
+    return shapes
+
+
+def _bench_topk_shape(prefix: int, isl: int, bs: int, sc, device: str) -> list:
+    """topk DELTA calibration for one CSA ``(prefix, isl, bs)`` shape: bench
+    topk_transform under FLAT (degenerate worst-case) and TOP_LAST
+    (representative) score distributions and return them as two
+    ``[("flat", latency), ("top_last", latency)]`` rows.
+
+    Trivial when c4 <= K (no select stage, no degenerate tie-break) -> both 0
+    (DELTA 0). ``rows`` = bs*isl is the per-token causal scan count."""
+    ratio = sc.csa_compress_ratio  # CSA compress ratio (=4)
+    topk_k = sc.index_topk  # V4-Pro=1024, V4-Flash=512
+    rows = max(bs * isl, 1)
+    c4_len = (prefix + isl) // ratio
+    if c4_len <= topk_k:
+        return [("flat", 0.0), ("top_last", 0.0)]
+    return [
+        (mode, round(_bench_topk_512(rows, c4_len, mode, device, topk_k=topk_k), 6)) for mode in ("flat", "top_last")
+    ]

--- a/collector/sglang/registry.py
+++ b/collector/sglang/registry.py
@@ -143,6 +143,22 @@ REGISTRY: list[OpEntry] = [
         perf_filename=PerfFile.DSV4_HCA_ATTN_MODULE,
     ),
     OpEntry(
+        op="dsv4_csa_attn_module",
+        module="collector.sglang.deepseekv4_sparse_modules",
+        get_func="get_dsv4_csa_attn_test_cases",
+        run_func="run_dsv4_sparse_kernel_worker",
+        perf_filename=PerfFile.DSV4_CSA_ATTN_MODULE,
+    ),
+    # CSA topk_512 DELTA calibration (flat vs top_last) — feeds the
+    # degenerate->representative topK correction in perf_database.
+    OpEntry(
+        op="dsv4_csa_topk_calib",
+        module="collector.sglang.deepseekv4_sparse_modules",
+        get_func="get_dsv4_topk_calib_test_cases",
+        run_func="run_dsv4_sparse_kernel_worker",
+        perf_filename=PerfFile.DSV4_CSA_TOPK_CALIB,
+    ),
+    OpEntry(
         op="gdn",
         module="collector.sglang.collect_gdn",
         get_func="get_gdn_test_cases",

--- a/collector/sglang/runtime_limits.py
+++ b/collector/sglang/runtime_limits.py
@@ -35,6 +35,45 @@ def required_kv_tokens(batch_size: int, seq_len: int, prefix_len: int, *, is_pre
     return batch_size * (seq_len + prefix_len) if is_prefill else batch_size * seq_len
 
 
+def kv_pool_page_size(model_runner) -> int:
+    """Page size of the SGLang KV allocator (1 for token-level allocators)."""
+    allocator = getattr(model_runner, "token_to_kv_pool_allocator", None)
+    page = getattr(allocator, "page_size", None)
+    return int(page) if isinstance(page, int) and page > 0 else 1
+
+
+def required_kv_alloc_tokens(
+    batch_size: int,
+    seq_len: int,
+    prefix_len: int,
+    page_size: int,
+    *,
+    is_prefill: bool,
+) -> int:
+    """KV tokens SGLang's paged ``alloc_extend`` must find free for this case.
+
+    The naive :func:`required_kv_tokens` (``bs*(sl+prefix)``) only counts logical
+    KV tokens, but SGLang's PAGED allocator rounds EACH request's KV span up to a
+    full page independently. With a large page (e.g. 256) and many requests, even
+    tiny ``seq_len`` forces ``batch_size`` whole pages: a bs=512 / sl=1 decode
+    needs 512 pages = ``512 * 256`` slots, which can exceed the KV pool even
+    though ``bs*sl`` is tiny — so ``alloc_extend`` fails with "Prefill out of
+    memory" while the naive check passes. This returns that true paged
+    requirement so such shapes are skipped BEFORE launching. With ``page_size==1``
+    it equals ``required_kv_tokens`` (a no-op for token-level allocators).
+
+    NOTE: this is the real allocation size only, NOT SGLang's eviction
+    over-estimate (``extend_num_tokens + bs*page_size``). The collector clears
+    the pool between shapes, so the cache is empty and nothing needs eviction;
+    adding that slack would over-skip valid shapes (e.g. bs=256/sl<=256).
+    """
+    if batch_size <= 0:
+        return 0
+    per_req = required_kv_tokens(batch_size, seq_len, prefix_len, is_prefill=is_prefill) // batch_size
+    pages_per_req = (per_req + page_size - 1) // page_size
+    return batch_size * pages_per_req * page_size
+
+
 def dsa_indexer_workspace_bytes(
     batch_size: int,
     seq_len: int,

--- a/src/aiconfigurator/sdk/common.py
+++ b/src/aiconfigurator/sdk/common.py
@@ -827,11 +827,17 @@ class PerfDataFilename(Enum):
     dsv4_hca_context_module = "dsv4_hca_context_module_perf.parquet"
     dsv4_csa_generation_module = "dsv4_csa_generation_module_perf.parquet"
     dsv4_hca_generation_module = "dsv4_hca_generation_module_perf.parquet"
-    # DeepSeek-V4 sparse-kernel data (kernel-level past_kv Δ correction).
-    # Indexed by ``arch -> tp -> past_kv -> isl -> bs``.
-    # topk_512 and csa_attn are modeled analytically — no CSV needed.
+    # DeepSeek-V4 sparse-op family — all share one column schema and load
+    # through ``operations.dsv4.load_dsv4_sparse_op_data``:
+    #   csa_attn / hca_attn / paged_mqa_logits : FMLA & indexer kernel latency,
+    #     keyed ``num_heads -> tp -> past_kv -> isl -> bs`` (kernel-level Δ data,
+    #     queried by ``_lookup_sparse_kernel``).
+    #   csa_topk_calib : two rows/shape (score_mode=flat|top_last); the topK
+    #     DELTA (flat-top_last) correction applied to CSA module latency.
     dsv4_paged_mqa_logits_module = "dsv4_paged_mqa_logits_module_perf.parquet"
     dsv4_hca_attn_module = "dsv4_hca_attn_module_perf.parquet"
+    dsv4_csa_attn_module = "dsv4_csa_attn_module_perf.parquet"
+    dsv4_csa_topk_calib = "dsv4_csa_topk_calib_perf.parquet"
     dsv4_megamoe_module = "dsv4_megamoe_module_perf.parquet"
 
 

--- a/src/aiconfigurator/sdk/common.py
+++ b/src/aiconfigurator/sdk/common.py
@@ -870,6 +870,18 @@ class MoEQuantMode(Enum):
     w4a16_mxfp4 = QuantMapping(0.5, 1, "w4a16_mxfp4")  # native data format for gpt oss
     w4a8_mxfp4_mxfp8 = QuantMapping(0.5, 2, "w4a8_mxfp4_mxfp8")
     # mxfp4 weights, mxfp8 activations (recommended for Blackwell)
+    w4a8_mxfp4_mxfp8_trtllm = QuantMapping(0.5, 2, "w4a8_mxfp4_mxfp8_trtllm")
+    # Blackwell trtllm-gen fused MoE: MXFP4 (E2M1, block-32) weights x MXFP8 (E4M3)
+    # activations -- the kernel DeepSeek-V4-Pro actually runs in prefill on sm100
+    # (bmm_MxE4m3_MxE2m1MxE4m3 ... sm100f, flashinfer trtllm_fp4_block_scale_moe).
+    # Distinct backend from w4a8_mxfp4_mxfp8 above (flashinfer cutedsl). DSV4 MoE
+    # weights are stored MXFP4 (I8-packed E2M1 + E8M0 scales), so sglang dispatches
+    # by GPU: sm100 -> this (trtllm-gen); sm90 -> w4a16_mxfp4_cutlass below.
+    w4a16_mxfp4_cutlass = QuantMapping(0.5, 1, "w4a16_mxfp4_cutlass")
+    # Hopper (sm90) DeepSeek-V4-Pro MoE: flashinfer cutlass SM90 mixed GEMM
+    # (cutlass_fused_moe(use_w4_group_scaling=True)) -- MXFP4 weights x BF16
+    # activations (weight-only). Distinct backend from w4a16_mxfp4 above, which is
+    # GPT-OSS's triton_kernels mxfp4 path. (DSV4 Hopper silicon data pending.)
 
 
 class FMHAQuantMode(Enum):

--- a/src/aiconfigurator/sdk/operations/dsv4.py
+++ b/src/aiconfigurator/sdk/operations/dsv4.py
@@ -32,6 +32,8 @@ Cache key matches every other migrated op:
 from __future__ import annotations
 
 import copy
+import csv
+import functools
 import logging
 import os
 from collections import defaultdict
@@ -191,6 +193,95 @@ def _dsv4_robust_3d_lookup(self, dict_, x, y, z, *, batch_axis: str = "z"):
     if batch_axis == "y":
         raise ValueError(f"DeepSeek-V4 robust lookup failed (tp={x}, b={y}, s={z})")
     raise ValueError(f"DeepSeek-V4 robust lookup failed (tp={x}, s={y}, b={z})")
+
+
+def _dsv4_resolve_head_key(quant_data, num_heads):
+    """SCHEME A head-key resolution.
+
+    The head axis is the rank-local head count (``native // tp``).  Prefer an
+    exact match on the value the model passes.  The b300 module data is a
+    universal sweep collected with a single local-head value; if the model's
+    local head count is not an exact bench point, fall back to the single
+    available head key so the universal data still resolves.  Returns the head
+    key to index ``quant_data`` with, or ``None`` if no head data is loaded.
+    """
+    if not isinstance(quant_data, dict) or not quant_data:
+        return None
+    if num_heads in quant_data:
+        return num_heads
+    head_keys = [k for k in quant_data if isinstance(k, int)]
+    if len(head_keys) == 1:
+        return head_keys[0]
+    if head_keys:
+        # Multiple head keys but no exact match: pick the nearest <= request,
+        # else the smallest available.
+        le = [k for k in head_keys if k <= num_heads]
+        return max(le) if le else min(head_keys)
+    return None
+
+
+def _dsv4_lookup_prefix_resolved(database, cr_dict, prefix, s, b):
+    """SCHEME A prefix-resolved silicon lookup.
+
+    ``cr_dict`` is ``{prefix: {s: {b: leaf}}}``.  At a measured prefix we wrap
+    the ``{s: {b}}`` slice and run the robust 3D lookup (exact -> cubic ->
+    sampled-batch fallback) with the prefix as the leading axis.  Off-grid
+    prefixes are linearly interpolated between the two nearest prefix anchors
+    that can answer the (s, b) query.  Returns a leaf dict or ``None``.
+    """
+    if not isinstance(cr_dict, dict) or not cr_dict:
+        return None
+
+    def _finite(result):
+        if not isinstance(result, dict):
+            return False
+        value = result.get("latency")
+        return value is not None and bool(np.all(np.isfinite(np.asarray(value))))
+
+    def _lookup_at_prefix(prefix_value):
+        sb_slice = cr_dict.get(prefix_value)
+        if not isinstance(sb_slice, dict):
+            return None
+        wrapped = {prefix_value: sb_slice}
+        try:
+            result = _dsv4_robust_3d_lookup(database, wrapped, prefix_value, s, b)
+        except Exception:
+            return None
+        return result if _finite(result) else None
+
+    prefix = int(prefix)
+    if prefix in cr_dict:
+        exact = _lookup_at_prefix(prefix)
+        if exact is not None:
+            return exact
+
+    prefix_points = sorted(p for p, sl in cr_dict.items() if isinstance(sl, dict))
+    if not prefix_points:
+        return None
+    if len(prefix_points) == 1:
+        return _lookup_at_prefix(prefix_points[0])
+
+    result_by_prefix = {}
+    for p in prefix_points:
+        r = _lookup_at_prefix(p)
+        if r is not None:
+            result_by_prefix[p] = r
+    if not result_by_prefix:
+        return None
+    keys = sorted(result_by_prefix)
+    if prefix in result_by_prefix:
+        return result_by_prefix[prefix]
+    if len(keys) == 1 or prefix <= keys[0]:
+        return result_by_prefix[keys[0]]
+    if prefix >= keys[-1]:
+        return result_by_prefix[keys[-1]]
+    left = max(k for k in keys if k < prefix)
+    right = min(k for k in keys if k > prefix)
+    rl, rr = result_by_prefix[left], result_by_prefix[right]
+    return {
+        field: interpolation.interp_1d([left, right], [rl.get(field, 0.0), rr.get(field, 0.0)], prefix)
+        for field in ("latency", "power", "energy")
+    }
 
 
 def _deepseek_v4_attention_sol(
@@ -937,115 +1028,44 @@ class ContextDeepSeekV4AttentionModule(_BaseDeepSeekV4AttentionModule):
                     f"DeepSeek-V4 context attention module data not loaded for system='{database.system}', "
                     f"backend='{database.backend}', version='{database.version}'."
                 )
-            native_dict = data[fmha_quant_mode][kvcache_quant_mode][gemm_quant_mode].get(native_heads)
-            if native_dict is None:
+            # SCHEME A: head axis is the rank-local head count the model passes.
+            quant_data = data[fmha_quant_mode][kvcache_quant_mode][gemm_quant_mode]
+            head_axis = _dsv4_resolve_head_key(quant_data, num_heads)
+            if head_axis is None:
                 raise PerfDataNotAvailableError(
-                    f"No DeepSeek-V4 context attention silicon data for native_heads={native_heads}, "
-                    f"loaded keys={list(data[fmha_quant_mode][kvcache_quant_mode][gemm_quant_mode].keys())}."
+                    f"No DeepSeek-V4 context attention silicon data for num_heads={num_heads}, "
+                    f"loaded head keys={list(quant_data.keys())}."
                 )
-            deepseek_v4_dict = native_dict[compress_ratio]
+            cr_dict = quant_data[head_axis].get(compress_ratio)
+            if cr_dict is None:
+                raise PerfDataNotAvailableError(
+                    f"No DeepSeek-V4 context attention silicon data for num_heads={num_heads}, "
+                    f"compress_ratio={compress_ratio}, loaded cr keys="
+                    f"{list(quant_data[head_axis].keys())}."
+                )
 
-            # Pick correction strategy up-front because it changes the lookup
-            # point: kernel-Δ uses chunk-0 baseline at (b, s); SOL ratio uses
-            # chunk-1 baseline at (b, s+prefix).
-            kernel = {4: "paged_mqa_logits", 128: "hca_attn"}.get(compress_ratio) if prefix > 0 else None
-            t_with = t_without = None
-            if kernel is not None:
-                # Use the operation tp_size for sparse-kernel lookup.
-                # paged_mqa_logits is collected only at tp=1 (kernel is replicated)
-                # — ``_lookup_sparse_kernel`` falls back to tp=1 when the
-                # requested tp isn't present, so passing ``tp_size`` works for
-                # both kernels.
-                t_with = cls._lookup_sparse_kernel(
-                    database,
-                    kernel=kernel,
-                    bs=b,
-                    isl=s,
-                    past_kv=prefix,
-                    tp_size=tp_size,
-                    native_heads=native_heads,
-                )
-                t_without = cls._lookup_sparse_kernel(
-                    database,
-                    kernel=kernel,
-                    bs=b,
-                    isl=s,
-                    past_kv=0,
-                    tp_size=tp_size,
-                    native_heads=native_heads,
-                )
-                if t_with is None or t_without is None:
-                    raise PerfDataNotAvailableError(
-                        f"DeepSeek-V4 {kernel} sparse-kernel correction data not available for "
-                        f"{b=}, {s=}, {prefix=}, {native_heads=}, {tp_size=}. "
-                        "Cannot query prefix context attention in SILICON mode without kernel delta."
-                    )
-            use_kernel_delta = kernel is not None
-            lookup_s = s if use_kernel_delta else s + prefix
-
-            result = None
-            if compress_ratio == 4:
-                raw_data = getattr(database, "_raw_context_deepseek_v4_attention_module_data", None)
-                raw_dict = None
-                if raw_data is not None and getattr(raw_data, "loaded", True):
-                    try:
-                        raw_native_dict = raw_data[fmha_quant_mode][kvcache_quant_mode][gemm_quant_mode].get(
-                            native_heads
-                        )
-                        raw_dict = None if raw_native_dict is None else raw_native_dict[compress_ratio]
-                    except KeyError:
-                        raw_dict = None
-                result = interpolation.interp_context_topk_piecewise_from_raw(
-                    tp_size, lookup_s, b, raw_dict, index_topk * compress_ratio
-                )
+            # SCHEME A: cr_dict is prefix-resolved -> {prefix: {s: {b: leaf}}}.
+            # Look the measured silicon up at the requested prefix (interpolating
+            # over the prefix axis when the exact prefix was not benched).
+            result = _dsv4_lookup_prefix_resolved(database, cr_dict, prefix, s, b)
             if result is None:
-                # Exact → cubic → linear to avoid qhull crashes on the
-                # caps-driven flat b axis.
-                result = _dsv4_robust_3d_lookup(database, deepseek_v4_dict, tp_size, lookup_s, b)
-            latency = result["latency"]
-            energy = result.get("energy", 0.0)
+                raise PerfDataNotAvailableError(
+                    f"DeepSeek-V4 prefix-resolved context attention module data not available for "
+                    f"{b=}, {s=}, {prefix=}, {num_heads=}, {compress_ratio=}."
+                )
+            latency = float(result["latency"])
+            energy = float(result.get("energy", 0.0))
 
-            if prefix > 0:
-                if use_kernel_delta:
-                    # Kernel-Δ correction (preferred when sparse data loaded).
-                    # CSA: paged_mqa_logits bench Δ + topk_512 IO formula Δ.
-                    # HCA: hca_attn bench Δ.
-                    latency += t_with - t_without
-                    if compress_ratio == 4:
-                        # topk_512 IO formula: Δ_bytes = M*past_kv (fp32 scan),
-                        # eff≈0.1 (radix bucket atomics dominate).  Empirically
-                        # within 8% of real on H20.
-                        M = b * s  # noqa: N806
-                        mem_bw = database.system_spec["gpu"]["mem_bw"]
-                        latency += M * prefix / (mem_bw * 0.1) * 1000.0
-                else:
-                    # SOL ratio scaling (fallback when sparse data unavailable).
-                    base_sol = _deepseek_v4_attention_sol(
-                        database,
-                        is_context=True,
-                        b=b,
-                        s=s + prefix,
-                        prefix=0,
-                        num_heads=num_heads,
-                        hidden_size=hidden_size,
-                        q_lora_rank=q_lora_rank,
-                        o_lora_rank=o_lora_rank,
-                        head_dim=head_dim,
-                        rope_head_dim=rope_head_dim,
-                        index_n_heads=index_n_heads,
-                        index_head_dim=index_head_dim,
-                        index_topk=index_topk,
-                        window_size=window_size,
-                        compress_ratio=compress_ratio,
-                        o_groups=o_groups,
-                        kvcache_quant_mode=kvcache_quant_mode,
-                        fmha_quant_mode=fmha_quant_mode,
-                        gemm_quant_mode=gemm_quant_mode,
-                    )[0]
-                    target_sol = get_sol()[0]
-                    correction = 1.0 if base_sol <= 0 else target_sol / base_sol
-                    latency *= correction
-                    energy *= correction
+            # SCHEME A: for CSA (compress_ratio==4) ONLY, subtract the measured
+            # topK DELTA = flat_ms - top_last_ms (degenerate collector topK vs
+            # representative silicon topK). HCA (cr==128) is left untouched.
+            if compress_ratio == 4 and _TOPK_CORRECTION_ENABLED:
+                calib = _get_dsv4_topk_calib(database)
+                delta = _dsv4_topk_delta_ms(calib, int(prefix), int(s), int(b))
+                corrected_latency = max(0.0, latency - delta)
+                if latency > 0.0 and energy:
+                    energy *= corrected_latency / latency
+                latency = corrected_latency
             return database._interp_pr(latency, energy=energy)
 
         return database._query_silicon_or_hybrid(
@@ -1225,16 +1245,37 @@ class GenerationDeepSeekV4AttentionModule(_BaseDeepSeekV4AttentionModule):
                     f"DeepSeek-V4 generation attention module data not loaded for system='{database.system}', "
                     f"backend='{database.backend}', version='{database.version}'."
                 )
-            native_dict = data[kvcache_quant_mode][gemm_quant_mode].get(native_heads)
-            if native_dict is None:
+            # SCHEME A: head axis is the rank-local head count the model passes.
+            quant_data = data[kvcache_quant_mode][gemm_quant_mode]
+            head_axis = _dsv4_resolve_head_key(quant_data, num_heads)
+            if head_axis is None:
                 raise PerfDataNotAvailableError(
-                    f"No DeepSeek-V4 generation attention silicon data for native_heads={native_heads}, "
-                    f"loaded keys={list(data[kvcache_quant_mode][gemm_quant_mode].keys())}."
+                    f"No DeepSeek-V4 generation attention silicon data for num_heads={num_heads}, "
+                    f"loaded head keys={list(quant_data.keys())}."
                 )
-            deepseek_v4_dict = native_dict[compress_ratio]
-            result = _dsv4_robust_3d_lookup(database, deepseek_v4_dict, tp_size, b, s, batch_axis="y")
-            latency = result["latency"]
-            energy = result.get("energy", 0.0)
+            deepseek_v4_dict = quant_data[head_axis].get(compress_ratio)
+            if deepseek_v4_dict is None:
+                raise PerfDataNotAvailableError(
+                    f"No DeepSeek-V4 generation attention silicon data for num_heads={num_heads}, "
+                    f"compress_ratio={compress_ratio}, loaded cr keys={list(quant_data[head_axis].keys())}."
+                )
+            # SCHEME A generation dict is {head}{cr}{b}{s_total}; wrap with the
+            # head key and let the robust lookup walk (head -> b -> s_total).
+            wrapped = {head_axis: deepseek_v4_dict}
+            result = _dsv4_robust_3d_lookup(database, wrapped, head_axis, b, s, batch_axis="y")
+            latency = float(result["latency"])
+            energy = float(result.get("energy", 0.0))
+
+            # SCHEME A: subtract the topK DELTA for CSA (cr==4) only. Decode is
+            # q_len=1 with past_kv = s_total - 1.
+            if compress_ratio == 4 and _TOPK_CORRECTION_ENABLED:
+                calib = _get_dsv4_topk_calib(database)
+                decode_prefix = max(int(s) - 1, 0)
+                delta = _dsv4_topk_delta_ms(calib, decode_prefix, 1, int(b))
+                corrected_latency = max(0.0, latency - delta)
+                if latency > 0.0 and energy:
+                    energy *= corrected_latency / latency
+                latency = corrected_latency
             return database._interp_pr(latency, energy=energy)
 
         return database._query_silicon_or_hybrid(
@@ -1580,25 +1621,219 @@ def _dsv4_normalize_dtype(name: str) -> str:
     return _DSV4_DTYPE_ALIASES.get(name, name)
 
 
+# ───────────────────────────────────────────────────────────────────────
+# DSV4 CSA topk DELTA calibration (SCHEME A correction).
+#
+# The CSA context-module collector runs the topK kernel on DEGENERATE scores
+# (dummy weights + zero/uninitialized prefix KV -> near-constant logits -> the
+# Small topK path falls into its O(n^2) tie-break). That inflates the measured
+# module latency vs real silicon, where logits are spread. We measured the topK
+# time standalone under a degenerate "flat" construction and a representative
+# "top_last" construction for every (prefix, isl, batch_size) shape, and store
+# as two rows (score_mode=flat | top_last, each a single latency) per shape in
+# dsv4_csa_topk_calib_perf; DELTA = flat.latency - top_last.latency. At query
+# time we SUBTRACT DELTA from the CSA (compress_ratio==4) module latency only.
+# Gate: AIC_DSV4_TOPK_CORRECTION (default on; set "0" to disable).
+# ───────────────────────────────────────────────────────────────────────
+_TOPK_CORRECTION_ENABLED = os.environ.get("AIC_DSV4_TOPK_CORRECTION", "1") != "0"
+_TOPK_CALIB_BASENAME = "dsv4_csa_topk_calib_perf"
+# Back-compat alias (older code/tests referenced the .txt name directly).
+_TOPK_CALIB_FILENAME = _TOPK_CALIB_BASENAME + ".txt"
+
+
+def _read_topk_calib_rows(dirpath: str):
+    """Yield calib rows (as dicts) from the canonical ``.parquet`` the collector
+    finalizes, falling back to the legacy ``.txt``. Returns None if neither
+    exists. The collector v2 finalizes every ``*_perf.txt`` to ``*_perf.parquet``
+    (the ``.txt`` is staging-only and deleted), so reading parquet keeps the topK
+    calibration reproducible from a plain ``collect.py --ops dsv4_csa_topk_calib``
+    run with no manual ``.txt`` step."""
+    parquet_path = os.path.join(dirpath, _TOPK_CALIB_BASENAME + ".parquet")
+    txt_path = os.path.join(dirpath, _TOPK_CALIB_BASENAME + ".txt")
+    if os.path.isfile(parquet_path):
+        try:
+            import pandas as pd
+
+            return parquet_path, pd.read_parquet(parquet_path).to_dict("records")
+        except Exception as exc:  # pragma: no cover - corrupt/unreadable parquet
+            logger.warning(f"failed reading {parquet_path} ({exc}); trying .txt")
+    if os.path.isfile(txt_path):
+        with open(txt_path, newline="") as f:
+            return txt_path, list(csv.DictReader(f))
+    return None, None
+
+
+def _topk_row_value(row, key):
+    """Fetch a field from a parquet-record or csv-row dict, treating NaN/'' as missing."""
+    v = row.get(key)
+    if v is None or v == "":
+        return None
+    # pandas NaN (float != itself)
+    if isinstance(v, float) and v != v:
+        return None
+    return v
+
+
+@functools.lru_cache(maxsize=16)
+def _load_dsv4_topk_calib(dirpath: str):
+    """Return {'exact': {(prefix, isl, bs): delta_ms},
+              'by_pi': {(prefix, isl): [(bs, delta_ms), ...]}} or None.
+
+    DELTA = flat.latency - top_last.latency (degenerate vs representative topK),
+    measured standalone on B300 over the full (prefix, isl, batch_size) grid.
+    The collector emits the calibration as TWO rows per shape, each a member of
+    the sparse-op family with a single ``latency``: ``score_mode=flat`` (the
+    degenerate worst-case the module CSV captured) and ``score_mode=top_last``
+    (the representative distribution). We pair the two rows per
+    ``(step, isl, batch_size)`` and subtract. Reads the canonical parquet
+    (collector output) or legacy .txt.
+    """
+    path, rows = _read_topk_calib_rows(dirpath)
+    if rows is None:
+        return None
+    # Pair the flat / top_last rows per (prefix, isl, bs) shape.
+    flat: dict = {}
+    top_last: dict = {}
+    for row in rows:
+        try:
+            prefix = int(float(_topk_row_value(row, "step")))
+            isl = int(float(row["isl"]))
+            bs = int(float(_topk_row_value(row, "batch_size") or 1))
+            mode = _topk_row_value(row, "score_mode")
+            latency = float(_topk_row_value(row, "latency"))
+        except (KeyError, ValueError, TypeError):
+            continue
+        if mode == "flat":
+            flat[(prefix, isl, bs)] = latency
+        elif mode == "top_last":
+            top_last[(prefix, isl, bs)] = latency
+    exact = {}
+    by_pi = {}
+    for key, flat_latency in flat.items():
+        top_last_latency = top_last.get(key)
+        if top_last_latency is None:
+            continue
+        delta = max(0.0, flat_latency - top_last_latency)
+        prefix, isl, bs = key
+        exact[key] = delta
+        by_pi.setdefault((prefix, isl), []).append((bs, delta))
+    if not exact:
+        return None
+    for k in by_pi:
+        by_pi[k].sort()
+    logger.debug(f"loaded DSV4 topk calib from {path}: {len(exact)} shapes")
+    return {"exact": exact, "by_pi": by_pi}
+
+
+def _dsv4_interp_1d_from_points(points, x):
+    """Linear interpolation with nearest-value extrapolation."""
+    if not points:
+        return None
+    merged = defaultdict(list)
+    for coord, value in points:
+        merged[int(coord)].append(float(value))
+    xs = sorted(merged)
+    vals = {k: sum(v) / len(v) for k, v in merged.items()}
+    if x in vals:
+        return vals[x]
+    if len(xs) == 1:
+        return vals[xs[0]]
+    if x <= xs[0]:
+        return vals[xs[0]]
+    if x >= xs[-1]:
+        return vals[xs[-1]]
+    left = max(v for v in xs if v < x)
+    right = min(v for v in xs if v > x)
+    if left == right:
+        return vals[left]
+    t = (float(x) - float(left)) / (float(right) - float(left))
+    return vals[left] * (1.0 - t) + vals[right] * t
+
+
+def _dsv4_topk_delta_ms(calib, prefix, isl, bs):
+    """Return topK DELTA (flat_ms - top_last_ms) from measured calibration.
+
+    Exact (prefix, isl, bs) rows are preferred; off-grid shapes are
+    interpolated prefix-first within a fixed (isl, bs), then isl, then bs.
+    Returns 0.0 when no calibration is available.
+    """
+    if not calib:
+        return 0.0
+    prefix = int(prefix)
+    isl = int(isl)
+    bs = int(bs)
+    exact = calib.get("exact", {})
+    direct = exact.get((prefix, isl, bs))
+    if direct is not None:
+        return max(0.0, float(direct))
+
+    def _prefix_interp(query_prefix, anchor_isl, anchor_bs):
+        points = [(p, d) for (p, i, b), d in exact.items() if int(i) == int(anchor_isl) and int(b) == int(anchor_bs)]
+        return _dsv4_interp_1d_from_points(points, query_prefix)
+
+    def _isl_interp(query_prefix, query_isl, anchor_bs):
+        isl_values = sorted({i for (_, i, b) in exact if int(b) == int(anchor_bs)})
+        points = []
+        for i in isl_values:
+            value = _prefix_interp(query_prefix, i, anchor_bs)
+            if value is not None:
+                points.append((i, value))
+        return _dsv4_interp_1d_from_points(points, query_isl)
+
+    bs_values = sorted({b for (_, _, b) in exact})
+    points = []
+    for b in bs_values:
+        value = _isl_interp(prefix, isl, b)
+        if value is not None:
+            points.append((b, value))
+    interpolated = _dsv4_interp_1d_from_points(points, bs)
+    if interpolated is None:
+        return 0.0
+    return max(0.0, float(interpolated))
+
+
+def _get_dsv4_topk_calib(database):
+    """Load (and cache on ``database``) the CSA topK DELTA calibration from the
+    same data dir the module CSVs are loaded from."""
+    cached = getattr(database, "_dsv4_csa_topk_calib", _MISSING)
+    if cached is not _MISSING:
+        return cached
+    import os as _os
+
+    system_data_root = _os.path.join(database.systems_root, database.system_spec["data_dir"])
+    data_dir = _os.path.join(system_data_root, database.backend, database.version)
+    calib = _load_dsv4_topk_calib(data_dir)
+    try:
+        database._dsv4_csa_topk_calib = calib
+    except Exception:
+        pass
+    return calib
+
+
+_MISSING = object()
+
+
 def load_context_dsv4_kind_module_data(file_path: str):
     """Load ONE DeepSeek-V4 context CSV (single attn_kind / compress_ratio).
 
-    Returns an 8-level nested dict:
-        data[fmha_quant][kv_quant][gemm_quant][native_heads][compress_ratio]
-            [tp_size][s][b] = {"latency": ms, "power": W, "energy": J}
+    SCHEME A.  Returns a 7-level prefix-resolved nested dict:
+        data[fmha_quant][kv_quant][gemm_quant][num_heads_local][compress_ratio]
+            [prefix][s][b] = {"latency": ms, "power": W, "energy": J}
 
-    ``tp_size`` is the data axis. The model layer passes it through the
-    attention operation for silicon lookup.
+    The head axis is the rank-LOCAL head count = ``int(row["num_heads"])``
+    (the collector writes ``local_attention_heads = native // tp``).  There is
+    NO separate ``tp_size`` key and NO reconstructed native-head key.
 
-    Multiple files (csa/hca/swa) merge cleanly because compress_ratio is
-    the differentiating leaf dimension.
+    ``prefix`` is the past-KV length, ``int(float(row["step"]))``; ``s`` is the
+    context chunk length (``isl``).  Multiple files (csa/hca) merge cleanly
+    because compress_ratio is a key dimension.
     """
     rows = _read_filtered_rows(file_path)
     if rows is None:
         logger.debug(f"DSV4 module data file {file_path} not found.")
         return None
 
-    # 8-level nesting: fmha → kv → gemm → native_heads → cr → tp → s → b
+    # 7-level nesting: fmha → kv → gemm → num_heads_local → cr → prefix → s → b
     def _make_nested(depth: int):
         if depth == 0:
             return defaultdict()
@@ -1613,20 +1848,23 @@ def load_context_dsv4_kind_module_data(file_path: str):
         try:
             b = int(row["batch_size"])
             s = int(row["isl"])
-            tp_size = int(row.get("tp_size", 1))
+            prefix = int(float(row.get("step", 0) or 0))
             cr = int(row["compress_ratio"])
             latency = float(row["latency"])
         except (TypeError, ValueError, KeyError):
             continue
         power = float(row.get("power", 0.0)) if has_power else 0.0
 
-        native_heads = int(row["num_heads"])
+        # SCHEME A: head key is the rank-local head count straight from the CSV.
+        num_heads_local = int(row["num_heads"])
         gemm_mode = common.GEMMQuantMode[row["gemm_type"]]
         fmha_mode = common.FMHAQuantMode[_dsv4_normalize_dtype(row["mla_dtype"])]
         kv_dtype = common.KVCacheQuantMode[_dsv4_normalize_dtype(row["kv_cache_dtype"])]
 
-        # The row-distinguishing axis is ``tp_size`` itself.
-        data[fmha_mode][kv_dtype][gemm_mode][native_heads][cr][tp_size][s][b] = {
+        # NOTE: the topK DELTA correction (degenerate -> representative) is
+        # applied ONCE at query time for compress_ratio==4 (CSA). Do NOT
+        # subtract it here, or the CSA module latency would be double-corrected.
+        data[fmha_mode][kv_dtype][gemm_mode][num_heads_local][cr][prefix][s][b] = {
             "latency": latency,
             "power": power,
             "energy": power * latency,
@@ -1638,24 +1876,22 @@ def load_generation_dsv4_kind_module_data(file_path: str):
     """Load ONE DeepSeek-V4 generation CSV.
 
     Generation lookup uses absolute KV length ``s_total = isl + step`` (decode
-    is q_len=1 with past_kv = step).  Dict shape:
-        data[kv_quant][gemm_quant][native_heads][compress_ratio]
-            [tp_size][b][s_total]
-
-    ``tp_size`` is passed by the attention operation for silicon lookup.
+    is q_len=1 with past_kv = step).  SCHEME A dict shape:
+        data[kv_quant][gemm_quant][num_heads_local][compress_ratio]
+            [b][s_total]
     """
     rows = _read_filtered_rows(file_path)
     if rows is None:
         logger.debug(f"DSV4 module data file {file_path} not found.")
         return None
 
-    # 7-level nesting: kv → gemm → native_heads → cr → tp → b → s_total
+    # SCHEME A: 5-level nesting kv → gemm → num_heads_local → cr → b → s_total
     def _make_nested(depth: int):
         if depth == 0:
             return defaultdict()
         return defaultdict(lambda d=depth: _make_nested(d - 1))
 
-    data = _make_nested(6)
+    data = _make_nested(5)
     has_power = bool(rows) and "power" in rows[0]
 
     for row in rows:
@@ -1664,22 +1900,20 @@ def load_generation_dsv4_kind_module_data(file_path: str):
         try:
             b = int(row["batch_size"])
             s_total = int(row["isl"]) + int(row["step"])
-            tp_size = int(row.get("tp_size", 1))
             cr = int(row["compress_ratio"])
             latency = float(row["latency"])
         except (TypeError, ValueError, KeyError):
             continue
         power = float(row.get("power", 0.0)) if has_power else 0.0
 
-        native_heads = int(row["num_heads"])
+        # SCHEME A: head key is the rank-local head count straight from the CSV;
+        # no tp_size key, no native reconstruction.  Generation convention puts
+        # ``b`` before ``s_total`` (matches the (head, b, s) lookup order).
+        num_heads_local = int(row["num_heads"])
         gemm_mode = common.GEMMQuantMode[row["gemm_type"]]
         kv_dtype = common.KVCacheQuantMode[_dsv4_normalize_dtype(row["kv_cache_dtype"])]
 
-        # DeepSeek-V4: tp_size is the axis that differentiates rows.  See note
-        # at the top of the file.  Generation convention puts ``b`` before
-        # ``s_total`` (matches existing ``_interp_3d(num_heads, b, s, ...)``
-        # call order in ``query_generation_*``).
-        data[kv_dtype][gemm_mode][native_heads][cr][tp_size][b][s_total] = {
+        data[kv_dtype][gemm_mode][num_heads_local][cr][b][s_total] = {
             "latency": latency,
             "power": power,
             "energy": power * latency,

--- a/src/aiconfigurator/sdk/operations/dsv4.py
+++ b/src/aiconfigurator/sdk/operations/dsv4.py
@@ -32,8 +32,6 @@ Cache key matches every other migrated op:
 from __future__ import annotations
 
 import copy
-import csv
-import functools
 import logging
 import os
 from collections import defaultdict
@@ -787,6 +785,7 @@ class ContextDeepSeekV4AttentionModule(_BaseDeepSeekV4AttentionModule):
             cls._sparse_kernel_cache[key] = {
                 "paged_mqa_logits": _load_sparse(PerfDataFilename.dsv4_paged_mqa_logits_module),
                 "hca_attn": _load_sparse(PerfDataFilename.dsv4_hca_attn_module),
+                "csa_attn": _load_sparse(PerfDataFilename.dsv4_csa_attn_module),
             }
 
             cls._record_load()
@@ -1636,92 +1635,37 @@ def _dsv4_normalize_dtype(name: str) -> str:
 # Gate: AIC_DSV4_TOPK_CORRECTION (default on; set "0" to disable).
 # ───────────────────────────────────────────────────────────────────────
 _TOPK_CORRECTION_ENABLED = os.environ.get("AIC_DSV4_TOPK_CORRECTION", "1") != "0"
-_TOPK_CALIB_BASENAME = "dsv4_csa_topk_calib_perf"
-# Back-compat alias (older code/tests referenced the .txt name directly).
-_TOPK_CALIB_FILENAME = _TOPK_CALIB_BASENAME + ".txt"
 
 
-def _read_topk_calib_rows(dirpath: str):
-    """Yield calib rows (as dicts) from the canonical ``.parquet`` the collector
-    finalizes, falling back to the legacy ``.txt``. Returns None if neither
-    exists. The collector v2 finalizes every ``*_perf.txt`` to ``*_perf.parquet``
-    (the ``.txt`` is staging-only and deleted), so reading parquet keeps the topK
-    calibration reproducible from a plain ``collect.py --ops dsv4_csa_topk_calib``
-    run with no manual ``.txt`` step."""
-    parquet_path = os.path.join(dirpath, _TOPK_CALIB_BASENAME + ".parquet")
-    txt_path = os.path.join(dirpath, _TOPK_CALIB_BASENAME + ".txt")
-    if os.path.isfile(parquet_path):
-        try:
-            import pandas as pd
+def _build_topk_calib_from_rows(by_mode):
+    """Pair the flat / top_last rows the sparse-op loader produced into the topK
+    DELTA table ``{'exact': {(step, isl, bs): delta_ms},
+                   'by_pi': {(step, isl): [(bs, delta_ms), ...]}}`` or ``None``.
 
-            return parquet_path, pd.read_parquet(parquet_path).to_dict("records")
-        except Exception as exc:  # pragma: no cover - corrupt/unreadable parquet
-            logger.warning(f"failed reading {parquet_path} ({exc}); trying .txt")
-    if os.path.isfile(txt_path):
-        with open(txt_path, newline="") as f:
-            return txt_path, list(csv.DictReader(f))
-    return None, None
-
-
-def _topk_row_value(row, key):
-    """Fetch a field from a parquet-record or csv-row dict, treating NaN/'' as missing."""
-    v = row.get(key)
-    if v is None or v == "":
-        return None
-    # pandas NaN (float != itself)
-    if isinstance(v, float) and v != v:
-        return None
-    return v
-
-
-@functools.lru_cache(maxsize=16)
-def _load_dsv4_topk_calib(dirpath: str):
-    """Return {'exact': {(prefix, isl, bs): delta_ms},
-              'by_pi': {(prefix, isl): [(bs, delta_ms), ...]}} or None.
-
-    DELTA = flat.latency - top_last.latency (degenerate vs representative topK),
-    measured standalone on B300 over the full (prefix, isl, batch_size) grid.
-    The collector emits the calibration as TWO rows per shape, each a member of
-    the sparse-op family with a single ``latency``: ``score_mode=flat`` (the
-    degenerate worst-case the module CSV captured) and ``score_mode=top_last``
-    (the representative distribution). We pair the two rows per
-    ``(step, isl, batch_size)`` and subtract. Reads the canonical parquet
-    (collector output) or legacy .txt.
+    ``by_mode`` is the ``_TOPK_CALIB_KEYS`` nesting
+    ``data[step][isl][bs][score_mode] = {"latency": ms}``. The calibration is
+    stored as two rows per shape — ``score_mode=flat`` is the degenerate
+    worst-case the module CSV captured, ``top_last`` the representative one —
+    and DELTA = flat.latency - top_last.latency.
     """
-    path, rows = _read_topk_calib_rows(dirpath)
-    if rows is None:
+    if not by_mode:
         return None
-    # Pair the flat / top_last rows per (prefix, isl, bs) shape.
-    flat: dict = {}
-    top_last: dict = {}
-    for row in rows:
-        try:
-            prefix = int(float(_topk_row_value(row, "step")))
-            isl = int(float(row["isl"]))
-            bs = int(float(_topk_row_value(row, "batch_size") or 1))
-            mode = _topk_row_value(row, "score_mode")
-            latency = float(_topk_row_value(row, "latency"))
-        except (KeyError, ValueError, TypeError):
-            continue
-        if mode == "flat":
-            flat[(prefix, isl, bs)] = latency
-        elif mode == "top_last":
-            top_last[(prefix, isl, bs)] = latency
     exact = {}
     by_pi = {}
-    for key, flat_latency in flat.items():
-        top_last_latency = top_last.get(key)
-        if top_last_latency is None:
-            continue
-        delta = max(0.0, flat_latency - top_last_latency)
-        prefix, isl, bs = key
-        exact[key] = delta
-        by_pi.setdefault((prefix, isl), []).append((bs, delta))
+    for step, isl_d in by_mode.items():
+        for isl, bs_d in isl_d.items():
+            for bs, mode_d in bs_d.items():
+                flat = mode_d.get("flat")
+                top_last = mode_d.get("top_last")
+                if not isinstance(flat, dict) or not isinstance(top_last, dict):
+                    continue
+                delta = max(0.0, float(flat["latency"]) - float(top_last["latency"]))
+                exact[(step, isl, bs)] = delta
+                by_pi.setdefault((step, isl), []).append((bs, delta))
     if not exact:
         return None
     for k in by_pi:
         by_pi[k].sort()
-    logger.debug(f"loaded DSV4 topk calib from {path}: {len(exact)} shapes")
     return {"exact": exact, "by_pi": by_pi}
 
 
@@ -1793,16 +1737,22 @@ def _dsv4_topk_delta_ms(calib, prefix, isl, bs):
 
 
 def _get_dsv4_topk_calib(database):
-    """Load (and cache on ``database``) the CSA topK DELTA calibration from the
-    same data dir the module CSVs are loaded from."""
+    """Load (and cache on ``database``) the CSA topK DELTA calibration through
+    the same sparse-op loader + source resolution the other DSV4 ops use."""
     cached = getattr(database, "_dsv4_csa_topk_calib", _MISSING)
     if cached is not _MISSING:
         return cached
     import os as _os
 
+    from aiconfigurator.sdk.perf_database import PerfDataFilename
+
     system_data_root = _os.path.join(database.systems_root, database.system_spec["data_dir"])
     data_dir = _os.path.join(system_data_root, database.backend, database.version)
-    calib = _load_dsv4_topk_calib(data_dir)
+    enum = PerfDataFilename.dsv4_csa_topk_calib
+    primary_path = _os.path.join(data_dir, enum.value)
+    sources = database._build_op_sources(enum, primary_path, system_data_root)
+    by_mode = load_dsv4_sparse_op_data(sources, _TOPK_CALIB_KEYS)
+    calib = _build_topk_calib_from_rows(by_mode)
     try:
         database._dsv4_csa_topk_calib = calib
     except Exception:
@@ -2045,35 +1995,65 @@ def load_dsv4_megamoe_module_data(dsv4_megamoe_module_file):
     return dsv4_megamoe_data
 
 
-def load_dsv4_sparse_kernel_data(file_path: str):
-    """Load DeepSeek-V4 sparse-kernel CSV (paged_mqa_logits or hca_attn).
+# ───────────────────────────────────────────────────────────────────────
+# DSV4 sparse-op family loader (ONE engine for all four)
+# ───────────────────────────────────────────────────────────────────────
+# csa_attn / hca_attn / paged_mqa_logits (FMLA & indexer kernels) and the
+# csa_topk_calib DELTA rows share ONE column schema, so they all parse through
+# ``load_dsv4_sparse_op_data``; each consumer just supplies the key columns it
+# indexes on (declared here so callers stay in sync).
+_SPARSE_KERNEL_KEYS = ("num_heads", "tp_size", "step", "isl", "batch_size")
+_TOPK_CALIB_KEYS = ("step", "isl", "batch_size", "score_mode")
 
-    Emitted by ``collector.sglang.deepseekv4_sparse_modules``.  Used for
-    kernel-level past_kv Δ correction on top of the chunk-0 module baseline.
 
-    Dict structure:
-        data[native_heads][tp_size][past_kv][isl][bs] = {"latency": ms}
+def load_dsv4_sparse_op_data(file_or_sources, key_columns):
+    """Generic loader for the DeepSeek-V4 sparse-op family.
+
+    Reads the shared perf schema (parquet or txt, single path or override
+    ``(path, kernel_source_filter)`` sources — see ``_read_filtered_rows``) and
+    nests every row under ``key_columns`` in order, leaf == ``{"latency": ms}``.
+
+    Numeric key cells coerce to ``int``; non-numeric stay ``str`` (e.g.
+    ``score_mode``). Rows with a NaN/blank key are skipped. Returns ``None``
+    when no source file exists.
+
+    Consumers:
+      - sparse kernels: ``_SPARSE_KERNEL_KEYS`` -> data[heads][tp][past_kv][isl][bs]
+      - topk calib:     ``_TOPK_CALIB_KEYS``    -> data[step][isl][bs][score_mode]
     """
-    rows = _read_filtered_rows(file_path)
+    rows = _read_filtered_rows(file_or_sources)
     if rows is None:
-        logger.debug(f"DSV4 sparse-kernel data file {file_path} not found.")
         return None
 
-    data = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict()))))
+    def _coerce(value):
+        try:
+            return int(float(value))
+        except (TypeError, ValueError):
+            return value
 
+    root: dict = {}
     for row in rows:
-        # Skip duplicate header rows (file may be appended to across runs)
+        # Skip duplicate header rows (files may be appended to across runs).
         if row.get("batch_size") in (None, "", "batch_size"):
             continue
         try:
-            bs = int(row["batch_size"])
-            isl = int(row["isl"])
-            past_kv = int(row["step"])
-            tp_size = int(row.get("tp_size", 1))
+            keys = [_coerce(row[col]) for col in key_columns]
             latency = float(row["latency"])
-        except (TypeError, ValueError):
+        except (KeyError, TypeError, ValueError):
             continue
-        native_heads = int(row["num_heads"])
-        data[native_heads][tp_size][past_kv][isl][bs] = {"latency": latency}
+        if any(isinstance(k, float) and k != k for k in keys):  # NaN key cell
+            continue
+        node = root
+        for k in keys[:-1]:
+            node = node.setdefault(k, {})
+        node[keys[-1]] = {"latency": latency}
+    return root or None
 
-    return data
+
+def load_dsv4_sparse_kernel_data(file_or_sources):
+    """DSV4 sparse-kernel CSV (csa_attn / hca_attn / paged_mqa_logits).
+
+    Thin wrapper over ``load_dsv4_sparse_op_data`` with the kernel key columns,
+    yielding ``data[native_heads][tp_size][past_kv][isl][bs] = {"latency": ms}``.
+    """
+    return load_dsv4_sparse_op_data(file_or_sources, _SPARSE_KERNEL_KEYS)

--- a/src/aiconfigurator/sdk/operations/dsv4.py
+++ b/src/aiconfigurator/sdk/operations/dsv4.py
@@ -2014,8 +2014,8 @@ def load_dsv4_sparse_op_data(file_or_sources, key_columns):
     nests every row under ``key_columns`` in order, leaf == ``{"latency": ms}``.
 
     Numeric key cells coerce to ``int``; non-numeric stay ``str`` (e.g.
-    ``score_mode``). Rows with a NaN/blank key are skipped. Returns ``None``
-    when no source file exists.
+    ``score_mode``). Rows with a blank or NaN/inf key cell are skipped.
+    Returns ``None`` when no source file exists.
 
     Consumers:
       - sparse kernels: ``_SPARSE_KERNEL_KEYS`` -> data[heads][tp][past_kv][isl][bs]
@@ -2028,8 +2028,28 @@ def load_dsv4_sparse_op_data(file_or_sources, key_columns):
     def _coerce(value):
         try:
             return int(float(value))
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, OverflowError):
             return value
+
+    def _is_bad_key(k):
+        # A key cell that is blank or a NaN/inf sentinel must not become a dict
+        # key: such rows are malformed and would misbucket (or KeyError) the
+        # downstream calibration lookup. Legitimate non-numeric keys (e.g.
+        # ``score_mode`` values like ``"default"``) are kept.
+        if k is None:
+            return True
+        if isinstance(k, float):  # uncoerced float NaN/inf
+            return k != k or k in (float("inf"), float("-inf"))
+        if isinstance(k, str):
+            return k.strip() == "" or k.strip().lower() in (
+                "nan",
+                "inf",
+                "-inf",
+                "+inf",
+                "infinity",
+                "-infinity",
+            )
+        return False
 
     root: dict = {}
     for row in rows:
@@ -2041,7 +2061,7 @@ def load_dsv4_sparse_op_data(file_or_sources, key_columns):
             latency = float(row["latency"])
         except (KeyError, TypeError, ValueError):
             continue
-        if any(isinstance(k, float) and k != k for k in keys):  # NaN key cell
+        if any(_is_bad_key(k) for k in keys):  # blank / NaN / inf key cell
             continue
         node = root
         for k in keys[:-1]:

--- a/src/aiconfigurator/sdk/operations/moe.py
+++ b/src/aiconfigurator/sdk/operations/moe.py
@@ -2091,6 +2091,23 @@ def load_moe_data(moe_file):
 
         quant_mode = common.MoEQuantMode[quant_mode]
 
+        # DeepSeek-V4-Pro's Blackwell MoE runs the trtllm-gen MXFP4xMXFP8 kernel
+        # (moe_runner_backend=flashinfer_mxfp4 -> Mxfp4FlashinferTrtllmMoEMethod ->
+        # trtllm_fp4_block_scale_routed_moe -> bmm_MxE4m3_MxE2m1MxE4m3 ... sm100f),
+        # which is a distinct precision from the flashinfer cutedsl kernel that the
+        # collector also logs under moe_dtype=w4a8_mxfp4_mxfp8. Route those rows to
+        # the dedicated quant mode so DeepSeek-V4 modeling can select it on Blackwell.
+        if quant_mode is common.MoEQuantMode.w4a8_mxfp4_mxfp8 and kernel_source == "sglang_mxfp4_flashinfer_trtllm_moe":
+            quant_mode = common.MoEQuantMode.w4a8_mxfp4_mxfp8_trtllm
+
+        # Same idea on Hopper: DeepSeek-V4-Pro runs the flashinfer cutlass SM90
+        # mixed-GEMM (cutlass_fused_moe(use_w4_group_scaling=True), MXFP4 weight x
+        # BF16 act), a distinct backend from GPT-OSS's triton_kernels mxfp4 that the
+        # collector also logs under moe_dtype=w4a16_mxfp4. Route those rows to the
+        # dedicated quant mode so DeepSeek-V4 modeling can select it on Hopper.
+        if quant_mode is common.MoEQuantMode.w4a16_mxfp4 and kernel_source == "sglang_flashinfer_cutlass_moe":
+            quant_mode = common.MoEQuantMode.w4a16_mxfp4_cutlass
+
         moe_data = moe_low_latency_data if kernel_source == "moe_torch_flow_min_latency" else moe_default_data
 
         try:

--- a/src/aiconfigurator/sdk/task.py
+++ b/src/aiconfigurator/sdk/task.py
@@ -512,6 +512,43 @@ class TaskConfigFactory:
                     _deep_merge(config_dict, promoted)
                     applied_layers.append("gptoss-blackwell-mxfp8")
 
+        # DeepSeek-V4-Pro ships MXFP4 MoE expert weights (I8-packed E2M1 + E8M0
+        # block scales). The fused-MoE kernel sglang runs is hardware-specific:
+        #   - Blackwell (sm100): trtllm-gen MXFP4xMXFP8 -> w4a8_mxfp4_mxfp8_trtllm
+        #   - Hopper    (sm90) : flashinfer cutlass SM90 mixed GEMM, MXFP4 weight x
+        #                        BF16 act -> w4a16_mxfp4_cutlass (weight-only).
+        # NOTE: w4a16_mxfp4 currently has no DSV4 sglang silicon data in the DB
+        # (AIC's w4a16_mxfp4 was GPT-OSS's triton kernel, a different backend than
+        # DSV4's cutlass-sm90), so Hopper modeling is roofline/SOL until DSV4 Hopper
+        # data is collected; the Hopper path may move to w4fp8 later.
+        if ctx.backend_name == "sglang" and ctx.model_path == "deepseek-ai/DeepSeek-V4-Pro":
+
+            def _dsv4_moe_mode(system_name):
+                if _is_blackwell_system(system_name):
+                    return "w4a8_mxfp4_mxfp8_trtllm"
+                if _is_hopper_system(system_name):
+                    return "w4a16_mxfp4_cutlass"
+                return None
+
+            if ctx.serving_mode == "agg":
+                mode = _dsv4_moe_mode(ctx.system_name)
+                if mode:
+                    _deep_merge(config_dict, {"worker_config": {"moe_quant_mode": mode}})
+                    applied_layers.append(f"dsv4pro-moe-{mode}")
+            else:
+                prefill_system = ctx.system_name
+                decode_system = ctx.decode_system_name or ctx.system_name
+                promoted = {}
+                pm = _dsv4_moe_mode(prefill_system)
+                dm = _dsv4_moe_mode(decode_system)
+                if pm:
+                    promoted["prefill_worker_config"] = {"moe_quant_mode": pm}
+                if dm:
+                    promoted["decode_worker_config"] = {"moe_quant_mode": dm}
+                if promoted:
+                    _deep_merge(config_dict, promoted)
+                    applied_layers.append("dsv4pro-moe-arch")
+
         for profile in ctx.profiles:
             layers = cls.PROFILE_REGISTRY.get(profile)
             if not layers:

--- a/src/aiconfigurator/sdk/task.py
+++ b/src/aiconfigurator/sdk/task.py
@@ -521,7 +521,14 @@ class TaskConfigFactory:
         # (AIC's w4a16_mxfp4 was GPT-OSS's triton kernel, a different backend than
         # DSV4's cutlass-sm90), so Hopper modeling is roofline/SOL until DSV4 Hopper
         # data is collected; the Hopper path may move to w4fp8 later.
-        if ctx.backend_name == "sglang" and ctx.model_path == "deepseek-ai/DeepSeek-V4-Pro":
+        # Skip when moe_backend == "megamoe": the fused MegaMoE path keys its perf
+        # table on its own quant (w4a8_mxfp4_mxfp8, not the trtllm-gen variant), so
+        # forcing w4a8_mxfp4_mxfp8_trtllm here would miss the megamoe data table.
+        if (
+            ctx.backend_name == "sglang"
+            and ctx.model_path == "deepseek-ai/DeepSeek-V4-Pro"
+            and ctx.moe_backend != "megamoe"
+        ):
 
             def _dsv4_moe_mode(system_name):
                 if _is_blackwell_system(system_name):

--- a/tests/unit/collector/test_dsv4_common_test_cases.py
+++ b/tests/unit/collector/test_dsv4_common_test_cases.py
@@ -57,9 +57,12 @@ def test_dsv4_sparse_smoke_cases_cover_default_models(monkeypatch):
 
     cases = common_test_cases.get_dsv4_paged_mqa_logits_test_cases()
 
+    # Sparse kernels are now one case per model ([model_path, kernel]); the worker
+    # derives the (prefix, isl, bs) shapes 1:1 from the owning module CSV at
+    # runtime instead of a separate smoke sweep grid.
     assert cases == [
-        [1, 1024, 8192, 1, "paged_mqa_logits", _FLASH],
-        [1, 1024, 8192, 1, "paged_mqa_logits", _PRO],
+        [_FLASH, "paged_mqa_logits"],
+        [_PRO, "paged_mqa_logits"],
     ]
 
 

--- a/tests/unit/sdk/database/test_deepseek_v4_module.py
+++ b/tests/unit/sdk/database/test_deepseek_v4_module.py
@@ -17,7 +17,6 @@ from aiconfigurator.sdk.operations.dsv4 import (
 )
 from aiconfigurator.sdk.perf_database import (
     LoadedOpData,
-    PerfDataNotAvailableError,
     load_mhc_module_data,
 )
 
@@ -268,7 +267,10 @@ class TestDeepSeekV4AttentionModule:
     def test_generation_silicon_extrapolates_query_below_min_sampled_s_total(self, mutable_comprehensive_perf_db):
         """Full-query regression for generated query b=1, s_total=1, tp=8."""
         db = mutable_comprehensive_perf_db
-        mock_grid = _dsv4_generation_sampled_grid()
+        # SCHEME A silicon data is {head}{cr}{b}{s_total} — no tp level. The shared
+        # grid is {tp}{b}{s_total} (for the direct _dsv4_robust_3d_lookup test);
+        # strip the tp wrapper so it lands as {b}{s_total} under {head}{cr}.
+        mock_grid = _dsv4_generation_sampled_grid()[8]
         db._generation_deepseek_v4_attention_module_data = LoadedOpData(
             _generation_deepseek_v4_data(4, mock_grid),
             common.PerfDataFilename.dsv4_csa_generation_module,
@@ -364,37 +366,27 @@ class TestDeepSeekV4AttentionModule:
         assert context_results["pro"][1] > context_results["flash"][1]
         assert generation_results["pro"][1] > generation_results["flash"][1]
 
-    def test_csa_context_uses_raw_piecewise_around_compressed_topk_boundary(self, mutable_comprehensive_perf_db):
-        db = mutable_comprehensive_perf_db
-        # Pro data is keyed by the tp_size passed by the attention operation.
-        raw_attn_dict = {
-            8: {
-                4096: {2: _deepseek_v4_value(20.0)},
-                8192: {2: _deepseek_v4_value(80.0)},
-                12288: {2: _deepseek_v4_value(100.0)},
-            }
-        }
-        extrapolated_attn_dict = {
-            8: {
+    def test_csa_context_silicon_reads_prefix_resolved_table(self, mutable_comprehensive_perf_db):
+        # SCHEME A reads the prefix-resolved silicon table {head}{cr}{prefix}{s}{b}
+        # directly (the topK regime change is modeled by the topK-calib DELTA, not
+        # a separate raw same-regime piecewise pass). Query (prefix=0, s=4097):
+        # c4_len = 4097//4 = 1024 <= index_topk, so the topK DELTA is 0 and the
+        # table value at s=4097 is returned unchanged.
+        attn_dict = {
+            0: {
                 4096: {2: _deepseek_v4_value(20.0)},
                 4097: {2: _deepseek_v4_value(21.0)},
                 8192: {2: _deepseek_v4_value(80.0)},
                 12288: {2: _deepseek_v4_value(100.0)},
             }
         }
-        db._raw_context_deepseek_v4_attention_module_data = LoadedOpData(
-            _context_deepseek_v4_data(4, raw_attn_dict), common.PerfDataFilename.dsv4_csa_context_module, "raw"
-        )
+        db = mutable_comprehensive_perf_db
         db._context_deepseek_v4_attention_module_data = LoadedOpData(
-            _context_deepseek_v4_data(4, extrapolated_attn_dict),
+            _context_deepseek_v4_data(4, attn_dict, native_heads=16),
             common.PerfDataFilename.dsv4_csa_context_module,
-            "extrapolated",
+            "models",
         )
-
-        def fail_interp_3d(*args, **kwargs):
-            raise AssertionError("_interp_3d should not be used when raw same-regime CSA anchors exist")
-
-        db._interp_3d = fail_interp_3d
+        db._raw_context_deepseek_v4_attention_module_data = None
 
         base = _deepseek_v4_attn_kwargs(4)
         result = db.query_context_deepseek_v4_attention_module(
@@ -402,21 +394,26 @@ class TestDeepSeekV4AttentionModule:
             database_mode=common.DatabaseMode.SILICON,
         )
 
-        expected = 80.0 + (100.0 - 80.0) / (12288 - 8192) * (4097 - 8192)
-        assert float(result) == pytest.approx(expected)
-        assert result.energy == pytest.approx(expected * 10.0)
+        assert float(result) == pytest.approx(21.0)
+        assert result.energy == pytest.approx(21.0 * 10.0)
 
-    def test_context_silicon_uses_native_head_bucket(self, mutable_comprehensive_perf_db):
+    def test_context_silicon_resolves_rank_local_head_bucket(self, mutable_comprehensive_perf_db):
+        # SCHEME A: the head axis is the rank-local head count (native // tp), in
+        # line with the universal attention convention (per-rank heads, no tp
+        # axis). A Pro query at tp=8 (native 128 -> num_heads=16) must resolve the
+        # 16-head bucket, not a smaller local-head bucket. cr=4 / prefix=0 ->
+        # c4_len=64 <= index_topk, so the topK DELTA is 0 and the raw latency is
+        # returned unchanged. Data is prefix-resolved: {head}{cr}{prefix}{s}{b}.
         db = mutable_comprehensive_perf_db
         data = _context_deepseek_v4_data(
             4,
-            {8: {256: {2: _deepseek_v4_value(11.0)}}},
-            native_heads=64,
+            {0: {256: {2: _deepseek_v4_value(11.0)}}},
+            native_heads=8,
         )
         pro_data = _context_deepseek_v4_data(
             4,
-            {8: {256: {2: _deepseek_v4_value(22.0)}}},
-            native_heads=128,
+            {0: {256: {2: _deepseek_v4_value(22.0)}}},
+            native_heads=16,
         )
         _deep_merge_dsv4_dicts(data, pro_data)
         db._context_deepseek_v4_attention_module_data = LoadedOpData(
@@ -555,27 +552,29 @@ class TestDeepSeekV4AttentionModule:
         assert float(result) > 0
         assert result.energy >= 0
 
-    def test_context_silicon_errors_when_prefix_sparse_kernel_delta_missing(self, mutable_comprehensive_perf_db):
-        """Prefix CSA needs paged_mqa_logits delta; do not silently query s+prefix."""
+    def test_context_silicon_prefix_csa_without_topk_calib_returns_uncorrected(self, mutable_comprehensive_perf_db):
+        """SCHEME A correction is the topK-calib DELTA (flat - top_last), not the
+        old paged_mqa_logits sparse-kernel delta. When the topK calib is absent,
+        the prefix CSA query returns the measured module latency UNCORRECTED
+        (DELTA = 0) instead of raising — the prefix-resolved table already carries
+        the prefix in its leading axis, so there is no s+prefix double-count."""
         db = mutable_comprehensive_perf_db
-        module_grid = _dsv4_sampled_batch_caps_grid()
+        # prefix-resolved {head}{cr}{prefix}{s}{b}; prefix=8192/s=54 -> c4_len=2061
+        # > index_topk, so a correction WOULD apply if a calib were loaded.
         db._context_deepseek_v4_attention_module_data = LoadedOpData(
-            _context_deepseek_v4_data(4, module_grid),
+            _context_deepseek_v4_data(4, {8192: {54: {1: _deepseek_v4_value(5.0)}}}, native_heads=16),
             common.PerfDataFilename.dsv4_csa_context_module,
-            "mock_dsv4_context_module_tp8",
+            "models",
+        )
+        db._raw_context_deepseek_v4_attention_module_data = None
+        db._dsv4_csa_topk_calib = None  # no topK calibration loaded
+
+        result = db.query_context_deepseek_v4_attention_module(
+            **{**_deepseek_v4_attn_kwargs(4), "b": 1, "s": 54, "prefix": 8192, "num_heads": 16},
+            database_mode=common.DatabaseMode.SILICON,
         )
 
-        with pytest.raises(PerfDataNotAvailableError, match="paged_mqa_logits sparse-kernel correction"):
-            db.query_context_deepseek_v4_attention_module(
-                **{
-                    **_deepseek_v4_attn_kwargs(4),
-                    "b": 1,
-                    "s": 54,
-                    "prefix": 2816,
-                    "num_heads": 8,
-                },
-                database_mode=common.DatabaseMode.SILICON,
-            )
+        assert float(result) == pytest.approx(5.0)
 
     def test_context_silicon_handles_b3_s2682_prefix0_num_heads8_from_sampled_batches(
         self, mutable_comprehensive_perf_db

--- a/tests/unit/sdk/database/test_dsv4_sparse.py
+++ b/tests/unit/sdk/database/test_dsv4_sparse.py
@@ -63,11 +63,15 @@ def _ctx_row(
     gemm: str = "fp8_block",
     lat: float = 1.0,
     model: str = _FLASH_MODEL,
+    num_heads: int | None = None,
 ) -> str:
+    # SCHEME A: the collector writes the rank-LOCAL head count (native // tp);
+    # callers may override it to simulate different shardings on one model.
+    heads = _native_heads_for_model(model) if num_heads is None else num_heads
     return (
         f"SGLang,test,NVIDIA H20-3e,dsv4_{attn_kind}_context_module,"
         f"compressed_flashmla,{model},DeepseekV4ForCausalLM,"
-        f"bfloat16,fp8_e4m3,{gemm},{_native_heads_for_model(model)},{bs},{isl},{tp},0,{cr},{lat:.4f}"
+        f"bfloat16,fp8_e4m3,{gemm},{heads},{bs},{isl},{tp},0,{cr},{lat:.4f}"
     )
 
 
@@ -157,25 +161,26 @@ def test_load_dsv4_sparse_kernel_data_missing_returns_none(tmp_path):
 # ───────────────────────────────────────────────────────────────────────
 
 
-def test_load_context_dsv4_kind_module_data_keys_by_tp(tmp_path):
-    """Context loader must key the inner cube by ``tp_size``, not ``num_heads``."""
+def test_load_context_dsv4_kind_module_data_keys_by_local_head(tmp_path):
+    """SCHEME A: TP is folded into the rank-LOCAL ``num_heads`` (native // tp),
+    so the loader keys the head axis by local head count — there is NO separate
+    tp_size key. Axis order after the head is [cr][prefix][s][b]."""
+    # Pro native=128 sharded at tp=1/2/4/8 -> local heads 128/64/32/16.
     rows = [
-        _ctx_row(attn_kind="csa", cr=4, bs=1, isl=8192, tp=1, lat=18.0),
-        _ctx_row(attn_kind="csa", cr=4, bs=1, isl=8192, tp=2, lat=14.0),
-        _ctx_row(attn_kind="csa", cr=4, bs=1, isl=8192, tp=4, lat=11.5),
-        _ctx_row(attn_kind="csa", cr=4, bs=1, isl=8192, tp=8, lat=10.5),
+        _ctx_row(attn_kind="csa", cr=4, bs=1, isl=8192, tp=1, lat=18.0, model=_PRO_MODEL, num_heads=128),
+        _ctx_row(attn_kind="csa", cr=4, bs=1, isl=8192, tp=2, lat=14.0, model=_PRO_MODEL, num_heads=64),
+        _ctx_row(attn_kind="csa", cr=4, bs=1, isl=8192, tp=4, lat=11.5, model=_PRO_MODEL, num_heads=32),
+        _ctx_row(attn_kind="csa", cr=4, bs=1, isl=8192, tp=8, lat=10.5, model=_PRO_MODEL, num_heads=16),
     ]
     path = _write_csv(tmp_path / "csa_ctx.txt", _CTX_HEADER, rows)
     data = load_context_dsv4_kind_module_data(path)
-    sub = data[common.FMHAQuantMode.bfloat16][common.KVCacheQuantMode.fp8][common.GEMMQuantMode.fp8_block][
-        _FLASH_NATIVE_HEADS
-    ][4]
-    # keys at the 6th level are tp_size {1, 2, 4, 8}
-    assert set(sub.keys()) == {1, 2, 4, 8}
-    # axis order continues [tp][s][b]
-    assert sub[8][8192][1]["latency"] == pytest.approx(10.5)
-    # TP variation must be preserved (smaller TP slower; projections 1/N sharded)
-    assert sub[1][8192][1]["latency"] > sub[8][8192][1]["latency"]
+    quant = data[common.FMHAQuantMode.bfloat16][common.KVCacheQuantMode.fp8][common.GEMMQuantMode.fp8_block]
+    # head axis keyed by local head count {128, 64, 32, 16} (no tp_size axis)
+    assert set(quant.keys()) == {128, 64, 32, 16}
+    # axis order after the head is [cr][prefix][s][b]
+    assert quant[16][4][0][8192][1]["latency"] == pytest.approx(10.5)
+    # more local heads (less sharded) is slower
+    assert quant[128][4][0][8192][1]["latency"] > quant[16][4][0][8192][1]["latency"]
 
 
 def test_load_generation_dsv4_kind_module_data_b_before_s(tmp_path):
@@ -193,12 +198,12 @@ def test_load_generation_dsv4_kind_module_data_b_before_s(tmp_path):
     path = _write_csv(tmp_path / "csa_gen.txt", _CTX_HEADER, rows)
     data = load_generation_dsv4_kind_module_data(path)
     sub = data[common.KVCacheQuantMode.fp8][common.GEMMQuantMode.fp8_block][_FLASH_NATIVE_HEADS][4]
-    # axis order [tp][b][s_total] — b comes before s_total
+    # SCHEME A axis order after [head][cr] is [b][s_total] (no tp axis); b first
     s_total_short = 1 + 1023  # isl + step
     s_total_long = 1 + 8191
-    assert sub[1][1][s_total_short]["latency"] == pytest.approx(0.1)
-    assert sub[1][4][s_total_short]["latency"] == pytest.approx(0.4)
-    assert sub[1][4][s_total_long]["latency"] == pytest.approx(1.0)
+    assert sub[1][s_total_short]["latency"] == pytest.approx(0.1)
+    assert sub[4][s_total_short]["latency"] == pytest.approx(0.4)
+    assert sub[4][s_total_long]["latency"] == pytest.approx(1.0)
 
 
 def test_load_context_dsv4_kind_module_data_keeps_native_heads_separate(tmp_path):
@@ -209,8 +214,9 @@ def test_load_context_dsv4_kind_module_data_keeps_native_heads_separate(tmp_path
     path = _write_csv(tmp_path / "csa_ctx_models.txt", _CTX_HEADER, rows)
     data = load_context_dsv4_kind_module_data(path)
     data = data[common.FMHAQuantMode.bfloat16][common.KVCacheQuantMode.fp8][common.GEMMQuantMode.fp8_block]
-    assert data[_FLASH_NATIVE_HEADS][4][1][8192][1]["latency"] == pytest.approx(18.0)
-    assert data[_PRO_NATIVE_HEADS][4][1][8192][1]["latency"] == pytest.approx(23.0)
+    # SCHEME A: [local_head][cr][prefix][s][b]; tp=1 rows -> local head == native, prefix=0
+    assert data[_FLASH_NATIVE_HEADS][4][0][8192][1]["latency"] == pytest.approx(18.0)
+    assert data[_PRO_NATIVE_HEADS][4][0][8192][1]["latency"] == pytest.approx(23.0)
 
 
 def test_load_generation_dsv4_kind_module_data_keeps_native_heads_separate(tmp_path):
@@ -221,8 +227,9 @@ def test_load_generation_dsv4_kind_module_data_keeps_native_heads_separate(tmp_p
     path = _write_csv(tmp_path / "hca_gen_models.txt", _CTX_HEADER, rows)
     data = load_generation_dsv4_kind_module_data(path)
     data = data[common.KVCacheQuantMode.fp8][common.GEMMQuantMode.fp8_block]
-    assert data[_FLASH_NATIVE_HEADS][128][1][1][1024]["latency"] == pytest.approx(0.2)
-    assert data[_PRO_NATIVE_HEADS][128][1][1][1024]["latency"] == pytest.approx(0.6)
+    # SCHEME A: [local_head][cr][b][s_total]; tp=1 -> local head == native, no tp axis
+    assert data[_FLASH_NATIVE_HEADS][128][1][1024]["latency"] == pytest.approx(0.2)
+    assert data[_PRO_NATIVE_HEADS][128][1][1024]["latency"] == pytest.approx(0.6)
 
 
 # ───────────────────────────────────────────────────────────────────────
@@ -600,8 +607,10 @@ def test_dsv4_test_cases_active_under_v4_filter(monkeypatch, model_path):
         "sgl-project/DeepSeek-V4-Pro-FP8",
     ],
 )
-def test_dsv4_sparse_test_cases_only_indexer_tp1(monkeypatch, model_path):
-    """Sweep is fixed at tp=[1] (kernel is TP-invariant)."""
+def test_dsv4_sparse_test_cases_emit_one_kernel_case_per_model(monkeypatch, model_path):
+    """SCHEME A: sparse-kernel cases are ``[model_path, kernel]`` (one per model);
+    TP is no longer a case axis — the worker fixes tp=1 internally because the
+    kernel is TP-invariant."""
     monkeypatch.setenv("COLLECTOR_MODEL_PATH", model_path)
     from collector.case_generator import (
         get_dsv4_hca_attn_test_cases,
@@ -610,8 +619,10 @@ def test_dsv4_sparse_test_cases_only_indexer_tp1(monkeypatch, model_path):
 
     paged = get_dsv4_paged_mqa_logits_test_cases()
     hca = get_dsv4_hca_attn_test_cases()
-    assert {c[3] for c in paged} == {1}
-    assert {c[3] for c in hca} == {1}
+    assert {c[1] for c in paged} == {"paged_mqa_logits"}
+    assert {c[1] for c in hca} == {"hca_attn"}
+    assert {c[0] for c in paged} == {model_path}
+    assert {c[0] for c in hca} == {model_path}
 
 
 # ───────────────────────────────────────────────────────────────────────

--- a/tests/unit/sdk/database/test_dsv4_sparse.py
+++ b/tests/unit/sdk/database/test_dsv4_sparse.py
@@ -67,7 +67,7 @@ def _ctx_row(
 ) -> str:
     # SCHEME A: the collector writes the rank-LOCAL head count (native // tp);
     # callers may override it to simulate different shardings on one model.
-    heads = _native_heads_for_model(model) if num_heads is None else num_heads
+    heads = _native_heads_for_model(model) // tp if num_heads is None else num_heads
     return (
         f"SGLang,test,NVIDIA H20-3e,dsv4_{attn_kind}_context_module,"
         f"compressed_flashmla,{model},DeepseekV4ForCausalLM,"


### PR DESCRIPTION
#### Overview:
                                                                                  
  Fixes DeepSeek-V4-Pro AIC accuracy for the CSA topK correction and the MoE
  kernel path, and unifies the DSV4 sparse-attention collectors so all sub-kernels  
  are same-source and 1:1 with their owning attention module. Adds the missing
  `dsv4_csa_attn_module` op and wires the production trtllm-gen MXFP4×MXFP8 MoE
  kernel. Validated on B300 SXM6 (sglang 0.5.12.post2.dev454+ge958f4561, locked
  clocks): 11 DSV4-Pro ops collect with 0 errors; re-collected trtllm MoE matches
  the deployed data within ±1%.                              

  #### Details:                                      
                                                        
  **Collector — DSV4 sparse-attention (`collector/sglang/deepseekv4_sparse_modules.py`, `case_generator.py`, `registry.py`, `DeepseekV4ForCausalLM_cases.yaml`):**                                                                                                                                                  
  - Add `dsv4_csa_attn_module`: the CSA sparse FMLA over the topk-selected c4
    positions (reuses `_bench_flash_mla_sparse`, `K = min(index_topk, full_s//4)`).            
  - Fold `topk_calib` into the single `run_dsv4_sparse_kernel_worker`: emit **two
    rows per shape** (`score_mode = flat | top_last`, one `latency` each) instead
    of one row with `flat_ms`/`top_last_ms` columns; delete
    `run_dsv4_topk_calib_worker`.
  - All four sparse kernels (`paged_mqa_logits` / `topk` / `csa_attn` / `hca_attn`)
    are TP-independent → bench once per unique `(prefix, isl, bs)` module shape,
    one row each (drop per-tp expansion). **Strict 1:1** with the owning CSA/HCA
    module CSV; removed the `min_full_s` work-threshold so every module shape is            
    covered.                                                  
  - Every constant is config/sglang-derived (`index_topk`, `sliding_window`,
    `head_dim`, `compress_ratio` validated ⊆{0,4,128}, `page_size` from
    `flashmla_backend`) — no magic numbers, env vars, or fallbacks. Slimmed     
    1084 → 967 lines.                                                    
                                                                               
  **SDK (`src/aiconfigurator/sdk/operations/dsv4.py`):**     
  - `_load_dsv4_topk_calib` reads the new two-row `(score_mode, latency)` schema
    and pairs `flat`/`top_last` per shape to derive the topK DELTA.

  **MoE (`collector/sglang/collect_moe.py`, `sdk/common.py`/`moe.py`/`task.py`):**
  - Add the Blackwell **trtllm-gen MXFP4×MXFP8** MoE bench path
    (`moe_backend="trtllm_mxfp4"`, `kernel_source=sglang_mxfp4_flashinfer_trtllm_moe`);
    wire the `w4a8_mxfp4_mxfp8_trtllm` precision through the SDK.

  **Module collector (`collect_dsv4_attn.py`, `runtime_limits.py`):**
  - Page-aware KV-pool capacity pre-skip (`required_kv_alloc_tokens`) so bs512/1024
    cleanly skip instead of crashing with "Prefill out of memory".

  #### Where should the reviewer start?

  - `collector/sglang/deepseekv4_sparse_modules.py` — the unified worker +
    `score_mode` two-row output + the new `csa_attn` bench (core of the change).
  - `src/aiconfigurator/sdk/operations/dsv4.py` — `_load_dsv4_topk_calib` must stay
    in sync with the collector's new topk schema.
  - `collector/sglang/collect_moe.py` — the `use_trtllm_mxfp4` branch and the
    trtllm case emission in `case_generator.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DeepSeek‑V4 CSA attention kernel support and top‑k calibration; new MoE quant mode for TRTLLM MXFP4 and automatic hardware‑aware MoE selection.

* **Improvements**
  * Simplified sparse case generation to one kernel case per model; model architecture now included in cases. Standardized perf identifiers, safer KV paging and capacity checks, improved sizing, more robust CSV/perf loading and calibration lookup, and env/runtime startup tweaks.

* **Tests**
  * Unit tests updated for new sparse layouts, one‑case‑per‑model behavior, and calibration handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->