### PR TITLE
fix: fp8 static quant

### DIFF
--- a/collector/sglang/collect_gemm.py
+++ b/collector/sglang/collect_gemm.py
@@ -257,9 +257,6 @@ def run_gemm(gemm_type, batch_size, N, K, *, perf_filename, device="cuda:0"):  #
         elif gemm_type == "fp8":
             _persistent_bytes += N * K + M * K + N * 4 + M * 4
             _transient_bytes = N * K * 4
-        elif gemm_type == "fp8_static":
-            _persistent_bytes += M * K + N * K + M * 4 + N * 4
-            _transient_bytes = (M * K + N * K) * 4
         elif gemm_type == "fp8_block":
             _persistent_bytes += N * K + cdiv(N, 128) * cdiv(K, 128) * 4
             _transient_bytes = N * K * 4

--- a/collector/trtllm/collect_gemm.py
+++ b/collector/trtllm/collect_gemm.py
@@ -51,7 +51,7 @@ _weight_cache: dict = {}
 
 
 def _skip_trtllm_large_fp8_projection_gemm(gemm_type: str, m: int, n: int, k: int) -> bool:
-    if gemm_type not in {"fp8", "fp8_static"} or not (1 <= m <= 8 and n >= 51200 and k >= 51200):
+    if gemm_type != "fp8" or not (1 <= m <= 8 and n >= 51200 and k >= 51200):
         return False
 
     sm_version = get_sm_version()
@@ -78,7 +78,7 @@ def _get_l2_cache_bytes(device_id: int = 0) -> int:
 
 def _build_weights(gemm_type: str, n: int, k: int, device, dtype, group_size, x) -> dict:
     """Allocate and return the weight tensors for one GEMM copy."""
-    if gemm_type in ("fp8", "fp8_static"):
+    if gemm_type == "fp8":
         return {
             "weight": torch.randn((n, k), dtype=torch.bfloat16, device=device).to(dtype=torch.float8_e4m3fn),
             "weight_scale": torch.randn(1, dtype=torch.float32, device=device),
@@ -114,7 +114,7 @@ def get_gemm_test_cases():
     gemm_list = ["bfloat16"]
     sm_version = get_sm_version()
     if sm_version > 86:
-        gemm_list += ["fp8", "fp8_static"]
+        gemm_list += ["fp8"]
         # SM90 (Hopper) and SM100 (Blackwell) both support fp8_block.
         # SM90 uses CUTLASS backend with FP32 scale.
         # SM100 uses TRTLLM/DeepGEMM backend with UE8M0 scale (MXFP8 style).
@@ -167,7 +167,7 @@ def run_gemm(gemm_type, m, n, k, *, perf_filename, device="cuda:0"):
     dtype = torch.bfloat16
     x = torch.randn((m, k), dtype=dtype).to(torch.device(device))
 
-    if gemm_type in ("fp8", "fp8_static"):
+    if gemm_type == "fp8":
         group_size = None
         qc = QuantConfig(quant_algo=QuantAlgo.FP8)
     elif gemm_type == "fp8_block":
@@ -181,7 +181,7 @@ def run_gemm(gemm_type, m, n, k, *, perf_filename, device="cuda:0"):
         group_size = None
 
     _l2_cache_bytes = _get_l2_cache_bytes(device.index or 0)
-    _bytes_per_elem = {"bfloat16": 2, "fp8": 1, "fp8_static": 1, "fp8_block": 1, "nvfp4": 0.5}
+    _bytes_per_elem = {"bfloat16": 2, "fp8": 1, "fp8_block": 1, "nvfp4": 0.5}
     _weight_bytes = int(n * k * _bytes_per_elem[gemm_type])
     outside_loop_count = max(1, min(5, math.ceil(_l2_cache_bytes / _weight_bytes)))
     op_list = []
@@ -202,17 +202,17 @@ def run_gemm(gemm_type, m, n, k, *, perf_filename, device="cuda:0"):
             x_sf_global = (448 * 6) / x.abs().max().float()
             weights = {**weights, "input_scale": 1.0 / x_sf_global.cpu()}
 
-        # TRT-LLM's FP8QDQ method uses its dynamic path when
-        # force_dynamic_quantization=True. AIC subtracts the measured
-        # compute-scale overhead for fp8_static queries, so the collected table
-        # must include that runtime work.
+        # The fp8 weights carry no input_scale, so TRT-LLM's FP8QDQ method runs
+        # its dynamic-quantization path and the collected fp8 GEMM includes the
+        # compute-scale overhead.  AIC derives fp8_static at query time by
+        # subtracting that overhead, so no separate fp8_static GEMM is collected.
         gemm = Linear(
             k,
             n,
             bias=False,
             dtype=dtype,
             quant_config=qc,
-            force_dynamic_quantization=(gemm_type == "fp8_static"),
+            force_dynamic_quantization=False,
         )
         gemm.load_weights([weights])
         if gemm_type == "fp8_block" and callable(getattr(gemm, "post_load_weights", None)):
@@ -231,7 +231,7 @@ def run_gemm(gemm_type, m, n, k, *, perf_filename, device="cuda:0"):
                 bias=False,
                 dtype=dtype,
                 quant_config=qc,
-                force_dynamic_quantization=(gemm_type == "fp8_static"),
+                force_dynamic_quantization=False,
             )
             gemm.load_weights([weights])
             if gemm_type == "fp8_block" and callable(getattr(gemm, "post_load_weights", None)):

