### PR TITLE
fix(sdk): support ModelOpt mixed precision quant metadata

### DIFF
--- a/src/aiconfigurator/sdk/models/helpers.py
+++ b/src/aiconfigurator/sdk/models/helpers.py
@@ -66,6 +66,125 @@ def _architecture_to_model_family(architecture: str) -> str:
     )
 
 
+def _normalize_mixed_precision_layer_algo(value: object) -> str | None:
+    """Normalize ModelOpt per-layer/group quantization algorithms."""
+    if value is None:
+        return None
+    algo = str(value).strip().lower()
+    if not algo:
+        return None
+    aliases = {
+        "fp8": "fp8",
+        "e4m3": "fp8",
+        "e5m2": "fp8",
+        "nvfp4": "nvfp4",
+        "fp4": "nvfp4",
+    }
+    return aliases.get(algo, algo)
+
+
+def _infer_mixed_precision_group_algo(group: dict) -> str | None:
+    """Infer the layer algorithm from a ModelOpt config_groups entry."""
+    weights = group.get("weights")
+    if not isinstance(weights, dict):
+        return None
+
+    quant_algo = _normalize_mixed_precision_layer_algo(
+        weights.get("quant_algo") or weights.get("quantization_algo") or weights.get("quant_method")
+    )
+    if quant_algo:
+        return quant_algo
+
+    num_bits = weights.get("num_bits")
+    weight_type = str(weights.get("type", "")).lower()
+    if not isinstance(num_bits, int):
+        return None
+    if num_bits == 8 and "float" in weight_type:
+        return "fp8"
+    if num_bits == 4 and "float" in weight_type:
+        return "nvfp4"
+    return None
+
+
+def _is_routing_expert_target(target: object) -> bool:
+    """Return whether a ModelOpt target path points at routed MoE experts."""
+    target_name = str(target).lower()
+    if "shared_expert" in target_name:
+        return False
+    return ".experts." in target_name or "routing_expert" in target_name
+
+
+def _collect_mixed_precision_layer_algos(raw_config: dict) -> tuple[set[str], set[str]]:
+    """Collect ModelOpt mixed precision algorithms by SDK GEMM/MoE category."""
+    gemm_algos: set[str] = set()
+    moe_algos: set[str] = set()
+
+    def add_target(target: object, algo_value: object) -> None:
+        algo = _normalize_mixed_precision_layer_algo(algo_value)
+        if algo is None:
+            return
+        if _is_routing_expert_target(target):
+            moe_algos.add(algo)
+        else:
+            gemm_algos.add(algo)
+
+    def add_quantized_layers(quantized_layers: object) -> None:
+        if not isinstance(quantized_layers, dict):
+            return
+        for target, metadata in quantized_layers.items():
+            if isinstance(metadata, dict):
+                algo = metadata.get("quant_algo") or metadata.get("quantization_algo") or metadata.get("quant_method")
+            else:
+                algo = metadata
+            add_target(target, algo)
+
+    hf_quant_config = raw_config.get("hf_quant_config")
+    if isinstance(hf_quant_config, dict):
+        hf_quant_section = hf_quant_config.get("quantization")
+        if isinstance(hf_quant_section, dict):
+            add_quantized_layers(hf_quant_section.get("quantized_layers"))
+
+    quant_cfg = raw_config.get("quantization_config")
+    if isinstance(quant_cfg, dict):
+        add_quantized_layers(quant_cfg.get("quantized_layers"))
+        config_groups = quant_cfg.get("config_groups")
+        if isinstance(config_groups, dict):
+            for group in config_groups.values():
+                if not isinstance(group, dict):
+                    continue
+                algo = _infer_mixed_precision_group_algo(group)
+                if algo is None:
+                    continue
+                for target in group.get("targets") or []:
+                    add_target(target, algo)
+
+    return gemm_algos, moe_algos
+
+
+def _infer_mixed_precision_quant_modes(raw_config: dict, quant_dynamic: bool | None) -> dict[str, object]:
+    """Map ModelOpt MIXED_PRECISION metadata onto coarse SDK quant modes."""
+    gemm_algos, moe_algos = _collect_mixed_precision_layer_algos(raw_config)
+    overrides: dict[str, object] = {}
+
+    if "fp8" in gemm_algos:
+        if quant_dynamic is not True:
+            overrides["gemm_quant_mode"] = common.GEMMQuantMode.fp8_static
+        else:
+            overrides["gemm_quant_mode"] = common.GEMMQuantMode.fp8
+    elif "nvfp4" in gemm_algos:
+        overrides["gemm_quant_mode"] = common.GEMMQuantMode.nvfp4
+
+    if "nvfp4" in moe_algos:
+        overrides["moe_quant_mode"] = common.MoEQuantMode.nvfp4
+    elif "fp8" in moe_algos:
+        overrides["moe_quant_mode"] = common.MoEQuantMode.fp8
+
+    if not overrides:
+        logger.warning("Unable to infer SDK quant modes from mixed_precision metadata")
+
+    return overrides
+
+
 def _infer_quant_modes_from_raw_config(raw_config: dict, architecture: str | None = None) -> dict[str, object]:
     quant_algo = raw_config.get("quant_algo")
     quant_dynamic = raw_config.get("quant_dynamic")
