### PR TITLE
fix(rust-core): gate pyo3 auto-initialize behind feature flag

### DIFF
--- a/rust/aiconfigurator-core/Cargo.toml
+++ b/rust/aiconfigurator-core/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["rlib", "cdylib"]
 [dependencies]
 bincode = "1.3"
 parquet = { version = "55", default-features = false, features = ["zstd", "snap"] }
-pyo3 = { version = "0.23", features = ["abi3-py39", "auto-initialize"] }
+pyo3 = { version = "0.23", features = ["abi3-py39"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
@@ -29,6 +29,10 @@ thiserror = "2.0"
 # libpython (via `auto-initialize`) for the Rust->Python embedding path,
 # while the maturin-built `.so` skips libpython linkage.
 default = []
+# Enable when building as a standalone Rust binary that embeds Python
+# (cargo build / cargo test). Do NOT enable when used as a dep of a
+# PyO3 extension-module crate — maturin sets extension-module instead.
+embed-python = ["pyo3/auto-initialize"]
 
 [dev-dependencies]
 tempfile = "3.23"


### PR DESCRIPTION
auto-initialize must be turned off when this crate is used as a dep of a PyO3 extension module (e.g., dynamo lib/bindings/python). Move auto-initialize behind an embed-python feature, opt-in for standalone builds.
e.g. dynamo CI failure in https://github.com/ai-dynamo/dynamo/actions/runs/27564227131/job/81484124332?pr=10615


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for Python integration to provide improved flexibility across different deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->