### PR TITLE
build: split AIC core into a separate wheel

### DIFF
--- a/.github/workflows/accuracy-regression-testing.yml
+++ b/.github/workflows/accuracy-regression-testing.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          python -m pip install -e src/aiconfigurator-core
           python -m pip install -e ".[dev]"
 
       - name: Resolve old revision
@@ -55,6 +56,17 @@ jobs:
         run: |
           git worktree add --detach ../aiconfigurator-old "${{ steps.old-ref.outputs.old_ref }}"
 
+      - name: Install old revision dependencies
+        run: |
+          OLD_ROOT="${{ github.workspace }}/../aiconfigurator-old"
+          OLD_VENV="${OLD_ROOT}/.venv"
+          python -m venv "${OLD_VENV}"
+          "${OLD_VENV}/bin/python" -m pip install --upgrade pip
+          if [ -f "${OLD_ROOT}/src/aiconfigurator-core/pyproject.toml" ]; then
+            "${OLD_VENV}/bin/python" -m pip install -e "${OLD_ROOT}/src/aiconfigurator-core"
+          fi
+          "${OLD_VENV}/bin/python" -m pip install -e "${OLD_ROOT}"
+
       - name: Generate new predictions
         run: |
           mkdir -p tools/accuracy_regression_testing/results
@@ -65,12 +77,16 @@ jobs:
 
       - name: Generate old predictions
         run: |
-          PYTHONPATH="${{ github.workspace }}/../aiconfigurator-old/src" \
-            python tools/accuracy_regression_testing/predict_silicon_sample.py \
-              tools/accuracy_regression_testing/results/silicon_result_new.csv \
+          OLD_ROOT="${{ github.workspace }}/../aiconfigurator-old"
+          OLD_VENV="${OLD_ROOT}/.venv"
+          RESULTS="${{ github.workspace }}/tools/accuracy_regression_testing/results"
+          cd "${OLD_ROOT}"
+          PYTHONPATH="${OLD_ROOT}/src" \
+            "${OLD_VENV}/bin/python" tools/accuracy_regression_testing/predict_silicon_sample.py \
+              "${RESULTS}/silicon_result_new.csv" \
               --aic-output-prefix old \
-              > tools/accuracy_regression_testing/results/silicon_result.csv \
-              2> tools/accuracy_regression_testing/results/old_predictions.log
+              > "${RESULTS}/silicon_result.csv" \
+              2> "${RESULTS}/old_predictions.log"
 
       - name: Compare predictions
         run: |

--- a/.github/workflows/create-charts.yml
+++ b/.github/workflows/create-charts.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install -e src/aiconfigurator-core
           pip install -e ".[dev]"
           # Ensure import_ipynb is available
           pip install import-ipynb

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -40,7 +40,8 @@ source .venv/bin/activate
 ### 4. Install Development Dependencies
 
 ```bash
-# Install the package in editable mode with dev dependencies
+# Install the lower modeling/Rust package first, then the upper package with dev dependencies
+pip install -e src/aiconfigurator-core
 pip install -e ".[dev]"
 ```
 
@@ -52,6 +53,7 @@ pre-commit install
 
 This installs:
 - The `aiconfigurator` package in editable mode
+- The `aiconfigurator-core` package in editable mode
 - All runtime dependencies
 - Development tools: `ruff`, `pre-commit`, `pytest` and related plugins
 
@@ -142,4 +144,3 @@ Refer to the [Automation README](tools/automation/README.md).
 ## License
 
 This project is licensed under Apache 2.0. All contributions must include SPDX license headers and DCO sign-off.
-

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ git lfs pull
 # 3. Create and activate a virtual environment
 python3 -m venv myenv && source myenv/bin/activate # (requires Python 3.9 or later)
 
-# 4. Install aiconfigurator
+# 4. Install aiconfigurator-core, then aiconfigurator
+pip3 install ./src/aiconfigurator-core
 pip3 install .
 
 # 5. Install aiconfigurator with webapp support
