### PR TITLE
feat(cli): add --log-level flag and AICONFIGURATOR_LOG_LEVEL env var

### DIFF
--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -86,13 +86,12 @@ def _latest_support_matrix_version(
 
 def _build_common_cli_parser() -> argparse.ArgumentParser:
     common_parser = argparse.ArgumentParser(add_help=False)
-    common_parser.add_argument("--debug", action="store_true", help="Enable debug mode.")
     common_parser.add_argument(
         "--log-level",
         type=str.upper,
         default=None,
         choices=["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"],
-        help=("Set the minimum log level (overrides --debug and the AICONFIGURATOR_LOG_LEVEL env var). Default: INFO."),
+        help=("Set the minimum log level. Priority: --log-level > AICONFIGURATOR_LOG_LEVEL > INFO."),
     )
     common_parser.add_argument(
         "--no-color",
@@ -2172,12 +2171,15 @@ def _run_estimate_mode(args):
 
 
 def _resolve_cli_log_level(args) -> int:
-    """Pick the log level with priority: --log-level > --debug > INFO."""
+    """Pick the log level with priority: --log-level > AICONFIGURATOR_LOG_LEVEL > INFO."""
     cli_level = getattr(args, "log_level", None)
     if cli_level:
         return getattr(logging, cli_level)
-    if getattr(args, "debug", False):
-        return logging.DEBUG
+    env_level = os.environ.get("AICONFIGURATOR_LOG_LEVEL")
+    if env_level:
+        resolved = env_level.strip().upper()
+        if resolved in {"CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"}:
+            return getattr(logging, resolved)
     return logging.INFO
 
 

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -88,6 +88,13 @@ def _build_common_cli_parser() -> argparse.ArgumentParser:
     common_parser = argparse.ArgumentParser(add_help=False)
     common_parser.add_argument("--debug", action="store_true", help="Enable debug mode.")
     common_parser.add_argument(
+        "--log-level",
+        type=str.upper,
+        default=None,
+        choices=["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"],
+        help=("Set the minimum log level (overrides --debug and the AICONFIGURATOR_LOG_LEVEL env var). Default: INFO."),
+    )
+    common_parser.add_argument(
         "--no-color",
         dest="no_color",
         action="store_true",
@@ -2164,9 +2171,19 @@ def _run_estimate_mode(args):
     print()
 
 
+def _resolve_cli_log_level(args) -> int:
+    """Pick the log level with priority: --log-level > --debug > INFO."""
+    cli_level = getattr(args, "log_level", None)
+    if cli_level:
+        return getattr(logging, cli_level)
+    if getattr(args, "debug", False):
+        return logging.DEBUG
+    return logging.INFO
+
+
 def main(args):
     setup_logging(
-        level=logging.DEBUG if args.debug else logging.INFO,
+        level=_resolve_cli_log_level(args),
         no_color=getattr(args, "no_color", False),
     )
 

--- a/src/aiconfigurator/logging_utils.py
+++ b/src/aiconfigurator/logging_utils.py
@@ -7,6 +7,41 @@ import logging
 import os
 import sys
 
+LOG_LEVEL_ENV = "AICONFIGURATOR_LOG_LEVEL"
+
+_LOG_LEVEL_NAMES = {
+    "CRITICAL": logging.CRITICAL,
+    "ERROR": logging.ERROR,
+    "WARNING": logging.WARNING,
+    "INFO": logging.INFO,
+    "DEBUG": logging.DEBUG,
+    "NOTSET": logging.NOTSET,
+}
+
+
+def _parse_log_level(value):
+    """Resolve a log level from a name (case-insensitive) or numeric value.
+
+    Returns the resolved ``logging`` level, or ``None`` if ``value`` is unset
+    or unrecognised.
+    """
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    name = str(value).strip().upper()
+    if name in _LOG_LEVEL_NAMES:
+        return _LOG_LEVEL_NAMES[name]
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _resolve_log_level(default):
+    """Pick a level using the ``AICONFIGURATOR_LOG_LEVEL`` env var if set."""
+    return _parse_log_level(os.environ.get(LOG_LEVEL_ENV)) or default
+
 
 def _stdout_env_suggests_plain() -> bool:
     """True when NO_COLOR or non-TTY stdout indicates avoiding ANSI."""
@@ -128,13 +163,15 @@ def setup_logging(level=logging.INFO, *, no_color: bool = False):
     """Configure root logging to stdout.
 
     Args:
-        level: Minimum log level for the root logger.
+        level: Minimum log level for the root logger. Overridden by the
+            ``AICONFIGURATOR_LOG_LEVEL`` environment variable when set (e.g.
+            ``AICONFIGURATOR_LOG_LEVEL=WARNING``).
         no_color: If True (CLI --no-color), disable ANSI in log lines and treat all
             CLI summaries as plain; see use_plain_cli_output. TTY and NO_COLOR
             are combined inside ColoredFormatter and use_plain_cli_output.
     """
     root_logger = logging.getLogger()
-    root_logger.setLevel(level)
+    root_logger.setLevel(_resolve_log_level(level))
 
     # Remove existing handlers
     root_logger.handlers.clear()

--- a/src/aiconfigurator/logging_utils.py
+++ b/src/aiconfigurator/logging_utils.py
@@ -7,41 +7,6 @@ import logging
 import os
 import sys
 
-LOG_LEVEL_ENV = "AICONFIGURATOR_LOG_LEVEL"
-
-_LOG_LEVEL_NAMES = {
-    "CRITICAL": logging.CRITICAL,
-    "ERROR": logging.ERROR,
-    "WARNING": logging.WARNING,
-    "INFO": logging.INFO,
-    "DEBUG": logging.DEBUG,
-    "NOTSET": logging.NOTSET,
-}
-
-
-def _parse_log_level(value):
-    """Resolve a log level from a name (case-insensitive) or numeric value.
-
-    Returns the resolved ``logging`` level, or ``None`` if ``value`` is unset
-    or unrecognised.
-    """
-    if value is None:
-        return None
-    if isinstance(value, int):
-        return value
-    name = str(value).strip().upper()
-    if name in _LOG_LEVEL_NAMES:
-        return _LOG_LEVEL_NAMES[name]
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return None
-
-
-def _resolve_log_level(default):
-    """Pick a level using the ``AICONFIGURATOR_LOG_LEVEL`` env var if set."""
-    return _parse_log_level(os.environ.get(LOG_LEVEL_ENV)) or default
-
 
 def _stdout_env_suggests_plain() -> bool:
     """True when NO_COLOR or non-TTY stdout indicates avoiding ANSI."""
@@ -163,15 +128,13 @@ def setup_logging(level=logging.INFO, *, no_color: bool = False):
     """Configure root logging to stdout.
 
     Args:
-        level: Minimum log level for the root logger. Overridden by the
-            ``AICONFIGURATOR_LOG_LEVEL`` environment variable when set (e.g.
-            ``AICONFIGURATOR_LOG_LEVEL=WARNING``).
+        level: Minimum log level for the root logger.
         no_color: If True (CLI --no-color), disable ANSI in log lines and treat all
             CLI summaries as plain; see use_plain_cli_output. TTY and NO_COLOR
             are combined inside ColoredFormatter and use_plain_cli_output.
     """
     root_logger = logging.getLogger()
-    root_logger.setLevel(_resolve_log_level(level))
+    root_logger.setLevel(level)
 
     # Remove existing handlers
     root_logger.handlers.clear()

--- a/tests/unit/cli/test_argument_parsing.py
+++ b/tests/unit/cli/test_argument_parsing.py
@@ -107,7 +107,7 @@ class TestCLIArgumentParsing:
         assert args.backend == common.BackendName.trtllm.value
         assert args.backend_version is None
         assert args.database_mode == common.DatabaseMode.SILICON.name
-        assert args.debug is False
+        assert args.log_level is None
         assert args.decode_system is None
         assert args.generated_config_version is None
         assert args.generator_dynamo_version is None
@@ -131,8 +131,8 @@ class TestCLIArgumentParsing:
         args = cli_parser.parse_args(["exp", "--yaml-path", str(mock_exp_yaml_path), "--inclusive-tpot"])
         assert args.inclusive_tpot is True
 
-    def test_debug_mode_flag(self, cli_parser):
-        """Test that debug mode can be enabled."""
+    def test_log_level_flag(self, cli_parser):
+        """Test that --log-level is parsed and normalized."""
         args = cli_parser.parse_args(
             [
                 "default",
@@ -142,11 +142,12 @@ class TestCLIArgumentParsing:
                 "8",
                 "--system",
                 "h200_sxm",
-                "--debug",
+                "--log-level",
+                "debug",
             ]
         )
 
-        assert args.debug is True
+        assert args.log_level == "DEBUG"
 
     def test_engine_step_backend_flag(self, cli_parser):
         """Test that the experimental engine step backend can be selected."""

--- a/tests/unit/cli/test_cli_workflow.py
+++ b/tests/unit/cli/test_cli_workflow.py
@@ -17,6 +17,7 @@ import pytest
 
 from aiconfigurator.cli.main import (
     _execute_tasks,
+    _resolve_cli_log_level,
     build_default_tasks,
     build_experiment_tasks,
     configure_parser,
@@ -26,6 +27,28 @@ from aiconfigurator.cli.report_and_save import _apply_inclusive_tpot
 from aiconfigurator.sdk.errors import NoFeasibleConfigError
 
 pytestmark = pytest.mark.unit
+
+
+class TestCLILogLevelResolution:
+    def test_defaults_to_info(self, monkeypatch) -> None:
+        monkeypatch.delenv("AICONFIGURATOR_LOG_LEVEL", raising=False)
+        args = argparse.Namespace(log_level=None)
+        assert _resolve_cli_log_level(args) == logging.INFO
+
+    def test_env_var_controls_level(self, monkeypatch) -> None:
+        monkeypatch.setenv("AICONFIGURATOR_LOG_LEVEL", "debug")
+        args = argparse.Namespace(log_level=None)
+        assert _resolve_cli_log_level(args) == logging.DEBUG
+
+    def test_cli_flag_overrides_env_var(self, monkeypatch) -> None:
+        monkeypatch.setenv("AICONFIGURATOR_LOG_LEVEL", "warning")
+        args = argparse.Namespace(log_level="DEBUG")
+        assert _resolve_cli_log_level(args) == logging.DEBUG
+
+    def test_invalid_env_var_falls_back_to_info(self, monkeypatch) -> None:
+        monkeypatch.setenv("AICONFIGURATOR_LOG_LEVEL", "not-a-level")
+        args = argparse.Namespace(log_level=None)
+        assert _resolve_cli_log_level(args) == logging.INFO
 
 
 class TestCLIIntegration:


### PR DESCRIPTION
Background:

default output is too loooooooooong
```
 python3 -m uv run aiconfigurator cli estimate \
    --estimate-mode static_ctx \
    --system b300_sxm --backend vllm \
    --model nvidia/GLM-5-NVFP4 \
    --isl 16000 --osl 1 \
    --tp 2 --dp 1 --etp 2 --ep 1 \
    --batch-size 8 \
    --gemm-quant-mode nvfp4 --moe-quant-mode nvfp4 --kvcache-quant-mode fp8
17:09:13 [aiconfigurator] [main.py:1978] [I] Loading AIConfigurator version: 0.9.0
17:09:13 [aiconfigurator] [main.py:1979] [I] Number of top configurations to output: 5 (change with --top-n)
17:09:13 [aiconfigurator] [main.py:1789] [I] Estimating performance (static_ctx) for nvidia/GLM-5-NVFP4 on b300_sxm (backend=vllm, tp=2, bs=8)
17:09:13 [aiconfigurator] [utils.py:1047] [I] Quant inference result: quant_algo=nvfp4, kv_cache_quant_algo=fp8, quant_dynamic=None
17:09:13 [aiconfigurator] [utils.py:1154] [I] Loaded model config for nvidia/GLM-5-NVFP4: architecture=GlmMoeDsaForCausalLM, layers=78, n=64, n_kv=64, d=64, hidden_size=6144, inter_size=12288, vocab=154880, context=202752, topk=8, num_experts=256, moe_inter_size=2048, extra_params={'q_lora_rank': 2048, 'kv_lora_rank': 512, 'qk_nope_head_dim': 192, 'qk_rope_head_dim': 64, 'v_head_dim': 256, 'index_head_dim': 128, 'index_n_heads': 32, 'index_topk': 2048}
17:09:13 [aiconfigurator] [helpers.py:183] [I] Resolved quant modes for GlmMoeDsaForCausalLM: gemm=GEMMQuantMode.nvfp4 moe=MoEQuantMode.nvfp4 kvcache=KVCacheQuantMode.fp8 fmha=FMHAQuantMode.bfloat16 comm=CommQuantMode.half
17:09:13 [aiconfigurator] [perf_database.py:384] [I] Loading database for system='b300_sxm', backend='vllm', version='0.19.0'
17:09:14 [aiconfigurator] [interpolation.py:697] [W] Skipping interpolation for z=51200 as it does not exist in both y_left=16384 and y_right=51200
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=20480
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=24576
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=28672
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=32768
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=40960
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=49152
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=51200
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=57344
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=65536
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=131072
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=262144
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=20480
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=24576
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=28672
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=32768
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=40960
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=49152
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=51200
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=57344
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=65536
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=131072
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=262144
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=20480
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=24576
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=28672
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=32768
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=40960
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=49152
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=51200
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=57344
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=65536
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=131072
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=262144
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=20480
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=24576
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=28672
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=32768
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=40960
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=49152
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=51200
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=57344
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=65536
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=131072
17:09:14 [aiconfigurator] [interpolation.py:764] [W] Skipping interpolation for z=51200 as it does not exist in both x_left=16384 and x_right=32768 for y=262144

============================================================
  Performance Estimate (static_ctx)
============================================================
  Model:            nvidia/GLM-5-NVFP4
  System:           b300_sxm
  Backend:          vllm (0.19.0)
------------------------------------------------------------
  ISL:              16000
  OSL:              1
  Batch Size:       8
  TP Size:          2
  PP Size:          1
------------------------------------------------------------
  TTFT:             9226.152 ms
  Power (per GPU):  0.0 W
------------------------------------------------------------
  tokens/s:         0.87
  tokens/s/gpu:     0.43
  tokens/s/user:    0.00
  seq/s:            0.867
  Concurrency:      8
  Memory (GPU):     256.05 GB
============================================================
```







#### Overview:

Add a way to control the CLI log level so noisy `[I]` info lines can be silenced
without recompiling. Two equivalent ways to set it:

- `--log-level WARNING` on every subcommand
- `AICONFIGURATOR_LOG_LEVEL=WARNING` env var

Useful when piping the CLI into a script/CI log and you only want warnings
and errors to show up.

#### Details:

- New `AICONFIGURATOR_LOG_LEVEL` env var is read by `setup_logging()` in
  `src/aiconfigurator/logging_utils.py`. Names are case-insensitive
  (`DEBUG`/`INFO`/`WARNING`/`ERROR`/`CRITICAL`); numeric values are also
  accepted. Unknown values are ignored, so a typo in the env var does not
  change the default.
- New `--log-level {CRITICAL,ERROR,WARNING,INFO,DEBUG}` flag on the common
  CLI parser in `src/aiconfigurator/cli/main.py`. It is accepted by every
  subcommand (`default`/`exp`/`generate`/`estimate`/`support`) because it
  lives on the shared parent parser.
- Resolution priority: `--log-level` > env var > `--debug` > default `INFO`.
  `--debug` is kept for backward compatibility and now means "no `--log-level`
  was given, force DEBUG".

#### Where should the reviewer start?

- `src/aiconfigurator/logging_utils.py` (env var resolution)
- `src/aiconfigurator/cli/main.py` (`--log-level` arg + priority logic in `main()`)

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a `--log-level` CLI option to control logging verbosity.
  * Added support for `AICONFIGURATOR_LOG_LEVEL` to set the default log level.

* **Behavior Changes**
  * Logging level now follows a clear priority order: `--log-level` overrides `AICONFIGURATOR_LOG_LEVEL`, otherwise defaults to `INFO`.
  * Removed the previous `--debug` flag in favor of `--log-level`.

* **Tests**
  * Updated CLI parsing and workflow tests to validate the new log-level behavior (including invalid environment values).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->