@@ -95,6 +214,8 @@ def _infer_quant_modes_from_raw_config(raw_config: dict, architecture: str | Non
     elif quant_algo == "nvfp4":
         overrides["gemm_quant_mode"] = common.GEMMQuantMode.nvfp4
         overrides["moe_quant_mode"] = common.MoEQuantMode.nvfp4
+    elif quant_algo == "mixed_precision":
+        overrides.update(_infer_mixed_precision_quant_modes(raw_config, quant_dynamic))
     elif quant_algo == "mxfp4":
         overrides["gemm_quant_mode"] = common.GEMMQuantMode.bfloat16
         overrides["moe_quant_mode"] = common.MoEQuantMode.w4a16_mxfp4

--- a/src/aiconfigurator/sdk/utils.py
+++ b/src/aiconfigurator/sdk/utils.py
@@ -870,6 +870,9 @@ def _normalize_quant_algo(value: object) -> str | None:
         "nvfp4": "nvfp4",
         "mxfp4": "mxfp4",
         "w4a16_mxfp4": "mxfp4",
+        "mixed_precision": "mixed_precision",
+        "mixed-precision": "mixed_precision",
+        "mixedprecision": "mixed_precision",
         # compressed-tensors: pass through as-is so models.py can handle it with
         # the correct partial-quantization semantics (MoE experts only, not all Linear layers).
         "compressed-tensors": "compressed-tensors",

--- a/tests/unit/sdk/test_utils.py
+++ b/tests/unit/sdk/test_utils.py
@@ -1208,6 +1208,84 @@ class TestParseCompressedTensorsQuant:
         assert overrides.get("gemm_quant_mode") == common.GEMMQuantMode.int4_wo
         assert overrides.get("moe_quant_mode") == common.MoEQuantMode.int4_wo
 
+    def test_modelopt_mixed_precision_config_groups_map_sdk_modes(self):
+        """ModelOpt MIXED_PRECISION config groups map FP8 dense layers and NVFP4 routed experts."""
+        from aiconfigurator.sdk import common
+        from aiconfigurator.sdk.models import _infer_quant_modes_from_raw_config
+        from aiconfigurator.sdk.utils import _attach_inferred_quant_fields
+
+        raw_config = _attach_inferred_quant_fields(
+            {
+                "quantization_config": {
+                    "quant_algo": "MIXED_PRECISION",
+                    "kv_cache_scheme": {"type": "float", "num_bits": 8},
+                    "config_groups": {
+                        "group_0": {
+                            "weights": {"dynamic": False, "num_bits": 8, "type": "float"},
+                            "input_activations": {"dynamic": False, "num_bits": 8, "type": "float"},
+                            "targets": [
+                                "backbone.layers.0.mixer.in_proj",
+                                "backbone.layers.1.mixer.shared_experts.up_proj",
+                            ],
+                        },
+                        "group_1": {
+                            "weights": {
+                                "dynamic": False,
+                                "group_size": 16,
+                                "num_bits": 4,
+                                "type": "float",
+                            },
+                            "input_activations": {
+                                "dynamic": False,
+                                "group_size": 16,
+                                "num_bits": 4,
+                                "type": "float",
+                            },
+                            "targets": ["backbone.layers.1.mixer.experts.0.up_proj"],
+                        },
+                    },
+                },
+            }
+        )
+
+        overrides = _infer_quant_modes_from_raw_config(raw_config)
+
+        assert raw_config["quant_algo"] == "mixed_precision"
+        assert overrides["gemm_quant_mode"] == common.GEMMQuantMode.fp8_static
+        assert overrides["moe_quant_mode"] == common.MoEQuantMode.nvfp4
+        assert overrides["kvcache_quant_mode"] == common.KVCacheQuantMode.fp8
+        assert overrides["fmha_quant_mode"] == common.FMHAQuantMode.fp8
+
+    def test_modelopt_mixed_precision_hf_quant_layers_map_sdk_modes(self):
+        """Standalone hf_quant_config.json MIXED_PRECISION metadata no longer raises unsupported quant_algo."""
+        from aiconfigurator.sdk import common
+        from aiconfigurator.sdk.models import _infer_quant_modes_from_raw_config
+        from aiconfigurator.sdk.utils import _attach_inferred_quant_fields
+
+        raw_config = _attach_inferred_quant_fields(
+            {
+                "hf_quant_config": {
+                    "quantization": {
+                        "quant_algo": "MIXED_PRECISION",
+                        "kv_cache_quant_algo": "FP8",
+                        "quantized_layers": {
+                            "backbone.layers.0.mixer.in_proj": {"quant_algo": "FP8"},
+                            "backbone.layers.1.mixer.shared_experts.up_proj": {"quant_algo": "FP8"},
+                            "backbone.layers.1.mixer.experts.0.up_proj": {"quant_algo": "NVFP4"},
+                        },
+                    }
+                },
+            }
+        )
+
+        overrides = _infer_quant_modes_from_raw_config(raw_config)
+
+        assert raw_config["quant_algo"] == "mixed_precision"
+        assert overrides["gemm_quant_mode"] == common.GEMMQuantMode.fp8_static
+        assert overrides["moe_quant_mode"] == common.MoEQuantMode.nvfp4
+        assert overrides["kvcache_quant_mode"] == common.KVCacheQuantMode.fp8
+        assert overrides["fmha_quant_mode"] == common.FMHAQuantMode.fp8
+
     def test_expert_dtype_fp4_is_deepseek_v4_specific(self):
         from aiconfigurator.sdk import common
         from aiconfigurator.sdk.models import _infer_quant_modes_from_raw_config


### PR DESCRIPTION
## Summary
- Support ModelOpt `MIXED_PRECISION` quant metadata in SDK model quant inference.
- Infer FP8/static GEMM for non-routed layers and NVFP4 MoE for routed expert targets from `hf_quant_config.quantized_layers` or `quantization_config.config_groups`.
- Normalize mixed precision quant algorithm aliases.

## Validation
- `PYTHONPATH=src /home/hongkuanz/Projects/dynamo/.venv/bin/python -m pytest -q tests/unit/sdk/test_utils.py::TestParseCompressedTensorsQuant`
- `PYTHONPATH=src /home/hongkuanz/Projects/dynamo/.venv/bin/python -m pytest -q tests/unit/sdk/test_utils.py`
- `PYTHONPATH=src /home/hongkuanz/Projects/dynamo/.venv/bin/python -m ruff check src/aiconfigurator/sdk/models/helpers.py src/aiconfigurator/sdk/utils.py tests/unit/sdk/test_utils.py`
- `PYTHONPATH=src /home/hongkuanz/Projects/dynamo/.venv/bin/python -m ruff format --check src/aiconfigurator/sdk/models/helpers.py src/aiconfigurator/sdk/utils.py tests/unit/sdk/test_utils.py`
- Smoke-tested raw `MIXED_PRECISION` + FP8 KV cache config mapping to GEMM `fp8_static`, MoE `nvfp4`, KV cache `fp8`, FMHA `fp8`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for mixed-precision quantization configuration inference
  * Enhanced quantization algorithm mapping for GEMM layers and routed experts
  * Improved recognition of multiple naming conventions for mixed-precision settings

* **Tests**
  * Added unit tests for mixed-precision configuration handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Related issue

Fixes #1224