### PR TITLE
fix(dsv4): use MQA-correct KV cache bytes in attention SOL formula

### DIFF
--- a/src/aiconfigurator/sdk/operations/dsv4.py
+++ b/src/aiconfigurator/sdk/operations/dsv4.py
@@ -391,7 +391,28 @@ def _deepseek_v4_attention_sol(
         * (hidden_size + q_lora_rank + num_heads * head_dim + head_dim + local_groups * o_lora_rank)
         * gemm_quant_mode.value.memory
     )
-    kv_cache_bytes = attention_pairs * num_heads * head_dim * kvcache_quant_mode.value.memory
+    # DeepSeek-V4 attention uses compressed (MLA / MQA-equivalent) KV cache: each
+    # cache entry stores a single ``head_dim``-sized vector that is shared by all
+    # ``num_heads`` query heads (see ``DeepSeekV4Model.get_kvcache_bytes_per_sequence``
+    # which derives storage as ``head_dim * kvcache_quant_mode.value.memory``).
+    # The previous formula multiplied by ``num_heads``, which double-counted KV
+    # traffic by a factor of ``num_heads`` (128x for DSv4-Pro). The inflated
+    # ``sol_mem`` pinned SOL TPOT above HYBRID at non-trivial decode batch sizes,
+    # reproducible with a single CLI invocation:
+    #
+    #   aiconfigurator cli estimate \
+    #     --model-path deepseek-ai/DeepSeek-V4-Pro --system gb300 \
+    #     --backend sglang --estimate-mode static_gen \
+    #     --isl 8192 --osl 1024 --batch-size 570 --tp 1 --dp 12 --ep 12 \
+    #     --database-mode HYBRID --detail all
+    #
+    # whose "Latency Summary" reported HYBRID at 99.3 ms vs SOL at 216.7 ms
+    # (HYBRID ~2.2x faster than SOL) and the ``generation_attention`` op alone
+    # at HYBRID 52.0 s vs SOL 197.8 s (3.8x violation), an impossible ordering
+    # since SOL is the per-op roofline lower bound. The corrected formula reads
+    # each KV entry once (pairs * head_dim), matching the storage layout and
+    # the underlying kernel's MQA broadcast pattern.
+    kv_cache_bytes = attention_pairs * head_dim * kvcache_quant_mode.value.memory
     rope_bytes = tokens * num_heads * rope_head_dim * fmha_quant_mode.value.memory
 
     sol_math = (

--- a/tests/unit/sdk/database/test_deepseek_v4_module.py
+++ b/tests/unit/sdk/database/test_deepseek_v4_module.py
@@ -397,6 +397,58 @@ class TestDeepSeekV4AttentionModule:
         assert float(result) == pytest.approx(21.0)
         assert result.energy == pytest.approx(21.0 * 10.0)
 
+    def test_generation_kv_bytes_independent_of_num_heads(self, comprehensive_perf_db):
+        """DeepSeek-V4 KV cache stores one ``head_dim``-sized vector per token,
+        shared across all attention heads (MLA / MQA-equivalent layout).
+
+        Therefore the KV-traffic component of the attention SOL ``sol_mem`` term
+        must NOT scale with ``num_heads``: scaling ``num_heads`` only changes the
+        compute (sol_math) and the projection-related weight/activation bytes.
+
+        Regression test for the bug where ``kv_cache_bytes`` was multiplied by
+        ``num_heads``, which produced unrealistically large ``sol_mem`` values
+        (often >100 ms per decode step at moderate batch sizes). The inflated
+        SOL caused HYBRID/silicon latency to fall *below* SOL latency in the
+        ``aiconfigurator cli estimate ... --detail all`` "Latency Summary"
+        report -- a physical impossibility, since SOL is the per-op roofline
+        lower bound and cannot exceed any silicon-measured execution time.
+        """
+        base = _deepseek_v4_attn_kwargs(4)
+        # Decode-mode shape: large batch, kv_len = s - 1, KV traffic dominates sol_mem.
+        kwargs = {
+            **base,
+            "b": 256,
+            "s": 8192,
+            "num_heads": 16,
+            "index_topk": 1024,
+        }
+        kwargs.pop("prefix")
+
+        # SOL_FULL returns a tuple-like (max(sol_math, sol_mem), sol_math, sol_mem).
+        small = comprehensive_perf_db.query_generation_deepseek_v4_attention_module(
+            **kwargs,
+            database_mode=common.DatabaseMode.SOL_FULL,
+        )
+        large = comprehensive_perf_db.query_generation_deepseek_v4_attention_module(
+            **{**kwargs, "num_heads": 128},
+            database_mode=common.DatabaseMode.SOL_FULL,
+        )
+
+        # sol_math (index 1) must scale with num_heads: more compute per token.
+        assert large[1] > small[1]
+        # KV-cache traffic (a major component of sol_mem at this batch) must NOT
+        # scale with num_heads -- sol_mem should be much closer to the small case
+        # than the 128/16 = 8x ratio that the buggy formula would produce. We
+        # leave headroom for projection/activation/weight scaling that DOES
+        # legitimately depend on num_heads (Q projection output is num_heads x
+        # head_dim per token).
+        ratio = float(large[2]) / float(small[2])
+        assert ratio < 4.0, (
+            f"sol_mem scaled by {ratio:.2f}x when num_heads went 16→128. KV "
+            f"cache bytes should be MQA-style (head_dim only), independent of "
+            f"num_heads."
+        )
+
     def test_context_silicon_resolves_rank_local_head_bucket(self, mutable_comprehensive_perf_db):
         # SCHEME A: the head axis is the rank-local head count (native // tp), in
         # line with the universal attention convention (per-rank heads, no tp


### PR DESCRIPTION
## Summary

DeepSeek-V4 attention stores **one `head_dim`-sized KV vector per token**, shared across all attention heads (MLA / MQA-equivalent layout). The storage-capacity formula in `DeepSeekV4Model.get_kvcache_bytes_per_sequence` already reflects this — it derives `cache_entry_bytes = head_dim * kvcache_quant_mode.value.memory` without a `num_heads` multiplier.

The SOL bandwidth formula in `_deepseek_v4_attention_sol`, however, computed:

```python
kv_cache_bytes = attention_pairs * num_heads * head_dim * memory
```

which over-counted KV-cache HBM traffic by a factor of `num_heads` (~128 for DSv4-Pro). The inflated `sol_mem` term made the analytic SOL latency **exceed** silicon-measured (HYBRID) latency at non-trivial decode batch sizes — a contradiction, since SOL is the per-op roofline lower bound.

## Reproduction

Single CLI command, no external data needed:

```bash
aiconfigurator cli estimate \
  --model-path deepseek-ai/DeepSeek-V4-Pro --system gb300 \
  --backend sglang --estimate-mode static_gen \
  --isl 8192 --osl 1024 --batch-size 570 --tp 1 --dp 12 --ep 12 \
  --database-mode HYBRID --detail all
```

**Before the fix** — HYBRID runs ~2.2× FASTER than its own SOL roofline:

```
Latency Summary
  metric                 latency            SOL     SOL%
  tpot                 99.299 ms     216.740 ms   218.3%
  request latency  101583.335 ms  221724.623 ms   218.3%

generation_attention     52020.6 ms   197818.9 ms   380.3%
                          [silicon]       [SOL]
```

The single `generation_attention` op alone shows silicon at 52 s vs SOL at 198 s — a 3.8× violation of the `SOL ≤ silicon` ordering contract that is the entire point of having both modes coexist.

**After the fix** — physically consistent ordering (`HYBRID ≥ SOL`):

```
Latency Summary
  metric                 latency            SOL     SOL%
  tpot                 99.299 ms      31.292 ms    31.5%
  request latency  101583.335 ms   32011.439 ms    31.5%

generation_attention     52020.6 ms     8105.8 ms    15.6%
```

HYBRID itself is unchanged (it queries the silicon perf table and never touched the SOL formula). Only SOL — used both as the analytic-mode result and as the empirical-fallback base (`sol_time / 0.8`) — is corrected: its attention-op contribution drops 24×, its TPOT drops from 216.7 ms to 31.3 ms, and the `SOL ≤ HYBRID` invariant is restored across the entire generation phase.

## Test plan

- [x] Added regression test asserting that scaling `num_heads` 16→128 does not proportionally scale `sol_mem`, since KV traffic should be independent of `num_heads` for MQA-style storage.
- [x] All 51 existing DeepSeek-V4 unit tests continue to pass (`pytest tests/unit/sdk/database/test_deepseek_v4_module.py -q` → 24 passed in the touched module + remaining suites green).
- [x] Re-ran the reproduction command above; before/after Latency Summary tables match the values quoted above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected KV cache memory calculation for DeepSeek-V4 inference; memory estimates no longer scale incorrectly with attention head count.

* **Tests**
  * Added a regression test ensuring KV/cache memory stays bounded when varying number of attention heads, preventing inflated memory estimates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->