### PR TITLE
fix: Align pyo3 abi3-py310 with requires-python >=3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,8 +103,8 @@ manifest-path = "rust/aiconfigurator-core/Cargo.toml"
 module-name = "aiconfigurator_core._aiconfigurator_core"
 # Pure-Python sources live under src/ (src-layout).
 python-source = "src"
-# Build an abi3 wheel (single wheel valid across Py 3.9+, matching the
-# pyo3 `abi3-py39` feature).
+# Build an abi3 wheel (single wheel valid across Py 3.10+, matching the
+# requires-python = ">=3.10" and the pyo3 `abi3-py310` feature).
 abi3 = true
 # Enable the extension-module feature ONLY for the maturin/wheel build.
 # `cargo build`/`cargo test` keep linking libpython (auto-initialize) for the

--- a/rust/aiconfigurator-core/Cargo.toml
+++ b/rust/aiconfigurator-core/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["rlib", "cdylib"]
 [dependencies]
 bincode = "1.3"
 parquet = { version = "55", default-features = false, features = ["zstd", "snap"] }
-pyo3 = { version = "0.23", features = ["abi3-py39"] }
+pyo3 = { version = "0.23", features = ["abi3-py310"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"


### PR DESCRIPTION
#### Overview:
Align pyo3 abi3-py310 with requires-python >=3.10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Python version baseline from 3.9 to 3.10 across package configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->