@@ -57,7 +58,7 @@ pip3 install ".[webapp]"
 ### Build with Docker
 
 ```bash
-# This will create a ./dist/ folder containing the wheel file
+# This will create a ./dist/ folder containing the core and upper wheel files
 docker build -f docker/Dockerfile --no-cache --target build -t aiconfigurator:latest .
 docker create --name aic aiconfigurator:latest && docker cp aic:/workspace/dist dist/ && docker rm aic
 ```

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,10 +16,11 @@ ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 ENV MPLCONFIGDIR=/tmp/matplotlib
 
 FROM base AS build
-# The `aiconfigurator_core` extension is compiled into the wheel by maturin
-# during `uv build`. maturin needs the Rust crate sources, a C linker (gcc),
-# and ca-certificates so cargo can fetch crates from crates.io over TLS. Rust
-# itself is bootstrapped by maturin's build backend.
+# The lower `aiconfigurator-core` wheel owns the `aiconfigurator_core`
+# extension and SDK/data payload, so build it before the upper CLI/generator
+# wheel. maturin needs the Rust crate sources, a C linker (gcc), and
+# ca-certificates so cargo can fetch crates from crates.io over TLS. Rust itself
+# is bootstrapped by maturin's build backend.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates gcc libc6-dev && \
     rm -rf /var/lib/apt/lists/*
@@ -36,21 +37,22 @@ RUN set -e; \
         echo "Run 'git lfs install && git lfs pull' in the source tree before building." >&2; \
         exit 1; \
     fi
-RUN uv build --wheel --out-dir /workspace/dist
+RUN cd src/aiconfigurator-core && uv build --wheel --out-dir /workspace/dist && \
+    cd /workspace && uv build --wheel --out-dir /workspace/dist
 
 FROM base AS runtime
 COPY --from=build /workspace/dist /wheelhouse
-RUN WHL=$(ls -d /wheelhouse/*) && \
-    uv pip install $WHL && \
+RUN uv pip install /wheelhouse/*.whl && \
     rm -rf /wheelhouse
 
 FROM runtime AS test
 
-# The `aiconfigurator_core` extension ships inside the wheel built in the
-# `build` stage, so the test stage only needs the dev extras and test sources.
+# The `aiconfigurator_core` extension ships inside the lower wheel built in the
+# `build` stage, so the test stage only adds the upper wheel's dev extras and
+# test sources.
 COPY --from=build /workspace/dist /wheelhouse
-RUN WHL=$(ls -d /wheelhouse/*) && \
-    uv pip install "$WHL[dev]" && \
+RUN AIC_WHL=$(ls /wheelhouse/aiconfigurator-*.whl) && \
+    uv pip install /wheelhouse/aiconfigurator_core-*.whl "${AIC_WHL}[dev]" && \
     rm -rf /wheelhouse
 
 COPY pytest.ini /workspace/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,21 +40,17 @@ license-files = ["LICENSE"]
 requires-python = ">=3.10"
 
 dependencies = [
+    "aiconfigurator-core==0.9.0",
     "jinja2>=3.1.0",
     "packaging>=20.0",
     "matplotlib>=3.9.4",
     "numpy~=1.26.4",
     "pandas>=2.2.3",
-    "plotext>=5.3.2",
     "plotly>=6.0.1",
     "prettytable>=3.16.0",
-    "pyarrow>=15.0.0",
     "pyyaml>=6.0",
-    "scipy>=1.13.1",
     "tqdm>=4.0.0",
     "bokeh",
-    "nvidia-ml-py",
-    "munch>=4.0.0"
 ]
 
 [project.optional-dependencies]
@@ -86,78 +82,27 @@ GitHub = "https://github.com/ai-dynamo/aiconfigurator"
 Repository = "https://github.com/ai-dynamo/aiconfigurator.git"
 
 [build-system]
-requires = ["maturin>=1.5,<2"]
-build-backend = "maturin"
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
 
 [project.scripts]
 aiconfigurator = "aiconfigurator.main:main"
 
-[tool.maturin]
-# The Rust crate lives in a subdirectory; pyproject.toml is at repo root.
-manifest-path = "rust/aiconfigurator-core/Cargo.toml"
-# The compiled extension is a submodule of the top-level `aiconfigurator_core`
-# package (src/aiconfigurator_core/), placed as
-# `_aiconfigurator_core.<abi>.so`. The package `__init__.py` re-exports the
-# public names so callers `import aiconfigurator_core`. The last component
-# must match the `#[pymodule]` function name in src/py.rs.
-module-name = "aiconfigurator_core._aiconfigurator_core"
-# Pure-Python sources live under src/ (src-layout).
-python-source = "src"
-# Build an abi3 wheel (single wheel valid across Py 3.10+, matching the
-# requires-python = ">=3.10" and the pyo3 `abi3-py310` feature).
-abi3 = true
-# Enable the extension-module feature ONLY for the maturin/wheel build.
-# `cargo build`/`cargo test` keep linking libpython (auto-initialize) for the
-# Rust->Python embedding path; this feature is what lets the built `.so` skip
-# libpython linkage. It is NOT a default Cargo feature (see Cargo.toml).
-features = ["pyo3/extension-module"]
-# Bundle the Python data files (parquet/yaml/csv/json/templates) that the
-# legacy setuptools package-data globs shipped, into BOTH the sdist and the
-# wheel, so non-editable installs keep finding the perf databases and config
-# templates. (Editable `maturin develop` resolves these in-place from src/;
-# these globs cover the wheel/sdist case mirrored from the old package-data.)
-include = [
-    # maturin auto-packages only the `aiconfigurator_core` package (the one the
-    # extension's module-name lives in). The pure-Python `aiconfigurator`
-    # package is a second top-level package under `src/`, so its modules must be
-    # included explicitly or the non-editable wheel ships without them.
-    "src/aiconfigurator/**/*.py",
-    "src/aiconfigurator/cli/*.yaml",
-    "src/aiconfigurator/cli/exps/*.yaml",
-    "src/aiconfigurator/generator/config/**/*.yaml",
-    "src/aiconfigurator/generator/config/backend_templates/**/*.j2",
-    "src/aiconfigurator/generator/rule_plugin/**/*.rule",
-    "src/aiconfigurator/generator/facts/**/*.yaml",
-    "src/aiconfigurator/generator/environment/*.yaml",
-    "src/aiconfigurator/systems/*.yaml",
-    "src/aiconfigurator/systems/*.csv",
-    "src/aiconfigurator/systems/**/*.csv",
-    "src/aiconfigurator/systems/**/*.json",
-    "src/aiconfigurator/systems/**/*.txt",
-    "src/aiconfigurator/systems/**/*.parquet",
-    "src/aiconfigurator/model_configs/*.json",
-    "src/aiconfigurator/webapp/components/profiling/styles.css",
-    "src/aiconfigurator/webapp/components/profiling/js/*.js",
-]
+[tool.setuptools]
+include-package-data = false
 
 [tool.setuptools.package-data]
 "aiconfigurator.cli" = ["*.yaml", "exps/*.yaml"]
 "aiconfigurator.generator" = ["config/**/*.yaml", "config/backend_templates/**/*.j2", "rule_plugin/**/*.rule", "facts/**/*.yaml", "environment/*.yaml"]
