### PR TITLE
ci: upgrade Node 20 GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/accuracy-regression-comment.yml
+++ b/.github/workflows/accuracy-regression-comment.yml
@@ -23,14 +23,14 @@ jobs:
 
     steps:
       - name: Checkout default branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           lfs: true
 
       - name: Download PR comment inputs
         id: download
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: accuracy-regression-comment-inputs
           path: ./comment-inputs
@@ -216,7 +216,7 @@ jobs:
 
       - name: Comment on PR
         if: always() && steps.metadata.outputs.pr_number != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/accuracy-regression-testing.yml
+++ b/.github/workflows/accuracy-regression-testing.yml
@@ -22,7 +22,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout incoming revision
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           lfs: true
@@ -31,7 +31,7 @@ jobs:
         run: git lfs pull
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -93,7 +93,7 @@ jobs:
       - name: Upload regression artifacts
         id: upload-regression-artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: accuracy-regression-testing-results
           path: |
@@ -139,7 +139,7 @@ jobs:
 
       - name: Upload PR comment inputs
         if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: accuracy-regression-comment-inputs
           path: accuracy-regression-comment-inputs/**

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,7 +17,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
       - name: Install and run cargo-deny
         working-directory: rust/aiconfigurator-core
         # Default log level (warn) surfaces "license inferred from file" notes
@@ -43,8 +45,9 @@ jobs:
             workers: "-n 2"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
+          persist-credentials: false
           lfs: true
           fetch-depth: 0
       - name: Detect generator golden changes

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install and run cargo-deny
         working-directory: rust/aiconfigurator-core
         # Default log level (warn) surfaces "license inferred from file" notes
@@ -43,7 +43,7 @@ jobs:
             workers: "-n 2"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           lfs: true
           fetch-depth: 0

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -31,7 +31,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/comment-charts.yml
+++ b/.github/workflows/comment-charts.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Download chart artifact bundle
         id: download
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: sanity-check-charts
           path: ./artifact
@@ -38,7 +38,7 @@ jobs:
 
       - name: Post comment with charts
         if: steps.download.outcome == 'success'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/comment-perf-parquet-diff.yml
+++ b/.github/workflows/comment-perf-parquet-diff.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Download parquet diff artifact bundle
         id: download
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: perf-parquet-diff
           path: ./artifact
@@ -32,7 +32,7 @@ jobs:
 
       - name: Post comment with parquet diff summary
         if: steps.download.outcome == 'success'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/copyright-checks.yml
+++ b/.github/workflows/copyright-checks.yml
@@ -15,7 +15,7 @@ jobs:
         contents: read
         packages: read
       steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         # Allowlist both variants of the mounted source directory.
       - run: git config --global --add safe.directory /__w/dynamo/dynamo
       - run: git config --global --add safe.directory /workspace

--- a/.github/workflows/create-charts.yml
+++ b/.github/workflows/create-charts.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Need full history to detect changes
           lfs: true
@@ -33,7 +33,7 @@ jobs:
         run: git lfs pull
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -57,7 +57,7 @@ jobs:
 
       - name: Upload chart artifact bundle
         if: steps.create-charts.outcome == 'success'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sanity-check-charts
           path: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -37,10 +37,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
 

--- a/.github/workflows/op-kernel-source-manifest-daily-run.yml
+++ b/.github/workflows/op-kernel-source-manifest-daily-run.yml
@@ -33,7 +33,7 @@ jobs:
       TARGET_BRANCH: ${{ inputs.branch != '' && inputs.branch || github.event.repository.default_branch }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ env.TARGET_BRANCH }}
           lfs: true
@@ -42,7 +42,7 @@ jobs:
         run: git lfs pull
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -79,7 +79,7 @@ jobs:
 
       - name: Create or Update Pull Request
         if: steps.drift.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           signoff: true

--- a/.github/workflows/perf-parquet-diff.yml
+++ b/.github/workflows/perf-parquet-diff.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
           lfs: true
@@ -66,7 +66,7 @@ jobs:
           fi
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.12'
 
@@ -92,7 +92,7 @@ jobs:
             --detail-dir parquet-diff-details
 
       - name: Upload parquet diff artifact bundle
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: perf-parquet-diff
           path: |

--- a/.github/workflows/random-review-assignment.yml
+++ b/.github/workflows/random-review-assignment.yml
@@ -14,12 +14,12 @@ jobs:
     if: github.event.pull_request.draft == false
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           sparse-checkout: .github/CODEOWNERS
           sparse-checkout-cone-mode: false
       
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/support-matrix-main.yml
+++ b/.github/workflows/support-matrix-main.yml
@@ -27,7 +27,7 @@ jobs:
           rm -rf ${{ github.workspace }}/.[!.]*
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ env.TARGET_BRANCH }}
           lfs: true
@@ -113,7 +113,7 @@ jobs:
 
       - name: Create or Update Pull Request
         if: steps.compare.outputs.needs_pr == 'true'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           signoff: true


### PR DESCRIPTION
## What

GitHub is deprecating the **Node 20** Actions runtime. This bumps every action whose `action.yml` declares `using: node20` to its Node 24 release, across all workflows **except `build-test.yml`** (that one's Node 20 actions are already handled in #1206).

Verified each target's runtime by reading its `action.yml` `runs.using`, and confirmed all targets are on the approved-actions allowlist.

| Action | Was (node20) | Now (node24) |
|---|---|---|
| `actions/checkout` | v4 | v5 |
| `actions/setup-python` | v5 | v6 |
| `actions/setup-node` | v4 | v5 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `actions/github-script` | v7 | v8 |
| `peter-evans/create-pull-request` | v6 | v8 |

`upload-artifact` v5/v6 and `download-artifact` v5/v6 and `create-pull-request` v7 are *also* node20, which is why those jump further than one major.

## Pinning

- **SHA-pinned files** (`perf-parquet-diff.yml`, `comment-perf-parquet-diff.yml`) keep the SHA-pin style — refreshed the pinned commit + the `# vN` comment.
- **Tag-pinned files** bump the major tag.

## ⚠️ Worth a closer review

- **Multi-major bumps to reach node24:** `github-script@v7→v8`, `download-artifact@v4→v8`, `create-pull-request@v6→v8`. Inputs/behavior for the inline `github-script` snippets and the `create-pull-request` steps should be sanity-checked, though the common inputs are stable across these majors.
- **Not fixable here:** `lint-pr-title.yaml` uses `ytanikin/pr-conventional-commits@b628c5a…`, which is **node20**. The approved-actions allowlist pins it to that single SHA, so upgrading requires a newer SHA to be added to the allowlist first.

## Scope note

`build-test.yml`'s Node 20 actions (`checkout@v4`, `upload-artifact@v5`) are upgraded in **#1206**, not here, to avoid a merge conflict between the two PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated multiple CI/CD workflows to use newer GitHub Actions versions for checkout, Python/Node setup, artifact upload/download, and automated PR/comment publishing.
  * Enhanced workflow security/configuration by setting `persist-credentials: false` on relevant checkouts in the build/test pipeline.
  * Kept existing workflow behavior, triggers, job logic, and reporting outputs the same while improving overall reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->