### PR TITLE
fix(operations): correct kv_cache_bytes formula in DSv4 attention SOL

### DIFF
--- a/src/aiconfigurator/sdk/operations/dsv4.py
+++ b/src/aiconfigurator/sdk/operations/dsv4.py
@@ -302,7 +302,8 @@ def _deepseek_v4_attention_sol(
         * (hidden_size + q_lora_rank + num_heads * head_dim + head_dim + local_groups * o_lora_rank)
         * gemm_quant_mode.value.memory
     )
-    kv_cache_bytes = attention_pairs * num_heads * head_dim * kvcache_quant_mode.value.memory
+    # DSv4 compressed attention stores one head_dim KV vector per token, shared by all query heads.
+    kv_cache_bytes = attention_pairs * head_dim * kvcache_quant_mode.value.memory
     rope_bytes = tokens * num_heads * rope_head_dim * fmha_quant_mode.value.memory
 
     sol_math = (


### PR DESCRIPTION
    DeepSeek-V4 uses compressed attention (SWA/CSA/HCA) with MQA-equivalent
    KV cache storage: each token stores a single head_dim-sized vector
    shared by all query heads, confirmed by
    DeepSeekV4Model.get_kvcache_bytes_per_sequence which derives
    cache_entry_bytes = head_dim * kvcache_quant_mode.value.memory
    (without a num_heads multiplier).
    
    The SOL bandwidth formula in _deepseek_v4_attention_sol computed:
    
        kv_cache_bytes = attention_pairs * num_heads * head_dim * memory
    
    which over-counted KV-cache HBM traffic by a factor of num_heads
    (~128x for DSv4-Pro). The inflated sol_mem term made the analytic
    SOL latency exceed silicon-measured latency at non-trivial decode
    batch sizes, violating the SOL <= silicon roofline invariant.
    
    Fix: simply remove the num_heads multiplier:
    
        kv_cache_bytes = attention_pairs * head_dim * memory
    
    This is a minimal one-factor fix. attention_pairs already correctly
    models the KV entries accessed per batch (window_pairs + compressed_pairs
    = b * entries_per_request for generation), matching the storage layout
    in get_kvcache_bytes_per_sequence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected memory calculation for DSv4 models to accurately reflect compressed KV-cache storage, providing more precise resource usage estimates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->