### PR TITLE
refactor(collector): prune v2 cases with artifact-aware coverage (cherry-pick #1256)

### DIFF
--- a/.agents/skills/aic-collector-op-development/SKILL.md
+++ b/.agents/skills/aic-collector-op-development/SKILL.md
@@ -1,0 +1,253 @@
+---
+name: aic-collector-op-development
+description: Design, add, review, or modify AIC Collector operations and their case population. Use for new Collector ops, backend registry entries, collector/cases YAML, case generators/getters, pruning or deduplication, persisted perf keys, framework-version routing, and audits of whether generated cases match Python/Rust consumers.
+---
+
+# AIC Collector OP Development
+
+Build the smallest Collector change whose benchmark invocations are valid and
+whose persisted rows satisfy the existing AIC consumer contract.
+
+## Required reading
+
+Before editing, read:
+
+1. `collector/README.md`
+2. `collector/cases/README.md`
+3. `docs/perf_database/collector-v2-population-design.md`, especially
+   **Three identities**, **Population flow**, and **Safe deduplication rules**
+4. The relevant `collector/<backend>/registry.py`, collector module, and model/base
+   case YAML
+5. Every Python and Rust loader/query that consumes the op's perf file
+
+If the task proceeds to GPU collection, also use `$aic-auto-collect`.
+
+## Non-negotiable rules
+
+- Treat Collector output as an existing-consumer contract. Do not modify SDK,
+  Rust, EngineSpec, or Dynamo Planner merely to make a generated case useful.
+  Consumer changes require separate explicit scope.
+- Do not call a case invalid merely because the synthetic collector cannot run
+  it. If the framework and consumer support the shape, fix or record the
+  Collector gap instead of pruning coverage.
+- Do not restore coverage with a different kernel under the same logical label.
+  Persisted quant/backend labels must describe the invocation that actually ran.
+- Do not modify historical snapshots to make an alignment test pass. Use
+  read-only comparisons as review evidence.
+- Do not add permanent `legacy_*` runtime concepts for a one-time migration.
+  Put production defaults in normal base-op YAML and keep migration comparisons
+  outside the runtime schema.
+- Do not ship a deduplication path unless current repository-owned YAML produces
+  at least one duplicate invocation. Record that stage's before/after counts
+  and prove that the unique invocation and persisted-key sets are unchanged.
+  Remove no-op deduplication instead of manufacturing duplicate-only fixtures
+  for it.
+- Treat the public getter and any subprocess or inner re-expansion as one
+  population contract. Full/raw and targeted entry paths must consume the same
+  resolved YAML quantization and SM gates; do not reconstruct the policy with a
+  second hard-coded hardware heuristic.
+- A case-population change may touch `collector/collect.py` only for model/op
+  plan selection required by the resolved case plan. Generic resume, retry,
+  checkpoint, logging, and output-finalization behavior require separate
+  explicit scope.
+- Anchor collector behavior to the requested framework version. Prefer one
+  verified `__compat__`/version route over speculative multi-version branches.
+
+## Step 1: Establish the consumer contract
+
+Search from the perf filename and op name through both producers and consumers:
+
+```bash
+rg -n "<op_name>|<perf_filename>|query_<op>" collector src rust tests
+rg -n "PerfFile|PerfDataFilename|log_perf" collector src rust
+```
+
+Record a temporary contract table; do not commit it unless it is useful product
+documentation:
+
+| Axis | Recipe source | Changes invocation? | Persisted key? | Consumer query values | Evidence |
+|---|---|---:|---:|---|---|
+
+Answer before coding:
+
+- Which columns form the exact lookup key?
+- Which axes interpolate, and which require an exact bucket?
+- Which TP, EP, head, window, quant, dtype, phase, and backend values can the
+  consumer request?
+- Does a missing key fail, use an empirical fallback, or silently select another
+  path?
+- Does the op have a production consumer? If not, keep it registry-only or
+  explicitly experimental instead of adding it to default model plans.
+
+Never assume an adjacent key is a fallback. Verify it in the loader/query code.
+
+## Step 2: Define three identities
+
+Keep these separate:
+
+1. **Recipe identity**: why YAML requested the work.
+2. **Benchmark invocation identity**: every value that can change the executed
+   model, kernel, runtime setup, or quantization.
+3. **Persisted physical key**: the columns used by current consumers.
+
+Deduplicate only when both invocation identity and persisted key are equivalent.
+A persisted-key collision is a bug unless the invocations are proven identical.
+If repository-owned cases map distinct invocation identities to one consumer
+key, fail population with the conflicting owners and key. Do not silently use
+first-wins or widen the SDK/Rust schema inside a Collector-only change.
+
+Examples:
+
+- Model aliases may collapse for a shape-only synthetic benchmark.
+- Checkpoint paths must remain separate while native quantization or module
+  behavior is path-dependent.
+- W4A16 and W4A8 are distinct when activation precision changes.
+- NVFP4, MXFP4, FP8, and INT4 labels are not interchangeable because geometry
+  happens to match.
+
+## Step 3: Design cases without accidental Cartesian products
+
+- Keep independent workload axes such as batch or token count as lists.
+- Keep correlated structural axes in one profile. Typical correlated fields are
+  `(heads, KV heads, head dimension, window, TP)` and
+  `(experts, top-k, hidden, intermediate, TP, EP, quant)`.
+- Put shared production defaults in `collector/cases/base_ops/<op>.yaml`.
+- Put model-native topology and artifact policy in
+  `collector/cases/models/*_cases.yaml`.
+- Make targeted structural population exact when a model profile exists; it
+  may still reuse shared workload sweeps. Full/raw collection may union
+  defaults and model profiles, then stably deduplicate.
+- Use stable first-wins deduplication by default. If a later selector can
+  distinguish equivalent recipe representations, choose and document a
+  canonical representative that remains selectable (for example the smallest
+  TP for a local-head key); otherwise deduplication can erase targeted coverage.
+- Add a generic synthetic default only when a consumer or interpolation need is
+  demonstrated.
+
+For an existing op, compare current and candidate physical key sets during the
+change. This is change-specific evidence, not a permanent compatibility mode.
+Report `kept`, `added`, `removed`, and `deduplicated` separately; totals alone
+cannot reveal coverage loss. Migration baselines, exact V1 totals, and
+historical snapshots are review evidence, not permanent unit-test contracts
+unless an unchanged consumer explicitly depends on that exact inventory.
+
+## Step 4: Implement one vertical slice
+
+Touch only the layers the op needs:
+
+1. Base/model YAML and model-plan selection
+2. Case generator/getter when YAML cannot express the required correlation
+3. Backend collector implementation
+4. Backend registry and exact framework version route
+5. Persisted schema/logging
+6. Focused tests for generated cases and consumer-visible keys
+
+Before adding a helper, schema field, or filter—and again before finalizing—find
+its producer in current repository-owned YAML and its reader on a production
+population path. If a later design decision removes either side, delete the
+orphan. Do not retain speculative aliases, phase selectors, compatibility
+modes, or one-time audit scaffolding.
+
+## Step 5: Prune and skip only with evidence
+
+Acceptable evidence includes:
+
+- Exact-version framework source showing the path is unsupported
+- A minimal runtime repro on the target framework/GPU
+- A proven invocation/key duplicate
+- A documented absence from every production consumer and default model plan
+
+Place runtime/SM/version exclusions as close as possible to the backend that
+owns the limitation. Keep shared generators deterministic; avoid framework
+imports or runtime availability probes in shared YAML population.
+
+Pay special attention to boundaries:
+
+- `EP>1` and `TP>1`, including combinations queried independently
+- Per-rank dimensions after TP/EP sharding
+- Global versus sliding-window attention
+- Hopper versus Blackwell quantization support
+- Native versus converted checkpoint artifacts
+- Context versus generation phases
+
+If the framework supports a boundary but the collector harness does not, file a
+TODO/issue and keep the missing coverage visible. Do not describe it as pruned
+unsupported input.
+
+## Step 6: Validate in layers
+
+### Static population
+
+- Generate full/raw and representative targeted plans through each changed
+  op's registry/public getter; testing only a shared case generator is not
+  sufficient.
+- Count generator recipes, raw getter tasks, post-selector scheduled tasks,
+  token-expanded benchmark invocations, and unique persisted keys separately.
+- For every deduplication, record stage-local before/after, unique invocation,
+  and unique persisted-key counts using repository-owned inputs. Name the
+  stage being counted (generator recipes, raw getter tasks, post-selector tasks,
+  or token-expanded invocations). If the count at the dedupe stage does not
+  decrease, remove the deduplication path.
+- When a runtime or subprocess expands an inner sweep, compare its quantization
+  and SM policy with the outer getter. Test both sides of every changed hardware
+  gate and assert that unsupported precision labels are absent.
+- Apply model, SM, and framework-version selectors before reporting a count as
+  the final scheduled queue; raw getter counts are not final plan counts.
+- Assert invocation IDs and persisted keys have no unexplained duplicates.
+- Assert required consumer query keys are covered.
+- Assert unrelated model dimensions never cross.
+- Assert targeted plans do not inherit unrelated defaults or ops.
+
+### Unit checks
+
+Prefer behavior tests over copied migration inventories or AST tests of which
+helper a function calls. Keep focused tests for:
+
+- Structural correlation and boundary TP/EP values
+- Quant/artifact policy
+- Alias versus path-sensitive behavior
+- Stable deduplication on the real invocation/key identity
+- Registry/version routing and plan selection
+- Persisted key names and local/global dimension semantics
+
+Run at minimum:
+
+```bash
+.venv/bin/pytest -q tests/unit/collector
+.venv/bin/ruff check collector tests/unit/collector
+.venv/bin/ruff format --check collector tests/unit/collector
+git diff --check
+```
+
+### Runtime smoke
+
+Run inside the exact target framework image and record the installed package
+version. Include representative cases for every material branch, not merely the
+smallest cases:
+
+- Each quantization/kernel path
+- EP1 and EP>1 when supported
+- Low and high TP
+- Global and each supported window family
+- Context and generation
+- At least one model/artifact per path-sensitive branch
+
+Then verify the produced rows can be loaded and queried by the unchanged AIC
+consumer. A successful kernel timing alone is insufficient.
+
+## Definition of done
+
+Do not call the op complete until the handoff states:
+
+- Exact framework version, GPU/SM, backend, and `__compat__` route
+- Consumer lookup contract and fallback behavior
+- Case counts by backend/op: kept, added, removed, deduplicated, skipped
+- Evidence for every prune/skip
+- Unit/lint/runtime-smoke results
+- A real consumer query or support-matrix sanity check
+- Remaining gaps, especially required EP/TP/quant/window buckets
+- Whether the change touched Collector only; if not, why broader scope was
+  explicitly authorized
+- A final changed-file and changed-symbol audit that accounts for every
+  production Python change and finds no orphan schema/helper, no no-op
+  deduplication, and no unrelated orchestration behavior

--- a/.agents/skills/aic-collector-op-development/agents/openai.yaml
+++ b/.agents/skills/aic-collector-op-development/agents/openai.yaml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+interface:
+  display_name: "AIC Collector OP Development"
+  short_description: "Add Collector ops with consumer-aligned cases"
+  default_prompt: "Use $aic-collector-op-development to add an AIC Collector op with consumer-aligned cases and validation."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,26 @@ Before making any change under:
 MUST read:
 - `.claude/rules/generator-development.md`
 
+## Required Collector First Step
+
+Before adding a Collector operation or changing Collector case population under:
+- `collector/cases/**`
+- `collector/case_generator.py`
+- `collector/model_cases.py`
+- `collector/collect.py`
+- `collector/registry_types.py`
+- `collector/framework_manifest.yaml`
+- `collector/*/registry.py`
+- `collector/*/collect_*.py`
+- `collector/wideep/*/registry.py`
+- `collector/wideep/*/collect_*.py`
+
+MUST read and follow:
+- `.agents/skills/aic-collector-op-development/SKILL.md`
+
+New operations MUST complete that skill's consumer-contract, case-identity,
+deduplication, and validation gates before they are treated as supported.
+
 ## Cursor Cloud specific instructions
 
 ### Project overview

--- a/collector/README.md
+++ b/collector/README.md
@@ -106,9 +106,15 @@ model_paths:
   - Qwen/Qwen3-30B-A3B
   - Qwen/Qwen3-235B-A22B
 include_base: true
+base_ops:
+  - attention_context
+  - attention_generation
+  - gemm
 ```
 
-It can include shared base op cases with `include_base: true`, then add:
+`include_base: true` selects only the universal recipes declared by base-file
+`model_ops`; it no longer means every file under `cases/base_ops/`. Use
+`base_ops` for model-required auxiliary recipes, then add model ops:
 
 ```yaml
 model_ops:
@@ -152,11 +158,28 @@ N use the same explicit size list. Base attention specs use `batch_sizes`,
 `sequence_lengths`, `query_head_counts`, `kv_head_options`, and `head_dims`;
 `kv_head_options: self` means the KV head count equals the query head count.
 
+Native attention tuples live in `model_case_values.attention`. They keep query
+heads, KV heads, head dimension, window, and valid TP sizes correlated. A
+targeted model run uses its exact structural profiles instead of crossing global
+head/window axes. Full/raw runs combine the base operation's `head_profiles`
+with all model-specific profiles, then remove duplicate physical tuples before
+the batch and sequence sweeps. Mamba's synthetic full/raw shapes live under
+`common_case_values.mamba2.default_model_cases`.
+
+Within `model_case_values`, use `model_aliases` only for a shape-only synthetic
+op where the artifact cannot change either the benchmark invocation or the
+persisted key. Do not merge base/FP8/NVFP4 checkpoints merely because another
+axis also sweeps quantization. When artifacts use different real quantization
+modes, declare their allowed union in
+`framework_quantization.<backend>.allowed_modes` so unrelated backend modes are
+not multiplied into that shape. Keep `model_paths` only for path-sensitive cases
+that must be instantiated separately.
+
 For targeted support-matrix healing, a case selector can run a subset using
 exact `case_ids`, string `contains` matches, `indices`, `ranges`, or `limit`.
 These filters are applied after the op collector generates cases for the
 selected model, so every op collector gets subset support through the central
-planner. Collectors that accept `model_path` receive it directly; legacy
+model-case filter/resolver. Collectors that accept `model_path` receive it directly; legacy
 collectors use the same value through `COLLECTOR_MODEL_PATH` while they are
 being migrated.
 
@@ -179,7 +202,7 @@ Each backend (trtllm, vllm, sglang) has a **registry** (`registry.py`) that maps
 ```text
 framework_manifest.yaml — current collector framework versions and images
 framework_manifest.py   — manifest loader/validator
-model_cases.py       — collector v2 model/SM case planner
+model_cases.py       — collector v2 model/SM case-plan resolver
 registry.py          — declares which module handles which version range
 version_resolver.py  — routes runtime version → module (packaging.version)
 collect.py/collect_ops — validates __compat__ and fails incompatible ops

--- a/collector/case_generator.py
+++ b/collector/case_generator.py
@@ -105,30 +105,235 @@ def get_attention_generation_shape_sweeps(backend: str) -> list[dict[str, object
 
 def get_attention_encoder_shape_sweeps(backend: str) -> list[dict[str, object]]:
     """Return YAML-backed encoder (non-causal) attention shape sweeps for one backend."""
-    return get_merged_base_op_case_specs(backend, "attention_encoder")
+    return get_merged_base_op_case_specs(backend, "encoder_attention")
 
 
-# GQA/MQA sliding-window: each head_dim is used by models with a SPECIFIC window,
-# so collecting the full head_dim x window_sizes cross is wasteful. Keep window=0
-# (full attention) for every head_dim, and a non-zero window only for the
-# (head_dim, window) pairs a real GQA/MQA model actually uses:
-#   head_dim 64  -> gpt-oss (sliding_window=128)
-#   head_dim 128 -> Llama-4 Scout/Maverick (attention_chunk_size=8192)
-#   head_dim 192 -> MiMo-V2-Flash (sliding_window=128)
-#   head_dim 256 -> gemma-4 (sliding_window=1024)
-# Update this map when a windowed model with a new (head_dim, window) is added.
-_HEAD_DIM_WINDOW_SIZES: dict[int, set[int]] = {64: {128}, 128: {8192}, 192: {128}, 256: {1024}}
+@dataclasses.dataclass(frozen=True)
+class AttentionHeadConfig:
+    """One structural attention lookup key before the batch/sequence sweep."""
+
+    num_heads: int
+    num_kv_heads: int
+    head_dim: int
+    window_size: int
 
 
-def windows_for_head_dim(window_sizes: list[int], head_dim: int) -> list[int]:
-    """Filter a window_sizes sweep to the values valid for ``head_dim``.
+@dataclasses.dataclass(frozen=True)
+class EncoderAttentionHeadConfig:
+    """One encoder-attention structural lookup key before the workload sweep."""
 
-    window=0 (full attention) is always kept; a non-zero window is kept only if a
-    real GQA/MQA model uses that (head_dim, window) pair (see ``_HEAD_DIM_WINDOW_SIZES``).
-    Order is preserved.
+    num_heads: int
+    head_dim: int
+
+
+def _profile_int_values(
+    profile: dict[str, object],
+    plural: str,
+    singular: str,
+    *,
+    fallback: object = None,
+) -> list[int]:
+    value = profile.get(plural)
+    if value is None and profile.get(singular) is not None:
+        value = [profile[singular]]
+    if value is None:
+        value = fallback
+    if not isinstance(value, list):
+        raise TypeError(f"attention profile {plural} must be a list")
+    return [int(item) for item in value]
+
+
+def _head_profiles(
+    shape_sweep: dict[str, object],
+    op_name: str,
+) -> list[dict[str, object]]:
+    raw_profiles = shape_sweep.get("head_profiles")
+    if raw_profiles is None:
+        base_profiles = [shape_sweep]
+    else:
+        if not isinstance(raw_profiles, list) or not all(isinstance(profile, dict) for profile in raw_profiles):
+            raise TypeError(f"{op_name}.head_profiles must be a list of mappings")
+        base_profiles = raw_profiles
+
+    model_profiles = _model_case_values(op_name)
+    if _get_model_path_filter() and model_profiles:
+        return model_profiles
+    return [*base_profiles, *model_profiles]
+
+
+def get_attention_head_configs(
+    shape_sweep: dict[str, object],
+    *,
+    phase: str,
+) -> list[AttentionHeadConfig]:
+    """Expand only valid ``(q, kv, head_dim, window)`` structural tuples.
+
+    Profiles may either describe a default rectangular sub-grid or one native
+    model topology plus its valid tensor-parallel sizes. The latter preserves
+    correlations between query heads, KV heads, head dimension, and window.
     """
-    allowed = _HEAD_DIM_WINDOW_SIZES.get(head_dim, set())
-    return [w for w in window_sizes if w == 0 or w in allowed]
+
+    if phase not in {"context", "generation"}:
+        raise ValueError(f"Unknown attention phase: {phase}")
+
+    configs: list[AttentionHeadConfig] = []
+    seen: set[AttentionHeadConfig] = set()
+
+    def append(num_heads: int, num_kv_heads: int, head_dim: int, window_size: int) -> None:
+        if num_heads <= 0 or num_kv_heads <= 0 or head_dim <= 0 or window_size < 0:
+            return
+        if num_kv_heads > num_heads or num_heads % num_kv_heads != 0:
+            return
+        config = AttentionHeadConfig(num_heads, num_kv_heads, head_dim, window_size)
+        if config not in seen:
+            seen.add(config)
+            configs.append(config)
+
+    for profile in _head_profiles(shape_sweep, "attention"):
+        head_dims = _profile_int_values(
+            profile,
+            "head_dims",
+            "head_dim",
+            fallback=shape_sweep.get("head_dims"),
+        )
+        window_sizes = _profile_int_values(
+            profile,
+            "window_sizes",
+            "window_size",
+            fallback=shape_sweep.get("window_sizes", [0]),
+        )
+
+        native_num_heads = profile.get("num_attention_heads")
+        if native_num_heads is not None:
+            native_num_kv_heads = profile.get("num_key_value_heads")
+            if native_num_kv_heads is None:
+                raise ValueError("native attention profiles require num_key_value_heads")
+            tp_sizes = _profile_int_values(
+                profile,
+                "tensor_parallel_sizes",
+                "tensor_parallel_size",
+            )
+            native_num_heads = int(native_num_heads)
+            native_num_kv_heads = int(native_num_kv_heads)
+            for tp_size in tp_sizes:
+                if tp_size <= 0 or native_num_heads % tp_size != 0:
+                    continue
+                num_heads = native_num_heads // tp_size
+                num_kv_heads = (native_num_kv_heads + tp_size - 1) // tp_size
+                for head_dim in head_dims:
+                    for window_size in window_sizes:
+                        append(num_heads, num_kv_heads, head_dim, window_size)
+            continue
+
+        if phase == "context":
+            query_head_counts = _profile_int_values(
+                profile,
+                "query_head_counts",
+                "query_head_count",
+                fallback=shape_sweep.get("query_head_counts"),
+            )
+            kv_head_options = profile.get("kv_head_options", shape_sweep.get("kv_head_options"))
+            if not isinstance(kv_head_options, list):
+                raise TypeError("attention profile kv_head_options must be a list")
+            for head_dim in head_dims:
+                for num_heads in sorted(query_head_counts, reverse=True):
+                    for raw_num_kv_heads in kv_head_options:
+                        num_kv_heads = (
+                            num_heads if raw_num_kv_heads in {"self", 0, "0", None} else int(raw_num_kv_heads)
+                        )
+                        if num_kv_heads != num_heads and (num_kv_heads >= num_heads or num_heads % num_kv_heads != 0):
+                            continue
+                        for window_size in window_sizes:
+                            append(num_heads, num_kv_heads, head_dim, window_size)
+            continue
+
+        mha_query_head_counts = _profile_int_values(
+            profile,
+            "mha_query_head_counts",
+            "mha_query_head_count",
+            fallback=shape_sweep.get("mha_query_head_counts", []),
+        )
+        xqa_query_head_counts = _profile_int_values(
+            profile,
+            "xqa_query_head_counts",
+            "xqa_query_head_count",
+            fallback=shape_sweep.get("xqa_query_head_counts", []),
+        )
+        kv_head_counts = _profile_int_values(
+            profile,
+            "kv_head_counts",
+            "kv_head_count",
+            fallback=shape_sweep.get("kv_head_counts", []),
+        )
+        allow_xqa_mha = bool(profile.get("allow_xqa_mha", False))
+        require_divisible = bool(profile.get("require_divisible", False))
+        for head_dim in head_dims:
+            for num_heads in sorted(mha_query_head_counts, reverse=True):
+                for window_size in window_sizes:
+                    append(num_heads, num_heads, head_dim, window_size)
+            for num_heads in sorted(xqa_query_head_counts, reverse=True):
+                for num_kv_heads in kv_head_counts:
+                    if num_kv_heads > num_heads or (num_kv_heads == num_heads and not allow_xqa_mha):
+                        continue
+                    if require_divisible and num_heads % num_kv_heads != 0:
+                        continue
+                    for window_size in window_sizes:
+                        append(num_heads, num_kv_heads, head_dim, window_size)
+    return configs
+
+
+def get_attention_encoder_head_configs(shape_sweep: dict[str, object]) -> list[EncoderAttentionHeadConfig]:
+    """Expand valid ``(num_heads, head_dim)`` encoder-attention structures.
+
+    Native profiles describe a ViT's unsharded head count and valid tensor
+    parallel sizes. Duplicate physical keys are removed while preserving their
+    first-seen order.
+    """
+
+    configs: list[EncoderAttentionHeadConfig] = []
+    seen: set[EncoderAttentionHeadConfig] = set()
+
+    def append(num_heads: int, head_dim: int) -> None:
+        if num_heads <= 0 or head_dim <= 0:
+            return
+        config = EncoderAttentionHeadConfig(num_heads, head_dim)
+        if config not in seen:
+            seen.add(config)
+            configs.append(config)
+
+    for profile in _head_profiles(shape_sweep, "encoder_attention"):
+        head_dims = _profile_int_values(
+            profile,
+            "head_dims",
+            "head_dim",
+            fallback=shape_sweep.get("head_dims"),
+        )
+        native_num_heads = profile.get("num_attention_heads")
+        if native_num_heads is not None:
+            native_num_heads = int(native_num_heads)
+            tp_sizes = _profile_int_values(
+                profile,
+                "tensor_parallel_sizes",
+                "tensor_parallel_size",
+            )
+            for tp_size in tp_sizes:
+                if tp_size <= 0 or native_num_heads % tp_size != 0:
+                    continue
+                for head_dim in head_dims:
+                    append(native_num_heads // tp_size, head_dim)
+            continue
+
+        head_counts = _profile_int_values(
+            profile,
+            "head_counts",
+            "head_count",
+            fallback=shape_sweep.get("head_counts"),
+        )
+        for head_dim in head_dims:
+            for num_heads in sorted(head_counts):
+                append(num_heads, head_dim)
+
+    return configs
 
 
 def get_base_common_case_values(name: str) -> dict[str, object]:
@@ -174,6 +379,20 @@ def _expand_model_case_entry(raw_value: object, *, field_name: str) -> list[dict
         raise TypeError(f"{field_name} entries must be mappings")
     value = dict(raw_value)
     raw_model_paths = value.pop("model_paths", None)
+    raw_model_aliases = value.get("model_aliases")
+    if raw_model_aliases is not None:
+        if raw_model_paths is not None:
+            raise ValueError(f"{field_name} entries cannot set both model_paths and model_aliases")
+        if value.get("model_path") is None:
+            raise ValueError(f"{field_name}.model_aliases requires model_path")
+        value["model_aliases"] = _as_str_list(
+            raw_model_aliases,
+            field_name=f"{field_name}.model_aliases",
+        )
+        # Aliases share one physical collector case.  Keep the representative
+        # model path instead of multiplying the same kernel shape by artifact
+        # names such as base/FP8/NVFP4.
+        return [value]
     if raw_model_paths is None:
         return [value]
     if value.get("model_path") is not None:
@@ -182,6 +401,10 @@ def _expand_model_case_entry(raw_value: object, *, field_name: str) -> list[dict
         {**value, "model_path": model_path}
         for model_path in _as_str_list(raw_model_paths, field_name=f"{field_name}.model_paths")
     ]
+
+
+def _model_case_matches_path(value: dict, model_path: str) -> bool:
+    return value.get("model_path") == model_path or model_path in (value.get("model_aliases") or [])
 
 
 def _model_case_values(op_name: str, *, apply_model_filter: bool = True) -> list[dict]:
@@ -210,7 +433,7 @@ def _model_case_values(op_name: str, *, apply_model_filter: bool = True) -> list
 
     model_path = _get_model_path_filter() if apply_model_filter else None
     if model_path:
-        values = [value for value in values if value.get("model_path") == model_path]
+        values = [value for value in values if _model_case_matches_path(value, model_path)]
     return values
 
 
@@ -246,7 +469,7 @@ def _framework_specific_model_case_values(op_name: str, backend: str, *, apply_m
 
     model_path = _get_model_path_filter() if apply_model_filter else None
     if model_path:
-        values = [value for value in values if value.get("model_path") == model_path]
+        values = [value for value in values if _model_case_matches_path(value, model_path)]
     return values
 
 
@@ -319,7 +542,7 @@ def get_mla_module_model_specs(
         for index, raw_value in enumerate(raw_values):
             for value in _expand_model_case_entry(raw_value, field_name=f"model_case_values.mla_module[{index}]"):
                 value.setdefault("architecture", architecture)
-                if model_path_filter and value.get("model_path") != model_path_filter:
+                if model_path_filter and not _model_case_matches_path(value, model_path_filter):
                     continue
                 if attention_type is not None and value.get("attention_type") != attention_type:
                     continue
@@ -495,7 +718,7 @@ def get_mla_module_sweep_spec(backend: str | None = None) -> MLAModuleSweepSpec:
 def is_wideep_moe_model(model_name: str) -> bool:
     """Return True if *model_name* needs WideEP MoE collection."""
     return any(
-        value.get("model_path") == model_name and value.get("wideep")
+        _model_case_matches_path(value, model_name) and value.get("wideep")
         for value in _model_case_values("moe", apply_model_filter=False)
     )
 
@@ -517,7 +740,10 @@ def get_all_model_names() -> list[str]:
                 values.extend(_expand_model_case_entry(item, field_name=f"{field_name}[{index}]"))
         else:
             return
-        model_names.extend(str(value["model_path"]) for value in values if value.get("model_path"))
+        for value in values:
+            if value.get("model_path"):
+                model_names.append(str(value["model_path"]))
+            model_names.extend(str(alias) for alias in value.get("model_aliases", []))
 
     model_names = []
     for data in _load_model_cases_data():
@@ -659,7 +885,7 @@ def get_moe_quantization_modes(
 
 def _model_moe_backend_quantization(model_name: str, backend: str) -> dict[str, object]:
     for model_case in _model_case_values("moe", apply_model_filter=False):
-        if model_case.get("model_path") != model_name:
+        if not _model_case_matches_path(model_case, model_name):
             continue
         framework_quantization = model_case.get("framework_quantization", {})
         if not isinstance(framework_quantization, dict):
@@ -816,7 +1042,7 @@ def _moe_backend_model_cases(backend: str) -> list[dict[str, object]]:
         if not isinstance(raw_case, dict):
             raise TypeError(f"common_case_values.moe_{backend}.model_cases entries must be mappings")
         case = dict(raw_case)
-        if model_path_filter and case.get("model_path") != model_path_filter:
+        if model_path_filter and not _model_case_matches_path(case, model_path_filter):
             continue
         cases.append(case)
 
@@ -848,7 +1074,7 @@ def get_moe_backend_model_activation(backend: str, model_name: str, *, default: 
     """Return YAML-backed activation metadata for a backend-specific MoE model."""
 
     for model_case in _moe_backend_model_cases(backend):
-        if model_case.get("model_path") == model_name:
+        if _model_case_matches_path(model_case, model_name):
             return str(model_case.get("activation", default))
     return default
 
@@ -1122,6 +1348,7 @@ class MLACommonTestCase:
 
 def _get_mla_case_specs(is_context: bool):
     test_cases = []
+    seen = set()
 
     model_config_list = _model_case_values("mla")
     mla_sweep = _required_base_common_case_values("mla")
@@ -1156,10 +1383,27 @@ def _get_mla_case_specs(is_context: bool):
         if b * s > max_tokens:
             continue
 
+        input_len = s if is_context else s - 1
+        physical_key = (
+            int(model_config["num_heads"]),
+            b,
+            input_len,
+            is_context,
+            kv_cache_block_size,
+            int(model_config["q_lora_rank"]),
+            int(model_config["kv_lora_rank"]),
+            int(model_config["qk_nope_head_dim"]),
+            int(model_config["qk_rope_head_dim"]),
+            int(model_config["v_head_dim"]),
+        )
+        if physical_key in seen:
+            continue
+        seen.add(physical_key)
+
         test_cases.append(
             MLACommonTestCase(
-                num_heads=int(model_config["num_heads"]),
-                input_len=s if is_context else s - 1,
+                num_heads=physical_key[0],
+                input_len=input_len,
                 batch_size=b,
                 is_context_phase=is_context,
                 kv_cache_block_size=kv_cache_block_size,
@@ -1270,7 +1514,22 @@ def get_common_mamba2_test_cases() -> list[Mamba2CommonTestCase]:
         field_name="mamba2.generation_batch_sizes",
     )
 
-    model_config_list = _model_case_values("mamba2")
+    raw_default_model_cases = mamba2_sweep.get("default_model_cases", [])
+    if not isinstance(raw_default_model_cases, list):
+        raise TypeError("common_case_values.mamba2.default_model_cases must be a list")
+    default_model_cases = []
+    for index, raw_case in enumerate(raw_default_model_cases):
+        default_model_cases.extend(
+            _expand_model_case_entry(
+                raw_case,
+                field_name=f"common_case_values.mamba2.default_model_cases[{index}]",
+            )
+        )
+    model_path = _get_model_path_filter()
+    if model_path:
+        default_model_cases = [case for case in default_model_cases if _model_case_matches_path(case, model_path)]
+
+    model_config_list = [*default_model_cases, *_model_case_values("mamba2")]
 
     for model_config in model_config_list:
         d_model = int(model_config["d_model"])
@@ -1515,6 +1774,11 @@ def _dsv4_config() -> dict:
         default_model_paths = supported_model_paths
     if not default_model_paths:
         raise RuntimeError("model_case_values.dsv4 needs at least one default model path")
+    if len(default_model_paths) != 1:
+        raise ValueError(
+            "DeepSeek-V4 module keys cannot distinguish models; "
+            "dsv4.default_model_paths must contain one canonical path"
+        )
 
     config["default_model_paths"] = default_model_paths
     config["supported_model_paths"] = _dedupe_strs([*supported_model_paths, *default_model_paths])
@@ -1561,11 +1825,6 @@ _DSV4_SPARSE_TP_LIST_INDEXER = _as_int_list(
     _DSV4_SPARSE_TP_SIZES["paged_mqa_logits"],
     field_name="dsv4.sparse_tp_sizes.paged_mqa_logits",
 )
-
-
-def is_dsv4_attention_model(model_name: str) -> bool:
-    """Return True for DeepSeek-V4 Flash/Pro models using the DSV4 attention collectors."""
-    return model_name in _DSV4_SUPPORTED_MODELS
 
 
 def _selected_dsv4_models() -> tuple[str, ...]:

--- a/collector/cases/README.md
+++ b/collector/cases/README.md
@@ -5,7 +5,8 @@ collector as a flat op list.
 
 ## File Layout
 
-- `base_ops/<op>.yaml`: shared common case values and op cases every model can include.
+- `base_ops/<op>.yaml`: shared recipe library. Only recipes named by a model's
+  `base_ops` (or declared universal through the base file's `model_ops`) are activated.
 - `models/<architecture>_cases.yaml`: architecture-specific op cases and model path aliases.
 - `sm_exceptions/sm<version>_exceptions.yaml`: SM-specific exceptions applied after base-op/model cases are merged.
 
@@ -22,10 +23,15 @@ model_paths:
   - Qwen/Qwen3-30B-A3B
   - Qwen/Qwen3-235B-A22B
 include_base: true
+base_ops:
+  - attention_context
+  - attention_generation
+  - gemm
 ```
 
-`model_path` is the default representative model. `model_paths` is the alias
-list used for support-matrix lookup and targeted collection.
+`model_path` is the default representative model. The top-level `model_paths`
+list resolves support-matrix names to this architecture plan; it does not by
+itself multiply kernel cases.
 
 ### Op Sections
 
@@ -76,8 +82,42 @@ model_case_values:
 
 The collector loads these values by op name and honors `COLLECTOR_MODEL_PATH`,
 so support-matrix healing can request cases for one model without editing
-Python. Use `model_paths` when aliases share the same dimensions, or
-`model_path` for a single model-specific entry.
+Python. There are two deliberately different multi-name forms:
+
+- `model_aliases` resolves multiple artifact names to one canonical physical
+  case. Use it only for shape-only ops where the artifact does not affect the
+  invoked kernel or persisted key.
+- `model_paths` expands one physical case per path. Use it only when the model
+  name changes runtime behavior, quantization policy, activation, or module
+  loading (for example a collector that actually loads each checkpoint).
+
+Keeping these meanings separate prevents checkpoint suffixes from multiplying
+the same shape by every independently swept quantization mode.
+
+### Structural Attention Profiles
+
+Attention correlations belong to the model, not to a global Cartesian product.
+Store a native topology under `model_case_values.attention`:
+
+```yaml
+model_case_values:
+  attention:
+    - model_path: openai/gpt-oss-120b
+      model_aliases: [openai/gpt-oss-20b]
+      num_attention_heads: 64
+      num_key_value_heads: 8
+      head_dim: 64
+      window_sizes: [0, 128]
+      tensor_parallel_sizes: [1, 2, 4, 8, 16, 32, 64]
+```
+
+The generator expands only valid TP shards of that tuple. It never crosses one
+model's query/KV heads with another model's head dimension or window. A targeted
+run with an explicit profile uses only that model profile. Full/raw runs combine
+the base operation's `head_profiles` with all model profiles and deduplicate the
+resulting physical tuples. A model without a native profile uses the base
+profiles. Mamba's generic synthetic shapes needed only by full/raw collection
+live under `common_case_values.mamba2.default_model_cases`.
 
 ### Framework-Specific Model Dimensions
 
@@ -123,6 +163,34 @@ The MoE Python generator only combines those shared sweep values with each
 model's `hidden_size`, `inter_size`, `topk`, and `num_experts`. The same pattern
 applies to MLA, Mamba2, GDN, and MHC: model YAML stores model dimensions, while
 base op YAML stores the reusable sweep policy.
+
+MoE quantization is resolved before a case is queued. Base `quantization_modes`
+may declare `min_sm`, `min_sm_exclusive`, runtime features,
+an `allowed_model_paths` allowlist, and optional `module_config` such as an
+INT4 group size. A model row narrows that list with
+`framework_quantization.<backend>.allowed_modes`. Quant-sensitive checkpoint
+artifacts therefore use separate model rows even when all geometry fields are
+identical; this prevents an FP8, INT4, MXFP4, or NVFP4 suffix from being crossed
+with unrelated backend modes.
+
+`include_base: true` means "include the small universal base set" declared by
+base-file `model_ops` (currently dense attention and GEMM). It does not opt a
+model into every recipe that happens to exist under `base_ops/`. Use an explicit
+model `base_ops` list for auxiliary recipes such as `encoder_attention`, or a
+`framework_specific_base_ops` list for framework-only recipes. When an op is
+required by one concrete checkpoint rather than the whole architecture, use an
+artifact-keyed `model_specific_base_ops` mapping. For example, the Qwen3 static
+FP8 checkpoint opts into `compute_scale` without making base Qwen3 or dynamic
+FP8 checkpoints collect it. Adding a new base recipe therefore cannot silently
+fan out across every model or artifact.
+
+```yaml
+model_specific_base_ops:
+  Qwen/Qwen3-32B-FP8-Static-PerTensor:
+    sglang: [compute_scale]
+    trtllm: [compute_scale]
+    vllm: [compute_scale]
+```
 
 ### Explicit Case Specs
 
@@ -199,6 +267,9 @@ framework_specific_op_exceptions:
 Use `drop: true` only when the whole op should be removed for the SM/backend.
 For narrower exclusions, use a case selector on the op.
 
+An SM exception only constrains an op already selected by the model plan. It
+never activates an unrelated op merely because the SM catalog mentions it.
+
 `reason_type` should be `hardware_unsupported` for SM capability/kernel-shape
 limits and `framework_version_unsupported` for a known runtime or framework
 version gap. Version-scoped rules can add `version_prefixes`, and computed
@@ -223,7 +294,9 @@ failures.
 Selectors are OR-based: a case matches when it satisfies any selector field. For
 include selectors, matched cases are kept. For exception selectors, matched cases
 are skipped or classified as expected failures. `limit` is applied after
-selection.
+selection. A concrete selector in a model file overrides the inherited
+base-recipe `cases: all`, so `case_ids` or `rules` can genuinely narrow a shared
+base op.
 
 Supported generated-case selector fields:
 
@@ -236,10 +309,12 @@ Supported generated-case selector fields:
 - `limit`: keeps only the first N cases after selection.
 - `rules`: structured matches over positional collector case fields.
 
-There is one important distinction: a dictionary under `cases` is a generation
-recipe, not a selector. For example, a GEMM shape sweep dictionary tells the
-collector to create many concrete GEMM cases. It should live in an include
-section such as `all_frameworks_op_cases` or `framework_specific_op_cases`.
+There is one important distinction: a dictionary under `cases` in a
+`base_ops/<op>.yaml` file is a generation recipe, not a selector. For example,
+a GEMM shape sweep dictionary tells the collector to create many concrete GEMM
+cases. Model files should put physical dimensions in `model_case_values` and use
+generated-case selectors (`rules`, `case_ids`, and so on) in op sections; they
+should not define a second generator recipe there.
 
 SM exceptions run after those concrete cases are generated. They should match
 the generated cases with `rules`, `contains`, `case_ids`, `indices`, or

--- a/collector/cases/base_ops/attention_context.yaml
+++ b/collector/cases/base_ops/attention_context.yaml
@@ -106,6 +106,12 @@ framework_specific_op_cases:
         - 0
         - 128
         - 1024
+        head_profiles:
+        - id: default
+          head_dims: [128, 256]
+          window_size: 0
+          query_head_counts: [1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 64, 96]
+          kv_head_options: [self, 1, 2, 4, 8]
   trtllm:
     attention_context:
       cases:
@@ -137,6 +143,17 @@ framework_specific_op_cases:
         - 0
         - 128
         - 1024
+        head_profiles:
+        - id: default_head64
+          head_dim: 64
+          window_sizes: [0, 128]
+          query_head_counts: [1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 64, 96]
+          kv_head_options: [self, 1, 2, 4, 8]
+        - id: default
+          head_dims: [128, 256]
+          window_size: 0
+          query_head_counts: [1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 64, 96]
+          kv_head_options: [self, 1, 2, 4, 8]
   vllm:
     attention_context:
       cases:
@@ -164,6 +181,17 @@ framework_specific_op_cases:
         - 128
         - 1024
         - 8192
+        head_profiles:
+        - id: default_head64
+          head_dim: 64
+          window_sizes: [0, 128]
+          query_head_counts: [1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 64]
+          kv_head_options: [self, 1, 2, 4, 8]
+        - id: default_head128
+          head_dim: 128
+          window_sizes: [0, 128]
+          query_head_counts: [1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 64]
+          kv_head_options: [self, 1, 2, 4, 8]
   vllm_xpu:
     attention_context:
       cases:
@@ -216,3 +244,14 @@ framework_specific_op_cases:
         window_sizes:
         - 0
         - 128
+        head_profiles:
+        - id: default_head64
+          head_dim: 64
+          window_sizes: [0, 128]
+          query_head_counts: [1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 64]
+          kv_head_options: [1, 2, 4, 8]
+        - id: default_head128
+          head_dim: 128
+          window_size: 0
+          query_head_counts: [1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 64]
+          kv_head_options: [1, 2, 4, 8]

--- a/collector/cases/base_ops/attention_encoder.yaml
+++ b/collector/cases/base_ops/attention_encoder.yaml
@@ -2,12 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 schema_version: 1
-op: attention_encoder
-description: Base collector v2 cases for attention_encoder (non-causal / encoder attention).
-model_ops:
-- attention_encoder
+op: encoder_attention
+description: Base collector v2 cases for encoder_attention (non-causal / encoder attention).
 all_frameworks_op_cases:
-  attention_encoder:
+  encoder_attention:
     cases:
     - id: base_attention_encoder_shape_sweep
       description: 'Encoder (non-causal) attention shapes for multimodal ViT / audio encoders. MHA only, bf16 only.
@@ -22,10 +20,16 @@ all_frameworks_op_cases:
       - 32
       - 64
       sequence_lengths:
+      # Keep the encoder collector's established image-token sizes and add the
+      # current model-specific lengths used by targeted collection.
       - 1
+      - 13
       - 16
+      - 26
       - 32
+      - 52
       - 64
+      - 104
       - 128
       - 192
       - 256

--- a/collector/cases/base_ops/attention_generation.yaml
+++ b/collector/cases/base_ops/attention_generation.yaml
@@ -97,6 +97,13 @@ framework_specific_op_cases:
         - 0
         - 128
         - 1024
+        head_profiles:
+        - id: default
+          head_dims: [128, 256]
+          window_size: 0
+          mha_query_head_counts: [1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 64]
+          xqa_query_head_counts: [1, 2, 4, 8, 16, 32, 64, 96, 128]
+          kv_head_counts: [1, 2, 4, 8]
   trtllm:
     attention_generation:
       cases:
@@ -147,6 +154,19 @@ framework_specific_op_cases:
         - 0
         - 128
         - 1024
+        head_profiles:
+        - id: default
+          head_dims: [64, 128, 256]
+          window_size: 0
+          mha_query_head_counts: [1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 64]
+          xqa_query_head_counts: [1, 2, 4, 8, 16, 32, 64, 96, 128]
+          kv_head_counts: [1, 2, 4, 8]
+        - id: default_head64_swa
+          head_dim: 64
+          window_size: 128
+          mha_query_head_counts: []
+          xqa_query_head_counts: [1, 2, 4, 8, 16, 32, 64, 96, 128]
+          kv_head_counts: [1, 2, 4, 8]
   vllm:
     attention_generation:
       cases:
@@ -185,6 +205,15 @@ framework_specific_op_cases:
         - 128
         - 1024
         - 8192
+        head_profiles:
+        - id: default
+          head_dims: [64, 128]
+          window_sizes: [0, 128]
+          mha_query_head_counts: []
+          xqa_query_head_counts: [1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 64]
+          kv_head_counts: [1, 2, 4, 8]
+          allow_xqa_mha: true
+          require_divisible: true
   vllm_xpu:
     attention_generation:
       cases:
@@ -219,3 +248,20 @@ framework_specific_op_cases:
         window_sizes:
         - 0
         - 128
+        head_profiles:
+        - id: default_head64
+          head_dim: 64
+          window_sizes: [0, 128]
+          mha_query_head_counts: []
+          xqa_query_head_counts: [1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 64]
+          kv_head_counts: [1, 2, 4, 8]
+          allow_xqa_mha: true
+          require_divisible: true
+        - id: default_head128
+          head_dim: 128
+          window_size: 0
+          mha_query_head_counts: []
+          xqa_query_head_counts: [1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 64]
+          kv_head_counts: [1, 2, 4, 8]
+          allow_xqa_mha: true
+          require_divisible: true

--- a/collector/cases/base_ops/compute_scale.yaml
+++ b/collector/cases/base_ops/compute_scale.yaml
@@ -5,6 +5,9 @@ schema_version: 1
 op: compute_scale
 description: Base collector v2 cases for compute_scale.
 framework_specific_op_cases:
+  sglang:
+    compute_scale:
+      cases: all
   trtllm:
     compute_scale:
       cases:
@@ -110,3 +113,6 @@ framework_specific_op_cases:
         - 16384
         - 51200
         - 65536
+  vllm:
+    compute_scale:
+      cases: all

--- a/collector/cases/base_ops/mamba2.yaml
+++ b/collector/cases/base_ops/mamba2.yaml
@@ -43,3 +43,22 @@ common_case_values:
     - 256
     - 512
     - 1024
+    # Default synthetic interpolation shapes used by full/raw collection.
+    # Targeted collection selects only the requested model profile.
+    default_model_cases:
+    - model_path: MAMBA2_GENERIC_4K
+      d_model: 8192
+      d_state: 128
+      d_conv: 4
+      nheads: 64
+      head_dim: 64
+      n_groups: 8
+      chunk_size: 256
+    - model_path: MAMBA2_GENERIC_1K
+      d_model: 1024
+      d_state: 64
+      d_conv: 4
+      nheads: 16
+      head_dim: 64
+      n_groups: 4
+      chunk_size: 128

--- a/collector/cases/base_ops/mla.yaml
+++ b/collector/cases/base_ops/mla.yaml
@@ -68,7 +68,7 @@ common_case_values:
     kv_cache_block_sizes:
     - 64
     max_context_tokens: 65536
-    max_generation_tokens: 8388608
+    max_generation_tokens: 16777216
     constraints:
     - 'context: batch_size * sequence_length <= max_context_tokens'
     - 'generation: batch_size * target_sequence_length <= max_generation_tokens'

--- a/collector/cases/base_ops/moe.yaml
+++ b/collector/cases/base_ops/moe.yaml
@@ -78,6 +78,10 @@ common_case_values:
     quantization_modes:
     - name: bfloat16
     - name: int4_wo
+      allowed_model_paths:
+      - moonshotai/Kimi-K2.5
+      module_config:
+        group_size: 32
     - name: fp8_block
       min_sm: 90
     - name: nvfp4
@@ -92,14 +96,8 @@ common_case_values:
       allowed_model_paths:
       - deepseek-ai/DeepSeek-V4-Flash
       - deepseek-ai/DeepSeek-V4-Pro
-      - sgl-project/DeepSeek-V4-Flash-FP8
-      - sgl-project/DeepSeek-V4-Pro-FP8
-    model_quantization_policies:
-    - model_paths:
       - openai/gpt-oss-20b
       - openai/gpt-oss-120b
-      allowed_modes:
-      - w4a16_mxfp4
   moe_trtllm:
     quantization_modes:
     - name: bfloat16
@@ -109,35 +107,32 @@ common_case_values:
       min_sm: 90
     - name: int4_wo
       min_sm: 100
+      allowed_model_paths:
+      - moonshotai/Kimi-K2.5
+      module_config:
+        group_size: 32
     - name: nvfp4
       min_sm: 100
     - name: w4a16_mxfp4
       min_sm_exclusive: 86
       allowed_model_paths:
-      - moonshotai/Kimi-K2-Instruct
-      - moonshotai/Kimi-K2.5
-      - nvidia/Kimi-K2.5-NVFP4
       - openai/gpt-oss-20b
       - openai/gpt-oss-120b
     - name: w4a8_mxfp4_mxfp8
       min_sm: 100
       allowed_model_paths:
-      - moonshotai/Kimi-K2-Instruct
-      - moonshotai/Kimi-K2.5
-      - nvidia/Kimi-K2.5-NVFP4
+      - deepseek-ai/DeepSeek-V4-Flash
+      - deepseek-ai/DeepSeek-V4-Pro
       - openai/gpt-oss-20b
       - openai/gpt-oss-120b
-    model_quantization_policies:
-    - model_paths:
-      - openai/gpt-oss-20b
-      - openai/gpt-oss-120b
-      allowed_modes:
-      - w4a16_mxfp4
-      - w4a8_mxfp4_mxfp8
   moe_vllm:
     quantization_modes:
     - name: bfloat16
     - name: int4_wo
+      allowed_model_paths:
+      - moonshotai/Kimi-K2.5
+      module_config:
+        group_size: 32
     - name: fp8
       min_sm_exclusive: 86
     - name: fp8_block
@@ -165,8 +160,8 @@ common_case_values:
         local_inter_size: 32
     - mode: int4_wo
       divisible_by:
-        hidden_size: 128
-        local_inter_size: 128
+        hidden_size: 32
+        local_inter_size: 32
   moe_vllm_xpu:
     token_counts:
     - 1

--- a/collector/cases/models/DeepseekV32ForCausalLM_cases.yaml
+++ b/collector/cases/models/DeepseekV32ForCausalLM_cases.yaml
@@ -7,18 +7,14 @@ model_path: deepseek-ai/DeepSeek-V3.2
 model_paths:
   - deepseek-ai/DeepSeek-V3.2
 include_base: true
+base_ops:
+  - gemm
 description: >
   DeepSeek-V3.2 DSA model-centric collection plan. DSA module data is
-  framework-specific while MoE and base attention/GEMM cases stay shared.
+  framework-specific; its shared expert shape reuses the DeepSeek-V3 physical
+  MoE profile and this plan adds only the common GEMM recipe.
 
 model_case_values:
-  moe:
-    - model_path: deepseek-ai/DeepSeek-V3.2
-      hidden_size: 7168
-      inter_size: 2048
-      topk: 8
-      num_experts: 256
-      wideep: true
   mla_module:
     - model_path: deepseek-ai/DeepSeek-V3.2
       attention_type: dsa

--- a/collector/cases/models/DeepseekV3ForCausalLM_cases.yaml
+++ b/collector/cases/models/DeepseekV3ForCausalLM_cases.yaml
@@ -9,25 +9,47 @@ model_paths:
   - deepseek-ai/DeepSeek-V3
   - nvidia/DeepSeek-V3.1-NVFP4
 include_base: true
+base_ops:
+  - gemm
 description: >
   DeepSeek-V3-family model-centric collection plan. Includes shared base op cases
   plus MoE, MLA, and DeepSeek-V3 WideEP cases.
 
 model_case_values:
   moe:
-    - model_paths:
+    - model_path: deepseek-ai/DeepSeek-V3
+      model_aliases:
         - deepseek-ai/DeepSeek-R1
-        - deepseek-ai/DeepSeek-V3
-        - nvidia/DeepSeek-V3.1-NVFP4
+        - deepseek-ai/DeepSeek-V3.2
       hidden_size: 7168
       inter_size: 2048
       topk: 8
       num_experts: 256
       wideep: true
+      framework_quantization:
+        sglang:
+          allowed_modes: [fp8_block]
+        trtllm:
+          allowed_modes: [fp8_block]
+        vllm:
+          allowed_modes: [fp8_block]
+    - model_path: nvidia/DeepSeek-V3.1-NVFP4
+      hidden_size: 7168
+      inter_size: 2048
+      topk: 8
+      num_experts: 256
+      wideep: true
+      framework_quantization:
+        sglang:
+          allowed_modes: [nvfp4]
+        trtllm:
+          allowed_modes: [nvfp4]
+        vllm:
+          allowed_modes: [nvfp4]
   mla:
-    - model_paths:
+    - model_path: deepseek-ai/DeepSeek-V3
+      model_aliases:
         - deepseek-ai/DeepSeek-R1
-        - deepseek-ai/DeepSeek-V3
         - nvidia/DeepSeek-V3.1-NVFP4
       num_heads: 128
       q_lora_rank: 1536
@@ -36,9 +58,12 @@ model_case_values:
       qk_rope_head_dim: 64
       v_head_dim: 128
   mla_module:
+    # Module collectors load checkpoint-specific quantization metadata. Keep
+    # every native-precision artifact available; operation-local deduplication
+    # may collapse only cases whose explicit precision key is already equal.
     - model_paths:
-        - deepseek-ai/DeepSeek-R1
         - deepseek-ai/DeepSeek-V3
+        - deepseek-ai/DeepSeek-R1
         - nvidia/DeepSeek-V3.1-NVFP4
       attention_type: mla
       native_num_heads: 128
@@ -47,17 +72,17 @@ model_case_values:
 all_frameworks_op_cases:
   moe:
     cases: all
-  mla_context:
-    cases: all
-  mla_generation:
-    cases: all
-  mla_bmm_gen_pre:
-    cases: all
-  mla_bmm_gen_post:
-    cases: all
 
 framework_specific_op_cases:
   trtllm:
+    mla_context:
+      cases: all
+    mla_generation:
+      cases: all
+    mla_bmm_gen_pre:
+      cases: all
+    mla_bmm_gen_post:
+      cases: all
     mla_context_module:
       cases: all
     mla_generation_module:
@@ -70,6 +95,14 @@ framework_specific_op_cases:
     mla_generation_module:
       cases: all
   sglang:
+    mla_context:
+      cases: all
+    mla_generation:
+      cases: all
+    mla_bmm_gen_pre:
+      cases: all
+    mla_bmm_gen_post:
+      cases: all
     wideep_mla_context:
       cases: all
     wideep_mla_generation:

--- a/collector/cases/models/DeepseekV4ForCausalLM_cases.yaml
+++ b/collector/cases/models/DeepseekV4ForCausalLM_cases.yaml
@@ -10,6 +10,8 @@ model_paths:
   - sgl-project/DeepSeek-V4-Flash-FP8
   - sgl-project/DeepSeek-V4-Pro-FP8
 include_base: true
+base_ops:
+  - gemm
 description: >
   DeepSeek-V4 model-centric collection plan. DSV4 attention and sparse kernel
   cases use the upstream DeepSeek-V4 op names and can target any listed V4
@@ -17,22 +19,71 @@ description: >
 
 model_case_values:
   moe:
-    - model_paths:
-        - deepseek-ai/DeepSeek-V4-Flash
-        - sgl-project/DeepSeek-V4-Flash-FP8
+    - model_path: deepseek-ai/DeepSeek-V4-Flash
       hidden_size: 4096
       inter_size: 2048
       topk: 6
       num_experts: 256
       wideep: true
-    - model_paths:
-        - deepseek-ai/DeepSeek-V4-Pro
-        - sgl-project/DeepSeek-V4-Pro-FP8
+      framework_quantization:
+        sglang:
+          # The pinned SGLang 0.5.10 predates the DeepSeek-V4-specific MXFP4
+          # method (added in 0.5.12). Do not run its GPT-OSS method under a
+          # DSV4 label; enable this only with a separately validated upgrade.
+          allowed_modes: []
+        trtllm:
+          allowed_modes:
+            - w4a8_mxfp4_mxfp8
+        vllm:
+          # The pinned vLLM 0.19.0 collector has no DeepSeek-V4 MXFP4/MXFP8
+          # implementation. Keep the native artifact out of its queue.
+          allowed_modes: []
+    - model_path: sgl-project/DeepSeek-V4-Flash-FP8
+      hidden_size: 4096
+      inter_size: 2048
+      topk: 6
+      num_experts: 256
+      wideep: true
+      framework_quantization:
+        sglang:
+          allowed_modes:
+            - fp8_block
+        trtllm:
+          allowed_modes:
+            - fp8_block
+        vllm:
+          allowed_modes:
+            - fp8_block
+    - model_path: deepseek-ai/DeepSeek-V4-Pro
       hidden_size: 7168
       inter_size: 3072
       topk: 6
       num_experts: 384
       wideep: true
+      framework_quantization:
+        sglang:
+          allowed_modes: []
+        trtllm:
+          allowed_modes:
+            - w4a8_mxfp4_mxfp8
+        vllm:
+          allowed_modes: []
+    - model_path: sgl-project/DeepSeek-V4-Pro-FP8
+      hidden_size: 7168
+      inter_size: 3072
+      topk: 6
+      num_experts: 384
+      wideep: true
+      framework_quantization:
+        sglang:
+          allowed_modes:
+            - fp8_block
+        trtllm:
+          allowed_modes:
+            - fp8_block
+        vllm:
+          allowed_modes:
+            - fp8_block
   mhc:
     - model_paths:
         - deepseek-ai/DeepSeek-V4-Flash
@@ -45,9 +96,11 @@ model_case_values:
       hidden_size: 7168
       hc_mult: 4
   dsv4:
+    # Module and calibration output keys cannot distinguish Flash from Pro.
+    # Use one canonical full/raw profile instead of silently overwriting one
+    # model with the other. Targeted runs still preserve all supported paths.
     default_model_paths:
-      - deepseek-ai/DeepSeek-V4-Flash
-      - deepseek-ai/DeepSeek-V4-Pro
+      - sgl-project/DeepSeek-V4-Flash-FP8
     supported_model_paths:
       - deepseek-ai/DeepSeek-V4-Flash
       - deepseek-ai/DeepSeek-V4-Pro
@@ -213,37 +266,16 @@ framework_specific_op_cases:
     # after the csa module entries).
     dsv4_csa_topk_calib:
       cases: all
-    # These kernel-level cases are kept as auxiliary data for future
-    # prefix/past_kv correction.  Current DeepSeek-V4 SGLang modeling uses the
-    # full CSA/HCA attention-module rows above as the primary path.
-    dsv4_paged_mqa_logits_module:
-      cases: all
-    dsv4_hca_attn_module:
-      cases: all
-    # CSA sparse FMLA over the topk-selected c4 positions. Same source as
-    # paged_mqa_logits/topk_calib (reads dsv4_csa_*_module_perf.txt), so it must
-    # run AFTER the CSA module ops (guaranteed by registry order).
-    dsv4_csa_attn_module:
-      cases: all
+    # Standalone paged_mqa/hca_attn/csa_attn rows are experimental-only: the
+    # production SDK has no query call-site for them. Keep their registry
+    # entries available for explicit research runs, but do not schedule them in
+    # the default model plan.
     mhc_module:
       cases: all
     wideep_moe:
       cases: all
-  vllm:
-    dsv4_csa_context_module:
-      cases: all
-    dsv4_hca_context_module:
-      cases: all
-    dsv4_csa_generation_module:
-      cases: all
-    dsv4_hca_generation_module:
-      cases: all
-    # These kernel-level cases are kept as auxiliary data for future
-    # prefix/past_kv correction.  Current DeepSeek-V4 SGLang modeling uses the
-    # full CSA/HCA attention-module rows above as the primary path.
-    dsv4_paged_mqa_logits_module:
-      cases: all
-    dsv4_hca_attn_module:
-      cases: all
-    mhc_module:
-      cases: all
+
+# vLLM DSV4 collectors remain available through the registry/direct module
+# entrypoints, but are not in the default model plan until the manifest runtime
+# satisfies their compatibility floor and prefix-aware context collection is
+# implemented.

--- a/collector/cases/models/Gemma4ForConditionalGeneration_cases.yaml
+++ b/collector/cases/models/Gemma4ForConditionalGeneration_cases.yaml
@@ -7,10 +7,29 @@ model_path: google/gemma-4-26B-A4B
 model_paths:
   - google/gemma-4-26B-A4B
 include_base: true
+base_ops:
+  - attention_context
+  - attention_generation
+  - gemm
 description: >
   Gemma 4 hybrid SWA/global attention plus routed-MoE collection plan.
 
 model_case_values:
+  attention:
+    - id: gemma4_swa_attention
+      model_path: google/gemma-4-26B-A4B
+      num_attention_heads: 16
+      num_key_value_heads: 8
+      head_dim: 256
+      window_size: 1024
+      tensor_parallel_sizes: [1, 2, 4, 8, 16]
+    - id: gemma4_global_attention
+      model_path: google/gemma-4-26B-A4B
+      num_attention_heads: 16
+      num_key_value_heads: 2
+      head_dim: 512
+      window_size: 0
+      tensor_parallel_sizes: [1, 2, 4, 8, 16]
   moe:
     - model_path: google/gemma-4-26B-A4B
       hidden_size: 2816

--- a/collector/cases/models/GlmMoeDsaForCausalLM_cases.yaml
+++ b/collector/cases/models/GlmMoeDsaForCausalLM_cases.yaml
@@ -24,6 +24,9 @@ model_case_values:
       num_experts: 256
       wideep: true
   mla_module:
+    # Keep every supported path targetable. SGLang resolves checkpoint-native
+    # quantization to reject impossible explicit GEMM modes, but still loads
+    # path-specific config for the remaining module invocations.
     - model_paths:
         - zai-org/GLM-5
         - zai-org/GLM-5-FP8

--- a/collector/cases/models/GptOssForCausalLM_cases.yaml
+++ b/collector/cases/models/GptOssForCausalLM_cases.yaml
@@ -12,6 +12,16 @@ description: >
   GPT-OSS MoE model-centric collection plan.
 
 model_case_values:
+  attention:
+    - id: gpt_oss_attention
+      model_path: openai/gpt-oss-120b
+      model_aliases:
+        - openai/gpt-oss-20b
+      num_attention_heads: 64
+      num_key_value_heads: 8
+      head_dim: 64
+      window_sizes: [0, 128]
+      tensor_parallel_sizes: [1, 2, 4, 8, 16, 32, 64]
   moe:
     - model_path: openai/gpt-oss-120b
       hidden_size: 2880
@@ -19,6 +29,14 @@ model_case_values:
       topk: 4
       num_experts: 128
       framework_quantization:
+        sglang:
+          allowed_modes:
+            - w4a16_mxfp4
+            - w4a8_mxfp4_mxfp8
+        trtllm:
+          allowed_modes:
+            - w4a16_mxfp4
+            - w4a8_mxfp4_mxfp8
         vllm:
           allowed_modes:
             - w4a16_mxfp4
@@ -39,6 +57,14 @@ model_case_values:
       topk: 4
       num_experts: 32
       framework_quantization:
+        sglang:
+          allowed_modes:
+            - w4a16_mxfp4
+            - w4a8_mxfp4_mxfp8
+        trtllm:
+          allowed_modes:
+            - w4a16_mxfp4
+            - w4a8_mxfp4_mxfp8
         vllm:
           allowed_modes:
             - w4a16_mxfp4

--- a/collector/cases/models/KimiK25ForConditionalGeneration_cases.yaml
+++ b/collector/cases/models/KimiK25ForConditionalGeneration_cases.yaml
@@ -9,23 +9,86 @@ model_paths:
   - moonshotai/Kimi-K2.5
   - nvidia/Kimi-K2.5-NVFP4
 include_base: true
+base_ops:
+  - gemm
+framework_specific_base_ops:
+  vllm:
+    - attention_context
+    - attention_generation
 description: >
   Kimi-K2.5 hybrid MLA/MoE model-centric collection plan.
 
 model_case_values:
-  moe:
-    - model_paths:
+  attention:
+    - id: kimi_k25_vllm_attention
+      model_path: moonshotai/Kimi-K2.5
+      model_aliases:
         - moonshotai/Kimi-K2-Instruct
-        - moonshotai/Kimi-K2.5
         - nvidia/Kimi-K2.5-NVFP4
+      num_attention_heads: 64
+      num_key_value_heads: 64
+      head_dim: 128
+      window_size: 0
+      tensor_parallel_sizes: [1, 2, 4, 8, 16, 32, 64]
+  moe:
+    - model_path: moonshotai/Kimi-K2-Instruct
       hidden_size: 7168
       inter_size: 2048
       topk: 8
       num_experts: 384
       wideep: true
+      framework_quantization:
+        sglang:
+          allowed_modes: [fp8_block]
+        trtllm:
+          allowed_modes: [fp8_block]
+        vllm:
+          allowed_modes: [fp8_block]
+    - model_path: moonshotai/Kimi-K2.5
+      hidden_size: 7168
+      inter_size: 2048
+      topk: 8
+      num_experts: 384
+      wideep: true
+      framework_quantization:
+        sglang:
+          allowed_modes: [int4_wo]
+        trtllm:
+          allowed_modes: [int4_wo]
+        vllm:
+          allowed_modes: [int4_wo]
+    - model_path: nvidia/Kimi-K2.5-NVFP4
+      hidden_size: 7168
+      inter_size: 2048
+      topk: 8
+      num_experts: 384
+      wideep: true
+      framework_quantization:
+        sglang:
+          allowed_modes: [nvfp4]
+        trtllm:
+          allowed_modes: [nvfp4]
+        vllm:
+          allowed_modes: [nvfp4]
   mla:
-    - model_paths:
-        - moonshotai/Kimi-K2.5
+    - model_path: moonshotai/Kimi-K2.5
+      model_aliases:
+        - moonshotai/Kimi-K2-Instruct
+        - nvidia/Kimi-K2.5-NVFP4
+      # The current SGLang/TRT-LLM AIC MLA consumer queries the historical
+      # DeepSeek-compatible 128-head table. vLLM's native 64-head attention
+      # shape is represented separately by the attention profile above.
+      num_heads: 128
+      q_lora_rank: 1536
+      kv_lora_rank: 512
+      qk_nope_head_dim: 128
+      qk_rope_head_dim: 64
+      v_head_dim: 128
+    # n=64 contributes local-head=1 in full collection and local-head=8 in the
+    # targeted TP<=8 plan. The getters deduplicate the overlap with n=128.
+    - model_path: moonshotai/Kimi-K2.5
+      model_aliases:
+        - moonshotai/Kimi-K2-Instruct
         - nvidia/Kimi-K2.5-NVFP4
       num_heads: 64
       q_lora_rank: 1536
@@ -37,12 +100,57 @@ model_case_values:
 all_frameworks_op_cases:
   moe:
     cases: all
-  mla_context:
-    cases: all
-  mla_generation:
-    cases: all
 
 framework_specific_op_cases:
   trtllm:
+    mla_context:
+      rules:
+        - fields: [input_len, batch_size, output_len, kv_cache_dtype, num_heads, world_size, tp_size, tokens_per_block, warming_up, test_ite, is_context_phase]
+          match:
+            tp_size:
+              in: [1, 2, 4, 8]
+    mla_generation:
+      rules:
+        - fields: [input_len, batch_size, output_len, kv_cache_dtype, num_heads, world_size, tp_size, tokens_per_block, warming_up, test_ite, is_context_phase]
+          match:
+            tp_size:
+              in: [1, 2, 4, 8]
+    mla_bmm_gen_pre:
+      rules:
+        - fields: [num_tokens, num_heads, dtype, num_warmups, num_runs]
+          match:
+            num_heads:
+              in: [64, 32, 16, 8]
+    mla_bmm_gen_post:
+      rules:
+        - fields: [num_tokens, num_heads, dtype, num_warmups, num_runs]
+          match:
+            num_heads:
+              in: [64, 32, 16, 8]
     trtllm_moe_wideep:
       cases: all
+  sglang:
+    mla_context:
+      rules:
+        - fields: [input_len, batch_size, output_len, kv_cache_dtype, num_heads, world_size, tp_size, tokens_per_block, warming_up, test_ite, is_context_phase]
+          match:
+            tp_size:
+              in: [1, 2, 4, 8]
+    mla_generation:
+      rules:
+        - fields: [input_len, batch_size, output_len, kv_cache_dtype, num_heads, world_size, tp_size, tokens_per_block, warming_up, test_ite, is_context_phase]
+          match:
+            tp_size:
+              in: [1, 2, 4, 8]
+    mla_bmm_gen_pre:
+      rules:
+        - fields: [num_tokens, num_heads, dtype, num_warmups, num_runs]
+          match:
+            num_heads:
+              in: [64, 32, 16, 8]
+    mla_bmm_gen_post:
+      rules:
+        - fields: [num_tokens, num_heads, dtype, num_warmups, num_runs]
+          match:
+            num_heads:
+              in: [64, 32, 16, 8]

--- a/collector/cases/models/Llama4ForConditionalGeneration_cases.yaml
+++ b/collector/cases/models/Llama4ForConditionalGeneration_cases.yaml
@@ -9,11 +9,26 @@ model_paths:
   - meta-llama/Llama-4-Scout-17B-16E-Instruct
   - meta-llama/Llama-4-Maverick-17B-128E-Instruct
 include_base: true
+base_ops:
+  - attention_context
+  - attention_generation
+  - gemm
 description: >
   Llama 4 hybrid model-centric collection plan. Starts with shared base op cases
   and includes the Scout/Maverick MoE shapes used by the support matrix.
 
 model_case_values:
+  attention:
+    - id: llama4_attention
+      model_path: meta-llama/Llama-4-Scout-17B-16E-Instruct
+      model_aliases:
+        - meta-llama/Llama-4-Scout-17B-16E
+        - meta-llama/Llama-4-Maverick-17B-128E-Instruct
+      num_attention_heads: 40
+      num_key_value_heads: 8
+      head_dim: 128
+      window_sizes: [0, 8192]
+      tensor_parallel_sizes: [1, 2, 4, 8]
   moe:
     - model_path: meta-llama/Llama-4-Scout-17B-16E-Instruct
       hidden_size: 5120

--- a/collector/cases/models/MiMoForCausalLM_cases.yaml
+++ b/collector/cases/models/MiMoForCausalLM_cases.yaml
@@ -9,3 +9,15 @@ model_paths:
 include_base: true
 description: >
   MiMo dense-family model-centric collection plan.
+
+model_case_values:
+  attention:
+    - id: mimo_7b_attention
+      model_path: XiaomiMiMo/MiMo-7B-Base
+      num_attention_heads: 32
+      num_key_value_heads: 8
+      head_dim: 128
+      # The cached model config sets use_sliding_window=false, and the AIC
+      # LLAMA model therefore queries the full-attention (window=0) table.
+      window_size: 0
+      tensor_parallel_sizes: [1, 2, 4, 8, 16, 32]

--- a/collector/cases/models/MiMoV2FlashForCausalLM_cases.yaml
+++ b/collector/cases/models/MiMoV2FlashForCausalLM_cases.yaml
@@ -12,6 +12,21 @@ description: >
   cases and includes the hybrid MoE shape used by the support matrix.
 
 model_case_values:
+  attention:
+    - id: mimo_v2_global_attention
+      model_path: XiaomiMiMo/MiMo-V2-Flash
+      num_attention_heads: 64
+      num_key_value_heads: 4
+      head_dim: 192
+      window_size: 0
+      tensor_parallel_sizes: [1, 2, 4, 8, 16, 32, 64]
+    - id: mimo_v2_swa_attention
+      model_path: XiaomiMiMo/MiMo-V2-Flash
+      num_attention_heads: 64
+      num_key_value_heads: 8
+      head_dim: 192
+      window_size: 128
+      tensor_parallel_sizes: [1, 2, 4, 8, 16, 32, 64]
   moe:
     - model_path: XiaomiMiMo/MiMo-V2-Flash
       hidden_size: 4096

--- a/collector/cases/models/MiniMaxM2ForCausalLM_cases.yaml
+++ b/collector/cases/models/MiniMaxM2ForCausalLM_cases.yaml
@@ -5,6 +5,7 @@ schema_version: 1
 architecture: MiniMaxM2ForCausalLM
 model_path: MiniMaxAI/MiniMax-M2.5
 model_paths:
+  - MiniMaxAI/MiniMax-M2
   - MiniMaxAI/MiniMax-M2.5
   - MiniMaxAI/MiniMax-M2.7
   - nvidia/MiniMax-M2.5-NVFP4
@@ -14,17 +15,51 @@ description: >
   MiniMax-M2 MoE model-centric collection plan.
 
 model_case_values:
-  moe:
-    - model_paths:
-        - MiniMaxAI/MiniMax-M2.5
+  attention:
+    - id: minimax_m2_attention
+      model_path: MiniMaxAI/MiniMax-M2.5
+      model_aliases:
+        - MiniMaxAI/MiniMax-M2
         - MiniMaxAI/MiniMax-M2.7
         - nvidia/MiniMax-M2.5-NVFP4
+        - nvidia/MiniMax-M2.7-NVFP4
+      num_attention_heads: 48
+      num_key_value_heads: 8
+      head_dim: 128
+      window_size: 0
+      tensor_parallel_sizes: [1, 2, 4, 8, 16]
+  moe:
+    - model_path: MiniMaxAI/MiniMax-M2.5
+      model_aliases:
+        - MiniMaxAI/MiniMax-M2
+        - MiniMaxAI/MiniMax-M2.7
+      hidden_size: 3072
+      inter_size: 1536
+      topk: 8
+      num_experts: 256
+      wideep: true
+      framework_quantization:
+        sglang:
+          allowed_modes: [fp8_block]
+        trtllm:
+          allowed_modes: [fp8_block]
+        vllm:
+          allowed_modes: [fp8_block]
+    - model_path: nvidia/MiniMax-M2.5-NVFP4
+      model_aliases:
         - nvidia/MiniMax-M2.7-NVFP4
       hidden_size: 3072
       inter_size: 1536
       topk: 8
       num_experts: 256
       wideep: true
+      framework_quantization:
+        sglang:
+          allowed_modes: [nvfp4]
+        trtllm:
+          allowed_modes: [nvfp4]
+        vllm:
+          allowed_modes: [nvfp4]
 
 all_frameworks_op_cases:
   moe:

--- a/collector/cases/models/NemotronHForCausalLM_cases.yaml
+++ b/collector/cases/models/NemotronHForCausalLM_cases.yaml
@@ -7,8 +7,11 @@ model_path: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
 model_paths:
   - nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
   - nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4
+  - nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16
+  - nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-FP8
   - nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
   - nvidia/Nemotron-H-56B-Base-8K
+  - nvidia/nemotron-ultra-rl-050826
 include_base: true
 description: >
   Nemotron-H hybrid Mamba/MoE model-centric collection plan.
@@ -20,26 +23,110 @@ model_case_values:
       inter_size: 1856
       topk: 6
       num_experts: 128
+      framework_quantization:
+        sglang:
+          allowed_modes: [bfloat16]
+        trtllm:
+          allowed_modes: [bfloat16]
+        vllm:
+          allowed_modes: [bfloat16]
     - model_path: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4
       hidden_size: 4096
       inter_size: 2688
       topk: 22
       num_experts: 512
+      framework_quantization:
+        sglang:
+          allowed_modes: [nvfp4]
+        trtllm:
+          allowed_modes: [nvfp4]
+        vllm:
+          # vLLM's pinned FlashInfer NVFP4 path is limited to top-k <= 10.
+          allowed_modes: []
     - model_path: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4
       hidden_size: 1024
       inter_size: 2688
       topk: 22
       num_experts: 512
+      framework_quantization:
+        sglang:
+          allowed_modes: [nvfp4]
+        trtllm:
+          allowed_modes: [nvfp4]
+        vllm:
+          allowed_modes: []
+    - model_path: nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16
+      hidden_size: 8192
+      inter_size: 5120
+      topk: 22
+      num_experts: 512
+      framework_quantization:
+        sglang:
+          allowed_modes: [bfloat16]
+        trtllm:
+          allowed_modes: [bfloat16]
+        vllm:
+          allowed_modes: [bfloat16]
+    - model_path: nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16
+      hidden_size: 2048
+      inter_size: 5120
+      topk: 22
+      num_experts: 512
+      framework_quantization:
+        sglang:
+          allowed_modes: [bfloat16]
+        trtllm:
+          allowed_modes: [bfloat16]
+        vllm:
+          allowed_modes: [bfloat16]
+    - model_path: nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-FP8
+      hidden_size: 8192
+      inter_size: 5120
+      topk: 22
+      num_experts: 512
+      framework_quantization:
+        sglang:
+          allowed_modes: []
+        trtllm:
+          allowed_modes: [fp8]
+        vllm:
+          allowed_modes: [fp8]
+    - model_path: nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-FP8
+      hidden_size: 2048
+      inter_size: 5120
+      topk: 22
+      num_experts: 512
+      framework_quantization:
+        sglang:
+          allowed_modes: []
+        trtllm:
+          allowed_modes: [fp8]
+        vllm:
+          allowed_modes: [fp8]
     - model_path: nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
       hidden_size: 8192
       inter_size: 5120
       topk: 22
       num_experts: 512
+      framework_quantization:
+        sglang:
+          allowed_modes: [nvfp4]
+        trtllm:
+          allowed_modes: [nvfp4]
+        vllm:
+          allowed_modes: []
     - model_path: nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
       hidden_size: 2048
       inter_size: 5120
       topk: 22
       num_experts: 512
+      framework_quantization:
+        sglang:
+          allowed_modes: [nvfp4]
+        trtllm:
+          allowed_modes: [nvfp4]
+        vllm:
+          allowed_modes: []
   mamba2:
     - model_path: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
       d_model: 2688
@@ -58,6 +145,10 @@ model_case_values:
       n_groups: 8
       chunk_size: 128
     - model_path: nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
+      model_aliases:
+        - nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16
+        - nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-FP8
+        - nvidia/nemotron-ultra-rl-050826
       d_model: 8192
       d_state: 128
       d_conv: 4
@@ -75,7 +166,10 @@ model_case_values:
       chunk_size: 128
 
 all_frameworks_op_cases:
-  mamba2:
-    cases: all
   moe:
     cases: all
+
+framework_specific_op_cases:
+  trtllm:
+    mamba2:
+      cases: all

--- a/collector/cases/models/Qwen3ForCausalLM_cases.yaml
+++ b/collector/cases/models/Qwen3ForCausalLM_cases.yaml
@@ -12,5 +12,42 @@ model_paths:
   - Qwen/Qwen3-32B-FP8
   - Qwen/Qwen3-32B-FP8-Static-PerTensor
 include_base: true
+model_specific_base_ops:
+  Qwen/Qwen3-32B-FP8-Static-PerTensor:
+    sglang:
+      - compute_scale
+    trtllm:
+      - compute_scale
+    vllm:
+      - compute_scale
 description: >
   Qwen3 dense-family model-centric collection plan.
+
+model_case_values:
+  attention:
+    - id: qwen3_small_attention
+      model_path: Qwen/Qwen3-0.6B
+      model_aliases:
+        - Qwen/Qwen3-1.7B
+      num_attention_heads: 16
+      num_key_value_heads: 8
+      head_dim: 128
+      window_size: 0
+      tensor_parallel_sizes: [1, 2, 4, 8, 16]
+    - id: qwen3_8b_attention
+      model_path: Qwen/Qwen3-8B
+      num_attention_heads: 32
+      num_key_value_heads: 8
+      head_dim: 128
+      window_size: 0
+      tensor_parallel_sizes: [1, 2, 4, 8, 16, 32]
+    - id: qwen3_32b_attention
+      model_path: Qwen/Qwen3-32B
+      model_aliases:
+        - Qwen/Qwen3-32B-FP8
+        - Qwen/Qwen3-32B-FP8-Static-PerTensor
+      num_attention_heads: 64
+      num_key_value_heads: 8
+      head_dim: 128
+      window_size: 0
+      tensor_parallel_sizes: [1, 2, 4, 8, 16, 32, 64]

--- a/collector/cases/models/Qwen3MoeForCausalLM_cases.yaml
+++ b/collector/cases/models/Qwen3MoeForCausalLM_cases.yaml
@@ -17,8 +17,38 @@ description: >
   Qwen3 MoE model-centric collection plan.
 
 model_case_values:
+  attention:
+    - id: qwen3_moe_30b_attention
+      model_path: Qwen/Qwen3-30B-A3B
+      model_aliases:
+        - Qwen/Qwen3-30B-A3B-FP8
+      num_attention_heads: 32
+      num_key_value_heads: 4
+      head_dim: 128
+      window_size: 0
+      tensor_parallel_sizes: [1, 2, 4, 8]
+    - id: qwen3_moe_235b_attention
+      model_path: Qwen/Qwen3-235B-A22B
+      model_aliases:
+        - Qwen/Qwen3-235B-A22B-FP8
+        - Qwen/Qwen3-235B-A22B-Instruct-2507
+        - nvidia/Qwen3-235B-A22B-NVFP4
+      num_attention_heads: 64
+      num_key_value_heads: 4
+      head_dim: 128
+      window_size: 0
+      tensor_parallel_sizes: [1, 2, 4, 8, 16, 32, 64]
+    - id: qwen3_coder_attention
+      model_path: Qwen/Qwen3-Coder-480B-A35B-Instruct
+      num_attention_heads: 96
+      num_key_value_heads: 8
+      head_dim: 128
+      window_size: 0
+      tensor_parallel_sizes: [1, 2, 4, 8, 16, 32]
   moe:
     - model_path: Qwen/Qwen3-30B-A3B
+      model_aliases:
+        - Qwen/Qwen3-30B-A3B-FP8
       hidden_size: 2048
       inter_size: 768
       topk: 8
@@ -28,15 +58,12 @@ model_case_values:
         vllm_xpu:
           sweep: small
           activation: silu
-    - model_path: Qwen/Qwen3-30B-A3B-FP8
-      hidden_size: 2048
-      inter_size: 768
-      topk: 8
-      num_experts: 128
-    - model_paths:
-        - Qwen/Qwen3-235B-A22B
+    - model_path: Qwen/Qwen3-235B-A22B
+      model_aliases:
         - Qwen/Qwen3-235B-A22B-FP8
+        - Qwen/Qwen3-235B-A22B-Instruct-2507
         - nvidia/Qwen3-235B-A22B-NVFP4
+        - Qwen/Qwen3-VL-235B-A22B-Instruct
       hidden_size: 4096
       inter_size: 1536
       topk: 8

--- a/collector/cases/models/Qwen3VLForConditionalGeneration_cases.yaml
+++ b/collector/cases/models/Qwen3VLForConditionalGeneration_cases.yaml
@@ -11,6 +11,63 @@ model_paths:
   - Qwen/Qwen3-VL-32B-Instruct
   - Qwen/Qwen3-VL-32B-Thinking
 include_base: true
+base_ops:
+  - attention_context
+  - attention_generation
+  - gemm
+framework_specific_base_ops:
+  # XPU has no verified encoder-attention collector. Keep the op out of its
+  # plan instead of advertising an uncollectable workload.
+  sglang:
+    - encoder_attention
+  trtllm:
+    - encoder_attention
+  vllm:
+    - encoder_attention
 description: >
   Qwen3-VL dense model-centric collection plan. Starts with shared base op
   cases and lists all dense Qwen3-VL aliases used by the support matrix.
+
+model_case_values:
+  attention:
+    - id: qwen3_vl_2b_attention
+      model_path: Qwen/Qwen3-VL-2B-Instruct
+      num_attention_heads: 16
+      num_key_value_heads: 8
+      head_dim: 128
+      window_size: 0
+      tensor_parallel_sizes: [1, 2, 4, 8, 16]
+    - id: qwen3_vl_4b_8b_attention
+      model_path: Qwen/Qwen3-VL-4B-Instruct
+      model_aliases:
+        - Qwen/Qwen3-VL-8B-Instruct
+      num_attention_heads: 32
+      num_key_value_heads: 8
+      head_dim: 128
+      window_size: 0
+      tensor_parallel_sizes: [1, 2, 4, 8, 16]
+    - id: qwen3_vl_32b_attention
+      model_path: Qwen/Qwen3-VL-32B-Instruct
+      model_aliases:
+        - Qwen/Qwen3-VL-32B-Thinking
+      num_attention_heads: 64
+      num_key_value_heads: 8
+      head_dim: 128
+      window_size: 0
+      tensor_parallel_sizes: [1, 2, 4, 8, 16]
+  encoder_attention:
+    - id: qwen3_vl_2b_4b_encoder_attention
+      model_path: Qwen/Qwen3-VL-2B-Instruct
+      model_aliases:
+        - Qwen/Qwen3-VL-4B-Instruct
+      num_attention_heads: 16
+      head_dim: 64
+      tensor_parallel_sizes: [1, 2, 4, 8, 16]
+    - id: qwen3_vl_8b_32b_encoder_attention
+      model_path: Qwen/Qwen3-VL-8B-Instruct
+      model_aliases:
+        - Qwen/Qwen3-VL-32B-Instruct
+        - Qwen/Qwen3-VL-32B-Thinking
+      num_attention_heads: 16
+      head_dim: 72
+      tensor_parallel_sizes: [1, 2, 4, 8, 16]

--- a/collector/cases/models/Qwen3VLMoeForConditionalGeneration_cases.yaml
+++ b/collector/cases/models/Qwen3VLMoeForConditionalGeneration_cases.yaml
@@ -8,23 +8,53 @@ model_paths:
   - Qwen/Qwen3-VL-30B-A3B-Instruct
   - Qwen/Qwen3-VL-235B-A22B-Instruct
 include_base: true
+base_ops:
+  - attention_context
+  - attention_generation
+  - gemm
+framework_specific_base_ops:
+  # XPU has no verified encoder-attention collector. Keep the op out of its
+  # plan instead of advertising an uncollectable workload.
+  sglang:
+    - encoder_attention
+  trtllm:
+    - encoder_attention
+  vllm:
+    - encoder_attention
 description: >
   Qwen3-VL MoE model-centric collection plan. Starts with shared base op cases
   and includes the Qwen3-VL MoE shapes used by the support matrix.
 
 model_case_values:
+  attention:
+    - id: qwen3_vl_moe_30b_attention
+      model_path: Qwen/Qwen3-VL-30B-A3B-Instruct
+      num_attention_heads: 32
+      num_key_value_heads: 4
+      head_dim: 128
+      window_size: 0
+      tensor_parallel_sizes: [1, 2, 4, 8, 16]
+    - id: qwen3_vl_moe_235b_attention
+      model_path: Qwen/Qwen3-VL-235B-A22B-Instruct
+      num_attention_heads: 64
+      num_key_value_heads: 4
+      head_dim: 128
+      window_size: 0
+      tensor_parallel_sizes: [1, 2, 4, 8, 16]
+  encoder_attention:
+    - id: qwen3_vl_moe_encoder_attention
+      model_path: Qwen/Qwen3-VL-30B-A3B-Instruct
+      model_aliases:
+        - Qwen/Qwen3-VL-235B-A22B-Instruct
+      num_attention_heads: 16
+      head_dim: 72
+      tensor_parallel_sizes: [1, 2, 4, 8, 16]
   moe:
     - model_path: Qwen/Qwen3-VL-30B-A3B-Instruct
       hidden_size: 2048
       inter_size: 768
       topk: 8
       num_experts: 128
-    - model_path: Qwen/Qwen3-VL-235B-A22B-Instruct
-      hidden_size: 4096
-      inter_size: 1536
-      topk: 8
-      num_experts: 128
-
 all_frameworks_op_cases:
   moe:
     cases: all

--- a/collector/cases/models/Qwen3_5ForConditionalGeneration_cases.yaml
+++ b/collector/cases/models/Qwen3_5ForConditionalGeneration_cases.yaml
@@ -11,10 +11,40 @@ model_paths:
   - Qwen/Qwen3.5-9B
   - Qwen/Qwen3.5-27B
 include_base: true
+base_ops:
+  - attention_context
+  - attention_generation
+  - gemm
 description: >
   Qwen3.5 dense/GDN model-centric collection plan.
 
 model_case_values:
+  attention:
+    - id: qwen35_08b_2b_attention
+      model_path: Qwen/Qwen3.5-0.8B
+      model_aliases:
+        - Qwen/Qwen3.5-2B
+      num_attention_heads: 8
+      num_key_value_heads: 2
+      head_dim: 256
+      window_size: 0
+      tensor_parallel_sizes: [1, 2, 4, 8]
+    - id: qwen35_4b_9b_attention
+      model_path: Qwen/Qwen3.5-4B
+      model_aliases:
+        - Qwen/Qwen3.5-9B
+      num_attention_heads: 16
+      num_key_value_heads: 4
+      head_dim: 256
+      window_size: 0
+      tensor_parallel_sizes: [1, 2, 4, 8, 16]
+    - id: qwen35_27b_attention
+      model_path: Qwen/Qwen3.5-27B
+      num_attention_heads: 24
+      num_key_value_heads: 4
+      head_dim: 256
+      window_size: 0
+      tensor_parallel_sizes: [1, 2, 4, 8]
   gdn:
     - model_path: Qwen/Qwen3.5-0.8B
       d_model: 1024

--- a/collector/cases/models/Qwen3_5MoeForConditionalGeneration_cases.yaml
+++ b/collector/cases/models/Qwen3_5MoeForConditionalGeneration_cases.yaml
@@ -9,14 +9,45 @@ model_paths:
   - Qwen/Qwen3.5-122B-A10B
   - Qwen/Qwen3.5-397B-A17B
 include_base: true
+base_ops:
+  - attention_context
+  - attention_generation
+  - gemm
 description: >
   Qwen3.5 MoE/GDN model-centric collection plan.
 
 model_case_values:
+  attention:
+    - id: qwen35_35b_attention
+      model_path: Qwen/Qwen3.5-35B-A3B
+      num_attention_heads: 16
+      num_key_value_heads: 2
+      head_dim: 256
+      window_size: 0
+      tensor_parallel_sizes: [1, 2, 4, 8, 16]
+    - id: qwen35_122b_attention
+      model_path: Qwen/Qwen3.5-122B-A10B
+      num_attention_heads: 32
+      num_key_value_heads: 2
+      head_dim: 256
+      window_size: 0
+      tensor_parallel_sizes: [1, 2, 4, 8, 16, 32]
+    - id: qwen35_397b_attention
+      model_path: Qwen/Qwen3.5-397B-A17B
+      num_attention_heads: 32
+      num_key_value_heads: 2
+      head_dim: 256
+      window_size: 0
+      tensor_parallel_sizes: [1, 2, 4, 8, 16, 32]
   moe:
     - model_path: Qwen/Qwen3.5-35B-A3B
       hidden_size: 2048
       inter_size: 512
+      topk: 8
+      num_experts: 256
+    - model_path: Qwen/Qwen3.5-122B-A10B
+      hidden_size: 3072
+      inter_size: 1024
       topk: 8
       num_experts: 256
     - model_path: Qwen/Qwen3.5-397B-A17B

--- a/collector/collect.py
+++ b/collector/collect.py
@@ -1459,13 +1459,11 @@ def main():
     )
     args = parser.parse_args()
     ops = args.ops