-"aiconfigurator" = [
-    "systems/*.yaml",
-    "systems/*.csv",
-    "systems/**/*.csv",
-    "systems/**/*.json",
-    "systems/**/*.txt",
-    "systems/**/*.parquet",
-    "model_configs/*.json",
-]
 "aiconfigurator.webapp.components.profiling" = ["styles.css", "js/*.js"]
 
 [tool.setuptools.packages.find]
 where = ["src"]
-include = ["*"]
-exclude = ["tests", "docker", "collector", "systems"]
+include = ["aiconfigurator", "aiconfigurator.cli*", "aiconfigurator.generator*", "aiconfigurator.webapp*"]
+exclude = ["aiconfigurator.sdk*", "aiconfigurator.systems*", "aiconfigurator.model_configs*", "aiconfigurator_core*"]
+
+[tool.uv.sources]
+aiconfigurator-core = { path = "src/aiconfigurator-core", editable = true }
 
 [tool.ruff]
 line-length = 120

--- a/src/aiconfigurator-core/pyproject.toml
+++ b/src/aiconfigurator-core/pyproject.toml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[project]
+name = "aiconfigurator-core"
+version = "0.9.0"
+authors = [
+    { name = "NVIDIA Inc.", email = "sw-dl-dynamo@nvidia.com" },
+]
+description = "Core modeling, data, and Rust estimators for AIConfigurator"
+readme = { text = "Core modeling, data, and Rust estimators for AIConfigurator.", content-type = "text/markdown" }
+license = "Apache-2.0"
+requires-python = ">=3.10"
+dependencies = [
+    "packaging>=20.0",
+    "matplotlib>=3.9.4",
+    "numpy~=1.26.4",
+    "pandas>=2.2.3",
+    "plotext>=5.3.2",
+    "pyarrow>=15.0.0",
+    "pyyaml>=6.0",
+    "scipy>=1.13.1",
+    "tqdm>=4.0.0",
+    "nvidia-ml-py",
+    "munch>=4.0.0",
+]
+
+[build-system]
+requires = ["maturin>=1.5,<2"]
+build-backend = "maturin"
+
+[tool.maturin]
+manifest-path = "../../rust/aiconfigurator-core/Cargo.toml"
+module-name = "aiconfigurator_core._aiconfigurator_core"
+python-source = ".."
+abi3 = true
+features = ["pyo3/extension-module"]
+include = [
+    "aiconfigurator_core/__init__.py",
+    "aiconfigurator/sdk/**/*.py",
+    "aiconfigurator/systems/*.yaml",
+    "aiconfigurator/systems/*.csv",
+    "aiconfigurator/systems/**/*.csv",
+    "aiconfigurator/systems/**/*.json",
+    "aiconfigurator/systems/**/*.txt",
+    "aiconfigurator/systems/**/*.parquet",
+    "aiconfigurator/model_configs/*.json",
+]

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -24,6 +24,8 @@ from aiconfigurator.cli.main import (
 )
 from aiconfigurator.cli.report_and_save import save_results
 from aiconfigurator.sdk.config import ModelConfig
