### PR TITLE
feat: add sparse performance surrogate interpolation

### DIFF
--- a/docs/design/interpolation_perfsurrogate_design.md
+++ b/docs/design/interpolation_perfsurrogate_design.md
@@ -1,0 +1,453 @@
+# Sparse Performance Surrogate Design
+
+Status: implemented in draft PR #1255. The Python integration and structural
+tests are complete; predictive-accuracy validation is not yet accepted.
+
+## Decision summary
+
+Performance data is modeled as a set of real, potentially ragged samples rather
+than as a complete Cartesian grid. A query declares one semantically meaningful
+`varying` axis, such as GEMM `m`, attention sequence length, or MoE token count.
+The estimator first evaluates real one-dimensional curves along that axis and
+then combines nearby curves with a line or triangle in the remaining axes.
+
+This is a deliberate middle ground:
+
+- it preserves operation knowledge about which dimension should be evaluated
+  first;
+- it fills holes without synthesizing a dense grid;
+- it supports physically anchored extrapolation through an operation-provided
+  baseline; and
+- it keeps one small numerical implementation shared by many operations.
+
+The design is not an arbitrary-dimensional or learned surrogate. It supports
+one varying axis plus at most two other continuous axes. Categorical routing,
+discontinuous regimes, and operation-specific physical formulas remain in the
+operation adapter.
+
+The curve-plus-simplex decomposition structurally accommodates the dimensionality
+of the measured tables in scope. Predictive suitability is not yet established.
+The main unresolved risks are the absence of a support-distance limit and the
+lack of data-backed acceptance results for interpolation and extrapolation. The
+implementation should not be expanded to more operation families until those
+risks are evaluated.
+
+## Problem
+
+AIConfigurator performance tables are collected at selected workload shapes.
+They are not guaranteed to contain every point in a Cartesian product:
+
+- expensive or invalid shape combinations may be omitted;
+- different fixed configurations may contain different sequence or token
+  samples;
+- collectors may stop at different frontiers; and
+- categorical regimes such as backend, kernel, quantization, or tensor
+  parallelism must never be interpolated together.
+
+The legacy approach often expected a dense nested grid or filled missing values
+axis by axis. That creates three problems:
+
+1. generated points are treated like measurements by later interpolation;
+2. the result can depend on the order in which axes are filled; and
+3. a Cartesian product cannot represent a genuinely ragged frontier cleanly.
+
+At the same time, a completely generic scattered interpolator would discard
+useful prior knowledge. For example, GEMM should form performance curves along
+`m` before combining neighboring `(n, k)` configurations. The common layer must
+therefore share numerical mechanics without erasing operation semantics.
+
+## Goals
+
+- Query real ragged samples without load-time Cartesian expansion.
+- Return an exact measurement unchanged when the core receives an exact point.
+- Preserve one operation-declared semantic varying axis.
+- Interpolate between neighboring real curves in up to two fixed axes.
+- Authorize exterior estimates per axis and per direction.
+- Allow the operation to provide a physical or empirical baseline for exterior
+  scaling.
+- Keep latency and energy internally consistent by interpolating average power
+  for modeled points.
+- Compile and cache table geometry once per unique query key, axis declaration,
+  varying axis, and table identity.
+- Keep operation adapters small enough that future measured operations can use
+  the same query path.
+
+## Non-goals
+
+- Arbitrary-dimensional interpolation.
+- Inferring categorical compatibility from numeric proximity.
+- Replacing analytical or formula-only operation paths.
+- Defining a universal SOL formula or a universal latency floor.
+- Providing uncertainty, confidence, provenance, or support-distance metadata.
+- Training or serving an ML model.
+- Rust parity in this change.
+- Changing collector schemas except where a loader must preserve dimensions
+  already present in collected data.
+
+## Public API and adapter contract
+
+The reusable surface in `sdk/perf_surrogate.py` consists of `Axis` and
+`estimate_sparse`:
+
+```python
+latency, energy = estimate_sparse(
+    database,
+    key=("gemm", table_quant_mode, quant_mode),
+    table=gemm_data,
+    query={"m": m, "n": n, "k": k},
+    axes=(
+        Axis("m", extrapolate="both"),
+        Axis("n", log=True, extrapolate="both"),
+        Axis("k", log=True, extrapolate="both"),
+    ),
+    varying="m",
+    curve="raw",
+    mesh="baseline_ratio",
+    exterior="baseline_ratio",
+    baseline=lambda point: get_sol(point["m"], point["n"], point["k"], quant_mode)[0],
+)
+```
+
+An adapter must provide:
+
+- numeric axes in exactly the same order as the nested table;
+- one unique `varying` axis;
+- optional `log=True` coordinate transforms;
+- one of `never`, `lower`, `upper`, or `both` as each axis's exterior policy;
+- `raw`, `sqrt`, or `baseline_ratio` responses for curve, mesh, and exterior
+  blending;
+- a finite positive baseline whenever `baseline_ratio` is selected; and
+- a cache key that uniquely identifies the already-selected categorical table.
+
+Before calling the common estimator, the adapter must select exact categories
+such as backend, kernel source, dtype, quantization mode, phase, TP/EP/CP size,
+head layout, or compression ratio. A discontinuity such as DSA's top-k regime
+must also be split before interpolation.
+
+After the call, operation-specific behavior remains outside the estimator. This
+includes prefix correction, decode smoothing, top-k deltas, topology scaling,
+and composite-operation assembly. The common estimator does not attempt to
+understand these semantics.
+
+## Data contract
+
+The table is a nested mapping in axis order:
+
+```text
+table[axis_0][axis_1]...[axis_n] -> metric leaf
+```
+
+A leaf may be a latency scalar or a mapping with `latency` and optional
+`energy` or `power`. If only power is present, the core derives
+`energy = power * latency`. Coordinates and metrics must be finite; log axes
+must be positive; latency and energy must be non-negative.
+
+The estimator flattens and sorts every leaf supplied by the adapter. It has no
+provenance field that can distinguish a measurement from a previously generated
+value. Adapters must therefore pass a measurement-only table or view. The
+estimator itself never inserts a synthetic sample into the source table.
+
+## Mathematical decomposition
+
+Write a query as `q = (z, t)`, where `t` is the semantic varying axis and `z`
+contains zero, one, or two fixed axes. In the support equations, coordinates
+mean their declared encoded values, such as `log2(n)` rather than raw `n`.
+Samples sharing the same raw fixed key form a real curve `C_z(t)`.
+
+For an interior fixed-axis query, the line or triangle support provides weights
+such that:
+
+```text
+z = sum_i w_i z_i
+sum_i w_i = 1
+w_i >= 0
+```
+
+Each supporting curve is first evaluated at `t`. Those component estimates are
+then combined with the same fixed-axis weights. This preserves the semantic
+axis ordering without an `X`, then `Y`, then `Z` chain and without requiring a
+rectangular grid.
+
+The three response functions are:
+
+```text
+raw:
+    L_hat(q) = sum_i w_i L_i
+
+sqrt:
+    L_hat(q) = (sum_i w_i sqrt(L_i))^2
+
+baseline_ratio:
+    L_hat(q) = B(q) * sum_i w_i * L_i / B(x_i)
+```
+
+`B` is supplied by the operation. It may be an analytical SOL, a measured
+boundary model, or a simpler workload proxy when that is the only justified
+policy. `baseline_ratio` is an arithmetic ratio interpolation; it is not a log
+residual model and does not by itself guarantee `L_hat >= B`.
+
+For modeled points, energy is reconstructed from interpolated average power:
+
+```text
+P_i = E_i / L_i                  # zero when L_i is zero
+P_hat = sum_i w_i P_i
+E_hat = P_hat * L_hat
+```
+
+An exact core hit returns the normalized exact latency and energy directly; a
+power-only leaf is normalized to energy while the table is flattened. An
+operation may still apply a correction after the core returns, so any such
+correction must separately preserve the desired power/energy semantics.
+
+## Query state machine
+
+The current implementation resolves a query in this order:
+
+1. Validate that query names exactly match the declared axes.
+2. Return an exact measured point when present.
+3. If the fixed key exactly matches a real curve, bracket the varying axis on
+   that curve.
+4. Otherwise locate the fixed key inside a real line segment or Delaunay
+   triangle and evaluate the supporting curves.
+5. If the fixed key is outside the convex hull, choose an allowed boundary
+   candidate from a line endpoint or two-dimensional hull edge.
+6. If the varying coordinate lies outside a supporting curve, use its permitted
+   endpoint.
+7. Use the requested curve or mesh response for an interior result. If either
+   the fixed support or a component curve is exterior, use the exterior
+   response.
+8. Reject non-finite or negative modeled metrics.
+
+If no authorized support exists, the core raises
+`InterpolationDataNotAvailableError`. It does not silently fall back to a
+global nearest neighbor.
+
+## Geometry
+
+The fixed-key mesh supports at most two axes:
+
+- zero active fixed axes: use the only curve;
+- one active fixed axis: sort curve keys and perform a line bracket; and
+- two active fixed axes: standardize coordinates and build a SciPy Delaunay
+  triangulation when at least three non-collinear points exist.
+
+Exactly constant fixed axes are treated as inactive. A query must match an
+inactive axis unless that axis explicitly authorizes the requested exterior
+direction.
+
+For a two-dimensional exterior query, the implementation scans convex-hull
+edges. Candidate boundary points include both endpoints, the orthogonal
+projection onto an edge, and intersections needed to keep a `never` axis equal
+to the query. It uses the closest admissible point from this finite candidate
+set. For `lower` and `upper` constraints it filters candidates but does not add
+the constraint-boundary/edge intersections, so this is an approximate
+projection and is not guaranteed to find the globally nearest feasible hull
+point. There is no SLSQP optimization, k-nearest-neighbor fallback, or learned
+boundary model.
+
+This design has no maximum interpolation diameter or extrapolation distance.
+An axis marked `both` can therefore authorize a query far beyond the measured
+frontier. Whether to add a small trust-region policy is an open decision that
+must be driven by holdout results rather than an arbitrary constant.
+
+## Operation integration
+
+| Family | Numeric model | Adapter behavior retained outside the core |
+| --- | --- | --- |
+| GEMM | `m` curves over log2 `(n, k)`; raw curve and baseline-ratio mesh/exterior | Exact fast path, load/query SOL correction, quantization routing, `m = 0` behavior |
+| GEMM scale overheads | `m` curves over log2 `k` | Separate compute-scale and scale-matrix tables and SOL baselines |
+| Context/encoder attention | sequence curves over heads and batch; sqrt curve response | Prefix correction, FMHA/KV categories, RoPE and memory additions |
+| Generation attention | sequence curves over heads and batch; raw curve response | Five-point sequence smoothing and SOL correction |
+| Communication | one-dimensional message-size curves | GPU-count selection, cross-node topology/bandwidth scaling; P2P remains separate |
+| Mamba/GDN | context sequence curves over batch; generation batch curves | Existing same-`d_model` structural fallback, GDN head-distance selection and kernel alias, then SOL fallback on a miss |
+| MLA | token curves over heads and batch | Backend/kernel routing, TP-to-head mapping, prefix correction, composite module formulas |
+| MoE | token curves; selected DeepEP tables also include SM count | Exact categorical routing, low-token launch policy, high-token utilization policy, dispatch/combine composition |
+| DSA | context `s` and generation `s_total` curves over heads and batch | Pre/post-top-k table split, outer prefix handling, backend selection, CP assembly |
+| DeepSeek-V4 attention | context sequence curves over prefix and batch; generation sequence curves over batch | Exact head/TP/compression/quantization selection and CSA top-k correction |
+
+These are the targeted measured-table paths, not every operation
+class in the repository. Intentionally unchanged paths include Rust, P2P,
+formula-only operations, `MLABmm`'s simple one-dimensional lookup, DeepSeek-V4
+MHC, and DeepSeek-V4 MegaMoE. DSA context prefix blending and CP composition
+also remain layered adapters rather than one monolithic surrogate call.
+
+## Cache and mutation contract
+
+Compiled geometry is stored on the database instance in
+`_sparse_surrogate_cache`. The logical key contains the caller key, axis
+declaration, and varying axis. The cache entry also retains the source table
+identity; replacing the table object rebuilds the model even if the logical key
+is reused.
+
+The flattened metrics are a snapshot. Mutating the same table object in place
+does not automatically invalidate that snapshot. Tests or SDK callers that
+intentionally mutate a table must call `PerfDatabase.clear_runtime_caches()`.
+Normal loaded performance tables are treated as immutable.
+
+## Complexity
+
+Let `N` be the number of measured leaves, `C` the number of real curves, and
+`H` the number of two-dimensional convex-hull edges.
+
+- The first query for a unique cache entry flattens and sorts `N` samples,
+  groups them into `C` curves, and builds at most a two-dimensional
+  triangulation. A cold exact query therefore pays this compilation cost.
+- A warm exact query is a dictionary lookup.
+- A curve query currently rebuilds and encodes that curve's `K` varying-axis
+  coordinates before applying a binary bracket, so it is `O(K)` rather than a
+  pure `O(log K)` lookup.
+- An interior mesh query evaluates at most three curves and performs a small
+  weighted blend.
+- A two-dimensional exterior query additionally scans `H` hull edges.
+
+There is no training, model weight loading, accelerator execution, or large
+matrix inference. The work is a small deterministic CPU geometry query and does
+not carry the training or serving machinery of an ML surrogate. Compilation is
+cached, but query cost should still be benchmarked if this path becomes a
+configuration-search hot spot.
+
+## Failure semantics
+
+The core distinguishes unsupported numerical support from invalid
+configuration:
+
+- unavailable authorized support raises `InterpolationDataNotAvailableError`;
+- malformed axes, tables, queries, responses, or baselines encountered by the
+  evaluated path raise `TypeError`/`ValueError`; and
+- valid estimates must have finite, non-negative latency and energy.
+
+Each operation retains its existing SILICON/HYBRID policy around the call. The
+common layer does not reinterpret a missing category as a nearby numeric point.
+
+## Known limitations and risks
+
+1. **At most three continuous axes.** There is one varying axis and at most two
+   fixed axes. A higher-dimensional table must first be partitioned by the
+   operation or use a different backend.
+2. **No trust region.** Large holes and distant authorized exterior queries are
+   not rejected by distance.
+3. **No uncertainty or provenance.** Callers receive only latency and energy;
+   they cannot distinguish exact, interior, or exterior results from the return
+   type alone.
+4. **No global physical floor.** Baseline quality and any final SOL clamp belong
+   to the adapter. A baseline is not necessarily a lower bound.
+5. **No monotonicity constraint.** Measured kernel teeth and simplex layout can
+   produce locally non-monotone estimates.
+6. **Rank-deficient correlated fixed axes.** The engine does not infer an
+   arbitrary lower-dimensional manifold when two nominally active axes are
+   collinear.
+7. **Delaunay topology.** Sparse layouts can admit more than one reasonable
+   diagonal; the selected local linear surface is not a tensor-product surface.
+8. **Directional hull projection is approximate.** The finite candidate set
+   can miss the true nearest feasible point where a one-way `lower` or `upper`
+   constraint intersects a hull edge.
+9. **Fixed support is selected without varying-axis coverage.** After choosing
+   a line or triangle in fixed space, the engine does not search an alternate
+   support if one selected curve cannot serve the varying coordinate. It can
+   also extrapolate a selected curve even when a different nearby support might
+   interpolate that coordinate.
+10. **Some declaration validation is lazy.** Exact hits bypass response and
+    baseline evaluation, and invalid exterior-policy strings are not rejected
+    eagerly. A bad declaration may therefore surface only on a modeled path.
+11. **Adapter postprocessing can break energy consistency.** Any latency clamp
+    after estimation must rescale energy if average power is intended to remain
+    constant. The current rollout audit identified GEMM and
+    generation-attention SOL corrections, plus DSA's independent prefix
+    interpolation of latency, power, and energy, as paths requiring review.
+12. **Prediction quality is not yet established.** Structural correctness and
+    finite outputs do not prove that held-out measurements are estimated well.
+
+## Alternatives considered
+
+### Dense Cartesian expansion
+
+Rejected as the default because it invents intermediate samples, makes later
+queries depend on generated values, increases load cost, and cannot represent a
+ragged frontier without arbitrary fill rules.
+
+### Per-operation hierarchical interpolation
+
+The semantic varying-axis idea is retained, but duplicating the numerical state
+machine in every operation makes bug fixes inconsistent. The fixed-axis
+line/simplex removes the need for a bespoke `X -> Y -> Z` implementation while
+preserving the operation's first-axis prior.
+
+### Global three-dimensional scattered interpolation
+
+Not selected because it discards the repeated-curve structure, uses more
+geometry than needed, and gives no natural priority to the physically meaningful
+axis.
+
+### kNN, RBF, Gaussian process, or learned model
+
+These remain possible research backends, but they add neighbor policy,
+hyperparameters, training or fitting cost, and difficult exterior behavior. A
+small deterministic estimator with an explicit operation baseline is easier to
+review and deploy. A learned model should be introduced only after a measured
+accuracy advantage justifies a second backend and its interface.
+
+## Verification status
+
+The current implementation has:
+
+- focused changed-area tests: 180 passed;
+- broader Python unit selection: 1,470 passed and 8 skipped;
+- passing Ruff, formatting, unit, e2e, DCO, and build checks; and
+- real-table smoke coverage for the DeepSeek-V4 head/TP loader variants.
+
+The end-to-end accuracy job is not an acceptance signal yet. Its GitHub job is
+green because the regression step is allowed to fail, but the regression test
+for PR #1255 reported `1 failed, 1 passed`:
+
+| Metric | Base | PR | Change |
+| --- | ---: | ---: | ---: |
+| TTFT MAPE | 55.2365% | 55.3236% | +0.0871 percentage points |
+| TPOT MAPE | 37.7661% | 39.1102% | +1.3441 percentage points |
+
+Four Qwen threshold checks exceeded the current 10-point limit: one model-level
+aggregate and three configuration slices. In addition, Qwen3.5-397B-A17B
+regressed by about 6.9 percentage points across 300 samples. The suite added no
+newly predictable end-to-end samples, so it does not demonstrate hole-filling
+coverage.
+
+These results do not identify whether the error comes from GEMM, attention,
+MoE, or a downstream composition. They show that implementation tests pass but
+the numerical policy has not yet earned a quality sign-off.
+
+## Required validation before merge
+
+Build a deterministic holdout study from raw performance tables and report each
+operation family separately:
+
+1. Remove interior points from existing semantic curves.
+2. Remove complete interior fixed-key curves to create genuine ragged holes.
+3. Hold out a measured boundary layer and query it as exterior support.
+4. Compare the new estimator with the legacy path, nearest sample, and the pure
+   baseline.
+5. Report coverage plus median, P95, and maximum absolute percentage error.
+6. Stratify error by support diameter and extrapolation distance, and include
+   ragged cases where candidate fixed supports have different varying-axis
+   coverage.
+7. Verify finite/non-negative output, exact-point preservation, boundary
+   continuity, and category isolation.
+8. Decompose the Qwen regressions by operation and shape.
+
+The existing end-to-end threshold test must pass without relying on
+`continue-on-error`. If holdout error grows materially with support distance,
+add the smallest data-backed trust-region rule and return a structured miss
+beyond it. Do not add a distance cap merely to silence individual examples.
+
+## Rollout
+
+1. **Current draft:** keep the common core and migrated Python adapters in one
+   reviewable PR.
+2. **Accuracy hardening:** run the holdout study, localize the Qwen regressions,
+   and fix adapter-level energy handling.
+3. **Policy decision:** retain the simple design if the data supports it;
+   otherwise add a minimal trust-region or revise only the failing operation's
+   response/baseline policy.
+4. **Ready for review:** rerun all functional and accuracy gates, then move the
+   PR out of Draft.
+5. **Later expansion:** use this path by default for new measured Python
+   operations only after the acceptance gates pass. Rust parity and richer
+   estimate metadata remain separate decisions.

--- a/docs/design/interpolation_perfsurrogate_design.md
+++ b/docs/design/interpolation_perfsurrogate_design.md
@@ -139,8 +139,10 @@ table[axis_0][axis_1]...[axis_n] -> metric leaf
 
 A leaf may be a latency scalar or a mapping with `latency` and optional
 `energy` or `power`. If only power is present, the core derives
-`energy = power * latency`. Coordinates and metrics must be finite; log axes
-must be positive; latency and energy must be non-negative.
+`energy = power * latency`; explicit energy takes precedence when both fields
+exist. Scalar leaves and mappings without either energy or power default to
+zero energy. Coordinates and metrics must be finite; log axes must be positive;
+latency and energy must be non-negative.
 
 The estimator flattens and sorts every leaf supplied by the adapter. It has no
 provenance field that can distinguish a measurement from a previously generated
@@ -201,7 +203,8 @@ correction must separately preserve the desired power/energy semantics.
 
 ## Query state machine
 
-The current implementation resolves a query in this order:
+After a cache hit or model compilation, the current implementation resolves a
+query in this order:
 
 1. Validate that query names exactly match the declared axes.
 2. Return an exact measured point when present.
@@ -210,7 +213,8 @@ The current implementation resolves a query in this order:
 4. Otherwise locate the fixed key inside a real line segment or Delaunay
    triangle and evaluate the supporting curves.
 5. If the fixed key is outside the convex hull, choose an allowed boundary
-   candidate from a line endpoint or two-dimensional hull edge.
+   candidate from a one-dimensional line segment/endpoint or a two-dimensional
+   hull edge.
 6. If the varying coordinate lies outside a supporting curve, use its permitted
    endpoint.
 7. Use the requested curve or mesh response for an interior result. If either
@@ -231,9 +235,11 @@ The fixed-key mesh supports at most two axes:
 - two active fixed axes: standardize coordinates and build a SciPy Delaunay
   triangulation when at least three non-collinear points exist.
 
-Exactly constant fixed axes are treated as inactive. A query must match an
-inactive axis unless that axis explicitly authorizes the requested exterior
-direction.
+Fixed axes whose encoded span is within numerical tolerance are treated as
+inactive. A query must match an inactive axis within tolerance unless that axis
+explicitly authorizes the requested exterior direction. `lower` and `upper`
+describe the query relative to the selected boundary candidate, not merely its
+position relative to the table's global minimum or maximum.
 
 For a two-dimensional exterior query, the implementation scans convex-hull
 edges. Candidate boundary points include both endpoints, the orthogonal
@@ -260,16 +266,21 @@ must be driven by holdout results rather than an arbitrary constant.
 | Generation attention | sequence curves over heads and batch; raw curve response | Five-point sequence smoothing and SOL correction |
 | Communication | one-dimensional message-size curves | GPU-count selection, cross-node topology/bandwidth scaling; P2P remains separate |
 | Mamba/GDN | context sequence curves over batch; generation batch curves | Existing same-`d_model` structural fallback, GDN head-distance selection and kernel alias, then SOL fallback on a miss |
-| MLA | token curves over heads and batch | Backend/kernel routing, TP-to-head mapping, prefix correction, composite module formulas |
+| MLA | token curves over heads and batch; MLABmm uses a one-dimensional token curve | Backend/kernel routing, TP-to-head mapping, prefix correction, composite module formulas |
 | MoE | token curves; selected DeepEP tables also include SM count | Exact categorical routing, low-token launch policy, high-token utilization policy, dispatch/combine composition |
 | DSA | context `s` and generation `s_total` curves over heads and batch | Pre/post-top-k table split, outer prefix handling, backend selection, CP assembly |
 | DeepSeek-V4 attention | context sequence curves over prefix and batch; generation sequence curves over batch | Exact head/TP/compression/quantization selection and CSA top-k correction |
+| DeepSeek-V4 MHC/MegaMoE | one-dimensional token curves | Exact module/category selection; MHC uses its SOL baseline, while MegaMoE holds below its first token sample and scales proportionally above its frontier |
 
-These are the targeted measured-table paths, not every operation
-class in the repository. Intentionally unchanged paths include Rust, P2P,
-formula-only operations, `MLABmm`'s simple one-dimensional lookup, DeepSeek-V4
-MHC, and DeepSeek-V4 MegaMoE. DSA context prefix blending and CP composition
-also remain layered adapters rather than one monolithic surrogate call.
+These are the targeted measured-table paths, not every operation class in the
+repository. Intentionally unchanged paths include Rust, P2P, and formula-only
+operations. DSA context prefix blending and CP composition also remain layered
+adapters rather than one monolithic surrogate call.
+
+All 24 concrete Python operation classes that own measured performance tables
+now route their main SILICON numeric lookup through `estimate_sparse`. Measured
+correction surfaces such as the DSV4 top-k delta remain adapter logic rather
+than independent operation classes.
 
 ## Cache and mutation contract
 
@@ -357,6 +368,58 @@ common layer does not reinterpret a missing category as a nearby numeric point.
 12. **Prediction quality is not yet established.** Structural correctness and
     finite outputs do not prove that held-out measurements are estimated well.
 
+## Future four-dimensional attention
+
+Future attention tables may retain prefix as an independent numeric dimension,
+for example:
+
+```text
+prefix x heads x sequence x batch -> metrics
+```
+
+With `sequence` as the semantic varying axis, this leaves three fixed axes and
+therefore exceeds the current mesh limit. This change deliberately does not
+generalize `_FixedMesh` to three dimensions before representative four-
+dimensional data and holdouts exist.
+
+Collectors and loaders for this shape must retain prefix as a real numeric axis
+rather than pre-filling prefix combinations or collapsing them into synthetic
+samples. Existing full-sequence reductions may remain operation-specific only
+where the measured data demonstrates that prefix has no independent effect.
+
+The preferred first extension is an explicit sliced axis rather than an
+unconditional three-dimensional Delaunay mesh:
+
+1. Select categorical regimes before numerical interpolation as today.
+2. Partition the table into exact prefix slices.
+3. Evaluate each usable prefix slice with the existing
+   `sequence + (heads, batch)` surrogate.
+4. For an off-grid prefix, use only bracketing prefix slices that can both
+   answer the complete inner query.
+5. Blend latency in the declared response space and blend average power before
+   reconstructing energy. Do not independently interpolate latency, power, and
+   energy.
+6. Apply baseline-ratio exterior behavior on prefix only when the adapter
+   explicitly authorizes it.
+7. Split any regime defined by `prefix + sequence`, such as a top-k boundary,
+   before selecting prefix support.
+
+The future API should declare the sliced axis explicitly, for example through
+an `outer="prefix"` policy, rather than infer it from axis order. Exact API
+naming is deferred until the first caller is implemented.
+
+A full tetrahedral mesh over `(prefix, heads, batch)` remains an alternative,
+but it would add three-dimensional Delaunay memory, sliver-tetrahedron behavior,
+triangular hull-facet projection, and more complex directional constraints. It
+should be adopted only if holdout data shows a material accuracy advantage over
+the sliced design.
+
+Four-dimensional validation must remove complete prefix slices as well as
+individual sequence points, exercise prefix/sequence regime boundaries, and
+report error versus prefix distance. Until that validation exists, the current
+DSA outer-prefix adapter is a compatibility layer, not the final generic 4-D
+implementation.
+
 ## Alternatives considered
 
 ### Dense Cartesian expansion
@@ -390,8 +453,8 @@ accuracy advantage justifies a second backend and its interface.
 
 The current implementation has:
 
-- focused changed-area tests: 180 passed;
-- broader Python unit selection: 1,470 passed and 8 skipped;
+- focused surrogate/MLA/DSV4/loader/model tests: 302 passed;
+- broader Python unit selection: 1,471 passed and 8 skipped;
 - passing Ruff, formatting, unit, e2e, DCO, and build checks; and
 - real-table smoke coverage for the DeepSeek-V4 head/TP loader variants.
 

--- a/docs/design/interpolation_perfsurrogate_design.md
+++ b/docs/design/interpolation_perfsurrogate_design.md
@@ -451,12 +451,17 @@ accuracy advantage justifies a second backend and its interface.
 
 ## Verification status
 
-The current implementation has:
+Local validation of the current implementation has:
 
-- focused surrogate/MLA/DSV4/loader/model tests: 302 passed;
-- broader Python unit selection: 1,471 passed and 8 skipped;
-- passing Ruff, formatting, unit, e2e, DCO, and build checks; and
+- focused surrogate and migrated-operation tests: 291 passed;
+- the complete unit selection: 1,524 passed and 39 skipped, with only the four
+  documented non-TTY `test_plain_output.py` failures;
+- the complete real-database sanity suite: 27 passed and 1 expected failure;
+- passing Ruff, formatting, and `git diff --check`; and
 - real-table smoke coverage for the DeepSeek-V4 head/TP loader variants.
+
+The pushed head is DCO-signed; hosted checks rerun for each updated head and
+remain separate from these local results.
 
 The end-to-end accuracy job is not an acceptance signal yet. Its GitHub job is
 green because the regression step is allowed to fail, but the regression test

--- a/src/aiconfigurator/sdk/operations/attention.py
+++ b/src/aiconfigurator/sdk/operations/attention.py
@@ -180,7 +180,8 @@ class ContextAttention(Operation):
             scale_factor = 0.6
             return latency / scale_factor
 
-        assert n_kv <= n, "n_kv must be less than or equal to n"
+        if n_kv > n:
+            raise ValueError("n_kv must be less than or equal to n")
 
         if database_mode is None:
             database_mode = database._default_database_mode
@@ -466,7 +467,8 @@ class GenerationAttention(Operation):
             scale_factor = 0.8
             return latency / scale_factor
 
-        assert n_kv <= n, "n_kv must be less than or equal to n"
+        if n_kv > n:
+            raise ValueError("n_kv must be less than or equal to n")
 
         if database_mode is None:
             database_mode = database._default_database_mode

--- a/src/aiconfigurator/sdk/operations/attention.py
+++ b/src/aiconfigurator/sdk/operations/attention.py
@@ -3,9 +3,9 @@
 
 """Context + Generation attention ops (ISSUE-06 / AIC-543).
 
-Both classes own their CSV-backed perf tables, SOL correction (generation
-only — context attention has no SOL clamp in the legacy
-``_correct_data``), and grid extrapolation.
+Both classes own their CSV-backed perf tables and query-time sparse
+interpolation. Generation attention also retains its existing SOL correction;
+context attention has no SOL clamp in the legacy ``_correct_data``.
 ``PerfDatabase.query_context_attention`` / ``query_generation_attention``
 delegate here.
 
@@ -24,47 +24,15 @@ import logging
 from collections import defaultdict
 from typing import TYPE_CHECKING, ClassVar
 
-from aiconfigurator.sdk import common, interpolation
+from aiconfigurator.sdk import common
 from aiconfigurator.sdk.operations.base import Operation, _read_filtered_rows
+from aiconfigurator.sdk.perf_surrogate import Axis, estimate_sparse
 from aiconfigurator.sdk.performance_result import PerformanceResult
 
 if TYPE_CHECKING:
     from aiconfigurator.sdk.perf_database import PerfDatabase
 
 logger = logging.getLogger(__name__)
-
-
-# Extrapolation target grids — lifted verbatim from the legacy blocks in
-# ``PerfDatabase.__init__`` so behavior stays bit-identical.
-
-# fmt: off
-_CONTEXT_ATTENTION_TARGET_X: list[int] = [
-    1, 2, 3, 4, 5, 6, 8, 9, 10, 12, 14, 16, 18, 20, 24, 28, 32, 36, 40, 48,
-    56, 72, 96, 128,
-]  # n
-_CONTEXT_ATTENTION_TARGET_Y: list[int] = (
-    [1, 16, 32, 64, 128, 256, 512, 1024, 2048]
-    + [4096 + i * 2048 for i in range(14)]
-    + [32768 + 16384 * i for i in range(6)]
-    + [131072 + 32768 * i for i in range(12)]
-    + [524288 + 65536 * i for i in range(9)]
-)  # s
-_CONTEXT_ATTENTION_TARGET_Z: list[int] = [
-    1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 384, 1024, 2048,
-]  # b
-
-_GENERATION_ATTENTION_TARGET_X: list[int] = [
-    1, 2, 3, 4, 5, 6, 8, 9, 10, 12, 14, 16, 18, 20, 24, 28, 32, 36, 40, 48,
-    56, 72, 96, 128,
-]  # n
-_GENERATION_ATTENTION_TARGET_Y: list[int] = [
-    1, 2, 4, 8, 16, 32, 64, 128, 256, 384, 512, 1024, 2048, 8192,
-]  # b
-_GENERATION_ATTENTION_TARGET_Z: list[int] = [
-    1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384,
-    32768, 65536, 131072, 262144, 2097152 * 8,
-]  # s
-# fmt: on
 
 
 def _cache_key(database: PerfDatabase) -> tuple:
@@ -88,8 +56,8 @@ class ContextAttention(Operation):
     Context (prefill) attention operation.
 
     Owns ``_data_cache: {key: LoadedOpData}`` for the context attention CSV.
-    No SOL clamp on the loaded table (legacy ``_correct_data`` did not
-    correct context attention) — only grid extrapolation runs in ``load_data``.
+    No SOL clamp is applied to the loaded table (legacy ``_correct_data`` did
+    not correct context attention).
     """
 
     _data_cache: ClassVar[dict] = {}
@@ -127,12 +95,7 @@ class ContextAttention(Operation):
 
     @classmethod
     def load_data(cls, database: PerfDatabase) -> None:
-        """Idempotent. Loads context_attention CSV into the class cache,
-        applies grid extrapolation, binds ``database._context_attention_data``.
-
-        Mirrors ``GEMM.load_data``: correction/extrapolation operate on the
-        canonical class-cache value (passed explicitly), then the instance
-        attr is bound, respecting any pre-set test override."""
+        """Load the raw context-attention samples and bind the instance view."""
         import os
 
         from aiconfigurator.sdk.perf_database import LoadedOpData, PerfDataFilename
@@ -147,7 +110,6 @@ class ContextAttention(Operation):
                 load_context_attention_data(sources), PerfDataFilename.context_attention, primary_path
             )
 
-            cls._extrapolate(cls._data_cache[key])
             cls._record_load()
 
         # Bind instance attr (respect intentional test pre-overrides).
@@ -157,29 +119,6 @@ class ContextAttention(Operation):
     @classmethod
     def clear_cache(cls) -> None:
         cls._data_cache.clear()
-
-    @classmethod
-    def _extrapolate(cls, data_wrapper) -> None:
-        """Apply the legacy 4-level (quant_mode → kv_cache_dtype → num_kv_heads
-        → head_size → window_size → grid) extrapolation."""
-        if data_wrapper is None or not getattr(data_wrapper, "loaded", False):
-            return
-
-        for quant_mode in data_wrapper:
-            for kv_cache_dtype in data_wrapper[quant_mode]:
-                for num_kv_heads in data_wrapper[quant_mode][kv_cache_dtype]:
-                    for head_size in data_wrapper[quant_mode][kv_cache_dtype][num_kv_heads]:
-                        for window_size in data_wrapper[quant_mode][kv_cache_dtype][num_kv_heads][head_size]:
-                            data_dict = data_wrapper[quant_mode][kv_cache_dtype][num_kv_heads][head_size][window_size]
-                            min_x = min(data_dict.keys())
-                            filtered_x = [i for i in _CONTEXT_ATTENTION_TARGET_X if i >= min_x]
-                            interpolation.extrapolate_data_grid(
-                                data_dict=data_dict,
-                                target_x_list=filtered_x,
-                                target_y_list=_CONTEXT_ATTENTION_TARGET_Y,
-                                target_z_list=_CONTEXT_ATTENTION_TARGET_Z,
-                                sqrt_y_value=True,
-                            )
 
     # ------------------------------------------------------------------
     # Query table (formerly PerfDatabase.query_context_attention)
@@ -265,16 +204,34 @@ class ContextAttention(Operation):
             prefix_correction = (full_s * full_s - prefix * prefix) / (full_s * full_s)
             n_kv_lookup = 0 if n == n_kv else n_kv
             attention_dict = data_wrapper[fmha_quant_mode][kvcache_quant_mode][n_kv_lookup][head_size][window_size]
-            result = interpolation.interp_3d(
-                n,
-                full_s,
-                b,
+            latency, energy = estimate_sparse(
+                database,
+                ("context_attention", fmha_quant_mode, kvcache_quant_mode, n_kv_lookup, head_size, window_size),
                 attention_dict,
-                "cubic",
-                database._extracted_metrics_cache,
+                {"heads": n, "full_sequence": full_s, "batch": b},
+                axes=(
+                    Axis("heads", extrapolate="both"),
+                    Axis("full_sequence", extrapolate="both"),
+                    Axis("batch", extrapolate="both"),
+                ),
+                varying="full_sequence",
+                curve="sqrt",
+                mesh="raw",
+                exterior="baseline_ratio",
+                baseline=lambda point: get_sol(
+                    point["batch"],
+                    point["full_sequence"],
+                    0,
+                    point["heads"],
+                    point["heads"] if n_kv_lookup == 0 else n_kv_lookup,
+                    head_size,
+                    window_size,
+                    kvcache_quant_mode,
+                    fmha_quant_mode,
+                )[0],
             )
-            latency = result["latency"] * prefix_correction
-            energy = result.get("energy", 0.0) * prefix_correction
+            latency *= prefix_correction
+            energy *= prefix_correction
             return database._interp_pr(latency, energy=energy)
 
         return database._query_silicon_or_hybrid(
@@ -344,8 +301,7 @@ class GenerationAttention(Operation):
     Generation (decode) attention operation.
 
     Owns ``_data_cache: {key: LoadedOpData}`` for the generation attention
-    CSV. ``load_data`` applies both SOL clamping AND grid extrapolation
-    (legacy ``_correct_data`` clamped, then ``__init__`` extrapolated).
+    CSV. ``load_data`` retains the legacy SOL clamp on measured samples.
     """
 
     _data_cache: ClassVar[dict] = {}
@@ -381,12 +337,7 @@ class GenerationAttention(Operation):
 
     @classmethod
     def load_data(cls, database: PerfDatabase) -> None:
-        """Idempotent. Loads generation_attention CSV, clamps to SOL, applies
-        grid extrapolation, binds ``database._generation_attention_data``.
-
-        Mirrors ``GEMM.load_data``: correction/extrapolation operate on the
-        canonical class-cache value (passed explicitly), then the instance
-        attr is bound, respecting any pre-set test override."""
+        """Load generation-attention samples, clamp them to SOL, and bind them."""
         import os
 
         from aiconfigurator.sdk.perf_database import LoadedOpData, PerfDataFilename
@@ -401,13 +352,6 @@ class GenerationAttention(Operation):
                 load_generation_attention_data(sources), PerfDataFilename.generation_attention, primary_path
             )
 
-            cls._correct_sol(database, cls._data_cache[key])
-            cls._extrapolate(cls._data_cache[key])
-            # Re-clamp after extrapolation: interpolated/extrapolated grid
-            # points can land below the SOL bound. The legacy init path ran
-            # ``_correct_data()`` a second time which caught these; replicate
-            # that here so standalone ``load_data`` callers get the same
-            # physically-consistent floor.
             cls._correct_sol(database, cls._data_cache[key])
             cls._record_load()
 
@@ -464,26 +408,6 @@ class GenerationAttention(Operation):
                                             ] = float(sol)
                                         else:
                                             data_wrapper[quant_mode][n_kv][head_size][window_size][n][b][s] = float(sol)
-
-    @classmethod
-    def _extrapolate(cls, data_wrapper) -> None:
-        """Apply the legacy 4-level extrapolation grid."""
-        if data_wrapper is None or not getattr(data_wrapper, "loaded", False):
-            return
-
-        for kv_cache_dtype in data_wrapper:
-            for num_kv_heads in data_wrapper[kv_cache_dtype]:
-                for head_size in data_wrapper[kv_cache_dtype][num_kv_heads]:
-                    for window_size in data_wrapper[kv_cache_dtype][num_kv_heads][head_size]:
-                        data_dict = data_wrapper[kv_cache_dtype][num_kv_heads][head_size][window_size]
-                        min_x = min(data_dict.keys())
-                        filtered_x = [i for i in _GENERATION_ATTENTION_TARGET_X if i >= min_x]
-                        interpolation.extrapolate_data_grid(
-                            data_dict=data_dict,
-                            target_x_list=filtered_x,
-                            target_y_list=_GENERATION_ATTENTION_TARGET_Y,
-                            target_z_list=_GENERATION_ATTENTION_TARGET_Z,
-                        )
 
     # ------------------------------------------------------------------
     # Query table (formerly PerfDatabase.query_generation_attention)
@@ -571,9 +495,37 @@ class GenerationAttention(Operation):
             latency_sum = 0.0
             energy_sum = 0.0
             for s_i in s_samples:
-                r = interpolation.interp_3d(n, b, s_i, attention_dict, "bilinear", database._extracted_metrics_cache)
-                latency_sum += float(r["latency"])
-                energy_sum += float(r.get("energy", 0.0))
+                latency, energy = estimate_sparse(
+                    database,
+                    ("generation_attention", kvcache_quant_mode, n_kv_lookup, head_size, window_size),
+                    attention_dict,
+                    {"heads": n, "batch": b, "sequence": s_i},
+                    axes=(
+                        Axis("heads", extrapolate="both"),
+                        Axis("batch", extrapolate="both"),
+                        Axis("sequence", extrapolate="both"),
+                    ),
+                    varying="sequence",
+                    curve="raw",
+                    mesh="raw",
+                    exterior="baseline_ratio",
+                    baseline=lambda point: get_sol(
+                        point["batch"],
+                        point["sequence"],
+                        point["heads"],
+                        point["heads"] if n_kv_lookup == 0 else n_kv_lookup,
+                        head_size,
+                        window_size,
+                        kvcache_quant_mode,
+                    )[0],
+                )
+                latency_sum += max(
+                    latency,
+                    get_sol(
+                        b, s_i, n, n if n_kv_lookup == 0 else n_kv_lookup, head_size, window_size, kvcache_quant_mode
+                    )[0],
+                )
+                energy_sum += energy
 
             latency = latency_sum / sample_cnt
             energy = energy_sum / sample_cnt
@@ -641,8 +593,7 @@ class EncoderAttention(Operation):
 
     Owns ``_data_cache: {key: LoadedOpData}`` for the encoder attention CSV.
     Schema is simpler than context attention: MHA only (no n_kv), no KV cache
-    (no kvcache_quant_mode), no sliding window. No SOL clamp. Grid extrapolation
-    reuses ``_CONTEXT_ATTENTION_TARGET_*``.
+    (no kvcache_quant_mode), no sliding window, and no SOL clamp.
     """
 
     _data_cache: ClassVar[dict] = {}
@@ -678,9 +629,7 @@ class EncoderAttention(Operation):
 
     @classmethod
     def load_data(cls, database: PerfDatabase) -> None:
-        """Idempotent. Loads encoder_attention CSV into the class cache,
-        applies grid extrapolation, binds ``database._encoder_attention_data``.
-        """
+        """Load the raw encoder-attention samples and bind the instance view."""
         import os
 
         from aiconfigurator.sdk.perf_database import LoadedOpData, PerfDataFilename
@@ -695,7 +644,6 @@ class EncoderAttention(Operation):
                 load_encoder_attention_data(sources), PerfDataFilename.encoder_attention, primary_path
             )
 
-            cls._extrapolate(cls._data_cache[key])
             cls._record_load()
 
         # Bind instance attr (respect intentional test pre-overrides).
@@ -705,26 +653,6 @@ class EncoderAttention(Operation):
     @classmethod
     def clear_cache(cls) -> None:
         cls._data_cache.clear()
-
-    @classmethod
-    def _extrapolate(cls, data_wrapper) -> None:
-        """Densify the (n, s, b) grid. Reuses ``_CONTEXT_ATTENTION_TARGET_*``
-        since the encoder query shape matches context attention exactly."""
-        if data_wrapper is None or not getattr(data_wrapper, "loaded", False):
-            return
-
-        for quant_mode in data_wrapper:
-            for head_size in data_wrapper[quant_mode]:
-                data_dict = data_wrapper[quant_mode][head_size]
-                min_x = min(data_dict.keys())
-                filtered_x = [i for i in _CONTEXT_ATTENTION_TARGET_X if i >= min_x]
-                interpolation.extrapolate_data_grid(
-                    data_dict=data_dict,
-                    target_x_list=filtered_x,
-                    target_y_list=_CONTEXT_ATTENTION_TARGET_Y,
-                    target_z_list=_CONTEXT_ATTENTION_TARGET_Z,
-                    sqrt_y_value=True,
-                )
 
     # ------------------------------------------------------------------
     # Query table (formerly PerfDatabase.query_encoder_attention)
@@ -777,8 +705,25 @@ class EncoderAttention(Operation):
         def get_silicon():
             data_wrapper.raise_if_not_loaded()
             attention_dict = data_wrapper[fmha_quant_mode][head_size]
-            result = interpolation.interp_3d(n, s, b, attention_dict, "cubic", database._extracted_metrics_cache)
-            return database._interp_pr(result["latency"], energy=result.get("energy", 0.0))
+            latency, energy = estimate_sparse(
+                database,
+                ("encoder_attention", fmha_quant_mode, head_size),
+                attention_dict,
+                {"heads": n, "sequence": s, "batch": b},
+                axes=(
+                    Axis("heads", extrapolate="both"),
+                    Axis("sequence", extrapolate="both"),
+                    Axis("batch", extrapolate="both"),
+                ),
+                varying="sequence",
+                curve="sqrt",
+                mesh="raw",
+                exterior="baseline_ratio",
+                baseline=lambda point: get_sol(
+                    point["batch"], point["sequence"], point["heads"], head_size, fmha_quant_mode
+                )[0],
+            )
+            return database._interp_pr(latency, energy=energy)
 
         return database._query_silicon_or_hybrid(
             get_silicon=get_silicon,

--- a/src/aiconfigurator/sdk/operations/communication.py
+++ b/src/aiconfigurator/sdk/operations/communication.py
@@ -30,8 +30,9 @@ import logging
 from collections import defaultdict
 from typing import TYPE_CHECKING, ClassVar
 
-from aiconfigurator.sdk import common, interpolation
+from aiconfigurator.sdk import common
 from aiconfigurator.sdk.operations.base import Operation, _read_filtered_rows
+from aiconfigurator.sdk.perf_surrogate import Axis, estimate_sparse
 from aiconfigurator.sdk.performance_result import PerformanceResult
 
 if TYPE_CHECKING:
@@ -176,19 +177,18 @@ class CustomAllReduce(Operation):
                     "Consider using HYBRID mode, or supply custom_allreduce_perf.txt rows "
                     "covering this tp_size."
                 )
-            size_left, size_right = interpolation.nearest_1d_point_helper(
-                size, list(comm_dict.keys()), inner_only=False
+            lat, energy = estimate_sparse(
+                database,
+                ("custom_allreduce", quant_mode, effective_tp, "AUTO"),
+                comm_dict,
+                {"message_size": size},
+                axes=(Axis("message_size", extrapolate="both"),),
+                varying="message_size",
+                curve="raw",
+                mesh="raw",
+                exterior="baseline_ratio",
+                baseline=lambda point: get_sol(quant_mode, effective_tp, point["message_size"])[0],
             )
-            result = interpolation.interp_1d(
-                [size_left, size_right], [comm_dict[size_left], comm_dict[size_right]], size
-            )
-
-            if isinstance(result, dict):
-                lat = result["latency"]
-                energy = result.get("energy", 0.0)
-            else:
-                lat = result
-                energy = 0.0
 
             if tp_size > database.system_spec["node"]["num_gpus_per_node"]:
                 base_bw = database._get_p2p_bandwidth(database.system_spec["node"]["num_gpus_per_node"])
@@ -378,24 +378,20 @@ class NCCL(Operation):
             nccl_source.raise_if_not_loaded()
 
             max_num_gpus = max(nccl_source[dtype][operation].keys())
-            nccl_dict = nccl_source[dtype][operation][min(num_gpus, max_num_gpus)]
-            size_left, size_right = interpolation.nearest_1d_point_helper(
-                message_size,
-                list(nccl_dict.keys()),
-                inner_only=False,
+            effective_num_gpus = min(num_gpus, max_num_gpus)
+            nccl_dict = nccl_source[dtype][operation][effective_num_gpus]
+            lat, energy = estimate_sparse(
+                database,
+                ("collective", dtype, operation, effective_num_gpus),
+                nccl_dict,
+                {"message_size": message_size},
+                axes=(Axis("message_size", extrapolate="both"),),
+                varying="message_size",
+                curve="raw",
+                mesh="raw",
+                exterior="baseline_ratio",
+                baseline=lambda point: get_sol(dtype, effective_num_gpus, operation, point["message_size"])[0],
             )
-            result = interpolation.interp_1d(
-                [size_left, size_right],
-                [nccl_dict[size_left], nccl_dict[size_right]],
-                message_size,
-            )
-
-            if isinstance(result, dict):
-                lat = result["latency"]
-                energy = result.get("energy", 0.0)
-            else:
-                lat = result
-                energy = 0.0
 
             if num_gpus > max_num_gpus:  # need to do some correction
                 logger.debug(f"nccl num_gpus {num_gpus} > max_num_gpus {max_num_gpus}, need to do some correction")

--- a/src/aiconfigurator/sdk/operations/dsa.py
+++ b/src/aiconfigurator/sdk/operations/dsa.py
@@ -62,23 +62,26 @@ DSA_MODEL_DIMS: dict[str, dict] = {
 DEFAULT_DSA_ARCHITECTURE = "DeepseekV32ForCausalLM"
 
 
+def _dsa_backend_for_row(row) -> str:
+    """Preserve the backend category when legacy rows use kernel_source=default."""
+    kernel_source = str(row.get("kernel_source") or "").lower()
+    framework = str(row.get("framework") or "").lower()
+    return "trtllm" if "trtllm" in kernel_source or framework == "trtllm" else "flashmla_kv"
+
+
 def _select_dsa_backend(arch_dict, dsa_backend):
     """Pick the per-backend sub-dict from a context-DSA architecture node.
 
     Context data is keyed ...[architecture][backend][num_heads]...; backend is
     "trtllm" (faster kernel, non-CP default) or "flashmla_kv" (used under CP).
-    Falls back to whichever backend is present so single-backend parquets still
-    resolve. Legacy nodes without a backend axis (int head keys) pass through."""
+    Backend is categorical, so a missing requested bucket must not silently use
+    measurements from another backend. Legacy nodes without a backend axis
+    (int head keys) pass through."""
     if not isinstance(arch_dict, dict) or not arch_dict:
         return arch_dict
     if not any(isinstance(k, str) for k in arch_dict):
         return arch_dict
-    return (
-        arch_dict.get(dsa_backend)
-        or arch_dict.get("flashmla_kv")
-        or arch_dict.get("trtllm")
-        or next(iter(arch_dict.values()))
-    )
+    return arch_dict[dsa_backend]
 
 
 def _cache_key(database: PerfDatabase) -> tuple:
@@ -293,7 +296,7 @@ class ContextDSAModule(Operation):
         index_n_heads: int | None = None,
         index_head_dim: int | None = None,
         index_topk: int | None = None,
-        dsa_backend: str = "trtllm",
+        dsa_backend: str | None = None,
     ):
         """Query context DSA module table. Verbatim port of the legacy body."""
         from aiconfigurator.sdk.perf_database import PerfDataNotAvailableError
@@ -304,6 +307,8 @@ class ContextDSAModule(Operation):
 
         if architecture is None:
             architecture = DEFAULT_DSA_ARCHITECTURE
+        if dsa_backend is None:
+            dsa_backend = "trtllm" if database.backend == common.BackendName.trtllm.value else "flashmla_kv"
 
         dims = DSA_MODEL_DIMS.get(architecture, DSA_MODEL_DIMS[DEFAULT_DSA_ARCHITECTURE])
         hidden_size = dims["hidden_size"]
@@ -901,7 +906,7 @@ class GenerationDSAModule(Operation):
         index_n_heads: int | None = None,
         index_head_dim: int | None = None,
         index_topk: int | None = None,
-        dsa_backend: str = "trtllm",
+        dsa_backend: str | None = None,
     ):
         """Query generation DSA module table. Verbatim port of the legacy body."""
         from aiconfigurator.sdk.perf_database import PerfDataNotAvailableError
@@ -912,6 +917,8 @@ class GenerationDSAModule(Operation):
 
         if architecture is None:
             architecture = DEFAULT_DSA_ARCHITECTURE
+        if dsa_backend is None:
+            dsa_backend = "trtllm" if database.backend == common.BackendName.trtllm.value else "flashmla_kv"
 
         dims = DSA_MODEL_DIMS.get(architecture, DSA_MODEL_DIMS[DEFAULT_DSA_ARCHITECTURE])
         hidden_size = dims["hidden_size"]
@@ -1125,7 +1132,7 @@ def load_context_dsa_module_data(dsa_file: str):
     Load context DSA data.
 
     Dict structure:
-        data[fmha_quant_mode][kv_cache_quant_mode][gemm_quant_mode][architecture][num_heads][prefix][s][b]
+        data[fmha_quant_mode][kv_cache_quant_mode][gemm_quant_mode][architecture][backend][num_heads][prefix][s][b]
 
     Quant modes are the outermost keys so that ``_enum_key_names`` can
     directly extract supported FMHAQuantMode names (aligned with
@@ -1172,13 +1179,9 @@ def load_context_dsa_module_data(dsa_file: str):
         fmha_mode = common.FMHAQuantMode[row["mla_dtype"]]
         kv_dtype = common.KVCacheQuantMode[row["kv_cache_dtype"]]
 
-        ks = row.get("kernel_source") or ""
-        dsa_backend = "trtllm" if "trtllm" in ks else "flashmla_kv"
-        dsa_data[fmha_mode][kv_dtype][gemm_mode][arch][dsa_backend][num_heads][prefix][s][b] = {
-            "latency": latency,
-            "power": power,
-            "energy": energy,
-        }
+        dsa_backend = _dsa_backend_for_row(row)
+        batch_data = dsa_data[fmha_mode][kv_dtype][gemm_mode][arch][dsa_backend][num_heads][prefix][s]
+        batch_data.setdefault(b, {"latency": latency, "power": power, "energy": energy})
 
     return dsa_data
 
@@ -1188,7 +1191,7 @@ def load_generation_dsa_module_data(dsa_file: str):
     Load generation DSA data.
 
     Dict structure:
-        data[kv_cache_quant_mode][gemm_quant_mode][architecture][num_heads][b][s]
+        data[kv_cache_quant_mode][gemm_quant_mode][architecture][backend][num_heads][b][s]
 
     Quant modes are the outermost keys so that ``_enum_key_names`` can
     directly extract supported KVCacheQuantMode names (aligned with
@@ -1222,12 +1225,8 @@ def load_generation_dsa_module_data(dsa_file: str):
         gemm_mode = common.GEMMQuantMode[row["gemm_type"]]
         kv_dtype = common.KVCacheQuantMode[row["kv_cache_dtype"]]
 
-        ks = row.get("kernel_source") or ""
-        dsa_backend = "trtllm" if "trtllm" in ks else "flashmla_kv"
-        dsa_data[kv_dtype][gemm_mode][arch][dsa_backend][num_heads][b][s] = {
-            "latency": latency,
-            "power": power,
-            "energy": energy,
-        }
+        dsa_backend = _dsa_backend_for_row(row)
+        sequence_data = dsa_data[kv_dtype][gemm_mode][arch][dsa_backend][num_heads][b]
+        sequence_data.setdefault(s, {"latency": latency, "power": power, "energy": energy})
 
     return dsa_data

--- a/src/aiconfigurator/sdk/operations/dsa.py
+++ b/src/aiconfigurator/sdk/operations/dsa.py
@@ -3,20 +3,10 @@
 
 """DSA (DeepSeek Sparse Attention) module-level ops (ISSUE-10 / AIC-538).
 
-Both ContextDSAModule and GenerationDSAModule own their CSV-backed perf
-tables and grid extrapolation. ``PerfDatabase.query_context_dsa_module``
-and ``query_generation_dsa_module`` delegate here.
-
-ContextDSAModule additionally maintains a ``_raw_data_cache`` — a
-``copy.deepcopy`` of the loaded table BEFORE extrapolation runs — because
-``interpolation.interp_dsa_context_topk_piecewise_from_raw`` needs the
-un-extrapolated rows for the topk-boundary regime-aware piecewise lookup
-(PR #903).
-
-No SOL clamping in the legacy ``_correct_data`` for either DSA op —
-extrapolation only. The legacy ``__init__`` loaded DSA twice (once near
-the MLA/Mamba block, once after); both loads are consolidated into a
-single ``load_data`` call per class.
+Both module ops keep their measured tables sparse and immutable. Numerical
+holes and authorized exterior points are answered lazily by the shared sparse
+surrogate; context and generation samples are split at the top-k boundary
+before interpolation so the kernel discontinuity is never crossed.
 
 DSA-specific helpers (``_is_dsa_interpolation_miss``,
 ``_format_dsa_unavailable_message``) also move here as module-level
@@ -27,14 +17,15 @@ revisits their home.
 
 from __future__ import annotations
 
-import copy
 import logging
-import math
 from collections import defaultdict
+from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, ClassVar
 
 from aiconfigurator.sdk import common, interpolation
+from aiconfigurator.sdk.interpolation import InterpolationDataNotAvailableError
 from aiconfigurator.sdk.operations.base import Operation, _read_filtered_rows
+from aiconfigurator.sdk.perf_surrogate import Axis, estimate_sparse
 from aiconfigurator.sdk.performance_result import PerformanceResult
 
 if TYPE_CHECKING:
@@ -71,31 +62,6 @@ DSA_MODEL_DIMS: dict[str, dict] = {
 DEFAULT_DSA_ARCHITECTURE = "DeepseekV32ForCausalLM"
 
 
-# Extrapolation grids — lifted verbatim from the legacy blocks in
-# ``PerfDatabase.__init__``.
-
-# fmt: off
-_CONTEXT_DSA_TARGET_Y: list[int] = (
-    [1, 16, 32, 64, 128, 256, 512, 1024, 2048]
-    + [4096 + i * 2048 for i in range(14)]
-    + [32768 + 16384 * i for i in range(6)]
-    + [131072 + 32768 * i for i in range(12)]
-    + [524288 + 65536 * i for i in range(9)]
-)  # s
-_CONTEXT_DSA_TARGET_Z: list[int] = [
-    1, 2, 4, 8, 16, 32, 64, 128, 256, 384, 512, 1024, 2048,
-]  # b
-
-_GENERATION_DSA_TARGET_Y: list[int] = [
-    1, 2, 4, 8, 16, 32, 64, 128, 256, 384, 512, 1024, 2048, 8192,
-]  # b
-_GENERATION_DSA_TARGET_Z: list[int] = [
-    1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192,
-    16384, 32768, 65536, 131072, 262144, 2097152 * 8,
-]  # s
-# fmt: on
-
-
 def _select_dsa_backend(arch_dict, dsa_backend):
     """Pick the per-backend sub-dict from a context-DSA architecture node.
 
@@ -128,6 +94,72 @@ def _cache_key(database: PerfDatabase) -> tuple:
         database.backend,
         database.version,
         database.enable_shared_layer,
+    )
+
+
+def _cached_sparse_view(
+    database: PerfDatabase,
+    key: tuple,
+    source: Mapping,
+    build: Callable[[], dict],
+) -> dict:
+    """Cache a small filtered/reordered view by source identity and policy."""
+    cache = database.__dict__.setdefault("_dsa_sparse_table_cache", {})
+    cache_key = (*key, id(source))
+    cached = cache.get(cache_key)
+    if cached is None or cached[0] is not source:
+        cached = (source, build())
+        cache[cache_key] = cached
+    return cached[1]
+
+
+def _context_regime_view(
+    database: PerfDatabase,
+    table: Mapping,
+    prefix: int,
+    index_topk: int,
+    above_topk: bool,
+) -> dict:
+    return _cached_sparse_view(
+        database,
+        ("context_dsa", prefix, index_topk, above_topk),
+        table,
+        lambda: {
+            head: {
+                sequence: by_batch
+                for sequence, by_batch in by_sequence.items()
+                if (sequence + prefix > index_topk) == above_topk
+            }
+            for head, by_sequence in table.items()
+            if isinstance(by_sequence, Mapping)
+        },
+    )
+
+
+def _generation_regime_view(
+    database: PerfDatabase,
+    table: Mapping,
+    index_topk: int,
+    above_topk: bool,
+) -> dict:
+    def build() -> dict:
+        result: dict = {}
+        for head, by_batch in table.items():
+            for batch, by_sequence in by_batch.items():
+                samples = {
+                    sequence: metric
+                    for sequence, metric in by_sequence.items()
+                    if (sequence > index_topk) == above_topk
+                }
+                if samples:
+                    result.setdefault(head, {})[batch] = samples
+        return result
+
+    return _cached_sparse_view(
+        database,
+        ("generation_dsa", index_topk, above_topk),
+        table,
+        build,
     )
 
 
@@ -171,9 +203,7 @@ class ContextDSAModule(Operation):
     """
     Context phase DSA (DeepSeek Sparse Attention) module-level operation.
 
-    Owns ``_data_cache`` (extrapolated context_dsa_module CSV) AND
-    ``_raw_data_cache`` (the same CSV pre-extrapolation, used by the
-    topk-boundary piecewise interpolation path).
+    Owns the measured sparse context DSA table.
 
     Models the full DSA attention block including:
     - kv_a_proj_with_mqa GEMM (includes indexer K projection)
@@ -185,7 +215,6 @@ class ContextDSAModule(Operation):
     """
 
     _data_cache: ClassVar[dict] = {}
-    _raw_data_cache: ClassVar[dict] = {}
 
     def __init__(
         self,
@@ -217,10 +246,7 @@ class ContextDSAModule(Operation):
 
     @classmethod
     def load_data(cls, database: PerfDatabase) -> None:
-        """Idempotent. Loads context_dsa_module CSV, deepcopies the raw
-        version, applies grid extrapolation to the main cache, binds
-        ``database._context_dsa_module_data`` and
-        ``database._raw_context_dsa_module_data``."""
+        """Load the measured sparse table without materializing a grid."""
         import os
 
         from aiconfigurator.sdk.perf_database import LoadedOpData, PerfDataFilename
@@ -234,80 +260,17 @@ class ContextDSAModule(Operation):
             cls._data_cache[key] = LoadedOpData(
                 load_context_dsa_module_data(sources), PerfDataFilename.dsa_context_module, primary_path
             )
-            # Deepcopy BEFORE extrapolation so the raw rows survive intact
-            # for ``interp_dsa_context_topk_piecewise_from_raw``.
-            cls._raw_data_cache[key] = copy.deepcopy(cls._data_cache[key])
-            cls._extrapolate(cls._data_cache[key])
             cls._record_load()
 
         if "_context_dsa_module_data" not in database.__dict__:
             database._context_dsa_module_data = cls._data_cache[key]
         if "_raw_context_dsa_module_data" not in database.__dict__:
-            database._raw_context_dsa_module_data = cls._raw_data_cache[key]
+            database._raw_context_dsa_module_data = cls._data_cache[key]
 
     @classmethod
     def clear_cache(cls) -> None:
         cls._data_cache.clear()
-        cls._raw_data_cache.clear()
         cls._glm5_sparse_cache.clear()
-
-    @classmethod
-    def _extrapolate(cls, data_wrapper) -> None:
-        """Apply the legacy 4-level (fmha_mode → kv_cache_dtype → gemm_mode
-        → arch → grid) extrapolation."""
-        if data_wrapper is None or not getattr(data_wrapper, "loaded", False):
-            return
-
-        for fmha_mode in data_wrapper:
-            for kv_cache_dtype in data_wrapper[fmha_mode]:
-                for gemm_mode in data_wrapper[fmha_mode][kv_cache_dtype]:
-                    for arch in data_wrapper[fmha_mode][kv_cache_dtype][gemm_mode]:
-                        data_dict = data_wrapper[fmha_mode][kv_cache_dtype][gemm_mode][arch]
-
-                        def _is_latency_leaf(value):
-                            return isinstance(value, dict) and "latency" in value
-
-                        def _has_prefix_axis(module_dict):
-                            for head_data in module_dict.values():
-                                if not isinstance(head_data, dict):
-                                    continue
-                                for first_slice in head_data.values():
-                                    if not isinstance(first_slice, dict):
-                                        continue
-                                    # Legacy shape: [num_heads][s][b].
-                                    return not any(_is_latency_leaf(v) for v in first_slice.values())
-                            return False
-
-                        if _has_prefix_axis(data_dict):
-                            prefix_values = sorted(
-                                {
-                                    prefix
-                                    for head_data in data_dict.values()
-                                    if isinstance(head_data, dict)
-                                    for prefix in head_data
-                                }
-                            )
-                            for prefix in prefix_values:
-                                prefix_slice = {
-                                    head: head_data[prefix]
-                                    for head, head_data in data_dict.items()
-                                    if isinstance(head_data, dict) and prefix in head_data
-                                }
-                                interpolation.extrapolate_data_grid(
-                                    data_dict=prefix_slice,
-                                    target_x_list=list(prefix_slice.keys()),
-                                    target_y_list=_CONTEXT_DSA_TARGET_Y,
-                                    target_z_list=_CONTEXT_DSA_TARGET_Z,
-                                )
-                                for head, head_slice in prefix_slice.items():
-                                    data_dict[head][prefix] = head_slice
-                        else:
-                            interpolation.extrapolate_data_grid(
-                                data_dict=data_dict,
-                                target_x_list=list(data_dict.keys()),
-                                target_y_list=_CONTEXT_DSA_TARGET_Y,
-                                target_z_list=_CONTEXT_DSA_TARGET_Z,
-                            )
 
     # ------------------------------------------------------------------
     # Query table (formerly PerfDatabase.query_context_dsa_module)
@@ -483,27 +446,6 @@ class ContextDSAModule(Operation):
                 dsa_dict = _select_dsa_backend(dsa_dict, dsa_backend)
             except (KeyError, TypeError) as exc:
                 raise missing_context_dsa_error() from exc
-            raw_dsa_dict = None
-            raw_dsa_module_data = database._raw_context_dsa_module_data
-            if raw_dsa_module_data is not None and getattr(raw_dsa_module_data, "loaded", True):
-                try:
-                    raw_dsa_dict = raw_dsa_module_data[fmha_quant_mode][kvcache_quant_mode][gemm_quant_mode][
-                        architecture
-                    ]
-                    raw_dsa_dict = _select_dsa_backend(raw_dsa_dict, dsa_backend)
-                except (KeyError, TypeError):
-                    raw_dsa_dict = None
-
-            def _finite_result(result):
-                if not isinstance(result, dict):
-                    return False
-                value = result.get("latency")
-                if value is None:
-                    return False
-                try:
-                    return math.isfinite(float(value))
-                except (TypeError, ValueError):
-                    return False
 
             def _is_latency_leaf(value):
                 return isinstance(value, dict) and "latency" in value
@@ -521,22 +463,35 @@ class ContextDSAModule(Operation):
                         if any(_is_latency_leaf(v) for v in maybe_batch_slice.values()):
                             if require_prefix_axis:
                                 return None, False
-                            return {0: module_dict}, False
+                            return _cached_sparse_view(
+                                database,
+                                ("context_dsa_prefix", False),
+                                module_dict,
+                                lambda: {0: module_dict},
+                            ), False
                         break
                     break
 
-                prefix_data = {}
-                for head, head_data in module_dict.items():
-                    if not isinstance(head_data, dict):
-                        continue
-                    for prefix_value, prefix_slice in head_data.items():
-                        if isinstance(prefix_slice, dict):
-                            prefix_data.setdefault(prefix_value, {})[head] = prefix_slice
+                def build_prefix_data() -> dict:
+                    result: dict = {}
+                    for head, head_data in module_dict.items():
+                        if not isinstance(head_data, dict):
+                            continue
+                        for prefix_value, prefix_slice in head_data.items():
+                            if isinstance(prefix_slice, dict):
+                                result.setdefault(prefix_value, {})[head] = prefix_slice
+                    return result
+
+                prefix_data = _cached_sparse_view(
+                    database,
+                    ("context_dsa_prefix", True),
+                    module_dict,
+                    build_prefix_data,
+                )
                 return (prefix_data or None), True
 
             require_prefix_axis = architecture == "GlmMoeDsaForCausalLM"
             prefix_data, has_prefix_axis = _context_prefix_data(dsa_dict, require_prefix_axis)
-            raw_prefix_data, _ = _context_prefix_data(raw_dsa_dict, require_prefix_axis)
 
             def _lookup_prefix_module_at(prefix_value: int):
                 if not isinstance(prefix_data, dict):
@@ -544,28 +499,52 @@ class ContextDSAModule(Operation):
                 prefix_slice = prefix_data.get(prefix_value)
                 if not isinstance(prefix_slice, dict):
                     return None
-
-                result = None
-                raw_slice = (
-                    raw_prefix_data.get(prefix_value)
-                    if isinstance(raw_prefix_data, dict) and isinstance(raw_prefix_data.get(prefix_value), dict)
-                    else None
+                above_topk = s + prefix_value > index_topk
+                regime_table = _context_regime_view(
+                    database,
+                    prefix_slice,
+                    prefix_value,
+                    index_topk,
+                    above_topk,
                 )
-                if index_topk is not None:
-                    boundary = index_topk - prefix_value
-                    result = interpolation.interp_dsa_context_topk_piecewise_from_raw(
-                        num_heads, s, b, raw_slice, boundary
-                    )
-                    if not _finite_result(result):
-                        result = None
-                if result is None:
-                    try:
-                        from aiconfigurator.sdk.operations.dsv4 import _dsv4_robust_3d_lookup
 
-                        result = _dsv4_robust_3d_lookup(database, prefix_slice, num_heads, s, b)
-                    except Exception:
-                        return None
-                return result if _finite_result(result) else None
+                def baseline(point: Mapping[str, float]) -> float:
+                    return get_sol(
+                        point["batch"],
+                        point["s"],
+                        prefix_value,
+                        point["heads"],
+                        kvcache_quant_mode,
+                        fmha_quant_mode,
+                    )[0]
+
+                try:
+                    latency, energy = estimate_sparse(
+                        database,
+                        (
+                            "context_dsa",
+                            fmha_quant_mode,
+                            kvcache_quant_mode,
+                            gemm_quant_mode,
+                            architecture,
+                            dsa_backend,
+                            prefix_value,
+                            above_topk,
+                        ),
+                        regime_table,
+                        {"heads": num_heads, "s": s, "batch": b},
+                        axes=(
+                            Axis("heads"),
+                            Axis("s", extrapolate="both"),
+                            Axis("batch", extrapolate="both"),
+                        ),
+                        varying="s",
+                        baseline=baseline,
+                    )
+                except InterpolationDataNotAvailableError:
+                    return None
+                power = 0.0 if latency == 0 else energy / latency
+                return {"latency": latency, "power": power, "energy": energy}
 
             def _interp_results_1d(x0, x1, r0, r1, x):
                 return {
@@ -581,6 +560,8 @@ class ContextDSAModule(Operation):
                     prefix_points = sorted(p for p, slice_ in prefix_data.items() if isinstance(slice_, dict))
                     result_by_prefix = {}
                     for prefix_point in prefix_points:
+                        if (s + prefix_point > index_topk) != (s + prefix > index_topk):
+                            continue
                         prefix_result = _lookup_prefix_module_at(prefix_point)
                         if prefix_result is not None:
                             result_by_prefix[prefix_point] = prefix_result
@@ -724,10 +705,10 @@ class ContextDSAModule(Operation):
                 dsa_backend="flashmla_kv",
             )
         )
-        mqa_full = self._lookup_2d(g.get("mqa"), isl, prefix)
-        mqa_perc = self._lookup_2d(g.get("mqa"), per_card, prefix)
-        tl_full = self._lookup_2d(g.get("topk_last"), isl, prefix)
-        tf_perc = self._lookup_2d(g.get("topk_flat"), per_card, prefix)
+        mqa_full = self._lookup_2d(database, "mqa", g.get("mqa"), isl, prefix)
+        mqa_perc = self._lookup_2d(database, "mqa", g.get("mqa"), per_card, prefix)
+        tl_full = self._lookup_2d(database, "topk_last", g.get("topk_last"), isl, prefix)
+        tf_perc = self._lookup_2d(database, "topk_flat", g.get("topk_flat"), per_card, prefix)
         latency = dsa_base
         if None not in (mqa_full, mqa_perc, tl_full, tf_perc):
             delta_mqa = mqa_full / cp - mqa_perc
@@ -796,9 +777,9 @@ class ContextDSAModule(Operation):
         return out
 
     @staticmethod
-    def _lookup_2d(table, isl, step):
+    def _lookup_2d(database: PerfDatabase, op_name: str, table, isl, step):
         """Lookup {(isl,step): latency} at a fixed isl (exact grid value), linear
-        interp/extrap on step. Used by the CP sub-kernel composition."""
+        interpolation and endpoint hold on step."""
         if not table:
             return None
         isls = sorted({i for (i, _s) in table})
@@ -811,18 +792,28 @@ class ContextDSAModule(Operation):
                 f"(docs/CONTEXT_PARALLEL_DSA_MODELING.md §9.1)."
             )
         use_isl = isl if isl in isls else min(isls, key=lambda x: abs(x - isl))
-        steps = sorted(st for (i, st) in table if i == use_isl)
-        if not steps:
+        curve = _cached_sparse_view(
+            database,
+            ("glm5_cp", op_name, use_isl),
+            table,
+            lambda: {
+                sampled_step: {"latency": latency}
+                for (sampled_isl, sampled_step), latency in table.items()
+                if sampled_isl == use_isl
+            },
+        )
+        if not curve:
             return None
-        if (use_isl, step) in table:
-            return table[(use_isl, step)]
-        lo = max([st for st in steps if st <= step], default=steps[0])
-        hi = min([st for st in steps if st >= step], default=steps[-1])
-        if lo == hi:
-            return table[(use_isl, lo)]
-        a = table[(use_isl, lo)]
-        bb = table[(use_isl, hi)]
-        return a + (bb - a) * (step - lo) / (hi - lo)
+        latency, _ = estimate_sparse(
+            database,
+            ("glm5_cp", op_name, use_isl),
+            curve,
+            {"prefix": step},
+            axes=(Axis("prefix", extrapolate="both"),),
+            varying="prefix",
+            exterior="raw",
+        )
+        return latency
 
     def get_weights(self, **kwargs):
         return self._weights * self._scale_factor
@@ -832,9 +823,7 @@ class GenerationDSAModule(Operation):
     """
     Generation phase DSA (DeepSeek Sparse Attention) module-level operation.
 
-    Owns ``_data_cache`` (extrapolated generation_dsa_module CSV). No
-    ``_raw_data_cache`` because the generation path doesn't use the
-    topk-boundary piecewise interpolation — straight 3D cubic.
+    Owns the measured sparse generation DSA table.
 
     Models the full DSA attention block during decode:
     - Same components as ContextDSAModule
@@ -870,8 +859,7 @@ class GenerationDSAModule(Operation):
 
     @classmethod
     def load_data(cls, database: PerfDatabase) -> None:
-        """Idempotent. Loads generation_dsa_module CSV, applies grid
-        extrapolation, binds ``database._generation_dsa_module_data``."""
+        """Load the measured sparse table without materializing a grid."""
         import os
 
         from aiconfigurator.sdk.perf_database import LoadedOpData, PerfDataFilename
@@ -885,7 +873,6 @@ class GenerationDSAModule(Operation):
             cls._data_cache[key] = LoadedOpData(
                 load_generation_dsa_module_data(sources), PerfDataFilename.dsa_generation_module, primary_path
             )
-            cls._extrapolate(cls._data_cache[key])
             cls._record_load()
 
         if "_generation_dsa_module_data" not in database.__dict__:
@@ -894,25 +881,6 @@ class GenerationDSAModule(Operation):
     @classmethod
     def clear_cache(cls) -> None:
         cls._data_cache.clear()
-
-    @classmethod
-    def _extrapolate(cls, data_wrapper) -> None:
-        """Apply the legacy 3-level (kv_cache_dtype → gemm_mode → arch
-        → grid) extrapolation."""
-        if data_wrapper is None or not getattr(data_wrapper, "loaded", False):
-            return
-
-        for kv_cache_dtype in data_wrapper:
-            for gemm_mode in data_wrapper[kv_cache_dtype]:
-                for arch in data_wrapper[kv_cache_dtype][gemm_mode]:
-                    data_dict = data_wrapper[kv_cache_dtype][gemm_mode][arch]
-                    tp_list = list(data_dict.keys())
-                    interpolation.extrapolate_data_grid(
-                        data_dict=data_dict,
-                        target_x_list=tp_list,
-                        target_y_list=_GENERATION_DSA_TARGET_Y,
-                        target_z_list=_GENERATION_DSA_TARGET_Z,
-                    )
 
     # ------------------------------------------------------------------
     # Query table (formerly PerfDatabase.query_generation_dsa_module)
@@ -1050,65 +1018,37 @@ class GenerationDSAModule(Operation):
             try:
                 dsa_dict = dsa_module_data[kv_cache_dtype][gemm_quant_mode][architecture]
                 dsa_dict = _select_dsa_backend(dsa_dict, dsa_backend)
+                above_topk = s > index_topk
+                regime_table = _generation_regime_view(database, dsa_dict, index_topk, above_topk)
 
-                def sequence_value(seq_dict):
-                    if s in seq_dict:
-                        return seq_dict[s]
-                    seq_keys = sorted(seq_dict)
-                    if len(seq_keys) < 2:
-                        return None
-                    left, right = interpolation.nearest_1d_point_helper(s, seq_keys, inner_only=False)
+                def baseline(point: Mapping[str, float]) -> float:
+                    return get_sol(
+                        point["batch"],
+                        point["s_total"],
+                        point["heads"],
+                        kv_cache_dtype,
+                    )[0]
 
-                    def interp_sequence_metric(metric: str) -> float:
-                        return interpolation.interp_1d(
-                            [left, right],
-                            [
-                                interpolation.get_value(seq_dict[left], metric),
-                                interpolation.get_value(seq_dict[right], metric),
-                            ],
-                            s,
-                        )
-
-                    return {
-                        "latency": interp_sequence_metric("latency"),
-                        "power": interp_sequence_metric("power"),
-                        "energy": interp_sequence_metric("energy"),
-                    }
-
-                result = None
-                if num_heads in dsa_dict and b in dsa_dict[num_heads]:
-                    result = sequence_value(dsa_dict[num_heads][b])
-                if result is None and num_heads in dsa_dict:
-                    batch_dict = {}
-                    for batch_key, seq_dict in dsa_dict[num_heads].items():
-                        value = sequence_value(seq_dict)
-                        if value is not None:
-                            batch_dict[batch_key] = value
-                    batch_keys = sorted(batch_dict)
-                    if len(batch_keys) >= 2:
-                        left, right = interpolation.nearest_1d_point_helper(b, batch_keys, inner_only=False)
-
-                        def interp_batch_metric(metric: str) -> float:
-                            return interpolation.interp_1d(
-                                [left, right],
-                                [
-                                    interpolation.get_value(batch_dict[left], metric),
-                                    interpolation.get_value(batch_dict[right], metric),
-                                ],
-                                b,
-                            )
-
-                        result = {
-                            "latency": interp_batch_metric("latency"),
-                            "power": interp_batch_metric("power"),
-                            "energy": interp_batch_metric("energy"),
-                        }
-                if result is None:
-                    result = interpolation.interp_3d(
-                        num_heads, b, s, dsa_dict, "cubic", database._extracted_metrics_cache
-                    )
-                latency = result["latency"]
-                energy = result.get("energy", 0.0)
+                latency, energy = estimate_sparse(
+                    database,
+                    (
+                        "generation_dsa",
+                        kv_cache_dtype,
+                        gemm_quant_mode,
+                        architecture,
+                        dsa_backend,
+                        above_topk,
+                    ),
+                    regime_table,
+                    {"heads": num_heads, "batch": b, "s_total": s},
+                    axes=(
+                        Axis("heads"),
+                        Axis("batch", extrapolate="both"),
+                        Axis("s_total", extrapolate="both"),
+                    ),
+                    varying="s_total",
+                    baseline=baseline,
+                )
             except (KeyError, TypeError, ValueError, AssertionError) as exc:
                 raise missing_generation_dsa_error() from exc
             return database._interp_pr(latency, energy=energy)

--- a/src/aiconfigurator/sdk/operations/dsv4.py
+++ b/src/aiconfigurator/sdk/operations/dsv4.py
@@ -41,6 +41,7 @@ import numpy as np
 
 from aiconfigurator.sdk import common, interpolation
 from aiconfigurator.sdk.operations.base import Operation, _read_filtered_rows
+from aiconfigurator.sdk.perf_surrogate import Axis, estimate_sparse
 
 logger = logging.getLogger(__name__)
 from aiconfigurator.sdk.performance_result import PerformanceResult
@@ -58,6 +59,17 @@ def _cache_key(database: PerfDatabase) -> tuple:
         database.version,
         database.enable_shared_layer,
     )
+
+
+_DSV4_CONTEXT_AXES = (
+    Axis("prefix", extrapolate="both"),
+    Axis("sequence", extrapolate="both"),
+    Axis("batch", extrapolate="both"),
+)
+_DSV4_GENERATION_AXES = (
+    Axis("batch", extrapolate="both"),
+    Axis("sequence", extrapolate="both"),
+)
 
 
 # ───────────────────────────────────────────────────────────────────────
@@ -193,28 +205,14 @@ def _dsv4_robust_3d_lookup(self, dict_, x, y, z, *, batch_axis: str = "z"):
     raise ValueError(f"DeepSeek-V4 robust lookup failed (tp={x}, s={y}, b={z})")
 
 
-def _dsv4_resolve_head_key(quant_data, num_heads):
-    """SCHEME A head-key resolution.
-
-    The head axis is the rank-local head count (``native // tp``).  Prefer an
-    exact match on the value the model passes.  The b300 module data is a
-    universal sweep collected with a single local-head value; if the model's
-    local head count is not an exact bench point, fall back to the single
-    available head key so the universal data still resolves.  Returns the head
-    key to index ``quant_data`` with, or ``None`` if no head data is loaded.
-    """
+def _dsv4_resolve_head_key(quant_data, native_heads, tp_size):
+    """Resolve native-head rows and older collector rows that stored local heads."""
     if not isinstance(quant_data, dict) or not quant_data:
         return None
-    if num_heads in quant_data:
-        return num_heads
-    head_keys = [k for k in quant_data if isinstance(k, int)]
-    if len(head_keys) == 1:
-        return head_keys[0]
-    if head_keys:
-        # Multiple head keys but no exact match: pick the nearest <= request,
-        # else the smallest available.
-        le = [k for k in head_keys if k <= num_heads]
-        return max(le) if le else min(head_keys)
+    candidates = (native_heads, max(1, native_heads // tp_size))
+    for head_key in candidates:
+        if head_key in quant_data and tp_size in quant_data[head_key]:
+            return head_key
     return None
 
 
@@ -1005,13 +1003,13 @@ class ContextDeepSeekV4AttentionModule(_BaseDeepSeekV4AttentionModule):
 
         cls.load_data(database)
 
-        def get_sol() -> tuple[float, float, float]:
+        def get_sol(query_b=b, query_s=s, query_prefix=prefix) -> tuple[float, float, float]:
             return _deepseek_v4_attention_sol(
                 database,
                 is_context=True,
-                b=b,
-                s=s,
-                prefix=prefix,
+                b=query_b,
+                s=query_s,
+                prefix=query_prefix,
                 num_heads=num_heads,
                 hidden_size=hidden_size,
                 q_lora_rank=q_lora_rank,
@@ -1048,33 +1046,45 @@ class ContextDeepSeekV4AttentionModule(_BaseDeepSeekV4AttentionModule):
                     f"DeepSeek-V4 context attention module data not loaded for system='{database.system}', "
                     f"backend='{database.backend}', version='{database.version}'."
                 )
-            # SCHEME A: head axis is the rank-local head count the model passes.
+            # Native-head and TP are independent exact physical categories.
             quant_data = data[fmha_quant_mode][kvcache_quant_mode][gemm_quant_mode]
-            head_axis = _dsv4_resolve_head_key(quant_data, num_heads)
+            head_axis = _dsv4_resolve_head_key(quant_data, native_heads, tp_size)
             if head_axis is None:
                 raise PerfDataNotAvailableError(
-                    f"No DeepSeek-V4 context attention silicon data for num_heads={num_heads}, "
+                    f"No DeepSeek-V4 context attention silicon data for native_heads={native_heads}, "
                     f"loaded head keys={list(quant_data.keys())}."
                 )
-            cr_dict = quant_data[head_axis].get(compress_ratio)
+            tp_data = quant_data[head_axis].get(tp_size)
+            if tp_data is None:
+                raise PerfDataNotAvailableError(
+                    f"No DeepSeek-V4 context attention silicon data for native_heads={native_heads}, "
+                    f"tp_size={tp_size}, loaded TP keys={list(quant_data[head_axis].keys())}."
+                )
+            cr_dict = tp_data.get(compress_ratio)
             if cr_dict is None:
                 raise PerfDataNotAvailableError(
-                    f"No DeepSeek-V4 context attention silicon data for num_heads={num_heads}, "
+                    f"No DeepSeek-V4 context attention silicon data for native_heads={native_heads}, "
                     f"compress_ratio={compress_ratio}, loaded cr keys="
-                    f"{list(quant_data[head_axis].keys())}."
+                    f"{list(tp_data.keys())}."
                 )
 
-            # SCHEME A: cr_dict is prefix-resolved -> {prefix: {s: {b: leaf}}}.
-            # Look the measured silicon up at the requested prefix (interpolating
-            # over the prefix axis when the exact prefix was not benched).
-            result = _dsv4_lookup_prefix_resolved(database, cr_dict, prefix, s, b)
-            if result is None:
-                raise PerfDataNotAvailableError(
-                    f"DeepSeek-V4 prefix-resolved context attention module data not available for "
-                    f"{b=}, {s=}, {prefix=}, {num_heads=}, {compress_ratio=}."
-                )
-            latency = float(result["latency"])
-            energy = float(result.get("energy", 0.0))
+            latency, energy = estimate_sparse(
+                database,
+                (
+                    "dsv4-context",
+                    fmha_quant_mode,
+                    kvcache_quant_mode,
+                    gemm_quant_mode,
+                    head_axis,
+                    tp_size,
+                    compress_ratio,
+                ),
+                cr_dict,
+                {"prefix": prefix, "sequence": s, "batch": b},
+                axes=_DSV4_CONTEXT_AXES,
+                varying="sequence",
+                baseline=lambda point: get_sol(point["batch"], point["sequence"], point["prefix"])[0],
+            )
 
             # SCHEME A: for CSA (compress_ratio==4) ONLY, subtract the measured
             # topK DELTA = flat_ms - top_last_ms (degenerate collector topK vs
@@ -1222,12 +1232,12 @@ class GenerationDeepSeekV4AttentionModule(_BaseDeepSeekV4AttentionModule):
 
         cls.load_data(database)
 
-        def get_sol() -> tuple[float, float, float]:
+        def get_sol(query_b=b, query_s=s) -> tuple[float, float, float]:
             return _deepseek_v4_attention_sol(
                 database,
                 is_context=False,
-                b=b,
-                s=s,
+                b=query_b,
+                s=query_s,
                 prefix=0,
                 num_heads=num_heads,
                 hidden_size=hidden_size,
@@ -1265,26 +1275,43 @@ class GenerationDeepSeekV4AttentionModule(_BaseDeepSeekV4AttentionModule):
                     f"DeepSeek-V4 generation attention module data not loaded for system='{database.system}', "
                     f"backend='{database.backend}', version='{database.version}'."
                 )
-            # SCHEME A: head axis is the rank-local head count the model passes.
-            quant_data = data[kvcache_quant_mode][gemm_quant_mode]
-            head_axis = _dsv4_resolve_head_key(quant_data, num_heads)
+            # Keep native-head, TP, and FMHA categories exact.
+            quant_data = data[kvcache_quant_mode][gemm_quant_mode][fmha_quant_mode]
+            head_axis = _dsv4_resolve_head_key(quant_data, native_heads, tp_size)
             if head_axis is None:
                 raise PerfDataNotAvailableError(
-                    f"No DeepSeek-V4 generation attention silicon data for num_heads={num_heads}, "
+                    f"No DeepSeek-V4 generation attention silicon data for native_heads={native_heads}, "
                     f"loaded head keys={list(quant_data.keys())}."
                 )
-            deepseek_v4_dict = quant_data[head_axis].get(compress_ratio)
+            tp_data = quant_data[head_axis].get(tp_size)
+            if tp_data is None:
+                raise PerfDataNotAvailableError(
+                    f"No DeepSeek-V4 generation attention silicon data for native_heads={native_heads}, "
+                    f"tp_size={tp_size}, loaded TP keys={list(quant_data[head_axis].keys())}."
+                )
+            deepseek_v4_dict = tp_data.get(compress_ratio)
             if deepseek_v4_dict is None:
                 raise PerfDataNotAvailableError(
-                    f"No DeepSeek-V4 generation attention silicon data for num_heads={num_heads}, "
-                    f"compress_ratio={compress_ratio}, loaded cr keys={list(quant_data[head_axis].keys())}."
+                    f"No DeepSeek-V4 generation attention silicon data for native_heads={native_heads}, "
+                    f"compress_ratio={compress_ratio}, loaded cr keys={list(tp_data.keys())}."
                 )
-            # SCHEME A generation dict is {head}{cr}{b}{s_total}; wrap with the
-            # head key and let the robust lookup walk (head -> b -> s_total).
-            wrapped = {head_axis: deepseek_v4_dict}
-            result = _dsv4_robust_3d_lookup(database, wrapped, head_axis, b, s, batch_axis="y")
-            latency = float(result["latency"])
-            energy = float(result.get("energy", 0.0))
+            latency, energy = estimate_sparse(
+                database,
+                (
+                    "dsv4-generation",
+                    kvcache_quant_mode,
+                    gemm_quant_mode,
+                    fmha_quant_mode,
+                    head_axis,
+                    tp_size,
+                    compress_ratio,
+                ),
+                deepseek_v4_dict,
+                {"batch": b, "sequence": s},
+                axes=_DSV4_GENERATION_AXES,
+                varying="sequence",
+                baseline=lambda point: get_sol(point["batch"], point["sequence"])[0],
+            )
 
             # SCHEME A: subtract the topK DELTA for CSA (cr==4) only. Decode is
             # q_len=1 with past_kv = s_total - 1.
@@ -1787,13 +1814,13 @@ _MISSING = object()
 def load_context_dsv4_kind_module_data(file_path: str):
     """Load ONE DeepSeek-V4 context CSV (single attn_kind / compress_ratio).
 
-    SCHEME A.  Returns a 7-level prefix-resolved nested dict:
-        data[fmha_quant][kv_quant][gemm_quant][num_heads_local][compress_ratio]
-            [prefix][s][b] = {"latency": ms, "power": W, "energy": J}
+    Returns a TP- and prefix-resolved nested dict:
+        data[fmha_quant][kv_quant][gemm_quant][native_heads][tp_size]
+            [compress_ratio][prefix][s][b] = metrics
 
-    The head axis is the rank-LOCAL head count = ``int(row["num_heads"])``
-    (the collector writes ``local_attention_heads = native // tp``).  There is
-    NO separate ``tp_size`` key and NO reconstructed native-head key.
+    Existing databases store native heads while some collector revisions wrote
+    rank-local heads. The query adapter accepts either representation; TP stays
+    a separate physical category in both cases.
 
     ``prefix`` is the past-KV length, ``int(float(row["step"]))``; ``s`` is the
     context chunk length (``isl``).  Multiple files (csa/hca) merge cleanly
@@ -1804,13 +1831,13 @@ def load_context_dsv4_kind_module_data(file_path: str):
         logger.debug(f"DSV4 module data file {file_path} not found.")
         return None
 
-    # 7-level nesting: fmha → kv → gemm → num_heads_local → cr → prefix → s → b
+    # fmha → kv → gemm → stored head key → TP → cr → prefix → s → b
     def _make_nested(depth: int):
         if depth == 0:
             return defaultdict()
         return defaultdict(lambda d=depth: _make_nested(d - 1))
 
-    data = _make_nested(7)
+    data = _make_nested(8)
     has_power = bool(rows) and "power" in rows[0]
 
     for row in rows:
@@ -1821,13 +1848,13 @@ def load_context_dsv4_kind_module_data(file_path: str):
             s = int(row["isl"])
             prefix = int(float(row.get("step", 0) or 0))
             cr = int(row["compress_ratio"])
+            tp_size = int(row["tp_size"])
             latency = float(row["latency"])
         except (TypeError, ValueError, KeyError):
             continue
         power = float(row.get("power", 0.0)) if has_power else 0.0
 
-        # SCHEME A: head key is the rank-local head count straight from the CSV.
-        num_heads_local = int(row["num_heads"])
+        head_key = int(row["num_heads"])
         gemm_mode = common.GEMMQuantMode[row["gemm_type"]]
         fmha_mode = common.FMHAQuantMode[_dsv4_normalize_dtype(row["mla_dtype"])]
         kv_dtype = common.KVCacheQuantMode[_dsv4_normalize_dtype(row["kv_cache_dtype"])]
@@ -1835,7 +1862,7 @@ def load_context_dsv4_kind_module_data(file_path: str):
         # NOTE: the topK DELTA correction (degenerate -> representative) is
         # applied ONCE at query time for compress_ratio==4 (CSA). Do NOT
         # subtract it here, or the CSA module latency would be double-corrected.
-        data[fmha_mode][kv_dtype][gemm_mode][num_heads_local][cr][prefix][s][b] = {
+        data[fmha_mode][kv_dtype][gemm_mode][head_key][tp_size][cr][prefix][s][b] = {
             "latency": latency,
             "power": power,
             "energy": power * latency,
@@ -1847,22 +1874,22 @@ def load_generation_dsv4_kind_module_data(file_path: str):
     """Load ONE DeepSeek-V4 generation CSV.
 
     Generation lookup uses absolute KV length ``s_total = isl + step`` (decode
-    is q_len=1 with past_kv = step).  SCHEME A dict shape:
-        data[kv_quant][gemm_quant][num_heads_local][compress_ratio]
-            [b][s_total]
+    is q_len=1 with past_kv = step). Dict shape:
+        data[kv_quant][gemm_quant][fmha_quant][native_heads][tp_size]
+            [compress_ratio][b][s_total]
     """
     rows = _read_filtered_rows(file_path)
     if rows is None:
         logger.debug(f"DSV4 module data file {file_path} not found.")
         return None
 
-    # SCHEME A: 5-level nesting kv → gemm → num_heads_local → cr → b → s_total
+    # kv → gemm → fmha → stored head key → TP → cr → b → s_total
     def _make_nested(depth: int):
         if depth == 0:
             return defaultdict()
         return defaultdict(lambda d=depth: _make_nested(d - 1))
 
-    data = _make_nested(5)
+    data = _make_nested(7)
     has_power = bool(rows) and "power" in rows[0]
 
     for row in rows:
@@ -1872,19 +1899,19 @@ def load_generation_dsv4_kind_module_data(file_path: str):
             b = int(row["batch_size"])
             s_total = int(row["isl"]) + int(row["step"])
             cr = int(row["compress_ratio"])
+            tp_size = int(row["tp_size"])
             latency = float(row["latency"])
         except (TypeError, ValueError, KeyError):
             continue
         power = float(row.get("power", 0.0)) if has_power else 0.0
 
-        # SCHEME A: head key is the rank-local head count straight from the CSV;
-        # no tp_size key, no native reconstruction.  Generation convention puts
-        # ``b`` before ``s_total`` (matches the (head, b, s) lookup order).
-        num_heads_local = int(row["num_heads"])
+        # Generation convention puts ``b`` before ``s_total``.
+        head_key = int(row["num_heads"])
         gemm_mode = common.GEMMQuantMode[row["gemm_type"]]
+        fmha_mode = common.FMHAQuantMode[_dsv4_normalize_dtype(row["mla_dtype"])]
         kv_dtype = common.KVCacheQuantMode[_dsv4_normalize_dtype(row["kv_cache_dtype"])]
 
-        data[kv_dtype][gemm_mode][num_heads_local][cr][b][s_total] = {
+        data[kv_dtype][gemm_mode][fmha_mode][head_key][tp_size][cr][b][s_total] = {
             "latency": latency,
             "power": power,
             "energy": power * latency,

--- a/src/aiconfigurator/sdk/operations/dsv4.py
+++ b/src/aiconfigurator/sdk/operations/dsv4.py
@@ -530,29 +530,27 @@ class DeepSeekV4MHCModule(Operation):
         hc_dim = hc_mult * hidden_size
         mix_hc = (2 + hc_mult) * hc_mult
 
-        def get_sol() -> tuple[float, float, float]:
+        def get_sol(tokens: float = num_tokens, op_value: str = op) -> tuple[float, float, float]:
             pre_ops = sites * (
-                2 * num_tokens * hc_dim * mix_hc
-                + num_tokens * hc_dim * 3
-                + num_tokens * (hc_mult * hc_mult + 2 * hc_mult) * sinkhorn_iters
-                + 2 * num_tokens * hc_mult * hidden_size
+                2 * tokens * hc_dim * mix_hc
+                + tokens * hc_dim * 3
+                + tokens * (hc_mult * hc_mult + 2 * hc_mult) * sinkhorn_iters
+                + 2 * tokens * hc_mult * hidden_size
             )
-            post_ops = sites * (
-                2 * num_tokens * hc_mult * hc_mult * hidden_size + 2 * num_tokens * hc_mult * hidden_size
-            )
-            if op == "pre":
+            post_ops = sites * (2 * tokens * hc_mult * hc_mult * hidden_size + 2 * tokens * hc_mult * hidden_size)
+            if op_value == "pre":
                 ops = pre_ops
-            elif op == "post":
+            elif op_value == "post":
                 ops = post_ops
-            elif op == "both":
+            elif op_value == "both":
                 ops = pre_ops + post_ops
             else:
-                raise ValueError(f"Unsupported DeepSeek-V4 mHC op: {op}")
+                raise ValueError(f"Unsupported DeepSeek-V4 mHC op: {op_value}")
 
             param_bytes = sites * (mix_hc * hc_dim + mix_hc + 3) * quant_mode.value.memory
-            activation_bytes = sites * num_tokens * hc_dim * quant_mode.value.memory * (3 if op == "both" else 2)
-            if op in {"pre", "both"}:
-                activation_bytes += sites * num_tokens * (2 * hc_mult + hc_mult * hc_mult) * 4
+            activation_bytes = sites * tokens * hc_dim * quant_mode.value.memory * (3 if op_value == "both" else 2)
+            if op_value in {"pre", "both"}:
+                activation_bytes += sites * tokens * (2 * hc_mult + hc_mult * hc_mult) * 4
             sol_math = ops / GEMM._get_quant_tc_flops(database.system_spec, quant_mode) * 1000
             sol_mem = (param_bytes + activation_bytes) / database.system_spec["gpu"]["mem_bw"] * 1000
             return max(sol_math, sol_mem), sol_math, sol_mem
@@ -580,10 +578,8 @@ class DeepSeekV4MHCModule(Operation):
             def _lookup_single(op_name: str) -> PerformanceResult:
                 # Validate bucket presence before chained indexing; mhc_data is
                 # a nested defaultdict, so `mhc_data[op][hc_mult][hidden_size]`
-                # would silently materialize empty dicts and then fall through
-                # to _nearest_1d_point_helper with an empty key list, surfacing
-                # as an opaque AssertionError instead of a structured
-                # PerfDataNotAvailableError.
+                # would silently materialize an empty table and lose the
+                # category context before the sparse estimator reports a miss.
                 if (
                     op_name not in mhc_data
                     or hc_mult not in mhc_data[op_name]
@@ -594,10 +590,15 @@ class DeepSeekV4MHCModule(Operation):
                         f"No mHC silicon data for op='{op_name}', hc_mult={hc_mult}, hidden_size={hidden_size}."
                     )
                 mhc_dict = mhc_data[op_name][hc_mult][hidden_size]
-                left, right = interpolation.nearest_1d_point_helper(num_tokens, list(mhc_dict.keys()), inner_only=False)
-                result = interpolation.interp_1d([left, right], [mhc_dict[left], mhc_dict[right]], num_tokens)
-                latency = result["latency"] if isinstance(result, dict) else result
-                energy = result.get("energy", 0.0) if isinstance(result, dict) else 0.0
+                latency, energy = estimate_sparse(
+                    database,
+                    ("dsv4-mhc", op_name, hc_mult, hidden_size),
+                    mhc_dict,
+                    {"tokens": num_tokens},
+                    axes=(Axis("tokens", extrapolate="both"),),
+                    varying="tokens",
+                    baseline=lambda point: get_sol(point["tokens"], op_name)[0],
+                )
                 return database._interp_pr(latency, energy=energy)
 
             # Silicon tables only store "pre" and "post" rows. For op=="both"
@@ -1525,18 +1526,32 @@ class DeepSeekV4MegaMoEModule(Operation):
                 f"{moe_tp_size=}, {moe_ep_size=}."
             ) from exc
 
-        num_left, num_right = interpolation.nearest_1d_point_helper(
-            num_tokens, list(token_dict.keys()), inner_only=False
+        minimum_tokens = float(min(token_dict))
+        latency, energy = estimate_sparse(
+            database,
+            (
+                "dsv4-megamoe",
+                phase,
+                kernel_source,
+                kernel_dtype,
+                quant_mode,
+                pre_dispatch,
+                source_policy,
+                workload_distribution,
+                topk,
+                num_experts,
+                num_fused_shared_experts,
+                hidden_size,
+                inter_size,
+                moe_tp_size,
+                moe_ep_size,
+            ),
+            token_dict,
+            {"tokens": num_tokens},
+            axes=(Axis("tokens", extrapolate="both"),),
+            varying="tokens",
+            baseline=lambda point: max(point["tokens"], minimum_tokens),
         )
-        result = interpolation.interp_1d(
-            [num_left, num_right], [token_dict[num_left], token_dict[num_right]], num_tokens
-        )
-        if isinstance(result, dict):
-            latency = float(result["latency"])
-            energy = float(result["energy"])
-        else:
-            latency = float(result)
-            energy = 0.0
         return PerformanceResult(latency, energy=energy)
 
     def query(self, database: PerfDatabase, **kwargs) -> PerformanceResult:

--- a/src/aiconfigurator/sdk/operations/dsv4.py
+++ b/src/aiconfigurator/sdk/operations/dsv4.py
@@ -70,6 +70,8 @@ _DSV4_GENERATION_AXES = (
     Axis("batch", extrapolate="both"),
     Axis("sequence", extrapolate="both"),
 )
+_MHC_SILICON_SINKHORN_ITERS = 20
+_MHC_SILICON_QUANT_MODE = common.GEMMQuantMode.bfloat16
 
 
 # ───────────────────────────────────────────────────────────────────────
@@ -576,6 +578,16 @@ class DeepSeekV4MHCModule(Operation):
                 )
 
             def _lookup_single(op_name: str) -> PerformanceResult:
+                if quant_mode is not _MHC_SILICON_QUANT_MODE:
+                    raise PerfDataNotAvailableError(
+                        f"mHC silicon data was collected for quant_mode={_MHC_SILICON_QUANT_MODE.name}, "
+                        f"not {quant_mode.name}."
+                    )
+                if op_name == "pre" and sinkhorn_iters != _MHC_SILICON_SINKHORN_ITERS:
+                    raise PerfDataNotAvailableError(
+                        "mHC pre silicon data was collected with "
+                        f"sinkhorn_iters={_MHC_SILICON_SINKHORN_ITERS}, not {sinkhorn_iters}."
+                    )
                 # Validate bucket presence before chained indexing; mhc_data is
                 # a nested defaultdict, so `mhc_data[op][hc_mult][hidden_size]`
                 # would silently materialize an empty table and lose the
@@ -592,7 +604,7 @@ class DeepSeekV4MHCModule(Operation):
                 mhc_dict = mhc_data[op_name][hc_mult][hidden_size]
                 latency, energy = estimate_sparse(
                     database,
-                    ("dsv4-mhc", op_name, hc_mult, hidden_size),
+                    ("dsv4-mhc", op_name, hc_mult, hidden_size, quant_mode, sinkhorn_iters),
                     mhc_dict,
                     {"tokens": num_tokens},
                     axes=(Axis("tokens", extrapolate="both"),),
@@ -621,7 +633,7 @@ class DeepSeekV4MHCModule(Operation):
             database_mode=database_mode,
             error_msg=(
                 f"Failed to query DeepSeek-V4 mHC module for {num_tokens=}, {hidden_size=}, "
-                f"{hc_mult=}, {sinkhorn_iters=}, {op=}"
+                f"{hc_mult=}, {sinkhorn_iters=}, {op=}, {quant_mode=}"
             ),
         )
 
@@ -1657,6 +1669,19 @@ def load_mhc_module_data(mhc_file: str):
 
     for row in rows:
         op = row["op_name"]
+        row_sinkhorn_iters = row.get("sinkhorn_iters")
+        if (
+            op == "pre"
+            and row_sinkhorn_iters is not None
+            and str(row_sinkhorn_iters).strip()
+            and float(row_sinkhorn_iters) != _MHC_SILICON_SINKHORN_ITERS
+        ):
+            logger.debug(
+                "Skipping mHC pre row collected with sinkhorn_iters=%s; expected %s",
+                row_sinkhorn_iters,
+                _MHC_SILICON_SINKHORN_ITERS,
+            )
+            continue
         hc_mult = int(row["hc_mult"])
         hidden_size = int(row["hidden_size"])
         num_tokens = int(row["num_tokens"])
@@ -1664,11 +1689,8 @@ def load_mhc_module_data(mhc_file: str):
         power = float(row.get("power", 0.0)) if has_power else 0.0
         energy = power * latency
 
-        mhc_data[op][hc_mult][hidden_size][num_tokens] = {
-            "latency": latency,
-            "power": power,
-            "energy": energy,
-        }
+        token_data = mhc_data[op][hc_mult][hidden_size]
+        token_data.setdefault(num_tokens, {"latency": latency, "power": power, "energy": energy})
 
     return mhc_data
 
@@ -1839,7 +1861,8 @@ def load_context_dsv4_kind_module_data(file_path: str):
 
     ``prefix`` is the past-KV length, ``int(float(row["step"]))``; ``s`` is the
     context chunk length (``isl``).  Multiple files (csa/hca) merge cleanly
-    because compress_ratio is a key dimension.
+    because compress_ratio is a key dimension. ``model`` and ``op_name`` are
+    provenance only; duplicate physical keys keep the first measurement.
     """
     rows = _read_filtered_rows(file_path)
     if rows is None:
@@ -1877,11 +1900,8 @@ def load_context_dsv4_kind_module_data(file_path: str):
         # NOTE: the topK DELTA correction (degenerate -> representative) is
         # applied ONCE at query time for compress_ratio==4 (CSA). Do NOT
         # subtract it here, or the CSA module latency would be double-corrected.
-        data[fmha_mode][kv_dtype][gemm_mode][head_key][tp_size][cr][prefix][s][b] = {
-            "latency": latency,
-            "power": power,
-            "energy": power * latency,
-        }
+        batch_data = data[fmha_mode][kv_dtype][gemm_mode][head_key][tp_size][cr][prefix][s]
+        batch_data.setdefault(b, {"latency": latency, "power": power, "energy": power * latency})
     return data
 
 
@@ -1892,6 +1912,8 @@ def load_generation_dsv4_kind_module_data(file_path: str):
     is q_len=1 with past_kv = step). Dict shape:
         data[kv_quant][gemm_quant][fmha_quant][native_heads][tp_size]
             [compress_ratio][b][s_total]
+    ``model`` and ``op_name`` are provenance only; duplicate physical keys keep
+    the first measurement.
     """
     rows = _read_filtered_rows(file_path)
     if rows is None:
@@ -1926,11 +1948,8 @@ def load_generation_dsv4_kind_module_data(file_path: str):
         fmha_mode = common.FMHAQuantMode[_dsv4_normalize_dtype(row["mla_dtype"])]
         kv_dtype = common.KVCacheQuantMode[_dsv4_normalize_dtype(row["kv_cache_dtype"])]
 
-        data[kv_dtype][gemm_mode][fmha_mode][head_key][tp_size][cr][b][s_total] = {
-            "latency": latency,
-            "power": power,
-            "energy": power * latency,
-        }
+        sequence_data = data[kv_dtype][gemm_mode][fmha_mode][head_key][tp_size][cr][b]
+        sequence_data.setdefault(s_total, {"latency": latency, "power": power, "energy": power * latency})
     return data
 
 
@@ -2129,7 +2148,7 @@ def load_dsv4_sparse_op_data(file_or_sources, key_columns):
         node = root
         for k in keys[:-1]:
             node = node.setdefault(k, {})
-        node[keys[-1]] = {"latency": latency}
+        node.setdefault(keys[-1], {"latency": latency})
     return root or None
 
 

--- a/src/aiconfigurator/sdk/operations/gemm.py
+++ b/src/aiconfigurator/sdk/operations/gemm.py
@@ -223,7 +223,7 @@ class GEMM(Operation):
 
         Mirrors the legacy ``_correct_data`` block — for each table entry,
         if SOL latency exceeds the measured latency, the measured value is
-        raised to SOL (preserving power/energy fields unchanged).
+        raised to SOL while preserving the sample's average power.
 
         ``gemm_data`` defaults to ``database._gemm_data`` (the instance
         attribute) so the backward-compat call from ``PerfDatabase._correct_data``
@@ -252,7 +252,13 @@ class GEMM(Operation):
                                 f"gemm quant {quant_mode} m{m} n{n} k{k}: sol {sol} > perf_db {current_latency}"
                             )
                             if isinstance(data, dict):
-                                gemm_data[quant_mode][m][n][k]["latency"] = float(max(sol, current_latency))
+                                corrected_latency = float(max(sol, current_latency))
+                                if "energy" in data:
+                                    if "power" in data:
+                                        data["energy"] = float(data["power"]) * corrected_latency
+                                    elif current_latency > 0:
+                                        data["energy"] = float(data["energy"]) * corrected_latency / current_latency
+                                data["latency"] = corrected_latency
                             else:
                                 gemm_data[quant_mode][m][n][k] = float(max(sol, current_latency))
 
@@ -320,7 +326,11 @@ class GEMM(Operation):
                 if isinstance(result, PerformanceResult):
                     return result
                 if isinstance(result, dict):
-                    return PerformanceResult(result["latency"], energy=result.get("energy", 0.0), source=source)
+                    latency = float(result["latency"])
+                    energy = result.get("energy")
+                    if energy is None:
+                        energy = float(result.get("power", 0.0)) * latency
+                    return PerformanceResult(latency, energy=energy, source=source)
                 return PerformanceResult(result, energy=0.0, source=source)
 
             gemm_data_wrapper.raise_if_not_loaded()
@@ -409,6 +419,8 @@ class GEMM(Operation):
         elif database_mode == common.DatabaseMode.EMPIRICAL:
             return PerformanceResult(get_empirical(m, k), energy=0.0, source="empirical")
 
+        if m == 0:
+            return database._interp_pr(0.0)
         cls.load_data(database)
         compute_scale_wrapper = database._compute_scale_data
 
@@ -425,8 +437,6 @@ class GEMM(Operation):
                     f"Supported modes: {supported}"
                 )
             table = compute_scale_wrapper[table_quant_mode]
-            if m == 0:
-                return database._interp_pr(0.0)
             latency, energy = estimate_sparse(
                 database,
                 ("compute_scale", table_quant_mode),
@@ -481,6 +491,8 @@ class GEMM(Operation):
         elif database_mode == common.DatabaseMode.EMPIRICAL:
             return PerformanceResult(get_empirical(m, k), energy=0.0, source="empirical")
 
+        if m == 0:
+            return database._interp_pr(0.0)
         cls.load_data(database)
         scale_matrix_wrapper = database._scale_matrix_data
 
@@ -497,8 +509,6 @@ class GEMM(Operation):
                     f"Supported modes: {supported}"
                 )
             table = scale_matrix_wrapper[table_quant_mode]
-            if m == 0:
-                return database._interp_pr(0.0)
             latency, energy = estimate_sparse(
                 database,
                 ("scale_matrix", table_quant_mode),

--- a/src/aiconfigurator/sdk/operations/gemm.py
+++ b/src/aiconfigurator/sdk/operations/gemm.py
@@ -4,7 +4,7 @@
 """GEMM operation and its associated CSV-backed data (compute_scale, scale_matrix).
 
 Stage 2 of ISSUE-05/AIC-542: GEMM now owns its three CSV tables, SOL
-correction, and grid extrapolation. ``PerfDatabase.query_gemm /
+correction, and sparse query path. ``PerfDatabase.query_gemm /
 query_compute_scale / query_scale_matrix`` delegate here.
 
 Lazy-load Pattern A: ``query()`` (and the delegating ``_query_*_table``
@@ -22,8 +22,9 @@ import logging
 from collections import defaultdict
 from typing import TYPE_CHECKING, ClassVar
 
-from aiconfigurator.sdk import common, interpolation
+from aiconfigurator.sdk import common
 from aiconfigurator.sdk.operations.base import Operation, _read_filtered_rows
+from aiconfigurator.sdk.perf_surrogate import Axis, estimate_sparse
 from aiconfigurator.sdk.performance_result import PerformanceResult
 
 if TYPE_CHECKING:
@@ -93,8 +94,8 @@ class GEMM(Operation):
     @classmethod
     def load_data(cls, database: PerfDatabase) -> None:
         """Idempotent. On cache miss: parses the three CSVs into the class-
-        level caches, applies SOL correction + grid extrapolation directly
-        on those canonical wrappers, and records the load. Always: binds
+        level caches, applies SOL correction directly on the canonical GEMM
+        wrapper, and records the load. Always: binds
         ``database._gemm_data``/``_compute_scale_data``/``_scale_matrix_data``
         to the cached wrappers.
 
@@ -126,29 +127,17 @@ class GEMM(Operation):
             compute_scale_loaded = _load(PerfDataFilename.compute_scale, load_compute_scale_data)
             scale_matrix_loaded = _load(PerfDataFilename.scale_matrix, load_scale_matrix_data)
 
-            # Correct + extrapolate the CANONICAL class-cache values directly
+            # Correct the CANONICAL class-cache value directly
             # (not via ``database._gemm_data``) so a pre-set test override
             # can't leave the cached wrapper uncorrected — a later DB sharing
-            # the same cache key would otherwise bind unextrapolated data.
+            # the same cache key would otherwise bind uncorrected data.
             #
-            # The ordering (clamp THEN extrapolate) matches the legacy
-            # ``PerfDatabase.__init__`` flow exactly: ``_correct_data()``
-            # ran before the GEMM extrapolation block. Newly-extrapolated
-            # rows are derived from already-clamped real measurements so
-            # they sit at or above the SOL bound by construction.
             # ``PerfDatabase._correct_data`` re-clamps via the backward-compat
             # forward when called from ``__init__``, but standalone callers
             # of ``GEMM.load_data`` get the legacy single-pass semantics.
             cls._correct_sol(database, gemm_loaded)
-            cls._extrapolate_gemm_data(gemm_loaded)
-            # Re-clamp after extrapolation: interpolated/extrapolated grid
-            # points can land below the SOL bound. The legacy init path ran
-            # ``_correct_data()`` a second time which caught these; replicate
-            # that here so standalone ``load_data`` callers get the same
-            # physically-consistent floor.
-            cls._correct_sol(database, gemm_loaded)
 
-            # All three loads + correction + extrapolation succeeded — commit
+            # All three loads + correction succeeded — commit
             # atomically so partially-populated cache state can never be observed.
             cls._data_cache[key] = gemm_loaded
             cls._compute_scale_cache[key] = compute_scale_loaded
@@ -268,103 +257,6 @@ class GEMM(Operation):
                                 gemm_data[quant_mode][m][n][k] = float(max(sol, current_latency))
 
     # ------------------------------------------------------------------
-    # Grid extrapolation (formerly in PerfDatabase.__init__)
-    # ------------------------------------------------------------------
-
-    # GEMM extrapolation target grid (lifted verbatim from perf_database.py
-    # so behavior stays bit-identical).
-    _EXTRAPOLATION_TARGET_X: ClassVar[list] = [
-        1,
-        2,
-        4,
-        8,
-        16,
-        32,
-        48,
-        64,
-        80,
-        96,
-        128,
-        160,
-        192,
-        224,
-        256,
-        320,
-        384,
-        448,
-        512,
-        640,
-        768,
-        896,
-        1024,
-        2048,
-        4096,
-        8192,
-        16384,
-        32768,
-        131072,
-        524288,
-        1048576,
-        2097152 * 8,
-    ]  # num_tokens
-
-    _EXTRAPOLATION_TARGET_Y: ClassVar[list] = [
-        32,
-        64,
-        128,
-        256,
-        512,
-        768,
-        1024,
-        1536,
-        2048,
-        2560,
-        3072,
-        3584,
-        4096,
-        5120,
-        6144,
-        7168,
-        8192,
-        10240,
-        12288,
-        14336,
-        16384,
-        20480,
-        24576,
-        28672,
-        32768,
-        40960,
-        49152,
-        57344,
-        65536,
-        131072,
-        262144,
-    ]  # to fit vocab gemm
-
-    @classmethod
-    def _extrapolate_gemm_data(cls, gemm_data) -> None:
-        """Apply the 3D extrapolation grid to each quant_mode's table.
-
-        Takes the GEMM data wrapper explicitly. ``load_data`` passes the
-        canonical class-cache value; tests that need to extrapolate a
-        custom-loaded dict can call this with their own LoadedOpData."""
-        if gemm_data is None or not gemm_data.loaded:
-            return
-
-        target_x_list = cls._EXTRAPOLATION_TARGET_X
-        target_y_list = cls._EXTRAPOLATION_TARGET_Y
-        target_z_list = cls._EXTRAPOLATION_TARGET_Y
-
-        for _quant_mode, data_dict in gemm_data.items():
-            interpolation.extrapolate_data_grid(
-                data_dict=data_dict,
-                target_x_list=target_x_list,
-                target_y_list=target_y_list,
-                target_z_list=target_z_list,
-            )
-
-    # ------------------------------------------------------------------
     # Table query classmethods (formerly PerfDatabase.query_*)
     # ------------------------------------------------------------------
 
@@ -449,16 +341,23 @@ class GEMM(Operation):
                 result = gemm_data[m][n][k]
                 return _to_performance_result(result)
 
-            m_values = sorted(m_key for m_key in gemm_data if n in gemm_data[m_key] and k in gemm_data[m_key][n])
-            if len(m_values) >= 2:
-                m_left, m_right = interpolation.nearest_1d_point_helper(m, m_values, inner_only=False)
-                result = interpolation.interp_1d(
-                    [m_left, m_right], [gemm_data[m_left][n][k], gemm_data[m_right][n][k]], m
-                )
-                return _to_performance_result(result)
-
             try:
-                result = interpolation.interp_3d(m, n, k, gemm_data, "cubic", database._extracted_metrics_cache)
+                latency, energy = estimate_sparse(
+                    database,
+                    ("gemm", table_quant_mode, quant_mode),
+                    gemm_data,
+                    {"m": m, "n": n, "k": k},
+                    axes=(
+                        Axis("m", extrapolate="both"),
+                        Axis("n", log=True, extrapolate="both"),
+                        Axis("k", log=True, extrapolate="both"),
+                    ),
+                    varying="m",
+                    curve="raw",
+                    mesh="baseline_ratio",
+                    exterior="baseline_ratio",
+                    baseline=lambda point: get_sol(point["m"], point["n"], point["k"], quant_mode)[0],
+                )
             except ValueError as exc:
                 from aiconfigurator.sdk.perf_database import PerfDataNotAvailableError
 
@@ -467,7 +366,8 @@ class GEMM(Operation):
                     f"system='{database.system}', backend='{database.backend}', version='{database.version}', "
                     f"quant_mode='{quant_mode.name}', m={m}, n={n}, k={k}."
                 ) from exc
-            return _to_performance_result(result)
+            latency = max(latency, get_sol(m, n, k, quant_mode)[0])
+            return database._interp_pr(latency, energy=energy)
 
         return database._query_silicon_or_hybrid(
             get_silicon=get_silicon,
@@ -525,27 +425,21 @@ class GEMM(Operation):
                     f"Supported modes: {supported}"
                 )
             table = compute_scale_wrapper[table_quant_mode]
-            m_i = int(m)
-            k_i = int(k)
-
-            m_keys = sorted(table.keys())
-            m_i = max(m_keys[0], min(m_i, m_keys[-1]))
-
-            k_min = None
-            k_max = None
-            for row in table.values():
-                if not row:
-                    continue
-                row_min = min(row.keys())
-                row_max = max(row.keys())
-                k_min = row_min if k_min is None else min(k_min, row_min)
-                k_max = row_max if k_max is None else max(k_max, row_max)
-
-            if k_min is not None and k_max is not None:
-                k_i = max(k_min, min(k_i, k_max))
-
-            result = interpolation.interp_2d_linear(m_i, k_i, table, database._extracted_metrics_cache)
-            return database._interp_pr(result["latency"], energy=result.get("energy", 0.0))
+            if m == 0:
+                return database._interp_pr(0.0)
+            latency, energy = estimate_sparse(
+                database,
+                ("compute_scale", table_quant_mode),
+                table,
+                {"m": m, "k": k},
+                axes=(Axis("m", extrapolate="both"), Axis("k", log=True, extrapolate="both")),
+                varying="m",
+                curve="raw",
+                mesh="raw",
+                exterior="baseline_ratio",
+                baseline=lambda point: get_sol(point["m"], point["k"])[0],
+            )
+            return database._interp_pr(latency, energy=energy)
 
         return database._query_silicon_or_hybrid(
             get_silicon=get_silicon,
@@ -603,27 +497,21 @@ class GEMM(Operation):
                     f"Supported modes: {supported}"
                 )
             table = scale_matrix_wrapper[table_quant_mode]
-            m_i = int(m)
-            k_i = int(k)
-
-            m_keys = sorted(table.keys())
-            m_i = max(m_keys[0], min(m_i, m_keys[-1]))
-
-            k_min = None
-            k_max = None
-            for row in table.values():
-                if not row:
-                    continue
-                row_min = min(row.keys())
-                row_max = max(row.keys())
-                k_min = row_min if k_min is None else min(k_min, row_min)
-                k_max = row_max if k_max is None else max(k_max, row_max)
-
-            if k_min is not None and k_max is not None:
-                k_i = max(k_min, min(k_i, k_max))
-
-            result = interpolation.interp_2d_linear(m_i, k_i, table, database._extracted_metrics_cache)
-            return database._interp_pr(result["latency"], energy=result.get("energy", 0.0))
+            if m == 0:
+                return database._interp_pr(0.0)
+            latency, energy = estimate_sparse(
+                database,
+                ("scale_matrix", table_quant_mode),
+                table,
+                {"m": m, "k": k},
+                axes=(Axis("m", extrapolate="both"), Axis("k", log=True, extrapolate="both")),
+                varying="m",
+                curve="raw",
+                mesh="raw",
+                exterior="baseline_ratio",
+                baseline=lambda point: get_sol(point["m"], point["k"])[0],
+            )
+            return database._interp_pr(latency, energy=energy)
 
         return database._query_silicon_or_hybrid(
             get_silicon=get_silicon,

--- a/src/aiconfigurator/sdk/operations/mamba.py
+++ b/src/aiconfigurator/sdk/operations/mamba.py
@@ -29,16 +29,69 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, ClassVar
 
-from aiconfigurator.sdk import common, interpolation
+from aiconfigurator.sdk import common
+from aiconfigurator.sdk.interpolation import InterpolationDataNotAvailableError
 from aiconfigurator.sdk.operations.base import Operation, _read_filtered_rows
+from aiconfigurator.sdk.perf_surrogate import Axis, estimate_sparse
 from aiconfigurator.sdk.performance_result import PerformanceResult
 
 if TYPE_CHECKING:
     from aiconfigurator.sdk.perf_database import PerfDatabase
 
 logger = logging.getLogger(__name__)
+
+
+_GDN_DATA_KERNEL_ALIASES = {
+    "fused_sigmoid_gating_delta_rule_update": "fused_recurrent_gated_delta_rule",
+}
+
+
+def _generation_entry(value):
+    """Normalize direct and legacy ``batch -> seq -> metric`` leaves."""
+    if not isinstance(value, Mapping) or "latency" in value:
+        return value
+    for candidate in value.values():
+        if not isinstance(candidate, Mapping) or "latency" in candidate:
+            return candidate
+    return None
+
+
+def _estimate_kernel_table(
+    database: PerfDatabase,
+    key: tuple,
+    table: Mapping,
+    phase: str,
+    batch_size: int,
+    seq_len: int | None,
+    baseline,
+) -> tuple[float, float]:
+    if phase == "context":
+        return estimate_sparse(
+            database,
+            key,
+            table,
+            {"batch_size": batch_size, "seq_len": seq_len},
+            axes=(Axis("batch_size"), Axis("seq_len", extrapolate="both")),
+            varying="seq_len",
+            mesh="baseline_ratio",
+            baseline=baseline,
+        )
+
+    normalized = table
+    if any(not isinstance(value, Mapping) or "latency" not in value for value in table.values()):
+        normalized = {batch: entry for batch, value in table.items() if (entry := _generation_entry(value)) is not None}
+    return estimate_sparse(
+        database,
+        key,
+        normalized,
+        {"batch_size": batch_size},
+        axes=(Axis("batch_size", extrapolate="both"),),
+        varying="batch_size",
+        baseline=baseline,
+    )
 
 
 def _cache_key(database: PerfDatabase) -> tuple:
@@ -161,10 +214,13 @@ class Mamba2Kernel(Operation):
         if not getattr(mamba2_data, "loaded", False):
             mamba2_data = {}
 
-        def get_sol() -> tuple[float, float, float]:
+        def get_sol(
+            batch_value: float = batch_size,
+            seq_value: float | None = seq_len,
+        ) -> tuple[float, float, float]:
             d_inner = nheads * head_dim
             conv_dim = d_inner + 2 * n_groups * d_state
-            x = (batch_size * seq_len) if phase == "context" and seq_len else batch_size
+            x = (batch_value * seq_value) if phase == "context" and seq_value else batch_value
             if kernel_source in ("causal_conv1d_fn", "causal_conv1d_update"):
                 conv_read_bytes = x * conv_dim * (d_conv + 1) * 2
                 conv_write_bytes = x * conv_dim * 2
@@ -177,6 +233,8 @@ class Mamba2Kernel(Operation):
             return sol_mem, 0, sol_mem
 
         if not mamba2_data:
+            return PerformanceResult(get_sol()[0], energy=0.0, source="sol")
+        if phase == "context" and (seq_len is None or seq_len <= 0):
             return PerformanceResult(get_sol()[0], energy=0.0, source="sol")
 
         model_key = (d_model, d_state, d_conv, nheads, head_dim, n_groups, chunk_size)
@@ -198,51 +256,19 @@ class Mamba2Kernel(Operation):
 
         table = by_key[model_key]
 
-        if phase == "context":
-            if seq_len is None or seq_len <= 0:
-                return PerformanceResult(get_sol()[0], energy=0.0, source="sol")
-            try:
-                result = interpolation.interp_2d_linear(batch_size, seq_len, table, database._extracted_metrics_cache)
-            except (KeyError, ValueError):
-                return PerformanceResult(get_sol()[0], energy=0.0, source="sol")
-            return database._interp_pr(
-                result["latency"],
-                energy=result.get("energy", result.get("power", 0.0) * result["latency"]),
-            )
-        else:
-            try:
-                batch_left, batch_right = interpolation.nearest_1d_point_helper(
-                    batch_size, list(table.keys()), inner_only=False
-                )
-            except (KeyError, ValueError):
-                return PerformanceResult(get_sol()[0], energy=0.0, source="sol")
-
-            # Ensure we pass entry dicts {latency, power, energy}; handle legacy nested batch_size -> seq_len -> entry
-            def _mamba2_gen_entry(val):
-                if isinstance(val, dict) and "latency" in val:
-                    return val
-                if isinstance(val, dict) and val:
-                    inner = next(iter(val.values()))
-                    if isinstance(inner, dict) and "latency" in inner:
-                        return inner
-                return None
-
-            y_left = _mamba2_gen_entry(table[batch_left])
-            y_right = _mamba2_gen_entry(table[batch_right])
-            if y_left is None or y_right is None:
-                return PerformanceResult(get_sol()[0], energy=0.0, source="sol")
-            result = interpolation.interp_1d(
-                [batch_left, batch_right],
-                [y_left, y_right],
+        try:
+            latency, energy = _estimate_kernel_table(
+                database,
+                ("mamba2", kernel_source, phase, model_key),
+                table,
+                phase,
                 batch_size,
+                seq_len,
+                lambda point: get_sol(point["batch_size"], point.get("seq_len"))[0],
             )
-            if isinstance(result, dict):
-                lat = result["latency"]
-                energy = result.get("energy", result.get("power", 0.0) * lat)
-            else:
-                lat = result
-                energy = 0.0
-            return database._interp_pr(lat, energy=energy)
+        except InterpolationDataNotAvailableError:
+            return PerformanceResult(get_sol()[0], energy=0.0, source="sol")
+        return database._interp_pr(latency, energy=energy)
 
     # ------------------------------------------------------------------
     # Op contract
@@ -374,8 +400,11 @@ class GDNKernel(Operation):
         if not getattr(gdn_data, "loaded", False):
             gdn_data = {}
 
-        def get_sol() -> tuple[float, float, float]:
-            x = (batch_size * seq_len) if phase == "context" and seq_len else batch_size
+        def get_sol(
+            batch_value: float = batch_size,
+            seq_value: float | None = seq_len,
+        ) -> tuple[float, float, float]:
+            x = (batch_value * seq_value) if phase == "context" and seq_value else batch_value
             if kernel_source in ("causal_conv1d_fn", "causal_conv1d_update"):
                 conv_channels = num_k_heads * head_k_dim + num_v_heads * head_v_dim
                 read_bytes = x * conv_channels * (d_conv + 1) * 2
@@ -388,23 +417,28 @@ class GDNKernel(Operation):
                 # (no dtype override), so matches input dtype: FP16/BF16 → 2 bytes.
                 chunk_size = 64  # flash-linear-attention default for chunk_gated_delta_rule
                 state_size = num_v_heads * head_k_dim * head_v_dim
-                num_chunks = (seq_len // chunk_size) if seq_len else 0
-                h_chunks_bytes = num_chunks * state_size * 2 * batch_size
+                num_chunks = (seq_value // chunk_size) if seq_value else 0
+                h_chunks_bytes = num_chunks * state_size * 2 * batch_value
                 read_bytes = (
                     x * (num_k_heads * head_k_dim + num_v_heads * head_v_dim) * 2
-                    + state_size * 2 * batch_size
+                    + state_size * 2 * batch_value
                     + h_chunks_bytes  # chunk_o reads h_chunks from global memory
                 )
                 write_bytes = (
                     x * num_v_heads * head_v_dim * 2
-                    + state_size * 2 * batch_size
+                    + state_size * 2 * batch_value
                     + h_chunks_bytes  # chunk_delta_h writes h_chunks to global memory
                 )
-            elif kernel_source == "fused_sigmoid_gating_delta_rule_update":
+            elif kernel_source in (
+                "fused_sigmoid_gating_delta_rule_update",
+                "fused_recurrent_gated_delta_rule",
+            ):
                 # GDN single-step decode. State stored as BF16 in global memory.
                 state_size = num_v_heads * head_k_dim * head_v_dim
-                read_bytes = x * (num_k_heads * head_k_dim + num_v_heads * head_v_dim) * 2 + state_size * 2 * batch_size
-                write_bytes = x * num_v_heads * head_v_dim * 2 + state_size * 2 * batch_size
+                read_bytes = (
+                    x * (num_k_heads * head_k_dim + num_v_heads * head_v_dim) * 2 + state_size * 2 * batch_value
+                )
+                write_bytes = x * num_v_heads * head_v_dim * 2 + state_size * 2 * batch_value
             else:
                 read_bytes = x * d_model * 2
                 write_bytes = x * d_model * 2
@@ -413,12 +447,19 @@ class GDNKernel(Operation):
 
         if not gdn_data:
             return PerformanceResult(get_sol()[0], energy=0.0, source="sol")
+        if phase == "context" and (seq_len is None or seq_len <= 0):
+            return PerformanceResult(get_sol()[0], energy=0.0, source="sol")
 
         model_key = (d_model, num_k_heads, head_k_dim, num_v_heads, head_v_dim, d_conv)
-        try:
-            by_phase = gdn_data[kernel_source]
-        except KeyError:
+        alias = _GDN_DATA_KERNEL_ALIASES.get(kernel_source)
+        candidates = (kernel_source,) if alias is None else (kernel_source, alias)
+        data_kernel_source = next(
+            (candidate for candidate in candidates if candidate in gdn_data and phase in gdn_data[candidate]),
+            None,
+        )
+        if data_kernel_source is None:
             return PerformanceResult(get_sol()[0], energy=0.0, source="sol")
+        by_phase = gdn_data[data_kernel_source]
         try:
             by_key = by_phase[phase]
         except KeyError:
@@ -433,50 +474,19 @@ class GDNKernel(Operation):
 
         table = by_key[model_key]
 
-        if phase == "context":
-            if seq_len is None or seq_len <= 0:
-                return PerformanceResult(get_sol()[0], energy=0.0, source="sol")
-            try:
-                result = interpolation.interp_2d_linear(batch_size, seq_len, table, database._extracted_metrics_cache)
-            except (KeyError, ValueError):
-                return PerformanceResult(get_sol()[0], energy=0.0, source="sol")
-            return database._interp_pr(
-                result["latency"],
-                energy=result.get("energy", result.get("power", 0.0) * result["latency"]),
-            )
-        else:
-            try:
-                batch_left, batch_right = interpolation.nearest_1d_point_helper(
-                    batch_size, list(table.keys()), inner_only=False
-                )
-            except (KeyError, ValueError):
-                return PerformanceResult(get_sol()[0], energy=0.0, source="sol")
-
-            def _gdn_gen_entry(val):
-                if isinstance(val, dict) and "latency" in val:
-                    return val
-                if isinstance(val, dict) and val:
-                    inner = next(iter(val.values()))
-                    if isinstance(inner, dict) and "latency" in inner:
-                        return inner
-                return None
-
-            y_left = _gdn_gen_entry(table[batch_left])
-            y_right = _gdn_gen_entry(table[batch_right])
-            if y_left is None or y_right is None:
-                return PerformanceResult(get_sol()[0], energy=0.0, source="sol")
-            result = interpolation.interp_1d(
-                [batch_left, batch_right],
-                [y_left, y_right],
+        try:
+            latency, energy = _estimate_kernel_table(
+                database,
+                ("gdn", data_kernel_source, phase, model_key),
+                table,
+                phase,
                 batch_size,
+                seq_len,
+                lambda point: get_sol(point["batch_size"], point.get("seq_len"))[0],
             )
-            if isinstance(result, dict):
-                lat = result["latency"]
-                energy = result.get("energy", result.get("power", 0.0) * lat)
-            else:
-                lat = result
-                energy = 0.0
-            return database._interp_pr(lat, energy=energy)
+        except InterpolationDataNotAvailableError:
+            return PerformanceResult(get_sol()[0], energy=0.0, source="sol")
+        return database._interp_pr(latency, energy=energy)
 
     # ------------------------------------------------------------------
     # Op contract

--- a/src/aiconfigurator/sdk/operations/mamba.py
+++ b/src/aiconfigurator/sdk/operations/mamba.py
@@ -417,7 +417,7 @@ class GDNKernel(Operation):
                 # (no dtype override), so matches input dtype: FP16/BF16 → 2 bytes.
                 chunk_size = 64  # flash-linear-attention default for chunk_gated_delta_rule
                 state_size = num_v_heads * head_k_dim * head_v_dim
-                num_chunks = (seq_value // chunk_size) if seq_value else 0
+                num_chunks = int((seq_value + chunk_size - 1) // chunk_size) if seq_value else 0
                 h_chunks_bytes = num_chunks * state_size * 2 * batch_value
                 read_bytes = (
                     x * (num_k_heads * head_k_dim + num_v_heads * head_v_dim) * 2
@@ -726,20 +726,18 @@ def load_mamba2_data(mamba2_file: str):
         model_key = (d_model, d_state, d_conv, nheads, head_dim, n_groups, chunk_size)
         entry = {"latency": latency, "power": power, "energy": energy}
 
-        try:
-            if phase == "context":
-                data[kernel_source][phase][model_key][batch_size][seq_len]
+        by_model = data[kernel_source][phase][model_key]
+        if phase == "context":
+            if batch_size in by_model and seq_len in by_model[batch_size]:
                 logger.debug(
                     f"value conflict in mamba2 data: {kernel_source} {phase} {model_key} {batch_size} {seq_len}"
                 )
             else:
-                data[kernel_source][phase][model_key][batch_size]
-                logger.debug(f"value conflict in mamba2 data: {kernel_source} {phase} {model_key} {batch_size}")
-        except KeyError:
-            if phase == "context":
-                data[kernel_source][phase][model_key][batch_size][seq_len] = entry
-            else:
-                data[kernel_source][phase][model_key][batch_size] = entry
+                by_model.setdefault(batch_size, {})[seq_len] = entry
+        elif batch_size in by_model:
+            logger.debug(f"value conflict in mamba2 data: {kernel_source} {phase} {model_key} {batch_size}")
+        else:
+            by_model[batch_size] = entry
 
     # Convert default dicts to regular dicts for predictable behavior; keep generation as 1D
     result = {}

--- a/src/aiconfigurator/sdk/operations/mla.py
+++ b/src/aiconfigurator/sdk/operations/mla.py
@@ -19,10 +19,8 @@ Six op classes migrate from ``_legacy.py`` into ``operations/mla.py``:
   the legacy conditional ``if backend == "sglang"`` block in
   ``PerfDatabase.__init__``).
 
-No SOL clamping for any MLA variant in the legacy ``_correct_data``.
-Extrapolation present for all 4 regular + 2 module variants + 2 WideEP
-variants (the WideEP variants extrapolate only when their data was
-loaded — SGLang-only).
+No SOL clamping is added. Sparse context, generation, module, and WideEP
+tables are estimated at query time without expanding them into dense grids.
 
 Cache key matches every other migrated op:
 ``(systems_root, system, backend, version, enable_shared_layer)``. For
@@ -38,6 +36,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 from aiconfigurator.sdk import common, interpolation
 from aiconfigurator.sdk.operations.base import Operation, _read_filtered_rows
+from aiconfigurator.sdk.perf_surrogate import Axis, estimate_sparse
 from aiconfigurator.sdk.performance_result import PerformanceResult
 
 if TYPE_CHECKING:
@@ -61,51 +60,41 @@ def _cache_key(database: PerfDatabase) -> tuple:
     )
 
 
-# Shared extrapolation target lists — lifted verbatim from the legacy
-# ``PerfDatabase.__init__`` blocks (lines 2984-3206 pre-migration).
-#
-# fmt: off
-_REGULAR_CONTEXT_MLA_TARGET_Y: list[int] = (
-    [1, 16, 32, 64, 128, 256, 512, 1024, 2048]
-    + [4096 + i * 2048 for i in range(14)]
-    + [32768 + 16384 * i for i in range(6)]
-    + [131072 + 32768 * i for i in range(12)]
-    + [524288 + 65536 * i for i in range(9)]
-)  # s
-_REGULAR_CONTEXT_MLA_TARGET_Z: list[int] = [
-    1, 2, 4, 8, 16, 32, 64, 128, 256, 384, 512, 1024, 2048,
-]  # b
+_CONTEXT_AXES = (
+    Axis("heads"),
+    Axis("tokens", extrapolate="both"),
+    Axis("batch", extrapolate="both"),
+)
+_GENERATION_AXES = (
+    Axis("heads"),
+    Axis("batch", extrapolate="both"),
+    Axis("tokens", extrapolate="both"),
+)
 
-_WIDEEP_CONTEXT_MLA_TARGET_Y: list[int] = (
-    [16, 32, 64, 128, 256, 512, 1024, 2048]
-    + [4096 + i * 2048 for i in range(14)]
-    + [32768 + 16384 * i for i in range(6)]
-    + [131072 + 32768 * i for i in range(12)]
-    + [524288 + 65536 * i for i in range(9)]
-)  # s — note: starts at 16, not 1
-_WIDEEP_CONTEXT_MLA_TARGET_Z: list[int] = [
-    1, 2, 4, 8, 16, 32, 64, 128, 256, 384, 512, 1024, 2048,
-]  # b
 
-_GENERATION_MLA_TARGET_Y: list[int] = [
-    1, 2, 4, 8, 16, 32, 64, 128, 256, 384, 512, 1024, 2048, 8192,
-]  # b
-_GENERATION_MLA_TARGET_Z: list[int] = [
-    1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192,
-    16384, 32768, 65536, 131072, 262144, 2097152 * 8,
-]  # s
+def _estimate_context(database, key, table, heads, tokens, batch, baseline, *, sqrt_curve=False):
+    return estimate_sparse(
+        database,
+        key,
+        table,
+        {"heads": heads, "tokens": tokens, "batch": batch},
+        axes=_CONTEXT_AXES,
+        varying="tokens",
+        curve="sqrt" if sqrt_curve else "raw",
+        baseline=baseline,
+    )
 
-_CONTEXT_MLA_MODULE_TARGET_Y: list[int] = (
-    [1, 16, 32, 64, 128, 256, 512, 1024, 2048]
-    + [4096 + i * 2048 for i in range(14)]
-    + [32768 + 16384 * i for i in range(6)]
-    + [131072 + 32768 * i for i in range(12)]
-    + [524288 + 65536 * i for i in range(9)]
-)  # s — same as regular context MLA
-_CONTEXT_MLA_MODULE_TARGET_Z: list[int] = [
-    1, 2, 4, 8, 16, 32, 64, 128, 256, 384, 512, 1024, 2048,
-]  # b — same as regular context MLA
-# fmt: on
+
+def _estimate_generation(database, key, table, heads, batch, tokens, baseline):
+    return estimate_sparse(
+        database,
+        key,
+        table,
+        {"heads": heads, "batch": batch, "tokens": tokens},
+        axes=_GENERATION_AXES,
+        varying="tokens",
+        baseline=baseline,
+    )
 
 
 class ContextMLA(Operation):
@@ -139,8 +128,7 @@ class ContextMLA(Operation):
 
     @classmethod
     def load_data(cls, database: PerfDatabase) -> None:
-        """Idempotent. Loads context_mla CSV, applies extrapolation, binds
-        ``database._context_mla_data``."""
+        """Idempotently load the raw context MLA samples."""
         import os
 
         from aiconfigurator.sdk.perf_database import LoadedOpData, PerfDataFilename
@@ -154,7 +142,6 @@ class ContextMLA(Operation):
             cls._data_cache[key] = LoadedOpData(
                 load_context_mla_data(sources), PerfDataFilename.context_mla, primary_path
             )
-            cls._extrapolate(cls._data_cache[key])
             cls._record_load()
 
         if "_context_mla_data" not in database.__dict__:
@@ -163,23 +150,6 @@ class ContextMLA(Operation):
     @classmethod
     def clear_cache(cls) -> None:
         cls._data_cache.clear()
-
-    @classmethod
-    def _extrapolate(cls, data_wrapper) -> None:
-        """Apply the 2-level (quant_mode → kv_cache_dtype → grid) extrapolation."""
-        if data_wrapper is None or not getattr(data_wrapper, "loaded", False):
-            return
-        for quant_mode in data_wrapper:
-            for kv_cache_dtype in data_wrapper[quant_mode]:
-                num_heads_list = list(data_wrapper[quant_mode][kv_cache_dtype].keys())
-                data_dict = data_wrapper[quant_mode][kv_cache_dtype]
-                interpolation.extrapolate_data_grid(
-                    data_dict=data_dict,
-                    target_x_list=num_heads_list,
-                    target_y_list=_REGULAR_CONTEXT_MLA_TARGET_Y,
-                    target_z_list=_REGULAR_CONTEXT_MLA_TARGET_Z,
-                    sqrt_y_value=True,
-                )
 
     # ------------------------------------------------------------------
     # Query table (formerly PerfDatabase.query_context_mla)
@@ -250,9 +220,20 @@ class ContextMLA(Operation):
             full_s = s + prefix
             prefix_correction = (full_s * full_s - prefix * prefix) / (full_s * full_s)
             mla_dict = data_wrapper[fmha_quant_mode][kvcache_quant_mode]
-            result = interpolation.interp_3d(num_heads, full_s, b, mla_dict, "cubic", database._extracted_metrics_cache)
-            latency = result["latency"] * prefix_correction
-            energy = result.get("energy", 0.0) * prefix_correction
+            latency, energy = _estimate_context(
+                database,
+                ("context-mla", fmha_quant_mode, kvcache_quant_mode),
+                mla_dict,
+                num_heads,
+                full_s,
+                b,
+                lambda point: get_sol(
+                    point["batch"], point["tokens"], 0, point["heads"], kvcache_quant_mode, fmha_quant_mode
+                )[0],
+                sqrt_curve=True,
+            )
+            latency *= prefix_correction
+            energy *= prefix_correction
             return database._interp_pr(latency, energy=energy)
 
         return database._query_silicon_or_hybrid(
@@ -322,8 +303,7 @@ class GenerationMLA(Operation):
 
     @classmethod
     def load_data(cls, database: PerfDatabase) -> None:
-        """Idempotent. Loads generation_mla CSV, applies extrapolation, binds
-        ``database._generation_mla_data``."""
+        """Idempotently load the raw generation MLA samples."""
         import os
 
         from aiconfigurator.sdk.perf_database import LoadedOpData, PerfDataFilename
@@ -337,7 +317,6 @@ class GenerationMLA(Operation):
             cls._data_cache[key] = LoadedOpData(
                 load_generation_mla_data(sources), PerfDataFilename.generation_mla, primary_path
             )
-            cls._extrapolate(cls._data_cache[key])
             cls._record_load()
 
         if "_generation_mla_data" not in database.__dict__:
@@ -346,21 +325,6 @@ class GenerationMLA(Operation):
     @classmethod
     def clear_cache(cls) -> None:
         cls._data_cache.clear()
-
-    @classmethod
-    def _extrapolate(cls, data_wrapper) -> None:
-        """Apply the 1-level (kv_cache_dtype → grid) extrapolation."""
-        if data_wrapper is None or not getattr(data_wrapper, "loaded", False):
-            return
-        for kv_cache_dtype in data_wrapper:
-            tp_list = list(data_wrapper[kv_cache_dtype].keys())
-            data_dict = data_wrapper[kv_cache_dtype]
-            interpolation.extrapolate_data_grid(
-                data_dict=data_dict,
-                target_x_list=tp_list,
-                target_y_list=_GENERATION_MLA_TARGET_Y,
-                target_z_list=_GENERATION_MLA_TARGET_Z,
-            )
 
     # ------------------------------------------------------------------
     # Query table (formerly PerfDatabase.query_generation_mla)
@@ -419,9 +383,15 @@ class GenerationMLA(Operation):
         def get_silicon():
             data_wrapper.raise_if_not_loaded()
             mla_dict = data_wrapper[kvcache_quant_mode]
-            result = interpolation.interp_3d(num_heads, b, s, mla_dict, "bilinear", database._extracted_metrics_cache)
-            latency = result["latency"]
-            energy = result.get("energy", 0.0)
+            latency, energy = _estimate_generation(
+                database,
+                ("generation-mla", kvcache_quant_mode),
+                mla_dict,
+                num_heads,
+                b,
+                s,
+                lambda point: get_sol(point["batch"], point["tokens"], point["heads"], kvcache_quant_mode)[0],
+            )
             return database._interp_pr(latency, energy=energy)
 
         return database._query_silicon_or_hybrid(
@@ -655,8 +625,7 @@ class MLAModule(Operation):
 
     @classmethod
     def load_data(cls, database: PerfDatabase) -> None:
-        """Idempotent. Loads BOTH context and generation module CSVs,
-        applies extrapolation to each, binds
+        """Idempotently load both raw module tables and bind
         ``database._context_mla_module_data`` and
         ``database._generation_mla_module_data``."""
         import os
@@ -682,8 +651,6 @@ class MLAModule(Operation):
                 load_generation_mla_module_data(gen_sources), PerfDataFilename.mla_generation_module, gen_path
             )
 
-            cls._extrapolate_context(cls._context_data_cache[key])
-            cls._extrapolate_generation(cls._generation_data_cache[key])
             cls._record_load()
 
         if "_context_mla_module_data" not in database.__dict__:
@@ -695,40 +662,6 @@ class MLAModule(Operation):
     def clear_cache(cls) -> None:
         cls._context_data_cache.clear()
         cls._generation_data_cache.clear()
-
-    @classmethod
-    def _extrapolate_context(cls, data_wrapper) -> None:
-        """3-level (fmha_mode → kv_dtype → gemm_mode → grid) extrapolation."""
-        if data_wrapper is None or not getattr(data_wrapper, "loaded", False):
-            return
-        for fmha_mode in data_wrapper:
-            for kv_cache_dtype in data_wrapper[fmha_mode]:
-                for gemm_mode in data_wrapper[fmha_mode][kv_cache_dtype]:
-                    data_dict = data_wrapper[fmha_mode][kv_cache_dtype][gemm_mode]
-                    num_heads_list = list(data_dict.keys())
-                    interpolation.extrapolate_data_grid(
-                        data_dict=data_dict,
-                        target_x_list=num_heads_list,
-                        target_y_list=_CONTEXT_MLA_MODULE_TARGET_Y,
-                        target_z_list=_CONTEXT_MLA_MODULE_TARGET_Z,
-                    )
-
-    @classmethod
-    def _extrapolate_generation(cls, data_wrapper) -> None:
-        """3-level (fmha_mode → kv_dtype → gemm_mode → grid) extrapolation."""
-        if data_wrapper is None or not getattr(data_wrapper, "loaded", False):
-            return
-        for fmha_mode in data_wrapper:
-            for kv_cache_dtype in data_wrapper[fmha_mode]:
-                for gemm_mode in data_wrapper[fmha_mode][kv_cache_dtype]:
-                    data_dict = data_wrapper[fmha_mode][kv_cache_dtype][gemm_mode]
-                    num_heads_list = list(data_dict.keys())
-                    interpolation.extrapolate_data_grid(
-                        data_dict=data_dict,
-                        target_x_list=num_heads_list,
-                        target_y_list=_GENERATION_MLA_TARGET_Y,
-                        target_z_list=_GENERATION_MLA_TARGET_Z,
-                    )
 
     # ------------------------------------------------------------------
     # Query tables (formerly PerfDatabase.query_context_mla_module /
@@ -798,9 +731,19 @@ class MLAModule(Operation):
             full_s = s + prefix
             prefix_correction = (full_s * full_s - prefix * prefix) / (full_s * full_s)
             mla_dict = data_wrapper[fmha_quant_mode][kvcache_quant_mode][gemm_quant_mode]
-            result = interpolation.interp_3d(num_heads, full_s, b, mla_dict, "cubic", database._extracted_metrics_cache)
-            latency = result["latency"] * prefix_correction
-            energy = result.get("energy", 0.0) * prefix_correction
+            latency, energy = _estimate_context(
+                database,
+                ("context-mla-module", fmha_quant_mode, kvcache_quant_mode, gemm_quant_mode),
+                mla_dict,
+                num_heads,
+                full_s,
+                b,
+                lambda point: get_sol(
+                    point["batch"], point["tokens"], 0, point["heads"], kvcache_quant_mode, fmha_quant_mode
+                )[0],
+            )
+            latency *= prefix_correction
+            energy *= prefix_correction
             return database._interp_pr(latency, energy=energy)
 
         return database._query_silicon_or_hybrid(
@@ -877,9 +820,15 @@ class MLAModule(Operation):
         def get_silicon():
             data_wrapper.raise_if_not_loaded()
             mla_dict = data_wrapper[fmha_quant_mode][kv_cache_dtype][gemm_quant_mode]
-            result = interpolation.interp_3d(num_heads, b, s, mla_dict, "cubic", database._extracted_metrics_cache)
-            latency = result["latency"]
-            energy = result.get("energy", 0.0)
+            latency, energy = _estimate_generation(
+                database,
+                ("generation-mla-module", fmha_quant_mode, kv_cache_dtype, gemm_quant_mode),
+                mla_dict,
+                num_heads,
+                b,
+                s,
+                lambda point: get_sol(point["batch"], point["tokens"], point["heads"], kv_cache_dtype)[0],
+            )
             return database._interp_pr(latency, energy=energy)
 
         return database._query_silicon_or_hybrid(
@@ -970,7 +919,7 @@ class WideEPGenerationMLA(Operation):
     @classmethod
     def load_data(cls, database: PerfDatabase) -> None:
         """Idempotent. Loads wideep_generation_mla CSV (SGLang only),
-        applies extrapolation, binds ``database._wideep_generation_mla_data``.
+        binds ``database._wideep_generation_mla_data``.
 
         Non-SGLang backends get ``None`` (matching the legacy
         ``if backend == "sglang"`` guard in ``__init__``)."""
@@ -994,7 +943,6 @@ class WideEPGenerationMLA(Operation):
                     PerfDataFilename.wideep_generation_mla,
                     primary_path,
                 )
-                cls._extrapolate(cls._data_cache[key])
             cls._record_load()
 
         if "_wideep_generation_mla_data" not in database.__dict__:
@@ -1003,22 +951,6 @@ class WideEPGenerationMLA(Operation):
     @classmethod
     def clear_cache(cls) -> None:
         cls._data_cache.clear()
-
-    @classmethod
-    def _extrapolate(cls, data_wrapper) -> None:
-        """Apply the 2-level (kernel_source → kv_cache_dtype → grid) extrapolation."""
-        if data_wrapper is None or not getattr(data_wrapper, "loaded", False):
-            return
-        for kernel_source in data_wrapper:
-            for kv_cache_dtype in data_wrapper[kernel_source]:
-                tp_list = list(data_wrapper[kernel_source][kv_cache_dtype].keys())
-                data_dict = data_wrapper[kernel_source][kv_cache_dtype]
-                interpolation.extrapolate_data_grid(
-                    data_dict=data_dict,
-                    target_x_list=tp_list,
-                    target_y_list=_GENERATION_MLA_TARGET_Y,
-                    target_z_list=_GENERATION_MLA_TARGET_Z,
-                )
 
     # ------------------------------------------------------------------
     # Query table (formerly PerfDatabase.query_wideep_generation_mla)
@@ -1147,9 +1079,21 @@ class WideEPGenerationMLA(Operation):
             # Convert tp_size to num_heads (assuming 128 total heads for DeepSeek)
             num_heads = 128 // tp_size
             mla_dict = attn_data[kvcache_quant_mode]
-            result = interpolation.interp_3d(num_heads, b, s, mla_dict, "bilinear", database._extracted_metrics_cache)
-            latency = result["latency"]
-            energy = result.get("energy", 0.0)
+            latency, energy = _estimate_generation(
+                database,
+                ("wideep-generation-mla", attn_backend, kvcache_quant_mode),
+                mla_dict,
+                num_heads,
+                b,
+                s,
+                lambda point: get_sol(
+                    point["batch"],
+                    point["tokens"],
+                    round(128 / point["heads"]),
+                    kvcache_quant_mode,
+                    fmha_quant_mode,
+                )[0],
+            )
             return database._interp_pr(latency, energy=energy)
 
         return database._query_silicon_or_hybrid(
@@ -1224,7 +1168,7 @@ class WideEPContextMLA(Operation):
     @classmethod
     def load_data(cls, database: PerfDatabase) -> None:
         """Idempotent. Loads wideep_context_mla CSV (SGLang only),
-        applies extrapolation, binds ``database._wideep_context_mla_data``."""
+        binds ``database._wideep_context_mla_data``."""
         import os
 
         from aiconfigurator.sdk.perf_database import LoadedOpData, PerfDataFilename
@@ -1245,7 +1189,6 @@ class WideEPContextMLA(Operation):
                     PerfDataFilename.wideep_context_mla,
                     primary_path,
                 )
-                cls._extrapolate(cls._data_cache[key])
             cls._record_load()
 
         if "_wideep_context_mla_data" not in database.__dict__:
@@ -1254,24 +1197,6 @@ class WideEPContextMLA(Operation):
     @classmethod
     def clear_cache(cls) -> None:
         cls._data_cache.clear()
-
-    @classmethod
-    def _extrapolate(cls, data_wrapper) -> None:
-        """Apply the 3-level (kernel_source → quant_mode → kv_cache_dtype → grid) extrapolation."""
-        if data_wrapper is None or not getattr(data_wrapper, "loaded", False):
-            return
-        for kernel_source in data_wrapper:
-            for quant_mode in data_wrapper[kernel_source]:
-                for kv_cache_dtype in data_wrapper[kernel_source][quant_mode]:
-                    num_heads_list = list(data_wrapper[kernel_source][quant_mode][kv_cache_dtype].keys())
-                    data_dict = data_wrapper[kernel_source][quant_mode][kv_cache_dtype]
-                    interpolation.extrapolate_data_grid(
-                        data_dict=data_dict,
-                        target_x_list=num_heads_list,
-                        target_y_list=_WIDEEP_CONTEXT_MLA_TARGET_Y,
-                        target_z_list=_WIDEEP_CONTEXT_MLA_TARGET_Z,
-                        sqrt_y_value=True,
-                    )
 
     # ------------------------------------------------------------------
     # Query table (formerly PerfDatabase.query_wideep_context_mla)
@@ -1402,9 +1327,25 @@ class WideEPContextMLA(Operation):
             mla_dict = attn_data[fmha_quant_mode][kvcache_quant_mode]
             full_s = s + prefix
             prefix_correction = (full_s * full_s - prefix * prefix) / (full_s * full_s)
-            result = interpolation.interp_3d(num_heads, full_s, b, mla_dict, "cubic", database._extracted_metrics_cache)
-            latency = result["latency"] * prefix_correction
-            energy = result.get("energy", 0.0) * prefix_correction
+            latency, energy = _estimate_context(
+                database,
+                ("wideep-context-mla", attn_backend, fmha_quant_mode, kvcache_quant_mode),
+                mla_dict,
+                num_heads,
+                full_s,
+                b,
+                lambda point: get_sol(
+                    point["batch"],
+                    point["tokens"],
+                    0,
+                    round(128 / point["heads"]),
+                    kvcache_quant_mode,
+                    fmha_quant_mode,
+                )[0],
+                sqrt_curve=True,
+            )
+            latency *= prefix_correction
+            energy *= prefix_correction
             return database._interp_pr(latency, energy=energy)
 
         return database._query_silicon_or_hybrid(

--- a/src/aiconfigurator/sdk/operations/mla.py
+++ b/src/aiconfigurator/sdk/operations/mla.py
@@ -34,7 +34,7 @@ import logging
 from collections import defaultdict
 from typing import TYPE_CHECKING, ClassVar
 
-from aiconfigurator.sdk import common, interpolation
+from aiconfigurator.sdk import common
 from aiconfigurator.sdk.operations.base import Operation, _read_filtered_rows
 from aiconfigurator.sdk.perf_surrogate import Axis, estimate_sparse
 from aiconfigurator.sdk.performance_result import PerformanceResult
@@ -70,6 +70,7 @@ _GENERATION_AXES = (
     Axis("batch", extrapolate="both"),
     Axis("tokens", extrapolate="both"),
 )
+_MLA_BMM_AXES = (Axis("tokens", extrapolate="both"),)
 
 
 def _estimate_context(database, key, table, heads, tokens, batch, baseline, *, sqrt_curve=False):
@@ -427,8 +428,8 @@ class GenerationMLA(Operation):
 class MLABmm(Operation):
     """
     MLABmm operation — pre/post BMM for MLA decoding. Owns ``_mla_bmm_data``.
-    No extrapolation in the legacy ``__init__`` path; data is 1D-keyed by
-    num_tokens within each (quant_mode, op_name, num_heads) bucket.
+    Data is 1D-keyed by num_tokens within each
+    (quant_mode, op_name, num_heads) bucket.
     """
 
     _data_cache: ClassVar[dict] = {}
@@ -457,8 +458,7 @@ class MLABmm(Operation):
 
     @classmethod
     def load_data(cls, database: PerfDatabase) -> None:
-        """Idempotent. Loads mla_bmm CSV, binds ``database._mla_bmm_data``.
-        No extrapolation (1D table)."""
+        """Idempotent. Loads mla_bmm CSV and binds ``database._mla_bmm_data``."""
         import os
 
         from aiconfigurator.sdk.perf_database import LoadedOpData, PerfDataFilename
@@ -532,24 +532,18 @@ class MLABmm(Operation):
         def get_silicon():
             data_wrapper.raise_if_not_loaded()
             quant_mode_lookup = quant_mode if quant_mode in data_wrapper else common.GEMMQuantMode.bfloat16
-            mla_bmm_dict = data_wrapper[quant_mode_lookup]["mla_gen_pre" if if_pre else "mla_gen_post"][num_heads]
-            num_left, num_right = interpolation.nearest_1d_point_helper(
-                num_tokens,
-                list(mla_bmm_dict.keys()),
-                inner_only=False,
+            op_name = "mla_gen_pre" if if_pre else "mla_gen_post"
+            mla_bmm_dict = data_wrapper[quant_mode_lookup][op_name][num_heads]
+            latency, energy = estimate_sparse(
+                database,
+                ("mla_bmm", quant_mode_lookup, op_name, num_heads),
+                mla_bmm_dict,
+                {"tokens": num_tokens},
+                axes=_MLA_BMM_AXES,
+                varying="tokens",
+                baseline=lambda point: get_sol(point["tokens"], num_heads, quant_mode, if_pre)[0],
             )
-            result = interpolation.interp_1d(
-                [num_left, num_right],
-                [mla_bmm_dict[num_left], mla_bmm_dict[num_right]],
-                num_tokens,
-            )
-            if isinstance(result, dict):
-                lat = result["latency"]
-                energy = result.get("energy", 0.0)
-            else:
-                lat = result
-                energy = 0.0
-            return database._interp_pr(lat, energy=energy)
+            return database._interp_pr(latency, energy=energy)
 
         return database._query_silicon_or_hybrid(
             get_silicon=get_silicon,

--- a/src/aiconfigurator/sdk/operations/mla.py
+++ b/src/aiconfigurator/sdk/operations/mla.py
@@ -71,6 +71,18 @@ _GENERATION_AXES = (
     Axis("tokens", extrapolate="both"),
 )
 _MLA_BMM_AXES = (Axis("tokens", extrapolate="both"),)
+_WIDEEP_MLA_KERNEL_SOURCES = {"flashinfer", "fa3", "trtllm_mla"}
+
+
+def _resolve_wideep_mla_kernel_source(data, attention_backend: str | None) -> str:
+    requested = attention_backend or "flashinfer"
+    if requested not in _WIDEEP_MLA_KERNEL_SOURCES:
+        raise ValueError(f"Unsupported attention backend: {requested}")
+    if requested in data:
+        return requested
+    if requested == "flashinfer" and "trtllm_mla" in data:
+        return "trtllm_mla"
+    raise KeyError(f"No WideEP MLA data for attention backend {requested!r}")
 
 
 def _estimate_context(database, key, table, heads, tokens, batch, baseline, *, sqrt_curve=False):
@@ -1063,19 +1075,16 @@ class WideEPGenerationMLA(Operation):
 
         def get_silicon():
             data_wrapper.raise_if_not_loaded()
-            attn_backend = attention_backend or "flashinfer"
-            if attn_backend == "flashinfer":
-                attn_data = data_wrapper["flashinfer"]
-            elif attn_backend == "fa3":
-                attn_data = data_wrapper["fa3"]
-            else:
-                raise ValueError(f"Unsupported attention backend: {attn_backend}")
+            kernel_source = _resolve_wideep_mla_kernel_source(data_wrapper, attention_backend)
+            attn_data = data_wrapper[kernel_source]
             # Convert tp_size to num_heads (assuming 128 total heads for DeepSeek)
             num_heads = 128 // tp_size
-            mla_dict = attn_data[kvcache_quant_mode]
+            # Keep KV before FMHA so the existing support-matrix API continues
+            # to expose generation KV-cache modes at this level.
+            mla_dict = attn_data[kvcache_quant_mode][fmha_quant_mode]
             latency, energy = _estimate_generation(
                 database,
-                ("wideep-generation-mla", attn_backend, kvcache_quant_mode),
+                ("wideep-generation-mla", kernel_source, fmha_quant_mode, kvcache_quant_mode),
                 mla_dict,
                 num_heads,
                 b,
@@ -1308,13 +1317,8 @@ class WideEPContextMLA(Operation):
 
         def get_silicon():
             data_wrapper.raise_if_not_loaded()
-            attn_backend = attention_backend or "flashinfer"
-            if attn_backend == "flashinfer":
-                attn_data = data_wrapper["flashinfer"]
-            elif attn_backend == "fa3":
-                attn_data = data_wrapper["fa3"]
-            else:
-                raise ValueError(f"Unsupported attention backend: {attn_backend}")
+            kernel_source = _resolve_wideep_mla_kernel_source(data_wrapper, attention_backend)
+            attn_data = data_wrapper[kernel_source]
 
             # Convert tp_size to num_heads (assuming 128 total heads for DeepSeek)
             num_heads = 128 // tp_size
@@ -1323,7 +1327,7 @@ class WideEPContextMLA(Operation):
             prefix_correction = (full_s * full_s - prefix * prefix) / (full_s * full_s)
             latency, energy = _estimate_context(
                 database,
-                ("wideep-context-mla", attn_backend, fmha_quant_mode, kvcache_quant_mode),
+                ("wideep-context-mla", kernel_source, fmha_quant_mode, kvcache_quant_mode),
                 mla_dict,
                 num_heads,
                 full_s,
@@ -1637,6 +1641,9 @@ def load_wideep_generation_mla_data(wideep_generation_mla_file):
     Load the SGLang wideep generation mla data from wideep_generation_mla_perf.txt
     with power support (backward compatible).
 
+    Keeps KV-cache dtype before FMHA dtype in the nested mapping because the
+    public generation support matrix reports KV-cache modes.
+
     Returns:
         dict: Nested dict structure where leaf values are dicts with 'latency' and 'power' keys.
     """
@@ -1645,7 +1652,7 @@ def load_wideep_generation_mla_data(wideep_generation_mla_file):
         logger.debug(f"SGLang wideep generation mla data file {wideep_generation_mla_file} not found.")
         return None
     wideep_generation_mla_data = defaultdict(
-        lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict())))
+        lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict()))))
     )
 
     # Check if power columns exist (backward compatibility)
@@ -1654,7 +1661,8 @@ def load_wideep_generation_mla_data(wideep_generation_mla_file):
         logger.debug("Legacy database format detected (wideep_generation_mla) - power will default to 0.0")
 
     for row in rows:
-        kv_cache_dtype, b, s, step, latency = (
+        quant_mode, kv_cache_dtype, b, s, step, latency = (
+            row["mla_dtype"],
             row["kv_cache_dtype"],
             row["batch_size"],
             row["isl"],
@@ -1683,17 +1691,19 @@ def load_wideep_generation_mla_data(wideep_generation_mla_file):
 
         s = s + step
 
+        quant_mode = common.FMHAQuantMode[quant_mode]
         kv_cache_dtype = common.KVCacheQuantMode[kv_cache_dtype]
 
         try:
             # Check for conflict
-            wideep_generation_mla_data[kernel_source][kv_cache_dtype][num_heads][b][s]
+            wideep_generation_mla_data[kernel_source][kv_cache_dtype][quant_mode][num_heads][b][s]
             logger.debug(
-                f"value conflict in generation mla data: {kernel_source} {kv_cache_dtype} {num_heads} {b} {s} "
+                f"value conflict in generation mla data: "
+                f"{kernel_source} {quant_mode} {kv_cache_dtype} {num_heads} {b} {s} "
             )
         except KeyError:
             # Store all three values
-            wideep_generation_mla_data[kernel_source][kv_cache_dtype][num_heads][b][s] = {
+            wideep_generation_mla_data[kernel_source][kv_cache_dtype][quant_mode][num_heads][b][s] = {
                 "latency": latency,
                 "power": power,
                 "energy": energy,  # NEW: precomputed energy
@@ -1736,11 +1746,14 @@ def load_context_mla_module_data(mla_module_file: str):
         kv_dtype = common.KVCacheQuantMode[row["kv_cache_dtype"]]
         gemm_mode = common.GEMMQuantMode[row["gemm_type"]]
 
-        mla_data[fmha_mode][kv_dtype][gemm_mode][num_heads][s][b] = {
-            "latency": latency,
-            "power": power,
-            "energy": energy,
-        }
+        try:
+            mla_data[fmha_mode][kv_dtype][gemm_mode][num_heads][s][b]
+        except KeyError:
+            mla_data[fmha_mode][kv_dtype][gemm_mode][num_heads][s][b] = {
+                "latency": latency,
+                "power": power,
+                "energy": energy,
+            }
 
     return mla_data
 
@@ -1779,10 +1792,13 @@ def load_generation_mla_module_data(mla_module_file: str):
         gemm_mode = common.GEMMQuantMode[row["gemm_type"]]
         kv_dtype = common.KVCacheQuantMode[row["kv_cache_dtype"]]
 
-        mla_data[fmha_mode][kv_dtype][gemm_mode][num_heads][b][s] = {
-            "latency": latency,
-            "power": power,
-            "energy": energy,
-        }
+        try:
+            mla_data[fmha_mode][kv_dtype][gemm_mode][num_heads][b][s]
+        except KeyError:
+            mla_data[fmha_mode][kv_dtype][gemm_mode][num_heads][b][s] = {
+                "latency": latency,
+                "power": power,
+                "energy": energy,
+            }
 
     return mla_data

--- a/src/aiconfigurator/sdk/operations/moe.py
+++ b/src/aiconfigurator/sdk/operations/moe.py
@@ -45,8 +45,9 @@ import logging
 from collections import defaultdict
 from typing import TYPE_CHECKING, ClassVar
 
-from aiconfigurator.sdk import common, interpolation
+from aiconfigurator.sdk import common
 from aiconfigurator.sdk.operations.base import Operation, _read_filtered_rows
+from aiconfigurator.sdk.perf_surrogate import Axis, estimate_sparse
 from aiconfigurator.sdk.performance_result import PerformanceResult
 
 if TYPE_CHECKING:
@@ -54,6 +55,27 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+_TOKEN_AXES = (Axis("tokens", extrapolate="both"),)
+_SMS_TOKEN_AXES = (Axis("sms"), *_TOKEN_AXES)
+
+
+def _estimate_token_table(database, key, table, tokens, baseline=None) -> tuple[float, float]:
+    if baseline is None:
+        minimum = float(min(table))
+
+        def baseline(point):
+            return max(point["tokens"], minimum)
+
+    return estimate_sparse(
+        database,
+        key,
+        table,
+        {"tokens": tokens},
+        axes=_TOKEN_AXES,
+        varying="tokens",
+        baseline=baseline,
+    )
 
 
 def _cache_key(database: PerfDatabase) -> tuple:
@@ -376,6 +398,87 @@ class MoE(Operation):
                 f"workload_distribution='{used_workload_distribution}'."
             )
 
+        def _estimate_moe_curve(
+            query_tokens: int,
+            moe_dict: dict,
+            used_workload_distribution: str,
+            curve_source: str,
+        ) -> PerformanceResult:
+            token_points = _require_moe_token_points(
+                moe_dict,
+                query_tokens,
+                used_workload_distribution,
+            )
+            if query_tokens > token_points[-1]:
+                return _estimate_overflow_with_last_token_util(
+                    query_tokens,
+                    moe_dict,
+                    hidden_size,
+                    inter_size,
+                    topk,
+                    num_experts,
+                    moe_tp_size,
+                    moe_ep_size,
+                    quant_mode,
+                    workload_distribution,
+                )
+
+            if query_tokens < token_points[0]:
+                first_tokens = token_points[0]
+                first = moe_dict[first_tokens]
+                first_latency = float(first["latency"] if isinstance(first, dict) else first)
+                if isinstance(first, dict):
+                    first_power = float(first.get("power", 0.0))
+                    if first_power == 0.0 and first_latency > 0:
+                        first_power = float(first.get("energy", 0.0)) / first_latency
+                else:
+                    first_power = 0.0
+                launch_latency = first_latency
+                if len(token_points) > 1:
+                    second_tokens = token_points[1]
+                    second = moe_dict[second_tokens]
+                    second_latency = float(second["latency"] if isinstance(second, dict) else second)
+                    slope = max(0.0, (second_latency - first_latency) / (second_tokens - first_tokens))
+                    launch_latency = max(0.0, first_latency - slope * first_tokens)
+                latency = launch_latency + (first_latency - launch_latency) * query_tokens / first_tokens
+                latency = max(
+                    latency,
+                    get_sol(
+                        query_tokens,
+                        hidden_size,
+                        inter_size,
+                        topk,
+                        num_experts,
+                        moe_tp_size,
+                        moe_ep_size,
+                        quant_mode,
+                        workload_distribution,
+                    )[0],
+                )
+                return database._interp_pr(latency, energy=first_power * latency)
+
+            latency, energy = estimate_sparse(
+                database,
+                (
+                    "moe",
+                    curve_source,
+                    quant_mode,
+                    used_workload_distribution,
+                    topk,
+                    num_experts,
+                    hidden_size,
+                    inter_size,
+                    moe_tp_size,
+                    moe_ep_size,
+                ),
+                moe_dict,
+                {"tokens": query_tokens},
+                axes=_TOKEN_AXES,
+                varying="tokens",
+                exterior="raw",
+            )
+            return database._interp_pr(latency, energy=energy)
+
         if database_mode is None:
             database_mode = database._default_database_mode
         if database_mode == common.DatabaseMode.SOL:
@@ -419,15 +522,19 @@ class MoE(Operation):
         else:
             # SILICON or HYBRID mode - use database
             def get_silicon():
+                query_tokens = num_tokens
+                curve_source = "regular"
                 if database.backend == common.BackendName.sglang.value:
                     # deepep_moe is for sglang wideep only
                     # Apply num_tokens correction when eplb is enabled (only during prefill)
-                    num_tokens_corrected = int(num_tokens * 0.8) if enable_eplb and is_context else num_tokens
+                    query_tokens = int(num_tokens * 0.8) if enable_eplb and is_context else num_tokens
                     if moe_backend == "deepep_moe":
                         if is_context:
                             moe_data = database._wideep_context_moe_data
+                            curve_source = "deepep_context"
                         else:
                             moe_data = database._wideep_generation_moe_data
+                            curve_source = "deepep_generation"
                     else:
                         moe_data = database._moe_data
 
@@ -439,41 +546,6 @@ class MoE(Operation):
                     moe_dict = moe_data[quant_mode][used_workload_distribution][topk][num_experts][hidden_size][
                         inter_size
                     ][moe_tp_size][moe_ep_size]
-                    token_points = _require_moe_token_points(
-                        moe_dict,
-                        num_tokens_corrected,
-                        used_workload_distribution,
-                    )
-                    if num_tokens_corrected > token_points[-1]:
-                        return _estimate_overflow_with_last_token_util(
-                            num_tokens_corrected,
-                            moe_dict,
-                            hidden_size,
-                            inter_size,
-                            topk,
-                            num_experts,
-                            moe_tp_size,
-                            moe_ep_size,
-                            quant_mode,
-                            workload_distribution,
-                        )
-                    num_left, num_right = interpolation.nearest_1d_point_helper(
-                        num_tokens_corrected,
-                        list(moe_dict.keys()),
-                        inner_only=False,
-                    )
-                    result = interpolation.interp_1d(
-                        [num_left, num_right],
-                        [moe_dict[num_left], moe_dict[num_right]],
-                        num_tokens_corrected,
-                    )
-                    if isinstance(result, dict):
-                        lat = result["latency"]
-                        energy = result.get("energy", 0.0)
-                    else:
-                        lat = result
-                        energy = 0.0
-                    return database._interp_pr(lat, energy=energy)
                 elif database.backend == common.BackendName.trtllm.value:
                     if database._moe_data is None and database._moe_low_latency_data is None:
                         raise PerfDataNotAvailableError(
@@ -510,6 +582,7 @@ class MoE(Operation):
                                 f"{workload_distribution} {topk} {num_experts} {hidden_size} "
                                 f"{inter_size} {moe_tp_size} {moe_ep_size}."
                             )
+                            curve_source = "low_latency"
                         except:
                             used_workload_distribution = (
                                 workload_distribution
@@ -528,37 +601,6 @@ class MoE(Operation):
                         moe_dict = database._moe_data[quant_mode][used_workload_distribution][topk][num_experts][
                             hidden_size
                         ][inter_size][moe_tp_size][moe_ep_size]
-                    token_points = _require_moe_token_points(moe_dict, num_tokens, used_workload_distribution)
-                    if num_tokens > token_points[-1]:
-                        return _estimate_overflow_with_last_token_util(
-                            num_tokens,
-                            moe_dict,
-                            hidden_size,
-                            inter_size,
-                            topk,
-                            num_experts,
-                            moe_tp_size,
-                            moe_ep_size,
-                            quant_mode,
-                            workload_distribution,
-                        )
-                    num_left, num_right = interpolation.nearest_1d_point_helper(
-                        num_tokens,
-                        list(moe_dict.keys()),
-                        inner_only=False,
-                    )
-                    result = interpolation.interp_1d(
-                        [num_left, num_right],
-                        [moe_dict[num_left], moe_dict[num_right]],
-                        num_tokens,
-                    )
-                    if isinstance(result, dict):
-                        lat = result["latency"]
-                        energy = result.get("energy", 0.0)
-                    else:
-                        lat = result
-                        energy = 0.0
-                    return database._interp_pr(lat, energy=energy)
                 elif database.backend == common.BackendName.vllm.value:
                     database._moe_data.raise_if_not_loaded()
                     used_workload_distribution = (
@@ -567,35 +609,15 @@ class MoE(Operation):
                     moe_dict = database._moe_data[quant_mode][used_workload_distribution][topk][num_experts][
                         hidden_size
                     ][inter_size][moe_tp_size][moe_ep_size]
-                    token_points = _require_moe_token_points(moe_dict, num_tokens, used_workload_distribution)
-                    if num_tokens > token_points[-1]:
-                        return _estimate_overflow_with_last_token_util(
-                            num_tokens,
-                            moe_dict,
-                            hidden_size,
-                            inter_size,
-                            topk,
-                            num_experts,
-                            moe_tp_size,
-                            moe_ep_size,
-                            quant_mode,
-                            workload_distribution,
-                        )
-                    num_left, num_right = interpolation.nearest_1d_point_helper(
-                        num_tokens, list(moe_dict.keys()), inner_only=False
-                    )
-                    result = interpolation.interp_1d(
-                        [num_left, num_right], [moe_dict[num_left], moe_dict[num_right]], num_tokens
-                    )
-                    if isinstance(result, dict):
-                        latency = result["latency"]
-                        energy = result.get("energy", 0.0)
-                    else:
-                        latency = result
-                        energy = 0.0
-                    return database._interp_pr(latency, energy=energy)
                 else:
                     raise NotImplementedError(f"backend {database.backend} not supported for moe")
+
+                return _estimate_moe_curve(
+                    query_tokens,
+                    moe_dict,
+                    used_workload_distribution,
+                    curve_source,
+                )
 
             return database._query_silicon_or_hybrid(
                 get_silicon=get_silicon,
@@ -800,10 +822,12 @@ class MoEDispatch(Operation):
             return PerformanceResult(get_empirical(num_tokens, topk, num_experts), energy=0.0, source="empirical")
         else:
             data = database._wideep_deepep_ll_data[node_num][hidden_size][topk][num_experts]
-            num_left, num_right = interpolation.nearest_1d_point_helper(num_tokens, list(data.keys()), inner_only=False)
-            result = interpolation.interp_1d([num_left, num_right], [data[num_left], data[num_right]], num_tokens)
-            lat = result["latency"] if isinstance(result, dict) else result
-            energy = result.get("energy", 0.0) if isinstance(result, dict) else 0.0
+            lat, energy = _estimate_token_table(
+                database,
+                ("deepep_ll", node_num, hidden_size, topk, num_experts),
+                data,
+                num_tokens,
+            )
             return database._interp_pr(lat / 1000.0, energy=energy / 1000.0)
 
     @classmethod
@@ -840,19 +864,26 @@ class MoEDispatch(Operation):
                 get_empirical(num_tokens, num_experts, topk, hidden_size), energy=0.0, source="empirical"
             )
         else:
+            category = ("deepep_normal", node_num, hidden_size, topk, num_experts)
+            data = database._wideep_deepep_normal_data[node_num][hidden_size][topk][num_experts]
             if node_num == 1 and sms == 20:  # only collect sm=20 for now
-                data = database._wideep_deepep_normal_data[node_num][hidden_size][topk][num_experts][sms]
-                num_left, num_right = interpolation.nearest_1d_point_helper(
-                    num_tokens, list(data.keys()), inner_only=False
+                lat, energy = _estimate_token_table(
+                    database,
+                    (*category, sms),
+                    data[sms],
+                    num_tokens,
                 )
-                result = interpolation.interp_1d([num_left, num_right], [data[num_left], data[num_right]], num_tokens)
-                lat = result["latency"] if isinstance(result, dict) else result
-                energy = result.get("energy", 0.0) if isinstance(result, dict) else 0.0
             else:
-                data = database._wideep_deepep_normal_data[node_num][hidden_size][topk][num_experts]
-                result = interpolation.interp_2d_linear(sms, num_tokens, data, database._extracted_metrics_cache)
-                lat = result["latency"] if isinstance(result, dict) else result
-                energy = result.get("energy", 0.0) if isinstance(result, dict) else 0.0
+                minimum = min(float(token) for token_data in data.values() for token in token_data)
+                lat, energy = estimate_sparse(
+                    database,
+                    category,
+                    data,
+                    {"sms": sms, "tokens": num_tokens},
+                    axes=_SMS_TOKEN_AXES,
+                    varying="tokens",
+                    baseline=lambda point: max(point["tokens"], minimum),
+                )
             return database._interp_pr(lat / 1000.0, energy=energy / 1000.0)
 
     # ------------------------------------------------------------------
@@ -1477,23 +1508,42 @@ class TrtLLMWideEPMoE(Operation):
                 num_slots
             ][moe_tp_size][moe_ep_size]
 
-            num_left, num_right = interpolation.nearest_1d_point_helper(
-                num_tokens,
-                list(moe_dict.keys()),
-                inner_only=False,
-            )
-            result = interpolation.interp_1d(
-                [num_left, num_right],
-                [moe_dict[num_left], moe_dict[num_right]],
-                num_tokens,
-            )
+            def baseline(point):
+                return max(
+                    get_sol(
+                        point["tokens"],
+                        hidden_size,
+                        inter_size,
+                        topk,
+                        num_experts,
+                        num_slots,
+                        moe_tp_size,
+                        moe_ep_size,
+                        quant_mode,
+                        used_distribution,
+                    )[0],
+                    1e-12,
+                )
 
-            if isinstance(result, dict):
-                lat = result["latency"]
-                energy = result.get("energy", 0.0)
-            else:
-                lat = result
-                energy = 0.0
+            lat, energy = _estimate_token_table(
+                database,
+                (
+                    "wideep_compute",
+                    kernel_source,
+                    quant_mode,
+                    used_distribution,
+                    topk,
+                    num_experts,
+                    hidden_size,
+                    inter_size,
+                    num_slots,
+                    moe_tp_size,
+                    moe_ep_size,
+                ),
+                moe_dict,
+                num_tokens,
+                baseline,
+            )
 
             return database._interp_pr(lat, energy=energy)
 
@@ -1889,23 +1939,37 @@ class TrtLLMWideEPMoEDispatch(Operation):
                 moe_ep_size
             ]
 
-            num_left, num_right = interpolation.nearest_1d_point_helper(
-                num_tokens,
-                list(alltoall_dict.keys()),
-                inner_only=False,
-            )
-            result = interpolation.interp_1d(
-                [num_left, num_right],
-                [alltoall_dict[num_left], alltoall_dict[num_right]],
-                num_tokens,
-            )
+            def baseline(point):
+                return max(
+                    get_sol(
+                        point["tokens"],
+                        hidden_size,
+                        topk,
+                        num_experts,
+                        moe_ep_size,
+                        quant_mode,
+                        node_num,
+                    )[0],
+                    1e-12,
+                )
 
-            if isinstance(result, dict):
-                lat = result["latency"]
-                energy = result.get("energy", 0.0)
-            else:
-                lat = result
-                energy = 0.0
+            lat, energy = _estimate_token_table(
+                database,
+                (
+                    "trtllm_alltoall",
+                    kernel_source,
+                    op_name,
+                    table_quant_mode,
+                    node_num,
+                    hidden_size,
+                    topk,
+                    num_experts,
+                    moe_ep_size,
+                ),
+                alltoall_dict,
+                num_tokens,
+                baseline,
+            )
 
             return database._interp_pr(lat, energy=energy)
 

--- a/src/aiconfigurator/sdk/operations/moe.py
+++ b/src/aiconfigurator/sdk/operations/moe.py
@@ -58,6 +58,32 @@ logger = logging.getLogger(__name__)
 
 _TOKEN_AXES = (Axis("tokens", extrapolate="both"),)
 _SMS_TOKEN_AXES = (Axis("sms"), *_TOKEN_AXES)
+_NONGATED_MOE_KEY = False
+
+
+def _store_first(root: dict, keys: tuple, value: dict) -> bool:
+    """Store one measured leaf without overriding an earlier source."""
+    node = root
+    for key in keys[:-1]:
+        node = node.setdefault(key, {})
+    if keys[-1] in node:
+        return False
+    node[keys[-1]] = value
+    return True
+
+
+def _select_gating_category(distribution_data: dict, is_gated: bool, table_name: str) -> dict:
+    """Select gating below the workload-distribution axis."""
+    if not is_gated:
+        category = distribution_data.get(_NONGATED_MOE_KEY)
+        if category:
+            return category
+        raise KeyError(f"No non-gated {table_name} data; legacy rows are gated-only")
+
+    category = {key: value for key, value in distribution_data.items() if key != _NONGATED_MOE_KEY}
+    if not category:
+        raise KeyError(f"No gated {table_name} data")
+    return category
 
 
 def _estimate_token_table(database, key, table, tokens, baseline=None) -> tuple[float, float]:
@@ -462,6 +488,7 @@ class MoE(Operation):
                 (
                     "moe",
                     curve_source,
+                    is_gated,
                     quant_mode,
                     used_workload_distribution,
                     topk,
@@ -524,6 +551,22 @@ class MoE(Operation):
             def get_silicon():
                 query_tokens = num_tokens
                 curve_source = "regular"
+
+                def select_distribution_data(table, table_name):
+                    table.raise_if_not_loaded()
+                    try:
+                        quant_data = table[quant_mode]
+                        used_distribution = workload_distribution if workload_distribution in quant_data else "uniform"
+                        return (
+                            _select_gating_category(quant_data[used_distribution], is_gated, table_name),
+                            used_distribution,
+                        )
+                    except KeyError as exc:
+                        gating = "gated" if is_gated else "non-gated"
+                        raise PerfDataNotAvailableError(
+                            f"No {gating} {table_name} silicon data for quant_mode={quant_mode.name}"
+                        ) from exc
+
                 if database.backend == common.BackendName.sglang.value:
                     # deepep_moe is for sglang wideep only
                     # Apply num_tokens correction when eplb is enabled (only during prefill)
@@ -538,14 +581,8 @@ class MoE(Operation):
                     else:
                         moe_data = database._moe_data
 
-                    moe_data.raise_if_not_loaded()
-
-                    used_workload_distribution = (
-                        workload_distribution if workload_distribution in moe_data[quant_mode] else "uniform"
-                    )
-                    moe_dict = moe_data[quant_mode][used_workload_distribution][topk][num_experts][hidden_size][
-                        inter_size
-                    ][moe_tp_size][moe_ep_size]
+                    distribution_data, used_workload_distribution = select_distribution_data(moe_data, curve_source)
+                    moe_dict = distribution_data[topk][num_experts][hidden_size][inter_size][moe_tp_size][moe_ep_size]
                 elif database.backend == common.BackendName.trtllm.value:
                     if database._moe_data is None and database._moe_low_latency_data is None:
                         raise PerfDataNotAvailableError(
@@ -562,14 +599,12 @@ class MoE(Operation):
                         and is_gated
                     ):
                         try:
-                            used_workload_distribution = (
-                                workload_distribution
-                                if workload_distribution in database._moe_low_latency_data[quant_mode]
-                                else "uniform"
+                            distribution_data, used_workload_distribution = select_distribution_data(
+                                database._moe_low_latency_data, "low-latency MoE"
                             )
-                            moe_dict = database._moe_low_latency_data[quant_mode][used_workload_distribution][topk][
-                                num_experts
-                            ][hidden_size][inter_size][moe_tp_size][moe_ep_size]
+                            moe_dict = distribution_data[topk][num_experts][hidden_size][inter_size][moe_tp_size][
+                                moe_ep_size
+                            ]
                             if not moe_dict:
                                 # Shape not present in low-latency table (nested defaultdict returned
                                 # an empty dict instead of raising KeyError). Fall back to regular data.
@@ -583,32 +618,25 @@ class MoE(Operation):
                                 f"{inter_size} {moe_tp_size} {moe_ep_size}."
                             )
                             curve_source = "low_latency"
-                        except:
-                            used_workload_distribution = (
-                                workload_distribution
-                                if workload_distribution in database._moe_data[quant_mode]
-                                else "uniform"
+                        except (KeyError, PerfDataNotAvailableError):
+                            distribution_data, used_workload_distribution = select_distribution_data(
+                                database._moe_data, "regular MoE"
                             )
-                            moe_dict = database._moe_data[quant_mode][used_workload_distribution][topk][num_experts][
-                                hidden_size
-                            ][inter_size][moe_tp_size][moe_ep_size]
+                            moe_dict = distribution_data[topk][num_experts][hidden_size][inter_size][moe_tp_size][
+                                moe_ep_size
+                            ]
                     else:
-                        used_workload_distribution = (
-                            workload_distribution
-                            if workload_distribution in database._moe_data[quant_mode]
-                            else "uniform"
+                        distribution_data, used_workload_distribution = select_distribution_data(
+                            database._moe_data, "regular MoE"
                         )
-                        moe_dict = database._moe_data[quant_mode][used_workload_distribution][topk][num_experts][
-                            hidden_size
-                        ][inter_size][moe_tp_size][moe_ep_size]
+                        moe_dict = distribution_data[topk][num_experts][hidden_size][inter_size][moe_tp_size][
+                            moe_ep_size
+                        ]
                 elif database.backend == common.BackendName.vllm.value:
-                    database._moe_data.raise_if_not_loaded()
-                    used_workload_distribution = (
-                        workload_distribution if workload_distribution in database._moe_data[quant_mode] else "uniform"
+                    distribution_data, used_workload_distribution = select_distribution_data(
+                        database._moe_data, "regular MoE"
                     )
-                    moe_dict = database._moe_data[quant_mode][used_workload_distribution][topk][num_experts][
-                        hidden_size
-                    ][inter_size][moe_tp_size][moe_ep_size]
+                    moe_dict = distribution_data[topk][num_experts][hidden_size][inter_size][moe_tp_size][moe_ep_size]
                 else:
                     raise NotImplementedError(f"backend {database.backend} not supported for moe")
 
@@ -1375,6 +1403,8 @@ class TrtLLMWideEPMoE(Operation):
         is_gated: bool = True,
     ) -> PerformanceResult | tuple[float, float, float]:
         """Verbatim port of legacy ``PerfDatabase.query_wideep_moe_compute``."""
+        from aiconfigurator.sdk.perf_database import PerfDataNotAvailableError
+
         cls.load_data(database)
 
         num_gemms = 3 if is_gated else 2
@@ -1491,10 +1521,15 @@ class TrtLLMWideEPMoE(Operation):
 
         # SILICON or HYBRID mode - use database
         def get_silicon():
+            if not is_gated:
+                raise PerfDataNotAvailableError(
+                    "TRT-LLM WideEP compute data does not distinguish gated and non-gated kernels"
+                )
             database._wideep_moe_compute_data.raise_if_not_loaded()
             # Find the best matching distribution
             kernel_data = database._wideep_moe_compute_data[kernel_source]
-            available_distributions = list(kernel_data[quant_mode].keys())
+            quant_data = kernel_data[quant_mode]
+            available_distributions = list(quant_data)
             if workload_distribution in available_distributions:
                 used_distribution = workload_distribution
             else:
@@ -1504,9 +1539,9 @@ class TrtLLMWideEPMoE(Operation):
                     raise KeyError(f"No distribution available for kernel={kernel_source}, quant_mode={quant_mode}")
                 logger.debug(f"Distribution '{workload_distribution}' not found, using '{used_distribution}' instead")
 
-            moe_dict = kernel_data[quant_mode][used_distribution][topk][num_experts][hidden_size][inter_size][
-                num_slots
-            ][moe_tp_size][moe_ep_size]
+            moe_dict = quant_data[used_distribution][topk][num_experts][hidden_size][inter_size][num_slots][
+                moe_tp_size
+            ][moe_ep_size]
 
             def baseline(point):
                 return max(
@@ -1550,7 +1585,7 @@ class TrtLLMWideEPMoE(Operation):
         def get_empirical() -> float:
             # Simple empirical fallback based on SOL
             total_tokens = num_tokens * topk
-            ops = total_tokens * hidden_size * inter_size * 3 * 2 // moe_ep_size // moe_tp_size
+            ops = total_tokens * hidden_size * inter_size * num_gemms * 2 // moe_ep_size // moe_tp_size
             sol_math = ops / (database.system_spec["gpu"]["bfloat16_tc_flops"] * quant_mode.value.compute) * 1000
             return sol_math / 0.4  # Empirical scale factor
 
@@ -1589,6 +1624,7 @@ class TrtLLMWideEPMoE(Operation):
             moe_ep_size=self._moe_ep_size,
             quant_mode=quant_mode,
             workload_distribution=self._workload_distribution,
+            is_gated=self._is_gated,
         )
 
         return PerformanceResult(
@@ -2148,7 +2184,7 @@ def load_moe_data(moe_file):
             row["distribution"],
             row["latency"],
         )
-        kernel_source = row["kernel_source"]  # moe_torch_flow, moe_torch_flow_min_latency, moe_torch_flow
+        kernel_source = row.get("kernel_source", "")
         num_tokens = int(num_tokens)
         hidden_size = int(hidden_size)
         inter_size = int(inter_size)
@@ -2184,26 +2220,33 @@ def load_moe_data(moe_file):
             quant_mode = common.MoEQuantMode.w4a16_mxfp4_cutlass
 
         moe_data = moe_low_latency_data if kernel_source == "moe_torch_flow_min_latency" else moe_default_data
-
-        try:
-            # Check for conflict
-            moe_data[quant_mode][workload_distribution][topk][num_experts][hidden_size][inter_size][moe_tp_size][
-                moe_ep_size
-            ][num_tokens]
+        gating_keys = (_NONGATED_MOE_KEY,) if "nongated" in kernel_source.lower() else ()
+        keys = (
+            quant_mode,
+            workload_distribution,
+            *gating_keys,
+            topk,
+            num_experts,
+            hidden_size,
+            inter_size,
+            moe_tp_size,
+            moe_ep_size,
+            num_tokens,
+        )
+        if not _store_first(
+            moe_data,
+            keys,
+            {
+                "latency": latency,
+                "power": power,
+                "energy": energy,
+            },
+        ):
             logger.debug(
                 f"value conflict in moe data: {workload_distribution} {quant_mode} {topk} "
                 f"{num_experts} {hidden_size} {inter_size} {moe_tp_size} {moe_ep_size} "
                 f"{num_tokens}"
             )
-        except KeyError:
-            # Store all three values
-            moe_data[quant_mode][workload_distribution][topk][num_experts][hidden_size][inter_size][moe_tp_size][
-                moe_ep_size
-            ][num_tokens] = {
-                "latency": latency,
-                "power": power,
-                "energy": energy,  # NEW: precomputed energy
-            }
 
     return moe_default_data, moe_low_latency_data
 
@@ -2259,14 +2302,21 @@ def load_wideep_context_moe_data(wideep_context_moe_file):
         # NEW: Calculate energy from power and latency
         energy = power * latency  # watt-milliseconds
 
-        # Store all three values
-        wideep_context_moe_data[quant_mode][distribution][topk][num_experts][hidden_size][inter_size][moe_tp_size][
-            moe_ep_size
-        ][num_tokens] = {
-            "latency": latency,
-            "power": power,
-            "energy": energy,  # NEW: precomputed energy
-        }
+        _store_first(
+            wideep_context_moe_data,
+            (
+                quant_mode,
+                distribution,
+                topk,
+                num_experts,
+                hidden_size,
+                inter_size,
+                moe_tp_size,
+                moe_ep_size,
+                num_tokens,
+            ),
+            {"latency": latency, "power": power, "energy": energy},
+        )
         logger.debug(
             f"Loaded SGLang wideep context MoE data: {quant_mode}, {distribution}, {topk}, "
             f"{num_experts}, {hidden_size}, {inter_size}, {moe_tp_size}, "
@@ -2327,14 +2377,21 @@ def load_wideep_generation_moe_data(wideep_generation_moe_file):
         # NEW: Calculate energy from power and latency
         energy = power * latency  # watt-milliseconds
 
-        # Store all three values
-        wideep_generation_moe_data[quant_mode][distribution][topk][num_experts][hidden_size][inter_size][moe_tp_size][
-            moe_ep_size
-        ][num_tokens] = {
-            "latency": latency,
-            "power": power,
-            "energy": energy,  # NEW: precomputed energy
-        }
+        _store_first(
+            wideep_generation_moe_data,
+            (
+                quant_mode,
+                distribution,
+                topk,
+                num_experts,
+                hidden_size,
+                inter_size,
+                moe_tp_size,
+                moe_ep_size,
+                num_tokens,
+            ),
+            {"latency": latency, "power": power, "energy": energy},
+        )
         logger.debug(
             f"Loaded SGLang wideep generation MoE data: {quant_mode}, {distribution}, {topk}, "
             f"{num_experts}, {hidden_size}, {inter_size}, {moe_tp_size}, "
@@ -2525,14 +2582,23 @@ def load_wideep_moe_compute_data(wideep_moe_compute_file):
         power = float(row.get("power", 0.0))
         energy = power * latency  # watt-milliseconds
 
-        # Store all three values with kernel_source dimension
-        wideep_moe_compute_data[kernel_source][quant_mode][distribution][topk][num_experts][hidden_size][inter_size][
-            num_slots
-        ][moe_tp_size][moe_ep_size][num_tokens] = {
-            "latency": latency,
-            "power": power,
-            "energy": energy,
-        }
+        _store_first(
+            wideep_moe_compute_data,
+            (
+                kernel_source,
+                quant_mode,
+                distribution,
+                topk,
+                num_experts,
+                hidden_size,
+                inter_size,
+                num_slots,
+                moe_tp_size,
+                moe_ep_size,
+                num_tokens,
+            ),
+            {"latency": latency, "power": power, "energy": energy},
+        )
         # logger.debug(
         #     f"Loaded TensorRT-LLM wideep MoE compute data: kernel={kernel_source}, {quant_mode}, "
         #     f"{distribution}, {topk}, {num_experts}, {hidden_size}, {inter_size}, {num_slots}, "
@@ -2627,14 +2693,11 @@ def load_trtllm_alltoall_data(trtllm_alltoall_file):
         power = float(row.get("power", 0.0))
         energy = power * latency  # watt-milliseconds
 
-        # Store all three values with kernel_source and num_nodes dimensions
-        trtllm_alltoall_data[kernel_source][op_name][quant_mode][num_nodes][hidden_size][topk][num_experts][
-            moe_ep_size
-        ][num_tokens] = {
-            "latency": latency,
-            "power": power,
-            "energy": energy,
-        }
+        _store_first(
+            trtllm_alltoall_data,
+            (kernel_source, op_name, quant_mode, num_nodes, hidden_size, topk, num_experts, moe_ep_size, num_tokens),
+            {"latency": latency, "power": power, "energy": energy},
+        )
         # logger.debug(
         #     f"Loaded TensorRT-LLM wideep All2All data: kernel={kernel_source}, {op_name}, {quant_mode}, "
         #     f"num_nodes={num_nodes}, {hidden_size}, {topk}, {num_experts}, {moe_ep_size}, "

--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -2310,7 +2310,7 @@ class PerfDatabase:
         index_n_heads: int | None = None,
         index_head_dim: int | None = None,
         index_topk: int | None = None,
-        dsa_backend: str = "trtllm",
+        dsa_backend: str | None = None,
     ) -> PerformanceResult | tuple[float, float, float]:
         """Query context DSA module latency. Delegates to
         ``ContextDSAModule._query_context_dsa_module_table``."""
@@ -2347,7 +2347,7 @@ class PerfDatabase:
         index_n_heads: int | None = None,
         index_head_dim: int | None = None,
         index_topk: int | None = None,
-        dsa_backend: str = "trtllm",
+        dsa_backend: str | None = None,
     ) -> PerformanceResult | tuple[float, float, float]:
         """Query generation DSA module latency. Delegates to
         GenerationDSAModule._query_generation_dsa_module_table."""

--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -1613,6 +1613,9 @@ class PerfDatabase:
     def clear_runtime_caches(self) -> None:
         """Clear cached query/interpolation state while preserving loaded op data."""
         self._extracted_metrics_cache.clear()
+        sparse_cache = getattr(self, "_sparse_surrogate_cache", None)
+        if sparse_cache is not None:
+            sparse_cache.clear()
         for attr_name in dir(self):
             attr = getattr(self, attr_name)
             cache_clear = getattr(attr, "cache_clear", None)

--- a/src/aiconfigurator/sdk/perf_surrogate.py
+++ b/src/aiconfigurator/sdk/perf_surrogate.py
@@ -244,6 +244,8 @@ class _SparseModel:
         self.names = names
         self.varying_index = names.index(varying)
         self.fixed_indices = tuple(index for index in range(len(axes)) if index != self.varying_index)
+        if len(self.fixed_indices) > 2:
+            raise ValueError("sparse surrogate supports at most two fixed axes")
         self.points, self.latencies, self.energies = _flatten(table, axes)
         self.exact = {point: index for index, point in enumerate(self.points)}
         self.powers = np.divide(
@@ -266,8 +268,20 @@ class _SparseModel:
             for key, indices in sorted(grouped.items())
         )
         self.curve_by_key = {curve.fixed_key: curve for curve in self.curves}
-        self.mesh = _FixedMesh(
-            tuple(axes[i] for i in self.fixed_indices), tuple(curve.fixed_key for curve in self.curves)
+        complete_curves = tuple(curve for curve in self.curves if len(curve.sample_indices) >= 2)
+        singleton_values = {
+            self.points[curve.sample_indices[0]][self.varying_index]
+            for curve in self.curves
+            if len(curve.sample_indices) == 1
+        }
+        self.mesh_curves = complete_curves or (self.curves if len(singleton_values) == 1 else ())
+        self.mesh = (
+            _FixedMesh(
+                tuple(axes[i] for i in self.fixed_indices),
+                tuple(curve.fixed_key for curve in self.mesh_curves),
+            )
+            if self.mesh_curves
+            else None
         )
 
     def _baseline(self, baseline: Baseline | None, point: tuple[float, ...]) -> float:
@@ -373,8 +387,8 @@ class _SparseModel:
             latency, energy, _ = self._curve_estimate(exact_curve, point, curve, exterior, baseline)
             return latency, energy
 
-        support = self.mesh.locate(fixed_key)
-        if support is None:
+        support = self.mesh.locate(fixed_key) if self.mesh is not None else None
+        if support is None and self.mesh is not None:
             support = self.mesh.project(fixed_key)
         if support is None:
             raise InterpolationDataNotAvailableError(
@@ -385,8 +399,15 @@ class _SparseModel:
         component_latency: list[float] = []
         component_power: list[float] = []
         component_exterior = False
-        for curve_index in support.indices:
-            selected_curve = self.curves[curve_index]
+        components = tuple(
+            (curve_index, weight)
+            for curve_index, weight in zip(support.indices, support.weights, strict=True)
+            if weight > 1e-12
+        )
+        total_weight = sum(weight for _, weight in components)
+        component_weights = tuple(weight / total_weight for _, weight in components)
+        for curve_index, _ in components:
+            selected_curve = self.mesh_curves[curve_index]
             component_query = list(point)
             for axis_index, value in zip(self.fixed_indices, selected_curve.fixed_key, strict=True):
                 component_query[axis_index] = value
@@ -404,7 +425,7 @@ class _SparseModel:
             tuple(component_points),
             np.asarray(component_latency),
             np.asarray(component_power),
-            support.weights,
+            component_weights,
             response,
             baseline,
         )

--- a/src/aiconfigurator/sdk/perf_surrogate.py
+++ b/src/aiconfigurator/sdk/perf_surrogate.py
@@ -1,0 +1,437 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compiled curve/simplex interpolation for sparse performance tables."""
+
+from __future__ import annotations
+
+import bisect
+import math
+from collections.abc import Callable, Hashable, Mapping
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+from scipy.spatial import Delaunay, QhullError
+
+from aiconfigurator.sdk.interpolation import InterpolationDataNotAvailableError
+
+Direction = Literal["never", "lower", "upper", "both"]
+Response = Literal["raw", "sqrt", "baseline_ratio"]
+Baseline = Callable[[Mapping[str, float]], float]
+
+
+@dataclass(frozen=True)
+class Axis:
+    """A numeric axis and its authorized exterior direction."""
+
+    name: str
+    log: bool = False
+    extrapolate: Direction = "never"
+
+    def encode(self, value: float) -> float:
+        value = float(value)
+        if not math.isfinite(value):
+            raise ValueError(f"axis {self.name!r} must be finite, got {value}")
+        if self.log:
+            if value <= 0:
+                raise ValueError(f"axis {self.name!r} uses log2 coordinates and requires a positive value")
+            return math.log2(value)
+        return value
+
+    def allows(self, query: float, boundary: float) -> bool:
+        if math.isclose(query, boundary, rel_tol=0.0, abs_tol=1e-10):
+            return True
+        direction = "upper" if query > boundary else "lower"
+        return self.extrapolate in (direction, "both")
+
+
+@dataclass(frozen=True)
+class _Curve:
+    fixed_key: tuple[float, ...]
+    sample_indices: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class _Support:
+    indices: tuple[int, ...]
+    weights: tuple[float, ...]
+    exterior: bool = False
+
+
+def _flatten(table: Mapping, axes: tuple[Axis, ...]) -> tuple[tuple, np.ndarray, np.ndarray]:
+    rows: list[tuple[tuple[float, ...], float, float]] = []
+
+    def visit(node, depth: int, point: tuple[float, ...]) -> None:
+        if depth < len(axes):
+            if not isinstance(node, Mapping):
+                raise TypeError(f"expected mapping at axis {axes[depth].name!r}")
+            for key, child in node.items():
+                value = float(key)
+                axes[depth].encode(value)
+                visit(child, depth + 1, (*point, value))
+            return
+
+        if isinstance(node, Mapping):
+            if "latency" not in node:
+                raise ValueError(f"metric leaf at {point} has no latency")
+            latency = float(node["latency"])
+            energy = float(node["energy"]) if "energy" in node else float(node.get("power", 0.0)) * latency
+        else:
+            latency = float(node)
+            energy = 0.0
+        if not math.isfinite(latency) or not math.isfinite(energy) or latency < 0 or energy < 0:
+            raise ValueError(f"invalid metric leaf at {point}: latency={latency}, energy={energy}")
+        rows.append((point, latency, energy))
+
+    visit(table, 0, ())
+    if not rows:
+        raise InterpolationDataNotAvailableError("sparse table contains no samples")
+    rows.sort(key=lambda row: row[0])
+    points = tuple(row[0] for row in rows)
+    return points, np.asarray([row[1] for row in rows]), np.asarray([row[2] for row in rows])
+
+
+class _FixedMesh:
+    """Simplex support over curve keys; production tables need at most 2-D."""
+
+    def __init__(self, axes: tuple[Axis, ...], points: tuple[tuple[float, ...], ...]) -> None:
+        if len(axes) > 2:
+            raise ValueError("sparse surrogate supports at most two fixed axes")
+        self.axes = axes
+        self.encoded = np.asarray(
+            [[axis.encode(value) for axis, value in zip(axes, point, strict=True)] for point in points],
+            dtype=float,
+        )
+        varying = np.ptp(self.encoded, axis=0) > 1e-12 if axes else np.empty(0, dtype=bool)
+        self.active = np.flatnonzero(varying)
+        self.inactive = np.flatnonzero(~varying)
+        active_values = self.encoded[:, self.active]
+        self.mean = active_values.mean(axis=0) if len(self.active) else np.empty(0)
+        self.scale = active_values.std(axis=0) if len(self.active) else np.empty(0)
+        self.scale[self.scale < 1e-12] = 1.0
+        self.points = (active_values - self.mean) / self.scale if len(self.active) else np.empty((len(points), 0))
+        self.line_order: np.ndarray | None = None
+        self.tri: Delaunay | None = None
+
+        if len(self.active) == 1:
+            self.line_order = np.argsort(self.points[:, 0])
+        elif len(self.active) == 2 and len(points) >= 3 and np.linalg.matrix_rank(self.points - self.points[0]) == 2:
+            try:
+                self.tri = Delaunay(self.points)
+            except QhullError as exc:
+                raise InterpolationDataNotAvailableError(f"cannot compile fixed curve mesh: {exc}") from exc
+
+    def _query(self, values: tuple[float, ...]) -> tuple[np.ndarray, np.ndarray]:
+        encoded = np.asarray([axis.encode(value) for axis, value in zip(self.axes, values, strict=True)], dtype=float)
+        normalized = (encoded[self.active] - self.mean) / self.scale if len(self.active) else np.empty(0)
+        return encoded, normalized
+
+    def _inactive_allowed(self, encoded: np.ndarray) -> bool:
+        return all(self.axes[int(index)].allows(encoded[index], self.encoded[0, index]) for index in self.inactive)
+
+    def locate(self, values: tuple[float, ...]) -> _Support | None:
+        encoded, query = self._query(values)
+        if any(not math.isclose(encoded[i], self.encoded[0, i], abs_tol=1e-10) for i in self.inactive):
+            return None
+        dimensions = len(self.active)
+        if dimensions == 0:
+            return _Support((0,), (1.0,))
+        if dimensions == 1:
+            assert self.line_order is not None
+            line = self.points[self.line_order, 0]
+            position = bisect.bisect_left(line.tolist(), query[0])
+            if position < len(line) and math.isclose(line[position], query[0], abs_tol=1e-10):
+                return _Support((int(self.line_order[position]),), (1.0,))
+            if position == 0 or position == len(line):
+                return None
+            left, right = position - 1, position
+            weight = float((query[0] - line[left]) / (line[right] - line[left]))
+            return _Support((int(self.line_order[left]), int(self.line_order[right])), (1.0 - weight, weight))
+
+        if self.tri is None:
+            return None
+        simplex = int(self.tri.find_simplex(query, tol=1e-9))
+        if simplex < 0:
+            return None
+        transform = self.tri.transform[simplex]
+        barycentric = transform[:2].dot(query - transform[2])
+        weights = np.append(barycentric, 1.0 - barycentric.sum())
+        weights = np.clip(weights, 0.0, None)
+        weights /= weights.sum()
+        return _Support(
+            tuple(int(index) for index in self.tri.simplices[simplex]),
+            tuple(float(weight) for weight in weights),
+        )
+
+    def project(self, values: tuple[float, ...]) -> _Support | None:
+        encoded, query = self._query(values)
+        if not self._inactive_allowed(encoded):
+            return None
+        dimensions = len(self.active)
+        if dimensions == 0:
+            return _Support((0,), (1.0,), exterior=True)
+        if dimensions == 1:
+            assert self.line_order is not None
+            line = self.points[self.line_order, 0]
+            position = bisect.bisect_left(line.tolist(), query[0])
+            if position < len(line) and math.isclose(line[position], query[0], abs_tol=1e-10):
+                return _Support((int(self.line_order[position]),), (1.0,), exterior=True)
+            if 0 < position < len(line):
+                left, right = position - 1, position
+                weight = float((query[0] - line[left]) / (line[right] - line[left]))
+                return _Support(
+                    (int(self.line_order[left]), int(self.line_order[right])),
+                    (1.0 - weight, weight),
+                    exterior=True,
+                )
+            endpoint = 0 if position == 0 else -1
+            index = int(self.line_order[endpoint])
+            axis_index = int(self.active[0])
+            if not self.axes[axis_index].allows(encoded[axis_index], self.encoded[index, axis_index]):
+                return None
+            return _Support((index,), (1.0,), exterior=True)
+
+        if self.tri is None:
+            return None
+        active_axes = tuple(self.axes[int(index)] for index in self.active)
+        best: tuple[float, int, int, float] | None = None
+        for left_index, right_index in self.tri.convex_hull:
+            left_index = int(left_index)
+            right_index = int(right_index)
+            left = self.points[left_index]
+            right = self.points[right_index]
+            delta = right - left
+            denominator = float(delta.dot(delta))
+            candidates = [0.0, 1.0]
+            if denominator > 0:
+                candidates.append(float(np.clip((query - left).dot(delta) / denominator, 0.0, 1.0)))
+            for axis_index, axis in enumerate(active_axes):
+                if axis.extrapolate == "never" and abs(delta[axis_index]) > 1e-12:
+                    candidates.append(float((query[axis_index] - left[axis_index]) / delta[axis_index]))
+            for weight_right in candidates:
+                if weight_right < -1e-10 or weight_right > 1.0 + 1e-10:
+                    continue
+                weight_right = float(np.clip(weight_right, 0.0, 1.0))
+                candidate = left + weight_right * delta
+                candidate_encoded = candidate * self.scale + self.mean
+                if not all(
+                    axis.allows(encoded[int(self.active[i])], candidate_encoded[i])
+                    for i, axis in enumerate(active_axes)
+                ):
+                    continue
+                distance = float(np.linalg.norm(query - candidate))
+                if best is None or distance < best[0]:
+                    best = (distance, left_index, right_index, weight_right)
+        if best is None:
+            return None
+        _, left_index, right_index, weight_right = best
+        if weight_right <= 1e-10:
+            return _Support((left_index,), (1.0,), exterior=True)
+        if weight_right >= 1.0 - 1e-10:
+            return _Support((right_index,), (1.0,), exterior=True)
+        return _Support((left_index, right_index), (1.0 - weight_right, weight_right), exterior=True)
+
+
+class _SparseModel:
+    def __init__(self, table: Mapping, axes: tuple[Axis, ...], varying: str) -> None:
+        if not axes or len({axis.name for axis in axes}) != len(axes):
+            raise ValueError("sparse surrogate requires unique named axes")
+        names = tuple(axis.name for axis in axes)
+        if varying not in names:
+            raise ValueError(f"varying axis {varying!r} is not in {names}")
+        self.axes = axes
+        self.names = names
+        self.varying_index = names.index(varying)
+        self.fixed_indices = tuple(index for index in range(len(axes)) if index != self.varying_index)
+        self.points, self.latencies, self.energies = _flatten(table, axes)
+        self.exact = {point: index for index, point in enumerate(self.points)}
+        self.powers = np.divide(
+            self.energies, self.latencies, out=np.zeros_like(self.energies), where=self.latencies > 0
+        )
+        grouped: dict[tuple[float, ...], list[int]] = {}
+        for index, point in enumerate(self.points):
+            key = tuple(point[i] for i in self.fixed_indices)
+            grouped.setdefault(key, []).append(index)
+        self.curves = tuple(
+            _Curve(
+                key,
+                tuple(
+                    sorted(
+                        indices,
+                        key=lambda index: axes[self.varying_index].encode(self.points[index][self.varying_index]),
+                    )
+                ),
+            )
+            for key, indices in sorted(grouped.items())
+        )
+        self.curve_by_key = {curve.fixed_key: curve for curve in self.curves}
+        self.mesh = _FixedMesh(
+            tuple(axes[i] for i in self.fixed_indices), tuple(curve.fixed_key for curve in self.curves)
+        )
+
+    def _baseline(self, baseline: Baseline | None, point: tuple[float, ...]) -> float:
+        if baseline is None:
+            raise ValueError("baseline_ratio response requires a baseline")
+        value = float(baseline(dict(zip(self.names, point, strict=True))))
+        if not math.isfinite(value) or value <= 0:
+            raise ValueError(f"baseline must return a finite positive value, got {value}")
+        return value
+
+    def _blend(
+        self,
+        query: tuple[float, ...],
+        points: tuple[tuple[float, ...], ...],
+        latencies: np.ndarray,
+        powers: np.ndarray,
+        weights: tuple[float, ...],
+        response: Response,
+        baseline: Baseline | None,
+    ) -> tuple[float, float]:
+        weight_array = np.asarray(weights)
+        if response == "raw":
+            latency = float(weight_array.dot(latencies))
+        elif response == "sqrt":
+            latency = float(weight_array.dot(np.sqrt(latencies)) ** 2)
+        elif response == "baseline_ratio":
+            ratios = np.asarray(
+                [latency / self._baseline(baseline, point) for latency, point in zip(latencies, points, strict=True)]
+            )
+            latency = float(weight_array.dot(ratios) * self._baseline(baseline, query))
+        else:
+            raise ValueError(f"unknown response {response!r}")
+        energy = float(weight_array.dot(powers) * latency)
+        if not math.isfinite(latency) or not math.isfinite(energy) or latency < 0 or energy < 0:
+            raise InterpolationDataNotAvailableError("sparse surrogate produced invalid metrics")
+        return latency, energy
+
+    def _curve_estimate(
+        self,
+        curve: _Curve,
+        query: tuple[float, ...],
+        response: Response,
+        exterior: Response,
+        baseline: Baseline | None,
+    ) -> tuple[float, float, bool]:
+        axis = self.axes[self.varying_index]
+        indices = curve.sample_indices
+        encoded = [axis.encode(self.points[index][self.varying_index]) for index in indices]
+        query_encoded = axis.encode(query[self.varying_index])
+        position = bisect.bisect_left(encoded, query_encoded)
+        is_exterior = (position == 0 and query_encoded < encoded[0]) or position == len(encoded)
+        if is_exterior:
+            endpoint = 0 if query_encoded < encoded[0] else -1
+            sample_index = indices[endpoint]
+            boundary = self.points[sample_index][self.varying_index]
+            if not axis.allows(query[self.varying_index], boundary):
+                raise InterpolationDataNotAvailableError(
+                    f"axis {axis.name!r} cannot extrapolate from {boundary} to {query[self.varying_index]}"
+                )
+            sample_indices = (sample_index,)
+            weights = (1.0,)
+            response = exterior
+        elif position < len(encoded) and math.isclose(encoded[position], query_encoded, abs_tol=1e-12):
+            sample_indices = (indices[position],)
+            weights = (1.0,)
+        else:
+            left, right = position - 1, position
+            weight_right = (query_encoded - encoded[left]) / (encoded[right] - encoded[left])
+            sample_indices = (indices[left], indices[right])
+            weights = (1.0 - weight_right, weight_right)
+        sample_points = tuple(self.points[index] for index in sample_indices)
+        latency, energy = self._blend(
+            query,
+            sample_points,
+            self.latencies[list(sample_indices)],
+            self.powers[list(sample_indices)],
+            weights,
+            response,
+            baseline,
+        )
+        return latency, energy, is_exterior
+
+    def estimate(
+        self,
+        query: Mapping[str, float],
+        *,
+        curve: Response,
+        mesh: Response,
+        exterior: Response,
+        baseline: Baseline | None,
+    ) -> tuple[float, float]:
+        if set(query) != set(self.names):
+            raise ValueError(f"query axes must be exactly {self.names}")
+        point = tuple(float(query[name]) for name in self.names)
+        for axis, value in zip(self.axes, point, strict=True):
+            axis.encode(value)
+        exact_index = self.exact.get(point)
+        if exact_index is not None:
+            return float(self.latencies[exact_index]), float(self.energies[exact_index])
+        fixed_key = tuple(point[index] for index in self.fixed_indices)
+        exact_curve = self.curve_by_key.get(fixed_key)
+        if exact_curve is not None:
+            latency, energy, _ = self._curve_estimate(exact_curve, point, curve, exterior, baseline)
+            return latency, energy
+
+        support = self.mesh.locate(fixed_key)
+        if support is None:
+            support = self.mesh.project(fixed_key)
+        if support is None:
+            raise InterpolationDataNotAvailableError(
+                f"fixed-axis point {fixed_key} lies outside authorized sparse support"
+            )
+
+        component_points: list[tuple[float, ...]] = []
+        component_latency: list[float] = []
+        component_power: list[float] = []
+        component_exterior = False
+        for curve_index in support.indices:
+            selected_curve = self.curves[curve_index]
+            component_query = list(point)
+            for axis_index, value in zip(self.fixed_indices, selected_curve.fixed_key, strict=True):
+                component_query[axis_index] = value
+            component_point = tuple(component_query)
+            latency, energy, curve_exterior = self._curve_estimate(
+                selected_curve, component_point, curve, exterior, baseline
+            )
+            component_points.append(component_point)
+            component_latency.append(latency)
+            component_power.append(0.0 if latency == 0 else energy / latency)
+            component_exterior |= curve_exterior
+        response = exterior if support.exterior or component_exterior else mesh
+        return self._blend(
+            point,
+            tuple(component_points),
+            np.asarray(component_latency),
+            np.asarray(component_power),
+            support.weights,
+            response,
+            baseline,
+        )
+
+
+def estimate_sparse(
+    database: object,
+    key: Hashable,
+    table: Mapping,
+    query: Mapping[str, float],
+    *,
+    axes: tuple[Axis, ...],
+    varying: str,
+    curve: Response = "raw",
+    mesh: Response = "raw",
+    exterior: Response = "baseline_ratio",
+    baseline: Baseline | None = None,
+) -> tuple[float, float]:
+    """Estimate ``(latency, energy)``; cache geometry by key and table identity."""
+
+    cache = getattr(database, "_sparse_surrogate_cache", None)
+    if cache is None:
+        cache = {}
+        database._sparse_surrogate_cache = cache
+    cache_key = (key, axes, varying)
+    cached = cache.get(cache_key)
+    if cached is None or cached[0] is not table:
+        cached = (table, _SparseModel(table, axes, varying))
+        cache[cache_key] = cached
+    return cached[1].estimate(query, curve=curve, mesh=mesh, exterior=exterior, baseline=baseline)

--- a/tests/unit/sdk/database/test_attention.py
+++ b/tests/unit/sdk/database/test_attention.py
@@ -106,9 +106,8 @@ class TestContextAttention:
         )
         assert result > 0
 
-    def test_query_context_attention_assertion_error(self, comprehensive_perf_db):
-        """Test that n_kv > n raises assertion error."""
-        with pytest.raises(AssertionError):
+    def test_query_context_attention_rejects_too_many_kv_heads(self, comprehensive_perf_db):
+        with pytest.raises(ValueError, match="n_kv must be less than or equal to n"):
             comprehensive_perf_db.query_context_attention(
                 1,
                 32,
@@ -205,6 +204,16 @@ class TestGenerationAttention:
             1, 1, 8, 4, common.KVCacheQuantMode.bfloat16, database_mode=common.DatabaseMode.SOL
         )
         assert result > 0
+
+    def test_query_generation_attention_rejects_too_many_kv_heads(self, comprehensive_perf_db):
+        with pytest.raises(ValueError, match="n_kv must be less than or equal to n"):
+            comprehensive_perf_db.query_generation_attention(
+                1,
+                32,
+                8,
+                16,
+                common.KVCacheQuantMode.bfloat16,
+            )
 
 
 class TestContextMLA:

--- a/tests/unit/sdk/database/test_base_queries.py
+++ b/tests/unit/sdk/database/test_base_queries.py
@@ -98,6 +98,22 @@ def test_query_gemm_fast_paths_support_legacy_scalar_leaves(mutable_comprehensiv
     assert interp.source == "silicon"
 
 
+def test_query_gemm_exact_power_only_leaf_preserves_energy(mutable_comprehensive_perf_db):
+    db = mutable_comprehensive_perf_db
+    quant_mode = common.GEMMQuantMode.bfloat16
+    db._gemm_data = LoadedOpData(
+        {quant_mode: {7: {11: {13: {"latency": 2.0, "power": 6.0}}}}},
+        common.PerfDataFilename.gemm,
+        "power-only",
+    )
+    db.query_gemm.cache_clear()
+
+    result = db.query_gemm(7, 11, 13, quant_mode, database_mode=common.DatabaseMode.SILICON)
+
+    assert float(result) == 2.0
+    assert result.energy == 12.0
+
+
 def test_query_trtllm_alltoall_normalizes_fp8_block_lookup(stub_perf_db):
     """
     fp8_block reuses the fp8 TRT-LLM alltoall perf tables.

--- a/tests/unit/sdk/database/test_base_queries.py
+++ b/tests/unit/sdk/database/test_base_queries.py
@@ -67,30 +67,15 @@ def test_query_gemm_exact_match_skips_3d_interpolation(comprehensive_perf_db, mo
     assert math.isclose(float(observed), expected)
 
 
-def test_query_gemm_interpolates_only_on_m_when_nk_match(comprehensive_perf_db, monkeypatch):
-    """GEMM lookup should use 1D interpolation on m when n and k match."""
+def test_query_gemm_interpolates_only_on_m_when_nk_match(comprehensive_perf_db):
+    """GEMM lookup should use its semantic m curve when n and k match."""
     quant_mode = common.GEMMQuantMode.bfloat16
     m, n, k = 12, 128, 128
-    calls = {}
-
-    def _fail_interp_3d(*args, **kwargs):
-        raise AssertionError("_interp_3d should not be used when n/k match and only m needs interpolation")
-
-    def _spy_interp_1d(x, y, value):
-        calls["x"] = x
-        calls["y"] = y
-        calls["value"] = value
-        return {"latency": 0.1 + value * 0.001 + n * 0.0001 + k * 0.00001, "power": 0.0, "energy": 0.0}
-
-    monkeypatch.setattr("aiconfigurator.sdk.interpolation.interp_3d", _fail_interp_3d)
-    monkeypatch.setattr("aiconfigurator.sdk.interpolation.interp_1d", _spy_interp_1d)
 
     observed = comprehensive_perf_db.query_gemm(m, n, k, quant_mode, database_mode=common.DatabaseMode.SILICON)
     expected = 0.1 + m * 0.001 + n * 0.0001 + k * 0.00001
 
     assert math.isclose(float(observed), expected)
-    assert calls["x"] == [8, 16]
-    assert calls["value"] == m
     assert observed.source == "silicon"
 
 

--- a/tests/unit/sdk/database/test_data_loaders.py
+++ b/tests/unit/sdk/database/test_data_loaders.py
@@ -605,7 +605,7 @@ def test_query_dsv4_megamoe_module_missing_data_raises(tmp_path):
         )
 
 
-def test_query_dsv4_megamoe_module_interpolates_energy_from_rows(tmp_path):
+def test_query_dsv4_megamoe_module_interpolates_power_consistently(tmp_path):
     systems_root = tmp_path / "systems"
     data_dir = systems_root / "data" / "sglang" / "0.5.10"
     data_dir.mkdir(parents=True)
@@ -618,22 +618,28 @@ def test_query_dsv4_megamoe_module_interpolates_energy_from_rows(tmp_path):
     )
 
     db = PerfDatabase("gb200", "sglang", "0.5.10", str(systems_root))
-    result = db.query_dsv4_megamoe_module(
-        num_tokens=1536,
-        hidden_size=7168,
-        inter_size=3072,
-        topk=6,
-        num_experts=384,
-        moe_tp_size=1,
-        moe_ep_size=8,
-        quant_mode=MoEQuantMode.w4a8_mxfp4_mxfp8,
-        workload_distribution="balanced",
-        is_context=True,
-    )
+    kwargs = {
+        "hidden_size": 7168,
+        "inter_size": 3072,
+        "topk": 6,
+        "num_experts": 384,
+        "moe_tp_size": 1,
+        "moe_ep_size": 8,
+        "quant_mode": MoEQuantMode.w4a8_mxfp4_mxfp8,
+        "workload_distribution": "balanced",
+        "is_context": True,
+    }
+    result = db.query_dsv4_megamoe_module(num_tokens=1536, **kwargs)
+    lower = db.query_dsv4_megamoe_module(num_tokens=512, **kwargs)
+    upper = db.query_dsv4_megamoe_module(num_tokens=4096, **kwargs)
 
     assert float(result) == pytest.approx(2.0)
-    assert result.power == pytest.approx(175.0)
-    assert result.energy == pytest.approx(350.0)
+    assert result.power == pytest.approx(150.0)
+    assert result.energy == pytest.approx(300.0)
+    assert float(lower) == pytest.approx(1.0)
+    assert lower.power == pytest.approx(100.0)
+    assert float(upper) == pytest.approx(6.0)
+    assert upper.power == pytest.approx(200.0)
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/unit/sdk/database/test_database_helpers.py
+++ b/tests/unit/sdk/database/test_database_helpers.py
@@ -402,6 +402,7 @@ def test_get_database_skips_incomplete_version_directory(tmp_path: Path, perf_da
 def test_perf_database_clear_runtime_caches_clears_interpolation_and_lru_state(perf_database):
     db = object.__new__(perf_database.PerfDatabase)
     db._extracted_metrics_cache = {"table": object()}
+    db._sparse_surrogate_cache = {"table": object()}
     cache_clear_calls = []
 
     def fake_cached_method():
@@ -413,6 +414,7 @@ def test_perf_database_clear_runtime_caches_clears_interpolation_and_lru_state(p
     db.clear_runtime_caches()
 
     assert db._extracted_metrics_cache == {}
+    assert db._sparse_surrogate_cache == {}
     assert cache_clear_calls == ["cleared"]
 
 

--- a/tests/unit/sdk/database/test_deepseek_v4_module.py
+++ b/tests/unit/sdk/database/test_deepseek_v4_module.py
@@ -17,6 +17,7 @@ from aiconfigurator.sdk.operations.dsv4 import (
 )
 from aiconfigurator.sdk.perf_database import (
     LoadedOpData,
+    PerfDataNotAvailableError,
     load_mhc_module_data,
 )
 
@@ -150,6 +151,34 @@ def test_mhc_module_loader_returns_none_for_missing_file(tmp_path):
 
 
 class TestDeepSeekV4MHCModule:
+    def test_mhc_loader_keeps_primary_row_on_shared_source_conflict(self, tmp_path):
+        primary = _write_mhc_perf(
+            tmp_path / "primary.txt",
+            ["SGLang,test,H20,pre,mhc,DeepseekV4ForCausalLM,512,4,7168,1.5"],
+        )
+        sibling = _write_mhc_perf(
+            tmp_path / "sibling.txt",
+            ["SGLang,test,H20,pre,mhc,DeepseekV4ForCausalLM,512,4,7168,9.5"],
+        )
+
+        data = load_mhc_module_data([(primary, None), (sibling, {"mhc"})])
+
+        assert data["pre"][4][7168][512]["latency"] == pytest.approx(1.5)
+
+    def test_mhc_loader_skips_pre_rows_with_other_sinkhorn_iterations(self, tmp_path):
+        header = (
+            "framework,version,device,op_name,kernel_source,architecture,num_tokens,"
+            "hc_mult,hidden_size,sinkhorn_iters,latency\n"
+        )
+        primary = tmp_path / "primary.txt"
+        sibling = tmp_path / "sibling.txt"
+        primary.write_text(header + "SGLang,test,H20,pre,mhc,DeepseekV4ForCausalLM,512,4,7168,8,1.5\n")
+        sibling.write_text(header + "SGLang,test,H20,pre,mhc,DeepseekV4ForCausalLM,512,4,7168,20,2.5\n")
+
+        data = load_mhc_module_data([(str(primary), None), (str(sibling), {"mhc"})])
+
+        assert data["pre"][4][7168][512]["latency"] == pytest.approx(2.5)
+
     def test_mhc_sol_and_hybrid_return_positive(self, comprehensive_perf_db):
         for mode in (common.DatabaseMode.SOL, common.DatabaseMode.HYBRID):
             result = comprehensive_perf_db.query_mhc_module(
@@ -240,6 +269,39 @@ class TestDeepSeekV4MHCModule:
         )
 
         assert float(result) == pytest.approx(2.5)
+
+    @pytest.mark.parametrize(
+        ("sinkhorn_iters", "quant_mode", "message"),
+        [
+            (8, common.GEMMQuantMode.bfloat16, "sinkhorn_iters=20"),
+            (20, common.GEMMQuantMode.fp8_block, "quant_mode=bfloat16"),
+        ],
+    )
+    def test_mhc_silicon_rejects_unmeasured_categories(
+        self,
+        mutable_comprehensive_perf_db,
+        tmp_path,
+        sinkhorn_iters,
+        quant_mode,
+        message,
+    ):
+        path = _write_mhc_perf(
+            tmp_path / "mhc_module_perf.txt",
+            ["SGLang,test,H20,pre,mhc,DeepseekV4ForCausalLM,512,4,7168,2.5"],
+        )
+        db = mutable_comprehensive_perf_db
+        db._mhc_module_data = load_mhc_module_data(path)
+
+        with pytest.raises(PerfDataNotAvailableError, match=message):
+            db.query_mhc_module(
+                num_tokens=512,
+                hidden_size=7168,
+                hc_mult=4,
+                sinkhorn_iters=sinkhorn_iters,
+                op="pre",
+                quant_mode=quant_mode,
+                database_mode=common.DatabaseMode.SILICON,
+            )
 
     def test_mhc_sparse_token_curve_uses_sol_ratio_at_upper_boundary(self, mutable_comprehensive_perf_db, tmp_path):
         path = _write_mhc_perf(

--- a/tests/unit/sdk/database/test_deepseek_v4_module.py
+++ b/tests/unit/sdk/database/test_deepseek_v4_module.py
@@ -58,13 +58,13 @@ def _write_mhc_perf(path, rows: list[str]) -> str:
     return str(path)
 
 
-def _context_deepseek_v4_data(compress_ratio: int, attn_dict: dict, native_heads: int = 128) -> dict:
+def _context_deepseek_v4_data(compress_ratio: int, attn_dict: dict, native_heads: int = 128, tp_size: int = 8) -> dict:
     return {
         common.FMHAQuantMode.bfloat16: {
             common.KVCacheQuantMode.fp8: {
                 common.GEMMQuantMode.fp8_block: {
                     native_heads: {
-                        compress_ratio: attn_dict,
+                        tp_size: {compress_ratio: attn_dict},
                     },
                 },
             },
@@ -72,12 +72,16 @@ def _context_deepseek_v4_data(compress_ratio: int, attn_dict: dict, native_heads
     }
 
 
-def _generation_deepseek_v4_data(compress_ratio: int, attn_dict: dict, native_heads: int = 128) -> dict:
+def _generation_deepseek_v4_data(
+    compress_ratio: int, attn_dict: dict, native_heads: int = 128, tp_size: int = 8
+) -> dict:
     return {
         common.KVCacheQuantMode.fp8: {
             common.GEMMQuantMode.fp8_block: {
-                native_heads: {
-                    compress_ratio: attn_dict,
+                common.FMHAQuantMode.bfloat16: {
+                    native_heads: {
+                        tp_size: {compress_ratio: attn_dict},
+                    },
                 },
             },
         },
@@ -264,13 +268,12 @@ class TestDeepSeekV4AttentionModule:
         assert math.isclose(result["latency"], expected, rel_tol=1e-6)
         assert math.isclose(result["energy"], expected * 10.0, rel_tol=1e-6)
 
-    def test_generation_silicon_extrapolates_query_below_min_sampled_s_total(self, mutable_comprehensive_perf_db):
-        """Full-query regression for generated query b=1, s_total=1, tp=8."""
+    def test_generation_silicon_extrapolates_below_sampled_batch_and_sequence(self, mutable_comprehensive_perf_db):
+        """Lower exterior estimates stay positive and anchored to measured data."""
         db = mutable_comprehensive_perf_db
-        # SCHEME A silicon data is {head}{cr}{b}{s_total} — no tp level. The shared
-        # grid is {tp}{b}{s_total} (for the direct _dsv4_robust_3d_lookup test);
-        # strip the tp wrapper so it lands as {b}{s_total} under {head}{cr}.
-        mock_grid = _dsv4_generation_sampled_grid()[8]
+        # The shared fixture is {tp}{b}{s_total}; select the TP=8 slice before
+        # placing it under the loader's exact head/TP/category hierarchy.
+        mock_grid = {2: _dsv4_generation_sampled_grid()[8][2]}
         db._generation_deepseek_v4_attention_module_data = LoadedOpData(
             _generation_deepseek_v4_data(4, mock_grid),
             common.PerfDataFilename.dsv4_csa_generation_module,
@@ -289,9 +292,8 @@ class TestDeepSeekV4AttentionModule:
             database_mode=common.DatabaseMode.SILICON,
         )
 
-        expected = 0.20 + (0.50 - 0.20) * (1 - 2) / (5 - 2)
-        assert float(result) == pytest.approx(expected)
-        assert result.energy == pytest.approx(expected * 10.0)
+        assert 0 < float(result) <= 0.40
+        assert result.energy == pytest.approx(float(result) * 10.0)
 
     def test_csa_topk_changes_attention_workload(self, comprehensive_perf_db):
         base = _deepseek_v4_attn_kwargs(4)
@@ -382,7 +384,7 @@ class TestDeepSeekV4AttentionModule:
         }
         db = mutable_comprehensive_perf_db
         db._context_deepseek_v4_attention_module_data = LoadedOpData(
-            _context_deepseek_v4_data(4, attn_dict, native_heads=16),
+            _context_deepseek_v4_data(4, attn_dict),
             common.PerfDataFilename.dsv4_csa_context_module,
             "models",
         )
@@ -449,23 +451,21 @@ class TestDeepSeekV4AttentionModule:
             f"num_heads."
         )
 
-    def test_context_silicon_resolves_rank_local_head_bucket(self, mutable_comprehensive_perf_db):
-        # SCHEME A: the head axis is the rank-local head count (native // tp), in
-        # line with the universal attention convention (per-rank heads, no tp
-        # axis). A Pro query at tp=8 (native 128 -> num_heads=16) must resolve the
-        # 16-head bucket, not a smaller local-head bucket. cr=4 / prefix=0 ->
+    def test_context_silicon_resolves_native_head_bucket(self, mutable_comprehensive_perf_db):
+        # A Pro query at tp=8 (native 128, local 16) must resolve the 128-head
+        # model bucket, not the 64-head Flash bucket. cr=4 / prefix=0 ->
         # c4_len=64 <= index_topk, so the topK DELTA is 0 and the raw latency is
-        # returned unchanged. Data is prefix-resolved: {head}{cr}{prefix}{s}{b}.
+        # returned unchanged.
         db = mutable_comprehensive_perf_db
         data = _context_deepseek_v4_data(
             4,
             {0: {256: {2: _deepseek_v4_value(11.0)}}},
-            native_heads=8,
+            native_heads=64,
         )
         pro_data = _context_deepseek_v4_data(
             4,
             {0: {256: {2: _deepseek_v4_value(22.0)}}},
-            native_heads=16,
+            native_heads=128,
         )
         _deep_merge_dsv4_dicts(data, pro_data)
         db._context_deepseek_v4_attention_module_data = LoadedOpData(
@@ -614,7 +614,7 @@ class TestDeepSeekV4AttentionModule:
         # prefix-resolved {head}{cr}{prefix}{s}{b}; prefix=8192/s=54 -> c4_len=2061
         # > index_topk, so a correction WOULD apply if a calib were loaded.
         db._context_deepseek_v4_attention_module_data = LoadedOpData(
-            _context_deepseek_v4_data(4, {8192: {54: {1: _deepseek_v4_value(5.0)}}}, native_heads=16),
+            _context_deepseek_v4_data(4, {8192: {54: {1: _deepseek_v4_value(5.0)}}}),
             common.PerfDataFilename.dsv4_csa_context_module,
             "models",
         )

--- a/tests/unit/sdk/database/test_deepseek_v4_module.py
+++ b/tests/unit/sdk/database/test_deepseek_v4_module.py
@@ -241,6 +241,48 @@ class TestDeepSeekV4MHCModule:
 
         assert float(result) == pytest.approx(2.5)
 
+    def test_mhc_sparse_token_curve_uses_sol_ratio_at_upper_boundary(self, mutable_comprehensive_perf_db, tmp_path):
+        path = _write_mhc_perf(
+            tmp_path / "mhc_module_perf.txt",
+            [
+                "VLLM,test,H20,pre,mhc,DeepseekV4ForCausalLM,256,4,7168,1.0",
+                "VLLM,test,H20,pre,mhc,DeepseekV4ForCausalLM,512,4,7168,3.0",
+            ],
+        )
+        db = mutable_comprehensive_perf_db
+        db._mhc_module_data = load_mhc_module_data(path)
+
+        kwargs = {
+            "hidden_size": 7168,
+            "hc_mult": 4,
+            "sinkhorn_iters": 20,
+            "op": "pre",
+            "quant_mode": common.GEMMQuantMode.bfloat16,
+        }
+        interior = db.query_mhc_module(
+            num_tokens=384,
+            **kwargs,
+            database_mode=common.DatabaseMode.SILICON,
+        )
+        endpoint_sol = db.query_mhc_module(
+            num_tokens=512,
+            **kwargs,
+            database_mode=common.DatabaseMode.SOL_FULL,
+        )[0]
+        query_sol = db.query_mhc_module(
+            num_tokens=1024,
+            **kwargs,
+            database_mode=common.DatabaseMode.SOL_FULL,
+        )[0]
+        exterior = db.query_mhc_module(
+            num_tokens=1024,
+            **kwargs,
+            database_mode=common.DatabaseMode.SILICON,
+        )
+
+        assert float(interior) == pytest.approx(2.0)
+        assert float(exterior) == pytest.approx(3.0 * query_sol / endpoint_sol)
+
 
 class TestDeepSeekV4AttentionModule:
     def test_generation_uses_pre_decode_kv_length(self, comprehensive_perf_db):

--- a/tests/unit/sdk/database/test_dsa_module.py
+++ b/tests/unit/sdk/database/test_dsa_module.py
@@ -47,6 +47,141 @@ def _generation_dsa_data(dsa_dict: dict) -> dict:
     }
 
 
+def test_dsa_loaders_keep_primary_row_on_shared_source_conflict(tmp_path):
+    header = "kernel_source,architecture,gemm_type,mla_dtype,kv_cache_dtype,num_heads,batch_size,isl,step,latency\n"
+    row = "default,DeepseekV32ForCausalLM,bfloat16,bfloat16,bfloat16,32,1,256,0,{latency}\n"
+    primary = tmp_path / "primary.txt"
+    sibling = tmp_path / "sibling.txt"
+    primary.write_text(header + row.format(latency=10.0))
+    sibling.write_text(header + row.format(latency=99.0))
+    sources = [(str(primary), None), (str(sibling), {"default"})]
+
+    context = load_context_dsa_module_data(sources)
+    context_leaf = context[common.FMHAQuantMode.bfloat16][common.KVCacheQuantMode.bfloat16][
+        common.GEMMQuantMode.bfloat16
+    ][DEFAULT_DSA_ARCHITECTURE]["flashmla_kv"][32][0][256][1]
+    assert context_leaf["latency"] == pytest.approx(10.0)
+
+    generation = load_generation_dsa_module_data(sources)
+    generation_leaf = generation[common.KVCacheQuantMode.bfloat16][common.GEMMQuantMode.bfloat16][
+        DEFAULT_DSA_ARCHITECTURE
+    ]["flashmla_kv"][32][1][256]
+    assert generation_leaf["latency"] == pytest.approx(10.0)
+
+
+def test_dsa_loaders_keep_legacy_default_rows_separate_by_framework(tmp_path):
+    data_path = tmp_path / "dsa_module_perf.txt"
+    data_path.write_text(
+        "framework,kernel_source,architecture,gemm_type,mla_dtype,kv_cache_dtype,"
+        "num_heads,batch_size,isl,step,latency\n"
+        "TRTLLM,default,DeepseekV32ForCausalLM,bfloat16,bfloat16,bfloat16,32,1,256,0,10.0\n"
+        "VLLM,default,DeepseekV32ForCausalLM,bfloat16,bfloat16,bfloat16,32,1,256,0,20.0\n"
+    )
+
+    context = load_context_dsa_module_data(str(data_path))
+    architecture_data = context[common.FMHAQuantMode.bfloat16][common.KVCacheQuantMode.bfloat16][
+        common.GEMMQuantMode.bfloat16
+    ][DEFAULT_DSA_ARCHITECTURE]
+    assert architecture_data["trtllm"][32][0][256][1]["latency"] == pytest.approx(10.0)
+    assert architecture_data["flashmla_kv"][32][0][256][1]["latency"] == pytest.approx(20.0)
+
+    generation = load_generation_dsa_module_data(str(data_path))
+    architecture_data = generation[common.KVCacheQuantMode.bfloat16][common.GEMMQuantMode.bfloat16][
+        DEFAULT_DSA_ARCHITECTURE
+    ]
+    assert architecture_data["trtllm"][32][1][256]["latency"] == pytest.approx(10.0)
+    assert architecture_data["flashmla_kv"][32][1][256]["latency"] == pytest.approx(20.0)
+
+
+def test_dsa_queries_default_to_active_backend(stub_perf_db):
+    stub_perf_db.backend = common.BackendName.vllm.value
+    stub_perf_db._context_dsa_module_data = LoadedOpData(
+        _context_dsa_data(
+            {
+                "trtllm": {32: {0: {256: {1: _dsa_value(10.0)}}}},
+                "flashmla_kv": {32: {0: {256: {1: _dsa_value(20.0)}}}},
+            }
+        ),
+        common.PerfDataFilename.dsa_context_module,
+        "backends",
+    )
+    stub_perf_db._generation_dsa_module_data = LoadedOpData(
+        _generation_dsa_data(
+            {
+                "trtllm": {32: {1: {256: _dsa_value(11.0)}}},
+                "flashmla_kv": {32: {1: {256: _dsa_value(21.0)}}},
+            }
+        ),
+        common.PerfDataFilename.dsa_generation_module,
+        "backends",
+    )
+
+    context = stub_perf_db.query_context_dsa_module(
+        b=1,
+        s=256,
+        prefix=0,
+        num_heads=32,
+        kvcache_quant_mode=common.KVCacheQuantMode.bfloat16,
+        fmha_quant_mode=common.FMHAQuantMode.bfloat16,
+        database_mode=common.DatabaseMode.SILICON,
+    )
+    generation = stub_perf_db.query_generation_dsa_module(
+        b=1,
+        s=256,
+        num_heads=32,
+        kv_cache_dtype=common.KVCacheQuantMode.bfloat16,
+        database_mode=common.DatabaseMode.SILICON,
+    )
+
+    assert float(context) == pytest.approx(20.0)
+    assert float(generation) == pytest.approx(21.0)
+
+
+def test_dsa_queries_do_not_fallback_to_another_backend(stub_perf_db):
+    stub_perf_db._context_dsa_module_data = LoadedOpData(
+        _context_dsa_data({"flashmla_kv": {32: {0: {256: {1: _dsa_value(20.0)}}}}}),
+        common.PerfDataFilename.dsa_context_module,
+        "flash-only",
+    )
+    stub_perf_db._generation_dsa_module_data = LoadedOpData(
+        _generation_dsa_data({"flashmla_kv": {32: {1: {256: _dsa_value(21.0)}}}}),
+        common.PerfDataFilename.dsa_generation_module,
+        "flash-only",
+    )
+
+    with pytest.raises(PerfDataNotAvailableError, match="Context DSA module data not available"):
+        stub_perf_db.query_context_dsa_module(
+            b=1,
+            s=256,
+            prefix=0,
+            num_heads=32,
+            kvcache_quant_mode=common.KVCacheQuantMode.bfloat16,
+            fmha_quant_mode=common.FMHAQuantMode.bfloat16,
+            dsa_backend="trtllm",
+            database_mode=common.DatabaseMode.SILICON,
+        )
+    with pytest.raises(PerfDataNotAvailableError, match="Generation DSA module data not available"):
+        stub_perf_db.query_generation_dsa_module(
+            b=1,
+            s=256,
+            num_heads=32,
+            kv_cache_dtype=common.KVCacheQuantMode.bfloat16,
+            dsa_backend="trtllm",
+            database_mode=common.DatabaseMode.SILICON,
+        )
+    hybrid = stub_perf_db.query_context_dsa_module(
+        b=1,
+        s=256,
+        prefix=0,
+        num_heads=32,
+        kvcache_quant_mode=common.KVCacheQuantMode.bfloat16,
+        fmha_quant_mode=common.FMHAQuantMode.bfloat16,
+        dsa_backend="trtllm",
+        database_mode=common.DatabaseMode.HYBRID,
+    )
+    assert hybrid.source == "empirical"
+
+
 # ═══════════════════════════════════════════════════════════════════════
 # Context DSA Module
 # ═══════════════════════════════════════════════════════════════════════

--- a/tests/unit/sdk/database/test_dsa_module.py
+++ b/tests/unit/sdk/database/test_dsa_module.py
@@ -203,33 +203,17 @@ class TestContextDSAModule:
         assert above["latency"] == pytest.approx(80.0 + (100.0 - 80.0) / 1024.0 * (2049 - 3072))
         assert above["latency"] > raw_dsa_dict[32][2048][1]["latency"]
 
-    def test_topk_plus_one_uses_raw_piecewise_instead_of_cubic_fallback(self, stub_perf_db, monkeypatch):
-        raw_dsa_dict = {
+    def test_topk_plus_one_uses_only_post_topk_sparse_samples(self, stub_perf_db):
+        dsa_dict = {
             32: {
                 2048: {1: _dsa_value(20.0)},
                 3072: {1: _dsa_value(80.0)},
                 4096: {1: _dsa_value(100.0)},
             }
         }
-        extrapolated_dsa_dict = {
-            32: {
-                2048: {1: _dsa_value(20.0)},
-                2049: {1: _dsa_value(21.0)},
-                3072: {1: _dsa_value(80.0)},
-                4096: {1: _dsa_value(100.0)},
-            }
-        }
-        stub_perf_db._raw_context_dsa_module_data = LoadedOpData(
-            _context_dsa_data(raw_dsa_dict), common.PerfDataFilename.dsa_context_module, "raw"
-        )
         stub_perf_db._context_dsa_module_data = LoadedOpData(
-            _context_dsa_data(extrapolated_dsa_dict), common.PerfDataFilename.dsa_context_module, "extrapolated"
+            _context_dsa_data(dsa_dict), common.PerfDataFilename.dsa_context_module, "sparse"
         )
-
-        def fail_interp_3d(*args, **kwargs):
-            raise AssertionError("_interp_3d should not be used for topk + 1 when raw right-regime anchors exist")
-
-        monkeypatch.setattr("aiconfigurator.sdk.interpolation.interp_3d", fail_interp_3d)
 
         result = stub_perf_db.query_context_dsa_module(
             b=1,
@@ -242,32 +226,7 @@ class TestContextDSAModule:
             gemm_quant_mode=common.GEMMQuantMode.bfloat16,
             database_mode=common.DatabaseMode.SILICON,
         )
-
-        assert float(result) == pytest.approx(80.0 + (100.0 - 80.0) / 1024.0 * (2049 - 3072))
-        assert result.energy == pytest.approx((80.0 + (100.0 - 80.0) / 1024.0 * (2049 - 3072)) * 10.0)
-
-    def test_topk_piecewise_falls_back_when_raw_same_regime_anchors_are_unavailable(self, stub_perf_db, monkeypatch):
-        raw_dsa_dict = {
-            32: {
-                2048: {1: _dsa_value(20.0)},
-                4096: {1: _dsa_value(100.0)},
-            }
-        }
-        stub_perf_db._raw_context_dsa_module_data = LoadedOpData(
-            _context_dsa_data(raw_dsa_dict), common.PerfDataFilename.dsa_context_module, "raw"
-        )
-        stub_perf_db._context_dsa_module_data = LoadedOpData(
-            _context_dsa_data(raw_dsa_dict), common.PerfDataFilename.dsa_context_module, "extrapolated"
-        )
-        cubic_calls = []
-
-        def fake_interp_3d(*args, **kwargs):
-            cubic_calls.append((args, kwargs))
-            return {"latency": 123.0, "power": 0.0, "energy": 456.0}
-
-        monkeypatch.setattr("aiconfigurator.sdk.interpolation.interp_3d", fake_interp_3d)
-
-        result = stub_perf_db.query_context_dsa_module(
+        query_sol = stub_perf_db.query_context_dsa_module(
             b=1,
             s=2049,
             prefix=0,
@@ -276,12 +235,22 @@ class TestContextDSAModule:
             kvcache_quant_mode=common.KVCacheQuantMode.bfloat16,
             fmha_quant_mode=common.FMHAQuantMode.bfloat16,
             gemm_quant_mode=common.GEMMQuantMode.bfloat16,
-            database_mode=common.DatabaseMode.SILICON,
+            database_mode=common.DatabaseMode.SOL,
         )
-
-        assert float(result) == pytest.approx(123.0)
-        assert result.energy == pytest.approx(456.0)
-        assert len(cubic_calls) == 1
+        anchor_sol = stub_perf_db.query_context_dsa_module(
+            b=1,
+            s=3072,
+            prefix=0,
+            num_heads=32,
+            index_topk=2048,
+            kvcache_quant_mode=common.KVCacheQuantMode.bfloat16,
+            fmha_quant_mode=common.FMHAQuantMode.bfloat16,
+            gemm_quant_mode=common.GEMMQuantMode.bfloat16,
+            database_mode=common.DatabaseMode.SOL,
+        )
+        expected = 80.0 * float(query_sol) / float(anchor_sol)
+        assert float(result) == pytest.approx(expected)
+        assert result.energy == pytest.approx(expected * 10.0)
 
     def test_prefix_axis_interpolates_measured_prefix_slices(self, stub_perf_db):
         dsa_dict = {
@@ -495,6 +464,28 @@ class TestContextDSAModule:
 
 class TestGenerationDSAModule:
     """Tests for query_generation_dsa_module."""
+
+    def test_sparse_ragged_mesh_stays_inside_topk_regime(self, stub_perf_db):
+        table = {
+            16: {
+                1: {1: _dsa_value(1.0), 5: _dsa_value(5.0), 6: _dsa_value(106.0), 10: _dsa_value(110.0)},
+                3: {1: _dsa_value(3.0), 5: _dsa_value(15.0), 6: _dsa_value(118.0), 10: _dsa_value(130.0)},
+            }
+        }
+        stub_perf_db._generation_dsa_module_data = LoadedOpData(
+            _generation_dsa_data(table), common.PerfDataFilename.dsa_generation_module, "sparse"
+        )
+
+        pre = stub_perf_db.query_generation_dsa_module(
+            2, 3, 16, common.KVCacheQuantMode.bfloat16, index_topk=5, database_mode=common.DatabaseMode.SILICON
+        )
+        post = stub_perf_db.query_generation_dsa_module(
+            2, 8, 16, common.KVCacheQuantMode.bfloat16, index_topk=5, database_mode=common.DatabaseMode.SILICON
+        )
+
+        assert float(pre) == pytest.approx(6.0)
+        assert float(post) == pytest.approx(116.0)
+        assert post.energy == pytest.approx(1160.0)
 
     def test_missing_architecture_raises_perf_data_not_available(self, stub_perf_db):
         dsa_dict = {32: {1: {256: _dsa_value(10.0)}}}

--- a/tests/unit/sdk/database/test_dsv4_sparse.py
+++ b/tests/unit/sdk/database/test_dsv4_sparse.py
@@ -136,6 +136,23 @@ def test_load_dsv4_sparse_kernel_data_basic(tmp_path):
     assert data[_FLASH_NATIVE_HEADS][1][0][8192][1]["latency"] == pytest.approx(0.55)
 
 
+def test_load_dsv4_sparse_kernel_data_keeps_primary_source(tmp_path):
+    primary = _write_csv(
+        tmp_path / "primary.txt",
+        _SPARSE_HEADER,
+        [_sparse_row(kernel="paged_mqa_logits", bs=1, isl=1024, past_kv=0, tp=1, cr=4, lat=0.1)],
+    )
+    sibling = _write_csv(
+        tmp_path / "sibling.txt",
+        _SPARSE_HEADER,
+        [_sparse_row(kernel="paged_mqa_logits", bs=1, isl=1024, past_kv=0, tp=1, cr=4, lat=0.9)],
+    )
+
+    data = load_dsv4_sparse_kernel_data([(primary, None), (sibling, {"paged_mqa_logits"})])
+
+    assert data[_FLASH_NATIVE_HEADS][1][0][1024][1]["latency"] == pytest.approx(0.1)
+
+
 def test_load_dsv4_sparse_kernel_data_skips_dup_headers(tmp_path):
     """Loader must skip CSV header lines mistakenly appended on re-runs."""
     rows = [
@@ -204,6 +221,38 @@ def test_load_generation_dsv4_kind_module_data_b_before_s(tmp_path):
     assert sub[1][s_total_short]["latency"] == pytest.approx(0.1)
     assert sub[4][s_total_short]["latency"] == pytest.approx(0.4)
     assert sub[4][s_total_long]["latency"] == pytest.approx(1.0)
+
+
+def test_dsv4_module_loaders_keep_first_duplicate_measurement(tmp_path):
+    flash_fp8_model = "sgl-project/DeepSeek-V4-Flash-FP8"
+    context_path = _write_csv(
+        tmp_path / "csa_ctx_duplicates.txt",
+        _CTX_HEADER,
+        [
+            _ctx_row(attn_kind="csa", cr=4, bs=1, isl=128, tp=8, lat=0.12, model=_FLASH_MODEL),
+            _ctx_row(attn_kind="csa", cr=4, bs=1, isl=128, tp=8, lat=0.99, model=flash_fp8_model),
+        ],
+    )
+    generation_path = _write_csv(
+        tmp_path / "csa_gen_duplicates.txt",
+        _CTX_HEADER,
+        [
+            _gen_row(attn_kind="csa", cr=4, bs=2, isl=1, step=256, tp=8, lat=0.10, model=_FLASH_MODEL),
+            _gen_row(attn_kind="csa", cr=4, bs=2, isl=1, step=256, tp=8, lat=0.90, model=flash_fp8_model),
+        ],
+    )
+
+    context = load_context_dsv4_kind_module_data(context_path)
+    context_leaf = context[common.FMHAQuantMode.bfloat16][common.KVCacheQuantMode.fp8][common.GEMMQuantMode.fp8_block][
+        _FLASH_NATIVE_HEADS
+    ][8][4][0][128][1]
+    assert context_leaf["latency"] == pytest.approx(0.12)
+
+    generation = load_generation_dsv4_kind_module_data(generation_path)
+    generation_leaf = generation[common.KVCacheQuantMode.fp8][common.GEMMQuantMode.fp8_block][
+        common.FMHAQuantMode.bfloat16
+    ][_FLASH_NATIVE_HEADS][8][4][2][257]
+    assert generation_leaf["latency"] == pytest.approx(0.10)
 
 
 def test_load_context_dsv4_kind_module_data_keeps_native_heads_separate(tmp_path):

--- a/tests/unit/sdk/database/test_dsv4_sparse.py
+++ b/tests/unit/sdk/database/test_dsv4_sparse.py
@@ -21,6 +21,7 @@ from aiconfigurator.sdk import common
 from aiconfigurator.sdk.operations.dsv4 import (
     ContextDeepSeekV4AttentionModule,
     _deep_merge_dsv4_dicts,
+    _dsv4_resolve_head_key,
     _dsv4_robust_3d_lookup,
 )
 from aiconfigurator.sdk.perf_database import (
@@ -65,9 +66,7 @@ def _ctx_row(
     model: str = _FLASH_MODEL,
     num_heads: int | None = None,
 ) -> str:
-    # SCHEME A: the collector writes the rank-LOCAL head count (native // tp);
-    # callers may override it to simulate different shardings on one model.
-    heads = _native_heads_for_model(model) // tp if num_heads is None else num_heads
+    heads = _native_heads_for_model(model) if num_heads is None else num_heads
     return (
         f"SGLang,test,NVIDIA H20-3e,dsv4_{attn_kind}_context_module,"
         f"compressed_flashmla,{model},DeepseekV4ForCausalLM,"
@@ -161,26 +160,26 @@ def test_load_dsv4_sparse_kernel_data_missing_returns_none(tmp_path):
 # ───────────────────────────────────────────────────────────────────────
 
 
-def test_load_context_dsv4_kind_module_data_keys_by_local_head(tmp_path):
-    """SCHEME A: TP is folded into the rank-LOCAL ``num_heads`` (native // tp),
-    so the loader keys the head axis by local head count — there is NO separate
-    tp_size key. Axis order after the head is [cr][prefix][s][b]."""
-    # Pro native=128 sharded at tp=1/2/4/8 -> local heads 128/64/32/16.
+def test_load_context_dsv4_kind_module_data_keeps_tp_separate(tmp_path):
+    """Native heads remain stable while TP is an exact category."""
     rows = [
-        _ctx_row(attn_kind="csa", cr=4, bs=1, isl=8192, tp=1, lat=18.0, model=_PRO_MODEL, num_heads=128),
-        _ctx_row(attn_kind="csa", cr=4, bs=1, isl=8192, tp=2, lat=14.0, model=_PRO_MODEL, num_heads=64),
-        _ctx_row(attn_kind="csa", cr=4, bs=1, isl=8192, tp=4, lat=11.5, model=_PRO_MODEL, num_heads=32),
-        _ctx_row(attn_kind="csa", cr=4, bs=1, isl=8192, tp=8, lat=10.5, model=_PRO_MODEL, num_heads=16),
+        _ctx_row(attn_kind="csa", cr=4, bs=1, isl=8192, tp=1, lat=18.0, model=_PRO_MODEL),
+        _ctx_row(attn_kind="csa", cr=4, bs=1, isl=8192, tp=2, lat=14.0, model=_PRO_MODEL),
+        _ctx_row(attn_kind="csa", cr=4, bs=1, isl=8192, tp=4, lat=11.5, model=_PRO_MODEL),
+        _ctx_row(attn_kind="csa", cr=4, bs=1, isl=8192, tp=8, lat=10.5, model=_PRO_MODEL),
     ]
     path = _write_csv(tmp_path / "csa_ctx.txt", _CTX_HEADER, rows)
     data = load_context_dsv4_kind_module_data(path)
     quant = data[common.FMHAQuantMode.bfloat16][common.KVCacheQuantMode.fp8][common.GEMMQuantMode.fp8_block]
-    # head axis keyed by local head count {128, 64, 32, 16} (no tp_size axis)
-    assert set(quant.keys()) == {128, 64, 32, 16}
-    # axis order after the head is [cr][prefix][s][b]
-    assert quant[16][4][0][8192][1]["latency"] == pytest.approx(10.5)
-    # more local heads (less sharded) is slower
-    assert quant[128][4][0][8192][1]["latency"] > quant[16][4][0][8192][1]["latency"]
+    assert set(quant) == {_PRO_NATIVE_HEADS}
+    assert quant[128][8][4][0][8192][1]["latency"] == pytest.approx(10.5)
+    assert quant[128][1][4][0][8192][1]["latency"] > quant[128][8][4][0][8192][1]["latency"]
+
+
+def test_dsv4_head_resolution_accepts_native_and_local_collector_rows():
+    assert _dsv4_resolve_head_key({128: {8: {}}}, native_heads=128, tp_size=8) == 128
+    assert _dsv4_resolve_head_key({16: {8: {}}}, native_heads=128, tp_size=8) == 16
+    assert _dsv4_resolve_head_key({64: {8: {}}}, native_heads=128, tp_size=8) is None
 
 
 def test_load_generation_dsv4_kind_module_data_b_before_s(tmp_path):
@@ -197,8 +196,9 @@ def test_load_generation_dsv4_kind_module_data_b_before_s(tmp_path):
     ]
     path = _write_csv(tmp_path / "csa_gen.txt", _CTX_HEADER, rows)
     data = load_generation_dsv4_kind_module_data(path)
-    sub = data[common.KVCacheQuantMode.fp8][common.GEMMQuantMode.fp8_block][_FLASH_NATIVE_HEADS][4]
-    # SCHEME A axis order after [head][cr] is [b][s_total] (no tp axis); b first
+    sub = data[common.KVCacheQuantMode.fp8][common.GEMMQuantMode.fp8_block][common.FMHAQuantMode.bfloat16][
+        _FLASH_NATIVE_HEADS
+    ][1][4]
     s_total_short = 1 + 1023  # isl + step
     s_total_long = 1 + 8191
     assert sub[1][s_total_short]["latency"] == pytest.approx(0.1)
@@ -214,9 +214,8 @@ def test_load_context_dsv4_kind_module_data_keeps_native_heads_separate(tmp_path
     path = _write_csv(tmp_path / "csa_ctx_models.txt", _CTX_HEADER, rows)
     data = load_context_dsv4_kind_module_data(path)
     data = data[common.FMHAQuantMode.bfloat16][common.KVCacheQuantMode.fp8][common.GEMMQuantMode.fp8_block]
-    # SCHEME A: [local_head][cr][prefix][s][b]; tp=1 rows -> local head == native, prefix=0
-    assert data[_FLASH_NATIVE_HEADS][4][0][8192][1]["latency"] == pytest.approx(18.0)
-    assert data[_PRO_NATIVE_HEADS][4][0][8192][1]["latency"] == pytest.approx(23.0)
+    assert data[_FLASH_NATIVE_HEADS][1][4][0][8192][1]["latency"] == pytest.approx(18.0)
+    assert data[_PRO_NATIVE_HEADS][1][4][0][8192][1]["latency"] == pytest.approx(23.0)
 
 
 def test_load_generation_dsv4_kind_module_data_keeps_native_heads_separate(tmp_path):
@@ -226,10 +225,9 @@ def test_load_generation_dsv4_kind_module_data_keeps_native_heads_separate(tmp_p
     ]
     path = _write_csv(tmp_path / "hca_gen_models.txt", _CTX_HEADER, rows)
     data = load_generation_dsv4_kind_module_data(path)
-    data = data[common.KVCacheQuantMode.fp8][common.GEMMQuantMode.fp8_block]
-    # SCHEME A: [local_head][cr][b][s_total]; tp=1 -> local head == native, no tp axis
-    assert data[_FLASH_NATIVE_HEADS][128][1][1024]["latency"] == pytest.approx(0.2)
-    assert data[_PRO_NATIVE_HEADS][128][1][1024]["latency"] == pytest.approx(0.6)
+    data = data[common.KVCacheQuantMode.fp8][common.GEMMQuantMode.fp8_block][common.FMHAQuantMode.bfloat16]
+    assert data[_FLASH_NATIVE_HEADS][1][128][1][1024]["latency"] == pytest.approx(0.2)
+    assert data[_PRO_NATIVE_HEADS][1][128][1][1024]["latency"] == pytest.approx(0.6)
 
 
 # ───────────────────────────────────────────────────────────────────────

--- a/tests/unit/sdk/database/test_edge_cases.py
+++ b/tests/unit/sdk/database/test_edge_cases.py
@@ -134,13 +134,8 @@ class TestAllreduceEdgeCases:
 class TestInitializationEdgeCases:
     """Test edge cases during PerfDatabase initialization."""
 
-    def test_extrapolation_during_init(self, tmp_path, monkeypatch, caplog):
-        """Test that extrapolation runs when ContextAttention's data is loaded.
-
-        Previously ``PerfDatabase.__init__`` warmed every op eagerly, so
-        extrapolation ran during construction. Now the load is lazy: we
-        explicitly trigger ``ContextAttention.load_data`` below (with
-        the loader patches still active) and assert on the result."""
+    def test_sparse_data_remains_raw_during_init(self, tmp_path, monkeypatch, caplog):
+        """Loading keeps measured rows sparse; off-grid queries compile lazily."""
         # Set up minimal system spec
         import yaml
 
@@ -217,15 +212,14 @@ class TestInitializationEdgeCases:
                 loader_func = lambda path, d=depth: create_nested_defaultdict(d)
             monkeypatch.setattr(f"aiconfigurator.sdk.operations.{module}.{loader}", loader_func)
 
-        # Initialize database, then trigger the lazy load explicitly so
-        # extrapolation runs while loader patches are still active.
+        # Initialize database, then trigger the lazy load explicitly while
+        # loader patches are still active.
         from aiconfigurator.sdk.operations.attention import ContextAttention
 
         db = PerfDatabase("test", "backend", "v1", str(tmp_path))
         ContextAttention.load_data(db)
 
-        # Check that extrapolation created new data points
-        # Should have more than the 4 original points
+        # Loading must not synthesize Cartesian rows.
         total_points = 0
         for quant_mode in db._context_attention_data:
             for kv_cache in db._context_attention_data[quant_mode]:
@@ -242,7 +236,19 @@ class TestInitializationEdgeCases:
                                         ][s]
                                     )
 
-        assert total_points > 4, "Extrapolation should have created additional data points"
+        assert total_points == 4
+
+        result = db.query_context_attention(
+            1,
+            24,
+            0,
+            6,
+            6,
+            common.KVCacheQuantMode.bfloat16,
+            common.FMHAQuantMode.bfloat16,
+            database_mode=common.DatabaseMode.SILICON,
+        )
+        assert result > 0
 
 
 class TestGemmInterpolation:

--- a/tests/unit/sdk/database/test_fp8_static.py
+++ b/tests/unit/sdk/database/test_fp8_static.py
@@ -184,7 +184,7 @@ def test_query_gemm_fp8_static_requires_dynamic_fp8_table(mutable_comprehensive_
         )
 
 
-def test_query_gemm_fp8_static_sparse_shape_miss_is_structured(mutable_comprehensive_perf_db):
+def test_query_gemm_fp8_static_sparse_shape_extrapolates(mutable_comprehensive_perf_db):
     db = mutable_comprehensive_perf_db
     db.backend = common.BackendName.sglang.value
     db._gemm_data = LoadedOpData(
@@ -202,14 +202,15 @@ def test_query_gemm_fp8_static_sparse_shape_miss_is_structured(mutable_comprehen
     )
     db.query_gemm.cache_clear()
 
-    with pytest.raises(PerfDataNotAvailableError, match=r"GEMM perf data not available.*fp8_static"):
-        db.query_gemm(
-            1,
-            4096,
-            4096,
-            common.GEMMQuantMode.fp8_static,
-            database_mode=common.DatabaseMode.SILICON,
-        )
+    result = db.query_gemm(
+        1,
+        4096,
+        4096,
+        common.GEMMQuantMode.fp8_static,
+        database_mode=common.DatabaseMode.SILICON,
+    )
+    assert float(result) > 0
+    assert result.source == "silicon"
 
 
 def test_query_compute_scale_fp8_static_reuses_fp8_table(mutable_comprehensive_perf_db):
@@ -237,11 +238,13 @@ def test_query_compute_scale_fp8_static_reuses_fp8_table(mutable_comprehensive_p
     assert float(static_result) == pytest.approx(float(fp8_result))
     assert static_result.energy == pytest.approx(fp8_result.energy)
 
-    # Out-of-range m should be clamped to the table range (avoid hard failure in SILICON mode).
-    clamped = db.query_compute_scale(10_000, k, common.GEMMQuantMode.fp8_static)
+    # Out-of-range m follows the same sparse boundary model for fp8_static and fp8.
+    extrapolated = db.query_compute_scale(10_000, k, common.GEMMQuantMode.fp8_static)
+    fp8_extrapolated = db.query_compute_scale(10_000, k, common.GEMMQuantMode.fp8)
     fp8_max_m = db.query_compute_scale(128, k, common.GEMMQuantMode.fp8)
-    assert float(clamped) == pytest.approx(float(fp8_max_m))
-    assert clamped.energy == pytest.approx(fp8_max_m.energy)
+    assert float(extrapolated) == pytest.approx(float(fp8_extrapolated))
+    assert extrapolated.energy == pytest.approx(fp8_extrapolated.energy)
+    assert float(extrapolated) > float(fp8_max_m)
 
 
 def test_query_scale_matrix_fp8_static_reuses_fp8_table(mutable_comprehensive_perf_db):
@@ -267,11 +270,13 @@ def test_query_scale_matrix_fp8_static_reuses_fp8_table(mutable_comprehensive_pe
     assert float(static_result) == pytest.approx(float(fp8_result))
     assert static_result.energy == pytest.approx(fp8_result.energy)
 
-    # Out-of-range m should be clamped to the table range (avoid hard failure in SILICON mode).
-    clamped = db.query_scale_matrix(10_000, k, common.GEMMQuantMode.fp8_static)
+    # Out-of-range m follows the same sparse boundary model for fp8_static and fp8.
+    extrapolated = db.query_scale_matrix(10_000, k, common.GEMMQuantMode.fp8_static)
+    fp8_extrapolated = db.query_scale_matrix(10_000, k, common.GEMMQuantMode.fp8)
     fp8_max_m = db.query_scale_matrix(128, k, common.GEMMQuantMode.fp8)
-    assert float(clamped) == pytest.approx(float(fp8_max_m))
-    assert clamped.energy == pytest.approx(fp8_max_m.energy)
+    assert float(extrapolated) == pytest.approx(float(fp8_extrapolated))
+    assert extrapolated.energy == pytest.approx(fp8_extrapolated.energy)
+    assert float(extrapolated) > float(fp8_max_m)
 
 
 def test_gemm_query_subtracts_overheads_for_fp8_static():

--- a/tests/unit/sdk/database/test_gemm_op.py
+++ b/tests/unit/sdk/database/test_gemm_op.py
@@ -129,6 +129,21 @@ class TestQueryDelegation:
         )
         assert float(result) > 0
 
+    @pytest.mark.parametrize("method_name", ["_query_compute_scale_table", "_query_scale_matrix_table"])
+    def test_zero_overhead_does_not_load_tables(self, stub_perf_db, monkeypatch, method_name):
+        def fail_load(_cls, _database):
+            raise AssertionError("zero-work query must not load a table")
+
+        monkeypatch.setattr(GEMM, "load_data", classmethod(fail_load))
+        result = getattr(GEMM, method_name)(
+            stub_perf_db,
+            0,
+            512,
+            common.GEMMQuantMode.fp8,
+            database_mode=common.DatabaseMode.SILICON,
+        )
+        assert float(result) == 0
+
 
 class TestSolCorrection:
     """``GEMM._correct_sol`` clamps mutated GEMM data back to >= SOL."""
@@ -141,13 +156,14 @@ class TestSolCorrection:
         sol_value = float(db.query_gemm(m, n, k, quant_mode, database_mode=common.DatabaseMode.SOL))
 
         # Set an artificially low value (lower than SOL)
-        db._gemm_data[quant_mode][m][n][k] = {"latency": sol_value * 0.5, "power": 0.0, "energy": 0.0}
+        db._gemm_data[quant_mode][m][n][k] = {"latency": sol_value * 0.5, "power": 4.0, "energy": sol_value * 2}
 
         GEMM._correct_sol(db)
 
         clamped = db._gemm_data[quant_mode][m][n][k]
         clamped_latency = clamped["latency"] if isinstance(clamped, dict) else clamped
         assert clamped_latency >= sol_value
+        assert clamped["energy"] == pytest.approx(clamped_latency * 4)
 
 
 @pytest.mark.parametrize("quant_mode", [common.GEMMQuantMode.bfloat16, common.GEMMQuantMode.fp8])

--- a/tests/unit/sdk/database/test_mamba_surrogate.py
+++ b/tests/unit/sdk/database/test_mamba_surrogate.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from aiconfigurator.sdk import common
+from aiconfigurator.sdk.perf_database import LoadedOpData
+
+pytestmark = pytest.mark.unit
+
+_MAMBA_KEY = (4096, 128, 4, 128, 64, 8, 128)
+_GDN_KEY = (4096, 16, 128, 16, 128, 4)
+
+
+def _metric(latency: float) -> dict[str, float]:
+    return {"latency": latency, "power": 10.0, "energy": latency * 10.0}
+
+
+def test_mamba_context_sparse_curve_mesh_and_local_exterior(mutable_comprehensive_perf_db):
+    db = mutable_comprehensive_perf_db
+    table = {
+        1: {1: _metric(1.0), 4: _metric(4.0), 8: _metric(8.0)},
+        2: {1: _metric(2.0), 8: _metric(16.0)},
+        4: {1: _metric(4.0), 4: _metric(16.0)},
+    }
+    db._mamba2_data = LoadedOpData(
+        {"causal_conv1d_fn": {"context": {_MAMBA_KEY: table}}},
+        common.PerfDataFilename.mamba2,
+        "synthetic-mamba",
+    )
+    db._sparse_surrogate_cache = {}
+
+    curve = db.query_mamba2("context", "causal_conv1d_fn", 2, 4, *_MAMBA_KEY)
+    mesh = db.query_mamba2("context", "causal_conv1d_fn", 3, 4, *_MAMBA_KEY)
+    exterior = db.query_mamba2("context", "causal_conv1d_fn", 4, 8, *_MAMBA_KEY)
+
+    assert float(curve) == pytest.approx(8.0)
+    assert float(mesh) == pytest.approx(12.0)
+    assert float(exterior) == pytest.approx(32.0)
+    assert exterior.energy == pytest.approx(320.0)
+
+    missing_model = db.query_mamba2(
+        "context",
+        "causal_conv1d_fn",
+        1,
+        4,
+        12345,
+        *_MAMBA_KEY[1:],
+    )
+    assert missing_model.source == "sol"
+
+
+def test_gdn_collector_alias_nearest_category_and_batch_exterior(mutable_comprehensive_perf_db):
+    db = mutable_comprehensive_perf_db
+    low = (_GDN_KEY[0], _GDN_KEY[1], _GDN_KEY[2], 8, _GDN_KEY[4], _GDN_KEY[5])
+    data = {
+        "fused_recurrent_gated_delta_rule": {
+            "generation": {
+                low: {1: _metric(8.0), 3: _metric(12.0)},
+                _GDN_KEY: {1: _metric(16.0), 3: _metric(20.0)},
+            }
+        }
+    }
+    db._gdn_data = LoadedOpData(data, common.PerfDataFilename.gdn, "synthetic-gdn")
+    db._sparse_surrogate_cache = {}
+
+    interior = db.query_gdn(
+        "generation",
+        "fused_sigmoid_gating_delta_rule_update",
+        2,
+        None,
+        _GDN_KEY[0],
+        _GDN_KEY[1],
+        _GDN_KEY[2],
+        14,
+        _GDN_KEY[4],
+        _GDN_KEY[5],
+    )
+    exterior = db.query_gdn(
+        "generation",
+        "fused_sigmoid_gating_delta_rule_update",
+        6,
+        None,
+        _GDN_KEY[0],
+        _GDN_KEY[1],
+        _GDN_KEY[2],
+        14,
+        _GDN_KEY[4],
+        _GDN_KEY[5],
+    )
+
+    assert float(interior) == pytest.approx(18.0)
+    assert float(exterior) == pytest.approx(40.0)
+    assert exterior.energy == pytest.approx(400.0)

--- a/tests/unit/sdk/database/test_mamba_surrogate.py
+++ b/tests/unit/sdk/database/test_mamba_surrogate.py
@@ -4,6 +4,7 @@
 import pytest
 
 from aiconfigurator.sdk import common
+from aiconfigurator.sdk.operations import mamba
 from aiconfigurator.sdk.perf_database import LoadedOpData
 
 pytestmark = pytest.mark.unit
@@ -14,6 +15,43 @@ _GDN_KEY = (4096, 16, 128, 16, 128, 4)
 
 def _metric(latency: float) -> dict[str, float]:
     return {"latency": latency, "power": 10.0, "energy": latency * 10.0}
+
+
+def _mamba_row(phase: str, latency: float, *, batch_size: int = 1, seq_len: int = 1) -> dict[str, object]:
+    return {
+        "kernel_source": "causal_conv1d_fn" if phase == "context" else "causal_conv1d_update",
+        "phase": phase,
+        "batch_size": batch_size,
+        "seq_len": seq_len,
+        "d_model": _MAMBA_KEY[0],
+        "d_state": _MAMBA_KEY[1],
+        "d_conv": _MAMBA_KEY[2],
+        "nheads": _MAMBA_KEY[3],
+        "head_dim": _MAMBA_KEY[4],
+        "n_groups": _MAMBA_KEY[5],
+        "chunk_size": _MAMBA_KEY[6],
+        "latency": latency,
+        "power": 10.0,
+    }
+
+
+def test_load_mamba2_data_keeps_generation_row_and_context_shape(monkeypatch):
+    rows = [_mamba_row("generation", 2.0), _mamba_row("context", 3.0, seq_len=4)]
+    monkeypatch.setattr(mamba, "_read_filtered_rows", lambda _: rows)
+
+    data = mamba.load_mamba2_data("unused")
+
+    assert data["causal_conv1d_update"]["generation"][_MAMBA_KEY][1] == _metric(2.0)
+    assert data["causal_conv1d_fn"]["context"][_MAMBA_KEY][1][4] == _metric(3.0)
+
+
+def test_load_mamba2_data_generation_conflict_keeps_first_source(monkeypatch):
+    rows = [_mamba_row("generation", 2.0), _mamba_row("generation", 99.0)]
+    monkeypatch.setattr(mamba, "_read_filtered_rows", lambda _: rows)
+
+    data = mamba.load_mamba2_data("unused")
+
+    assert data["causal_conv1d_update"]["generation"][_MAMBA_KEY][1] == _metric(2.0)
 
 
 def test_mamba_context_sparse_curve_mesh_and_local_exterior(mutable_comprehensive_perf_db):
@@ -92,3 +130,14 @@ def test_gdn_collector_alias_nearest_category_and_batch_exterior(mutable_compreh
     assert float(interior) == pytest.approx(18.0)
     assert float(exterior) == pytest.approx(40.0)
     assert exterior.energy == pytest.approx(400.0)
+
+
+def test_gdn_chunked_sol_counts_partial_chunk(mutable_comprehensive_perf_db):
+    db = mutable_comprehensive_perf_db
+    db._gdn_data = LoadedOpData({}, common.PerfDataFilename.gdn, "empty-gdn")
+
+    result = db.query_gdn("context", "chunk_gated_delta_rule", 1, 65, 1, 1, 1, 1, 1, 1)
+
+    expected_bytes = 402  # 65 tokens plus two read/write h_chunks buffers.
+    expected = expected_bytes / db.system_spec["gpu"]["mem_bw"] * 1000
+    assert float(result) == pytest.approx(expected)

--- a/tests/unit/sdk/database/test_mla_surrogate.py
+++ b/tests/unit/sdk/database/test_mla_surrogate.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import aiconfigurator.sdk.operations.mla as mla_module
+from aiconfigurator.sdk import common
+from aiconfigurator.sdk.operations.mla import ContextMLA, GenerationMLA, WideEPGenerationMLA
+from aiconfigurator.sdk.performance_result import PerformanceResult
+
+
+class _Data(dict):
+    def raise_if_not_loaded(self) -> None:
+        return None
+
+
+class _Database:
+    def __init__(self, backend: str = "trtllm") -> None:
+        self.backend = backend
+        self.system = "test"
+        self.version = "test"
+        self.systems_root = "/tmp"
+        self.enable_shared_layer = False
+        self._default_database_mode = common.DatabaseMode.SILICON
+        self.system_spec = {
+            "data_dir": "data",
+            "gpu": {"bfloat16_tc_flops": 1e12, "mem_bw": 1e12},
+        }
+
+    @staticmethod
+    def _build_op_sources(*_args):
+        return []
+
+    @staticmethod
+    def _interp_pr(latency, energy=0.0):
+        return PerformanceResult(latency, energy=energy, source="silicon")
+
+    @staticmethod
+    def _query_silicon_or_hybrid(*, get_silicon, **_kwargs):
+        return get_silicon()
+
+
+def _metric(latency: float, power: float) -> dict[str, float]:
+    return {"latency": latency, "power": power, "energy": latency * power}
+
+
+def test_generation_load_keeps_raw_sparse_coordinates(monkeypatch) -> None:
+    kv = common.KVCacheQuantMode.bfloat16
+    raw = {kv: {4: {1: {8: _metric(2, 3), 16: _metric(4, 3)}}}}
+    monkeypatch.setattr(mla_module, "load_generation_mla_data", lambda _sources: raw)
+    GenerationMLA.clear_cache()
+    db = _Database()
+    try:
+        GenerationMLA.load_data(db)
+        assert set(db._generation_mla_data[kv][4][1]) == {8, 16}
+    finally:
+        GenerationMLA.clear_cache()
+
+
+def test_context_prefix_uses_full_sequence_exact_point(monkeypatch) -> None:
+    monkeypatch.setattr(ContextMLA, "load_data", classmethod(lambda _cls, _db: None))
+    db = _Database()
+    fmha = common.FMHAQuantMode.bfloat16
+    kv = common.KVCacheQuantMode.bfloat16
+    db._context_mla_data = _Data({fmha: {kv: {4: {16: {1: _metric(8, 5)}}}}})
+
+    result = ContextMLA._query_context_mla_table(db, 1, 8, 8, 4, kv, fmha, database_mode=common.DatabaseMode.SILICON)
+    assert float(result) == 6  # exact full_s=16 multiplied by the 3/4 prefix correction
+    assert result.energy == 30
+    sol = ContextMLA._query_context_mla_table(db, 1, 8, 8, 4, kv, fmha, common.DatabaseMode.SOL)
+    assert sol.source == "sol" and float(sol) > 0
+
+
+def test_generation_off_grid_interpolates_power_consistent_energy(monkeypatch) -> None:
+    monkeypatch.setattr(GenerationMLA, "load_data", classmethod(lambda _cls, _db: None))
+    db = _Database()
+    kv = common.KVCacheQuantMode.bfloat16
+    table = {
+        4: {
+            1: {10: _metric(2, 2), 20: _metric(4, 4)},
+            3: {10: _metric(6, 6), 20: _metric(8, 8)},
+        }
+    }
+    db._generation_mla_data = _Data({kv: table})
+
+    result = GenerationMLA._query_generation_mla_table(db, 2, 15, 4, kv, database_mode=common.DatabaseMode.SILICON)
+    assert float(result) == 5
+    assert result.energy == 25  # interpolated 5 W * predicted 5 ms
+    assert set(table[4]) == {1, 3} and set(table[4][1]) == {10, 20}
+
+
+def test_wideep_backend_categories_do_not_share_exact_values(monkeypatch) -> None:
+    monkeypatch.setattr(WideEPGenerationMLA, "load_data", classmethod(lambda _cls, _db: None))
+    db = _Database("sglang")
+    kv = common.KVCacheQuantMode.bfloat16
+    fmha = common.FMHAQuantMode.bfloat16
+    db._wideep_generation_mla_data = _Data(
+        {
+            "flashinfer": {kv: {4: {1: {16: _metric(2, 2)}}}},
+            "fa3": {kv: {4: {1: {16: _metric(9, 3)}}}},
+        }
+    )
+
+    def query(backend: str) -> PerformanceResult:
+        return WideEPGenerationMLA._query_wideep_generation_mla_table(
+            db, 1, 16, 32, kv, fmha, attention_backend=backend, database_mode=common.DatabaseMode.SILICON
+        )
+
+    assert float(query("flashinfer")) == 2
+    assert float(query("fa3")) == 9

--- a/tests/unit/sdk/database/test_mla_surrogate.py
+++ b/tests/unit/sdk/database/test_mla_surrogate.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import aiconfigurator.sdk.operations.mla as mla_module
 from aiconfigurator.sdk import common
-from aiconfigurator.sdk.operations.mla import ContextMLA, GenerationMLA, WideEPGenerationMLA
+from aiconfigurator.sdk.operations.mla import ContextMLA, GenerationMLA, MLABmm, WideEPGenerationMLA
 from aiconfigurator.sdk.performance_result import PerformanceResult
 
 
@@ -87,6 +87,37 @@ def test_generation_off_grid_interpolates_power_consistent_energy(monkeypatch) -
     assert float(result) == 5
     assert result.energy == 25  # interpolated 5 W * predicted 5 ms
     assert set(table[4]) == {1, 3} and set(table[4][1]) == {10, 20}
+
+
+def test_mla_bmm_uses_sparse_curve_for_exact_interior_and_exterior(monkeypatch) -> None:
+    def fail_legacy_interpolation(*_args, **_kwargs):
+        raise AssertionError("legacy interpolation used")
+
+    monkeypatch.setattr(MLABmm, "load_data", classmethod(lambda _cls, _db: None))
+    monkeypatch.setattr("aiconfigurator.sdk.interpolation.nearest_1d_point_helper", fail_legacy_interpolation)
+    monkeypatch.setattr("aiconfigurator.sdk.interpolation.interp_1d", fail_legacy_interpolation)
+    db = _Database()
+    quant = common.GEMMQuantMode.bfloat16
+    table = {10: _metric(2, 3), 20: _metric(4, 5)}
+    db._mla_bmm_data = _Data({quant: {"mla_gen_pre": {4: table}}})
+
+    def query(tokens: int) -> PerformanceResult:
+        return MLABmm._query_mla_bmm_table(db, tokens, 4, quant, if_pre=True, database_mode=common.DatabaseMode.SILICON)
+
+    exact = query(10)
+    assert float(exact) == 2
+    assert exact.energy == 6
+
+    interior = query(15)
+    assert float(interior) == 3
+    assert interior.energy == 12  # interpolated 4 W * predicted 3 ms
+
+    for tokens, boundary_tokens, boundary_latency, boundary_power in ((5, 10, 2, 3), (30, 20, 4, 5)):
+        boundary_sol = float(MLABmm._query_mla_bmm_table(db, boundary_tokens, 4, quant, True, common.DatabaseMode.SOL))
+        query_sol = float(MLABmm._query_mla_bmm_table(db, tokens, 4, quant, True, common.DatabaseMode.SOL))
+        exterior = query(tokens)
+        assert float(exterior) == boundary_latency * query_sol / boundary_sol
+        assert exterior.energy == boundary_power * float(exterior)
 
 
 def test_wideep_backend_categories_do_not_share_exact_values(monkeypatch) -> None:

--- a/tests/unit/sdk/database/test_mla_surrogate.py
+++ b/tests/unit/sdk/database/test_mla_surrogate.py
@@ -3,9 +3,17 @@
 
 from __future__ import annotations
 
+import pytest
+
 import aiconfigurator.sdk.operations.mla as mla_module
 from aiconfigurator.sdk import common
-from aiconfigurator.sdk.operations.mla import ContextMLA, GenerationMLA, MLABmm, WideEPGenerationMLA
+from aiconfigurator.sdk.operations.mla import (
+    ContextMLA,
+    GenerationMLA,
+    MLABmm,
+    WideEPContextMLA,
+    WideEPGenerationMLA,
+)
 from aiconfigurator.sdk.performance_result import PerformanceResult
 
 
@@ -127,8 +135,8 @@ def test_wideep_backend_categories_do_not_share_exact_values(monkeypatch) -> Non
     fmha = common.FMHAQuantMode.bfloat16
     db._wideep_generation_mla_data = _Data(
         {
-            "flashinfer": {kv: {4: {1: {16: _metric(2, 2)}}}},
-            "fa3": {kv: {4: {1: {16: _metric(9, 3)}}}},
+            "flashinfer": {kv: {fmha: {4: {1: {16: _metric(2, 2)}}}}},
+            "fa3": {kv: {fmha: {4: {1: {16: _metric(9, 3)}}}}},
         }
     )
 
@@ -139,3 +147,100 @@ def test_wideep_backend_categories_do_not_share_exact_values(monkeypatch) -> Non
 
     assert float(query("flashinfer")) == 2
     assert float(query("fa3")) == 9
+
+
+def test_mla_module_multisource_loaders_keep_active_rows(tmp_path) -> None:
+    headers = (
+        "framework,version,device,op_name,kernel_source,model,architecture,"
+        "mla_dtype,kv_cache_dtype,gemm_type,num_heads,batch_size,isl,tp_size,step,latency\n"
+    )
+    context_active = tmp_path / "context_active.txt"
+    context_sibling = tmp_path / "context_sibling.txt"
+    context_row = "TRTLLM,1,NVIDIA,mla_context_module,default,m,A,bfloat16,bfloat16,bfloat16,4,1,16,1,0,{latency}\n"
+    context_active.write_text(headers + context_row.format(latency=2.0))
+    context_sibling.write_text(headers + context_row.format(latency=9.0))
+
+    generation_active = tmp_path / "generation_active.txt"
+    generation_sibling = tmp_path / "generation_sibling.txt"
+    generation_row = (
+        "TRTLLM,1,NVIDIA,mla_generation_module,default,m,A,bfloat16,bfloat16,bfloat16,4,1,8,1,8,{latency}\n"
+    )
+    generation_active.write_text(headers + generation_row.format(latency=3.0))
+    generation_sibling.write_text(headers + generation_row.format(latency=10.0))
+
+    def sources(active, sibling):
+        return [(str(active), None), (str(sibling), {"default"})]
+
+    context = mla_module.load_context_mla_module_data(sources(context_active, context_sibling))
+    generation = mla_module.load_generation_mla_module_data(sources(generation_active, generation_sibling))
+    fmha = common.FMHAQuantMode.bfloat16
+    kv = common.KVCacheQuantMode.bfloat16
+    gemm = common.GEMMQuantMode.bfloat16
+
+    assert context[fmha][kv][gemm][4][16][1]["latency"] == 2
+    assert generation[fmha][kv][gemm][4][1][16]["latency"] == 3
+
+
+def test_wideep_generation_loader_and_query_isolate_fmha_dtype(tmp_path, monkeypatch) -> None:
+    perf_file = tmp_path / "wideep_generation_mla_perf.txt"
+    headers = (
+        "framework,version,device,op_name,kernel_source,model,architecture,"
+        "mla_dtype,kv_cache_dtype,gemm_type,num_heads,batch_size,isl,tp_size,step,latency\n"
+    )
+    rows = (
+        "SGLANG,1,NVIDIA,wideep_generation_mla,flashinfer,m,A,"
+        "bfloat16,fp8,bfloat16,4,1,8,32,8,2.0\n"
+        "SGLANG,1,NVIDIA,wideep_generation_mla,flashinfer,m,A,"
+        "fp8_block,fp8,bfloat16,4,1,8,32,8,9.0\n"
+    )
+    perf_file.write_text(headers + rows)
+    data = mla_module.load_wideep_generation_mla_data(str(perf_file))
+    kv = common.KVCacheQuantMode.fp8
+    assert set(data["flashinfer"]) == {kv}
+    assert set(data["flashinfer"][kv]) == {
+        common.FMHAQuantMode.bfloat16,
+        common.FMHAQuantMode.fp8_block,
+    }
+
+    monkeypatch.setattr(WideEPGenerationMLA, "load_data", classmethod(lambda _cls, _db: None))
+    db = _Database("sglang")
+    db._wideep_generation_mla_data = _Data(data)
+
+    def query(fmha: common.FMHAQuantMode) -> PerformanceResult:
+        return WideEPGenerationMLA._query_wideep_generation_mla_table(
+            db, 1, 16, 32, kv, fmha, attention_backend="flashinfer", database_mode=common.DatabaseMode.SILICON
+        )
+
+    assert float(query(common.FMHAQuantMode.bfloat16)) == 2
+    assert float(query(common.FMHAQuantMode.fp8_block)) == 9
+    caller_keys = {key[0] for key in db._sparse_surrogate_cache}
+    assert ("wideep-generation-mla", "flashinfer", common.FMHAQuantMode.bfloat16, kv) in caller_keys
+    assert ("wideep-generation-mla", "flashinfer", common.FMHAQuantMode.fp8_block, kv) in caller_keys
+
+
+def test_wideep_flashinfer_explicitly_maps_to_trtllm_mla(monkeypatch) -> None:
+    monkeypatch.setattr(WideEPContextMLA, "load_data", classmethod(lambda _cls, _db: None))
+    monkeypatch.setattr(WideEPGenerationMLA, "load_data", classmethod(lambda _cls, _db: None))
+    db = _Database("sglang")
+    fmha = common.FMHAQuantMode.fp8_block
+    kv = common.KVCacheQuantMode.fp8
+    db._wideep_context_mla_data = _Data({"trtllm_mla": {fmha: {kv: {4: {16: {1: _metric(6, 2)}}}}}})
+    db._wideep_generation_mla_data = _Data({"trtllm_mla": {kv: {fmha: {4: {1: {16: _metric(7, 3)}}}}}})
+
+    context = WideEPContextMLA._query_wideep_context_mla_table(
+        db, 1, 16, 0, 32, kv, fmha, attention_backend="flashinfer", database_mode=common.DatabaseMode.SILICON
+    )
+    generation = WideEPGenerationMLA._query_wideep_generation_mla_table(
+        db, 1, 16, 32, kv, fmha, attention_backend=None, database_mode=common.DatabaseMode.SILICON
+    )
+    explicit = WideEPGenerationMLA._query_wideep_generation_mla_table(
+        db, 1, 16, 32, kv, fmha, attention_backend="trtllm_mla", database_mode=common.DatabaseMode.SILICON
+    )
+
+    assert float(context) == 6
+    assert float(generation) == 7
+    assert float(explicit) == 7
+    with pytest.raises(KeyError, match="fa3"):
+        WideEPGenerationMLA._query_wideep_generation_mla_table(
+            db, 1, 16, 32, kv, fmha, attention_backend="fa3", database_mode=common.DatabaseMode.SILICON
+        )

--- a/tests/unit/sdk/database/test_moe_surrogate.py
+++ b/tests/unit/sdk/database/test_moe_surrogate.py
@@ -3,8 +3,20 @@
 
 from __future__ import annotations
 
+import pytest
+
 from aiconfigurator.sdk import common
-from aiconfigurator.sdk.operations.moe import MoE, MoEDispatch, TrtLLMWideEPMoE
+from aiconfigurator.sdk.operations.moe import (
+    MoE,
+    MoEDispatch,
+    TrtLLMWideEPMoE,
+    load_moe_data,
+    load_trtllm_alltoall_data,
+    load_wideep_context_moe_data,
+    load_wideep_generation_moe_data,
+    load_wideep_moe_compute_data,
+)
+from aiconfigurator.sdk.perf_database import PerfDataNotAvailableError
 from aiconfigurator.sdk.performance_result import PerformanceResult
 
 
@@ -72,6 +84,98 @@ def test_moe_token_curve_and_low_token_launch(monkeypatch) -> None:
     assert lower.energy == 16
 
 
+def test_regular_moe_gated_and_nongated_rows_do_not_leak(monkeypatch) -> None:
+    row = {
+        "moe_dtype": "bfloat16",
+        "num_tokens": "4",
+        "hidden_size": "16",
+        "inter_size": "32",
+        "topk": "2",
+        "num_experts": "8",
+        "moe_tp_size": "1",
+        "moe_ep_size": "1",
+        "distribution": "uniform",
+    }
+    monkeypatch.setattr(
+        "aiconfigurator.sdk.operations.moe._read_filtered_rows",
+        lambda _source: [
+            {**row, "kernel_source": "moe_torch_flow", "latency": "10"},
+            {**row, "kernel_source": "moe_torch_flow_nongated", "latency": "20"},
+        ],
+    )
+    data, _ = load_moe_data("unused")
+    monkeypatch.setattr(MoE, "load_data", classmethod(lambda _cls, _database: None))
+    db = _Database(common.BackendName.vllm.value)
+    db._moe_data = _Data(data)
+    quant = common.MoEQuantMode.bfloat16
+    assert set(data[quant]) == {"uniform"}
+
+    def query(is_gated: bool) -> PerformanceResult:
+        return MoE._query_moe_table(
+            db,
+            4,
+            16,
+            32,
+            2,
+            8,
+            1,
+            1,
+            quant,
+            "uniform",
+            database_mode=common.DatabaseMode.SILICON,
+            is_gated=is_gated,
+        )
+
+    assert float(query(True)) == 10
+    assert float(query(False)) == 20
+
+
+def test_source_priority_is_first_wins_for_wideep_loaders(monkeypatch) -> None:
+    common_row = {
+        "moe_dtype": "bfloat16",
+        "num_tokens": "4",
+        "hidden_size": "16",
+        "inter_size": "32",
+        "topk": "2",
+        "num_experts": "8",
+        "moe_tp_size": "1",
+        "moe_ep_size": "1",
+        "distribution": "uniform",
+    }
+    rows = [{**common_row, "latency": "10"}, {**common_row, "latency": "99"}]
+    monkeypatch.setattr("aiconfigurator.sdk.operations.moe._read_filtered_rows", lambda _source: rows)
+    quant = common.MoEQuantMode.bfloat16
+    for loader in (load_wideep_context_moe_data, load_wideep_generation_moe_data):
+        data = loader("unused")
+        assert data[quant]["uniform"][2][8][16][32][1][1][4]["latency"] == 10
+
+    compute_rows = [
+        {**common_row, "kernel_source": "kernel", "num_slots": "8", "latency": "11"},
+        {**common_row, "kernel_source": "kernel", "num_slots": "8", "latency": "98"},
+    ]
+    monkeypatch.setattr("aiconfigurator.sdk.operations.moe._read_filtered_rows", lambda _source: compute_rows)
+    compute = load_wideep_moe_compute_data("unused")
+    assert compute["kernel"][quant]["uniform"][2][8][16][32][8][1][1][4]["latency"] == 11
+
+    alltoall_row = {
+        "op_name": "alltoall_dispatch",
+        "kernel_source": "NVLinkTwoSided",
+        "moe_dtype": "bfloat16",
+        "num_nodes": "1",
+        "num_tokens": "4",
+        "hidden_size": "16",
+        "topk": "2",
+        "num_experts": "8",
+        "moe_ep_size": "4",
+    }
+    monkeypatch.setattr(
+        "aiconfigurator.sdk.operations.moe._read_filtered_rows",
+        lambda _source: [{**alltoall_row, "latency": "12"}, {**alltoall_row, "latency": "97"}],
+    )
+    alltoall = load_trtllm_alltoall_data("unused")
+    assert alltoall["NVLinkTwoSided"]["alltoall_dispatch"][quant][1][16][2][8][4][4]["latency"] == 12
+
+
 def test_deepep_independent_sms_token_mesh(monkeypatch) -> None:
     monkeypatch.setattr(MoEDispatch, "load_data", classmethod(lambda _cls, _database: None))
     db = _Database(common.BackendName.sglang.value)
@@ -132,3 +236,30 @@ def test_wideep_moe_upper_boundary_carries_sol_ratio(monkeypatch) -> None:
     expected = 10 * sol_at_16 / sol_at_8
     assert float(result) == expected
     assert result.energy == 3 * expected
+
+
+def test_wideep_compute_rejects_non_gated_query(monkeypatch) -> None:
+    monkeypatch.setattr(TrtLLMWideEPMoE, "load_data", classmethod(lambda _cls, _database: None))
+    db = _Database(common.BackendName.trtllm.value)
+    quant = common.MoEQuantMode.bfloat16
+    legacy_curve = {4: _metric(7, 1)}
+    db._wideep_moe_compute_data = _Data(
+        {"kernel": {quant: {"uniform": {2: {8: {16: {32: {8: {1: {1: legacy_curve}}}}}}}}}}
+    )
+
+    with pytest.raises(PerfDataNotAvailableError, match="does not distinguish gated and non-gated"):
+        TrtLLMWideEPMoE._query_compute_table(
+            db,
+            4,
+            16,
+            32,
+            2,
+            8,
+            8,
+            1,
+            1,
+            quant,
+            "uniform",
+            database_mode=common.DatabaseMode.SILICON,
+            is_gated=False,
+        )

--- a/tests/unit/sdk/database/test_moe_surrogate.py
+++ b/tests/unit/sdk/database/test_moe_surrogate.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from aiconfigurator.sdk import common
+from aiconfigurator.sdk.operations.moe import MoE, MoEDispatch, TrtLLMWideEPMoE
+from aiconfigurator.sdk.performance_result import PerformanceResult
+
+
+class _Data(dict):
+    def raise_if_not_loaded(self) -> None:
+        return None
+
+
+class _Database:
+    def __init__(self, backend: str) -> None:
+        self.backend = backend
+        self.system = "test"
+        self.version = "test"
+        self._default_database_mode = common.DatabaseMode.SILICON
+        self.system_spec = {
+            "gpu": {
+                "bfloat16_tc_flops": 1e30,
+                "mem_bw": 1e30,
+                "sm_version": 100,
+            },
+            "node": {"num_gpus_per_node": 8},
+        }
+
+    @staticmethod
+    def _interp_pr(latency, energy=0.0):
+        return PerformanceResult(latency, energy=energy, source="silicon")
+
+    @staticmethod
+    def _query_silicon_or_hybrid(*, get_silicon, **_kwargs):
+        return get_silicon()
+
+
+def _metric(latency: float, power: float) -> dict[str, float]:
+    return {"latency": latency, "power": power, "energy": latency * power}
+
+
+def test_moe_token_curve_and_low_token_launch(monkeypatch) -> None:
+    monkeypatch.setattr(MoE, "load_data", classmethod(lambda _cls, _database: None))
+    db = _Database(common.BackendName.vllm.value)
+    quant = common.MoEQuantMode.bfloat16
+    curve = {4: _metric(10, 2), 8: _metric(14, 4)}
+    db._moe_data = _Data({quant: {"uniform": {2: {8: {16: {32: {1: {1: curve}}}}}}}})
+
+    def query(tokens: int) -> PerformanceResult:
+        return MoE._query_moe_table(
+            db,
+            tokens,
+            16,
+            32,
+            2,
+            8,
+            1,
+            1,
+            quant,
+            "uniform",
+            database_mode=common.DatabaseMode.SILICON,
+        )
+
+    interior = query(6)
+    assert float(interior) == 12
+    assert interior.energy == 36  # interpolated 3 W * 12 ms
+
+    lower = query(2)
+    assert float(lower) == 8  # launch=6, re-anchored to 10 at token=4
+    assert lower.energy == 16
+
+
+def test_deepep_independent_sms_token_mesh(monkeypatch) -> None:
+    monkeypatch.setattr(MoEDispatch, "load_data", classmethod(lambda _cls, _database: None))
+    db = _Database(common.BackendName.sglang.value)
+    table = {
+        10: {4: _metric(2, 2), 8: _metric(4, 4)},
+        30: {4: _metric(6, 6), 8: _metric(8, 8)},
+    }
+    db._wideep_deepep_normal_data = _Data({2: {16: {2: {8: table}}}})
+
+    result = MoEDispatch._query_wideep_deepep_normal_table(
+        db,
+        node_num=2,
+        num_tokens=6,
+        num_experts=8,
+        topk=2,
+        hidden_size=16,
+        sms=20,
+        database_mode=common.DatabaseMode.SILICON,
+    )
+
+    assert float(result) == 0.005
+    assert result.energy == 0.025  # interpolated 5 W * 5 us, converted to ms
+
+
+def test_wideep_moe_upper_boundary_carries_sol_ratio(monkeypatch) -> None:
+    monkeypatch.setattr(TrtLLMWideEPMoE, "load_data", classmethod(lambda _cls, _database: None))
+    monkeypatch.setattr(
+        TrtLLMWideEPMoE,
+        "_select_kernel",
+        classmethod(lambda _cls, _database, _quant: "kernel"),
+    )
+    db = _Database(common.BackendName.trtllm.value)
+    db.system_spec["gpu"]["bfloat16_tc_flops"] = 1e9
+    db.system_spec["gpu"]["mem_bw"] = 1e9
+    quant = common.MoEQuantMode.bfloat16
+    curve = {4: _metric(8, 2), 8: _metric(10, 3)}
+    db._wideep_moe_compute_data = _Data({"kernel": {quant: {"uniform": {2: {8: {16: {32: {8: {1: {1: curve}}}}}}}}}})
+
+    def query(tokens: int, mode: common.DatabaseMode) -> PerformanceResult:
+        return TrtLLMWideEPMoE._query_compute_table(
+            db,
+            tokens,
+            16,
+            32,
+            2,
+            8,
+            8,
+            1,
+            1,
+            quant,
+            "uniform",
+            database_mode=mode,
+        )
+
+    sol_at_8 = float(query(8, common.DatabaseMode.SOL))
+    sol_at_16 = float(query(16, common.DatabaseMode.SOL))
+    result = query(16, common.DatabaseMode.SILICON)
+    expected = 10 * sol_at_16 / sol_at_8
+    assert float(result) == expected
+    assert result.energy == 3 * expected

--- a/tests/unit/sdk/database/test_trtllm_wideep_moe.py
+++ b/tests/unit/sdk/database/test_trtllm_wideep_moe.py
@@ -151,12 +151,33 @@ class TestTrtLLMWideEPMoE:
             moe_ep_size=2,
             quant_mode=common.MoEQuantMode.bfloat16,
             workload_distribution="power_law_1.01_eplb",
+            is_gated=True,
         )
 
         # Verify result
         assert isinstance(result, PerformanceResult)
         assert float(result) == 10.5  # PerformanceResult IS the latency value
         assert result.energy == 2.5  # mock energy value
+
+    def test_query_propagates_non_gated_category(self, mock_database):
+        moe = TrtLLMWideEPMoE(
+            name="test_moe",
+            scale_factor=1.0,
+            hidden_size=2048,
+            inter_size=8192,
+            topk=2,
+            num_experts=8,
+            moe_tp_size=1,
+            moe_ep_size=1,
+            quant_mode=common.MoEQuantMode.bfloat16,
+            workload_distribution="uniform",
+            attention_dp_size=1,
+            is_gated=False,
+        )
+
+        moe.query(mock_database, x=16)
+
+        assert mock_database.query_wideep_moe_compute.call_args.kwargs["is_gated"] is False
 
     def test_query_with_attention_dp_scaling(self, mock_database):
         """Test query with attention_dp_size scaling."""

--- a/tests/unit/sdk/test_cp_dsa_modeling.py
+++ b/tests/unit/sdk/test_cp_dsa_modeling.py
@@ -9,6 +9,7 @@ future drift -- the nsys validation in docs/CONTEXT_PARALLEL_DSA_MODELING.md is
 not a CI regression gate.
 """
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -19,12 +20,12 @@ pytestmark = pytest.mark.unit
 
 
 def test_lookup_2d_exact_and_step_interp():
-    # table keyed by (isl, step) -> latency; linear interp/extrap on the step axis.
+    db = SimpleNamespace()
     t = {(4096, 0): 100.0, (4096, 1024): 200.0, (8192, 0): 400.0}
-    assert ContextDSAModule._lookup_2d(t, 4096, 0) == 100.0  # exact grid point
-    assert ContextDSAModule._lookup_2d(t, 4096, 512) == pytest.approx(150.0)  # step interp
-    assert ContextDSAModule._lookup_2d(t, 4096, 4096) == 200.0  # step clamp to max
-    assert ContextDSAModule._lookup_2d({}, 4096, 0) is None  # empty table
+    assert ContextDSAModule._lookup_2d(db, "mqa", t, 4096, 0) == 100.0
+    assert ContextDSAModule._lookup_2d(db, "mqa", t, 4096, 512) == pytest.approx(150.0)
+    assert ContextDSAModule._lookup_2d(db, "mqa", t, 4096, 4096) == 200.0
+    assert ContextDSAModule._lookup_2d(db, "mqa", {}, 4096, 0) is None
 
 
 def test_lookup_2d_fails_loud_on_out_of_grid_isl():
@@ -32,7 +33,7 @@ def test_lookup_2d_fails_loud_on_out_of_grid_isl():
     # quadratic in isl, so clamping 16384->8192 would halve... quarter it.
     t = {(4096, 0): 100.0, (8192, 0): 400.0}
     with pytest.raises(ValueError, match="exceeds the collected"):
-        ContextDSAModule._lookup_2d(t, 16384, 0)
+        ContextDSAModule._lookup_2d(SimpleNamespace(), "mqa", t, 16384, 0)
 
 
 def test_query_cp_composition(monkeypatch):
@@ -50,6 +51,7 @@ def test_query_cp_composition(monkeypatch):
     monkeypatch.setattr(ContextDSAModule, "_load_glm5_sparse", classmethod(lambda cls, db: tables))
 
     db = MagicMock()
+    db._sparse_surrogate_cache = {}
     db.query_context_dsa_module.return_value = 4300.0  # per-card monolithic base
     db.query_nccl.return_value = 50.0  # each AG
 
@@ -88,6 +90,7 @@ def test_query_cp_raises_when_isl_beyond_grid(monkeypatch):
     }
     monkeypatch.setattr(ContextDSAModule, "_load_glm5_sparse", classmethod(lambda cls, db: tables))
     db = MagicMock()
+    db._sparse_surrogate_cache = {}
     db.query_context_dsa_module.return_value = 4300.0
     db.query_nccl.return_value = 50.0
 

--- a/tests/unit/sdk/test_perf_surrogate.py
+++ b/tests/unit/sdk/test_perf_surrogate.py
@@ -65,6 +65,16 @@ def test_fixed_line_mesh_interpolates_real_curves() -> None:
     assert result == pytest.approx((5, 10))
 
 
+def test_singleton_curve_does_not_block_neighboring_curve_mesh() -> None:
+    table = {
+        0: {10: _m(10), 20: _m(20)},
+        1: {10: _m(100)},
+        2: {10: _m(30), 20: _m(40)},
+    }
+    result = _estimate(table, {"batch": 1.5, "tokens": 15}, (Axis("batch"), Axis("tokens")), "tokens")
+    assert result == pytest.approx((30, 60))
+
+
 def _triangle_table():
     return {
         0: {0: {10: _m(2), 20: _m(3)}, 2: {10: _m(6), 40: _m(9)}},
@@ -80,6 +90,23 @@ def test_ragged_triangle_fills_interior_without_cartesian_product() -> None:
         "tokens",
     )
     assert result == pytest.approx((4, 8))
+
+
+def test_zero_weight_ragged_curve_is_not_evaluated() -> None:
+    table = {
+        0: {
+            0: {10: _m(10), 20: _m(20)},
+            2: {30: _m(100), 40: _m(110)},
+        },
+        2: {0: {10: _m(30), 20: _m(40)}},
+    }
+    result = _estimate(
+        table,
+        {"x": 1, "y": 0, "tokens": 15},
+        (Axis("x"), Axis("y"), Axis("tokens")),
+        "tokens",
+    )
+    assert result == pytest.approx((25, 50))
 
 
 def test_triangle_bounding_box_requires_authorized_extrapolation() -> None:

--- a/tests/unit/sdk/test_perf_surrogate.py
+++ b/tests/unit/sdk/test_perf_surrogate.py
@@ -1,0 +1,189 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+
+from aiconfigurator.sdk.interpolation import InterpolationDataNotAvailableError
+from aiconfigurator.sdk.perf_surrogate import Axis, estimate_sparse
+
+
+def _m(latency: float, power: float = 2.0) -> dict[str, float]:
+    return {"latency": latency, "power": power, "energy": latency * power}
+
+
+def _estimate(table, query, axes, varying, **kwargs):
+    database = kwargs.pop("database", SimpleNamespace())
+    key = kwargs.pop("key", "test")
+    return estimate_sparse(database, key, table, query, axes=axes, varying=varying, **kwargs)
+
+
+def test_exact_and_power_only_leaves_preserve_energy() -> None:
+    axes = (Axis("batch"), Axis("tokens"))
+    assert _estimate({1: {8: _m(3, 4)}}, {"batch": 1, "tokens": 8}, axes, "tokens") == (3, 12)
+    assert _estimate({1: {"latency": 2.5, "power": 6}}, {"tokens": 1}, (Axis("tokens"),), "tokens") == (2.5, 15)
+
+
+@pytest.mark.parametrize(
+    ("table", "axis", "response", "expected"),
+    [
+        ({1: _m(2, 4), 3: _m(6, 8)}, Axis("x"), "raw", (4, 24)),
+        ({1: _m(1), 3: _m(9)}, Axis("x"), "sqrt", (4, 8)),
+        ({1: _m(2), 4: _m(8)}, Axis("x", log=True), "raw", (5, 10)),
+    ],
+)
+def test_curve_coordinate_and_response(table, axis, response, expected) -> None:
+    assert _estimate(table, {"x": 2}, (axis,), "x", curve=response) == pytest.approx(expected)
+
+
+def test_curve_exterior_uses_baseline_ratio_and_direction() -> None:
+    table = {10: _m(4), 20: _m(7)}
+    axis = (Axis("tokens", extrapolate="upper"),)
+    baseline = lambda point: point["tokens"]
+    assert _estimate(table, {"tokens": 40}, axis, "tokens", baseline=baseline) == pytest.approx((14, 28))
+    with pytest.raises(InterpolationDataNotAvailableError, match="cannot extrapolate"):
+        _estimate(table, {"tokens": 5}, axis, "tokens", baseline=baseline)
+    assert _estimate(table, {"tokens": 40}, axis, "tokens", exterior="raw") == (7, 14)
+
+
+def test_baseline_ratio_supports_zero_latency() -> None:
+    latency, energy = _estimate(
+        {1: _m(0, 0), 3: _m(4)},
+        {"tokens": 2},
+        (Axis("tokens"),),
+        "tokens",
+        curve="baseline_ratio",
+        baseline=lambda point: point["tokens"],
+    )
+    assert (latency, energy) == pytest.approx((4 / 3, 4 / 3))
+
+
+def test_fixed_line_mesh_interpolates_real_curves() -> None:
+    table = {1: {10: _m(2), 20: _m(4)}, 3: {10: _m(6), 20: _m(8)}}
+    result = _estimate(table, {"batch": 2, "tokens": 15}, (Axis("batch"), Axis("tokens")), "tokens")
+    assert result == pytest.approx((5, 10))
+
+
+def _triangle_table():
+    return {
+        0: {0: {10: _m(2), 20: _m(3)}, 2: {10: _m(6), 40: _m(9)}},
+        2: {0: {10: _m(4), 30: _m(6)}},
+    }
+
+
+def test_ragged_triangle_fills_interior_without_cartesian_product() -> None:
+    result = _estimate(
+        _triangle_table(),
+        {"x": 0.5, "y": 0.5, "tokens": 15},
+        (Axis("x"), Axis("y"), Axis("tokens")),
+        "tokens",
+    )
+    assert result == pytest.approx((4, 8))
+
+
+def test_triangle_bounding_box_requires_authorized_extrapolation() -> None:
+    query = {"x": 1.5, "y": 1.5, "tokens": 15}
+    forbidden = (Axis("x"), Axis("y"), Axis("tokens"))
+    with pytest.raises(InterpolationDataNotAvailableError, match="outside authorized"):
+        _estimate(_triangle_table(), query, forbidden, "tokens")
+
+    allowed = (Axis("x", extrapolate="upper"), Axis("y", extrapolate="upper"), Axis("tokens"))
+    latency, _ = _estimate(_triangle_table(), query, allowed, "tokens", exterior="raw")
+    assert latency == pytest.approx(5.5)
+    with pytest.raises(InterpolationDataNotAvailableError):
+        _estimate(
+            _triangle_table(),
+            {"x": -1, "y": -1, "tokens": 15},
+            allowed,
+            "tokens",
+            exterior="raw",
+        )
+
+
+def test_hull_projection_can_keep_never_axis_fixed() -> None:
+    axes = (Axis("x"), Axis("y", extrapolate="upper"), Axis("tokens"))
+    latency, _ = _estimate(_triangle_table(), {"x": 1, "y": 2, "tokens": 15}, axes, "tokens", exterior="raw")
+    assert latency == pytest.approx(5.5)
+
+
+def test_mesh_baseline_ratio_uses_component_baselines() -> None:
+    table = {1: {10: _m(4), 20: _m(8)}, 3: {10: _m(8), 20: _m(16)}}
+    latency, _ = _estimate(
+        table,
+        {"batch": 2, "tokens": 15},
+        (Axis("batch"), Axis("tokens")),
+        "tokens",
+        mesh="baseline_ratio",
+        baseline=lambda point: point["batch"] * point["tokens"],
+    )
+    assert latency == pytest.approx(((4 / 10 + 8 / 30) / 2) * 30)
+
+
+def test_constant_fixed_axis_only_moves_when_authorized() -> None:
+    table = {2: {10: _m(2), 20: _m(4)}}
+    query = {"batch": 3, "tokens": 15}
+    with pytest.raises(InterpolationDataNotAvailableError):
+        _estimate(table, query, (Axis("batch"), Axis("tokens")), "tokens", exterior="raw")
+    result = _estimate(table, query, (Axis("batch", extrapolate="upper"), Axis("tokens")), "tokens", exterior="raw")
+    assert result == pytest.approx((3, 6))
+
+
+def test_constant_fixed_axis_can_move_while_active_axis_interpolates() -> None:
+    table = {0: {1: {10: _m(10)}, 4: {10: _m(40)}}}
+    result = _estimate(
+        table,
+        {"prefix": 8, "batch": 2, "tokens": 10},
+        (Axis("prefix", extrapolate="both"), Axis("batch"), Axis("tokens")),
+        "tokens",
+        exterior="raw",
+    )
+    assert result == pytest.approx((20, 40))
+
+
+def test_table_identity_invalidates_cached_geometry() -> None:
+    database = SimpleNamespace()
+    axes = (Axis("tokens"),)
+    first = _estimate({1: _m(1), 3: _m(3)}, {"tokens": 2}, axes, "tokens", database=database)
+    second = _estimate({1: _m(10), 3: _m(30)}, {"tokens": 2}, axes, "tokens", database=database)
+    assert first == (2, 4)
+    assert second == (20, 40)
+    assert len(database._sparse_surrogate_cache) == 1
+
+
+def test_rank_deficient_mesh_still_allows_exact_curve() -> None:
+    table = {0: {0: {1: _m(1)}}, 1: {1: {1: _m(2)}}, 2: {2: {1: _m(3)}}}
+    axes = (Axis("x"), Axis("y"), Axis("tokens"))
+    assert _estimate(table, {"x": 1, "y": 1, "tokens": 1}, axes, "tokens") == (2, 4)
+    with pytest.raises(InterpolationDataNotAvailableError):
+        _estimate(table, {"x": 1, "y": 1.5, "tokens": 1}, axes, "tokens")
+
+
+@pytest.mark.parametrize(
+    ("table", "query", "axes", "varying", "message"),
+    [
+        ({1: _m(1)}, {"wrong": 1}, (Axis("tokens"),), "tokens", "query axes"),
+        ({1: _m(1)}, {"tokens": 1}, (Axis("tokens"),), "batch", "varying axis"),
+        (
+            {1: {1: {1: {1: _m(1)}}}},
+            {"a": 1, "b": 1, "c": 1, "t": 1},
+            (Axis("a"), Axis("b"), Axis("c"), Axis("t")),
+            "t",
+            "at most two fixed axes",
+        ),
+    ],
+)
+def test_configuration_errors_fail_loudly(table, query, axes, varying, message) -> None:
+    with pytest.raises(ValueError, match=message):
+        _estimate(table, query, axes, varying)
+
+
+def test_invalid_log_baseline_and_table_fail_loudly() -> None:
+    with pytest.raises(ValueError, match="positive"):
+        _estimate({1: _m(1)}, {"x": 0}, (Axis("x", log=True),), "x")
+    with pytest.raises(ValueError, match="requires a baseline"):
+        _estimate({1: _m(1), 2: _m(2)}, {"x": 3}, (Axis("x", extrapolate="upper"),), "x")
+    with pytest.raises(InterpolationDataNotAvailableError, match="no samples"):
+        _estimate({}, {"x": 1}, (Axis("x"),), "x")
+    with pytest.raises(ValueError, match="no latency"):
+        _estimate({1: {"power": 2}}, {"x": 1}, (Axis("x"),), "x")


### PR DESCRIPTION
## Summary

- add one shared sparse performance-surrogate query path for ragged measurements
- preserve exact samples, use semantic 1-D curves first, then interpolate over local lines/triangles without materializing a Cartesian product
- use operation-provided baselines for authorized exterior estimates while keeping modeled latency and average power consistent
- route the main SILICON numeric lookup of all 24 concrete Python operations that own measured performance tables through the shared abstraction
- document the current design, limitations, merge gates, and a prefix-sliced path for future four-dimensional attention without adding 4-D code in this PR

## Scope

- Python SDK and design documentation only; no Rust, generator, collector, or dependency changes
- keep analytical/formula-only paths and existing operation-specific corrections intact
- remove load-time Cartesian expansion from migrated sparse tables
- cache compiled sparse geometry per logical key/table identity and clear it with the existing runtime caches
- retain DeepSeek-V4 TP and generation FMHA dimensions; accept both native-head and collector local-head row conventions without unrelated-head fallback
- keep DSA prefix blending and DSV4 top-k calibration as explicit adapter layers until a measured 4-D design is validated

## Interpolation behavior

1. return an exact measured latency/energy pair when present
2. prefer the operation's semantic varying-axis curve
3. interpolate fixed axes from nearby measured points using a line or triangle
4. permit exterior estimates only on explicitly enabled axes, anchored to an operation-specific baseline

Categorical routing stays in each operation adapter, so interpolation does not cross backend, kernel, dtype, quantization, phase, or parallelism boundaries.

See the [sparse performance surrogate design](https://github.com/tianhaox/aiconfigurator/blob/codex/perf-surrogate-v2/docs/design/interpolation_perfsurrogate_design.md) for the exact mathematics, current limitations, four-dimensional extension plan, and required holdout methodology.

## Validation

- focused surrogate and migrated-operation suite: **291 passed**
- complete local unit selection: **1,524 passed, 39 skipped, 735 deselected**; only the four documented non-TTY `test_plain_output.py` cases fail
- complete real-database sanity suite: **27 passed, 1 xfailed**
- `ruff check .`, `ruff format --check .`, commit hooks, and `git diff --check` pass
- real B200 DeepSeek-V4 Parquet smoke checks pass for context/generation, Flash/Pro, native 64/128 heads, and TP=8
- latest pushed head is DCO-signed; hosted CI is rerunning

The accuracy workflow is currently non-blocking and its threshold test still reports known Qwen regressions. The design document records holdout validation and a genuinely passing accuracy gate as requirements before this Draft is ready for merge.

