### PR TITLE
feat(spica): expand prefill candidates and bump Dynamo

### DIFF
--- a/spica/docs/search-space.md
+++ b/spica/docs/search-space.md
@@ -60,7 +60,7 @@ separate study. `min_gpu_budget` is validated against `gpu_budget` by `_validate
 | knob | type | default | searched / pinned | allowed choices |
 |---|---|---|---|---|
 | `prefill_max_num_batched_tokens` | list[int] | `[8192, 16384, 32768]` | searched | `8192`, `16384`, `32768` |
-| `prefill_max_num_seqs` | list[int] | `[1, 2, 4, 8]` | searched | `1`, `2`, `4`, `8` |
+| `prefill_max_num_seqs` | list[int] | `[1, 2, 4, 8, 16, 32, 64, 128, 256]` | searched | `1`, `2`, `4`, `8`, `16`, `32`, `64`, `128`, `256` |
 | `prefill_block_size` | int | `64` | pinned | — |
 | `prefill_gpu_memory_utilization` | float | `0.9` | pinned | — |
 | `prefill_enable_prefix_caching` | bool | `True` | pinned | — |

--- a/spica/pyproject.toml
+++ b/spica/pyproject.toml
@@ -29,10 +29,11 @@ dev = [
 ]
 # Planner load-predictor sweep + Replay evaluator.
 #
-# Pinned to the #10964 merge commit (c7378f8e). main now carries the unified
+# Pinned to cb7dc1a3. This includes the unified
 # run_trace_replay that takes planner_config / benchmark_granularity / goodput SLA on the
 # trace-replay path (so the evaluator drives static + planner trace replays through one
-# entrypoint), plus #10964 scaling AIC num_gpu_blocks by attention_dp_size for DP-attention.
+# entrypoint), #10964 scaling AIC num_gpu_blocks by attention_dp_size for DP-attention,
+# and #11002 converting aggregate offline-replay batches to per-rank AIC batches.
 # Builds on #10888 planner-replay load modes (closed-loop concurrency + synthetic workloads),
 # #10849 goodput SLA on the plain trace-replay binding, #10739 replay goodput + provisioned
 # GPU-hours, and the #10670 warmup empty-window densify fix.
@@ -53,8 +54,8 @@ dev = [
 # Pinned here to the same versions (same commit) so spica's predictors behave
 # identically to the planner's. Keep in sync with that file on dynamo bumps.
 dynamo = [
-    "ai-dynamo @ git+https://github.com/ai-dynamo/dynamo@c7378f8e082cb5d2923edb0f8f57bb8d28e722aa",
-    "ai-dynamo-runtime @ git+https://github.com/ai-dynamo/dynamo@c7378f8e082cb5d2923edb0f8f57bb8d28e722aa#subdirectory=lib/bindings/python",
+    "ai-dynamo @ git+https://github.com/ai-dynamo/dynamo@cb7dc1a3a74018b7824ab7ef9d0191b80946758b",
+    "ai-dynamo-runtime @ git+https://github.com/ai-dynamo/dynamo@cb7dc1a3a74018b7824ab7ef9d0191b80946758b#subdirectory=lib/bindings/python",
     "filterpy==1.4.5",
     "pmdarima==2.1.1",
     "prophet==1.2.1",

--- a/spica/src/spica/config.py
+++ b/spica/src/spica/config.py
@@ -293,7 +293,7 @@ SEARCH_CHOICES: dict[str, tuple] = {
     "deployment_mode": ("disagg", "agg"),
     "backend": ("vllm", "sglang", "trtllm"),
     "prefill_max_num_batched_tokens": (8192, 16384, 32768),
-    "prefill_max_num_seqs": (1, 2, 4, 8),
+    "prefill_max_num_seqs": (1, 2, 4, 8, 16, 32, 64, 128, 256),
     "decode_max_num_batched_tokens": (8192,),
     "decode_max_num_seqs": (256, 512, 1024),
     "agg_max_num_batched_tokens": (8192, 16384, 32768),
@@ -402,7 +402,7 @@ class SearchSpace(BaseModel):
 
     # prefill engine (disagg branch): scheduler batching capacity
     prefill_max_num_batched_tokens: list[int] = [8192, 16384, 32768]
-    prefill_max_num_seqs: list[int] = [1, 2, 4, 8]
+    prefill_max_num_seqs: list[int] = [1, 2, 4, 8, 16, 32, 64, 128, 256]
     # pinned
     prefill_block_size: int = 64
     prefill_gpu_memory_utilization: float = 0.9

--- a/spica/tests/test_config.py
+++ b/spica/tests/test_config.py
@@ -30,6 +30,7 @@ def test_defaults_fill_in():
     # search-space defaults
     assert cfg.search_space.gpu_budget == 32
     assert cfg.search_space.prefill_block_size == 64
+    assert cfg.search_space.prefill_max_num_seqs == [1, 2, 4, 8, 16, 32, 64, 128, 256]
     assert len(cfg.search_space.load_predictor_candidates) == 11
     # goal/sweep default factories
     assert cfg.goal.target is OptimizationTarget.THROUGHPUT


### PR DESCRIPTION
## Summary

- Bump Spica's `ai-dynamo` and `ai-dynamo-runtime` source pins from `c7378f8e` to `cb7dc1a3` so sweeps use the latest replay and attention-DP fixes.
- Expand the default `prefill_max_num_seqs` search choices from `[1, 2, 4, 8]` to `[1, 2, 4, 8, 16, 32, 64, 128, 256]`.
- Update the search-space documentation and add a regression assertion for the expanded default.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=spica/src .venv/bin/pytest -q spica/tests/test_config.py spica/tests/test_search_space.py` (52 passed)
- `uvx ruff check spica/src/spica/config.py spica/tests/test_config.py`
- `uvx ruff format --check spica/src/spica/config.py spica/tests/test_config.py`
- `uv build spica --out-dir /tmp/spica-pr-dist`