### PR TITLE
feat: upgrade collector to sglang 0.5.14 and fix current issues.

### DIFF
--- a/.agents/skills/aic-auto-collect/SKILL.md
+++ b/.agents/skills/aic-auto-collect/SKILL.md
@@ -1,483 +1,280 @@
 ---
 name: aic-auto-collect
-description: Use when running long AIC/aiconfigurator GPU perf auto-collection for a specific GPU/framework/framework_version, including draft-PR checkpoints, resumable collect_xx.py runs, framework-version/kernel preflight, collector fixes/skips, special runtime images, validation, and PR handoff.
+description: Upgrade or run one AIC/aiconfigurator GPU performance collector for one exact framework version and GPU platform. Use for fixed-version SGLang, TensorRT-LLM, or vLLM collector bring-up; framework backend/kernel audits; SM90/SM100/SM103/SM120/SM89 validation; deterministic smoke tests; resumable full Collector V2 runs; failure triage; artifact validation; and code/data handoff.
 ---
 
 # AIC Auto Collect
 
 ## Goal
 
-You are already on a GPU node with one or more GPUs. Your job is to collect AIC perf data for one target `(GPU system, framework/backend, framework version)`, fix collector failures, recollect until the perf files are good enough, verify AIC can consume the new data, and maintain a draft PR to `ai-dynamo/aiconfigurator` as the checkpoint.
+Upgrade or run one AIC GPU performance collector for one exact framework
+version and GPU platform. Keep implementation, validation, artifact delivery,
+and Git authority explicit. Do not mix unrelated framework upgrades or commit
+transient run artifacts.
 
-This is a long-running workflow. Be persistent. Iterate carefully. Do not hide failures by shrinking coverage or deleting hard cases unless the configuration is genuinely unsupported and documented.
+## Lock the scope
 
-## Operating Mode
+Write down the contract before acting:
 
-Assume the user wants the complete bring-up unless they explicitly ask for a smoke test only.
+- repository, base branch or dependent PR, and working branch;
+- exactly one backend and one framework version;
+- stock or special/WideEP runtime;
+- target GPU product, AIC system name, and SM;
+- container image tag/digest and framework source revision;
+- operations and model families in scope;
+- collector-code-only versus performance-data delivery;
+- Git permissions: local changes, commit, push, and PR creation are separate
+  authorities.
 
-- Run collectors inside the target backend runtime containers. Do not claim data was collected for a backend/version unless the collector code ran in that container on the target GPU.
-- Full collection means every supported registry op for the requested backend/version has either finished with real rows or is explicitly unsupported by that runtime/GPU with evidence.
-- Smoke and `--limit` runs are only gates before the full run; never present them as final data.
-- Keep working through multi-hour or multi-day runs. Use stable resume checkpoints, inspect errors, patch, and retry.
-- The unit of work is one draft PR per `(system, backend, backend_version)`. Use that PR as the checkpoint, not a private local branch.
-- Make small sign-off commits as progress checkpoints after each `collect_xx.py`/op-family collection finishes. If a single collection runs longer than about one hour, checkpoint safe collector fixes, current perf outputs, and the failure/status summary before continuing.
-- If multiple frameworks are requested, finish and checkpoint one framework/version PR first, then create a new draft PR for the next framework/version.
-- Do not synthesize missing rows. Unsupported runtime/kernel paths should be filtered or documented, not filled with fake numbers.
-- If the PR body says customer support is ready, verify the default AIC workflow can actually choose a valid configuration for at least the expected representative model/backend/system path.
+Treat `collector/framework_manifest.yaml` as the stock version/image source of
+truth. Module `__compat__` metadata may narrow it but must not silently widen
+it. Keep stock and WideEP/special runtimes separate.
 
-## Required Inputs
+Treat requests for multiple frameworks as an ordered queue. Finish one
+framework/version change before starting another. Do not update an untouched
+framework merely because a common collector file or SDK consumer is nearby.
 
-Establish these before collecting:
+Prefer an exact version contract when requested. Do not add speculative
+compatibility branches for older or future releases.
 
-- Target AIC repo and branch.
-- Target backend and version: `sglang`, `vllm`, or `trtllm`. Treat "all three" as an ordered queue of separate draft PRs.
-- Target runtime container image for each backend, such as:
-  - `nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:<tag>`
-  - `nvcr.io/nvidia/ai-dynamo/sglang-runtime:<tag>`
-  - `nvcr.io/nvidia/ai-dynamo/vllm-runtime:<tag>`
-- Target system name, such as `rtx_pro_6000_server`.
-- Target ops: start narrow, then expand to all relevant registry ops.
-- Whether to collect power columns.
-- Whether the GPU type is already supported by AIC.
+## Protect the host and other workloads
 
-Discover the node:
+Run framework inspection and collection inside the pinned container. Treat the
+host driver, CUDA toolkit, kernel, container runtime, and system packages as
+immutable.
+
+Before every GPU run, inspect:
 
 ```bash
+docker ps
 nvidia-smi
-nvidia-smi --query-gpu=name,memory.total,power.limit --format=csv
-python3 - <<'PY'
-import torch
-print("cuda available:", torch.cuda.is_available())
-print("device count:", torch.cuda.device_count())
-for i in range(torch.cuda.device_count()):
-    print(i, torch.cuda.get_device_name(i), torch.cuda.get_device_capability(i))
-PY
+nvidia-smi --query-compute-apps=pid,process_name,used_gpu_memory --format=csv
+df -h
+df -h /dev/shm
 ```
 
-## Phase 1: Prepare Repo
+Use task-unique container names and persistent output/checkpoint/log roots.
+Clean only task-owned workers and containers. Never kill or restart another
+container, restart Docker, or run a global prune. If another workload blocks
+the run, report it.
 
-1. Clone or update `ai-dynamo/aiconfigurator`.
-2. Create a branch named like `data/<system>-<backend>-<version>` or `codex/<system>-<backend>-<version>`.
-3. Immediately create a draft PR for this `(system, backend, version)` once the branch exists and the scope is known. Use it as the remote checkpoint even before all data is ready.
-4. Install only lightweight local dev dependencies needed for tests. Do not install the target backend locally unless the collector is not running in a backend container.
-5. Set:
+Treat an OOM as unclassified until the same case fails on a clean GPU. Check
+for stale workers, retained weights, descriptor/JIT caches, and oversized dummy
+allocations before adding a capacity rule.
+
+## Prove the runtime
+
+Inside the container, record:
+
+- the installed framework version, not only the image tag;
+- source SHA when available;
+- CUDA/runtime versions;
+- GPU name, memory, and compute capability;
+- exact command and task-local artifact roots.
+
+If the image cannot run on the host, try an official image variant for the same
+framework release. Do not silently modify the host or downgrade the framework.
+
+## Audit framework backend truth
+
+Do not trust existing collector labels, comments, or historical workarounds.
+For each affected per-model path:
+
+1. inspect the exact framework source in the container;
+2. call the framework selector or instrument a minimal runtime probe;
+3. record model/architecture, phase, dtype/quantization, Q/K/V dimensions,
+   window/sink semantics, SM, and selected backend/kernel;
+4. compare the selection with the collector invocation, persisted
+   `kernel_source`, SDK resolver, and Python/Rust database keys;
+5. fix only proven mismatches and add focused tests.
+
+Keep `framework default`, `collector simulation`, and `persisted key` distinct.
+A benchmark that successfully invokes the wrong model class or backend is
+invalid.
+
+Use this platform priority unless the user changes it:
+
+1. SM90 execution and SM100 datacenter Blackwell;
+2. SM120 RTX Blackwell;
+3. SM89 Ada.
+
+Preserve SM103 as a distinct selector where the framework does. Mark source
+inspection as `source-derived / hardware-unvalidated`; change that label only
+after a run on the actual platform.
+
+## Generate and audit the plan
+
+Use the model-centric Collector V2 plan:
 
 ```bash
-export PYTHONPATH="$PWD"
-export COLLECTOR_LOG_DIR="$PWD/collector_logs"
-export COLLECTOR_CHECKPOINT_DIR="$PWD/collector_checkpoints"
-mkdir -p "$COLLECTOR_LOG_DIR"
-mkdir -p "$COLLECTOR_CHECKPOINT_DIR"
+python3 collector/collect.py \
+  --backend <backend> \
+  --model-cases-full \
+  --sm <sm> \
+  --plan-only
 ```
 
-Local validation often works with the repo's pinned environment:
+Full collection means this complete retained plan after intentional pruning.
+It is not the raw registry run with no model-case flags.
+
+Before GPU work, record per-op raw, retained, and unique physical counts;
+artifact/model coverage; dtype counts; and SM exception counts. Verify every
+required model produces executable cases. Preserve checkpoint-native
+quantization identities when they change the invoked kernel.
+
+## Validate progressively
+
+For each operation:
+
+1. run focused unit/contract tests;
+2. run source and selector probes;
+3. run deterministic multi-case smoke coverage;
+4. run representative boundary smoke coverage;
+5. launch the complete retained op plan with a stable checkpoint;
+6. validate the checkpoint, summary, output, exit status, and GPU state;
+7. continue automatically to the next op unless a real anomaly appears.
+
+Cover phases, sequence and batch boundaries, dtypes/quants, TP/EP boundaries,
+model families, and SM-specific paths. Do not treat a default four-case random
+smoke as sufficient.
+
+Put MoE last unless the user specifies another order. It is expensive and most
+sensitive to artifact policy, routing semantics, TP/EP enumeration, and
+retained framework caches.
+
+Inspect a slow op at roughly 10%-20% progress increments based on observed
+speed. Do not poll every minute and do not pause for approval between healthy
+operations.
+
+Use stable resume namespaces:
 
 ```bash
-uv run --frozen ruff check <files>
-uv run --frozen ruff format --check <files>
-uv run --frozen pytest <tests> -q
+python3 collector/collect.py \
+  --backend <backend> \
+  --model-cases-full \
+  --sm <sm> \
+  --checkpoint-dir <checkpoint-root> \
+  --resume
 ```
 
-If the local `uv` environment lacks framework packages such as `torch`, run framework-dependent collector smoke tests in the runtime container instead of trying to mutate the host environment.
+Resume only when the framework pin, code revision, plan, backend/op, and output
+target still match. Before migrating a checkpoint after an intentional plan
+change, back it up, hash it, and prove which completed task IDs and persisted
+keys remain valid.
 
-Container pattern:
+## Triage failures with evidence
 
-```bash
-docker run --rm -it --gpus all --ipc=host --network host \
-  --ulimit memlock=-1 --ulimit stack=67108864 \
-  -v "$PWD:/workspace" -w /workspace \
-  <runtime-image> bash
+For every failure group, record:
 
-export PYTHONPATH=/workspace
-export COLLECTOR_LOG_DIR=/workspace/collector_logs/<backend>/<version>/<op>
-mkdir -p "$COLLECTOR_LOG_DIR"
-python collector/collect.py --backend <backend> --ops <op> --smoke
-python collector/collect.py --backend <backend> --ops <op> \
-  --checkpoint-dir "$COLLECTOR_CHECKPOINT_DIR/<backend>/<version>/<op>" --resume
-```
+- op, model/artifact, dtype, SM, TP/EP, and shape;
+- exact exception and selected framework path;
+- GPU/container state;
+- classification and evidence;
+- action and rerun result.
 
-Inside the container, record the real framework version:
+Classify it as collector integration, unsupported configuration,
+framework/kernel defect, resource/capacity boundary, or transient environment.
 
-```bash
-python - <<'PY'
-import importlib.metadata as m
-for pkg in ("tensorrt_llm", "sglang", "vllm"):
-    try:
-        print(pkg, m.version(pkg))
-    except Exception:
-        pass
-PY
-```
+Use these thresholds as heuristics:
 
-Update the draft PR body whenever scope changes or a meaningful checkpoint lands. Include current status, what is still partial, and links or paths to failure summaries.
+- isolated failures or a few dozen among a large plan can be acceptable when
+  explained and unclustered;
+- investigate around 10% unexpected failure, or earlier when failures cluster
+  by op, backend, dtype, model, shape family, or SM;
+- treat roughly one-third or more failures, or an entire family failing, as a
+  systemic collector problem.
 
-## Phase 2: Add Or Validate System Metadata
+Do not hide failures with broad skips, retries, generic OOM labels, reduced
+coverage, synthetic rows, or weakened benchmarks. Keep predicates narrow and
+source-backed. Record a failed result before resetting a worker after a fatal
+CUDA error.
 
-If the system is new or incomplete:
+## Accept artifacts fail-closed
 
-1. Add `src/aiconfigurator/systems/<system>.yaml`.
-2. Add `<system>` to `SupportedSystems` in `src/aiconfigurator/sdk/common.py`.
-3. Create `src/aiconfigurator/systems/data/<system>/`.
-4. Populate YAML with conservative, documented values:
-   - `gpu.mem_bw`
-   - `gpu.mem_capacity`
-   - tensor core FLOPS fields relevant to the architecture
-   - `gpu.power`
-   - `gpu.sm_version`
-   - `node.num_gpus_per_node`
-   - inter-node, intra-node, PCIe bandwidth
-   - `misc.nccl_version`
-   - `misc.other_mem`
+For every completed op, verify:
 
-Prefer verified values from `nvidia-smi`, node docs, or nearby existing YAML files. If a value is an estimate, leave a comment.
+- requested/done/failed/expected-failed checkpoint counts;
+- output row count, schema, and unique persisted keys;
+- task-key versus output-key coverage;
+- framework version, architecture, dtype, quant, and kernel provenance;
+- finite latency, positive unless the operation contract explicitly permits a
+  modeled zero, and valid power when collected;
+- no malformed rows, unintended duplicates, or partial writes;
+- container exit and final GPU state.
 
-Run:
+Preserve separate stage summaries. Disclose accepted capacity failures exactly;
+do not call a staged run globally green when one stage exited nonzero.
 
-```bash
-pytest tests/unit/sdk/test_common.py -q
-```
+## Verify consumers and untouched frameworks
 
-## Phase 3: Framework Version And Kernel Preflight
+When a collector adds or changes a database dimension, verify all producers and
+consumers that share it. Test the target backend and representative packaged
+data for untouched backends so a single-framework upgrade does not regress
+them.
 
-Before collecting a new framework version or a new GPU SM target, check whether collector code matches the runtime. This avoids spending hours on known-bad grids.
-
-1. Record the exact runtime package version from inside the container. Do not trust only the image tag.
-2. Inspect `collector/<backend>/registry.py` for version routes and the concrete `collect_xx.py` files registered for this version.
-3. Read the top of each relevant `collect_xx.py` file: docstring, `__compat__`, version notes, SM gates, and known unsupported filters.
-4. Compare against the framework source for the exact version/tag when there is any sign of API or kernel churn:
-   - SGLang: attention backends, DeepGEMM, FlashInfer, DeepSeek/DSV module code, MoE runner paths.
-   - vLLM: attention/MLA modules, quantized GEMM paths, GDN/Mamba modules, custom all-reduce.
-   - TRT-LLM: attention plugins, MLA/DSA modules, MoE, compute-scale, GDN/Mamba modules.
-5. For a new SM such as SM120, check kernel architecture support before full collection: tiny smoke cases, import probes, and direct framework source guards.
-6. Patch collector routing or test-case generation before full collection when the runtime cannot support a case. Use version routing and explicit SM filters rather than discovering the same failure across thousands of tasks.
-7. If a special framework image exists for a model family or kernel family, try that image before declaring the op unsupported. Record its exact package version and image digest.
-
-Commit and push preflight collector fixes before starting long full runs.
-
-## Phase 4: Choose Collection Plan
-
-Read the backend registry:
+Run relevant checks, including:
 
 ```bash
-python3 - <<'PY'
-from collector.sglang.registry import REGISTRY as SGLANG
-from collector.vllm.registry import REGISTRY as VLLM
-from collector.trtllm.registry import REGISTRY as TRTLLM
-for name, reg in [("sglang", SGLANG), ("vllm", VLLM), ("trtllm", TRTLLM)]:
-    print(name, [e.op for e in reg])
-PY
-```
-
-Recommended order:
-
-1. `gemm`
-2. `moe`
-3. attention / MLA ops
-4. module-level ops such as DSA, GDN, MHC, WideEP
-5. communication ops separately, because they may require multi-GPU or full-node ownership
-
-For new GPUs, prioritize ops used by the target models and backend first, but do not claim full support until all expected ops for that backend/version are collected or explicitly marked unsupported.
-
-For an all-backend bring-up, run this as separate draft PRs:
-
-1. Finish one GPU/framework/framework_version PR.
-2. Push final data and collector fixes for that framework.
-3. Create the next draft PR for the next framework/version.
-
-For each backend/version, enumerate registry ops and create a tracking table with: op, collector file, perf filename, smoke status, full status, row count, duplicate-key status, AIC sanity status, and unsupported notes. Keep this table in a local scratch file and summarize it in the PR body.
-
-## Phase 5: Progressive Collection Loop
-
-For each op:
-
-```bash
-python3 collector/collect.py --backend <backend> --ops <op> --smoke
-python3 collector/collect.py --backend <backend> --ops <op> --shuffle --limit 20
-python3 collector/collect.py --backend <backend> --ops <op> --shuffle --limit 100
-python3 collector/collect.py --backend <backend> --ops <op> \
-  --checkpoint-dir "$COLLECTOR_CHECKPOINT_DIR/<backend>/<version>/<op>" --resume
-```
-
-Use a separate log directory per op when iterating:
-
-```bash
-export COLLECTOR_LOG_DIR="$PWD/collector_logs/<backend>/<version>/<op>"
-export COLLECTOR_CHECKPOINT_DIR="$PWD/collector_checkpoints"
-mkdir -p "$COLLECTOR_LOG_DIR"
-mkdir -p "$COLLECTOR_CHECKPOINT_DIR/<backend>/<version>/<op>"
-```
-
-If the process times out or crashes after partial progress, rerun with the same `--checkpoint-dir` and `--resume`. Keep checkpoints until the op is accepted. If the process has been running for about an hour, checkpoint safe progress:
-
-- Commit collector fixes and tests.
-- Copy currently produced perf files only if they are clearly labeled or known to be append-safe for replacement by a later full run.
-- Push the draft PR branch.
-- Update the PR body or a tracked status note with current op, completed cases, row counts, and active failures.
-
-Full-collection acceptance for an op:
-
-- The final collector run has zero unclassified errors, or every remaining skipped case is intentionally filtered before execution.
-- The output perf file was copied from the full output directory, not from an earlier smoke/limited run.
-- Row counts are plausible compared with nearby systems or the generated case count.
-- Duplicate shape keys are removed only when they are true repeated measurements for the same key; keep the latest or best-defined row consistently and document the policy.
-- The op is not required by AIC's default query path, or if it is required, representative AIC CLI/chart generation can consume it.
-
-For very long runs, commit and push safe progress periodically:
-
-```bash
-git status --short
-git add collector tests src/aiconfigurator/systems
-git commit --signoff -m "<backend>: <op family> progress"
-git push
-```
-
-Use sign-off commits. If DCO fails because a commit lacks `Signed-off-by`, amend only the latest commit if appropriate:
-
-```bash
-git commit --amend --no-edit --signoff
-git push --force-with-lease
-```
-
-## Phase 6: Fix Collector Errors
-
-When a run fails, inspect:
-
-- `collection_summary_<backend>.json`
-- `errors_*.json`
-- worker logs in `COLLECTOR_LOG_DIR`
-- traceback module and task parameters
-
-Maintain a failure ledger for the active PR. For each failure group record: op, collector file, runtime image/version, SM, task params, exact error, classification, action taken, and whether an upstream issue was filed.
-
-Classify each error group:
-
-- **collector_bug**: import/API/mock object/signature/test generation issue.
-- **unsupported_config**: generated case is invalid for this SM/backend/kernel.
-- **framework_bug**: backend kernel crashes or rejects a valid production-like case.
-- **resource_issue**: OOM, shared memory, graph capture, worker restart, timeout.
-- **transient**: rare cache/race/infra issue that passes on retry.
-
-Fix policy:
-
-- For API/import/signature errors:
-  1. Read `collector/<backend>/registry.py` to map the failing op to its collector module.
-  2. Read the failing `collector/<backend>/collect_*.py`.
-  3. Search the framework source checkout for the missing class, function, import path, or attribute.
-  4. Verify the real API in source. Do not trust Python's "Did you mean" suggestions blindly.
-  5. Patch the collector with a minimal compatibility-preserving change.
-- For API changes, use version routing and `__compat__` where needed.
-- For GPU capability gaps, filter test cases before execution using `get_sm_version()`.
-- For Blackwell/SM100+ features, gate FP4/NVFP4/FP8 paths carefully.
-- For dimension constraints, filter on per-rank dimensions such as `inter_size // tp`.
-- For CUDA-fatal errors, prefer worker restart and skip only the exact invalid region.
-- Preserve data quality. Do not reduce benchmark repetitions or broad test dimensions just to pass.
-- Keep older backend versions working.
-- Keep shared test-case generators deterministic when unit tests depend on them. Put runtime availability probes in backend collector wrappers when the skip is caused by a partially installed framework package.
-- Guard `importlib.util.find_spec("a.b.c")` with `try/except ModuleNotFoundError`; partial packages can make `find_spec` raise instead of return `None`.
-- If a collector route only exists for future framework versions, use `VersionRoute` in `collector/<backend>/registry.py` and add a wrapper module with an explicit `__compat__`.
-- If a collector helper silently returns `None` after a dry-run or subprocess failure, make it raise or record the skip explicitly so failed coverage is visible.
-- If a valid production-like case fails in the framework kernel, file or prepare an upstream bug for SGLang, vLLM, or TRT-LLM with exact image/version, SM, minimal repro, and traceback. Link it in the PR or failure ledger.
-- If the case is not production-like or the runtime explicitly does not support that SM/path, skip it in `collect_xx.py` before execution with a clear comment and a narrow predicate.
-
-After a fix:
-
-```bash
+ruff check .
+ruff format --check .
 pytest tests/unit/collector -q
-python3 collector/collect.py --backend <backend> --ops <op> --smoke
-python3 collector/collect.py --backend <backend> --ops <op> --shuffle --limit 100
-python3 collector/collect.py --backend <backend> --ops <op> \
-  --checkpoint-dir "$COLLECTOR_CHECKPOINT_DIR/<backend>/<version>/<op>" --resume
-```
-
-Commit small fixes:
-
-```bash
-git add collector tests
-git commit --signoff -m "fix <backend> <op> collector for <system>"
-```
-
-### Backend-Specific Failure Patterns
-
-Use these as starting hypotheses, then verify against the actual runtime source and logs.
-
-TRT-LLM:
-
-- Compute-scale latency may legitimately be zero when `max(0, dynamic_quantize - static_quantize)` clamps a dynamic path that measured faster than the static baseline. Verify with remeasurement; do not invent positive latency.
-- Some GDN collectors require newer TRT-LLM than the runtime image provides. Route by framework version instead of registering an unusable op.
-- DSA or sparse MLA modules may be unsupported for a new SM/runtime combination. Filter unsupported cases before execution and document the runtime limitation.
-- For Blackwell/SM120 attention and FP8/FP4 paths, check per-rank dimensions, kv dtype, and kernel architecture support before collecting.
-
-SGLang:
-
-- DeepGEMM, FlashInfer, DSV4, MHC, and MLA paths can be present in source but unavailable for the active SM or installed package set.
-- MLA prefill/generation may have hard-coded head/group constraints on new architectures. Restrict to verified safe shapes rather than allowing fatal CUDA crashes.
-- If `sglang` is partially installed in a unit-test image, `sglang.srt...` probes can raise. Runtime skip checks belong in `collector/sglang/collect_*.py` wrappers, not necessarily in `collector/common_test_cases.py`.
-- For DSV4/MHC, distinguish "case grid exists" from "runtime module exists"; unit tests may assert the former while the collector should enforce the latter.
-
-vLLM:
-
-- Newer ops such as GDN may not exist in older vLLM runtime images. Add version routing, for example route GDN only for `vllm>=0.17.0` if `0.16.0` lacks the collector API.
-- FP8 block GEMM and quantized GEMM paths can have high memory use or graph/eager timing differences. Prefer the runtime-supported timing mode and reduce memory pressure without reducing intended coverage.
-- FP8 KV-cache attention or MLA module combinations may not be supported by the installed runtime. Filter unsupported kv dtype/module combinations early.
-- Cap generation module cases that exceed runtime limits such as very large `batch * sequence` regions, and document the cap.
-- When copying final vLLM data, scan for duplicate keys. Some repeated collection paths can produce duplicate shape rows.
-
-## Phase 7: Perf File Quality Gates
-
-Accept a perf file only when:
-
-- It exists under `src/aiconfigurator/systems/data/<system>/<backend>/<version>/`.
-- It is not empty and has the expected CSV header.
-- Rows contain the expected framework, version, and device name.
-- Latency values are finite and plausible. They should usually be positive; allow zero only for documented modeled-overhead files such as compute-scale where the collector intentionally clamps negative overhead to zero.
-- Power values, when collected, are positive and below/near the configured power limit.
-- There are no unexplained duplicate rows for identical keys.
-- Coverage is comparable to the nearest existing system/backend/version.
-- Missing cases are explained by documented unsupported config filters.
-- Re-running sample does not produce large unexplained variance.
-
-Useful checks:
-
-```bash
-find src/aiconfigurator/systems/data/<system>/<backend>/<version> -maxdepth 1 -type f -name '*_perf.txt' -print
-python3 - <<'PY'
-from pathlib import Path
-import csv, math
-root = Path("src/aiconfigurator/systems/data/<system>/<backend>/<version>")
-for path in sorted(root.glob("*_perf.txt")):
-    with path.open() as f:
-        rows = list(csv.DictReader(f))
-    bad = [r for r in rows if "latency" in r and (not r["latency"] or not math.isfinite(float(r["latency"])) or float(r["latency"]) <= 0)]
-    print(path.name, "rows", len(rows), "bad_latency", len(bad))
-PY
-```
-
-Compare row counts and latency ranges with nearby systems, such as H100/H200 for Hopper or B200/B300 for Blackwell.
-
-Run a duplicate-key scan using the loader's expected key columns when possible. If no helper exists, group rows by all non-metric columns and report duplicates per file. Do not blindly dedupe rows before understanding whether repeated dimensions differ by dtype, backend, tensor parallelism, or model field.
-
-## Phase 8: Verify AIC Consumption
-
-Run loader and SDK tests:
-
-```bash
-pytest tests/unit/sdk/test_common.py -q
 pytest tests/unit/sdk/database -q
-pytest tests/unit/collector -q
 ```
 
-Instantiate the database:
+Run native/Rust tests and a rebuilt-wheel/container integration test when
+shared SDK or Rust contracts change. Record environmental exclusions.
+Run fork/parallel collector tests in a fresh process when importing the target
+framework before fork can deadlock the combined suite.
 
-```bash
-python3 - <<'PY'
-from aiconfigurator.sdk.perf_database import get_database
-db = get_database("<system>", "<backend>", "<version>")
-print(db is not None)
-print(db.system_spec["gpu"])
-PY
-```
+## Keep code and data delivery explicit
 
-Run representative CLI queries for models expected to use this backend/system:
+Treat collector code and performance data as separate deliverables unless the
+user explicitly combines them.
 
-```bash
-aiconfigurator cli default --model <model> --total-gpus <n> --system <system> --backend <backend>
-aiconfigurator cli generate --model-path <model> --total-gpus <n> --system <system> --backend <backend>
-```
+For a code change, track manifest pins, collector adaptation, case policies,
+tests, and durable documentation. Do not commit checkpoints, logs, temporary
+probes, or raw generated artifacts.
 
-If AIC raises `PerfDataNotAvailableError`, either collect the missing op or document that the model/backend mode is not supported. Do not claim support for a model path that still hits missing data.
+For data delivery, map measurements to the actual GPU system, finalize parquet,
+regenerate kernel-source metadata, review parquet diffs, run Python/Rust lookup
+smoke, and test a representative AIC workflow. Never label measurements from
+one GPU product as a nearby product merely because both share an SM.
 
-Run sanity chart generation before declaring the PR ready:
+## B200/SM100 validation
 
-```bash
-rm -rf sanity_<system> && mkdir -p sanity_<system>
-uv run --frozen python tools/sanity_check/create_charts.py \
-  --base-ref origin/main \
-  --head-ref HEAD \
-  --output-dir sanity_<system> \
-  --output-md-file sanity_<system>/comment.md
-```
+When applying a source-derived plan to B200:
 
-Read the generated report, not just the exit code. Fix hard failures where possible:
+1. keep the same framework/version scope;
+2. record fresh B200 and container provenance;
+3. use the registered B200 system and assert compute capability 10.0 instead of
+   trusting only `--sm 100`;
+4. regenerate and compare expanded SM100 case IDs/counts/exceptions; do not
+   treat `--plan-only` as the complete expanded-case artifact;
+5. runtime-probe per-model backend choices;
+6. smoke SM100-specific attention, encoder, FP8/FP4 GEMM, MoE, DSA/DSV, and
+   alignment/reduced-head boundaries;
+7. revalidate source-derived SM100 exceptions, especially reduced-head DSA at
+   long KV lengths, before claiming complete B200 support;
+8. update comments/tests from source-derived to hardware-validated only for
+   paths that passed;
+9. run the complete retained SM100 plan with MoE last;
+10. publish data only under the matching B200 system definition.
 
-- Missing data for default workflow shapes usually means collection coverage is incomplete.
-- Empty chart grids can be acceptable only when the runtime has no valid silicon data for that op/shape family; convert those to explicit skips with a clear reason.
-- If both aggregated and disaggregated configs have no valid parallel configuration, the backend/version is registered but not usable. Collect the missing required shapes or do not claim default workflow support.
-- CLI smoke in the report must pass for each backend/version claimed ready.
+Do not reuse Hopper performance values, capacity skips, or alignment rules
+without B200 evidence.
 
-## Phase 9: Support Matrix And Documentation
+## Hand off truthfully
 
-If the new GPU should become user-visible:
+Report separately:
 
-1. Update system support metadata.
-2. Update support matrix outputs if required by the repo workflow.
-3. Add or update tests for new SM filters or version routes.
-4. Document known gaps in the PR body.
+- code and tests completed;
+- hardware-validated platforms;
+- source-derived platform paths;
+- collected but unpublished artifacts;
+- accepted failures with exact cases;
+- future frameworks, platforms, and special runtimes;
+- validation commands and results.
 
-## Phase 10: PR Preparation
-
-Keep commits reviewable:
-
-1. `add <system> system spec`
-2. `fix <backend> collectors for <system>`
-3. `add <system> <backend> <version> perf data`
-4. `test <system> data loading`
-
-Before marking the draft PR ready:
-
-```bash
-git status --short
-git diff --stat main...HEAD
-pytest tests/unit/collector -q
-pytest tests/unit/sdk/test_common.py -q
-```
-
-PR body checklist:
-
-- A concrete "Release at a Glance"; avoid generic claims like "metrics below show improvements" unless the tables explain those improvements.
-- Customer impact: what is now selectable/usable in AIC, and for which default model/backend/system path.
-- GPU node identity and `nvidia-smi` summary.
-- CUDA driver/container/backend image for each backend.
-- Backend version detected at runtime, not assumed from the image tag.
-- System YAML changes.
-- Ops collected and perf files added.
-- Row counts by backend/version and perf file count.
-- Collector errors fixed.
-- Unsupported/skipped configs with reasons and whether they are runtime-version limits, SM limits, or collector gaps.
-- Validation commands and results.
-- Remaining risks.
-
-If GitHub CLI PR editing fails because of deprecated project-card GraphQL fields, update the PR body through the REST API:
-
-```bash
-gh api repos/<owner>/<repo>/pulls/<number> -X PATCH -f body="$(cat pr_body.md)"
-```
-
-Check CI after every push:
-
-```bash
-gh pr checks <number>
-gh run view <run-id> --log-failed
-```
-
-Ruff CI runs both `ruff check` and `ruff format --check`; local targeted `ruff check` alone is not enough.
-
-If the draft PR does not exist yet, open it before more long-running work:
-
-```bash
-gh repo fork ai-dynamo/aiconfigurator --clone=false
-git push -u <your-fork-remote> HEAD
-gh pr create --repo ai-dynamo/aiconfigurator --head <your-user>:<branch> --title "<title>" --body-file <body-file>
-```
-
-## Stop And Escalate
-
-Escalate instead of looping forever when:
-
-- The framework kernel crashes consistently on valid production-like configs.
-- The backend container cannot run on the node.
-- The GPU platform or driver is unstable.
-- The system spec values are unknown and materially affect AIC decisions.
-- Data quality is suspect and cannot be explained.
-- AIC requires broad SDK/model changes beyond collector/data bring-up.
-
-In the final report, separate collected data, collector fixes, known gaps, and validation evidence.
+Commit, push, or create/update a PR only when authorized. Keep dependent PRs
+and base branches explicit, use signed-off commits, and do not mix unrelated
+framework or baseline-test fixes into the collector upgrade.