+from aiconfigurator.sdk.config_builders import apply_nextn as _apply_nextn
+from aiconfigurator.sdk.config_builders import build_model_config as _build_model_config
 from aiconfigurator.sdk.models import check_is_moe
 from aiconfigurator.sdk.task_v2 import Task
 
@@ -591,42 +593,6 @@ def _resolve_moe_parallelism(
     return cfg.resolve_moe_parallelism()
 
 
-def _build_model_config(
-    tp_size: int,
-    pp_size: int,
-    attention_dp_size: int,
-    moe_tp_size: int,
-    moe_ep_size: int,
-    gemm_quant_mode: str | None = None,
-    kvcache_quant_mode: str | None = None,
-    fmha_quant_mode: str | None = None,
-    moe_quant_mode: str | None = None,
-    comm_quant_mode: str | None = None,
-):
-    """Build a ModelConfig with optional quant mode overrides."""
-    from aiconfigurator.sdk.common import (
-        CommQuantMode,
-        FMHAQuantMode,
-        GEMMQuantMode,
-        KVCacheQuantMode,
-        MoEQuantMode,
-    )
-    from aiconfigurator.sdk.config import ModelConfig
-
-    return ModelConfig(
-        tp_size=tp_size,
-        pp_size=pp_size,
-        attention_dp_size=attention_dp_size,
-        moe_tp_size=moe_tp_size,
-        moe_ep_size=moe_ep_size,
-        gemm_quant_mode=GEMMQuantMode[gemm_quant_mode] if gemm_quant_mode else None,
-        kvcache_quant_mode=KVCacheQuantMode[kvcache_quant_mode] if kvcache_quant_mode else None,
-        fmha_quant_mode=FMHAQuantMode[fmha_quant_mode] if fmha_quant_mode else None,
-        moe_quant_mode=MoEQuantMode[moe_quant_mode] if moe_quant_mode else None,
-        comm_quant_mode=CommQuantMode[comm_quant_mode] if comm_quant_mode else None,
-    )
-
-
 def cli_estimate(
     model_path: str,
     system_name: str,
@@ -1118,25 +1084,6 @@ def cli_estimate(
         raise ValueError(
             f"Unsupported estimate mode: {mode!r}. Use 'agg', 'disagg', 'afd', 'static', 'static_ctx', or 'static_gen'."
         )
-
-
-def _apply_nextn(
-    model_config,
-    nextn: int | None,
-    nextn_accept_rates: list[float] | None,
-) -> None:
-    """Apply common ``nextn`` / ``nextn_accept_rates`` overrides onto a ModelConfig.
-
-    Mirrors the static-mode path so agg / disagg / static all respond to the
-    same CLI flags. When ``nextn>0`` and no explicit accept rates are given,
-    fall back to the project-wide default ``[0.85, 0.3, 0, 0, 0]`` (matches
-    ``cli default``'s _base_common_layer).
-    """
-    model_config.nextn = int(nextn or 0)
-    if nextn_accept_rates is not None:
-        model_config.nextn_accept_rates = list(nextn_accept_rates)
-    elif model_config.nextn > 0:
-        model_config.nextn_accept_rates = [0.85, 0.3, 0.0, 0.0, 0.0]
 
 
 def _run_agg_estimate(

--- a/src/aiconfigurator/sdk/config_builders.py
+++ b/src/aiconfigurator/sdk/config_builders.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared ModelConfig construction helpers.
+
+These helpers are used by both the upper CLI layer and lower modeling/engine
+paths. Keeping them in ``sdk`` prevents the core wheel from importing CLI code.
+"""
+
+from __future__ import annotations
+
+from aiconfigurator.sdk.common import (
+    CommQuantMode,
+    FMHAQuantMode,
+    GEMMQuantMode,
+    KVCacheQuantMode,
+    MoEQuantMode,
+)
+from aiconfigurator.sdk.config import ModelConfig
+
+
+def build_model_config(
+    tp_size: int,
+    pp_size: int,
+    attention_dp_size: int,
+    moe_tp_size: int,
+    moe_ep_size: int,
+    gemm_quant_mode: str | None = None,
+    kvcache_quant_mode: str | None = None,
+    fmha_quant_mode: str | None = None,
+    moe_quant_mode: str | None = None,
+    comm_quant_mode: str | None = None,
+) -> ModelConfig:
+    """Build a ModelConfig with optional quant mode overrides."""
+    return ModelConfig(
+        tp_size=tp_size,
+        pp_size=pp_size,
+        attention_dp_size=attention_dp_size,
+        moe_tp_size=moe_tp_size,
+        moe_ep_size=moe_ep_size,
+        gemm_quant_mode=GEMMQuantMode[gemm_quant_mode] if gemm_quant_mode else None,
+        kvcache_quant_mode=KVCacheQuantMode[kvcache_quant_mode] if kvcache_quant_mode else None,
+        fmha_quant_mode=FMHAQuantMode[fmha_quant_mode] if fmha_quant_mode else None,
+        moe_quant_mode=MoEQuantMode[moe_quant_mode] if moe_quant_mode else None,
+        comm_quant_mode=CommQuantMode[comm_quant_mode] if comm_quant_mode else None,
+    )
+
+
+def apply_nextn(
+    model_config: ModelConfig,
+    nextn: int | None,
+    nextn_accept_rates: list[float] | None,
+) -> None:
+    """Apply common ``nextn`` / ``nextn_accept_rates`` overrides onto a ModelConfig.
+
+    Mirrors the static-mode path so agg / disagg / static all respond to the
+    same CLI flags. When ``nextn>0`` and no explicit accept rates are given,
+    fall back to the project-wide default ``[0.85, 0.3, 0, 0, 0]``.
+    """
+    model_config.nextn = int(nextn or 0)
+    if nextn_accept_rates is not None:
+        model_config.nextn_accept_rates = list(nextn_accept_rates)
+    elif model_config.nextn > 0:
+        model_config.nextn_accept_rates = [0.85, 0.3, 0.0, 0.0, 0.0]

--- a/src/aiconfigurator/sdk/engine.py
+++ b/src/aiconfigurator/sdk/engine.py
@@ -37,7 +37,7 @@ import json
 from typing import Any
 
 import aiconfigurator_core
-from aiconfigurator.cli.api import _build_model_config
+from aiconfigurator.sdk.config_builders import build_model_config
 from aiconfigurator.sdk.models import get_model
 from aiconfigurator.sdk.operations import (
     GEMM,
@@ -667,7 +667,7 @@ def compile_engine(
     # does not take a model_path (quant inference is done inside `get_model`).
     resolved_moe_tp = moe_tp_size if moe_tp_size is not None else 1
     resolved_moe_ep = moe_ep_size if moe_ep_size is not None else 1
-    model_config = _build_model_config(
+    model_config = build_model_config(
         tp_size=tp_size,
         pp_size=pp_size,
         attention_dp_size=attention_dp_size,

--- a/src/aiconfigurator/sdk/memory.py
+++ b/src/aiconfigurator/sdk/memory.py
@@ -40,10 +40,10 @@ import os
 from collections.abc import Callable
 from typing import Any
 
-from aiconfigurator.cli.api import _apply_nextn, _build_model_config
 from aiconfigurator.sdk import perf_database
 from aiconfigurator.sdk.backends.factory import get_backend
 from aiconfigurator.sdk.common import DefaultHFModels
+from aiconfigurator.sdk.config_builders import apply_nextn, build_model_config
 from aiconfigurator.sdk.models import get_model
 from aiconfigurator.sdk.utils import (
     _download_hf_config,
@@ -285,7 +285,7 @@ class KVCacheEstimator:
         """
         resolved_moe_tp = moe_tp_size if moe_tp_size is not None else 1
         resolved_moe_ep = moe_ep_size if moe_ep_size is not None else 1
-        model_config = _build_model_config(
+        model_config = build_model_config(
             tp_size=tp_size,
             pp_size=pp_size,
             attention_dp_size=attention_dp_size,
@@ -301,7 +301,7 @@ class KVCacheEstimator:
         # model.config.nextn to scale activation memory for speculative decoding, so
         # skipping this would size non-KV memory as if nextn=0 and overstate the KV
         # budget. Mirrors the agg/disagg/static estimate paths in cli.api.
-        _apply_nextn(model_config, nextn, nextn_accept_rates)
+        apply_nextn(model_config, nextn, nextn_accept_rates)
         model = get_model(model_path, model_config, backend)
         backend_obj = get_backend(backend)
         database = perf_database.get_database(system, backend, backend_version)

--- a/tests/README.md
+++ b/tests/README.md
@@ -17,6 +17,7 @@ The test runner is **just pytest** (no custom wrapper scripts).
 The E2E CLI tests execute the installed `aiconfigurator` console script, so make sure you have an editable install:
 
 ```bash
+python3 -m pip install -e src/aiconfigurator-core
 python3 -m pip install -e ".[dev]"
 ```
 

--- a/tests/unit/sdk/test_package_layering.py
+++ b/tests/unit/sdk/test_package_layering.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Packaging boundary checks for the lower SDK/core wheel."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+SDK_ROOT = Path(__file__).parents[3] / "src" / "aiconfigurator" / "sdk"
+
+
+def _is_cli_child(name: str) -> bool:
+    return name == "cli" or name.startswith("cli.")
+
+
+def _is_absolute_cli_import(name: str) -> bool:
+    return name == "aiconfigurator.cli" or name.startswith("aiconfigurator.cli.")
+
+
+def _sdk_package_parts(path: Path) -> tuple[str, ...]:
+    return ("aiconfigurator", "sdk", *path.parent.parts)
+
+
+def _resolve_import_from_module(node: ast.ImportFrom, package_parts: tuple[str, ...]) -> str | None:
+    module = node.module or ""
+    if node.level == 0:
+        return module
+
+    if node.level > len(package_parts):
+        return None
+
+    base_parts = package_parts[: len(package_parts) - node.level + 1]
+    if module:
+        return ".".join((*base_parts, *module.split(".")))
+    return ".".join(base_parts)
+
+
+def _is_cli_import_from(node: ast.ImportFrom, package_parts: tuple[str, ...]) -> bool:
+    resolved_module = _resolve_import_from_module(node, package_parts)
+    if resolved_module is None:
+        return False
+    if _is_absolute_cli_import(resolved_module):
+        return True
+    if resolved_module == "aiconfigurator":
+        return any(_is_cli_child(alias.name) for alias in node.names)
+    return False
+
+
+def _cli_import_offenders(path: Path, source: str, root: Path | None = None) -> list[str]:
+    offenders: list[str] = []
+    display_path = path.relative_to(root) if root is not None else path
+    package_parts = _sdk_package_parts(display_path)
+    tree = ast.parse(source, filename=str(path))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if _is_absolute_cli_import(alias.name):
+                    offenders.append(f"{display_path}:{node.lineno}")
+        elif isinstance(node, ast.ImportFrom) and _is_cli_import_from(node, package_parts):
+            offenders.append(f"{display_path}:{node.lineno}")
+    return offenders
+
+
+def test_sdk_modules_do_not_import_cli_layer() -> None:
+    offenders: list[str] = []
+    for path in sorted(SDK_ROOT.rglob("*.py")):
+        offenders.extend(_cli_import_offenders(path, path.read_text(encoding="utf-8"), SDK_ROOT))
+
+    assert offenders == []
+
+
+@pytest.mark.parametrize(
+    ("path", "source"),
+    [
+        (Path("memory.py"), "import aiconfigurator.cli\n"),
+        (Path("memory.py"), "import aiconfigurator.cli.api\n"),
+        (Path("memory.py"), "from aiconfigurator import cli\n"),
+        (Path("memory.py"), "from aiconfigurator.cli import api\n"),
+        (Path("memory.py"), "from aiconfigurator.cli.api import cli_estimate\n"),
+        (Path("memory.py"), "from .. import cli\n"),
+        (Path("memory.py"), "from ..cli import api\n"),
+        (Path("memory.py"), "from ..cli.api import cli_estimate\n"),
+        (Path("subpkg/module.py"), "from ... import cli\n"),
+        (Path("subpkg/module.py"), "from ...cli.api import cli_estimate\n"),
+    ],
+)
+def test_cli_import_offenders_flags_absolute_and_relative_cli_imports(path: Path, source: str) -> None:
+    assert _cli_import_offenders(path, source) == [f"{path}:1"]
+
+
+@pytest.mark.parametrize(
+    ("path", "source"),
+    [
+        (Path("memory.py"), "import aiconfigurator.sdk.memory\n"),
+        (Path("memory.py"), "from aiconfigurator import sdk\n"),
+        (Path("memory.py"), "from . import cli\n"),
+        (Path("subpkg/module.py"), "from .. import cli\n"),
+        (Path("subpkg/module.py"), "from ..cli import api\n"),
+    ],
+)
+def test_cli_import_offenders_ignores_non_cli_layer_imports(path: Path, source: str) -> None:
+    assert _cli_import_offenders(path, source) == []

--- a/uv.lock
+++ b/uv.lock
@@ -22,22 +22,17 @@ name = "aiconfigurator"
 version = "0.9.0"
 source = { editable = "." }
 dependencies = [
+    { name = "aiconfigurator-core" },
     { name = "bokeh" },
     { name = "jinja2" },
     { name = "matplotlib" },
-    { name = "munch" },
     { name = "numpy" },
-    { name = "nvidia-ml-py" },
     { name = "packaging" },
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
     { name = "pandas", version = "3.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "plotext" },
     { name = "plotly" },
     { name = "prettytable" },
-    { name = "pyarrow" },
     { name = "pyyaml" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "tqdm" },
 ]
 
@@ -67,23 +62,20 @@ webapp = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiconfigurator-core", editable = "src/aiconfigurator-core" },
     { name = "bokeh" },
     { name = "fastapi", marker = "extra == 'service'", specifier = ">=0.115.12" },
     { name = "gradio", marker = "extra == 'webapp'", specifier = "==6.8.0" },
     { name = "import-ipynb", marker = "extra == 'dev'", specifier = "==0.2" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "matplotlib", specifier = ">=3.9.4" },
-    { name = "munch", specifier = ">=4.0.0" },
     { name = "numpy", specifier = "~=1.26.4" },
-    { name = "nvidia-ml-py" },
     { name = "orjson", marker = "extra == 'service'", specifier = ">=3.10.16" },
     { name = "packaging", specifier = ">=20.0" },
     { name = "pandas", specifier = ">=2.2.3" },
-    { name = "plotext", specifier = ">=5.3.2" },
     { name = "plotly", specifier = ">=6.0.1" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = "==4.3.0" },
     { name = "prettytable", specifier = ">=3.16.0" },
-    { name = "pyarrow", specifier = ">=15.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.5" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.26.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.1.1" },
@@ -94,12 +86,46 @@ requires-dist = [
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = "==3.8.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.14.1" },
-    { name = "scipy", specifier = ">=1.13.1" },
     { name = "tqdm", specifier = ">=4.0.0" },
     { name = "uv", marker = "extra == 'dev'" },
     { name = "uvicorn", marker = "extra == 'service'", specifier = ">=0.34.2" },
 ]
 provides-extras = ["dev", "webapp", "service"]
+
+[[package]]
+name = "aiconfigurator-core"
+version = "0.9.0"
+source = { editable = "src/aiconfigurator-core" }
+dependencies = [
+    { name = "matplotlib" },
+    { name = "munch" },
+    { name = "numpy" },
+    { name = "nvidia-ml-py" },
+    { name = "packaging" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
+    { name = "pandas", version = "3.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "plotext" },
+    { name = "pyarrow" },
+    { name = "pyyaml" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "tqdm" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "matplotlib", specifier = ">=3.9.4" },
+    { name = "munch", specifier = ">=4.0.0" },
+    { name = "numpy", specifier = "~=1.26.4" },
+    { name = "nvidia-ml-py" },
+    { name = "packaging", specifier = ">=20.0" },
+    { name = "pandas", specifier = ">=2.2.3" },
+    { name = "plotext", specifier = ">=5.3.2" },
+    { name = "pyarrow", specifier = ">=15.0.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
+    { name = "scipy", specifier = ">=1.13.1" },
+    { name = "tqdm", specifier = ">=4.0.0" },
+]
 
 [[package]]
 name = "aiofiles"


### PR DESCRIPTION
## Overview
Splits AIConfigurator into two wheels: the upper `aiconfigurator` package for CLI/generator/webapp code, and the lower `aiconfigurator-core` package for SDK modeling, estimator code, systems data, model configs, and the Rust extension.

## Details
- Moves the lower-wheel Python project root to `src/aiconfigurator-core` while keeping the Rust crate under `rust/aiconfigurator-core`.
- Makes the upper wheel depend on `aiconfigurator-core==0.9.0` and updates local, Docker, and CI install/build paths for the two-wheel layout.
- Moves shared model-config construction into `aiconfigurator.sdk.config_builders` so SDK engine and memory estimators do not import CLI code at runtime.
- Adds and expands package-layering tests to catch both absolute and relative SDK-to-CLI imports.
- Isolates accuracy regression old-ref prediction generation in an old-revision virtualenv so the old run cannot resolve the incoming core package.

## reviewer-start
Start with `src/aiconfigurator-core/pyproject.toml`, `pyproject.toml`, and `docker/Dockerfile` to review the packaging boundary, then check `src/aiconfigurator/sdk/config_builders.py`, `src/aiconfigurator/sdk/engine.py`, and `src/aiconfigurator/sdk/memory.py` for the runtime dependency change.

## Related Issues
- None.

## Verification
- `uv run ruff check tests/unit/sdk/test_package_layering.py`
- `uv run pytest -q tests/unit/sdk/test_package_layering.py`
- `uv run pytest -q tests/unit/sdk/test_memory_estimation.py tests/unit/sdk/test_rust_engine_step.py tests/unit/sdk/backends/test_base_backend.py`
- `cd src/aiconfigurator-core && uv build --wheel --out-dir /tmp/aic-core-dist`
- `uv build --wheel --out-dir /tmp/aic-root-dist`
- `docker build -f docker/Dockerfile --target build -t aiconfigurator:pr1251-build .`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved installation/build flow so the core component is built/installed first and reused across local, Docker, and CI workflows.
* **Bug Fixes**
  * Unified model configuration creation and `nextn` / accept-rate override behavior across CLI and SDK memory/engine paths.
* **Documentation**
  * Updated README, DEVELOPMENT.md, Docker build guidance, and test setup instructions to match core-first installation.
* **Tests**
  * Added unit coverage to prevent SDK modules from importing CLI-layer internals.
* **Chores**
  * Refreshed packaging and CI dependency/install logic, including legacy-revision prediction runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->