### PR TITLE
fix(systems): correct B200 SXM HBM bandwidth to 7.7 TB/s

### DIFF
--- a/src/aiconfigurator/systems/b200_sxm.yaml
+++ b/src/aiconfigurator/systems/b200_sxm.yaml
@@ -1,9 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# https://nvdam.widen.net/s/wwnsxrhm2w/blackwell-datasheet-3384703
+
 data_dir: data/b200_sxm # relative to systems_dir
 gpu:
-  mem_bw: 8000000000000 # 8TB/s
+  mem_bw: 7700000000000 # 7.7TB/s
   mem_bw_empirical_scaling_factor: 0.8 # some nonofficial correction based on observations, you should try to modify based on your own observations
   mem_empirical_constant_latency: 0.000003 # 3us some nonofficial correction based on observations, you should try to modify based on your own observations
   mem_capacity: 193273528320 # 180GiB


### PR DESCRIPTION
## Summary
- Corrected B200 SXM `mem_bw` from 8 TB/s to 7.7 TB/s per the [official NVIDIA Blackwell datasheet](https://nvdam.widen.net/s/wwnsxrhm2w/blackwell-datasheet-3384703)
- The previous 8 TB/s value was higher than B300 SXM (7.75 TB/s), causing decode throughput inversion in simulations where B200 incorrectly outperformed B300

## Test plan
- [ ] Verify B200 SXM decode throughput is now lower than B300 SXM for memory-bandwidth-bound workloads (e.g. DeepSeek-V4-Flash decode ISL=8192 OSL=1024)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the configured GPU memory bandwidth for one system profile (from 8TB/s to 7.7TB/s) to better align with the expected hardware specification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->