-    _dsv4_auto_expand = False
     case_plan = None
     logger_message = None
     if args.plan_only and not (args.model_path or args.model_architecture or args.model_cases or args.model_cases_full):
         parser.error("--plan-only requires --model-path, --model-architecture, --model-cases, or --model-cases-full")
     if args.model_path or args.model_architecture or args.model_cases or args.model_cases_full:
-        from collector.case_generator import is_dsv4_attention_model
         from collector.model_cases import build_collection_case_plan
 
         if args.model_path:
@@ -1505,21 +1503,6 @@ def main():
                 "using base op cases only plus legacy model filtering."
             )
 
-        # DeepSeek-V4 Flash/Pro special-case: when no explicit ``--ops`` is
-        # given, collect the full set of AIC data needed by the model. The
-        # attention path uses prefix-aware full modules, so the old sparse
-        # kernel correction files are intentionally not part of the default.
-        if args.ops is None and args.model_path and is_dsv4_attention_model(args.model_path):
-            ops = [
-                "gemm",
-                "moe",
-                "mhc_module",
-                "dsv4_csa_context_module",
-                "dsv4_hca_context_module",
-                "dsv4_csa_generation_module",
-                "dsv4_hca_generation_module",
-            ]
-            _dsv4_auto_expand = True
         if args.plan_only:
             log_dict = case_plan.to_log_dict()
             log_dict["ops"] = ops
