### PR TITLE
fix: fail accurately on insufficient data instead of silent handling

### DIFF
--- a/src/aiconfigurator/sdk/interpolation.py
+++ b/src/aiconfigurator/sdk/interpolation.py
@@ -29,6 +29,16 @@ logger = logging.getLogger(__name__)
 _MISSING = object()
 
 
+class InterpolationDataNotAvailableError(ValueError):
+    """Raised when interpolation cannot produce a real value from available data.
+
+    Subclasses ``ValueError`` so existing callers that catch ``ValueError``
+    keep working. The perf-DB layer catches this specific class to classify
+    the failure as "missing silicon data" without swallowing genuine
+    programming bugs that raise plain ``ValueError`` deeper in the stack.
+    """
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -46,7 +56,7 @@ def validate_interpolation_result(value):
     """Validate that an interpolated value is finite; log a debug line if negative."""
     value_array = np.asarray(value)
     if not np.all(np.isfinite(value_array)):
-        raise ValueError(f"Non-finite value detected {value}")
+        raise InterpolationDataNotAvailableError(f"Non-finite value detected {value}")
     if np.any(value_array < 0.0):
         logger.debug(f"Negative value detected {value}, pass")
     return value
@@ -77,7 +87,7 @@ def _reduced_griddata(points: list[list[int]], values: list, target: tuple[int, 
         constant_dims = np.where(~varying)[0]
         for dim in constant_dims:
             if not math.isclose(target_array[dim], point_array[0, dim]):
-                raise ValueError(
+                raise InterpolationDataNotAvailableError(
                     f"Target coordinate does not match constant interpolation dimension. "
                     f"target={target_array[dim]}, value={point_array[0, dim]}, dim={dim}"
                 )
@@ -179,7 +189,7 @@ def _require_3d_axis_coverage(data: dict, *, context: str) -> None:
     ]
     if missing_axes:
         axes = ", ".join(missing_axes)
-        raise ValueError(
+        raise InterpolationDataNotAvailableError(
             f"{context} requires data that varies across all 3 dimensions; "
             f"missing variation on axis/axes: {axes}. "
             "Collect more perf data points instead of reducing to lower-dimensional interpolation."
@@ -196,7 +206,7 @@ def nearest_1d_point_helper(x: int, values: list[int], inner_only: bool = True) 
     assert values is not None and len(values) >= 1, "values is None or empty"
     if len(values) == 1:
         if inner_only and x != values[0]:
-            raise ValueError(f"x is not equal to the only value in the list. {x=}, {values=}")
+            raise InterpolationDataNotAvailableError(f"x is not equal to the only value in the list. {x=}, {values=}")
         return values[0], values[0]
 
     sorted_values = sorted(values)
@@ -205,11 +215,15 @@ def nearest_1d_point_helper(x: int, values: list[int], inner_only: bool = True) 
 
     if x < sorted_values[0]:
         if inner_only:
-            raise ValueError(f"x is less than the smallest value in the list. {x=}, {sorted_values=}")
+            raise InterpolationDataNotAvailableError(
+                f"x is less than the smallest value in the list. {x=}, {sorted_values=}"
+            )
         return sorted_values[0], sorted_values[1]
     if x > sorted_values[-1]:
         if inner_only:
-            raise ValueError(f"x is greater than the largest value in the list. {x=}, {sorted_values=}")
+            raise InterpolationDataNotAvailableError(
+                f"x is greater than the largest value in the list. {x=}, {sorted_values=}"
+            )
         return sorted_values[-2], sorted_values[-1]
 
     start = end = None
@@ -220,7 +234,9 @@ def nearest_1d_point_helper(x: int, values: list[int], inner_only: bool = True) 
         start = sorted_values[i - 1]
         break
     if start is None or end is None:
-        raise ValueError(f"start or end is None. {x=}, {sorted_values=}, start={start=}, end={end=}")
+        raise InterpolationDataNotAvailableError(
+            f"start or end is None. {x=}, {sorted_values=}, start={start=}, end={end=}"
+        )
     return start, end
 
 
@@ -445,9 +461,10 @@ def interp_2d_1d(
                 value = _reduced_griddata(points_list, values_list, (y, z), "cubic")
             except QhullError as exc:
                 # Degenerate slice (collinear/coplanar/too few points): no usable
-                # cubic surface. Re-raise as ValueError so the perf DB classifies
-                # this as missing data instead of letting a raw RuntimeError escape.
-                raise ValueError(f"degenerate cubic slice: {exc}") from exc
+                # cubic surface. Re-raise as InterpolationDataNotAvailableError so
+                # the perf DB classifies this as missing data instead of letting a
+                # raw RuntimeError escape.
+                raise InterpolationDataNotAvailableError(f"degenerate cubic slice: {exc}") from exc
             x_values.append(validate_interpolation_result(value))
         elif method == "bilinear":
             x_values.append(

--- a/src/aiconfigurator/sdk/interpolation.py
+++ b/src/aiconfigurator/sdk/interpolation.py
@@ -23,6 +23,7 @@ import math
 
 import numpy as np
 from scipy import interpolate
+from scipy.spatial import QhullError
 
 logger = logging.getLogger(__name__)
 _MISSING = object()
@@ -223,16 +224,6 @@ def nearest_1d_point_helper(x: int, values: list[int], inner_only: bool = True) 
     return start, end
 
 
-def nearest_1d_point_allow_singleton_axis(x: int, values: list[int]) -> tuple[int, int]:
-    """Return strict brackets, but allow sparse singleton axes to collapse."""
-    try:
-        return nearest_1d_point_helper(x, values)
-    except ValueError:
-        if len(values) == 1:
-            return values[0], values[0]
-        raise
-
-
 # ---------------------------------------------------------------------------
 # Metric extraction
 # ---------------------------------------------------------------------------
@@ -420,7 +411,6 @@ def interp_2d_1d(
     z: int,
     data: dict,
     method: str = "bilinear",
-    allow_singleton_axes: bool = False,
 ) -> float:
     """3-D interpolation done as 2-D (over y, z) followed by 1-D (over x)."""
     exact = _get_exact_3d(data, x, y, z)
@@ -428,7 +418,7 @@ def interp_2d_1d(
         return exact
 
     x_values = []
-    point_helper = nearest_1d_point_allow_singleton_axis if allow_singleton_axes else nearest_1d_point_helper
+    point_helper = nearest_1d_point_helper
     x_left, x_right = point_helper(x, list(data.keys()))
     slice_bounds = []
 
@@ -440,8 +430,7 @@ def interp_2d_1d(
             z_bounds.append((j, z_left, z_right))
         slice_bounds.append((i, y_left, y_right, z_bounds))
 
-    if not allow_singleton_axes:
-        _require_3d_axis_coverage(data, context=f"3-D {method} interpolation")
+    _require_3d_axis_coverage(data, context=f"3-D {method} interpolation")
 
     for i, y_left, y_right, z_bounds in slice_bounds:
         points_list = []
@@ -454,19 +443,11 @@ def interp_2d_1d(
         if method == "cubic":
             try:
                 value = _reduced_griddata(points_list, values_list, (y, z), "cubic")
-            except ValueError as exc:
-                if not allow_singleton_axes:
-                    raise
-                logger.debug("Falling back to rectangular interpolation for degenerate cubic slice: %s", exc)
-                value = interp_2d_rectangular_slice(
-                    y_left,
-                    y_right,
-                    z_bounds[0][1],
-                    z_bounds[0][2],
-                    y,
-                    z,
-                    data[i],
-                )
+            except QhullError as exc:
+                # Degenerate slice (collinear/coplanar/too few points): no usable
+                # cubic surface. Re-raise as ValueError so the perf DB classifies
+                # this as missing data instead of letting a raw RuntimeError escape.
+                raise ValueError(f"degenerate cubic slice: {exc}") from exc
             x_values.append(validate_interpolation_result(value))
         elif method == "bilinear":
             x_values.append(
@@ -521,7 +502,6 @@ def interp_3d(
     data: dict,
     method: str,
     extracted_metrics_cache: dict | None = None,
-    allow_singleton_axes: bool = False,
 ) -> dict:
     """3-D interpolation. Returns a metrics dict (latency/power/energy).
 
@@ -541,14 +521,14 @@ def interp_3d(
             latency = interp_3d_linear(x, y, z, latency_data)
             energy = interp_3d_linear(x, y, z, energy_data)
         else:
-            latency = interp_2d_1d(x, y, z, latency_data, method, allow_singleton_axes=allow_singleton_axes)
-            energy = interp_2d_1d(x, y, z, energy_data, method, allow_singleton_axes=allow_singleton_axes)
+            latency = interp_2d_1d(x, y, z, latency_data, method)
+            energy = interp_2d_1d(x, y, z, energy_data, method)
         return {"latency": latency, "power": 0.0, "energy": energy}
 
     if method == "linear":
         latency = interp_3d_linear(x, y, z, data)
     else:
-        latency = interp_2d_1d(x, y, z, data, method, allow_singleton_axes=allow_singleton_axes)
+        latency = interp_2d_1d(x, y, z, data, method)
     return {"latency": latency, "power": 0.0, "energy": 0.0}
 
 

--- a/src/aiconfigurator/sdk/operations/attention.py
+++ b/src/aiconfigurator/sdk/operations/attention.py
@@ -272,7 +272,6 @@ class ContextAttention(Operation):
                 attention_dict,
                 "cubic",
                 database._extracted_metrics_cache,
-                allow_singleton_axes=True,
             )
             latency = result["latency"] * prefix_correction
             energy = result.get("energy", 0.0) * prefix_correction

--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -24,7 +24,7 @@ databases_cache = defaultdict(lambda: defaultdict(lambda: defaultdict()))
 logger = logging.getLogger(__name__)
 
 _SYSTEMS_PATHS: list[str] = [os.fspath(pkg_resources.files("aiconfigurator") / "systems")]
-_MISSING_SILICON_DATA_EXCEPTIONS = (KeyError, IndexError)
+_MISSING_SILICON_DATA_EXCEPTIONS = (KeyError, IndexError, ValueError)
 
 
 def _normalize_systems_paths(raw_paths: str | Iterable[str] | None) -> list[str]:

--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -17,6 +17,7 @@ import yaml
 
 from aiconfigurator.sdk import common
 from aiconfigurator.sdk.common import PerfDataFilename, parse_support_matrix_version
+from aiconfigurator.sdk.interpolation import InterpolationDataNotAvailableError
 from aiconfigurator.sdk.performance_result import PerformanceResult
 from aiconfigurator.sdk.system_spec import SystemSpec
 
@@ -24,7 +25,7 @@ databases_cache = defaultdict(lambda: defaultdict(lambda: defaultdict()))
 logger = logging.getLogger(__name__)
 
 _SYSTEMS_PATHS: list[str] = [os.fspath(pkg_resources.files("aiconfigurator") / "systems")]
-_MISSING_SILICON_DATA_EXCEPTIONS = (KeyError, IndexError, ValueError)
+_MISSING_SILICON_DATA_EXCEPTIONS = (KeyError, IndexError, InterpolationDataNotAvailableError)
 
 
 def _normalize_systems_paths(raw_paths: str | Iterable[str] | None) -> list[str]:

--- a/tests/unit/sdk/database/test_interpolation.py
+++ b/tests/unit/sdk/database/test_interpolation.py
@@ -262,8 +262,12 @@ class TestInterpolationMethods:
             2: {256: {1: 21.0, 2: 22.0}},
         }
 
-        with pytest.raises(ValueError, match="only value"):
+        with pytest.raises(interpolation.InterpolationDataNotAvailableError, match="only value"):
             interpolation.interp_2d_1d(1.5, 257, 1.5, data, method="bilinear")
+
+    def test_data_unavailable_errors_subclass_value_error(self):
+        """Existing ``except ValueError`` callers must keep working."""
+        assert issubclass(interpolation.InterpolationDataNotAvailableError, ValueError)
 
     def test_interp_3d(self, comprehensive_perf_db):
         """Test general 3D interpolation dispatcher."""

--- a/tests/unit/sdk/database/test_interpolation.py
+++ b/tests/unit/sdk/database/test_interpolation.py
@@ -255,24 +255,6 @@ class TestInterpolationMethods:
         with pytest.raises(NotImplementedError):
             interpolation.interp_2d_1d(15, 35, 55, data, method="invalid")
 
-    def test_interp_2d_1d_handles_singleton_inner_axis(self, comprehensive_perf_db):
-        """Sparse singleton axes should collapse instead of failing bracketing."""
-        data = {
-            1: {256: {1: 11.0, 2: 12.0}},
-            2: {256: {1: 21.0, 2: 22.0}},
-        }
-
-        result = interpolation.interp_2d_1d(
-            1.5,
-            257,
-            1.5,
-            data,
-            method="bilinear",
-            allow_singleton_axes=True,
-        )
-
-        assert result == pytest.approx(16.5)
-
     def test_interp_2d_1d_rejects_singleton_axis_by_default(self, comprehensive_perf_db):
         """Generic callers should not silently accept sparse shape misses."""
         data = {
@@ -282,24 +264,6 @@ class TestInterpolationMethods:
 
         with pytest.raises(ValueError, match="only value"):
             interpolation.interp_2d_1d(1.5, 257, 1.5, data, method="bilinear")
-
-    def test_interp_2d_1d_cubic_falls_back_on_degenerate_slice(self, comprehensive_perf_db):
-        """Cubic interpolation should fall back when a 2-D slice is degenerate."""
-        data = {
-            1: {256: {1: 11.0, 2: 12.0}},
-            2: {256: {1: 21.0, 2: 22.0}},
-        }
-
-        result = interpolation.interp_2d_1d(
-            1.5,
-            257,
-            1.5,
-            data,
-            method="cubic",
-            allow_singleton_axes=True,
-        )
-
-        assert result == pytest.approx(16.5)
 
     def test_interp_3d(self, comprehensive_perf_db):
         """Test general 3D interpolation dispatcher."""

--- a/tests/unit/sdk/database/test_perf_database_errors.py
+++ b/tests/unit/sdk/database/test_perf_database_errors.py
@@ -3,7 +3,9 @@
 
 import pytest
 
+from aiconfigurator.sdk.interpolation import InterpolationDataNotAvailableError
 from aiconfigurator.sdk.perf_database import (
+    _MISSING_SILICON_DATA_EXCEPTIONS,
     PerfDataNotAvailableError,
     has_perf_data_not_available_cause,
 )
@@ -26,3 +28,20 @@ def test_perf_data_cause_detection_avoids_cycles() -> None:
     nested.__context__ = error
 
     assert not has_perf_data_not_available_cause(error)
+
+
+def test_missing_silicon_data_exceptions_narrowed_to_interpolation_class() -> None:
+    """A genuine programming bug raising plain ``ValueError`` must not be misclassified as missing data.
+
+    The interpolation-data signal is ``InterpolationDataNotAvailableError`` (a
+    ``ValueError`` subclass); the perf-DB layer should only treat that class —
+    plus ``KeyError``/``IndexError`` — as "missing silicon data".
+    """
+    assert InterpolationDataNotAvailableError in _MISSING_SILICON_DATA_EXCEPTIONS
+    assert ValueError not in _MISSING_SILICON_DATA_EXCEPTIONS
+
+    bug = ValueError("a deeper programming bug, not missing data")
+    assert not isinstance(bug, _MISSING_SILICON_DATA_EXCEPTIONS)
+
+    missing = InterpolationDataNotAvailableError("axis has only 1 value")
+    assert isinstance(missing, _MISSING_SILICON_DATA_EXCEPTIONS)


### PR DESCRIPTION
#### Overview:

#1114/#1158 made the interpolation engine silently return wrong values (or crash uncaught) on insufficient perf-data slices. This makes it fail accurately instead — degenerate/missing slices raise `PerfDataNotAvailableError`, which sweep (skip) and HYBRID (empirical) already handle. No new recovery logic.

#### Details:

- Remove `allow_singleton_axes` (ContextAttention): it returned the `batch=1` latency for any batch. Now fails loudly like other ops.
- Cubic `QhullError` (previously escaped uncaught) → `ValueError`.
- Classify interpolation `ValueError` as missing silicon data so it surfaces as `PerfDataNotAvailableError`.

4 files, +12/−69. Doesn't touch the extrapolation warnings (ragged data → re-collection) or `fp8_static` (separate PR).

#### Where should the reviewer start?

`perf_database.py` (`_MISSING_SILICON_DATA_EXCEPTIONS`) and `interpolation.py`.

#### Related Issues:

Relates to #1114, #1158


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling for degenerate or missing interpolation data by introducing a dedicated `InterpolationDataNotAvailableError` (subclass of `ValueError`) for consistent reporting.
  * Performance-data lookups in silicon/hybrid modes now treat interpolation-data unavailability as missing data, matching existing fallback behavior.

* **Breaking Changes**
  * Stricter interpolation validation now enforces required axis coverage and rejects singleton-axis cases (the previous relaxed behavior is removed).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->