### PR TITLE
fix: enable b60 support in generator

### DIFF
--- a/src/aiconfigurator/generator/config/backend_templates/vllm/run.sh.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/vllm/run.sh.j2
@@ -3,6 +3,7 @@ set -e
 trap 'echo "Cleaning up..."; kill 0 2>/dev/null || true' EXIT INT TERM
 
 {% set enable_router = DynConfig.enable_router | default(false) %}
+{% set _device_env = 'ONEAPI_DEVICE_SELECTOR=level_zero:$GPU_LIST' if (NodeConfig.system_name | default('')) == 'b60' else 'CUDA_VISIBLE_DEVICES=$GPU_LIST' %}
 {% if enable_router %}
 export PYTHONHASHSEED=0
 {% endif %}
@@ -29,7 +30,7 @@ for ((w=0; w<AGG_WORKERS; w++)); do
   ( DYN_SYSTEM_PORT=$SYSTEM_PORT \
     DYN_VLLM_KV_EVENT_PORT=$EVENT_PORT \
     VLLM_NIXL_SIDE_CHANNEL_PORT=$SIDE_CHANNEL_PORT \
-    CUDA_VISIBLE_DEVICES=$GPU_LIST python3 -m dynamo.vllm \
+    {{ _device_env }} python3 -m dynamo.vllm \
     --model "$MODEL_PATH" \
     {% if enable_router %}--kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${EVENT_PORT}\",\"enable_kv_cache_events\":true}" {% endif %}\
     {{ agg_cli_args }} 2>&1 | sed "s/^/[Worker $w] /" ) &
@@ -56,7 +57,7 @@ for ((w=0; w<PREFILL_WORKERS; w++)); do
   ( DYN_SYSTEM_PORT=$SYSTEM_PORT \
   DYN_VLLM_KV_EVENT_PORT=$EVENT_PORT \
   VLLM_NIXL_SIDE_CHANNEL_PORT=$SIDE_CHANNEL_PORT \
-  CUDA_VISIBLE_DEVICES=$GPU_LIST \
+  {{ _device_env }} \
     python3 -m dynamo.vllm \
       --model "$MODEL_PATH" \
       {% if enable_router %}--kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${EVENT_PORT}\",\"enable_kv_cache_events\":true}" {% endif %}\
@@ -76,7 +77,7 @@ for ((w=0; w<DECODE_WORKERS; w++)); do
   ( DYN_SYSTEM_PORT=$SYSTEM_PORT \
   DYN_VLLM_KV_EVENT_PORT=$EVENT_PORT \
   VLLM_NIXL_SIDE_CHANNEL_PORT=$SIDE_CHANNEL_PORT \
-  CUDA_VISIBLE_DEVICES=$GPU_LIST \
+  {{ _device_env }} \
     python3 -m dynamo.vllm \
       --model "$MODEL_PATH" \
       {% if enable_router %}--kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${EVENT_PORT}\",\"enable_kv_cache_events\":true}" {% endif %}\

--- a/src/aiconfigurator/generator/module_bridge.py
+++ b/src/aiconfigurator/generator/module_bridge.py
@@ -260,6 +260,8 @@ def task_config_to_generator_config(
     )
 
     params = _deep_merge(params, overrides.get("Params"))
+    # Expose SDK's system identifier to templates via NodeConfig.system_name
+    params.setdefault("NodeConfig", {})["system_name"] = task_config.system_name
     rule_name = overrides.get("rule")
     if rule_name:
         params["rule"] = rule_name


### PR DESCRIPTION
Fixed hard-coded CUDA_VISIBLE_DEVICES in the generated artifacts by passing system name into the template. If system is b60, use ONEAPI_DEVICE_SELECTOR. Otherwise, unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added automatic GPU device binding that detects and selects the appropriate environment configuration based on system hardware type (Intel oneAPI or CUDA).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->