### PR TITLE
feat: enhance case generator for attention and GEMM model sweeps

### DIFF
--- a/collector/case_generator.py
+++ b/collector/case_generator.py
@@ -95,17 +95,118 @@ def get_merged_base_op_case_specs(backend: str, op_name: str) -> list[dict[str, 
 
 def get_attention_context_shape_sweeps(backend: str) -> list[dict[str, object]]:
     """Return YAML-backed context attention shape sweeps for one backend."""
-    return get_merged_base_op_case_specs(backend, "attention_context")
+    return [
+        *get_merged_base_op_case_specs(backend, "attention_context"),
+        *get_attention_context_model_sweeps(backend),
+    ]
 
 
 def get_attention_generation_shape_sweeps(backend: str) -> list[dict[str, object]]:
     """Return YAML-backed generation attention shape sweeps for one backend."""
-    return get_merged_base_op_case_specs(backend, "attention_generation")
+    return [
+        *get_merged_base_op_case_specs(backend, "attention_generation"),
+        *get_attention_generation_model_sweeps(backend),
+    ]
 
 
 def get_attention_encoder_shape_sweeps(backend: str) -> list[dict[str, object]]:
     """Return YAML-backed encoder (non-causal) attention shape sweeps for one backend."""
-    return get_merged_base_op_case_specs(backend, "attention_encoder")
+    return [
+        *get_merged_base_op_case_specs(backend, "attention_encoder"),
+        *get_attention_encoder_model_sweeps(backend),
+    ]
+
+
+# Per-model entry metadata that must not leak into generated shape-sweep dicts:
+# ``model_path`` drives COLLECTOR_MODEL_PATH filtering and ``architecture`` is
+# auto-injected by ``_model_case_values``. Neither is a shape dimension.
+_MODEL_METADATA_FIELDS = frozenset({"model_path", "architecture"})
+
+
+def _sanitize_sweep_id(value: str) -> str:
+    return "".join(char if char.isalnum() else "_" for char in str(value))
+
+
+def _normalize_attention_model_entry(entry: dict, *, op_name: str) -> dict[str, object]:
+    """Map a per-model attention entry onto phase-specific sweep keys.
+
+    A generic ``query_head_counts`` fans out to the field each phase's collector
+    actually reads: generation needs both ``mha_query_head_counts`` and
+    ``xqa_query_head_counts``; encoder reads ``head_counts``; context reads
+    ``query_head_counts`` directly. This keeps a uniform ``query_head_counts``
+    field across all three attention phases in model YAML. Explicit phase-specific
+    keys win over the generic one. Every other key (batch/sequence sweeps, kv
+    heads, head dims, window sizes, precision cases, and token-budget cap
+    overrides) passes through unchanged so it overlays the inherited base template.
+    """
+    overrides = {key: value for key, value in entry.items() if key not in _MODEL_METADATA_FIELDS}
+    generic_query_heads = overrides.pop("query_head_counts", None)
+    if generic_query_heads is None:
+        return overrides
+
+    if op_name == "attention_context":
+        overrides["query_head_counts"] = generic_query_heads
+    elif op_name == "attention_generation":
+        overrides.setdefault("mha_query_head_counts", generic_query_heads)
+        overrides.setdefault("xqa_query_head_counts", generic_query_heads)
+    elif op_name == "attention_encoder":
+        overrides.setdefault("head_counts", generic_query_heads)
+    else:
+        raise ValueError(f"unsupported attention op_name: {op_name!r}")
+    return overrides
+
+
+def _attention_model_shape_sweeps(backend: str, op_name: str) -> list[dict[str, object]]:
+    """Build per-model attention sweeps by overlaying model dims on the base template.
+
+    Each sweep starts as a deep copy of the per-backend merged base template, so
+    backend-correct caps, ``precision_cases`` (trtllm/sglang) and ``window_sizes``
+    (vllm) are inherited; a model entry may override any of them. Entries honor
+    ``COLLECTOR_MODEL_PATH`` via ``_model_case_values``.
+    """
+    entries = _model_case_values(op_name)
+    if not entries:
+        return []
+    base_specs = get_merged_base_op_case_specs(backend, op_name)
+    if len(base_specs) != 1:
+        raise RuntimeError(
+            f"{op_name}: per-model attention sweeps assume exactly one base sweep template, "
+            f"found {len(base_specs)} for backend={backend}. Add explicit handling if a second "
+            "base sweep is introduced."
+        )
+    template = base_specs[0]
+
+    sweeps: list[dict[str, object]] = []
+    seen: set[str] = set()
+    for entry in entries:
+        overrides = _normalize_attention_model_entry(entry, op_name=op_name)
+        sweep = copy.deepcopy(template)
+        sweep.update(overrides)
+        label = entry.get("model_path") or entry.get("architecture") or "model"
+        sweep["id"] = f"model_{_sanitize_sweep_id(label)}_{op_name}"
+        # Drop exact-duplicate sweeps (same content ignoring id) from multiple
+        # model files declaring identical dimensions.
+        dedupe_key = repr(sorted((key, repr(value)) for key, value in sweep.items() if key != "id"))
+        if dedupe_key in seen:
+            continue
+        seen.add(dedupe_key)
+        sweeps.append(sweep)
+    return sweeps
+
+
+def get_attention_context_model_sweeps(backend: str) -> list[dict[str, object]]:
+    """Return per-model context attention shape sweeps for one backend."""
+    return _attention_model_shape_sweeps(backend, "attention_context")
+
+
+def get_attention_generation_model_sweeps(backend: str) -> list[dict[str, object]]:
+    """Return per-model generation attention shape sweeps for one backend."""
+    return _attention_model_shape_sweeps(backend, "attention_generation")
+
+
+def get_attention_encoder_model_sweeps(backend: str) -> list[dict[str, object]]:
+    """Return per-model encoder attention shape sweeps for one backend."""
+    return _attention_model_shape_sweeps(backend, "attention_encoder")
 
 
 def get_base_common_case_values(name: str) -> dict[str, object]:
@@ -999,9 +1100,42 @@ def _get_base_gemm_shape_sweeps(backend: str | None = None) -> list[dict[str, ob
     return shape_sweeps
 
 
+def _gemm_model_shape_sweeps(backend: str | None = None) -> list[dict[str, object]]:
+    """Return per-model GEMM shape sweeps from ``model_case_values.gemm``.
+
+    Each model entry is a GEMM shape-sweep dict (``feature_sizes`` shorthand or
+    explicit ``input_feature_sizes``/``output_feature_sizes``, optional
+    ``token_counts``/``skip_shapes``). ``token_counts`` is inherited from the
+    base GEMM sweep when the entry omits it, so a model only needs to declare its
+    projection feature shapes. Entries honor ``COLLECTOR_MODEL_PATH`` via
+    ``_model_case_values``; ``model_path``/``architecture`` metadata is stripped.
+    """
+    entries = _model_case_values("gemm")
+    if not entries:
+        return []
+
+    base_sweeps = _get_base_gemm_shape_sweeps(backend)
+    if len(base_sweeps) != 1:
+        raise RuntimeError(
+            f"gemm: per-model GEMM sweeps assume exactly one base GEMM sweep template, "
+            f"found {len(base_sweeps)} for backend={backend}."
+        )
+
+    default_token_counts = base_sweeps[0].get("token_counts")
+
+    sweeps: list[dict[str, object]] = []
+    for entry in entries:
+        sweep = {key: value for key, value in entry.items() if key not in _MODEL_METADATA_FIELDS}
+        if "token_counts" not in sweep and default_token_counts is not None:
+            sweep["token_counts"] = list(default_token_counts)
+        sweeps.append(sweep)
+    return sweeps
+
+
 def get_gemm_case_specs(backend: str | None = None) -> list[GemmCommonTestCase]:
     test_cases = []
-    for shape_sweep in _get_base_gemm_shape_sweeps(backend):
+    seen: set[tuple[int, int, int]] = set()
+    for shape_sweep in [*_get_base_gemm_shape_sweeps(backend), *_gemm_model_shape_sweeps(backend)]:
         token_counts = _as_int_list(shape_sweep.get("token_counts"), field_name="gemm.token_counts")
         feature_sizes = shape_sweep.get("feature_sizes")
         input_feature_sizes = _as_int_list(
@@ -1023,6 +1157,12 @@ def get_gemm_case_specs(backend: str | None = None) -> list[GemmCommonTestCase]:
                         continue
                     if output_features * input_features == 65536 * 65536:
                         continue
+
+                    # Do not duplicate cases covered in the base grid.
+                    key = (token_count, output_features, input_features)
+                    if key in seen:
+                        continue
+                    seen.add(key)
                     test_cases.append(GemmCommonTestCase(x=token_count, n=output_features, k=input_features))
 
     return test_cases

--- a/collector/case_generator.py
+++ b/collector/case_generator.py
@@ -176,17 +176,22 @@ def _attention_model_shape_sweeps(backend: str, op_name: str) -> list[dict[str, 
         )
     template = base_specs[0]
 
+    def _dedupe_key(sweep_dict: dict[str, object]) -> str:
+        return repr(sorted((key, repr(value)) for key, value in sweep_dict.items() if key != "id"))
+
     sweeps: list[dict[str, object]] = []
-    seen: set[str] = set()
+    # Seed with the base template so an overlay that changes nothing (already
+    # covered by the base sweep) is not emitted as a redundant duplicate.
+    seen: set[str] = {_dedupe_key(template)}
     for entry in entries:
         overrides = _normalize_attention_model_entry(entry, op_name=op_name)
         sweep = copy.deepcopy(template)
         sweep.update(overrides)
         label = entry.get("model_path") or entry.get("architecture") or "model"
         sweep["id"] = f"model_{_sanitize_sweep_id(label)}_{op_name}"
-        # Drop exact-duplicate sweeps (same content ignoring id) from multiple
-        # model files declaring identical dimensions.
-        dedupe_key = repr(sorted((key, repr(value)) for key, value in sweep.items() if key != "id"))
+        # Drop exact-duplicate sweeps (same content ignoring id): both overlays
+        # identical to the base template and identical entries across model files.
+        dedupe_key = _dedupe_key(sweep)
         if dedupe_key in seen:
             continue
         seen.add(dedupe_key)

--- a/collector/cases/README.md
+++ b/collector/cases/README.md
@@ -98,6 +98,64 @@ framework_specific_model_case_values:
         activation: silu
 ```
 
+### Model Dimensions for GEMM and Attention
+
+`gemm`, `attention_context`, `attention_generation`, and `attention_encoder`
+also accept `model_case_values` blocks. Unlike MoE/MLA, these ops have a large
+shared model-agnostic grid in `base_ops/`; a model entry simply *adds* its own
+shape points on top of that grid. Entries are filtered by `COLLECTOR_MODEL_PATH`
+when set, so a single-model run only adds that model's shapes. The shared generic
+grid is still generated.
+
+GEMM entries are GEMM shape-sweep dicts. `token_counts` (the M dimension) is
+inherited from the base GEMM sweep when omitted, so a model only needs its
+projection feature shapes (`feature_sizes` shorthand, or explicit
+`input_feature_sizes` = K and `output_feature_sizes` = N):
+
+```yaml
+model_case_values:
+  gemm:
+    - model_paths: [org/MyModel]
+      output_feature_sizes: [4096, 12288]
+      input_feature_sizes: [7168]
+      # token_counts: [...]   # optional; omit to inherit base
+```
+
+Attention entries overlay onto the per-backend merged base sweep, so caps,
+`precision_cases` (trtllm/sglang) and `window_sizes` (vllm) are inherited unless
+the entry overrides them. A generic `query_head_counts` is mapped to the field
+each phase actually reads (uniform across phases in model YAML): context keeps
+`query_head_counts`; generation fans it out to both `mha_query_head_counts` and
+`xqa_query_head_counts` (explicit `mha_*`/`xqa_*` win); encoder maps it to
+`head_counts`.
+
+```yaml
+model_case_values:
+  attention_context:
+    - model_path: org/MyModel
+      query_head_counts: [64]
+      kv_head_options: [8]        # `self`/`0` means num_kv_heads == query heads
+      head_dims: [192]
+      window_sizes: [0, 4096]
+      sequence_lengths: [1024, 8192]
+      precision_cases:            # optional; omit to inherit base
+        - {id: bf16, fp8_kv_cache: false, fp8_context_fmha: false}
+  attention_generation:
+    - model_path: org/MyModel
+      query_head_counts: [64]     # -> both mha and xqa head counts
+      kv_head_counts: [8]
+      head_dims: [192]
+```
+
+Caps behavior: a model entry may override token-budget caps in its own block
+(`max_tokens_self_attention`, `max_tokens_grouped_query_attention`,
+`max_mha_tokens_per_step`, `max_xqa_tokens_per_step`, `max_kv_elements`,
+`max_batch_size_self_attention`, `drop_largest_sequence_for_batch_at_least`,
+`min_batch_options_per_sequence`). The hardware `m_num_heads_q_per_kv`
+CTA-divisibility check and the SM/version `_skip_*` guards live in the backend
+collectors and always apply; they cannot be relaxed from YAML because they are
+correctness guards, not budget heuristics.
+
 ## Base Op Files
 
 Shared sweep recipes live in per-op files under `base_ops/<op>.yaml`. For

--- a/tests/unit/collector/test_model_attention_gemm_cases.py
+++ b/tests/unit/collector/test_model_attention_gemm_cases.py
@@ -1,0 +1,385 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for per-model GEMM/attention shape injection in ``case_generator``.
+
+These cover the lean/additive feature: model files declare
+``model_case_values.{gemm,attention_context,attention_generation,attention_encoder}``
+blocks that are appended to the model-agnostic base grid (filtered by
+``COLLECTOR_MODEL_PATH``), with attention entries overlaying the per-backend base
+template so caps / precision_cases / window_sizes are inherited. The tests are
+GPU-free: they exercise ``collector.case_generator`` directly and inject
+synthetic model data by monkeypatching the model-cases loader.
+"""
+
+import pytest
+
+from collector import case_generator
+from collector.case_generator import GemmCommonTestCase
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _clear_model_path(monkeypatch):
+    """Do not inherit COLLECTOR_MODEL_PATH from the env."""
+    monkeypatch.delenv("COLLECTOR_MODEL_PATH", raising=False)
+
+
+@pytest.fixture
+def gemm_base_only(monkeypatch) -> list[GemmCommonTestCase]:
+    """Base-only GEMM specs (no model data), for additive/prefix assertions."""
+    with monkeypatch.context() as m:
+        m.setattr(case_generator, "_load_model_cases_data", lambda: ())
+        return case_generator.get_gemm_case_specs("vllm")
+
+
+def _set_model_cases(monkeypatch, *model_dicts: dict) -> None:
+    """Replace the model-cases loader with synthetic data and clear the filter."""
+    monkeypatch.delenv("COLLECTOR_MODEL_PATH", raising=False)
+    monkeypatch.setattr(case_generator, "_load_model_cases_data", lambda: tuple(model_dicts))
+
+
+def _model_file(model_path: str, **model_case_values: object) -> dict:
+    return {
+        "architecture": "SyntheticArch",
+        "model_path": model_path,
+        "model_case_values": dict(model_case_values),
+    }
+
+
+# ---------------------------------------------------------------------------
+# GEMM
+# ---------------------------------------------------------------------------
+
+
+def test_gemm_model_shapes_are_appended_and_inherit_token_counts(monkeypatch, gemm_base_only):
+    _set_model_cases(
+        monkeypatch,
+        _model_file("org/M", gemm=[{"output_feature_sizes": [99], "input_feature_sizes": [77]}]),
+    )
+
+    with_model = case_generator.get_gemm_case_specs("vllm")
+
+    # Base grid is preserved verbatim as a prefix; model shapes are appended.
+    assert with_model[: len(gemm_base_only)] == gemm_base_only
+    assert len(with_model) > len(gemm_base_only)
+
+    # token_counts inherited from base -> every base M value emitted for (99, 77).
+    base_x = {case.x for case in gemm_base_only}
+    model_x = {case.x for case in with_model if case.n == 99 and case.k == 77}
+    assert model_x == base_x
+    assert GemmCommonTestCase(x=1, n=99, k=77) in with_model
+
+
+def test_gemm_model_explicit_token_counts_override(monkeypatch):
+    _set_model_cases(
+        monkeypatch,
+        _model_file(
+            "org/M",
+            gemm=[{"output_feature_sizes": [99], "input_feature_sizes": [77], "token_counts": [3, 5]}],
+        ),
+    )
+
+    cases = case_generator.get_gemm_case_specs("vllm")
+    model_x = {case.x for case in cases if case.n == 99 and case.k == 77}
+    assert model_x == {3, 5}
+
+
+def test_gemm_model_feature_sizes_shorthand(monkeypatch):
+    _set_model_cases(monkeypatch, _model_file("org/M", gemm=[{"feature_sizes": [99]}]))
+
+    cases = case_generator.get_gemm_case_specs("vllm")
+    assert any(case.n == 99 and case.k == 99 for case in cases)
+
+
+def test_gemm_model_shapes_reach_all_backends(monkeypatch):
+    _set_model_cases(
+        monkeypatch,
+        _model_file("org/M", gemm=[{"output_feature_sizes": [99], "input_feature_sizes": [77]}]),
+    )
+
+    for backend in (None, "trtllm", "vllm", "sglang", "vllm_xpu"):
+        cases = case_generator.get_gemm_case_specs(backend)
+        assert any(case.n == 99 and case.k == 77 for case in cases), backend
+
+
+def test_gemm_model_shapes_filtered_by_collector_model_path(monkeypatch):
+    monkeypatch.setattr(
+        case_generator,
+        "_load_model_cases_data",
+        lambda: (
+            _model_file(
+                "org/A", gemm=[{"model_path": "org/A", "output_feature_sizes": [99], "input_feature_sizes": [77]}]
+            ),
+            _model_file(
+                "org/B", gemm=[{"model_path": "org/B", "output_feature_sizes": [55], "input_feature_sizes": [33]}]
+            ),
+        ),
+    )
+    monkeypatch.setenv("COLLECTOR_MODEL_PATH", "org/A")
+
+    cases = case_generator.get_gemm_case_specs("vllm")
+    assert any(case.n == 99 and case.k == 77 for case in cases)
+    assert not any(case.n == 55 and case.k == 33 for case in cases)
+
+
+def test_gemm_model_shapes_dedupe_against_base(monkeypatch, gemm_base_only):
+    # 4096 x 7168 are both on the base feature grid, so the model entry is fully
+    # redundant and must not add duplicate (x, n, k) cases.
+    _set_model_cases(
+        monkeypatch,
+        _model_file("org/M", gemm=[{"output_feature_sizes": [4096], "input_feature_sizes": [7168]}]),
+    )
+    with_model = case_generator.get_gemm_case_specs("vllm")
+    assert with_model == gemm_base_only
+
+
+def test_gemm_model_paths_plural_expansion(monkeypatch):
+    _set_model_cases(
+        monkeypatch,
+        _model_file(
+            "org/primary",
+            gemm=[{"model_paths": ["org/a", "org/b"], "output_feature_sizes": [99], "input_feature_sizes": [77]}],
+        ),
+    )
+    # No filter -> the shape is present once (deduped across both aliases).
+    cases = case_generator.get_gemm_case_specs("vllm")
+    assert any(case.n == 99 and case.k == 77 for case in cases)
+
+    # Filter to one alias -> still present.
+    monkeypatch.setenv("COLLECTOR_MODEL_PATH", "org/b")
+    cases_b = case_generator.get_gemm_case_specs("vllm")
+    assert any(case.n == 99 and case.k == 77 for case in cases_b)
+
+
+# ---------------------------------------------------------------------------
+# Attention context
+# ---------------------------------------------------------------------------
+
+
+def test_attention_context_model_sweep_inherits_caps_and_window(monkeypatch):
+    _set_model_cases(
+        monkeypatch,
+        _model_file(
+            "org/M",
+            attention_context=[
+                {
+                    "model_path": "org/M",
+                    "query_head_counts": [64],
+                    "kv_head_options": [8],
+                    "head_dims": [192],
+                    "sequence_lengths": [1024, 8192],
+                }
+            ],
+        ),
+    )
+
+    sweeps = case_generator.get_attention_context_model_sweeps("vllm")
+    assert len(sweeps) == 1
+    sweep = sweeps[0]
+    base = case_generator.get_merged_base_op_case_specs("vllm", "attention_context")[0]
+
+    assert sweep["id"].startswith("model_")
+    assert sweep["query_head_counts"] == [64]
+    assert sweep["head_dims"] == [192]
+    # Caps and window_sizes (vllm-required) inherited from the base template.
+    assert sweep["max_tokens_self_attention"] == base["max_tokens_self_attention"]
+    assert sweep["window_sizes"] == base["window_sizes"]
+    # Metadata (entry model_path + file-injected architecture) is stripped, not leaked.
+    assert "model_path" not in sweep
+    assert "architecture" not in sweep
+
+
+@pytest.mark.parametrize("backend", ["trtllm", "sglang"])
+def test_attention_context_model_sweep_carries_precision_cases(monkeypatch, backend):
+    _set_model_cases(
+        monkeypatch,
+        _model_file("org/M", attention_context=[{"query_head_counts": [64], "head_dims": [192]}]),
+    )
+
+    sweep = case_generator.get_attention_context_model_sweeps(backend)[0]
+    base = case_generator.get_merged_base_op_case_specs(backend, "attention_context")[0]
+    assert sweep["precision_cases"] == base["precision_cases"]
+
+
+def test_attention_context_cap_override(monkeypatch):
+    _set_model_cases(
+        monkeypatch,
+        _model_file(
+            "org/M",
+            attention_context=[{"query_head_counts": [64], "head_dims": [192], "max_tokens_self_attention": 999}],
+        ),
+    )
+    sweep = case_generator.get_attention_context_model_sweeps("vllm")[0]
+    assert sweep["max_tokens_self_attention"] == 999
+
+
+def test_attention_context_bf16_only_precision_override(monkeypatch):
+    _set_model_cases(
+        monkeypatch,
+        _model_file(
+            "org/M",
+            attention_context=[
+                {
+                    "query_head_counts": [64],
+                    "head_dims": [192],
+                    "precision_cases": [{"id": "bf16", "fp8_kv_cache": False, "fp8_context_fmha": False}],
+                }
+            ],
+        ),
+    )
+    sweep = case_generator.get_attention_context_model_sweeps("trtllm")[0]
+    assert [pc["fp8_kv_cache"] for pc in sweep["precision_cases"]] == [False]
+
+
+# ---------------------------------------------------------------------------
+# Attention generation
+# ---------------------------------------------------------------------------
+
+
+def test_attention_generation_generic_query_heads_fan_out(monkeypatch):
+    _set_model_cases(
+        monkeypatch,
+        _model_file(
+            "org/M",
+            attention_generation=[{"query_head_counts": [64], "kv_head_counts": [8], "head_dims": [192]}],
+        ),
+    )
+    sweep = case_generator.get_attention_generation_model_sweeps("trtllm")[0]
+    assert sweep["mha_query_head_counts"] == [64]
+    assert sweep["xqa_query_head_counts"] == [64]
+    assert sweep["kv_head_counts"] == [8]
+    assert "query_head_counts" not in sweep
+
+
+def test_attention_generation_explicit_xqa_overrides_generic(monkeypatch):
+    _set_model_cases(
+        monkeypatch,
+        _model_file(
+            "org/M",
+            attention_generation=[{"query_head_counts": [64], "xqa_query_head_counts": [8], "kv_head_counts": [8]}],
+        ),
+    )
+    sweep = case_generator.get_attention_generation_model_sweeps("trtllm")[0]
+    assert sweep["mha_query_head_counts"] == [64]
+    assert sweep["xqa_query_head_counts"] == [8]
+
+
+# ---------------------------------------------------------------------------
+# Attention encoder
+# ---------------------------------------------------------------------------
+
+
+def test_attention_encoder_maps_to_head_counts(monkeypatch):
+    _set_model_cases(
+        monkeypatch,
+        _model_file("org/M", attention_encoder=[{"query_head_counts": [16], "head_dims": [80]}]),
+    )
+    sweep = case_generator.get_attention_encoder_model_sweeps("trtllm")[0]
+    assert sweep["head_counts"] == [16]
+    assert sweep["head_dims"] == [80]
+    assert "query_head_counts" not in sweep
+
+
+def test_normalize_rejects_unknown_op_name():
+    with pytest.raises(ValueError, match="unsupported attention op_name"):
+        case_generator._normalize_attention_model_entry({"query_head_counts": [8]}, op_name="bogus")
+
+
+# ---------------------------------------------------------------------------
+# Dedupe
+# ---------------------------------------------------------------------------
+
+
+def test_attention_model_sweeps_dedupe_identical_entries(monkeypatch):
+    entry = {"query_head_counts": [64], "head_dims": [192]}
+    monkeypatch.setattr(
+        case_generator,
+        "_load_model_cases_data",
+        lambda: (
+            _model_file("org/A", attention_context=[dict(entry)]),
+            _model_file("org/B", attention_context=[dict(entry)]),
+        ),
+    )
+    monkeypatch.delenv("COLLECTOR_MODEL_PATH", raising=False)
+    sweeps = case_generator.get_attention_context_model_sweeps("vllm")
+    assert len(sweeps) == 1
+
+
+# ---------------------------------------------------------------------------
+# Single-base-template invariant (guard against >1 base sweep)
+# ---------------------------------------------------------------------------
+
+
+def test_attention_model_sweeps_reject_multiple_base_specs(monkeypatch):
+    _set_model_cases(
+        monkeypatch,
+        _model_file("org/M", attention_context=[{"query_head_counts": [64], "head_dims": [192]}]),
+    )
+    monkeypatch.setattr(
+        case_generator,
+        "get_merged_base_op_case_specs",
+        lambda backend, op_name: [{"id": "a"}, {"id": "b"}],
+    )
+    with pytest.raises(RuntimeError, match="exactly one base"):
+        case_generator.get_attention_context_model_sweeps("vllm")
+
+
+def test_gemm_model_sweeps_reject_multiple_base_specs(monkeypatch):
+    _set_model_cases(
+        monkeypatch,
+        _model_file("org/M", gemm=[{"output_feature_sizes": [99], "input_feature_sizes": [77]}]),
+    )
+    monkeypatch.setattr(
+        case_generator,
+        "_get_base_gemm_shape_sweeps",
+        lambda backend=None: [{"token_counts": [1]}, {"token_counts": [2]}],
+    )
+    with pytest.raises(RuntimeError, match="exactly one base"):
+        case_generator._gemm_model_shape_sweeps("vllm")
+
+
+# ---------------------------------------------------------------------------
+# Backward-compat regression
+# ---------------------------------------------------------------------------
+
+
+def test_no_model_data_yields_base_only(monkeypatch):
+    monkeypatch.delenv("COLLECTOR_MODEL_PATH", raising=False)
+    monkeypatch.setattr(case_generator, "_load_model_cases_data", lambda: ())
+
+    assert case_generator._gemm_model_shape_sweeps("vllm") == []
+    assert case_generator.get_attention_context_model_sweeps("vllm") == []
+    assert case_generator.get_attention_generation_model_sweeps("vllm") == []
+    assert case_generator.get_attention_encoder_model_sweeps("vllm") == []
+
+    context = case_generator.get_attention_context_shape_sweeps("vllm")
+    assert context == case_generator.get_merged_base_op_case_specs("vllm", "attention_context")
+
+
+def test_attention_base_sweeps_preserved_when_model_present(monkeypatch):
+    # Generic base sweeps must survive unchanged (as a prefix) when a model adds
+    # its own shapes, for every attention phase.
+    bases = {
+        op: case_generator.get_merged_base_op_case_specs("vllm", op)
+        for op in ("attention_context", "attention_generation", "attention_encoder")
+    }
+    _set_model_cases(
+        monkeypatch,
+        _model_file(
+            "org/M",
+            attention_context=[{"query_head_counts": [64], "head_dims": [192]}],
+            attention_generation=[{"query_head_counts": [64], "kv_head_counts": [8], "head_dims": [192]}],
+            attention_encoder=[{"query_head_counts": [16], "head_dims": [80]}],
+        ),
+    )
+    combined = {
+        "attention_context": case_generator.get_attention_context_shape_sweeps("vllm"),
+        "attention_generation": case_generator.get_attention_generation_shape_sweeps("vllm"),
+        "attention_encoder": case_generator.get_attention_encoder_shape_sweeps("vllm"),
+    }
+    for op, base in bases.items():
+        assert combined[op][: len(base)] == base, op
+        assert len(combined[op]) == len(base) + 1, op
+        assert combined[op][-1]["id"].startswith("model_"), op

--- a/tests/unit/collector/test_model_attention_gemm_cases.py
+++ b/tests/unit/collector/test_model_attention_gemm_cases.py
@@ -143,9 +143,12 @@ def test_gemm_model_paths_plural_expansion(monkeypatch):
             gemm=[{"model_paths": ["org/a", "org/b"], "output_feature_sizes": [99], "input_feature_sizes": [77]}],
         ),
     )
-    # No filter -> the shape is present once (deduped across both aliases).
+    # No filter -> both aliases expand to the same sweep; dedupe means each
+    # (x, n, k) for (99, 77) appears exactly once (no per-alias duplication).
     cases = case_generator.get_gemm_case_specs("vllm")
-    assert any(case.n == 99 and case.k == 77 for case in cases)
+    matching = [(case.x, case.n, case.k) for case in cases if case.n == 99 and case.k == 77]
+    assert matching, "expected the model (99, 77) shape to be present"
+    assert len(matching) == len(set(matching)), "model shape duplicated across aliases (dedupe failed)"
 
     # Filter to one alias -> still present.
     monkeypatch.setenv("COLLECTOR_MODEL_PATH", "org/b")
@@ -305,6 +308,33 @@ def test_attention_model_sweeps_dedupe_identical_entries(monkeypatch):
     monkeypatch.delenv("COLLECTOR_MODEL_PATH", raising=False)
     sweeps = case_generator.get_attention_context_model_sweeps("vllm")
     assert len(sweeps) == 1
+
+
+def test_attention_context_model_sweeps_filtered_by_collector_model_path(monkeypatch):
+    monkeypatch.setattr(
+        case_generator,
+        "_load_model_cases_data",
+        lambda: (
+            _model_file(
+                "org/A", attention_context=[{"model_path": "org/A", "query_head_counts": [64], "head_dims": [192]}]
+            ),
+            _model_file(
+                "org/B", attention_context=[{"model_path": "org/B", "query_head_counts": [40], "head_dims": [128]}]
+            ),
+        ),
+    )
+    monkeypatch.setenv("COLLECTOR_MODEL_PATH", "org/A")
+
+    sweeps = case_generator.get_attention_context_model_sweeps("vllm")
+    assert len(sweeps) == 1
+    assert sweeps[0]["query_head_counts"] == [64]
+
+
+def test_attention_overlay_identical_to_base_is_dropped(monkeypatch):
+    # An overlay with no shape fields equals the base sweep, which already covers
+    # those shapes, so it must not be emitted as a redundant duplicate.
+    _set_model_cases(monkeypatch, _model_file("org/M", attention_context=[{"model_path": "org/M"}]))
+    assert case_generator.get_attention_context_model_sweeps("vllm") == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION


#### Overview:

Expands model specific shape support to GEMM and Attention operations and adds relevant tests.

#### Details:

- Added support for per-model shape sweeps in attention operations (context, generation, encoder) by integrating model-specific dimensions into the existing base templates.
- Introduced new functions to handle model-specific attention sweeps, ensuring that model entries can overlay their configurations on top of the shared base grid.
- Updated documentation to reflect the new model dimensions for GEMM and attention, clarifying how model-specific entries interact with the base configurations.
- Added unit tests to validate the new functionality for attention and GEMM model shape injections.

#### Where should the reviewer start?

Changes to the case generator, docs, and unit tests

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added model-driven overlay for GEMM and attention (context, generation, encoder) shape sweep generation on top of base templates.
  * Improved sweep/model handling by mapping head-count fields per phase, inheriting base values when not overridden, and deduplicating overlapping sweeps/test cases.
* **Documentation**
  * Documented how `model_case_values` extends the GEMM and attention shape grids, including inheritance/override behavior and head-count field mapping.
* **Tests**
  * Added comprehensive unit coverage validating overlays, filtering, deduplication, and expected fallback/error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->