--- a/collector/README.md
+++ b/collector/README.md
@@ -213,9 +213,8 @@ wideep/*/registry.py — WideEP-only ops appended when the v2 plan requests them
 network/             — collective communication collectors and Slurm network jobs
 ```
 
-WideEP entries in `framework_manifest.yaml` must keep the same framework version
-as their non-WideEP framework entry. If a WideEP collector needs a special image,
-put only the image override in the WideEP entry and keep the version aligned.
+WideEP entries in `framework_manifest.yaml` describe independent runtimes.
+`collect.py` requires the exact public version and rejects mixed-pin runs.
 
 ## File Naming Convention
 
@@ -466,17 +465,23 @@ Running without `--resume` always starts fresh (overwrites old checkpoint).
 
 ## For SGLang
 
-Suggest to start from lmsysorg docker image. Say, for 0.5.6.post2, we can use lmsysorg/sglang:v0.5.6.post2-cu126
+Use the pinned stock image, `lmsysorg/sglang:v0.5.14` (or its `-cu130`
+variant), for normal SGLang collection.
+
 ```bash
 python3 collect.py --backend sglang
 ```
-This collects all SGLang ops in a single pass, including:
+
+This collects the stock SGLang ops, including:
+
 - GEMM operations (FP8, BF16, INT8, INT4)
 - MLA (Multi-head Latent Attention) for context and generation
 - MLA BMM (Batch Matrix Multiplication) operations
 - MoE (Mixture of Experts) operations
 - Normal attention operations
-- WideEP / DeepSeek-specific collectors (MLA, MLP, DeepEP MoE)
+
+WideEP ops remain pinned to their separate SGLang 0.5.10 image and are not part
+of the stock model plans. Request them explicitly in a separate run.
 
 ### DeepEP multi-node collector
 For **DeepSeek V3** models with DeepEP MoE, inter-node communication data requires a separate multi-node setup:

--- a/collector/case_generator.py
+++ b/collector/case_generator.py
@@ -146,6 +146,8 @@ def _profile_int_values(
 def _head_profiles(
     shape_sweep: dict[str, object],
     op_name: str,
+    *,
+    include_model_profiles: bool = True,
 ) -> list[dict[str, object]]:
     raw_profiles = shape_sweep.get("head_profiles")
     if raw_profiles is None:
@@ -155,7 +157,7 @@ def _head_profiles(
             raise TypeError(f"{op_name}.head_profiles must be a list of mappings")
         base_profiles = raw_profiles
 
-    model_profiles = _model_case_values(op_name)
+    model_profiles = _model_case_values(op_name) if include_model_profiles else []
     if _get_model_path_filter() and model_profiles:
         return model_profiles
     return [*base_profiles, *model_profiles]
@@ -165,6 +167,7 @@ def get_attention_head_configs(
     shape_sweep: dict[str, object],
     *,
     phase: str,
+    include_model_profiles: bool = True,
 ) -> list[AttentionHeadConfig]:
     """Expand only valid ``(q, kv, head_dim, window)`` structural tuples.
 
@@ -189,7 +192,11 @@ def get_attention_head_configs(
             seen.add(config)
             configs.append(config)
 
-    for profile in _head_profiles(shape_sweep, "attention"):
+    for profile in _head_profiles(
+        shape_sweep,
+        "attention",
+        include_model_profiles=include_model_profiles,
+    ):
         head_dims = _profile_int_values(
             profile,
             "head_dims",

--- a/collector/cases/base_ops/moe.yaml
+++ b/collector/cases/base_ops/moe.yaml
@@ -77,18 +77,25 @@ common_case_values:
   moe_sglang:
     quantization_modes:
     - name: bfloat16
-    - name: int4_wo
-      allowed_model_paths:
-      - moonshotai/Kimi-K2.5
-      module_config:
-        group_size: 32
     - name: fp8_block
       min_sm: 90
     - name: nvfp4
-      min_sm: 100
-    - name: w4a16_mxfp4
-      min_sm: 100
+      min_sm: 90
       allowed_model_paths:
+      - nvidia/DeepSeek-V3.1-NVFP4
+      - nvidia/GLM-5-NVFP4
+      - nvidia/GLM-5.2-NVFP4
+      - nvidia/Kimi-K2.5-NVFP4
+      - nvidia/MiniMax-M2.5-NVFP4
+      - nvidia/MiniMax-M2.7-NVFP4
+      - nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4
+      - nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
+      - Qwen/Qwen3-235B-A22B
+      - nvidia/Qwen3-235B-A22B-NVFP4
+    - name: w4a16_mxfp4
+      min_sm: 90
+      allowed_model_paths:
+      - deepseek-ai/DeepSeek-V4-Pro
       - openai/gpt-oss-20b
       - openai/gpt-oss-120b
     - name: w4a8_mxfp4_mxfp8

--- a/collector/cases/models/DeepseekV32ForCausalLM_cases.yaml
+++ b/collector/cases/models/DeepseekV32ForCausalLM_cases.yaml
@@ -42,5 +42,3 @@ framework_specific_op_cases:
       cases: all
     dsa_generation_module:
       cases: all
-    wideep_moe:
-      cases: all

--- a/collector/cases/models/DeepseekV3ForCausalLM_cases.yaml
+++ b/collector/cases/models/DeepseekV3ForCausalLM_cases.yaml
@@ -13,7 +13,8 @@ base_ops:
   - gemm
 description: >
   DeepSeek-V3-family model-centric collection plan. Includes shared base op cases
-  plus MoE, MLA, and DeepSeek-V3 WideEP cases.
+  plus stock MoE and MLA cases. WideEP requires a separate runtime and must be
+  requested independently.
 
 model_case_values:
   moe:
@@ -102,10 +103,4 @@ framework_specific_op_cases:
     mla_bmm_gen_pre:
       cases: all
     mla_bmm_gen_post:
-      cases: all
-    wideep_mla_context:
-      cases: all
-    wideep_mla_generation:
-      cases: all
-    wideep_moe:
       cases: all

--- a/collector/cases/models/DeepseekV4ForCausalLM_cases.yaml
+++ b/collector/cases/models/DeepseekV4ForCausalLM_cases.yaml
@@ -27,10 +27,8 @@ model_case_values:
       wideep: true
       framework_quantization:
         sglang:
-          # The pinned SGLang 0.5.10 predates the DeepSeek-V4-specific MXFP4
-          # method (added in 0.5.12). Do not run its GPT-OSS method under a
-          # DSV4 label; enable this only with a separately validated upgrade.
-          allowed_modes: []
+          allowed_modes:
+            - w4a8_mxfp4_mxfp8
         trtllm:
           allowed_modes:
             - w4a8_mxfp4_mxfp8
@@ -62,7 +60,9 @@ model_case_values:
       wideep: true
       framework_quantization:
         sglang:
-          allowed_modes: []
+          allowed_modes:
+            - w4a8_mxfp4_mxfp8
+            - w4a16_mxfp4
         trtllm:
           allowed_modes:
             - w4a8_mxfp4_mxfp8
@@ -271,8 +271,6 @@ framework_specific_op_cases:
     # entries available for explicit research runs, but do not schedule them in
     # the default model plan.
     mhc_module:
-      cases: all
-    wideep_moe:
       cases: all
 
 # vLLM DSV4 collectors remain available through the registry/direct module

--- a/collector/cases/sm_exceptions/sm100_exceptions.yaml
+++ b/collector/cases/sm_exceptions/sm100_exceptions.yaml
@@ -92,20 +92,3 @@ framework_specific_op_exceptions:
                 numerator: num_heads
                 denominator: num_key_value_heads
                 gt: 16
-
-known_exceptions:
-  - framework: sglang
-    op: dsa_generation_module
-    reason_type: framework_version_unsupported
-    source: collector/sglang/collect_mla_module.py
-    case_fields: [seq_len, batch_size, num_heads, kv_cache_dtype, compute_dtype, gemm_type, model_path, attn_type, attention_backend]
-    reason: >
-      On B200/SM100, SGLang DSv3.2 DSA generation with reduced heads (<= 32)
-      and kv_cache_length >= 256 can SIGABRT from an async CUDA illegal memory
-      access in the collector's dummy-weight setup. The collector keeps the
-      top-level case but drops only inner seq_len >= 256 shapes.
-    match:
-      model_path: deepseek-ai/DeepSeek-V3.2
-      attn_type: dsa
-      num_heads_lte: 32
-      inner_seq_len_gte: 256

--- a/collector/cases/sm_exceptions/sm90_exceptions.yaml
+++ b/collector/cases/sm_exceptions/sm90_exceptions.yaml
@@ -9,7 +9,8 @@ gpu_types:
   - h200_sxm
 description: >
   SM90 Hopper exceptions extracted from collector SM gates. Hopper supports
-  FP8/block-FP8 paths but not Blackwell NVFP4 paths.
+  SGLang 0.5.14 ModelOpt NVFP4 MoE through its Marlin fallback; standalone
+  NVFP4 GEMM and the other frameworks' NVFP4 paths remain Blackwell-only.
 
 all_frameworks_op_exceptions:
   gemm:
@@ -22,20 +23,6 @@ all_frameworks_op_exceptions:
 
 framework_specific_op_exceptions:
   sglang:
-    moe:
-      rules:
-        - reason_type: hardware_unsupported
-          reason: SGLang NVFP4 MoE is only emitted for datacenter Blackwell SM100/SM103.
-          fields: [moe_type, num_tokens, hidden_size, inter_size, topk, num_experts, tensor_parallel_size, expert_parallel_size, model_path, token_expert_distribution, power_law_alpha, swiglu_limit]
-          match:
-            moe_type: nvfp4
-        - reason_type: framework_version_unsupported
-          version_prefixes: ["0.5.10"]
-          reason: SGLang 0.5.10 MoE collector does not support GPT-OSS MoE cases.
-          fields: [moe_type, num_tokens, hidden_size, inter_size, topk, num_experts, tensor_parallel_size, expert_parallel_size, model_path, token_expert_distribution, power_law_alpha, swiglu_limit]
-          match:
-            model_path:
-              in: [openai/gpt-oss-20b, openai/gpt-oss-120b]
     dsa_context_module:
       rules:
         - reason_type: hardware_unsupported

--- a/collector/collect.py
+++ b/collector/collect.py
@@ -1132,9 +1132,6 @@ def collect_sglang(
     case_plan=None,
 ):
     """Collect performance data for SGLang with enhanced error tracking"""
-    from collector.sglang.registry import REGISTRY
-    from collector.version_resolver import build_collections
-
     os.environ["FLASHINFER_LOG_LEVEL"] = "ERROR"
 
     # DSV4-Pro mhc-pre fast path: the DeepGEMM tf32 prenorm + TileLang fused
@@ -1154,6 +1151,15 @@ def collect_sglang(
     except Exception:
         logger.exception("SGLang is not installed")
         return
+
+    from collector.framework_manifest import require_collector_runtime
+
+    requested_ops = set(ops if ops is not None else (case_plan.ops if case_plan is not None else []))
+    wideep_ops = {entry.op for entry in _wideep_registry_for_backend("sglang")}
+    require_collector_runtime("sglang", version, requested_ops=requested_ops, wideep_ops=wideep_ops)
+
+    from collector.sglang.registry import REGISTRY
+    from collector.version_resolver import build_collections
 
     registry = _registry_with_requested_wideep(REGISTRY, "sglang", ops, case_plan)
     collections = build_collections(registry, "sglang", version, ops, logger=logger)

--- a/collector/framework_manifest.py
+++ b/collector/framework_manifest.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+from packaging.version import InvalidVersion, Version
 
 MANIFEST_PATH = Path(__file__).with_name("framework_manifest.yaml")
 
@@ -65,6 +66,44 @@ def get_collector_runtime(
     )
 
 
+def require_collector_runtime(
+    framework: str,
+    installed_version: str,
+    *,
+    requested_ops: set[str],
+    wideep_ops: set[str] | None = None,
+    path: str | Path = MANIFEST_PATH,
+) -> CollectorRuntime:
+    """Select the requested workload runtime and enforce its exact public version."""
+    wideep_ops = wideep_ops or set()
+    requested_wideep = requested_ops & wideep_ops
+    requested_stock = not requested_ops or bool(requested_ops - wideep_ops)
+    runtime = get_collector_runtime(framework, path=path)
+
+    if requested_wideep:
+        wideep_runtime = get_collector_runtime(framework, workload="wideep", path=path)
+        if requested_stock and runtime.version != wideep_runtime.version:
+            raise RuntimeError(
+                f"Stock {framework} and WideEP ops require different runtime versions "
+                f"({runtime.version} != {wideep_runtime.version}); run them in separate containers"
+            )
+        runtime = wideep_runtime
+
+    try:
+        installed_public = Version(installed_version).public
+    except InvalidVersion as error:
+        raise RuntimeError(f"Invalid installed {framework} version {installed_version!r}") from error
+
+    expected_public = Version(runtime.version).public
+    if installed_public != expected_public:
+        workload = "WideEP" if runtime.workload == "wideep" else "stock"
+        raise RuntimeError(
+            f"{framework} {workload} collector requires exactly {runtime.version}, found {installed_version}; "
+            f"use {runtime.image()}"
+        )
+    return runtime
+
+
 def validate_manifest(manifest: dict[str, Any]) -> None:
     if manifest.get("schema_version") != 1:
         raise ValueError("collector framework manifest schema_version must be 1")
@@ -82,11 +121,6 @@ def validate_manifest(manifest: dict[str, Any]) -> None:
         if framework not in frameworks:
             raise ValueError(f"wideep.{framework} does not have a matching framework entry")
         _validate_runtime_spec(f"wideep.{framework}", spec)
-        if spec["version"] != frameworks[framework]["version"]:
-            raise ValueError(
-                f"wideep.{framework}.version must match frameworks.{framework}.version "
-                f"({spec['version']} != {frameworks[framework]['version']})"
-            )
         if not spec.get("collector_dir"):
             raise ValueError(f"wideep.{framework}.collector_dir is required")
 

--- a/collector/framework_manifest.yaml
+++ b/collector/framework_manifest.yaml
@@ -5,10 +5,10 @@ schema_version: 1
 
 frameworks:
   sglang:
-    version: "0.5.10"
+    version: "0.5.14"
     images:
-      default: "lmsysorg/sglang:v0.5.10"
-      cu130: "lmsysorg/sglang:v0.5.10-cu130"
+      default: "lmsysorg/sglang:v0.5.14"
+      cu130: "lmsysorg/sglang:v0.5.14-cu130"
     source_repo: "https://github.com/sgl-project/sglang.git"
   trtllm:
     version: "1.3.0rc10"

--- a/collector/helper.py
+++ b/collector/helper.py
@@ -660,7 +660,7 @@ def log_perf(
     kernel_source: str,
     perf_filename: str,
     power_stats: dict | None = None,
-):
+) -> bool:
     lock_file = perf_filename + ".lock"
 
     # Try for 1 sec (10 * 0.1s)
@@ -676,7 +676,7 @@ def log_perf(
 
     if not got_lock:
         print(f"Skipping log: can not get lock for {perf_filename}")
-        return
+        return False
 
     try:
         with open(perf_filename, "a", newline="") as f:
@@ -719,10 +719,13 @@ def log_perf(
             os.fsync(f.fileno())
     except Exception as e:
         print(f"Error writing log: {e}")
+        return False
     finally:
         # Delete the lock file, even if writing crashed
         if got_lock and os.path.exists(lock_file):
             os.unlink(lock_file)
+
+    return True
 
 
 def convert_perf_csv_to_parquet(

--- a/collector/sglang/README.md
+++ b/collector/sglang/README.md
@@ -19,10 +19,14 @@ The collected performance data can be used for performance modeling, scheduling 
 
 ## Requirements
 
-- SGLang framework: v0.5.6.post2
+- Stock SGLang collectors: v0.5.14
+
 ```bash
-docker run -itd --shm-size 32g --gpus all --ipc=host --network=host --name sglang lmsysorg/sglang:v0.5.6.post2-cu126
+docker run -itd --shm-size 32g --gpus all --ipc=host --network=host --name sglang lmsysorg/sglang:v0.5.14-cu130
 ```
+
+- WideEP MoE collector: the independent v0.5.10 image declared in
+  `../framework_manifest.yaml`; WideEP MLA is not registered for stock v0.5.14.
 - DeepSeek model config (or use dummy weights)
 
 ## Execution Modes
@@ -52,18 +56,20 @@ Use the `collect.py` framework for integrated collection with other operators:
 ```bash
 cd /path/to/collector/
 
-# Run ALL sglang operators (13 total: 8 non-wideep + 5 wideep)
+# Run all stock SGLang operators
 python collect.py --backend sglang
 
-# Run MLA/DSA module operators
-python collect.py --backend sglang --ops wideep_mla_context wideep_mla_generation \
-    dsa_context_module dsa_generation_module
+# Run stock DSA module operators in the v0.5.14 container
+python collect.py --backend sglang --ops dsa_context_module dsa_generation_module
+
+# Run the retained WideEP MoE operator separately in the v0.5.10 container
+python collect.py --backend sglang --ops wideep_moe
 
 # Mixed: kernel-level + module-level (all run in parallel across GPUs)
 python collect.py --backend sglang --ops mla_bmm_gen_pre dsa_context_module
 ```
 
-**All available operators (when no `--ops` specified):**
+**Available operators (`wideep_moe` requires its separate v0.5.10 run):**
 
 | Category | Operator | Description |
 |----------|----------|-------------|
@@ -75,8 +81,6 @@ python collect.py --backend sglang --ops mla_bmm_gen_pre dsa_context_module
 | Kernel | `moe` | MOE operator |
 | Kernel | `attention_context` | Standard Attention prefill |
 | Kernel | `attention_generation` | Standard Attention decode |
-| Module | `wideep_mla_context` | MLA module prefill (DeepSeek-V3) |
-| Module | `wideep_mla_generation` | MLA module decode (DeepSeek-V3) |
 | Module | `dsa_context_module` | DSA module prefill (DeepSeek-V3.2, GLM-5) |
 | Module | `dsa_generation_module` | DSA module decode (DeepSeek-V3.2, GLM-5) |
 | Wideep | `wideep_moe` | Wideep MOE |
@@ -111,11 +115,6 @@ SGLANG_LOAD_FORMAT=dummy SGLANG_TEST_NUM_LAYERS=2 \
 # DSA generation phase
 SGLANG_LOAD_FORMAT=dummy SGLANG_TEST_NUM_LAYERS=2 \
     python collect_mla_module.py --mode generation --attn-type dsa
-```
-
-#### Framework Mode
-```bash
-python collect.py --backend sglang --ops wideep_mla_context wideep_mla_generation dsa_context_module dsa_generation_module
 ```
 
 #### Environment Variables
@@ -210,4 +209,3 @@ Output format:
 ```
 framework,version,device,op_name,kernel_source,moe_dtype,num_tokens,hidden_size,inter_size,topk,num_experts,moe_tp_size,moe_ep_size,distribution,latency
 ```
-

--- a/collector/sglang/collect_attn.py
+++ b/collector/sglang/collect_attn.py
@@ -9,40 +9,22 @@ shape intent should live in YAML; this file owns SGLang backend construction,
 KV-cache setup, SM-specific skips, and perf logging for the SGLang runtime.
 """
 
-__compat__ = "sglang>=0.5.10rc0"
+__compat__ = "sglang==0.5.14"
 
 import math
 import os
+from types import SimpleNamespace
 from typing import NamedTuple
 
 import pkg_resources
-import sglang.srt.layers.dp_attention as dp_attention
 import torch
 from sglang.srt.configs.model_config import AttentionArch
-
-# Initialize DP attention variables globally for FlashInfer backend compatibility
-dp_attention.get_attention_tp_size = lambda: 1
-dp_attention.get_attention_tp_rank = lambda: 0
-dp_attention.get_attention_dp_size = lambda: 1
-dp_attention.get_attention_dp_rank = lambda: 0
-dp_attention.get_local_attention_dp_size = lambda: 1
-dp_attention.get_local_attention_dp_rank = lambda: 0
-dp_attention.is_dp_attention_enabled = lambda: False
-dp_attention._ENABLE_DP_ATTENTION_FLAG = False
-
-# Also set the private variables if they exist
-if hasattr(dp_attention, "_ATTN_TP_SIZE"):
-    dp_attention._ATTN_TP_SIZE = 1
-    dp_attention._ATTN_TP_RANK = 0
-dp_attention._ATTN_DP_SIZE = 1
-dp_attention._ATTN_DP_RANK = 0
-dp_attention._LOCAL_ATTN_DP_SIZE = 1
-dp_attention._LOCAL_ATTN_DP_RANK = 0
-
 from sglang.srt.layers.attention.flashattention_backend import FlashAttentionBackend
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool, ReqToTokenPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.srt.model_executor.forward_context import ForwardContext, forward_context
+from sglang.srt.runtime_context import get_parallel
 
 from collector.case_generator import (
     get_attention_context_shape_sweeps,
@@ -60,17 +42,21 @@ class Timing(NamedTuple):
 
 # Mock objects to satisfy RadixAttention dependencies
 class MockModelConfig:
-    def __init__(self, num_attention_heads, num_key_value_heads, head_dim):
+    def __init__(self, num_attention_heads, num_key_value_heads, head_dim, window_size):
         self.is_encoder_decoder = False
         self.context_len = 32768
         self.attention_arch = AttentionArch.MHA
         self.num_attention_heads = num_attention_heads
         self.num_key_value_heads = num_key_value_heads
         self.head_dim = head_dim
-        # Align with newer sglang ModelConfig while remaining harmless on older versions
-        self.is_hybrid_swa = False
-        self.swa_attention_layer_ids = []
-        self.full_attention_layer_ids = []
+        self.v_head_dim = head_dim
+        self.swa_head_dim = head_dim
+        self.swa_v_head_dim = head_dim
+        self.sliding_window_size = window_size or None
+        self.attention_chunk_size = None
+        self.is_hybrid_swa = window_size > 0
+        self.swa_attention_layer_ids = [0] if self.is_hybrid_swa else []
+        self.full_attention_layer_ids = [] if self.is_hybrid_swa else [0]
         self.is_multimodal = False
         self.hidden_size = num_attention_heads * head_dim
         self.is_local_attention_model = False
@@ -81,6 +67,9 @@ class MockModelConfig:
                 self.num_attention_heads = num_attention_heads
                 self.num_key_value_heads = num_key_value_heads
                 self.head_dim = head_dim
+                self.v_head_dim = head_dim
+                self.swa_head_dim = head_dim
+                self.swa_v_head_dim = head_dim
                 self.hidden_size = num_attention_heads * head_dim
                 self.attn_logit_softcapping = None
 
@@ -108,8 +97,6 @@ class MockServerArgs:
         self.multi_item_scoring_delimiter = None
         self.dllm_algorithm = None
         self.dllm_algorithm_config = None
-        self.enable_piecewise_cuda_graph = False  # sglang <=0.5.9
-        self.disable_piecewise_cuda_graph = True  # sglang >=0.5.10
         self.is_embedding = False
         self.disable_radix_cache = False
         self.enable_dp_attention = False
@@ -120,6 +107,10 @@ class MockServerArgs:
         self.triton_attention_split_tile_size = None
         self.disable_cuda_graph = False
         self.chunked_prefill_size = -1
+        self.enable_mis = False
+        self.enable_two_batch_overlap = False
+        self.disable_attn_tp_gather = False
+        self.moe_dense_tp_size = None
 
 
 class MockModelRunner:
@@ -131,6 +122,7 @@ class MockModelRunner:
         num_heads=None,
         num_kv_heads=None,
         head_dim=None,
+        window_size=0,
     ):
         self.device = device
         self.req_to_token_pool = None
@@ -140,11 +132,11 @@ class MockModelRunner:
         self.attn_cp_size = 1  # Context parallelism size; required by FlashAttentionBackend in sglang >=0.5.10
         self.is_draft_worker = False
         self.model_is_mrope = False
-        self.sliding_window_size = 0
+        self.sliding_window_size = window_size or None
         self.attention_chunk_size = None
-        # FlashInferIndicesUpdaterPrefill expects an allocator; keep None for mock.
+        # Initialized after the KV pool is created.
         self.token_to_kv_pool_allocator = None
-        self.model_config = MockModelConfig(num_heads, num_kv_heads, head_dim)
+        self.model_config = MockModelConfig(num_heads, num_kv_heads, head_dim, window_size)
         self.kv_cache_dtype = kv_cache_dtype  # Default
         self.page_size = page_size
         self.tp_size = 1
@@ -158,6 +150,7 @@ class MockModelRunner:
         self.gpu_id = 0
         self.hybrid_gdn_config = None
         self.kimi_linear_config = None
+        self.linear_attn_model_spec = None
 
 
 def create_req_to_token_pool(batch_size, total_len, page_size, torch_device, device_str):
@@ -195,7 +188,12 @@ def get_context_attention_test_cases():
         max_batch_size_self_attention = int(shape_sweep["max_batch_size_self_attention"])
         max_kv_elements = int(shape_sweep["max_kv_elements"])
 
-        for head_config in get_attention_head_configs(shape_sweep, phase="context"):
+        # Defer profiles that need sinks, asymmetric V heads, or chunk semantics.
+        for head_config in get_attention_head_configs(
+            shape_sweep,
+            phase="context",
+            include_model_profiles=False,
+        ):
             n = head_config.num_heads
             num_kv_heads = head_config.num_kv_heads
             head_dim = head_config.head_dim
@@ -221,6 +219,10 @@ def get_context_attention_test_cases():
                         use_fp8_kv_cache = bool(precision_case["fp8_kv_cache"])
                         use_fp8_context_fmha = bool(precision_case["fp8_context_fmha"])
                         if skip_fp8 and use_fp8_kv_cache:
+                            continue
+                        # Blackwell accepts an FP8 KV pool but plans live Q/K/V
+                        # from BF16; do not persist a fake FP8-attn label.
+                        if sm_version in {100, 103, 120} and use_fp8_context_fmha:
                             continue
                         test_cases.append(
                             [
@@ -272,7 +274,11 @@ def get_generation_attention_test_cases():
         batch_sizes = _int_list(shape_sweep["batch_sizes"])
         sequence_lengths = _int_list(shape_sweep["sequence_lengths"])
         min_drop_batch = int(shape_sweep["drop_largest_sequence_for_batch_at_least"])
-        for head_config in get_attention_head_configs(shape_sweep, phase="generation"):
+        for head_config in get_attention_head_configs(
+            shape_sweep,
+            phase="generation",
+            include_model_profiles=False,
+        ):
             n = head_config.num_heads
             n_kv = head_config.num_kv_heads
             head_dim = head_config.head_dim
@@ -303,6 +309,14 @@ def get_generation_attention_test_cases():
     return test_cases
 
 
+@get_parallel().override(
+    attn_tp_size=1,
+    attn_tp_rank=0,
+    attn_cp_size=1,
+    attn_cp_rank=0,
+    attn_dp_size=1,
+    attn_dp_rank=0,
+)
 def run_attention_torch(
     batch_size,
     input_len,
@@ -316,7 +330,7 @@ def run_attention_torch(
     *,
     perf_filename,
     device="cuda:0",
-    page_size: int = 64,
+    page_size: int | None = None,
 ):
     if use_fp8_context_fmha:
         assert use_fp8_kv_cache, "If you want to use fp8 context fmha, kv cache must be fp8"
@@ -325,6 +339,23 @@ def run_attention_torch(
     torch_device = torch.device(device)
     device_str = str(torch_device)
 
+    sm_version = get_sm_version()
+    if head_dim == 192:
+        raise ValueError("head_dim=192 requires a model-specific SGLang attention contract")
+    if sm_version in {80, 86, 89}:
+        # SGLang's Triton backend is the 0.5.14 fallback for pre-Hopper CUDA.
+        attn_backend_name = "triton"
+    elif sm_version == 90:
+        attn_backend_name = "fa3"
+    elif sm_version in {100, 103}:
+        attn_backend_name = "trtllm_mha"
+    elif sm_version == 120:
+        attn_backend_name = "flashinfer"
+    else:
+        raise ValueError(f"No SGLang 0.5.14 attention backend mapping for SM{sm_version}")
+    if page_size is None:
+        page_size = 64 if attn_backend_name == "trtllm_mha" else 1
+
     model_runner = MockModelRunner(
         torch_device,
         kv_cache_dtype="fp8_e4m3" if use_fp8_kv_cache else "auto",
@@ -332,11 +363,13 @@ def run_attention_torch(
         num_heads=num_heads,
         num_kv_heads=num_key_value_heads,
         head_dim=head_dim,
+        window_size=window_size,
     )
     model_runner.kv_cache_dtype = kvtype
-    model_runner.sliding_window_size = window_size
 
     total_len = input_len if is_context_phase else input_len + 1
+    # TRTLLM MHA sizes its page table from context_len.
+    model_runner.model_config.context_len = max(model_runner.model_config.context_len, total_len)
     req_to_token_pool, token_matrix = create_req_to_token_pool(
         batch_size=batch_size,
         total_len=total_len,
@@ -357,36 +390,33 @@ def run_attention_torch(
         dtype=kvtype,
         head_num=num_key_value_heads,
         head_dim=head_dim,
+        v_head_dim=head_dim,
         layer_num=1,
         device=device_str,
         enable_memory_saver=False,
     )
     model_runner.token_to_kv_pool = kv_pool
+    model_runner.token_to_kv_pool_allocator = SimpleNamespace(
+        page_size=model_runner.page_size,
+        get_kvcache=lambda: model_runner.token_to_kv_pool,
+    )
 
-    sm_version = get_sm_version()
-    use_triton_attention = sm_version >= 110 or (sm_version >= 100 and head_dim == 192)
-    if use_triton_attention:
-        # SM120+ (workstation Blackwell): TRTLLM prefill (TllmGenFmhaRunner) is unsupported;
-        # FA3 is not compiled for SM120. B200/SM100 TRTLLM also lacks head-dim 192
-        # kernels, which MiMo-style models need. Use Triton JIT-compiled backend instead.
+    if attn_backend_name == "flashinfer":
+        from sglang.srt.layers.attention.flashinfer_backend import FlashInferAttnBackend
+
+        attn_backend = FlashInferAttnBackend(model_runner)
+    elif attn_backend_name == "trtllm_mha":
+        from sglang.srt.layers.attention.trtllm_mha_backend import TRTLLMHAAttnBackend
+
+        attn_backend = TRTLLMHAAttnBackend(model_runner)
+    elif attn_backend_name == "triton":
         from sglang.srt.layers.attention.triton_backend import TritonAttnBackend
 
         attn_backend = TritonAttnBackend(model_runner)
-        attn_backend_name = "triton"
-    elif sm_version >= 100:
-        try:
-            from sglang.srt.layers.attention.trtllm_mha_backend import (
-                TRTLLMHAAttnBackend,
-            )
-
-            attn_backend = TRTLLMHAAttnBackend(model_runner)
-            attn_backend_name = "trtllm_mha"
-        except ImportError:
-            attn_backend = FlashAttentionBackend(model_runner)
-            attn_backend_name = "flash_attention"
-    else:
+    elif attn_backend_name == "fa3":
         attn_backend = FlashAttentionBackend(model_runner)
-        attn_backend_name = "flash_attention"
+    else:
+        raise ValueError(f"Unsupported SGLang attention backend: {attn_backend_name}")
 
     model_runner.attn_backend = attn_backend
 
@@ -396,8 +426,10 @@ def run_attention_torch(
         scaling=head_dim**-0.5,
         num_kv_heads=num_key_value_heads,
         layer_id=0,
+        v_head_dim=head_dim,
+        sliding_window_size=window_size or -1,
+        use_irope=False,
     ).to(torch_device)
-    layer.sliding_window_size = window_size
 
     seqlen_q = input_len if is_context_phase else 1
     q = torch.randn(
@@ -446,7 +478,6 @@ def run_attention_torch(
             extend_seq_lens_cpu=seq_lens_cpu,
             extend_prefix_lens_cpu=prefix_lens.cpu(),
             extend_num_tokens=int(seq_lens.sum().item()),
-            attn_backend=attn_backend,
         )
     else:
         forward_mode = ForwardMode.DECODE
@@ -479,7 +510,6 @@ def run_attention_torch(
             out_cache_loc=new_token_loc.to(torch.int32),
             seq_lens_sum=int(seq_lens.sum().item()),
             seq_lens_cpu=seq_lens.cpu(),
-            attn_backend=attn_backend,
         )
 
         if history_loc is not None and history_loc.numel() > 0:
@@ -509,28 +539,29 @@ def run_attention_torch(
     forward_batch.req_to_token_pool = req_to_token_pool
     forward_batch.token_to_kv_pool = kv_pool
 
-    attn_backend.init_forward_metadata(forward_batch)
+    with forward_context(ForwardContext(attn_backend=attn_backend)):
+        attn_backend.init_forward_metadata(forward_batch)
 
-    # FP8 KV cache controls cache storage.  Live q/k/v activations remain
-    # BF16 in the normal decode path; only explicit FP8 context FMHA casts them.
-    if is_context_phase and use_fp8_context_fmha:
-        q = q.to(kvtype)
-        k = k.to(kvtype)
-        v = v.to(kvtype)
+        # FP8 KV cache controls storage. TRTLLM MHA takes BF16 live Q/K/V
+        # for both logical FMHA modes and converts inside the backend.
+        if is_context_phase and use_fp8_context_fmha and attn_backend_name != "trtllm_mha":
+            if attn_backend_name == "flashinfer":
+                raise ValueError("SGLang 0.5.14 FlashInfer has no FP8 live-activation prefill path")
+            q = q.to(kvtype)
+            k = k.to(kvtype)
+            v = v.to(kvtype)
 
-    def run_iter():
-        layer(q, k, v, forward_batch)
+        def run_iter():
+            layer(q, k, v, forward_batch)
 
-    warmup = 3
-    # Use benchmark_with_power context manager
-    with benchmark_with_power(
-        device=torch_device,
-        kernel_func=run_iter,
-        num_warmups=warmup,
-        num_runs=20,
-        repeat_n=1,
-    ) as results:
-        pass
+        with benchmark_with_power(
+            device=torch_device,
+            kernel_func=run_iter,
+            num_warmups=3,
+            num_runs=20,
+            repeat_n=1,
+        ) as results:
+            pass
 
     latency = results["latency_ms"]
 
@@ -543,6 +574,7 @@ def run_attention_torch(
         step = input_len
         op_name = "generation_attention"
 
+    kernel_source = "flash_attention" if attn_backend_name == "fa3" else attn_backend_name
     log_perf(
         item_list=[
             {
@@ -563,7 +595,7 @@ def run_attention_torch(
         version=pkg_resources.get_distribution("sglang").version,
         device_name=torch.cuda.get_device_name(device),
         op_name=op_name,
-        kernel_source=attn_backend_name,
+        kernel_source=kernel_source,
         perf_filename=perf_filename,
         power_stats=results["power_stats"],
     )

--- a/collector/sglang/collect_attn_encoder.py
+++ b/collector/sglang/collect_attn_encoder.py
@@ -12,7 +12,7 @@ SM dispatch mirrors ``VisionAttention._determine_attention_backend``:
 Quant: bf16 only. SGLang upstream does not support fp8 ViT FMHA.
 """
 
-__compat__ = "sglang>=0.5.11"
+__compat__ = "sglang==0.5.14"
 
 from typing import NamedTuple
 

--- a/collector/sglang/collect_computescale.py
+++ b/collector/sglang/collect_computescale.py
@@ -3,7 +3,7 @@
 
 """Measure SGLang FP8 activation quantization overhead for static-FP8 GEMM."""
 
-__compat__ = "sglang>=0.5.10rc0"
+__compat__ = "sglang==0.5.14"
 
 import pkg_resources
 import torch

--- a/collector/sglang/collect_dsv4_attn.py
+++ b/collector/sglang/collect_dsv4_attn.py
@@ -23,11 +23,10 @@ Manual CLI use::
         --batch-sizes 1,4 --seq-lens 128,1024
 """
 
-# Requires an SGLang build with DeepSeek-V4 support. Stock lmsysorg/sglang:v*
-# images may not include the required deepseek_v4 modules; use a
-# deepseek-v4-blackwell/deepseek-v4-grace-blackwell image or matching Dynamo
-# sglang-runtime:*deepseek-v4* image.
+# Requires stock SGLang 0.5.14 with its matching ``sgl-kernel`` package.
 from __future__ import annotations
+
+__compat__ = "sglang==0.5.14"
 
 import argparse
 import contextlib
@@ -53,16 +52,11 @@ os.environ.setdefault("SGLANG_APPLY_CONFIG_BACKUP", "none")
 # Hard-disable DeepGEMM bulk pre-compile.  Each test case touches only a
 # few shapes which the bench's own warmup JIT-compiles on first use.
 os.environ["SGLANG_JIT_DEEPGEMM_PRECOMPILE"] = "0"
-# Older DeepSeek-V4 SGLang containers ship the CUDA kernels as ``sgl-kernel``
-# instead of the newer ``sglang-kernel`` package name.  The collector should
-# run on those pinned environments, so skip only SGLang's package-name check.
-os.environ.setdefault("SGLANG_SKIP_SGL_KERNEL_VERSION_CHECK", "1")
-
 try:
-    from helper import benchmark_with_power, log_perf
+    from helper import _resolve_local_model_path, benchmark_with_power, log_perf
 except ModuleNotFoundError:
     sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-    from helper import benchmark_with_power, log_perf
+    from helper import _resolve_local_model_path, benchmark_with_power, log_perf
 
 try:
     from collector.sglang.runtime_limits import (
@@ -78,9 +72,13 @@ try:
         required_kv_alloc_tokens,
         required_kv_tokens,
         required_prefill_extend_tokens,
+        required_swa_kv_alloc_tokens,
     )
     from collector.sglang.runtime_limits import (
         runtime_chunk_size as _runtime_chunk_size,
+    )
+    from collector.sglang.runtime_limits import (
+        swa_kv_pool_capacity_tokens as _swa_kv_pool_capacity_tokens,
     )
     from collector.sglang.runtime_limits import (
         temporarily_chunked_alloc_extend as _temporarily_chunked_alloc_extend,
@@ -99,9 +97,13 @@ except ModuleNotFoundError:
         required_kv_alloc_tokens,
         required_kv_tokens,
         required_prefill_extend_tokens,
+        required_swa_kv_alloc_tokens,
     )
     from runtime_limits import (
         runtime_chunk_size as _runtime_chunk_size,
+    )
+    from runtime_limits import (
+        swa_kv_pool_capacity_tokens as _swa_kv_pool_capacity_tokens,
     )
     from runtime_limits import (
         temporarily_chunked_alloc_extend as _temporarily_chunked_alloc_extend,
@@ -171,6 +173,19 @@ def _expand_grid():
     return list(_BATCH_SIZES), list(_SEQ_LENGTHS)
 
 
+def _dsv4_max_position_embeddings(model_path: str) -> int:
+    """Read the context boundary from the selected model config."""
+    try:
+        from collector.sglang.deepseekv4_sparse_modules import _dsv4_model_config
+    except ModuleNotFoundError:
+        from deepseekv4_sparse_modules import _dsv4_model_config
+
+    value = _dsv4_model_config(model_path).get("max_position_embeddings")
+    if value in (None, "") or int(value) <= 0:
+        raise ValueError(f"invalid max_position_embeddings={value!r} for {model_path!r}")
+    return int(value)
+
+
 def get_dsv4_csa_context_test_cases():
     return _get_dsv4_csa_context_test_cases_impl()
 
@@ -212,6 +227,10 @@ __all__ = [
 
 
 NATIVE_HEADS = 64
+
+_DSV4_CUDA_PAGE_SIZE = 256
+_DSV4_SWA_WINDOW_SIZE = 128
+_DSV4_SWA_TO_FULL_SCALE = 10
 
 ATTN_KIND_TO_COMPRESS_RATIO = {
     "csa": 4,
@@ -359,6 +378,7 @@ def _resolve_model_path(
     disable_weight_quant: bool,
     strip_auto_map: bool = True,
     gemm_type: str = "bfloat16",
+    load_format: str = "dummy",
 ) -> str:
     """Create a local config dir patched for a single DSV4 attention kind.
 
@@ -383,6 +403,10 @@ def _resolve_model_path(
 
     if os.path.isdir(model_path):
         src_dir = model_path
+        with open(os.path.join(src_dir, "config.json")) as f:
+            config = json.load(f)
+    elif load_format == "dummy":
+        src_dir = _resolve_local_model_path(model_path)
         with open(os.path.join(src_dir, "config.json")) as f:
             config = json.load(f)
     else:
@@ -547,6 +571,7 @@ def _load_model_runner(
     suppress_other_loggers()
     torch.cuda.set_device(device)
 
+    load_format = os.environ.get("SGLANG_LOAD_FORMAT", "dummy")
     local_model_path = _resolve_model_path(
         model_path,
         attn_kind=attn_kind,
@@ -554,6 +579,7 @@ def _load_model_runner(
         shrink_unused_moe=shrink_unused_moe,
         disable_weight_quant=disable_weight_quant,
         gemm_type=gemm_type,
+        load_format=load_format,
     )
     gpu_id = int(device.split(":")[-1]) if ":" in device else 0
     # CUDA_VISIBLE_DEVICES remaps every child to cuda:0; keep the physical GPU
@@ -580,14 +606,15 @@ def _load_model_runner(
         model_path=local_model_path,
         dtype="auto",
         device="cuda",
-        load_format=os.environ.get("SGLANG_LOAD_FORMAT", "dummy"),
+        load_format=load_format,
         tp_size=1,
         trust_remote_code=True,
         disable_radix_cache=True,
         # The module benchmark below captures its own CUDA Graph and fails if
         # capture is not possible.  Keep SGLang's serving-level graph runner off
         # so it does not add unrelated full-model graph state to this collector.
-        disable_cuda_graph=True,
+        disable_decode_cuda_graph=True,
+        disable_prefill_cuda_graph=True,
         kv_cache_dtype=kv_cache_dtype,
         # The bench sweep includes batch_size up to 1024 (collector's
         # ``_BATCH_SIZES``).  sglang's ``alloc_req_slots`` exposes
@@ -607,7 +634,6 @@ def _load_model_runner(
     # gemm_type controls projection GEMM dispatch.  "fp8_block" → DeepGEMM
     # (matches production V4-Flash-FP8); anything else → cuBLASLt bf16.
     server_args.quantization = "fp8" if gemm_type == "fp8_block" else None
-    server_args.enable_piecewise_cuda_graph = False
     server_args.attention_backend = "dsv4"
 
     print(
@@ -639,6 +665,9 @@ def _load_model_runner(
             nccl_port=nccl_port,
             server_args=server_args,
         )
+    # SGLang 0.5.14 separates model construction from serving-state setup.
+    model_runner.alloc_memory_pool()
+    model_runner.init_attention_backends()
     # --- AIC proper init (env-gated) -------------------------------------
     # Dummy load uses uniform(-1e-3, 1e-3) (sglang initialize_dummy_weights).
     # Those tiny weights make the C4 indexer's q.k logits land in the fp16
@@ -708,12 +737,13 @@ def _make_reqs(
     decode: bool,
     prefix_len: int = 0,
     prefix_indices: list[torch.Tensor] | None = None,
+    swa_evicted_seqlen: int = 0,
 ):
+    from array import array
+
     from sglang.srt.managers.schedule_batch import Req
     from sglang.srt.sampling.sampling_params import SamplingParams
 
-    if decode and prefix_len:
-        raise ValueError("prefix_len is only supported for context/extend collection")
     full_len = prefix_len + seq_len
     prefix_indices = prefix_indices or [torch.empty((0,), dtype=torch.int64, device="cuda") for _ in range(batch_size)]
 
@@ -726,9 +756,11 @@ def _make_reqs(
             sampling_params=SamplingParams(temperature=0, max_new_tokens=1),
         )
         req.prefix_indices = prefix_indices[i]
-        req.fill_ids = req.origin_input_ids
-        req.extend_input_len = seq_len if prefix_len else len(req.fill_ids)
+        req.full_untruncated_fill_ids = array("q", req.origin_input_ids)
+        req.fill_len = full_len
         req.logprob_start_len = 0
+        req.set_extend_input_len(seq_len if prefix_len else full_len)
+        req.swa_evicted_seqlen = swa_evicted_seqlen
         if decode:
             req.cached_tokens = 0
             req.already_computed = 0
@@ -753,13 +785,30 @@ def _build_forward_batch(
     model_runner.req_to_token_pool.clear()
     model_runner.token_to_kv_pool_allocator.clear()
 
-    prefix_indices = _alloc_prefix_indices(model_runner, batch_size, prefix_len)
+    cached_prefix_len = prefix_len if is_prefill else seq_len
+    extend_seq_len = seq_len if is_prefill else 0
+    prefix_indices = _alloc_prefix_indices(model_runner, batch_size, cached_prefix_len)
+    swa_evicted_seqlen = 0
+    allocator = model_runner.token_to_kv_pool_allocator
+    window_size = getattr(model_runner.model_config, "window_size", None)
+    page_size = getattr(allocator, "page_size", None)
+    if (
+        cached_prefix_len > 0
+        and callable(getattr(allocator, "alloc_extend_swa_tail", None))
+        and isinstance(window_size, int)
+        and window_size > 0
+        and isinstance(page_size, int)
+        and page_size > 1
+    ):
+        swa_evicted_seqlen = max(0, cached_prefix_len - window_size)
+        swa_evicted_seqlen = (swa_evicted_seqlen // page_size) * page_size
     reqs = _make_reqs(
         batch_size,
-        seq_len,
+        extend_seq_len,
         decode=not is_prefill,
-        prefix_len=prefix_len,
+        prefix_len=cached_prefix_len,
         prefix_indices=prefix_indices,
+        swa_evicted_seqlen=swa_evicted_seqlen,
     )
     cache_params = CacheInitParams(
         disable=True,
@@ -778,19 +827,16 @@ def _build_forward_batch(
         spec_algorithm=SpeculativeAlgorithm.NONE,
     )
 
-    with _temporarily_chunked_alloc_extend(model_runner, batch_size * seq_len):
+    with _temporarily_chunked_alloc_extend(model_runner, batch_size * extend_seq_len):
         if is_prefill:
             batch.prepare_for_extend()
         else:
             batch.prepare_for_extend()
-            batch.output_ids = torch.randint(0, 10000, (batch_size,), dtype=torch.int64, device="cuda")
+            for req in batch.reqs:
+                req.output_ids.append(0)
             batch.prepare_for_decode()
 
-    if hasattr(batch, "get_model_worker_batch"):
-        batch_for_forward = batch.get_model_worker_batch()
-    else:
-        batch_for_forward = batch
-    forward_batch = ForwardBatch.init_new(batch_for_forward, model_runner)
+    forward_batch = ForwardBatch.init_new(batch, model_runner)
     model_runner.attn_backend.init_forward_metadata(forward_batch)
     return forward_batch
 
@@ -924,7 +970,7 @@ def _log_result(
     perf_filename = _resolve_perf_path(output_path, consolidated_filename)
     is_prefill = mode == "context"
     step_value = step if step is not None else (0 if is_prefill else seq_len)
-    log_perf(
+    if not log_perf(
         item_list=[
             {
                 "model": _canonical_dsv4_model_id(model_path),
@@ -950,7 +996,8 @@ def _log_result(
         kernel_source="compressed_flashmla",
         perf_filename=perf_filename,
         power_stats=power_stats,
-    )
+    ):
+        raise RuntimeError(f"failed to persist DeepSeek-V4 attention row to {perf_filename}")
 
 
 def run_dsv4_mla_module(
@@ -979,6 +1026,8 @@ def run_dsv4_mla_module(
     max_total_tokens: int | None = None,
 ) -> list[dict[str, float]]:
     is_prefill = mode == "context"
+    batch_sizes = list(batch_sizes)
+    default_seq_lens = list(seq_lens)
     if prefix_lens is None:
         prefix_values = [prefix_len]
     else:
@@ -987,6 +1036,46 @@ def run_dsv4_mla_module(
         prefix_values = [0]
     if any(p > 0 for p in prefix_values) and not is_prefill:
         raise ValueError("prefix_len is only supported for context/extend collection")
+
+    # SGLang derives compressed-pool sizes from max_total_tokens. Direct
+    # probes with an explicit value must account for both the full pool and
+    # the smaller page-rounded SWA tail pool before ModelRunner construction.
+    if max_total_tokens is not None:
+        max_full_alloc = 0
+        max_swa_alloc = 0
+        for cur_prefix in prefix_values:
+            seq_lens_for_prefix = (
+                seq_lens_by_prefix.get(cur_prefix, default_seq_lens)
+                if seq_lens_by_prefix is not None
+                else default_seq_lens
+            )
+            for batch_size in batch_sizes:
+                for seq_len in seq_lens_for_prefix:
+                    max_full_alloc = max(
+                        max_full_alloc,
+                        required_kv_alloc_tokens(
+                            batch_size,
+                            seq_len,
+                            cur_prefix,
+                            _DSV4_CUDA_PAGE_SIZE,
+                            is_prefill=is_prefill,
+                        ),
+                    )
+                    max_swa_alloc = max(
+                        max_swa_alloc,
+                        required_swa_kv_alloc_tokens(
+                            batch_size,
+                            seq_len,
+                            cur_prefix,
+                            _DSV4_CUDA_PAGE_SIZE,
+                            _DSV4_SWA_WINDOW_SIZE,
+                            is_prefill=is_prefill,
+                        ),
+                    )
+        max_total_tokens = max(max_total_tokens, max_full_alloc, max_swa_alloc * _DSV4_SWA_TO_FULL_SCALE)
+        max_total_tokens = (
+            (max_total_tokens + _DSV4_CUDA_PAGE_SIZE - 1) // _DSV4_CUDA_PAGE_SIZE
+        ) * _DSV4_CUDA_PAGE_SIZE
 
     compress_ratio = ATTN_KIND_TO_COMPRESS_RATIO[attn_kind]
     if tp_size not in (1, 2, 4, 8, 16, 32):
@@ -1022,9 +1111,10 @@ def run_dsv4_mla_module(
     skipped_shapes: list[tuple[int, int, int, str]] = []
     sweep_label = f"kind={attn_kind} mode={mode} tp={tp_size} gemm={gemm_type}"
     try:
-        default_seq_lens = list(seq_lens)
         kv_capacity = _kv_pool_capacity_tokens(model_runner)
         kv_page_size = _kv_pool_page_size(model_runner)
+        swa_capacity = _swa_kv_pool_capacity_tokens(model_runner)
+        swa_window_size = getattr(getattr(model_runner, "model_config", None), "window_size", None)
         runtime_chunk = _runtime_chunk_size(model_runner) if is_prefill else None
         if is_prefill and runtime_chunk is not None:
             # FlashMLA's get_decoding_sched_meta kernel allocates dynamic shared
@@ -1092,6 +1182,23 @@ def run_dsv4_mla_module(
                         )
                         skipped_shapes.append((batch_size, seq_len, cur_prefix, "KVPoolAllocPaged"))
                         continue
+                    if swa_capacity is not None and isinstance(swa_window_size, int) and swa_window_size > 0:
+                        swa_alloc_tokens = required_swa_kv_alloc_tokens(
+                            batch_size,
+                            seq_len,
+                            cur_prefix,
+                            kv_page_size,
+                            swa_window_size,
+                            is_prefill=is_prefill,
+                        )
+                        if swa_alloc_tokens > swa_capacity:
+                            print(
+                                f"[SKIP] dsv4-flash {sweep_label} bs={batch_size} sl={seq_len} "
+                                f"prefix={cur_prefix}: swa_alloc_tokens={swa_alloc_tokens} exceeds "
+                                f"SWA KV pool capacity={swa_capacity}"
+                            )
+                            skipped_shapes.append((batch_size, seq_len, cur_prefix, "KVPoolSWACapacity"))
+                            continue
                     print(f"\n{mode}: batch_size={batch_size}, seq_len={seq_len}, prefix_len={cur_prefix}")
                     try:
                         forward_batch = _build_forward_batch(
@@ -1111,25 +1218,9 @@ def run_dsv4_mla_module(
                         )
 
                         def kernel_func(model_runner=model_runner):
-                            # e958 sglang DeepSeek-V4 forward reads the attn backend
-                            # from the global forward context (get_attn_backend), so
-                            # enter sglang's default forward_context around the call.
-                            # (model_runner bound as a default arg to make the closure
-                            # explicit for static analysis.)
-                            # 0.5.13+ reads the attn backend from the global ForwardContext
-                            # (deepseek_v4: get_attn_backend()); v0.5.12/e958 reads it off
-                            # forward_batch and ships no such module, so use a no-op there.
-                            import sglang as _sgl
+                            from sglang.srt.model_executor.forward_context import ForwardContext, forward_context
 
-                            if _sgl.__version__.startswith("0.5.13"):
-                                from sglang.srt.model_executor.forward_context import ForwardContext, forward_context
-
-                                ctx = forward_context(ForwardContext(attn_backend=model_runner.attn_backend))
-                            else:
-                                from contextlib import nullcontext
-
-                                ctx = nullcontext()
-                            with ctx:
+                            with forward_context(ForwardContext(attn_backend=model_runner.attn_backend)):
                                 return attention_module(
                                     x=hidden_states,
                                     positions=positions,
@@ -1195,6 +1286,7 @@ def run_dsv4_mla_module(
                         )
                         skipped_shapes.append((batch_size, seq_len, cur_prefix, type(exc).__name__))
                     finally:
+                        cleanup_errors = []
                         for _cleanup_label, _cleanup_step in (
                             ("req_to_token_pool.clear", model_runner.req_to_token_pool.clear),
                             ("token_to_kv_pool_allocator.clear", model_runner.token_to_kv_pool_allocator.clear),
@@ -1204,42 +1296,44 @@ def run_dsv4_mla_module(
                             try:
                                 _cleanup_step()
                             except Exception as _cleanup_exc:
-                                print(
-                                    f"[WARN] dsv4-flash {sweep_label} bs={batch_size} sl={seq_len} "
-                                    f"prefix={cur_prefix}: cleanup step '{_cleanup_label}' failed with "
-                                    f"{type(_cleanup_exc).__name__}; CUDA context likely poisoned, "
-                                    "remaining shapes in this sweep may be unreliable"
+                                cleanup_errors.append(
+                                    f"{_cleanup_label}: {type(_cleanup_exc).__name__}: {_cleanup_exc}"
                                 )
+                        if cleanup_errors:
+                            raise RuntimeError(
+                                f"dsv4-flash {sweep_label} bs={batch_size} sl={seq_len} "
+                                f"prefix={cur_prefix}: cleanup failed: {'; '.join(cleanup_errors)}"
+                            )
     finally:
-        try:
-            del model_runner
-            torch.cuda.empty_cache()
-            gc.collect()
-        except Exception:
-            pass
+        final_cleanup_errors = []
+        del model_runner
+        for cleanup_name, cleanup_fn in (
+            ("torch.cuda.empty_cache", torch.cuda.empty_cache),
+            ("gc.collect", gc.collect),
+        ):
+            try:
+                cleanup_fn()
+            except Exception as cleanup_exc:
+                final_cleanup_errors.append(f"{cleanup_name}: {type(cleanup_exc).__name__}: {cleanup_exc}")
+        if final_cleanup_errors:
+            raise RuntimeError(f"dsv4-flash {sweep_label}: final cleanup failed: {'; '.join(final_cleanup_errors)}")
+    capacity_skip_reasons = {
+        "ChunkedPrefillSize",
+        "KVPoolCapacity",
+        "KVPoolAllocPaged",
+        "KVPoolSWACapacity",
+    }
+    skip_count = sum(reason in capacity_skip_reasons for _, _, _, reason in skipped_shapes)
+    error_count = len(skipped_shapes) - skip_count
+    ok_count = len(results)
+    total_count = ok_count + error_count + skip_count
+    summary = f"ok={ok_count} error={error_count} skip={skip_count} total={total_count}"
     if skipped_shapes:
         skipped_str = ", ".join(f"(bs={b},sl={s},prefix={p},reason={r})" for b, s, p, r in skipped_shapes)
-        print(
-            f"[WARN] dsv4-flash {sweep_label}: SWEEP SUMMARY - {len(skipped_shapes)} of "
-            f"{len(skipped_shapes) + len(results)} shapes failed: {skipped_str}"
-        )
-    if not results:
-        # Distinguish "nothing fits on this GPU/TP config" (every shape pre-skipped
-        # for a known capacity limit) from a genuine all-crash. The former is a
-        # legitimate empty result — the parent must NOT count it as an op error
-        # (otherwise large-bs sweeps where every shape exceeds KV capacity, e.g.
-        # bs512/1024 generation, are reported as failures even though they were
-        # cleanly skipped). Only raise when a real runtime failure occurred.
-        _capacity_skip_reasons = {"ChunkedPrefillSize", "KVPoolCapacity", "KVPoolAllocPaged"}
-        _reasons = {r for _, _, _, r in skipped_shapes}
-        if skipped_shapes and _reasons <= _capacity_skip_reasons:
-            print(
-                f"[WARN] dsv4-flash {sweep_label}: all {len(skipped_shapes)} shapes "
-                f"skipped for capacity reasons {sorted(_reasons)}; no rows collected "
-                "(clean skip, not a failure)"
-            )
-            return results
-        raise RuntimeError(f"dsv4-flash {sweep_label}: all shapes failed")
+        print(f"[WARN] dsv4-flash {sweep_label}: skipped or errored shapes: {skipped_str}")
+    print(f"[dsv4-collector] {sweep_label}: {summary}")
+    if error_count > 0 or (ok_count == 0 and skip_count == 0):
+        raise RuntimeError(f"dsv4-flash {sweep_label}: {summary}")
     return results
 
 
@@ -1273,7 +1367,6 @@ def _run_subprocess(
     env["AIC_DSV4_PORT_SHARD"] = str(gpu_id)
     env.setdefault("SGLANG_APPLY_CONFIG_BACKUP", "none")
     env.setdefault("SGLANG_LOAD_FORMAT", "dummy")
-    env.setdefault("SGLANG_SKIP_SGL_KERNEL_VERSION_CHECK", "1")
     # Hard-disable DeepGEMM bulk pre-compile.  First sl in this sweep
     # triggers runtime lazy JIT for the (M, N, K) shapes it needs;
     # subsequent sl within the same subprocess hit in-memory cache.
@@ -1386,12 +1479,15 @@ def _subprocess_entry(
     elif mode != "context":
         prefix_values = [0]
 
+    max_position_embeddings = _dsv4_max_position_embeddings(model_path) if mode == "context" else None
+
     seq_lens_by_prefix: dict[int, list[int]] = {}
     for cur_prefix in prefix_values:
         pairs = [
             (bs, sl)
             for bs, sl in _filter_pairs(mode, [batch_size], sl_grid)
             if _is_valid_shape(mode, bs, sl, cur_prefix)
+            and (max_position_embeddings is None or cur_prefix + sl <= max_position_embeddings)
         ]
         if not pairs:
             print(f"[dsv4-flash] no valid sl values for mode={mode}, bs={batch_size}, prefix_len={cur_prefix}")
@@ -1402,24 +1498,9 @@ def _subprocess_entry(
         print(f"[dsv4-flash] no valid prefix/sl values for mode={mode}, bs={batch_size}")
         return
 
-    # mem_fraction_static stays sglang-derived (see _load_model_runner).  Size
-    # max_total_tokens to THIS worker's actual swept (bs, sl, prefix) set rather
-    # than leaving it None (sglang would then size the KV pool to fill all GPU
-    # memory) or hardcoding a global cap.  Mirrors collect_mla_module.py: take
-    # max(required_kv_tokens(...)) over the cases this subprocess will run and
-    # add ~5% headroom (>=1024).  Shapes still exceeding the resulting pool are
-    # skipped via the ``_kv_pool_capacity_tokens`` SKIP path.
-    is_prefill = mode == "context"
-    swept_kv = [
-        required_kv_tokens(batch_size, sl, cur_prefix, is_prefill=is_prefill)
-        for cur_prefix, sls in seq_lens_by_prefix.items()
-        for sl in sls
-    ]
+    # Let SGLang derive a realizable hybrid KV pool, then use the live full/SWA
+    # allocator capacities and page size to skip over-capacity cells.
     max_total_tokens = None
-    if swept_kv:
-        max_total_tokens = max(swept_kv)
-        if max_total_tokens > 0:
-            max_total_tokens += max(1024, max_total_tokens // 20)
 
     run_dsv4_mla_module(
         model_path=model_path,
@@ -1472,7 +1553,9 @@ def run_dsv4_attn_worker(
 
     is_prefill = "context" in perf_filename
     mode = "context" if is_prefill else "generation"
-    prefix_lens = list(_PREFIX_LENGTHS) if is_prefill else None
+    # The SDK consumer resolves only zero-prefix persisted keys, so context
+    # collection must not emit nonzero-prefix rows.
+    prefix_lens = [p for p in _PREFIX_LENGTHS if p == 0] if is_prefill else None
 
     device_str = str(device)
     gpu_id = int(device_str.split(":")[-1]) if ":" in device_str else 0

--- a/collector/sglang/collect_gdn.py
+++ b/collector/sglang/collect_gdn.py
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-__compat__ = "sglang>=0.5.9"
-
 """
 GDN (Gated DeltaNet) Collector for AIConfigurator — SGLang backend.
 
@@ -11,18 +9,18 @@ Qwen3.5 linear_attention layers. Profiling the SGLang-bundled kernels
 ensures the collected data reflects SGLang's actual runtime performance.
 
 Context (prefill) phase:
-    - causal_conv1d_fn: Causal 1D convolution over key channels
+    - causal_conv1d_fn: Causal 1D convolution over packed Q+K+V channels
     - chunk_gated_delta_rule: GDN chunked scan (Q, K, V, g, beta)
 
 Generation (decode) phase:
     - causal_conv1d_update: Single-step conv state update
-    - fused_recurrent_gated_delta_rule: Single-step GDN recurrence
+    - fused_recurrent_gated_delta_rule_packed_decode: Packed GDN recurrence
 
 The in_proj and out_proj GEMMs are standard linear layers modeled by the
 existing GEMM infrastructure. This collector focuses on the unique GDN ops.
 
 GDN Layer Flow:
-    in_proj (GEMM) → Conv1D (keys) → GDN Scan/Update → out_proj (GEMM)
+    in_proj (GEMM) → Conv1D (packed QKV) → GDN Scan/Update → out_proj (GEMM)
     ^^^^^^^^^^^^^    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    ^^^^^^^^^^^^^^^^
     Use GEMM model          Benchmarked here            Use GEMM model
 
@@ -33,13 +31,17 @@ Output:
     gdn_perf.txt - Performance data for GDN Conv1D + scan operations
 """
 
+__compat__ = "sglang==0.5.14"
+
 import gc
 import os
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from sglang.srt.layers.attention.fla.chunk import chunk_gated_delta_rule
-    from sglang.srt.layers.attention.fla.fused_recurrent import fused_recurrent_gated_delta_rule
+    from sglang.srt.layers.attention.fla.fused_recurrent import (
+        fused_recurrent_gated_delta_rule_packed_decode,
+    )
     from sglang.srt.layers.attention.mamba.causal_conv1d import causal_conv1d_fn, causal_conv1d_update
 
 import torch
@@ -66,8 +68,8 @@ except ModuleNotFoundError:
     )
 
 aic_debug = int(os.getenv("aic_gdn_debug", "0"))  # noqa: SIM112
-# Use cached inputs (same data each iteration) instead of randomized inputs
-aic_cached_inputs = int(os.getenv("AIC_GDN_CACHED_INPUTS", "0"))
+MAX_GDN_CONTEXT_TOKENS = 262_144
+MAX_GDN_CONTEXT_VALUE_ELEMENTS = 1_073_741_824
 
 
 def get_gdn_test_cases():
@@ -114,18 +116,6 @@ def get_gdn_test_cases():
     return test_cases
 
 
-def _make_input_pool(
-    shapes: dict[str, tuple[int, ...]],
-    count: int,
-    dtype: torch.dtype,
-    device: torch.device,
-) -> dict[str, list[torch.Tensor]]:
-    """Pre-generate a pool of random input tensors for randomized benchmarking."""
-    return {
-        name: [torch.randn(*shape, dtype=dtype, device=device) for _ in range(count)] for name, shape in shapes.items()
-    }
-
-
 def run_gdn_context_benchmark(
     d_model: int,
     d_conv: int,
@@ -144,7 +134,7 @@ def run_gdn_context_benchmark(
     Benchmark GDN operations for context (prefill) phase using SGLang's Triton FLA kernels.
 
     Benchmarks:
-    1. causal_conv1d_fn  — Conv1D over key channels
+    1. causal_conv1d_fn  — Conv1D over packed Q+K+V channels
     2. chunk_gated_delta_rule — GDN scan (Q, K, V, g, beta) via SGLang's vendored FLA
     """
     device = torch.device(device)
@@ -153,8 +143,9 @@ def run_gdn_context_benchmark(
 
     dtype = torch.bfloat16
 
-    # key channels only go through conv; q/v bypass conv
-    conv_channels = num_k_heads * head_k_dim
+    qk_dim = num_k_heads * head_k_dim
+    value_dim = num_v_heads * head_v_dim
+    conv_channels = 2 * qk_dim + value_dim
 
     if aic_debug:
         print(
@@ -162,28 +153,77 @@ def run_gdn_context_benchmark(
             f"num_v_heads={num_v_heads}, head_v_dim={head_v_dim}, d_conv={d_conv}"
         )
 
-    # Conv weights (key channels)
     conv_weight = torch.randn(conv_channels, d_conv, dtype=dtype, device=device)
-    conv_bias = torch.randn(conv_channels, dtype=dtype, device=device)
+    successful_points = 0
+    failed_points = 0
+    skipped_points = 0
 
     for batch_size in batch_size_list:
         for seq_len in seq_len_list:
+            total_tokens = batch_size * seq_len
+            value_elements = total_tokens * value_dim
+            if total_tokens > MAX_GDN_CONTEXT_TOKENS or value_elements > MAX_GDN_CONTEXT_VALUE_ELEMENTS:
+                skipped_points += 1
+                if aic_debug:
+                    print(
+                        f"  Skipping batch_size={batch_size}, seq_len={seq_len}: "
+                        f"total_tokens={total_tokens}, value_elements={value_elements} exceed "
+                        "the SGLang 0.5.14 GDN context limits "
+                        f"({MAX_GDN_CONTEXT_TOKENS} tokens, "
+                        f"{MAX_GDN_CONTEXT_VALUE_ELEMENTS} value elements)"
+                    )
+                continue
             if aic_debug:
                 print(f"  Benchmarking batch_size={batch_size}, seq_len={seq_len}")
 
+            beta = conv_input = conv_state = cu_seqlens = g = has_initial_state = None
+            k = mixed_qkv = q = recurrent_state = seq_lens_cpu = state_indices = v = None
             try:
                 num_warmups = 3
                 num_runs = 10
-                total_iters = num_warmups + num_runs
+                cu_seqlens = torch.arange(
+                    0,
+                    total_tokens + 1,
+                    seq_len,
+                    dtype=torch.int32,
+                    device=device,
+                )
+                seq_lens_cpu = [seq_len] * batch_size
+                state_indices = torch.arange(batch_size, dtype=torch.int32, device=device)
+                has_initial_state = torch.zeros(batch_size, dtype=torch.bool, device=device)
+                conv_state = torch.zeros(
+                    batch_size,
+                    conv_channels,
+                    d_conv - 1,
+                    dtype=dtype,
+                    device=device,
+                )
+                recurrent_state = torch.zeros(
+                    batch_size,
+                    num_v_heads,
+                    head_v_dim,
+                    head_k_dim,
+                    dtype=torch.float32,
+                    device=device,
+                )
 
-                # Conv state: (batch, channels, d_conv - 1)
-                conv_state = torch.randn(batch_size, conv_channels, d_conv - 1, dtype=dtype, device=device)
+                # SGLang flattens continuous-batching requests, then
+                # transposes packed QKV before the varlen convolution.
+                mixed_qkv = torch.randn(total_tokens, conv_channels, dtype=dtype, device=device)
+                conv_input = mixed_qkv.transpose(0, 1)
+                q = torch.randn(1, total_tokens, num_k_heads, head_k_dim, dtype=dtype, device=device)
+                k = torch.randn(1, total_tokens, num_k_heads, head_k_dim, dtype=dtype, device=device)
+                v = torch.randn(1, total_tokens, num_v_heads, head_v_dim, dtype=dtype, device=device)
+                g = torch.nn.functional.logsigmoid(
+                    torch.randn(1, total_tokens, num_v_heads, dtype=torch.float32, device=device)
+                )
+                beta = torch.sigmoid(torch.randn(1, total_tokens, num_v_heads, dtype=torch.float32, device=device))
 
                 common_log_data = {
                     "phase": "context",
                     "batch_size": batch_size,
                     "seq_len": seq_len,
-                    "num_tokens": batch_size * seq_len,
+                    "num_tokens": total_tokens,
                     "d_model": d_model,
                     "d_conv": d_conv,
                     "num_k_heads": num_k_heads,
@@ -193,177 +233,97 @@ def run_gdn_context_benchmark(
                     "model_name": model_name,
                 }
 
-                if aic_cached_inputs:
-                    k_input = torch.randn(batch_size, conv_channels, seq_len, dtype=dtype, device=device)
-                    q = torch.randn(batch_size, seq_len, num_k_heads, head_k_dim, dtype=dtype, device=device)
-                    k = torch.randn(batch_size, seq_len, num_k_heads, head_k_dim, dtype=dtype, device=device)
-                    v = torch.randn(batch_size, seq_len, num_v_heads, head_v_dim, dtype=dtype, device=device)
-                    g = torch.nn.functional.logsigmoid(
-                        torch.randn(batch_size, seq_len, num_v_heads, dtype=dtype, device=device)
-                    )
-                    beta = torch.sigmoid(torch.randn(batch_size, seq_len, num_v_heads, dtype=dtype, device=device))
-
-                    # --- Benchmark causal_conv1d_fn ---
-                    torch.cuda.synchronize()
-                    causal_conv1d_fn(k_input, conv_weight, conv_bias, activation="silu", conv_states=conv_state)
-                    torch.cuda.synchronize()
-
-                    def run_conv1d(_ki=k_input, _cs=conv_state):
-                        causal_conv1d_fn(_ki, conv_weight, conv_bias, activation="silu", conv_states=_cs)
-
-                    with benchmark_with_power(
-                        device=device,
-                        kernel_func=run_conv1d,
-                        num_warmups=num_warmups,
-                        num_runs=num_runs,
-                        repeat_n=1,
-                        allow_graph_fail=True,
-                    ) as results:
-                        log_perf(
-                            item_list=[{**common_log_data, "latency": results["latency_ms"]}],
-                            framework="SGLang",
-                            version=sglang_version,
-                            device_name=torch.cuda.get_device_name(device),
-                            op_name="gdn",
-                            kernel_source="causal_conv1d_fn",
-                            perf_filename=perf_filename,
-                            power_stats=results["power_stats"],
-                        )
-
-                    # --- Benchmark chunk_gated_delta_rule ---
-                    torch.cuda.synchronize()
-                    chunk_gated_delta_rule(q, k, v, g, beta)
-                    torch.cuda.synchronize()
-
-                    def run_gdn_scan(_q=q, _k=k, _v=v, _g=g, _beta=beta):
-                        chunk_gated_delta_rule(_q, _k, _v, _g, _beta)
-
-                    with benchmark_with_power(
-                        device=device,
-                        kernel_func=run_gdn_scan,
-                        num_warmups=num_warmups,
-                        num_runs=num_runs,
-                        repeat_n=1,
-                        allow_graph_fail=True,
-                    ) as results:
-                        log_perf(
-                            item_list=[{**common_log_data, "latency": results["latency_ms"]}],
-                            framework="SGLang",
-                            version=sglang_version,
-                            device_name=torch.cuda.get_device_name(device),
-                            op_name="gdn",
-                            kernel_source="chunk_gated_delta_rule",
-                            perf_filename=perf_filename,
-                            power_stats=results["power_stats"],
-                        )
-
-                else:
-                    input_pool = _make_input_pool(
-                        {
-                            "k_input": (batch_size, conv_channels, seq_len),
-                            "q": (batch_size, seq_len, num_k_heads, head_k_dim),
-                            "k": (batch_size, seq_len, num_k_heads, head_k_dim),
-                            "v": (batch_size, seq_len, num_v_heads, head_v_dim),
-                            "g": (batch_size, seq_len, num_v_heads),
-                            "beta": (batch_size, seq_len, num_v_heads),
-                        },
-                        total_iters,
-                        dtype,
-                        device,
-                    )
-                    for i in range(total_iters):
-                        input_pool["g"][i] = torch.nn.functional.logsigmoid(input_pool["g"][i])
-                        input_pool["beta"][i] = torch.sigmoid(input_pool["beta"][i])
-
-                    # --- Benchmark causal_conv1d_fn ---
-                    torch.cuda.synchronize()
+                def run_conv1d():
                     causal_conv1d_fn(
-                        input_pool["k_input"][0], conv_weight, conv_bias, activation="silu", conv_states=conv_state
+                        conv_input,
+                        conv_weight,
+                        None,
+                        query_start_loc=cu_seqlens,
+                        cache_indices=state_indices,
+                        has_initial_state=has_initial_state,
+                        conv_states=conv_state,
+                        activation="silu",
+                        seq_lens_cpu=seq_lens_cpu,
                     )
-                    torch.cuda.synchronize()
 
-                    conv1d_iter_idx = [0]
+                with benchmark_with_power(
+                    device=device,
+                    kernel_func=run_conv1d,
+                    num_warmups=num_warmups,
+                    num_runs=num_runs,
+                    repeat_n=1,
+                    allow_graph_fail=True,
+                ) as results:
+                    if not log_perf(
+                        item_list=[{**common_log_data, "latency": results["latency_ms"]}],
+                        framework="SGLang",
+                        version=sglang_version,
+                        device_name=torch.cuda.get_device_name(device),
+                        op_name="gdn",
+                        kernel_source="causal_conv1d_fn",
+                        perf_filename=perf_filename,
+                        power_stats=results["power_stats"],
+                    ):
+                        raise RuntimeError(f"failed to persist SGLang GDN context row to {perf_filename}")
 
-                    def run_conv1d(_pool=input_pool, _cs=conv_state, _idx=conv1d_iter_idx):
-                        idx = _idx[0] % total_iters
-                        _idx[0] += 1
-                        causal_conv1d_fn(
-                            _pool["k_input"][idx], conv_weight, conv_bias, activation="silu", conv_states=_cs
-                        )
-
-                    with benchmark_with_power(
-                        device=device,
-                        kernel_func=run_conv1d,
-                        num_warmups=num_warmups,
-                        num_runs=num_runs,
-                        repeat_n=1,
-                        allow_graph_fail=True,
-                    ) as results:
-                        log_perf(
-                            item_list=[{**common_log_data, "latency": results["latency_ms"]}],
-                            framework="SGLang",
-                            version=sglang_version,
-                            device_name=torch.cuda.get_device_name(device),
-                            op_name="gdn",
-                            kernel_source="causal_conv1d_fn",
-                            perf_filename=perf_filename,
-                            power_stats=results["power_stats"],
-                        )
-
-                    # --- Benchmark chunk_gated_delta_rule ---
-                    torch.cuda.synchronize()
+                def run_gdn_scan():
                     chunk_gated_delta_rule(
-                        input_pool["q"][0],
-                        input_pool["k"][0],
-                        input_pool["v"][0],
-                        input_pool["g"][0],
-                        input_pool["beta"][0],
+                        q,
+                        k,
+                        v,
+                        g,
+                        beta,
+                        initial_state=recurrent_state,
+                        initial_state_indices=state_indices,
+                        cu_seqlens=cu_seqlens,
+                        head_first=False,
+                        use_qk_l2norm_in_kernel=True,
                     )
-                    torch.cuda.synchronize()
 
-                    gdn_iter_idx = [0]
-
-                    def run_gdn_scan(_pool=input_pool, _idx=gdn_iter_idx):
-                        idx = _idx[0] % total_iters
-                        _idx[0] += 1
-                        chunk_gated_delta_rule(
-                            _pool["q"][idx],
-                            _pool["k"][idx],
-                            _pool["v"][idx],
-                            _pool["g"][idx],
-                            _pool["beta"][idx],
-                        )
-
-                    with benchmark_with_power(
-                        device=device,
-                        kernel_func=run_gdn_scan,
-                        num_warmups=num_warmups,
-                        num_runs=num_runs,
-                        repeat_n=1,
-                        allow_graph_fail=True,
-                    ) as results:
-                        log_perf(
-                            item_list=[{**common_log_data, "latency": results["latency_ms"]}],
-                            framework="SGLang",
-                            version=sglang_version,
-                            device_name=torch.cuda.get_device_name(device),
-                            op_name="gdn",
-                            kernel_source="chunk_gated_delta_rule",
-                            perf_filename=perf_filename,
-                            power_stats=results["power_stats"],
-                        )
-
-                # Cleanup
-                if aic_cached_inputs:
-                    del k_input, q, k, v, g, beta, conv_state
-                else:
-                    del input_pool, conv_state
-                gc.collect()
-                torch.cuda.empty_cache()
+                with benchmark_with_power(
+                    device=device,
+                    kernel_func=run_gdn_scan,
+                    num_warmups=num_warmups,
+                    num_runs=num_runs,
+                    repeat_n=1,
+                    allow_graph_fail=True,
+                ) as results:
+                    if not log_perf(
+                        item_list=[{**common_log_data, "latency": results["latency_ms"]}],
+                        framework="SGLang",
+                        version=sglang_version,
+                        device_name=torch.cuda.get_device_name(device),
+                        op_name="gdn",
+                        kernel_source="chunk_gated_delta_rule",
+                        perf_filename=perf_filename,
+                        power_stats=results["power_stats"],
+                    ):
+                        raise RuntimeError(f"failed to persist SGLang GDN context row to {perf_filename}")
+                successful_points += 1
 
             except Exception as e:
+                failed_points += 1
                 print(f"  Error at batch_size={batch_size}, seq_len={seq_len}: {e}")
                 continue
+            finally:
+                beta = conv_input = conv_state = cu_seqlens = g = has_initial_state = None
+                k = mixed_qkv = q = recurrent_state = seq_lens_cpu = state_indices = v = None
+                cleanup_errors = []
+                for cleanup_name, cleanup_fn in (
+                    ("gc.collect", gc.collect),
+                    ("torch.cuda.empty_cache", torch.cuda.empty_cache),
+                ):
+                    try:
+                        cleanup_fn()
+                    except Exception as cleanup_error:
+                        cleanup_errors.append(f"{cleanup_name}: {type(cleanup_error).__name__}: {cleanup_error}")
+                if cleanup_errors:
+                    raise RuntimeError(f"SGLang GDN context cleanup failed: {'; '.join(cleanup_errors)}")
+
+    summary = f"ok={successful_points} error={failed_points} skip={skipped_points}"
+    print(f"GDN context summary: {summary}")
+    if failed_points or (successful_points == 0 and skipped_points == 0):
+        raise RuntimeError(f"SGLang GDN context collection failed strict completeness: {summary}")
 
 
 def run_gdn_generation_benchmark(
@@ -384,15 +344,16 @@ def run_gdn_generation_benchmark(
 
     Benchmarks:
     1. causal_conv1d_update  — Single-step conv state update
-    2. fused_recurrent_gated_delta_rule — Single-step GDN recurrence
+    2. fused_recurrent_gated_delta_rule_packed_decode — Packed GDN recurrence
     """
     device = torch.device(device)
     torch.cuda.set_device(device)
     torch.set_default_device(device)
 
     dtype = torch.bfloat16
-
-    conv_channels = num_k_heads * head_k_dim
+    qk_dim = num_k_heads * head_k_dim
+    value_dim = num_v_heads * head_v_dim
+    conv_channels = 2 * qk_dim + value_dim
 
     if aic_debug:
         print(
@@ -401,20 +362,47 @@ def run_gdn_generation_benchmark(
         )
 
     conv_weight = torch.randn(conv_channels, d_conv, dtype=dtype, device=device)
-    conv_bias = torch.randn(conv_channels, dtype=dtype, device=device)
+    successful_points = 0
+    failed_points = 0
 
     for batch_size in batch_size_list:
         if aic_debug:
             print(f"  Benchmarking batch_size={batch_size}")
 
+        a = a_log = b = conv_state = dt_bias = mixed_qkv = None
+        output = recurrent_state = state_indices = None
         try:
             num_warmups = 3
             num_runs = 10
-            total_iters = num_warmups + num_runs
-
-            conv_state = torch.randn(batch_size, conv_channels, d_conv - 1, dtype=dtype, device=device)
-            # SGLang GDN state layout: [batch, num_v_heads, head_v_dim, head_k_dim]
-            gdn_state = torch.randn(batch_size, num_v_heads, head_v_dim, head_k_dim, dtype=dtype, device=device)
+            mixed_qkv = torch.randn(batch_size, conv_channels, dtype=dtype, device=device)
+            conv_state = torch.zeros(
+                batch_size,
+                conv_channels,
+                d_conv - 1,
+                dtype=dtype,
+                device=device,
+            )
+            state_indices = torch.arange(batch_size, dtype=torch.int32, device=device)
+            recurrent_state = torch.zeros(
+                batch_size,
+                num_v_heads,
+                head_v_dim,
+                head_k_dim,
+                dtype=torch.float32,
+                device=device,
+            )
+            a = torch.randn(batch_size, num_v_heads, dtype=dtype, device=device)
+            b = torch.randn(batch_size, num_v_heads, dtype=dtype, device=device)
+            a_log = torch.zeros(num_v_heads, dtype=torch.float32, device=device)
+            dt_bias = torch.ones(num_v_heads, dtype=torch.float32, device=device)
+            output = torch.empty(
+                batch_size,
+                1,
+                num_v_heads,
+                head_v_dim,
+                dtype=dtype,
+                device=device,
+            )
 
             common_log_data = {
                 "phase": "generation",
@@ -430,191 +418,94 @@ def run_gdn_generation_benchmark(
                 "model_name": model_name,
             }
 
-            if aic_cached_inputs:
-                k_input = torch.randn(batch_size, conv_channels, dtype=dtype, device=device)
-                q = torch.randn(batch_size, 1, num_k_heads, head_k_dim, dtype=dtype, device=device)
-                k = torch.randn(batch_size, 1, num_k_heads, head_k_dim, dtype=dtype, device=device)
-                v = torch.randn(batch_size, 1, num_v_heads, head_v_dim, dtype=dtype, device=device)
-                g = torch.nn.functional.logsigmoid(torch.randn(batch_size, 1, num_v_heads, dtype=dtype, device=device))
-                beta = torch.sigmoid(torch.randn(batch_size, 1, num_v_heads, dtype=dtype, device=device))
-
-                # --- Benchmark causal_conv1d_update ---
-                torch.cuda.synchronize()
-                causal_conv1d_update(k_input, conv_state, conv_weight, conv_bias, activation="silu")
-                torch.cuda.synchronize()
-
-                def run_conv1d_update(_k=k_input, _cs=conv_state):
-                    causal_conv1d_update(_k, _cs, conv_weight, conv_bias, activation="silu")
-
-                with benchmark_with_power(
-                    device=device,
-                    kernel_func=run_conv1d_update,
-                    num_warmups=num_warmups,
-                    num_runs=num_runs,
-                    repeat_n=1,
-                    allow_graph_fail=True,
-                ) as results:
-                    log_perf(
-                        item_list=[{**common_log_data, "latency": results["latency_ms"]}],
-                        framework="SGLang",
-                        version=sglang_version,
-                        device_name=torch.cuda.get_device_name(device),
-                        op_name="gdn",
-                        kernel_source="causal_conv1d_update",
-                        perf_filename=perf_filename,
-                        power_stats=results["power_stats"],
-                    )
-
-                # --- Benchmark fused_recurrent_gated_delta_rule ---
-                torch.cuda.synchronize()
-                fused_recurrent_gated_delta_rule(
-                    q,
-                    k,
-                    v,
-                    g,
-                    beta,
-                    initial_state=gdn_state,
-                    output_final_state=True,
+            def run_conv1d_update():
+                causal_conv1d_update(
+                    mixed_qkv,
+                    conv_state,
+                    conv_weight,
+                    None,
+                    activation="silu",
+                    conv_state_indices=state_indices,
                 )
-                torch.cuda.synchronize()
 
-                def run_gdn_update(_q=q, _k=k, _v=v, _g=g, _beta=beta, _state=gdn_state):
-                    fused_recurrent_gated_delta_rule(
-                        _q,
-                        _k,
-                        _v,
-                        _g,
-                        _beta,
-                        initial_state=_state,
-                        output_final_state=True,
-                    )
+            with benchmark_with_power(
+                device=device,
+                kernel_func=run_conv1d_update,
+                num_warmups=num_warmups,
+                num_runs=num_runs,
+                repeat_n=1,
+                allow_graph_fail=True,
+            ) as results:
+                if not log_perf(
+                    item_list=[{**common_log_data, "latency": results["latency_ms"]}],
+                    framework="SGLang",
+                    version=sglang_version,
+                    device_name=torch.cuda.get_device_name(device),
+                    op_name="gdn",
+                    kernel_source="causal_conv1d_update",
+                    perf_filename=perf_filename,
+                    power_stats=results["power_stats"],
+                ):
+                    raise RuntimeError(f"failed to persist SGLang GDN generation row to {perf_filename}")
 
-                with benchmark_with_power(
-                    device=device,
-                    kernel_func=run_gdn_update,
-                    num_warmups=num_warmups,
-                    num_runs=num_runs,
-                    repeat_n=1,
-                    allow_graph_fail=True,
-                ) as results:
-                    log_perf(
-                        item_list=[{**common_log_data, "latency": results["latency_ms"]}],
-                        framework="SGLang",
-                        version=sglang_version,
-                        device_name=torch.cuda.get_device_name(device),
-                        op_name="gdn",
-                        kernel_source="fused_recurrent_gated_delta_rule",
-                        perf_filename=perf_filename,
-                        power_stats=results["power_stats"],
-                    )
-
-            else:
-                input_pool = _make_input_pool(
-                    {
-                        "k_input": (batch_size, conv_channels),
-                        "q": (batch_size, 1, num_k_heads, head_k_dim),
-                        "k": (batch_size, 1, num_k_heads, head_k_dim),
-                        "v": (batch_size, 1, num_v_heads, head_v_dim),
-                        "g": (batch_size, 1, num_v_heads),
-                        "beta": (batch_size, 1, num_v_heads),
-                    },
-                    total_iters,
-                    dtype,
-                    device,
+            def run_gdn_update():
+                fused_recurrent_gated_delta_rule_packed_decode(
+                    mixed_qkv=mixed_qkv,
+                    a=a,
+                    b=b,
+                    A_log=a_log,
+                    dt_bias=dt_bias,
+                    scale=head_k_dim**-0.5,
+                    initial_state=recurrent_state,
+                    out=output,
+                    ssm_state_indices=state_indices,
+                    use_qk_l2norm_in_kernel=True,
                 )
-                for i in range(total_iters):
-                    input_pool["g"][i] = torch.nn.functional.logsigmoid(input_pool["g"][i])
-                    input_pool["beta"][i] = torch.sigmoid(input_pool["beta"][i])
 
-                # --- Benchmark causal_conv1d_update ---
-                torch.cuda.synchronize()
-                causal_conv1d_update(input_pool["k_input"][0], conv_state, conv_weight, conv_bias, activation="silu")
-                torch.cuda.synchronize()
-
-                conv1d_iter_idx = [0]
-
-                def run_conv1d_update(_pool=input_pool, _cs=conv_state, _idx=conv1d_iter_idx):
-                    idx = _idx[0] % total_iters
-                    _idx[0] += 1
-                    causal_conv1d_update(_pool["k_input"][idx], _cs, conv_weight, conv_bias, activation="silu")
-
-                with benchmark_with_power(
-                    device=device,
-                    kernel_func=run_conv1d_update,
-                    num_warmups=num_warmups,
-                    num_runs=num_runs,
-                    repeat_n=1,
-                    allow_graph_fail=True,
-                ) as results:
-                    log_perf(
-                        item_list=[{**common_log_data, "latency": results["latency_ms"]}],
-                        framework="SGLang",
-                        version=sglang_version,
-                        device_name=torch.cuda.get_device_name(device),
-                        op_name="gdn",
-                        kernel_source="causal_conv1d_update",
-                        perf_filename=perf_filename,
-                        power_stats=results["power_stats"],
-                    )
-
-                # --- Benchmark fused_recurrent_gated_delta_rule ---
-                torch.cuda.synchronize()
-                fused_recurrent_gated_delta_rule(
-                    input_pool["q"][0],
-                    input_pool["k"][0],
-                    input_pool["v"][0],
-                    input_pool["g"][0],
-                    input_pool["beta"][0],
-                    initial_state=gdn_state,
-                    output_final_state=True,
-                )
-                torch.cuda.synchronize()
-
-                gdn_iter_idx = [0]
-
-                def run_gdn_update(_pool=input_pool, _state=gdn_state, _idx=gdn_iter_idx):
-                    idx = _idx[0] % total_iters
-                    _idx[0] += 1
-                    fused_recurrent_gated_delta_rule(
-                        _pool["q"][idx],
-                        _pool["k"][idx],
-                        _pool["v"][idx],
-                        _pool["g"][idx],
-                        _pool["beta"][idx],
-                        initial_state=_state,
-                        output_final_state=True,
-                    )
-
-                with benchmark_with_power(
-                    device=device,
-                    kernel_func=run_gdn_update,
-                    num_warmups=num_warmups,
-                    num_runs=num_runs,
-                    repeat_n=1,
-                    allow_graph_fail=True,
-                ) as results:
-                    log_perf(
-                        item_list=[{**common_log_data, "latency": results["latency_ms"]}],
-                        framework="SGLang",
-                        version=sglang_version,
-                        device_name=torch.cuda.get_device_name(device),
-                        op_name="gdn",
-                        kernel_source="fused_recurrent_gated_delta_rule",
-                        perf_filename=perf_filename,
-                        power_stats=results["power_stats"],
-                    )
-
-            # Cleanup
-            if aic_cached_inputs:
-                del k_input, q, k, v, g, beta, conv_state, gdn_state
-            else:
-                del input_pool, conv_state, gdn_state
-            gc.collect()
-            torch.cuda.empty_cache()
+            with benchmark_with_power(
+                device=device,
+                kernel_func=run_gdn_update,
+                num_warmups=num_warmups,
+                num_runs=num_runs,
+                repeat_n=1,
+                allow_graph_fail=True,
+            ) as results:
+                if not log_perf(
+                    item_list=[{**common_log_data, "latency": results["latency_ms"]}],
+                    framework="SGLang",
+                    version=sglang_version,
+                    device_name=torch.cuda.get_device_name(device),
+                    op_name="gdn",
+                    kernel_source="fused_recurrent_gated_delta_rule_packed_decode",
+                    perf_filename=perf_filename,
+                    power_stats=results["power_stats"],
+                ):
+                    raise RuntimeError(f"failed to persist SGLang GDN generation row to {perf_filename}")
+            successful_points += 1
 
         except Exception as e:
+            failed_points += 1
             print(f"  Error at batch_size={batch_size}: {e}")
             continue
+        finally:
+            a = a_log = b = conv_state = dt_bias = mixed_qkv = None
+            output = recurrent_state = state_indices = None
+            cleanup_errors = []
+            for cleanup_name, cleanup_fn in (
+                ("gc.collect", gc.collect),
+                ("torch.cuda.empty_cache", torch.cuda.empty_cache),
+            ):
+                try:
+                    cleanup_fn()
+                except Exception as cleanup_error:
+                    cleanup_errors.append(f"{cleanup_name}: {type(cleanup_error).__name__}: {cleanup_error}")
+            if cleanup_errors:
+                raise RuntimeError(f"SGLang GDN generation cleanup failed: {'; '.join(cleanup_errors)}")
+
+    summary = f"ok={successful_points} error={failed_points} skip=0"
+    print(f"GDN generation summary: {summary}")
+    if failed_points or successful_points == 0:
+        raise RuntimeError(f"SGLang GDN generation collection failed strict completeness: {summary}")
 
 
 def run_gdn_torch(
@@ -636,8 +527,7 @@ def run_gdn_torch(
     Main entry point for GDN benchmarking using SGLang's Triton FLA kernels.
 
     Routes to appropriate benchmark function based on phase.
-    Imports GDN kernels from SGLang's vendored FLA copy at runtime,
-    falling back to the standalone fla package if not found.
+    Imports the target SGLang kernels at runtime.
     """
     import contextlib
 
@@ -647,7 +537,9 @@ def run_gdn_torch(
         contextlib.redirect_stderr(_devnull_file),
     ):
         from sglang.srt.layers.attention.fla.chunk import chunk_gated_delta_rule
-        from sglang.srt.layers.attention.fla.fused_recurrent import fused_recurrent_gated_delta_rule
+        from sglang.srt.layers.attention.fla.fused_recurrent import (
+            fused_recurrent_gated_delta_rule_packed_decode,
+        )
         from sglang.srt.layers.attention.mamba.causal_conv1d import causal_conv1d_fn, causal_conv1d_update
 
     from importlib.metadata import version as _get_version
@@ -659,7 +551,7 @@ def run_gdn_torch(
             "causal_conv1d_fn": causal_conv1d_fn,
             "causal_conv1d_update": causal_conv1d_update,
             "chunk_gated_delta_rule": chunk_gated_delta_rule,
-            "fused_recurrent_gated_delta_rule": fused_recurrent_gated_delta_rule,
+            "fused_recurrent_gated_delta_rule_packed_decode": fused_recurrent_gated_delta_rule_packed_decode,
         }
     )
 

--- a/collector/sglang/collect_gemm.py
+++ b/collector/sglang/collect_gemm.py
@@ -9,10 +9,14 @@ available. The module owns SGLang-specific kernel selection, quantization
 helpers, SM filters, and perf logging.
 """
 
-__compat__ = "sglang>=0.5.10rc0"
+__compat__ = "sglang==0.5.14"
 
 import os
 import random
+
+# SGLang reads this flag while importing ``deep_gemm_wrapper.compile_utils``.
+# Set it before any SGLang imports so a task compiles only its requested M.
+os.environ.setdefault("SGLANG_JIT_DEEPGEMM_PRECOMPILE", "0")
 
 import pkg_resources
 import torch
@@ -27,7 +31,6 @@ from collector.case_generator import get_gemm_case_specs
 try:
     from flashinfer import fp4_quantize as flashinfer_fp4_quantize
     from flashinfer import mm_fp4 as flashinfer_mm_fp4
-    from flashinfer import shuffle_matrix_sf_a as flashinfer_shuffle_sf_a
 
     HAS_FLASHINFER_FP4 = True
 except ImportError:
@@ -40,10 +43,6 @@ from sglang.srt.layers.deep_gemm_wrapper import (
 from sglang.srt.layers.quantization.fp8_kernel import sglang_per_token_group_quant_fp8
 
 from collector.helper import benchmark_with_power, get_sm_version, log_perf
-
-# Disable DeepGEMM JIT precompilation (compiles ALL M values per unique N,K pair).
-# The collector only needs the specific M being tested.
-os.environ.setdefault("SGLANG_JIT_DEEPGEMM_PRECOMPILE", "0")
 
 
 def get_gemm_test_cases():
@@ -77,6 +76,10 @@ def get_gemm_test_cases():
         k = gemm_common_testcase.k
         for gemm_type in gemm_list:
             if (gemm_type == "nvfp4" or gemm_type == "fp8_block") and (n < 128 or k < 128):
+                continue
+            if gemm_type == "nvfp4" and (n % 128 != 0 or k % 64 != 0):
+                # The 0.5.14 FlashInfer path uses the modelopt 128x4
+                # block-scale layout without synthetic padding.
                 continue
 
             test_cases.append([gemm_type, x, n, k])
@@ -144,16 +147,21 @@ def run_gemm(gemm_type, batch_size, N, K, *, perf_filename, device="cuda:0"):  #
     ], "not support gemm type"
     torch.cuda.set_device(device)
     M = batch_size  # noqa: N806
-
-    def round_up(x, m):
-        return (x + m - 1) // m * m
+    sm_version = get_sm_version()
+    fp4_backend = None
+    if gemm_type == "nvfp4":
+        if not HAS_FLASHINFER_FP4:
+            raise RuntimeError("SGLang NVFP4 GEMM requires FlashInfer FP4 quantization support")
+        if sm_version in {100, 103}:
+            fp4_backend = "cute-dsl"
+        elif sm_version == 120:
+            fp4_backend = "cutlass"
+        else:
+            raise ValueError(f"SGLang NVFP4 dense GEMM is not implemented for SM{sm_version}")
 
     def create_gemm():
         dtype = torch.bfloat16
         if gemm_type == "nvfp4":
-            if not HAS_FLASHINFER_FP4:
-                return None
-
             # Prepare source data: Activation A [M, K] in BF16
             a_bf16 = torch.randn((M, K), device=device, dtype=dtype)
 
@@ -165,27 +173,18 @@ def run_gemm(gemm_type, batch_size, N, K, *, perf_filename, device="cuda:0"):  #
             b_global_scale = torch.tensor([1.0], device=device, dtype=torch.float32)
             alpha = 1.0 / (a_global_scale * b_global_scale)
 
-            # Pre-quantize and Shuffle Weight B (load time process)
-            b_fp4_linear, b_sf_linear = flashinfer_fp4_quantize(
-                b_bf16_dummy, b_global_scale, is_sf_swizzled_layout=False
+            # SGLang 0.5.14 selects CuTeDSL on SM100/103 and CUTLASS on
+            # SM120. Both consume the modelopt swizzled scale layout; the
+            # shuffle_matrix_a/sf_a layout belongs to the TRTLLM backend.
+            b_fp4, b_sf = flashinfer_fp4_quantize(
+                b_bf16_dummy,
+                b_global_scale,
+                is_sf_swizzled_layout=True,
             )
-
-            from flashinfer import shuffle_matrix_a as flashinfer_shuffle_a
-
-            epilogue_tile_m = 128
             del b_bf16_dummy
-            b_fp4_shuffled = flashinfer_shuffle_a(b_fp4_linear, epilogue_tile_m)
-            del b_fp4_linear
-            b_sf_shuffled = flashinfer_shuffle_sf_a(b_sf_linear.view(torch.uint8), epilogue_tile_m).view(
-                torch.float8_e4m3fn
-            )
-            del b_sf_linear
-            b_fp4_final = b_fp4_shuffled.t()
-            del b_fp4_shuffled
-            b_sf_final = b_sf_shuffled.t()
-            del b_sf_shuffled
-
-            out = torch.empty((M, round_up(N, 128)), device=device, dtype=dtype)
+            b_fp4 = b_fp4.t()
+            b_sf = b_sf.t()
+            out = torch.empty((M, N), device=device, dtype=dtype)
 
             def gemm_op():
                 # Dynamic Quantization of Activation + GEMM
@@ -193,7 +192,14 @@ def run_gemm(gemm_type, batch_size, N, K, *, perf_filename, device="cuda:0"):  #
                     a_bf16, a_global_scale, is_sf_swizzled_layout=True
                 )
                 return flashinfer_mm_fp4(
-                    a_fp4_dynamic, b_fp4_final, a_sf_dynamic, b_sf_final, alpha, dtype, backend="cutlass", out=out
+                    a_fp4_dynamic,
+                    b_fp4,
+                    a_sf_dynamic,
+                    b_sf,
+                    alpha,
+                    dtype,
+                    backend=fp4_backend,
+                    out=out,
                 )
 
             return gemm_op
@@ -299,6 +305,11 @@ def run_gemm(gemm_type, batch_size, N, K, *, perf_filename, device="cuda:0"):  #
         finally:
             torch.cuda.nvtx.range_pop()
 
+        kernel_source = "sglang"
+        if gemm_type == "nvfp4":
+            kernel_source = (
+                "sglang_flashinfer_cutedsl_nvfp4" if fp4_backend == "cute-dsl" else "sglang_flashinfer_cutlass_nvfp4"
+            )
         log_perf(
             item_list=[
                 {"gemm_dtype": gemm_type, "m": M, "n": N, "k": K, "latency": results["latency_ms"] / len(op_list)}
@@ -307,7 +318,7 @@ def run_gemm(gemm_type, batch_size, N, K, *, perf_filename, device="cuda:0"):  #
             version=pkg_resources.get_distribution("sglang").version,
             device_name=torch.cuda.get_device_name(device),
             op_name="gemm",
-            kernel_source="sglang",
+            kernel_source=kernel_source,
             perf_filename=perf_filename,
             power_stats=results["power_stats"],
         )

--- a/collector/sglang/collect_mhc_module.py
+++ b/collector/sglang/collect_mhc_module.py
@@ -8,6 +8,8 @@
 # capable image or put a matching SGLang source tree on PYTHONPATH.
 from __future__ import annotations
 
+__compat__ = "sglang==0.5.14"
+
 import argparse
 import copy
 import gc
@@ -22,7 +24,6 @@ from importlib.metadata import version as get_version
 import torch
 
 os.environ.setdefault("SGLANG_APPLY_CONFIG_BACKUP", "none")
-os.environ.setdefault("SGLANG_OPT_DEEPGEMM_HC_PRENORM", "0")
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 if THIS_DIR not in sys.path:
@@ -198,7 +199,6 @@ def _load_one_layer_runner(
         max_running_requests=16,
         max_prefill_tokens=4096,
     )
-    server_args.enable_piecewise_cuda_graph = False
     server_args.attention_backend = "dsv4"
 
     print(f"[mhc-collector] model_path {model_path} -> {local_model_path}")
@@ -238,8 +238,8 @@ def _mhc_call_args(layer):
     # A real DSV4 layer executes mHC once before attention and once before FFN.
     # This collector folds both calls into the reported pre/post op.
     return (
-        (layer.hc_attn_fn, layer.hc_attn_scale, layer.hc_attn_base),
-        (layer.hc_ffn_fn, layer.hc_ffn_scale, layer.hc_ffn_base),
+        (layer.hc_attn_fn, layer.hc_attn_scale, layer.hc_attn_base, layer.input_layernorm),
+        (layer.hc_ffn_fn, layer.hc_ffn_scale, layer.hc_ffn_base, layer.post_attention_layernorm),
     )
 
 
@@ -257,13 +257,16 @@ def _make_kernel(layer, op: str, residual: torch.Tensor):
         call_args = _mhc_call_args(layer)
 
         def kernel():
-            return [layer.hc_pre(residual, *args) for args in call_args]
+            return [layer.hc_pre(residual, fn, scale, base, norm=norm) for fn, scale, base, norm in call_args]
 
         return kernel
 
     if op == "post":
         with torch.no_grad():
-            post_inputs = [_hc_pre_post_inputs(layer.hc_pre(residual, *args)) for args in _mhc_call_args(layer)]
+            post_inputs = [
+                _hc_pre_post_inputs(layer.hc_pre(residual, fn, scale, base, norm=norm))
+                for fn, scale, base, norm in _mhc_call_args(layer)
+            ]
         torch.cuda.synchronize()
 
         def kernel():

--- a/collector/sglang/collect_mla.py
+++ b/collector/sglang/collect_mla.py
@@ -9,7 +9,7 @@ this file owns SGLang MLA backend choice, paged KV-cache setup, DP-attention
 mocking, SM-specific skips, and perf logging.
 """
 
-__compat__ = "sglang>=0.5.10rc0"
+__compat__ = "sglang==0.5.14"
 
 import math
 import os
@@ -26,34 +26,18 @@ from sglang.srt.layers.attention.trtllm_mla_backend import TRTLLMMLABackend
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.mem_cache.memory_pool import MLATokenToKVPool, ReqToTokenPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.srt.model_executor.forward_context import ForwardContext, forward_context
+from sglang.srt.runtime_context import get_parallel
 
 from collector.case_generator import get_context_mla_case_specs, get_generation_mla_case_specs
 from collector.helper import benchmark_with_power, get_sm_version, log_perf
 from collector.registry_types import PerfFile
 
-# Mocking for standalone collector script
-# sglang >=0.5.10 removed _ATTN_TP_SIZE/_ATTN_TP_RANK/_ATTN_TP_GROUP from dp_attention;
-# get_attention_tp_size() now delegates to sglang.srt.distributed. Set the remaining
-# private variables for older versions and always override the public functions.
-if hasattr(sglang.srt.layers.dp_attention, "_ATTN_TP_SIZE"):
-    sglang.srt.layers.dp_attention._ATTN_TP_SIZE = 1
-    sglang.srt.layers.dp_attention._ATTN_TP_RANK = 0
+# The standalone collector has no scheduler to initialize DP state.
 sglang.srt.layers.dp_attention._ATTN_DP_SIZE = 1
 sglang.srt.layers.dp_attention._ATTN_DP_RANK = 0
 sglang.srt.layers.dp_attention._LOCAL_ATTN_DP_SIZE = 1
 sglang.srt.layers.dp_attention._LOCAL_ATTN_DP_RANK = 0
-sglang.srt.layers.dp_attention.get_attention_tp_size = lambda: 1
-sglang.srt.layers.dp_attention.get_attention_tp_rank = lambda: 0
-sglang.srt.layers.dp_attention.get_attention_dp_size = lambda: 1
-sglang.srt.layers.dp_attention.get_attention_dp_rank = lambda: 0
-# Patch imported versions in other modules
-import sglang.srt.layers.attention.flashinfer_mla_backend
-import sglang.srt.layers.attention.triton_backend
-import sglang.srt.layers.attention.trtllm_mla_backend
-
-sglang.srt.layers.attention.flashinfer_mla_backend.get_attention_tp_size = lambda: 1
-sglang.srt.layers.attention.triton_backend.get_attention_tp_size = lambda: 1
-sglang.srt.layers.attention.trtllm_mla_backend.get_attention_tp_size = lambda: 1
 
 DISABLE_BACKWARD = os.getenv("FLASH_ATTENTION_DISABLE_BACKWARD", "FALSE") == "TRUE"
 
@@ -61,12 +45,10 @@ DISABLE_BACKWARD = os.getenv("FLASH_ATTENTION_DISABLE_BACKWARD", "FALSE") == "TR
 KV_LORA_RANK = 512
 QK_NOPE_HEAD_DIM = 128  # DeepSeek configs
 QK_ROPE_HEAD_DIM = 64
-MLA_PAGE_SIZE = 64
 # Scaling follows production: 1 / sqrt(qk_nope + qk_rope)
 MLA_SCALING = 1 / math.sqrt(QK_NOPE_HEAD_DIM + QK_ROPE_HEAD_DIM)
 INT32_MAX = 2**31 - 1
-# Largest kv slot index we can safely touch before the old flashmla kernels overflow
-MAX_KV_LOC = (INT32_MAX // (KV_LORA_RANK + QK_ROPE_HEAD_DIM)) - MLA_PAGE_SIZE
+MAX_KV_LOC = INT32_MAX // (KV_LORA_RANK + QK_ROPE_HEAD_DIM)
 
 # We only cover deepseek v3 in this collector script.
 
@@ -79,14 +61,16 @@ def _cuda_version_at_least(major: int, minor: int) -> bool:
 
 
 def _select_default_mla_backend() -> str:
-    """Match SGLang 0.5.10's default MLA backend for DeepSeek V3."""
+    """Match SGLang 0.5.14's default MLA backend for DeepSeek V3."""
     sm_version = get_sm_version()
-    if 100 <= sm_version < 110 and _cuda_version_at_least(12, 8):
+    if sm_version in {100, 103} and _cuda_version_at_least(12, 8):
         # DeepSeek V3/R1/V3.1 special-case in SGLang server_args.py.
         return "trtllm_mla"
-    if 90 <= sm_version < 100 and _cuda_version_at_least(12, 3):
+    if sm_version == 90 and _cuda_version_at_least(12, 3):
         return "fa3"
-    return "triton"
+    if sm_version in {90, 100, 103, 120}:
+        return "triton"
+    raise ValueError(f"No SGLang 0.5.14 MLA backend mapping for SM{sm_version}")
 
 
 class MockModelConfig:
@@ -114,7 +98,9 @@ class MockModelConfig:
         self.kv_lora_rank = kv_lora_rank
         self.qk_nope_head_dim = qk_nope_head_dim
         self.qk_rope_head_dim = qk_rope_head_dim
+        self.head_dim = 256
         self.v_head_dim = v_head_dim
+        self.hf_text_config = self
         self.scaling = scaling
         self.is_local_attention_model = False
 
@@ -136,6 +122,7 @@ class MockServerArgs:
         self.decode_attention_backend = "fa3"
         self.page_size = page_size
         self.device = "cuda"
+        self.is_embedding = False
         self.disable_chunked_prefix_cache = True
         self.disaggregation_mode = None
         self.flashinfer_mla_disable_ragged = False
@@ -157,6 +144,7 @@ class MockModelRunner:
     ):
         self.device = device
         self.gpu_id = device.index if device.index is not None else torch.cuda.current_device()
+        self.tp_size = 1
         self.kv_cache_dtype = kv_cache_dtype
         self.dtype = torch.bfloat16
         self.page_size = page_size
@@ -207,7 +195,8 @@ def benchmark_layer(layer, forward_batch, q, k, v, q_rope, k_rope, **kwargs):
             extra_kwargs["q_rope"] = q_rope
         if k_rope is not None:
             extra_kwargs["k_rope"] = k_rope
-        layer(q, k, v, forward_batch, **extra_kwargs)
+        with forward_context(ForwardContext(attn_backend=forward_batch.attn_backend)):
+            layer(q, k, v, forward_batch, **extra_kwargs)
 
     with benchmark_with_power(
         device=device,
@@ -233,6 +222,7 @@ def get_context_mla_test_cases():
         get_context_mla_case_specs(),
         dtype_list=dtype_list,
         tp_sizes=(1, 2, 4, 8, 16, 32, 64),
+        backend=backend,
     )
 
 
@@ -268,17 +258,13 @@ def _build_mla_test_cases(case_specs, *, dtype_list, tp_sizes, backend=None, sm_
     """
 
     cases_by_physical_key = {}
+    page_size = 64 if backend == "trtllm_mla" else 1
+    max_kv_loc = MAX_KV_LOC - page_size
     expected_geometry = (KV_LORA_RANK, QK_NOPE_HEAD_DIM, QK_ROPE_HEAD_DIM, 128)
     for spec in case_specs:
         geometry = (spec.kv_lora_rank, spec.qk_nope_head_dim, spec.qk_rope_head_dim, spec.v_head_dim)
         if geometry != expected_geometry:
             raise ValueError(f"Unsupported SGLang MLA geometry for {spec.model_name}: {geometry}")
-        if spec.kv_cache_block_size != MLA_PAGE_SIZE:
-            raise ValueError(
-                f"Unsupported SGLang MLA page size for {spec.model_name}: "
-                f"{spec.kv_cache_block_size} (expected {MLA_PAGE_SIZE})"
-            )
-
         for dtype in dtype_list:
             for tp_size in tp_sizes:
                 if spec.num_heads % tp_size:
@@ -293,7 +279,7 @@ def _build_mla_test_cases(case_specs, *, dtype_list, tp_sizes, backend=None, sm_
                     # 128 Q heads from the q tensor regardless of the runtime head count.
                     # local_heads != 128 causes out-of-bounds GPU memory reads and crashes.
                     continue
-                if not spec.is_context_phase and (spec.batch_size * (spec.input_len + 1)) + MLA_PAGE_SIZE > MAX_KV_LOC:
+                if not spec.is_context_phase and (spec.batch_size * (spec.input_len + 1)) + page_size > max_kv_loc:
                     # Guard against int32 overflow in the legacy flashmla kernel path.
                     continue
 
@@ -305,7 +291,7 @@ def _build_mla_test_cases(case_specs, *, dtype_list, tp_sizes, backend=None, sm_
                     spec.num_heads,
                     tp_size,
                     tp_size,
-                    spec.kv_cache_block_size,
+                    page_size,
                     10,
                     6,
                     spec.is_context_phase,
@@ -330,6 +316,14 @@ def _build_mla_test_cases(case_specs, *, dtype_list, tp_sizes, backend=None, sm_
     return list(cases_by_physical_key.values())
 
 
+@get_parallel().override(
+    attn_tp_size=1,
+    attn_tp_rank=0,
+    attn_cp_size=1,
+    attn_cp_rank=0,
+    attn_dp_size=1,
+    attn_dp_rank=0,
+)
 def run_mla(
     input_len,
     batch_size,
@@ -350,16 +344,21 @@ def run_mla(
     torch_device = torch.device(device)
     random.seed(0)
     torch.manual_seed(0)
-    del world_size, tokens_per_block, warming_up, test_ite, output_len
+    del world_size, warming_up, test_ite, output_len
 
     assert kv_cache_dtype in [torch.bfloat16, torch.float8_e4m3fn], "Unsupported kv cache dtype"
     assert num_heads % tp_size == 0, "num_heads must be divisible by tp_size"
     local_num_heads = num_heads // tp_size
 
+    selected_backend = _select_default_mla_backend()
+    expected_page_size = 64 if selected_backend == "trtllm_mla" else 1
+    if tokens_per_block != expected_page_size:
+        raise ValueError(f"SGLang {selected_backend} requires page_size={expected_page_size}, got {tokens_per_block}")
+
     model_runner = MockModelRunner(
         torch_device,
         kv_cache_dtype,
-        MLA_PAGE_SIZE,
+        tokens_per_block,
         num_attention_heads=num_heads,
         scaling=MLA_SCALING,
     )
@@ -367,13 +366,12 @@ def run_mla(
     req_to_token_pool, token_matrix = create_req_to_token_pool(
         batch_size=batch_size,
         total_len=total_len,
-        page_size=MLA_PAGE_SIZE,
+        page_size=tokens_per_block,
         torch_device=torch_device,
         device_str=str(torch_device),
     )
     model_runner.req_to_token_pool = req_to_token_pool
 
-    selected_backend = _select_default_mla_backend()
     model_runner.server_args.attention_backend = selected_backend
     model_runner.server_args.prefill_attention_backend = selected_backend
     model_runner.server_args.decode_attention_backend = selected_backend
@@ -410,10 +408,13 @@ def run_mla(
     model_runner.model_config.scaling = MLA_SCALING
 
     total_tokens = max(1, batch_size * total_len)
-    kv_cache_size = max(MLA_PAGE_SIZE, math.ceil(total_tokens / MLA_PAGE_SIZE) * MLA_PAGE_SIZE)
+    kv_cache_size = max(
+        tokens_per_block,
+        math.ceil(total_tokens / tokens_per_block) * tokens_per_block,
+    )
     kv_pool = MLATokenToKVPool(
         size=kv_cache_size,
-        page_size=MLA_PAGE_SIZE,
+        page_size=tokens_per_block,
         dtype=kv_cache_dtype,
         kv_lora_rank=kv_lora_rank,
         qk_rope_head_dim=qk_rope_head_dim,

--- a/collector/sglang/collect_mla_bmm.py
+++ b/collector/sglang/collect_mla_bmm.py
@@ -8,6 +8,8 @@ generation pre/post processing. It consumes YAML-backed synthetic tensor
 shapes, selects SGLang kernel helpers, and logs the resulting MLA BMM perf rows.
 """
 
+__compat__ = "sglang==0.5.14"
+
 import pkg_resources
 import torch
 from sgl_kernel import bmm_fp8
@@ -111,7 +113,6 @@ def run_mla_gen_post(num_tokens, num_heads, dtype, num_warmups, num_runs, *, per
 
     assert dtype == "bfloat16" or dtype == "fp8", "only support fp8 and bfloat16"
 
-    qk_nope_head_dim = 128
     kv_lora_rank = 512
     v_head_dim = 128
 
@@ -120,7 +121,7 @@ def run_mla_gen_post(num_tokens, num_heads, dtype, num_warmups, num_runs, *, per
         w_vc = torch.randn([num_heads, v_head_dim, kv_lora_rank]).bfloat16().to(torch.device(device))
         w_vc = w_vc.transpose(1, 2)
         attn_bmm_output = torch.empty(
-            (attn_output.shape[0], qk_nope_head_dim * v_head_dim),
+            (num_tokens, num_heads, v_head_dim),
             dtype=attn_output.dtype,
             device=attn_output.device,
         )
@@ -128,14 +129,14 @@ def run_mla_gen_post(num_tokens, num_heads, dtype, num_warmups, num_runs, *, per
         torch.bmm(
             attn_output.transpose(0, 1),
             w_vc,
-            out=attn_bmm_output.view(-1, qk_nope_head_dim, v_head_dim).transpose(0, 1),
+            out=attn_bmm_output.transpose(0, 1),
         )
 
         def kernel_func():
             torch.bmm(
                 attn_output.transpose(0, 1),
                 w_vc,
-                out=attn_bmm_output.view(-1, qk_nope_head_dim, v_head_dim).transpose(0, 1),
+                out=attn_bmm_output.transpose(0, 1),
             )
     else:
         attn_output = torch.randn([num_tokens, num_heads, kv_lora_rank], dtype=torch.bfloat16, device=device)
@@ -146,7 +147,7 @@ def run_mla_gen_post(num_tokens, num_heads, dtype, num_warmups, num_runs, *, per
         w_scale = torch.randn([num_heads, v_head_dim // 128, kv_lora_rank // 128], dtype=torch.float32, device=device)
         attn_bmm_output = torch.randn([num_tokens, num_heads, v_head_dim]).bfloat16().to(torch.device(device))
 
-        zeroscale = torch.tensor([1], dtype=torch.float32, device=device)
+        zeroscale = torch.zeros((1,), dtype=torch.float32, device=device)
 
         def kernel_func():
             attn_output_val, attn_output_scale = per_tensor_quant_mla_fp8(

--- a/collector/sglang/collect_mla_module.py
+++ b/collector/sglang/collect_mla_module.py
@@ -22,6 +22,8 @@ Usage:
         python collect_mla_module.py --mode generation --attn-type mla
 """
 
+__compat__ = "sglang==0.5.14"
+
 import argparse
 import gc
 import json
@@ -68,6 +70,8 @@ try:
         dsa_indexer_total_kv_tokens_supported,
         dsa_indexer_workspace_bytes,
         dsa_indexer_workspace_limit_bytes,
+        kv_pool_page_size,
+        required_kv_alloc_tokens,
         required_kv_tokens,
         required_prefill_extend_tokens,
         sglang_dsa_mqa_logits_chunking_supported,
@@ -90,6 +94,8 @@ except ModuleNotFoundError:
         dsa_indexer_total_kv_tokens_supported,
         dsa_indexer_workspace_bytes,
         dsa_indexer_workspace_limit_bytes,
+        kv_pool_page_size,
+        required_kv_alloc_tokens,
         required_kv_tokens,
         required_prefill_extend_tokens,
         sglang_dsa_mqa_logits_chunking_supported,
@@ -115,6 +121,7 @@ SGLANG_KV_DTYPE: dict[str, str] = {
     "bfloat16": "bfloat16",
     "fp8": "fp8_e4m3",
 }
+SGLANG_DSA_PAGE_SIZE = 64
 
 # AIC's cached HuggingFace model configs — avoids HF downloads in CI.
 _MODEL_CONFIG_DIR = os.path.join(
@@ -181,17 +188,6 @@ def _is_glm5_dsa_model(model_id: str) -> bool:
     return _module_model_architecture(model_id) == _GLM5_DSA_ARCHITECTURE
 
 
-def _enable_glm5_dsa_piecewise_graph(attn_type: str, model_id: str, dsa_prefill_backend: str = "flashmla_kv") -> bool:
-    if not (attn_type == "dsa" and _is_glm5_dsa_model(model_id)):
-        return False
-    # Incremental trtllm variant collects WITH piecewise CUDA graph (trtllm
-    # prefill avoids the flashmla concat_mla.cuh:309 capture crash). flashmla_kv
-    # is instead timed EAGERLY: piecewise capture of the flashmla path crashes
-    # in concat_mla.cuh:309 (cudaErrorInvalidValue) on sglang >= 0.5.13, and
-    # eager is also what CP prefill serve runs.
-    return dsa_prefill_backend == "trtllm"
-
-
 # Set by run_mla_module() at the start of each benchmark subprocess from its
 # skip_indexer arg (threaded down from run_mla_module_worker, which derives it
 # from the op's perf_filename). Process-local: each subprocess runs exactly one
@@ -217,30 +213,6 @@ def _dsa_skip_indexer_enabled(attn_type: str, model_path: str) -> bool:
     )
 
 
-_MODULE_PIECEWISE_REPLAY_AVAILABLE = None
-
-
-def _module_piecewise_replay_available() -> bool:
-    """Whether the module-level piecewise CUDA graph replay path can run.
-
-    That path imports ``sglang.srt.model_executor.piecewise_cuda_graph_runner``
-    and monkey-patches ``PiecewiseCudaGraphRunner``. The refactored sglang
-    (glm52 dev image) moved piecewise into ``srt/compilation`` and removed that
-    model_executor module, so the replay path can't import -> the collector must
-    time the DSA module EAGERLY instead (which is what GLM-5 DSA flashmla_kv
-    prefill runs in serve anyway). Cached; returns False on the dev image so
-    callers fall back to the existing eager path. Backward compatible: returns
-    True on older sglang where the module exists."""
-    global _MODULE_PIECEWISE_REPLAY_AVAILABLE
-    if _MODULE_PIECEWISE_REPLAY_AVAILABLE is None:
-        import importlib.util
-
-        _MODULE_PIECEWISE_REPLAY_AVAILABLE = (
-            importlib.util.find_spec("sglang.srt.model_executor.piecewise_cuda_graph_runner") is not None
-        )
-    return _MODULE_PIECEWISE_REPLAY_AVAILABLE
-
-
 def _generation_cuda_graph_enabled_for_tokens(model_runner, num_tokens: int) -> bool:
     """Match SGLang decode CUDA graph coverage for the decode microbench.
 
@@ -249,13 +221,13 @@ def _generation_cuda_graph_enabled_for_tokens(model_runner, num_tokens: int) -> 
     that coverage using sglang's own settings -- no AIC env override -- so the
     decode benchmark uses graph timing exactly where serve would.
     """
-    sa = model_runner.server_args
-    if getattr(sa, "disable_cuda_graph", False):
+    decode_config = model_runner.server_args.cuda_graph_config.decode
+    if decode_config.backend == "disabled":
         return False
-    capture_bs = getattr(sa, "cuda_graph_bs", None)
+    capture_bs = decode_config.bs
     if capture_bs:
         return int(num_tokens) in set(capture_bs)
-    max_bs = getattr(sa, "cuda_graph_max_bs", None) or 256
+    max_bs = decode_config.max_bs or 256
     return 0 < int(num_tokens) <= int(max_bs)
 
 
@@ -282,41 +254,9 @@ def _resolve_local_model_path(model_id: str) -> str:
     with open(config_file) as f:
         config = json.load(f)
 
-    # Normalise model_type so sglang's AutoConfig recognises it.
-    original_arch = None
-    if config.get("model_type") in ("deepseek_v32", "glm_moe_dsa"):
-        original_arch = (config.get("architectures") or [None])[0]
-        config["architectures"] = ["DeepseekV3ForCausalLM"]
-        config["model_type"] = "deepseek_v3"
-
     # Strip auto_map to prevent transformers from attempting to download
     # custom config/model classes from HuggingFace when trust_remote_code=True.
     config.pop("auto_map", None)
-
-    # Strip layer_types: transformers >= 5.3 strictly validates layer_types
-    # against a per-architecture whitelist, and GLM-5.2's
-    # "deepseek_sparse_attention" entries are not in the DeepseekV3 whitelist we
-    # rewrote architectures to above -> AutoConfig load raises. The collector
-    # detects DSA via index_topk (is_deepseek_nsa), not layer_types, so dropping
-    # it is safe. Harmless no-op on configs/transformers without layer_types.
-    config.pop("layer_types", None)
-
-    # Re-apply GLM-5 arch-specific overrides that sglang would normally
-    # apply in server_args.py:1609-1612 based on
-    # hf_config.architectures[0] == "GlmMoeDsaForCausalLM" - but we just
-    # rewrote that string to "DeepseekV3ForCausalLM" above so AutoConfig
-    # can find the model_type, so sglang's gate never fires. Without
-    # this, on Blackwell every GLM-5 DSA context probe with max_kv_len
-    # <= 2048 (the default DENSE_ATTN threshold) dispatches to
-    # _forward_standard_mha -> flashinfer.prefill.trtllm_ragged_attention_deepseek
-    # which asserts on GLM-5's v_head_dim=256 and kills the subprocess
-    # after ~14 rows/bucket.
-    if (
-        original_arch == "GlmMoeDsaForCausalLM"
-        and get_sm_version() >= 100
-        and "SGLANG_NSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD" not in os.environ
-    ):
-        os.environ["SGLANG_NSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD"] = "0"
 
     tmp_dir = os.path.join(
         tempfile.gettempdir(),
@@ -356,14 +296,13 @@ def _get_precision_combos(phase: str):
 def _get_backends(attn_type: str):
     """Return the attention backend string to use for a given attention type.
 
-    For DSA: returns "nsa" — SGLang auto-detects nsa_prefill_backend /
-    nsa_decode_backend based on SM + kv_cache_dtype.
+    For DSA: returns the SGLang 0.5.14 "dsa" backend.
     For MLA: returns the best available backend based on SM version.
     Aligns with sglang's _get_default_attn_backend() in server_args.py.
     """
     sm = get_sm_version()
     if attn_type == "dsa":
-        return "nsa"
+        return "dsa"
     else:
         if sm >= 100:
             return "trtllm_mla"
@@ -513,19 +452,15 @@ def _model_shares_dsa_index(model_id: str) -> bool:
 
 
 def _model_native_gemm_quant(model_id: str) -> str | None:
-    """Return the checkpoint's native weight-quantization gemm kind, or ``None``
-    for an unquantized (bf16) checkpoint.
+    """Return the checkpoint loader's native weight quantization, or ``None``.
 
     Different GLM-5 / DeepSeek checkpoints ship at different precisions —
     ``nvidia/GLM-5-NVFP4`` (ModelOpt NVFP4), ``zai-org/GLM-5-FP8`` (block-fp8),
     ``zai-org/GLM-5`` (bf16) — and they are *separate models*, not one model
-    reinterpreted at several precisions.  A module precision combo whose
-    ``gemm_type`` asks for a quantization the checkpoint does not carry (e.g.
-    ``gemm_type=fp8_block`` against the NVFP4 checkpoint) cannot load: SGLang
-    routes to the checkpoint's own quant loader, which then rejects the foreign
-    config (``Cannot find 'quant_algo'``) and the subprocess dies at model load.
-    This reads the checkpoint's quant config so the caller only enumerates
-    combos the input model actually supports.
+    reinterpreted at several precisions. This value therefore selects SGLang's
+    checkpoint loader; it is not automatically the persisted module
+    ``gemm_type``. In particular, the NVFP4 checkpoint's timed DSA projections
+    remain BF16 and are logged as ``bfloat16``.
 
     Reads the same AIC cached config files :func:`_resolve_local_model_path`
     loads:
@@ -566,19 +501,6 @@ def _model_native_gemm_quant(model_id: str) -> str | None:
     return None
 
 
-def _gemm_type_supported_by_model(gemm_type: str | None, native_quant: str | None) -> bool:
-    """Whether a module precision combo's ``gemm_type`` can load on this model.
-
-    ``bfloat16`` always works (unquantized / dummy-weight path).  Any quantized
-    ``gemm_type`` is loadable only when it matches the checkpoint's native
-    quantization (see :func:`_model_native_gemm_quant`) — a mismatch is a
-    different model and fails at load.
-    """
-    if gemm_type in (None, "bfloat16", "bf16"):
-        return True
-    return gemm_type == native_quant
-
-
 def _dsa_context_prefix_shape_is_valid(
     batch_size: int,
     seq_len: int,
@@ -611,25 +533,26 @@ def _dsa_context_prefix_shape_is_valid(
     return not (max_position_embeddings is not None and prefix_len + seq_len > max_position_embeddings)
 
 
-def _dedup_same_precision_dsa_models(model_specs):
-    """Collapse DSA models that share an architecture AND a native quant to a
-    single representative (the longest-context one) so a batch collection of
-    several same-precision GLM checkpoints doesn't re-collect identical DSA data.
+def _model_dsa_operator_gemm_type(model_id: str) -> str:
+    """Return the persisted GEMM type of the model's DSA attention module."""
+    return "fp8_block" if _model_native_gemm_quant(model_id) == "fp8_block" else "bfloat16"
 
-    The DSA attention module is bf16 for every GLM checkpoint (self_attn is
-    excluded from quant), so checkpoints of the same (architecture, native_quant)
-    produce identical DSA module timings and differ only in context length. When
-    e.g. nvidia/GLM-5-NVFP4 and nvidia/GLM-5.2-NVFP4 are collected together (both
-    NVFP4 / GlmMoeDsaForCausalLM), keep only GLM-5.2-NVFP4 (max_position 1M ⊇
-    GLM-5) — the others reuse its rows via the model-agnostic DSA loader. Models
-    of a DIFFERENT precision (zai-org/GLM-5 bf16, GLM-5-FP8 fp8_block) or a
-    different architecture (DeepSeek-V3.2) are NOT merged. A single model, or one
-    model per (arch, quant) group, passes through unchanged.
+
+def _dedup_dsa_consumer_models(model_specs):
+    """Keep one longest-context model per DSA consumer identity.
+
+    The persisted DSA key contains architecture and attention-module GEMM type,
+    but not checkpoint path or top-level MoE quantization. GLM BF16 and NVFP4
+    checkpoints therefore share the BF16 DSA key; GLM-5.2 is their canonical
+    full-sweep representative because its 1M context covers the shorter GLM-5
+    range. The block-FP8 checkpoint remains separate because its DSA projections
+    execute and persist as ``fp8_block``. A targeted model filter still contains
+    one checkpoint and is never replaced.
     """
     groups: dict = {}
     order: list = []
     for spec in model_specs:
-        key = (spec.architecture, _model_native_gemm_quant(spec.model_path))
+        key = (spec.architecture, _model_dsa_operator_gemm_type(spec.model_path))
         if key not in groups:
             groups[key] = []
             order.append(key)
@@ -645,7 +568,7 @@ def _dedup_same_precision_dsa_models(model_specs):
         dropped = [s.model_path for s in specs if s is not best]
         print(
             f"[DSA dedup] {key[0]}/{key[1]}: collecting DSA module on {best.model_path}; "
-            f"reusing for same-precision {dropped}"
+            f"reusing for consumer-equivalent {dropped}"
         )
     return out
 
@@ -684,20 +607,18 @@ def _build_module_test_cases(attn_type: str, mode: str):
     if attn_type == "dsa" and _skip_sm120_deepgemm_attention_modules():
         return []
     model_specs = get_mla_module_model_specs(attention_type=attn_type)
-    # Same-precision DSA dedup (DSA module is bf16 for all GLM checkpoints; only
-    # context length differs). Skip-indexer collection is unaffected: its get_func
-    # already filters to index_topk_freq>1 (GLM-5.2 only), so this is a no-op there.
+    # Canonicalize model paths that map to the same persisted DSA consumer key.
+    # Skip-indexer collection remains non-empty because GLM-5.2 is the
+    # longest-context representative for the shared BF16 GLM key.
     if attn_type == "dsa":
-        model_specs = _dedup_same_precision_dsa_models(model_specs)
+        model_specs = _dedup_dsa_consumer_models(model_specs)
     sweep = get_mla_module_sweep_spec("sglang")
     precision_combos = _get_precision_combos(mode)
     cases = []
     for model_spec in model_specs:
-        # Each checkpoint ships at one native precision; only enumerate the
-        # precision combos it can actually load (bf16 always + its own quant).
-        # Prevents e.g. gemm_type=fp8_block being applied to the NVFP4 checkpoint
-        # (a different model), which dies at model load with "Cannot find quant_algo".
-        native_quant = _model_native_gemm_quant(model_spec.model_path)
+        # Checkpoint load precision and the timed DSA projection label are
+        # separate. Native block-FP8 checkpoints execute FP8 projections;
+        # BF16 and NVFP4 checkpoints keep these DSA projections in BF16.
         # NOTE: do NOT force the checkpoint's top-level gemm (e.g. nvfp4) onto the
         # DSA/MLA attention module. GLM-5 / GLM-5.2 NVFP4 quantize ONLY the MoE
         # expert linears; self_attn (q_a/kv_a/q_b/o_proj + indexer wq_b/wk) is in
@@ -708,8 +629,9 @@ def _build_module_test_cases(attn_type: str, mode: str):
         # CORRECT precision here (fp8_block is filtered out by
         # _gemm_type_supported_by_model for an nvfp4 checkpoint). KV is fp8,
         # carried by kv_dtype independently of gemm_type.
+        operator_gemm_type = _model_dsa_operator_gemm_type(model_spec.model_path)
         for compute_dtype, kv_dtype, gemm_type in precision_combos:
-            if not _gemm_type_supported_by_model(gemm_type, native_quant):
+            if gemm_type != operator_gemm_type:
                 continue
             target_tps = sweep.module_tp_sizes if attn_type == "dsa" else [1]
             for target_tp_size in target_tps:
@@ -720,18 +642,16 @@ def _build_module_test_cases(attn_type: str, mode: str):
                     continue
                 batch_sizes = sweep.context_batch_sizes if attn_type == "dsa" and mode == "context" else [0]
                 for batch_size in batch_sizes:
-                    # Split each DSA fp8 context shape into TWO tasks (one per nsa
-                    # prefill backend) so flashmla_kv and trtllm each get a fresh,
-                    # short-lived subprocess -- avoids the cross-case memory
-                    # accumulation that crashed the long combined sweep
-                    # ("Offset increment outside graph capture"). Other cases keep
-                    # a single flashmla_kv task.
-                    _dsa_backends = (
-                        ["flashmla_kv", "trtllm"]
-                        if (attn_type == "dsa" and kv_dtype == "fp8" and mode == "context")
-                        else ["flashmla_kv"]
-                    )
-                    for _dsa_backend in _dsa_backends:
+                    if attn_type == "dsa" and kv_dtype == "fp8":
+                        default_backend = "trtllm" if get_sm_version() >= 100 else "flashmla_kv"
+                        dsa_backends = (
+                            ("flashmla_kv", "trtllm")
+                            if mode == "context" and get_sm_version() >= 100
+                            else (default_backend,)
+                        )
+                    else:
+                        dsa_backends = (None,)
+                    for dsa_backend in dsa_backends:
                         cases.append(
                             [
                                 0,
@@ -744,7 +664,7 @@ def _build_module_test_cases(attn_type: str, mode: str):
                                 attn_type,
                                 None,
                                 target_tp_size,
-                                _dsa_backend,
+                                dsa_backend,
                             ]
                         )
     return cases
@@ -771,11 +691,19 @@ def _build_wideep_mla_test_cases(mode: str):
     sweep = get_mla_module_sweep_spec("sglang")
     backends = _get_mla_backend_list()
     cases = []
+    seen_consumer_keys = set()
     for model_spec in model_specs:
         for backend in backends:
             for num_heads in sweep.inner_sweep_head_counts:
                 if num_heads > model_spec.native_num_heads:
                     continue
+                # WideEP MLA consumers do not key on model/checkpoint path.
+                # Full collection keeps the first V3-family representative;
+                # an explicit COLLECTOR_MODEL_PATH is filtered before here.
+                consumer_key = (backend, num_heads)
+                if consumer_key in seen_consumer_keys:
+                    continue
+                seen_consumer_keys.add(consumer_key)
                 # Single precision: run with bfloat16, log as fp8_block/fp8
                 cases.append(
                     [
@@ -796,7 +724,7 @@ def _build_wideep_mla_test_cases(mode: str):
 def _skip_sm120_deepgemm_attention_modules() -> bool:
     """Return True when SGLang's DeepGEMM-backed module path is unsupported.
 
-    On SM120 with the SGLang 0.5.10 runtime container, forcing these module
+    On SM120 with the SGLang 0.5.14 runtime container, forcing these module
     collectors produced no usable rows:
     - WideEP MLA context/generation subprocesses failed after every shape was
       skipped, ending with "MLA module ... produced no perf rows".
@@ -805,7 +733,7 @@ def _skip_sm120_deepgemm_attention_modules() -> bool:
       attention.hpp:136 and gemm.hpp:376 "Unsupported architecture".
 
     Keep the skip as the default for this collector/runtime combo so the RTX
-    PRO 6000 collection reflects runnable SGLang 0.5.10 paths. Developers can
+    PRO 6000 collection reflects runnable SGLang 0.5.14 paths. Developers can
     set COLLECTOR_FORCE_DEEPGEMM_ATTENTION_MODULES=1 to repro or validate a
     newer runtime.
     """
@@ -933,7 +861,7 @@ def _patch_nsa_rope_contiguity(model_runner):
     The NSA Indexer's _get_k_bf16 calls torch.split on q/k, producing
     non-contiguous views.  The JIT RoPE kernel rejects these:
       - <=0.5.9  rope.cuh:498 check_cuda_contiguous  (q/k assertion)
-      - >=0.5.10 rope.cuh:299 TensorMatcher verify    (positions stride check)
+      - 0.5.14  rope.cuh:299 TensorMatcher verify    (positions stride check)
 
     We monkey-patch rotary_emb.forward on each NSA Indexer layer to call
     .contiguous() on positions, q, and k before the kernel.
@@ -1002,6 +930,10 @@ def _patch_nsa_indexer_compile_for_module_cuda_graph(attention_module) -> None:
 
 class CudaIllegalAccessError(RuntimeError):
     """Stop the current subprocess after a CUDA illegal access poisons context."""
+
+
+class PerfLogWriteError(RuntimeError):
+    """Fail the subprocess when a measured row was not durably persisted."""
 
 
 def _expect_module_attr(module, attr_name: str, expected: int, module_name: str) -> None:
@@ -1076,7 +1008,7 @@ def load_model_runner(
     head_num: int,
     kv_cache_dtype: str,
     attention_backend: str,
-    dsa_prefill_backend: str = "flashmla_kv",
+    dsa_prefill_backend: str | None = None,
     device: str = "cuda:0",
     tp_rank: int = 0,
     gemm_type: str = "bfloat16",
@@ -1091,12 +1023,10 @@ def load_model_runner(
         head_num: Number of local attention heads to benchmark for one target TP rank.
         kv_cache_dtype: Perf-DB-compatible string ("bfloat16" or "fp8").
             Mapped to SGLang-native string via SGLANG_KV_DTYPE.
-        attention_backend: Backend string for ServerArgs (e.g. "nsa", "fa3").
-        gemm_type: Perf-DB-compatible string ("bfloat16" or "fp8_block").
-            "fp8_block" launches sglang with quantization="fp8" so the
-            attention module's linear projections and the paged MQA scoring
-            kernel fire on real fp8 weights; "bfloat16" keeps quantization
-            disabled and all projections run bf16 with dummy weights.
+        attention_backend: Backend string for ServerArgs (e.g. "dsa", "fa3").
+        gemm_type: Expected Perf-DB label for the timed DSA projections. The
+            checkpoint's own quantization metadata independently selects the
+            SGLang loader; callers pre-filter this label to the executed path.
 
     Environment variables:
         SGLANG_TEST_NUM_LAYERS: Number of layers to load (default 2).
@@ -1106,6 +1036,9 @@ def load_model_runner(
 
     from sglang.srt.configs.model_config import ModelConfig
     from sglang.srt.entrypoints.engine import _set_envs_and_config
+    from sglang.srt.layers.moe import initialize_moe_config
+    from sglang.srt.layers.quantization.fp4_utils import initialize_fp4_gemm_config
+    from sglang.srt.layers.quantization.fp8_utils import initialize_fp8_gemm_config
     from sglang.srt.model_executor.model_runner import ModelRunner
     from sglang.srt.server_args import ServerArgs
     from sglang.srt.utils import suppress_other_loggers
@@ -1127,9 +1060,11 @@ def load_model_runner(
     if attention_backend == "trtllm_mla" and sglang_kv_dtype == "bfloat16":
         sglang_kv_dtype = "bf16"
 
-    # Use AIC's local model configs to avoid HF downloads.  Also patches
-    # model_type for sglang compatibility (glm_moe_dsa → deepseek_v3).
+    # Use AIC's local model configs to avoid HF downloads while preserving
+    # SGLang 0.5.14's native model identity.
     local_model_path = _resolve_local_model_path(model_path)
+    native_quant = _model_native_gemm_quant(model_path)
+    load_quantization = {"fp8_block": "fp8", "nvfp4": "modelopt_fp4", None: None}[native_quant]
 
     server_args = ServerArgs(
         model_path=local_model_path,
@@ -1139,46 +1074,11 @@ def load_model_runner(
         tp_size=1,
         trust_remote_code=True,
         disable_radix_cache=True,
-        # Decode CUDA graphs (sglang init_device_graphs: one full-model decode
-        # capture per batch size, default bs=512..1 = 52 captures) are NEVER
-        # used by the prefill DSA-module measurement and are the multi-second
-        # 'various kernels' burst at the front of the timeline. Skip them
-        # entirely (init_device_graphs early-returns on disable_cuda_graph).
-        # The prefill PIECEWISE graph is independent (init_piecewise_cuda_graphs,
-        # gated only by disable_piecewise_cuda_graph) so it still captures.
-        disable_cuda_graph=True,
+        disable_prefill_cuda_graph=True,
         kv_cache_dtype=sglang_kv_dtype,
         max_total_tokens=max_total_tokens,
+        quantization=load_quantization,
     )
-
-    # Quantization control: bf16 (dummy weights) vs fp8 (real fp8 weight
-    # paths so attention projections and indexer MQA scoring actually fire in
-    # fp8).
-    if gemm_type == "fp8_block":
-        server_args.quantization = "fp8"
-    elif gemm_type == "nvfp4":
-        server_args.quantization = "modelopt_fp4"
-    else:
-        server_args.quantization = None
-
-    if enable_piecewise_cuda_graph:
-        server_args.disable_cuda_graph_padding = True
-        # cuda_graph_max_bs / cuda_graph_bs are left at sglang's own defaults
-        # (ServerArgs.__post_init__ tiers cuda_graph_max_bs by GPU memory; cuda_graph_bs
-        # is auto-generated). They only govern decode cuda graphs, which are disabled
-        # here (disable_cuda_graph=True), so the collector never overrides them.
-        # piecewise_cuda_graph_max_tokens / piecewise_cuda_graph_tokens are left
-        # entirely at sglang's own defaults (ServerArgs.__post_init__ sets 2048 for
-        # MLA backends). The per-case gate below times any token_count above that
-        # default EAGERLY (sglang runs those prefill chunks without a piecewise
-        # graph), so the collector never overrides the ceiling.
-        if hasattr(server_args, "enforce_piecewise_cuda_graph"):
-            server_args.enforce_piecewise_cuda_graph = True
-
-    if hasattr(server_args, "disable_piecewise_cuda_graph"):
-        server_args.disable_piecewise_cuda_graph = not enable_piecewise_cuda_graph
-    else:
-        server_args.enable_piecewise_cuda_graph = enable_piecewise_cuda_graph
 
     server_args.attention_backend = attention_backend
     # Do NOT warm up gemm at sglang ModelRunner init (that is the separate
@@ -1186,32 +1086,19 @@ def load_model_runner(
     # module gemm tuning is instead absorbed into the dsa-module warmup below
     # (run_mla_module, under `with autotune(True)`), so it is part of the module
     # init we actually measure -- not a global init phase.
-    if hasattr(server_args, "disable_flashinfer_autotune"):
-        server_args.disable_flashinfer_autotune = True
-    # Match the serve config: force nsa sub-backends so the DSA FMHA uses the
-    # topk-capped flash_fwd_splitkv_mla_fp8_sparse kernel (flat in prefix),
-    # not the default full-attention paged kernel (scales with prefix).
-    # Only fp8 KV: force flashmla_kv so the DSA FMHA uses the topk-capped
-    # flash_fwd_splitkv_mla_fp8_sparse kernel (flat in prefix). bf16 KV is left
-    # at sglang default (flashmla_kv rejects bf16). Gated by env so reversible.
-    # GLM5 DSA fp8 MUST use flashmla_kv so the FMHA is the topk-capped
-    # flash_fwd_splitkv_mla_fp8_sparse kernel (flat in prefix) = serve. Hardcoded
-    # ON for nsa+fp8 (no env gate); bf16 KV left at sglang default.
-    if attention_backend == "nsa" and sglang_kv_dtype == "fp8_e4m3":
-        # Sub-backend hardcoded by the collection sweep: flashmla_kv (serve
-        # default, topk-capped) or trtllm (incremental variant, piecewise graph).
-        # sglang renamed nsa_* -> dsa_* around e958f4561; set whichever exists.
-        for _pre in ("nsa_prefill_backend", "dsa_prefill_backend"):
-            if hasattr(server_args, _pre):
-                setattr(server_args, _pre, dsa_prefill_backend)
-        for _dec in ("nsa_decode_backend", "dsa_decode_backend"):
-            if hasattr(server_args, _dec):
-                setattr(server_args, _dec, dsa_prefill_backend)
+    server_args.disable_flashinfer_autotune = True
+    # Match SGLang 0.5.14 serving dispatch for FP8 KV. Hopper uses FlashMLA's
+    # sparse kernel; datacenter Blackwell uses TRT-LLM. BF16 KV stays on the
+    # runtime default because flashmla_kv rejects BF16.
+    if attention_backend == "dsa" and sglang_kv_dtype == "fp8_e4m3":
+        if dsa_prefill_backend is None:
+            dsa_prefill_backend = "trtllm" if get_sm_version() >= 100 else "flashmla_kv"
+        server_args.dsa_prefill_backend = dsa_prefill_backend
+        server_args.dsa_decode_backend = dsa_prefill_backend
     print(
         f"Using attention backend: {attention_backend}, kv_cache_dtype: {sglang_kv_dtype}, "
         f"gpu_id: {gpu_id}, chunked_prefill_size={server_args.chunked_prefill_size}, "
-        f"max_prefill_tokens={server_args.max_prefill_tokens}, max_total_tokens={max_total_tokens}, "
-        f"piecewise_cuda_graph={enable_piecewise_cuda_graph}"
+        f"max_prefill_tokens={server_args.max_prefill_tokens}, max_total_tokens={max_total_tokens}"
     )
 
     if num_layers > 0 and load_format == "dummy":
@@ -1223,20 +1110,28 @@ def load_model_runner(
         server_args.json_model_override_args = json.dumps(override_args)
 
     _set_envs_and_config(server_args)
+    initialize_moe_config(server_args)
+    initialize_fp8_gemm_config(server_args)
+    initialize_fp4_gemm_config(server_args)
 
     nccl_port = 29500 + random.randint(0, 10000) + gpu_id * 100
 
     model_config = ModelConfig.from_server_args(server_args)
+    expected_architecture = _module_model_architecture(model_path)
+    actual_architecture = (model_config.hf_config.architectures or [None])[0]
+    if actual_architecture != expected_architecture:
+        raise RuntimeError(
+            f"SGLang loaded architecture={actual_architecture!r} for {model_path}, expected {expected_architecture!r}"
+        )
 
     # Bug A fix: ensure hf_config.quantization_config carries weight_block_size
     # so sglang constructs Fp8Config with block_quant=True. Without this, the
     # Fp8LinearMethod post-load path at fp8.py:660 transposes kv_b_proj.weight
     # from (out=7168, in=512) to (in=512, out=7168), and then
     # deepseek_weight_loader.py:555 unflatten(dim0=512, 448) fails with
-    # `448 ∤ 512`. Our _resolve_local_model_path writes quantization_config into
-    # the tmp config.json, but after the model_type rewrite to deepseek_v3 the
-    # attribute may not survive onto hf_config — re-inject it here.
-    if gemm_type == "fp8_block":
+    # `448 ∤ 512`. Re-inject the cached checkpoint metadata after
+    # AutoConfig parsing so the block shape remains explicit on hf_config.
+    if native_quant == "fp8_block":
         _ensure_fp8_block_quant_config(model_config.hf_config)
 
     model_runner = ModelRunner(
@@ -1253,37 +1148,13 @@ def load_model_runner(
         server_args=server_args,
     )
 
-    _ensure_kv_pool_and_attn_backend(model_runner)
+    model_runner.alloc_memory_pool()
+    model_runner.init_attention_backends()
 
     _patch_nsa_rope_contiguity(model_runner)
     _validate_dsa_tp_module_shapes(model_runner, head_num, target_tp_size)
 
     return model_runner
-
-
-def _ensure_kv_pool_and_attn_backend(model_runner) -> None:
-    """Allocate the KV cache pool and attention backend when the runtime split
-    ModelRunner construction from pool/backend init (newer sglang).
-
-    Older sglang (<= 0.5.x release) allocated ``req_to_token_pool`` /
-    ``token_to_kv_pool_allocator`` and the attention backend inside
-    ``ModelRunner.__init__``, so a bare construction was fully usable. The
-    refactored sglang (0.0.0.dev / glm52 image) moves these out of ``__init__``
-    into ``alloc_memory_pool()`` + ``init_attention_backend()`` that the engine's
-    Scheduler/TpWorker drives after construction — steps the collector does not
-    run, leaving ``req_to_token_pool`` (and ``attn_backend``) as ``None`` and the
-    forward path crashing on ``None.clear()`` / ``None.init_forward_metadata``.
-
-    Detect the split by ``req_to_token_pool is None`` after construction and run
-    the two init steps ourselves. On older sglang the pool is already set, so
-    this is a no-op -> backward compatible.
-    """
-    if getattr(model_runner, "req_to_token_pool", None) is not None:
-        return  # old sglang: __init__ already allocated everything
-    if hasattr(model_runner, "alloc_memory_pool"):
-        model_runner.alloc_memory_pool()
-    if hasattr(model_runner, "init_attention_backend"):
-        model_runner.init_attention_backend()
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -1308,7 +1179,7 @@ def run_attention_torch(
     gemm_type: str,
     target_tp_size: int = 1,
     use_module_cuda_graph: bool = False,
-    dsa_prefill_backend: str = "flashmla_kv",
+    dsa_prefill_backend: str | None = None,
 ):
     """Run attention benchmark for both prefill and decode phases.
 
@@ -1321,6 +1192,8 @@ def run_attention_torch(
     attention_module = model_runner.model.model.layers[test_layer].self_attn
     architecture = _module_model_architecture(model_path)
     backend_name = model_runner.server_args.attention_backend
+    resolved_dsa_prefill_backend = getattr(model_runner.server_args, "dsa_prefill_backend", None) or dsa_prefill_backend
+    resolved_dsa_decode_backend = getattr(model_runner.server_args, "dsa_decode_backend", None) or dsa_prefill_backend
     version = get_version("sglang")
     device_name = torch.cuda.get_device_name(device)
 
@@ -1386,7 +1259,7 @@ def run_attention_torch(
                     target_tp_size=target_tp_size,
                     prefix_len=prefix_len,
                     use_module_cuda_graph=use_module_cuda_graph,
-                    dsa_prefill_backend=dsa_prefill_backend,
+                    dsa_prefill_backend=resolved_dsa_prefill_backend,
                 )
             )
         else:
@@ -1413,7 +1286,7 @@ def run_attention_torch(
                     log_gemm_type=log_gemm_type,
                     target_tp_size=target_tp_size,
                     use_module_cuda_graph=use_module_cuda_graph,
-                    dsa_prefill_backend=dsa_prefill_backend,
+                    dsa_prefill_backend=resolved_dsa_decode_backend,
                 )
             )
     return logged_count
@@ -1442,9 +1315,11 @@ def _run_prefill(
     target_tp_size: int,
     prefix_len: int = 0,
     use_module_cuda_graph: bool = False,
-    dsa_prefill_backend: str = "flashmla_kv",
+    dsa_prefill_backend: str | None = None,
 ):
     """Run prefill (context) benchmark for a single (batch_size, seq_length) point."""
+    from array import array
+
     is_wideep_mla = attn_type == "mla"
     from sglang.srt.layers.communicator import AttentionInputs, get_attn_tp_context
     from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
@@ -1475,29 +1350,9 @@ def _run_prefill(
                 sampling_params=SamplingParams(temperature=0, max_new_tokens=1),
             )
             req.prefix_indices = prefix_indices[i]
-            req.fill_ids = req.origin_input_ids
-            # sglang >= 0.5.13: ScheduleBatch.prepare_for_extend reads the per-req
-            # sequence length from req.fill_len and the token ids from
-            # req.get_fill_ids() == full_untruncated_fill_ids[:fill_len] (NOT
-            # req.fill_ids). fill_len defaults to 0, so the admission assert
-            # `seq_len - pre_len == req.extend_input_len` fails for every case.
-            # Populate the new fields (full prefix+seq) when they exist; older
-            # sglang has neither attribute and keeps using req.fill_ids.
-            if hasattr(req, "full_untruncated_fill_ids"):
-                from array import array as _array
-
-                req.full_untruncated_fill_ids = _array("q", req.origin_input_ids)
-                req.fill_len = full_length
-            # sglang dev (glm52 image): get_fill_ids() returns
-            # full_untruncated_fill_ids[: extend_range.end] instead of reading
-            # fill_len, and extend_range defaults to None -> AttributeError
-            # ('NoneType' has no attribute 'end') in prepare_for_extend. Set the
-            # extend range [prefix_len, full_length) so get_fill_ids yields the
-            # full prefix+seq ids (prepare_for_extend then strips the prefix).
-            # Guarded: older sglang has no set_extend_range (uses fill_len).
-            if hasattr(req, "set_extend_range"):
-                req.set_extend_range(prefix_len, full_length)
-            req.extend_input_len = seq_length if prefix_len else len(req.fill_ids)
+            req.full_untruncated_fill_ids = array("q", req.origin_input_ids)
+            req.fill_len = full_length
+            req.set_extend_input_len(seq_length if prefix_len else full_length)
             req.logprob_start_len = 0
             reqs.append(req)
 
@@ -1520,11 +1375,7 @@ def _run_prefill(
         )
         with _temporarily_chunked_alloc_extend(model_runner, batch_size * seq_length):
             batch.prepare_for_extend()
-        if hasattr(batch, "get_model_worker_batch"):
-            batch_for_forward = batch.get_model_worker_batch()
-        else:
-            batch_for_forward = batch
-        forward_batch = ForwardBatch.init_new(batch_for_forward, model_runner)
+        forward_batch = ForwardBatch.init_new(batch, model_runner)
         model_runner.attn_backend.init_forward_metadata(forward_batch)
 
         hidden_states = torch.randn(
@@ -1545,18 +1396,12 @@ def _run_prefill(
         attn_inputs = AttentionInputs(hidden_states, forward_batch, dummy_qkv_latent_func)
         get_attn_tp_context().set_attn_inputs(attn_inputs)
 
-        # Newer sglang (glm52 image) removed the model_executor piecewise runner
-        # module the replay path patches; time the module EAGERLY there (the
-        # existing fallback flag both disables replay below and selects the eager
-        # DSA context path at use_module_eager_dsa_context). No-op on old sglang.
-        if not _module_piecewise_replay_available():
-            model_runner._aic_module_piecewise_fallback_eager = True
-        use_module_piecewise_replay = not getattr(model_runner, "_aic_module_piecewise_fallback_eager", False) and (
-            _env_flag("AIC_ENABLE_MODULE_PIECEWISE_REPLAY") or (attn_type == "dsa" and _is_glm5_dsa_model(model_path))
-        )
-        use_full_model_piecewise_replay = _env_flag("AIC_ENABLE_FULL_MODEL_PIECEWISE_REPLAY")
-        use_module_cuda_graph = use_module_cuda_graph or _env_flag("AIC_ENABLE_MODULE_CUDA_GRAPH")
-        use_module_piecewise_context = _env_flag("AIC_ENABLE_MODULE_PIECEWISE_CONTEXT")
+        # SGLang 0.5.14's prefill graph runner owns a full-model compile
+        # contract. This module microbenchmark measures the eager serving path.
+        use_module_piecewise_replay = False
+        use_full_model_piecewise_replay = False
+        use_module_cuda_graph = False
+        use_module_piecewise_context = False
         # Eager DSA timing: proper forward context but NO piecewise CUDA graph.
         # Used when the prefill chunk exceeds the piecewise graph's captured token
         # ceiling (see the fallback just below).
@@ -1594,15 +1439,10 @@ def _run_prefill(
             use_module_cuda_graph = False
             use_module_piecewise_context = False
             use_module_eager_dsa_context = True
-        # piecewise_cuda_graph_tokens was a top-level ServerArgs field on older
-        # sglang; the refactored sglang (glm52 image) moved piecewise config into
-        # cuda_graph_config, so the attribute is absent -> getattr-guard it
-        # (absent => 0 => the token gate below is inert, correct for the eager
-        # flashmla_kv path which runs no piecewise graph anyway).
-        _pw_tokens = getattr(model_runner.server_args, "piecewise_cuda_graph_tokens", None)
-        max_piecewise_tokens = int(getattr(model_runner.server_args, "piecewise_cuda_graph_max_tokens", 0) or 0) or (
-            max(int(x) for x in _pw_tokens) if _pw_tokens else 0
-        )
+        # SGLang 0.5.14 removed the legacy piecewise-prefill ServerArgs fields.
+        # This collector intentionally times the eager module path above, so no
+        # piecewise token ceiling applies here.
+        max_piecewise_tokens = 0
         if use_module_piecewise_replay and max_piecewise_tokens and token_count > max_piecewise_tokens:
             # piecewise_cuda_graph_max_tokens is an sglang serving knob (2048 by
             # default for MLA backends, to avoid kernel-dispatch regression) — NOT
@@ -2052,7 +1892,7 @@ def _run_prefill(
                 if attn_type == "dsa" and dsa_prefill_backend == "trtllm":
                     kernel_source = f"{kernel_source}_trtllm"
             perf_filename = _resolve_perf_path(output_path, perf_fname)
-            log_perf(
+            if not log_perf(
                 item_list=[
                     {
                         "model": model_path,
@@ -2074,7 +1914,10 @@ def _run_prefill(
                 op_name=op_name,
                 kernel_source=kernel_source,
                 perf_filename=perf_filename,
-            )
+            ):
+                raise PerfLogWriteError(f"failed to persist prefill row to {perf_filename}")
+        except PerfLogWriteError:
+            raise
         except Exception as e:
             print(f"  Warning: failed to log prefill metrics: {e}")
             return False
@@ -2082,6 +1925,8 @@ def _run_prefill(
         print(f"  Prefill: {avg_time_ms:.3f} ms (back-to-back avg over {num_iterations} iters)")
         return True
 
+    except PerfLogWriteError:
+        raise
     except (torch.cuda.OutOfMemoryError, torch.OutOfMemoryError):
         print(f"  OOM: b={batch_size}, s={seq_length} — skipping")
         torch.cuda.empty_cache()
@@ -2099,6 +1944,7 @@ def _run_prefill(
         print("  Skipping this configuration...")
         return False
     finally:
+        cleanup_errors = []
         for cleanup_name, cleanup_fn in (
             ("req_to_token_pool.clear", model_runner.req_to_token_pool.clear),
             ("token_to_kv_pool_allocator.clear", model_runner.token_to_kv_pool_allocator.clear),
@@ -2107,10 +1953,9 @@ def _run_prefill(
             try:
                 cleanup_fn()
             except Exception as cleanup_exc:
-                print(
-                    f"  Warning: cleanup step {cleanup_name} failed after benchmark: "
-                    f"{type(cleanup_exc).__name__}: {cleanup_exc}"
-                )
+                cleanup_errors.append(f"{cleanup_name}: {type(cleanup_exc).__name__}: {cleanup_exc}")
+        if cleanup_errors:
+            raise RuntimeError(f"DSA/MLA prefill cleanup failed: {'; '.join(cleanup_errors)}")
 
 
 def _run_decode(
@@ -2135,9 +1980,11 @@ def _run_decode(
     log_gemm_type: str,
     target_tp_size: int,
     use_module_cuda_graph: bool = False,
-    dsa_prefill_backend: str = "flashmla_kv",
+    dsa_prefill_backend: str | None = None,
 ):
     """Run decode (generation) benchmark for a single (batch_size, kv_cache_length) point."""
+    from array import array
+
     is_wideep_mla = attn_type == "mla"
     from sglang.srt.layers.communicator import AttentionInputs, get_attn_tp_context
     from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
@@ -2165,26 +2012,9 @@ def _run_decode(
                 sampling_params=SamplingParams(temperature=0, max_new_tokens=1),
             )
             req.prefix_indices = torch.empty((0,), dtype=torch.int64)
-            req.fill_ids = req.origin_input_ids
-            # sglang >= 0.5.13: ScheduleBatch.prepare_for_extend reads the per-req
-            # length from req.fill_len and the ids from req.get_fill_ids() ==
-            # full_untruncated_fill_ids[:fill_len] (NOT req.fill_ids). fill_len
-            # defaults to 0, so the admission assert
-            # `seq_len - pre_len == req.extend_input_len` fails for every decode
-            # case. Decode has no prefix (pre_len=0) -> fill_len = full kv length.
-            # Older sglang lacks both attributes and keeps using req.fill_ids.
-            if hasattr(req, "full_untruncated_fill_ids"):
-                from array import array as _array
-
-                req.full_untruncated_fill_ids = _array("q", req.origin_input_ids)
-                req.fill_len = len(req.origin_input_ids)
-            # sglang dev (glm52 image): get_fill_ids() slices
-            # full_untruncated_fill_ids[: extend_range.end]; extend_range defaults
-            # to None -> AttributeError in prepare_for_extend. Decode has no prefix,
-            # so the extend range covers all tokens [0, len). hasattr-guarded.
-            if hasattr(req, "set_extend_range"):
-                req.set_extend_range(0, len(req.origin_input_ids))
-            req.extend_input_len = len(req.fill_ids)
+            req.full_untruncated_fill_ids = array("q", req.origin_input_ids)
+            req.fill_len = len(req.origin_input_ids)
+            req.set_extend_input_len(req.fill_len)
             req.logprob_start_len = 0
             req.cached_tokens = 0
             req.already_computed = 0
@@ -2209,13 +2039,10 @@ def _run_decode(
         )
         # Allocate KV cache slots, then switch to decode
         batch.prepare_for_extend()
-        batch.output_ids = torch.randint(0, 10000, (batch_size,), dtype=torch.int64, device="cuda")
+        for req in batch.reqs:
+            req.output_ids.append(0)
         batch.prepare_for_decode()
-        if hasattr(batch, "get_model_worker_batch"):
-            batch_for_forward_decode = batch.get_model_worker_batch()
-        else:
-            batch_for_forward_decode = batch
-        forward_batch_decode = ForwardBatch.init_new(batch_for_forward_decode, model_runner)
+        forward_batch_decode = ForwardBatch.init_new(batch, model_runner)
         model_runner.attn_backend.init_forward_metadata(forward_batch_decode)
 
         decode_hidden = torch.randn(
@@ -2332,7 +2159,7 @@ def _run_decode(
                 log_isl = 1
                 log_step = seq_length
             perf_filename = _resolve_perf_path(output_path, perf_fname)
-            log_perf(
+            if not log_perf(
                 item_list=[
                     {
                         "model": model_path,
@@ -2355,7 +2182,10 @@ def _run_decode(
                 kernel_source=kernel_source,
                 perf_filename=perf_filename,
                 power_stats=power_stats,
-            )
+            ):
+                raise PerfLogWriteError(f"failed to persist decode row to {perf_filename}")
+        except PerfLogWriteError:
+            raise
         except Exception as e:
             print(f"  Warning: failed to log decode metrics: {e}")
             return False
@@ -2363,6 +2193,8 @@ def _run_decode(
         print(f"  Decode: {avg_time_ms:.3f} ms")
         return True
 
+    except PerfLogWriteError:
+        raise
     except (torch.cuda.OutOfMemoryError, torch.OutOfMemoryError):
         print(f"  OOM: b={batch_size}, s={seq_length} — skipping")
         torch.cuda.empty_cache()
@@ -2380,6 +2212,7 @@ def _run_decode(
         print("  Skipping this configuration...")
         return False
     finally:
+        cleanup_errors = []
         for cleanup_name, cleanup_fn in (
             ("req_to_token_pool.clear", model_runner.req_to_token_pool.clear),
             ("token_to_kv_pool_allocator.clear", model_runner.token_to_kv_pool_allocator.clear),
@@ -2388,10 +2221,9 @@ def _run_decode(
             try:
                 cleanup_fn()
             except Exception as cleanup_exc:
-                print(
-                    f"  Warning: cleanup step {cleanup_name} failed after benchmark: "
-                    f"{type(cleanup_exc).__name__}: {cleanup_exc}"
-                )
+                cleanup_errors.append(f"{cleanup_name}: {type(cleanup_exc).__name__}: {cleanup_exc}")
+        if cleanup_errors:
+            raise RuntimeError(f"DSA/MLA decode cleanup failed: {'; '.join(cleanup_errors)}")
 
 
 def _resolve_perf_path(output_path: str | None, filename: str) -> str:
@@ -2420,7 +2252,7 @@ def run_mla_module(
     attention_backend: str | None = None,
     batch_size_filter: int | None = None,
     target_tp_size: int = 1,
-    dsa_prefill_backend: str = "flashmla_kv",
+    dsa_prefill_backend: str | None = None,
     skip_indexer: bool = False,
 ):
     """Run MLA/DSA module benchmark — called inside a subprocess.
@@ -2530,34 +2362,6 @@ def run_mla_module(
         cases = [(bs, seq_len, ip, 0) for bs, seq_len, ip in base_cases]
     cases = _filter_cases_from_env(cases, is_prefill=is_prefill, attn_type=attn_type)
 
-    # Known-crash skip: B200 DSv3.2 DSA generation at reduced heads ≤ 32 and
-    # kv_cache_length ≥ 256 produces an async CUDA illegal memory access
-    # inside the flashinfer trtllm_batch_decode_with_kv_cache_mla kernel —
-    # the subprocess SIGABRTs and every remaining (bs, kv_len) in this task
-    # is lost. Root cause is collector-setup divergence from production
-    # (dummy weights + cleared KV pool + json_model_override_args heads
-    # override) rather than a real kernel bug — InferenceX SemiAnalysis
-    # benchmarks show GLM-5 tp=4 on B200 + fp8-KV works in production.
-    # Skipping these points lets the subprocess complete the sweep and
-    # populate rows for bs in {2..1024} x kv_len in {1..128} at reduced heads
-    # instead of losing them behind the first SIGABRT at (bs=1, kv_len=256).
-    if (
-        not is_prefill
-        and attn_type == "dsa"
-        and model_path == "deepseek-ai/DeepSeek-V3.2"
-        and head_num <= 32
-        and get_sm_version() == 100
-    ):
-        before = len(cases)
-        cases = [(bs, seq_len, ip, prefix_len) for (bs, seq_len, ip, prefix_len) in cases if seq_len < 256]
-        skipped = before - len(cases)
-        if skipped:
-            print(
-                f"[SKIP] B200 DSv3.2 DSA gen reduced-heads: dropping {skipped} "
-                f"(bs, kv_len) cases with kv_len>=256 to avoid SIGABRT "
-                f"(heads={head_num}, kv={kv_cache_dtype}, gemm={gemm_type})"
-            )
-
     print(f"\n{'=' * 60}")
     print(
         f"{attn_type.upper()} Module {phase_name}: model={model_path}, backend={attention_backend}, "
@@ -2567,8 +2371,8 @@ def run_mla_module(
     print(f"Test cases: {len(cases)}")
     print(f"{'=' * 60}")
 
-    use_module_cuda_graph = _enable_glm5_dsa_piecewise_graph(attn_type, model_path, dsa_prefill_backend)
-    enable_runner_piecewise_cuda_graph = _enable_glm5_dsa_piecewise_graph(attn_type, model_path, dsa_prefill_backend)
+    use_module_cuda_graph = False
+    enable_runner_piecewise_cuda_graph = False
 
     if is_prefill and attn_type == "dsa":
         before = len(cases)
@@ -2609,7 +2413,12 @@ def run_mla_module(
     max_total_tokens = None
     if cases:
         max_total_tokens = max(
-            required_kv_tokens(bs, seq_len, prefix_len, is_prefill=ip) for (bs, seq_len, ip, prefix_len) in cases
+            (
+                required_kv_alloc_tokens(bs, seq_len, prefix_len, SGLANG_DSA_PAGE_SIZE, is_prefill=ip)
+                if attn_type == "dsa"
+                else required_kv_tokens(bs, seq_len, prefix_len, is_prefill=ip)
+            )
+            for (bs, seq_len, ip, prefix_len) in cases
         )
         if max_total_tokens > 0:
             max_total_tokens += max(1024, max_total_tokens // 20)
@@ -2654,11 +2463,12 @@ def run_mla_module(
 
             kv_capacity = _kv_pool_capacity_tokens(model_runner)
             if kv_capacity is not None:
+                page_size = kv_pool_page_size(model_runner)
                 before = len(cases)
                 cases = [
                     (bs, seq_len, ip, prefix_len)
                     for (bs, seq_len, ip, prefix_len) in cases
-                    if required_kv_tokens(bs, seq_len, prefix_len, is_prefill=True) <= kv_capacity
+                    if required_kv_alloc_tokens(bs, seq_len, prefix_len, page_size, is_prefill=True) <= kv_capacity
                 ]
                 skipped = before - len(cases)
                 if skipped:
@@ -2708,10 +2518,13 @@ def run_mla_module(
             use_module_cuda_graph=use_module_cuda_graph,
             dsa_prefill_backend=dsa_prefill_backend,
         )
-        if cases and logged_count == 0:
+        error_count = len(cases) - logged_count
+        summary = f"ok={logged_count} error={error_count} skip=0 total={len(cases)}"
+        print(f"[{attn_type.upper()}] {phase_name.lower()} {summary}")
+        if error_count > 0:
             raise RuntimeError(
-                f"{attn_type.upper()} module {phase_name.lower()} produced no perf rows "
-                f"for model={model_path}, heads={head_num}, kv={kv_cache_dtype}, gemm={gemm_type}"
+                f"{attn_type.upper()} module {phase_name.lower()} failed strict completeness: {summary}; "
+                f"model={model_path}, heads={head_num}, kv={kv_cache_dtype}, gemm={gemm_type}"
             )
     finally:
         cleanup_distributed()
@@ -2732,7 +2545,7 @@ def _run_mla_subprocess(
     attention_backend: str | None = None,
     batch_size_filter: int | None = None,
     target_tp_size: int = 1,
-    dsa_prefill_backend: str = "flashmla_kv",
+    dsa_prefill_backend: str | None = None,
     skip_indexer: bool = False,
 ):
     """Run MLA/DSA benchmark in a subprocess with CUDA_VISIBLE_DEVICES isolation."""
@@ -2742,6 +2555,7 @@ def _run_mla_subprocess(
     phase = "context" if is_prefill else "generation"
     output_repr = f'"{output_path}"' if output_path else "None"
     backend_repr = f'"{attention_backend}"' if attention_backend else "None"
+    dsa_backend_repr = f'"{dsa_prefill_backend}"' if dsa_prefill_backend else "None"
     batch_filter_repr = "None" if batch_size_filter is None else str(batch_size_filter)
     code = (
         f'import sys; sys.path.insert(0, "{os.path.dirname(os.path.abspath(__file__))}")\n'
@@ -2749,7 +2563,7 @@ def _run_mla_subprocess(
         f'run_mla_module("{attn_type}", {head_num}, "{model_path}", '
         f'"{kv_cache_dtype}", "{compute_dtype}", "{gemm_type}", {is_prefill}, '
         f"0, {output_repr}, {backend_repr}, {batch_filter_repr}, {target_tp_size}, "
-        f'"{dsa_prefill_backend}", skip_indexer={skip_indexer})\n'
+        f"{dsa_backend_repr}, skip_indexer={skip_indexer})\n"
     )
 
     proc = subprocess.Popen(
@@ -2808,7 +2622,7 @@ def run_mla_module_worker(
     attn_type: str,
     attention_backend: str | None = None,
     target_tp_size: int = 1,
-    dsa_prefill_backend: str = "flashmla_kv",
+    dsa_prefill_backend: str | None = None,
     *,
     perf_filename: str,
     device: str = "cuda:0",
@@ -2854,9 +2668,9 @@ def run_mla_module_worker(
     # the perf files land next to vllm's output — matching artifact collection.
     output_path = os.path.dirname(perf_filename) or os.getcwd()
 
-    # DSA fp8: collect BOTH sub-backends into the SAME perf file, distinguished
-    # by kernel_source ("dsa_nsa" = flashmla_kv, "dsa_nsa_trtllm" = trtllm). The
-    # query side picks flashmla_kv for CP and trtllm (faster) otherwise.
+    # The case builder selects one SGLang 0.5.14 DSA FP8 sub-backend per GPU:
+    # flashmla_kv on Hopper, trtllm on datacenter Blackwell. BF16 leaves the
+    # sub-backend unset so SGLang applies its serving default.
     _run_mla_subprocess(
         attn_type=attn_type,
         head_num=num_heads,

--- a/collector/sglang/collect_moe.py
+++ b/collector/sglang/collect_moe.py
@@ -9,10 +9,18 @@ owns SGLang kernel compatibility, server-args mocking, routing-logit synthesis,
 rank-local workload construction, quantized weight setup, and perf logging.
 """
 
+__compat__ = "sglang==0.5.14"
+
+import gc
+import importlib
 import inspect
 import itertools
+import json
 import os
+import tempfile
 from contextlib import contextmanager, nullcontext
+from pathlib import Path
+from types import SimpleNamespace
 from typing import TypedDict
 from unittest.mock import MagicMock
 
@@ -27,15 +35,21 @@ if _server_args_module._global_server_args is None:
     _mock_server_args = MagicMock()
     _mock_server_args.enable_deterministic_inference = False
     _mock_server_args.enable_fused_moe_sum_all_reduce = (
-        False  # sglang >=0.5.10; prevents fused all-reduce in single-GPU benchmarks
+        False  # SGLang 0.5.14; prevents fused all-reduce in single-GPU benchmarks
     )
     _mock_server_args.kt_weight_path = None
     _mock_server_args.flashinfer_mxfp4_moe_precision = "default"
     _server_args_module._global_server_args = _mock_server_args
 
 import sglang.srt.layers.moe.fused_moe_triton.layer as _moe_layer_mod
+import sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe_triton_kernels as _fmoe_kernels_mod
 import sglang.srt.layers.moe.token_dispatcher.standard as _std_dispatch_mod
+import sglang.srt.layers.moe.topk as _topk_mod
 import sglang.srt.layers.moe.utils as _moe_utils
+import sglang.srt.layers.quantization.compressed_tensors.schemes.compressed_tensors_w4a4_mxint4_moe as _mxint4_mod
+import sglang.srt.layers.quantization.fp8 as _fp8_mod
+import sglang.srt.layers.quantization.modelopt_quant as _modelopt_mod
+import sglang.srt.layers.quantization.mxfp4 as _mxfp4_mod
 
 try:
     from sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe import fused_moe
@@ -52,8 +66,17 @@ except ImportError:
         get_moe_configs,
     )
 from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
-from sglang.srt.layers.moe.topk import BypassedTopKOutput, StandardTopKOutput, TopKConfig, select_experts
-from sglang.srt.layers.moe.utils import MoeRunnerBackend
+from sglang.srt.layers.moe.topk import (
+    BypassedTopKOutput,
+    StandardTopKOutput,
+    TopK,
+    TopKConfig,
+    TopKOutputFormat,
+    select_experts,
+)
+from sglang.srt.layers.moe.utils import MoeRunnerBackend, RoutingMethodType
+from sglang.srt.layers.quantization.fp8 import Fp8Config
+from sglang.srt.layers.quantization.modelopt_quant import ModelOptFp4Config
 from sglang.srt.utils import is_hip
 
 try:
@@ -65,7 +88,7 @@ try:
 except ImportError:
     _HAS_SGLANG_MXFP4 = False
 
-# sglang >=0.5.10: fused_experts_impl uses @torch.compile on moe_sum_reduce_torch_compile
+# SGLang 0.5.14: fused_experts_impl uses @torch.compile on moe_sum_reduce_torch_compile
 # for tokens_in_chunk <= 32 and topk > 2.  torch.compile's JIT compilation can hang
 # during CUDA graph capture or in headless benchmark contexts.  Replace the compiled
 # function with an eager equivalent so benchmarks don't stall.
@@ -175,28 +198,73 @@ def _mxfp4_activation_precision(moe_type: str) -> str:
     return "bf16" if moe_type == "w4a16_mxfp4" else "default"
 
 
+def _ensure_writable_flashinfer_cubin_dir() -> None:
+    """Overlay packaged cubins when FlashInfer needs to create JIT symlinks."""
+    from flashinfer.jit import cubin_loader
+    from flashinfer.jit import env as jit_env
+
+    source = Path(jit_env.FLASHINFER_CUBIN_DIR)
+    if os.access(source, os.W_OK):
+        return
+    configured = os.environ.get("FLASHINFER_CUBIN_DIR")
+    target = Path(configured) if configured and Path(configured) != source else None
+    if target is None:
+        version = str(jit_env.flashinfer_version).replace("+", "_")
+        target = Path(tempfile.gettempdir()) / f"aic_flashinfer_cubins_{os.getuid()}_{version}"
+    target.mkdir(mode=0o700, parents=True, exist_ok=True)
+    for artifact_root in source.iterdir():
+        overlay_entry = target / artifact_root.name
+        try:
+            overlay_entry.symlink_to(artifact_root, target_is_directory=artifact_root.is_dir())
+        except FileExistsError:
+            pass
+    jit_env.FLASHINFER_CUBIN_DIR = target
+    cubin_loader.FLASHINFER_CUBIN_DIR = target
+    os.environ["FLASHINFER_CUBIN_DIR"] = str(target)
+
+
+def _resolve_framework_moe_backend(moe_type: str, sm_version: int) -> str:
+    """Pinned SGLang 0.5.14 backend map for quantized framework paths."""
+    if moe_type == "nvfp4":
+        if sm_version == 90:
+            return "marlin"
+        if sm_version in {100, 103}:
+            return "flashinfer_trtllm"
+        if sm_version == 120:
+            return "flashinfer_cutlass"
+    if moe_type == "w4a8_mxfp4_mxfp8" and sm_version in {100, 103}:
+        return "flashinfer_mxfp4"
+    if moe_type == "w4a16_mxfp4" and sm_version == 90:
+        # DeepSeek-V4 FP4 experts: the 0.5.14 flashinfer_mxfp4 selector
+        # resolves to Mxfp4FlashinferCutlassMoEMethod on Hopper.
+        return "flashinfer_mxfp4"
+    raise ValueError(f"No SGLang 0.5.14 backend for moe_type={moe_type!r}, sm={sm_version}")
+
+
+_MODEL_CONFIG_DIR = Path(__file__).resolve().parents[2] / "src" / "aiconfigurator" / "model_configs"
+
+
 def get_moe_test_cases():
     # fp8_block MOE requires SM90+ due to shared memory requirements
     # L40S (SM89) has 100KB shared memory, fp8_block kernel needs ~144KB
     sm_version = get_sm_version()
     if sm_version < 90:
-        moe_list = ["bfloat16", "int4_wo"]
+        moe_list = ["bfloat16"]
     elif sm_version < 100:
-        moe_list = ["bfloat16", "fp8_block", "int4_wo"]
+        moe_list = ["bfloat16", "fp8_block", "nvfp4", "w4a16_mxfp4"]
     elif sm_version in (100, 103):
         moe_list = [
             "bfloat16",
             "fp8_block",
             "nvfp4",
-            "int4_wo",
             "w4a16_mxfp4",
             "w4a8_mxfp4_mxfp8",
         ]
     else:
-        # SGLang 0.5.10 routes many nvfp4 MoE cases through FlashInfer paths
+        # SGLang 0.5.14 routes many nvfp4 MoE cases through FlashInfer paths
         # that were not validated on SM120. Add back only live-smoked Nemotron
         # NVFP4 model cases below instead of enabling the mode globally.
-        moe_list = ["bfloat16", "fp8_block", "int4_wo"]
+        moe_list = ["bfloat16", "fp8_block"]
 
     common_cases = get_common_moe_test_cases()
     # When both GLM-5-NVFP4 and GLM-5.2-NVFP4 are present, collect only
@@ -230,6 +298,23 @@ def get_moe_test_cases():
         for moe_type, num_tokens in itertools.product(model_moe_list, num_tokens_list):
             if not moe_model_allows_quantization("sglang", model_name, moe_type):
                 continue
+            if _uses_relu2_moe_activation(model_name) and moe_type in {"bfloat16", "fp8_block"}:
+                # Non-gated ReLU2 models remain on the model-aware NVFP4 path.
+                continue
+            is_native_dsv4 = common_moe_testcase.architecture == "DeepseekV4ForCausalLM"
+            is_dsv4_pro = model_name == "deepseek-ai/DeepSeek-V4-Pro"
+            if is_native_dsv4 and moe_type in {"w4a16_mxfp4", "w4a8_mxfp4_mxfp8"}:
+                if moe_type == "w4a16_mxfp4" and not (is_dsv4_pro and sm_version == 90):
+                    continue
+                if moe_type == "w4a8_mxfp4_mxfp8" and sm_version not in {100, 103}:
+                    continue
+                # The validated standalone FP4-expert path is single-EP; the
+                # TRT-LLM generated Blackwell method is additionally bounded
+                # to production prefill chunks and TP<=8.
+                if common_moe_testcase.ep != 1 or num_tokens > 8192:
+                    continue
+                if moe_type == "w4a8_mxfp4_mxfp8" and common_moe_testcase.tp > 8:
+                    continue
             if (
                 sm_version >= 120
                 and moe_type == "nvfp4"
@@ -237,7 +322,7 @@ def get_moe_test_cases():
                 and common_moe_testcase.ep == 1
                 and (common_moe_testcase.inter_size // common_moe_testcase.tp) % 32 != 0
             ):
-                # The SGLang 0.5.10 EP=1 NVFP4 path uses FlashInfer's TRTLLM
+                # The SGLang 0.5.14 EP=1 NVFP4 path uses FlashInfer's TRTLLM
                 # BF16xFP4 routed kernel, which requires the local intermediate
                 # size to be divisible by 32. Keep non-divisible Nemotron
                 # slices out of generated collection plans.
@@ -262,7 +347,7 @@ def get_moe_test_cases():
                     or (common_moe_testcase.ep == 8 and num_tokens >= 2)
                 )
             ):
-                # SGLang 0.5.10 uses the default Triton fp8 block MoE config for
+                # SGLang 0.5.14 uses the default Triton fp8 block MoE config for
                 # Mixtral on SM120 at this TP slice. These token counts require
                 # 144 KiB shared memory, above the 99 KiB runtime limit.
                 continue
@@ -306,7 +391,7 @@ def get_moe_test_cases():
                     or (common_moe_testcase.tp == 32 and common_moe_testcase.ep == 8 and num_tokens >= 80)
                 )
             ):
-                # SGLang 0.5.10 falls back to the default Triton fp8 block MoE
+                # SGLang 0.5.14 falls back to the default Triton fp8 block MoE
                 # config for Nemotron-3 Super on SM120 for these TP/EP slices.
                 # That config requires 144 KiB shared memory, above the 99 KiB
                 # runtime limit.
@@ -329,7 +414,7 @@ def get_moe_test_cases():
                     or (common_moe_testcase.ep == 64 and num_tokens >= 8)
                 )
             ):
-                # SGLang 0.5.10 also uses the default Triton fp8 block MoE config
+                # SGLang 0.5.14 also uses the default Triton fp8 block MoE config
                 # for Qwen3-30B-A3B on SM120. For these larger token counts that
                 # config requires 144 KiB shared memory, above the 99 KiB limit.
                 continue
@@ -373,7 +458,7 @@ def get_moe_test_cases():
                     )
                 )
             ):
-                # SGLang 0.5.10 uses the default Triton fp8 block MoE config for
+                # SGLang 0.5.14 uses the default Triton fp8 block MoE config for
                 # Qwen3-235B-A22B on SM120. For these token counts that config
                 # requires 144 KiB shared memory, above the 99 KiB limit.
                 continue
@@ -417,7 +502,7 @@ def get_moe_test_cases():
                     )
                 )
             ):
-                # SGLang 0.5.10 uses the default Triton fp8 block MoE config for
+                # SGLang 0.5.14 uses the default Triton fp8 block MoE config for
                 # Qwen3-Coder-480B-A35B on SM120. For these token counts that
                 # config requires 144 KiB shared memory, above the 99 KiB limit.
                 continue
@@ -440,7 +525,7 @@ def get_moe_test_cases():
                     or (common_moe_testcase.tp == 32 and common_moe_testcase.ep == 8 and num_tokens >= 80)
                 )
             ):
-                # SGLang 0.5.10 uses the default Triton fp8 block MoE config for
+                # SGLang 0.5.14 uses the default Triton fp8 block MoE config for
                 # Qwen3.5-397B-A17B on SM120. For these token counts that config
                 # requires 144 KiB shared memory, above the 99 KiB limit.
                 continue
@@ -459,7 +544,7 @@ def get_moe_test_cases():
                     or (common_moe_testcase.ep == 8 and num_tokens >= 48)
                 )
             ):
-                # SGLang 0.5.10 uses the default Triton fp8 block MoE config for
+                # SGLang 0.5.14 uses the default Triton fp8 block MoE config for
                 # GLM-5 on SM120 at this TP slice. For these token counts that
                 # config requires 144 KiB shared memory, above the 99 KiB limit.
                 continue
@@ -478,7 +563,7 @@ def get_moe_test_cases():
                     or (common_moe_testcase.ep == 8 and num_tokens >= 48)
                 )
             ):
-                # SGLang 0.5.10 uses the default Triton fp8 block MoE config for
+                # SGLang 0.5.14 uses the default Triton fp8 block MoE config for
                 # DeepSeek-V3 on SM120 at this TP slice. For these token counts
                 # that config requires 144 KiB shared memory, above the 99 KiB
                 # limit.
@@ -498,7 +583,7 @@ def get_moe_test_cases():
                     or (common_moe_testcase.ep == 8 and num_tokens >= 48)
                 )
             ):
-                # SGLang 0.5.10 uses the default Triton fp8 block MoE config for
+                # SGLang 0.5.14 uses the default Triton fp8 block MoE config for
                 # DeepSeek-V4-Flash on SM120 at this TP slice. For these token
                 # counts that config requires 144 KiB shared memory, above the
                 # 99 KiB limit.
@@ -523,7 +608,7 @@ def get_moe_test_cases():
                     or (common_moe_testcase.tp == 32 and common_moe_testcase.ep >= 16 and num_tokens >= 48)
                 )
             ):
-                # SGLang 0.5.10 uses the default Triton fp8 block MoE config for
+                # SGLang 0.5.14 uses the default Triton fp8 block MoE config for
                 # DeepSeek-V4-Pro on SM120 for these TP/EP slices. For these
                 # token counts that config requires 144 KiB shared memory,
                 # above the 99 KiB limit.
@@ -543,7 +628,7 @@ def get_moe_test_cases():
                     or (common_moe_testcase.ep == 8 and num_tokens >= 64)
                 )
             ):
-                # SGLang 0.5.10 uses the default Triton fp8 block MoE config for
+                # SGLang 0.5.14 uses the default Triton fp8 block MoE config for
                 # Kimi-K2 on SM120 at this TP slice. For these token counts that
                 # config requires 144 KiB shared memory, above the 99 KiB limit.
                 continue
@@ -568,7 +653,7 @@ def get_moe_test_cases():
                     or (common_moe_testcase.tp == 32 and num_tokens >= 320)
                 )
             ):
-                # SGLang 0.5.10 uses the default Triton fp8 block MoE config for
+                # SGLang 0.5.14 uses the default Triton fp8 block MoE config for
                 # MiniMax-M2.5 on SM120. For these token counts that config
                 # requires 144 KiB shared memory, above the 99 KiB limit.
                 continue
@@ -990,7 +1075,7 @@ def benchmark_config(
                 masked_m=masked_m_list[i % num_iters],
             )
     elif use_mxfp4_moe:
-        # Reuse SGLang 0.5.10's production Mxfp4Config/FusedMoE path. It owns
+        # Reuse SGLang 0.5.14's production Mxfp4Config/FusedMoE path. It owns
         # the exact FlashInfer API, weight layout, TP padding, and EP-local
         # expert mapping for both W4A16 and W4A8.
         if not _HAS_SGLANG_MXFP4:
@@ -1196,7 +1281,7 @@ def benchmark_config(
         num_warmups=5,
         num_runs=num_iters,
         repeat_n=1,
-        # sglang >=0.5.10 adds @torch.compile paths inside fused_experts_impl
+        # SGLang 0.5.14 adds @torch.compile paths inside fused_experts_impl
         # (moe_sum_reduce_torch_compile) that can hang during CUDA graph capture.
         # allow_graph_fail gracefully falls back to eager execution.
         allow_graph_fail=True,
@@ -1237,6 +1322,242 @@ def _patch_mxfp4_single_process_parallel(*, moe_tp_size: int, moe_ep_size: int):
                 delattr(module, name)
             else:
                 setattr(module, name, original)
+
+
+@contextmanager
+def _patch_framework_moe_parallel(*, moe_tp_size: int, moe_ep_size: int):
+    """Patch the SGLang 0.5.14 helpers cached by framework MoE backends."""
+    parallel = SimpleNamespace(
+        tp_size=moe_tp_size,
+        tp_rank=0,
+        moe_tp_size=moe_tp_size,
+        moe_tp_rank=0,
+        moe_ep_size=moe_ep_size,
+        moe_ep_rank=0,
+    )
+    missing = object()
+    originals = []
+
+    def replace(module, name, value):
+        originals.append((module, name, getattr(module, name, missing)))
+        setattr(module, name, value)
+
+    modules = [_moe_layer_mod, _std_dispatch_mod, _topk_mod, _mxint4_mod, _mxfp4_mod, _fp8_mod, _modelopt_mod]
+    for module_name in (
+        "sglang.srt.layers.moe.moe_runner.flashinfer_trtllm",
+        "sglang.srt.layers.moe.moe_runner.flashinfer_mxfp4",
+        "sglang.srt.layers.quantization.mxfp4_flashinfer_trtllm_moe",
+    ):
+        try:
+            modules.append(importlib.import_module(module_name))
+        except ImportError:
+            pass
+    try:
+        for module in modules:
+            replace(module, "get_tp_group", lambda: None)
+            replace(module, "is_allocation_symmetric", lambda: False)
+            if module in {
+                _moe_layer_mod,
+                _std_dispatch_mod,
+                _topk_mod,
+                _mxint4_mod,
+                _mxfp4_mod,
+                _fp8_mod,
+                _modelopt_mod,
+            }:
+                replace(module, "get_parallel", lambda: parallel)
+        replace(_moe_layer_mod, "get_moe_expert_parallel_world_size", lambda: moe_ep_size)
+        replace(_moe_layer_mod, "get_moe_expert_parallel_rank", lambda: 0)
+        replace(_moe_layer_mod, "get_moe_tensor_parallel_world_size", lambda: moe_tp_size)
+        replace(_moe_layer_mod, "get_moe_tensor_parallel_rank", lambda: 0)
+        replace(_moe_layer_mod, "create_kt_config_from_server_args", lambda _server_args, _layer_id: None)
+        replace(_std_dispatch_mod, "get_moe_expert_parallel_world_size", lambda: moe_ep_size)
+        replace(_std_dispatch_mod, "get_moe_expert_parallel_rank", lambda: 0)
+        yield
+    finally:
+        for module, name, original in reversed(originals):
+            if original is missing:
+                delattr(module, name)
+            else:
+                setattr(module, name, original)
+
+
+def _framework_routing(model_name: str):
+    """Read production router semantics from the bundled model config.
+
+    ``text_config`` overrides the outer multimodal config (Kimi-K2.5). The
+    only architecture fallback is Nemotron-H's SGLang-defined sigmoid router;
+    every numeric scaling factor and grouping value still comes from config.
+    """
+    config_path = _MODEL_CONFIG_DIR / f"{model_name.replace('/', '--')}_config.json"
+    if not config_path.exists():
+        raise FileNotFoundError(f"missing local MoE routing config for {model_name!r}: {config_path}")
+    with config_path.open() as config_file:
+        outer = json.load(config_file)
+    config = dict(outer)
+    if isinstance(outer.get("text_config"), dict):
+        config.update(outer["text_config"])
+
+    architecture = (outer.get("architectures") or [None])[0]
+    activation = str(config.get("mlp_hidden_act") or config.get("hidden_act") or "silu")
+    is_gated = activation != "relu2"
+    scoring_func = config.get("scoring_func")
+    if scoring_func is None and architecture == "NemotronHForCausalLM":
+        scoring_func = "sigmoid"
+    scoring_func = str(scoring_func or "softmax")
+    topk_method = config.get("topk_method")
+    if topk_method == "noaux_tc" or architecture == "NemotronHForCausalLM":
+        routing_method = RoutingMethodType.DeepSeekV3
+    elif architecture == "Qwen3MoeForCausalLM":
+        routing_method = RoutingMethodType.Renormalize
+    else:
+        routing_method = None
+    routed_scale = config.get("routed_scaling_factor")
+    routed_scale = float(routed_scale) if routed_scale is not None else None
+    num_expert_group = config.get("n_group")
+    topk_group = config.get("topk_group")
+    return SimpleNamespace(
+        activation=activation,
+        is_gated=is_gated,
+        scoring_func=scoring_func,
+        routing_method=routing_method,
+        routed_scale=routed_scale,
+        renormalize=bool(config.get("norm_topk_prob", True)),
+        has_correction_bias=scoring_func == "sigmoid" or bool(config.get("use_routing_bias", False)),
+        num_expert_group=int(num_expert_group) if num_expert_group is not None else None,
+        topk_group=int(topk_group) if topk_group is not None else None,
+        topk_method=topk_method,
+    )
+
+
+def _benchmark_framework_quantized_moe(
+    *,
+    moe_type: str,
+    num_tokens: int,
+    hidden_size: int,
+    inter_size: int,
+    topk: int,
+    num_experts: int,
+    moe_tp_size: int,
+    moe_ep_size: int,
+    model_name: str,
+    distributed: str,
+    power_law_alpha: float,
+    swiglu_limit: float | None,
+    device: str,
+) -> tuple[float, dict, str]:
+    """Benchmark NVFP4 and DSV4 MXFP4 through SGLang 0.5.14 FusedMoE."""
+    sm_version = get_sm_version()
+    backend = _resolve_framework_moe_backend(moe_type, sm_version)
+    if backend.startswith("flashinfer"):
+        _ensure_writable_flashinfer_cubin_dir()
+
+    routing = _framework_routing(model_name)
+    is_fp4_experts = moe_type in {"w4a16_mxfp4", "w4a8_mxfp4_mxfp8"} and "DeepSeek-V4" in model_name
+    if moe_type == "nvfp4":
+        quant_config = ModelOptFp4Config(is_checkpoint_nvfp4_serialized=True, group_size=16)
+    elif is_fp4_experts:
+        quant_config = Fp8Config(
+            is_checkpoint_fp8_serialized=True,
+            activation_scheme="dynamic",
+            weight_block_size=[128, 128],
+            is_fp4_experts=True,
+        )
+    else:
+        raise ValueError(f"Unsupported framework quantized MoE case: {moe_type=} {model_name=}")
+
+    previous_backend = _moe_utils.MOE_RUNNER_BACKEND
+    server_args = _server_args_module._global_server_args
+    previous_precision = server_args.flashinfer_mxfp4_moe_precision
+    _moe_utils.MOE_RUNNER_BACKEND = MoeRunnerBackend(backend)
+    if backend == "flashinfer_mxfp4":
+        server_args.flashinfer_mxfp4_moe_precision = _mxfp4_activation_precision(moe_type)
+
+    moe_layer = None
+    try:
+        with _patch_framework_moe_parallel(moe_tp_size=moe_tp_size, moe_ep_size=moe_ep_size):
+            moe_layer = FusedMoE(
+                num_experts=num_experts,
+                hidden_size=hidden_size,
+                intermediate_size=inter_size,
+                layer_id=0,
+                top_k=topk,
+                params_dtype=torch.bfloat16,
+                reduce_results=False,
+                quant_config=quant_config,
+                prefix="aic_sglang_moe",
+                activation=routing.activation,
+                is_gated=routing.is_gated,
+                swiglu_limit=swiglu_limit,
+                routing_method_type=routing.routing_method,
+                routed_scaling_factor=routing.routed_scale,
+            ).to(device)
+            with torch.no_grad():
+                for name, parameter in moe_layer.named_parameters():
+                    parameter.fill_(1) if "scale" in name or "alpha" in name else parameter.zero_()
+            moe_layer.quant_method.process_weights_after_loading(moe_layer)
+
+            # Collector logits encode the persisted balanced/power-law expert
+            # load. Production grouped routing can intentionally discard some
+            # of those selected groups, changing the measured rank-local load;
+            # keep grouping disabled here so the label remains true. A zero
+            # correction bias likewise exercises the noaux TopK API without
+            # changing the synthetic rankings.
+            correction_bias = (
+                torch.zeros(num_experts, dtype=torch.float32, device=device) if routing.has_correction_bias else None
+            )
+            topk_layer = TopK(
+                top_k=topk,
+                layer_id=0,
+                use_grouped_topk=False,
+                num_expert_group=None,
+                topk_group=None,
+                renormalize=routing.renormalize,
+                scoring_func=routing.scoring_func,
+                correction_bias=correction_bias,
+                output_format=TopKOutputFormat.STANDARD if routing.routing_method is None else None,
+                routed_scaling_factor=routing.routed_scale,
+                apply_routed_scaling_factor_on_output=(
+                    routing.routed_scale is not None and moe_layer.should_fuse_routed_scaling_factor_in_topk
+                ),
+                is_fp4_experts=is_fp4_experts,
+            )
+            hidden_states = torch.randn(num_tokens, hidden_size, dtype=torch.bfloat16, device=device)
+            if distributed == "balanced":
+                logits = [balanced_logits(num_tokens, num_experts, topk).to(device) for _ in range(5)]
+            elif distributed == "power_law":
+                logits = [
+                    power_law_logits_v3(num_tokens, num_experts, topk, moe_ep_size, power_law_alpha).to(device)
+                    for _ in range(5)
+                ]
+            else:
+                logits = [torch.randn(num_tokens, num_experts, device=device) for _ in range(5)]
+
+            def kernel_func():
+                for router_logits in logits:
+                    moe_layer(hidden_states, topk_layer(hidden_states, router_logits))
+
+            with benchmark_with_power(
+                device=device,
+                kernel_func=kernel_func,
+                num_warmups=5,
+                num_runs=10,
+                repeat_n=1,
+                allow_graph_fail=True,
+            ) as results:
+                pass
+            return results["latency_ms"] / len(logits), results["power_stats"], backend
+    finally:
+        if moe_layer is not None:
+            for parameter in moe_layer.parameters():
+                parameter.__dict__.pop("weight_loader", None)
+            parameter = None
+            moe_layer = None
+        _fmoe_kernels_mod._B_DESC_CACHE.clear()
+        _moe_utils.MOE_RUNNER_BACKEND = previous_backend
+        server_args.flashinfer_mxfp4_moe_precision = previous_precision
+        gc.collect()
+        torch.cuda.empty_cache()
 
 
 def benchmark(
@@ -1452,6 +1773,60 @@ def run_moe_torch(
     ], "only support moe type = fp8_block, bfloat16, nvfp4, int4_wo, w4a16_mxfp4, or w4a8_mxfp4_mxfp8"
     assert inter_size % moe_tp_size == 0, "inter_size % moe_tp_size must be 0"
     assert num_experts % moe_ep_size == 0, "num_experts must be divisible by moe_ep_size"
+
+    if moe_type == "nvfp4" or (moe_type in {"w4a16_mxfp4", "w4a8_mxfp4_mxfp8"} and "DeepSeek-V4" in model_name):
+        latency, power_stats, moe_backend = _benchmark_framework_quantized_moe(
+            moe_type=moe_type,
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            inter_size=inter_size,
+            topk=topk,
+            num_experts=num_experts,
+            moe_tp_size=moe_tp_size,
+            moe_ep_size=moe_ep_size,
+            model_name=model_name,
+            distributed=distributed,
+            power_law_alpha=power_law_alpha,
+            swiglu_limit=swiglu_limit,
+            device=device,
+        )
+        if moe_backend == "flashinfer_mxfp4":
+            if moe_type == "w4a16_mxfp4":
+                kernel_source = "sglang_flashinfer_cutlass_moe"
+            elif model_name == "deepseek-ai/DeepSeek-V4-Pro":
+                kernel_source = "sglang_mxfp4_flashinfer_trtllm_moe"
+            else:
+                kernel_source = "sglang_flashinfer_mxfp4_moe"
+        else:
+            kernel_source = {
+                "marlin": "sglang_marlin_moe",
+                "flashinfer_trtllm": "sglang_flashinfer_trtllm_moe",
+                "flashinfer_cutlass": "sglang_flashinfer_cutlass_moe",
+            }[moe_backend]
+        log_perf(
+            item_list=[
+                {
+                    "moe_dtype": moe_type,
+                    "num_tokens": num_tokens,
+                    "hidden_size": hidden_size,
+                    "inter_size": inter_size,
+                    "topk": topk,
+                    "num_experts": num_experts,
+                    "moe_tp_size": moe_tp_size,
+                    "moe_ep_size": moe_ep_size,
+                    "distribution": "power_law_" + str(power_law_alpha) if distributed == "power_law" else distributed,
+                    "latency": latency,
+                }
+            ],
+            framework="SGLang",
+            version=pkg_resources.get_distribution("sglang").version,
+            device_name=torch.cuda.get_device_name(device),
+            op_name="moe",
+            kernel_source=kernel_source,
+            perf_filename=perf_filename,
+            power_stats=power_stats,
+        )
+        return None
 
     num_local_experts = num_experts // moe_ep_size
     use_int4_w4a16 = moe_type == "int4_wo"

--- a/collector/sglang/deepseekv4_sparse_modules.py
+++ b/collector/sglang/deepseekv4_sparse_modules.py
@@ -30,11 +30,10 @@ CSV schema matches existing aic dsv4 module CSVs (so loaders can be shared):
 CSA(=4) / HCA(=128).
 """
 
-# Requires an SGLang build with DeepSeek-V4 support. Stock lmsysorg/sglang:v*
-# images may not include the required deepseek_v4 modules; use a
-# deepseek-v4-blackwell/deepseek-v4-grace-blackwell image or matching Dynamo
-# sglang-runtime:*deepseek-v4* image.
+# Requires stock SGLang 0.5.14 with its matching ``sgl-kernel`` package.
 from __future__ import annotations
+
+__compat__ = "sglang==0.5.14"
 
 import functools
 import importlib.util
@@ -283,16 +282,17 @@ def _dsv4_sparse_kernel_supported(kernel: str) -> bool:
     """Return True when the active runtime can execute a DSV4 sparse kernel."""
     if os.environ.get("COLLECTOR_FORCE_DSV4_SPARSE") == "1":
         return True
+    if torch.cuda.is_available():
+        major, minor = torch.cuda.get_device_capability()
+        sm_version = major * 10 + minor
+        # The pinned DeepGEMM/FlashMLA sparse APIs cover Hopper and datacenter
+        # Blackwell. SM120 has a different API and pre-Hopper lacks the kernels.
+        if sm_version not in {90, 100, 103}:
+            return False
     if kernel in ("hca_attn", "csa_attn"):
         return importlib.util.find_spec("flash_mla") is not None
     if kernel == "paged_mqa_logits":
-        if importlib.util.find_spec("deep_gemm") is None:
-            return False
-        if torch.cuda.is_available():
-            major, _minor = torch.cuda.get_device_capability()
-            if major >= 12:
-                return False
-        return True
+        return importlib.util.find_spec("deep_gemm") is not None
     raise ValueError(f"unknown DSV4 sparse kernel: {kernel}")
 
 
@@ -459,17 +459,16 @@ def _bench_paged_mqa_logits(
 ) -> float:
     """Benchmark paged_mqa_logits.
 
-    Note: the SM90 kernel imposes ``next_n ≤ 2`` (smem capacity); larger M
-    must be split into multiple per-request entries.  For prefill chunks
-    with many tokens we map ``M → batch_dim`` and keep ``next_n=1``.  Work
-    is identical (M x full_c4 x n_idx_heads x idx_head_dim) — only the
-    request grouping changes.  In real serving, sglang's
-    ``fp8_paged_mqa_logits_chunked`` wraps the same idea (chunk along M).
+    The kernel imposes ``next_n ≤ 2`` (smem capacity), so prefill tokens map
+    to ``batch_dim`` with ``next_n=1``. Per-request causal lengths remain
+    distinct even though those token rows share one physical KV cache.
     """
     from deep_gemm import fp8_paged_mqa_logits, get_paged_mqa_logits_metadata
 
-    del batch_size  # ignored — we treat each new token as its own batch entry
-    full_s = M + past_kv
+    if batch_size <= 0 or M % batch_size:
+        raise ValueError(f"M={M} must be divisible by positive batch_size={batch_size}")
+    isl = M // batch_size
+    full_s = isl + past_kv
     full_c4 = max(1, full_s // 4)
     block_kv = _dsv4_kv_page_size()
 
@@ -489,12 +488,8 @@ def _bench_paged_mqa_logits(
 
     weights = torch.randn(b * next_n, index_n_heads, dtype=torch.float32, device=device)
 
-    # Per-token causal context_lens — matches sglang's ``seq_lens_casual``
-    # (deepseek_v4_backend_radix.py:1124).  Each new token i has effective
-    # past+i+1 KV positions (causal); c4_seq_lens = (past+i+1) // 4.
-    # Without this, each query scans the full c4 cache uniformly →
-    # benchmark work is M x full_c4 instead of triangular M x full_c4 / 2.
-    causal_seq = torch.arange(past_kv + 1, past_kv + M + 1, dtype=torch.int32, device=device)
+    # Compute each request's causal span before flattening the token rows.
+    causal_seq = torch.arange(past_kv + 1, past_kv + isl + 1, dtype=torch.int32, device=device).repeat(batch_size)
     causal_c4 = (causal_seq // 4).clamp(min=1)  # min=1 to avoid empty scans
     context_lens = causal_c4.view(b, next_n)
 
@@ -729,7 +724,7 @@ def _write_row(
     if score_mode is not None:
         item["score_mode"] = score_mode
 
-    log_perf(
+    if not log_perf(
         item_list=[item],
         framework="SGLang",
         version="kernel-level",
@@ -738,7 +733,8 @@ def _write_row(
         kernel_source=KERNEL_TO_KERNEL_SOURCE[kernel],
         perf_filename=perf_filename,
         power_stats=power_stats,
-    )
+    ):
+        raise RuntimeError(f"failed to persist DeepSeek-V4 sparse row to {perf_filename}")
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -766,8 +762,9 @@ def _guarded_bench(bench_fn: Callable[[], object], label: str):
 
 def _bench_sparse_kernel_shape(kernel, prefix, isl, bs, sc, device):
     """Bench one module ``(prefix, isl, bs)`` shape; return a list of
-    ``(score_mode, latency_ms)`` rows. TP-independent (paged_mqa flattens bs→b=M;
-    FMLA pads to full native heads), so this is computed once per shape.
+    ``(score_mode, latency_ms)`` rows. TP-independent (paged_mqa maps tokens to
+    b=M while preserving request-local causal lengths; FMLA pads to full native
+    heads), so this is computed once per shape.
 
     Single-latency kernels return one ``(None, latency)``; topk returns the
     flat-vs-representative pair ``[("flat", …), ("top_last", …)]`` whose DELTA
@@ -791,12 +788,14 @@ def _bench_sparse_kernel_shape(kernel, prefix, isl, bs, sc, device):
         return [(None, lat)]
     if kernel == "topk":
         return _bench_topk_shape(prefix, isl, bs, sc, device)
-    # paged_mqa_logits: bs flattened to b=M, next_n=1
+    # paged_mqa_logits: tokens map to b=M, next_n=1, while causal lengths repeat
+    # per request.
     lat = _bench_paged_mqa_logits(
         M,
         prefix,
         index_n_heads=sc.index_n_heads,
         index_head_dim=sc.index_head_dim,
+        batch_size=bs,
         device=device,
     )["latency_ms"]
     return [(None, lat)]
@@ -859,8 +858,10 @@ def _sglang_chunked_prefill_size():
     global _CHUNKED_PREFILL
     if _CHUNKED_PREFILL is None:
         try:
+            from sglang.srt.model_executor.cuda_graph_config import default_cuda_graph_config
             from sglang.srt.server_args import ServerArgs, get_device_memory_capacity
         except ModuleNotFoundError:
+            from srt.model_executor.cuda_graph_config import default_cuda_graph_config
             from srt.server_args import ServerArgs, get_device_memory_capacity
         gpu_mem = None
         try:
@@ -869,8 +870,7 @@ def _sglang_chunked_prefill_size():
             pass
         sa = ServerArgs.__new__(ServerArgs)
         sa.chunked_prefill_size = None
-        sa.cuda_graph_max_bs = None
-        sa.cuda_graph_bs = None
+        sa.cuda_graph_config = default_cuda_graph_config()
         sa.tp_size = 1
         sa.device = "cuda"
         try:
@@ -1043,7 +1043,13 @@ def run_dsv4_sparse_kernel_worker(
         )
         if results is None:
             continue
-        n_ok += 1
+        expected_modes = {"flat", "top_last"} if kernel == "topk" else {None}
+        if len(results) != len(expected_modes) or {score_mode for score_mode, _ in results} != expected_modes:
+            print(
+                f"  incomplete result at bs={bs} isl={isl} past_kv={prefix}: "
+                f"expected score modes {expected_modes}, got {results}"
+            )
+            continue
         for score_mode, latency_ms in results:
             _write_row(
                 perf_path,
@@ -1058,7 +1064,12 @@ def run_dsv4_sparse_kernel_worker(
                 model_path=model_path,
                 score_mode=score_mode,
             )
-    print(f"  {kernel}: benched {n_ok}/{len(shapes)} unique shapes")
+        n_ok += 1
+    error_count = len(shapes) - n_ok
+    summary = f"ok={n_ok} error={error_count} skip=0 total={len(shapes)}"
+    print(f"  {kernel}: {summary}")
+    if error_count > 0:
+        raise RuntimeError(f"dsv4-sparse {kernel} bs={bs_only}: {summary}")
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -1079,9 +1090,13 @@ def run_dsv4_sparse_kernel_worker(
 
 
 def _dsv4_topk_kernel_supported() -> bool:
-    """True when the SGLang build exposes the sm_100 topk_512 indexer kernel."""
+    """True when the Hopper/datacenter-Blackwell topk indexer is available."""
     if os.environ.get("COLLECTOR_FORCE_DSV4_SPARSE") == "1":
         return True
+    if torch.cuda.is_available():
+        major, minor = torch.cuda.get_device_capability()
+        if major * 10 + minor not in {90, 100, 103}:
+            return False
     try:
         # find_spec raises (not returns None) when a PARENT package is absent.
         return importlib.util.find_spec("sglang.jit_kernel.dsv4.topk") is not None
@@ -1089,20 +1104,34 @@ def _dsv4_topk_kernel_supported() -> bool:
         return False
 
 
-def _make_topk_scores(mode: str, rows: int, seq: int, device: str, generator, topk_k: int) -> torch.Tensor:
+def _make_topk_scores(
+    mode: str,
+    seq_lens: torch.Tensor,
+    seq: int,
+    device: str,
+    generator,
+    topk_k: int,
+) -> torch.Tensor:
     # score_stride must be a multiple of 4 (kernel TMA 16B alignment); allocate
     # padded width and let the kernel read [:, :seq].
+    rows = seq_lens.numel()
     pad = ((seq + 3) // 4) * 4
     if mode == "flat":
         return torch.zeros(rows, pad, device=device)
     if mode == "top_last":
         s = -5.0 + 0.05 * torch.randn(rows, pad, device=device, generator=generator)
-        s[:, seq - topk_k : seq] = 5.0 + torch.randn(rows, topk_k, device=device, generator=generator)
+        counts = seq_lens.to(torch.int64).clamp(min=0, max=min(topk_k, seq))
+        offsets = torch.arange(topk_k, device=device)
+        columns = seq_lens.to(torch.int64).unsqueeze(1) - counts.unsqueeze(1) + offsets.unsqueeze(0)
+        valid = offsets.unsqueeze(0) < counts.unsqueeze(1)
+        row_ids = torch.arange(rows, device=device).unsqueeze(1).expand_as(columns)
+        selected = int(valid.sum().item())
+        s[row_ids[valid], columns[valid]] = 5.0 + torch.randn(selected, device=device, generator=generator)
         return s.contiguous()
     raise ValueError(f"unknown topk score mode: {mode}")
 
 
-def _bench_topk_512(rows: int, c4_len: int, mode: str, device: str, topk_k: int) -> float:
+def _bench_topk_512(seq_lens: torch.Tensor, mode: str, device: str, topk_k: int) -> float:
     """Time one topk_transform shape via the shared ``_bench_cuda_graph`` path
     (same bench helper as paged_mqa_logits/hca_attn).
 
@@ -1116,12 +1145,13 @@ def _bench_topk_512(rows: int, c4_len: int, mode: str, device: str, topk_k: int)
 
     generator = torch.Generator(device=device)
     generator.manual_seed(1234)
-    seq_lens = torch.full((rows,), c4_len, dtype=torch.int32, device=device)
+    rows = seq_lens.numel()
+    c4_len = int(seq_lens.max().item())
     meta = plan_topk_v2(seq_lens, 0)
     torch.cuda.synchronize(device)
     pages = (c4_len + _dsv4_kv_page_size() - 1) // _dsv4_kv_page_size()
     page_table = torch.arange(pages, dtype=torch.int32, device=device).unsqueeze(0).repeat(rows, 1)
-    scores = _make_topk_scores(mode, rows, c4_len, device, generator, topk_k=topk_k)
+    scores = _make_topk_scores(mode, seq_lens, c4_len, device, generator, topk_k=topk_k)
     out = torch.empty((rows, topk_k), dtype=torch.int32, device=device)
 
     def kernel_func():
@@ -1147,10 +1177,9 @@ def _bench_topk_shape(prefix: int, isl: int, bs: int, sc, device: str) -> list:
     (DELTA 0). ``rows`` = bs*isl is the per-token causal scan count."""
     ratio = sc.csa_compress_ratio  # CSA compress ratio (=4)
     topk_k = sc.index_topk  # V4-Pro=1024, V4-Flash=512
-    rows = max(bs * isl, 1)
-    c4_len = (prefix + isl) // ratio
+    causal_seq = torch.arange(prefix + 1, prefix + isl + 1, dtype=torch.int32, device=device)
+    seq_lens = (causal_seq // ratio).clamp(min=1).repeat(bs)
+    c4_len = int(seq_lens.max().item())
     if c4_len <= topk_k:
         return [("flat", 0.0), ("top_last", 0.0)]
-    return [
-        (mode, round(_bench_topk_512(rows, c4_len, mode, device, topk_k=topk_k), 6)) for mode in ("flat", "top_last")
-    ]
+    return [(mode, round(_bench_topk_512(seq_lens, mode, device, topk_k=topk_k), 6)) for mode in ("flat", "top_last")]

--- a/collector/sglang/glm5_dsa_sparse_modules.py
+++ b/collector/sglang/glm5_dsa_sparse_modules.py
@@ -25,6 +25,8 @@ CSV schema matches the aic module CSVs (``isl``=M, ``step``=past_kv).
 
 from __future__ import annotations
 
+__compat__ = "sglang==0.5.14"
+
 import os
 
 import torch
@@ -43,9 +45,9 @@ from collector.sglang.deepseekv4_sparse_modules import (
 )
 
 try:
-    from collector.sglang.helper import log_perf
+    from collector.sglang.helper import get_sm_version, log_perf
 except ModuleNotFoundError:
-    from helper import log_perf
+    from helper import get_sm_version, log_perf
 
 __all__ = [
     "get_glm5_dsa_attn_test_cases",
@@ -54,7 +56,6 @@ __all__ = [
     "run_glm5_dsa_sparse_kernel_worker",
 ]
 
-GLM5_DEFAULT_MODEL = "nvidia/GLM-5-NVFP4"
 GLM5_ARCHITECTURE = "GlmMoeDsaForCausalLM"
 
 
@@ -63,24 +64,21 @@ def _selected_glm5_models():
     are bf16 and identical across GLM-5 variants, differing only in prefix range.
     When both GLM-5-NVFP4 and GLM-5.2-NVFP4 are configured, collect only
     GLM-5.2-NVFP4 (longest context — its range + the max_position ceiling in the
-    derived shapes covers GLM-5); otherwise the default."""
+    derived shapes covers GLM-5). Return no cases when a targeted model filter
+    selects a non-GLM checkpoint."""
     try:
         from collector.sglang.collect_mla_module import get_mla_module_model_specs
     except ModuleNotFoundError:
         from collect_mla_module import get_mla_module_model_specs
-    # apply_model_filter=False: decide the representative from the configured
-    # set, independent of a COLLECTOR_MODEL_PATH pin, so a pin to GLM-5.2-NVFP4
-    # still resolves sparse to GLM-5.2-NVFP4 (not the default). Prefer the
-    # longest-context GLM present (GLM-5.2 covers GLM-5 via its range + the
-    # max_position ceiling in derived shapes); only the genuine absence of any
-    # GLM-5.x configured spec falls back to the default. Discovery errors
-    # propagate instead of being silently swallowed into the default path.
-    paths = {s.model_path for s in get_mla_module_model_specs(attention_type="dsa", apply_model_filter=False)}
+    # Respect COLLECTOR_MODEL_PATH for targeted runs. Without a model filter,
+    # prefer the longest-context GLM representative so one full/raw sparse sweep
+    # covers the shorter GLM-5 range as well.
+    paths = {s.model_path for s in get_mla_module_model_specs(attention_type="dsa")}
     if "nvidia/GLM-5.2-NVFP4" in paths:
         return ["nvidia/GLM-5.2-NVFP4"]
     if "nvidia/GLM-5-NVFP4" in paths:
         return ["nvidia/GLM-5-NVFP4"]
-    return [GLM5_DEFAULT_MODEL]
+    return []
 
 
 def _glm5_sparse_config(model_path: str):
@@ -161,7 +159,7 @@ def _write_row(
     }
     if score_mode is not None:
         item["score_mode"] = score_mode
-    log_perf(
+    if not log_perf(
         item_list=[item],
         framework="SGLang",
         version="kernel-level",
@@ -169,7 +167,8 @@ def _write_row(
         op_name=op_name_map[kernel],
         kernel_source=kernel_source or KERNEL_TO_KERNEL_SOURCE[kernel],
         perf_filename=perf_filename,
-    )
+    ):
+        raise RuntimeError(f"failed to persist {architecture} sparse row to {perf_filename}")
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -206,15 +205,21 @@ def _bench_glm5_mqa(M, past_kv, isl, *, index_n_heads, index_head_dim, device): 
 
 def _glm5_fuse_topk_enabled() -> bool:
     """Whether SGLang runs the FUSED topk+index-transform (env default = True)."""
-    try:
-        from sglang.srt import environ as _environ
+    from sglang.srt import environ as _environ
 
-        return bool(_environ.envs.SGLANG_NSA_FUSE_TOPK.get())
-    except Exception:
-        return True  # sglang environ.py: SGLANG_NSA_FUSE_TOPK = EnvBool(True)
+    return bool(_environ.envs.SGLANG_DSA_FUSE_TOPK.get())
 
 
-def _make_glm5_topk_scores(mode, rows, seq, device, generator, topk_k):
+def _glm5_topk_metadata(bs, isl, past_kv):
+    """Return causal row lengths, ragged KV offsets, and full KV width."""
+    max_seqlen_k = max(1, past_kv + isl)
+    lengths = [past_kv + token_idx + 1 for _ in range(bs) for token_idx in range(isl)]
+    cu_seqlens_k = [request_idx * max_seqlen_k for request_idx in range(bs + 1)]
+    topk_indices_offset = [cu_seqlens_k[request_idx] for request_idx in range(bs) for _ in range(isl)]
+    return lengths, topk_indices_offset, max_seqlen_k
+
+
+def _make_glm5_topk_scores(mode, lengths, seq, device, generator, topk_k):
     """DSV4-style score distributions for the topk DELTA calibration.
 
     * ``flat``     — all zeros: degenerate worst case (every element ties, so
@@ -222,30 +227,38 @@ def _make_glm5_topk_scores(mode, rows, seq, device, generator, topk_k):
     * ``top_last`` — background ~-5 with the last ``topk_k`` positions ~+5:
                      representative (clear winners, the common real case).
 
-    Width padded to a multiple of 4 (kernel TMA 16B alignment); kernel reads
-    ``[:, :seq]``.
+    Each row's winners occupy its own causal ``[length-k:length)`` span.
+    Width is padded to a multiple of 4 (kernel TMA 16B alignment).
     """
+    rows = lengths.numel()
     pad = ((seq + 3) // 4) * 4
     if mode == "flat":
         return torch.zeros(rows, pad, dtype=torch.float32, device=device)
     if mode == "top_last":
         s = -5.0 + 0.05 * torch.randn(rows, pad, dtype=torch.float32, device=device, generator=generator)
-        k = min(topk_k, seq)
-        s[:, seq - k : seq] = 5.0 + torch.randn(rows, k, dtype=torch.float32, device=device, generator=generator)
+        counts = lengths.to(torch.int64).clamp(min=0, max=min(topk_k, seq))
+        offsets = torch.arange(topk_k, device=device)
+        columns = lengths.to(torch.int64).unsqueeze(1) - counts.unsqueeze(1) + offsets.unsqueeze(0)
+        valid = offsets.unsqueeze(0) < counts.unsqueeze(1)
+        row_ids = torch.arange(rows, device=device).unsqueeze(1).expand_as(columns)
+        selected = int(valid.sum().item())
+        s[row_ids[valid], columns[valid]] = 5.0 + torch.randn(
+            selected, dtype=torch.float32, device=device, generator=generator
+        )
         return s.contiguous()
     raise ValueError(f"unknown topk score mode: {mode}")
 
 
 def _bench_glm5_topk(M, past_kv, isl, bs, *, topk, device):  # noqa: N803
-    """GLM-5 indexer top-k — the kernel SGLang's NSA backend ACTUALLY runs,
+    """GLM-5 indexer top-k — the kernel SGLang's DSA backend ACTUALLY runs,
     benched as a FLAT/TOP_LAST DELTA calibration (DSV4-style).
 
-    Kernel selection (``SGLANG_NSA_FUSE_TOPK`` env default = True → fused):
+    Kernel selection (``SGLANG_DSA_FUSE_TOPK`` env default = True → fused):
       * prefill / context (isl > 1, ragged): ``fast_topk_transform_ragged_fused``
       * decode  / generation (isl == 1, paged): ``fast_topk_transform_fused``
       * fuse-topk disabled: plain ``fast_topk_v2``.
     All metadata (``cu_seqlens`` / ``topk_indices_offset`` / page table /
-    lengths) is built from ``(bs, isl, past_kv)`` EXACTLY as the NSA backend
+    lengths) is built from ``(bs, isl, past_kv)`` EXACTLY as the DSA backend
     does — no model weights — so the standalone call is the real kernel with
     real arg shapes.
 
@@ -264,11 +277,6 @@ def _bench_glm5_topk(M, past_kv, isl, bs, *, topk, device):  # noqa: N803
         fast_topk_v2,
     )
 
-    try:
-        from sglang.srt.layers.attention.nsa_backend import compute_cu_seqlens
-    except Exception:
-        from sglang.srt.layers.attention.dsa.dsa_backend_mtp_precompute import compute_cu_seqlens
-
     fused = _glm5_fuse_topk_enabled()
     if not fused:
         kernel_src = "fast_topk_v2"
@@ -278,12 +286,12 @@ def _bench_glm5_topk(M, past_kv, isl, bs, *, topk, device):  # noqa: N803
         kernel_src = "fast_topk_transform_ragged_fused"
 
     # GLM-5 is uniform DSA (ratio=1): per-request full context = past_kv + isl.
-    seq = max(1, past_kv + isl)
-    if seq <= topk:
+    length_values, topk_offset_values, max_seqlen_k = _glm5_topk_metadata(bs, isl, past_kv)
+    if max_seqlen_k <= topk:
         # nothing to select -> no data-dependent cost; DELTA is 0.
         return [("flat", 0.0), ("top_last", 0.0)], kernel_src
 
-    lengths = torch.full((M,), seq, dtype=torch.int32, device=device)
+    lengths = torch.tensor(length_values, dtype=torch.int32, device=device)
     ks = torch.zeros(M, dtype=torch.int32, device=device)
     generator = torch.Generator(device=device)
     generator.manual_seed(1234)
@@ -293,10 +301,9 @@ def _bench_glm5_topk(M, past_kv, isl, bs, *, topk, device):  # noqa: N803
         def make_fn(score):
             return lambda: fast_topk_v2(score, lengths, topk, row_starts=ks)
     elif isl == 1:
-        cols = max(topk, 1)
-        pt = torch.arange(cols, dtype=torch.int32, device=device).clamp(max=seq - 1)
-        page_table_size_1 = pt.view(1, cols).repeat(M, 1).contiguous()
-        cu_seqlens_q = compute_cu_seqlens(torch.ones(M, dtype=torch.int32, device=device))
+        pt = torch.arange(max_seqlen_k, dtype=torch.int32, device=device)
+        page_table_size_1 = pt.view(1, max_seqlen_k).repeat(M, 1).contiguous()
+        cu_seqlens_q = torch.arange(M + 1, dtype=torch.int32, device=device)
 
         def make_fn(score):
             return lambda: fast_topk_transform_fused(
@@ -308,22 +315,20 @@ def _bench_glm5_topk(M, past_kv, isl, bs, *, topk, device):  # noqa: N803
                 row_starts=ks,
             )
     else:
-        seqlens_q = torch.full((bs,), isl, dtype=torch.int32, device=device)
-        cu_seqlens_q_topk = compute_cu_seqlens(seqlens_q)
-        cu_topk_indices_offset = torch.repeat_interleave(cu_seqlens_q_topk[:-1], seqlens_q)
+        topk_indices_offset = torch.tensor(topk_offset_values, dtype=torch.int32, device=device)
 
         def make_fn(score):
             return lambda: fast_topk_transform_ragged_fused(
                 score=score,
                 lengths=lengths,
-                topk_indices_offset=cu_topk_indices_offset,
+                topk_indices_offset=topk_indices_offset,
                 topk=topk,
                 row_starts=ks,
             )
 
     results = []
     for mode in ("flat", "top_last"):
-        score = _make_glm5_topk_scores(mode, M, seq, device, generator, topk)
+        score = _make_glm5_topk_scores(mode, lengths, max_seqlen_k, device, generator, topk)
         r = _bench_cuda_graph(make_fn(score), allow_graph_fail=True, device=device)
         results.append((mode, round(r["latency_ms"], 6)))
     return results, kernel_src
@@ -331,26 +336,26 @@ def _bench_glm5_topk(M, past_kv, isl, bs, *, topk, device):  # noqa: N803
 
 def _bench_glm5_dsa_attn(M, past_kv, isl, *, native_heads, d_qk, d_v, topk, device):  # noqa: N803
     """flash_mla_sparse_fwd — sparse FMLA, ragged batch of bs = M // isl reqs.
-    q (M=bs*isl, heads->pad128, d_qk), kv = CONCATENATED bs segments of
+    q (M=bs*isl, heads->64 on SM90 / pad128 on SM100+, d_qk), kv = CONCATENATED bs segments of
     (past_kv + isl); indices (M, 1, K) are absolute into each token's own
-    segment. K = min(topk, per-request context)."""
+    segment. The production top-k transform always returns ``topk`` columns,
+    filling positions beyond the current context with -1."""
     from sgl_kernel.flash_mla import flash_mla_sparse_fwd
 
     bs = max(1, M // isl)
     seg = past_kv + isl
     full_s = max(1, bs * seg)  # concatenated bs segments of (past_kv + isl)
-    k = min(topk, seg)  # topk capped by PER-REQUEST context
-    pad_heads = 128 if (native_heads % 128) else native_heads
-    q = torch.randn(M, pad_heads, d_qk, dtype=torch.bfloat16, device=device)
+    valid_k = min(topk, seg)
+    sm_major, _ = torch.cuda.get_device_capability(device)
+    q_heads = 128 if sm_major >= 10 else native_heads
+    q = torch.randn(M, q_heads, d_qk, dtype=torch.bfloat16, device=device)
     kv = torch.randn(full_s, 1, d_qk, dtype=torch.bfloat16, device=device)
     # each token selects k positions inside its own segment [r*seg, r*seg+seg)
     seg_start = torch.repeat_interleave(torch.arange(bs, dtype=torch.int32, device=device) * seg, isl)
-    indices = seg_start.view(M, 1, 1) + torch.arange(k, dtype=torch.int32, device=device).view(1, 1, k)
-    if k % 64:
-        pad = 64 - k % 64
-        indices = torch.cat(
-            [indices, torch.full((M, 1, pad), -1, dtype=torch.int32, device=device)], dim=-1
-        ).contiguous()
+    indices = torch.full((M, 1, topk), -1, dtype=torch.int32, device=device)
+    indices[:, :, :valid_k] = seg_start.view(M, 1, 1) + torch.arange(valid_k, dtype=torch.int32, device=device).view(
+        1, 1, valid_k
+    )
     sm_scale = 1.0 / (d_qk**0.5)
 
     def kernel_fn():
@@ -561,7 +566,13 @@ def run_glm5_dsa_sparse_kernel_worker(
         if out is None:
             continue
         kernel_source, results = out
-        n_ok += 1
+        expected_modes = {"flat", "top_last"} if kernel == "topk" else {None}
+        if len(results) != len(expected_modes) or {score_mode for score_mode, _ in results} != expected_modes:
+            print(
+                f"  incomplete result at bs={bs} isl={isl} past_kv={prefix}: "
+                f"expected score modes {expected_modes}, got {results}"
+            )
+            continue
         for score_mode, latency_ms in results:
             _write_row(
                 perf_path,
@@ -579,10 +590,17 @@ def run_glm5_dsa_sparse_kernel_worker(
                 architecture=architecture,
                 op_name_map=op_name_map,
             )
-    print(f"  {kernel}: benched {n_ok}/{len(shapes)} unique shapes")
+        n_ok += 1
+    error_count = len(shapes) - n_ok
+    summary = f"ok={n_ok} error={error_count} skip=0 total={len(shapes)}"
+    print(f"  {kernel}: {summary}")
+    if error_count > 0:
+        raise RuntimeError(f"{label}-sparse {kernel} bs={bs_only}: {summary}")
 
 
 def _glm5_sparse_kernel_cases(kernel):
+    if get_sm_version() not in {90, 100, 103}:
+        return []
     # One task per (model, bs) so collect.py spreads bs across the GPU workers
     # (no single-worker cuda-graph private-pool buildup -> no 1-worker-sweep
     # deadlock). All sparse kernels run a single fixed head config: the FMLA

--- a/collector/sglang/runtime_limits.py
+++ b/collector/sglang/runtime_limits.py
@@ -18,6 +18,13 @@ def kv_pool_capacity_tokens(model_runner) -> int | None:
     allocator = getattr(model_runner, "token_to_kv_pool_allocator", None)
     if allocator is None:
         return None
+    # Hybrid SWA allocators report min(full, swa) from available_size().
+    # Logical sequence capacity follows the full-attention pool instead.
+    if hasattr(allocator, "full_available_size"):
+        try:
+            return int(allocator.full_available_size())
+        except Exception:
+            return None
     if hasattr(allocator, "available_size"):
         try:
             return int(allocator.available_size())
@@ -28,6 +35,18 @@ def kv_pool_capacity_tokens(model_runner) -> int | None:
         if isinstance(value, int) and value > 0:
             return value
     return None
+
+
+def swa_kv_pool_capacity_tokens(model_runner) -> int | None:
+    """Best-effort token capacity of SGLang's hybrid SWA KV pool."""
+    allocator = getattr(model_runner, "token_to_kv_pool_allocator", None)
+    available_size = getattr(allocator, "swa_available_size", None)
+    if not callable(available_size):
+        return None
+    try:
+        return int(available_size())
+    except Exception:
+        return None
 
 
 def required_kv_tokens(batch_size: int, seq_len: int, prefix_len: int, *, is_prefill: bool) -> int:
@@ -60,7 +79,12 @@ def required_kv_alloc_tokens(
     though ``bs*sl`` is tiny — so ``alloc_extend`` fails with "Prefill out of
     memory" while the naive check passes. This returns that true paged
     requirement so such shapes are skipped BEFORE launching. With ``page_size==1``
-    it equals ``required_kv_tokens`` (a no-op for token-level allocators).
+    it equals the logical span plus the fresh decode token (a no-op for
+    token-level page rounding).
+
+    Decode also allocates one fresh token per request. When ``seq_len`` lands
+    exactly on a page boundary, that token requires one additional page for
+    every request.
 
     NOTE: this is the real allocation size only, NOT SGLang's eviction
     over-estimate (``extend_num_tokens + bs*page_size``). The collector clears
@@ -70,8 +94,33 @@ def required_kv_alloc_tokens(
     if batch_size <= 0:
         return 0
     per_req = required_kv_tokens(batch_size, seq_len, prefix_len, is_prefill=is_prefill) // batch_size
+    if not is_prefill:
+        per_req += 1
     pages_per_req = (per_req + page_size - 1) // page_size
     return batch_size * pages_per_req * page_size
+
+
+def required_swa_kv_alloc_tokens(
+    batch_size: int,
+    seq_len: int,
+    prefix_len: int,
+    page_size: int,
+    window_size: int,
+    *,
+    is_prefill: bool,
+) -> int:
+    """Page-rounded hybrid SWA allocation needed by one collector shape."""
+    if batch_size <= 0:
+        return 0
+    past_len = prefix_len if is_prefill else seq_len
+    fresh_len = seq_len if is_prefill else 1
+    window_start = max(0, past_len - window_size)
+    window_start = (window_start // page_size) * page_size
+    swa_tail_len = past_len - window_start
+    rounded_tail = ((swa_tail_len + page_size - 1) // page_size) * page_size
+    rounded_past = ((past_len + page_size - 1) // page_size) * page_size
+    rounded_total = ((past_len + fresh_len + page_size - 1) // page_size) * page_size
+    return batch_size * (rounded_tail + rounded_total - rounded_past)
 
 
 def dsa_indexer_workspace_bytes(
@@ -246,6 +295,38 @@ def alloc_prefix_indices(model_runner, batch_size: int, prefix_len: int) -> list
         return [torch.empty((0,), dtype=torch.int64, device=device) for _ in range(batch_size)]
 
     allocator = model_runner.token_to_kv_pool_allocator
+    alloc_swa_tail = getattr(allocator, "alloc_extend_swa_tail", None)
+    window_size = getattr(getattr(model_runner, "model_config", None), "window_size", None)
+    page_size = getattr(allocator, "page_size", None)
+    if callable(alloc_swa_tail) and isinstance(window_size, int) and window_size > 0:
+        if not isinstance(page_size, int) or page_size <= 1:
+            raise RuntimeError("SGLang SWA tail allocation requires a paged KV allocator")
+        window_start = max(0, prefix_len - window_size)
+        window_start = (window_start // page_size) * page_size
+        swa_tail_len = prefix_len - window_start
+        per_request = []
+        for _ in range(batch_size):
+            prefix_lens_cpu = torch.zeros(1, dtype=torch.int64)
+            seq_lens_cpu = torch.full((1,), prefix_len, dtype=torch.int64)
+            prefix_lens = prefix_lens_cpu.to(device, non_blocking=True)
+            seq_lens = seq_lens_cpu.to(device, non_blocking=True)
+            last_loc = torch.full((1,), -1, dtype=torch.int64, device=device)
+            indices = alloc_swa_tail(
+                prefix_lens,
+                prefix_lens_cpu,
+                seq_lens,
+                seq_lens_cpu,
+                last_loc,
+                prefix_len,
+                swa_tail_len,
+            )
+            if indices is None:
+                raise RuntimeError(
+                    f"failed to allocate SWA-tail prefix cache: prefix_len={prefix_len}, swa_tail_len={swa_tail_len}"
+                )
+            per_request.append(indices.contiguous())
+        return per_request
+
     chunk_size = runtime_chunk_size(model_runner)
     alloc_extend = allocator.alloc_extend
     if batch_size * prefix_len > chunk_size:

--- a/collector/wideep/README.md
+++ b/collector/wideep/README.md
@@ -8,12 +8,13 @@ registries stay free of WideEP ops; `collect.py` appends a WideEP registry only
 when the collector-v2 plan or explicit `--ops` requests those ops.
 
 The authoritative framework versions and collector images are in
-`collector/framework_manifest.yaml`. WideEP entries must use the same framework
-version as their non-WideEP framework entry.
+`collector/framework_manifest.yaml`. WideEP entries describe their special
+runtime independently from the non-WideEP framework entry.
 
 Layout:
 
-- `sglang/collect_mla_module.py`: SGLang WideEP MLA entrypoints.
+- `sglang/collect_mla_module.py`: legacy WideEP MLA wrappers (not registered
+  while stock SGLang and the WideEP image use different releases).
 - `sglang/collect_deepep_moe.py`: SGLang DeepEP MoE entrypoint.
 - `sglang/deepep/`: multi-node DeepEP log collection and extraction scripts.
 - `trtllm/collect_moe_compute.py`: TensorRT-LLM WideEP MoE compute entrypoint.

--- a/collector/wideep/sglang/registry.py
+++ b/collector/wideep/sglang/registry.py
@@ -12,20 +12,6 @@ from collector.registry_types import OpEntry, PerfFile
 
 REGISTRY: list[OpEntry] = [
     OpEntry(
-        op="wideep_mla_context",
-        module="collector.wideep.sglang.collect_mla_module",
-        get_func="get_wideep_mla_context_test_cases",
-        run_func="run_mla_module_worker",
-        perf_filename=PerfFile.WIDEEP_CONTEXT_MLA,
-    ),
-    OpEntry(
-        op="wideep_mla_generation",
-        module="collector.wideep.sglang.collect_mla_module",
-        get_func="get_wideep_mla_generation_test_cases",
-        run_func="run_mla_module_worker",
-        perf_filename=PerfFile.WIDEEP_GENERATION_MLA,
-    ),
-    OpEntry(
         op="wideep_moe",
         module="collector.wideep.sglang.collect_deepep_moe",
         get_func="get_wideep_moe_test_cases",

--- a/rust/aiconfigurator-core/src/operators/mamba.rs
+++ b/rust/aiconfigurator-core/src/operators/mamba.rs
@@ -98,7 +98,8 @@ pub struct GdnOp {
     pub scale_factor: f64,
     /// GDN kernel name. Context uses `causal_conv1d_fn` and
     /// `chunk_gated_delta_rule`; generation uses `causal_conv1d_update`
-    /// and `fused_sigmoid_gating_delta_rule_update`.
+    /// plus `fused_recurrent_gated_delta_rule_packed_decode` for SGLang or
+    /// `fused_sigmoid_gating_delta_rule_update` for other backends.
     pub kernel_source: String,
     pub phase: String, // "context" | "generation" (matches Python; SOL branch keys on phase == "context")
     pub d_model: u32,
@@ -157,7 +158,11 @@ impl GdnOp {
         let hk = self.head_k_dim as f64;
         let nv = self.num_v_heads as f64;
         let hv = self.head_v_dim as f64;
-        let conv_channels = nk * hk + nv * hv;
+        let conv_channels = if db.backend.eq_ignore_ascii_case("sglang") {
+            2.0 * nk * hk + nv * hv
+        } else {
+            nk * hk + nv * hv
+        };
         let d_conv = self.d_conv as f64;
         let d_model = self.d_model as f64;
         let state_size = nv * hk * hv;
@@ -183,6 +188,13 @@ impl GdnOp {
                 x * (nk * hk + nv * hv) * 2.0 + state_size * 2.0 * bs,
                 x * nv * hv * 2.0 + state_size * 2.0 * bs,
             ),
+            "fused_recurrent_gated_delta_rule_packed_decode" => {
+                let packed_qkv = 2.0 * nk * hk + nv * hv;
+                (
+                    x * (packed_qkv + 2.0 * nv) * 2.0 + 2.0 * nv * 4.0 + state_size * 4.0 * bs,
+                    x * nv * hv * 2.0 + state_size * 4.0 * bs,
+                )
+            }
             _ => (x * d_model * 2.0, x * d_model * 2.0),
         };
         let mem_bw = db.system_spec.gpu.mem_bw.max(1.0);

--- a/src/aiconfigurator/sdk/models/qwen35.py
+++ b/src/aiconfigurator/sdk/models/qwen35.py
@@ -39,10 +39,12 @@ class Qwen35Model(BaseModel):
             model_info["context"],
             model_config,
             model_info["extra_params"],
+            backend_name=backend_name,
         )
 
-    def __init__(self, *args) -> None:
+    def __init__(self, *args, backend_name: str = "") -> None:
         super().__init__(*args)
+        self._backend_name = backend_name
         cfg: common.Qwen35Config = self.extra_params
         assert isinstance(cfg, common.Qwen35Config), "Qwen35Model requires Qwen35Config extra_params"
 
@@ -332,7 +334,11 @@ class Qwen35Model(BaseModel):
                     ops.GDNKernel(
                         "generation_gdn_recurrence",
                         c,
-                        "fused_sigmoid_gating_delta_rule_update",
+                        (
+                            "fused_recurrent_gated_delta_rule_packed_decode"
+                            if self._backend_name == "sglang"
+                            else "fused_sigmoid_gating_delta_rule_update"
+                        ),
                         "generation",
                         h,
                         nk,

--- a/src/aiconfigurator/sdk/operations/mamba.py
+++ b/src/aiconfigurator/sdk/operations/mamba.py
@@ -286,7 +286,8 @@ class GDNKernel(Operation):
         - "chunk_gated_delta_rule": GDN chunked scan (core recurrence)
       Generation phase:
         - "causal_conv1d_update": Single-step causal conv state update
-        - "fused_sigmoid_gating_delta_rule_update": Single-step GDN recurrence
+        - "fused_recurrent_gated_delta_rule_packed_decode": SGLang packed recurrence
+        - "fused_sigmoid_gating_delta_rule_update": Other-backend recurrence
 
     Uses full (unsharded) dimensions for database lookup; collector data is per-layer.
 
@@ -379,7 +380,10 @@ class GDNKernel(Operation):
         def get_sol() -> tuple[float, float, float]:
             x = (batch_size * seq_len) if phase == "context" and seq_len else batch_size
             if kernel_source in ("causal_conv1d_fn", "causal_conv1d_update"):
-                conv_channels = num_k_heads * head_k_dim + num_v_heads * head_v_dim
+                if database.backend.lower() == "sglang":
+                    conv_channels = 2 * num_k_heads * head_k_dim + num_v_heads * head_v_dim
+                else:
+                    conv_channels = num_k_heads * head_k_dim + num_v_heads * head_v_dim
                 read_bytes = x * conv_channels * (d_conv + 1) * 2
                 write_bytes = x * conv_channels * 2
             elif kernel_source == "chunk_gated_delta_rule":
@@ -407,6 +411,12 @@ class GDNKernel(Operation):
                 state_size = num_v_heads * head_k_dim * head_v_dim
                 read_bytes = x * (num_k_heads * head_k_dim + num_v_heads * head_v_dim) * 2 + state_size * 2 * batch_size
                 write_bytes = x * num_v_heads * head_v_dim * 2 + state_size * 2 * batch_size
+            elif kernel_source == "fused_recurrent_gated_delta_rule_packed_decode":
+                # SGLang 0.5.14 consumes packed Q+K+V, a/b gates, and an FP32 state pool.
+                state_size = num_v_heads * head_k_dim * head_v_dim
+                packed_qkv = 2 * num_k_heads * head_k_dim + num_v_heads * head_v_dim
+                read_bytes = x * (packed_qkv + 2 * num_v_heads) * 2 + 2 * num_v_heads * 4 + state_size * 4 * batch_size
+                write_bytes = x * num_v_heads * head_v_dim * 2 + state_size * 4 * batch_size
             else:
                 read_bytes = x * d_model * 2
                 write_bytes = x * d_model * 2

--- a/tests/unit/collector/sglang/test_collect_mla_module.py
+++ b/tests/unit/collector/sglang/test_collect_mla_module.py
@@ -1,8 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import ast
 import sys
 import types
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -88,12 +90,12 @@ class TestGetPrecisionCombos:
 
 
 class TestGetBackends:
-    def test_dsa_always_nsa(self):
+    def test_dsa_uses_0514_backend_name(self):
         mod = _import_module()
         with patch.object(mod, "get_sm_version", return_value=90):
-            assert mod._get_backends("dsa") == "nsa"
+            assert mod._get_backends("dsa") == "dsa"
         with patch.object(mod, "get_sm_version", return_value=100):
-            assert mod._get_backends("dsa") == "nsa"
+            assert mod._get_backends("dsa") == "dsa"
 
     def test_mla_hopper(self):
         mod = _import_module()
@@ -168,20 +170,28 @@ class TestDsaRuntimeLimits:
         assert not dsa_indexer_total_kv_tokens_supported(32, 4, 1_048_575, is_prefill=True)
         assert not dsa_indexer_total_kv_tokens_supported(64, 4, 524_288, is_prefill=True)
 
+    def test_decode_allocation_counts_fresh_token_before_page_rounding(self):
+        from collector.sglang.runtime_limits import required_kv_alloc_tokens
 
-class TestDsaPiecewiseCudaGraph:
-    def test_glm5_dsa_piecewise_graph_is_only_for_trtllm_prefill(self):
-        mod = _import_module()
+        assert required_kv_alloc_tokens(2, 256, 0, 256, is_prefill=True) == 512
+        assert required_kv_alloc_tokens(2, 256, 0, 256, is_prefill=False) == 1024
 
-        assert not mod._enable_glm5_dsa_piecewise_graph("dsa", "nvidia/GLM-5-NVFP4")
-        assert mod._enable_glm5_dsa_piecewise_graph("dsa", "zai-org/GLM-5", "trtllm")
-        assert not mod._enable_glm5_dsa_piecewise_graph("mla", "zai-org/GLM-5", "trtllm")
-        assert not mod._enable_glm5_dsa_piecewise_graph("dsa", "deepseek-ai/DeepSeek-V3.2", "trtllm")
+    def test_hybrid_swa_allocation_counts_tail_and_fresh_page(self):
+        from collector.sglang.runtime_limits import required_swa_kv_alloc_tokens
 
+        assert required_swa_kv_alloc_tokens(2, 1, 256, 256, 128, is_prefill=True) == 1024
+        assert required_swa_kv_alloc_tokens(2, 256, 0, 256, 128, is_prefill=False) == 1024
+
+
+class TestDsaCudaGraph:
     def test_generation_cuda_graph_uses_max_batch_tokens(self):
         mod = _import_module()
         runner = types.SimpleNamespace(
-            server_args=types.SimpleNamespace(disable_cuda_graph=False, cuda_graph_bs=None, cuda_graph_max_bs=256)
+            server_args=types.SimpleNamespace(
+                cuda_graph_config=types.SimpleNamespace(
+                    decode=types.SimpleNamespace(backend="cudagraphs", bs=None, max_bs=256)
+                )
+            )
         )
 
         assert mod._generation_cuda_graph_enabled_for_tokens(runner, 256)
@@ -190,7 +200,11 @@ class TestDsaPiecewiseCudaGraph:
     def test_generation_cuda_graph_uses_explicit_batch_list(self):
         mod = _import_module()
         runner = types.SimpleNamespace(
-            server_args=types.SimpleNamespace(disable_cuda_graph=False, cuda_graph_bs=[1, 4, 16])
+            server_args=types.SimpleNamespace(
+                cuda_graph_config=types.SimpleNamespace(
+                    decode=types.SimpleNamespace(backend="cudagraphs", bs=[1, 4, 16], max_bs=None)
+                )
+            )
         )
 
         assert mod._generation_cuda_graph_enabled_for_tokens(runner, 4)
@@ -199,7 +213,11 @@ class TestDsaPiecewiseCudaGraph:
     def test_generation_cuda_graph_can_be_disabled(self):
         mod = _import_module()
         runner = types.SimpleNamespace(
-            server_args=types.SimpleNamespace(disable_cuda_graph=True, cuda_graph_bs=[1, 4, 16])
+            server_args=types.SimpleNamespace(
+                cuda_graph_config=types.SimpleNamespace(
+                    decode=types.SimpleNamespace(backend="disabled", bs=[1, 4, 16], max_bs=None)
+                )
+            )
         )
 
         assert not mod._generation_cuda_graph_enabled_for_tokens(runner, 4)
@@ -236,17 +254,14 @@ class TestBuildModuleTestCases:
         assert cases
         assert calls == [("sglang", "generation", 89)]
 
-    def test_dsa_keeps_path_sensitive_checkpoints_after_precision_filtering(self):
+    def test_full_dsa_sweep_canonicalizes_consumer_equivalent_checkpoints(self):
         mod = _import_module()
         with patch.object(mod, "get_sm_version", return_value=100):
             cases = mod._build_module_test_cases("dsa", "context")
         model_paths = {case[6] for case in cases}
         assert "deepseek-ai/DeepSeek-V3.2" in model_paths
-        assert "zai-org/GLM-5" in model_paths
+        assert "zai-org/GLM-5" not in model_paths
         assert "zai-org/GLM-5-FP8" in model_paths
-        # Same-precision DSA dedup collapses the nvfp4 GLM checkpoints
-        # (GLM-5-NVFP4 + GLM-5.2-NVFP4) to the longest-context representative
-        # GLM-5.2-NVFP4; the other distinct-precision checkpoints are untouched.
         assert "nvidia/GLM-5.2-NVFP4" in model_paths
         assert "nvidia/GLM-5-NVFP4" not in model_paths
 
@@ -278,7 +293,45 @@ class TestBuildModuleTestCases:
                 assert case[7] == "dsa"
                 assert case[8] is None  # DSA backend resolved at runtime
                 assert case[9] in {1, 2, 4, 8}
-                assert case[10] == "flashmla_kv"
+                assert case[10] == ("flashmla_kv" if case[3] == "fp8" else None)
+
+    def test_blackwell_context_keeps_both_consumer_backends(self):
+        mod = _import_module()
+        with patch.object(mod, "get_sm_version", return_value=100):
+            cases = mod._build_module_test_cases("dsa", "context")
+        assert {case[10] for case in cases if case[3] == "fp8"} == {"flashmla_kv", "trtllm"}
+
+    def test_blackwell_generation_uses_0514_default_backend(self):
+        mod = _import_module()
+        with patch.object(mod, "get_sm_version", return_value=100):
+            cases = mod._build_module_test_cases("dsa", "generation")
+        assert {case[10] for case in cases if case[3] == "fp8"} == {"trtllm"}
+
+    def test_skip_indexer_cases_use_glm52_canonical_model(self):
+        mod = _import_module()
+        with patch.object(mod, "get_sm_version", return_value=100):
+            cases = mod.get_dsa_context_module_skip_indexer_test_cases()
+        assert cases
+        assert {case[6] for case in cases} == {"nvidia/GLM-5.2-NVFP4"}
+
+    def test_glm_sparse_selector_preserves_targeted_artifact(self, monkeypatch):
+        _import_module()
+        source_path = Path("collector/sglang/glm5_dsa_sparse_modules.py")
+        tree = ast.parse(source_path.read_text(), filename=str(source_path))
+        selector_node = next(
+            node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == "_selected_glm5_models"
+        )
+        namespace = {}
+        exec(compile(ast.Module(body=[selector_node], type_ignores=[]), str(source_path), "exec"), namespace)
+        selector = namespace["_selected_glm5_models"]
+
+        monkeypatch.delenv("COLLECTOR_MODEL_PATH", raising=False)
+        assert selector() == ["nvidia/GLM-5.2-NVFP4"]
+        for model_path in ("nvidia/GLM-5-NVFP4", "nvidia/GLM-5.2-NVFP4"):
+            monkeypatch.setenv("COLLECTOR_MODEL_PATH", model_path)
+            assert selector() == [model_path]
+        monkeypatch.setenv("COLLECTOR_MODEL_PATH", "deepseek-ai/DeepSeek-V3.2")
+        assert selector() == []
 
     def test_deduplication(self):
         """One entry per top-level sweep tuple, not per inner (seq, batch) shape."""
@@ -308,15 +361,13 @@ class TestBuildModuleTestCases:
         batch_sizes = {c[1] for c in cases}
         assert batch_sizes == set(mod.get_mla_module_sweep_spec("sglang").context_batch_sizes)
 
-    def test_glm5_nvfp4_context_includes_fp8_kv_module_case(self):
+    def test_targeted_glm5_nvfp4_context_includes_fp8_kv_module_case(self, monkeypatch):
         mod = _import_module()
+        monkeypatch.setenv("COLLECTOR_MODEL_PATH", "nvidia/GLM-5-NVFP4")
         with patch.object(mod, "get_sm_version", return_value=90):
             cases = mod._build_module_test_cases("dsa", "context")
-        # nvfp4 GLM is represented by GLM-5.2-NVFP4 after the same-precision
-        # DSA dedup (GLM-5-NVFP4 is collapsed into it).
         assert any(
-            c[6] == "nvidia/GLM-5.2-NVFP4" and c[3] == "fp8" and c[4] == "bfloat16" and c[5] == "bfloat16"
-            for c in cases
+            c[6] == "nvidia/GLM-5-NVFP4" and c[3] == "fp8" and c[4] == "bfloat16" and c[5] == "bfloat16" for c in cases
         )
 
     def test_placeholder_seq_batch(self):
@@ -428,16 +479,12 @@ class TestBuildWideepMlaTestCases:
         assert {c[7] for c in cases} == {"mla"}
 
     def test_only_mla_models(self):
-        """Wideep MLA only includes MLA-type models, not DSA."""
+        """Full WideEP MLA keeps one consumer-equivalent V3 representative."""
         mod = _import_module()
         with patch.object(mod, "get_sm_version", return_value=90):
             cases = mod._build_wideep_mla_test_cases("context")
         model_paths = {c[6] for c in cases}
-        assert model_paths == {
-            "deepseek-ai/DeepSeek-R1",
-            "deepseek-ai/DeepSeek-V3",
-            "nvidia/DeepSeek-V3.1-NVFP4",
-        }
+        assert model_paths == {"deepseek-ai/DeepSeek-V3"}
 
     def test_sweeps_backends(self):
         """Hopper should sweep flashinfer and fa3 backends."""

--- a/tests/unit/collector/sglang/test_collect_moe_population.py
+++ b/tests/unit/collector/sglang/test_collect_moe_population.py
@@ -3,6 +3,7 @@
 
 import ast
 import itertools
+import json
 from contextlib import contextmanager, nullcontext
 from pathlib import Path
 from types import SimpleNamespace
@@ -13,6 +14,7 @@ pytestmark = pytest.mark.unit
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 SOURCE_PATH = REPO_ROOT / "collector" / "sglang" / "collect_moe.py"
+MODEL_CONFIG_DIR = REPO_ROOT / "src" / "aiconfigurator" / "model_configs"
 
 
 def _load_functions(*names: str, namespace: dict | None = None) -> dict:
@@ -39,19 +41,50 @@ def _gptoss_case(*, tp: int, ep: int):
     )
 
 
-def _populate_gptoss_cases(cases):
+def _populate_gptoss_cases(cases, *, sm_version=100, allowed_mode="w4a8_mxfp4_mxfp8"):
+    allowed_modes = {allowed_mode} if isinstance(allowed_mode, str) else set(allowed_mode)
     loaded = _load_functions(
         "get_moe_test_cases",
         namespace={
             "itertools": itertools,
-            "get_sm_version": lambda: 100,
+            "get_sm_version": lambda: sm_version,
             "get_common_moe_test_cases": lambda: cases,
-            "moe_model_allows_quantization": (lambda _backend, _model, mode: mode == "w4a8_mxfp4_mxfp8"),
+            "moe_model_allows_quantization": (lambda _backend, _model, mode: mode in allowed_modes),
+            "_uses_relu2_moe_activation": lambda _model: False,
             "get_moe_quantization_module_config": lambda *_args, **_kwargs: {},
             "_SM120_NEMOTRON_NVFP4_MODELS": set(),
         },
     )
     return loaded["get_moe_test_cases"]()
+
+
+def _glm5_case(model_name: str):
+    return SimpleNamespace(
+        num_tokens_list=[128],
+        hidden_size=7168,
+        inter_size=2048,
+        topk=8,
+        num_experts=256,
+        tp=1,
+        ep=1,
+        model_name=model_name,
+        token_expert_distribution="balanced",
+        power_law_alpha=None,
+        architecture="GlmMoeDsaForCausalLM",
+    )
+
+
+def test_glm52_nvfp4_replaces_consumer_equivalent_glm5_moe_cases():
+    populated = _populate_gptoss_cases(
+        [
+            _glm5_case("nvidia/GLM-5-NVFP4"),
+            _glm5_case("nvidia/GLM-5.2-NVFP4"),
+        ],
+        allowed_mode="nvfp4",
+    )
+
+    assert populated
+    assert {case[8] for case in populated} == {"nvidia/GLM-5.2-NVFP4"}
 
 
 @pytest.mark.parametrize(("tp", "ep"), [(4, 8), (32, 1), (32, 8)])
@@ -62,6 +95,51 @@ def test_gptoss_mxfp4_population_retains_tp_and_ep_buckets(tp, ep):
     assert populated[0][0] == "w4a8_mxfp4_mxfp8"
     assert populated[0][6:8] == [tp, ep]
     assert populated[0][-1] is None
+
+
+@pytest.mark.parametrize(
+    ("mode", "sm_version", "expected"),
+    [
+        ("nvfp4", 90, "marlin"),
+        ("nvfp4", 100, "flashinfer_trtllm"),
+        ("nvfp4", 103, "flashinfer_trtllm"),
+        ("nvfp4", 120, "flashinfer_cutlass"),
+        ("w4a16_mxfp4", 90, "flashinfer_mxfp4"),
+        ("w4a8_mxfp4_mxfp8", 100, "flashinfer_mxfp4"),
+    ],
+)
+def test_quantized_framework_backend_map_matches_sglang_0514(mode, sm_version, expected):
+    resolve = _load_functions("_resolve_framework_moe_backend")["_resolve_framework_moe_backend"]
+
+    assert resolve(mode, sm_version) == expected
+
+
+@pytest.mark.parametrize(
+    ("model_name", "activation", "scoring", "routing_method", "scale"),
+    [
+        ("nvidia/Kimi-K2.5-NVFP4", "silu", "sigmoid", "DeepSeekV3", 2.827),
+        ("nvidia/MiniMax-M2.5-NVFP4", "silu", "sigmoid", None, None),
+        ("nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4", "relu2", "sigmoid", "DeepSeekV3", 5.0),
+        ("Qwen/Qwen3-235B-A22B", "silu", "softmax", "Renormalize", None),
+        ("deepseek-ai/DeepSeek-V4-Pro", "silu", "sqrtsoftplus", "DeepSeekV3", 2.5),
+    ],
+)
+def test_framework_routing_comes_from_local_model_contract(model_name, activation, scoring, routing_method, scale):
+    enum = SimpleNamespace(DeepSeekV3="DeepSeekV3", Renormalize="Renormalize")
+    route = _load_functions(
+        "_framework_routing",
+        namespace={
+            "_MODEL_CONFIG_DIR": MODEL_CONFIG_DIR,
+            "json": json,
+            "RoutingMethodType": enum,
+            "SimpleNamespace": SimpleNamespace,
+        },
+    )["_framework_routing"](model_name)
+
+    assert route.activation == activation
+    assert route.scoring_func == scoring
+    assert route.routing_method == routing_method
+    assert route.routed_scale == scale
 
 
 @pytest.mark.parametrize("fail_during_benchmark", [False, True])

--- a/tests/unit/collector/test_framework_manifest.py
+++ b/tests/unit/collector/test_framework_manifest.py
@@ -3,12 +3,11 @@
 
 """Tests for collector framework version/image manifest."""
 
-import copy
 from pathlib import Path
 
 import pytest
 
-from collector.framework_manifest import get_collector_runtime, load_manifest, validate_manifest
+from collector.framework_manifest import get_collector_runtime, require_collector_runtime
 from collector.sglang.registry import REGISTRY as SGLANG_REGISTRY
 from collector.trtllm.registry import REGISTRY as TRTLLM_REGISTRY
 from collector.wideep.sglang.registry import REGISTRY as WIDEEP_SGLANG_REGISTRY
@@ -23,33 +22,51 @@ def test_manifest_exposes_current_framework_versions_and_images():
     trtllm = get_collector_runtime("trtllm")
     vllm = get_collector_runtime("vllm")
 
-    assert sglang.version == "0.5.10"
-    assert sglang.image() == "lmsysorg/sglang:v0.5.10"
-    assert sglang.image("cu130") == "lmsysorg/sglang:v0.5.10-cu130"
+    assert sglang.version == "0.5.14"
+    assert sglang.image() == "lmsysorg/sglang:v0.5.14"
+    assert sglang.image("cu130") == "lmsysorg/sglang:v0.5.14-cu130"
     assert trtllm.version == "1.3.0rc10"
     assert trtllm.image() == "nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10"
     assert vllm.version == "0.19.0"
     assert vllm.image("cu130") == "vllm/vllm-openai:v0.19.0-cu130"
 
 
-def test_wideep_versions_stay_aligned_with_default_framework_versions():
-    manifest = load_manifest()
-
-    for framework, wideep_spec in manifest["wideep"].items():
-        assert wideep_spec["version"] == manifest["frameworks"][framework]["version"]
-
+def test_wideep_runtime_stays_independent_from_default_framework_runtime():
     wideep_sglang = get_collector_runtime("sglang", workload="wideep")
-    assert wideep_sglang.version == get_collector_runtime("sglang").version
+    assert wideep_sglang.version == "0.5.10"
+    assert wideep_sglang.version != get_collector_runtime("sglang").version
     assert wideep_sglang.collector_dir == "collector/wideep/sglang"
     assert "deepseek-v4" in wideep_sglang.image()
 
 
-def test_manifest_validation_rejects_wideep_version_drift():
-    manifest = copy.deepcopy(load_manifest())
-    manifest["wideep"]["sglang"]["version"] = "0.5.9"
+WIDEEP_OPS = {entry.op for entry in WIDEEP_SGLANG_REGISTRY}
 
-    with pytest.raises(ValueError, match=r"wideep\.sglang\.version must match"):
-        validate_manifest(manifest)
+
+@pytest.mark.parametrize(
+    ("installed_version", "requested_ops", "workload", "version"),
+    [
+        ("0.5.14+cu130", set(), "default", "0.5.14"),
+        ("0.5.10", {"wideep_moe"}, "wideep", "0.5.10"),
+    ],
+)
+def test_runtime_selection_accepts_only_the_matching_pin(installed_version, requested_ops, workload, version):
+    runtime = require_collector_runtime("sglang", installed_version, requested_ops=requested_ops, wideep_ops=WIDEEP_OPS)
+    assert (runtime.workload, runtime.version) == (workload, version)
+
+
+@pytest.mark.parametrize(
+    ("installed_version", "requested_ops", "match"),
+    [
+        ("0.5.13", {"gemm"}, r"stock collector requires exactly 0\.5\.14"),
+        ("0.5.14rc1", {"gemm"}, r"stock collector requires exactly 0\.5\.14"),
+        ("0.5.14.post1", {"gemm"}, r"stock collector requires exactly 0\.5\.14"),
+        ("0.5.14", {"wideep_moe"}, r"WideEP collector requires exactly 0\.5\.10"),
+        ("0.5.14", {"gemm", "wideep_moe"}, r"0\.5\.14 != 0\.5\.10.*separate containers"),
+    ],
+)
+def test_runtime_selection_rejects_mismatched_or_mixed_pins(installed_version, requested_ops, match):
+    with pytest.raises(RuntimeError, match=match):
+        require_collector_runtime("sglang", installed_version, requested_ops=requested_ops, wideep_ops=WIDEEP_OPS)
 
 
 def test_wideep_registry_entries_are_separate_from_stock_backend_registries():
@@ -62,8 +79,8 @@ def test_wideep_registry_entries_are_separate_from_stock_backend_registries():
     assert "wideep_mla_generation" not in sglang_modules
     assert "wideep_moe" not in sglang_modules
     assert "trtllm_moe_wideep" not in trtllm_modules
-    assert wideep_sglang_modules["wideep_mla_context"].startswith("collector.wideep.sglang.")
-    assert wideep_sglang_modules["wideep_mla_generation"].startswith("collector.wideep.sglang.")
+    assert "wideep_mla_context" not in wideep_sglang_modules
+    assert "wideep_mla_generation" not in wideep_sglang_modules
     assert wideep_sglang_modules["wideep_moe"].startswith("collector.wideep.sglang.")
     assert wideep_trtllm_modules["trtllm_moe_wideep"].startswith("collector.wideep.trtllm.")
 

--- a/tests/unit/collector/test_model_cases.py
+++ b/tests/unit/collector/test_model_cases.py
@@ -52,8 +52,8 @@ def test_model_case_plan_merges_required_base_and_framework_specific_ops():
     assert "attention_generation" not in plan.op_cases
     assert "moe" in plan.op_cases
     assert "mla_context" in plan.op_cases
-    assert "wideep_mla_context" in plan.op_cases
-    assert "wideep_moe" in plan.op_cases
+    assert "wideep_mla_context" not in plan.op_cases
+    assert "wideep_moe" not in plan.op_cases
     assert "trtllm_moe_wideep" not in plan.op_cases
 
 
@@ -296,9 +296,10 @@ def test_base_gemm_cases_are_readable_shape_specs():
 
 
 def test_moe_model_quantization_policy_is_yaml_backed():
-    assert not moe_model_allows_quantization("sglang", "deepseek-ai/DeepSeek-V4-Flash", "w4a8_mxfp4_mxfp8")
+    assert moe_model_allows_quantization("sglang", "deepseek-ai/DeepSeek-V4-Flash", "w4a8_mxfp4_mxfp8")
     assert not moe_model_allows_quantization("sglang", "deepseek-ai/DeepSeek-V4-Flash", "bfloat16")
     assert not moe_model_allows_quantization("sglang", "Qwen/Qwen3-235B-A22B", "w4a8_mxfp4_mxfp8")
+    assert moe_model_allows_quantization("sglang", "nvidia/GLM-5.2-NVFP4", "nvfp4")
 
     assert moe_model_allows_quantization("sglang", "openai/gpt-oss-120b", "w4a16_mxfp4")
     assert moe_model_allows_quantization("sglang", "openai/gpt-oss-120b", "w4a8_mxfp4_mxfp8")
@@ -314,8 +315,8 @@ def test_moe_model_quantization_policy_is_yaml_backed():
 def test_dsv4_moe_quantization_policy_prunes_unrelated_modes():
     expected_by_backend = {
         "sglang": {
-            "deepseek-ai/DeepSeek-V4-Flash": set(),
-            "deepseek-ai/DeepSeek-V4-Pro": set(),
+            "deepseek-ai/DeepSeek-V4-Flash": {"w4a8_mxfp4_mxfp8"},
+            "deepseek-ai/DeepSeek-V4-Pro": {"w4a16_mxfp4", "w4a8_mxfp4_mxfp8"},
             "sgl-project/DeepSeek-V4-Flash-FP8": {"fp8_block"},
             "sgl-project/DeepSeek-V4-Pro-FP8": {"fp8_block"},
         },
@@ -350,6 +351,7 @@ def test_kimi_moe_quantization_is_artifact_specific():
     for backend in ("sglang", "trtllm", "vllm"):
         available_modes = {spec.name for spec in get_moe_quantization_specs(backend)}
         for model_path, expected in expected_by_artifact.items():
+            expected = set() if backend == "sglang" and model_path == "moonshotai/Kimi-K2.5" else expected
             allowed = {mode for mode in available_modes if moe_model_allows_quantization(backend, model_path, mode)}
             assert allowed == expected, (backend, model_path)
 
@@ -396,6 +398,7 @@ def test_gptoss_mxfp4_modes_are_additive_on_blackwell():
         }
 
     assert selected_modes("sglang", 100) == {"w4a16_mxfp4", "w4a8_mxfp4_mxfp8"}
+    assert selected_modes("sglang", 90) == {"w4a16_mxfp4"}
     assert selected_modes("trtllm", 90) == {"w4a16_mxfp4"}
     assert selected_modes("trtllm", 100) == {"w4a16_mxfp4", "w4a8_mxfp4_mxfp8"}
 
@@ -906,7 +909,7 @@ def test_dsv4_plan_only_uses_backend_specific_case_plan():
 
     assert payload["ops"] == expected_ops
     assert "dsv4_csa_topk_calib" in payload["ops"]
-    assert "wideep_moe" in payload["ops"]
+    assert "wideep_moe" not in payload["ops"]
 
 
 def test_vllm_dsv4_collectors_are_registry_only():
@@ -1012,7 +1015,7 @@ def test_full_mode_aggregates_all_model_case_files():
 
     assert plan.model_path is None
     assert len(plan.model_cases_paths) >= 18
-    assert "wideep_mla_context" in plan.op_cases
+    assert "wideep_mla_context" not in plan.op_cases
     assert "dsv4_csa_context_module" in plan.op_cases
     assert "gdn" in plan.op_cases
 
@@ -1126,7 +1129,7 @@ schema_version: 1
 sm_version: 100
 framework_specific_op_exceptions:
   sglang:
-    wideep_moe:
+    mla_context:
       drop: true
 """,
         encoding="utf-8",
@@ -1141,8 +1144,8 @@ framework_specific_op_exceptions:
 
     assert plan.sm_version == 100
     assert plan.sm_exceptions_path == exceptions.resolve()
-    assert "wideep_moe" not in plan.op_cases
-    assert "wideep_mla_context" in plan.op_cases
+    assert "mla_context" not in plan.op_cases
+    assert "mla_generation" in plan.op_cases
 
 
 def test_sm_exception_catalog_does_not_activate_unrelated_ops():
@@ -1168,7 +1171,7 @@ schema_version: 1
 sm_version: 100
 framework_specific_op_exceptions:
   sglang:
-    wideep_moe:
+    mla_context:
       drop: true
 """,
         encoding="utf-8",
@@ -1185,7 +1188,7 @@ framework_specific_op_exceptions:
     assert plan.sm_version == 100
     assert plan.sm_exceptions_path == default_sm_exceptions_path(100)
     assert plan.sm_exceptions_path == exceptions
-    assert "wideep_moe" not in plan.op_cases
+    assert "mla_context" not in plan.op_cases
 
 
 def test_sm_exception_files_list_matching_gpu_types():

--- a/tests/unit/sdk/models/test_model_config.py
+++ b/tests/unit/sdk/models/test_model_config.py
@@ -466,6 +466,22 @@ class TestHFModelSupport:
         assert op_ratio_counts[4] == expected_ratio_counts.get(4, 0)
         assert op_ratio_counts[128] == expected_ratio_counts.get(128, 0) + expected_ratio_counts.get(0, 0)
 
+    @pytest.mark.parametrize(
+        ("backend_name", "expected_kernel_source"),
+        [
+            ("sglang", "fused_recurrent_gated_delta_rule_packed_decode"),
+            ("trtllm", "fused_sigmoid_gating_delta_rule_update"),
+            ("vllm", "fused_sigmoid_gating_delta_rule_update"),
+        ],
+    )
+    def test_qwen35_generation_gdn_uses_backend_kernel_source(self, backend_name, expected_kernel_source):
+        model_config = config.ModelConfig(tp_size=1, moe_tp_size=1, moe_ep_size=1)
+
+        model = get_model("Qwen/Qwen3.5-27B", model_config, backend_name=backend_name)
+        recurrence = next(op for op in model.generation_ops if op._name == "generation_gdn_recurrence")
+
+        assert recurrence._kernel_source == expected_kernel_source
+
     def test_deepseek_v4_kvcache_bytes_include_csa_indexer_cache_and_decode_buffers(self):
         model_config = config.ModelConfig(
             tp_size=8,


### PR DESCRIPTION
#### Overview:

Upgrade the stock SGLang collector runtime to v0.5.14 while keeping WideEP on its independently pinned v0.5.10 runtime.

#### Details:

- Adapt SGLang collector APIs, kernel routing, runtime limits, and case population for Hopper and Blackwell.
- Keep stock SGLang and WideEP runtime selection separate and fail closed on mismatched runtimes or incomplete output.
- Canonicalize GLM-5 and GLM-5.2 DSA and MoE collection without breaking exact COLLECTOR_MODEL_PATH runs.
- Update the Python and Rust GDN consumer key used by the SGLang 0.5.14 decode kernel.
- Retain the reusable aic-auto-collect skill requested for follow-up work.
- Do not include performance data, checkpoints, logs, INCOMPLETE markers, or the upgrade process playbook.

#### Where should the reviewer start?

- collector/framework_manifest.yaml and collector/framework_manifest.py
- collector/sglang/collect_mla_module.py and collector/sglang/collect_moe.py
- collector/sglang/collect_gdn.py and the corresponding SDK consumer updates

#### Validation:

- pytest -m unit -q: 1789 passed, 36 skipped
- pytest -q tests/unit/collector: 322 passed, 2 skipped
- Ruff check and format verification passed for all changed Python files
- cargo check -p aiconfigurator-core passed