@@ -1530,11 +1513,7 @@ def main():
 
     # Setup logging - debug flag is handled inside setup_logging
     if logger is None:
-        # Use short label when V4-Flash auto-expanded ops to several names
-        # (the joined scope may exceed Linux filename length limit).
-        if _dsv4_auto_expand:
-            log_scope = ["dsv4"]
-        elif args.model_cases_full:
+        if args.model_cases_full:
             log_scope = ["model_cases_full"]
         else:
             log_scope = ops if ops else ["all"]

--- a/collector/model_cases.py
+++ b/collector/model_cases.py
@@ -242,7 +242,10 @@ def _parse_selector(raw: Any, *, default_all: bool) -> CaseSelector:
     if not isinstance(raw, dict):
         raise TypeError(f"case selector must be 'all', a list, or a mapping; got {type(raw).__name__}")
 
-    cases = raw.get("cases", "all" if default_all else None)
+    has_specific_selector = any(
+        field_name in raw for field_name in ("case_ids", "contains", "indices", "ranges", "rules")
+    )
+    cases = raw.get("cases", "all" if default_all and not has_specific_selector else None)
     selector = CaseSelector(all_cases=cases == "all" or cases is True)
     if cases not in (None, "all", True):
         if not isinstance(cases, list):
@@ -270,23 +273,51 @@ def _parse_selector(raw: Any, *, default_all: bool) -> CaseSelector:
 
 def _ensure_op_plan(op_cases: dict[str, OpCasePlan], op: str) -> OpCasePlan:
     if op not in op_cases:
-        op_cases[op] = OpCasePlan()
+        # A newly discovered op has not selected any generated cases yet.  The
+        # merge that activates it (``model_ops`` or an op case section) decides
+        # whether it means "all" or a narrower selector.  Starting at ``all``
+        # makes a YAML ``case_ids``/``rules`` selector impossible to narrow.
+        op_cases[op] = OpCasePlan(include=CaseSelector())
     return op_cases[op]
 
 
 def _merge_model_ops(op_cases: dict[str, OpCasePlan], data: dict[str, Any]) -> None:
     for op in _as_list(data.get("model_ops"), field_name="model_ops"):
-        _ensure_op_plan(op_cases, str(op))
+        _ensure_op_plan(op_cases, str(op)).include.all_cases = True
 
 
-def _merge_case_section(op_cases: dict[str, OpCasePlan], section: dict[str, Any]) -> None:
+def _merge_case_section(
+    op_cases: dict[str, OpCasePlan],
+    section: dict[str, Any],
+    *,
+    allowed_ops: set[str] | None = None,
+    override_specific_selectors: bool = False,
+) -> None:
     for op, raw_selector in section.items():
-        _ensure_op_plan(op_cases, str(op)).include.merge(_parse_selector(raw_selector, default_all=True))
+        op = str(op)
+        if allowed_ops is not None and op not in allowed_ops:
+            continue
+        plan = _ensure_op_plan(op_cases, op)
+        selector = _parse_selector(raw_selector, default_all=True)
+        if override_specific_selectors and selector.has_specific_selectors() and not selector.all_cases:
+            # Base files activate generator recipes and therefore select all
+            # generated cases by default.  A model's concrete selector is an
+            # intentional narrowing of that base workload, not an OR with the
+            # inherited ``all``.  Keep recipe specs for plan inspection while
+            # replacing the runnable selector state.
+            selector.case_specs = [*plan.include.case_specs, *selector.case_specs]
+            plan.include = selector
+        else:
+            plan.include.merge(selector)
 
 
 def _merge_exception_section(op_cases: dict[str, OpCasePlan], section: dict[str, Any]) -> None:
     for op, raw_selector in section.items():
-        plan = _ensure_op_plan(op_cases, str(op))
+        # Exceptions constrain an existing workload; they must never activate a
+        # model-unrelated op merely because an SM catalog happens to mention it.
+        plan = op_cases.get(str(op))
+        if plan is None:
+            continue
         if raw_selector is True:
             plan.drop = True
             continue
