### PR TITLE
fix(dsa): extrapolate per-backend sub-dicts instead of backend-keyed outer dict (cherry-pick #1250)

### DIFF
--- a/src/aiconfigurator/sdk/operations/dsa.py
+++ b/src/aiconfigurator/sdk/operations/dsa.py
@@ -288,8 +288,8 @@ class ContextDSAModule(Operation):
 
     @classmethod
     def _extrapolate(cls, data_wrapper) -> None:
-        """Apply the legacy 4-level (fmha_mode → kv_cache_dtype → gemm_mode
-        → arch → grid) extrapolation."""
+        """Apply the 5-level (fmha_mode → kv_cache_dtype → gemm_mode → arch
+        → dsa_backend → grid) extrapolation."""
         if data_wrapper is None or not getattr(data_wrapper, "loaded", False):
             return
 
@@ -297,7 +297,7 @@ class ContextDSAModule(Operation):
             for kv_cache_dtype in data_wrapper[fmha_mode]:
                 for gemm_mode in data_wrapper[fmha_mode][kv_cache_dtype]:
                     for arch in data_wrapper[fmha_mode][kv_cache_dtype][gemm_mode]:
-                        data_dict = data_wrapper[fmha_mode][kv_cache_dtype][gemm_mode][arch]
+                        arch_dict = data_wrapper[fmha_mode][kv_cache_dtype][gemm_mode][arch]
 
                         def _is_latency_leaf(value):
                             return isinstance(value, dict) and "latency" in value
@@ -313,36 +313,40 @@ class ContextDSAModule(Operation):
                                     return not any(_is_latency_leaf(v) for v in first_slice.values())
                             return False
 
-                        if _has_prefix_axis(data_dict):
-                            prefix_values = sorted(
-                                {
-                                    prefix
-                                    for head_data in data_dict.values()
-                                    if isinstance(head_data, dict)
-                                    for prefix in head_data
-                                }
-                            )
-                            for prefix in prefix_values:
-                                prefix_slice = {
-                                    head: head_data[prefix]
-                                    for head, head_data in data_dict.items()
-                                    if isinstance(head_data, dict) and prefix in head_data
-                                }
+                        # arch_dict is {dsa_backend: {num_heads: {prefix: {s: {b}}}}}.
+                        for dsa_backend_key in list(arch_dict.keys()):
+                            data_dict = arch_dict[dsa_backend_key]
+
+                            if _has_prefix_axis(data_dict):
+                                prefix_values = sorted(
+                                    {
+                                        prefix
+                                        for head_data in data_dict.values()
+                                        if isinstance(head_data, dict)
+                                        for prefix in head_data
+                                    }
+                                )
+                                for prefix in prefix_values:
+                                    prefix_slice = {
+                                        head: head_data[prefix]
+                                        for head, head_data in data_dict.items()
+                                        if isinstance(head_data, dict) and prefix in head_data
+                                    }
+                                    interpolation.extrapolate_data_grid(
+                                        data_dict=prefix_slice,
+                                        target_x_list=list(prefix_slice.keys()),
+                                        target_y_list=_CONTEXT_DSA_TARGET_Y,
+                                        target_z_list=_CONTEXT_DSA_TARGET_Z,
+                                    )
+                                    for head, head_slice in prefix_slice.items():
+                                        data_dict[head][prefix] = head_slice
+                            else:
                                 interpolation.extrapolate_data_grid(
-                                    data_dict=prefix_slice,
-                                    target_x_list=list(prefix_slice.keys()),
+                                    data_dict=data_dict,
+                                    target_x_list=list(data_dict.keys()),
                                     target_y_list=_CONTEXT_DSA_TARGET_Y,
                                     target_z_list=_CONTEXT_DSA_TARGET_Z,
                                 )
-                                for head, head_slice in prefix_slice.items():
-                                    data_dict[head][prefix] = head_slice
-                        else:
-                            interpolation.extrapolate_data_grid(
-                                data_dict=data_dict,
-                                target_x_list=list(data_dict.keys()),
-                                target_y_list=_CONTEXT_DSA_TARGET_Y,
-                                target_z_list=_CONTEXT_DSA_TARGET_Z,
-                            )
 
     # ------------------------------------------------------------------
     # Query table (formerly PerfDatabase.query_context_dsa_module)
@@ -1126,22 +1130,24 @@ class GenerationDSAModule(Operation):
 
     @classmethod
     def _extrapolate(cls, data_wrapper) -> None:
-        """Apply the legacy 3-level (kv_cache_dtype → gemm_mode → arch
-        → grid) extrapolation."""
+        """Apply the 4-level (kv_cache_dtype → gemm_mode → arch
+        → dsa_backend → grid) extrapolation."""
         if data_wrapper is None or not getattr(data_wrapper, "loaded", False):
             return
 
         for kv_cache_dtype in data_wrapper:
             for gemm_mode in data_wrapper[kv_cache_dtype]:
                 for arch in data_wrapper[kv_cache_dtype][gemm_mode]:
-                    data_dict = data_wrapper[kv_cache_dtype][gemm_mode][arch]
-                    tp_list = list(data_dict.keys())
-                    interpolation.extrapolate_data_grid(
-                        data_dict=data_dict,
-                        target_x_list=tp_list,
-                        target_y_list=_GENERATION_DSA_TARGET_Y,
-                        target_z_list=_GENERATION_DSA_TARGET_Z,
-                    )
+                    arch_dict = data_wrapper[kv_cache_dtype][gemm_mode][arch]
+                    # arch_dict is {dsa_backend: {num_heads: {b: {s}}}}.
+                    for dsa_backend_key in list(arch_dict.keys()):
+                        data_dict = arch_dict[dsa_backend_key]
+                        interpolation.extrapolate_data_grid(
+                            data_dict=data_dict,
+                            target_x_list=list(data_dict.keys()),
+                            target_y_list=_GENERATION_DSA_TARGET_Y,
+                            target_z_list=_GENERATION_DSA_TARGET_Z,
+                        )
 
     # ------------------------------------------------------------------
     # Query table (formerly PerfDatabase.query_generation_dsa_module)
@@ -1585,7 +1591,7 @@ def load_context_dsa_module_data(dsa_file: str):
     Load context DSA data.
 
     Dict structure:
-        data[fmha_quant_mode][kv_cache_quant_mode][gemm_quant_mode][architecture][num_heads][prefix][s][b]
+        data[fmha_quant_mode][kv_cache_quant_mode][gemm_quant_mode][architecture][dsa_backend][num_heads][prefix][s][b]
 
     Quant modes are the outermost keys so that ``_enum_key_names`` can
     directly extract supported FMHAQuantMode names (aligned with
@@ -1664,7 +1670,7 @@ def load_generation_dsa_module_data(dsa_file: str):
     Load generation DSA data.
 
     Dict structure:
-        data[kv_cache_quant_mode][gemm_quant_mode][architecture][num_heads][b][s]
+        data[kv_cache_quant_mode][gemm_quant_mode][architecture][dsa_backend][num_heads][b][s]
 
     Quant modes are the outermost keys so that ``_enum_key_names`` can
     directly extract supported KVCacheQuantMode names (aligned with

--- a/tests/unit/sdk/database/test_dsa_module.py
+++ b/tests/unit/sdk/database/test_dsa_module.py
@@ -10,6 +10,8 @@ import pytest
 from aiconfigurator.sdk import common, interpolation
 from aiconfigurator.sdk.operations.dsa import (
     DEFAULT_DSA_ARCHITECTURE,
+    ContextDSAModule,
+    GenerationDSAModule,
     load_context_dsa_module_data,
     load_generation_dsa_module_data,
 )
@@ -662,6 +664,53 @@ class TestContextDSAModule:
         )
         assert r1 != r2
 
+    def test_extrapolate_descends_into_each_dsa_backend_independently(self):
+        """Regression: ``_extrapolate`` must descend through the ``dsa_backend``
+        level and extrapolate each backend's ``{num_heads: {prefix: {s: {b}}}}``
+        grid independently.  Before the fix the backend names ("flashmla_kv",
+        "trtllm") were treated as the num_heads x-axis, silently extrapolating
+        at the wrong nesting level."""
+        flashmla = {
+            32: {0: {1: {1: _dsa_value(10.0), 4: _dsa_value(40.0)}, 32: {1: _dsa_value(20.0), 4: _dsa_value(50.0)}}}
+        }
+        trtllm = {
+            32: {0: {1: {1: _dsa_value(100.0), 4: _dsa_value(400.0)}, 32: {1: _dsa_value(200.0), 4: _dsa_value(500.0)}}}
+        }
+        dsa_dict = {"flashmla_kv": flashmla, "trtllm": trtllm}
+        data_wrapper = LoadedOpData(
+            _context_dsa_data(dsa_dict, GLM5_ARCHITECTURE),
+            common.PerfDataFilename.dsa_context_module,
+            "test",
+        )
+
+        ContextDSAModule._extrapolate(data_wrapper)
+
+        arch_dict = data_wrapper[common.FMHAQuantMode.bfloat16][common.KVCacheQuantMode.bfloat16][
+            common.GEMMQuantMode.bfloat16
+        ][GLM5_ARCHITECTURE]
+
+        # Backend names survive as backend-level keys (not consumed as grid keys).
+        assert set(arch_dict.keys()) == {"flashmla_kv", "trtllm"}
+
+        for backend in ("flashmla_kv", "trtllm"):
+            backend_grid = arch_dict[backend]
+            # num_heads level untouched: still plain int keys.
+            assert set(backend_grid.keys()) == {32}
+            # New b=2 interpolated within each (num_heads, prefix, s) slice.
+            assert 2 in backend_grid[32][0][1]
+            assert 2 in backend_grid[32][0][32]
+            # New s=16 interpolated within each (num_heads, prefix) slice.
+            assert 16 in backend_grid[32][0]
+            # All s-level keys are ints (no backend-name leakage into the grid).
+            assert all(isinstance(k, int) for k in backend_grid[32][0])
+
+        # Backends extrapolated independently: same grid point, different values.
+        flashmla_b2 = arch_dict["flashmla_kv"][32][0][1][2]["latency"]
+        trtllm_b2 = arch_dict["trtllm"][32][0][1][2]["latency"]
+        assert flashmla_b2 == pytest.approx(20.0)
+        assert trtllm_b2 == pytest.approx(200.0)
+        assert flashmla_b2 != trtllm_b2
+
 
 # ═══════════════════════════════════════════════════════════════════════
 # Generation DSA Module
@@ -964,3 +1013,53 @@ class TestGenerationDSAModule:
 
         assert float(result) == pytest.approx(11.0 * sol_query / sol_boundary)
         assert result.source == "empirical"
+
+    def test_extrapolate_descends_into_each_dsa_backend_independently(self):
+        """Regression: ``_extrapolate`` must descend through the ``dsa_backend``
+        level and extrapolate each backend's ``{num_heads: {b: {s}}}`` grid
+        independently.  Before the fix the backend names ("flashmla_kv",
+        "trtllm") were treated as the num_heads x-axis, silently extrapolating
+        at the wrong nesting level."""
+        flashmla = {
+            32: {1: {256: _dsa_value(10.0), 1024: _dsa_value(20.0)}, 8: {256: _dsa_value(30.0), 1024: _dsa_value(40.0)}}
+        }
+        trtllm = {
+            32: {
+                1: {256: _dsa_value(100.0), 1024: _dsa_value(200.0)},
+                8: {256: _dsa_value(300.0), 1024: _dsa_value(400.0)},
+            }
+        }
+        dsa_dict = {"flashmla_kv": flashmla, "trtllm": trtllm}
+        data_wrapper = LoadedOpData(
+            _generation_dsa_data(dsa_dict),
+            common.PerfDataFilename.dsa_generation_module,
+            "test",
+        )
+
+        GenerationDSAModule._extrapolate(data_wrapper)
+
+        arch_dict = data_wrapper[common.KVCacheQuantMode.bfloat16][common.GEMMQuantMode.bfloat16][
+            DEFAULT_DSA_ARCHITECTURE
+        ]
+
+        # Backend names survive as backend-level keys (not consumed as grid keys).
+        assert set(arch_dict.keys()) == {"flashmla_kv", "trtllm"}
+
+        for backend in ("flashmla_kv", "trtllm"):
+            backend_grid = arch_dict[backend]
+            # num_heads level untouched: still plain int keys.
+            assert set(backend_grid.keys()) == {32}
+            # New b=2 interpolated within each num_heads slice (between b=1 and b=8).
+            assert 2 in backend_grid[32]
+            # New s=512 interpolated within each (num_heads, b) slice (between s=256 and s=1024).
+            assert 512 in backend_grid[32][1]
+            assert 512 in backend_grid[32][8]
+            # All b-level keys are ints (no backend-name leakage into the grid).
+            assert all(isinstance(k, int) for k in backend_grid[32])
+
+        # Backends extrapolated independently: same grid point, different values.
+        flashmla_s512 = arch_dict["flashmla_kv"][32][1][512]["latency"]
+        trtllm_s512 = arch_dict["trtllm"][32][1][512]["latency"]
+        assert flashmla_s512 == pytest.approx(13.333333, rel=1e-4)
+        assert trtllm_s512 == pytest.approx(133.333333, rel=1e-4)
+        assert flashmla_s512 != trtllm_s512


### PR DESCRIPTION
#### Overview:

Backports #1250 to release/0.10.0.

#### Details:

- Cherry-picks source commit 036ab41bf745b41b8a14d0f71e899be5330aec1c.
- Contains exactly one commit based directly on release/0.10.0.
- The backport patch is identical to the original merged patch and preserves its DCO sign-offs.

#### Validation:

- tests/unit/sdk/database/test_dsa_module.py: 39 passed
- git diff --check: passed

#### Where should the reviewer start?

See the original PR: https://github.com/ai-dynamo/aiconfigurator/pull/1250

#### Related Issues:

- Relates to #1250