--- a/collector/vllm/collect_gemm.py
+++ b/collector/vllm/collect_gemm.py
@@ -51,7 +51,7 @@ _NVFP4_QUANT_ARGS = {
 
 
 def _skip_vllm_sm89_022_fp8_gemm(gemm_type: str) -> bool:
-    return vllm_version.startswith("0.22.0") and get_sm_version() == 89 and gemm_type in {"fp8", "fp8_static"}
+    return vllm_version.startswith("0.22.0") and get_sm_version() == 89 and gemm_type == "fp8"
 
 
 def get_gemm_test_cases():

--- a/src/aiconfigurator/sdk/models/helpers.py
+++ b/src/aiconfigurator/sdk/models/helpers.py
@@ -78,7 +78,13 @@ def _infer_quant_modes_from_raw_config(raw_config: dict, architecture: str | Non
 
     # GEMM quant mode, MoE quant mode
     if quant_algo == "fp8":
-        if quant_dynamic is False:
+        # Non-block per-tensor FP8 is static unless the checkpoint explicitly
+        # marks dynamic activations.  Dynamic FP8 always tags itself
+        # (activation_scheme="dynamic" or config_groups[*].dynamic=true -> quant_dynamic=True),
+        # and block-scaled FP8 is classified as fp8_block above, so treating the
+        # unknown case (quant_dynamic is None) as static correctly covers
+        # ModelOpt/NVIDIA per-tensor FP8 checkpoints that ship no activation scheme.
+        if quant_dynamic is not True:
             overrides["gemm_quant_mode"] = common.GEMMQuantMode.fp8_static
         else:
             overrides["gemm_quant_mode"] = common.GEMMQuantMode.fp8

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -1028,10 +1028,11 @@ class Task:
         """Check that the resolved task is internally consistent and supported.
 
         Two layers:
-        - Static checks: required fields, fp8_static→trtllm constraint,
-          DeepSeek+vLLM exclusion.  Always run, no I/O.
+        - Static checks: required fields, DeepSeek+vLLM exclusion.  Always
+          run, no I/O.
         - Database-dependent checks: each user-selected quant mode is in
           the perf database's ``supported_quant_mode`` list for its op
+          (this is where fp8_static is gated by overhead-table availability)
           (gemm, moe / wideep_*_moe, context_attention / context_mla /
           dsa_context_module / deepseek_v4_context_module / wideep_context_mla,
           and the corresponding generation_* op).  Skipped silently if

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -1145,14 +1145,28 @@ class Task:
         except (PerfDataNotAvailableError, FileNotFoundError) as exc:
             # DB unavailable; let sweep surface the real error later.
             logger.debug("validate: skipping DB-side quant check (DB unavailable): %s", exc)
-            return
+            database = None
         except Exception as exc:
             # Match the legacy "DB error" envelope (e.g. wrapped FileNotFoundError
             # inside RuntimeError) without swallowing programmer typos.
-            if has_perf_data_not_available_cause(exc):
-                logger.debug("validate: skipping DB-side quant check (DB unavailable): %s", exc)
-                return
-            raise
+            if not has_perf_data_not_available_cause(exc):
+                raise
+            logger.debug("validate: skipping DB-side quant check (DB unavailable): %s", exc)
+            database = None
+
+        if database is None:
+            # In SILICON mode the DB must exist; fp8_static is derived from
+            # compute_scale/scale_matrix overhead tables we can't confirm without it,
+            # so fail fast rather than defer to a late run() failure.  Other modes
+            # (and other quant modes) keep deferring to the sweep.
+            if self.database_mode in (None, common.DatabaseMode.SILICON.name) and (
+                self._role_attr(role, "gemm_quant_mode") == common.GEMMQuantMode.fp8_static
+            ):
+                raise ValueError(
+                    f"fp8_static GEMM mode requires perf data that is unavailable for "
+                    f"system={system!r}, backend={backend!r}, version={version!r}."
+                )
+            return
 
         supported: dict = getattr(database, "supported_quant_mode", {}) or {}
         enable_wideep = bool(self._role_attr(role, "enable_wideep"))

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -1066,10 +1066,10 @@ class Task:
             raise ValueError("agg mode requires system_name")
         if self.backend_name == "vllm" and self._model_family == "DEEPSEEK":
             raise NotImplementedError("AIConfigurator does not yet support the DeepSeek family on the vLLM backend.")
-        if self.gemm_quant_mode == common.GEMMQuantMode.fp8_static and self.backend_name != "trtllm":
-            raise ValueError(
-                f"fp8_static GEMM mode is only supported on the trtllm backend, got backend={self.backend_name!r}."
-            )
+        # fp8_static is not hard-gated to trtllm: it is derived from the dynamic
+        # fp8 GEMM minus compute_scale/scale_matrix overhead and works on any
+        # backend whose perf DB carries those tables.  _validate_database_quant_modes
+        # rejects it on backends/systems that lack the data.
 
     def _validate_disagg(self) -> None:
         if not self.prefill_model_path or not self.decode_model_path:
@@ -1089,12 +1089,8 @@ class Task:
             raise ValueError("disagg mode requires both prefill_system_name and decode_system_name.")
         for role in ("prefill", "decode"):
             backend = self._role_attr(role, "backend_name")
-            gemm = self._role_attr(role, "gemm_quant_mode")
-            if gemm == common.GEMMQuantMode.fp8_static and backend != "trtllm":
-                raise ValueError(
-                    f"fp8_static GEMM mode is only supported on the trtllm backend, "
-                    f"got {role}_backend_name={backend!r}."
-                )
+            # fp8_static is not hard-gated to trtllm (see _validate_agg); the
+            # per-role DB check in _validate_database_quant_modes governs support.
             if backend == "vllm" and self._model_family == "DEEPSEEK":
                 raise NotImplementedError(
                     f"AIConfigurator does not yet support the DeepSeek family on the vLLM backend ({role} side)."

--- a/tests/unit/sdk/models/test_model_config.py
+++ b/tests/unit/sdk/models/test_model_config.py
@@ -304,7 +304,7 @@ class TestHFModelSupport:
             ),
             (
                 "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-FP8",
-                common.GEMMQuantMode.fp8,
+                common.GEMMQuantMode.fp8_static,
                 common.MoEQuantMode.fp8,
                 common.KVCacheQuantMode.fp8,
                 common.FMHAQuantMode.fp8,

--- a/tests/unit/sdk/task_v2/test_task_config.py
+++ b/tests/unit/sdk/task_v2/test_task_config.py
@@ -1383,6 +1383,21 @@ def test_validate_skips_db_check_when_database_unavailable():
     t.validate()  # static checks pass, DB silently skipped
 
 
+def test_validate_fp8_static_fails_fast_when_db_unavailable_in_silicon():
+    """SILICON mode can't confirm fp8_static overhead data without the DB, so an
+    unloadable (system, backend, version) must fail fast instead of deferring."""
+    t = Task(
+        serving_mode="agg",
+        model_path="deepseek-ai/DeepSeek-V3",
+        system_name="h200_sxm",
+        backend_name="trtllm",
+        gemm_quant_mode=common.GEMMQuantMode.fp8_static,
+    )
+    t.backend_version = "9.99.99-nonexistent"  # DB load fails -> can't confirm support
+    with pytest.raises(ValueError, match="fp8_static GEMM mode requires perf data"):
+        t.validate()
+
+
 def test_validate_skips_db_check_for_deepseekv4_synthetic_mode():
     """DeepSeek-V4 in synthetic database modes skips DB validation entirely."""
     t = Task(

--- a/tests/unit/sdk/task_v2/test_task_config.py
+++ b/tests/unit/sdk/task_v2/test_task_config.py
@@ -1255,15 +1255,20 @@ def test_validate_agg_rejects_deepseek_on_vllm():
         t.validate()
 
 
-def test_validate_agg_rejects_fp8_static_on_non_trtllm():
+def test_validate_agg_fp8_static_on_sglang_is_data_driven():
+    """fp8_static is no longer hard-gated to trtllm; support is decided by the
+    perf DB.  h200_sxm/sglang has fp8 GEMM data but no compute_scale/scale_matrix
+    overhead tables, so fp8_static is rejected by the DB-side check rather than a
+    backend allowlist."""
     t = Task(
         serving_mode="agg",
         model_path="deepseek-ai/DeepSeek-V3",
         system_name="h200_sxm",
         backend_name="sglang",
+        backend_version="0.5.10",
         gemm_quant_mode=common.GEMMQuantMode.fp8_static,
     )
-    with pytest.raises(ValueError, match="fp8_static GEMM mode is only supported on the trtllm backend"):
+    with pytest.raises(ValueError, match="Unsupported gemm quant mode 'fp8_static'"):
         t.validate()
 
 
@@ -1303,17 +1308,21 @@ def test_validate_disagg_rejects_mismatched_prefill_decode_model_paths():
         t.validate()
 
 
-def test_validate_disagg_rejects_fp8_static_on_non_trtllm_per_role():
+def test_validate_disagg_fp8_static_is_data_driven_per_role():
+    """Per-role fp8_static support is decided by the perf DB, not a trtllm
+    allowlist.  h200_sxm/sglang lacks the overhead tables, so the prefill role's
+    fp8_static is rejected by the DB-side check."""
     t = Task(
         serving_mode="disagg",
         prefill_model_path="deepseek-ai/DeepSeek-V3",
         prefill_system_name="h200_sxm",
         prefill_backend_name="sglang",
+        prefill_backend_version="0.5.10",
         prefill_gemm_quant_mode=common.GEMMQuantMode.fp8_static,
         decode_model_path="deepseek-ai/DeepSeek-V3",
         decode_system_name="h200_sxm",
     )
-    with pytest.raises(ValueError, match="prefill_backend_name='sglang'"):
+    with pytest.raises(ValueError, match="Unsupported gemm quant mode 'fp8_static'"):
         t.validate()
 
 


### PR DESCRIPTION
#### Overview:

Fixes FP8 per-tensor (static) handling across the collector, the SDK quant-mode
gating, and model quant-mode inference. Three independent, self-contained changes:

1. **Collector** — stop collecting a redundant `fp8_static` GEMM.
2. **SDK** — gate `fp8_static` by perf-DB data availability instead of a trtllm allowlist.
3. **SDK** — infer `fp8_static` for non-dynamic per-tensor FP8 checkpoints (e.g. ModelOpt FP8).

#### Details:

**1. `refactor(collector)`: stop collecting redundant fp8_static GEMM**
`fp8_static` is derived at query time from the dynamic `fp8` GEMM minus the
`compute_scale` / `scale_matrix` overhead tables; the SDK never reads a collected
`fp8_static` GEMM row (`perf_database._gemm_key_names` discards it and re-derives the
mode). The trtllm collector was still spending time on an `fp8_static` GEMM that ran
the *dynamic* path (no `input_scale`) — i.e. a duplicate of the `fp8` row — and was
then thrown away. Dropped `fp8_static` from the trtllm `gemm_list` and all its
special-casing; the collected `fp8` row already carries the compute-scale overhead AIC
subtracts. Also removed dead `fp8_static` references in the sglang/vllm collectors
(neither ever collected it).

**2. `refactor(sdk)`: gate fp8_static by perf-DB data, not a trtllm allowlist**
`fp8_static` was hard-restricted to trtllm, but the derivation is backend-agnostic and
all three backends ship a `collect_computescale.py` that emits both overhead tables.
Whether `fp8_static` is supported is purely a function of whether a given
`(system, backend, version)` has `fp8 + compute_scale + scale_matrix` data. Removed the
`!= "trtllm"` guards in `_validate_agg` / `_validate_disagg` and let the existing
data-driven `_validate_database_quant_modes` govern it via
`supported_quant_mode["gemm"]` (`_gemm_key_names`). This opens sglang where data exists
(e.g. `b200_sxm/0.5.10`) and gives a clear "Unsupported gemm quant mode" error
elsewhere, uniformly across backends — no per-framework special-casing.

**3. `fix(sdk)`: infer fp8_static for non-dynamic per-tensor FP8 checkpoints**
ModelOpt/NVIDIA per-tensor FP8 checkpoints (e.g. `nvidia/Llama-3.1-8B-Instruct-FP8`)
ship `hf_quant_config` `quant_algo=FP8` with no activation scheme, so `quant_dynamic`
was `None` and the model was mis-inferred as *dynamic* `fp8`. Now FP8 is treated as
static unless the checkpoint explicitly marks dynamic activations
(`quant_dynamic is not True`). Dynamic FP8 always tags itself
(`activation_scheme="dynamic"` / `config_groups[*].dynamic=true`) and block-scaled FP8
is classified as `fp8_block` earlier, so this flips only genuine static per-tensor
checkpoints. A scan of all shipped FP8 model configs confirmed the only flips are the
NVIDIA/ModelOpt static checkpoints (Llama-3.1-70B-FP8, Nemotron-3-Ultra-550B-FP8); no
dynamic or block-scaled model is affected. If you want dynamic, provide a dynamic model
config — there is intentionally no silent fallback (downgrading a static model to
dynamic would report wrong numbers).

#### Where should the reviewer start?

- `src/aiconfigurator/sdk/models/helpers.py` — the one-line semantic change in quant-mode inference (`quant_dynamic is False` → `is not True`) and the comment explaining why.
- `src/aiconfigurator/sdk/task_v2.py` — `_validate_agg` / `_validate_disagg` guard removal; confirm `_validate_database_quant_modes` (`_check("gemm", ...)`) covers the rejection path.
- `collector/trtllm/collect_gemm.py` — the collection removal and updated comment (`force_dynamic_quantization` now `False` for the `fp8` row).
- Tests: `tests/unit/sdk/task_v2/test_task_config.py`, `tests/unit/sdk/models/test_model_config.py`.


#### Support matrix impact (intentional):

Change #3 re-classifies exactly one model currently in the support matrix — `nvidia/Llama-3.1-70B-Instruct-FP8` — from `fp8` to `fp8_static` (the other `*-FP8` entries are `fp8_block` and are untouched). Combined with the data-driven gating (#2), ~50 rows move `PASS -> FRAMEWORK_INCOMPATIBLE` on backends/systems without `compute_scale`/`scale_matrix` overhead data (all vllm, and sglang except `b200_sxm/0.5.10`); trtllm stays `PASS`. **This is intended, not a regression** — AIC cannot model static per-tensor FP8 where the overhead tables haven't been collected, and silently modeling it as dynamic would report wrong numbers. The committed CSVs are regenerated by the scheduled support-matrix job (not this PR); note that `compare_support_matrix.find_blocking_status_transitions` treats `PASS -> FRAMEWORK_INCOMPATIBLE` as a blocking transition, so the next regen will flag these ~50 transitions — they should be acknowledged as expected. Restoring `PASS` is a future follow-up: collect the overhead tables for vllm / more sglang systems (the collectors already support it).

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #1215 (task v2 integration), now merged; this branch is rebased onto `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated GEMM collection and memory/byte estimation so FP8 handling is consistent, with `fp8_static` no longer treated as a separately collected GEMM variant across SGLang/TRT-LLM/vLLM.
  * Refined quantization mode inference so `fp8` may be interpreted as `fp8_static` when dynamic settings are unset/unknown.
  * Adjusted `fp8_static` validation to be driven by perf-data availability (including faster failure in SILICON when perf data can’t be loaded).

* **Tests**
  * Updated unit tests to reflect the new defaults and perf-data-dependent validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->