@@ -389,19 +420,43 @@ def _merge_known_exception_section(op_cases: dict[str, OpCasePlan], data: dict[s
             raise ValueError("known_exceptions entries must include op")
         selector = _parse_selector(raw_exception, default_all=False)
         selector.rules.extend(_known_exception_rules(raw_exception))
-        _ensure_op_plan(op_cases, str(op)).expected_failures.merge(selector)
+        plan = op_cases.get(str(op))
+        if plan is not None:
+            plan.expected_failures.merge(selector)
 
 
-def _merge_case_file(op_cases: dict[str, OpCasePlan], data: dict[str, Any], backend: str) -> None:
-    _merge_model_ops(op_cases, data)
-    _merge_case_section(op_cases, _section(data, "all_frameworks_op_cases"))
+def _merge_case_file(
+    op_cases: dict[str, OpCasePlan],
+    data: dict[str, Any],
+    backend: str,
+    *,
+    allowed_ops: set[str] | None = None,
+    override_specific_selectors: bool = False,
+) -> None:
+    if allowed_ops is None:
+        _merge_model_ops(op_cases, data)
+    else:
+        model_ops = {str(op) for op in _as_list(data.get("model_ops"), field_name="model_ops")}
+        for op in sorted(model_ops & allowed_ops):
+            _ensure_op_plan(op_cases, op).include.all_cases = True
+    _merge_case_section(
+        op_cases,
+        _section(data, "all_frameworks_op_cases"),
+        allowed_ops=allowed_ops,
+        override_specific_selectors=override_specific_selectors,
+    )
     framework_cases = _section(data, "framework_specific_op_cases")
     backend_cases = framework_cases.get(backend, {})
     if backend_cases is None:
         return
     if not isinstance(backend_cases, dict):
         raise TypeError(f"framework_specific_op_cases.{backend} must be a mapping")
-    _merge_case_section(op_cases, backend_cases)
+    _merge_case_section(
+        op_cases,
+        backend_cases,
+        allowed_ops=allowed_ops,
+        override_specific_selectors=override_specific_selectors,
+    )
 
 
 def _merge_exception_file(op_cases: dict[str, OpCasePlan], data: dict[str, Any], backend: str) -> None:
@@ -495,6 +550,94 @@ def _load_model_case_files(
     return []
 
 
+def _base_case_file_ops(data: dict[str, Any], backend: str) -> set[str]:
+    """Return collectable op names exposed by one base case document."""
+
+    ops = {str(op) for op in _as_list(data.get("model_ops"), field_name="model_ops")}
+    ops.update(str(op) for op in _section(data, "all_frameworks_op_cases"))
+    framework_cases = _section(data, "framework_specific_op_cases")
+    backend_cases = framework_cases.get(backend, {})
+    if backend_cases is not None:
+        if not isinstance(backend_cases, dict):
+            raise TypeError(f"framework_specific_op_cases.{backend} must be a mapping")
+        ops.update(str(op) for op in backend_cases)
+    return ops
+
+
+def _selected_base_ops(
+    base_data_files: list[dict[str, Any]],
+    model_data: list[dict[str, Any]],
+    backend: str,
+    model_path: str | None,
+) -> set[str]:
+    """Resolve the shared recipe ops required by the selected model plans.
+
+    ``base_ops`` is an explicit allowlist.  Model files that only set
+    ``include_base: true`` receive the small universal set declared through
+    base-file ``model_ops``; they no longer activate every auxiliary recipe
+    merely because another base YAML was added to the repository.
+    """
+
+    available_ops: set[str] = set()
+    default_ops: set[str] = set()
+    for data in base_data_files:
+        available_ops.update(_base_case_file_ops(data, backend))
+        default_ops.update(str(op) for op in _as_list(data.get("model_ops"), field_name="model_ops"))
+
+    if not model_data:
+        return default_ops
+
+    selected: set[str] = set()
+    for data in model_data:
+        explicit = data.get("base_ops")
+        if explicit is not None:
+            selected.update(str(op) for op in _as_list(explicit, field_name="base_ops"))
+        elif bool(data.get("include_base", True)):
+            selected.update(default_ops)
+
+        framework_base_ops = data.get("framework_specific_base_ops", {})
+        if not isinstance(framework_base_ops, dict):
+            raise TypeError("framework_specific_base_ops must be a mapping")
+        backend_base_ops = framework_base_ops.get(backend, [])
+        selected.update(
+            str(op)
+            for op in _as_list(
+                backend_base_ops,
+                field_name=f"framework_specific_base_ops.{backend}",
+            )
+        )
+
+        model_specific_base_ops = data.get("model_specific_base_ops", {})
+        if not isinstance(model_specific_base_ops, dict):
+            raise TypeError("model_specific_base_ops must be a mapping")
+        if model_path is None:
+            # Full/raw plans collect the union needed by every listed artifact.
+            selected_model_specific_ops = model_specific_base_ops.values()
+        else:
+            selected_model_specific_ops = [model_specific_base_ops.get(model_path, [])]
+        for artifact_config in selected_model_specific_ops:
+            if isinstance(artifact_config, dict):
+                artifact_ops = artifact_config.get(backend, [])
+                field_name = f"model_specific_base_ops.<model_path>.{backend}"
+            else:
+                # A flat list remains valid for artifacts whose recipe applies
+                # to every backend exposing that base op.
+                artifact_ops = artifact_config
+                field_name = "model_specific_base_ops.<model_path>"
+            selected.update(
+                str(op)
+                for op in _as_list(
+                    artifact_ops,
+                    field_name=field_name,
+                )
+            )
+
+    unknown = selected - available_ops
+    if unknown:
+        raise ValueError(f"Unknown base_ops entries for backend {backend}: {sorted(unknown)}")
+    return selected
+
+
 def build_collection_case_plan(
     *,
     backend: str,
@@ -519,16 +662,15 @@ def build_collection_case_plan(
     if model_architecture is None and len(model_data) == 1:
         model_architecture = _model_case_architecture(model_data[0])
 
-    include_base = True
-    if len(model_data) == 1:
-        include_base = bool(model_data[0].get("include_base", True))
-
     op_cases: dict[str, OpCasePlan] = {}
-    if include_base:
-        for base_data in base_data_files:
-            _merge_case_file(op_cases, base_data, backend)
+    selected_base_ops = _selected_base_ops(base_data_files, model_data, backend, model_path)
+    for base_data in base_data_files:
+        _merge_case_file(op_cases, base_data, backend, allowed_ops=selected_base_ops)
     for data in model_data:
-        _merge_case_file(op_cases, data, backend)
+        # A targeted model may intentionally narrow a broad base recipe. Full
+        # mode is additive: a later model selector must not replace cases
+        # selected by an earlier model document.
+        _merge_case_file(op_cases, data, backend, override_specific_selectors=not full)
 
     resolved_sm_version = resolve_sm_version(gpu_type=gpu_type, sm_version=sm_version)
     resolved_sm_exceptions_path = None
@@ -789,20 +931,19 @@ def expected_failure_for_test_case(
     runtime_version: str | None = None,
     index: int = 0,
 ) -> dict[str, Any] | None:
-    """Return expected-failure metadata when an SM exception covers a failed case."""
+    """Return expected-failure metadata when a known exception covers a failed case."""
     if plan is None:
         return None
     case_id = create_test_case_id(test_case, run_func_name, full_module_name)
-    for source, selector in (("sm_exception", plan.exclude), ("known_exception", plan.expected_failures)):
-        details = _selector_match_details(
-            test_case,
-            case_id,
-            index,
-            selector,
-            runtime_version=runtime_version,
-        )
-        if details is not None:
-            return {"case_id": case_id, "source": source, **details}
+    details = _selector_match_details(
+        test_case,
+        case_id,
+        index,
+        plan.expected_failures,
+        runtime_version=runtime_version,
+    )
+    if details is not None:
+        return {"case_id": case_id, "source": "known_exception", **details}
     return None
 
 

--- a/collector/sglang/collect_attn.py
+++ b/collector/sglang/collect_attn.py
@@ -47,7 +47,7 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMo
 from collector.case_generator import (
     get_attention_context_shape_sweeps,
     get_attention_generation_shape_sweeps,
-    windows_for_head_dim,
+    get_attention_head_configs,
 )
 from collector.helper import benchmark_with_power, get_sm_version, log_perf
 
@@ -180,10 +180,6 @@ def _int_list(values):
     return [int(value) for value in values]
 
 
-def _kv_head_options(values, num_heads):
-    return [num_heads if value == "self" else int(value) for value in values]
-
-
 def get_context_attention_test_cases():
     test_cases = []
 
@@ -194,57 +190,51 @@ def get_context_attention_test_cases():
     for shape_sweep in get_attention_context_shape_sweeps("sglang"):
         batch_sizes = _int_list(shape_sweep["batch_sizes"])
         sequence_lengths = _int_list(shape_sweep["sequence_lengths"])
-        query_head_counts = _int_list(shape_sweep["query_head_counts"])
-        kv_head_options = shape_sweep["kv_head_options"]
-        head_dims = _int_list(shape_sweep["head_dims"])
-        window_sizes = _int_list(shape_sweep.get("window_sizes", [0]))
         max_tokens_self_attention = int(shape_sweep["max_tokens_self_attention"])
         max_tokens_grouped_query_attention = int(shape_sweep["max_tokens_grouped_query_attention"])
         max_batch_size_self_attention = int(shape_sweep["max_batch_size_self_attention"])
         max_kv_elements = int(shape_sweep["max_kv_elements"])
 
-        for head_dim in head_dims:
-            for n in sorted(query_head_counts, reverse=True):
-                for s in sorted(sequence_lengths, reverse=True):
-                    for b in sorted(batch_sizes, reverse=True):
-                        for num_kv_heads in _kv_head_options(kv_head_options, n):
-                            if num_kv_heads != n and (num_kv_heads >= n or n % num_kv_heads != 0):
-                                continue
+        for head_config in get_attention_head_configs(shape_sweep, phase="context"):
+            n = head_config.num_heads
+            num_kv_heads = head_config.num_kv_heads
+            head_dim = head_config.head_dim
+            window_size = head_config.window_size
+            for s in sorted(sequence_lengths, reverse=True):
+                for b in sorted(batch_sizes, reverse=True):
+                    if num_kv_heads == n:
+                        if b * s > max_tokens_self_attention or b > max_batch_size_self_attention:
+                            continue
+                    else:
+                        if b * s > max_tokens_grouped_query_attention:
+                            continue
+                    if b * s * num_kv_heads * head_dim * 2 >= max_kv_elements:
+                        continue
+                    # SGLang's SM120 Triton context attention path uses
+                    # 32-bit indexing for large Q/O tensors.  Shapes at or
+                    # above this element boundary crash with an illegal
+                    # memory access and poison the worker CUDA context.
+                    if sm_version >= 120 and b * s * n * head_dim >= max_kv_elements:
+                        continue
 
-                            if num_kv_heads == n:
-                                if b * s > max_tokens_self_attention or b > max_batch_size_self_attention:
-                                    continue
-                            else:
-                                if b * s > max_tokens_grouped_query_attention:
-                                    continue
-                            if b * s * num_kv_heads * head_dim * 2 >= max_kv_elements:
-                                continue
-                            # SGLang's SM120 Triton context attention path uses
-                            # 32-bit indexing for large Q/O tensors.  Shapes at or
-                            # above this element boundary crash with an illegal
-                            # memory access and poison the worker CUDA context.
-                            if sm_version >= 120 and b * s * n * head_dim >= max_kv_elements:
-                                continue
-
-                            for window_size in windows_for_head_dim(window_sizes, head_dim):
-                                for precision_case in shape_sweep["precision_cases"]:
-                                    use_fp8_kv_cache = bool(precision_case["fp8_kv_cache"])
-                                    use_fp8_context_fmha = bool(precision_case["fp8_context_fmha"])
-                                    if skip_fp8 and use_fp8_kv_cache:
-                                        continue
-                                    test_cases.append(
-                                        [
-                                            b,
-                                            s,
-                                            n,
-                                            num_kv_heads,
-                                            head_dim,
-                                            use_fp8_kv_cache,
-                                            use_fp8_context_fmha,
-                                            True,
-                                            window_size,
-                                        ]
-                                    )
+                    for precision_case in shape_sweep["precision_cases"]:
+                        use_fp8_kv_cache = bool(precision_case["fp8_kv_cache"])
+                        use_fp8_context_fmha = bool(precision_case["fp8_context_fmha"])
+                        if skip_fp8 and use_fp8_kv_cache:
+                            continue
+                        test_cases.append(
+                            [
+                                b,
+                                s,
+                                n,
+                                num_kv_heads,
+                                head_dim,
+                                use_fp8_kv_cache,
+                                use_fp8_context_fmha,
+                                True,
+                                window_size,
+                            ]
+                        )
 
     return test_cases
 
@@ -281,60 +271,35 @@ def get_generation_attention_test_cases():
     for shape_sweep in get_attention_generation_shape_sweeps("sglang"):
         batch_sizes = _int_list(shape_sweep["batch_sizes"])
         sequence_lengths = _int_list(shape_sweep["sequence_lengths"])
-        head_dims = _int_list(shape_sweep["head_dims"])
-        window_sizes = _int_list(shape_sweep.get("window_sizes", [0]))
         min_drop_batch = int(shape_sweep["drop_largest_sequence_for_batch_at_least"])
-
-        for head_dim in head_dims:
-            for n in sorted(_int_list(shape_sweep["mha_query_head_counts"]), reverse=True):
-                b_s_dict = _generation_target_sequence_lengths(
-                    batch_sizes,
-                    sequence_lengths,
-                    n,
-                    head_dim,
-                    int(shape_sweep["max_mha_tokens_per_step"]),
-                    shape_sweep,
-                )
-
-                for b, s_list_limited in b_s_dict.items():
-                    target_s_list = sorted(s_list_limited)
-                    if b >= min_drop_batch:
-                        target_s_list = target_s_list[:-1]
-                    for s in target_s_list:
-                        for window_size in windows_for_head_dim(window_sizes, head_dim):
-                            for precision_case in shape_sweep["precision_cases"]:
-                                use_fp8_kv_cache = bool(precision_case["fp8_kv_cache"])
-                                if skip_fp8 and use_fp8_kv_cache:
-                                    continue
-                                test_cases.append([b, s, n, n, head_dim, use_fp8_kv_cache, False, False, window_size])
-
-        for head_dim in head_dims:
-            for n in sorted(_int_list(shape_sweep["xqa_query_head_counts"]), reverse=True):
-                b_s_dict = _generation_target_sequence_lengths(
-                    batch_sizes,
-                    sequence_lengths,
-                    n,
-                    head_dim,
-                    int(shape_sweep["max_xqa_tokens_per_step"]),
-                    shape_sweep,
-                )
-
-                for b, s_list_limited in b_s_dict.items():
-                    target_s_list = sorted(s_list_limited)
-                    if b >= min_drop_batch:
-                        target_s_list = target_s_list[:-1]
-                    for n_kv in _int_list(shape_sweep["kv_head_counts"]):
-                        if n_kv >= n:
+        for head_config in get_attention_head_configs(shape_sweep, phase="generation"):
+            n = head_config.num_heads
+            n_kv = head_config.num_kv_heads
+            head_dim = head_config.head_dim
+            window_size = head_config.window_size
+            max_tokens = (
+                int(shape_sweep["max_mha_tokens_per_step"])
+                if n == n_kv
+                else int(shape_sweep["max_xqa_tokens_per_step"])
+            )
+            b_s_dict = _generation_target_sequence_lengths(
+                batch_sizes,
+                sequence_lengths,
+                n,
+                head_dim,
+                max_tokens,
+                shape_sweep,
+            )
+            for b, s_list_limited in b_s_dict.items():
+                target_s_list = sorted(s_list_limited)
+                if b >= min_drop_batch:
+                    target_s_list = target_s_list[:-1]
+                for s in target_s_list:
+                    for precision_case in shape_sweep["precision_cases"]:
+                        use_fp8_kv_cache = bool(precision_case["fp8_kv_cache"])
+                        if skip_fp8 and use_fp8_kv_cache:
                             continue
-                        for s in target_s_list:
-                            for window_size in windows_for_head_dim(window_sizes, head_dim):
-                                for precision_case in shape_sweep["precision_cases"]:
-                                    use_fp8_kv_cache = bool(precision_case["fp8_kv_cache"])
-                                    if skip_fp8 and use_fp8_kv_cache:
-                                        continue
-                                    test_cases.append(
-                                        [b, s, n, n_kv, head_dim, use_fp8_kv_cache, False, False, window_size]
-                                    )
+                        test_cases.append([b, s, n, n_kv, head_dim, use_fp8_kv_cache, False, False, window_size])
     return test_cases
 
 

--- a/collector/sglang/collect_attn_encoder.py
+++ b/collector/sglang/collect_attn_encoder.py
@@ -19,7 +19,7 @@ from typing import NamedTuple
 import pkg_resources
 import torch
 
-from collector.case_generator import get_attention_encoder_shape_sweeps
+from collector.case_generator import get_attention_encoder_head_configs, get_attention_encoder_shape_sweeps
 from collector.helper import benchmark_with_power, get_sm_version, log_perf
 
 
@@ -37,19 +37,18 @@ def get_encoder_attention_test_cases():
     for shape_sweep in get_attention_encoder_shape_sweeps("sglang"):
         batch_sizes = _int_list(shape_sweep["batch_sizes"])
         sequence_lengths = _int_list(shape_sweep["sequence_lengths"])
-        head_counts = _int_list(shape_sweep["head_counts"])
-        head_dims = _int_list(shape_sweep["head_dims"])
 
-        for head_dim in head_dims:
-            for n in sorted(head_counts):
-                for s in sorted(sequence_lengths):
-                    for b in sorted(batch_sizes):
-                        # Workload token budget (128K) + 32-bit indexing safety.
-                        if b * s > 131072:
-                            continue
-                        if 4 * b * s * n * head_dim * 2 >= 2**31:
-                            continue
-                        test_cases.append([b, s, n, head_dim])
+        for head_config in get_attention_encoder_head_configs(shape_sweep):
+            n = head_config.num_heads
+            head_dim = head_config.head_dim
+            for s in sorted(sequence_lengths):
+                for b in sorted(batch_sizes):
+                    # Workload token budget (128K) + 32-bit indexing safety.
+                    if b * s > 131072:
+                        continue
+                    if 4 * b * s * n * head_dim * 2 >= 2**31:
+                        continue
+                    test_cases.append([b, s, n, head_dim])
 
     return test_cases
 

--- a/collector/sglang/collect_mla.py
+++ b/collector/sglang/collect_mla.py
@@ -27,6 +27,7 @@ from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.mem_cache.memory_pool import MLATokenToKVPool, ReqToTokenPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 
+from collector.case_generator import get_context_mla_case_specs, get_generation_mla_case_specs
 from collector.helper import benchmark_with_power, get_sm_version, log_perf
 from collector.registry_types import PerfFile
 
@@ -228,33 +229,11 @@ def get_context_mla_test_cases():
 
     backend = _select_default_mla_backend()
     dtype_list = [torch.bfloat16] if backend == "triton" else [torch.bfloat16, torch.float8_e4m3fn]
-    test_cases = []
-    n_list = [64, 128]
-    b_list = [1, 2, 4, 8, 16, 32, 64, 128, 256]
-    s_list = [1, 16, 32, 64, 128, 256, 512, 1024, 1536, 2048, 3072, 4096, 6144, 8192, 10240, 12288, 16384, 32768]
-    for n in n_list:
-        for b in b_list:
-            for s in s_list:
-                for dtype in dtype_list:
-                    for tp_size in [1, 2, 4, 8, 16, 32, 64]:
-                        if b * s > 65536:
-                            continue
-                        test_cases.append(
-                            [
-                                s,
-                                b,
-                                1,
-                                dtype,
-                                n,
-                                tp_size,
-                                tp_size,
-                                64,
-                                10,
-                                6,
-                                True,
-                            ]
-                        )
-    return test_cases
+    return _build_mla_test_cases(
+        get_context_mla_case_specs(),
+        dtype_list=dtype_list,
+        tp_sizes=(1, 2, 4, 8, 16, 32, 64),
+    )
 
 
 def get_generation_mla_test_cases():
@@ -269,59 +248,86 @@ def get_generation_mla_test_cases():
         dtype_list = [torch.bfloat16]
     else:
         dtype_list = [torch.bfloat16, torch.float8_e4m3fn]
-    test_cases = []
-    n_list = [64, 128]
-    for n in n_list:
-        for b in [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024]:
-            for s in [
-                2,
-                4,
-                8,
-                16,
-                32,
-                64,
-                128,
-                256,
-                512,
-                1024,
-                2048,
-                4096,
-                8192,
-                16384,
-                32768,
-                65536,
-                131072,
-            ]:
-                for dtype in dtype_list:
-                    for tp_size in [1, 2, 4, 8, 16, 32, 64]:
-                        if backend == "trtllm_mla" and sm_version == 120 and n // tp_size != 128:
-                            # XQA MLA kernel has head_group_ratio=128 hardcoded; it always reads
-                            # 128 Q heads from the q tensor regardless of the runtime head count.
-                            # local_heads != 128 causes out-of-bounds GPU memory reads and crashes.
-                            # Only n=128, tp=1 (local_heads=128) is safe.
-                            continue
-                        if b * s > 1024 * 4096 * 4:
-                            continue
-                        total_len = s
-                        # Guard against hitting int32 limits in the legacy flashmla kernel path.
-                        if (b * total_len) + MLA_PAGE_SIZE > MAX_KV_LOC:
-                            continue
-                        test_cases.append(
-                            [
-                                s - 1,
-                                b,
-                                1,
-                                dtype,
-                                n,
-                                tp_size,
-                                tp_size,
-                                64,
-                                10,
-                                6,
-                                False,
-                            ]
-                        )
-    return test_cases
+    return _build_mla_test_cases(
+        get_generation_mla_case_specs(),
+        dtype_list=dtype_list,
+        tp_sizes=(1, 2, 4, 8, 16, 32, 64),
+        backend=backend,
+        sm_version=sm_version,
+    )
+
+
+def _build_mla_test_cases(case_specs, *, dtype_list, tp_sizes, backend=None, sm_version=None):
+    """Adapt the shared YAML MLA catalog to SGLang's legacy run tuple.
+
+    The perf DB key does not contain a model name, so model aliases that resolve
+    to the same physical shape are emitted once.  SGLang's standalone MLA
+    harness currently supports the DeepSeek/Kimi geometry declared below; fail
+    loudly if a future catalog entry needs a different kernel layout instead of
+    silently collecting it under the wrong DB key.
+    """
+
+    cases_by_physical_key = {}
+    expected_geometry = (KV_LORA_RANK, QK_NOPE_HEAD_DIM, QK_ROPE_HEAD_DIM, 128)
+    for spec in case_specs:
+        geometry = (spec.kv_lora_rank, spec.qk_nope_head_dim, spec.qk_rope_head_dim, spec.v_head_dim)
+        if geometry != expected_geometry:
+            raise ValueError(f"Unsupported SGLang MLA geometry for {spec.model_name}: {geometry}")
+        if spec.kv_cache_block_size != MLA_PAGE_SIZE:
+            raise ValueError(
+                f"Unsupported SGLang MLA page size for {spec.model_name}: "
+                f"{spec.kv_cache_block_size} (expected {MLA_PAGE_SIZE})"
+            )
+
+        for dtype in dtype_list:
+            for tp_size in tp_sizes:
+                if spec.num_heads % tp_size:
+                    continue
+                if (
+                    not spec.is_context_phase
+                    and backend == "trtllm_mla"
+                    and sm_version == 120
+                    and spec.num_heads // tp_size != 128
+                ):
+                    # XQA MLA kernel has head_group_ratio=128 hardcoded; it always reads
+                    # 128 Q heads from the q tensor regardless of the runtime head count.
+                    # local_heads != 128 causes out-of-bounds GPU memory reads and crashes.
+                    continue
+                if not spec.is_context_phase and (spec.batch_size * (spec.input_len + 1)) + MLA_PAGE_SIZE > MAX_KV_LOC:
+                    # Guard against int32 overflow in the legacy flashmla kernel path.
+                    continue
+
+                case = (
+                    spec.input_len,
+                    spec.batch_size,
+                    1,
+                    dtype,
+                    spec.num_heads,
+                    tp_size,
+                    tp_size,
+                    spec.kv_cache_block_size,
+                    10,
+                    6,
+                    spec.is_context_phase,
+                )
+                # This is the exact loader key (phase/file and backend are fixed
+                # for one getter).  Total heads and TP are only two ways to
+                # produce the same local-head kernel shape and are not stored by
+                # load_{context,generation}_mla_data.
+                physical_key = (
+                    dtype,
+                    spec.num_heads // tp_size,
+                    spec.batch_size,
+                    spec.input_len,
+                )
+                # Selectors run after getter population and commonly cap TP.
+                # Keep the equivalent representation with the smallest TP so
+                # deduplication cannot hide a local-head point from a targeted
+                # TP<=N plan.
+                existing = cases_by_physical_key.get(physical_key)
+                if existing is None or tp_size < existing[6]:
+                    cases_by_physical_key[physical_key] = list(case)
+    return list(cases_by_physical_key.values())
 
 
 def run_mla(

--- a/collector/sglang/collect_mla_module.py
+++ b/collector/sglang/collect_mla_module.py
@@ -50,10 +50,14 @@ except ModuleNotFoundError:
     from helper import benchmark_with_power, get_sm_version, log_perf
 
 try:
-    from collector.case_generator import get_mla_module_model_specs, get_mla_module_sweep_spec
+    from collector.case_generator import (
+        get_mla_module_model_specs,
+        get_mla_module_precision_specs,
+        get_mla_module_sweep_spec,
+    )
 except ModuleNotFoundError:
     sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-    from case_generator import get_mla_module_model_specs, get_mla_module_sweep_spec
+    from case_generator import get_mla_module_model_specs, get_mla_module_precision_specs, get_mla_module_sweep_spec
 
 try:
     from collector.sglang.runtime_limits import (
@@ -280,43 +284,16 @@ def _resolve_local_model_path(model_id: str) -> str:
 # ═══════════════════════════════════════════════════════════════════════
 
 
-def _get_precision_combos(phase: str, model_id: str | None = None):
-    """Return (compute_dtype, kv_cache_dtype, gemm_type) triples for a phase.
-
-    All strings are perf-database-compatible (not SGLang-native).
-
-    SGLang precision axes:
-      compute_dtype:  always "bfloat16" (DSA / NSA kernels run bf16 FMHA;
-                      on B200 decode with fp8 KV the trtllm path runs fp8
-                      FMHA internally, but the latency is captured under the
-                      fp8 KV row).
-      kv_cache_dtype: "bfloat16" always; "fp8" on SM >= 90 (Hopper+).
-      gemm_type:      "bfloat16" for bf16 weights; "fp8_block" on SM >= 89,
-                      in which case load_model_runner launches sglang with
-                      quantization="fp8" so the inner attention projections
-                      (q_b_proj, kv_b_proj, o_proj, wq_b, wk) and the fp8
-                      paged MQA scoring kernel fire on real fp8 weights.
-
-    fp4_e2m1 omitted — SGLang supports it on SM >= 100, but KVCacheQuantMode
-    enum has no fp4 entry, so perf_database cannot consume it yet.
-    """
-    sm = get_sm_version()
-    kv_dtypes = ["bfloat16"]
-    if sm >= 90:
-        kv_dtypes.append("fp8")
-    combos = [("bfloat16", kv, "bfloat16") for kv in kv_dtypes]
-    if sm >= 89:
-        # GLM5-NVFP4 / DSV4 are modelopt NVFP4 models -> use nvfp4 gemm
-        # (quantization=modelopt_fp4, native hf_quant_config) to MATCH serve
-        # (--quantization modelopt_fp4). attention proj are NVFP4-excluded
-        # (bf16) so the bf16 combo above still covers the proj path.
-        combos += [("bfloat16", kv, "nvfp4") for kv in kv_dtypes]
-    # GLM5-NVFP4 weights ARE nvfp4 -> the bf16-gemm combos are meaningless and
-    # just duplicate the case. Serve runs --quantization modelopt_fp4, so for
-    # GLM5 DSA collect ONLY the nvfp4 combos. Hardcoded (no env gate).
-    if model_id is not None and _is_glm5_dsa_model(model_id):
-        combos = [c for c in combos if c[2] == "nvfp4"]
-    return combos
+def _get_precision_combos(phase: str):
+    """Return YAML-backed operator precision triples for one phase and SM."""
+    return [
+        (spec.compute_dtype, spec.kv_cache_dtype, spec.gemm_type)
+        for spec in get_mla_module_precision_specs(
+            "sglang",
+            phase=phase,
+            sm_version=get_sm_version(),
+        )
+    ]
 
 
 def _get_backends(attn_type: str):
@@ -429,22 +406,6 @@ def get_generation_test_cases(attn_type: str):
                         continue
                     cases.append([seq_len, batch_size, num_heads, kv_dtype, compute_dtype, gemm_type])
     return cases
-
-
-def _get_module_precision_combos():
-    """Return a single baseline precision combo for module-level benchmarks.
-
-    Module benchmarks spawn a subprocess per (model, precision, heads) group.
-    Each subprocess loads a full ModelRunner (~15-20 s), so fewer groups means
-    faster overall collection.  Use a single bfloat16 baseline — matching the
-    wideep MLA pattern — so the total subprocess count stays manageable.
-
-    Precision-specific kernel performance is already captured by kernel-level
-    collectors (collect_mla.py, collect_attn.py).  The module benchmark
-    captures module-level overhead (scheduling, memory management, attention
-    dispatch) which is largely precision-independent with dummy weights.
-    """
-    return get_mla_module_sweep_spec("sglang").module_precision_combos
 
 
 def _model_max_position_embeddings(model_id: str) -> int | None:
@@ -594,6 +555,7 @@ def _build_module_test_cases(attn_type: str, mode: str):
         return []
     model_specs = get_mla_module_model_specs(attention_type=attn_type)
     sweep = get_mla_module_sweep_spec("sglang")
+    precision_combos = _get_precision_combos(mode)
     cases = []
     for model_spec in model_specs:
         # Each checkpoint ships at one native precision; only enumerate the
@@ -601,7 +563,7 @@ def _build_module_test_cases(attn_type: str, mode: str):
         # Prevents e.g. gemm_type=fp8_block being applied to the NVFP4 checkpoint
         # (a different model), which dies at model load with "Cannot find quant_algo".
         native_quant = _model_native_gemm_quant(model_spec.model_path)
-        for compute_dtype, kv_dtype, gemm_type in _get_module_precision_combos():
+        for compute_dtype, kv_dtype, gemm_type in precision_combos:
             if not _gemm_type_supported_by_model(gemm_type, native_quant):
                 continue
             target_tps = sweep.module_tp_sizes if attn_type == "dsa" else [1]
@@ -2597,7 +2559,7 @@ def main():
                 else [h for h in get_mla_module_sweep_spec("sglang").inner_sweep_head_counts if h <= native_heads]
             )
 
-            for compute_dtype, kv_dtype, gemm_type in _get_precision_combos(args.mode, model_path):
+            for compute_dtype, kv_dtype, gemm_type in _get_precision_combos(args.mode):
                 if args.kv_cache_dtype and kv_dtype != args.kv_cache_dtype:
                     continue
 

--- a/collector/sglang/collect_moe.py
+++ b/collector/sglang/collect_moe.py
@@ -12,6 +12,7 @@ rank-local workload construction, quantized weight setup, and perf logging.
 import inspect
 import itertools
 import os
+from contextlib import contextmanager, nullcontext
 from typing import TypedDict
 from unittest.mock import MagicMock
 
@@ -111,7 +112,11 @@ except ImportError:
     pass
 
 try:
-    from case_generator import get_common_moe_test_cases, moe_model_allows_quantization
+    from case_generator import (
+        get_common_moe_test_cases,
+        get_moe_quantization_module_config,
+        moe_model_allows_quantization,
+    )
 
     from helper import (
         balanced_logits,
@@ -126,7 +131,11 @@ except ModuleNotFoundError:
     import sys
 
     sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-    from case_generator import get_common_moe_test_cases, moe_model_allows_quantization
+    from case_generator import (
+        get_common_moe_test_cases,
+        get_moe_quantization_module_config,
+        moe_model_allows_quantization,
+    )
 
     from helper import (
         balanced_logits,
@@ -158,6 +167,12 @@ def _make_moe_runner_config(swiglu_limit: float | None = None) -> MoeRunnerConfi
 
 def _uses_relu2_moe_activation(model_name: str) -> bool:
     return any(pattern in model_name for pattern in _NON_GATED_MOE_MODEL_PATTERNS)
+
+
+def _mxfp4_activation_precision(moe_type: str) -> str:
+    """Map the persisted quant label to SGLang's explicit activation mode."""
+
+    return "bf16" if moe_type == "w4a16_mxfp4" else "default"
 
 
 def get_moe_test_cases():
@@ -206,21 +221,6 @@ def get_moe_test_cases():
 
         for moe_type, num_tokens in itertools.product(model_moe_list, num_tokens_list):
             if not moe_model_allows_quantization("sglang", model_name, moe_type):
-                continue
-            # Native DeepSeek-V4 detection by config-derived architecture (not a
-            # model_name string pattern), so aliased/FP8 variants like
-            # sgl-project/DeepSeek-V4-Pro-FP8 are still recognized.
-            is_native_dsv4 = common_moe_testcase.architecture == "DeepseekV4ForCausalLM"
-            if is_native_dsv4 and moe_type == "w4a8_mxfp4_mxfp8" and num_tokens > 8192:
-                # DeepSeek-V4 FP4 experts are only exercised up to the SGLang
-                # prefill chunk size. Larger synthetic masked-CuteDSL cases
-                # allocate per-expert temporary buffers that exceed GB300 memory.
-                continue
-            if moe_type == "nvfp4" and is_native_dsv4:
-                # Native DeepSeek-V4 experts are queried by AIC as
-                # w4a8_mxfp4_mxfp8.  The SGLang kernel path is the same FP4
-                # FlashInfer/CuteDSL path, but the perf row must use the AIC
-                # quant-mode name so silicon lookup can find it.
                 continue
             if (
                 sm_version >= 120
@@ -565,7 +565,7 @@ def get_moe_test_cases():
                 # requires 144 KiB shared memory, above the 99 KiB limit.
                 continue
 
-            if moe_type in ("nvfp4", "w4a8_mxfp4_mxfp8"):
+            if moe_type == "nvfp4":
                 shard_k = common_moe_testcase.inter_size // common_moe_testcase.tp
                 # fp4_quantize requires weight dims divisible by 16 after TP sharding.
                 # CuteDSL grouped GEMM additionally requires 16-byte contiguous alignment:
@@ -575,14 +575,15 @@ def get_moe_test_cases():
                 if shard_k % 32 != 0:
                     continue
 
-            # int4_wo (W4A16): packed K dims must be divisible by group_size (128).
-            # w1 packed K = hidden_size // 2  → need hidden_size % 256 == 0
-            # w2 packed K = shard_inter // 4 = inter_size // (2*tp) → need (inter_size // tp) % 256 == 0
-            if moe_type == "int4_wo" and (
-                common_moe_testcase.hidden_size % 256 != 0
-                or (common_moe_testcase.inter_size // common_moe_testcase.tp) % 256 != 0
-            ):
-                continue
+            if moe_type == "int4_wo":
+                int4_group_size = int(
+                    get_moe_quantization_module_config("sglang", moe_type, model_name=model_name).get("group_size", 128)
+                )
+                if (
+                    common_moe_testcase.hidden_size % int4_group_size != 0
+                    or (common_moe_testcase.inter_size // common_moe_testcase.tp) % int4_group_size != 0
+                ):
+                    continue
             if moe_type == "int4_wo" and common_moe_testcase.topk > (
                 common_moe_testcase.num_experts // common_moe_testcase.ep
             ):
@@ -610,26 +611,8 @@ def get_moe_test_cases():
                 common_moe_testcase.token_expert_distribution,
                 common_moe_testcase.power_law_alpha,
                 swiglu_limit,
-                "",  # moe_backend: "" = default (CuteDSL for w4a8_mxfp4_mxfp8)
             ]
             test_cases.append(base_case)
-
-            # DeepSeek-V4 production runs the trtllm-gen MXFP4xMXFP8 MoE kernel,
-            # NOT CuteDSL. Collect that kernel too (same w4a8_mxfp4_mxfp8 dtype,
-            # kernel_source=sglang_mxfp4_flashinfer_trtllm_moe). Single-rank
-            # (ep==1) synthetic case, matching the trtllm routed-moe bench path.
-            # Restrict to tp<=8: the trtllm-gen kernel asserts on the tiny
-            # per-rank intermediate sizes produced at tp16/32 (and the reference
-            # trtllm grid only covers tp 1/2/4/8 too).
-            if (
-                is_native_dsv4
-                and moe_type == "w4a8_mxfp4_mxfp8"
-                and common_moe_testcase.ep == 1
-                and common_moe_testcase.tp <= 8
-            ):
-                trtllm_case = list(base_case)
-                trtllm_case[-1] = "trtllm_mxfp4"
-                test_cases.append(trtllm_case)
 
     return test_cases
 
@@ -656,7 +639,6 @@ def benchmark_config(
     use_int8_w8a16: bool,
     use_nvfp4: bool = False,
     use_trtllm_bf16_fp4: bool = False,
-    use_trtllm_mxfp4: bool = False,
     use_int4_w4a16: bool = False,
     use_mxfp4_w4a16: bool = False,
     use_mxfp4_w4a8: bool = False,
@@ -917,131 +899,6 @@ def benchmark_config(
                 tune_max_num_tokens=tune_max_num_tokens,
             )
 
-    elif use_trtllm_mxfp4 and workloads is None:
-        # DeepSeek-V4 production MoE path on Blackwell: MXFP4 weights (E2M1,
-        # block-32 E8M0 scales) x MXFP8 (E4M3) activations through the trtllm-gen
-        # routed kernel. Mirrors sglang Mxfp4FlashinferTrtllmMoEMethod
-        # (mxfp4_flashinfer_trtllm_moe.py): weights are int8 (hidden//2 packed),
-        # scales are block-32 cast to e8m0 then shuffled with shuffle_matrix_a /
-        # shuffle_matrix_sf_a (epilogue_tile_m=128), activations quantized with
-        # mxfp8_quantize. This is a DIFFERENT kernel from CuteDSL
-        # (sglang_flashinfer_cutedsl_moe) which the plain w4a8_mxfp4_mxfp8 uses.
-        from flashinfer import mxfp8_quantize, shuffle_matrix_a, shuffle_matrix_sf_a
-        from flashinfer.fused_moe import trtllm_fp4_block_scale_routed_moe
-        from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
-            _pack_topk_for_flashinfer_routed,
-        )
-
-        if hidden_size % 32 != 0 or (shard_intermediate_size // 2) % 32 != 0:
-            raise ValueError(
-                "TRTLLM MXFP4 MoE requires hidden and intermediate dims divisible by 32, "
-                f"got hidden_size={hidden_size}, intermediate_size={shard_intermediate_size // 2}"
-            )
-
-        fp4_block_k = 32
-        epilogue_tile_m = 128
-        intermediate_size = shard_intermediate_size // 2
-        x = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device)
-        router_logits_list = (
-            gating_output
-            if isinstance(gating_output, list)
-            else [gating_output[i] for i in range(gating_output.shape[0])]
-        )
-
-        # Dummy MXFP4 expert weights (E2M1 packed -> hidden//2) + block-32 scales.
-        w13 = torch.randint(
-            0,
-            256,
-            (num_experts, shard_intermediate_size, hidden_size // 2),
-            dtype=torch.uint8,
-            device=device,
-        )
-        w2 = torch.randint(
-            0,
-            256,
-            (num_experts, hidden_size, intermediate_size // 2),
-            dtype=torch.uint8,
-            device=device,
-        )
-        w13_scale = torch.ones(
-            (num_experts, shard_intermediate_size, hidden_size // fp4_block_k),
-            dtype=torch.float32,
-            device=device,
-        ).to(torch.float8_e8m0fnu)
-        w2_scale = torch.ones(
-            (num_experts, hidden_size, intermediate_size // fp4_block_k),
-            dtype=torch.float32,
-            device=device,
-        ).to(torch.float8_e8m0fnu)
-
-        # Shuffle weights/scales into the trtllm-gen kernel layout (matches
-        # mxfp4_flashinfer_trtllm_moe.process_weights_after_loading non-official path).
-        g1w, g1s, g2w, g2s = [], [], [], []
-        for e in range(num_experts):
-            g1w.append(shuffle_matrix_a(w13[e].view(torch.uint8), epilogue_tile_m))
-            g1s.append(shuffle_matrix_sf_a(w13_scale[e].view(torch.uint8), epilogue_tile_m))
-            g2w.append(shuffle_matrix_a(w2[e].view(torch.uint8), epilogue_tile_m))
-            g2s.append(shuffle_matrix_sf_a(w2_scale[e].view(torch.uint8), epilogue_tile_m))
-        w13 = torch.stack(g1w)
-        w13_scale = torch.stack(g1s).view(torch.float8_e4m3fn).reshape(num_experts, shard_intermediate_size, -1)
-        w2 = torch.stack(g2w)
-        w2_scale = torch.stack(g2s).view(torch.float8_e4m3fn).reshape(num_experts, hidden_size, -1)
-
-        output = torch.empty(num_tokens, hidden_size, dtype=torch.bfloat16, device=device)
-        scale_ones = torch.ones(num_experts, dtype=torch.float32, device=device)
-        tune_max_num_tokens = max(1, 1 << (num_tokens - 1).bit_length())
-        topk_config = TopKConfig(
-            top_k=topk,
-            renormalize=True,
-            scoring_func="sigmoid",
-            routed_scaling_factor=1.0,
-        )
-        packed_topk_list = []
-        for logits in router_logits_list:
-            topk_output = select_experts(x, logits, topk_config)
-            packed_topk_list.append(
-                _pack_topk_for_flashinfer_routed(
-                    topk_output.topk_ids,
-                    topk_output.topk_weights,
-                )
-            )
-        torch.cuda.synchronize()
-
-        def run_op(i):
-            x_quant, x_scale = mxfp8_quantize(x, False, alignment=hidden_size)
-            x_scale = x_scale.view(torch.float8_e4m3fn).reshape(*x.shape[:-1], -1)
-            packed_topk = packed_topk_list[i % len(packed_topk_list)]
-            trtllm_fp4_block_scale_routed_moe(
-                topk_ids=packed_topk,
-                routing_bias=None,
-                hidden_states=x_quant,
-                hidden_states_scale=x_scale,
-                gemm1_weights=w13,
-                gemm1_weights_scale=w13_scale,
-                gemm1_bias=None,
-                gemm1_alpha=None,
-                gemm1_beta=None,
-                gemm1_clamp_limit=None,
-                gemm2_weights=w2,
-                gemm2_weights_scale=w2_scale,
-                gemm2_bias=None,
-                output1_scale_scalar=scale_ones,
-                output1_scale_gate_scalar=scale_ones,
-                output2_scale_scalar=scale_ones,
-                num_experts=num_experts,
-                top_k=packed_topk.shape[1],
-                n_group=1,
-                topk_group=1,
-                intermediate_size=intermediate_size,
-                local_expert_offset=0,
-                local_num_experts=num_experts,
-                routed_scaling_factor=1.0,
-                routing_method_type=1,
-                do_finalize=True,
-                output=output,
-                tune_max_num_tokens=tune_max_num_tokens,
-            )
-
     elif use_nvfp4:
         if not HAS_FLASHINFER_CUTE:
             raise ImportError("FlashInfer CuteDSL not available")
@@ -1115,32 +972,41 @@ def benchmark_config(
                 masked_m=masked_m_list[i % num_iters],
             )
     elif use_mxfp4_moe:
+        # Reuse SGLang 0.5.10's production Mxfp4Config/FusedMoE path. It owns
+        # the exact FlashInfer API, weight layout, TP padding, and EP-local
+        # expert mapping for both W4A16 and W4A8.
         if not _HAS_SGLANG_MXFP4:
             raise ImportError("SGLang MXFP4 MoE support is not available")
         if workloads is not None:
             raise ValueError("MXFP4 benchmarking uses full-router logits, not rank-local workloads")
 
         previous_backend = _moe_utils.MOE_RUNNER_BACKEND
+        server_args = _server_args_module._global_server_args
+        previous_precision = server_args.flashinfer_mxfp4_moe_precision
         _moe_utils.MOE_RUNNER_BACKEND = MoeRunnerBackend.FLASHINFER_MXFP4
-        _patch_mxfp4_single_process_parallel(moe_tp_size=moe_tp_size, moe_ep_size=moe_ep_size)
-
-        intermediate_size = shard_intermediate_size // 2 * moe_tp_size
-        mxfp4_config_kwargs = {}
-        if "is_checkpoint_mxfp4_serialized" in inspect.signature(Mxfp4Config).parameters:
-            mxfp4_config_kwargs["is_checkpoint_mxfp4_serialized"] = True
-        quant_config = Mxfp4Config(**mxfp4_config_kwargs)
-        moe_layer = FusedMoE(
-            num_experts=num_experts,
-            hidden_size=hidden_size,
-            intermediate_size=intermediate_size,
-            layer_id=0,
-            top_k=topk,
-            params_dtype=dtype,
-            reduce_results=False,
-            quant_config=quant_config,
-            prefix="aic_sglang_mxfp4_moe",
-        ).to(device)
-        _moe_utils.MOE_RUNNER_BACKEND = previous_backend
+        server_args.flashinfer_mxfp4_moe_precision = _mxfp4_activation_precision(
+            "w4a16_mxfp4" if use_mxfp4_w4a16 else "w4a8_mxfp4_mxfp8"
+        )
+        try:
+            intermediate_size = shard_intermediate_size // 2 * moe_tp_size
+            mxfp4_config_kwargs = {}
+            if "is_checkpoint_mxfp4_serialized" in inspect.signature(Mxfp4Config).parameters:
+                mxfp4_config_kwargs["is_checkpoint_mxfp4_serialized"] = True
+            quant_config = Mxfp4Config(**mxfp4_config_kwargs)
+            moe_layer = FusedMoE(
+                num_experts=num_experts,
+                hidden_size=hidden_size,
+                intermediate_size=intermediate_size,
+                layer_id=0,
+                top_k=topk,
+                params_dtype=dtype,
+                reduce_results=False,
+                quant_config=quant_config,
+                prefix="aic_sglang_mxfp4_moe",
+            ).to(device)
+        finally:
+            _moe_utils.MOE_RUNNER_BACKEND = previous_backend
+            server_args.flashinfer_mxfp4_moe_precision = previous_precision
 
         with torch.no_grad():
             moe_layer.w13_weight.zero_()
@@ -1322,21 +1188,37 @@ def benchmark_config(
     return results["latency_ms"] / outside_loop_count, results["power_stats"]
 
 
-def _patch_mxfp4_single_process_parallel(*, moe_tp_size: int, moe_ep_size: int) -> None:
-    """Patch SGLang distributed helpers so a collector process can time rank-0 MoE."""
+@contextmanager
+def _patch_mxfp4_single_process_parallel(*, moe_tp_size: int, moe_ep_size: int):
+    """Temporarily patch SGLang distributed helpers for a rank-0 MoE benchmark."""
 
-    for module in (_moe_layer_mod, _std_dispatch_mod, _mxfp4_mod):
-        if hasattr(module, "get_tp_group"):
-            module.get_tp_group = lambda: None
-        if hasattr(module, "is_allocation_symmetric"):
-            module.is_allocation_symmetric = lambda: False
-    _moe_layer_mod.get_moe_expert_parallel_world_size = lambda: moe_ep_size
-    _moe_layer_mod.get_moe_expert_parallel_rank = lambda: 0
-    _moe_layer_mod.get_moe_tensor_parallel_world_size = lambda: moe_tp_size
-    _moe_layer_mod.get_moe_tensor_parallel_rank = lambda: 0
-    _moe_layer_mod.create_kt_config_from_server_args = lambda server_args, layer_id: None
-    _std_dispatch_mod.get_moe_expert_parallel_world_size = lambda: moe_ep_size
-    _std_dispatch_mod.get_moe_expert_parallel_rank = lambda: 0
+    missing = object()
+    originals = []
+
+    def replace(module, name, value):
+        originals.append((module, name, getattr(module, name, missing)))
+        setattr(module, name, value)
+
+    try:
+        for module in (_moe_layer_mod, _std_dispatch_mod, _mxfp4_mod):
+            if hasattr(module, "get_tp_group"):
+                replace(module, "get_tp_group", lambda: None)
+            if hasattr(module, "is_allocation_symmetric"):
+                replace(module, "is_allocation_symmetric", lambda: False)
+        replace(_moe_layer_mod, "get_moe_expert_parallel_world_size", lambda: moe_ep_size)
+        replace(_moe_layer_mod, "get_moe_expert_parallel_rank", lambda: 0)
+        replace(_moe_layer_mod, "get_moe_tensor_parallel_world_size", lambda: moe_tp_size)
+        replace(_moe_layer_mod, "get_moe_tensor_parallel_rank", lambda: 0)
+        replace(_moe_layer_mod, "create_kt_config_from_server_args", lambda _server_args, _layer_id: None)
+        replace(_std_dispatch_mod, "get_moe_expert_parallel_world_size", lambda: moe_ep_size)
+        replace(_std_dispatch_mod, "get_moe_expert_parallel_rank", lambda: 0)
+        yield
+    finally:
+        for module, name, original in reversed(originals):
+            if original is missing:
+                delattr(module, name)
+            else:
+                setattr(module, name, original)
 
 
 def benchmark(
@@ -1351,7 +1233,6 @@ def benchmark(
     use_int8_w8a16: bool,
     use_nvfp4: bool = False,
     use_trtllm_bf16_fp4: bool = False,
-    use_trtllm_mxfp4: bool = False,
     use_int4_w4a16: bool = False,
     use_mxfp4_w4a16: bool = False,
     use_mxfp4_w4a8: bool = False,
@@ -1371,34 +1252,41 @@ def benchmark(
     use_mxfp4_moe = use_mxfp4_w4a16 or use_mxfp4_w4a8
 
     if use_nvfp4 or use_mxfp4_moe or (use_int4_w4a16 and _HAS_MARLIN_MOE):
-        # nvfp4 uses flashinfer cutedsl backend; mxfp4 (incl. DSV4 trtllm-gen)
-        # uses flashinfer; int4_w4a16 uses Marlin CUDA — none need Triton tuning.
-        kernel_time, power_stats = benchmark_config(
-            None,
-            benchmark_num_tokens,
-            num_experts,
-            shard_intermediate_size,
-            hidden_size,
-            topk,
-            dtype,
-            use_fp8_w8a8,
-            use_int8_w8a8,
-            use_int8_w8a16,
-            use_nvfp4,
-            use_trtllm_bf16_fp4,
-            use_trtllm_mxfp4,
-            use_int4_w4a16,
-            use_mxfp4_w4a16,
-            use_mxfp4_w4a8,
-            block_shape,
-            distributed=distributed,
-            power_law_alpha=power_law_alpha,
-            workloads=workloads,
-            swiglu_limit=swiglu_limit,
-            moe_tp_size=moe_tp_size,
-            moe_ep_size=moe_ep_size,
-            model_name=model_name,
+        # NVFP4 uses FlashInfer CuteDSL; MXFP4 uses SGLang's high-level
+        # FlashInfer runner; INT4_W4A16 uses Marlin. None need Triton tuning.
+        # MXFP4 reads the patched helpers during forward, so keep them scoped
+        # through setup, warmup, and timing rather than only layer construction.
+        parallel_context = (
+            _patch_mxfp4_single_process_parallel(moe_tp_size=moe_tp_size, moe_ep_size=moe_ep_size)
+            if use_mxfp4_moe and _HAS_SGLANG_MXFP4
+            else nullcontext()
         )
+        with parallel_context:
+            kernel_time, power_stats = benchmark_config(
+                None,
+                benchmark_num_tokens,
+                num_experts,
+                shard_intermediate_size,
+                hidden_size,
+                topk,
+                dtype,
+                use_fp8_w8a8,
+                use_int8_w8a8,
+                use_int8_w8a16,
+                use_nvfp4,
+                use_trtllm_bf16_fp4,
+                use_int4_w4a16,
+                use_mxfp4_w4a16,
+                use_mxfp4_w4a8,
+                block_shape,
+                distributed=distributed,
+                power_law_alpha=power_law_alpha,
+                workloads=workloads,
+                swiglu_limit=swiglu_limit,
+                moe_tp_size=moe_tp_size,
+                moe_ep_size=moe_ep_size,
+                model_name=model_name,
+            )
         return kernel_time, power_stats
 
     dtype_str = get_config_dtype_str(
@@ -1437,7 +1325,6 @@ def benchmark(
         use_int8_w8a8,
         use_int8_w8a16,
         use_nvfp4,
-        False,
         False,
         use_int4_w4a16,
         use_mxfp4_w4a16,
@@ -1530,7 +1417,6 @@ def run_moe_torch(
     distributed="power_law",
     power_law_alpha=0,
     swiglu_limit=None,
-    moe_backend="",
     *,
     perf_filename,
     device="cuda:0",
@@ -1546,31 +1432,21 @@ def run_moe_torch(
         "int4_wo",
         "w4a16_mxfp4",
     ], "only support moe type = fp8_block, bfloat16, nvfp4, int4_wo, w4a16_mxfp4, or w4a8_mxfp4_mxfp8"
-    # Only w4a8_mxfp4_mxfp8 consumes the trtllm-gen backend; reject other combos
-    # up-front so we never benchmark one kernel while log_perf tags the row as
-    # kernel_source="sglang_mxfp4_flashinfer_trtllm_moe".
-    if moe_backend == "trtllm_mxfp4" and moe_type != "w4a8_mxfp4_mxfp8":
-        raise ValueError(
-            f"moe_backend='trtllm_mxfp4' is only valid with moe_type='w4a8_mxfp4_mxfp8', got moe_type={moe_type!r}"
-        )
     assert inter_size % moe_tp_size == 0, "inter_size % moe_tp_size must be 0"
     assert num_experts % moe_ep_size == 0, "num_experts must be divisible by moe_ep_size"
 
     num_local_experts = num_experts // moe_ep_size
     use_int4_w4a16 = moe_type == "int4_wo"
-    # GPT-OSS uses W4A16 MXFP4; DeepSeek-V4 uses W4A8 MXFP4/MXFP8.
-    # Both currently run through SGLang's FlashInfer MXFP4 MoE backend.
+    # GPT-OSS can use BF16 or MXFP8 activations with MXFP4 weights. Both labels
+    # run through SGLang's version-matched high-level FlashInfer backend.
     use_mxfp4_w4a16 = moe_type == "w4a16_mxfp4"
     use_mxfp4_w4a8 = moe_type == "w4a8_mxfp4_mxfp8"
     use_mxfp4_moe = use_mxfp4_w4a16 or use_mxfp4_w4a8
-    # DeepSeek-V4 production runs the trtllm-gen MXFP4xMXFP8 MoE kernel
-    # (moe_backend="trtllm_mxfp4"); the plain w4a8_mxfp4_mxfp8 stays on CuteDSL.
-    use_trtllm_mxfp4 = moe_backend == "trtllm_mxfp4"
-    use_nvfp4_kernel = moe_type in ("nvfp4", "w4a8_mxfp4_mxfp8") and not use_trtllm_mxfp4
+    use_nvfp4_kernel = moe_type == "nvfp4"
     use_trtllm_bf16_fp4 = moe_type == "nvfp4" and moe_ep_size == 1
-    # int4_wo uses block_shape=[0, group_size] for grouped scales (group_size=128)
     if use_int4_w4a16:
-        block_shape = [0, 128]
+        int4_config = get_moe_quantization_module_config("sglang", moe_type, model_name=model_name)
+        block_shape = [0, int(int4_config.get("group_size", 128))]
     elif moe_type == "fp8_block" and (inter_size // moe_tp_size) % 128 == 0 and hidden_size % 128 == 0:
         block_shape = [128, 128]
     else:
@@ -1604,7 +1480,6 @@ def run_moe_torch(
             False,
             use_nvfp4=use_nvfp4_kernel,
             use_trtllm_bf16_fp4=use_trtllm_bf16_fp4,
-            use_trtllm_mxfp4=use_trtllm_mxfp4,
             use_int4_w4a16=use_int4_w4a16,
             use_mxfp4_w4a16=False,
             use_mxfp4_w4a8=False,
@@ -1630,7 +1505,6 @@ def run_moe_torch(
             False,
             use_nvfp4=use_nvfp4_kernel,
             use_trtllm_bf16_fp4=use_trtllm_bf16_fp4,
-            use_trtllm_mxfp4=use_trtllm_mxfp4,
             use_int4_w4a16=use_int4_w4a16,
             use_mxfp4_w4a16=use_mxfp4_w4a16,
             use_mxfp4_w4a8=use_mxfp4_w4a8,
@@ -1663,9 +1537,7 @@ def run_moe_torch(
         device_name=torch.cuda.get_device_name(device),
         op_name="moe",
         kernel_source=(
-            "sglang_mxfp4_flashinfer_trtllm_moe"
-            if use_trtllm_mxfp4
-            else "sglang_flashinfer_trtllm_bf16_fp4_moe"
+            "sglang_flashinfer_trtllm_bf16_fp4_moe"
             if use_trtllm_bf16_fp4
             else "sglang_flashinfer_cutedsl_moe"
             if use_nvfp4_kernel

--- a/collector/trtllm/collect_attn.py
+++ b/collector/trtllm/collect_attn.py
@@ -29,7 +29,7 @@ from tensorrt_llm.models.modeling_utils import QuantAlgo, QuantConfig
 from collector.case_generator import (
     get_attention_context_shape_sweeps,
     get_attention_generation_shape_sweeps,
-    windows_for_head_dim,
+    get_attention_head_configs,
 )
 from collector.helper import benchmark_with_power, get_sm_version, log_perf
 from collector.registry_types import PerfFile
@@ -387,21 +387,6 @@ def _int_list(values):
     return [int(value) for value in values]
 
 
-def _kv_head_options(values, num_heads):
-    return [num_heads if value == "self" else int(value) for value in values]
-
-
-def _default_attention_window_options(head_dim: int) -> list[int]:
-    return [128, 0] if head_dim == 64 else [0]
-
-
-def _attention_window_options(shape_sweep: dict, head_dim: int) -> list[int]:
-    windows = _default_attention_window_options(head_dim)
-    if "window_sizes" in shape_sweep:
-        windows = [*windows, *windows_for_head_dim(_int_list(shape_sweep["window_sizes"]), head_dim)]
-    return sorted(set(windows), reverse=True)
-
-
 def get_context_attention_test_cases():
     has_fp8 = get_sm_version() > 86
     test_cases = []
@@ -409,82 +394,80 @@ def get_context_attention_test_cases():
     for shape_sweep in get_attention_context_shape_sweeps("trtllm"):
         batch_sizes = _int_list(shape_sweep["batch_sizes"])
         sequence_lengths = _int_list(shape_sweep["sequence_lengths"])
-        query_head_counts = _int_list(shape_sweep["query_head_counts"])
-        kv_head_options = shape_sweep["kv_head_options"]
-        head_dims = _int_list(shape_sweep["head_dims"])
         max_tokens_self_attention = int(shape_sweep["max_tokens_self_attention"])
         max_tokens_grouped_query_attention = int(shape_sweep["max_tokens_grouped_query_attention"])
         max_batch_size_self_attention = int(shape_sweep["max_batch_size_self_attention"])
         max_kv_elements = int(shape_sweep["max_kv_elements"])
 
-        for h in head_dims:
-            for n in sorted(query_head_counts, reverse=True):
-                for s in sorted(sequence_lengths, reverse=True):
-                    for b in sorted(batch_sizes, reverse=True):
-                        for num_kv_heads in _kv_head_options(kv_head_options, n):
-                            if num_kv_heads != n and (num_kv_heads >= n or n % num_kv_heads != 0):
-                                continue
+        for head_config in get_attention_head_configs(shape_sweep, phase="context"):
+            n = head_config.num_heads
+            num_kv_heads = head_config.num_kv_heads
+            h = head_config.head_dim
+            attention_window_size = head_config.window_size
+            if num_kv_heads != n and (num_kv_heads >= n or n % num_kv_heads != 0):
+                continue
 
-                            if num_kv_heads == n:
-                                if b * s > max_tokens_self_attention or b > max_batch_size_self_attention:
-                                    continue
-                            else:
-                                if b * s > max_tokens_grouped_query_attention:
-                                    continue
-                            if b * s * num_kv_heads * h * 2 >= max_kv_elements:
-                                continue
-                            if get_sm_version() >= 100:
-                                # though it's a precheck of gen kernels during the attention op init,
-                                # this cannot be skipped for now
-                                # TLLM_CHECK_WITH_INFO((params.m_num_heads_q_per_kv < max_num_heads_q_per_kv_in_cta || params.m_num_heads_q_per_kv % max_num_heads_q_per_kv_in_cta == 0), # noqa: E501
-                                m_num_heads_q_per_kv = n // num_kv_heads
-                                max_num_heads_q_per_kv_in_cta = 32
-                                if (
-                                    m_num_heads_q_per_kv >= max_num_heads_q_per_kv_in_cta
-                                    and m_num_heads_q_per_kv % max_num_heads_q_per_kv_in_cta != 0
-                                ):
-                                    continue
+            for s in sorted(sequence_lengths, reverse=True):
+                for b in sorted(batch_sizes, reverse=True):
+                    if num_kv_heads == n:
+                        if b * s > max_tokens_self_attention or b > max_batch_size_self_attention:
+                            continue
+                    else:
+                        if b * s > max_tokens_grouped_query_attention:
+                            continue
+                    if b * s * num_kv_heads * h * 2 >= max_kv_elements:
+                        continue
+                    if get_sm_version() >= 100:
+                        # though it's a precheck of gen kernels during the attention op init,
+                        # this cannot be skipped for now
+                        # TLLM_CHECK_WITH_INFO((params.m_num_heads_q_per_kv < max_num_heads_q_per_kv_in_cta || params.m_num_heads_q_per_kv % max_num_heads_q_per_kv_in_cta == 0), # noqa: E501
+                        m_num_heads_q_per_kv = n // num_kv_heads
+                        max_num_heads_q_per_kv_in_cta = 32
+                        if (
+                            m_num_heads_q_per_kv >= max_num_heads_q_per_kv_in_cta
+                            and m_num_heads_q_per_kv % max_num_heads_q_per_kv_in_cta != 0
+                        ):
+                            continue
 
-                            skip_fp8_context_fmha = _skip_trtllm_sm120_fp8_context_fmha(
+                    skip_fp8_context_fmha = _skip_trtllm_sm120_fp8_context_fmha(
+                        b,
+                        s,
+                        n,
+                        num_kv_heads,
+                        h,
+                    )
+                    if _skip_trtllm_sm89_rc15_long_context_gqa(b, s, n, num_kv_heads, h):
+                        continue
+                    for precision_case in shape_sweep["precision_cases"]:
+                        use_fp8_kv_cache = bool(precision_case["fp8_kv_cache"])
+                        use_fp8_context_fmha = bool(precision_case["fp8_context_fmha"])
+                        if not has_fp8 and use_fp8_kv_cache:
+                            continue
+                        if skip_fp8_context_fmha and use_fp8_context_fmha:
+                            continue
+                        if _skip_trtllm_sm89_rc15_fp8_context_mha(
+                            b,
+                            s,
+                            n,
+                            num_kv_heads,
+                            h,
+                            use_fp8_kv_cache,
+                            use_fp8_context_fmha,
+                        ):
+                            continue
+                        test_cases.append(
+                            [
                                 b,
                                 s,
                                 n,
                                 num_kv_heads,
                                 h,
-                            )
-                            if _skip_trtllm_sm89_rc15_long_context_gqa(b, s, n, num_kv_heads, h):
-                                continue
-                            for attention_window_size in _attention_window_options(shape_sweep, h):
-                                for precision_case in shape_sweep["precision_cases"]:
-                                    use_fp8_kv_cache = bool(precision_case["fp8_kv_cache"])
-                                    use_fp8_context_fmha = bool(precision_case["fp8_context_fmha"])
-                                    if not has_fp8 and use_fp8_kv_cache:
-                                        continue
-                                    if skip_fp8_context_fmha and use_fp8_context_fmha:
-                                        continue
-                                    if _skip_trtllm_sm89_rc15_fp8_context_mha(
-                                        b,
-                                        s,
-                                        n,
-                                        num_kv_heads,
-                                        h,
-                                        use_fp8_kv_cache,
-                                        use_fp8_context_fmha,
-                                    ):
-                                        continue
-                                    test_cases.append(
-                                        [
-                                            b,
-                                            s,
-                                            n,
-                                            num_kv_heads,
-                                            h,
-                                            attention_window_size,
-                                            use_fp8_kv_cache,
-                                            use_fp8_context_fmha,
-                                            True,
-                                        ]
-                                    )
+                                attention_window_size,
+                                use_fp8_kv_cache,
+                                use_fp8_context_fmha,
+                                True,
+                            ]
+                        )
 
     return test_cases
 
@@ -518,68 +501,40 @@ def get_generation_attention_test_cases():
     for shape_sweep in get_attention_generation_shape_sweeps("trtllm"):
         batch_sizes = _int_list(shape_sweep["batch_sizes"])
         sequence_lengths = _int_list(shape_sweep["sequence_lengths"])
-        head_dims = _int_list(shape_sweep["head_dims"])
         min_drop_batch = int(shape_sweep["drop_largest_sequence_for_batch_at_least"])
 
-        # MHA
-        for n in sorted(_int_list(shape_sweep["mha_query_head_counts"]), reverse=True):
+        for head_config in get_attention_head_configs(shape_sweep, phase="generation"):
+            n = head_config.num_heads
+            n_kv = head_config.num_kv_heads
+            h = head_config.head_dim
+            attention_window_size = head_config.window_size
+            max_tokens_key = "max_mha_tokens_per_step" if n == n_kv else "max_xqa_tokens_per_step"
             b_s_dict = _generation_target_sequence_lengths(
                 batch_sizes,
                 sequence_lengths,
                 n,
-                int(shape_sweep["max_mha_tokens_per_step"]),
+                int(shape_sweep[max_tokens_key]),
                 shape_sweep,
             )
-            for h in head_dims:
-                for b, s_list_limited in b_s_dict.items():
-                    target_s_list = sorted(s_list_limited)
-                    if b >= min_drop_batch:
-                        target_s_list = target_s_list[:-1]
-                    for s in target_s_list:
-                        for attention_window_size in _attention_window_options(shape_sweep, h):
-                            for precision_case in shape_sweep["precision_cases"]:
-                                use_fp8_kv_cache = bool(precision_case["fp8_kv_cache"])
-                                if not has_fp8 and use_fp8_kv_cache:
-                                    continue
-                                test_cases.append(
-                                    [b, s, n, n, h, attention_window_size, use_fp8_kv_cache, False, False]
-                                )
-
-        # XQA
-        for n in sorted(_int_list(shape_sweep["xqa_query_head_counts"]), reverse=True):
-            b_s_dict = _generation_target_sequence_lengths(
-                batch_sizes,
-                sequence_lengths,
-                n,
-                int(shape_sweep["max_xqa_tokens_per_step"]),
-                shape_sweep,
-            )
-            for h in head_dims:
-                for b, s_list_limited in b_s_dict.items():
-                    target_s_list = sorted(s_list_limited)
-                    if b >= min_drop_batch:
-                        target_s_list = target_s_list[:-1]
-                    for n_kv in _int_list(shape_sweep["kv_head_counts"]):
-                        if n_kv >= n:
+            if n_kv != n and get_sm_version() >= 100:
+                # TLLM_CHECK_WITH_INFO((params.m_num_heads_q_per_kv < max_num_heads_q_per_kv_in_cta || params.m_num_heads_q_per_kv % max_num_heads_q_per_kv_in_cta == 0), # noqa: E501
+                m_num_heads_q_per_kv = n // n_kv
+                max_num_heads_q_per_kv_in_cta = 32
+                if (
+                    m_num_heads_q_per_kv >= max_num_heads_q_per_kv_in_cta
+                    and m_num_heads_q_per_kv % max_num_heads_q_per_kv_in_cta != 0
+                ):
+                    continue
+            for b, s_list_limited in b_s_dict.items():
+                target_s_list = sorted(s_list_limited)
+                if b >= min_drop_batch:
+                    target_s_list = target_s_list[:-1]
+                for s in target_s_list:
+                    for precision_case in shape_sweep["precision_cases"]:
+                        use_fp8_kv_cache = bool(precision_case["fp8_kv_cache"])
+                        if not has_fp8 and use_fp8_kv_cache:
                             continue
-                        if get_sm_version() >= 100:
-                            # TLLM_CHECK_WITH_INFO((params.m_num_heads_q_per_kv < max_num_heads_q_per_kv_in_cta || params.m_num_heads_q_per_kv % max_num_heads_q_per_kv_in_cta == 0), # noqa: E501
-                            m_num_heads_q_per_kv = n // n_kv
-                            max_num_heads_q_per_kv_in_cta = 32
-                            if (
-                                m_num_heads_q_per_kv >= max_num_heads_q_per_kv_in_cta
-                                and m_num_heads_q_per_kv % max_num_heads_q_per_kv_in_cta != 0
-                            ):
-                                continue
-                        for s in target_s_list:
-                            for attention_window_size in _attention_window_options(shape_sweep, h):
-                                for precision_case in shape_sweep["precision_cases"]:
-                                    use_fp8_kv_cache = bool(precision_case["fp8_kv_cache"])
-                                    if not has_fp8 and use_fp8_kv_cache:
-                                        continue
-                                    test_cases.append(
-                                        [b, s, n, n_kv, h, attention_window_size, use_fp8_kv_cache, False, False]
-                                    )
+                        test_cases.append([b, s, n, n_kv, h, attention_window_size, use_fp8_kv_cache, False, False])
     return test_cases
 
 

--- a/collector/trtllm/collect_attn_encoder.py
+++ b/collector/trtllm/collect_attn_encoder.py
@@ -28,7 +28,7 @@ from tensorrt_llm._torch.metadata import KVCacheParams
 from tensorrt_llm.mapping import Mapping
 from tensorrt_llm.models.modeling_utils import QuantConfig
 
-from collector.case_generator import get_attention_encoder_shape_sweeps
+from collector.case_generator import get_attention_encoder_head_configs, get_attention_encoder_shape_sweeps
 from collector.helper import benchmark_with_power, log_perf
 from collector.registry_types import PerfFile
 
@@ -43,19 +43,18 @@ def get_encoder_attention_test_cases():
     for shape_sweep in get_attention_encoder_shape_sweeps("trtllm"):
         batch_sizes = _int_list(shape_sweep["batch_sizes"])
         sequence_lengths = _int_list(shape_sweep["sequence_lengths"])
-        head_counts = _int_list(shape_sweep["head_counts"])
-        head_dims = _int_list(shape_sweep["head_dims"])
 
-        for head_dim in head_dims:
-            for n in sorted(head_counts):
-                for s in sorted(sequence_lengths):
-                    for b in sorted(batch_sizes):
-                        # Workload token budget (128K) + 32-bit indexing safety.
-                        if b * s > 131072:
-                            continue
-                        if 4 * b * s * n * head_dim * 2 >= 2**31:
-                            continue
-                        test_cases.append([b, s, n, head_dim])
+        for head_config in get_attention_encoder_head_configs(shape_sweep):
+            n = head_config.num_heads
+            head_dim = head_config.head_dim
+            for s in sorted(sequence_lengths):
+                for b in sorted(batch_sizes):
+                    # Workload token budget (128K) + 32-bit indexing safety.
+                    if b * s > 131072:
+                        continue
+                    if 4 * b * s * n * head_dim * 2 >= 2**31:
+                        continue
+                    test_cases.append([b, s, n, head_dim])
 
     return test_cases
 

--- a/collector/trtllm/collect_mla.py
+++ b/collector/trtllm/collect_mla.py
@@ -32,6 +32,7 @@ from tensorrt_llm.models.modeling_utils import QuantConfig
 from tensorrt_llm.quantization.mode import QuantAlgo
 from tensorrt_llm.sampling_params import SamplingParams
 
+from collector.case_generator import get_context_mla_case_specs, get_generation_mla_case_specs
 from collector.helper import benchmark_with_power, log_perf
 
 
@@ -45,84 +46,69 @@ def _mla_tokens_per_block() -> int:
 
 def get_context_mla_test_cases():
     dtype_list = [tensorrt_llm.bindings.DataType.BF16, tensorrt_llm.bindings.DataType.FP8]
-    test_cases = []
-    n_list = [128]
-    b_list = [1, 2, 4, 8, 16, 32, 64, 128, 256]
-    s_list = [1, 16, 32, 64, 128, 256, 512, 1024, 1536, 2048, 3072, 4096, 6144, 8192, 10240, 12288, 16384, 32768]
-    for n in n_list:
-        for b in b_list:
-            for s in s_list:  # [2,4,8,16,32,64,128,256,512,1024,2048,4096,8192,16384,32768,65536,131072]:
-                for dtype in dtype_list:
-                    for tp_size in [1, 2, 4, 8, 16, 32, 64, 128]:
-                        if b * s > 65536:
-                            continue
-                        # (input_len, batch_size, output_len, kv_cache_dtype, num_heads, world_size,
-                        #  tp_size, tokens_per_block, warming_up, test_ite, is_context_phase)
-                        test_cases.append(
-                            [
-                                s,
-                                b,
-                                1,
-                                dtype,
-                                n,
-                                tp_size,
-                                tp_size,
-                                _mla_tokens_per_block(),
-                                10,
-                                6,
-                                True,
-                            ]
-                        )
-    return test_cases
+    return _build_mla_test_cases(get_context_mla_case_specs(), dtype_list=dtype_list)
 
 
 def get_generation_mla_test_cases():
     dtype_list = [tensorrt_llm.bindings.DataType.BF16, tensorrt_llm.bindings.DataType.FP8]
-    test_cases = []
-    n_list = [128]
-    for n in n_list:
-        for b in [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024]:
-            for s in [
-                2,
-                4,
-                8,
-                16,
-                32,
-                64,
-                128,
-                256,
-                512,
-                1024,
-                2048,
-                4096,
-                8192,
-                16384,
-                32768,
-                65536,
-                131072,
-            ]:  # [target token s] is equivalent to [in: s-1, step=1]
-                for dtype in dtype_list:
-                    for tp_size in [1, 2, 4, 8, 16, 32, 64, 128]:
-                        if b * s > 1024 * 4096 * 2 * 2:
-                            continue
-                        # (input_len, batch_size, output_len, kv_cache_dtype, num_heads, world_size,
-                        #  tp_size, tokens_per_block, warming_up, test_ite, is_context_phase)
-                        test_cases.append(
-                            [
-                                s - 1,
-                                b,
-                                1,
-                                dtype,
-                                n,
-                                tp_size,
-                                tp_size,
-                                _mla_tokens_per_block(),
-                                10,
-                                6,
-                                False,
-                            ]
-                        )
-    return test_cases
+    return _build_mla_test_cases(get_generation_mla_case_specs(), dtype_list=dtype_list)
+
+
+def _build_mla_test_cases(case_specs, *, dtype_list):
+    """Adapt the shared YAML MLA catalog to TRT-LLM's legacy run tuple."""
+
+    cases_by_physical_key = {}
+    scenario = Scenario()
+    expected_geometry = (
+        scenario.q_lora_rank,
+        scenario.kv_lora_rank,
+        scenario.qk_nope_head_dim,
+        scenario.qk_rope_head_dim,
+        scenario.v_head_dim,
+    )
+    for spec in case_specs:
+        geometry = (
+            spec.q_lora_rank,
+            spec.kv_lora_rank,
+            spec.qk_nope_head_dim,
+            spec.qk_rope_head_dim,
+            spec.v_head_dim,
+        )
+        if geometry != expected_geometry:
+            raise ValueError(f"Unsupported TRT-LLM MLA geometry for {spec.model_name}: {geometry}")
+
+        for dtype in dtype_list:
+            for tp_size in (1, 2, 4, 8, 16, 32, 64, 128):
+                if spec.num_heads % tp_size:
+                    continue
+                case = (
+                    spec.input_len,
+                    spec.batch_size,
+                    1,
+                    dtype,
+                    spec.num_heads,
+                    tp_size,
+                    tp_size,
+                    _mla_tokens_per_block(),
+                    10,
+                    6,
+                    spec.is_context_phase,
+                )
+                # The perf loader keys on local heads, not total heads or TP.
+                # Equivalent total-head/TP pairs therefore share one row.
+                physical_key = (
+                    dtype,
+                    spec.num_heads // tp_size,
+                    spec.batch_size,
+                    spec.input_len,
+                )
+                # Selectors run after getter population and commonly cap TP.
+                # Prefer the smallest-TP representation of an equivalent
+                # local-head key so targeted plans do not lose that key.
+                existing = cases_by_physical_key.get(physical_key)
+                if existing is None or tp_size < existing[6]:
+                    cases_by_physical_key[physical_key] = list(case)
+    return list(cases_by_physical_key.values())
 
 
 # Copied from transformers.models.llama.modeling_llama.rotate_half

--- a/collector/trtllm/collect_moe.py
+++ b/collector/trtllm/collect_moe.py
@@ -41,7 +41,11 @@ except ImportError:
 NON_GATED_MOE_MODELS = ["Nemotron-3"]
 _MXFP4_MOE_TYPES = {"w4a16_mxfp4", "w4a8_mxfp4_mxfp8"}
 
-from collector.case_generator import get_common_moe_test_cases, moe_model_allows_quantization
+from collector.case_generator import (
+    get_common_moe_test_cases,
+    get_moe_quantization_module_config,
+    moe_model_allows_quantization,
+)
 from collector.helper import (
     EXIT_CODE_RESTART,
     balanced_logits,
@@ -63,6 +67,63 @@ def _is_trtllm_130rc5_runtime():
 
 def _is_trtllm_130rc5_or_rc10_runtime():
     return _TRTLLM_VERSION.startswith(("1.3.0rc5", "1.3.0rc10"))
+
+
+def _moe_model_behavior(model_name: str) -> str:
+    """Resolve model-name branches that change the synthetic invocation."""
+    if any(pattern in model_name for pattern in NON_GATED_MOE_MODELS):
+        return "relu2"
+    if model_name in {"openai/gpt-oss-120b", "openai/gpt-oss-20b"}:
+        return "swigluoai"
+    return "swiglu"
+
+
+def _moe_execution_key(common_moe_testcase, moe_type: str, min_latency_mode: bool):
+    module_config = get_moe_quantization_module_config(
+        "trtllm",
+        moe_type,
+        model_name=common_moe_testcase.model_name,
+    )
+    return (
+        moe_type,
+        tuple(common_moe_testcase.num_tokens_list),
+        common_moe_testcase.hidden_size,
+        common_moe_testcase.inter_size,
+        common_moe_testcase.topk,
+        common_moe_testcase.num_experts,
+        common_moe_testcase.tp,
+        common_moe_testcase.ep,
+        min_latency_mode,
+        common_moe_testcase.token_expert_distribution,
+        common_moe_testcase.power_law_alpha,
+        _moe_model_behavior(common_moe_testcase.model_name),
+        json.dumps(module_config, sort_keys=True, separators=(",", ":")),
+    )
+
+
+def _moe_consumer_keys(common_moe_testcase, moe_type: str, min_latency_mode: bool):
+    """Return every consumer-visible key emitted by one getter task."""
+    distribution = (
+        f"power_law_{common_moe_testcase.power_law_alpha}"
+        if common_moe_testcase.token_expert_distribution == "power_law"
+        else common_moe_testcase.token_expert_distribution
+    )
+    table = "low_latency" if min_latency_mode else "default"
+    return tuple(
+        (
+            table,
+            moe_type,
+            distribution,
+            common_moe_testcase.topk,
+            common_moe_testcase.num_experts,
+            common_moe_testcase.hidden_size,
+            common_moe_testcase.inter_size,
+            common_moe_testcase.tp,
+            common_moe_testcase.ep,
+            num_tokens,
+        )
+        for num_tokens in common_moe_testcase.num_tokens_list
+    )
 
 
 def _patch_moe_runners_for_tuple_tactics():
@@ -183,6 +244,8 @@ def get_moe_test_cases():
         moe_list += ["int4_wo", "nvfp4", "w4a16_mxfp4", "w4a8_mxfp4_mxfp8"]
 
     test_cases = []
+    seen = set()
+    consumer_key_owners = {}
 
     for common_moe_testcase in get_common_moe_test_cases():
         model_name = common_moe_testcase.model_name
@@ -251,6 +314,23 @@ def get_moe_test_cases():
                 num_tokens_list = common_moe_testcase.num_tokens_list
                 if not num_tokens_list:
                     continue
+                execution_key = _moe_execution_key(common_moe_testcase, moe_type, min_latency_mode)
+                if execution_key in seen:
+                    continue
+                consumer_keys = _moe_consumer_keys(common_moe_testcase, moe_type, min_latency_mode)
+                for consumer_key in consumer_keys:
+                    previous_owner = consumer_key_owners.get(consumer_key)
+                    if previous_owner is not None and previous_owner[0] != execution_key:
+                        previous_model = previous_owner[1]
+                        raise ValueError(
+                            "TRT-LLM MoE population collision: "
+                            f"models {previous_model!r} and {model_name!r} map distinct benchmark "
+                            f"invocations to consumer key {consumer_key!r}; "
+                            "the current moe_perf consumer cannot represent both"
+                        )
+                for consumer_key in consumer_keys:
+                    consumer_key_owners[consumer_key] = (execution_key, model_name)
+                seen.add(execution_key)
                 test_cases.append(
                     [
                         moe_type,
@@ -318,6 +398,8 @@ def run_moe_torch(
         dtype = torch.float8_e4m3fn
     elif moe_type == "int4_wo":
         quant_algo = QuantAlgo.W4A16
+        int4_config = get_moe_quantization_module_config("trtllm", moe_type, model_name=model_name)
+        quant_group_size = int(int4_config.get("group_size", 128))
     elif moe_type == "nvfp4":
         quant_algo = QuantAlgo.NVFP4
         quant_group_size = 16

--- a/collector/vllm/collect_attn.py
+++ b/collector/vllm/collect_attn.py
@@ -47,7 +47,7 @@ from vllm.config import set_current_vllm_config
 from collector.case_generator import (
     get_attention_context_shape_sweeps,
     get_attention_generation_shape_sweeps,
-    windows_for_head_dim,
+    get_attention_head_configs,
 )
 from collector.helper import EXIT_CODE_RESTART, benchmark_with_power, get_sm_version, log_perf
 from collector.vllm.utils import (
@@ -457,55 +457,41 @@ def get_context_attention_test_cases(if_unit_test=False):
     for shape_sweep in shape_sweeps:
         batch_sizes = [int(value) for value in shape_sweep["batch_sizes"]]
         sequence_lengths = [int(value) for value in shape_sweep["sequence_lengths"]]
-        query_head_counts = [int(value) for value in shape_sweep["query_head_counts"]]
-        kv_head_options = shape_sweep["kv_head_options"]
-        head_dims = [int(value) for value in shape_sweep["head_dims"]]
-        window_sizes = [int(value) for value in shape_sweep["window_sizes"]]
         max_tokens_self_attention = int(shape_sweep["max_tokens_self_attention"])
         max_tokens_grouped_query_attention = int(shape_sweep["max_tokens_grouped_query_attention"])
         max_kv_elements = int(shape_sweep["max_kv_elements"])
 
-        for head_dim in head_dims:
-            for n in sorted(query_head_counts, reverse=True):
-                for s in sorted(sequence_lengths, reverse=True):
-                    for b in sorted(batch_sizes, reverse=True):
-                        for kv_head_option in kv_head_options:
-                            is_self_kv = kv_head_option in ("self", 0, "0", None)
-                            num_kv_heads = n if is_self_kv else int(kv_head_option)
-                            if num_kv_heads <= 0:
-                                continue
-                            if num_kv_heads != n and (num_kv_heads > n or n % num_kv_heads != 0):
-                                continue
-                            # Only keep self-attention case
-                            # if n != num_kv_heads:
-                            #    continue
-                            if num_kv_heads == n:
-                                if b * s > max_tokens_self_attention or b > 128:
-                                    continue
-                            else:
-                                if b * s > max_tokens_grouped_query_attention:
-                                    continue
-                            if b * s * num_kv_heads * head_dim * 2 >= max_kv_elements:
-                                continue
-
-                            for window_size in windows_for_head_dim(window_sizes, head_dim):
-                                if _skip_vllm_sm89_022_flashinfer_head_dim(head_dim):
-                                    continue
-                                for is_fp8_kv_cache in kv_cache_dtype_list:
-                                    if _skip_vllm_sm89_022_fp8_kv_cache(is_fp8_kv_cache):
-                                        continue
-                                    test_cases.append(
-                                        [
-                                            b,
-                                            s,
-                                            n,
-                                            num_kv_heads,
-                                            head_dim,
-                                            is_fp8_kv_cache,
-                                            True,
-                                            window_size,
-                                        ]
-                                    )
+        for head_config in get_attention_head_configs(shape_sweep, phase="context"):
+            n = head_config.num_heads
+            num_kv_heads = head_config.num_kv_heads
+            head_dim = head_config.head_dim
+            window_size = head_config.window_size
+            if _skip_vllm_sm89_022_flashinfer_head_dim(head_dim):
+                continue
+            for s in sorted(sequence_lengths, reverse=True):
+                for b in sorted(batch_sizes, reverse=True):
+                    if num_kv_heads == n:
+                        if b * s > max_tokens_self_attention or b > 128:
+                            continue
+                    elif b * s > max_tokens_grouped_query_attention:
+                        continue
+                    if b * s * num_kv_heads * head_dim * 2 >= max_kv_elements:
+                        continue
+                    for is_fp8_kv_cache in kv_cache_dtype_list:
+                        if _skip_vllm_sm89_022_fp8_kv_cache(is_fp8_kv_cache):
+                            continue
+                        test_cases.append(
+                            [
+                                b,
+                                s,
+                                n,
+                                num_kv_heads,
+                                head_dim,
+                                is_fp8_kv_cache,
+                                True,
+                                window_size,
+                            ]
+                        )
 
     return test_cases
 
@@ -542,51 +528,52 @@ def get_generation_attention_test_cases():
     for shape_sweep in get_attention_generation_shape_sweeps("vllm"):
         batch_sizes = [int(value) for value in shape_sweep["batch_sizes"]]
         sequence_lengths = [int(value) for value in shape_sweep["sequence_lengths"]]
-        head_dims = [int(value) for value in shape_sweep["head_dims"]]
-        window_sizes = [int(value) for value in shape_sweep["window_sizes"]]
         min_drop_batch = int(shape_sweep["drop_largest_sequence_for_batch_at_least"])
 
-        for head_dim in head_dims:
-            for n in sorted([int(value) for value in shape_sweep["xqa_query_head_counts"]], reverse=True):
-                b_s_dict = _generation_target_sequence_lengths(
-                    batch_sizes,
-                    sequence_lengths,
-                    n,
-                    head_dim,
-                    int(shape_sweep["max_mha_tokens_per_step"]),
-                    shape_sweep,
-                )
-                for b, s_list_limited in b_s_dict.items():
-                    target_s_list = sorted(s_list_limited)
-                    if b >= min_drop_batch:
-                        target_s_list = target_s_list[:-1]
-                    for n_kv in [int(value) for value in shape_sweep["kv_head_counts"]]:
-                        if n_kv > n or n % n_kv != 0:
+        for head_config in get_attention_head_configs(shape_sweep, phase="generation"):
+            n = head_config.num_heads
+            n_kv = head_config.num_kv_heads
+            head_dim = head_config.head_dim
+            window_size = head_config.window_size
+            if _skip_vllm_sm89_022_flashinfer_head_dim(head_dim):
+                continue
+            # The generation schema has separate caps because MHA and GQA have
+            # different memory/throughput limits. The old loop used the MHA cap
+            # for every case even though it enumerated GQA shapes as well.
+            max_tokens_key = "max_mha_tokens_per_step" if n == n_kv else "max_xqa_tokens_per_step"
+            b_s_dict = _generation_target_sequence_lengths(
+                batch_sizes,
+                sequence_lengths,
+                n,
+                head_dim,
+                int(shape_sweep[max_tokens_key]),
+                shape_sweep,
+            )
+            for b, s_list_limited in b_s_dict.items():
+                target_s_list = sorted(s_list_limited)
+                if b >= min_drop_batch:
+                    target_s_list = target_s_list[:-1]
+                # On SM100 (Blackwell), vLLM uses FlashInfer which routes
+                # decode to trtllm_batch_decode_with_kv_cache. That kernel
+                # only supports GQA ratios up to 16.
+                if get_sm_version() >= 100 and n // n_kv > 16:
+                    continue
+                for s in target_s_list:
+                    for is_fp8_kv_cache in kv_cache_dtype_list:
+                        if _skip_vllm_sm89_022_fp8_kv_cache(is_fp8_kv_cache):
                             continue
-                        if _skip_vllm_sm89_022_flashinfer_head_dim(head_dim):
-                            continue
-                        # On SM100 (Blackwell), vLLM uses FlashInfer which routes
-                        # decode to trtllm_batch_decode_with_kv_cache. That kernel
-                        # only supports GQA ratios up to 16.
-                        if get_sm_version() >= 100 and n // n_kv > 16:
-                            continue
-                        for s in target_s_list:
-                            for window_size in windows_for_head_dim(window_sizes, head_dim):
-                                for is_fp8_kv_cache in kv_cache_dtype_list:
-                                    if _skip_vllm_sm89_022_fp8_kv_cache(is_fp8_kv_cache):
-                                        continue
-                                    test_cases.append(
-                                        [
-                                            b,
-                                            s,
-                                            n,
-                                            n_kv,
-                                            head_dim,
-                                            is_fp8_kv_cache,
-                                            False,
-                                            window_size,
-                                        ]
-                                    )
+                        test_cases.append(
+                            [
+                                b,
+                                s,
+                                n,
+                                n_kv,
+                                head_dim,
+                                is_fp8_kv_cache,
+                                False,
+                                window_size,
+                            ]
+                        )
     return test_cases
 
 

--- a/collector/vllm/collect_attn_encoder.py
+++ b/collector/vllm/collect_attn_encoder.py
@@ -23,7 +23,7 @@ from vllm.v1.attention.ops.vit_attn_wrappers import (
 )
 from vllm.version import __version__ as vllm_version
 
-from collector.case_generator import get_attention_encoder_shape_sweeps
+from collector.case_generator import get_attention_encoder_head_configs, get_attention_encoder_shape_sweeps
 from collector.helper import benchmark_with_power, log_perf
 
 
@@ -37,19 +37,18 @@ def get_encoder_attention_test_cases():
     for shape_sweep in get_attention_encoder_shape_sweeps("vllm"):
         batch_sizes = _int_list(shape_sweep["batch_sizes"])
         sequence_lengths = _int_list(shape_sweep["sequence_lengths"])
-        head_counts = _int_list(shape_sweep["head_counts"])
-        head_dims = _int_list(shape_sweep["head_dims"])
 
-        for head_dim in head_dims:
-            for n in sorted(head_counts):
-                for s in sorted(sequence_lengths):
-                    for b in sorted(batch_sizes):
-                        # Workload token budget (128K) + 32-bit indexing safety.
-                        if b * s > 131072:
-                            continue
-                        if 4 * b * s * n * head_dim * 2 >= 2**31:
-                            continue
-                        test_cases.append([b, s, n, head_dim])
+        for head_config in get_attention_encoder_head_configs(shape_sweep):
+            n = head_config.num_heads
+            head_dim = head_config.head_dim
+            for s in sorted(sequence_lengths):
+                for b in sorted(batch_sizes):
+                    # Workload token budget (128K) + 32-bit indexing safety.
+                    if b * s > 131072:
+                        continue
+                    if 4 * b * s * n * head_dim * 2 >= 2**31:
+                        continue
+                    test_cases.append([b, s, n, head_dim])
 
     return test_cases
 

--- a/collector/vllm/collect_attn_xpu.py
+++ b/collector/vllm/collect_attn_xpu.py
@@ -43,7 +43,11 @@ except ImportError:
 
 from vllm.config import set_current_vllm_config
 
-from collector.case_generator import get_attention_context_shape_sweeps, get_attention_generation_shape_sweeps
+from collector.case_generator import (
+    get_attention_context_shape_sweeps,
+    get_attention_generation_shape_sweeps,
+    get_attention_head_configs,
+)
 from collector.helper import benchmark_with_power, get_device_module, log_perf
 from collector.vllm.utils import (
     BatchSpec,
@@ -436,54 +440,47 @@ def get_context_attention_test_cases(if_unit_test=False):
     for shape_sweep in shape_sweeps:
         batch_sizes = [int(value) for value in shape_sweep["batch_sizes"]]
         sequence_lengths = [int(value) for value in shape_sweep["sequence_lengths"]]
-        query_head_counts = [int(value) for value in shape_sweep["query_head_counts"]]
-        kv_head_options = shape_sweep["kv_head_options"]
-        head_dims = [int(value) for value in shape_sweep["head_dims"]]
-        window_sizes = [int(value) for value in shape_sweep["window_sizes"]]
+        supported_head_dims = {int(value) for value in shape_sweep["head_dims"]}
+        supported_window_sizes = {int(value) for value in shape_sweep["window_sizes"]}
         max_tokens_self_attention = int(shape_sweep["max_tokens_self_attention"])
         max_tokens_grouped_query_attention = int(shape_sweep["max_tokens_grouped_query_attention"])
         max_kv_elements = int(shape_sweep["max_kv_elements"])
 
-        for n in sorted(query_head_counts, reverse=True):
+        for head_config in get_attention_head_configs(shape_sweep, phase="context"):
+            n = head_config.num_heads
+            num_kv_heads = head_config.num_kv_heads
+            head_dim = head_config.head_dim
+            window_size = head_config.window_size
+            if head_dim not in supported_head_dims or window_size not in supported_window_sizes:
+                continue
+            # XPU paged flash attention only supports GQA ratio <= 16.
+            if n // num_kv_heads > max_gqa_ratio:
+                continue
+            # Keep the backend limitation from the previous enumerator.
+            if window_size > 0 and head_dim == 128:
+                continue
             for s in sorted(sequence_lengths, reverse=True):
                 for b in sorted(batch_sizes, reverse=True):
-                    for kv_head_option in kv_head_options:
-                        is_self_kv = kv_head_option in ("self", 0, "0", None)
-                        num_kv_heads = n if is_self_kv else int(kv_head_option)
-                        if num_kv_heads <= 0:
+                    if num_kv_heads == n:
+                        if b * s > max_tokens_self_attention or b > 128:
                             continue
-                        if num_kv_heads != n and (num_kv_heads > n or n % num_kv_heads != 0):
-                            continue
-                        # XPU paged flash attention only supports GQA ratio <= 16
-                        if n // num_kv_heads > max_gqa_ratio:
-                            continue
-                        if num_kv_heads == n:
-                            if b * s > max_tokens_self_attention or b > 128:
-                                continue
-                        else:
-                            if b * s > max_tokens_grouped_query_attention:
-                                continue
-                        for head_dim in head_dims:
-                            if b * s * num_kv_heads * head_dim * 2 >= max_kv_elements:
-                                continue
-
-                            for window_size in window_sizes:
-                                # Skip SWA for head_dim=128 (no models use it)
-                                if window_size > 0 and head_dim == 128:
-                                    continue
-                                for is_fp8_kv_cache in kv_cache_dtype_list:
-                                    test_cases.append(
-                                        [
-                                            b,
-                                            s,
-                                            n,
-                                            num_kv_heads,
-                                            head_dim,
-                                            is_fp8_kv_cache,
-                                            True,
-                                            window_size,
-                                        ]
-                                    )
+                    elif b * s > max_tokens_grouped_query_attention:
+                        continue
+                    if b * s * num_kv_heads * head_dim * 2 >= max_kv_elements:
+                        continue
+                    for is_fp8_kv_cache in kv_cache_dtype_list:
+                        test_cases.append(
+                            [
+                                b,
+                                s,
+                                n,
+                                num_kv_heads,
+                                head_dim,
+                                is_fp8_kv_cache,
+                                True,
+                                window_size,
+                            ]
+                        )
 
     return test_cases
 
@@ -521,47 +518,49 @@ def get_generation_attention_test_cases():
     for shape_sweep in get_attention_generation_shape_sweeps("vllm_xpu"):
         batch_sizes = [int(value) for value in shape_sweep["batch_sizes"]]
         sequence_lengths = [int(value) for value in shape_sweep["sequence_lengths"]]
-        head_dims = [int(value) for value in shape_sweep["head_dims"]]
-        window_sizes = [int(value) for value in shape_sweep["window_sizes"]]
+        supported_head_dims = {int(value) for value in shape_sweep["head_dims"]}
+        supported_window_sizes = {int(value) for value in shape_sweep["window_sizes"]}
         min_drop_batch = int(shape_sweep["drop_largest_sequence_for_batch_at_least"])
 
-        for n in sorted([int(value) for value in shape_sweep["xqa_query_head_counts"]], reverse=True):
+        for head_config in get_attention_head_configs(shape_sweep, phase="generation"):
+            n = head_config.num_heads
+            n_kv = head_config.num_kv_heads
+            head_dim = head_config.head_dim
+            window_size = head_config.window_size
+            if head_dim not in supported_head_dims or window_size not in supported_window_sizes:
+                continue
+            # XPU paged flash attention only supports GQA ratio <= 16.
+            if n // n_kv > max_gqa_ratio:
+                continue
+            # Keep the backend limitation from the previous enumerator.
+            if window_size > 0 and head_dim == 128:
+                continue
+            max_tokens_key = "max_mha_tokens_per_step" if n == n_kv else "max_xqa_tokens_per_step"
             b_s_dict = _generation_target_sequence_lengths(
                 batch_sizes,
                 sequence_lengths,
                 n,
-                int(shape_sweep["max_mha_tokens_per_step"]),
+                int(shape_sweep[max_tokens_key]),
                 shape_sweep,
             )
             for b, s_list_limited in b_s_dict.items():
                 target_s_list = sorted(s_list_limited)
                 if b >= min_drop_batch:
                     target_s_list = target_s_list[:-1]
-                for n_kv in [int(value) for value in shape_sweep["kv_head_counts"]]:
-                    if n_kv > n or n % n_kv != 0:
-                        continue
-                    # XPU paged flash attention only supports GQA ratio <= 16
-                    if n // n_kv > max_gqa_ratio:
-                        continue
-                    for s in target_s_list:
-                        for head_dim in head_dims:
-                            for window_size in window_sizes:
-                                # Skip SWA for head_dim=128 (no models use it)
-                                if window_size > 0 and head_dim == 128:
-                                    continue
-                                for is_fp8_kv_cache in kv_cache_dtype_list:
-                                    test_cases.append(
-                                        [
-                                            b,
-                                            s,
-                                            n,
-                                            n_kv,
-                                            head_dim,
-                                            is_fp8_kv_cache,
-                                            False,
-                                            window_size,
-                                        ]
-                                    )
+                for s in target_s_list:
+                    for is_fp8_kv_cache in kv_cache_dtype_list:
+                        test_cases.append(
+                            [
+                                b,
+                                s,
+                                n,
+                                n_kv,
+                                head_dim,
+                                is_fp8_kv_cache,
+                                False,
+                                window_size,
+                            ]
+                        )
     return test_cases
 
 

--- a/collector/vllm/collect_moe.py
+++ b/collector/vllm/collect_moe.py
@@ -12,6 +12,7 @@ logits, and perf logging.
 __compat__ = "vllm>=0.17.0"
 
 import inspect
+import json
 import os
 
 import torch
@@ -109,6 +110,50 @@ aic_debug = int(os.getenv("aic_moe_debug", "0"))  # noqa: SIM112
 _WORKSPACE_MANAGER_DEVICES: set[str] = set()
 
 
+def _moe_execution_key(common_moe_testcase, moe_type: str):
+    module_config = get_moe_quantization_module_config(
+        "vllm",
+        moe_type,
+        model_name=common_moe_testcase.model_name,
+    )
+    return (
+        moe_type,
+        tuple(common_moe_testcase.num_tokens_list),
+        common_moe_testcase.hidden_size,
+        common_moe_testcase.inter_size,
+        common_moe_testcase.topk,
+        common_moe_testcase.num_experts,
+        common_moe_testcase.tp,
+        common_moe_testcase.ep,
+        common_moe_testcase.token_expert_distribution,
+        common_moe_testcase.power_law_alpha,
+        json.dumps(module_config, sort_keys=True, separators=(",", ":")),
+    )
+
+
+def _moe_consumer_keys(common_moe_testcase, moe_type: str):
+    """Return every consumer-visible key emitted by one getter task."""
+    distribution = (
+        f"power_law_{common_moe_testcase.power_law_alpha}"
+        if common_moe_testcase.token_expert_distribution == "power_law"
+        else common_moe_testcase.token_expert_distribution
+    )
+    return tuple(
+        (
+            moe_type,
+            distribution,
+            common_moe_testcase.topk,
+            common_moe_testcase.num_experts,
+            common_moe_testcase.hidden_size,
+            common_moe_testcase.inter_size,
+            common_moe_testcase.tp,
+            common_moe_testcase.ep,
+            num_tokens,
+        )
+        for num_tokens in common_moe_testcase.num_tokens_list
+    )
+
+
 def _ensure_workspace_manager(device: str) -> None:
     if init_workspace_manager is None:
         return
@@ -138,6 +183,8 @@ def get_moe_test_cases():
     )
 
     test_cases = []
+    seen = set()
+    consumer_key_owners = {}
 
     for common_moe_testcase in get_common_moe_test_cases():
         model_name = common_moe_testcase.model_name
@@ -158,6 +205,24 @@ def get_moe_test_cases():
                 topk=common_moe_testcase.topk,
             ):
                 continue
+
+            execution_key = _moe_execution_key(common_moe_testcase, moe_type)
+            if execution_key in seen:
+                continue
+            consumer_keys = _moe_consumer_keys(common_moe_testcase, moe_type)
+            for consumer_key in consumer_keys:
+                previous_owner = consumer_key_owners.get(consumer_key)
+                if previous_owner is not None and previous_owner[0] != execution_key:
+                    previous_model = previous_owner[1]
+                    raise ValueError(
+                        "vLLM MoE population collision: "
+                        f"models {previous_model!r} and {model_name!r} map distinct benchmark "
+                        f"invocations to consumer key {consumer_key!r}; "
+                        "the current moe_perf consumer cannot represent both"
+                    )
+            for consumer_key in consumer_keys:
+                consumer_key_owners[consumer_key] = (execution_key, model_name)
+            seen.add(execution_key)
 
             test_cases.append(
                 [
@@ -229,10 +294,11 @@ def run_moe_torch(
 
     # INT4_WO path: W4A16 via vLLM's Marlin kernel using int4_w4a16_moe_quant_config.
     # Weights are packed uint8 (2 int4 per byte, shape K//2). Scales are per-group
-    # along K (group_size=128). Zero-points are None (symmetric quantization).
+    # along K (Kimi-K2.5 uses group_size=32). Zero-points are None.
     use_int4_wo = moe_type == "int4_wo"
     if use_int4_wo:
-        int4_group_size = 128
+        int4_config = get_moe_quantization_module_config("vllm", moe_type, model_name=model_name)
+        int4_group_size = int(int4_config.get("group_size", 128))
         # w1: (E, 2*local_inter, hidden) packed → (E, 2*local_inter, hidden//2) uint8
         w1 = torch.randint(
             0, 127, (local_num_experts, 2 * local_inter_size, hidden_size // 2), dtype=torch.uint8, device=device

--- a/docs/perf_database/collector-v2-population-design.md
+++ b/docs/perf_database/collector-v2-population-design.md
@@ -1,0 +1,396 @@
+# Collector V2 Case Pruning
+
+## Goal
+
+Collector V2 should retain useful measurement coverage and intentional model
+additions while avoiding cases created only by unrelated Cartesian-product axes
+or execution-equivalent artifact aliases.
+
+The attention migration used the following comparison as a one-time check:
+
+```text
+V1 physical cases ⊆ cleaned V2 physical cases
+```
+
+`removed_v1_cases` was required to be zero for attention. That audit is not
+part of the runtime schema: production YAML contains ordinary default and model
+profiles, and the generator has no Collector-V1 compatibility mode.
+
+For the quant-sensitive MoE families migrated in this PR, a physical point must
+have a verified checkpoint artifact whose quantization can request it.
+Collector V1 crossed each geometry with most backend quant modes, so preserving
+every V1 MoE key would preserve measurements that no reviewed artifact can
+consume. Those historical cross-products are reported separately below instead
+of being reintroduced as synthetic or `legacy_*` profiles. Existing model
+families without verified artifact policy retain their broad synthetic sweep;
+this document does not claim that every MoE family has been migrated.
+
+Targeted structural population is model-exact. It does not inherit unrelated
+default topology profiles when the selected model has an explicit structural
+profile; shared workload sweeps remain reusable.
+
+## Scope
+
+This work changes Collector-only population and the operation-local execution
+plumbing required to keep generated quantization labels truthful:
+
+- `collector/cases/**/*.yaml`
+- `collector/case_generator.py`
+- `collector/model_cases.py`
+- operation-local case getters and the minimal runtime parameters required by
+  declared quantization/precision cases
+- the model-specific op selection path in `collector/collect.py`
+- Collector tests and documentation
+
+The `collector/collect.py` change removes only the DeepSeek V4 hard-coded op
+override so that the resolved YAML case plan remains authoritative. Generic
+resume, checkpoint, and output-finalization behavior is unchanged. This work
+does not change AIC SDK or Rust lookup behavior, EngineSpec, or Dynamo Planner.
+Collector output continues to satisfy the existing consumers; consumer changes
+are outside this PR.
+
+The final implementation intentionally contains no Collector-V1 runtime mode,
+historical snapshot rewrite, generic resume/checkpoint/finalization change, or
+defensive deduplication that has no effect on repository-owned YAML. Schema
+fields and filters that lost their only producer during the design were removed
+instead of being kept as speculative compatibility surface.
+
+## Baselines
+
+- Attention V1: `a4827ce203e9fbc24fe6c6779a7eaa2a7dc79f1a`, immediately before
+  Collector V2.
+- Encoder attention: the original hardcoded grid from PR #1092, because the
+  pre-V2 attention baseline predates this collector.
+- Collector V2 before pruning: upstream `66c6e05fef00cbee6546847fa2280116ef4a38cd`.
+
+The comparison uses consumer-visible physical lookup keys, not model aliases,
+scheduler task IDs, latency, or power measurements.
+
+Historical data was used only for the read-only comparison recorded below. This
+PR does not add, move, regenerate, or update snapshots.
+
+## Three identities
+
+Collector population must keep three different identities separate:
+
+1. **Recipe identity** explains why YAML requested a case. Multiple model
+   documents may provide provenance for the same work.
+2. **Benchmark invocation identity** contains everything that can change the
+   executed kernel or runtime setup, including path-dependent checkpoint
+   quantization.
+3. **Persisted physical key** is the unchanged key used by the current AIC
+   consumer to load a measurement.
+
+Deduplication is safe only when benchmark invocation identity is equivalent and
+the persisted physical key is also equivalent. A consumer-key collision alone
+does not prove two invocations are interchangeable. In particular, a BF16,
+FP8, or NVFP4 checkpoint path may select different runtime behavior before its
+native quantization becomes explicit.
+
+## Population flow
+
+```text
+additive YAML profiles
+    -> select the model/backend operations
+    -> expand correlated structural tuples
+    -> resolve model/backend quantization policy
+    -> reject unreachable/backend-unsupported tuples
+    -> derive operation-local invocation identity
+    -> stable deduplication of proven-equivalent invocations
+    -> apply model and SM selectors
+    -> benchmark queue
+```
+
+The important distinction is between an axis list and a structural profile.
+For attention, `(query heads, KV heads, head dimension, window size, TP)` is a
+correlated tuple. Combining global lists for those fields produces shapes that
+no model uses. Batch and sequence axes can still be swept after the structural
+tuple is selected.
+
+YAML remains additive. Deduplication happens after enough information is known
+to identify the actual benchmark point. Stable first-wins is the default. When
+a later selector can distinguish two equivalent recipe representations, the
+getter must choose a documented canonical representative that remains
+selectable; standalone MLA uses the smallest TP for this reason.
+
+## Safe deduplication rules
+
+1. Never change a downstream consumer to make a Collector case appear useful.
+2. Preserve a field if it changes either the benchmark invocation or any
+   current Python/Rust consumer key.
+3. Collapse artifact aliases only for shape-only collectors where the model
+   path is neither loaded by the benchmark nor part of its persisted key.
+4. Do not alias BF16, FP8, or NVFP4 checkpoints before a module benchmark has
+   resolved path-dependent native quantization. Once quantization is explicit,
+   an operation-local key may collapse only truly identical benchmark inputs.
+5. For standalone MLA, total heads and TP may produce the same local-head
+   kernel. The getter deduplicates on `(dtype, local heads, batch, sequence)`
+   and retains the smallest-TP representation so a later TP selector cannot
+   hide that physical point.
+6. SM exclusions are pre-execution skips. They are not expected failures after
+   a case has already run.
+7. Unknown or unproved equivalence is retained. It is better to prune less than
+   to silently remove a useful physical point.
+8. If distinct benchmark invocations map to one persisted consumer key, fail
+   population with both owners and the conflicting key. Do not silently pick a
+   representative unless the invocations are already proven equivalent, and do
+   not widen the consumer schema inside a Collector-only change.
+
+## Pruning decisions
+
+| Situation | Population behavior | Reason |
+|---|---|---|
+| Head/KV-head/head-dim/window values from different models | Keep correlated model profiles; do not cross them | Cross-model tuples are not deployable shapes |
+| Shape-only collector with base/FP8/NVFP4 names and no checkpoint-native behavior | Canonicalize artifact aliases | Artifact name does not change the invocation or persisted key |
+| Quant-sensitive MoE family with verified artifact metadata | Keep one row per artifact and allow only the artifact's declared quant mode | A shared geometry does not make INT4, FP8, MXFP4, and NVFP4 checkpoints interchangeable |
+| Module collector that reads checkpoint-native quantization | Retain each path until native quantization is explicit | The path can change the executed kernel |
+| Different total-head/TP pairs with the same standalone-MLA local-head key | Deduplicate in the getter | Both invocation and current loader key are equivalent |
+| Experimental op with no production consumer | Keep the registry entry, omit it from default model plans | Explicit research runs remain possible without default collection cost |
+| Equivalence is uncertain | Retain the cases | Conservative pruning avoids silent coverage loss |
+
+## Attention result
+
+The following canonical B200/SM100 counts compare full/raw physical attention
+cases. `Removed` is always measured against the V1 baseline.
+
+| Backend | Operation | V1 | V2 before | Cleaned V2 | Added | Removed |
+|---|---|---:|---:|---:|---:|---:|
+| SGLang | context | 33,714 | 122,676 | 50,901 | 17,187 | 0 |
+| SGLang | generation | 19,484 | 53,654 | 40,468 | 20,984 | 0 |
+| TRT-LLM | context | 63,192 | 143,739 | 75,483 | 12,291 | 0 |
+| TRT-LLM | generation | 40,240 | 155,582 | 55,230 | 14,990 | 0 |
+| vLLM | context | 40,392 | 84,296 | 51,408 | 11,016 | 0 |
+| vLLM | generation | 36,288 | 68,920 | 54,270 | 17,982 | 0 |
+| vLLM XPU | context | 16,188 | 16,188 | 17,838 | 1,650 | 0 |
+| vLLM XPU | generation | 26,322 | 26,322 | 30,728 | 4,406 | 0 |
+| **Total** | | **275,820** | **671,377** | **376,326** | **100,506** | **0** |
+
+Relative to upstream Collector V2, this removes 295,051 accidental attention
+keys while retaining 100,506 intentional additions over V1.
+
+The unpruned V2 vLLM grids also removed 10,098 context and 8,774 generation
+V1 cases, all from the historical `(head_dim=128, window=128)` region. The
+final default profiles retain those points, while model-native profiles add
+valid new window/head combinations without recreating the global Cartesian
+product.
+
+Encoder attention retains all 7,008 original hardcoded cases and adds 671
+model-native cases, for 7,679 total.
+
+## Other operation results
+
+These are deterministic shared YAML recipe counts. Backend-specific expansion
+may multiply a recipe by dtype, TP/EP, or token lists.
+
+| Operation | V1 | V2 before | Cleaned V2 | Notes |
+|---|---:|---:|---:|---|
+| GEMM | 35,742 | 35,742 | 35,742 | unchanged |
+| ComputeScale | 1,628 | 1,628 | 1,628 | shared recipe unchanged; V2 also activates SGLang/vLLM |
+| MoE common | 1,797 | 4,548 | 4,209 | quant-sensitive artifacts have separate recipe identity; backend policy removes invalid products before execution |
+| MLA context specs | 220 | 550 | 220 | SGLang/TRT-LLM getters each emit 1,760 unique loader keys |
+| MLA generation specs | 362 | 885 | 362 | SGLang emits 2,656 keys after its int32 KV guard; TRT-LLM emits 2,896 |
+| Mamba | 8 | 8 | 12 | four default synthetic interpolation profiles added |
+| GDN | 16 | 16 | 16 | unchanged |
+| mHC | 8 | 8 | 8 | artifact recipes remain distinct; backend getters collapse them to four phase/shape groups before the unchanged token sweep |
+| MLA BMM pre/post | 400 / 448 | 400 / 448 | 400 / 448 | unchanged |
+
+With `COLLECTOR_MODEL_PATH` unset, the SM100 raw public-getter audit separates
+candidate getter tasks from actual invocation identity. These counts are
+measured after artifact quantization policy, before model/SM/version plan
+selectors, and before expanding each task's token list:
+
+| Backend | Raw getter tasks before dedupe | Raw getter tasks now | Duplicate tasks removed | Unique invocation/key loss |
+|---|---:|---:|---:|---:|
+| TRT-LLM | 9,414 | 7,944 | 1,470 | 0 |
+| vLLM | 2,799 | 2,352 | 447 | 0 |
+
+The vLLM audit enables the `per_block_fp8`, `nvfp4`, and `mxfp4` runtime
+features. Full model plans may filter these raw tasks later, so the table is not
+a post-selector or token-expanded queue count.
+
+Artifact-exact policy is a separate pruning stage, not part of the dedupe row
+above. Relative to the pre-review population, the reviewed DeepSeek V3,
+MiniMax M2, and Nemotron 3 families remove 1,110 TRT-LLM getter tasks / 29,970
+token-expanded rows and 501 vLLM getter tasks / 13,527 rows. Every removed row
+in this subset combines a model geometry with a quant mode that none of that
+geometry's verified checkpoints use. DeepSeek V3/R1/V3.2 and MiniMax M2 use
+FP8-block artifacts; their NVIDIA variants use NVFP4. Nemotron Nano is BF16,
+Super is NVFP4, and Ultra keeps distinct BF16, FP8, and NVFP4 recipe rows.
+Pinned SGLang has no plain per-tensor FP8 MoE path, so the Ultra FP8 artifact
+intentionally schedules no SGLang MoE case rather than being relabeled as
+FP8-block. Pinned vLLM limits its NVFP4 path to top-k <= 10, so Nemotron
+Super/Ultra top-k-22 NVFP4 is likewise an explicit gap rather than a mislabeled
+fallback case.
+
+`nvidia/nemotron-ultra-rl-050826` remains available to the shape-only Mamba
+profile, but it has no MoE profile: the repository has no checkpoint quant
+config proving whether its required FP4 format is NVFP4 or MXFP4. It can be
+enabled after that artifact contract and an exact-version runtime smoke exist.
+
+The same distinction makes the V1 comparison explicit. The following SM100
+counts are token-expanded consumer keys, with vLLM runtime features enabled:
+
+| Backend | V1 keys | Current keys | V1 keys retained | New keys | V1 cross-products removed |
+|---|---:|---:|---:|---:|---:|
+| TRT-LLM | 157,869 | 214,488 | 110,160 | 104,328 | 47,709 |
+| vLLM | 63,342 | 63,504 | 35,964 | 27,540 | 27,378 |
+
+The removed V1 keys are historical geometry-by-quant products, not modes
+requested by the migrated artifact families. Attention retains its stricter
+zero-V1-key-loss guarantee; MoE deliberately does not manufacture a legacy
+artifact to keep an unreachable physical point alive.
+
+These dedupe paths remain because current repository YAML produces real
+duplicates. The analogous MLA-module `seen` guards were removed: current model
+specs and sweeps are already unique, so those guards changed no scheduled work
+and obscured the path-sensitive checkpoint contract.
+
+The MLA spec rows above are recipes, not final getter queues. With two dtypes on
+SM90/SM100, the standalone getters compare as follows:
+
+| Backend | Operation | V1 scheduled | V1 unique physical | Current scheduled | Current unique physical | Removed physical |
+|---|---|---:|---:|---:|---:|---:|
+| SGLang | context | 3,080 | 1,760 | 1,760 | 1,760 | 0 |
+| SGLang | generation | 4,648 | 2,656 | 2,656 | 2,656 | 0 |
+| TRT-LLM | context | 1,760 | 1,760 | 1,760 | 1,760 | 0 |
+| TRT-LLM | generation | 2,896 | 2,896 | 2,896 | 2,896 | 0 |
+
+For a targeted Kimi TP<=8 plan, SGLang emits 1,100 context / 1,660 generation
+cases and TRT-LLM emits 1,100 / 1,810. Both retain local heads
+`{128, 64, 32, 16, 8}`. The 64-head YAML profile is required for the last
+targeted bucket and for `local_heads=1` in full collection; overlap with the
+128-head profile is removed only in the backend getter.
+
+For migrated quant-sensitive MoE families, geometry and checkpoint
+quantization are separate identities. New model profiles remain additive, but
+a backend schedules only the declared artifact mode rather than taking the
+Cartesian product of every shape and every backend quant mode. DeepSeek V4
+native artifacts schedule
+`w4a8_mxfp4_mxfp8` in TRT-LLM. Pinned SGLang 0.5.10 predates the DSV4-specific
+MXFP4 method, and pinned vLLM 0.19.0 has no DSV4 MXFP4/MXFP8 implementation,
+so neither schedules a native V4 MoE case. The `sgl-project/*-FP8` artifacts
+schedule `fp8_block`.
+Kimi-K2-Instruct schedules `fp8_block`, native Kimi-K2.5 schedules
+`int4_wo` with group size 32, and NVIDIA Kimi-K2.5 schedules `nvfp4`.
+
+GPT-OSS is also backend- and hardware-specific. On SM100, SGLang and TRT-LLM
+retain `w4a16_mxfp4` and add `w4a8_mxfp4_mxfp8` because the two labels select
+distinct activation precisions. On SM103, TRT-LLM retains both modes while the
+pinned SGLang 0.5.10 path is skipped by a version exception. On SM120, pinned
+SGLang 0.5.10 is likewise skipped, and pinned TRT-LLM 1.3.0rc10 skips both
+GPT-OSS modes because its fused MoE path rejects them. TRT-LLM retains only
+`w4a16_mxfp4` on Hopper, while vLLM collects `w4a16_mxfp4`. SGLang explicitly
+selects BF16 activation precision for the W4A16 label and its runtime `default`
+selects MXFP8 activation for the W4A8 label.
+SGLang 0.5.10's generic MXFP4 method is retained for GPT-OSS W4A16/W4A8, where
+its high-level `FusedMoE + Mxfp4Config` path owns the FlashInfer API, TP
+padding, and EP-local expert layout. It is not reused for DeepSeek V4: the
+DSV4-specific method was added later and has a different top-k/clamp contract.
+A future SGLang 0.5.14 collector upgrade can enable native DSV4 W4A8 after an
+exact-version smoke instead of carrying a newer-version kernel shim here.
+
+DSA module population retains checkpoint paths because all three backends load
+model-path-specific config. SGLang resolves native checkpoint quantization to
+reject impossible explicit GEMM combinations, but `quantization=None` may still
+auto-detect the artifact's config for a BF16-labelled module case. The getters
+therefore retain distinct paths even when those rows later project to the same
+consumer key. A physical-key collision by itself is not permission to drop a
+path-sensitive invocation.
+
+SGLang's inner MLA/DSA module sweep reads the same YAML precision specs and SM
+gates as the population layer. In particular, Ada/Hopper expand `fp8_block`,
+not `nvfp4`; any future NVFP4 module precision must be declared with a
+Blackwell `min_sm` gate in YAML.
+
+The following SM100 counts are raw tasks returned by each public getter with
+`COLLECTOR_MODEL_PATH` unset, before model/SM/version plan selectors. For
+SGLang, each raw task is a subprocess group whose batch, sequence, prefix, and
+precision inner sweep is expanded later; these are not token-expanded
+invocation counts.
+
+| Backend | Operation | Upstream V2 raw getter tasks | Current raw getter tasks | Current unique task projections | Removed upstream task projections |
+|---|---|---:|---:|---:|---:|
+| SGLang | context | 792 | 792 | 528 | 0 |
+| SGLang | generation | 48 | 48 | 32 | 0 |
+| TRT-LLM | context | 46,848 | 46,848 | 23,424 | 0 |
+| TRT-LLM | generation | 35,328 | 35,328 | 17,664 | 0 |
+| vLLM | context | 70,272 | 70,272 | 35,136 | 0 |
+| vLLM | generation | 35,328 | 35,328 | 17,664 | 0 |
+
+The analogous GLM MoE artifacts are deliberately not merged: SGLang selects
+native FP8/NVFP4 MoE quantization by artifact path, so those paths represent
+real additional measurements rather than scheduler duplicates.
+
+## Current-model completeness and DeepSeek V4 safety
+
+The correlated-profile audit also covers model paths that were advertised by
+Collector V2 but previously fell back to the broad default grid or produced no
+model-specific cases:
+
+- Qwen3.5 dense 0.8B/2B and 4B/9B share their exact attention topologies.
+- Qwen3.5-122B-A10B has exact attention and MoE profiles.
+- MiniMax M2/M2.5/M2.7 share one exact attention topology.
+- Qwen3-30B-A3B includes its valid TP8 attention point, and the Qwen3
+  235B-2507 artifact resolves to the existing 235B MoE shape.
+
+DeepSeek V4 has three additional population constraints:
+
+1. The persisted module and top-k calibration keys do not contain enough
+   model geometry to distinguish Flash from Pro. Full/raw collection therefore
+   uses one canonical `sgl-project/DeepSeek-V4-Flash-FP8` profile and never
+   combines both models in one output. Targeted native and FP8 artifact paths
+   remain supported.
+2. The model YAML is the source of truth for backend-specific operations.
+   SGLang schedules CSA/HCA context and generation modules, top-k calibration,
+   mHC, MoE, and WideEP MoE. vLLM's DSV4 collectors remain registry-only until
+   the declared runtime compatibility floor and prefix-aware context contract
+   are both satisfied. TRT-LLM continues to schedule only the operations its
+   registry implements.
+3. MoE artifact aliases are not merged across quantization formats. Native
+   DeepSeek V4 artifacts retain only `w4a8_mxfp4_mxfp8` for TRT-LLM, while the
+   converted `sgl-project/*-FP8` artifacts retain only `fp8_block`. Pinned
+   SGLang 0.5.10 and vLLM 0.19.0 native mode lists are explicitly empty instead
+   of advertising unverified future-version paths.
+
+The NVIDIA DeepSeek-V4 NVFP4 checkpoints are intentionally not advertised by
+this Collector-only change. The current AIC model catalog and the DSV4 module
+collector do not yet define an end-to-end NVFP4 artifact contract; adding only
+a standalone MoE shape would create a plan that AIC cannot consume correctly.
+
+mHC keeps native and converted artifacts separate in the shared recipes.
+SGLang and vLLM collapse only identical phase/hidden-size/hc-mult groups in
+their operation-local getters before sweeping token counts; a targeted run
+first filters to the requested artifact, so that artifact remains the
+representative.
+
+## Review checklist
+
+When adding or changing a model profile:
+
+1. Identify whether the collector loads the model or only uses its dimensions.
+2. Keep correlated dimensions in one profile; do not append them to unrelated
+   global axes.
+3. State whether quantization is selected by the model artifact or expanded by
+   the collector.
+4. Compare physical key sets, not only totals.
+5. Derive benchmark invocation identity before deciding that artifact names or
+   quantization variants are duplicates.
+6. Verify targeted model plans do not activate unrelated base operations or
+   inherit unrelated default profiles.
+7. Keep a synthetic default point when an unchanged consumer still queries it,
+   even if the current model metadata would choose a different value.
+
+## Validation
+
+```bash
+pytest -q tests/unit/collector
+ruff check collector tests/unit/collector
+ruff format --check collector tests/unit/collector
+git diff --check
+```
+
+The final Collector suite reports 299 passed and 2 skipped. The unit coverage
+checks final profile expansion, per-operation recipe counts, selector narrowing,
+alias handling, hardware/precision boundaries, and operation-local physical
+deduplication. The historical key-set comparison above was a one-time read-only
+audit, not an ongoing Collector behavior or exact-count unit-test dependency.

--- a/tests/unit/collector/sglang/test_collect_mla_module.py
+++ b/tests/unit/collector/sglang/test_collect_mla_module.py
@@ -55,11 +55,12 @@ class TestGetPrecisionCombos:
         mod = _import_module()
         with patch.object(mod, "get_sm_version", return_value=90):
             combos = mod._get_precision_combos("context")
-        assert ("bfloat16", "bfloat16", "bfloat16") in combos
-        assert ("bfloat16", "fp8", "bfloat16") in combos
-        assert ("bfloat16", "bfloat16", "fp8_block") in combos
-        assert ("bfloat16", "fp8", "fp8_block") in combos
-        assert len(combos) == 4
+        assert combos == [
+            ("bfloat16", "bfloat16", "bfloat16"),
+            ("bfloat16", "fp8", "bfloat16"),
+            ("bfloat16", "bfloat16", "fp8_block"),
+            ("bfloat16", "fp8", "fp8_block"),
+        ]
 
     def test_ada_sm89_no_fp8(self):
         mod = _import_module()
@@ -169,86 +170,80 @@ class TestDsaRuntimeLimits:
 
 
 class TestDsaPiecewiseCudaGraph:
-    def test_glm5_dsa_piecewise_graph_is_opt_in(self, monkeypatch):
+    def test_glm5_dsa_piecewise_graph_is_only_for_trtllm_prefill(self):
         mod = _import_module()
-        monkeypatch.delenv("AIC_ENABLE_PIECEWISE_CUDA_GRAPH", raising=False)
-        monkeypatch.delenv("AIC_DISABLE_PIECEWISE_CUDA_GRAPH", raising=False)
 
         assert not mod._enable_glm5_dsa_piecewise_graph("dsa", "nvidia/GLM-5-NVFP4")
-        assert not mod._enable_glm5_dsa_piecewise_graph("dsa", "zai-org/GLM-5")
-        assert not mod._enable_glm5_dsa_piecewise_graph("mla", "nvidia/GLM-5-NVFP4")
-        assert not mod._enable_glm5_dsa_piecewise_graph("dsa", "deepseek-ai/DeepSeek-V3.2")
+        assert mod._enable_glm5_dsa_piecewise_graph("dsa", "zai-org/GLM-5", "trtllm")
+        assert not mod._enable_glm5_dsa_piecewise_graph("mla", "zai-org/GLM-5", "trtllm")
+        assert not mod._enable_glm5_dsa_piecewise_graph("dsa", "deepseek-ai/DeepSeek-V3.2", "trtllm")
 
-    def test_glm5_dsa_piecewise_graph_can_be_enabled(self, monkeypatch):
+    def test_generation_cuda_graph_uses_max_batch_tokens(self):
         mod = _import_module()
-        monkeypatch.setenv("AIC_ENABLE_PIECEWISE_CUDA_GRAPH", "1")
-        monkeypatch.delenv("AIC_DISABLE_PIECEWISE_CUDA_GRAPH", raising=False)
+        runner = types.SimpleNamespace(
+            server_args=types.SimpleNamespace(disable_cuda_graph=False, cuda_graph_bs=None, cuda_graph_max_bs=256)
+        )
 
-        assert mod._enable_glm5_dsa_piecewise_graph("dsa", "nvidia/GLM-5-NVFP4")
-        assert mod._enable_glm5_dsa_piecewise_graph("dsa", "zai-org/GLM-5")
-        assert not mod._enable_glm5_dsa_piecewise_graph("mla", "nvidia/GLM-5-NVFP4")
+        assert mod._generation_cuda_graph_enabled_for_tokens(runner, 256)
+        assert not mod._generation_cuda_graph_enabled_for_tokens(runner, 257)
 
-    def test_piecewise_graph_can_be_disabled(self, monkeypatch):
+    def test_generation_cuda_graph_uses_explicit_batch_list(self):
         mod = _import_module()
-        monkeypatch.setenv("AIC_DISABLE_PIECEWISE_CUDA_GRAPH", "1")
-        monkeypatch.setenv("AIC_ENABLE_PIECEWISE_CUDA_GRAPH", "1")
+        runner = types.SimpleNamespace(
+            server_args=types.SimpleNamespace(disable_cuda_graph=False, cuda_graph_bs=[1, 4, 16])
+        )
 
-        assert not mod._enable_glm5_dsa_piecewise_graph("dsa", "nvidia/GLM-5-NVFP4")
+        assert mod._generation_cuda_graph_enabled_for_tokens(runner, 4)
+        assert not mod._generation_cuda_graph_enabled_for_tokens(runner, 8)
 
-    def test_piecewise_token_buckets_follow_case_shape(self, monkeypatch):
+    def test_generation_cuda_graph_can_be_disabled(self):
         mod = _import_module()
-        monkeypatch.delenv("AIC_PIECEWISE_CUDA_GRAPH_TOKENS", raising=False)
-        cases = [(2, 128, True, 0), (4, 64, True, 1024)]
+        runner = types.SimpleNamespace(
+            server_args=types.SimpleNamespace(disable_cuda_graph=True, cuda_graph_bs=[1, 4, 16])
+        )
 
-        assert mod._piecewise_cuda_graph_tokens_for_cases(cases, is_prefill=True) == [256]
-        assert mod._piecewise_cuda_graph_tokens_for_cases(cases, is_prefill=False) == [2, 4]
-
-    def test_piecewise_token_buckets_accept_env_override(self, monkeypatch):
-        mod = _import_module()
-        monkeypatch.setenv("AIC_PIECEWISE_CUDA_GRAPH_TOKENS", "256,512")
-
-        assert mod._piecewise_cuda_graph_tokens_for_cases([(2, 128, True, 0)], is_prefill=True) == [256, 512]
-
-    def test_generation_cuda_graph_uses_max_batch_tokens(self, monkeypatch):
-        mod = _import_module()
-        monkeypatch.delenv("AIC_CUDA_GRAPH_BS", raising=False)
-        monkeypatch.delenv("AIC_DISABLE_CUDA_GRAPH", raising=False)
-        monkeypatch.setenv("AIC_CUDA_GRAPH_MAX_BS", "256")
-
-        assert mod._generation_cuda_graph_enabled_for_tokens(256)
-        assert not mod._generation_cuda_graph_enabled_for_tokens(257)
-
-    def test_generation_cuda_graph_uses_explicit_batch_list(self, monkeypatch):
-        mod = _import_module()
-        monkeypatch.delenv("AIC_DISABLE_CUDA_GRAPH", raising=False)
-        monkeypatch.setenv("AIC_CUDA_GRAPH_BS", "1,4,16")
-
-        assert mod._generation_cuda_graph_enabled_for_tokens(4)
-        assert not mod._generation_cuda_graph_enabled_for_tokens(8)
-
-    def test_generation_cuda_graph_can_be_disabled(self, monkeypatch):
-        mod = _import_module()
-        monkeypatch.setenv("AIC_DISABLE_CUDA_GRAPH", "1")
-        monkeypatch.setenv("AIC_CUDA_GRAPH_BS", "1,4,16")
-
-        assert not mod._generation_cuda_graph_enabled_for_tokens(4)
+        assert not mod._generation_cuda_graph_enabled_for_tokens(runner, 4)
 
 
 class TestBuildModuleTestCases:
-    def test_module_precision_includes_fp8_kv_for_sglang(self):
+    def test_module_precision_respects_outer_sm_gate(self):
         mod = _import_module()
-        with patch.object(mod, "get_sm_version", return_value=90):
-            combos = mod._get_module_precision_combos()
-        assert ("bfloat16", "bfloat16", "bfloat16") in combos
-        assert ("bfloat16", "fp8", "bfloat16") in combos
-
-    def test_dsa_includes_both_models(self):
-        mod = _import_module()
-        with patch.object(mod, "get_sm_version", return_value=90):
+        with patch.object(mod, "get_sm_version", return_value=89):
             cases = mod._build_module_test_cases("dsa", "context")
-        model_paths = {c[6] for c in cases}
+        assert cases
+        assert {case[3] for case in cases} == {"bfloat16"}
+
+    def test_module_precision_passes_phase_and_sm_to_yaml(self):
+        mod = _import_module()
+        calls = []
+
+        def precision_specs(backend, *, phase, sm_version):
+            calls.append((backend, phase, sm_version))
+            return [
+                types.SimpleNamespace(
+                    compute_dtype="bfloat16",
+                    kv_cache_dtype="bfloat16",
+                    gemm_type="bfloat16",
+                )
+            ]
+
+        with (
+            patch.object(mod, "get_sm_version", return_value=89),
+            patch.object(mod, "get_mla_module_precision_specs", side_effect=precision_specs),
+        ):
+            cases = mod._build_module_test_cases("dsa", "generation")
+
+        assert cases
+        assert calls == [("sglang", "generation", 89)]
+
+    def test_dsa_keeps_path_sensitive_checkpoints_after_precision_filtering(self):
+        mod = _import_module()
+        with patch.object(mod, "get_sm_version", return_value=100):
+            cases = mod._build_module_test_cases("dsa", "context")
+        model_paths = {case[6] for case in cases}
         assert "deepseek-ai/DeepSeek-V3.2" in model_paths
         assert "zai-org/GLM-5" in model_paths
+        assert "zai-org/GLM-5-FP8" in model_paths
         assert "nvidia/GLM-5-NVFP4" in model_paths
 
     def test_mla_includes_v3_family(self):
@@ -262,22 +257,43 @@ class TestBuildModuleTestCases:
             "nvidia/DeepSeek-V3.1-NVFP4",
         }
 
-    def test_format_length_10(self):
-        """Each DSA module test case includes a target TP size."""
+    def test_targeted_quantized_artifact_keeps_requested_checkpoint(self, monkeypatch):
+        mod = _import_module()
+        monkeypatch.setenv("COLLECTOR_MODEL_PATH", "nvidia/GLM-5-NVFP4")
+        with patch.object(mod, "get_sm_version", return_value=100):
+            cases = mod._build_module_test_cases("dsa", "context")
+        assert cases
+        assert {case[6] for case in cases} == {"nvidia/GLM-5-NVFP4"}
+
+    def test_format_length_11(self):
+        """Each DSA module case includes target TP and prefill backend."""
         mod = _import_module()
         with patch.object(mod, "get_sm_version", return_value=90):
             for case in mod._build_module_test_cases("dsa", "generation"):
-                assert len(case) == 10
+                assert len(case) == 11
                 assert case[7] == "dsa"
                 assert case[8] is None  # DSA backend resolved at runtime
                 assert case[9] in {1, 2, 4, 8}
+                assert case[10] == "flashmla_kv"
 
     def test_deduplication(self):
         """One entry per top-level sweep tuple, not per inner (seq, batch) shape."""
         mod = _import_module()
         with patch.object(mod, "get_sm_version", return_value=90):
             cases = mod._build_module_test_cases("dsa", "context")
-        keys = {(c[6], c[2], c[3], c[4], c[5], c[1]) for c in cases}
+        keys = {
+            (
+                c[6],
+                c[2],
+                c[3],
+                c[4],
+                c[5],
+                c[1],
+                c[9],
+                c[10],
+            )
+            for c in cases
+        }
         assert len(cases) == len(keys)
         assert all(c[0] == 0 for c in cases)
 

--- a/tests/unit/collector/sglang/test_collect_moe_population.py
+++ b/tests/unit/collector/sglang/test_collect_moe_population.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import ast
+import itertools
+from contextlib import contextmanager, nullcontext
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+SOURCE_PATH = REPO_ROOT / "collector" / "sglang" / "collect_moe.py"
+
+
+def _load_functions(*names: str, namespace: dict | None = None) -> dict:
+    tree = ast.parse(SOURCE_PATH.read_text(), filename=str(SOURCE_PATH))
+    selected = [node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name in names]
+    loaded = dict(namespace or {})
+    exec(compile(ast.Module(body=selected, type_ignores=[]), str(SOURCE_PATH), "exec"), loaded)
+    return loaded
+
+
+def _gptoss_case(*, tp: int, ep: int):
+    return SimpleNamespace(
+        num_tokens_list=[128],
+        hidden_size=2880,
+        inter_size=2880,
+        topk=4,
+        num_experts=128,
+        tp=tp,
+        ep=ep,
+        model_name="openai/gpt-oss-120b",
+        token_expert_distribution="balanced",
+        power_law_alpha=None,
+        architecture="GptOssForCausalLM",
+    )
+
+
+def _populate_gptoss_cases(cases):
+    loaded = _load_functions(
+        "get_moe_test_cases",
+        namespace={
+            "itertools": itertools,
+            "get_sm_version": lambda: 100,
+            "get_common_moe_test_cases": lambda: cases,
+            "moe_model_allows_quantization": (lambda _backend, _model, mode: mode == "w4a8_mxfp4_mxfp8"),
+            "get_moe_quantization_module_config": lambda *_args, **_kwargs: {},
+            "_SM120_NEMOTRON_NVFP4_MODELS": set(),
+        },
+    )
+    return loaded["get_moe_test_cases"]()
+
+
+@pytest.mark.parametrize(("tp", "ep"), [(4, 8), (32, 1), (32, 8)])
+def test_gptoss_mxfp4_population_retains_tp_and_ep_buckets(tp, ep):
+    populated = _populate_gptoss_cases([_gptoss_case(tp=tp, ep=ep)])
+
+    assert len(populated) == 1
+    assert populated[0][0] == "w4a8_mxfp4_mxfp8"
+    assert populated[0][6:8] == [tp, ep]
+    assert populated[0][-1] is None
+
+
+@pytest.mark.parametrize("fail_during_benchmark", [False, True])
+def test_mxfp4_parallel_patch_covers_benchmark_and_restores_helpers(fail_during_benchmark):
+    def original_helper(name):
+        def helper(*_args, **_kwargs):
+            return name
+
+        return helper
+
+    moe_layer = SimpleNamespace(
+        get_tp_group=original_helper("layer_tp_group"),
+        is_allocation_symmetric=original_helper("layer_symmetric"),
+        get_moe_expert_parallel_world_size=original_helper("layer_ep_world"),
+        get_moe_expert_parallel_rank=original_helper("layer_ep_rank"),
+        get_moe_tensor_parallel_world_size=original_helper("layer_tp_world"),
+        get_moe_tensor_parallel_rank=original_helper("layer_tp_rank"),
+        create_kt_config_from_server_args=original_helper("layer_kt_config"),
+    )
+    standard_dispatch = SimpleNamespace(
+        get_tp_group=original_helper("dispatch_tp_group"),
+        is_allocation_symmetric=original_helper("dispatch_symmetric"),
+        get_moe_expert_parallel_world_size=original_helper("dispatch_ep_world"),
+        get_moe_expert_parallel_rank=original_helper("dispatch_ep_rank"),
+    )
+    mxfp4 = SimpleNamespace(
+        get_tp_group=original_helper("mxfp4_tp_group"),
+        is_allocation_symmetric=original_helper("mxfp4_symmetric"),
+    )
+    modules = (moe_layer, standard_dispatch, mxfp4)
+    originals = [(module, name, value) for module in modules for name, value in vars(module).items()]
+
+    def benchmark_config(*_args, **_kwargs):
+        assert moe_layer.get_moe_expert_parallel_world_size() == 8
+        assert moe_layer.get_moe_expert_parallel_rank() == 0
+        assert moe_layer.get_moe_tensor_parallel_world_size() == 4
+        assert moe_layer.get_moe_tensor_parallel_rank() == 0
+        assert moe_layer.create_kt_config_from_server_args(object(), 0) is None
+        assert standard_dispatch.get_moe_expert_parallel_world_size() == 8
+        assert standard_dispatch.get_moe_expert_parallel_rank() == 0
+        for module in modules:
+            assert module.get_tp_group() is None
+            assert not module.is_allocation_symmetric()
+        if fail_during_benchmark:
+            raise RuntimeError("benchmark failed")
+        return 1.25, {"power": 100.0}
+
+    fake_torch = SimpleNamespace(dtype=object, cuda=SimpleNamespace(manual_seed_all=lambda _seed: None))
+    loaded = _load_functions(
+        "_patch_mxfp4_single_process_parallel",
+        "benchmark",
+        namespace={
+            "contextmanager": contextmanager,
+            "nullcontext": nullcontext,
+            "torch": fake_torch,
+            "_moe_layer_mod": moe_layer,
+            "_std_dispatch_mod": standard_dispatch,
+            "_mxfp4_mod": mxfp4,
+            "_HAS_SGLANG_MXFP4": True,
+            "_HAS_MARLIN_MOE": False,
+            "benchmark_config": benchmark_config,
+        },
+    )
+    benchmark = loaded["benchmark"]
+    kwargs = {
+        "num_tokens": 128,
+        "num_experts": 8,
+        "shard_intermediate_size": 512,
+        "hidden_size": 256,
+        "topk": 2,
+        "dtype": object(),
+        "use_fp8_w8a8": False,
+        "use_int8_w8a8": False,
+        "use_int8_w8a16": False,
+        "use_mxfp4_w4a16": True,
+        "moe_tp_size": 4,
+        "moe_ep_size": 8,
+    }
+
+    if fail_during_benchmark:
+        with pytest.raises(RuntimeError, match="benchmark failed"):
+            benchmark(**kwargs)
+    else:
+        assert benchmark(**kwargs) == (1.25, {"power": 100.0})
+
+    for module, name, original in originals:
+        assert getattr(module, name) is original

--- a/tests/unit/collector/test_dsv4_common_test_cases.py
+++ b/tests/unit/collector/test_dsv4_common_test_cases.py
@@ -14,45 +14,49 @@ pytestmark = pytest.mark.unit
 
 _FLASH = "deepseek-ai/DeepSeek-V4-Flash"
 _PRO = "deepseek-ai/DeepSeek-V4-Pro"
+_FLASH_FP8 = "sgl-project/DeepSeek-V4-Flash-FP8"
+_PRO_FP8 = "sgl-project/DeepSeek-V4-Pro-FP8"
+_SUPPORTED_MODELS = (_FLASH, _PRO, _FLASH_FP8, _PRO_FP8)
 
 
-def test_dsv4_attn_cases_cover_default_models(monkeypatch):
+def test_dsv4_no_filter_uses_one_canonical_model(monkeypatch):
     monkeypatch.delenv("COLLECTOR_MODEL_PATH", raising=False)
     monkeypatch.setattr(sys, "argv", ["pytest"])
 
-    cases = common_test_cases.get_dsv4_csa_context_test_cases()
+    module_cases = common_test_cases.get_dsv4_csa_context_test_cases()
+    assert module_cases
+    assert {case[6] for case in module_cases} == {_FLASH_FP8}
+    assert common_test_cases.get_dsv4_paged_mqa_logits_test_cases() == [[_FLASH_FP8, "paged_mqa_logits"]]
+    assert common_test_cases.get_dsv4_topk_calib_test_cases() == [[_FLASH_FP8, "topk"]]
 
-    assert {case[6] for case in cases} == {_FLASH, _PRO}
-    assert {case[7] for case in cases} == {"csa"}
 
-
-def test_dsv4_attn_cases_include_same_gemm_types_for_default_models(monkeypatch):
-    monkeypatch.delenv("COLLECTOR_MODEL_PATH", raising=False)
+@pytest.mark.parametrize("model_path", _SUPPORTED_MODELS)
+def test_dsv4_attn_cases_include_same_gemm_types_for_supported_models(monkeypatch, model_path):
+    monkeypatch.setenv("COLLECTOR_MODEL_PATH", model_path)
     monkeypatch.setattr(sys, "argv", ["pytest"])
     monkeypatch.setattr(common_test_cases, "_has_native_fp4_experts", lambda: True)
 
     cases = common_test_cases.get_dsv4_csa_context_test_cases()
 
     assert cases
-    assert {model_path: {case[5] for case in cases if case[6] == model_path} for model_path in (_FLASH, _PRO)} == {
-        _FLASH: {"bfloat16", "fp8_block"},
-        _PRO: {"bfloat16", "fp8_block"},
-    }
+    assert {case[5] for case in cases} == {"bfloat16", "fp8_block"}
+    assert {case[6] for case in cases} == {model_path}
 
 
-def test_dsv4_attn_cases_honor_model_filter(monkeypatch):
-    monkeypatch.setenv("COLLECTOR_MODEL_PATH", _PRO)
+@pytest.mark.parametrize("model_path", _SUPPORTED_MODELS)
+def test_dsv4_attn_cases_honor_model_filter(monkeypatch, model_path):
+    monkeypatch.setenv("COLLECTOR_MODEL_PATH", model_path)
     monkeypatch.setattr(sys, "argv", ["pytest"])
 
     cases = common_test_cases.get_dsv4_hca_generation_test_cases()
 
     assert cases
-    assert {case[6] for case in cases} == {_PRO}
+    assert {case[6] for case in cases} == {model_path}
     assert {case[7] for case in cases} == {"hca"}
 
 
-def test_dsv4_sparse_smoke_cases_cover_default_models(monkeypatch):
-    monkeypatch.delenv("COLLECTOR_MODEL_PATH", raising=False)
+def test_dsv4_sparse_smoke_cases_honor_model_filter(monkeypatch):
+    monkeypatch.setenv("COLLECTOR_MODEL_PATH", _FLASH)
     monkeypatch.setattr(sys, "argv", ["collect.py", "--smoke"])
 
     cases = common_test_cases.get_dsv4_paged_mqa_logits_test_cases()
@@ -60,10 +64,17 @@ def test_dsv4_sparse_smoke_cases_cover_default_models(monkeypatch):
     # Sparse kernels are now one case per model ([model_path, kernel]); the worker
     # derives the (prefix, isl, bs) shapes 1:1 from the owning module CSV at
     # runtime instead of a separate smoke sweep grid.
-    assert cases == [
-        [_FLASH, "paged_mqa_logits"],
-        [_PRO, "paged_mqa_logits"],
-    ]
+    assert cases == [[_FLASH, "paged_mqa_logits"]]
+
+
+@pytest.mark.parametrize("model_path", (_FLASH_FP8, _PRO_FP8))
+def test_dsv4_mhc_preserves_requested_fp8_artifact(monkeypatch, model_path):
+    monkeypatch.setenv("COLLECTOR_MODEL_PATH", model_path)
+
+    cases = common_test_cases.get_common_mhc_test_cases()
+
+    assert len(cases) == 2
+    assert {case.model_name for case in cases} == {model_path}
 
 
 def test_dsv4_cases_skip_unrelated_model_filter(monkeypatch):

--- a/tests/unit/collector/test_getter_deduplication.py
+++ b/tests/unit/collector/test_getter_deduplication.py
@@ -1,0 +1,374 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+import sys
+import types
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from collector.case_generator import MoeCommonTestCase
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+class _Dummy:
+    def __init__(self, *_args, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+def _noop(*_args, **_kwargs):
+    return None
+
+
+def _stub_module(monkeypatch, name: str, **attrs):
+    module = types.ModuleType(name)
+    module.__path__ = []
+    module.__dict__.update(attrs)
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+def _load_collector(monkeypatch, module_name: str, relative_path: str):
+    monkeypatch.delitem(sys.modules, module_name, raising=False)
+    spec = importlib.util.spec_from_file_location(module_name, REPO_ROOT / relative_path)
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _install_trtllm_stubs(monkeypatch):
+    _stub_module(
+        monkeypatch,
+        "torch",
+        Tensor=object,
+        bfloat16="bfloat16",
+        float8_e4m3fn="float8_e4m3fn",
+        float32="float32",
+        cuda=types.SimpleNamespace(empty_cache=_noop, Stream=_noop),
+        device=lambda value: value,
+    )
+    _stub_module(monkeypatch, "tensorrt_llm", __version__="1.3.0rc10")
+    for package in (
+        "tensorrt_llm._torch",
+        "tensorrt_llm._torch.models",
+        "tensorrt_llm._torch.modules",
+        "tensorrt_llm.models",
+    ):
+        _stub_module(monkeypatch, package)
+
+    _stub_module(monkeypatch, "tensorrt_llm._torch.autotuner", AutoTuner=_Dummy, autotune=_noop)
+    _stub_module(monkeypatch, "tensorrt_llm._torch.model_config", ModelConfig=_Dummy)
+    _stub_module(
+        monkeypatch,
+        "tensorrt_llm._torch.models.modeling_deepseekv3",
+        DeepseekV3Gate=_Dummy,
+    )
+    _stub_module(
+        monkeypatch,
+        "tensorrt_llm._torch.modules.fused_moe",
+        RenormalizeMoeRoutingMethod=_Dummy,
+        create_moe=_noop,
+    )
+    _stub_module(monkeypatch, "tensorrt_llm.mapping", Mapping=_Dummy)
+    _stub_module(monkeypatch, "tensorrt_llm.models.modeling_utils", QuantAlgo=_Dummy(), QuantConfig=_Dummy)
+    _stub_module(
+        monkeypatch,
+        "collector.helper",
+        EXIT_CODE_RESTART=1,
+        balanced_logits=_noop,
+        benchmark_with_power=_noop,
+        get_sm_version=lambda: 100,
+        log_perf=_noop,
+        power_law_logits_v3=_noop,
+    )
+
+
+def _install_vllm_stubs(monkeypatch):
+    torch = _stub_module(
+        monkeypatch,
+        "torch",
+        Tensor=object,
+        bfloat16="bfloat16",
+        float8_e4m3fn="float8_e4m3fn",
+        float32="float32",
+        uint8="uint8",
+        device=lambda value: value,
+    )
+    torch_nn = _stub_module(monkeypatch, "torch.nn")
+    torch.nn = torch_nn
+    _stub_module(monkeypatch, "torch.nn.functional")
+
+    _stub_module(monkeypatch, "vllm")
+    for package in (
+        "vllm.model_executor",
+        "vllm.model_executor.layers",
+        "vllm.model_executor.layers.fused_moe",
+    ):
+        _stub_module(monkeypatch, package)
+    sys.modules["vllm.model_executor.layers.fused_moe"].fused_experts = _noop
+    _stub_module(monkeypatch, "vllm.config", VllmConfig=_Dummy, set_current_vllm_config=_noop)
+    _stub_module(monkeypatch, "vllm.forward_context", get_forward_context=_noop, set_forward_context=_noop)
+    _stub_module(
+        monkeypatch,
+        "vllm.model_executor.layers.fused_moe.config",
+        fp8_w8a8_moe_quant_config=_noop,
+        int4_w4a16_moe_quant_config=_noop,
+    )
+    _stub_module(
+        monkeypatch,
+        "vllm.model_executor.layers.fused_moe.layer",
+        determine_expert_map=_noop,
+    )
+    _stub_module(monkeypatch, "vllm.version", __version__="0.19.0")
+    _stub_module(
+        monkeypatch,
+        "collector.helper",
+        balanced_logits=_noop,
+        benchmark_with_power=_noop,
+        get_sm_version=lambda: 100,
+        log_perf=_noop,
+        power_law_logits_v3=_noop,
+    )
+
+
+def _moe_case(model_name: str, *, distribution: str = "balanced", alpha: float = 0.0, ep: int = 1):
+    return MoeCommonTestCase(
+        num_tokens_list=[1, 8],
+        hidden_size=4096,
+        inter_size=2048,
+        topk=2,
+        num_experts=8,
+        tp=1,
+        ep=ep,
+        model_name=model_name,
+        token_expert_distribution=distribution,
+        power_law_alpha=alpha,
+    )
+
+
+def _persisted_distribution(distribution: str, alpha: float | None) -> str:
+    return f"power_law_{alpha}" if distribution == "power_law" else distribution
+
+
+def test_trtllm_moe_getter_dedupes_equal_resolved_invocations(monkeypatch):
+    _install_trtllm_stubs(monkeypatch)
+    module = _load_collector(monkeypatch, "collector.trtllm.collect_moe", "collector/trtllm/collect_moe.py")
+    common_cases = [
+        _moe_case("model-a"),
+        _moe_case("model-b"),
+        _moe_case("model-a", distribution="power_law", alpha=1.2),
+    ]
+    module_configs = {
+        "model-a": {"group_size": 32},
+        "model-b": {"group_size": 32},
+    }
+    monkeypatch.setattr(module, "get_common_moe_test_cases", lambda: common_cases)
+    monkeypatch.setattr(module, "moe_model_allows_quantization", lambda _backend, _model, mode: mode == "int4_wo")
+    monkeypatch.setattr(
+        module,
+        "get_moe_quantization_module_config",
+        lambda _backend, _mode, *, model_name: module_configs[model_name],
+    )
+
+    cases = module.get_moe_test_cases()
+
+    assert {(case[9], case[10], case[11]) for case in cases} == {
+        ("model-a", "balanced", 0.0),
+        ("model-a", "power_law", 1.2),
+    }
+
+
+@pytest.mark.parametrize(
+    ("conflicting_model", "conflicting_config"),
+    [
+        ("model-c", {"group_size": 128}),
+        ("vendor/Nemotron-3-test", {"group_size": 32}),
+    ],
+)
+def test_trtllm_moe_getter_rejects_consumer_key_collision(
+    monkeypatch,
+    conflicting_model,
+    conflicting_config,
+):
+    _install_trtllm_stubs(monkeypatch)
+    module = _load_collector(monkeypatch, "collector.trtllm.collect_moe", "collector/trtllm/collect_moe.py")
+    common_cases = [
+        _moe_case("model-a"),
+        replace(_moe_case(conflicting_model), num_tokens_list=[8, 16]),
+    ]
+    module_configs = {
+        "model-a": {"group_size": 32},
+        conflicting_model: conflicting_config,
+    }
+    monkeypatch.setattr(module, "get_common_moe_test_cases", lambda: common_cases)
+    monkeypatch.setattr(module, "moe_model_allows_quantization", lambda _backend, _model, mode: mode == "int4_wo")
+    monkeypatch.setattr(
+        module,
+        "get_moe_quantization_module_config",
+        lambda _backend, _mode, *, model_name: module_configs[model_name],
+    )
+
+    with pytest.raises(ValueError, match="TRT-LLM MoE population collision") as exc_info:
+        module.get_moe_test_cases()
+
+    assert "model-a" in str(exc_info.value)
+    assert conflicting_model in str(exc_info.value)
+
+
+def test_trtllm_dsv4_moe_getter_retains_tp_and_ep_buckets(monkeypatch):
+    _install_trtllm_stubs(monkeypatch)
+    module = _load_collector(monkeypatch, "collector.trtllm.collect_moe", "collector/trtllm/collect_moe.py")
+    tp_ep_pairs = {(tp, ep) for tp in (4, 16, 32) for ep in (1, 2, 4, 8)}
+    base_case = MoeCommonTestCase(
+        num_tokens_list=[128],
+        hidden_size=4096,
+        inter_size=2048,
+        topk=6,
+        num_experts=256,
+        tp=1,
+        ep=1,
+        model_name="deepseek-ai/DeepSeek-V4-Flash",
+        token_expert_distribution="balanced",
+        power_law_alpha=None,
+        architecture="DeepseekV4ForCausalLM",
+    )
+    monkeypatch.setattr(
+        module,
+        "get_common_moe_test_cases",
+        lambda: [replace(base_case, tp=tp, ep=ep) for tp, ep in sorted(tp_ep_pairs)],
+    )
+    monkeypatch.setattr(
+        module,
+        "moe_model_allows_quantization",
+        lambda _backend, _model, mode: mode == "w4a8_mxfp4_mxfp8",
+    )
+    monkeypatch.setattr(module, "get_moe_quantization_module_config", lambda *_args, **_kwargs: {})
+
+    cases = module.get_moe_test_cases()
+
+    assert {(case[6], case[7]) for case in cases} == tp_ep_pairs
+    assert {case[0] for case in cases} == {"w4a8_mxfp4_mxfp8"}
+
+
+def test_vllm_moe_getter_dedupes_equal_resolved_invocations(monkeypatch):
+    _install_vllm_stubs(monkeypatch)
+    module = _load_collector(monkeypatch, "collector.vllm.collect_moe", "collector/vllm/collect_moe.py")
+    common_cases = [
+        _moe_case("model-a"),
+        _moe_case("model-b"),
+        _moe_case("model-a", distribution="power_law", alpha=1.2),
+        _moe_case("model-b", ep=2),
+    ]
+    module_configs = {
+        "model-a": {"activation": "silu", "has_bias": False},
+        "model-b": {"activation": "silu", "has_bias": False},
+    }
+    monkeypatch.setattr(module, "get_common_moe_test_cases", lambda: common_cases)
+    monkeypatch.setattr(module, "get_moe_quantization_modes", lambda *_args, **_kwargs: ["w4a16_mxfp4"])
+    monkeypatch.setattr(module, "moe_model_allows_quantization", lambda *_args: True)
+    monkeypatch.setattr(module, "moe_shape_satisfies_constraints", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(
+        module,
+        "get_moe_quantization_module_config",
+        lambda _backend, _mode, *, model_name: module_configs[model_name],
+    )
+
+    cases = module.get_moe_test_cases()
+    model_names = [case[8] for case in cases]
+
+    assert len(cases) == 3
+    assert model_names.count("model-a") == 2
+    assert model_names.count("model-b") == 1
+
+
+def test_vllm_moe_getter_rejects_consumer_key_collision(monkeypatch):
+    _install_vllm_stubs(monkeypatch)
+    module = _load_collector(monkeypatch, "collector.vllm.collect_moe", "collector/vllm/collect_moe.py")
+    common_cases = [
+        _moe_case("model-a"),
+        replace(_moe_case("model-c"), num_tokens_list=[8, 16]),
+    ]
+    module_configs = {
+        "model-a": {"activation": "silu", "has_bias": False},
+        "model-c": {"activation": "swigluoai", "has_bias": True},
+    }
+    monkeypatch.setattr(module, "get_common_moe_test_cases", lambda: common_cases)
+    monkeypatch.setattr(module, "get_moe_quantization_modes", lambda *_args, **_kwargs: ["w4a16_mxfp4"])
+    monkeypatch.setattr(module, "moe_model_allows_quantization", lambda *_args: True)
+    monkeypatch.setattr(module, "moe_shape_satisfies_constraints", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(
+        module,
+        "get_moe_quantization_module_config",
+        lambda _backend, _mode, *, model_name: module_configs[model_name],
+    )
+
+    with pytest.raises(ValueError, match="vLLM MoE population collision") as exc_info:
+        module.get_moe_test_cases()
+
+    assert "model-a" in str(exc_info.value)
+    assert "model-c" in str(exc_info.value)
+
+
+def test_trtllm_repository_moe_getter_has_unique_consumer_keys(monkeypatch):
+    monkeypatch.delenv("COLLECTOR_MODEL_PATH", raising=False)
+    _install_trtllm_stubs(monkeypatch)
+    module = _load_collector(monkeypatch, "collector.trtllm.collect_moe", "collector/trtllm/collect_moe.py")
+
+    consumer_keys = []
+    for case in module.get_moe_test_cases():
+        moe_type, num_tokens_list, hidden_size, inter_size, topk, num_experts, tp, ep = case[:8]
+        min_latency_mode, _, distribution, alpha = case[8:]
+        table = "low_latency" if min_latency_mode else "default"
+        distribution = _persisted_distribution(distribution, alpha)
+        consumer_keys.extend(
+            (table, moe_type, distribution, topk, num_experts, hidden_size, inter_size, tp, ep, num_tokens)
+            for num_tokens in num_tokens_list
+        )
+
+    assert consumer_keys
+    assert len(consumer_keys) == len(set(consumer_keys))
+
+
+def test_vllm_repository_moe_getter_has_unique_consumer_keys(monkeypatch):
+    monkeypatch.delenv("COLLECTOR_MODEL_PATH", raising=False)
+    _install_vllm_stubs(monkeypatch)
+    module = _load_collector(monkeypatch, "collector.vllm.collect_moe", "collector/vllm/collect_moe.py")
+    monkeypatch.setattr(module, "per_block_cast_to_fp8", _noop)
+    monkeypatch.setattr(module, "_nvfp4_available", True)
+    monkeypatch.setattr(module, "_mxfp4_available", True)
+
+    consumer_keys = []
+    for case in module.get_moe_test_cases():
+        moe_type, num_tokens_list, hidden_size, inter_size, topk, num_experts, tp, ep = case[:8]
+        _, distribution, alpha = case[8:]
+        distribution = _persisted_distribution(distribution, alpha)
+        consumer_keys.extend(
+            (moe_type, distribution, topk, num_experts, hidden_size, inter_size, tp, ep, num_tokens)
+            for num_tokens in num_tokens_list
+        )
+
+    assert consumer_keys
+    assert len(consumer_keys) == len(set(consumer_keys))
+
+
+@pytest.mark.parametrize(
+    "model_path",
+    [
+        "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
+        "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4",
+    ],
+)
+def test_vllm_nemotron_topk22_nvfp4_artifacts_are_not_scheduled(monkeypatch, model_path):
+    monkeypatch.setenv("COLLECTOR_MODEL_PATH", model_path)
+    _install_vllm_stubs(monkeypatch)
+    module = _load_collector(monkeypatch, "collector.vllm.collect_moe", "collector/vllm/collect_moe.py")
+    monkeypatch.setattr(module, "per_block_cast_to_fp8", _noop)
+    monkeypatch.setattr(module, "_nvfp4_available", True)
+
+    assert module.get_moe_test_cases() == []

--- a/tests/unit/collector/test_model_cases.py
+++ b/tests/unit/collector/test_model_cases.py
@@ -1,11 +1,19 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import ast
 import csv
+import json
+import subprocess
+import sys
 from itertools import pairwise
 from pathlib import Path
 
-from collector.case_generator import moe_model_allows_quantization, windows_for_head_dim
+from collector.case_generator import (
+    get_attention_head_configs,
+    get_moe_quantization_specs,
+    moe_model_allows_quantization,
+)
 from collector.helper import create_test_case_id
 from collector.model_cases import (
     CaseSelector,
@@ -23,13 +31,25 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 SUPPORT_MATRIX_ROOT = REPO_ROOT / "src" / "aiconfigurator" / "systems" / "support_matrix"
 
 
-def test_model_case_plan_merges_base_op_and_framework_specific_ops():
+def _load_mla_adapter(module_path: str, globals_dict: dict):
+    source_path = REPO_ROOT / module_path
+    tree = ast.parse(source_path.read_text(), filename=str(source_path))
+    function = next(
+        node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == "_build_mla_test_cases"
+    )
+    namespace = dict(globals_dict)
+    exec(compile(ast.Module(body=[function], type_ignores=[]), str(source_path), "exec"), namespace)
+    return namespace["_build_mla_test_cases"]
+
+
+def test_model_case_plan_merges_required_base_and_framework_specific_ops():
     plan = build_collection_case_plan(backend="sglang", model_path="deepseek-ai/DeepSeek-V3")
 
     assert plan.model_architecture == "DeepseekV3ForCausalLM"
     assert plan.model_cases_paths == [default_architecture_cases_path("DeepseekV3ForCausalLM")]
     assert "gemm" in plan.op_cases
-    assert "attention_context" in plan.op_cases
+    assert "attention_context" not in plan.op_cases
+    assert "attention_generation" not in plan.op_cases
     assert "moe" in plan.op_cases
     assert "mla_context" in plan.op_cases
     assert "wideep_mla_context" in plan.op_cases
@@ -37,23 +57,222 @@ def test_model_case_plan_merges_base_op_and_framework_specific_ops():
     assert "trtllm_moe_wideep" not in plan.op_cases
 
 
-def test_windows_for_head_dim_gates_sliding_window_by_head_dim():
-    # head_dim -> the only sliding-window value any surveyed model uses at that head_dim:
-    #   64=gpt-oss(128), 128=Llama-4(8192), 192=MiMo-V2-Flash(128), 256=gemma-4(1024).
-    # window=0 (dense) is always kept; unrelated window values for that head_dim are pruned.
-    sweep = [0, 128, 1024, 8192]
-    assert windows_for_head_dim(sweep, 64) == [0, 128]
-    assert windows_for_head_dim(sweep, 128) == [0, 8192]
-    assert windows_for_head_dim(sweep, 192) == [0, 128]
-    assert windows_for_head_dim(sweep, 256) == [0, 1024]
-    # unknown head_dim keeps only the dense (window=0) case
-    assert windows_for_head_dim(sweep, 96) == [0]
-    # order is preserved and no spurious values are added
-    assert windows_for_head_dim([128, 0], 64) == [128, 0]
+def test_attention_head_configs_preserve_real_model_structures_without_cross_mixing():
+    from collector.case_generator import get_attention_context_shape_sweeps, get_attention_generation_shape_sweeps
+
+    expected_model_structures = {
+        # Gemma 4 local/global attention.
+        (16, 8, 256, 1024),
+        (16, 2, 512, 0),
+        # Llama 4 local attention.
+        (40, 8, 128, 8192),
+        # MiMo-V2 global/local attention.
+        (64, 4, 192, 0),
+        (64, 8, 192, 128),
+    }
+    impossible_cross_model_mixes = {
+        (64, 8, 256, 1024),
+        (40, 8, 192, 8192),
+        (16, 8, 512, 1024),
+        (64, 4, 64, 128),
+    }
+
+    for phase, get_shape_sweeps in (
+        ("context", get_attention_context_shape_sweeps),
+        ("generation", get_attention_generation_shape_sweeps),
+    ):
+        configs = {
+            (config.num_heads, config.num_kv_heads, config.head_dim, config.window_size)
+            for config in get_attention_head_configs(get_shape_sweeps("sglang")[0], phase=phase)
+        }
+
+        assert expected_model_structures <= configs
+        assert configs.isdisjoint(impossible_cross_model_mixes)
+
+
+def test_native_attention_profiles_drop_non_integral_local_gqa(monkeypatch):
+    monkeypatch.setenv("COLLECTOR_MODEL_PATH", "example/unregistered-model")
+    shape_sweep = {
+        "num_attention_heads": 6,
+        "num_key_value_heads": 3,
+        "head_dim": 128,
+        "window_size": 0,
+        "tensor_parallel_sizes": [1, 2],
+    }
+
+    assert [
+        (config.num_heads, config.num_kv_heads, config.head_dim, config.window_size)
+        for config in get_attention_head_configs(shape_sweep, phase="generation")
+    ] == [
+        (6, 3, 128, 0),
+    ]
+
+
+def test_targeted_attention_profile_uses_model_topology(monkeypatch):
+    from collector.case_generator import get_attention_context_shape_sweeps
+
+    monkeypatch.setenv("COLLECTOR_MODEL_PATH", "Qwen/Qwen3-32B-FP8")
+    configs = {
+        (config.num_heads, config.num_kv_heads, config.head_dim, config.window_size)
+        for config in get_attention_head_configs(
+            get_attention_context_shape_sweeps("sglang")[0],
+            phase="context",
+        )
+    }
+
+    assert configs == {
+        (64, 8, 128, 0),
+        (32, 4, 128, 0),
+        (16, 2, 128, 0),
+        (8, 1, 128, 0),
+        (4, 1, 128, 0),
+        (2, 1, 128, 0),
+        (1, 1, 128, 0),
+    }
+
+    monkeypatch.setenv("COLLECTOR_MODEL_PATH", "moonshotai/Kimi-K2.5")
+    kimi_configs = {
+        (config.num_heads, config.num_kv_heads, config.head_dim, config.window_size)
+        for config in get_attention_head_configs(
+            get_attention_context_shape_sweeps("vllm")[0],
+            phase="context",
+        )
+    }
+    assert kimi_configs == {
+        (64, 64, 128, 0),
+        (32, 32, 128, 0),
+        (16, 16, 128, 0),
+        (8, 8, 128, 0),
+        (4, 4, 128, 0),
+        (2, 2, 128, 0),
+        (1, 1, 128, 0),
+    }
+
+
+def test_added_model_attention_profiles_resolve_targeted_topology(monkeypatch):
+    from collector.case_generator import get_attention_context_shape_sweeps
+
+    profiles = (
+        (("Qwen/Qwen3.5-0.8B", "Qwen/Qwen3.5-2B"), 8, 2, 256, (1, 2, 4, 8)),
+        (("Qwen/Qwen3.5-4B", "Qwen/Qwen3.5-9B"), 16, 4, 256, (1, 2, 4, 8, 16)),
+        (("Qwen/Qwen3.5-122B-A10B",), 32, 2, 256, (1, 2, 4, 8, 16, 32)),
+        (("MiniMaxAI/MiniMax-M2", "MiniMaxAI/MiniMax-M2.5", "MiniMaxAI/MiniMax-M2.7"), 48, 8, 128, (1, 2, 4, 8, 16)),
+        (("Qwen/Qwen3-30B-A3B",), 32, 4, 128, (1, 2, 4, 8)),
+    )
+
+    for model_paths, num_heads, num_kv_heads, head_dim, tp_sizes in profiles:
+        expected = {
+            (num_heads // tp, (num_kv_heads + tp - 1) // tp, head_dim, 0)
+            for tp in tp_sizes
+            if (num_heads // tp) % ((num_kv_heads + tp - 1) // tp) == 0
+        }
+        for model_path in model_paths:
+            monkeypatch.setenv("COLLECTOR_MODEL_PATH", model_path)
+            configs = {
+                (config.num_heads, config.num_kv_heads, config.head_dim, config.window_size)
+                for config in get_attention_head_configs(
+                    get_attention_context_shape_sweeps("sglang")[0],
+                    phase="context",
+                )
+            }
+            assert configs == expected, model_path
+
+
+def test_added_model_moe_profiles_resolve_targeted_aliases(monkeypatch):
+    from collector.case_generator import get_common_moe_test_cases
+
+    expected_by_model = {
+        "Qwen/Qwen3.5-122B-A10B": ("Qwen/Qwen3.5-122B-A10B", 3072, 1024, 8, 256),
+        "Qwen/Qwen3-235B-A22B-Instruct-2507": ("Qwen/Qwen3-235B-A22B", 4096, 1536, 8, 128),
+        "MiniMaxAI/MiniMax-M2": ("MiniMaxAI/MiniMax-M2.5", 3072, 1536, 8, 256),
+    }
+    for model_path, expected in expected_by_model.items():
+        monkeypatch.setenv("COLLECTOR_MODEL_PATH", model_path)
+        cases = get_common_moe_test_cases()
+        assert {
+            (case.model_name, case.hidden_size, case.inter_size, case.topk, case.num_experts) for case in cases
+        } == {expected}
+
+
+def test_mimo_attention_profile_matches_aic_full_attention_window(monkeypatch):
+    from collector.case_generator import get_attention_context_shape_sweeps
+
+    monkeypatch.setenv("COLLECTOR_MODEL_PATH", "XiaomiMiMo/MiMo-7B-Base")
+    configs = {
+        (config.num_heads, config.num_kv_heads, config.head_dim, config.window_size)
+        for config in get_attention_head_configs(
+            get_attention_context_shape_sweeps("vllm")[0],
+            phase="context",
+        )
+    }
+
+    assert configs == {
+        (32, 8, 128, 0),
+        (16, 4, 128, 0),
+        (8, 2, 128, 0),
+        (4, 1, 128, 0),
+        (2, 1, 128, 0),
+        (1, 1, 128, 0),
+    }
+
+
+def test_qwen_vl_attention_profiles_stop_at_sdk_valid_tp16(monkeypatch):
+    from collector.case_generator import get_attention_context_shape_sweeps
+
+    monkeypatch.setenv("COLLECTOR_MODEL_PATH", "Qwen/Qwen3-VL-32B-Instruct")
+    configs = {
+        (config.num_heads, config.num_kv_heads, config.head_dim, config.window_size)
+        for config in get_attention_head_configs(
+            get_attention_context_shape_sweeps("vllm")[0],
+            phase="context",
+        )
+    }
+
+    assert configs == {
+        (64, 8, 128, 0),
+        (32, 4, 128, 0),
+        (16, 2, 128, 0),
+        (8, 1, 128, 0),
+        (4, 1, 128, 0),
+    }
+
+
+def test_full_encoder_attention_profiles_combine_defaults_and_model_deltas(monkeypatch):
+    from collector.case_generator import get_attention_encoder_head_configs, get_attention_encoder_shape_sweeps
+
+    monkeypatch.delenv("COLLECTOR_MODEL_PATH", raising=False)
+    sweep = get_attention_encoder_shape_sweeps("vllm")[0]
+    configs = get_attention_encoder_head_configs(sweep)
+    keys = {(config.num_heads, config.head_dim) for config in configs}
+    default_keys = {(num_heads, head_dim) for head_dim in sweep["head_dims"] for num_heads in sweep["head_counts"]}
+
+    assert default_keys <= keys
+    assert keys - default_keys == {(1, 64), (1, 72)}
+
+
+def test_targeted_encoder_attention_profile_is_model_exact(monkeypatch):
+    from collector.case_generator import get_attention_encoder_head_configs, get_attention_encoder_shape_sweeps
+
+    sweep = get_attention_encoder_shape_sweeps("vllm")[0]
+    for model_path, head_dim in (
+        ("Qwen/Qwen3-VL-4B-Instruct", 64),
+        ("Qwen/Qwen3-VL-32B-Instruct", 72),
+        ("Qwen/Qwen3-VL-235B-A22B-Instruct", 72),
+    ):
+        monkeypatch.setenv("COLLECTOR_MODEL_PATH", model_path)
+        configs = get_attention_encoder_head_configs(sweep)
+
+        assert {(config.num_heads, config.head_dim) for config in configs} == {
+            (16, head_dim),
+            (8, head_dim),
+            (4, head_dim),
+            (2, head_dim),
+            (1, head_dim),
+        }
 
 
 def test_base_gemm_cases_are_readable_shape_specs():
-    plan = build_collection_case_plan(backend="sglang", model_path="deepseek-ai/DeepSeek-V3")
+    plan = build_collection_case_plan(backend="sglang", model_path="Qwen/Qwen3-32B")
     gemm_plan = plan.op_cases["gemm"]
     context_plan = plan.op_cases["attention_context"]
     generation_plan = plan.op_cases["attention_generation"]
@@ -77,17 +296,121 @@ def test_base_gemm_cases_are_readable_shape_specs():
 
 
 def test_moe_model_quantization_policy_is_yaml_backed():
-    assert moe_model_allows_quantization("sglang", "deepseek-ai/DeepSeek-V4-Flash", "w4a8_mxfp4_mxfp8")
-    assert moe_model_allows_quantization("sglang", "deepseek-ai/DeepSeek-V4-Flash", "bfloat16")
+    assert not moe_model_allows_quantization("sglang", "deepseek-ai/DeepSeek-V4-Flash", "w4a8_mxfp4_mxfp8")
+    assert not moe_model_allows_quantization("sglang", "deepseek-ai/DeepSeek-V4-Flash", "bfloat16")
     assert not moe_model_allows_quantization("sglang", "Qwen/Qwen3-235B-A22B", "w4a8_mxfp4_mxfp8")
 
     assert moe_model_allows_quantization("sglang", "openai/gpt-oss-120b", "w4a16_mxfp4")
+    assert moe_model_allows_quantization("sglang", "openai/gpt-oss-120b", "w4a8_mxfp4_mxfp8")
     assert not moe_model_allows_quantization("sglang", "openai/gpt-oss-120b", "bfloat16")
 
-    assert moe_model_allows_quantization("trtllm", "moonshotai/Kimi-K2.5", "w4a16_mxfp4")
-    assert moe_model_allows_quantization("trtllm", "moonshotai/Kimi-K2.5", "bfloat16")
+    assert moe_model_allows_quantization("trtllm", "moonshotai/Kimi-K2.5", "int4_wo")
+    assert not moe_model_allows_quantization("trtllm", "moonshotai/Kimi-K2.5", "w4a16_mxfp4")
+    assert not moe_model_allows_quantization("trtllm", "moonshotai/Kimi-K2.5", "bfloat16")
     assert not moe_model_allows_quantization("trtllm", "Qwen/Qwen3-235B-A22B", "w4a16_mxfp4")
     assert not moe_model_allows_quantization("trtllm", "openai/gpt-oss-20b", "fp8")
+
+
+def test_dsv4_moe_quantization_policy_prunes_unrelated_modes():
+    expected_by_backend = {
+        "sglang": {
+            "deepseek-ai/DeepSeek-V4-Flash": set(),
+            "deepseek-ai/DeepSeek-V4-Pro": set(),
+            "sgl-project/DeepSeek-V4-Flash-FP8": {"fp8_block"},
+            "sgl-project/DeepSeek-V4-Pro-FP8": {"fp8_block"},
+        },
+        "trtllm": {
+            "deepseek-ai/DeepSeek-V4-Flash": {"w4a8_mxfp4_mxfp8"},
+            "deepseek-ai/DeepSeek-V4-Pro": {"w4a8_mxfp4_mxfp8"},
+            "sgl-project/DeepSeek-V4-Flash-FP8": {"fp8_block"},
+            "sgl-project/DeepSeek-V4-Pro-FP8": {"fp8_block"},
+        },
+        "vllm": {
+            "deepseek-ai/DeepSeek-V4-Flash": set(),
+            "deepseek-ai/DeepSeek-V4-Pro": set(),
+            "sgl-project/DeepSeek-V4-Flash-FP8": {"fp8_block"},
+            "sgl-project/DeepSeek-V4-Pro-FP8": {"fp8_block"},
+        },
+    }
+
+    for backend, expected_by_artifact in expected_by_backend.items():
+        available_modes = {spec.name for spec in get_moe_quantization_specs(backend)}
+        for model_path, expected in expected_by_artifact.items():
+            allowed = {mode for mode in available_modes if moe_model_allows_quantization(backend, model_path, mode)}
+            assert allowed == expected, (backend, model_path)
+
+
+def test_kimi_moe_quantization_is_artifact_specific():
+    expected_by_artifact = {
+        "moonshotai/Kimi-K2-Instruct": {"fp8_block"},
+        "moonshotai/Kimi-K2.5": {"int4_wo"},
+        "nvidia/Kimi-K2.5-NVFP4": {"nvfp4"},
+    }
+
+    for backend in ("sglang", "trtllm", "vllm"):
+        available_modes = {spec.name for spec in get_moe_quantization_specs(backend)}
+        for model_path, expected in expected_by_artifact.items():
+            allowed = {mode for mode in available_modes if moe_model_allows_quantization(backend, model_path, mode)}
+            assert allowed == expected, (backend, model_path)
+
+
+def test_deepseek_minimax_and_nemotron_moe_quantization_is_artifact_specific():
+    shared_expected = {
+        "deepseek-ai/DeepSeek-V3": {"fp8_block"},
+        "deepseek-ai/DeepSeek-R1": {"fp8_block"},
+        "deepseek-ai/DeepSeek-V3.2": {"fp8_block"},
+        "nvidia/DeepSeek-V3.1-NVFP4": {"nvfp4"},
+        "MiniMaxAI/MiniMax-M2": {"fp8_block"},
+        "MiniMaxAI/MiniMax-M2.5": {"fp8_block"},
+        "MiniMaxAI/MiniMax-M2.7": {"fp8_block"},
+        "nvidia/MiniMax-M2.5-NVFP4": {"nvfp4"},
+        "nvidia/MiniMax-M2.7-NVFP4": {"nvfp4"},
+        "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16": {"bfloat16"},
+        "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4": {"nvfp4"},
+        "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16": {"bfloat16"},
+        "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4": {"nvfp4"},
+    }
+
+    for backend in ("sglang", "trtllm", "vllm"):
+        available_modes = {spec.name for spec in get_moe_quantization_specs(backend)}
+        expected_by_artifact = {
+            **shared_expected,
+            "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-FP8": set() if backend == "sglang" else {"fp8"},
+        }
+        if backend == "vllm":
+            expected_by_artifact["nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4"] = set()
+            expected_by_artifact["nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4"] = set()
+        for model_path, expected in expected_by_artifact.items():
+            allowed = {mode for mode in available_modes if moe_model_allows_quantization(backend, model_path, mode)}
+            assert allowed == expected, (backend, model_path)
+
+
+def test_gptoss_mxfp4_modes_are_additive_on_blackwell():
+    from collector.case_generator import get_moe_quantization_modes
+
+    def selected_modes(backend, sm_version):
+        return {
+            mode
+            for mode in get_moe_quantization_modes(backend, sm_version=sm_version)
+            if moe_model_allows_quantization(backend, "openai/gpt-oss-120b", mode)
+        }
+
+    assert selected_modes("sglang", 100) == {"w4a16_mxfp4", "w4a8_mxfp4_mxfp8"}
+    assert selected_modes("trtllm", 90) == {"w4a16_mxfp4"}
+    assert selected_modes("trtllm", 100) == {"w4a16_mxfp4", "w4a8_mxfp4_mxfp8"}
+
+
+def test_sglang_mxfp4_quant_labels_select_explicit_activation_precision():
+    source_path = REPO_ROOT / "collector/sglang/collect_moe.py"
+    tree = ast.parse(source_path.read_text(), filename=str(source_path))
+    helper = next(
+        node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == "_mxfp4_activation_precision"
+    )
+    namespace = {}
+    exec(compile(ast.Module(body=[helper], type_ignores=[]), str(source_path), "exec"), namespace)
+
+    assert namespace["_mxfp4_activation_precision"]("w4a16_mxfp4") == "bf16"
+    assert namespace["_mxfp4_activation_precision"]("w4a8_mxfp4_mxfp8") == "default"
 
 
 def test_attention_shape_specs_are_yaml_backed_with_backend_overrides():
@@ -153,7 +476,7 @@ def test_cross_model_common_cases_expand_from_base_op_yaml_sweeps(monkeypatch):
     monkeypatch.delenv("COLLECTOR_MODEL_PATH", raising=False)
 
     moe_cases = get_common_moe_test_cases()
-    assert len(moe_cases) == 4548
+    assert len(moe_cases) == 4209
     assert any(
         case.model_name == "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4"
         and case.hidden_size == 1024
@@ -166,11 +489,121 @@ def test_cross_model_common_cases_expand_from_base_op_yaml_sweeps(monkeypatch):
         and case.inter_size == 5120
         for case in moe_cases
     )
-    assert len(get_context_mla_case_specs()) == 550
-    assert len(get_generation_mla_case_specs()) == 885
-    assert len(get_common_mamba2_test_cases()) == 8
+    assert len(get_context_mla_case_specs()) == 220
+    assert len(get_generation_mla_case_specs()) == 362
+    mamba_cases = get_common_mamba2_test_cases()
+    assert len(mamba_cases) == 12
+    assert {case.model_name for case in mamba_cases} >= {"MAMBA2_GENERIC_4K", "MAMBA2_GENERIC_1K"}
     assert len(get_common_gdn_test_cases()) == 16
-    assert len(get_common_mhc_test_cases()) == 8
+    mhc_cases = get_common_mhc_test_cases()
+    assert len(mhc_cases) == 8
+    assert {(case.model_name, case.phase, case.hidden_size, case.hc_mult) for case in mhc_cases} == {
+        (model_name, phase, hidden_size, 4)
+        for model_name, hidden_size in (
+            ("deepseek-ai/DeepSeek-V4-Flash", 4096),
+            ("sgl-project/DeepSeek-V4-Flash-FP8", 4096),
+            ("deepseek-ai/DeepSeek-V4-Pro", 7168),
+            ("sgl-project/DeepSeek-V4-Pro-FP8", 7168),
+        )
+        for phase in ("pre", "post")
+    }
+    assert {(case.phase, case.hidden_size, case.hc_mult) for case in mhc_cases} == {
+        (phase, hidden_size, 4) for hidden_size in (4096, 7168) for phase in ("pre", "post")
+    }
+
+
+def test_mla_collectors_dedupe_on_loader_physical_keys(monkeypatch):
+    from types import SimpleNamespace
+
+    from collector.case_generator import get_context_mla_case_specs, get_generation_mla_case_specs
+
+    sglang_adapter = _load_mla_adapter(
+        "collector/sglang/collect_mla.py",
+        {
+            "KV_LORA_RANK": 512,
+            "QK_NOPE_HEAD_DIM": 128,
+            "QK_ROPE_HEAD_DIM": 64,
+            "MLA_PAGE_SIZE": 64,
+            "MAX_KV_LOC": ((2**31 - 1) // (512 + 64)) - 64,
+        },
+    )
+    trtllm_adapter = _load_mla_adapter(
+        "collector/trtllm/collect_mla.py",
+        {
+            "Scenario": lambda: SimpleNamespace(
+                q_lora_rank=1536,
+                kv_lora_rank=512,
+                qk_nope_head_dim=128,
+                qk_rope_head_dim=64,
+                v_head_dim=128,
+            ),
+            "_mla_tokens_per_block": lambda: 32,
+        },
+    )
+
+    def physical_keys(cases):
+        return {(case[3], case[4] // case[6], case[1], case[0]) for case in cases}
+
+    monkeypatch.delenv("COLLECTOR_MODEL_PATH", raising=False)
+    full_specs = (get_context_mla_case_specs(), get_generation_mla_case_specs())
+    for adapter, kwargs in (
+        (sglang_adapter, {"tp_sizes": (1, 2, 4, 8, 16, 32, 64)}),
+        (trtllm_adapter, {}),
+    ):
+        context_cases = adapter(full_specs[0], dtype_list=("bf16", "fp8"), **kwargs)
+        generation_cases = adapter(full_specs[1], dtype_list=("bf16", "fp8"), **kwargs)
+        assert len(context_cases) == len(physical_keys(context_cases))
+        assert len(generation_cases) == len(physical_keys(generation_cases))
+        assert 1 in {case[4] // case[6] for case in context_cases}
+        assert 1 in {case[4] // case[6] for case in generation_cases}
+
+
+def test_kimi_mla_plan_includes_generation_bmm_helpers():
+    required_ops = {"mla_context", "mla_generation", "mla_bmm_gen_pre", "mla_bmm_gen_post"}
+    for backend in ("sglang", "trtllm"):
+        plan = build_collection_case_plan(backend=backend, model_path="moonshotai/Kimi-K2.5")
+        assert required_ops <= set(plan.op_cases)
+        for op_name in ("mla_context", "mla_generation"):
+            assert plan.op_cases[op_name].include.rules[0]["match"] == {"tp_size": {"in": [1, 2, 4, 8]}}
+        for op_name in ("mla_bmm_gen_pre", "mla_bmm_gen_post"):
+            assert plan.op_cases[op_name].include.rules[0]["match"] == {"num_heads": {"in": [64, 32, 16, 8]}}
+
+
+def test_kimi_targeted_mla_selector_keeps_consumer_local_head_grid(monkeypatch):
+    from types import SimpleNamespace
+
+    from collector.case_generator import get_context_mla_case_specs
+
+    monkeypatch.setenv("COLLECTOR_MODEL_PATH", "moonshotai/Kimi-K2.5")
+    adapter = _load_mla_adapter(
+        "collector/trtllm/collect_mla.py",
+        {
+            "Scenario": lambda: SimpleNamespace(
+                q_lora_rank=1536,
+                kv_lora_rank=512,
+                qk_nope_head_dim=128,
+                qk_rope_head_dim=64,
+                v_head_dim=128,
+            ),
+            "_mla_tokens_per_block": lambda: 32,
+        },
+    )
+    generated = adapter(get_context_mla_case_specs(), dtype_list=("bf16",))
+    op_plan = build_collection_case_plan(
+        backend="trtllm",
+        model_path="moonshotai/Kimi-K2.5",
+    ).op_cases["mla_context"]
+    selected = filter_test_cases(
+        generated,
+        plan=op_plan,
+        full_module_name="trtllm.mla_context",
+        run_func_name="run_mla",
+    )
+
+    assert {case[4] for case in selected} == {64, 128}
+    assert {case[6] for case in selected} == {1, 2, 4, 8}
+    assert {case[4] // case[6] for case in selected} == {128, 64, 32, 16, 8}
+    assert any(case[4] == 64 and case[6] == 8 for case in selected)
 
 
 def test_dsa_module_prefix_context_sweeps_are_yaml_backed():
@@ -216,6 +649,9 @@ def test_vllm_moe_quantization_metadata_is_yaml_backed():
         "activation": "swigluoai",
     }
     assert get_moe_quantization_module_config("vllm", "w4a16_mxfp4", model_name="Qwen/Qwen3-235B-A22B") == {}
+    assert get_moe_quantization_module_config("vllm", "int4_wo", model_name="moonshotai/Kimi-K2.5") == {
+        "group_size": 32
+    }
 
     assert moe_shape_satisfies_constraints(
         "vllm",
@@ -403,6 +839,28 @@ def test_mla_module_metadata_and_micro_sweeps_are_yaml_backed():
     }
 
 
+def test_mla_module_targeted_artifacts_keep_requested_checkpoint(monkeypatch):
+    from collector.case_generator import get_mla_module_model_specs
+
+    for model_path, attention_type, architecture in (
+        ("nvidia/DeepSeek-V3.1-NVFP4", "mla", "DeepseekV3ForCausalLM"),
+        ("nvidia/GLM-5-NVFP4", "dsa", "GlmMoeDsaForCausalLM"),
+    ):
+        monkeypatch.setenv("COLLECTOR_MODEL_PATH", model_path)
+        specs = get_mla_module_model_specs(attention_type=attention_type)
+        assert [(spec.model_path, spec.architecture) for spec in specs] == [(model_path, architecture)]
+
+
+def test_shape_only_mla_alias_uses_canonical_model(monkeypatch):
+    monkeypatch.setenv("COLLECTOR_MODEL_PATH", "moonshotai/Kimi-K2-Instruct")
+    from collector.case_generator import get_context_mla_case_specs
+
+    kimi_specs = get_context_mla_case_specs()
+    assert kimi_specs
+    assert {spec.model_name for spec in kimi_specs} == {"moonshotai/Kimi-K2.5"}
+    assert {spec.num_heads for spec in kimi_specs} == {64, 128}
+
+
 def test_model_cases_path_can_infer_model_path():
     model_cases_path = default_architecture_cases_path("DeepseekV4ForCausalLM")
 
@@ -411,7 +869,56 @@ def test_model_cases_path_can_infer_model_path():
     assert plan.model_path == "sgl-project/DeepSeek-V4-Flash-FP8"
     assert plan.model_architecture == "DeepseekV4ForCausalLM"
     assert "dsv4_csa_context_module" in plan.op_cases
+    assert "dsv4_csa_topk_calib" in plan.op_cases
     assert "mhc_module" in plan.op_cases
+    assert {
+        "dsv4_paged_mqa_logits_module",
+        "dsv4_hca_attn_module",
+        "dsv4_csa_attn_module",
+    }.isdisjoint(plan.op_cases)
+
+
+def test_dsv4_plan_only_uses_backend_specific_case_plan():
+    model_path = "deepseek-ai/DeepSeek-V4-Pro"
+    expected_ops = build_collection_case_plan(backend="sglang", model_path=model_path).ops
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "collector/collect.py",
+            "--backend",
+            "sglang",
+            "--model-path",
+            model_path,
+            "--plan-only",
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(result.stdout)
+
+    assert payload["ops"] == expected_ops
+    assert "dsv4_csa_topk_calib" in payload["ops"]
+    assert "wideep_moe" in payload["ops"]
+
+
+def test_vllm_dsv4_collectors_are_registry_only():
+    from collector.vllm.registry import REGISTRY
+
+    dsv4_ops = {
+        "dsv4_csa_context_module",
+        "dsv4_hca_context_module",
+        "dsv4_csa_generation_module",
+        "dsv4_hca_generation_module",
+        "mhc_module",
+    }
+    plan = build_collection_case_plan(backend="vllm", model_path="sgl-project/DeepSeek-V4-Pro-FP8")
+
+    assert plan.ops == ["gemm", "moe"]
+    assert dsv4_ops.isdisjoint(plan.op_cases)
+    assert dsv4_ops <= {entry.op for entry in REGISTRY}
 
 
 def test_model_architecture_can_select_case_file():
@@ -433,6 +940,68 @@ def test_model_path_alias_resolves_architecture_case_file():
     assert "moe" in plan.op_cases
 
 
+def test_encoder_attention_plan_matches_sdk_model_and_backend_support():
+    dense_plan = build_collection_case_plan(backend="sglang", model_path="Qwen/Qwen3-32B")
+    assert dense_plan.ops == ["attention_context", "attention_generation", "gemm"]
+    assert "encoder_attention" not in dense_plan.op_cases
+
+    for backend in ("sglang", "trtllm", "vllm"):
+        assert (
+            "encoder_attention"
+            in build_collection_case_plan(
+                backend=backend,
+                model_path="Qwen/Qwen3-VL-32B-Instruct",
+            ).op_cases
+        )
+    assert (
+        "encoder_attention"
+        not in build_collection_case_plan(
+            backend="vllm_xpu",
+            model_path="Qwen/Qwen3-VL-32B-Instruct",
+        ).op_cases
+    )
+
+
+def test_compute_scale_is_selected_only_for_static_fp8_artifact():
+    static_model = "Qwen/Qwen3-32B-FP8-Static-PerTensor"
+    non_static_models = ("Qwen/Qwen3-32B", "Qwen/Qwen3-32B-FP8", "Qwen/Qwen3-0.6B")
+
+    for backend in ("sglang", "trtllm", "vllm"):
+        static_plan = build_collection_case_plan(backend=backend, model_path=static_model, sm_version=100)
+        assert "compute_scale" in static_plan.op_cases
+        assert "compute_scale" in build_collection_case_plan(backend=backend, full=True).op_cases
+
+        for model_path in non_static_models:
+            plan = build_collection_case_plan(backend=backend, model_path=model_path, sm_version=100)
+            assert "compute_scale" not in plan.op_cases
+
+    xpu_plan = build_collection_case_plan(backend="vllm_xpu", model_path=static_model)
+    assert "compute_scale" not in xpu_plan.op_cases
+
+
+def test_model_plans_do_not_request_ops_missing_from_backend_registry():
+    deepseek_vllm = build_collection_case_plan(backend="vllm", model_path="deepseek-ai/DeepSeek-V3")
+    kimi_vllm = build_collection_case_plan(backend="vllm", model_path="moonshotai/Kimi-K2.5")
+    nemotron_sglang = build_collection_case_plan(
+        backend="sglang",
+        model_path="nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4",
+    )
+    nemotron_trtllm = build_collection_case_plan(
+        backend="trtllm",
+        model_path="nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4",
+    )
+
+    assert "mla_context" not in deepseek_vllm.op_cases
+    assert "mla_generation" not in deepseek_vllm.op_cases
+    assert "mla_context_module" in deepseek_vllm.op_cases
+    assert "attention_context" in kimi_vllm.op_cases
+    assert "attention_generation" in kimi_vllm.op_cases
+    assert "mla_context" not in kimi_vllm.op_cases
+    assert "mla_generation" not in kimi_vllm.op_cases
+    assert "mamba2" not in nemotron_sglang.op_cases
+    assert "mamba2" in nemotron_trtllm.op_cases
+
+
 def test_full_mode_aggregates_all_model_case_files():
     plan = build_collection_case_plan(backend="sglang", full=True)
 
@@ -441,6 +1010,13 @@ def test_full_mode_aggregates_all_model_case_files():
     assert "wideep_mla_context" in plan.op_cases
     assert "dsv4_csa_context_module" in plan.op_cases
     assert "gdn" in plan.op_cases
+
+
+def test_full_mode_unions_model_selectors_instead_of_last_model_wins():
+    for backend in ("sglang", "trtllm"):
+        plan = build_collection_case_plan(backend=backend, full=True)
+        for op in ("mla_context", "mla_generation", "mla_bmm_gen_pre", "mla_bmm_gen_post"):
+            assert plan.op_cases[op].include.all_cases, f"{backend}/{op} was narrowed by a later model document"
 
 
 def test_support_matrix_models_have_model_case_aliases():
@@ -470,7 +1046,60 @@ def test_support_matrix_moe_alias_generates_targeted_cases(monkeypatch):
     cases = get_common_moe_test_cases()
 
     assert cases
-    assert {case.model_name for case in cases} == {"Qwen/Qwen3-235B-A22B-FP8"}
+    assert {case.model_name for case in cases} == {"Qwen/Qwen3-235B-A22B"}
+
+
+def test_qwen3_30b_fp8_alias_reuses_canonical_case_and_tp_constraints(monkeypatch):
+    from collector.case_generator import get_common_moe_test_cases
+
+    monkeypatch.setenv("COLLECTOR_MODEL_PATH", "Qwen/Qwen3-30B-A3B-FP8")
+
+    cases = get_common_moe_test_cases()
+
+    assert cases
+    assert {case.model_name for case in cases} == {"Qwen/Qwen3-30B-A3B"}
+    assert all(case.tp < 8 for case in cases)
+
+
+def test_quant_sensitive_moe_artifacts_use_quant_equivalent_representatives(monkeypatch):
+    from collector.case_generator import get_common_moe_test_cases
+
+    expected_representatives = {
+        "nvidia/DeepSeek-V3.1-NVFP4": "nvidia/DeepSeek-V3.1-NVFP4",
+        "nvidia/MiniMax-M2.5-NVFP4": "nvidia/MiniMax-M2.5-NVFP4",
+        "nvidia/MiniMax-M2.7-NVFP4": "nvidia/MiniMax-M2.5-NVFP4",
+        "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16",
+        "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-FP8": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-FP8",
+        "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4",
+    }
+
+    for model_path, expected_representative in expected_representatives.items():
+        monkeypatch.setenv("COLLECTOR_MODEL_PATH", model_path)
+        cases = get_common_moe_test_cases()
+        assert cases and {case.model_name for case in cases} == {expected_representative}
+
+
+def test_nemotron_ultra_quant_artifact_keeps_moe_path_but_reuses_mamba_profile(monkeypatch):
+    from collector.case_generator import get_common_mamba2_test_cases, get_common_moe_test_cases
+
+    monkeypatch.setenv("COLLECTOR_MODEL_PATH", "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-FP8")
+
+    moe_cases = get_common_moe_test_cases()
+    mamba_cases = get_common_mamba2_test_cases()
+
+    assert moe_cases and {case.model_name for case in moe_cases} == {"nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-FP8"}
+    assert mamba_cases and {case.model_name for case in mamba_cases} == {
+        "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4"
+    }
+
+
+def test_unverified_nemotron_rl_artifact_has_no_moe_profile(monkeypatch):
+    from collector.case_generator import get_common_mamba2_test_cases, get_common_moe_test_cases
+
+    monkeypatch.setenv("COLLECTOR_MODEL_PATH", "nvidia/nemotron-ultra-rl-050826")
+
+    assert get_common_moe_test_cases() == []
+    assert get_common_mamba2_test_cases()
 
 
 def test_support_matrix_mamba_alias_generates_targeted_cases(monkeypatch):
@@ -509,6 +1138,19 @@ framework_specific_op_exceptions:
     assert plan.sm_exceptions_path == exceptions.resolve()
     assert "wideep_moe" not in plan.op_cases
     assert "wideep_mla_context" in plan.op_cases
+
+
+def test_sm_exception_catalog_does_not_activate_unrelated_ops():
+    base_plan = build_collection_case_plan(backend="sglang", model_path="Qwen/Qwen3-32B")
+    sm120_plan = build_collection_case_plan(
+        backend="sglang",
+        model_path="Qwen/Qwen3-32B",
+        sm_version=120,
+    )
+
+    assert sm120_plan.ops == base_plan.ops == ["attention_context", "attention_generation", "gemm"]
+    assert "moe" not in sm120_plan.op_cases
+    assert "wideep_mla_context" not in sm120_plan.op_cases
 
 
 def test_gpu_type_resolves_default_sm_exception_file(tmp_path: Path, monkeypatch):
@@ -596,6 +1238,42 @@ def test_filter_test_cases_supports_case_ids_contains_and_indices():
     filtered = filter_test_cases(cases, plan=plan, full_module_name="sglang.moe", run_func_name="run_moe_torch")
 
     assert filtered == ["tp=2 ep=1", "tp=4 ep=1"]
+
+
+def test_yaml_include_selector_can_narrow_a_new_op_plan(tmp_path: Path):
+    cases = ["case0", "case1", "case2"]
+    selected_case_id = create_test_case_id(cases[1], "run_gemm", "sglang.gemm")
+    model_cases = tmp_path / "SelectorArchitecture_cases.yaml"
+    model_cases.write_text(
+        f"""
+schema_version: 1
+architecture: SelectorArchitecture
+model_path: test/selector-model
+include_base: true
+base_ops:
+  - gemm
+all_frameworks_op_cases:
+  gemm:
+    case_ids:
+      - '{selected_case_id}'
+""",
+        encoding="utf-8",
+    )
+
+    plan = build_collection_case_plan(
+        backend="sglang",
+        model_cases_path=str(model_cases),
+    )
+    gemm_plan = plan.op_cases["gemm"]
+
+    assert not gemm_plan.include.all_cases
+    assert gemm_plan.include.case_ids == {selected_case_id}
+    assert filter_test_cases(
+        cases,
+        plan=gemm_plan,
+        full_module_name="sglang.gemm",
+        run_func_name="run_gemm",
+    ) == [cases[1]]
 
 
 def test_filter_test_cases_supports_index_ranges_and_limit():
@@ -718,7 +1396,7 @@ def test_filter_test_cases_reports_expected_sm_exception_reasons():
     ]
 
 
-def test_sm89_exception_marks_sglang_head_dim_256_context_attention_expected_failure():
+def test_sm89_exception_excludes_sglang_head_dim_256_context_attention_before_execution():
     plan = build_collection_case_plan(
         backend="sglang",
         model_path="google/gemma-4-26B-A4B",
@@ -727,25 +1405,40 @@ def test_sm89_exception_marks_sglang_head_dim_256_context_attention_expected_fai
     case = [1, 256, 2, 1, 256, False, False, True, 1024]
 
     for version in ("0.5.9", "0.5.10", "0.5.12"):
-        expected = expected_failure_for_test_case(
-            case,
+        filtered, skipped = filter_test_cases_with_report(
+            [case],
             plan=plan.op_cases["attention_context"],
             full_module_name="sglang.attention_context",
             run_func_name="run_attention_torch",
             runtime_version=version,
         )
 
-        assert expected is not None
-        assert expected["reason_type"] == "framework_version_unsupported"
-        assert "head_dim=256" in expected["reason"]
+        assert filtered == []
+        assert skipped[0]["reason_type"] == "framework_version_unsupported"
+        assert "head_dim=256" in skipped[0]["reason"]
+
+    filtered, skipped = filter_test_cases_with_report(
+        [case],
+        plan=plan.op_cases["attention_context"],
+        full_module_name="sglang.attention_context",
+        run_func_name="run_attention_torch",
+        runtime_version="0.5.8",
+    )
+    assert filtered == [case]
+    assert skipped == []
+
+
+def test_expected_failure_matching_does_not_consider_exclude_selector():
+    case = ["remaining"]
+    plan = OpCasePlan(exclude=CaseSelector(indices={1}))
 
     assert (
         expected_failure_for_test_case(
             case,
-            plan=plan.op_cases["attention_context"],
-            full_module_name="sglang.attention_context",
-            run_func_name="run_attention_torch",
-            runtime_version="0.5.8",
+            plan=plan,
+            full_module_name="sglang.unmigrated_op",
+            run_func_name="run_case",
+            index=1,
         )
         is None
     )
@@ -772,31 +1465,34 @@ def test_sm120_exception_filters_trtllm_gptoss_mxfp4():
         1.01,
     ]
 
-    expected = expected_failure_for_test_case(
-        case,
+    filtered, skipped = filter_test_cases_with_report(
+        [case],
         plan=plan.op_cases["moe"],
         full_module_name="trtllm.moe",
         run_func_name="run_moe_torch",
         runtime_version="1.3.0rc10",
     )
 
-    assert expected == {
-        "case_id": create_test_case_id(case, "run_moe_torch", "trtllm.moe"),
-        "source": "sm_exception",
-        "selector": "rule",
-        "reason_type": "framework_version_unsupported",
-        "reason": "TRT-LLM 1.3.0rc5/rc10 TRTLLMGenFusedMoE rejects GPT-OSS MXFP4 paths on SM120.",
-    }
-    assert (
-        expected_failure_for_test_case(
-            case,
-            plan=plan.op_cases["moe"],
-            full_module_name="trtllm.moe",
-            run_func_name="run_moe_torch",
-            runtime_version="1.3.0rc4",
-        )
-        is None
+    assert filtered == []
+    assert skipped == [
+        {
+            "case_id": create_test_case_id(case, "run_moe_torch", "trtllm.moe"),
+            "index": 0,
+            "source": "sm_exception",
+            "selector": "rule",
+            "reason_type": "framework_version_unsupported",
+            "reason": "TRT-LLM 1.3.0rc5/rc10 TRTLLMGenFusedMoE rejects GPT-OSS MXFP4 paths on SM120.",
+        }
+    ]
+    filtered, skipped = filter_test_cases_with_report(
+        [case],
+        plan=plan.op_cases["moe"],
+        full_module_name="trtllm.moe",
+        run_func_name="run_moe_torch",
+        runtime_version="1.3.0rc4",
     )
+    assert filtered == [case]
+    assert skipped == []
 
 
 def test_sm100_exception_filters_trtllm_int4_wo():
@@ -820,34 +1516,37 @@ def test_sm100_exception_filters_trtllm_int4_wo():
         1.2,
     ]
 
-    expected = expected_failure_for_test_case(
-        case,
+    filtered, skipped = filter_test_cases_with_report(
+        [case],
         plan=plan.op_cases["moe"],
         full_module_name="trtllm.moe",
         run_func_name="run_moe_torch",
         runtime_version="1.3.0rc10",
     )
 
-    assert expected == {
-        "case_id": create_test_case_id(case, "run_moe_torch", "trtllm.moe"),
-        "source": "sm_exception",
-        "selector": "rule",
-        "reason_type": "framework_version_unsupported",
-        "reason": (
-            "TRT-LLM 1.3.0rc10 SM100 CutlassFusedMoE rejects plain W4A16/int4_wo "
-            "in create_moe with ValueError Unsupported quantization mode [1]."
-        ),
-    }
-    assert (
-        expected_failure_for_test_case(
-            case,
-            plan=plan.op_cases["moe"],
-            full_module_name="trtllm.moe",
-            run_func_name="run_moe_torch",
-            runtime_version="1.3.0rc9",
-        )
-        is None
+    assert filtered == []
+    assert skipped == [
+        {
+            "case_id": create_test_case_id(case, "run_moe_torch", "trtllm.moe"),
+            "index": 0,
+            "source": "sm_exception",
+            "selector": "rule",
+            "reason_type": "framework_version_unsupported",
+            "reason": (
+                "TRT-LLM 1.3.0rc10 SM100 CutlassFusedMoE rejects plain W4A16/int4_wo "
+                "in create_moe with ValueError Unsupported quantization mode [1]."
+            ),
+        }
+    ]
+    filtered, skipped = filter_test_cases_with_report(
+        [case],
+        plan=plan.op_cases["moe"],
+        full_module_name="trtllm.moe",
+        run_func_name="run_moe_torch",
+        runtime_version="1.3.0rc9",
     )
+    assert filtered == [case]
+    assert skipped == []
 
 
 def test_filter_test_cases_supports_computed_rule_conditions():


### PR DESCRIPTION
#### Overview:

Backports #1256 to release/0.10.0.

#### Details:

- Cherry-picks source commit e015c0ed6c19af13f12986835c1fec27d575fba2.
- Contains exactly one commit based directly on release/0.10.0.
- The backport patch is identical to the original merged patch and preserves its DCO sign-offs.

#### Validation:

- Focused collector test files: 137 passed
- git diff --check: passed

#### Where should the reviewer start?

See the original PR: https://github.com/ai-dynamo/aiconfigurator/pull/1256

#### Related Issues:

- Relates to #1256
