### PR TITLE
feat(cli): add Spica thorough sweeps to default mode (cherry-pick #1244)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -105,3 +105,82 @@ jobs:
         if: always()
         run: |
             docker cp aic:/workspace/test_report.md ./test_report.md
+
+  spica-thorough-e2e:
+    name: Build and Test (Spica thorough e2e)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+          lfs: true
+          fetch-depth: 0
+      - name: Git LFS Pull
+        run: git lfs pull
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.12'
+      - name: Install AIC and Spica test dependencies
+        run: |
+          python -m pip install uv
+          uv sync --extra dev --extra spica
+          uv pip install --python .venv/bin/python maturin
+      - name: Install Dynamo build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends protobuf-compiler
+      - name: Checkout pinned Dynamo replay source
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          repository: ai-dynamo/dynamo
+          ref: cb7dc1a3a74018b7824ab7ef9d0191b80946758b
+          path: dynamo-src
+          persist-credentials: false
+          lfs: false
+      - name: Build Dynamo replay bindings with AIC perf model
+        working-directory: dynamo-src/lib/bindings/python
+        env:
+          CARGO_NET_GIT_FETCH_WITH_CLI: 'true'
+        run: |
+          VIRTUAL_ENV="${GITHUB_WORKSPACE}/.venv" \
+            "${GITHUB_WORKSPACE}/.venv/bin/maturin" develop \
+            --uv --release --features aic-forward-pass,mocker-kvbm-offload
+      - name: Install Dynamo replay and planner dependencies
+        # maturin installs ai-dynamo-runtime only; the planner modules exposed
+        # through PYTHONPATH below also need Dynamo's root + planner dependencies.
+        run: |
+          uv pip install --python .venv/bin/python \
+            --editable ./dynamo-src \
+            --requirement ./dynamo-src/container/deps/requirements.planner.txt
+      - name: Run real Spica thorough sweeps
+        env:
+          AIC_RUN_SPICA_THOROUGH_E2E: 'true'
+          AIC_SPICA_THOROUGH_E2E_ARTIFACT_DIR: ${{ runner.temp }}/spica-thorough-e2e-results
+          PYTHONPATH: ${{ github.workspace }}/dynamo-src/components/src:${{ github.workspace }}/dynamo-src/lib/bindings/python/src
+        run: |
+          set +e
+          "${GITHUB_WORKSPACE}/.venv/bin/pytest" \
+            tests/e2e/cli/test_cli_default_thorough_sweep_real.py -vv
+          test_status=$?
+          set -e
+          for log_name in stdout.txt stderr.txt native_stdout.txt native_stderr.txt; do
+            log_path="${AIC_SPICA_THOROUGH_E2E_ARTIFACT_DIR}/${log_name}"
+            if [ -s "${log_path}" ]; then
+              echo "::group::${log_name}"
+              cat "${log_path}"
+              echo "::endgroup::"
+            fi
+          done
+          exit "${test_status}"
+      - name: Upload Spica thorough sweep results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: spica-thorough-e2e-results
+          path: ${{ runner.temp }}/spica-thorough-e2e-results
+          if-no-files-found: warn
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -66,12 +66,22 @@ docker create --name aic aiconfigurator:latest && docker cp aic:/workspace/dist 
 
 ```bash
 aiconfigurator cli default --model Qwen/Qwen3-32B-FP8 --total-gpus 32 --system h200_sxm
+aiconfigurator cli default --model Qwen/Qwen3-32B-FP8 --total-gpus 32 --system h200_sxm --thorough-sweep
+aiconfigurator cli default --thorough-config spica_smart_sweep.yaml
 aiconfigurator cli exp --yaml-path exp.yaml
 aiconfigurator cli generate --model-path Qwen/Qwen3-32B-FP8 --total-gpus 8 --system h200_sxm
 aiconfigurator cli support --model-path Qwen/Qwen3-32B-FP8 --system h200_sxm
 ```
 - We have four modes: `default`, `exp`, `generate`, and `support`.
 - Use `default` to find the estimated best deployment by searching the configuration space.
+- **Experimental:** Spica thorough mode is an early preview. Its CLI, config schema, search behavior, and generated artifacts may change in future releases, and sweeps can take substantially longer than the legacy estimator.
+- Use `default --thorough-sweep` to run Spica's replay-backed thorough sweeper. Without `--thorough-config`, AIC converts the normal default CLI inputs into a legacy-compatible Spica `SmartSearchConfig` that keeps routing round-robin and planner scaling disabled.
+- Install the optional `spica` extra when using thorough mode from a packaged wheel, for example `pip install 'aiconfigurator[spica]'`.
+- Use `default --thorough-config spica_smart_sweep.yaml` to pass a native Spica `SmartSearchConfig` YAML that owns the search space, workload, goal, and sweep controls.
+- A native config's `goal` owns ranking and SLA semantics; CLI `--ttft` / `--tpot` defaults are not applied. Scalar targets and custom Pareto objectives are reported in their own units and directions.
+- For replay-backed Spica sweeps, put `workload.trace_path` and `workload.trace_format` in the `--thorough-config` YAML. Today Spica supports `trace_format: mooncake`; example trace: [Dynamo's Mooncake trace fixture](https://github.com/ai-dynamo/dynamo/blob/main/lib/bench/testdata/mooncake_trace_1000.jsonl).
+- In Spica thorough mode, `--save-dir DIR` writes sweep result artifacts and generated Dynamo configs: `spica_candidates.yaml`, `spica_candidates.csv`, `pareto.csv`, `pareto_frontier.png`, per-mode `pareto.csv` / `best_config_topn.csv`, and per-rank `topN` deployment artifacts.
+- Spica candidates using router, planner, or KVBM features currently require `--deployment-target dynamo-j2` for faithful deployment artifacts; other targets fail closed instead of silently dropping those features. KVBM artifact activation is supported for vLLM and TensorRT-LLM, not SGLang.
 - Use `exp` to run customized experiments defined in a YAML file.
 - Use `generate` to quickly create a naive configuration without a parameter sweep.
 - Use `support` to verify if AIC supports a model/hardware combination for agg and disagg modes.
@@ -274,8 +284,47 @@ You can customize llm-d-specific settings using generator overrides:
 
 Please refer to the [Deployment Guide](docs/dynamo_deployment_guide.md) for details about deployment and reproduction especially about the benchmark methodology.
 
-To simplify the deployment and reproduction, in the `aiconfigurator` CLI, if you specify `--save-dir`, the tool generates configuration files for your chosen deployment target.
-The folder structure varies based on `--deployment-target`:
+To simplify the deployment and reproduction, in the `aiconfigurator` CLI, if you specify `--save-dir`, the tool writes the search results to disk. The legacy estimator also generates configuration files for your chosen deployment target.
+The folder structure varies based on mode and `--deployment-target`:
+
+**For Spica thorough mode** (`default --thorough-sweep` or `default --thorough-config spica_smart_sweep.yaml`; trace replay is configured in the Spica YAML):
+
+```text
+results/Qwen_Qwen3-32B-FP8_h200_sxm_trtllm_trace_mooncake_tiny_ttft2000_tpot30_904495
+├── agg
+│   ├── best_config_topn.csv
+│   ├── exp_config.yaml
+│   ├── pareto.csv
+│   └── top1
+│       ├── agg_config.yaml
+│       ├── bench_run.sh
+│       ├── generator_config.yaml
+│       ├── k8s_bench.yaml
+│       ├── k8s_deploy.yaml
+│       ├── run_0.sh
+│       ├── sflow.yaml
+│       └── spica_candidate.yaml
+├── disagg
+│   ├── best_config_topn.csv
+│   ├── exp_config.yaml
+│   ├── pareto.csv
+│   └── top1
+│       ├── bench_run.sh
+│       ├── decode_config.yaml
+│       ├── generator_config.yaml
+│       ├── k8s_bench.yaml
+│       ├── k8s_deploy.yaml
+│       ├── prefill_config.yaml
+│       ├── run_0.sh
+│       ├── sflow.yaml
+│       └── spica_candidate.yaml
+├── pareto.csv
+├── pareto_frontier.png
+├── spica_candidates.csv
+└── spica_candidates.yaml
+```
+
+Spica candidate knobs that map to Dynamo runtime fields are copied into `generator_config.yaml` and the generated engine/K8s/SFlow artifacts. This includes the resolved backend version, engine batching and context limits, router weights, planner objective/SLA and GPU limits, KVBM host-offload controls, prefix caching, attention-DP, and NextN. Active router/planner/KVBM candidates currently require `--deployment-target dynamo-j2`; unsupported targets fail closed rather than producing a deployment that differs from the evaluated candidate. KV-router admission-control pins are also rejected until Dynamo replay can score them.
 
 **For Dynamo deployments** (`--deployment-target dynamo-j2` or `dynamo-python`):
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates gcc libc6-dev && \
     rm -rf /var/lib/apt/lists/*
 COPY src/ /workspace/src/
+COPY spica/ /workspace/spica/
 COPY rust/ /workspace/rust/
 COPY LICENSE pyproject.toml README.md /workspace/
 # Fail fast if Git LFS content wasn't materialized before the build — otherwise

--- a/docs/cli_user_guide.md
+++ b/docs/cli_user_guide.md
@@ -349,8 +349,12 @@ This mode is triggered by
 aiconfigurator cli default --model-path Qwen/Qwen3-32B-FP8 --total-gpus 32 --system h200_sxm
 or
 aiconfigurator cli default --model-path Qwen/Qwen3-32B-FP8 --total-gpus 32 --system h200_sxm --ttft 1000 --tpot 10 --isl 3000 --osl 512 --prefix 0
+or
+aiconfigurator cli default --model-path Qwen/Qwen3-32B-FP8 --total-gpus 32 --system h200_sxm --thorough-sweep
+or
+aiconfigurator cli default --thorough-config spica_smart_sweep.yaml
 ```
-`model_path`, `total_gpus`, `system` are three required arguments to define the problem.  
+`model_path`, `total_gpus`, `system` are three required arguments to define the problem, except when `--thorough-config` provides a native Spica `SmartSearchConfig` YAML.
 If you want to specify your problem with more details, we allow to define `ttft`, `tpot`, `isl`, `osl` and `prefix`.
 
 #### Additional arguments
@@ -361,6 +365,8 @@ Beyond `--ttft`, `--tpot`, `--isl`, `--osl`, and `--prefix`, `default` mode acce
 - `--backend-version`: Backend database version. Default: latest.
 - `--free-gpu-memory-fraction`: Fraction of free GPU memory TRT-LLM allocates for KV cache (default: `1.0`). Filters batch sizes that would exceed KV cache capacity.
 - `--max-seq-len`: TRT-LLM `--max_seq_len` (default: `isl + osl`). Controls how many KV blocks are pre-allocated per sequence; set to match your deployment for accurate KV-capacity filtering.
+- `--thorough-sweep`: Use Spica's replay-backed thorough sweeper instead of the legacy AIC Pareto sweep. Without `--thorough-config`, CLI inputs are converted to a legacy-compatible Spica `SmartSearchConfig` that keeps routing round-robin and planner scaling disabled.
+- `--thorough-config`: Path to a native Spica `SmartSearchConfig` YAML file. The file defines the search space, workload, goal, and sweep controls. Its goal owns ranking and SLA semantics; CLI SLA defaults are not inherited. For replay-backed sweeps, put `workload.trace_path` and `workload.trace_format` in this file.
 - `--enable-chunked-prefill`: Enable chunked prefill for a finer-grained context-token sweep. When off (default), the context-token stride is aligned to ISL for faster sweeping.
 - `--enable-wideep`: Enable Wide Expert Parallelism (WideEP) for MoE models — EP-only parallelism via the `deepep_moe` backend. Applies to DeepSeek and Qwen3-235B on SGLang.
 - `--moe-backend`: Explicit SGLang MoE backend — `deepep_moe` or `megamoe` (use `megamoe` to model DeepSeek-V4 MegaMoE on Blackwell).
@@ -392,6 +398,86 @@ Both agg and disagg results are merged across backends and the globally optimal 
 is selected. This is useful for finding the best backend without running separate commands.
 
 The command will create two experiments for the given problem, one is `agg` and another one is `disagg`. Compare them to find the better one and estimates the perf gain.
+
+#### Spica Thorough Sweep
+
+> [!WARNING]
+> Spica thorough mode is experimental. Its CLI, config schema, search behavior, and generated artifacts may change in future releases. Thorough sweeps also take substantially longer than the legacy estimator.
+
+Pass `--thorough-sweep` to run Spica's replay-backed thorough sweeper instead of the legacy AIC Pareto estimator. Spica is more thorough because it evaluates complete deployment candidates through Dynamo's end-to-end simulator and, with a native `--thorough-config`, can jointly explore deployment topology and parallelism, engine batching limits, router policy, multi-tier KV-cache offload, and planner scaling. This broader search captures interactions among Dynamo components, but replaying candidates takes substantially longer than the legacy estimator's narrower performance sweep.
+
+Without `--thorough-config`, the CLI converts the normal default inputs into a legacy-compatible Spica config: synthetic workload from `--isl` / `--osl`, closed-loop concurrency derived from GPU budget, the CLI `--ttft` / `--tpot` goodput SLA, round-robin routing, and planner scaling disabled:
+
+```bash
+aiconfigurator cli default \
+  --model-path Qwen/Qwen3-32B-FP8 \
+  --total-gpus 32 \
+  --system h200_sxm \
+  --backend trtllm \
+  --isl 4000 \
+  --osl 1000 \
+  --ttft 2000 \
+  --tpot 30 \
+  --thorough-sweep
+```
+
+Pass `--thorough-config` when you want to provide Spica's native `SmartSearchConfig` directly:
+
+```bash
+aiconfigurator cli default --thorough-config spica_smart_sweep.yaml
+```
+
+The Spica config file maps directly to Spica's schema:
+
+```yaml
+search_space:
+  deployment_mode: [disagg, agg]
+  model_name: Qwen/Qwen3-32B-FP8
+  hardware_sku: h200_sxm
+  gpu_budget: 32
+  backend: [trtllm]
+workload:
+  isl: 4000
+  osl: 1000
+  concurrency: 4096
+  num_request_ratio: 2
+goal:
+  target: goodput_per_gpu
+  sla: {ttft_ms: 2000, itl_ms: 30}
+sweep:
+  max_rounds: 40
+  parallel_evals: 16
+```
+
+For replay-backed sweeps, put the trace information in the Spica config and pass it with `--thorough-config`. This keeps the CLI independent of any single trace schema while Spica can add more `trace_format` values over time. Today Spica supports Mooncake JSONL traces with `trace_format: mooncake`:
+
+```yaml
+search_space:
+  deployment_mode: [disagg, agg]
+  model_name: Qwen/Qwen3-32B-FP8
+  hardware_sku: h200_sxm
+  gpu_budget: 32
+  backend: [trtllm]
+workload:
+  trace_path: /data/replay/traffic.jsonl
+  trace_format: mooncake
+goal:
+  target: goodput_per_gpu
+  sla: {ttft_ms: 2000, itl_ms: 30}
+sweep:
+  max_rounds: 40
+  parallel_evals: 16
+```
+
+```bash
+aiconfigurator cli default --thorough-config spica_mooncake_trace.yaml
+```
+
+For Mooncake, each JSONL row describes one request with fields such as `timestamp`, `input_length`, `output_length`, and `hash_ids`; see [Dynamo's Mooncake trace fixture](https://github.com/ai-dynamo/dynamo/blob/main/lib/bench/testdata/mooncake_trace_1000.jsonl) for a concrete example.
+
+In trace mode, traffic shape and request lengths come from the trace, so the workload must not also set synthetic `isl` / `osl` fields. For synthetic workloads, `num_request_ratio` controls the generated request count relative to load (`round(num_request_ratio * concurrency)` for closed-loop concurrency). The printed summary and top-N selection use the native goal: scalar targets retain their physical units and direction, while Pareto goals use the configured objective axes. Physical throughput remains a separate deployment metric rather than an alias for `Candidate.score`. If `--save-dir` is set, the CLI writes `spica_candidates.yaml`, `spica_candidates.csv`, `pareto.csv`, an objective diagnostic plot when two distinct axes are available, per-mode `pareto.csv` / `best_config_topn.csv`, and per-rank `topN` deployment artifacts.
+
+Generated Spica artifacts preserve the replay's resolved backend version, context length, router weights, planner objective/SLA and GPU limits, and KVBM transfer controls. Candidates using router, planner, or KVBM features currently require `--deployment-target dynamo-j2`; `dynamo-python` and llm-d targets fail closed because their deployment manifests cannot yet encode the full evaluated contract. KV-router admission-control pins are rejected until Dynamo replay can score them. KVBM activation is supported for vLLM and TensorRT-LLM, not SGLang.
 
 #### Systems Paths
 
@@ -521,7 +607,46 @@ Each replica has a system of 4 prefill workers and 1 decode workers. Each prefil
 `bs` is required to be set in framework as it limits the largest batch_size of the worker which is crucial to control the TPOT of the deployment.  
 `concurrency` = `concurrency * replicas` Use it to benchmark your deployment on total GPUs. If you only want to benchmark 1 replica, divide it by `replicas`
 
-As this is still a little bit challenging to get the right configs for your deployment, we can further specify `--save-dir DIR` to output all the results here as well as **generate the configs for frameworks automatically**. Here's a stucture of the output folder,
+As this is still a little bit challenging to get the right configs for your deployment, we can further specify `--save-dir DIR` to output all the results here as well as **generate the configs for frameworks automatically**. For Spica thorough mode, the CLI creates a similar run directory with per-rank `topN` folders, including the Spica ranking, generator bridge config, Pareto artifacts, and generated Dynamo deployment artifacts:
+
+```text
+results/Qwen_Qwen3-32B-FP8_h200_sxm_trtllm_trace_mooncake_tiny_ttft2000_tpot30_904495
+├── agg
+│   ├── best_config_topn.csv
+│   ├── exp_config.yaml
+│   ├── pareto.csv
+│   └── top1
+│       ├── agg_config.yaml
+│       ├── bench_run.sh
+│       ├── generator_config.yaml
+│       ├── k8s_bench.yaml
+│       ├── k8s_deploy.yaml
+│       ├── run_0.sh
+│       ├── sflow.yaml
+│       └── spica_candidate.yaml
+├── disagg
+│   ├── best_config_topn.csv
+│   ├── exp_config.yaml
+│   ├── pareto.csv
+│   └── top1
+│       ├── bench_run.sh
+│       ├── decode_config.yaml
+│       ├── generator_config.yaml
+│       ├── k8s_bench.yaml
+│       ├── k8s_deploy.yaml
+│       ├── prefill_config.yaml
+│       ├── run_0.sh
+│       ├── sflow.yaml
+│       └── spica_candidate.yaml
+├── pareto.csv
+├── pareto_frontier.png
+├── spica_candidates.csv
+└── spica_candidates.yaml
+```
+
+Spica candidate knobs that map to Dynamo runtime fields, including batch/context limits, router policy, planner target and budgets, KVBM transfer controls, prefix caching, attention-DP, and NextN, are copied into `generator_config.yaml` and the generated engine/K8s/SFlow artifacts. Active router/planner/KVBM candidates require `--deployment-target dynamo-j2` until the alternate deployment targets can encode the same contract.
+
+For the legacy estimator, here's a structure of the output folder,
 ```text
 results/Qwen_Qwen3-32B-FP8_h200_sxm_trtllm_isl4000_osl1000_ttft1000_tpot20_904495
 ├── agg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ dev = [
     "pytest-split>=0.10.0",
     "pytest-timeout>=2.3.1",
     "pytest-xdist==3.8.0",
+    "prometheus-api-client==0.6.0",
     "import-ipynb==0.2",
 ]
 webapp = [
@@ -75,6 +76,16 @@ service = [
     "fastapi>=0.115.12",
     "orjson>=3.10.16",
     "uvicorn>=0.34.2"
+]
+spica = [
+    "pydantic>=2.5; python_version < '3.13'",
+    "google-vizier[jax]==0.1.21; python_version < '3.13'",
+    "jax==0.4.38; python_version < '3.13'",
+    "jaxlib==0.4.38; python_version < '3.13'",
+    "flax==0.10.0; python_version < '3.13'",
+    "optax==0.2.4; python_version < '3.13'",
+    "chex==0.1.87; python_version < '3.13'",
+    "tensorflow-probability[jax]==0.25.0; python_version < '3.13'",
 ]
 
 [project.urls]
@@ -97,8 +108,14 @@ include-package-data = false
 "aiconfigurator.webapp.components.profiling" = ["styles.css", "js/*.js"]
 
 [tool.setuptools.packages.find]
-where = ["src"]
-include = ["aiconfigurator", "aiconfigurator.cli*", "aiconfigurator.generator*", "aiconfigurator.webapp*"]
+where = ["src", "spica/src"]
+include = [
+    "aiconfigurator",
+    "aiconfigurator.cli*",
+    "aiconfigurator.generator*",
+    "aiconfigurator.webapp*",
+    "spica*",
+]
 exclude = ["aiconfigurator.sdk*", "aiconfigurator.systems*", "aiconfigurator.model_configs*", "aiconfigurator_core*"]
 
 [tool.uv.sources]

--- a/spica/docs/sample.md
+++ b/spica/docs/sample.md
@@ -36,12 +36,16 @@ this order.
 
 Folded straight off the `SearchSpace` (`_DEPLOYMENT_PINNED` + `_KV_MANAGER`):
 
-- `model_name`, `hardware_sku`, `aic_nextn`
-- kv-manager offload: `num_g2_blocks`, `bandwidth_g1_to_g2_gbps`,
+- deployment/runtime context: `model_name`, `hardware_sku`, `context_length`,
+  `startup_time`, `aic_nextn`
+- planner limits: `gpu_budget`, `min_gpu_budget`, `min_endpoint`
+- kv-manager offload: `num_g2_blocks`, `kv_bytes_per_token`, `bandwidth_g1_to_g2_gbps`,
   `bandwidth_g2_to_g1_gbps`, `offload_batch_size`
 
-Search-only constraints (`gpu_budget`, `min_gpu_budget`, `min_endpoint`) are **excluded by
-design** — they bound the search, not a single deployment.
+The GPU bounds and endpoint floor constrain candidate enumeration, and they also become
+live runtime policy (`max_gpu_budget`, `min_gpu_budget`, `min_endpoint`) when the selected
+candidate enables the planner. Keeping them in the flat sample makes replay and generated
+deployment artifacts reproduce the search contract.
 
 ### Parallel fields (`_unroll_parallel`)
 
@@ -80,7 +84,8 @@ The inactive branch's engine keys are not emitted.
   `branch_knob_choices`), so the `if key in selection` guard simply skips them when absent.
 - `_ROUTER_ADMISSION` (pinned, from `search_space`): `active_decode_blocks_threshold`,
   `active_prefill_tokens_threshold`, `active_prefill_tokens_threshold_frac`,
-  `no_admission_control`.
+  `no_admission_control`. For searches including `kv_router`, these fields are currently
+  reserved and rejected when set because Dynamo replay cannot model them yet.
 
 Under `round_robin` none of these are emitted.
 

--- a/spica/docs/search-space.md
+++ b/spica/docs/search-space.md
@@ -88,10 +88,13 @@ separate study. `min_gpu_budget` is validated against `gpu_budget` by `_validate
 ## KV manager (multi-tier offload)
 
 All pinned. G3/G4 extend G2; offload is **off by default** (`num_g2_blocks = 0`).
+When G2 is enabled, `kv_bytes_per_token` is required so replay cannot silently
+disable offload if model metadata is private or unavailable.
 
 | knob | type | default | searched / pinned | allowed choices |
 |---|---|---|---|---|
 | `num_g2_blocks` | int | `0` | pinned | `0` disables host offload |
+| `kv_bytes_per_token` | int? | `None` | pinned | required when `num_g2_blocks > 0` |
 | `bandwidth_g1_to_g2_gbps` | float? | `None` | pinned | — |
 | `bandwidth_g2_to_g1_gbps` | float? | `None` | pinned | — |
 | `offload_batch_size` | int? | `None` | pinned | — |
@@ -122,6 +125,11 @@ dimensions. They are only swept when multi-tier KV offload is enabled (`num_g2_b
 | `active_prefill_tokens_threshold` | int? | `None` | pinned | — |
 | `active_prefill_tokens_threshold_frac` | float? | `None` | pinned | — |
 | `no_admission_control` | bool | `False` | pinned | — |
+
+For a search that includes `kv_router`, these fields are reserved but currently rejected
+when set: Dynamo's replay API does not accept admission-control configuration, so scoring
+them would diverge from the generated frontend. Leave them at their defaults until replay
+support is available. They remain inert under a round-robin-only search.
 
 ## Planner composites
 

--- a/spica/src/spica/config.py
+++ b/spica/src/spica/config.py
@@ -425,7 +425,8 @@ class SearchSpace(BaseModel):
     agg_enable_prefix_caching: bool = True
 
     # kv manager: multi-tier offload policy (all pinned; G3/G4 extend G2)
-    num_g2_blocks: int = 0  # 0 disables host offload
+    num_g2_blocks: int = Field(default=0, ge=0)  # 0 disables host offload
+    kv_bytes_per_token: int | None = Field(default=None, gt=0)  # required replay transfer sizing when G2 is on
     bandwidth_g1_to_g2_gbps: float | None = None
     bandwidth_g2_to_g1_gbps: float | None = None
     offload_batch_size: int | None = None
@@ -510,11 +511,51 @@ class SearchSpace(BaseModel):
     @model_validator(mode="after")
     def _validate_gpu_budget(self) -> "SearchSpace":
         """When ``min_gpu_budget`` is set it must be a positive value not exceeding
-        ``gpu_budget`` (``min_endpoint`` is a declared-but-unused field; left as-is)."""
+        ``gpu_budget``. ``min_endpoint`` is carried into scaling candidates as a planner
+        runtime floor; its detailed feasibility is validated by the planner."""
         if self.min_gpu_budget is not None and not (0 < self.min_gpu_budget <= self.gpu_budget):
             raise ValueError(
                 f"min_gpu_budget must satisfy 0 < min_gpu_budget <= gpu_budget "
                 f"(got min_gpu_budget={self.min_gpu_budget}, gpu_budget={self.gpu_budget})"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _validate_kv_offload_replay_sizing(self) -> "SearchSpace":
+        """Require deterministic transfer sizing whenever G2 offload is enabled.
+
+        Dynamo can try to infer this value from model metadata, but inference may
+        fail for private, gated, or offline models and silently skip attaching the
+        offload engine. Requiring the pinned value keeps replay and deployment
+        artifacts on the same KVBM policy.
+        """
+        if self.num_g2_blocks > 0 and self.kv_bytes_per_token is None:
+            raise ValueError("kv_bytes_per_token is required when num_g2_blocks > 0 so replay can model KVBM offload")
+        return self
+
+    @model_validator(mode="after")
+    def _validate_router_admission_replay_support(self) -> "SearchSpace":
+        """Reject admission-control pins until Dynamo replay can model them.
+
+        Generated deployments support these frontend flags, but the pinned replay
+        API accepts only ``KvRouterConfig`` and would silently score a different
+        router policy. Failing here keeps optimized and generated artifacts aligned.
+        """
+        if "kv_router" not in self.router_mode:
+            return self
+
+        admission_pins = {
+            "active_decode_blocks_threshold": self.active_decode_blocks_threshold,
+            "active_prefill_tokens_threshold": self.active_prefill_tokens_threshold,
+            "active_prefill_tokens_threshold_frac": self.active_prefill_tokens_threshold_frac,
+        }
+        enabled = [name for name, value in admission_pins.items() if value is not None]
+        if self.no_admission_control:
+            enabled.append("no_admission_control")
+        if enabled:
+            raise ValueError(
+                "router admission-control knobs are not supported by the Dynamo replay API; "
+                f"remove {', '.join(enabled)} so replay and generated artifacts stay equivalent"
             )
         return self
 

--- a/spica/src/spica/deploy.py
+++ b/spica/src/spica/deploy.py
@@ -110,14 +110,21 @@ def _engine_args_payload(sample: dict, role: str, *, backend_version: str) -> di
     #   test/polish items from the PR review are deferred until then.
     if sample.get("aic_nextn") is not None:
         payload["aic_nextn"] = int(sample["aic_nextn"])
-    # KV-manager multi-tier offload knobs (host/disk G2..G4). The sample carries the
-    # pinned subset that is set; copy every num_g*/bandwidth_* plus offload_batch_size
-    # through to the mocker so the simulated offload matches the swept policy.
-    for key, value in sample.items():
-        if value is None:
-            continue
-        if key == "offload_batch_size" or key.startswith("num_g") or key.startswith("bandwidth_g"):
-            payload[key] = value
+    if sample.get("startup_time") is not None:
+        payload["startup_time"] = float(sample["startup_time"])
+    # KVBM is disabled when G2 has no blocks. When enabled it runs on aggregate or
+    # prefill workers only; disaggregated decode workers use the transfer connector
+    # and must not be scored with a second local offload tier.
+    if role != "decode" and int(sample.get("num_g2_blocks") or 0) > 0:
+        for key, value in sample.items():
+            if value is None:
+                continue
+            if (
+                key in {"kv_bytes_per_token", "offload_batch_size"}
+                or key.startswith("num_g")
+                or key.startswith("bandwidth_g")
+            ):
+                payload[key] = value
     return payload
 
 
@@ -157,6 +164,14 @@ def _planner_config_payload(
     for key in _PLANNER_PASSTHROUGH:
         if key in sample:
             payload[key] = sample[key]
+    # Search-space limits become runtime policy once the planner is active. Keep
+    # them explicit rather than broadly passing arbitrary sample fields through.
+    if sample.get("gpu_budget") is not None:
+        payload["max_gpu_budget"] = int(sample["gpu_budget"])
+    if sample.get("min_gpu_budget") is not None:
+        payload["min_gpu_budget"] = int(sample["min_gpu_budget"])
+    if sample.get("min_endpoint") is not None:
+        payload["min_endpoint"] = int(sample["min_endpoint"])
     # Per-engine GPU counts for the planner's cost logic (gpu_hours itself is
     # derived by the mocker from aic_tp x aic_attention_dp, not from these).
     if sample["deployment_mode"] == "disagg":

--- a/spica/src/spica/evaluator.py
+++ b/spica/src/spica/evaluator.py
@@ -34,6 +34,7 @@ replay entrypoints.
 
 from __future__ import annotations
 
+import inspect
 import json
 
 from .config import OptimizationGoal, Workload
@@ -53,8 +54,67 @@ def _build_kv_router_config(payload: dict | None):
 def _unwrap(report) -> dict[str, float]:
     """Normalize a replay result to the flat ``trace_report`` dict: a static replay
     returns that dict directly; planner-in-the-loop returns a ``ReplayPlannerReport``
-    whose ``.trace_report`` carries the identical shape."""
-    return report.trace_report if hasattr(report, "trace_report") else report
+    whose ``.trace_report`` carries the identical shape. Preserve the planner tick
+    count so callers and e2e coverage can distinguish bridge initialization from an
+    actual planner callback."""
+    if not hasattr(report, "trace_report"):
+        return report
+    trace_report = dict(report.trace_report)
+    if hasattr(report, "total_ticks"):
+        trace_report["planner_total_ticks"] = float(report.total_ticks)
+    return trace_report
+
+
+def _replay_accepts_kw(func, name: str) -> bool:
+    params = inspect.signature(func).parameters
+    return name in params or any(param.kind is inspect.Parameter.VAR_KEYWORD for param in params.values())
+
+
+def _replay_kwargs(func, kwargs: dict) -> dict:
+    params = inspect.signature(func).parameters
+    if any(param.kind is inspect.Parameter.VAR_KEYWORD for param in params.values()):
+        return kwargs
+    return {name: value for name, value in kwargs.items() if name in params}
+
+
+def _check_planner_supported(func, planner_config: dict | None) -> None:
+    if planner_config is not None and not _replay_accepts_kw(func, "planner_config"):
+        raise RuntimeError(
+            "installed Dynamo replay API does not accept planner_config; use static planner_scaling_policy='disabled'"
+        )
+
+
+def _run_trace_replay_compat(func, trace_path: str, kwargs: dict):
+    _check_planner_supported(func, kwargs.get("planner_config"))
+    if "trace_file" in inspect.signature(func).parameters:
+        return func(trace_path, **_replay_kwargs(func, kwargs))
+    kwargs = dict(kwargs, trace_files=trace_path)
+    return func(**_replay_kwargs(func, kwargs))
+
+
+def _run_synthetic_trace_replay_compat(func, kwargs: dict):
+    _check_planner_supported(func, kwargs.get("planner_config"))
+    return func(**_replay_kwargs(func, kwargs))
+
+
+def _require_goodput_metric(report: dict[str, float], goal: OptimizationGoal) -> dict[str, float]:
+    """Fail closed when a goodput objective cannot be measured per request.
+
+    Aggregate mean latency cannot recover goodput: a mixed population may have the
+    same means while a very different fraction of requests satisfies the SLA. Older
+    replay APIs that omit the metric are therefore incompatible with goodput goals.
+    """
+    if "goodput_output_throughput_tok_s" in report:
+        return report
+    target = goal.target.value
+    objectives = {item.value for item in goal.resolved_pareto_objectives} if goal.is_pareto else {target}
+    if not objectives.intersection({"goodput", "goodput_per_gpu"}):
+        return report
+    raise RuntimeError(
+        "Dynamo replay did not emit goodput_output_throughput_tok_s for a goodput objective; "
+        "install a replay version with per-request SLA accounting (aggregate mean latency "
+        "cannot be used as a goodput fallback)"
+    )
 
 
 class ReplayEvaluator:
@@ -109,8 +169,10 @@ class ReplayEvaluator:
         closed-loop cap and the ``num_request_ratio``-derived request count. Trace
         workloads ignore it (they cap via ``replay_concurrency``)."""
         if self.workload.is_trace_based:
-            return self._evaluate_trace(plan)
-        return self._evaluate_synthetic(plan, concurrency_override=concurrency_override)
+            return _require_goodput_metric(self._evaluate_trace(plan), self.goal)
+        return _require_goodput_metric(
+            self._evaluate_synthetic(plan, concurrency_override=concurrency_override), self.goal
+        )
 
     # -- trace workloads -------------------------------------------------------
 
@@ -120,7 +182,6 @@ class ReplayEvaluator:
 
         wl = self.workload
         common = dict(
-            trace_files=wl.trace_path,
             router_mode=plan.router_mode,
             router_config=self._router_config(plan),
             arrival_speedup_ratio=wl.arrival_speedup_ratio,
@@ -132,16 +193,24 @@ class ReplayEvaluator:
         )
         if plan.deployment_mode == "agg":
             extra = MockEngineArgs.from_json(json.dumps(plan.agg_engine_args))
-            report = run_trace_replay(extra_engine_args=extra, num_workers=plan.num_workers, **common)
+            report = _run_trace_replay_compat(
+                run_trace_replay,
+                wl.trace_path,
+                dict(extra_engine_args=extra, num_workers=plan.num_workers, **common),
+            )
         else:
             prefill = MockEngineArgs.from_json(json.dumps(plan.prefill_engine_args))
             decode = MockEngineArgs.from_json(json.dumps(plan.decode_engine_args))
-            report = run_trace_replay(
-                prefill_engine_args=prefill,
-                decode_engine_args=decode,
-                num_prefill_workers=plan.num_prefill_workers,
-                num_decode_workers=plan.num_decode_workers,
-                **common,
+            report = _run_trace_replay_compat(
+                run_trace_replay,
+                wl.trace_path,
+                dict(
+                    prefill_engine_args=prefill,
+                    decode_engine_args=decode,
+                    num_prefill_workers=plan.num_prefill_workers,
+                    num_decode_workers=plan.num_decode_workers,
+                    **common,
+                ),
             )
         return _unwrap(report)
 
@@ -163,15 +232,21 @@ class ReplayEvaluator:
         )
         if plan.deployment_mode == "agg":
             extra = MockEngineArgs.from_json(json.dumps(plan.agg_engine_args))
-            report = run_synthetic_trace_replay(extra_engine_args=extra, num_workers=plan.num_workers, **common)
+            report = _run_synthetic_trace_replay_compat(
+                run_synthetic_trace_replay,
+                dict(extra_engine_args=extra, num_workers=plan.num_workers, **common),
+            )
         else:
             prefill = MockEngineArgs.from_json(json.dumps(plan.prefill_engine_args))
             decode = MockEngineArgs.from_json(json.dumps(plan.decode_engine_args))
-            report = run_synthetic_trace_replay(
-                prefill_engine_args=prefill,
-                decode_engine_args=decode,
-                num_prefill_workers=plan.num_prefill_workers,
-                num_decode_workers=plan.num_decode_workers,
-                **common,
+            report = _run_synthetic_trace_replay_compat(
+                run_synthetic_trace_replay,
+                dict(
+                    prefill_engine_args=prefill,
+                    decode_engine_args=decode,
+                    num_prefill_workers=plan.num_prefill_workers,
+                    num_decode_workers=plan.num_decode_workers,
+                    **common,
+                ),
             )
         return _unwrap(report)

--- a/spica/src/spica/sample.py
+++ b/spica/src/spica/sample.py
@@ -35,11 +35,27 @@ from .load_predictor_sweep import LoadPredictorResult, predictor_fields
 from .parallel_enum import DisaggParallelConfig, ParallelShape, ReplicaParallelConfig
 from .planner import fpm_fields, load_sensitivity_fields, scaling_fields
 
-# pinned deployment scalars folded in so the sample stands alone (search-only
-# constraints like gpu_budget / min_gpu_budget / min_endpoint are intentionally
-# excluded — they bound the search, not a single deployment).
-_DEPLOYMENT_PINNED = ("model_name", "hardware_sku", "aic_nextn")
-_KV_MANAGER = ("num_g2_blocks", "bandwidth_g1_to_g2_gbps", "bandwidth_g2_to_g1_gbps", "offload_batch_size")
+# Pinned deployment/runtime scalars folded in so the selected sample stands alone.
+# The GPU bounds and endpoint floor are search constraints for a static candidate,
+# but become live planner limits for a scaling candidate and therefore must survive
+# into replay and generated deployment artifacts.
+_DEPLOYMENT_PINNED = (
+    "model_name",
+    "hardware_sku",
+    "gpu_budget",
+    "min_gpu_budget",
+    "min_endpoint",
+    "context_length",
+    "startup_time",
+    "aic_nextn",
+)
+_KV_MANAGER = (
+    "num_g2_blocks",
+    "kv_bytes_per_token",
+    "bandwidth_g1_to_g2_gbps",
+    "bandwidth_g2_to_g1_gbps",
+    "offload_batch_size",
+)
 
 # engine knobs per branch: searched batching + pinned scalars.
 _AGG_SEARCHED = ("agg_max_num_batched_tokens", "agg_max_num_seqs")

--- a/spica/src/spica/score.py
+++ b/spica/src/spica/score.py
@@ -45,6 +45,7 @@ _METRIC_KEYS = (
     "goodput_output_throughput_tok_s",
     "gpu_hours",
     "duration_ms",
+    "planner_total_ticks",
 )
 
 

--- a/spica/src/spica/search.py
+++ b/spica/src/spica/search.py
@@ -81,6 +81,10 @@ def _evaluate_one(
         if concurrency is not None:
             sample["concurrency"] = concurrency
         backend_version = resolve_backend_version(config.search_space.hardware_sku, selection["backend"])
+        # The resolved perf-model version is part of the evaluated contract. Keep it
+        # on the candidate so downstream artifact generation cannot independently
+        # select a different backend version.
+        sample["backend_version"] = backend_version
         plan = build_deployment(
             sample,
             backend_version=backend_version,
@@ -220,6 +224,7 @@ def run_smart_search(
     total = len(branches) * sweep.max_rounds * per_round
     candidates: list[Candidate] = []
     tally = {"feasible": 0, "infeasible": 0, "failed": 0, "unsupported": 0}
+    failure_reasons: dict[str, int] = {}
     # Unique per run: Vizier's datastore persists studies by id, so a fixed id would
     # make a later run inherit a stale study (and its old param space) -> decode crash.
     run_nonce = uuid.uuid4().hex[:8]
@@ -344,6 +349,8 @@ def run_smart_search(
                         sampler.observe_infeasible(s, reason)
                     else:
                         sampler.observe(s, observe_metrics)
+                    if outcome == "failed":
+                        failure_reasons[reason] = failure_reasons.get(reason, 0) + 1
                     _record(outcome, candidate)
                 round_no += 1
                 if on_round is not None:
@@ -372,4 +379,11 @@ def run_smart_search(
         else:
             summary += f"; best {goal.target.value}={_best():.4g}"
         tqdm.write(summary)
+        if failure_reasons:
+            displayed = []
+            for reason, count in list(failure_reasons.items())[:3]:
+                displayed.append(f"{reason} (x{count})" if count > 1 else reason)
+            remaining = len(failure_reasons) - len(displayed)
+            suffix = f" | +{remaining} more distinct reason(s)" if remaining else ""
+            tqdm.write(f"smart-sweep failure reason(s): {' | '.join(displayed)}{suffix}")
     return result

--- a/spica/tests/test_config.py
+++ b/spica/tests/test_config.py
@@ -120,6 +120,51 @@ def test_empty_choice_list_rejected():
         )
 
 
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("active_decode_blocks_threshold", 64),
+        ("active_prefill_tokens_threshold", 4096),
+        ("active_prefill_tokens_threshold_frac", 0.5),
+        ("no_admission_control", True),
+    ],
+)
+def test_kv_router_admission_controls_fail_closed_until_replay_supports_them(field, value):
+    with pytest.raises(ValidationError, match="not supported by the Dynamo replay API"):
+        SearchSpace(**_search_space(router_mode=["kv_router"], **{field: value}))
+
+
+def test_round_robin_ignores_router_admission_controls():
+    cfg = SearchSpace(
+        **_search_space(
+            router_mode=["round_robin"],
+            active_prefill_tokens_threshold=4096,
+            no_admission_control=True,
+        )
+    )
+    assert cfg.active_prefill_tokens_threshold == 4096
+    assert cfg.no_admission_control is True
+
+
+def test_kv_offload_requires_explicit_replay_transfer_sizing():
+    with pytest.raises(ValidationError, match="kv_bytes_per_token is required"):
+        SearchSpace(**_search_space(num_g2_blocks=128))
+
+    cfg = SearchSpace(**_search_space(num_g2_blocks=128, kv_bytes_per_token=131072))
+    assert cfg.kv_bytes_per_token == 131072
+
+
+@pytest.mark.parametrize("value", [0, -1])
+def test_kv_offload_rejects_non_positive_transfer_sizing(value):
+    with pytest.raises(ValidationError, match="kv_bytes_per_token"):
+        SearchSpace(**_search_space(num_g2_blocks=128, kv_bytes_per_token=value))
+
+
+def test_negative_g2_block_count_rejected():
+    with pytest.raises(ValidationError, match="num_g2_blocks"):
+        SearchSpace(**_search_space(num_g2_blocks=-1))
+
+
 # --- composite knobs accept raw dicts (preset OR pinned-dict per entry) ---
 
 

--- a/spica/tests/test_deploy.py
+++ b/spica/tests/test_deploy.py
@@ -79,6 +79,28 @@ def test_agg_scaling_builds_planner_config():
     assert pc["ttft_ms"] == 2000.0 and pc["itl_ms"] == 30.0  # ttft/itl seeded only under "sla"
 
 
+def test_scaling_preserves_search_space_runtime_limits():
+    sample = unroll_sample(
+        search_space=_space(
+            gpu_budget=24,
+            min_gpu_budget=8,
+            min_endpoint=2,
+            context_length=32768,
+            startup_time=45.0,
+        ),
+        selection=_agg_sel(planner_scaling_policy="load_180_5"),
+        parallel_config=AGG_MOE,
+    )
+    plan = build_deployment(sample, backend_version=BV, optimization_target="throughput")
+
+    assert sample["context_length"] == 32768
+    assert plan.agg_engine_args["startup_time"] == 45.0
+    assert plan.planner_config["optimization_target"] == "throughput"
+    assert plan.planner_config["max_gpu_budget"] == 24
+    assert plan.planner_config["min_gpu_budget"] == 8
+    assert plan.planner_config["min_endpoint"] == 2
+
+
 def test_disagg_builds_both_roles():
     cfg = DisaggParallelConfig(
         prefill=ReplicaParallelConfig(ParallelShape(tp=8, dp=1, moe_tp=1, moe_ep=8), 1),
@@ -170,6 +192,7 @@ def test_offload_knobs_thread_into_payload():
     # KV-manager offload knobs present in the sample must reach the engine-args payload.
     space = _space(
         num_g2_blocks=1024,
+        kv_bytes_per_token=131072,
         offload_batch_size=64,
         bandwidth_g1_to_g2_gbps=200.0,
         bandwidth_g2_to_g1_gbps=180.0,
@@ -177,6 +200,7 @@ def test_offload_knobs_thread_into_payload():
     sample = unroll_sample(search_space=space, selection=_agg_sel(), parallel_config=AGG_MOE)
     ea = build_deployment(sample, backend_version=BV).agg_engine_args
     assert ea["num_g2_blocks"] == 1024
+    assert ea["kv_bytes_per_token"] == 131072
     assert ea["offload_batch_size"] == 64
     assert ea["bandwidth_g1_to_g2_gbps"] == 200.0
     assert ea["bandwidth_g2_to_g1_gbps"] == 180.0
@@ -184,7 +208,47 @@ def test_offload_knobs_thread_into_payload():
     default = build_deployment(
         unroll_sample(search_space=_space(), selection=_agg_sel(), parallel_config=AGG_MOE), backend_version=BV
     ).agg_engine_args
-    assert "offload_batch_size" not in default  # unset -> not emitted
+    assert "num_g2_blocks" not in default
+    assert "offload_batch_size" not in default
+
+    # A batch-size pin cannot independently enable KVBM when zero G2 blocks disables it.
+    disabled = build_deployment(
+        unroll_sample(
+            search_space=_space(num_g2_blocks=0, kv_bytes_per_token=131072, offload_batch_size=64),
+            selection=_agg_sel(),
+            parallel_config=AGG_MOE,
+        ),
+        backend_version=BV,
+    ).agg_engine_args
+    assert "num_g2_blocks" not in disabled
+    assert "kv_bytes_per_token" not in disabled
+    assert "offload_batch_size" not in disabled
+
+
+def test_disagg_offload_is_scored_on_prefill_only():
+    cfg = DisaggParallelConfig(
+        prefill=ReplicaParallelConfig(ParallelShape(tp=8, dp=1, moe_tp=1, moe_ep=8), 1),
+        decode=ReplicaParallelConfig(ParallelShape(tp=1, dp=8, moe_tp=1, moe_ep=8), 2),
+    )
+    sample = unroll_sample(
+        search_space=_space(num_g2_blocks=1024, kv_bytes_per_token=131072, offload_batch_size=64),
+        selection=_agg_sel(
+            deployment_mode="disagg",
+            prefill_max_num_batched_tokens=32768,
+            prefill_max_num_seqs=4,
+            decode_max_num_batched_tokens=8192,
+            decode_max_num_seqs=1024,
+        ),
+        parallel_config=cfg,
+    )
+    plan = build_deployment(sample, backend_version=BV)
+
+    assert plan.prefill_engine_args["num_g2_blocks"] == 1024
+    assert plan.prefill_engine_args["kv_bytes_per_token"] == 131072
+    assert plan.prefill_engine_args["offload_batch_size"] == 64
+    assert "num_g2_blocks" not in plan.decode_engine_args
+    assert "kv_bytes_per_token" not in plan.decode_engine_args
+    assert "offload_batch_size" not in plan.decode_engine_args
 
 
 def test_e2e_only_sla_with_sla_target_raises():

--- a/spica/tests/test_evaluator.py
+++ b/spica/tests/test_evaluator.py
@@ -13,7 +13,6 @@ pytest.importorskip("dynamo.mocker")
 
 import dynamo.mocker  # noqa: E402
 import dynamo.replay.api  # noqa: E402
-import dynamo.replay.main  # noqa: E402
 
 from spica.config import OptimizationGoal, OptimizationTarget, SLATarget, Workload  # noqa: E402
 from spica.deploy import DeploymentPlan  # noqa: E402
@@ -63,7 +62,7 @@ def _disagg_plan(static):
 
 
 def test_static_agg_uses_plain_path(monkeypatch):
-    monkeypatch.setattr(dynamo.mocker, "MockEngineArgs", _FakeArgs)
+    monkeypatch.setattr(dynamo.mocker, "MockEngineArgs", _FakeArgs, raising=False)
     rec = {}
     monkeypatch.setattr(
         dynamo.replay.api, "run_trace_replay", lambda **kw: rec.update(kw) or {"output_throughput_tok_s": 42.0}
@@ -78,7 +77,7 @@ def test_static_agg_uses_plain_path(monkeypatch):
 def test_static_path_threads_goodput_sla(monkeypatch):
     # the mocker is SLA-aware on the plain path too, so a static/disabled candidate
     # still receives the goodput SLA and can emit goodput.
-    monkeypatch.setattr(dynamo.mocker, "MockEngineArgs", _FakeArgs)
+    monkeypatch.setattr(dynamo.mocker, "MockEngineArgs", _FakeArgs, raising=False)
     rec = {}
     monkeypatch.setattr(
         dynamo.replay.api,
@@ -91,25 +90,83 @@ def test_static_path_threads_goodput_sla(monkeypatch):
     assert rec["sla_ttft_ms"] == 2000.0 and rec["sla_itl_ms"] == 30.0  # SLA threaded to the plain path
 
 
-def test_scaling_agg_uses_run_planner_replay(monkeypatch):
-    # planner -> run_trace_replay(planner_config=...) routes into _run_planner_replay
-    # (the Rust bridge owns the sim loop and calls back into the Python planner adapter).
-    monkeypatch.setattr(dynamo.mocker, "MockEngineArgs", _FakeArgs)
+def test_current_trace_api_filters_legacy_kwargs_and_fails_closed_without_goodput(monkeypatch):
+    # Current Dynamo replay wrappers do not accept planner_config, benchmark_granularity,
+    # or SLA kwargs on static replay. Aggregate means cannot reconstruct per-request
+    # goodput, so an incompatible wrapper must fail instead of fabricating a score.
+    monkeypatch.setattr(dynamo.mocker, "MockEngineArgs", _FakeArgs, raising=False)
+    rec = {}
+
+    def run_trace_replay(
+        trace_file, *, extra_engine_args=None, num_workers=1, replay_concurrency=None, router_mode=None
+    ):
+        rec.update(
+            trace_file=trace_file,
+            extra_engine_args=extra_engine_args,
+            num_workers=num_workers,
+            replay_concurrency=replay_concurrency,
+            router_mode=router_mode,
+        )
+        return {
+            "output_throughput_tok_s": 77.0,
+            "mean_ttft_ms": 10.0,
+            "mean_tpot_ms": 2.0,
+            "mean_e2e_latency_ms": 42.0,
+        }
+
+    monkeypatch.setattr(dynamo.replay.api, "run_trace_replay", run_trace_replay)
+    goal = OptimizationGoal(target=OptimizationTarget.GOODPUT_PER_GPU, sla=SLATarget(ttft_ms=2000.0, itl_ms=30.0))
+    with pytest.raises(RuntimeError, match="per-request SLA accounting"):
+        ReplayEvaluator(_wl(), goal).evaluate(_agg_plan(static=True))
+    assert rec["trace_file"] == "/tmp/t.jsonl"
+    assert set(rec) == {"trace_file", "extra_engine_args", "num_workers", "replay_concurrency", "router_mode"}
+
+
+def test_current_trace_api_rejects_planner_config(monkeypatch):
+    monkeypatch.setattr(dynamo.mocker, "MockEngineArgs", _FakeArgs, raising=False)
+
+    def run_trace_replay(trace_file, *, extra_engine_args=None, num_workers=1):
+        return {"output_throughput_tok_s": 1.0}
+
+    monkeypatch.setattr(dynamo.replay.api, "run_trace_replay", run_trace_replay)
+    goal = OptimizationGoal(target=OptimizationTarget.GOODPUT_PER_GPU, sla=SLATarget(ttft_ms=2000.0, itl_ms=30.0))
+    with pytest.raises(RuntimeError, match="does not accept planner_config"):
+        ReplayEvaluator(_wl(), goal).evaluate(_agg_plan(static=False))
+
+
+def test_scaling_agg_threads_planner_config_when_supported(monkeypatch):
+    # Older Dynamo replay wrappers accept planner_config directly; keep threading it
+    # when the installed API advertises that kwarg.
+    monkeypatch.setattr(dynamo.mocker, "MockEngineArgs", _FakeArgs, raising=False)
     rec = {}
     monkeypatch.setattr(
-        dynamo.replay.main,
-        "_run_planner_replay",
-        lambda **kw: (
-            rec.update(kw) or SimpleNamespace(trace_report={"gpu_hours": 2.0, "goodput_output_throughput_tok_s": 100.0})
-        ),
+        dynamo.replay.api,
+        "run_trace_replay",
+        lambda **kw: rec.update(kw) or {"gpu_hours": 2.0, "goodput_output_throughput_tok_s": 100.0},
     )
     goal = OptimizationGoal(target=OptimizationTarget.GOODPUT_PER_GPU, sla=SLATarget(ttft_ms=2000.0, itl_ms=30.0))
     report = ReplayEvaluator(_wl(), goal).evaluate(_agg_plan(static=False))
     assert report["gpu_hours"] == 2.0
-    # goodput SLA threaded to the planner path; planner config carried as inline JSON
+    # goodput SLA threaded to the planner path; planner config carried as a dict
     assert rec["sla_ttft_ms"] == 2000.0 and rec["sla_itl_ms"] == 30.0
-    assert json.loads(rec["planner_config_arg"])["optimization_target"] == "sla"
+    assert rec["planner_config"]["optimization_target"] == "sla"
     assert rec["num_workers"] == 2
+
+
+def test_scaling_report_preserves_planner_tick_count(monkeypatch):
+    monkeypatch.setattr(dynamo.mocker, "MockEngineArgs", _FakeArgs, raising=False)
+    monkeypatch.setattr(
+        dynamo.replay.api,
+        "run_trace_replay",
+        lambda **kw: SimpleNamespace(
+            trace_report={"output_throughput_tok_s": 42.0},
+            total_ticks=3,
+        ),
+    )
+    goal = OptimizationGoal(target=OptimizationTarget.THROUGHPUT)
+    report = ReplayEvaluator(_wl(), goal).evaluate(_agg_plan(static=False))
+    assert report["output_throughput_tok_s"] == 42.0
+    assert report["planner_total_ticks"] == 3.0
 
 
 def test_kv_router_config_is_built_and_passed(monkeypatch):
@@ -117,7 +174,7 @@ def test_kv_router_config_is_built_and_passed(monkeypatch):
     # (round_robin -> None). Regression for the "router_config=None" stub.
     from dynamo._core import KvRouterConfig
 
-    monkeypatch.setattr(dynamo.mocker, "MockEngineArgs", _FakeArgs)
+    monkeypatch.setattr(dynamo.mocker, "MockEngineArgs", _FakeArgs, raising=False)
     rec = {}
     monkeypatch.setattr(
         dynamo.replay.api, "run_trace_replay", lambda **kw: rec.update(kw) or {"output_throughput_tok_s": 1.0}
@@ -142,7 +199,7 @@ def test_kv_router_config_is_built_and_passed(monkeypatch):
 def test_static_trace_threads_replay_concurrency(monkeypatch):
     # a closed-loop concurrency cap on a trace reaches run_trace_replay as
     # replay_concurrency (run_trace_replay defaults replay_mode='offline').
-    monkeypatch.setattr(dynamo.mocker, "MockEngineArgs", _FakeArgs)
+    monkeypatch.setattr(dynamo.mocker, "MockEngineArgs", _FakeArgs, raising=False)
     rec = {}
     monkeypatch.setattr(
         dynamo.replay.api, "run_trace_replay", lambda **kw: rec.update(kw) or {"output_throughput_tok_s": 1.0}
@@ -152,20 +209,20 @@ def test_static_trace_threads_replay_concurrency(monkeypatch):
     assert rec["replay_concurrency"] == 32
 
 
-def test_scaling_trace_threads_replay_concurrency(monkeypatch):
-    # closed-loop concurrency over a trace + planner now works (the bridge takes a cap):
-    # the evaluator threads replay_concurrency into _run_planner_replay.
-    monkeypatch.setattr(dynamo.mocker, "MockEngineArgs", _FakeArgs)
+def test_scaling_trace_threads_replay_concurrency_when_supported(monkeypatch):
+    # closed-loop concurrency over a trace + planner works when the replay wrapper
+    # accepts planner_config.
+    monkeypatch.setattr(dynamo.mocker, "MockEngineArgs", _FakeArgs, raising=False)
     rec = {}
     monkeypatch.setattr(
-        dynamo.replay.main,
-        "_run_planner_replay",
-        lambda **kw: rec.update(kw) or SimpleNamespace(trace_report={"gpu_hours": 1.0}),
+        dynamo.replay.api,
+        "run_trace_replay",
+        lambda **kw: rec.update(kw) or {"gpu_hours": 1.0, "goodput_output_throughput_tok_s": 1.0},
     )
     wl = Workload(trace_path="/tmp/t.jsonl", replay_concurrency=32)
     goal = OptimizationGoal(target=OptimizationTarget.GOODPUT_PER_GPU, sla=SLATarget(ttft_ms=2000.0, itl_ms=30.0))
     ReplayEvaluator(wl, goal).evaluate(_agg_plan(static=False))
-    assert rec["replay_concurrency"] == 32 and rec["trace_file"] == "/tmp/t.jsonl"
+    assert rec["replay_concurrency"] == 32 and rec["trace_files"] == "/tmp/t.jsonl"
 
 
 def _syn_wl(**kw):
@@ -179,7 +236,7 @@ def _syn_wl(**kw):
 def test_synthetic_static_uses_run_synthetic_trace_replay(monkeypatch):
     # synthetic + static -> a single run_synthetic_trace_replay call with planner_config=None
     # (fixed-fleet replay, no scaling); goodput SLA threaded; in-flight cap = concurrency.
-    monkeypatch.setattr(dynamo.mocker, "MockEngineArgs", _FakeArgs)
+    monkeypatch.setattr(dynamo.mocker, "MockEngineArgs", _FakeArgs, raising=False)
     rec = {}
     monkeypatch.setattr(
         dynamo.replay.api,
@@ -199,7 +256,7 @@ def test_synthetic_static_uses_run_synthetic_trace_replay(monkeypatch):
 def test_concurrency_override_drives_cap_and_request_count(monkeypatch):
     # Pareto sweep: workload.concurrency is a LIST; the per-trial concurrency_override sets
     # BOTH the closed-loop in-flight cap and the num_request_ratio-scaled request count.
-    monkeypatch.setattr(dynamo.mocker, "MockEngineArgs", _FakeArgs)
+    monkeypatch.setattr(dynamo.mocker, "MockEngineArgs", _FakeArgs, raising=False)
     rec = {}
     monkeypatch.setattr(
         dynamo.replay.api,
@@ -214,29 +271,29 @@ def test_concurrency_override_drives_cap_and_request_count(monkeypatch):
     assert rec["planner_config"] is None
 
 
-def test_synthetic_planner_uses_run_planner_replay(monkeypatch):
-    # synthetic + planner -> _run_planner_replay(synthetic=SyntheticWorkload(...), trace_file=None).
-    monkeypatch.setattr(dynamo.mocker, "MockEngineArgs", _FakeArgs)
-    monkeypatch.setattr(dynamo.replay.main, "SyntheticWorkload", lambda **kw: ("SYN", kw), raising=False)
+def test_synthetic_planner_threads_planner_config_when_supported(monkeypatch):
+    # synthetic + planner -> run_synthetic_trace_replay with planner_config when supported.
+    monkeypatch.setattr(dynamo.mocker, "MockEngineArgs", _FakeArgs, raising=False)
     rec = {}
     monkeypatch.setattr(
-        dynamo.replay.main,
-        "_run_planner_replay",
-        lambda **kw: rec.update(kw) or SimpleNamespace(trace_report={"gpu_hours": 2.0}),
+        dynamo.replay.api,
+        "run_synthetic_trace_replay",
+        lambda **kw: rec.update(kw) or {"gpu_hours": 2.0, "goodput_output_throughput_tok_s": 1.0},
     )
     goal = OptimizationGoal(target=OptimizationTarget.GOODPUT_PER_GPU, sla=SLATarget(ttft_ms=1500.0, itl_ms=50.0))
     # request-rate workload -> open-loop (no cap); arrival_interval derived from the rate
     ReplayEvaluator(_syn_wl(request_rate=20.0), goal).evaluate(_agg_plan(static=False))
-    assert rec["trace_file"] is None and rec["replay_concurrency"] is None
-    assert rec["synthetic"][0] == "SYN"
-    assert rec["synthetic"][1]["arrival_interval_ms"] == 50.0  # 1000 / 20
+    assert rec["replay_concurrency"] is None
+    assert rec["input_tokens"] == 128 and rec["output_tokens"] == 64
+    assert rec["arrival_interval_ms"] == 50.0  # 1000 / 20
+    assert rec["planner_config"]["mode"] == "agg"
     assert rec["sla_ttft_ms"] == 1500.0
 
 
 def test_static_trace_disagg_uses_plain_path(monkeypatch):
     # disagg + trace + static -> run_trace_replay gets prefill/decode engine args
     # and the per-role worker counts (no agg num_workers/extra_engine_args).
-    monkeypatch.setattr(dynamo.mocker, "MockEngineArgs", _FakeArgs)
+    monkeypatch.setattr(dynamo.mocker, "MockEngineArgs", _FakeArgs, raising=False)
     rec = {}
     monkeypatch.setattr(
         dynamo.replay.api, "run_trace_replay", lambda **kw: rec.update(kw) or {"output_throughput_tok_s": 7.0}
@@ -251,35 +308,30 @@ def test_static_trace_disagg_uses_plain_path(monkeypatch):
     assert "num_workers" not in rec and "extra_engine_args" not in rec
 
 
-def test_scaling_trace_disagg_uses_run_planner_replay(monkeypatch):
-    # disagg + trace + planner -> _run_planner_replay with disagg args (num_workers=0,
-    # per-role workers + engine args) and the disagg planner config carried as JSON.
-    monkeypatch.setattr(dynamo.mocker, "MockEngineArgs", _FakeArgs)
+def test_scaling_trace_disagg_threads_planner_config_when_supported(monkeypatch):
+    # disagg + trace + planner -> run_trace_replay with per-role workers and planner_config
+    # when supported.
+    monkeypatch.setattr(dynamo.mocker, "MockEngineArgs", _FakeArgs, raising=False)
     rec = {}
     monkeypatch.setattr(
-        dynamo.replay.main,
-        "_run_planner_replay",
-        lambda **kw: (
-            rec.update(kw) or SimpleNamespace(trace_report={"gpu_hours": 3.0, "goodput_output_throughput_tok_s": 90.0})
-        ),
+        dynamo.replay.api,
+        "run_trace_replay",
+        lambda **kw: rec.update(kw) or {"gpu_hours": 3.0, "goodput_output_throughput_tok_s": 90.0},
     )
     goal = OptimizationGoal(target=OptimizationTarget.GOODPUT_PER_GPU, sla=SLATarget(ttft_ms=2000.0, itl_ms=30.0))
     report = ReplayEvaluator(_wl(), goal).evaluate(_disagg_plan(static=False))
     assert report["gpu_hours"] == 3.0
-    # disagg -> the wrapper's default num_workers=1 flows through but the binding ignores it
-    # (it sizes the deployment from the per-role prefill/decode worker counts).
-    assert rec["extra_engine_args"] is None and rec["num_workers"] == 1
     assert rec["prefill_engine_args"][1] == {"aic_tp_size": 2, "max_num_seqs": 256}
     assert rec["decode_engine_args"][1] == {"aic_tp_size": 4, "max_num_seqs": 512}
     assert rec["num_prefill_workers"] == 3 and rec["num_decode_workers"] == 5
     assert rec["sla_ttft_ms"] == 2000.0 and rec["sla_itl_ms"] == 30.0
-    assert json.loads(rec["planner_config_arg"])["mode"] == "disagg"
+    assert rec["planner_config"]["mode"] == "disagg"
 
 
 def test_synthetic_static_disagg_uses_run_synthetic_trace_replay(monkeypatch):
     # disagg + synthetic + static -> run_synthetic_trace_replay with prefill/decode args and
     # planner_config=None; goodput SLA threaded; closed-loop in-flight cap = concurrency.
-    monkeypatch.setattr(dynamo.mocker, "MockEngineArgs", _FakeArgs)
+    monkeypatch.setattr(dynamo.mocker, "MockEngineArgs", _FakeArgs, raising=False)
     rec = {}
     monkeypatch.setattr(
         dynamo.replay.api,
@@ -299,28 +351,25 @@ def test_synthetic_static_disagg_uses_run_synthetic_trace_replay(monkeypatch):
     assert "num_workers" not in rec and "extra_engine_args" not in rec
 
 
-def test_synthetic_planner_disagg_uses_run_planner_replay(monkeypatch):
-    # disagg + synthetic + planner -> _run_planner_replay(synthetic=…, prefill/decode).
-    monkeypatch.setattr(dynamo.mocker, "MockEngineArgs", _FakeArgs)
-    monkeypatch.setattr(dynamo.replay.main, "SyntheticWorkload", lambda **kw: ("SYN", kw), raising=False)
+def test_synthetic_planner_disagg_threads_planner_config_when_supported(monkeypatch):
+    # disagg + synthetic + planner -> run_synthetic_trace_replay with per-role workers and
+    # planner_config when supported.
+    monkeypatch.setattr(dynamo.mocker, "MockEngineArgs", _FakeArgs, raising=False)
     rec = {}
     monkeypatch.setattr(
-        dynamo.replay.main,
-        "_run_planner_replay",
-        lambda **kw: rec.update(kw) or SimpleNamespace(trace_report={"gpu_hours": 2.0}),
+        dynamo.replay.api,
+        "run_synthetic_trace_replay",
+        lambda **kw: rec.update(kw) or {"gpu_hours": 2.0, "goodput_output_throughput_tok_s": 1.0},
     )
     goal = OptimizationGoal(target=OptimizationTarget.GOODPUT_PER_GPU, sla=SLATarget(ttft_ms=1500.0, itl_ms=50.0))
     # request-rate workload -> open-loop (no cap); arrival_interval derived from the rate
     ReplayEvaluator(_syn_wl(request_rate=20.0), goal).evaluate(_disagg_plan(static=False))
-    assert rec["trace_file"] is None and rec["replay_concurrency"] is None
-    # disagg -> the wrapper's default num_workers=1 flows through but the binding ignores it
-    # (it sizes the deployment from the per-role prefill/decode worker counts).
-    assert rec["extra_engine_args"] is None and rec["num_workers"] == 1
+    assert rec["replay_concurrency"] is None
     assert rec["prefill_engine_args"][1] == {"aic_tp_size": 2, "max_num_seqs": 256}
     assert rec["decode_engine_args"][1] == {"aic_tp_size": 4, "max_num_seqs": 512}
     assert rec["num_prefill_workers"] == 3 and rec["num_decode_workers"] == 5
-    assert rec["synthetic"][0] == "SYN"
-    assert rec["synthetic"][1]["arrival_interval_ms"] == 50.0  # 1000 / 20
+    assert rec["arrival_interval_ms"] == 50.0  # 1000 / 20
+    assert rec["planner_config"]["mode"] == "disagg"
     assert rec["sla_ttft_ms"] == 1500.0
 
 

--- a/spica/tests/test_sample.py
+++ b/spica/tests/test_sample.py
@@ -180,16 +180,22 @@ def test_load_predictor_winner_can_be_a_custom_dict():
 
 def test_pinned_scalars_folded_in():
     s = unroll_sample(
-        search_space=_space(context_length=4096, startup_time=300.0, aic_nextn=2),
+        search_space=_space(
+            gpu_budget=16,
+            min_gpu_budget=8,
+            min_endpoint=2,
+            context_length=4096,
+            startup_time=300.0,
+            aic_nextn=2,
+            kv_bytes_per_token=131072,
+        ),
         selection=_agg_selection(),
         parallel_config=AGG_CFG,
     )
     assert s["model_name"] == "deepseek-ai/DeepSeek-V3" and s["hardware_sku"] == "gb200"
     assert s["aic_nextn"] == 2
     assert s["num_g2_blocks"] == 0  # kv-manager pinned
+    assert s["kv_bytes_per_token"] == 131072
     assert s["agg_block_size"] == 64 and s["agg_gpu_memory_utilization"] == 0.9
-    # search-only constraints are not deployment knobs
-    assert "gpu_budget" not in s and "min_gpu_budget" not in s
-    # context_length / startup_time bound the search but are not folded into the
-    # deployment sample (no downstream stage reads them off the unrolled dict)
-    assert "context_length" not in s and "startup_time" not in s
+    assert s["gpu_budget"] == 16 and s["min_gpu_budget"] == 8 and s["min_endpoint"] == 2
+    assert s["context_length"] == 4096 and s["startup_time"] == 300.0

--- a/spica/tests/test_score.py
+++ b/spica/tests/test_score.py
@@ -30,6 +30,7 @@ REPORT = {
     "goodput_output_throughput_tok_s": 4000.0,
     "gpu_hours": 2.0,
     "duration_ms": 1_800_000.0,  # 0.5 h
+    "planner_total_ticks": 3.0,
 }
 
 
@@ -42,6 +43,11 @@ def test_objective_per_target():
     assert objective_value(REPORT, OptimizationTarget.GOODPUT_PER_GPU) == 1000.0
     # throughput_per_gpu = throughput / avg_gpu = 5000 / 4 = 1250
     assert objective_value(REPORT, OptimizationTarget.THROUGHPUT_PER_GPU) == 1250.0
+
+
+def test_candidate_preserves_planner_tick_metric():
+    candidate = make_candidate({"used_gpus": 4}, REPORT, OptimizationTarget.THROUGHPUT)
+    assert candidate.metrics["planner_total_ticks"] == 3.0
 
 
 def test_throughput_per_gpu_zero_when_avg_gpu_unavailable():

--- a/spica/tests/test_search.py
+++ b/spica/tests/test_search.py
@@ -95,6 +95,7 @@ def test_ranks_feasible_best_first(monkeypatch):
     cands = run_smart_search(_config(), evaluator=_FakeEvaluator(), sampler_factory=_FakeSampler)
     assert [c.score for c in cands] == [768.0, 512.0, 256.0]  # throughput, best first
     assert all(c.used_gpus == 8 for c in cands)
+    assert all(c.config["backend_version"] == "1.3.0rc10" for c in cands)
     assert cands[0].metrics["gpu_hours"] == 1.0
 
 
@@ -253,7 +254,7 @@ def test_e2e_only_goodput_drops_planner_scaling_and_proceeds(monkeypatch):
     assert len(cands) == 1
 
 
-def test_candidate_build_error_is_reported_not_raised(monkeypatch):
+def test_candidate_build_error_is_reported_not_raised(monkeypatch, capsys):
     branch = _branch(ReplicaParallelConfig(ParallelShape(tp=4, dp=1, moe_tp=1, moe_ep=4), replicas=2))
     _stub(monkeypatch, branch)
     sampler_seen = {}
@@ -277,13 +278,14 @@ def test_candidate_build_error_is_reported_not_raised(monkeypatch):
         sampler_seen["s"] = s
         return s
 
-    cands = run_smart_search(_config(), evaluator=_FakeEvaluator(), sampler_factory=factory, show_progress=False)
+    cands = run_smart_search(_config(), evaluator=_FakeEvaluator(), sampler_factory=factory, show_progress=True)
 
     assert cands == []
     scored = sampler_seen["s"].scored
     assert len(scored) == 1
     assert scored[0][0] == "infeasible"
     assert "candidate build failed" in scored[0][1]
+    assert "smart-sweep failure reason(s): candidate build failed" in capsys.readouterr().out
 
 
 # --- pareto (multi-objective) sweep over a swept concurrency ---

--- a/spica/tests/test_search_space.py
+++ b/spica/tests/test_search_space.py
@@ -45,7 +45,7 @@ def test_host_disk_cache_weights_gated_on_offload():
     assert "host_cache_hit_weight" not in off and "disk_cache_hit_weight" not in off
     assert "overlap_score_credit" in off and "prefill_load_scale" in off  # live knobs kept
 
-    on = branch_knob_choices(_config(num_g2_blocks=4096).search_space, "agg")
+    on = branch_knob_choices(_config(num_g2_blocks=4096, kv_bytes_per_token=131072).search_space, "agg")
     assert "host_cache_hit_weight" in on and "disk_cache_hit_weight" in on
 
 

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -14,6 +14,7 @@ import yaml
 from aiconfigurator import __version__
 from aiconfigurator.cli.estimate_detail_report import detail_requests_time, format_estimate_detail_report
 from aiconfigurator.cli.report_and_save import log_final_summary, save_results
+from aiconfigurator.cli.spica.cli_adapter import run_spica_thorough_default
 from aiconfigurator.cli.utils import merge_experiment_results_by_mode, process_experiment_result
 from aiconfigurator.generator.api import (
     add_generator_override_arguments,
@@ -183,15 +184,15 @@ def _add_default_mode_arguments(parser):
         "--model",
         dest="model_path",
         type=_validate_model_path,
-        required=True,
+        default=None,
         help="Model path: HuggingFace model path (e.g., 'Qwen/Qwen3-32B') or "
         "local path to directory containing config.json.",
     )
-    parser.add_argument("--total-gpus", type=int, required=True, help="Total GPUs for deployment.")
+    parser.add_argument("--total-gpus", type=int, default=None, help="Total GPUs for deployment.")
     parser.add_argument(
         "--system",
         type=str,
-        required=True,
+        default=None,
         help=(
             "System name (GPU type). Example: "
             "h200_sxm,h100_sxm,h100_pcie,b200_sxm,b300_sxm,gb200,a100_sxm,a100_pcie,l40s,l4,a30,gb300."
@@ -290,6 +291,24 @@ def _add_default_mode_arguments(parser):
         type=float,
         default=None,
         help="Optional end-to-end request latency target (ms). Enables request-latency optimization mode.",
+    )
+    parser.add_argument(
+        "--thorough-sweep",
+        action="store_true",
+        default=False,
+        help=(
+            "Experimental: use Spica's replay-backed thorough sweeper instead of the legacy AIC Pareto sweep. "
+            "Without --thorough-config, CLI inputs are converted to a Spica SmartSearchConfig."
+        ),
+    )
+    parser.add_argument(
+        "--thorough-config",
+        type=str,
+        default=None,
+        help=(
+            "Experimental: path to a native Spica SmartSearchConfig YAML file. Implies --thorough-sweep and "
+            "lets the file define the Spica search space, workload, goal, and sweep controls."
+        ),
     )
     parser.add_argument(
         "--inclusive-tpot",
@@ -902,6 +921,16 @@ aiconfigurator cli default --model Qwen/Qwen3-32B-FP8 \\
     --perf-db-version 1.2.0rc5 \\
     --config-template-version 1.2.0rc6 \\
     --save-dir results
+# Install the Spica thorough sweeper with pip install 'aiconfigurator[spica]'
+# Run a Spica thorough sweep from normal default CLI inputs
+aiconfigurator cli default --model Qwen/Qwen3-32B-FP8 \\
+    --backend trtllm \\
+    --total-gpus 32 --system h200_sxm \\
+    --isl 4000 --osl 1000 \\
+    --thorough-sweep
+
+# Run a Spica thorough sweep from a native SmartSearchConfig YAML
+aiconfigurator cli default --thorough-config spica_smart_sweep.yaml
 """
 
 
@@ -2232,6 +2261,27 @@ def _resolve_cli_log_level(args) -> int:
     return logging.INFO
 
 
+def _validate_default_mode_inputs(args) -> None:
+    """Validate default-mode args that are conditional on the selected sweeper."""
+    if args.mode != "default":
+        return
+    if getattr(args, "thorough_config", None):
+        return
+
+    required = {
+        "model_path": "--model-path/--model",
+        "total_gpus": "--total-gpus",
+        "system": "--system",
+    }
+    missing = [flag for attr, flag in required.items() if getattr(args, attr, None) is None]
+    if missing:
+        raise SystemExit(
+            "default mode requires "
+            + ", ".join(missing)
+            + " unless --thorough-config provides a native Spica SmartSearchConfig."
+        )
+
+
 def main(args):
     setup_logging(
         level=_resolve_cli_log_level(args),
@@ -2262,6 +2312,11 @@ def main(args):
         return
 
     if args.mode == "default":
+        _validate_default_mode_inputs(args)
+        if getattr(args, "thorough_sweep", False) or getattr(args, "thorough_config", None):
+            run_spica_thorough_default(args)
+            return
+
         # Warn when SLA/workload parameters are implicitly defaulted
         _default_params = {"isl": 4000, "osl": 1000, "ttft": 2000.0, "tpot": 30.0}
         _implicit = [

--- a/src/aiconfigurator/cli/report_and_save.py
+++ b/src/aiconfigurator/cli/report_and_save.py
@@ -80,6 +80,8 @@ def _plot_worker_setup_table(
     is_moe: bool,
     request_latency_target: float | None,
     show_power: bool = True,
+    preserve_ranking: bool = False,
+    objective_target: str | None = None,
 ) -> str:
     """Plot worker setup table for a single experiment."""
     buf = []
@@ -87,14 +89,21 @@ def _plot_worker_setup_table(
     if config_df is None or config_df.empty:
         return ""
 
-    config_df["tokens/s/gpu_cluster"] = (
-        config_df["tokens/s/gpu"]
-        * (total_gpus // config_df["num_total_gpus"])
-        * config_df["num_total_gpus"]
-        / total_gpus
-        if total_gpus > 0
-        else 0
-    )
+    config_df = config_df.copy()
+    if preserve_ranking:
+        # A Spica replay row is already a complete evaluated deployment (and may
+        # have been planner-scaled). Do not extrapolate it to the search budget or
+        # re-rank it by the legacy throughput/GPU heuristic.
+        config_df["tokens/s/gpu_cluster"] = config_df["tokens/s/gpu"]
+    else:
+        config_df["tokens/s/gpu_cluster"] = (
+            config_df["tokens/s/gpu"]
+            * (total_gpus // config_df["num_total_gpus"])
+            * config_df["num_total_gpus"]
+            / total_gpus
+            if total_gpus > 0
+            else 0
+        )
     constraint_col = "tpot"
     constraint_target = tpot_target
     constraint_label = "TPOT"
@@ -102,26 +111,39 @@ def _plot_worker_setup_table(
         constraint_col = "request_latency"
         constraint_target = request_latency_target
         constraint_label = "request latency"
-    top_configs = (
-        config_df[config_df[constraint_col] <= constraint_target]
-        .sort_values(by="tokens/s/gpu_cluster", ascending=False)
-        .head(top)
-        .copy()
-    )
+    if preserve_ranking:
+        # Native Spica objectives already define feasibility/ranking. In
+        # particular, goodput uses per-request SLA accounting, so an aggregate
+        # mean-latency gate here would incorrectly hide a valid selected row.
+        top_configs = config_df.copy()
+    elif constraint_target is not None and constraint_target > 0:
+        top_configs = config_df[config_df[constraint_col] <= constraint_target].copy()
+    else:
+        top_configs = config_df.copy()
+    if not preserve_ranking:
+        top_configs = top_configs.sort_values(by="tokens/s/gpu_cluster", ascending=False)
+    top_configs = top_configs.head(top).copy()
 
     if top_configs.empty:
         return f"\nNo configurations for {exp_name} met the {constraint_label} constraint."
 
-    top_configs["replicas"] = total_gpus // top_configs["num_total_gpus"]
-    top_configs["total_gpus_used"] = top_configs["num_total_gpus"] * top_configs["replicas"]
+    if preserve_ranking:
+        top_configs["replicas"] = 1
+        top_configs["total_gpus_used"] = top_configs["num_total_gpus"]
+    else:
+        top_configs["replicas"] = total_gpus // top_configs["num_total_gpus"]
+        top_configs["total_gpus_used"] = top_configs["num_total_gpus"] * top_configs["replicas"]
 
-    buf.append(f"\n{exp_name} Top Configurations: (Sorted by tokens/s/gpu)")
+    ranking_label = objective_target if preserve_ranking and objective_target else "tokens/s/gpu"
+    buf.append(f"\n{exp_name} Top Configurations: (Ranked by {ranking_label})")
     table = PrettyTable()
 
     # Check if it is disagg config by checking for prefill/decode specific columns
     is_disagg = "(p)tp" in top_configs.columns
 
-    top_configs["cluster_request_rate"] = top_configs["request_rate"] * top_configs["replicas"]
+    top_configs["cluster_request_rate"] = (
+        top_configs["request_rate"] if preserve_ranking else top_configs["request_rate"] * top_configs["replicas"]
+    )
 
     if is_disagg:
         field_names = [
@@ -149,6 +171,8 @@ def _plot_worker_setup_table(
             field_names.append("power_w")
         table.field_names = field_names
         for i, row in enumerate(top_configs.to_dict("records")):
+            display_total_gpus = row["total_gpus_used"] if preserve_ranking else total_gpus
+            display_concurrency = row["concurrency"] if preserve_ranking else row["concurrency"] * row["replicas"]
             if is_moe:
                 p_parallel = (
                     f"tp{_cli_underline(str(row['(p)tp']))}"
@@ -203,8 +227,8 @@ def _plot_worker_setup_table(
                     f"{row['cluster_request_rate']:.2f}",
                     f"{row['ttft']:.2f}",
                     f"{row['request_latency']:.2f}",
-                    f"{row['concurrency'] * row['replicas']} (={row['concurrency']}x{row['replicas']})",
-                    f"{total_gpus} ({row['total_gpus_used']}={row['replicas']}x{row['num_total_gpus']})",
+                    f"{display_concurrency} (={row['concurrency']}x{row['replicas']})",
+                    f"{display_total_gpus} ({row['total_gpus_used']}={row['replicas']}x{row['num_total_gpus']})",
                     row["replicas"],
                     gpus_replica_str,
                     row["(p)workers"],
@@ -241,6 +265,8 @@ def _plot_worker_setup_table(
             field_names.append("power_w")
         table.field_names = field_names
         for i, row in enumerate(top_configs.to_dict("records")):
+            display_total_gpus = row["total_gpus_used"] if preserve_ranking else total_gpus
+            display_concurrency = row["concurrency"] if preserve_ranking else row["concurrency"] * row["replicas"]
             if is_moe:
                 parallel = (
                     f"tp{_cli_underline(str(row['tp']))}"
@@ -257,7 +283,7 @@ def _plot_worker_setup_table(
             else:
                 parallel = f"tp{_cli_underline(str(row['tp']))}pp{_cli_underline(str(row['pp']))}"
                 gpus_worker = (
-                    f"{row['pp'] * row['tp']} (={_cli_underline(str(row['tp']))}x{_cli_underline(str(row['pp']))}"
+                    f"{row['pp'] * row['tp']} (={_cli_underline(str(row['tp']))}x{_cli_underline(str(row['pp']))})"
                 )
             row_data = [
                 i + 1,
@@ -270,8 +296,8 @@ def _plot_worker_setup_table(
                     f"{row['cluster_request_rate']:.2f}",
                     f"{row['ttft']:.2f}",
                     f"{row['request_latency']:.2f}",
-                    f"{row['concurrency'] * row['replicas']} (={row['concurrency']}x{row['replicas']})",
-                    f"{total_gpus} ({row['total_gpus_used']}={row['replicas']}x{row['num_total_gpus']})",
+                    f"{display_concurrency} (={row['concurrency']}x{row['replicas']})",
+                    f"{display_total_gpus} ({row['total_gpus_used']}={row['replicas']}x{row['num_total_gpus']})",
                     row["replicas"],
                     row["num_total_gpus"],
                     gpus_worker,
@@ -287,6 +313,37 @@ def _plot_worker_setup_table(
     return "\n".join(buf)
 
 
+_OBJECTIVE_LABELS = {
+    "throughput": "throughput",
+    "throughput_per_gpu": "throughput per GPU",
+    "throughput_per_user": "throughput per user",
+    "e2e_latency": "end-to-end latency",
+    "goodput": "goodput",
+    "goodput_per_gpu": "goodput per GPU",
+    "pareto": "Pareto",
+}
+
+_OBJECTIVE_UNITS = {
+    "throughput": "tokens/s",
+    "throughput_per_gpu": "tokens/s/gpu",
+    "throughput_per_user": "tokens/s/user",
+    "e2e_latency": "ms",
+    "goodput": "tokens/s",
+    "goodput_per_gpu": "tokens/s/gpu",
+}
+
+
+def _format_objective_value(target: str, value: object) -> str:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return "n/a"
+    if pd.isna(numeric):
+        return "n/a"
+    unit = _OBJECTIVE_UNITS.get(target)
+    return f"{numeric:,.2f}{f' {unit}' if unit else ''}"
+
+
 def log_final_summary(
     chosen_exp: str,
     best_throughputs: dict[str, float],
@@ -299,6 +356,11 @@ def log_final_summary(
     target_request_rate: float | None = None,
     target_concurrency: float | None = None,
     inclusive_tpot: bool = False,
+    extra_input_lines: list[str] | None = None,
+    objective_target: str | None = None,
+    best_objective_scores: dict[str, float] | None = None,
+    pareto_y_axis: dict[str, str] | None = None,
+    objective_directions: dict[str, bool] | None = None,
 ):
     """Log final summary of configuration results"""
     # display_* copies carry inclusive TPOT for printed values only.
@@ -313,6 +375,7 @@ def log_final_summary(
         display_pareto_fronts = pareto_fronts
 
     load_match = target_request_rate is not None or target_concurrency is not None
+    objective_aware = objective_target is not None and best_objective_scores is not None
 
     # Consolidate and format results into a summary box for clear presentation
     summary_box = []
@@ -338,6 +401,19 @@ def log_final_summary(
 
     summary_box.append(f"    Model: {chosen_task.primary_model_path} (is_moe: {chosen_task.is_moe})")
     summary_box.append(f"    Total GPUs: {chosen_task.total_gpus}")
+    if extra_input_lines:
+        for line in extra_input_lines:
+            summary_box.append(f"    {line}")
+    if objective_aware:
+        if objective_target == "pareto":
+            x_axis = (pareto_x_axis or {}).get(chosen_exp, "unknown")
+            y_axis = (pareto_y_axis or {}).get(chosen_exp, "unknown")
+            summary_box.append(f"    Optimization Objective: Pareto ({y_axis} vs {x_axis})")
+        else:
+            maximize = (objective_directions or {}).get(objective_target, objective_target != "e2e_latency")
+            direction = "maximize" if maximize else "minimize"
+            label = _OBJECTIVE_LABELS.get(objective_target, objective_target)
+            summary_box.append(f"    Optimization Objective: {label} ({direction})")
 
     if load_match:
         # Load-match mode summary
@@ -358,20 +434,42 @@ def log_final_summary(
                         line += f" -- WARNING: only {pct:.1f}% of target load can be served"
                 summary_box.append(line)
         summary_box.append(f"    Best Experiment Chosen: {_cli_bold(chosen_exp)}")
+    elif objective_aware:
+        chosen_row = best_configs[chosen_exp].iloc[0] if not best_configs[chosen_exp].empty else pd.Series(dtype=object)
+        if objective_target == "pareto":
+            primary_axis = (pareto_y_axis or {}).get(chosen_exp, "objective_value")
+            raw_value = chosen_row.get(primary_axis)
+            value_text = _format_objective_value(primary_axis, raw_value)
+            bold_msg = _cli_bold(f"{chosen_exp} at {primary_axis}={value_text}")
+            summary_box.append(f"    Representative Experiment: {bold_msg} (primary Pareto objective)")
+        else:
+            raw_value = chosen_row.get("objective_value")
+            value_text = _format_objective_value(objective_target, raw_value)
+            label = _OBJECTIVE_LABELS.get(objective_target, objective_target)
+            comparisons = []
+            for exp_name, config_df in best_configs.items():
+                if config_df is None or config_df.empty:
+                    continue
+                comparisons.append(
+                    f"{exp_name}={_format_objective_value(objective_target, config_df.iloc[0].get('objective_value'))}"
+                )
+            comparison_text = f"; {', '.join(comparisons)}" if len(comparisons) > 1 else ""
+            bold_msg = _cli_bold(f"{chosen_exp} at {value_text} {label}{comparison_text}")
+            summary_box.append(f"    Best Experiment Chosen: {bold_msg}")
     elif mode == "default":
         agg_value = best_throughputs.get("agg", 0.0)
         disagg_value = best_throughputs.get("disagg", 0.0)
-        if agg_value > 0 and disagg_value > 0:
-            benefit_ratio = disagg_value / agg_value
-        elif agg_value == 0 and disagg_value > 0:
-            benefit_ratio = float("inf")
-        elif agg_value > 0 and disagg_value == 0:
-            benefit_ratio = 0.0
+        if "agg" in best_throughputs and "disagg" in best_throughputs:
+            if agg_value == disagg_value:
+                comparison = "agg and disagg tied"
+            else:
+                winner, loser = ("agg", "disagg") if agg_value >= disagg_value else ("disagg", "agg")
+                loser_value = best_throughputs[loser]
+                benefit_ratio = float("inf") if loser_value == 0 else best_throughputs[winner] / loser_value
+                comparison = f"{winner} {benefit_ratio:.2f}x better than {loser}"
+            bold_msg = _cli_bold(f"{chosen_exp} at {best_throughputs[chosen_exp]:.2f} tokens/s/gpu ({comparison})")
         else:
-            benefit_ratio = 0.0  # handle case where both are 0
-        bold_msg = _cli_bold(
-            f"{chosen_exp} at {best_throughputs[chosen_exp]:.2f} tokens/s/gpu (disagg {benefit_ratio:.2f}x better)"
-        )
+            bold_msg = _cli_bold(f"{chosen_exp} at {best_throughputs[chosen_exp]:.2f} tokens/s/gpu")
         summary_box.append(f"    Best Experiment Chosen: {bold_msg}")
     else:
         bold_msg = _cli_bold(f"{chosen_exp} at {best_throughputs[chosen_exp]:.2f} tokens/s/gpu")
@@ -380,52 +478,99 @@ def log_final_summary(
     summary_box.append("  " + "-" * 76)
 
     # ============================= overall summary
-    summary_box.append("  Overall Best Configuration:")
+    summary_box.append("  Selected Configuration:" if objective_aware else "  Overall Best Configuration:")
     best_config_df = display_best_configs[chosen_exp]
     best_throughput = best_throughputs[chosen_exp]
 
-    summary_box.append(f"    - Best Throughput: {best_throughput * chosen_task.total_gpus:,.2f} tokens/s")
-    summary_box.append(f"    - Per-GPU Throughput: {best_throughput:.2f} tokens/s/gpu")
     if not best_config_df.empty:
         best_conf_details = best_config_df.iloc[0]
+        if objective_aware:
+            if objective_target == "pareto":
+                x_axis = (pareto_x_axis or {}).get(chosen_exp)
+                y_axis = (pareto_y_axis or {}).get(chosen_exp)
+                if y_axis:
+                    summary_box.append(
+                        f"    - Primary Pareto Objective ({y_axis}): "
+                        f"{_format_objective_value(y_axis, best_conf_details.get(y_axis))}"
+                    )
+                if x_axis and x_axis != y_axis:
+                    summary_box.append(
+                        f"    - Secondary Pareto Objective ({x_axis}): "
+                        f"{_format_objective_value(x_axis, best_conf_details.get(x_axis))}"
+                    )
+            else:
+                label = _OBJECTIVE_LABELS.get(objective_target, objective_target)
+                summary_box.append(
+                    f"    - Objective ({label}): "
+                    f"{_format_objective_value(objective_target, best_conf_details.get('objective_value'))}"
+                )
+
+            physical_throughput = best_conf_details.get("throughput")
+            if physical_throughput is not None and not pd.isna(physical_throughput):
+                summary_box.append(f"    - Throughput: {float(physical_throughput):,.2f} tokens/s")
+            summary_box.append(f"    - Per-GPU Throughput: {best_throughput:.2f} tokens/s/gpu")
+            average_gpus = best_conf_details.get("average_gpus")
+            if average_gpus is not None and not pd.isna(average_gpus):
+                summary_box.append(f"    - Average Provisioned GPUs: {float(average_gpus):.2f}")
+        else:
+            summary_box.append(f"    - Best Throughput: {best_throughput * chosen_task.total_gpus:,.2f} tokens/s")
+            summary_box.append(f"    - Per-GPU Throughput: {best_throughput:.2f} tokens/s/gpu")
         summary_box.append(f"    - Per-User Throughput: {best_conf_details['tokens/s/user']:.2f} tokens/s/user")
-        replicas = chosen_task.total_gpus // int(best_conf_details["num_total_gpus"])
-        cluster_rr = float(best_conf_details["request_rate"]) * replicas
+        if objective_aware:
+            cluster_rr = float(best_conf_details["request_rate"])
+        else:
+            replicas = chosen_task.total_gpus // int(best_conf_details["num_total_gpus"])
+            cluster_rr = float(best_conf_details["request_rate"]) * replicas
         summary_box.append(f"    - Request Rate: {cluster_rr:.2f} req/s")
         summary_box.append(f"    - TTFT: {best_conf_details['ttft']:.2f}ms")
         summary_box.append(f"    - TPOT: {best_conf_details['tpot']:.2f}ms")
         summary_box.append(f"    - Request Latency: {best_conf_details['request_latency']:.2f}ms")
+    elif not objective_aware:
+        summary_box.append(f"    - Best Throughput: {best_throughput * chosen_task.total_gpus:,.2f} tokens/s")
+        summary_box.append(f"    - Per-GPU Throughput: {best_throughput:.2f} tokens/s/gpu")
     summary_box.append("  " + "-" * 76)
 
     # ============================= pareto frontier
     pareto_plot_buf = ""
     if len(display_pareto_fronts) <= 10:  # avoid overly crowded plots
-        summary_box.append("  Pareto Frontier:")
         target_x_axis = "tokens/s/user"
+        target_y_axis = "tokens/s/gpu_cluster"
         if pareto_x_axis:
             target_x_axis = pareto_x_axis.get(chosen_exp, target_x_axis)
+        if pareto_y_axis:
+            target_y_axis = pareto_y_axis.get(chosen_exp, target_y_axis)
         series_payload = []
-        for name, df in display_pareto_fronts.items():
-            if df is None or df.empty:
-                continue
-            series_axis = pareto_x_axis.get(name, target_x_axis) if pareto_x_axis else target_x_axis
-            if series_axis != target_x_axis:
-                continue
-            series_payload.append({"df": df, "label": name})
-        highlight_series = None
-        if not best_config_df.empty:
-            highlight_series = {
-                "df": best_config_df.head(1),
-                "label": f"{chosen_exp} best",
-            }
-        pareto_plot_buf = draw_pareto_to_string(
-            f"{chosen_task.primary_model_path} Pareto Frontier",
-            series_payload,
-            highlight=highlight_series,
-            x_label=target_x_axis,
-            y_label="tokens/s/gpu_cluster",
-        )
-        summary_box.append(pareto_plot_buf)
+        if target_x_axis != target_y_axis:
+            for name, df in display_pareto_fronts.items():
+                if df is None or df.empty:
+                    continue
+                series_x_axis = pareto_x_axis.get(name, target_x_axis) if pareto_x_axis else target_x_axis
+                series_y_axis = pareto_y_axis.get(name, target_y_axis) if pareto_y_axis else target_y_axis
+                if series_x_axis != target_x_axis or series_y_axis != target_y_axis:
+                    continue
+                if target_x_axis not in df.columns or target_y_axis not in df.columns:
+                    continue
+                series_payload.append({"df": df, "label": name})
+        if series_payload:
+            summary_box.append("  Pareto Frontier:")
+            highlight_series = None
+            if (
+                not best_config_df.empty
+                and target_x_axis in best_config_df.columns
+                and target_y_axis in best_config_df.columns
+            ):
+                highlight_series = {
+                    "df": best_config_df.head(1),
+                    "label": f"{chosen_exp} selected",
+                }
+            pareto_plot_buf = draw_pareto_to_string(
+                f"{chosen_task.primary_model_path} Pareto Frontier",
+                series_payload,
+                highlight=highlight_series,
+                x_label=target_x_axis,
+                y_label=target_y_axis,
+            )
+            summary_box.append(pareto_plot_buf)
     summary_box.append("  " + "-" * 76)
 
     # ============================= deployment details
@@ -479,6 +624,8 @@ def log_final_summary(
             exp_task.is_moe,
             exp_task.request_latency,
             show_power,
+            preserve_ranking=objective_aware,
+            objective_target=objective_target,
         )
         summary_box.append(table_buf)
 

--- a/src/aiconfigurator/cli/spica/__init__.py
+++ b/src/aiconfigurator/cli/spica/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Spica integration for the AIC CLI."""

--- a/src/aiconfigurator/cli/spica/cli_adapter.py
+++ b/src/aiconfigurator/cli/spica/cli_adapter.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public entry points for the AIC CLI's Spica integration."""
+
+from aiconfigurator.cli.spica.helper import run_spica_thorough_default
+
+__all__ = ["run_spica_thorough_default"]

--- a/src/aiconfigurator/cli/spica/helper.py
+++ b/src/aiconfigurator/cli/spica/helper.py
@@ -1,0 +1,1848 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Implementation helpers for adapting Spica thorough sweeps to the AIC CLI."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import logging
+import math
+import os
+import secrets
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import yaml
+
+from aiconfigurator.generator.dynamo_features import normalize_router_mode
+from aiconfigurator.sdk import common, pareto_analysis, perf_database
+
+logger = logging.getLogger(__name__)
+
+SPICA_THOROUGH_SWEEP_ROUNDS = 3
+SPICA_THOROUGH_PARALLEL_EVALS = 16
+SPICA_THOROUGH_SYNTHETIC_CONCURRENCY_PER_GPU = 128
+SPICA_THOROUGH_SYNTHETIC_REQUEST_COUNT_TARGET = 1000
+
+
+@dataclass
+class _SpicaTraceTask:
+    primary_model_path: str
+    primary_system_name: str
+    primary_backend_name: str
+    primary_backend_version: str
+    total_gpus: int
+    serving_mode: str
+    ttft: float
+    tpot: float
+    request_latency: float | None
+    is_moe: bool
+    objective_target: str
+    planner_optimization_target: str
+    min_gpu_budget: int | None = None
+    min_endpoint: int | None = None
+    isl: int = 0
+    osl: int = 0
+
+    def to_yaml(self) -> str:
+        return yaml.safe_dump(self.__dict__, sort_keys=False)
+
+
+@dataclass
+class _SpicaTraceResultBundle:
+    candidates: list[dict[str, Any]]
+    candidate_df: pd.DataFrame
+    tasks: dict[str, _SpicaTraceTask]
+    trace_path: str | None
+    config_path: str | None
+    workload_label: str
+    chosen_exp: str
+    best_configs: dict[str, pd.DataFrame]
+    pareto_fronts: dict[str, pd.DataFrame | None]
+    best_throughputs: dict[str, float]
+    best_objective_scores: dict[str, float]
+    best_latencies: dict[str, dict[str, float]]
+    pareto_x_axis: dict[str, str]
+    pareto_y_axis: dict[str, str]
+    objective_target: str
+    objective_directions: dict[str, bool]
+
+
+def _positive_int_env(name: str, default: int, *, aliases: tuple[str, ...] = ()) -> int:
+    selected_name = name
+    raw_value = os.environ.get(name)
+    if raw_value is None:
+        for alias in aliases:
+            raw_value = os.environ.get(alias)
+            if raw_value is not None:
+                selected_name = alias
+                break
+    if raw_value is None:
+        return default
+    try:
+        value = int(raw_value)
+    except ValueError:
+        logger.warning("Ignoring %s=%r; expected a positive integer.", selected_name, raw_value)
+        return default
+    if value < 1:
+        logger.warning("Ignoring %s=%r; expected a positive integer.", selected_name, raw_value)
+        return default
+    return value
+
+
+def _positive_float_env(name: str, *, aliases: tuple[str, ...] = ()) -> float | None:
+    selected_name = name
+    raw_value = os.environ.get(name)
+    if raw_value is None:
+        for alias in aliases:
+            raw_value = os.environ.get(alias)
+            if raw_value is not None:
+                selected_name = alias
+                break
+    if raw_value is None:
+        return None
+    try:
+        value = float(raw_value)
+    except ValueError:
+        logger.warning("Ignoring %s=%r; expected a positive float.", selected_name, raw_value)
+        return None
+    if value <= 0 or not math.isfinite(value):
+        logger.warning("Ignoring %s=%r; expected a positive finite float.", selected_name, raw_value)
+        return None
+    return value
+
+
+def _spica_thorough_sweep_config() -> dict[str, int]:
+    sweep_config = {
+        "max_rounds": _positive_int_env(
+            "AIC_SPICA_THOROUGH_SWEEP_ROUNDS",
+            SPICA_THOROUGH_SWEEP_ROUNDS,
+            aliases=("AIC_SPICA_TRACE_SWEEP_ROUNDS",),
+        ),
+        "parallel_evals": _positive_int_env(
+            "AIC_SPICA_THOROUGH_PARALLEL_EVALS",
+            SPICA_THOROUGH_PARALLEL_EVALS,
+            aliases=("AIC_SPICA_TRACE_PARALLEL_EVALS",),
+        ),
+    }
+    candidates_per_round = os.environ.get("AIC_SPICA_THOROUGH_CANDIDATES_PER_ROUND")
+    candidates_env = "AIC_SPICA_THOROUGH_CANDIDATES_PER_ROUND"
+    if candidates_per_round is None:
+        candidates_per_round = os.environ.get("AIC_SPICA_TRACE_CANDIDATES_PER_ROUND")
+        candidates_env = "AIC_SPICA_TRACE_CANDIDATES_PER_ROUND"
+    if candidates_per_round is not None:
+        sweep_config["candidates_per_round"] = _positive_int_env(
+            candidates_env,
+            sweep_config["parallel_evals"],
+        )
+    return sweep_config
+
+
+def _spica_candidate_to_dict(candidate: Any) -> dict[str, Any]:
+    if hasattr(candidate, "model_dump"):
+        return candidate.model_dump()
+    if isinstance(candidate, dict):
+        return dict(candidate)
+    return {
+        "config": getattr(candidate, "config", {}),
+        "used_gpus": getattr(candidate, "used_gpus", None),
+        "score": getattr(candidate, "score", None),
+        "metrics": getattr(candidate, "metrics", {}),
+        "objectives": getattr(candidate, "objectives", None),
+    }
+
+
+def _metric_value(metrics: dict[str, Any], *names: str) -> Any:
+    for name in names:
+        if name in metrics and metrics[name] is not None:
+            return metrics[name]
+    return None
+
+
+def _spica_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        number = float(value)
+        if pd.isna(number):
+            return None
+        return number
+    except (TypeError, ValueError):
+        return None
+
+
+def _spica_int(value: Any) -> int | None:
+    number = _spica_float(value)
+    if number is None:
+        return None
+    try:
+        return int(number)
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+
+def _spica_deployment_mode(payload: dict[str, Any]) -> str:
+    config = payload.get("config") or {}
+    mode = config.get("deployment_mode")
+    return str(mode) if mode else "unknown"
+
+
+def _spica_parallel_key(config: dict[str, Any], prefix: str | None = None) -> str:
+    key_prefix = f"{prefix}_" if prefix else ""
+    tp = _spica_int(config.get(f"{key_prefix}tp")) or 1
+    pp = _spica_int(config.get(f"{key_prefix}pp")) or 1
+    dp = _spica_int(config.get(f"{key_prefix}attention_dp")) or 1
+    moe_tp = _spica_int(config.get(f"{key_prefix}moe_tp")) or 1
+    moe_ep = _spica_int(config.get(f"{key_prefix}moe_ep")) or 1
+    parts = [f"tp{tp}", f"pp{pp}"]
+    if dp != 1:
+        parts.append(f"dp{dp}")
+    if moe_tp != 1 or moe_ep != 1:
+        parts.append(f"etp{moe_tp}ep{moe_ep}")
+    return "_".join(parts)
+
+
+def _spica_batch_label(config: dict[str, Any], prefix: str) -> str:
+    tokens = config.get(f"{prefix}_max_num_batched_tokens")
+    seqs = config.get(f"{prefix}_max_num_seqs")
+    if tokens is None and seqs is None:
+        return "n/a"
+    return f"{tokens or 'n/a'}/{seqs or 'n/a'}"
+
+
+def _spica_planner(config: dict[str, Any]) -> str:
+    if config.get("enable_throughput_scaling") or config.get("enable_load_scaling"):
+        return str(config.get("planner_scaling_policy", "enabled"))
+    return "static"
+
+
+def _spica_router(config: dict[str, Any]) -> str:
+    return str(config.get("router_mode") or "n/a")
+
+
+def _spica_metric_summary(payload: dict[str, Any]) -> dict[str, Any]:
+    metrics = payload.get("metrics") or {}
+    return {
+        "score": payload.get("score"),
+        "goodput": _metric_value(metrics, "goodput_output_throughput_tok_s"),
+        "throughput": _metric_value(metrics, "output_throughput_tok_s"),
+        "ttft": _metric_value(metrics, "mean_ttft_ms", "ttft_ms"),
+        "tpot": _metric_value(metrics, "mean_tpot_ms", "tpot_ms", "itl_ms"),
+        "request_latency": _metric_value(metrics, "mean_e2e_latency_ms", "e2e_latency_ms", "request_latency_ms"),
+    }
+
+
+def _spica_tokens_per_user(metrics: dict[str, Any], metric_summary: dict[str, Any]) -> float | None:
+    tokens_per_user = _spica_float(
+        _metric_value(
+            metrics,
+            "mean_output_token_throughput_per_user",
+            "output_token_throughput_per_user",
+            "tokens_per_second_per_user",
+            "tokens/s/user",
+        )
+    )
+    if tokens_per_user is not None:
+        return tokens_per_user
+
+    # Legacy Pareto plots use generation speed on the x-axis; mean TPOT is its inverse.
+    tpot_ms = _spica_float(metric_summary.get("tpot"))
+    if tpot_ms is None or tpot_ms <= 0:
+        return None
+    return 1000.0 / tpot_ms
+
+
+def _spica_load_shape(metrics: dict[str, Any], metric_summary: dict[str, Any]) -> tuple[float, float]:
+    request_rate = _spica_float(
+        _metric_value(metrics, "request_rate", "request_throughput", "request_throughput_rps", "completed_req_s")
+    )
+    concurrency = _spica_float(_metric_value(metrics, "concurrency", "mean_concurrency", "active_requests"))
+
+    if concurrency is None:
+        throughput = _spica_float(metric_summary.get("throughput")) or _spica_float(metric_summary.get("goodput"))
+        tokens_per_user = _spica_tokens_per_user(metrics, metric_summary)
+        if throughput is not None and tokens_per_user is not None and tokens_per_user > 0:
+            concurrency = throughput / tokens_per_user
+
+    if request_rate is None and concurrency is not None:
+        latency_ms = _spica_float(metric_summary.get("request_latency"))
+        if latency_ms is not None and latency_ms > 0:
+            request_rate = concurrency / (latency_ms / 1000.0)
+
+    return request_rate or 0.0, concurrency or 0.0
+
+
+def _spica_enum_value(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(getattr(value, "value", value))
+
+
+def _spica_goal_target(goal: Any | None) -> str | None:
+    return _spica_enum_value(getattr(goal, "target", None))
+
+
+def _spica_planner_target(goal: Any | None) -> str:
+    target = getattr(goal, "target", None)
+    planner_target = getattr(target, "planner_optimization_target", None)
+    if planner_target:
+        return str(planner_target)
+    return {
+        "throughput": "throughput",
+        "throughput_per_gpu": "throughput",
+        "throughput_per_user": "throughput",
+        "e2e_latency": "latency",
+        "goodput": "sla",
+        "goodput_per_gpu": "sla",
+        "pareto": "throughput",
+    }.get(_spica_goal_target(goal) or "", "sla")
+
+
+def _spica_pareto_objectives(goal: Any | None) -> list[str]:
+    if _spica_goal_target(goal) != "pareto":
+        return []
+    objectives = getattr(goal, "resolved_pareto_objectives", None)
+    if callable(objectives):
+        objectives = objectives()
+    if objectives is None:
+        objectives = getattr(goal, "pareto_objectives", None)
+    if objectives is None:
+        return ["throughput_per_gpu", "throughput_per_user"]
+    return [value for item in objectives if (value := _spica_enum_value(item)) is not None]
+
+
+def _spica_target_maximize(target: str) -> bool:
+    return target != "e2e_latency"
+
+
+def _spica_average_gpus(metrics: dict[str, Any], used_gpus: int | None) -> float | None:
+    gpu_hours = _spica_float(metrics.get("gpu_hours"))
+    duration_ms = _spica_float(metrics.get("duration_ms"))
+    if gpu_hours is not None and gpu_hours > 0 and duration_ms is not None and duration_ms > 0:
+        return gpu_hours / (duration_ms / 3_600_000.0)
+    if used_gpus is not None and used_gpus > 0:
+        return float(used_gpus)
+    return None
+
+
+def _spica_scalar_objective_value(
+    target: str | None,
+    *,
+    score: float | None,
+    throughput: float | None,
+    throughput_per_gpu: float | None,
+    tokens_per_user: float | None,
+    goodput: float | None,
+    goodput_per_gpu: float | None,
+    request_latency: float | None,
+) -> float | None:
+    # Candidate.score is Spica's authoritative scalar objective, signed so higher
+    # is always better. Recover natural units from it before consulting physical
+    # display metrics; legacy display fallbacks (for example 1000 / mean TPOT for
+    # tokens/s/user) must never redefine the configured objective.
+    if score is not None and target != "pareto":
+        return -score if target == "e2e_latency" else score
+
+    values = {
+        "throughput": throughput,
+        "throughput_per_gpu": throughput_per_gpu,
+        "throughput_per_user": tokens_per_user,
+        "goodput": goodput,
+        "goodput_per_gpu": goodput_per_gpu,
+        "e2e_latency": request_latency,
+    }
+    return values.get(target or "")
+
+
+def _spica_candidates_to_result_df(candidates: list[Any], goal: Any | None = None) -> pd.DataFrame:
+    """Convert Spica candidates without changing the meaning of their objective.
+
+    ``goal=None`` retains the pre-native-config compatibility layout, where callers
+    supplied goodput-per-GPU scores and expected the legacy token/GPU columns to mirror
+    ``Candidate.score``. With a Spica goal, physical throughput columns are computed from
+    replay metrics while ``objective_score``/``objective_value`` carry the actual scalar
+    target; Pareto candidates expose their raw ``Candidate.objectives`` vector.
+    """
+    rows: list[dict[str, Any]] = []
+    target = _spica_goal_target(goal)
+    legacy_score_layout = target is None
+    for candidate_index, candidate in enumerate(candidates):
+        payload = _spica_candidate_to_dict(candidate)
+        config = payload.get("config") or {}
+        raw_metrics = payload.get("metrics") or {}
+        metrics = _spica_metric_summary(payload)
+        used_gpus = _spica_int(payload.get("used_gpus")) or _spica_int(config.get("used_gpus"))
+        goodput = _spica_float(metrics["goodput"])
+        score = _spica_float(metrics["score"])
+        if legacy_score_layout and score is None and goodput is not None and used_gpus and used_gpus > 0:
+            score = goodput / used_gpus
+        tokens_per_user = _spica_tokens_per_user(raw_metrics, metrics)
+        request_rate, concurrency = _spica_load_shape(raw_metrics, metrics)
+        mode = _spica_deployment_mode(payload)
+        throughput = _spica_float(metrics["throughput"])
+        request_latency = _spica_float(metrics["request_latency"])
+        average_gpus = _spica_average_gpus(raw_metrics, used_gpus)
+        throughput_per_gpu = throughput / average_gpus if throughput is not None and average_gpus else None
+        goodput_per_gpu = goodput / average_gpus if goodput is not None and average_gpus else None
+
+        if legacy_score_layout:
+            objective_target = "goodput_per_gpu"
+            objective_score = score or 0.0
+            objective_value = objective_score
+            throughput_per_gpu = objective_score
+            goodput_per_gpu = objective_score
+            tokens_per_user = tokens_per_user or 0.0
+        elif target == "pareto":
+            objective_target = target
+            objective_score = None
+            objective_value = None
+        else:
+            objective_target = target
+            objective_score = score
+            objective_value = _spica_scalar_objective_value(
+                target,
+                score=score,
+                throughput=throughput,
+                throughput_per_gpu=throughput_per_gpu,
+                tokens_per_user=tokens_per_user,
+                goodput=goodput,
+                goodput_per_gpu=goodput_per_gpu,
+                request_latency=request_latency,
+            )
+
+        row = {
+            "spica_candidate_id": candidate_index,
+            "deployment_mode": mode,
+            "backend": config.get("backend", "n/a"),
+            "objective_target": objective_target,
+            "objective_score": objective_score,
+            "objective_value": objective_value,
+            "tokens/s/user": tokens_per_user,
+            "tokens/s/gpu": throughput_per_gpu,
+            "tokens/s/gpu_cluster": throughput_per_gpu,
+            "goodput/s/gpu": goodput_per_gpu,
+            "goodput": goodput,
+            "throughput": throughput,
+            "ttft": _spica_float(metrics["ttft"]),
+            "tpot": _spica_float(metrics["tpot"]),
+            "request_latency": request_latency,
+            "request_rate": request_rate,
+            "concurrency": round(concurrency, 2),
+            "num_total_gpus": used_gpus,
+            "total_gpus": used_gpus,
+            "average_gpus": average_gpus,
+            "router": _spica_router(config),
+            "planner": _spica_planner(config),
+        }
+        objectives = payload.get("objectives") or {}
+        for name, value in objectives.items():
+            row[str(name)] = _spica_float(value)
+        if mode == "disagg":
+            row.update(
+                {
+                    "(p)workers": _spica_int(config.get("prefill_replicas")) or 1,
+                    "(p)tp": _spica_int(config.get("prefill_tp")) or 1,
+                    "(p)pp": _spica_int(config.get("prefill_pp")) or 1,
+                    "(p)dp": _spica_int(config.get("prefill_attention_dp")) or 1,
+                    "(p)moe_tp": _spica_int(config.get("prefill_moe_tp")) or 1,
+                    "(p)moe_ep": _spica_int(config.get("prefill_moe_ep")) or 1,
+                    "(p)bs": _spica_batch_label(config, "prefill"),
+                    "(p)parallel": _spica_parallel_key(config, "prefill"),
+                    "(d)workers": _spica_int(config.get("decode_replicas")) or 1,
+                    "(d)tp": _spica_int(config.get("decode_tp")) or 1,
+                    "(d)pp": _spica_int(config.get("decode_pp")) or 1,
+                    "(d)dp": _spica_int(config.get("decode_attention_dp")) or 1,
+                    "(d)moe_tp": _spica_int(config.get("decode_moe_tp")) or 1,
+                    "(d)moe_ep": _spica_int(config.get("decode_moe_ep")) or 1,
+                    "(d)bs": _spica_batch_label(config, "decode"),
+                    "(d)parallel": _spica_parallel_key(config, "decode"),
+                }
+            )
+        else:
+            row.update(
+                {
+                    "tp": _spica_int(config.get("tp")) or 1,
+                    "pp": _spica_int(config.get("pp")) or 1,
+                    "dp": _spica_int(config.get("attention_dp")) or 1,
+                    "moe_tp": _spica_int(config.get("moe_tp")) or 1,
+                    "moe_ep": _spica_int(config.get("moe_ep")) or 1,
+                    "bs": _spica_batch_label(config, "agg"),
+                    "parallel": _spica_parallel_key(config),
+                }
+            )
+        for key, value in config.items():
+            if isinstance(value, (str, int, float, bool)) or value is None:
+                row.setdefault(key, value)
+        rows.append(row)
+
+    if not rows:
+        return pd.DataFrame()
+
+    df = pd.DataFrame(rows)
+    metric_cols = [
+        "tokens/s/user",
+        "objective_score",
+        "objective_value",
+        "tokens/s/gpu",
+        "tokens/s/gpu_cluster",
+        "goodput/s/gpu",
+        "goodput",
+        "throughput",
+        "ttft",
+        "tpot",
+        "request_latency",
+        "request_rate",
+        "concurrency",
+        "num_total_gpus",
+        "total_gpus",
+        "average_gpus",
+    ]
+    metric_cols.extend(name for name in _spica_pareto_objectives(goal) if name not in metric_cols)
+    for col in metric_cols:
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce")
+    return df
+
+
+def _spica_trace_is_moe(candidate_df: pd.DataFrame) -> bool:
+    moe_cols = [col for col in candidate_df.columns if col.endswith("moe_tp") or col.endswith("moe_ep")]
+    return any((pd.to_numeric(candidate_df[col], errors="coerce").fillna(1) > 1).any() for col in moe_cols)
+
+
+_SPICA_INTEGER_RESULT_COLUMNS = (
+    "spica_candidate_id",
+    "num_total_gpus",
+    "total_gpus",
+    "tp",
+    "pp",
+    "dp",
+    "moe_tp",
+    "moe_ep",
+    "replicas",
+    "(p)workers",
+    "(p)tp",
+    "(p)pp",
+    "(p)dp",
+    "(p)moe_tp",
+    "(p)moe_ep",
+    "(d)workers",
+    "(d)tp",
+    "(d)pp",
+    "(d)dp",
+    "(d)moe_tp",
+    "(d)moe_ep",
+)
+
+
+def _normalize_spica_result_dtypes(df: pd.DataFrame) -> pd.DataFrame:
+    for col in _SPICA_INTEGER_RESULT_COLUMNS:
+        if col not in df.columns:
+            continue
+        numeric = pd.to_numeric(df[col], errors="coerce")
+        if numeric.notna().all():
+            df[col] = numeric.round().astype(int)
+    return df
+
+
+def _spica_search_space_value(config: Any, name: str, default: Any = None) -> Any:
+    search_space = getattr(config, "search_space", None)
+    return getattr(search_space, name, default)
+
+
+def _spica_workload_value(config: Any, name: str, default: Any = None) -> Any:
+    workload = getattr(config, "workload", None)
+    return getattr(workload, name, default)
+
+
+def _spica_sla_value(config: Any, name: str, default: Any = None) -> Any:
+    goal = getattr(config, "goal", None)
+    sla = getattr(goal, "sla", None)
+    return getattr(sla, name, default)
+
+
+def _spica_enrich_candidate_payload(payload: dict[str, Any], config: Any | None) -> dict[str, Any]:
+    """Make a saved candidate self-describing without mutating Spica's Candidate.
+
+    Native goal metadata is passed separately during replay, so copy it alongside the
+    selected sample before artifact generation. This lets a generated deployment retain
+    the same planner target/SLA and search-space runtime limits as the evaluated candidate.
+    """
+    enriched = dict(payload)
+    candidate_config = dict(payload.get("config") or {})
+    enriched["config"] = candidate_config
+    if config is None:
+        return enriched
+
+    for name in ("context_length", "gpu_budget", "min_gpu_budget", "min_endpoint", "startup_time"):
+        candidate_config.setdefault(name, _spica_search_space_value(config, name))
+
+    goal = getattr(config, "goal", None)
+    target = _spica_goal_target(goal)
+    if target is not None:
+        candidate_config["objective_target"] = target
+        candidate_config["planner_optimization_target"] = _spica_planner_target(goal)
+    for source_name, artifact_name in (
+        ("ttft_ms", "planner_ttft_ms"),
+        ("itl_ms", "planner_itl_ms"),
+        ("e2e_ms", "planner_e2e_ms"),
+    ):
+        candidate_config[artifact_name] = _spica_sla_value(config, source_name, None)
+    return enriched
+
+
+def _spica_scalar_value(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            scalar = _spica_scalar_value(item)
+            if scalar is not None:
+                return scalar
+        return None
+    if isinstance(value, set):
+        for item in sorted(value, key=str):
+            scalar = _spica_scalar_value(item)
+            if scalar is not None:
+                return scalar
+        return None
+    if isinstance(value, dict):
+        return None
+    try:
+        if pd.isna(value):
+            return None
+    except (TypeError, ValueError):
+        pass
+    return value
+
+
+def _spica_first_scalar(*values: Any, default: Any = None) -> Any:
+    for value in values:
+        scalar = _spica_scalar_value(value)
+        if scalar is not None:
+            return scalar
+    return default
+
+
+def _spica_pinned_scalar(value: Any) -> Any:
+    if isinstance(value, (list, tuple, set, dict)):
+        return None
+    return _spica_scalar_value(value)
+
+
+def _spica_trace_task(args, mode: str, candidate_df: pd.DataFrame, config: Any | None = None) -> _SpicaTraceTask:
+    first_row = candidate_df.iloc[0] if not candidate_df.empty else pd.Series(dtype=object)
+    backend = getattr(args, "backend", None) or "spica"
+    backend_series = candidate_df["backend"] if "backend" in candidate_df else pd.Series(dtype=object)
+    mode_backends = sorted(str(backend_name) for backend_name in backend_series.dropna().unique())
+    if mode_backends and (backend == "auto" or config is not None):
+        backend = ",".join(mode_backends)
+    backend_version_series = (
+        candidate_df["backend_version"] if "backend_version" in candidate_df else pd.Series(dtype=object)
+    )
+    mode_backend_versions = sorted(str(version) for version in backend_version_series.dropna().unique())
+    backend_version = ",".join(mode_backend_versions) if mode_backend_versions else "spica"
+
+    model_path = _spica_first_scalar(
+        first_row.get("model_name"),
+        _spica_search_space_value(config, "model_name"),
+        getattr(args, "model_path", None),
+        default="unknown",
+    )
+    system = _spica_first_scalar(
+        first_row.get("hardware_sku"),
+        _spica_search_space_value(config, "hardware_sku"),
+        getattr(args, "system", None),
+        default="unknown",
+    )
+    total_gpus = _spica_first_scalar(
+        _spica_pinned_scalar(_spica_search_space_value(config, "gpu_budget")),
+        first_row.get("gpu_budget"),
+        first_row.get("total_gpus"),
+        getattr(args, "total_gpus", None),
+        default=0,
+    )
+    goal = getattr(config, "goal", None)
+    if goal is not None:
+        # A native Spica config owns its goal. In particular, a throughput/latency
+        # config with no SLA must not inherit the CLI parser's legacy SLA defaults.
+        ttft = _spica_sla_value(config, "ttft_ms", None) or 0.0
+        tpot = _spica_sla_value(config, "itl_ms", None) or 0.0
+        request_latency = _spica_sla_value(config, "e2e_ms", None)
+    else:
+        ttft = getattr(args, "ttft", 0.0) or 0.0
+        tpot = getattr(args, "tpot", 0.0) or 0.0
+        request_latency = getattr(args, "request_latency", None)
+    workload_isl = _spica_first_scalar(_spica_workload_value(config, "isl"), getattr(args, "isl", None), default=0)
+    workload_osl = _spica_first_scalar(_spica_workload_value(config, "osl"), getattr(args, "osl", None), default=0)
+    objective_target = _spica_goal_target(goal) or "goodput_per_gpu"
+
+    return _SpicaTraceTask(
+        primary_model_path=str(model_path),
+        primary_system_name=str(system),
+        primary_backend_name=backend,
+        primary_backend_version=backend_version,
+        total_gpus=int(total_gpus),
+        serving_mode=mode,
+        ttft=float(ttft),
+        tpot=float(tpot),
+        request_latency=request_latency,
+        is_moe=_spica_trace_is_moe(candidate_df),
+        objective_target=objective_target,
+        planner_optimization_target=_spica_planner_target(goal),
+        min_gpu_budget=_spica_int(_spica_search_space_value(config, "min_gpu_budget")),
+        min_endpoint=_spica_int(_spica_search_space_value(config, "min_endpoint")),
+        isl=int(workload_isl),
+        osl=int(workload_osl),
+    )
+
+
+def _spica_trace_path_from_config(config: Any | None) -> str | None:
+    trace_path = _spica_workload_value(config, "trace_path", None)
+    return str(trace_path) if trace_path else None
+
+
+def _spica_workload_label(config: Any | None, args, config_path: str | None) -> str:
+    if _spica_trace_path_from_config(config):
+        return "trace"
+    if config_path:
+        return "config"
+    return "synthetic"
+
+
+def _spica_row_latencies(row: pd.Series) -> dict[str, float]:
+    return {
+        "ttft": _spica_float(row.get("ttft")) or 0.0,
+        "tpot": _spica_float(row.get("tpot")) or 0.0,
+        "request_latency": _spica_float(row.get("request_latency")) or 0.0,
+    }
+
+
+def _spica_pareto_front_df(
+    candidate_df: pd.DataFrame,
+    objectives: list[str],
+    directions: dict[str, bool],
+) -> pd.DataFrame:
+    """Compute dominance from Candidate.objectives in their natural directions."""
+    if candidate_df.empty or not objectives or any(name not in candidate_df.columns for name in objectives):
+        return candidate_df.iloc[0:0].copy()
+    pool = candidate_df.dropna(subset=objectives).copy()
+    if pool.empty:
+        return pool
+
+    records = list(pool[objectives].to_dict(orient="index").items())
+
+    def dominates(left: dict[str, Any], right: dict[str, Any]) -> bool:
+        strictly_better = False
+        for name in objectives:
+            left_value = float(left[name])
+            right_value = float(right[name])
+            better = left_value > right_value if directions[name] else left_value < right_value
+            worse = left_value < right_value if directions[name] else left_value > right_value
+            if worse:
+                return False
+            strictly_better = strictly_better or better
+        return strictly_better
+
+    retained = [
+        index
+        for index, values in records
+        if not any(other_index != index and dominates(other, values) for other_index, other in records)
+    ]
+    # Match Spica's public Pareto contract: trace the frontier left-to-right by
+    # the final configured objective, regardless of whether that axis is min/max.
+    return pool.loc[retained].sort_values(objectives[-1], ascending=True).reset_index(drop=True)
+
+
+def _spica_native_mode_result(
+    mode_df: pd.DataFrame,
+    goal: Any,
+    top_n: int,
+) -> tuple[pd.DataFrame, float, float, pd.DataFrame, str, str, dict[str, float], dict[str, bool]]:
+    target = _spica_goal_target(goal) or "throughput"
+    if target == "pareto":
+        objectives = _spica_pareto_objectives(goal)
+        directions = {name: _spica_target_maximize(name) for name in objectives}
+        frontier = _spica_pareto_front_df(mode_df, objectives, directions)
+        primary = objectives[0]
+        ranked = frontier.sort_values(primary, ascending=not directions[primary], kind="stable")
+        best = ranked.head(top_n).copy()
+        best_objective_score = 0.0
+        if not best.empty:
+            raw = _spica_float(best.iloc[0].get(primary)) or 0.0
+            best_objective_score = raw if directions[primary] else -raw
+        x_axis, y_axis = objectives[-1], objectives[0]
+    else:
+        target_maximize = _spica_target_maximize(target)
+        directions = {target: target_maximize, "objective_value": target_maximize, "tokens/s/user": True}
+        ranked = mode_df.sort_values("objective_score", ascending=False, kind="stable", na_position="last")
+        best = ranked.head(top_n).copy()
+        frontier = _spica_pareto_front_df(
+            mode_df,
+            ["objective_value", "tokens/s/user"],
+            directions,
+        )
+        best_objective_score = _spica_float(best.iloc[0].get("objective_score")) if not best.empty else 0.0
+        best_objective_score = best_objective_score or 0.0
+        x_axis, y_axis = "tokens/s/user", "objective_value"
+
+    best_throughput = _spica_float(best.iloc[0].get("tokens/s/gpu")) if not best.empty else 0.0
+    best_throughput = best_throughput or 0.0
+    latencies = _spica_row_latencies(best.iloc[0]) if not best.empty else _spica_row_latencies(pd.Series(dtype=object))
+    return best, best_throughput, best_objective_score, frontier, x_axis, y_axis, latencies, directions
+
+
+def _build_spica_trace_result_bundle(
+    candidates: list[Any],
+    args,
+    config: Any | None = None,
+    config_path: str | None = None,
+) -> _SpicaTraceResultBundle:
+    from aiconfigurator.cli.utils import process_experiment_result
+
+    payloads = [
+        _spica_enrich_candidate_payload(_spica_candidate_to_dict(candidate), config) for candidate in candidates
+    ]
+    goal = getattr(config, "goal", None)
+    candidate_df = _spica_candidates_to_result_df(payloads, goal=goal)
+    tasks: dict[str, _SpicaTraceTask] = {}
+    best_configs: dict[str, pd.DataFrame] = {}
+    best_throughputs: dict[str, float] = {}
+    best_objective_scores: dict[str, float] = {}
+    best_latencies: dict[str, dict[str, float]] = {}
+    pareto_fronts: dict[str, pd.DataFrame | None] = {}
+    pareto_x_axis: dict[str, str] = {}
+    pareto_y_axis: dict[str, str] = {}
+    objective_directions: dict[str, bool] = {}
+
+    for mode, mode_df in candidate_df.groupby("deployment_mode", sort=False):
+        mode = str(mode)
+        mode_df = mode_df.dropna(axis=1, how="all").copy()
+        mode_df = _normalize_spica_result_dtypes(mode_df)
+        task = _spica_trace_task(args, mode, mode_df, config)
+        tasks[mode] = task
+        if goal is not None:
+            (
+                best_config_df,
+                best_throughput,
+                best_objective_score,
+                pareto_frontier_df,
+                x_axis_col,
+                y_axis_col,
+                latencies,
+                mode_directions,
+            ) = _spica_native_mode_result(mode_df, goal, args.top_n)
+            objective_directions.update(mode_directions)
+        else:
+            best_config_df, best_throughput, pareto_frontier_df, x_axis_col, latencies = process_experiment_result(
+                task,
+                {"pareto_df": mode_df},
+                top_n=args.top_n,
+                strict_sla=getattr(args, "strict_sla", False),
+            )
+            best_objective_score = best_throughput
+            y_axis_col = "tokens/s/gpu"
+            objective_directions["goodput_per_gpu"] = True
+        best_configs[mode] = best_config_df
+        best_throughputs[mode] = best_throughput
+        best_objective_scores[mode] = best_objective_score
+        best_latencies[mode] = latencies
+        pareto_fronts[mode] = pareto_frontier_df
+        pareto_x_axis[mode] = x_axis_col
+        pareto_y_axis[mode] = y_axis_col
+
+    chosen_exp = max(best_objective_scores, key=best_objective_scores.get) if best_objective_scores else "none"
+    return _SpicaTraceResultBundle(
+        candidates=payloads,
+        candidate_df=candidate_df,
+        tasks=tasks,
+        trace_path=_spica_trace_path_from_config(config),
+        config_path=config_path,
+        workload_label=_spica_workload_label(config, args, config_path),
+        chosen_exp=chosen_exp,
+        best_configs=best_configs,
+        pareto_fronts=pareto_fronts,
+        best_throughputs=best_throughputs,
+        best_objective_scores=best_objective_scores,
+        best_latencies=best_latencies,
+        pareto_x_axis=pareto_x_axis,
+        pareto_y_axis=pareto_y_axis,
+        objective_target=_spica_goal_target(goal) or "goodput_per_gpu",
+        objective_directions=objective_directions,
+    )
+
+
+def _spica_safe_path_component(value: Any, *, strip_extension: bool = False) -> str:
+    text = str(value or "unknown")
+    if os.path.exists(text):
+        text = os.path.basename(os.path.abspath(text))
+    if strip_extension:
+        stem, ext = os.path.splitext(text)
+        if ext:
+            text = stem
+    safe = "".join(char if char.isalnum() or char in "._-" else "_" for char in text)
+    safe = safe.strip("._-")
+    return safe or "unknown"
+
+
+def _spica_trace_result_dir(result_bundle: _SpicaTraceResultBundle, save_dir: str) -> str:
+    first_task = next(iter(result_bundle.tasks.values()), None)
+    model = _spica_safe_path_component(getattr(first_task, "primary_model_path", "model"))
+    system = _spica_safe_path_component(getattr(first_task, "primary_system_name", "system"))
+    backend = _spica_safe_path_component(getattr(first_task, "primary_backend_name", "backend"))
+    ttft = int(getattr(first_task, "ttft", 0) or 0)
+    tpot = int(getattr(first_task, "tpot", 0) or 0)
+    if result_bundle.trace_path:
+        trace_name = _spica_safe_path_component(os.path.basename(result_bundle.trace_path), strip_extension=True)
+        workload = f"trace_{trace_name}"
+    elif result_bundle.config_path:
+        workload = "thorough_" + _spica_safe_path_component(
+            os.path.basename(result_bundle.config_path),
+            strip_extension=True,
+        )
+    else:
+        isl = int(getattr(first_task, "isl", 0) or 0)
+        osl = int(getattr(first_task, "osl", 0) or 0)
+        workload = f"thorough_isl{isl}_osl{osl}"
+    result_prefix = f"{model}_{system}_{backend}_{workload}_ttft{ttft}_tpot{tpot}"
+    return os.path.join(save_dir, f"{result_prefix}_{secrets.randbelow(1_000_000)}")
+
+
+def _spica_first_int(*values: Any, default: int = 1) -> int:
+    for value in values:
+        number = _spica_int(value)
+        if number is not None:
+            return number
+    return default
+
+
+def _spica_yaml_safe(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {str(key): _spica_yaml_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_spica_yaml_safe(item) for item in value]
+    try:
+        if bool(pd.isna(value)):
+            return None
+    except (TypeError, ValueError):
+        pass
+    if hasattr(value, "item"):
+        try:
+            return value.item()
+        except (TypeError, ValueError):
+            pass
+    return value
+
+
+def _spica_value_present(value: Any) -> bool:
+    if value is None:
+        return False
+    try:
+        return not bool(pd.isna(value))
+    except (TypeError, ValueError):
+        return True
+
+
+def _spica_bool(value: Any) -> bool | None:
+    if not _spica_value_present(value):
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "y", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "n", "off"}:
+            return False
+    return bool(value)
+
+
+def _spica_deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    merged = {key: _spica_deep_merge(value, {}) if isinstance(value, dict) else value for key, value in base.items()}
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _spica_deep_merge(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def _spica_set_if_present(target: dict[str, Any], key: str, value: Any) -> None:
+    if _spica_value_present(value):
+        target[key] = _spica_yaml_safe(value)
+
+
+def _spica_role_worker_overrides(
+    row: pd.Series,
+    role: str,
+    args: argparse.Namespace | None,
+) -> dict[str, Any]:
+    prefix = "agg" if role == "agg" else role
+    worker: dict[str, Any] = {}
+    engine_overrides: dict[str, Any] = {}
+
+    block_size = _spica_int(row.get(f"{prefix}_block_size"))
+    max_tokens = _spica_int(row.get(f"{prefix}_max_num_batched_tokens"))
+    if block_size and max_tokens is not None and max_tokens % block_size != 0:
+        raise ValueError(
+            f"{prefix}_max_num_batched_tokens={max_tokens} must be divisible by {prefix}_block_size={block_size}"
+        )
+    if max_tokens is not None:
+        worker["max_num_tokens"] = max_tokens
+        worker["max_prefill_tokens"] = max_tokens
+        engine_overrides["max_num_tokens"] = max_tokens
+
+    _spica_set_if_present(worker, "tokens_per_block", block_size)
+    _spica_set_if_present(
+        worker,
+        "kv_cache_free_gpu_memory_fraction",
+        _spica_float(row.get(f"{prefix}_gpu_memory_utilization")),
+    )
+
+    prefix_caching = _spica_bool(row.get(f"{prefix}_enable_prefix_caching"))
+    if prefix_caching is not None:
+        worker["disable_prefix_cache"] = not prefix_caching
+
+    attention_dp_key = "attention_dp" if role == "agg" else f"{prefix}_attention_dp"
+    attention_dp = _spica_int(row.get(attention_dp_key))
+    if attention_dp is not None and attention_dp > 1:
+        worker["enable_attention_dp"] = True
+        engine_overrides["enable_attention_dp"] = True
+
+    max_seq_len = _spica_first_int(row.get("context_length"), getattr(args, "max_seq_len", None), default=0)
+    if max_seq_len > 0:
+        worker["max_seq_len"] = max_seq_len
+        engine_overrides["max_seq_len"] = max_seq_len
+
+    transfer_buffer_tokens = max(max_tokens or 0, max_seq_len)
+    if role != "agg" and transfer_buffer_tokens > 0:
+        if block_size and transfer_buffer_tokens % block_size != 0:
+            raise ValueError(
+                f"{role} cache_transceiver_max_tokens_in_buffer={transfer_buffer_tokens} must be divisible by "
+                f"{prefix}_block_size={block_size}"
+            )
+        worker["cache_transceiver_max_tokens_in_buffer"] = transfer_buffer_tokens
+        engine_overrides["cache_transceiver_config"] = {
+            "backend": "DEFAULT",
+            "max_tokens_in_buffer": transfer_buffer_tokens,
+        }
+
+    nextn = _spica_int(row.get("aic_nextn"))
+    if nextn is not None and nextn > 0:
+        worker["speculative_decoding_type"] = "MTP"
+        worker["num_nextn_predict_layers"] = nextn
+        engine_overrides["speculative_config"] = {
+            "decoding_type": "MTP",
+            "num_nextn_predict_layers": nextn,
+        }
+
+    if engine_overrides:
+        worker["extra_engine_args"] = engine_overrides
+
+    return worker
+
+
+def _spica_router_enabled(row: pd.Series) -> bool | None:
+    router_mode = row.get("router_mode")
+    if not _spica_value_present(router_mode):
+        return None
+    normalized = str(router_mode).strip().lower()
+    return normalized not in {"", "n/a", "none", "disabled"}
+
+
+def _spica_router_mode(row: pd.Series) -> str | None:
+    if not _spica_value_present(row.get("router_mode")):
+        return None
+    return normalize_router_mode(str(row.get("router_mode")))
+
+
+def _spica_router_block_size(row: pd.Series) -> int | None:
+    mode = str(row.get("deployment_mode") or "")
+    if mode == "agg":
+        return _spica_int(row.get("agg_block_size"))
+    return _spica_first_int(row.get("decode_block_size"), row.get("prefill_block_size"), default=0) or None
+
+
+def _spica_router_config(row: pd.Series) -> dict[str, Any] | None:
+    if _spica_router_enabled(row) is not True:
+        return None
+
+    router: dict[str, Any] = {}
+    _spica_set_if_present(router, "kv_cache_block_size", _spica_router_block_size(row))
+    for key in (
+        "overlap_score_credit",
+        "prefill_load_scale",
+        "host_cache_hit_weight",
+        "disk_cache_hit_weight",
+        "router_temperature",
+    ):
+        _spica_set_if_present(router, key, row.get(key))
+
+    no_admission_control = _spica_bool(row.get("no_admission_control"))
+    if no_admission_control is True:
+        router["admission_control"] = "none"
+    else:
+        threshold_keys = ("active_decode_blocks_threshold", "active_prefill_tokens_threshold_frac")
+        for key in threshold_keys:
+            _spica_set_if_present(router, key, row.get(key))
+        # pandas promotes sparse integer columns to float (e.g. 10000 -> 10000.0),
+        # but Dynamo's router schema requires an actual integer for this threshold.
+        _spica_set_if_present(
+            router,
+            "active_prefill_tokens_threshold",
+            _spica_int(row.get("active_prefill_tokens_threshold")),
+        )
+        all_threshold_keys = (*threshold_keys, "active_prefill_tokens_threshold")
+        if any(_spica_value_present(row.get(key)) for key in all_threshold_keys):
+            router["admission_control"] = "token-capacity"
+
+    return router or None
+
+
+def _spica_engine_num_gpu(row: pd.Series, role: str) -> int:
+    if role == "agg":
+        return (
+            _spica_first_int(row.get("tp"), default=1)
+            * _spica_first_int(row.get("pp"), default=1)
+            * _spica_first_int(row.get("attention_dp"), default=1)
+        )
+    return (
+        _spica_first_int(row.get(f"{role}_tp"), default=1)
+        * _spica_first_int(row.get(f"{role}_pp"), default=1)
+        * _spica_first_int(row.get(f"{role}_attention_dp"), default=1)
+    )
+
+
+def _spica_planner_config(
+    args: argparse.Namespace | None,
+    row: pd.Series,
+    task: _SpicaTraceTask | argparse.Namespace | None = None,
+) -> dict[str, Any] | None:
+    enable_throughput = bool(_spica_bool(row.get("enable_throughput_scaling")))
+    enable_load = bool(_spica_bool(row.get("enable_load_scaling")))
+    if not (enable_throughput or enable_load):
+        return None
+
+    backend = str(
+        row.get("backend") or getattr(args, "backend", None) or getattr(args, "primary_backend_name", None) or "trtllm"
+    )
+    mode = str(row.get("deployment_mode") or "disagg")
+    model_name = row.get("model_name")
+    if not _spica_value_present(model_name) and task is not None:
+        model_name = getattr(task, "primary_model_path", None)
+    if not _spica_value_present(model_name) and args is not None:
+        model_name = getattr(args, "model_path", None) or getattr(args, "primary_model_path", None)
+    planner: dict[str, Any] = {
+        "environment": "kubernetes",
+        "backend": backend,
+        "mode": mode,
+        "optimization_target": str(
+            row.get("planner_optimization_target") or getattr(task, "planner_optimization_target", None) or "sla"
+        ),
+        "enable_throughput_scaling": enable_throughput,
+        "enable_load_scaling": enable_load,
+    }
+    if model_name or _spica_value_present(row.get("model_name")):
+        planner["model_name"] = model_name or row.get("model_name")
+
+    for key in (
+        "throughput_adjustment_interval_seconds",
+        "load_adjustment_interval_seconds",
+        "max_num_fpm_samples",
+        "fpm_sample_bucket_size",
+        "load_scaling_down_sensitivity",
+        "load_min_observations",
+        "load_predictor",
+        "load_predictor_log1p",
+        "prophet_window_size",
+        "kalman_q_level",
+        "kalman_q_trend",
+        "kalman_r",
+        "kalman_min_points",
+    ):
+        _spica_set_if_present(planner, key, row.get(key))
+
+    max_gpu_budget = _spica_first_int(row.get("max_gpu_budget"), row.get("gpu_budget"), default=0)
+    if max_gpu_budget > 0:
+        planner["max_gpu_budget"] = max_gpu_budget
+    min_gpu_budget = _spica_int(row.get("min_gpu_budget"))
+    if min_gpu_budget is None and task is not None:
+        min_gpu_budget = _spica_int(getattr(task, "min_gpu_budget", None))
+    if min_gpu_budget is not None:
+        planner["min_gpu_budget"] = min_gpu_budget
+    min_endpoint = _spica_int(row.get("min_endpoint"))
+    if min_endpoint is None and task is not None:
+        min_endpoint = _spica_int(getattr(task, "min_endpoint", None))
+    if min_endpoint is not None:
+        planner["min_endpoint"] = min_endpoint
+
+    if mode == "agg":
+        planner["decode_engine_num_gpu"] = _spica_engine_num_gpu(row, "agg")
+    else:
+        planner["prefill_engine_num_gpu"] = _spica_engine_num_gpu(row, "prefill")
+        planner["decode_engine_num_gpu"] = _spica_engine_num_gpu(row, "decode")
+
+    if planner["optimization_target"] == "sla":
+        ttft = row.get("planner_ttft_ms")
+        tpot = row.get("planner_itl_ms")
+        if not _spica_value_present(ttft) and task is not None:
+            ttft = getattr(task, "ttft", None)
+        if not _spica_value_present(tpot) and task is not None:
+            tpot = getattr(task, "tpot", None)
+        if not _spica_value_present(ttft) and args is not None:
+            ttft = getattr(args, "ttft", None)
+        if not _spica_value_present(tpot) and args is not None:
+            tpot = getattr(args, "tpot", None)
+        _spica_set_if_present(planner, "ttft_ms", ttft)
+        _spica_set_if_present(planner, "itl_ms", tpot)
+
+    # Spica replay suppresses large periodic planner reports; keep live deploy
+    # artifacts similarly quiet unless the user overrides this later.
+    planner.setdefault("report_interval_hours", None)
+    planner.setdefault("live_dashboard_port", 0)
+    return planner
+
+
+def _spica_kvbm_config(row: pd.Series) -> dict[str, Any] | None:
+    num_g2_blocks = _spica_int(row.get("num_g2_blocks"))
+    # SearchSpace defines zero G2 blocks as disabling host offload. Do not let an
+    # independently pinned batch size accidentally turn KVBM back on in artifacts.
+    if num_g2_blocks is None or num_g2_blocks <= 0:
+        return None
+
+    kvbm: dict[str, Any] = {"cpu_cache_override_num_blocks": num_g2_blocks}
+    offload_batch_size = _spica_int(row.get("offload_batch_size"))
+    if offload_batch_size is not None and offload_batch_size > 0:
+        kvbm["max_transfer_batch_size"] = offload_batch_size
+        kvbm["max_concurrent_transfers"] = offload_batch_size
+    return kvbm or None
+
+
+def _spica_generator_overrides(
+    args: argparse.Namespace | None,
+    row: pd.Series,
+    task: _SpicaTraceTask | argparse.Namespace | None = None,
+) -> dict[str, Any]:
+    from aiconfigurator.generator.api import load_generator_overrides_from_args
+
+    mode = str(row.get("deployment_mode") or "")
+    roles = ["agg"] if mode == "agg" else ["prefill", "decode"]
+    spica_overrides: dict[str, Any] = {"Workers": {}}
+
+    for role in roles:
+        worker = _spica_role_worker_overrides(row, role, args)
+        if worker:
+            spica_overrides["Workers"][role] = worker
+    if not spica_overrides["Workers"]:
+        spica_overrides.pop("Workers")
+
+    dyn_overrides: dict[str, Any] = {}
+    router_enabled = _spica_router_enabled(row)
+    if router_enabled is not None:
+        dyn_overrides["enable_router"] = router_enabled
+        router_mode = _spica_router_mode(row)
+        if router_mode is not None:
+            dyn_overrides["router_mode"] = router_mode
+        router_config = _spica_router_config(row)
+        if router_config:
+            dyn_overrides["router_config"] = router_config
+    planner_config = _spica_planner_config(args, row, task)
+    if planner_config:
+        dyn_overrides["planner_config"] = planner_config
+    kvbm_config = _spica_kvbm_config(row)
+    if kvbm_config:
+        dyn_overrides["kvbm_config"] = kvbm_config
+    if dyn_overrides:
+        spica_overrides["DynConfig"] = dyn_overrides
+
+    nextn = _spica_int(row.get("aic_nextn"))
+    if nextn is not None and nextn > 0:
+        spica_overrides["ModelConfig"] = {"nextn": nextn}
+
+    user_overrides = load_generator_overrides_from_args(args) if args is not None else {}
+    return _spica_deep_merge(spica_overrides, user_overrides)
+
+
+def _spica_generator_result_row(row: pd.Series) -> pd.Series:
+    generator_row = row.copy()
+    mode = str(generator_row.get("deployment_mode") or "")
+    if mode == "agg":
+        generator_row["workers"] = _spica_first_int(generator_row.get("replicas"), generator_row.get("workers"))
+        generator_row["bs"] = _spica_first_int(
+            generator_row.get("agg_max_num_seqs"),
+            generator_row.get("max_num_seqs"),
+            generator_row.get("bs"),
+        )
+    elif mode == "disagg":
+        generator_row["(p)bs"] = _spica_first_int(
+            generator_row.get("prefill_max_num_seqs"),
+            generator_row.get("(p)bs"),
+        )
+        generator_row["(d)bs"] = _spica_first_int(
+            generator_row.get("decode_max_num_seqs"),
+            generator_row.get("(d)bs"),
+        )
+    return generator_row
+
+
+def _spica_generator_task(task: _SpicaTraceTask, row: pd.Series) -> argparse.Namespace:
+    nextn = _spica_int(row.get("aic_nextn")) or 0
+    backend_version = _spica_first_scalar(
+        row.get("backend_version"),
+        task.primary_backend_version,
+        default="spica",
+    )
+    return argparse.Namespace(
+        primary_backend_name=str(row.get("backend") or task.primary_backend_name),
+        primary_system_name=task.primary_system_name,
+        primary_backend_version=str(backend_version),
+        primary_model_path=task.primary_model_path,
+        prefix=0,
+        is_moe=task.is_moe,
+        nextn=nextn,
+        nextn_accept_rates=[0.85, 0.8, 0.6, 0.0, 0.0],
+        serving_mode=str(row.get("deployment_mode") or task.serving_mode),
+        total_gpus=_spica_first_int(row.get("total_gpus"), row.get("num_total_gpus"), task.total_gpus),
+        system_name=task.primary_system_name,
+        isl=task.isl,
+        osl=task.osl,
+        ttft=task.ttft,
+        tpot=task.tpot,
+    )
+
+
+def _spica_num_gpus_per_node(system_name: str) -> int:
+    try:
+        spec = perf_database.load_system_spec(system_name)
+        return int(((spec or {}).get("node") or {}).get("num_gpus_per_node") or 8)
+    except Exception:
+        return 8
+
+
+def _spica_generated_backend_version(
+    args: argparse.Namespace | None,
+    backend_name: str,
+    evaluated_backend_version: str | None = None,
+) -> str | None:
+    from aiconfigurator.generator.api import (
+        get_default_dynamo_version_mapping,
+        load_generator_overrides_from_args,
+        resolve_backend_version_for_dynamo,
+    )
+
+    # A selected Spica row must render against the same backend version that its
+    # replay used. CLI/default generator mappings are only a fallback for legacy
+    # candidate payloads that predate this field.
+    if evaluated_backend_version and evaluated_backend_version != "spica":
+        return evaluated_backend_version
+    if args is None:
+        return None
+    if generated_config_version := getattr(args, "generated_config_version", None):
+        return generated_config_version
+    generator_overrides = load_generator_overrides_from_args(args)
+    if dynamo_version := generator_overrides.get("generator_dynamo_version"):
+        try:
+            return resolve_backend_version_for_dynamo(dynamo_version, backend_name)
+        except ValueError:
+            logger.exception("Failed to resolve backend version for generator_dynamo_version=%s.", dynamo_version)
+            return None
+    default_dynamo_version, default_backend_versions = get_default_dynamo_version_mapping()
+    backend_version = default_backend_versions.get(backend_name)
+    if backend_version is None:
+        logger.warning(
+            "No default backend version mapping for backend '%s' in dynamo '%s'; using generator defaults.",
+            backend_name,
+            default_dynamo_version,
+        )
+    return backend_version
+
+
+def _spica_generated_artifact_paths(top_config_dir: str, known_paths: set[str]) -> list[str]:
+    paths: list[str] = []
+    for root, _, filenames in os.walk(top_config_dir):
+        for filename in filenames:
+            path = os.path.join(root, filename)
+            if path not in known_paths:
+                paths.append(path)
+    return sorted(paths)
+
+
+def _validate_spica_artifact_target(generator_config: dict[str, Any], deployment_target: str) -> None:
+    """Reject deployment targets that would silently drop evaluated Spica features."""
+    if deployment_target == "dynamo-j2":
+        return
+    dyn_config = generator_config.get("DynConfig") or {}
+    if not isinstance(dyn_config, dict):
+        return
+
+    unsupported: list[str] = []
+    if dyn_config.get("enable_router") or dyn_config.get("router_mode") or dyn_config.get("router_config"):
+        unsupported.append("router")
+    if dyn_config.get("planner_config"):
+        unsupported.append("planner")
+    if dyn_config.get("kvbm_config"):
+        unsupported.append("KVBM")
+    if unsupported:
+        features = ", ".join(unsupported)
+        raise RuntimeError(
+            f"Spica artifact generation cannot faithfully emit {features} for deployment target "
+            f"'{deployment_target}'. Use --deployment-target dynamo-j2 or disable those Spica features."
+        )
+
+
+def _generate_spica_backend_artifacts(
+    args: argparse.Namespace | None,
+    generator_config: dict[str, Any],
+    generator_task: argparse.Namespace,
+    top_config_dir: str,
+    written_paths: list[str],
+) -> None:
+    from aiconfigurator.generator.api import generate_from_request
+    from aiconfigurator.generator.request import from_legacy_params
+
+    backend_version = _spica_generated_backend_version(
+        args,
+        generator_task.primary_backend_name,
+        getattr(generator_task, "primary_backend_version", None),
+    )
+    deployment_target = getattr(args, "deployment_target", "dynamo-j2") if args is not None else "dynamo-j2"
+    _validate_spica_artifact_target(generator_config, deployment_target)
+    req = from_legacy_params(generator_config, backend=generator_task.primary_backend_name)
+    req = dataclasses.replace(
+        req,
+        backend=dataclasses.replace(req.backend, generated_config_version=backend_version),
+        emit=dataclasses.replace(req.emit, deployment_target=deployment_target, output_dir=top_config_dir),
+    )
+    known_paths = set(written_paths)
+    try:
+        generate_from_request(req)
+    except Exception as exc:
+        raise RuntimeError(f"Failed to generate backend config from Spica result in {top_config_dir}: {exc}") from exc
+    written_paths.extend(_spica_generated_artifact_paths(top_config_dir, known_paths))
+
+
+def _save_spica_top_config_artifacts(
+    result_bundle: _SpicaTraceResultBundle,
+    mode: str,
+    mode_dir: str,
+    best_config_df: pd.DataFrame,
+    args: argparse.Namespace | None = None,
+) -> list[str]:
+    from aiconfigurator.generator.module_bridge import task_config_to_generator_config
+
+    task = result_bundle.tasks.get(mode)
+    if task is None or best_config_df.empty:
+        return []
+
+    written_paths: list[str] = []
+    num_gpus_per_node = _spica_num_gpus_per_node(task.primary_system_name)
+    for rank, (_, row) in enumerate(best_config_df.iterrows(), start=1):
+        top_config_dir = os.path.join(mode_dir, f"top{rank}")
+        os.makedirs(top_config_dir, exist_ok=True)
+
+        generator_row = _spica_generator_result_row(row)
+        generator_task = _spica_generator_task(task, generator_row)
+        override_args = args if args is not None else task
+        generator_config = task_config_to_generator_config(
+            task_config=generator_task,
+            result_df=generator_row,
+            generator_overrides=_spica_generator_overrides(override_args, generator_row, generator_task),
+            num_gpus_per_node=num_gpus_per_node,
+        )
+        generator_config_yaml = os.path.join(top_config_dir, "generator_config.yaml")
+        with open(generator_config_yaml, "w", encoding="utf-8") as fh:
+            yaml.safe_dump(_spica_yaml_safe(generator_config), fh, sort_keys=False)
+        written_paths.append(generator_config_yaml)
+        _generate_spica_backend_artifacts(args, generator_config, generator_task, top_config_dir, written_paths)
+
+        candidate_id = _spica_int(row.get("spica_candidate_id"))
+        if candidate_id is not None and 0 <= candidate_id < len(result_bundle.candidates):
+            candidate_payload = result_bundle.candidates[candidate_id]
+        else:
+            candidate_payload = {"row": row.to_dict()}
+        candidate_yaml = os.path.join(top_config_dir, "spica_candidate.yaml")
+        with open(candidate_yaml, "w", encoding="utf-8") as fh:
+            yaml.safe_dump(_spica_yaml_safe(candidate_payload), fh, sort_keys=False)
+        written_paths.append(candidate_yaml)
+
+    return written_paths
+
+
+def _save_spica_pareto_plot(result_bundle: _SpicaTraceResultBundle, save_dir: str) -> str | None:
+    pareto_fronts = {name: df for name, df in result_bundle.pareto_fronts.items() if df is not None and not df.empty}
+    if not pareto_fronts:
+        return None
+
+    axes = {
+        (
+            result_bundle.pareto_x_axis.get(name, "tokens/s/user"),
+            result_bundle.pareto_y_axis.get(name, "tokens/s/gpu"),
+        )
+        for name in pareto_fronts
+    }
+    if len(axes) > 1:
+        logger.warning("Skipping combined Spica Pareto plot because modes use different axes: %s", sorted(axes))
+        return None
+    x_axis, y_axis = axes.pop()
+    if x_axis == y_axis:
+        # Scalar searches have a ranking, not a two-dimensional Pareto tradeoff.
+        return None
+    if any(x_axis not in df.columns or y_axis not in df.columns for df in pareto_fronts.values()):
+        logger.warning(
+            "Skipping Spica Pareto plot because axes (%s, %s) are missing from one or more frontiers",
+            x_axis,
+            y_axis,
+        )
+        return None
+
+    path = os.path.join(save_dir, "pareto_frontier.png")
+    fig, ax = plt.subplots(1, 1, figsize=(8, 5))
+    colors = ["#1f77b4", "#ff7f0e", "#2ca02c", "#9467bd", "#8c564b", "#17becf"]
+    maximize_x = result_bundle.objective_directions.get(x_axis, x_axis != "request_latency")
+    maximize_y = result_bundle.objective_directions.get(y_axis, y_axis != "request_latency")
+
+    preferred_modes = [mode for mode in ("agg", "disagg") if mode in pareto_fronts]
+    other_modes = sorted(mode for mode in pareto_fronts if mode not in {"agg", "disagg"})
+    for idx, mode in enumerate([*preferred_modes, *other_modes]):
+        df = pareto_fronts[mode]
+        pareto_analysis.draw_pareto(
+            df,
+            x_axis,
+            y_axis,
+            ax,
+            colors[idx % len(colors)],
+            mode,
+            maximize_x=maximize_x,
+            maximize_y=maximize_y,
+        )
+
+    best = result_bundle.best_configs.get(result_bundle.chosen_exp, pd.DataFrame()).head(1)
+    if not best.empty and x_axis in best and y_axis in best:
+        ax.scatter(best[x_axis], best[y_axis], color="black", marker="x", label="best")
+
+    ax.set_title("Spica Pareto Frontier")
+    ax.set_xlabel(x_axis)
+    ax.set_ylabel(y_axis)
+    ax.legend()
+    plt.savefig(path)
+    plt.close(fig)
+    return path
+
+
+def _save_spica_trace_artifacts(
+    result_bundle: _SpicaTraceResultBundle,
+    save_dir: str,
+    args: argparse.Namespace | None = None,
+) -> list[str]:
+    result_dir = _spica_trace_result_dir(result_bundle, save_dir)
+    os.makedirs(result_dir, exist_ok=True)
+    written_paths: list[str] = []
+
+    candidates_yaml = os.path.join(result_dir, "spica_candidates.yaml")
+    with open(candidates_yaml, "w", encoding="utf-8") as fh:
+        yaml.safe_dump(result_bundle.candidates, fh, sort_keys=False)
+    written_paths.append(candidates_yaml)
+
+    if not result_bundle.candidate_df.empty:
+        candidates_csv = os.path.join(result_dir, "spica_candidates.csv")
+        result_bundle.candidate_df.to_csv(candidates_csv, index=False)
+        written_paths.append(candidates_csv)
+
+    nonempty_fronts = [df for df in result_bundle.pareto_fronts.values() if df is not None and not df.empty]
+    if nonempty_fronts:
+        combined_pareto = pd.concat(nonempty_fronts, ignore_index=True)
+    else:
+        combined_pareto = result_bundle.candidate_df.iloc[0:0].copy()
+    pareto_csv = os.path.join(result_dir, "pareto.csv")
+    combined_pareto.to_csv(pareto_csv, index=False)
+    written_paths.append(pareto_csv)
+
+    plot_path = _save_spica_pareto_plot(result_bundle, result_dir)
+    if plot_path is not None:
+        written_paths.append(plot_path)
+
+    for mode, pareto_df in result_bundle.pareto_fronts.items():
+        mode_dir = os.path.join(result_dir, str(mode))
+        os.makedirs(mode_dir, exist_ok=True)
+
+        if mode in result_bundle.tasks:
+            mode_config_yaml = os.path.join(mode_dir, "exp_config.yaml")
+            with open(mode_config_yaml, "w", encoding="utf-8") as fh:
+                fh.write(result_bundle.tasks[mode].to_yaml())
+            written_paths.append(mode_config_yaml)
+
+        mode_pareto_csv = os.path.join(mode_dir, "pareto.csv")
+        if pareto_df is None:
+            pareto_df = result_bundle.candidate_df.iloc[0:0].copy()
+        pareto_df.to_csv(mode_pareto_csv, index=False)
+        written_paths.append(mode_pareto_csv)
+
+        mode_best_csv = os.path.join(mode_dir, "best_config_topn.csv")
+        best_config_df = result_bundle.best_configs.get(mode, pd.DataFrame())
+        best_config_df.to_csv(mode_best_csv, index=False)
+        written_paths.append(mode_best_csv)
+        written_paths.extend(_save_spica_top_config_artifacts(result_bundle, mode, mode_dir, best_config_df, args))
+
+    return written_paths
+
+
+def _build_spica_default_search_space(args, backends: list[str]) -> dict[str, Any]:
+    search_space: dict[str, Any] = {
+        "model_name": args.model_path,
+        "hardware_sku": args.system,
+        "gpu_budget": args.total_gpus,
+        "backend": backends,
+        "router_mode": ["round_robin"],
+        "overlap_score_credit": [0.0],
+        "prefill_load_scale": [0.0],
+        "router_temperature": [0.0],
+        "planner_scaling_policy": ["disabled"],
+        "planner_fpm_sampling": ["default"],
+        "planner_load_sensitivity": ["default"],
+        "prefill_gpu_memory_utilization": args.free_gpu_memory_fraction,
+        "decode_gpu_memory_utilization": args.free_gpu_memory_fraction,
+        "agg_gpu_memory_utilization": args.free_gpu_memory_fraction,
+    }
+    if args.max_seq_len is not None:
+        search_space["context_length"] = args.max_seq_len
+    if args.nextn > 0:
+        search_space["aic_nextn"] = args.nextn
+
+    if args.total_gpus == 1:
+        logger.info("Constraining Spica default search to aggregate mode for a single-GPU budget.")
+        search_space.update(
+            {
+                "deployment_mode": ["agg"],
+            }
+        )
+
+    return search_space
+
+
+def _build_spica_trace_search_space(args, backends: list[str]) -> dict[str, Any]:
+    return _build_spica_default_search_space(args, backends)
+
+
+def _spica_synthetic_concurrency(args) -> int:
+    default = max(1, int(args.total_gpus or 1) * SPICA_THOROUGH_SYNTHETIC_CONCURRENCY_PER_GPU)
+    return _positive_int_env("AIC_SPICA_THOROUGH_SYNTHETIC_CONCURRENCY", default)
+
+
+def _spica_synthetic_num_request_ratio(concurrency: int) -> float:
+    ratio = _positive_float_env(
+        "AIC_SPICA_THOROUGH_SYNTHETIC_NUM_REQUEST_RATIO",
+        aliases=("AIC_SPICA_TRACE_SYNTHETIC_NUM_REQUEST_RATIO",),
+    )
+    if ratio is not None:
+        return ratio
+
+    target_request_count = _positive_int_env(
+        "AIC_SPICA_THOROUGH_SYNTHETIC_REQUEST_COUNT",
+        SPICA_THOROUGH_SYNTHETIC_REQUEST_COUNT_TARGET,
+        aliases=("AIC_SPICA_TRACE_SYNTHETIC_REQUEST_COUNT",),
+    )
+    return float(target_request_count) / float(concurrency)
+
+
+def _build_spica_default_workload(args) -> dict[str, Any]:
+    concurrency = _spica_synthetic_concurrency(args)
+    workload: dict[str, Any] = {
+        "isl": args.isl,
+        "osl": args.osl,
+        "concurrency": concurrency,
+        "num_request_ratio": _spica_synthetic_num_request_ratio(concurrency),
+    }
+    if getattr(args, "prefix", 0) > 0 and args.isl > 0:
+        workload["shared_prefix_ratio"] = min(1.0, max(0.0, float(args.prefix) / float(args.isl)))
+        workload["num_prefix_groups"] = 1
+    return workload
+
+
+def _build_spica_thorough_config_data(args, backends: list[str]) -> dict[str, Any]:
+    return {
+        "search_space": _build_spica_default_search_space(args, backends),
+        "workload": _build_spica_default_workload(args),
+        "goal": {"target": "goodput_per_gpu", "sla": {"ttft_ms": args.ttft, "itl_ms": args.tpot}},
+        "sweep": _spica_thorough_sweep_config(),
+    }
+
+
+def _spica_config_summary(config: Any) -> dict[str, Any]:
+    search_space = getattr(config, "search_space", None)
+    workload = getattr(config, "workload", None)
+    goal = getattr(config, "goal", None)
+    sweep = getattr(config, "sweep", None)
+    return {
+        "model": getattr(search_space, "model_name", None),
+        "system": getattr(search_space, "hardware_sku", None),
+        "gpu_budget": getattr(search_space, "gpu_budget", None),
+        "backend": getattr(search_space, "backend", None),
+        "workload": workload,
+        "goal": goal,
+        "sweep": {
+            "max_rounds": getattr(sweep, "max_rounds", None),
+            "parallel_evals": getattr(sweep, "parallel_evals", None),
+            "candidates_per_round": getattr(sweep, "candidates_per_round", None),
+        },
+    }
+
+
+def _spica_extra_input_lines(config: Any, config_path: str | None) -> list[str]:
+    workload = getattr(config, "workload", None)
+    goal = getattr(config, "goal", None)
+    sla = getattr(goal, "sla", None)
+    lines: list[str] = []
+    if config_path:
+        lines.append(f"Spica Config: {config_path}")
+    if getattr(workload, "trace_path", None):
+        trace_format = getattr(workload, "trace_format", None)
+        lines.append(f"Trace: {workload.trace_path}")
+        if trace_format:
+            lines.append(f"Trace Format: {trace_format}")
+        lines.append("Trace workload: request lengths come from replay.")
+    else:
+        lines.append(
+            "Synthetic Workload: "
+            f"ISL={getattr(workload, 'isl', 'n/a')}, "
+            f"OSL={getattr(workload, 'osl', 'n/a')}, "
+            f"concurrency={getattr(workload, 'concurrency', 'n/a')}, "
+            f"num_request_ratio={getattr(workload, 'num_request_ratio', 'n/a')}"
+        )
+    if sla is not None:
+        if getattr(sla, "ttft_ms", None) is not None:
+            lines.append(f"TTFT Target: {sla.ttft_ms:.2f}ms")
+        if getattr(sla, "itl_ms", None) is not None:
+            lines.append(f"TPOT Target: {sla.itl_ms:.2f}ms")
+        if getattr(sla, "e2e_ms", None) is not None:
+            lines.append(f"Request Latency Target: {sla.e2e_ms:.2f}ms")
+    return lines
+
+
+def _load_spica_config(args, smart_search_config_cls):
+    config_path = getattr(args, "thorough_config", None)
+    if config_path:
+        return smart_search_config_cls.from_yaml(config_path), config_path
+
+    backends = [backend.value for backend in common.BackendName] if args.backend == "auto" else [args.backend]
+    config_data = _build_spica_thorough_config_data(args, backends)
+    return smart_search_config_cls.model_validate(config_data), None
+
+
+def _install_dynamo_planner_bridge_compat() -> None:
+    """Keep older Spica synthetic replay imports working with newer Dynamo module layout."""
+    try:
+        import dynamo.mocker as dynamo_mocker
+        from dynamo.llm import MockEngineArgs, PlannerReplayBridge
+
+        if not hasattr(dynamo_mocker, "MockEngineArgs"):
+            dynamo_mocker.MockEngineArgs = MockEngineArgs
+        if not hasattr(dynamo_mocker, "PlannerReplayBridge"):
+            dynamo_mocker.PlannerReplayBridge = PlannerReplayBridge
+    except Exception as exc:
+        logger.debug("Could not install Dynamo replay compatibility shim: %s", exc)
+
+
+class _SpicaReplayEvaluatorCompat:
+    """ReplayEvaluator wrapper that installs AIC/Dynamo compatibility in spawned workers."""
+
+    def __init__(self, workload: Any, goal: Any):
+        self.workload = workload
+        self.goal = goal
+        self._evaluator: Any | None = None
+
+    def evaluate(self, plan: Any, *, concurrency_override: int | None = None) -> dict[str, float]:
+        _install_dynamo_planner_bridge_compat()
+        if self._evaluator is None:
+            from spica.evaluator import ReplayEvaluator
+
+            self._evaluator = ReplayEvaluator(self.workload, self.goal)
+        return self._evaluator.evaluate(plan, concurrency_override=concurrency_override)
+
+
+def run_spica_thorough_default(args) -> list[Any]:
+    """Run the Spica thorough sweeper for ``default --thorough-sweep`` / ``--thorough-config``."""
+    from aiconfigurator.cli.report_and_save import log_final_summary
+
+    if (
+        getattr(args, "thorough_config", None) is None
+        and getattr(args, "decode_system", None) is not None
+        and getattr(args, "decode_system", None) != getattr(args, "system", None)
+    ):
+        raise SystemExit(
+            "Spica thorough sweep currently requires homogeneous hardware when deriving config from CLI inputs; "
+            "omit --decode-system, set it to --system, or provide a native --thorough-config."
+        )
+
+    if getattr(args, "backend_version", None) is not None:
+        logger.warning(
+            "--backend-version is currently ignored in Spica thorough mode; Spica resolves backend versions."
+        )
+    if getattr(args, "database_mode", common.DatabaseMode.SILICON.name) != common.DatabaseMode.SILICON.name:
+        logger.warning("--database-mode is currently ignored in Spica thorough mode.")
+    if getattr(args, "request_latency", None) is not None:
+        logger.warning("--request-latency is currently ignored in Spica thorough mode; using --ttft/--tpot as the SLA.")
+    if getattr(args, "enable_wideep", False):
+        logger.warning("--enable-wideep is currently ignored in Spica thorough mode.")
+    if getattr(args, "moe_backend", None) is not None:
+        logger.warning("--moe-backend is currently ignored in Spica thorough mode.")
+
+    if sys.version_info >= (3, 13):
+        raise SystemExit(
+            "Spica thorough sweep currently requires Python 3.10-3.12 because its Vizier/JAX search "
+            "dependencies are not supported on Python 3.13 yet."
+        )
+
+    try:
+        from spica.config import SmartSearchConfig
+        from spica.search import run_smart_search
+    except ImportError as exc:
+        raise SystemExit(
+            "Spica thorough sweep requires the optional Spica smart-sweep dependencies. "
+            "Install AIC with the 'spica' extra, then rerun with --thorough-sweep or --thorough-config."
+        ) from exc
+
+    _install_dynamo_planner_bridge_compat()
+    config, config_path = _load_spica_config(args, SmartSearchConfig)
+    config_summary = _spica_config_summary(config)
+
+    logger.info(
+        "Running Spica thorough sweep: model=%s, system=%s, gpu_budget=%s, backend=%s, workload=%s, sweep=%s",
+        config_summary["model"],
+        config_summary["system"],
+        config_summary["gpu_budget"],
+        config_summary["backend"],
+        config_summary["workload"],
+        config_summary["sweep"],
+    )
+    candidates = run_smart_search(config, evaluator=_SpicaReplayEvaluatorCompat(config.workload, config.goal))
+    if not candidates:
+        logger.error("Spica thorough sweep returned no feasible candidates.")
+        raise SystemExit(1)
+
+    result_bundle = _build_spica_trace_result_bundle(candidates, args, config=config, config_path=config_path)
+    log_final_summary(
+        chosen_exp=result_bundle.chosen_exp,
+        best_throughputs=result_bundle.best_throughputs,
+        best_configs=result_bundle.best_configs,
+        pareto_fronts=result_bundle.pareto_fronts,
+        tasks=result_bundle.tasks,
+        mode="default",
+        pareto_x_axis=result_bundle.pareto_x_axis,
+        pareto_y_axis=result_bundle.pareto_y_axis,
+        top_n=args.top_n,
+        inclusive_tpot=args.inclusive_tpot,
+        extra_input_lines=_spica_extra_input_lines(config, config_path),
+        objective_target=result_bundle.objective_target,
+        best_objective_scores=result_bundle.best_objective_scores,
+        objective_directions=result_bundle.objective_directions,
+    )
+
+    if args.save_dir:
+        written_paths = _save_spica_trace_artifacts(result_bundle, args.save_dir, args)
+        logger.info("Saved Spica thorough artifacts to %s: %s", args.save_dir, ", ".join(written_paths))
+
+    return candidates

--- a/src/aiconfigurator/generator/builders/k8s_builder.py
+++ b/src/aiconfigurator/generator/builders/k8s_builder.py
@@ -23,6 +23,15 @@ import json
 import math
 from typing import Any
 
+from aiconfigurator.generator.dynamo_features import (
+    frontend_cli_args_from_dyn_config,
+    kvbm_env_from_dyn_config,
+    normalize_router_mode,
+    planner_config_from_dyn_config,
+    planner_config_json,
+    planner_image_from_k8s_config,
+)
+
 from .dgd_model import DGD, ComputeDomainDoc, ConfigMapDoc, DGDService, ExtraPodSpec, MainContainer
 
 
@@ -106,6 +115,95 @@ def _apply_passthrough_to_service(svc: DGDService, eps_overlay: Any, extra_env: 
         mc.env = (mc.env or []) + copy.deepcopy(list(extra_env))
         eps.main_container = mc
     svc.extra_pod_spec = eps
+
+
+def _append_envs(base: list[dict[str, str]] | None, extra: list[dict[str, str]]) -> list[dict[str, str]] | None:
+    if not extra:
+        return base
+    merged = list(base or [])
+    names = {entry.get("name") for entry in merged if isinstance(entry, dict)}
+    for entry in extra:
+        if entry.get("name") in names:
+            continue
+        merged.append(copy.deepcopy(entry))
+    return merged or None
+
+
+def _kvbm_env_for_role(
+    dyn: dict[str, Any],
+    role: str | None,
+    *,
+    backend: str,
+) -> list[dict[str, str]]:
+    if role not in (None, "prefill"):
+        return []
+    return kvbm_env_from_dyn_config(dyn, backend=backend)
+
+
+def _frontend_main_container(
+    *,
+    image: str | None,
+    image_pull_policy: str | None,
+    volume_mounts: list[Any] | None,
+    dyn: dict[str, Any],
+    svc_cfg: dict[str, Any],
+) -> MainContainer:
+    # Keep the historical enable_router-only DGD shape unchanged; Spica/Dynamo
+    # feature mappings set router_mode/router_config when a frontend command is
+    # required to pass richer CLI flags.
+    frontend_dyn = dyn if dyn.get("router_mode") or dyn.get("router_config") else {}
+    frontend_args = frontend_cli_args_from_dyn_config(frontend_dyn, svc_cfg)
+    if frontend_args:
+        return MainContainer(
+            image=image,
+            image_pull_policy=image_pull_policy,
+            volume_mounts=volume_mounts,
+            command=["python3", "-m", "dynamo.frontend"],
+            args=frontend_args,
+        )
+    return MainContainer(
+        image=image,
+        image_pull_policy=image_pull_policy,
+        volume_mounts=volume_mounts,
+    )
+
+
+def _planner_service(
+    *,
+    k8s: dict[str, Any],
+    dyn: dict[str, Any],
+    backend: str,
+    mode: str,
+    svc_cfg: dict[str, Any],
+    node_selector: dict[str, Any] | None,
+    tolerations: list[Any] | None,
+    image_pull_secret: str | None,
+) -> DGDService | None:
+    planner_config = planner_config_from_dyn_config(dyn, backend=backend, mode=mode, service=svc_cfg)
+    if not planner_config:
+        return None
+    return DGDService(
+        env_from_secret="hf-token-secret",
+        component_type="planner",
+        replicas=1,
+        extra_pod_spec=ExtraPodSpec(
+            image_pull_secrets=[{"name": image_pull_secret}] if image_pull_secret else None,
+            node_selector=copy.deepcopy(node_selector),
+            tolerations=copy.deepcopy(tolerations),
+            main_container=MainContainer(
+                image=planner_image_from_k8s_config(k8s),
+                image_pull_policy="IfNotPresent",
+                command=["python3", "-m", "dynamo.planner"],
+                args=["--config", planner_config_json(planner_config)],
+            ),
+        ),
+    )
+
+
+def _frontend_router_env(enable_router: bool, dyn: dict[str, Any]) -> dict[str, str] | None:
+    if not enable_router and not dyn.get("router_mode"):
+        return None
+    return {"name": "DYN_ROUTER_MODE", "value": normalize_router_mode(dyn.get("router_mode") or "kv")}
 
 
 # ---------------------------------------------------------------------------
@@ -195,6 +293,7 @@ def _populate_vllm(context: dict[str, Any], resolved_facts: Any = None) -> list[
                 envs.append({"name": "ETCD_ENDPOINTS", "value": etcd_endpoints})
             if hf_home:
                 envs.append({"name": "HF_HOME", "value": hf_home})
+        envs = _append_envs(envs, _kvbm_env_for_role(dyn, role, backend="vllm"))
 
         volumes = None
         if use_model_cache:
@@ -222,13 +321,28 @@ def _populate_vllm(context: dict[str, Any], resolved_facts: Any = None) -> list[
             args.append(
                 f'{{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:{port}","enable_kv_cache_events":true}}'
             )
+        kvbm_enabled = bool(kvbm_env_from_dyn_config(dyn, backend="vllm"))
         if role == "prefill":
-            args.extend(
-                ["--is-prefill-worker", "--kv-transfer-config", '{"kv_connector":"NixlConnector","kv_role":"kv_both"}']
-            )
+            if kvbm_enabled:
+                transfer_config = (
+                    '{"kv_connector":"PdConnector","kv_role":"kv_both","kv_connector_extra_config":'
+                    '{"connectors":[{"kv_connector":"DynamoConnector","kv_connector_module_path":'
+                    '"kvbm.vllm_integration.connector","kv_role":"kv_both"},{"kv_connector":"NixlConnector",'
+                    '"kv_role":"kv_both"}]},"kv_connector_module_path":"kvbm.vllm_integration.connector"}'
+                )
+            else:
+                transfer_config = '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
+            args.extend(["--is-prefill-worker", "--kv-transfer-config", transfer_config])
         elif role == "decode":
             args.extend(
                 ["--is-decode-worker", "--kv-transfer-config", '{"kv_connector":"NixlConnector","kv_role":"kv_both"}']
+            )
+        elif role is None and kvbm_enabled:
+            args.extend(
+                [
+                    "--kv-transfer-config",
+                    '{"kv_connector":"DynamoConnector","kv_connector_module_path":"kvbm.vllm_integration.connector","kv_role":"kv_both"}',
+                ]
             )
         elif role == "encode":
             # Multimodal EPD encode worker (vision encoder only).
@@ -319,10 +433,12 @@ def _populate_vllm(context: dict[str, Any], resolved_facts: Any = None) -> list[
             image_pull_secrets=[{"name": image_pull_secret}] if image_pull_secret else None,
             node_selector=copy.deepcopy(node_selector_fact),
             tolerations=copy.deepcopy(tolerations_fact),
-            main_container=MainContainer(
+            main_container=_frontend_main_container(
                 image=k8s.get("k8s_image"),
                 image_pull_policy="IfNotPresent",
                 volume_mounts=fe_volume_mounts,
+                dyn=dyn,
+                svc_cfg=svc_cfg,
             ),
         ),
     )
@@ -331,13 +447,25 @@ def _populate_vllm(context: dict[str, Any], resolved_facts: Any = None) -> list[
         if etcd_endpoints:
             fe_envs.append({"name": "ETCD_ENDPOINTS", "value": etcd_endpoints})
         if enable_router:
-            fe_envs.append({"name": "DYN_ROUTER_MODE", "value": "kv"})
+            fe_envs.append(_frontend_router_env(enable_router, dyn))
         if hf_home:
             fe_envs.append({"name": "HF_HOME", "value": hf_home})
         frontend.extra["envs"] = fe_envs
 
     services: dict[str, DGDService] = {"Frontend": frontend}
     mode = dyn.get("mode", "disagg") or "disagg"
+    planner = _planner_service(
+        k8s=k8s,
+        dyn=dyn,
+        backend="vllm",
+        mode=mode,
+        svc_cfg=svc_cfg,
+        node_selector=node_selector_fact,
+        tolerations=tolerations_fact,
+        image_pull_secret=image_pull_secret,
+    )
+    if planner is not None:
+        services["Planner"] = planner
     # Multimodal EPD: optional encode worker + mm flags on the PD workers
     # (the prefill/entry worker also routes to the encoder). Presence-guarded.
     is_epd = bool(context.get("encode_workers"))
@@ -472,6 +600,7 @@ def _populate_sglang(context: dict[str, Any], resolved_facts: Any = None) -> lis
                 envs.append({"name": "ETCD_ENDPOINTS", "value": etcd_endpoints})
             if hf_home:
                 envs.append({"name": "HF_HOME", "value": hf_home})
+        envs = _append_envs(envs, _kvbm_env_for_role(dyn, role, backend="sglang"))
 
         volumes = None
         if use_model_cache:
@@ -597,10 +726,12 @@ def _populate_sglang(context: dict[str, Any], resolved_facts: Any = None) -> lis
             image_pull_secrets=[{"name": image_pull_secret}] if image_pull_secret else None,
             node_selector=copy.deepcopy(node_selector_fact),
             tolerations=copy.deepcopy(tolerations_fact),
-            main_container=MainContainer(
+            main_container=_frontend_main_container(
                 image=k8s.get("k8s_image"),
                 image_pull_policy="IfNotPresent",
                 volume_mounts=fe_volume_mounts,
+                dyn=dyn,
+                svc_cfg=svc_cfg,
             ),
         ),
     )
@@ -609,12 +740,24 @@ def _populate_sglang(context: dict[str, Any], resolved_facts: Any = None) -> lis
         if etcd_endpoints:
             fe_envs.append({"name": "ETCD_ENDPOINTS", "value": etcd_endpoints})
         if enable_router:
-            fe_envs.append({"name": "DYN_ROUTER_MODE", "value": "kv"})
+            fe_envs.append(_frontend_router_env(enable_router, dyn))
         if hf_home:
             fe_envs.append({"name": "HF_HOME", "value": hf_home})
         frontend.extra["envs"] = fe_envs
 
     services: dict[str, DGDService] = {"Frontend": frontend}
+    planner = _planner_service(
+        k8s=k8s,
+        dyn=dyn,
+        backend="sglang",
+        mode=mode,
+        svc_cfg=svc_cfg,
+        node_selector=node_selector_fact,
+        tolerations=tolerations_fact,
+        image_pull_secret=image_pull_secret,
+    )
+    if planner is not None:
+        services["Planner"] = planner
     # Multimodal EPD: optional encode worker + --multimodal-worker on the PD
     # worker(s) (sglang E/PD is typically 2-stage: encode + aggregated PD).
     is_epd = bool(context.get("encode_workers"))
@@ -840,6 +983,7 @@ def _populate_trtllm(context: dict[str, Any], resolved_facts: Any = None) -> lis
                 envs.append({"name": "ETCD_ENDPOINTS", "value": etcd_endpoints})
             if hf_home:
                 envs.append({"name": "HF_HOME", "value": hf_home})
+        envs = _append_envs(envs, _kvbm_env_for_role(dyn, sub_component_type, backend="trtllm"))
 
         image_pull_secrets = None
         if image_pull_secret:
@@ -876,6 +1020,8 @@ def _populate_trtllm(context: dict[str, Any], resolved_facts: Any = None) -> lis
             lines.append(f"args+=(--disaggregation-mode {disagg_mode})")
         if publish_metrics:
             lines.append("args+=(--publish-events-and-metrics)")
+        if sub_component_type in (None, "prefill") and kvbm_env_from_dyn_config(dyn, backend="trtllm"):
+            lines.append("args+=(--connector kvbm)")
         for _flag in extra_flags or []:
             lines.append(f"args+=({_flag})")
         lines.append('exec python3 -m dynamo.trtllm "${args[@]}"')
@@ -986,10 +1132,12 @@ def _populate_trtllm(context: dict[str, Any], resolved_facts: Any = None) -> lis
             image_pull_secrets=[{"name": image_pull_secret}] if image_pull_secret else None,
             node_selector=copy.deepcopy(node_selector_fact),
             tolerations=copy.deepcopy(tolerations_fact),
-            main_container=MainContainer(
+            main_container=_frontend_main_container(
                 image=k8s.get("k8s_image"),
                 image_pull_policy="IfNotPresent",
                 volume_mounts=fe_volume_mounts,
+                dyn=dyn,
+                svc_cfg=svc_cfg,
             ),
         ),
     )
@@ -998,12 +1146,24 @@ def _populate_trtllm(context: dict[str, Any], resolved_facts: Any = None) -> lis
         if etcd_endpoints:
             fe_envs.append({"name": "ETCD_ENDPOINTS", "value": etcd_endpoints})
         if enable_router:
-            fe_envs.append({"name": "DYN_ROUTER_MODE", "value": "kv"})
+            fe_envs.append(_frontend_router_env(enable_router, dyn))
         if hf_home:
             fe_envs.append({"name": "HF_HOME", "value": hf_home})
         frontend.extra["envs"] = fe_envs
 
     services: dict[str, DGDService] = {"Frontend": frontend}
+    planner = _planner_service(
+        k8s=k8s,
+        dyn=dyn,
+        backend="trtllm",
+        mode=mode,
+        svc_cfg=svc_cfg,
+        node_selector=node_selector_fact,
+        tolerations=tolerations_fact,
+        image_pull_secret=image_pull_secret,
+    )
+    if planner is not None:
+        services["Planner"] = planner
     if mode == "agg":
         services["TRTLLMWorker"] = render_worker(
             None,

--- a/src/aiconfigurator/generator/config/backend_templates/sglang/run.sh.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/sglang/run.sh.j2
@@ -18,12 +18,13 @@ DECODE_SYSTEM_PORT_BASE=${DECODE_SYSTEM_PORT_BASE:-$((PREFILL_SYSTEM_PORT_BASE +
 
 {% set mode = DynConfig.mode | default('disagg') %}
 {% set enable_router = DynConfig.enable_router | default(false) %}
+{% set frontend_args = frontend_extra_args | default('') %}
 {% if enable_router %}
 SGLANG_KV_EVENT_PORT_BASE=${SGLANG_KV_EVENT_PORT_BASE:-{{ ServiceConfig.sglang_kv_event_port | default(5557, true) }}}
 {% endif %}
 {% if ServiceConfig.include_frontend %}
 OTEL_SERVICE_NAME=dynamo-frontend \
-python3 -m dynamo.frontend {% if enable_router %}--router-mode kv {% endif %}--http-port "{{ ServiceConfig.port }}" 2>&1 | sed "s/^/[Frontend] /" &
+python3 -m dynamo.frontend {% if frontend_args %}{{ frontend_args }} {% elif enable_router %}--router-mode kv {% endif %}--http-port "{{ ServiceConfig.port }}" 2>&1 | sed "s/^/[Frontend] /" &
 {% endif %}
 
 {% if mode == 'agg' %}
@@ -42,7 +43,11 @@ for ((w=0; w<AGG_WORKERS; w++)); do
   {% if enable_router %}
   EVENT_PORT=$(( SGLANG_KV_EVENT_PORT_BASE + w ))
   {% endif %}
-  ( CUDA_VISIBLE_DEVICES=$GPU_LIST \
+  (
+  {% for export_line in kvbm_env_exports | default([]) %}
+  {{ export_line }}
+  {% endfor %}
+  CUDA_VISIBLE_DEVICES=$GPU_LIST \
   OTEL_SERVICE_NAME="${WORKER_NAME}" \
   DYN_SYSTEM_PORT="${SYSTEM_PORT}" \
   python3 -m dynamo.sglang \
@@ -71,7 +76,11 @@ for ((w=0; w<PREFILL_WORKERS; w++)); do
   {% if enable_router %}
   EVENT_PORT=$(( SGLANG_KV_EVENT_PORT_BASE + w ))
   {% endif %}
-  ( CUDA_VISIBLE_DEVICES=$GPU_LIST \
+  (
+  {% for export_line in kvbm_env_exports | default([]) %}
+  {{ export_line }}
+  {% endfor %}
+  CUDA_VISIBLE_DEVICES=$GPU_LIST \
   OTEL_SERVICE_NAME="${WORKER_NAME}" \
   DYN_SYSTEM_PORT="${SYSTEM_PORT}" \
     python3 -m dynamo.sglang \

--- a/src/aiconfigurator/generator/config/backend_templates/trtllm/run.sh.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/trtllm/run.sh.j2
@@ -10,9 +10,11 @@ export ETCD_ENDPOINTS="${HEAD_NODE_IP}:2379"
 export NATS_SERVER="nats://${HEAD_NODE_IP}:4222"
 
 {% set enable_router = DynConfig.enable_router | default(false) %}
+{% set frontend_args = frontend_extra_args | default('') %}
+{% set kvbm_enabled = (kvbm_env_exports | default([]) | length) > 0 %}
 
 {% if ServiceConfig.include_frontend %}
-python3 -m dynamo.frontend {% if enable_router %}--router-mode kv {% endif %}--http-port "{{ ServiceConfig.port }}" 2>&1 | sed "s/^/[Frontend] /" &
+python3 -m dynamo.frontend {% if frontend_args %}{{ frontend_args }} {% elif enable_router %}--router-mode kv {% endif %}--http-port "{{ ServiceConfig.port }}" 2>&1 | sed "s/^/[Frontend] /" &
 {% endif %}
 
 {% if DynConfig.mode | default('disagg') == "agg" %}
@@ -22,10 +24,15 @@ AGG_GPU_OFFSET={{ agg_gpu_offset | default(0) }}
 for ((w=0; w<AGG_WORKERS; w++)); do
   BASE=$(( AGG_GPU_OFFSET + w * AGG_GPU ))
   GPU_LIST=$(seq -s, $BASE $((BASE+AGG_GPU-1)))
-  ( CUDA_VISIBLE_DEVICES=$GPU_LIST python3 -m dynamo.trtllm \
+  (
+    {% for export_line in kvbm_env_exports | default([]) %}
+    {{ export_line }}
+    {% endfor %}
+    CUDA_VISIBLE_DEVICES=$GPU_LIST python3 -m dynamo.trtllm \
     --model-path "$MODEL_PATH" \
     --served-model-name "$SERVED_MODEL_NAME" \
     --extra-engine-args "{{ agg_engine_args }}" \
+    {% if kvbm_enabled %}--connector kvbm {% endif %}\
     {% if enable_router %}--publish-events-and-metrics {% endif %} 2>&1 | sed "s/^/[Worker $w] /" ) &
 done
 wait
@@ -36,11 +43,16 @@ PREFILL_WORKERS={{ prefill_workers }}
 for ((w=0; w<PREFILL_WORKERS; w++)); do
   BASE=$(( w * PREFILL_GPU ))
   GPU_LIST=$(seq -s, $BASE $((BASE+PREFILL_GPU-1)))
-  ( CUDA_VISIBLE_DEVICES=$GPU_LIST python3 -m dynamo.trtllm \
+  (
+    {% for export_line in kvbm_env_exports | default([]) %}
+    {{ export_line }}
+    {% endfor %}
+    CUDA_VISIBLE_DEVICES=$GPU_LIST python3 -m dynamo.trtllm \
     --model-path "$MODEL_PATH" \
     --served-model-name "$SERVED_MODEL_NAME" \
     --extra-engine-args "{{ prefill_engine_args }}" \
     --disaggregation-mode prefill \
+    {% if kvbm_enabled %}--connector kvbm {% endif %}\
     {% if enable_router %}--publish-events-and-metrics{% endif %} 2>&1 | sed "s/^/[Prefill $w] /" ) &
 done
 {% endif %}

--- a/src/aiconfigurator/generator/config/backend_templates/vllm/run.sh.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/vllm/run.sh.j2
@@ -3,13 +3,15 @@ set -e
 trap 'echo "Cleaning up..."; kill 0 2>/dev/null || true' EXIT INT TERM
 
 {% set enable_router = DynConfig.enable_router | default(false) %}
+{% set frontend_args = frontend_extra_args | default('') %}
+{% set kvbm_enabled = (kvbm_env_exports | default([]) | length) > 0 %}
 {% set _device_env = 'ONEAPI_DEVICE_SELECTOR=level_zero:$GPU_LIST' if (NodeConfig.system_name | default('')) == 'b60' else 'CUDA_VISIBLE_DEVICES=$GPU_LIST' %}
 {% if enable_router %}
 export PYTHONHASHSEED=0
 {% endif %}
 export MODEL_PATH=${MODEL_PATH:-"{{ ServiceConfig.model_path }}"}
 export HF_TOKEN=${HF_TOKEN:-"{{ ServiceConfig.hf_token }}"}
-python3 -m dynamo.frontend {% if enable_router %}--router-mode kv --router-reset-states {% endif %}--http-port "{{ ServiceConfig.port }}" 2>&1 | sed "s/^/[Frontend] /" &
+python3 -m dynamo.frontend {% if frontend_args %}{{ frontend_args }} {% elif enable_router %}--router-mode kv --router-reset-states {% endif %}--http-port "{{ ServiceConfig.port }}" 2>&1 | sed "s/^/[Frontend] /" &
 
 {% if DynConfig.mode | default('disagg') == 'agg' %}
 AGG_GPU={{ agg_gpu }}
@@ -27,13 +29,17 @@ for ((w=0; w<AGG_WORKERS; w++)); do
   fi
   EVENT_PORT=$(( AGG_EVENT_PORT_BASE + w ))
   SIDE_CHANNEL_PORT=$(( AGG_SIDE_CHANNEL_PORT_BASE + w ))
-  ( DYN_SYSTEM_PORT=$SYSTEM_PORT \
+  (
+    {% for export_line in kvbm_env_exports | default([]) %}
+    {{ export_line }}
+    {% endfor %}
+    DYN_SYSTEM_PORT=$SYSTEM_PORT \
     DYN_VLLM_KV_EVENT_PORT=$EVENT_PORT \
     VLLM_NIXL_SIDE_CHANNEL_PORT=$SIDE_CHANNEL_PORT \
     {{ _device_env }} python3 -m dynamo.vllm \
     --model "$MODEL_PATH" \
     {% if enable_router %}--kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${EVENT_PORT}\",\"enable_kv_cache_events\":true}" {% endif %}\
-    {{ agg_cli_args }} 2>&1 | sed "s/^/[Worker $w] /" ) &
+    {{ agg_cli_args }} {% if kvbm_enabled %}--kv-transfer-config '{"kv_connector":"DynamoConnector","kv_connector_module_path":"kvbm.vllm_integration.connector","kv_role":"kv_both"}' {% endif %}2>&1 | sed "s/^/[Worker $w] /" ) &
 done
 wait
 {% else %}
@@ -54,14 +60,18 @@ for ((w=0; w<PREFILL_WORKERS; w++)); do
   SYSTEM_PORT=$(( PREFILL_SYSTEM_PORT_BASE + w ))
   EVENT_PORT=$(( PREFILL_EVENT_PORT_BASE + w ))
   SIDE_CHANNEL_PORT=$(( PREFILL_SIDE_CHANNEL_PORT_BASE + w ))
-  ( DYN_SYSTEM_PORT=$SYSTEM_PORT \
+  (
+  {% for export_line in kvbm_env_exports | default([]) %}
+  {{ export_line }}
+  {% endfor %}
+  DYN_SYSTEM_PORT=$SYSTEM_PORT \
   DYN_VLLM_KV_EVENT_PORT=$EVENT_PORT \
   VLLM_NIXL_SIDE_CHANNEL_PORT=$SIDE_CHANNEL_PORT \
   {{ _device_env }} \
     python3 -m dynamo.vllm \
       --model "$MODEL_PATH" \
       {% if enable_router %}--kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${EVENT_PORT}\",\"enable_kv_cache_events\":true}" {% endif %}\
-      {{ prefill_cli_args }} --is-prefill-worker --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' 2>&1 | sed "s/^/[Prefill $w] /" ) &
+      {{ prefill_cli_args }} --is-prefill-worker --kv-transfer-config '{% if kvbm_enabled %}{"kv_connector":"PdConnector","kv_role":"kv_both","kv_connector_extra_config":{"connectors":[{"kv_connector":"DynamoConnector","kv_connector_module_path":"kvbm.vllm_integration.connector","kv_role":"kv_both"},{"kv_connector":"NixlConnector","kv_role":"kv_both"}]},"kv_connector_module_path":"kvbm.vllm_integration.connector"}{% else %}{"kv_connector":"NixlConnector","kv_role":"kv_both"}{% endif %}' 2>&1 | sed "s/^/[Prefill $w] /" ) &
 done
 {% endif %}
 

--- a/src/aiconfigurator/generator/config/deployment_config.yaml
+++ b/src/aiconfigurator/generator/config/deployment_config.yaml
@@ -63,6 +63,14 @@ inputs:
   - key: DynConfig.enable_router
     required: false
     default: false
+  - key: DynConfig.router_mode
+    required: false
+  - key: DynConfig.router_config
+    required: false
+  - key: DynConfig.planner_config
+    required: false
+  - key: DynConfig.kvbm_config
+    required: false
 
   # K8sConfig
   - key: K8sConfig.name_prefix
@@ -78,6 +86,9 @@ inputs:
       trtllm: *default_trtllm_image
       vllm: '"nvcr.io/nvidia/ai-dynamo/vllm-runtime:" ~ generator_dynamo_version'
       sglang: '"nvcr.io/nvidia/ai-dynamo/sglang-runtime:" ~ generator_dynamo_version'
+  - key: K8sConfig.k8s_planner_image
+    required: false
+    default: ""
   - key: K8sConfig.k8s_image_pull_secret
     required: false
     default: ""

--- a/src/aiconfigurator/generator/dynamo_features.py
+++ b/src/aiconfigurator/generator/dynamo_features.py
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared helpers for Dynamo feature knobs surfaced through ``DynConfig``."""
+
+from __future__ import annotations
+
+import copy
+import json
+import shlex
+from typing import Any
+
+KVBM_SUPPORTED_BACKENDS = frozenset({"trtllm", "vllm"})
+
+
+def _present(value: Any) -> bool:
+    return value is not None and value != ""
+
+
+def normalize_router_mode(value: Any) -> str:
+    text = str(value or "round-robin").strip().lower().replace("_", "-")
+    if text in {"kv", "kv-router"}:
+        return "kv"
+    if text in {"round-robin", "round robin"}:
+        return "round-robin"
+    return text
+
+
+def frontend_cli_args_from_dyn_config(
+    dyn: dict[str, Any] | None,
+    service: dict[str, Any] | None = None,
+    *,
+    include_http_port: bool = True,
+) -> list[str]:
+    """Build ``dynamo.frontend`` CLI args from generator ``DynConfig``."""
+
+    dyn = dyn or {}
+    service = service or {}
+    router_config = dyn.get("router_config") or {}
+    if not isinstance(router_config, dict):
+        router_config = {}
+
+    router_mode = dyn.get("router_mode")
+    if not _present(router_mode) and (dyn.get("enable_router") or router_config):
+        router_mode = "kv"
+
+    args: list[str] = []
+    if include_http_port:
+        port = service.get("port")
+        if _present(port):
+            args.extend(["--http-port", str(port)])
+
+    if _present(router_mode):
+        args.extend(["--router-mode", normalize_router_mode(router_mode)])
+
+    value_flags = (
+        ("kv_cache_block_size", "--kv-cache-block-size"),
+        ("overlap_score_credit", "--router-kv-overlap-score-credit"),
+        ("prefill_load_scale", "--router-prefill-load-scale"),
+        ("host_cache_hit_weight", "--router-host-cache-hit-weight"),
+        ("disk_cache_hit_weight", "--router-disk-cache-hit-weight"),
+        ("router_temperature", "--router-temperature"),
+        ("active_decode_blocks_threshold", "--active-decode-blocks-threshold"),
+        ("active_prefill_tokens_threshold", "--active-prefill-tokens-threshold"),
+        ("active_prefill_tokens_threshold_frac", "--active-prefill-tokens-threshold-frac"),
+        ("admission_control", "--admission-control"),
+        ("router_queue_threshold", "--router-queue-threshold"),
+        ("router_event_threads", "--router-event-threads"),
+        ("router_queue_policy", "--router-queue-policy"),
+        ("router_ttl_secs", "--router-ttl-secs"),
+        ("router_snapshot_threshold", "--router-snapshot-threshold"),
+        ("shared_cache_multiplier", "--shared-cache-multiplier"),
+        ("shared_cache_type", "--shared-cache-type"),
+        ("router_predicted_ttl_secs", "--router-predicted-ttl-secs"),
+    )
+    for key, flag in value_flags:
+        value = router_config.get(key)
+        if _present(value):
+            args.extend([flag, str(value)])
+
+    bool_flags = (
+        ("router_reset_states", "--router-reset-states"),
+        ("use_kv_events", "--router-kv-events"),
+        ("durable_kv_events", "--router-durable-kv-events"),
+        ("router_replica_sync", "--router-replica-sync"),
+        ("router_track_active_blocks", "--router-track-active-blocks"),
+        ("router_track_output_blocks", "--router-track-output-blocks"),
+        ("router_assume_kv_reuse", "--router-assume-kv-reuse"),
+        ("router_track_prefill_tokens", "--router-track-prefill-tokens"),
+        ("use_remote_indexer", "--use-remote-indexer"),
+        ("serve_indexer", "--serve-indexer"),
+        ("load_aware", "--load-aware"),
+    )
+    for key, flag in bool_flags:
+        if key not in router_config:
+            continue
+        if bool(router_config[key]):
+            args.append(flag)
+        else:
+            args.append(f"--no-{flag[2:]}")
+
+    return args
+
+
+def frontend_cli_args_string(
+    dyn: dict[str, Any] | None,
+    service: dict[str, Any] | None = None,
+    *,
+    include_http_port: bool = True,
+) -> str:
+    args = frontend_cli_args_from_dyn_config(
+        dyn,
+        service,
+        include_http_port=include_http_port,
+    )
+    return " ".join(shlex.quote(arg) for arg in args)
+
+
+def planner_config_from_dyn_config(
+    dyn: dict[str, Any] | None,
+    *,
+    backend: str,
+    mode: str,
+    service: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    dyn = dyn or {}
+    raw = dyn.get("planner_config")
+    if not isinstance(raw, dict) or not raw:
+        return None
+    service = service or {}
+    planner = copy.deepcopy(raw)
+    planner.setdefault("environment", "kubernetes")
+    planner.setdefault("backend", backend)
+    planner.setdefault("mode", mode)
+    model_name = service.get("model_path") or service.get("served_model_path") or service.get("served_model_name")
+    if model_name:
+        planner.setdefault("model_name", model_name)
+    return planner
+
+
+def planner_image_from_k8s_config(k8s: dict[str, Any] | None) -> str | None:
+    k8s = k8s or {}
+    if k8s.get("k8s_planner_image"):
+        return k8s.get("k8s_planner_image")
+    image = k8s.get("k8s_image")
+    if not image:
+        return None
+    image = str(image)
+    for runtime in ("tensorrtllm-runtime", "vllm-runtime", "sglang-runtime"):
+        if runtime in image:
+            return image.replace(runtime, "dynamo-planner")
+    return image
+
+
+def planner_config_json(config: dict[str, Any]) -> str:
+    return json.dumps(config, separators=(",", ":"))
+
+
+def kvbm_env_from_dyn_config(
+    dyn: dict[str, Any] | None,
+    *,
+    backend: str | None = None,
+) -> list[dict[str, str]]:
+    """Return KVBM environment variables for a supported Dynamo backend.
+
+    Dynamo's vLLM and TensorRT-LLM runtimes expose KVBM connectors. SGLang
+    uses its own hierarchical-cache integration, so a nonempty KVBM config is
+    rejected instead of producing an artifact that cannot activate it.
+    ``backend=None`` preserves the helper's backend-agnostic use in callers
+    that separately enforce support.
+    """
+
+    dyn = dyn or {}
+    cfg = dyn.get("kvbm_config") or {}
+    if not isinstance(cfg, dict) or not cfg:
+        return []
+    if backend is not None and backend not in KVBM_SUPPORTED_BACKENDS:
+        supported = ", ".join(sorted(KVBM_SUPPORTED_BACKENDS))
+        raise ValueError(
+            f"DynConfig.kvbm_config is not supported for backend '{backend}'; supported backends: {supported}"
+        )
+
+    env: list[dict[str, str]] = []
+    mappings = (
+        ("cpu_cache_gb", "DYN_KVBM_CPU_CACHE_GB"),
+        ("cpu_cache_override_num_blocks", "DYN_KVBM_CPU_CACHE_OVERRIDE_NUM_BLOCKS"),
+        ("disk_cache_gb", "DYN_KVBM_DISK_CACHE_GB"),
+        ("disk_cache_override_num_blocks", "DYN_KVBM_DISK_CACHE_OVERRIDE_NUM_BLOCKS"),
+        ("max_transfer_batch_size", "DYN_KVBM_MAX_TRANSFER_BATCH_SIZE"),
+        ("max_concurrent_transfers", "DYN_KVBM_MAX_CONCURRENT_TRANSFERS"),
+    )
+    for key, name in mappings:
+        value = cfg.get(key)
+        if _present(value):
+            env.append({"name": name, "value": str(value)})
+    return env
+
+
+def kvbm_shell_exports_from_dyn_config(
+    dyn: dict[str, Any] | None,
+    *,
+    backend: str | None = None,
+) -> list[str]:
+    return [
+        f"export {entry['name']}={shlex.quote(entry['value'])}"
+        for entry in kvbm_env_from_dyn_config(dyn, backend=backend)
+    ]

--- a/src/aiconfigurator/generator/rendering/engine.py
+++ b/src/aiconfigurator/generator/rendering/engine.py
@@ -19,6 +19,11 @@ import yaml
 from jinja2 import Environment, FileSystemLoader, Undefined
 from packaging.version import InvalidVersion, Version
 
+from aiconfigurator.generator.dynamo_features import (
+    frontend_cli_args_string,
+    kvbm_shell_exports_from_dyn_config,
+)
+
 from .rule_engine import apply_rule_plugins
 
 _JINJA_ENV = Environment(trim_blocks=True, lstrip_blocks=True)
@@ -1043,6 +1048,13 @@ def prepare_template_context(param_values: dict[str, Any], backend: str) -> dict
     dyn_config = param_values.get("DynConfig", {})
     if isinstance(dyn_config, dict):
         context["DynConfig"] = dyn_config
+        frontend_dyn = dyn_config if dyn_config.get("router_mode") or dyn_config.get("router_config") else {}
+        context["frontend_extra_args"] = frontend_cli_args_string(
+            frontend_dyn,
+            service_config,
+            include_http_port=False,
+        )
+        context["kvbm_env_exports"] = kvbm_shell_exports_from_dyn_config(dyn_config, backend=backend)
     mode_value = dyn_config.get("mode") if isinstance(dyn_config, dict) else None
     mode_value = mode_value or "disagg"
     enable_router = bool(dyn_config.get("enable_router")) if isinstance(dyn_config, dict) else False

--- a/src/aiconfigurator/generator/sflow.py
+++ b/src/aiconfigurator/generator/sflow.py
@@ -24,6 +24,11 @@ import re
 import shlex
 from typing import Any
 
+from aiconfigurator.generator.dynamo_features import (
+    frontend_cli_args_string,
+    kvbm_shell_exports_from_dyn_config,
+)
+
 _SUPPORTED_BACKENDS = {"trtllm", "sglang", "vllm"}
 _SFLOW_EXPR_RE = re.compile(r"\$\[\[(.+?)\]\]")
 _SFLOW_VARIABLE_PROFILES = {"minimal", "expanded"}
@@ -75,7 +80,15 @@ def enrich_context_for_sflow(
     if ctx["sflow_slurm_timelimit"] in (None, ""):
         ctx["sflow_slurm_timelimit"] = 240
     ctx["sflow_aiperf_image"] = sflow_cfg.get("aiperf_image") or "python:3.12-slim"
-    ctx["sflow_extra_frontend_args"] = sflow_cfg.get("extra_frontend_args") or ""
+    frontend_dyn = dyn if dyn.get("enable_router") or dyn.get("router_mode") or dyn.get("router_config") else {}
+    generated_frontend_args = frontend_cli_args_string(
+        frontend_dyn,
+        param_values.get("ServiceConfig", {}),
+        include_http_port=False,
+    )
+    user_frontend_args = sflow_cfg.get("extra_frontend_args") or ""
+    ctx["sflow_extra_frontend_args"] = " ".join(part for part in [generated_frontend_args, user_frontend_args] if part)
+    ctx["sflow_kvbm_env_exports"] = kvbm_shell_exports_from_dyn_config(dyn, backend=backend)
     ctx["sflow_variable_profile"] = variable_profile
 
     total_gpus = _total_gpus(wp, worker_cfg, mode)
@@ -183,6 +196,12 @@ def _build_server_script(
     return _trtllm_server_script(role, disagg_mode, context)
 
 
+def _kvbm_export_lines(context: dict[str, Any], role: str) -> list[str]:
+    if role not in {"agg", "prefill"}:
+        return []
+    return [f"- {line}" for line in context.get("sflow_kvbm_env_exports") or []]
+
+
 def _sglang_server_script(
     role: str,
     disagg_mode: str | None,
@@ -213,6 +232,7 @@ def _sglang_server_script(
         "- echo ${CUDA_VISIBLE_DEVICES}",
         "- export FIRST_CUDA_DEVICE=$(echo ${CUDA_VISIBLE_DEVICES} | cut -d',' -f1)",
     ]
+    lines.extend(_kvbm_export_lines(context, role))
 
     if npw > 1:
         lines.extend(
@@ -285,6 +305,7 @@ def _trtllm_server_script(
         "- env | grep UCX",
         "- unset UCX_TLS",
     ]
+    lines.extend(_kvbm_export_lines(context, role))
 
     cmd_parts = [
         "trtllm-llmapi-launch python3 -m dynamo.trtllm \\",
@@ -293,6 +314,8 @@ def _trtllm_server_script(
     ]
     if disagg_mode:
         cmd_parts.append(f"  --disaggregation-mode {disagg_mode} \\")
+    if role in {"agg", "prefill"} and context.get("sflow_kvbm_env_exports"):
+        cmd_parts.append("  --connector kvbm \\")
     cmd_parts.append(f"  --extra-engine-args $[[ artifacts.{config_name}.path ]] ${{{extra_var}}}")
 
     lines.append("- |-")
@@ -318,6 +341,7 @@ def _vllm_server_script(
         '- echo "Worker starting"',
         "- echo ${CUDA_VISIBLE_DEVICES}",
     ]
+    lines.extend(_kvbm_export_lines(context, role))
 
     cmd_parts = [
         "python3 -m dynamo.vllm \\",
@@ -328,10 +352,24 @@ def _vllm_server_script(
 
     if disagg_mode == "prefill":
         cmd_parts.append("  --is-prefill-worker \\")
-        cmd_parts.append('  --kv-transfer-config \'{"kv_connector":"NixlConnector","kv_role":"kv_both"}\' \\')
+        if context.get("sflow_kvbm_env_exports"):
+            cmd_parts.append(
+                '  --kv-transfer-config \'{"kv_connector":"PdConnector","kv_role":"kv_both",'
+                '"kv_connector_extra_config":{"connectors":[{"kv_connector":"DynamoConnector",'
+                '"kv_connector_module_path":"kvbm.vllm_integration.connector","kv_role":"kv_both"},'
+                '{"kv_connector":"NixlConnector","kv_role":"kv_both"}]},'
+                '"kv_connector_module_path":"kvbm.vllm_integration.connector"}\' \\'
+            )
+        else:
+            cmd_parts.append('  --kv-transfer-config \'{"kv_connector":"NixlConnector","kv_role":"kv_both"}\' \\')
     elif disagg_mode == "decode":
         cmd_parts.append("  --is-decode-worker \\")
         cmd_parts.append('  --kv-transfer-config \'{"kv_connector":"NixlConnector","kv_role":"kv_both"}\' \\')
+    elif context.get("sflow_kvbm_env_exports"):
+        cmd_parts.append(
+            '  --kv-transfer-config \'{"kv_connector":"DynamoConnector",'
+            '"kv_connector_module_path":"kvbm.vllm_integration.connector","kv_role":"kv_both"}\' \\'
+        )
 
     cmd_parts.append(f"  ${{{extra_var}}}")
 

--- a/tests/e2e/cli/README.md
+++ b/tests/e2e/cli/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
 
@@ -23,4 +23,29 @@ python3 -m pytest tests/e2e/cli -m build
 python3 -m pytest tests/e2e/cli -m sweep
 ```
 
+### Real Spica Thorough Sweep
 
+`test_cli_default_thorough_sweep_real.py` is skipped by default because it requires
+Spica's optional thorough-sweep dependencies and Dynamo replay bindings. It runs two
+bounded real sweeps:
+
+- A small `default --thorough-sweep` case derived from ordinary CLI inputs.
+- A one-candidate native `--thorough-config` case that carries a throughput objective,
+  KV router, load-enabled planner policy, and KVBM host offload through replay into the
+  generated Dynamo artifacts. The test parses the emitted frontend and planner args
+  with the pinned Dynamo runtime schemas.
+
+Both cases exercise the real thorough sweeper, final report, and saved deployment
+artifacts. The native fixture pins its parallel config and all searched dimensions so
+CI evaluates exactly one candidate.
+
+```bash
+AIC_RUN_SPICA_THOROUGH_E2E=true \
+PYTHONPATH=/path/to/dynamo/components/src:/path/to/dynamo/lib/bindings/python/src \
+python3 -m pytest tests/e2e/cli/test_cli_default_thorough_sweep_real.py -q
+```
+
+Set `AIC_SPICA_THOROUGH_E2E_ARTIFACT_DIR` to retain the command/stdout/stderr logs
+and complete generated `save_dir` and `native_save_dir` trees. The dedicated GitHub
+Actions job sets this automatically and uploads the directory as the
+`spica-thorough-e2e-results` artifact.

--- a/tests/e2e/cli/data/spica_native_features.yaml
+++ b/tests/e2e/cli/data/spica_native_features.yaml
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# One fully pinned candidate keeps the real replay bounded while covering the
+# native SmartSearchConfig -> Spica -> generator feature bridge.
+search_space:
+  deployment_mode: [agg]
+  backend: [trtllm]
+  parallel_configs:
+    # Offline KV-router replay needs at least two workers to make a routing choice.
+    - tp: 1
+      replicas: 2
+  model_name: meta-llama/Meta-Llama-3.1-8B
+  hardware_sku: gb200
+  gpu_budget: 2
+  min_gpu_budget: 2
+  min_endpoint: 2
+  context_length: 4096
+
+  agg_max_num_batched_tokens: [8192]
+  agg_max_num_seqs: [256]
+  agg_block_size: 64
+  agg_gpu_memory_utilization: 0.9
+  agg_enable_prefix_caching: true
+
+  num_g2_blocks: 128
+  # Avoid an external model-config lookup and guarantee that replay attaches
+  # the KVBM offload engine (Llama 3.1 8B BF16 KV bytes per token).
+  kv_bytes_per_token: 131072
+  offload_batch_size: 4
+
+  router_mode: [kv_router]
+  overlap_score_credit: [0.5]
+  prefill_load_scale: [2.0]
+  host_cache_hit_weight: [0.75]
+  disk_cache_hit_weight: [0.25]
+  router_temperature: [0.2]
+
+  # A one-second load cadence fires while the open-loop workload is active, so
+  # the e2e covers the planner callback as well as bridge initialization.
+  planner_scaling_policy:
+    - enable_throughput_scaling: false
+      enable_load_scaling: true
+      throughput_adjustment_interval_seconds: 180
+      load_adjustment_interval_seconds: 1
+  planner_fpm_sampling: [default]
+  planner_load_sensitivity: [default]
+
+workload:
+  isl: 128
+  osl: 16
+  request_rate: 1
+  num_request_ratio: 3
+
+goal:
+  target: throughput
+
+sweep:
+  max_rounds: 1
+  parallel_evals: 1
+  candidates_per_round: 1
+  random_seed: 1
+  max_eval_seconds: 180

--- a/tests/e2e/cli/test_cli_default_thorough_sweep_real.py
+++ b/tests/e2e/cli/test_cli_default_thorough_sweep_real.py
@@ -1,0 +1,296 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess as sp
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = [pytest.mark.e2e, pytest.mark.sweep]
+
+
+def _enabled() -> bool:
+    return os.environ.get("AIC_RUN_SPICA_THOROUGH_E2E", "").lower() in {"1", "true", "yes", "on"}
+
+
+def _yaml(path: Path):
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+@pytest.mark.skipif(not _enabled(), reason="set AIC_RUN_SPICA_THOROUGH_E2E=true to run real Spica thorough sweep")
+@pytest.mark.timeout(300)
+def test_cli_default_thorough_sweep_real_static_workload(tmp_path: Path):
+    """Run a small real Spica thorough sweep from ordinary default CLI inputs."""
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "AIC_SPICA_THOROUGH_SWEEP_ROUNDS": "1",
+            "AIC_SPICA_THOROUGH_PARALLEL_EVALS": "4",
+            "AIC_SPICA_THOROUGH_CANDIDATES_PER_ROUND": "4",
+            "AIC_SPICA_THOROUGH_SYNTHETIC_CONCURRENCY": "1",
+            "AIC_SPICA_THOROUGH_SYNTHETIC_NUM_REQUEST_RATIO": "4",
+        }
+    )
+    for key in (
+        "AIC_SPICA_TRACE_SWEEP_ROUNDS",
+        "AIC_SPICA_TRACE_PARALLEL_EVALS",
+        "AIC_SPICA_TRACE_CANDIDATES_PER_ROUND",
+    ):
+        env.pop(key, None)
+
+    artifact_dir = Path(os.environ.get("AIC_SPICA_THOROUGH_E2E_ARTIFACT_DIR", tmp_path))
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    save_dir = artifact_dir / "save_dir"
+    if save_dir.exists():
+        shutil.rmtree(save_dir)
+    cmd = [
+        sys.executable,
+        "-m",
+        "aiconfigurator.cli.main",
+        "default",
+        "--model-path",
+        "meta-llama/Meta-Llama-3.1-8B",
+        "--total-gpus",
+        "4",
+        "--system",
+        "gb200",
+        "--backend",
+        "trtllm",
+        "--isl",
+        "128",
+        "--osl",
+        "16",
+        "--ttft",
+        "8000",
+        "--tpot",
+        "200",
+        "--max-seq-len",
+        "8192",
+        "--top-n",
+        "2",
+        "--thorough-sweep",
+        "--save-dir",
+        str(save_dir),
+    ]
+
+    (artifact_dir / "command.txt").write_text(f"{shlex.join(cmd)}\n", encoding="utf-8")
+    completed = sp.run(cmd, capture_output=True, text=True, timeout=300, env=env)
+    (artifact_dir / "stdout.txt").write_text(completed.stdout, encoding="utf-8")
+    (artifact_dir / "stderr.txt").write_text(completed.stderr, encoding="utf-8")
+    combined = f"{completed.stdout}\n{completed.stderr}"
+    assert completed.returncode == 0, combined
+
+    assert "sweep={'max_rounds': 1, 'parallel_evals': 4, 'candidates_per_round': 4}" in combined
+    sweep_done = re.search(
+        r"smart-sweep done: (?P<feasible>\d+)/8 feasible, 0 gated, 0 backend-unsupported, "
+        r"(?P<replay_failed>\d+) replay-failed",
+        combined,
+    )
+    assert sweep_done, combined
+    assert int(sweep_done.group("feasible")) > 0
+    assert "AIConfigurator Final Results" in combined
+    assert "Total GPUs: 4" in combined
+    assert "Synthetic Workload: ISL=128, OSL=16, concurrency=1, num_request_ratio=4.0" in combined
+    assert "Best Experiment Chosen:" in combined
+
+    result_dirs = [path for path in save_dir.iterdir() if path.is_dir()]
+    assert len(result_dirs) == 1
+    result_dir = result_dirs[0]
+    assert result_dir.name.startswith(
+        "meta-llama_Meta-Llama-3.1-8B_gb200_trtllm_thorough_isl128_osl16_ttft8000_tpot200_"
+    )
+    assert (result_dir / "spica_candidates.yaml").is_file()
+    assert (result_dir / "spica_candidates.csv").is_file()
+    assert (result_dir / "pareto.csv").is_file()
+    assert (result_dir / "pareto_frontier.png").is_file()
+    feasible_modes = [mode for mode in ("agg", "disagg") if (result_dir / mode / "exp_config.yaml").is_file()]
+    assert feasible_modes
+    for mode in feasible_modes:
+        assert (result_dir / mode / "exp_config.yaml").is_file()
+        assert (result_dir / mode / "best_config_topn.csv").is_file()
+        assert (result_dir / mode / "pareto.csv").is_file()
+        assert (result_dir / mode / "top1" / "generator_config.yaml").is_file()
+        assert (result_dir / mode / "top1" / "bench_run.sh").is_file()
+        assert (result_dir / mode / "top1" / "k8s_bench.yaml").is_file()
+        assert (result_dir / mode / "top1" / "k8s_deploy.yaml").is_file()
+        assert (result_dir / mode / "top1" / "run_0.sh").is_file()
+        assert (result_dir / mode / "top1" / "sflow.yaml").is_file()
+        assert (result_dir / mode / "top1" / "spica_candidate.yaml").is_file()
+
+        if mode == "agg":
+            assert (result_dir / mode / "top1" / "agg_config.yaml").is_file()
+        else:
+            assert (result_dir / mode / "top1" / "prefill_config.yaml").is_file()
+            assert (result_dir / mode / "top1" / "decode_config.yaml").is_file()
+
+
+@pytest.mark.skipif(not _enabled(), reason="set AIC_RUN_SPICA_THOROUGH_E2E=true to run real Spica thorough sweep")
+@pytest.mark.timeout(300)
+def test_cli_native_thorough_config_preserves_dynamo_features(tmp_path: Path):
+    """Run one real native-config candidate and validate its deployable feature contract."""
+
+    env = os.environ.copy()
+    env.update(
+        {
+            # The YAML is already bounded; these also prevent an inherited CI
+            # override from expanding the run if native configs gain env overrides.
+            "AIC_SPICA_THOROUGH_SWEEP_ROUNDS": "1",
+            "AIC_SPICA_THOROUGH_PARALLEL_EVALS": "1",
+            "AIC_SPICA_THOROUGH_CANDIDATES_PER_ROUND": "1",
+            # The runtime's definitive KVBM-attachment signal is debug-level.
+            "DYN_LOG": ("info,dynamo_mocker::scheduler=debug,dynamo_mocker::kvbm_offload::engine=debug"),
+        }
+    )
+    artifact_dir = Path(os.environ.get("AIC_SPICA_THOROUGH_E2E_ARTIFACT_DIR", tmp_path))
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    save_dir = artifact_dir / "native_save_dir"
+    if save_dir.exists():
+        shutil.rmtree(save_dir)
+
+    config_path = Path(__file__).parent / "data" / "spica_native_features.yaml"
+    cmd = [
+        sys.executable,
+        "-m",
+        "aiconfigurator.cli.main",
+        "default",
+        "--thorough-config",
+        str(config_path),
+        "--top-n",
+        "1",
+        "--generator-set",
+        "ServiceConfig.port=8123",
+        "--save-dir",
+        str(save_dir),
+    ]
+
+    (artifact_dir / "native_command.txt").write_text(f"{shlex.join(cmd)}\n", encoding="utf-8")
+    completed = sp.run(cmd, capture_output=True, text=True, timeout=300, env=env)
+    (artifact_dir / "native_stdout.txt").write_text(completed.stdout, encoding="utf-8")
+    (artifact_dir / "native_stderr.txt").write_text(completed.stderr, encoding="utf-8")
+    combined = f"{completed.stdout}\n{completed.stderr}"
+    assert completed.returncode == 0, combined
+
+    assert "sweep={'max_rounds': 1, 'parallel_evals': 1, 'candidates_per_round': 1}" in combined
+    assert "concurrency=None request_rate=1.0 num_request_ratio=3.0" in combined
+    assert re.search(r"smart-sweep done: 1/1 feasible, 0 gated, 0 backend-unsupported, 0 replay-failed", combined)
+    assert combined.count("kvbm-offload: init_kvbm_offline attaching engine") == 2
+    assert combined.count("kvbm-offload: building mock offload engine") == 2
+    assert "kvbm-offload offline init failed" not in combined
+    assert "Could not compute kv_bytes_per_token" not in combined
+
+    result_dirs = [path for path in save_dir.iterdir() if path.is_dir()]
+    assert len(result_dirs) == 1
+    result_dir = result_dirs[0]
+    assert "_thorough_spica_native_features_ttft0_tpot0_" in result_dir.name
+
+    exp_config = _yaml(result_dir / "agg" / "exp_config.yaml")
+    assert exp_config["ttft"] == 0.0
+    assert exp_config["tpot"] == 0.0
+    assert exp_config["objective_target"] == "throughput"
+    assert exp_config["planner_optimization_target"] == "throughput"
+    assert exp_config["primary_backend_version"] == "1.3.0rc10"
+    assert exp_config["total_gpus"] == 2
+    assert exp_config["min_gpu_budget"] == 2
+    assert exp_config["min_endpoint"] == 2
+
+    top_dir = result_dir / "agg" / "top1"
+    candidate = _yaml(top_dir / "spica_candidate.yaml")
+    candidate_config = candidate["config"]
+    assert candidate_config["objective_target"] == "throughput"
+    assert candidate_config["planner_optimization_target"] == "throughput"
+    assert candidate_config["backend_version"] == "1.3.0rc10"
+    assert candidate_config["planner_ttft_ms"] is None
+    assert candidate_config["planner_itl_ms"] is None
+    assert candidate_config["context_length"] == 4096
+    assert candidate_config["gpu_budget"] == 2
+    assert candidate_config["min_gpu_budget"] == 2
+    assert candidate_config["min_endpoint"] == 2
+    assert candidate_config["replicas"] == 2
+    assert candidate_config["router_mode"] == "kv_router"
+    assert candidate_config["host_cache_hit_weight"] == pytest.approx(0.75)
+    assert candidate_config["disk_cache_hit_weight"] == pytest.approx(0.25)
+    assert candidate_config["num_g2_blocks"] == 128
+    assert candidate_config["kv_bytes_per_token"] == 131072
+    assert candidate_config["offload_batch_size"] == 4
+    assert candidate["metrics"]["planner_total_ticks"] >= 1
+
+    generator_config = _yaml(top_dir / "generator_config.yaml")
+    assert generator_config["ServiceConfig"]["port"] == 8123
+    assert generator_config["WorkerConfig"]["agg_workers"] == 2
+    assert generator_config["params"]["agg"]["max_seq_len"] == 4096
+    assert _yaml(top_dir / "agg_config.yaml")["max_seq_len"] == 4096
+    dyn_config = generator_config["DynConfig"]
+    assert dyn_config["router_mode"] == "kv"
+    router_config = dyn_config["router_config"]
+    assert router_config["host_cache_hit_weight"] == pytest.approx(0.75)
+    assert router_config["disk_cache_hit_weight"] == pytest.approx(0.25)
+
+    planner_config = dyn_config["planner_config"]
+    assert planner_config["optimization_target"] == "throughput"
+    assert planner_config["max_gpu_budget"] == 2
+    assert planner_config["min_gpu_budget"] == 2
+    assert planner_config["min_endpoint"] == 2
+    assert planner_config["enable_load_scaling"] is True
+    assert planner_config["enable_throughput_scaling"] is False
+    assert planner_config["load_adjustment_interval_seconds"] == 1
+    assert "ttft_ms" not in planner_config
+    assert "itl_ms" not in planner_config
+
+    kvbm_config = dyn_config["kvbm_config"]
+    assert kvbm_config["cpu_cache_override_num_blocks"] == 128
+    assert kvbm_config["max_transfer_batch_size"] == 4
+    assert kvbm_config["max_concurrent_transfers"] == 4
+
+    k8s_deploy = _yaml(top_dir / "k8s_deploy.yaml")
+    services = k8s_deploy["spec"]["services"]
+    frontend_args = services["Frontend"]["extraPodSpec"]["mainContainer"]["args"]
+    assert frontend_args[:4] == ["--http-port", "8123", "--router-mode", "kv"]
+
+    # Parse exactly what the generated pod will pass to Dynamo.
+    from dynamo.frontend.frontend_args import FrontendArgGroup
+
+    frontend_parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(frontend_parser)
+    parsed_frontend = frontend_parser.parse_args(frontend_args)
+    assert parsed_frontend.http_port == 8123
+    assert parsed_frontend.router_mode == "kv"
+    assert parsed_frontend.host_cache_hit_weight == pytest.approx(0.75)
+    assert parsed_frontend.disk_cache_hit_weight == pytest.approx(0.25)
+
+    planner_container = services["Planner"]["extraPodSpec"]["mainContainer"]
+    planner_payload = json.loads(planner_container["args"][planner_container["args"].index("--config") + 1])
+    assert planner_payload == planner_config
+    from dynamo.planner.config.planner_config import PlannerConfig
+
+    validated_planner = PlannerConfig.model_validate(planner_payload)
+    assert validated_planner.optimization_target == "throughput"
+    assert validated_planner.max_gpu_budget == 2
+    assert validated_planner.min_gpu_budget == 2
+    assert validated_planner.min_endpoint == 2
+
+    worker = services["TRTLLMWorker"]
+    worker_env = {item["name"]: item["value"] for item in worker["envs"]}
+    assert worker_env["DYN_KVBM_CPU_CACHE_OVERRIDE_NUM_BLOCKS"] == "128"
+    assert worker_env["DYN_KVBM_MAX_TRANSFER_BATCH_SIZE"] == "4"
+    assert worker_env["DYN_KVBM_MAX_CONCURRENT_TRANSFERS"] == "4"
+    worker_script = worker["extraPodSpec"]["mainContainer"]["args"][0]
+    assert "args+=(--connector kvbm)" in worker_script
+
+    run_script = (top_dir / "run_0.sh").read_text(encoding="utf-8")
+    assert '--http-port "8123"' in run_script
+    assert "--router-host-cache-hit-weight 0.75" in run_script
+    assert "--router-disk-cache-hit-weight 0.25" in run_script
+    assert "--connector kvbm" in run_script
+    assert "DYN_KVBM_MAX_TRANSFER_BATCH_SIZE=4" in run_script
+    assert "DYN_KVBM_MAX_CONCURRENT_TRANSFERS=4" in run_script

--- a/tests/golden/generator/test_release_1_2_0_backend_contracts.py
+++ b/tests/golden/generator/test_release_1_2_0_backend_contracts.py
@@ -193,6 +193,45 @@ def _render(backend: str) -> dict[str, str]:
     )
 
 
+def _render_router_kvbm_candidate(backend: str) -> dict[str, str]:
+    params = copy.deepcopy(_GOLDEN_PARAMS)
+    role_params = params["params"].pop("agg")
+    params["params"].update(
+        {
+            "prefill": role_params,
+            "decode": copy.deepcopy(role_params),
+        }
+    )
+    params["ServiceConfig"]["port"] = 9123
+    params["WorkerConfig"] = {
+        "agg_workers": 0,
+        "prefill_workers": 1,
+        "decode_workers": 1,
+        "prefill_gpus_per_worker": 1,
+        "decode_gpus_per_worker": 1,
+    }
+    params["DynConfig"] = {
+        "mode": "disagg",
+        "enable_router": True,
+        "router_mode": "kv_router",
+        "router_config": {
+            "host_cache_hit_weight": 0.75,
+            "disk_cache_hit_weight": 0.25,
+        },
+        "kvbm_config": {
+            "cpu_cache_override_num_blocks": 4096,
+            "max_transfer_batch_size": 32,
+            "max_concurrent_transfers": 4,
+        },
+    }
+    return generate_backend_artifacts(
+        params,
+        backend,
+        backend_version=_BACKEND_VERSIONS[backend],
+        deployment_target="dynamo-j2",
+    )
+
+
 def _split_cli(cli: str) -> list[str]:
     return shlex.split(cli)
 
@@ -296,6 +335,18 @@ def test_vllm_0_20_1_k8s_router_contract():
     }
 
 
+def test_routed_vllm_run_preserves_frontend_port_and_cache_weights():
+    artifacts = _render_router_kvbm_candidate("vllm")
+    run_sh = next(
+        content for name, content in artifacts.items() if name.startswith("run_") and "dynamo.frontend" in content
+    )
+    frontend_line = next(line for line in run_sh.splitlines() if "python3 -m dynamo.frontend" in line)
+
+    assert "--router-host-cache-hit-weight 0.75" in frontend_line
+    assert "--router-disk-cache-hit-weight 0.25" in frontend_line
+    assert '--http-port "9123"' in frontend_line
+
+
 def test_sglang_0_5_11_cli_args_golden_contract():
     tokens = _split_cli(_render("sglang")["cli_args_agg"])
     flags = _flag_set(tokens)
@@ -336,6 +387,14 @@ def test_sglang_0_5_11_run_router_contract():
     assert "python3 -m dynamo.frontend --router-mode kv --http-port" in run_sh
     assert "--kv-events-config" in run_sh
     assert "tcp://*:${EVENT_PORT}" in run_sh
+
+
+def test_sglang_rejects_unsupported_kvbm_config():
+    with pytest.raises(
+        ValueError,
+        match=r"DynConfig\.kvbm_config is not supported for backend 'sglang'; supported backends: trtllm, vllm",
+    ):
+        _render_router_kvbm_candidate("sglang")
 
 
 def test_sglang_0_5_11_optional_cli_args_golden_contract():
@@ -407,6 +466,40 @@ def test_trtllm_1_3_0rc14_extra_engine_args_golden_contract():
         "decoding_type": "MTP",
         "num_nextn_predict_layers": 2,
     }
+
+
+def test_trtllm_dynamo_j2_router_and_kvbm_artifact_fidelity():
+    artifacts = _render_router_kvbm_candidate("trtllm")
+    k8s = yaml.safe_load(artifacts["k8s_deploy.yaml"])
+    services = k8s["spec"]["services"]
+
+    frontend_args = services["Frontend"]["extraPodSpec"]["mainContainer"]["args"]
+    assert _value_after(frontend_args, "--http-port") == "9123"
+    assert _value_after(frontend_args, "--router-mode") == "kv"
+    assert _value_after(frontend_args, "--router-host-cache-hit-weight") == "0.75"
+    assert _value_after(frontend_args, "--router-disk-cache-hit-weight") == "0.25"
+
+    prefill = services["TRTLLMPrefillWorker"]
+    prefill_env = {entry["name"]: entry["value"] for entry in prefill["envs"]}
+    assert prefill_env["DYN_KVBM_CPU_CACHE_OVERRIDE_NUM_BLOCKS"] == "4096"
+    assert prefill_env["DYN_KVBM_MAX_TRANSFER_BATCH_SIZE"] == "32"
+    assert prefill_env["DYN_KVBM_MAX_CONCURRENT_TRANSFERS"] == "4"
+    prefill_script = prefill["extraPodSpec"]["mainContainer"]["args"][0]
+    assert "args+=(--connector kvbm)" in prefill_script
+
+    decode = services["TRTLLMDecodeWorker"]
+    assert decode.get("envs") is None
+    decode_script = decode["extraPodSpec"]["mainContainer"]["args"][0]
+    assert "--connector kvbm" not in decode_script
+
+    run_scripts = [content for name, content in artifacts.items() if name.startswith("run_")]
+    prefill_run = next(content for content in run_scripts if "--disaggregation-mode prefill" in content)
+    decode_run = next(content for content in run_scripts if "--disaggregation-mode decode" in content)
+    assert "export DYN_KVBM_MAX_TRANSFER_BATCH_SIZE=32" in prefill_run
+    assert "export DYN_KVBM_MAX_CONCURRENT_TRANSFERS=4" in prefill_run
+    assert "--connector kvbm" in prefill_run
+    assert "DYN_KVBM_" not in decode_run
+    assert "--connector kvbm" not in decode_run
 
 
 def test_benchmark_prefix_defaults_from_model_config():

--- a/tests/unit/cli/test_argument_parsing.py
+++ b/tests/unit/cli/test_argument_parsing.py
@@ -17,8 +17,8 @@ pytestmark = pytest.mark.unit
 class TestCLIArgumentParsing:
     """Test CLI argument parsing and validation."""
 
-    def test_default_mode_required_args(self, cli_parser):
-        """Test that configure_parser creates a valid argument parser."""
+    def test_default_mode_core_args_are_conditionally_required(self, cli_parser):
+        """Default core args are validated after parsing so --thorough-config can stand alone."""
         subparsers = [action for action in cli_parser._actions if action.dest == "mode"]
         assert len(subparsers) == 1
 
@@ -28,9 +28,9 @@ class TestCLIArgumentParsing:
         required_actions = [action for action in default_parser._actions if getattr(action, "required", False)]
         required_args = [action.dest for action in required_actions]
 
-        assert "model_path" in required_args
-        assert "total_gpus" in required_args
-        assert "system" in required_args
+        assert "model_path" not in required_args
+        assert "total_gpus" not in required_args
+        assert "system" not in required_args
 
     def test_exp_mode_required_args(self, cli_parser):
         """Test that exp mode requires the yaml_path argument."""
@@ -117,9 +117,69 @@ class TestCLIArgumentParsing:
         assert args.ttft == 2000.0
         assert args.tpot == 30.0
         assert args.request_latency is None
+        assert args.thorough_sweep is False
+        assert args.thorough_config is None
         assert args.inclusive_tpot is False
         assert args.prefix == 0
         assert args.engine_step_backend is None
+
+    def test_default_trace_path_is_not_public_cli(self, cli_parser):
+        """Trace replay should be configured through --thorough-config, not a single-format CLI shortcut."""
+        with pytest.raises(SystemExit):
+            cli_parser.parse_args(
+                [
+                    "default",
+                    "--model-path",
+                    "Qwen/Qwen3-32B",
+                    "--total-gpus",
+                    "8",
+                    "--system",
+                    "h200_sxm",
+                    "--trace-path",
+                    "/tmp/traffic.jsonl",
+                ]
+            )
+
+    def test_default_thorough_sweep_parses(self, cli_parser):
+        """--thorough-sweep selects Spica while still using regular default inputs."""
+        args = cli_parser.parse_args(
+            [
+                "default",
+                "--model-path",
+                "Qwen/Qwen3-32B",
+                "--total-gpus",
+                "8",
+                "--system",
+                "h200_sxm",
+                "--thorough-sweep",
+            ]
+        )
+
+        assert args.thorough_sweep is True
+        assert args.thorough_config is None
+
+    def test_default_thorough_config_parses_without_legacy_required_args(self, cli_parser):
+        """A native Spica config owns model/system/GPU inputs."""
+        args = cli_parser.parse_args(["default", "--thorough-config", "/tmp/spica.yaml"])
+
+        assert args.thorough_config == "/tmp/spica.yaml"
+        assert args.model_path is None
+        assert args.total_gpus is None
+        assert args.system is None
+
+    @pytest.mark.parametrize("flag", ["--trace-sweep-rounds", "--trace-parallel-evals"])
+    def test_default_trace_tuning_flags_are_not_public_cli(self, cli_parser, flag):
+        """Trace sweep tuning is intentionally configured by Spica config or internal env defaults."""
+        with pytest.raises(SystemExit):
+            cli_parser.parse_args(
+                [
+                    "default",
+                    "--thorough-config",
+                    "/tmp/spica.yaml",
+                    flag,
+                    "5",
+                ]
+            )
 
     def test_inclusive_tpot_default_false_in_exp_mode(self, cli_parser, mock_exp_yaml_path):
         """--inclusive-tpot defaults to False in exp mode."""

--- a/tests/unit/cli/test_cli_workflow.py
+++ b/tests/unit/cli/test_cli_workflow.py
@@ -9,11 +9,15 @@ while keeping heavy computation mocked out.
 """
 
 import argparse
+import json
 import logging
+import sys
+import types
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
+import yaml
 
 from aiconfigurator.cli.main import (
     _execute_tasks,
@@ -24,6 +28,20 @@ from aiconfigurator.cli.main import (
 )
 from aiconfigurator.cli.main import main as cli_main
 from aiconfigurator.cli.report_and_save import _apply_inclusive_tpot
+from aiconfigurator.cli.spica.helper import (
+    _build_spica_thorough_config_data,
+    _build_spica_trace_result_bundle,
+    _build_spica_trace_search_space,
+    _save_spica_trace_artifacts,
+    _spica_candidates_to_result_df,
+    _spica_generated_backend_version,
+    _spica_generator_overrides,
+    _spica_kvbm_config,
+    _spica_role_worker_overrides,
+    _spica_router_enabled,
+    _SpicaReplayEvaluatorCompat,
+    _validate_spica_artifact_target,
+)
 from aiconfigurator.sdk.errors import NoFeasibleConfigError
 
 pytestmark = pytest.mark.unit
@@ -159,6 +177,921 @@ class TestCLIIntegration:
 
         mock_builder.assert_called_once()
         mock_execute.assert_called_once_with({"agg": mock_task_config}, mode, top_n=5)
+
+    @patch("aiconfigurator.cli.main.run_spica_thorough_default")
+    @patch("aiconfigurator.cli.main._execute_tasks")
+    @patch("aiconfigurator.cli.main.build_default_tasks")
+    def test_cli_default_thorough_sweep_dispatches_to_spica(
+        self,
+        mock_build_default,
+        mock_execute,
+        mock_run_spica,
+        cli_args_factory,
+    ):
+        """default --thorough-sweep should use Spica with CLI-derived config."""
+        args = cli_args_factory(mode="default", thorough_sweep=True)
+
+        cli_main(args)
+
+        mock_run_spica.assert_called_once_with(args)
+        mock_build_default.assert_not_called()
+        mock_execute.assert_not_called()
+
+    @patch("aiconfigurator.cli.main.run_spica_thorough_default")
+    @patch("aiconfigurator.cli.main._execute_tasks")
+    @patch("aiconfigurator.cli.main.build_default_tasks")
+    def test_cli_default_thorough_config_dispatches_without_default_inputs(
+        self,
+        mock_build_default,
+        mock_execute,
+        mock_run_spica,
+        tmp_path,
+    ):
+        """default --thorough-config should not require dummy model/system/GPU args."""
+        parser = argparse.ArgumentParser()
+        configure_parser(parser)
+        config_path = tmp_path / "spica.yaml"
+        config_path.write_text("search_space: {}\n", encoding="utf-8")
+        args = parser.parse_args(["default", "--thorough-config", str(config_path)])
+
+        cli_main(args)
+
+        mock_run_spica.assert_called_once_with(args)
+        mock_build_default.assert_not_called()
+        mock_execute.assert_not_called()
+
+    def test_cli_default_missing_required_inputs_raises(self):
+        """Legacy default still needs model/system/GPU when no native Spica config is provided."""
+        parser = argparse.ArgumentParser()
+        configure_parser(parser)
+        args = parser.parse_args(["default"])
+
+        with pytest.raises(SystemExit, match="default mode requires"):
+            cli_main(args)
+
+    def test_spica_default_search_space_collapses_single_gpu_noops(self, cli_args_factory):
+        """Single-GPU Spica default sweeps should avoid routing/planner choices that cannot help."""
+        args = cli_args_factory(
+            mode="default",
+            total_gpus=1,
+            max_seq_len=8192,
+        )
+
+        search_space = _build_spica_trace_search_space(args, ["trtllm"])
+
+        assert search_space["gpu_budget"] == 1
+        assert search_space["context_length"] == 8192
+        assert search_space["deployment_mode"] == ["agg"]
+        assert search_space["router_mode"] == ["round_robin"]
+        assert search_space["planner_scaling_policy"] == ["disabled"]
+
+    def test_spica_thorough_config_data_uses_cli_inputs(self, cli_args_factory):
+        """CLI-derived thorough mode should build a Spica config-shaped payload."""
+        args = cli_args_factory(
+            mode="default",
+            thorough_sweep=True,
+            model_path="meta-llama/Meta-Llama-3.1-8B",
+            total_gpus=4,
+            system="gb200",
+            backend="trtllm",
+            isl=2048,
+            osl=512,
+            prefix=256,
+            max_seq_len=8192,
+            nextn=1,
+            ttft=8000.0,
+            tpot=200.0,
+        )
+
+        config_data = _build_spica_thorough_config_data(args, ["trtllm"])
+
+        assert config_data["search_space"]["model_name"] == "meta-llama/Meta-Llama-3.1-8B"
+        assert config_data["search_space"]["hardware_sku"] == "gb200"
+        assert config_data["search_space"]["gpu_budget"] == 4
+        assert config_data["search_space"]["backend"] == ["trtllm"]
+        assert config_data["search_space"]["context_length"] == 8192
+        assert config_data["search_space"]["aic_nextn"] == 1
+        assert config_data["search_space"]["router_mode"] == ["round_robin"]
+        assert config_data["search_space"]["planner_scaling_policy"] == ["disabled"]
+        assert config_data["search_space"]["planner_fpm_sampling"] == ["default"]
+        assert config_data["search_space"]["planner_load_sensitivity"] == ["default"]
+        assert config_data["workload"]["isl"] == 2048
+        assert config_data["workload"]["osl"] == 512
+        assert config_data["workload"]["concurrency"] == 512
+        assert config_data["workload"]["num_request_ratio"] == pytest.approx(1000 / 512)
+        assert "request_count" not in config_data["workload"]
+        assert config_data["workload"]["shared_prefix_ratio"] == 0.125
+        assert config_data["workload"]["num_prefix_groups"] == 1
+        assert config_data["goal"] == {"target": "goodput_per_gpu", "sla": {"ttft_ms": 8000.0, "itl_ms": 200.0}}
+        assert config_data["sweep"]["max_rounds"] == 3
+        assert config_data["sweep"]["parallel_evals"] == 16
+
+    def test_spica_replay_evaluator_compat_forwards_concurrency_override(self, monkeypatch):
+        """Spica pareto sweeps pass a per-trial concurrency override into the evaluator."""
+        captured: dict[str, object] = {}
+
+        class FakeReplayEvaluator:
+            def __init__(self, workload, goal):
+                captured["workload"] = workload
+                captured["goal"] = goal
+
+            def evaluate(self, plan, *, concurrency_override=None):
+                captured["plan"] = plan
+                captured["concurrency_override"] = concurrency_override
+                return {"goodput_output_throughput_tok_s": 123.0}
+
+        fake_spica = types.ModuleType("spica")
+        fake_spica.__path__ = []
+        fake_evaluator = types.ModuleType("spica.evaluator")
+        fake_evaluator.ReplayEvaluator = FakeReplayEvaluator
+        fake_spica.evaluator = fake_evaluator
+        monkeypatch.setitem(sys.modules, "spica", fake_spica)
+        monkeypatch.setitem(sys.modules, "spica.evaluator", fake_evaluator)
+
+        evaluator = _SpicaReplayEvaluatorCompat(workload="workload", goal="goal")
+        assert evaluator.evaluate("plan", concurrency_override=7) == {"goodput_output_throughput_tok_s": 123.0}
+        assert captured == {
+            "workload": "workload",
+            "goal": "goal",
+            "plan": "plan",
+            "concurrency_override": 7,
+        }
+
+    def test_spica_trace_results_use_default_result_shape(self, cli_args_factory):
+        """Spica trace candidates should be adapted to the legacy default-mode result bundle."""
+        candidates = [
+            {
+                "config": {
+                    "deployment_mode": "disagg",
+                    "backend": "trtllm",
+                    "model_name": "Qwen/Qwen3-32B-FP8",
+                    "prefill_replicas": 2,
+                    "prefill_tp": 2,
+                    "prefill_pp": 1,
+                    "prefill_attention_dp": 1,
+                    "prefill_moe_tp": 1,
+                    "prefill_moe_ep": 1,
+                    "prefill_max_num_batched_tokens": 8192,
+                    "prefill_max_num_seqs": 64,
+                    "decode_replicas": 4,
+                    "decode_tp": 1,
+                    "decode_pp": 1,
+                    "decode_attention_dp": 1,
+                    "decode_moe_tp": 1,
+                    "decode_moe_ep": 1,
+                    "decode_max_num_batched_tokens": 4096,
+                    "decode_max_num_seqs": 128,
+                    "router_mode": "kv_router",
+                    "planner_scaling_policy": "predictive",
+                    "enable_throughput_scaling": True,
+                    "enable_load_scaling": False,
+                },
+                "used_gpus": 8,
+                "score": 321.5,
+                "metrics": {
+                    "goodput_output_throughput_tok_s": 2572.0,
+                    "output_throughput_tok_s": 3000.0,
+                    "mean_ttft_ms": 120.0,
+                    "mean_tpot_ms": 8.0,
+                    "mean_e2e_latency_ms": 900.0,
+                },
+            },
+            {
+                "config": {
+                    "deployment_mode": "agg",
+                    "backend": "vllm",
+                    "model_name": "Qwen/Qwen3-32B-FP8",
+                    "replicas": 4,
+                    "tp": 2,
+                    "pp": 1,
+                    "attention_dp": 1,
+                    "moe_tp": 1,
+                    "moe_ep": 1,
+                    "agg_max_num_batched_tokens": 4096,
+                    "agg_max_num_seqs": 128,
+                    "router_mode": "round_robin",
+                    "enable_throughput_scaling": False,
+                    "enable_load_scaling": False,
+                },
+                "used_gpus": 8,
+                "score": 280.0,
+                "metrics": {
+                    "goodput_output_throughput_tok_s": 2240.0,
+                    "output_throughput_tok_s": 2500.0,
+                    "mean_ttft_ms": 150.0,
+                    "mean_tpot_ms": 9.0,
+                    "mean_e2e_latency_ms": 950.0,
+                },
+            },
+        ]
+
+        args = cli_args_factory(
+            mode="default",
+            model_path="Qwen/Qwen3-32B-FP8",
+            total_gpus=16,
+            top_n=5,
+            ttft=2000.0,
+            tpot=30.0,
+        )
+        config = argparse.Namespace(workload=argparse.Namespace(trace_path="/data/replay/traffic.jsonl"))
+        result_bundle = _build_spica_trace_result_bundle(candidates, args, config=config)
+
+        assert result_bundle.chosen_exp == "disagg"
+        assert result_bundle.trace_path == "/data/replay/traffic.jsonl"
+        assert set(result_bundle.tasks) == {"agg", "disagg"}
+        assert result_bundle.tasks["disagg"].serving_mode == "disagg"
+        assert result_bundle.tasks["disagg"].primary_model_path == "Qwen/Qwen3-32B-FP8"
+        assert result_bundle.best_throughputs["disagg"] == pytest.approx(321.5)
+        assert result_bundle.pareto_x_axis == {"disagg": "tokens/s/user", "agg": "tokens/s/user"}
+
+        disagg_best = result_bundle.best_configs["disagg"].iloc[0]
+        assert disagg_best["tokens/s/gpu"] == pytest.approx(321.5)
+        assert disagg_best["tokens/s/gpu_cluster"] == pytest.approx(321.5)
+        assert disagg_best["tokens/s/user"] == pytest.approx(125.0)
+        assert disagg_best["(p)parallel"] == "tp2_pp1"
+        assert disagg_best["(d)parallel"] == "tp1_pp1"
+        assert disagg_best["router"] == "kv_router"
+
+        agg_best = result_bundle.best_configs["agg"].iloc[0]
+        assert "(p)tp" not in result_bundle.best_configs["agg"].columns
+        assert agg_best["parallel"] == "tp2_pp1"
+        assert agg_best["tokens/s/gpu"] == pytest.approx(280.0)
+
+    def test_spica_thorough_config_result_bundle_uses_candidate_scalars(self):
+        """Native Spica configs can use multi-value search-space fields; reports use evaluated candidate values."""
+        config = argparse.Namespace(
+            search_space=argparse.Namespace(
+                model_name=["Qwen/Qwen3-32B-FP8"],
+                hardware_sku=["gb200"],
+                gpu_budget=[1, 4],
+                backend=["trtllm", "vllm"],
+            ),
+            workload=argparse.Namespace(isl=128, osl=16),
+            goal=argparse.Namespace(
+                target="goodput_per_gpu",
+                sla=argparse.Namespace(ttft_ms=8000.0, itl_ms=200.0, e2e_ms=None),
+            ),
+        )
+        args = argparse.Namespace(
+            backend="auto",
+            model_path="Wrong/CLI-Model",
+            system="wrong_cli_system",
+            total_gpus=99,
+            top_n=1,
+            strict_sla=False,
+            ttft=1.0,
+            tpot=2.0,
+        )
+        candidates = [
+            {
+                "config": {
+                    "deployment_mode": "agg",
+                    "backend": "trtllm",
+                    "model_name": "Qwen/Qwen3-32B-FP8",
+                    "hardware_sku": "gb200",
+                    "tp": 4,
+                    "pp": 1,
+                    "attention_dp": 1,
+                    "replicas": 1,
+                    "router_mode": "round_robin",
+                    "planner_scaling_policy": "disabled",
+                },
+                "used_gpus": 4,
+                "score": 250.0,
+                "metrics": {
+                    "goodput_output_throughput_tok_s": 1000.0,
+                    "output_throughput_tok_s": 1100.0,
+                    "mean_ttft_ms": 100.0,
+                    "mean_tpot_ms": 10.0,
+                    "mean_e2e_latency_ms": 260.0,
+                },
+            }
+        ]
+
+        result_bundle = _build_spica_trace_result_bundle(
+            candidates,
+            args,
+            config=config,
+            config_path="/tmp/spica.yaml",
+        )
+
+        task = result_bundle.tasks["agg"]
+        assert task.primary_model_path == "Qwen/Qwen3-32B-FP8"
+        assert task.primary_system_name == "gb200"
+        assert task.primary_backend_name == "trtllm"
+        assert task.total_gpus == 4
+        assert task.isl == 128
+        assert task.osl == 16
+        assert task.ttft == 8000.0
+        assert task.tpot == 200.0
+        assert result_bundle.workload_label == "config"
+
+    def test_native_throughput_goal_owns_ranking_and_does_not_inherit_cli_sla(self):
+        config = argparse.Namespace(
+            search_space=argparse.Namespace(
+                model_name="model",
+                hardware_sku="h200_sxm",
+                gpu_budget=8,
+                min_gpu_budget=4,
+                min_endpoint=2,
+                context_length=32768,
+            ),
+            workload=argparse.Namespace(isl=128, osl=32),
+            goal=argparse.Namespace(target="throughput", sla=None),
+        )
+        args = argparse.Namespace(
+            backend="trtllm",
+            model_path="wrong",
+            system="wrong",
+            total_gpus=99,
+            top_n=1,
+            strict_sla=True,
+            ttft=2000.0,
+            tpot=30.0,
+        )
+        candidates = [
+            {
+                "config": {"deployment_mode": "agg", "backend": "trtllm", "used_gpus": 1},
+                "used_gpus": 1,
+                "score": 500.0,
+                "metrics": {
+                    "output_throughput_tok_s": 500.0,
+                    "mean_tpot_ms": 20.0,
+                    "mean_e2e_latency_ms": 100.0,
+                },
+            },
+            {
+                "config": {"deployment_mode": "agg", "backend": "trtllm", "used_gpus": 4},
+                "used_gpus": 4,
+                "score": 1000.0,
+                "metrics": {
+                    "output_throughput_tok_s": 1000.0,
+                    "mean_tpot_ms": 40.0,
+                    "mean_e2e_latency_ms": 200.0,
+                },
+            },
+        ]
+
+        bundle = _build_spica_trace_result_bundle(candidates, args, config=config, config_path="/tmp/native.yaml")
+
+        best = bundle.best_configs["agg"].iloc[0]
+        assert best["spica_candidate_id"] == 1
+        assert best["objective_target"] == "throughput"
+        assert best["objective_score"] == pytest.approx(1000.0)
+        assert best["objective_value"] == pytest.approx(1000.0)
+        assert best["tokens/s/gpu"] == pytest.approx(250.0)  # physical throughput/GPU, not score
+        assert bundle.best_throughputs["agg"] == pytest.approx(250.0)
+        assert bundle.best_objective_scores["agg"] == pytest.approx(1000.0)
+        assert bundle.tasks["agg"].ttft == 0.0
+        assert bundle.tasks["agg"].tpot == 0.0
+        assert bundle.pareto_x_axis["agg"] == "tokens/s/user"
+        assert bundle.pareto_y_axis["agg"] == "objective_value"
+        saved_config = bundle.candidates[1]["config"]
+        assert saved_config["context_length"] == 32768
+        assert saved_config["gpu_budget"] == 8
+        assert saved_config["min_gpu_budget"] == 4
+        assert saved_config["min_endpoint"] == 2
+        assert saved_config["planner_optimization_target"] == "throughput"
+        assert saved_config["planner_ttft_ms"] is None
+        assert saved_config["planner_itl_ms"] is None
+
+    def test_native_latency_and_custom_pareto_use_raw_objectives(self):
+        latency_goal = argparse.Namespace(target="e2e_latency", sla=None)
+        latency_df = _spica_candidates_to_result_df(
+            [
+                {
+                    "config": {"deployment_mode": "agg"},
+                    "used_gpus": 2,
+                    "score": -125.0,
+                    "metrics": {"output_throughput_tok_s": 400.0, "mean_e2e_latency_ms": 125.0},
+                }
+            ],
+            goal=latency_goal,
+        )
+        assert latency_df.loc[0, "objective_score"] == pytest.approx(-125.0)
+        assert latency_df.loc[0, "objective_value"] == pytest.approx(125.0)
+        assert latency_df.loc[0, "tokens/s/gpu"] == pytest.approx(200.0)
+
+        per_user_df = _spica_candidates_to_result_df(
+            [
+                {
+                    "config": {"deployment_mode": "agg"},
+                    "used_gpus": 1,
+                    "score": 0.0,
+                    "metrics": {"mean_tpot_ms": 10.0},
+                }
+            ],
+            goal=argparse.Namespace(target="throughput_per_user", sla=None),
+        )
+        assert per_user_df.loc[0, "tokens/s/user"] == pytest.approx(100.0)
+        assert per_user_df.loc[0, "objective_value"] == pytest.approx(0.0)
+
+        pareto_goal = argparse.Namespace(
+            target="pareto",
+            sla=None,
+            resolved_pareto_objectives=["throughput", "e2e_latency"],
+        )
+        config = argparse.Namespace(
+            search_space=argparse.Namespace(model_name="model", hardware_sku="h200_sxm", gpu_budget=8),
+            workload=argparse.Namespace(isl=128, osl=32),
+            goal=pareto_goal,
+        )
+        args = argparse.Namespace(
+            backend="trtllm",
+            model_path="wrong",
+            system="wrong",
+            total_gpus=99,
+            top_n=2,
+            strict_sla=False,
+            ttft=2000.0,
+            tpot=30.0,
+        )
+        candidates = [
+            {
+                "config": {"deployment_mode": "agg"},
+                "used_gpus": 1,
+                "score": 100.0,
+                "objectives": {"throughput": 100.0, "e2e_latency": 100.0},
+                "metrics": {"output_throughput_tok_s": 100.0, "mean_e2e_latency_ms": 100.0},
+            },
+            {
+                "config": {"deployment_mode": "agg"},
+                "used_gpus": 1,
+                "score": 90.0,
+                "objectives": {"throughput": 90.0, "e2e_latency": 90.0},
+                "metrics": {"output_throughput_tok_s": 90.0, "mean_e2e_latency_ms": 90.0},
+            },
+            {
+                "config": {"deployment_mode": "agg"},
+                "used_gpus": 1,
+                "score": 80.0,
+                "objectives": {"throughput": 80.0, "e2e_latency": 120.0},
+                "metrics": {"output_throughput_tok_s": 80.0, "mean_e2e_latency_ms": 120.0},
+            },
+        ]
+
+        bundle = _build_spica_trace_result_bundle(candidates, args, config=config, config_path="/tmp/pareto.yaml")
+        assert bundle.pareto_x_axis["agg"] == "e2e_latency"
+        assert bundle.pareto_y_axis["agg"] == "throughput"
+        assert bundle.pareto_fronts["agg"]["spica_candidate_id"].tolist() == [1, 0]
+        assert bundle.best_configs["agg"]["spica_candidate_id"].tolist() == [0, 1]
+        assert bundle.best_objective_scores["agg"] == pytest.approx(100.0)
+
+    def test_spica_generator_overrides_prefer_task_over_cli_for_planner(self):
+        """Generated planner config should use evaluated Spica config values, not stale default CLI args."""
+        args = argparse.Namespace(
+            model_path="Wrong/CLI-Model",
+            total_gpus=99,
+            system="wrong_cli_system",
+            ttft=1.0,
+            tpot=2.0,
+            generator_config=None,
+            generator_set=None,
+            generator_dynamo_version=None,
+            namespace=None,
+            transport=None,
+            image_pull_secret=None,
+            model_cache=None,
+        )
+        task = argparse.Namespace(primary_model_path="Qwen/Qwen3-32B-FP8", ttft=8000.0, tpot=200.0)
+        row = pd.Series(
+            {
+                "deployment_mode": "disagg",
+                "backend": "trtllm",
+                "model_name": "Qwen/Qwen3-32B-FP8",
+                "enable_throughput_scaling": True,
+                "enable_load_scaling": True,
+                "prefill_tp": 1,
+                "prefill_pp": 1,
+                "prefill_attention_dp": 1,
+                "decode_tp": 2,
+                "decode_pp": 1,
+                "decode_attention_dp": 1,
+            }
+        )
+
+        planner_config = _spica_generator_overrides(args, row, task)["DynConfig"]["planner_config"]
+
+        assert planner_config["model_name"] == "Qwen/Qwen3-32B-FP8"
+        assert planner_config["ttft_ms"] == pytest.approx(8000.0)
+        assert planner_config["itl_ms"] == pytest.approx(200.0)
+        assert planner_config["prefill_engine_num_gpu"] == 1
+        assert planner_config["decode_engine_num_gpu"] == 2
+
+    @pytest.mark.parametrize("deployment_target", ["dynamo-python", "llm-d-helm", "llm-d-kustomize"])
+    def test_spica_artifacts_fail_closed_when_target_drops_native_features(self, deployment_target):
+        generator_config = {
+            "DynConfig": {
+                "enable_router": True,
+                "router_mode": "kv",
+                "router_config": {"host_cache_hit_weight": 0.75},
+                "planner_config": {"optimization_target": "throughput"},
+                "kvbm_config": {"cpu_cache_override_num_blocks": 128},
+            }
+        }
+
+        with pytest.raises(
+            RuntimeError,
+            match=rf"cannot faithfully emit router, planner, KVBM.*'{deployment_target}'",
+        ):
+            _validate_spica_artifact_target(generator_config, deployment_target)
+
+        _validate_spica_artifact_target(generator_config, "dynamo-j2")
+
+    def test_native_generator_overrides_preserve_planner_router_and_kvbm_contract(self):
+        args = argparse.Namespace(
+            model_path="Wrong/CLI-Model",
+            backend="trtllm",
+            ttft=2000.0,
+            tpot=30.0,
+            max_seq_len=None,
+            generator_config=None,
+            generator_set=None,
+            generator_dynamo_version=None,
+            namespace=None,
+            transport=None,
+            image_pull_secret=None,
+            model_cache=None,
+        )
+        task = argparse.Namespace(
+            primary_model_path="model",
+            planner_optimization_target="throughput",
+            ttft=0.0,
+            tpot=0.0,
+            min_gpu_budget=4,
+            min_endpoint=2,
+        )
+        row = pd.Series(
+            {
+                "deployment_mode": "disagg",
+                "backend": "trtllm",
+                "model_name": "model",
+                "planner_optimization_target": "throughput",
+                "planner_ttft_ms": None,
+                "planner_itl_ms": None,
+                "enable_throughput_scaling": False,
+                "enable_load_scaling": True,
+                "gpu_budget": 16,
+                "min_gpu_budget": 4,
+                "min_endpoint": 2,
+                "prefill_tp": 1,
+                "prefill_pp": 1,
+                "prefill_attention_dp": 1,
+                "decode_tp": 2,
+                "decode_pp": 1,
+                "decode_attention_dp": 1,
+                "decode_block_size": 64,
+                "router_mode": "kv_router",
+                "host_cache_hit_weight": 0.75,
+                "disk_cache_hit_weight": 0.25,
+                "active_prefill_tokens_threshold": 10000.0,
+                "num_g2_blocks": 4096,
+                "offload_batch_size": 4,
+            }
+        )
+
+        dyn_config = _spica_generator_overrides(args, row, task)["DynConfig"]
+        planner = dyn_config["planner_config"]
+        assert planner["optimization_target"] == "throughput"
+        assert planner["max_gpu_budget"] == 16
+        assert planner["min_gpu_budget"] == 4
+        assert planner["min_endpoint"] == 2
+        assert "ttft_ms" not in planner and "itl_ms" not in planner
+        router = dyn_config["router_config"]
+        assert router["host_cache_hit_weight"] == pytest.approx(0.75)
+        assert router["disk_cache_hit_weight"] == pytest.approx(0.25)
+        assert router["active_prefill_tokens_threshold"] == 10000
+        assert isinstance(router["active_prefill_tokens_threshold"], int)
+        assert dyn_config["kvbm_config"] == {
+            "cpu_cache_override_num_blocks": 4096,
+            "max_transfer_batch_size": 4,
+            "max_concurrent_transfers": 4,
+        }
+
+    def test_kvbm_batch_size_cannot_enable_offload_without_g2_blocks(self):
+        assert _spica_kvbm_config(pd.Series({"num_g2_blocks": 0, "offload_batch_size": 4})) is None
+        assert _spica_kvbm_config(pd.Series({"offload_batch_size": 4})) is None
+
+    def test_spica_artifacts_prefer_the_backend_version_used_by_replay(self):
+        args = argparse.Namespace(generated_config_version="1.3.0rc14")
+
+        assert _spica_generated_backend_version(args, "trtllm", "1.3.0rc10") == "1.3.0rc10"
+
+    def test_spica_round_robin_router_mode_still_enables_router(self):
+        row = pd.Series(
+            {
+                "deployment_mode": "agg",
+                "router_mode": "round_robin",
+                "agg_block_size": 64,
+            }
+        )
+        args = argparse.Namespace(
+            generator_config=None,
+            generator_set=None,
+            generator_dynamo_version=None,
+            namespace=None,
+            transport=None,
+            image_pull_secret=None,
+            model_cache=None,
+        )
+        task = argparse.Namespace(primary_model_path="Qwen/Qwen3-32B-FP8", ttft=8000.0, tpot=200.0)
+
+        overrides = _spica_generator_overrides(args, row, task)
+
+        assert _spica_router_enabled(row) is True
+        assert overrides["DynConfig"]["enable_router"] is True
+
+    @pytest.mark.parametrize(
+        ("row_data", "expected_message"),
+        [
+            (
+                {"decode_block_size": 64, "decode_max_num_batched_tokens": 4100, "context_length": 8192},
+                "decode_max_num_batched_tokens=4100 must be divisible by decode_block_size=64",
+            ),
+            (
+                {"decode_block_size": 64, "decode_max_num_batched_tokens": 4096, "context_length": 8200},
+                "decode cache_transceiver_max_tokens_in_buffer=8200 must be divisible by decode_block_size=64",
+            ),
+        ],
+    )
+    def test_spica_worker_overrides_reject_unaligned_token_limits(self, row_data, expected_message):
+        row = pd.Series(row_data)
+
+        with pytest.raises(ValueError, match=expected_message):
+            _spica_role_worker_overrides(row, "decode", argparse.Namespace(max_seq_len=None))
+
+    def test_spica_trace_artifacts_include_pareto_outputs(self, tmp_path, cli_args_factory):
+        candidates = [
+            {
+                "config": {
+                    "deployment_mode": "agg",
+                    "backend": "trtllm",
+                    "model_name": "Qwen/Qwen3-32B-FP8",
+                    "tp": 1,
+                    "pp": 1,
+                    "attention_dp": 1,
+                    "replicas": 1,
+                    "aic_nextn": 2,
+                    "agg_max_num_batched_tokens": 4096,
+                    "agg_max_num_seqs": 128,
+                    "agg_block_size": 64,
+                    "agg_gpu_memory_utilization": 0.91,
+                    "agg_enable_prefix_caching": True,
+                    "context_length": 8192,
+                    "router_mode": "round_robin",
+                    "planner_scaling_policy": "disabled",
+                },
+                "used_gpus": 1,
+                "score": 100.0,
+                "metrics": {
+                    "goodput_output_throughput_tok_s": 100.0,
+                    "output_throughput_tok_s": 110.0,
+                    "mean_ttft_ms": 100.0,
+                    "mean_tpot_ms": 10.0,
+                    "mean_e2e_latency_ms": 500.0,
+                },
+            },
+            {
+                "config": {
+                    "deployment_mode": "agg",
+                    "backend": "trtllm",
+                    "model_name": "Qwen/Qwen3-32B-FP8",
+                    "tp": 2,
+                    "pp": 1,
+                    "attention_dp": 1,
+                    "replicas": 1,
+                    "agg_max_num_batched_tokens": 2048,
+                    "agg_max_num_seqs": 64,
+                    "agg_block_size": 32,
+                    "agg_gpu_memory_utilization": 0.82,
+                    "agg_enable_prefix_caching": False,
+                    "router_mode": "round_robin",
+                    "planner_scaling_policy": "disabled",
+                },
+                "used_gpus": 2,
+                "score": 80.0,
+                "metrics": {
+                    "goodput_output_throughput_tok_s": 80.0,
+                    "output_throughput_tok_s": 90.0,
+                    "mean_ttft_ms": 90.0,
+                    "mean_tpot_ms": 20.0,
+                    "mean_e2e_latency_ms": 700.0,
+                },
+            },
+            {
+                "config": {
+                    "deployment_mode": "disagg",
+                    "backend": "trtllm",
+                    "model_name": "Qwen/Qwen3-32B-FP8",
+                    "prefill_replicas": 1,
+                    "prefill_tp": 1,
+                    "prefill_pp": 1,
+                    "prefill_attention_dp": 1,
+                    "prefill_max_num_batched_tokens": 8192,
+                    "prefill_max_num_seqs": 64,
+                    "prefill_block_size": 64,
+                    "prefill_gpu_memory_utilization": 0.88,
+                    "prefill_enable_prefix_caching": True,
+                    "decode_replicas": 1,
+                    "decode_tp": 1,
+                    "decode_pp": 1,
+                    "decode_attention_dp": 2,
+                    "decode_max_num_batched_tokens": 4096,
+                    "decode_max_num_seqs": 128,
+                    "decode_block_size": 32,
+                    "decode_gpu_memory_utilization": 0.86,
+                    "decode_enable_prefix_caching": False,
+                    "context_length": 8192,
+                    "router_mode": "kv_router",
+                    "overlap_score_credit": 0.5,
+                    "prefill_load_scale": 2.0,
+                    "router_temperature": 0.2,
+                    "active_decode_blocks_threshold": 0.75,
+                    "active_prefill_tokens_threshold": 10000,
+                    "active_prefill_tokens_threshold_frac": 2.0,
+                    "no_admission_control": False,
+                    "planner_scaling_policy": "predictive",
+                    "enable_throughput_scaling": True,
+                    "enable_load_scaling": True,
+                    "throughput_adjustment_interval_seconds": 180,
+                    "load_adjustment_interval_seconds": 5,
+                    "max_num_fpm_samples": 25,
+                    "fpm_sample_bucket_size": 4,
+                    "load_scaling_down_sensitivity": 20,
+                    "load_min_observations": 6,
+                    "num_g2_blocks": 4096,
+                    "offload_batch_size": 32,
+                },
+                "used_gpus": 3,
+                "score": 120.0,
+                "metrics": {
+                    "goodput_output_throughput_tok_s": 240.0,
+                    "output_throughput_tok_s": 260.0,
+                    "mean_ttft_ms": 80.0,
+                    "mean_tpot_ms": 12.5,
+                    "mean_e2e_latency_ms": 600.0,
+                },
+            },
+        ]
+
+        pareto_df = _spica_candidates_to_result_df(candidates)
+        assert pareto_df["tokens/s/user"].tolist() == pytest.approx([100.0, 50.0, 80.0])
+        assert pareto_df["tokens/s/gpu"].tolist() == pytest.approx([100.0, 80.0, 120.0])
+        assert pareto_df["goodput/s/gpu"].tolist() == pytest.approx([100.0, 80.0, 120.0])
+
+        args = cli_args_factory(
+            mode="default",
+            model_path="Qwen/Qwen3-32B-FP8",
+            total_gpus=3,
+            top_n=2,
+            max_seq_len=8192,
+        )
+        config = argparse.Namespace(
+            workload=argparse.Namespace(trace_path="/tmp/traffic.jsonl", trace_format="mooncake")
+        )
+        result_bundle = _build_spica_trace_result_bundle(candidates, args, config=config)
+        written_paths = _save_spica_trace_artifacts(result_bundle, str(tmp_path))
+        result_dir = next(tmp_path.iterdir())
+        written_names = {str(path).replace(f"{result_dir}/", "") for path in written_paths}
+
+        assert {
+            "spica_candidates.yaml",
+            "spica_candidates.csv",
+            "pareto.csv",
+            "pareto_frontier.png",
+            "agg/exp_config.yaml",
+            "agg/pareto.csv",
+            "agg/best_config_topn.csv",
+            "agg/top1/agg_config.yaml",
+            "agg/top1/bench_run.sh",
+            "agg/top1/generator_config.yaml",
+            "agg/top1/k8s_bench.yaml",
+            "agg/top1/k8s_deploy.yaml",
+            "agg/top1/run_0.sh",
+            "agg/top1/sflow.yaml",
+            "agg/top1/spica_candidate.yaml",
+            "agg/top2/agg_config.yaml",
+            "agg/top2/generator_config.yaml",
+            "agg/top2/sflow.yaml",
+            "agg/top2/spica_candidate.yaml",
+            "disagg/exp_config.yaml",
+            "disagg/pareto.csv",
+            "disagg/best_config_topn.csv",
+            "disagg/top1/bench_run.sh",
+            "disagg/top1/decode_config.yaml",
+            "disagg/top1/generator_config.yaml",
+            "disagg/top1/k8s_bench.yaml",
+            "disagg/top1/k8s_deploy.yaml",
+            "disagg/top1/prefill_config.yaml",
+            "disagg/top1/run_0.sh",
+            "disagg/top1/sflow.yaml",
+            "disagg/top1/spica_candidate.yaml",
+        }.issubset(written_names)
+        assert result_dir.parent == tmp_path
+        assert result_dir.name.startswith("Qwen_Qwen3-32B-FP8_h200_sxm_trtllm_trace_traffic_ttft2000_tpot30_")
+
+        combined_pareto = pd.read_csv(result_dir / "pareto.csv")
+        assert set(combined_pareto["deployment_mode"]) == {"agg", "disagg"}
+        agg_best = pd.read_csv(result_dir / "agg" / "best_config_topn.csv")
+        assert agg_best.loc[0, "tokens/s/gpu"] == pytest.approx(100.0)
+        agg_generator_config = yaml.safe_load((result_dir / "agg" / "top1" / "generator_config.yaml").read_text())
+        assert agg_generator_config["WorkerConfig"]["agg_workers"] == 1
+        assert agg_generator_config["params"]["agg"]["max_batch_size"] == 128
+        assert agg_generator_config["params"]["agg"]["max_num_tokens"] == 4096
+        assert agg_generator_config["params"]["agg"]["tokens_per_block"] == 64
+        assert agg_generator_config["params"]["agg"]["kv_cache_free_gpu_memory_fraction"] == pytest.approx(0.91)
+        assert agg_generator_config["params"]["agg"]["disable_prefix_cache"] is False
+        assert agg_generator_config["params"]["agg"]["max_seq_len"] == 8192
+        assert agg_generator_config["params"]["agg"]["extra_engine_args"]["max_num_tokens"] == 4096
+        assert agg_generator_config["ModelConfig"]["nextn"] == 2
+        agg_engine_config = yaml.safe_load((result_dir / "agg" / "top1" / "agg_config.yaml").read_text())
+        assert agg_engine_config["max_num_tokens"] == 4096
+        assert agg_engine_config["max_seq_len"] == 8192
+        assert agg_engine_config["kv_cache_config"]["free_gpu_memory_fraction"] == pytest.approx(0.91)
+        assert agg_engine_config["kv_cache_config"]["tokens_per_block"] == 64
+        assert agg_engine_config["kv_cache_config"]["enable_block_reuse"] is True
+        assert agg_engine_config["speculative_config"]["num_nextn_predict_layers"] == 2
+        agg_top2_generator_config = yaml.safe_load((result_dir / "agg" / "top2" / "generator_config.yaml").read_text())
+        assert agg_top2_generator_config["params"]["agg"]["max_batch_size"] == 64
+        assert agg_top2_generator_config["params"]["agg"]["disable_prefix_cache"] is True
+        disagg_generator_config = yaml.safe_load((result_dir / "disagg" / "top1" / "generator_config.yaml").read_text())
+        assert disagg_generator_config["DynConfig"]["enable_router"] is True
+        assert disagg_generator_config["DynConfig"]["router_mode"] == "kv"
+        router_config = disagg_generator_config["DynConfig"]["router_config"]
+        assert router_config["kv_cache_block_size"] == 32
+        assert router_config["overlap_score_credit"] == pytest.approx(0.5)
+        assert router_config["prefill_load_scale"] == pytest.approx(2.0)
+        assert router_config["router_temperature"] == pytest.approx(0.2)
+        assert router_config["admission_control"] == "token-capacity"
+        assert router_config["active_decode_blocks_threshold"] == pytest.approx(0.75)
+        assert router_config["active_prefill_tokens_threshold"] == 10000
+        assert router_config["active_prefill_tokens_threshold_frac"] == pytest.approx(2.0)
+        planner_config = disagg_generator_config["DynConfig"]["planner_config"]
+        assert planner_config["enable_throughput_scaling"] is True
+        assert planner_config["enable_load_scaling"] is True
+        assert planner_config["throughput_adjustment_interval_seconds"] == 180
+        assert planner_config["load_adjustment_interval_seconds"] == 5
+        assert planner_config["max_num_fpm_samples"] == 25
+        assert planner_config["fpm_sample_bucket_size"] == 4
+        assert planner_config["load_scaling_down_sensitivity"] == 20
+        assert planner_config["load_min_observations"] == 6
+        assert planner_config["prefill_engine_num_gpu"] == 1
+        assert planner_config["decode_engine_num_gpu"] == 2
+        assert planner_config["ttft_ms"] == pytest.approx(2000.0)
+        assert planner_config["itl_ms"] == pytest.approx(30.0)
+        assert disagg_generator_config["DynConfig"]["kvbm_config"]["cpu_cache_override_num_blocks"] == 4096
+        assert disagg_generator_config["DynConfig"]["kvbm_config"]["max_transfer_batch_size"] == 32
+        assert disagg_generator_config["params"]["prefill"]["max_num_tokens"] == 8192
+        assert disagg_generator_config["params"]["decode"]["max_num_tokens"] == 4096
+        assert disagg_generator_config["params"]["decode"]["enable_attention_dp"] is True
+        assert disagg_generator_config["params"]["decode"]["cache_transceiver_max_tokens_in_buffer"] == 8192
+        assert disagg_generator_config["params"]["decode"]["extra_engine_args"]["max_num_tokens"] == 4096
+        prefill_engine_config = yaml.safe_load((result_dir / "disagg" / "top1" / "prefill_config.yaml").read_text())
+        decode_engine_config = yaml.safe_load((result_dir / "disagg" / "top1" / "decode_config.yaml").read_text())
+        assert prefill_engine_config["max_num_tokens"] == 8192
+        assert prefill_engine_config["cache_transceiver_config"]["max_tokens_in_buffer"] == 8192
+        assert prefill_engine_config["kv_cache_config"]["enable_block_reuse"] is True
+        assert decode_engine_config["max_num_tokens"] == 4096
+        assert decode_engine_config["enable_attention_dp"] is True
+        assert decode_engine_config["cache_transceiver_config"]["max_tokens_in_buffer"] == 8192
+        assert decode_engine_config["kv_cache_config"]["enable_block_reuse"] is False
+        k8s_deploy = yaml.safe_load((result_dir / "disagg" / "top1" / "k8s_deploy.yaml").read_text())
+        services = k8s_deploy["spec"]["services"]
+        frontend = services["Frontend"]["extraPodSpec"]["mainContainer"]
+        assert frontend["command"] == ["python3", "-m", "dynamo.frontend"]
+        assert frontend["args"][:4] == ["--http-port", "8000", "--router-mode", "kv"]
+        assert "--router-kv-overlap-score-credit" in frontend["args"]
+        assert "0.5" in frontend["args"]
+        assert "--router-prefill-load-scale" in frontend["args"]
+        assert "2.0" in frontend["args"]
+        assert "--router-temperature" in frontend["args"]
+        assert "0.2" in frontend["args"]
+        assert "--admission-control" in frontend["args"]
+        assert "token-capacity" in frontend["args"]
+        planner = services["Planner"]["extraPodSpec"]["mainContainer"]
+        assert planner["command"] == ["python3", "-m", "dynamo.planner"]
+        planner_payload = json.loads(planner["args"][planner["args"].index("--config") + 1])
+        assert planner_payload["enable_throughput_scaling"] is True
+        assert planner_payload["enable_load_scaling"] is True
+        assert planner_payload["prefill_engine_num_gpu"] == 1
+        assert planner_payload["decode_engine_num_gpu"] == 2
+        prefill_envs = {item["name"]: item["value"] for item in services["TRTLLMPrefillWorker"]["envs"]}
+        assert prefill_envs["DYN_KVBM_CPU_CACHE_OVERRIDE_NUM_BLOCKS"] == "4096"
+        assert prefill_envs["DYN_KVBM_MAX_TRANSFER_BATCH_SIZE"] == "32"
+        decode_script = k8s_deploy["spec"]["services"]["TRTLLMDecodeWorker"]["extraPodSpec"]["mainContainer"]["args"][0]
+        assert "max_num_tokens: 4096" in decode_script
+        assert "enable_attention_dp: true" in decode_script
+        assert "max_tokens_in_buffer: 8192" in decode_script
+        sflow_yaml = (result_dir / "disagg" / "top1" / "sflow.yaml").read_text()
+        assert "--router-kv-overlap-score-credit 0.5" in sflow_yaml
+        assert "export DYN_KVBM_CPU_CACHE_OVERRIDE_NUM_BLOCKS=4096" in sflow_yaml
+        assert "max_num_tokens: 4096" in sflow_yaml
+        assert "max_tokens_in_buffer: 8192" in sflow_yaml
+        run_script = (result_dir / "disagg" / "top1" / "run_0.sh").read_text()
+        assert "--router-kv-overlap-score-credit 0.5" in run_script
+        assert "export DYN_KVBM_CPU_CACHE_OVERRIDE_NUM_BLOCKS=4096" in run_script
+        disagg_candidate = yaml.safe_load((result_dir / "disagg" / "top1" / "spica_candidate.yaml").read_text())
+        assert disagg_candidate["config"]["deployment_mode"] == "disagg"
 
     @pytest.mark.parametrize(
         "builder_patch",

--- a/tests/unit/cli/test_plain_output.py
+++ b/tests/unit/cli/test_plain_output.py
@@ -30,9 +30,11 @@ def mock_stdout_isatty(monkeypatch):
 
 @pytest.fixture(autouse=True)
 def _reset_logging_after_test(monkeypatch):
-    yield
-    setup_logging(no_color=False)
     monkeypatch.delenv("NO_COLOR", raising=False)
+    setup_logging(no_color=False)
+    yield
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    setup_logging(no_color=False)
 
 
 def test_cli_parser_accepts_no_color(cli_parser):
@@ -211,6 +213,86 @@ def test_log_final_summary_no_disagg_results():
         pareto_x_axis={"agg": "tokens/s/user", "disagg": "tokens/s/user"},
         top_n=1,
     )
+
+
+def test_log_final_summary_uses_native_objective_and_keeps_zero_sla_rows(caplog):
+    caplog.set_level("INFO")
+    setup_logging(no_color=True)
+    logging.getLogger().addHandler(caplog.handler)
+
+    task = MagicMock()
+    task.primary_model_path = "unit-test-model"
+    task.primary_backend_name = "trtllm"
+    task.is_moe = False
+    task.total_gpus = 2
+    task.tpot = 0.0
+    task.request_latency = None
+
+    row = {
+        "backend": "trtllm",
+        "objective_target": "throughput",
+        "objective_score": 1000.0,
+        "objective_value": 1000.0,
+        "throughput": 1000.0,
+        "average_gpus": 1.5,
+        "tokens/s/gpu": 666.67,
+        "tokens/s/gpu_cluster": 666.67,
+        "tokens/s/user": 100.0,
+        "request_rate": 3.0,
+        "ttft": 100.0,
+        "tpot": 10.0,
+        "request_latency": 250.0,
+        "concurrency": 2.0,
+        "num_total_gpus": 2,
+        "tp": 2,
+        "pp": 1,
+        "dp": 1,
+        "moe_tp": 1,
+        "moe_ep": 1,
+        "bs": 64,
+    }
+    config_df = pd.DataFrame([row])
+
+    log_final_summary(
+        chosen_exp="agg",
+        best_throughputs={"agg": 666.67},
+        best_configs={"agg": config_df},
+        pareto_fronts={"agg": config_df},
+        tasks={"agg": task},
+        mode="default",
+        pareto_x_axis={"agg": "tokens/s/user"},
+        pareto_y_axis={"agg": "objective_value"},
+        objective_target="throughput",
+        best_objective_scores={"agg": 1000.0},
+        objective_directions={"throughput": True},
+        top_n=1,
+    )
+
+    logged = "\n".join(record.message for record in caplog.records)
+    assert "Optimization Objective: throughput (maximize)" in logged
+    assert "Best Experiment Chosen: agg at 1,000.00 tokens/s throughput" in logged
+    assert "Throughput: 1,000.00 tokens/s" in logged
+    # A native config with no SLA has a zero task TPOT target; its ranked row must
+    # still be displayed instead of being filtered as an SLA violation.
+    assert "agg Top Configurations: (Ranked by throughput)" in logged
+    assert "No configurations for agg met the TPOT constraint" not in logged
+
+    # Goodput is measured per request. A selected row whose aggregate mean TPOT
+    # exceeds the SLA must not be re-gated by the legacy report table.
+    goodput_table = _plot_worker_setup_table(
+        "agg",
+        config_df,
+        total_gpus=2,
+        tpot_target=5.0,
+        top=1,
+        is_moe=False,
+        request_latency_target=None,
+        show_power=False,
+        preserve_ranking=True,
+        objective_target="goodput_per_gpu",
+    )
+    assert "agg Top Configurations: (Ranked by goodput_per_gpu)" in goodput_table
+    assert "No configurations for agg met the TPOT constraint" not in goodput_table
 
 
 def test_draw_pareto_plain_output_is_pure_ascii():

--- a/uv.lock
+++ b/uv.lock
@@ -18,6 +18,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "absl-py"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/c7/8de93764ad66968d19329a7e0c147a2bb3c7054c554d4a119111b8f9440f/absl_py-2.4.0.tar.gz", hash = "sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4", size = 116543, upload-time = "2026-01-28T10:17:05.322Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl", hash = "sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d", size = 135750, upload-time = "2026-01-28T10:17:04.19Z" },
+]
+
+[[package]]
 name = "aiconfigurator"
 version = "0.9.0"
 source = { editable = "." }
@@ -40,6 +49,7 @@ dependencies = [
 dev = [
     { name = "import-ipynb" },
     { name = "pre-commit" },
+    { name = "prometheus-api-client" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -56,6 +66,16 @@ service = [
     { name = "orjson" },
     { name = "uvicorn" },
 ]
+spica = [
+    { name = "chex", marker = "python_full_version < '3.13'" },
+    { name = "flax", marker = "python_full_version < '3.13'" },
+    { name = "google-vizier", extra = ["jax"], marker = "python_full_version < '3.13'" },
+    { name = "jax", marker = "python_full_version < '3.13'" },
+    { name = "jaxlib", marker = "python_full_version < '3.13'" },
+    { name = "optax", marker = "python_full_version < '3.13'" },
+    { name = "pydantic", marker = "python_full_version < '3.13'" },
+    { name = "tensorflow-probability", extra = ["jax"], marker = "python_full_version < '3.13'" },
+]
 webapp = [
     { name = "gradio" },
 ]
@@ -64,18 +84,26 @@ webapp = [
 requires-dist = [
     { name = "aiconfigurator-core", editable = "src/aiconfigurator-core" },
     { name = "bokeh" },
+    { name = "chex", marker = "python_full_version < '3.13' and extra == 'spica'", specifier = "==0.1.87" },
     { name = "fastapi", marker = "extra == 'service'", specifier = ">=0.115.12" },
+    { name = "flax", marker = "python_full_version < '3.13' and extra == 'spica'", specifier = "==0.10.0" },
+    { name = "google-vizier", extras = ["jax"], marker = "python_full_version < '3.13' and extra == 'spica'", specifier = "==0.1.21" },
     { name = "gradio", marker = "extra == 'webapp'", specifier = "==6.8.0" },
     { name = "import-ipynb", marker = "extra == 'dev'", specifier = "==0.2" },
+    { name = "jax", marker = "python_full_version < '3.13' and extra == 'spica'", specifier = "==0.4.38" },
+    { name = "jaxlib", marker = "python_full_version < '3.13' and extra == 'spica'", specifier = "==0.4.38" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "matplotlib", specifier = ">=3.9.4" },
     { name = "numpy", specifier = "~=1.26.4" },
+    { name = "optax", marker = "python_full_version < '3.13' and extra == 'spica'", specifier = "==0.2.4" },
     { name = "orjson", marker = "extra == 'service'", specifier = ">=3.10.16" },
     { name = "packaging", specifier = ">=20.0" },
     { name = "pandas", specifier = ">=2.2.3" },
     { name = "plotly", specifier = ">=6.0.1" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = "==4.3.0" },
     { name = "prettytable", specifier = ">=3.16.0" },
+    { name = "prometheus-api-client", marker = "extra == 'dev'", specifier = "==0.6.0" },
+    { name = "pydantic", marker = "python_full_version < '3.13' and extra == 'spica'", specifier = ">=2.5" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.5" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.26.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.1.1" },
@@ -86,11 +114,12 @@ requires-dist = [
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = "==3.8.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.14.1" },
+    { name = "tensorflow-probability", extras = ["jax"], marker = "python_full_version < '3.13' and extra == 'spica'", specifier = "==0.25.0" },
     { name = "tqdm", specifier = ">=4.0.0" },
     { name = "uv", marker = "extra == 'dev'" },
     { name = "uvicorn", marker = "extra == 'service'", specifier = ">=0.34.2" },
 ]
-provides-extras = ["dev", "webapp", "service"]
+provides-extras = ["dev", "webapp", "service", "spica"]
 
 [[package]]
 name = "aiconfigurator-core"
@@ -358,6 +387,129 @@ wheels = [
 ]
 
 [[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/08/0f303cb0b529e456bb116f2d50565a482694fbb94340bf56d44677e7ed03/charset_normalizer-3.4.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cdd68a1fb318e290a2077696b7eb7a21a49163c455979c639bf5a5dcdc46617d", size = 315182, upload-time = "2026-04-02T09:25:40.673Z" },
+    { url = "https://files.pythonhosted.org/packages/24/47/b192933e94b546f1b1fe4df9cc1f84fcdbf2359f8d1081d46dd029b50207/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e17b8d5d6a8c47c85e68ca8379def1303fd360c3e22093a807cd34a71cd082b8", size = 209329, upload-time = "2026-04-02T09:25:42.354Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b4/01fa81c5ca6141024d89a8fc15968002b71da7f825dd14113207113fabbd/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:511ef87c8aec0783e08ac18565a16d435372bc1ac25a91e6ac7f5ef2b0bff790", size = 231230, upload-time = "2026-04-02T09:25:44.281Z" },
+    { url = "https://files.pythonhosted.org/packages/20/f7/7b991776844dfa058017e600e6e55ff01984a063290ca5622c0b63162f68/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:007d05ec7321d12a40227aae9e2bc6dca73f3cb21058999a1df9e193555a9dcc", size = 225890, upload-time = "2026-04-02T09:25:45.475Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e7/bed0024a0f4ab0c8a9c64d4445f39b30c99bd1acd228291959e3de664247/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf29836da5119f3c8a8a70667b0ef5fdca3bb12f80fd06487cfa575b3909b393", size = 216930, upload-time = "2026-04-02T09:25:46.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ab/b18f0ab31cdd7b3ddb8bb76c4a414aeb8160c9810fdf1bc62f269a539d87/charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:12d8baf840cc7889b37c7c770f478adea7adce3dcb3944d02ec87508e2dcf153", size = 202109, upload-time = "2026-04-02T09:25:48.031Z" },
+    { url = "https://files.pythonhosted.org/packages/82/e5/7e9440768a06dfb3075936490cb82dbf0ee20a133bf0dd8551fa096914ec/charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d560742f3c0d62afaccf9f41fe485ed69bd7661a241f86a3ef0f0fb8b1a397af", size = 214684, upload-time = "2026-04-02T09:25:49.245Z" },
+    { url = "https://files.pythonhosted.org/packages/71/94/8c61d8da9f062fdf457c80acfa25060ec22bf1d34bbeaca4350f13bcfd07/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b14b2d9dac08e28bb8046a1a0434b1750eb221c8f5b87a68f4fa11a6f97b5e34", size = 212785, upload-time = "2026-04-02T09:25:50.671Z" },
+    { url = "https://files.pythonhosted.org/packages/66/cd/6e9889c648e72c0ab2e5967528bb83508f354d706637bc7097190c874e13/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:bc17a677b21b3502a21f66a8cc64f5bfad4df8a0b8434d661666f8ce90ac3af1", size = 203055, upload-time = "2026-04-02T09:25:51.802Z" },
+    { url = "https://files.pythonhosted.org/packages/92/2e/7a951d6a08aefb7eb8e1b54cdfb580b1365afdd9dd484dc4bee9e5d8f258/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:750e02e074872a3fad7f233b47734166440af3cdea0add3e95163110816d6752", size = 232502, upload-time = "2026-04-02T09:25:53.388Z" },
+    { url = "https://files.pythonhosted.org/packages/58/d5/abcf2d83bf8e0a1286df55cd0dc1d49af0da4282aa77e986df343e7de124/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:4e5163c14bffd570ef2affbfdd77bba66383890797df43dc8b4cc7d6f500bf53", size = 214295, upload-time = "2026-04-02T09:25:54.765Z" },
+    { url = "https://files.pythonhosted.org/packages/47/3a/7d4cd7ed54be99973a0dc176032cba5cb1f258082c31fa6df35cff46acfc/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:6ed74185b2db44f41ef35fd1617c5888e59792da9bbc9190d6c7300617182616", size = 227145, upload-time = "2026-04-02T09:25:55.904Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/98/3a45bf8247889cf28262ebd3d0872edff11565b2a1e3064ccb132db3fbb0/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:94e1885b270625a9a828c9793b4d52a64445299baa1fea5a173bf1d3dd9a1a5a", size = 218884, upload-time = "2026-04-02T09:25:57.074Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/80/2e8b7f8915ed5c9ef13aa828d82738e33888c485b65ebf744d615040c7ea/charset_normalizer-3.4.7-cp310-cp310-win32.whl", hash = "sha256:6785f414ae0f3c733c437e0f3929197934f526d19dfaa75e18fdb4f94c6fb374", size = 148343, upload-time = "2026-04-02T09:25:58.199Z" },
+    { url = "https://files.pythonhosted.org/packages/35/1b/3b8c8c77184af465ee9ad88b5aea46ea6b2e1f7b9dc9502891e37af21e30/charset_normalizer-3.4.7-cp310-cp310-win_amd64.whl", hash = "sha256:6696b7688f54f5af4462118f0bfa7c1621eeb87154f77fa04b9295ce7a8f2943", size = 159174, upload-time = "2026-04-02T09:25:59.322Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/feb40dca40dbb21e0a908801782d9288c64fc8d8e562c2098e9994c8c21b/charset_normalizer-3.4.7-cp310-cp310-win_arm64.whl", hash = "sha256:66671f93accb62ed07da56613636f3641f1a12c13046ce91ffc923721f23c008", size = 147805, upload-time = "2026-04-02T09:26:00.756Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7", size = 309705, upload-time = "2026-04-02T09:26:02.191Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7", size = 206419, upload-time = "2026-04-02T09:26:03.583Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/e8146dc6591a37a00e5144c63f29fb7c97a734ea8a111190783c0e60ab63/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e", size = 227901, upload-time = "2026-04-02T09:26:04.738Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/73/77486c4cd58f1267bf17db420e930c9afa1b3be3fe8c8b8ebbebc9624359/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c", size = 222742, upload-time = "2026-04-02T09:26:06.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df", size = 214061, upload-time = "2026-04-02T09:26:08.347Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/92/42bd3cefcf7687253fb86694b45f37b733c97f59af3724f356fa92b8c344/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265", size = 199239, upload-time = "2026-04-02T09:26:09.823Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/3d/069e7184e2aa3b3cddc700e3dd267413dc259854adc3380421c805c6a17d/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4", size = 210173, upload-time = "2026-04-02T09:26:10.953Z" },
+    { url = "https://files.pythonhosted.org/packages/62/51/9d56feb5f2e7074c46f93e0ebdbe61f0848ee246e2f0d89f8e20b89ebb8f/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e", size = 209841, upload-time = "2026-04-02T09:26:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/59/893d8f99cc4c837dda1fe2f1139079703deb9f321aabcb032355de13b6c7/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38", size = 200304, upload-time = "2026-04-02T09:26:13.711Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/1d/ee6f3be3464247578d1ed5c46de545ccc3d3ff933695395c402c21fa6b77/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c", size = 229455, upload-time = "2026-04-02T09:26:14.941Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bb/8fb0a946296ea96a488928bdce8ef99023998c48e4713af533e9bb98ef07/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b", size = 210036, upload-time = "2026-04-02T09:26:16.478Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bc/015b2387f913749f82afd4fcba07846d05b6d784dd16123cb66860e0237d/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c", size = 224739, upload-time = "2026-04-02T09:26:17.751Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ab/63133691f56baae417493cba6b7c641571a2130eb7bceba6773367ab9ec5/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d", size = 216277, upload-time = "2026-04-02T09:26:18.981Z" },
+    { url = "https://files.pythonhosted.org/packages/06/6d/3be70e827977f20db77c12a97e6a9f973631a45b8d186c084527e53e77a4/charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad", size = 147819, upload-time = "2026-04-02T09:26:20.295Z" },
+    { url = "https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00", size = 159281, upload-time = "2026-04-02T09:26:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/83/6413f36c5a34afead88ce6f66684d943d91f233d76dd083798f9602b75ae/charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1", size = 147843, upload-time = "2026-04-02T09:26:22.901Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
+name = "chex"
+version = "0.1.87"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py", marker = "python_full_version < '3.13'" },
+    { name = "jax", marker = "python_full_version < '3.13'" },
+    { name = "jaxlib", marker = "python_full_version < '3.13'" },
+    { name = "numpy", marker = "python_full_version < '3.13'" },
+    { name = "setuptools", marker = "python_full_version == '3.12.*'" },
+    { name = "toolz", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/8a/857474810b64ab135a0c3e594b0453c7f39f140757c4cd26a32bccadcbc4/chex-0.1.87.tar.gz", hash = "sha256:0096d89cc8d898bb521ef4bfbf5c24549022b0e5b301f529ab57238896fe6c5d", size = 90063, upload-time = "2024-09-30T14:40:56.93Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/dd/c1ff2eb8fbf95a8ca804abb1cc3ce70b283ee7b4bc653c3abac245670400/chex-0.1.87-py3-none-any.whl", hash = "sha256:ce536475661fd96d21be0c1728ecdbedd03f8ff950c662dfc338c92ea782cb16", size = 99369, upload-time = "2024-09-30T14:40:54.862Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -367,6 +519,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+]
+
+[[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
 ]
 
 [[package]]
@@ -685,6 +846,21 @@ wheels = [
 ]
 
 [[package]]
+name = "dateparser"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "regex" },
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/f4/561c49bca97af561d34eed27e3e831135eb5cb88e754c1150be41820f5c6/dateparser-1.4.1.tar.gz", hash = "sha256:f265df13c0380e2e07543ba74b67c0681aaa1096981ffcd35227e1aa0cb81c7c", size = 314734, upload-time = "2026-06-15T08:45:47.659Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/7c/2e5dcf53909deddd0bf38cbe277ad9806be038276b1c6c436561b4d9b2e2/dateparser-1.4.1-py3-none-any.whl", hash = "sha256:f25d4e051a84be27a35bd297e3e1dc59ff78373701b89be352ba80372d22d0d0", size = 300503, upload-time = "2026-06-15T08:45:45.951Z" },
+]
+
+[[package]]
 name = "decorator"
 version = "5.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -700,6 +876,111 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
+name = "dm-tree"
+version = "0.1.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py", marker = "python_full_version < '3.13'" },
+    { name = "attrs", marker = "python_full_version < '3.13'" },
+    { name = "numpy", marker = "python_full_version < '3.13'" },
+    { name = "wrapt", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/66/a3ec619d22b6baffa5ab853e8dc6ec9d0c837127948af59bb15b988d7312/dm_tree-0.1.10.tar.gz", hash = "sha256:22f37b599e01cc3402a17f79c257a802aebd8d326de05b54657650845956208a", size = 35748, upload-time = "2026-03-31T17:35:39.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/76/781bc1a8ce0f4be153755e36be547d7d36964fb6d265b9b29503ed3e0a0f/dm_tree-0.1.10-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b8b606661abcb5336e60ce4cd6f3bec794ec794f91d8de001c1ea451dd7a7411", size = 311543, upload-time = "2026-03-31T17:35:04.766Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b9/2f6278c07728c60411d363aab1b5de53b75bb3bdf27032e871c240f3b4de/dm_tree-0.1.10-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0fcf11edc379723b8a17b76b6f63643e9280d55f23c37994805bf27282074192", size = 181202, upload-time = "2026-03-31T17:35:06.266Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d6/2b88e4eb5e3e5ecf9d61afe55e463ce7c9e4d1dc6630b9f7038a62e548d1/dm_tree-0.1.10-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7644b24bb5c7810b601f4b28cf6e4b516da96713ebfd9e45585240318c6b9384", size = 183874, upload-time = "2026-03-31T17:35:07.746Z" },
+    { url = "https://files.pythonhosted.org/packages/49/9f/6fea8ba8cb69136af0511868bc41dfb88d0b8c3a85497dbbf16271cd84a7/dm_tree-0.1.10-cp310-cp310-win_amd64.whl", hash = "sha256:d7f42b2148a1a3758230fbf93c06b9475e5d4bd62a4d19eacafa8210b03421ac", size = 110740, upload-time = "2026-03-31T17:35:09.045Z" },
+    { url = "https://files.pythonhosted.org/packages/87/dc/b01d0f70cde99b306731216a98287ba5926a50f27222f2ada0b99ad0911f/dm_tree-0.1.10-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:8218af7b99701bb8b03001c82961dc2cf81d7a734958206d2ea1ede8fbbe2b5f", size = 314603, upload-time = "2026-03-31T17:35:10.052Z" },
+    { url = "https://files.pythonhosted.org/packages/40/72/3bafa58492862360113c1cccb26747c7863d417271e1572bacb3c281162f/dm_tree-0.1.10-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cacef6180fcfef30bab2cac5164e753e2f7a2e60e5da0feb81f2d318416f8d98", size = 182657, upload-time = "2026-03-31T17:35:11.462Z" },
+    { url = "https://files.pythonhosted.org/packages/78/10/587a2cdc05995069aa63b659d884eb3e58a3c86a5b4a00acdb7a316bddf3/dm_tree-0.1.10-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f0e8907bb6809dc195be3af077e382126eaebe06c00f835d09ae26e36d2165ff", size = 185008, upload-time = "2026-03-31T17:35:12.838Z" },
+    { url = "https://files.pythonhosted.org/packages/60/0e/08d938d84cbf791dde009b3d3a6637f27a0004235e700641a0ac038daac5/dm_tree-0.1.10-cp311-cp311-win_amd64.whl", hash = "sha256:a1c82dd4726a16ac6b6f7a77a5fb097ee396fd349ae301407eb5736f15b8fa16", size = 111472, upload-time = "2026-03-31T17:35:14.035Z" },
+    { url = "https://files.pythonhosted.org/packages/34/a1/17e0d68eec978c483db4712b14d083ee01484381b29ea85edb2b20210bd0/dm_tree-0.1.10-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:94af18e4fd22ce69eccae89eeed8ed498b6b4cc4957f4ed10b4160e59f620e1d", size = 315976, upload-time = "2026-03-31T17:35:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6f/ed603715fbc29c887a8985252e2cfe0d449497aea96bac51010159771617/dm_tree-0.1.10-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b442a0c1e9d0960e0314a2e4af81fd328a87921b6d6db6dc41bfa420536884d6", size = 184053, upload-time = "2026-03-31T17:35:16.512Z" },
+    { url = "https://files.pythonhosted.org/packages/83/eb/1d55c679cee9a54e552480d308535753c72e2250cf720d7aa777bff2a4fe/dm_tree-0.1.10-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:012c2b376e88d3685c73a4b5c23be41fe933e14e380dcd90172971690b0e02d2", size = 186506, upload-time = "2026-03-31T17:35:17.593Z" },
+    { url = "https://files.pythonhosted.org/packages/89/2d/adef6924f8dc7f1665eea4ce066387820c14a629d0e1005568892d56ea6a/dm_tree-0.1.10-cp312-cp312-win_amd64.whl", hash = "sha256:da8d5b8995bea1b6bb93f457e0dad5d16e6e2344a6488ced55320e7f3fd50f56", size = 112708, upload-time = "2026-03-31T17:35:18.699Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/29/f39e8412c16740f4c914c6674a04a66ace344ce5cb99b537c2270ef4f204/dm_tree-0.1.10-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:4a782f0382be16d66c9ed003e6992e56674504a1d9636f44d2807123f5df6343", size = 316108, upload-time = "2026-03-31T17:35:20.139Z" },
+    { url = "https://files.pythonhosted.org/packages/02/83/1b94d45351bd75a83976a88c9fcf109da6ce336f38a3b443703bb6b18e5d/dm_tree-0.1.10-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0e8f8f1354f178112732b30d2293bc53d212ea64a9556db80a926af3d4647a6b", size = 183834, upload-time = "2026-03-31T17:35:21.463Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/23/bd3e75cbff06a464339d32667d740acf49812b027142a013b54d2c4d830a/dm_tree-0.1.10-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6d7134c0805294c640b94d85cc725084f0c5087bcda5a7fb38eeb7f479ecc37c", size = 186187, upload-time = "2026-03-31T17:35:23.495Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/75/4b460253b9af862388940404b5df6a22b399800c850aab4724c95f8635f9/dm_tree-0.1.10-cp313-cp313-win_amd64.whl", hash = "sha256:b42e04482880b017d931511d7b5997be372fff26a1ee9b9be55eef03ef1c2918", size = 112768, upload-time = "2026-03-31T17:35:24.622Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/ca/3b40a8a50f9c3492b795b157d769180edb5f2605e3c61ae826208f917baa/dm_tree-0.1.10-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:bde02efacca66514524922538b8a0c5dc15d482565d1c796edc34a726b376830", size = 324138, upload-time = "2026-03-31T17:35:25.627Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e4/33c9218aa607f610e2b0334fc824c2abd5a6bc232bf0726cf275f88e639d/dm_tree-0.1.10-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:033f9a063e1e19b6c65fb5c76079bd923044f5a6095357ad2637845513d47938", size = 185110, upload-time = "2026-03-31T17:35:26.784Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/da/f8811666d61b6829ba1c2716c4119039428dd86078eddd120354aaf26a3b/dm_tree-0.1.10-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6d4237da7b072fff1e93db109ab545f00d2b978ead35e85e7a84908e15197826", size = 187013, upload-time = "2026-03-31T17:35:27.969Z" },
+    { url = "https://files.pythonhosted.org/packages/94/8d/135ddeea875fd1a2768e7aee6c224f92c9b7643ead1ec8b68bdbee52c60a/dm_tree-0.1.10-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:f395390d6acfb5d39c564c8bbcaf35352a81eb2f0d34d449739039b2ef786e14", size = 316599, upload-time = "2026-03-31T17:35:29.339Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/50/1eda610e9ca8ac59950ae028080e7c5320d7abc5567d6723d0cb3623e838/dm_tree-0.1.10-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c0f54547fbd4b82e88c71694b3836c90059b97102d3e36209f5d2fa66950964", size = 184263, upload-time = "2026-03-31T17:35:30.534Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/59/07461ceb563702ba3943725bdf0e04be4de0ed7ef093837cdd2d67141d2a/dm_tree-0.1.10-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf6706ac425272c9b7e05f05a23a1ff3e670fb59a787f6089a638eea2d06f1d0", size = 186328, upload-time = "2026-03-31T17:35:31.894Z" },
+    { url = "https://files.pythonhosted.org/packages/88/af/d9c84787fefe9f7c35f474a945217c38396f2ca5ab06432fb566e32a7d1a/dm_tree-0.1.10-cp314-cp314-win_amd64.whl", hash = "sha256:a132047e846e769ddacefe77c42ae79bf3d0e9fce2a6adb638a0ea4cbadb8cdb", size = 114799, upload-time = "2026-03-31T17:35:33.361Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/2c/2aaa63a510db520cd9e0c51e053a608486169bb9710f51f4ecf5699cebb4/dm_tree-0.1.10-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:23682221f63ad011dbd762ce5314740d7900b0426a2681614ea2472369b0c49c", size = 324205, upload-time = "2026-03-31T17:35:34.679Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/89/a5a302bcf9c345e6bd0498627ee2aa12f0a1c3538d08a2f5884d3c6783ba/dm_tree-0.1.10-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8baeb3db1e92587d686022fb67a52f6c584a7d32bd98444ed3aafb399ad9ce67", size = 185113, upload-time = "2026-03-31T17:35:36.179Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/e8/2d4fbc54bb68905588945cfb47c05445c66cab2d822b05827f1c62e23a70/dm_tree-0.1.10-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2236c9a4cf64ed0b04004a94902f39341be652b70dce322b33f08ada9b146baa", size = 187009, upload-time = "2026-03-31T17:35:37.584Z" },
+]
+
+[[package]]
+name = "equinox"
+version = "0.11.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jax", marker = "python_full_version < '3.13'" },
+    { name = "jaxtyping", version = "0.3.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "jaxtyping", version = "0.3.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/48/ed7ba0849bea18b8be49f471b8e597ca6e5975f75ed05c3be84c1e0ef7c4/equinox-0.11.7.tar.gz", hash = "sha256:96e0216a9d822ec4b1465b0cbfbab14a36fb7e7d62c55f521287db3aaaa251be", size = 139909, upload-time = "2024-09-18T17:10:15.415Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/3f/2fa4627a902a38cd836aa8f7e5a0753114bb23d6b4d2a73784dd9f5ff2e6/equinox-0.11.7-py3-none-any.whl", hash = "sha256:1177354e1795061fbad71535fe54096d8887dc059b4ab7d400fea2d47dfaa283", size = 178416, upload-time = "2024-09-18T17:10:13.699Z" },
+]
+
+[[package]]
+name = "etils"
+version = "1.13.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/a0/522bbff0f3cdd37968f90dd7f26c7aa801ed87f5ba335f156de7f2b88a48/etils-1.13.0.tar.gz", hash = "sha256:a5b60c71f95bcd2d43d4e9fb3dc3879120c1f60472bb5ce19f7a860b1d44f607", size = 106368, upload-time = "2025-07-15T10:29:10.563Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/98/87b5946356095738cb90a6df7b35ff69ac5750f6e783d5fbcc5cb3b6cbd7/etils-1.13.0-py3-none-any.whl", hash = "sha256:d9cd4f40fbe77ad6613b7348a18132cc511237b6c076dbb89105c0b520a4c6bb", size = 170603, upload-time = "2025-07-15T10:29:09.076Z" },
+]
+
+[package.optional-dependencies]
+epath = [
+    { name = "fsspec", marker = "python_full_version < '3.11'" },
+    { name = "importlib-resources", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "zipp", marker = "python_full_version < '3.11'" },
+]
+epy = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+
+[[package]]
+name = "etils"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/ce/6e067242fde898841922ac6fc82b0bb2fe35c38e995880bdffdfbe30182a/etils-1.14.0.tar.gz", hash = "sha256:8136e7f4c4173cd0af0ca5481c4475152f0b8686192951eefa60ee8711e1ede4", size = 108127, upload-time = "2026-03-04T17:41:36.291Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/3d/589663aeeacd59bb2f3e8596bfd3e81cf0fb18d70bb433199041f469771b/etils-1.14.0-py3-none-any.whl", hash = "sha256:b5df7341f54dbe1405a4450b2741207b4a8c279780402b45f87202b94dfc52b4", size = 172934, upload-time = "2026-03-04T17:41:35.01Z" },
+]
+
+[package.optional-dependencies]
+epath = [
+    { name = "fsspec", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "zipp", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+]
+epy = [
+    { name = "typing-extensions", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
 ]
 
 [[package]]
@@ -776,6 +1057,27 @@ wheels = [
 ]
 
 [[package]]
+name = "flax"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jax", marker = "python_full_version < '3.13'" },
+    { name = "msgpack", marker = "python_full_version < '3.13'" },
+    { name = "numpy", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "optax", marker = "python_full_version < '3.13'" },
+    { name = "orbax-checkpoint", marker = "python_full_version < '3.13'" },
+    { name = "pyyaml", marker = "python_full_version < '3.13'" },
+    { name = "rich", marker = "python_full_version < '3.13'" },
+    { name = "tensorstore", version = "0.1.78", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "tensorstore", version = "0.1.84", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e6/d8/767804f923b473790e283b6e5d0812d792195e140cacfad08a2760e0afe8/flax-0.10.0.tar.gz", hash = "sha256:8025607abc6077e29554af00996041454e89d10d6d2939d7cb4b86ecbc3fe360", size = 3623416, upload-time = "2024-10-16T23:26:25.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/00/c19d0108f3ce4da076f41e59019149d53f3319ee96a3db880c5f01ba40ac/flax-0.10.0-py3-none-any.whl", hash = "sha256:b3025c5c7d33ba400e123656ad66b0a1900ec67685365bf322ffa47c40a1d16c", size = 420218, upload-time = "2024-10-16T23:26:23.225Z" },
+]
+
+[[package]]
 name = "fonttools"
 version = "4.62.1"
 source = { registry = "https://pypi.org/simple" }
@@ -842,6 +1144,62 @@ wheels = [
 ]
 
 [[package]]
+name = "gast"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/f6/e73969782a2ecec280f8a176f2476149dd9dba69d5f8779ec6108a7721e6/gast-0.7.0.tar.gz", hash = "sha256:0bb14cd1b806722e91ddbab6fb86bba148c22b40e7ff11e248974e04c8adfdae", size = 33630, upload-time = "2025-11-29T15:30:05.266Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/33/f1c6a276de27b7d7339a34749cc33fa87f077f921969c47185d34a887ae2/gast-0.7.0-py3-none-any.whl", hash = "sha256:99cbf1365633a74099f69c59bd650476b96baa5ef196fec88032b00b31ba36f7", size = 22966, upload-time = "2025-11-29T15:30:03.983Z" },
+]
+
+[[package]]
+name = "google-vizier"
+version = "0.1.21"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py", marker = "python_full_version < '3.13'" },
+    { name = "attrs", marker = "python_full_version < '3.13'" },
+    { name = "googleapis-common-protos", marker = "python_full_version < '3.13'" },
+    { name = "grpcio", marker = "python_full_version < '3.13'" },
+    { name = "grpcio-tools", marker = "python_full_version < '3.13'" },
+    { name = "numpy", marker = "python_full_version < '3.13'" },
+    { name = "portpicker", marker = "python_full_version < '3.13'" },
+    { name = "protobuf", marker = "python_full_version < '3.13'" },
+    { name = "sqlalchemy", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/25/38c4cd3a3cc9786fd87998016a709cae88ebacc11eb3b5395737b5eccebb/google-vizier-0.1.21.tar.gz", hash = "sha256:b0ef8514675ee618ae126c4c418c7c38c2934f4f0ddfb1a3670c01d6499e17f3", size = 515482, upload-time = "2025-01-07T21:02:04.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/b6/00c7d87a565d98727dcd857e65b3bf6e2c09d060e680fbea6e44abc90fc5/google_vizier-0.1.21-py3-none-any.whl", hash = "sha256:ae457cb42ab55f531223dcbc2b973f2050850eba40808d4927afb3ab0d7e4d2c", size = 799598, upload-time = "2025-01-07T21:02:03.047Z" },
+]
+
+[package.optional-dependencies]
+jax = [
+    { name = "chex", marker = "python_full_version < '3.13'" },
+    { name = "equinox", marker = "python_full_version < '3.13'" },
+    { name = "flax", marker = "python_full_version < '3.13'" },
+    { name = "jax", marker = "python_full_version < '3.13'" },
+    { name = "jaxlib", marker = "python_full_version < '3.13'" },
+    { name = "jaxopt", marker = "python_full_version < '3.13'" },
+    { name = "jaxtyping", version = "0.3.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "jaxtyping", version = "0.3.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "optax", marker = "python_full_version < '3.13'" },
+    { name = "tfp-nightly", extra = ["jax"], marker = "python_full_version < '3.13'" },
+    { name = "typeguard", marker = "python_full_version < '3.13'" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[[package]]
 name = "gradio"
 version = "6.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -899,12 +1257,206 @@ wheels = [
 ]
 
 [[package]]
+name = "greenlet"
+version = "3.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/f1/fbbfef6af0bad0548f09bc28948ea3c275b4edb19e17fc5ca9900a6a634d/greenlet-3.5.3.tar.gz", hash = "sha256:a61efc018fd3eb317eeca31aba90ee9e7f26f22884a79b6c6ec715bf71bb62f1", size = 200270, upload-time = "2026-06-26T19:28:24.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/a1/1f7f0c555f5858fd2906fe9f7b0a3554fddb85cb70df7a6aaec41dc292c2/greenlet-3.5.3-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:c180d22d325fb613956b443c3c6f4406eb70e6defc70d3974da2a7b59e06f48c", size = 285838, upload-time = "2026-06-26T18:21:05.167Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/29/be9f43ed61677a5759b38c8a9389248133c8c731bbfc0574ecdff66c99fc/greenlet-3.5.3-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:483d08c11181c83a6ce1a7a61df0f624a208ec40817a3bb2302714592eee4f04", size = 602342, upload-time = "2026-06-26T19:07:06.908Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/42/ba41c97ec36aa4b3ec25e5aa691d79561254805fad7f2f826dd6770587e2/greenlet-3.5.3-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1dae6e0091eae084317e411f047f0b7cb241c6db570f7c45fd6b900a274914ce", size = 615541, upload-time = "2026-06-26T19:10:04.909Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/c7/28747042e1df8a9cd120a1ebe15529fc4be3b486e13e8d551ff307a82412/greenlet-3.5.3-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9bcd2d72ccd70a1ec68ba6ef93e7fbb4420ef9997dabc7010d893bd4015e0bec", size = 615675, upload-time = "2026-06-26T18:32:14.444Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/a8/b85525a6c8fba9f009a5f7c8df1545de8fb0f0bf3e0179194ef4e500317f/greenlet-3.5.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:73f152c895e09907e0dbe24f6c2db37beb085cd63db91c3825a0fcd0064124a8", size = 1575057, upload-time = "2026-06-26T19:09:00.264Z" },
+    { url = "https://files.pythonhosted.org/packages/03/79/fb76edb218fe6735ab0edeba176c7ab80df9618f7c02ce4208979f3ae7db/greenlet-3.5.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8bdb43e1a1d1873721acab2be99c5befd4d2044ddfd52e4d610801019880a702", size = 1641692, upload-time = "2026-06-26T18:31:41.454Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/79/86fe3ee50ed55d9b3907eecd3208b5c3fe8a79515519aae98b4753c3fa1d/greenlet-3.5.3-cp310-cp310-win_amd64.whl", hash = "sha256:0909f9355a9f24845d3299f3112e266a06afb68302041989fd26bd68894933db", size = 238742, upload-time = "2026-06-26T18:20:40.758Z" },
+    { url = "https://files.pythonhosted.org/packages/51/58/5404031044f55afad7aad1aff8be3f22b1bed03e237cfeabbc7e5c8cfde0/greenlet-3.5.3-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:aca9b4ce85b152b5524ef7d88170efdff80dc0032aa8b75f9aaf7f3479ea95b4", size = 287424, upload-time = "2026-06-26T18:20:31.469Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/bf/1c65e9b94a54d547068fa5b5a8a06f221f3316b48908e08668d29c77cb50/greenlet-3.5.3-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f71be4920368fe1fabeeaa53d1e3548337e2b223d9565f8ad5e392a75ba23fc", size = 606523, upload-time = "2026-06-26T19:07:08.859Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c7/b66baacc95775ad511287acb0137b95574a9ce5491902372b7564799d790/greenlet-3.5.3-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4d77e67f65f98449e3fb83f795b5d0a8437aead2f874ca89c96576caf4be3af6", size = 618315, upload-time = "2026-06-26T19:10:06.055Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2b/28ed29463522fdbe4c15b1f63922041626a7478316b34ab4adda3f0a4aba/greenlet-3.5.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8540f1e6205bd13ca0ce685581037219ca54a1b41a0a15d228c6c9b8ad5903d7", size = 617381, upload-time = "2026-06-26T18:32:16.077Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/7b/ad04e9d1337fc04965dc9fc616b6a72cb65a24b800a014c011ec812f5489/greenlet-3.5.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7ef56fe650f50575bf843acde967b9c567687f3c22340941a899b7bc56e956a8", size = 1577771, upload-time = "2026-06-26T19:09:01.537Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/33/6c87ab7ba663f70ca21f3022aad1ffe56d3f3e0521e836c2415e13abcc3c/greenlet-3.5.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5121af01cf911e70056c00d4b46d5e9b5d1415550038573d744138bacb59e6b8", size = 1644048, upload-time = "2026-06-26T18:31:42.996Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/35/f0d8ee998b422cf8693b270f098e55d8d4ec8006b061b333f54f177d28d9/greenlet-3.5.3-cp311-cp311-win_amd64.whl", hash = "sha256:0f41e4a05a3c0cb31b17023eff28dd111e1d16bf7d7d00406cd7df23f31398a7", size = 239137, upload-time = "2026-06-26T18:23:21.664Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/96/b9820295576ef18c9edc404f10e260ae7215ceaf3781a54b720ed2627862/greenlet-3.5.3-cp311-cp311-win_arm64.whl", hash = "sha256:ec6f1af59f6b5f3fc9678e2ea062d8377d22ac644f7844cb7a292910cf12ff44", size = 237630, upload-time = "2026-06-26T18:24:00.281Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/6e/4c37d51a2b7f82d2ff11bb6b5f7d766d9a011726624af255e843727627a3/greenlet-3.5.3-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:719757059f5a53fd0dde23f78cffeafcdd97b21c850ddb7ca684a3c1a1f122e2", size = 288685, upload-time = "2026-06-26T18:22:08.977Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/73/815dd90131c1b71ebdf53dbc7c276cafec2a1173b97559f97aba72724a87/greenlet-3.5.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:efa9f765dd09f9d0cdac651ffdf631ee59ec5dc6ee7a73e0c012ba9c52fbdf5b", size = 604761, upload-time = "2026-06-26T19:07:10.114Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/57/079cfe76bcef36b153b25607ee91c6fcb58f17f8b23c86bbbeabe0c88d72/greenlet-3.5.3-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7faba15ac005376e02a0384504e0243be3370ce010296a44a820feb342b505ab", size = 617044, upload-time = "2026-06-26T19:10:07.25Z" },
+    { url = "https://files.pythonhosted.org/packages/37/87/b4d095775a3fb1bcafbb483fc206b27ebb785724c83051447737085dc54e/greenlet-3.5.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:87142215824be6ac05e2e8e2786eec307ccbc27c36723c3881959df654af6861", size = 614244, upload-time = "2026-06-26T18:32:17.594Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/70/7559b609683650fa2b95b8ab84b4ab0b26556a635d19675e12aa832d826d/greenlet-3.5.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:215275b1b49320987352e6c1b054acca0064f965a2c66992bed9a6f7d913f149", size = 1574210, upload-time = "2026-06-26T19:09:03.077Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/73/be55392074c60fc37655ca40fa6022457bfbf6718e9e342a7b0b41f96dd2/greenlet-3.5.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6b1b0eed82364b0e32c4ea0f221452d33e6bb17ae094d9f72aed9851812747ea", size = 1638627, upload-time = "2026-06-26T18:31:44.748Z" },
+    { url = "https://files.pythonhosted.org/packages/14/40/c57489acf8e37d74e2913d4eff63aa0dba17acccc4bdeef874dde2dbbec9/greenlet-3.5.3-cp312-cp312-win_amd64.whl", hash = "sha256:cde8adafa2365676f74a979744629589999093bc86e2484214f58e61df08902c", size = 239882, upload-time = "2026-06-26T18:23:27.518Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/6fea0e3d6600f785069481ee637e09378dd4118acdfd38ad88ae2db31c98/greenlet-3.5.3-cp312-cp312-win_arm64.whl", hash = "sha256:c4e7b79d83805475f0102008843f6eb45fd3bb0b2e88c774adab5fbaab27117d", size = 238211, upload-time = "2026-06-26T18:22:37.671Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ff/a620267401db30a50cc8450ee90730e2d4a85658c055c0e760d4ed47fb13/greenlet-3.5.3-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:c8d87c2134d871df96ecdea9cec7cbaab286dadab0f56476e57aaf9e8ac11550", size = 287609, upload-time = "2026-06-26T18:21:14.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fa/5401ac78021c826a25b6dde0c705e0a8f29b617509f9185a31dac15fbe1b/greenlet-3.5.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2d185dd1621757e70c3861cceffd5317ab4e7ed7eb09c82994828468527ade5", size = 607435, upload-time = "2026-06-26T19:07:11.412Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/76/1dc144a2e56e65d36405078ed774224375ea520a1870a6e46e08bb4ac7bf/greenlet-3.5.3-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1c514a468149bf8fbbab874188a3535cd8a48a3e353eb53a3d424296f8dbacd3", size = 619787, upload-time = "2026-06-26T19:10:08.396Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/87/c298cee62df1de4ad7fec32abda73526cff347fd143a6ed4ac369246668a/greenlet-3.5.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:915f887cf2682b66419b879423a2e072634aa7b7dce6f3ada4957cfced3f1e9a", size = 616786, upload-time = "2026-06-26T18:32:19.128Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/2e/e6f009885ed0705ccf33fe0583c117cfd03cde77e31a596dd5785a30762b/greenlet-3.5.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:766cfd421c13e450feb340cd472a3ed9957d438727b7b4593ad7c76c5d2b0deb", size = 1574316, upload-time = "2026-06-26T19:09:04.273Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fe/43fd110b01e40da0adb7c90ac7ea744bef2d43dca00de5095fd2351c2a68/greenlet-3.5.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2ecda9ec22edf38fa389369eaed8c3d37c05f3c54e69f69438dbb2cc1de1458b", size = 1638614, upload-time = "2026-06-26T18:31:46.297Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/7c/062447147a61f8b4337b156fe70d32a165fcf2f89d7ca6255e572806705c/greenlet-3.5.3-cp313-cp313-win_amd64.whl", hash = "sha256:c82304750f057167ff60d188df1d0cc1764ce9567eadf03e6a7443bcedd0b30b", size = 239850, upload-time = "2026-06-26T18:21:54.613Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7e/220a7f5824a64a60443fc03b39dfac4ea63a7fb6d481efa27eafa928e7f4/greenlet-3.5.3-cp313-cp313-win_arm64.whl", hash = "sha256:dc133a1569ee667b2a6ef56ce551084aeefd87a5acbc4736d336d1e2edc6cfc4", size = 238141, upload-time = "2026-06-26T18:22:48.507Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/93/43e116ee114b28737ba7e12952a0d4e2f55944d0f84e42bc91ba7192a3c9/greenlet-3.5.3-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:fd2e02fa07485778536a036222d616ab957b1d533f36b3ed98ce725d9c9d3117", size = 288202, upload-time = "2026-06-26T18:23:49.604Z" },
+    { url = "https://files.pythonhosted.org/packages/82/2f/146d218299046a43d1f029fd544b3d110d0f175a09c715c7e8da4a4a345d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df0a0628d1597eb0897b62f55d1343f772405fd25f3b2a796c76874b0c2e22e8", size = 654096, upload-time = "2026-06-26T19:07:12.71Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/cc/04738cafb3f45fa991ea44f9de94c47dcec964f5a972300988a6751f49d9/greenlet-3.5.3-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ebd933a6adabc298bab47731a130fe6bfb888bd934eee37810f151159544540d", size = 666304, upload-time = "2026-06-26T19:10:09.503Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/aa/4e0dad5e605c270c784ab911c43da6adb136ccd4d81180f763ca429a723d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b9d501b40e80b70e32323c799dd9b420a5577a9601469d362ae1ffb690f3a7c", size = 663635, upload-time = "2026-06-26T18:32:20.802Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/50/13efdbea246fe3d3b735e191fec08fb50809f53cd2383ebe123d0809e44b/greenlet-3.5.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a1fad1d11e7d6aab184107baa8e4ece11ccba3ec9599cd7efa5ff4d70d43256a", size = 1621252, upload-time = "2026-06-26T19:09:05.647Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/22/c0a336ae4a1410fd5f5121098e5bfbf1865f64c5ef80b4b5412886c4a332/greenlet-3.5.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fad5aec764399f1b5cc347ad250a59660f20c8f8888ea6bae1f93b769cce1154", size = 1684824, upload-time = "2026-06-26T18:31:47.738Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/94/91aec0030bea75c4b3244251d0de60a1f3432d1ecb53ab6c437fb5c3ba61/greenlet-3.5.3-cp314-cp314-win_amd64.whl", hash = "sha256:7669aa24cf2a1041d6f7899575b494a3ab4cf68bfcc8609b1dc0be7272db835e", size = 240754, upload-time = "2026-06-26T18:22:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/06/68d0983e79e02138f64b4d303c500c27ddb48e5e77f3debb80888a921eae/greenlet-3.5.3-cp314-cp314-win_arm64.whl", hash = "sha256:5b4807c4082c9d1b6d9eed56fcd041863e37f2228106eef24c30ca096e238605", size = 239549, upload-time = "2026-06-26T18:22:42.996Z" },
+    { url = "https://files.pythonhosted.org/packages/91/95/3e161213d7f1d378d15aa9e792093e9bfe01844680d04b7fd6e0107c9098/greenlet-3.5.3-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:271a8ea7c1024e8a0d7dd2be66dd66dda8a07193f41a17b9e924f7600f5b62be", size = 296389, upload-time = "2026-06-26T18:22:20.657Z" },
+    { url = "https://files.pythonhosted.org/packages/00/92/715c44721abe2b4d1ae9abde4179411868a5bff312479f54e105d372f131/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:19131729ae0ddc3c2e1ef85e650169b5e37ee32e400f215f78b94d7b0d567310", size = 653382, upload-time = "2026-06-26T19:07:14.209Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/83/37a10372a1090a6624cca8e74c12df1a36c2dc36429ed0255b7fb1aeee23/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1540dd8e5fc2a5aec40fbb98ef8e149fa47c89a4b4a1cf2575a14d3d1869d7a8", size = 659401, upload-time = "2026-06-26T19:10:10.876Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e2/d1509cad4207da559cc42986ecdd8fc67ad0d1bba2bf03023c467fd5e0f3/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e81fa194a1d20967877bdf9c7794db2bc99063e5be36aee710c08f04c5bb087f", size = 656969, upload-time = "2026-06-26T18:32:22.272Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7d/eaf70de20aadca3a5884aec58362861c64ce45e7b277f47ed026926a3b89/greenlet-3.5.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:55cf4d777485d43110e47133cbba6d74a8885a87ec1227ef0267f9ee80c5aa21", size = 1617822, upload-time = "2026-06-26T19:09:06.893Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f9/414d38fc400ae4350d4185eaad1827676f7cf5287b9136e0ed1cbbe20a7f/greenlet-3.5.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:12a248ba75f6a9a236375f52296c498c89ff1d8badf32deb9eca7abd5853f7da", size = 1677983, upload-time = "2026-06-26T18:31:49.396Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/15/7edb977e08f9bff702fe42d6c902702786ff6b9694058b4e6a2a6ac90e57/greenlet-3.5.3-cp314-cp314t-win_amd64.whl", hash = "sha256:efc6bd60ea02e085862c74a3ef64b147ffc6f1a5ea7d9f26e7a939943f68c1e3", size = 243626, upload-time = "2026-06-26T18:24:41.485Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/8a/93928dce91e6b3598b5e779e8d1fd6576a504640c58e78627077f6a7a91a/greenlet-3.5.3-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:ea03f2f04367845d6b58eeed276e1e56e51f0b97d8ad5a88a7d20a91dc9056cc", size = 288860, upload-time = "2026-06-26T18:22:48.07Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ca/69db42d447a1378043e2c8f19c09cbbd1263371505053c496b49066d3d16/greenlet-3.5.3-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78dbef602fda6d97d957eb7937f70c9ce9e9527330347f8f6b6f9e554a9e7a47", size = 659747, upload-time = "2026-06-26T19:07:15.565Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/0b/af7ac2ef8dd41e3da1a40dda6305c23b9a03e13ba975ec916357b50f8575/greenlet-3.5.3-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f73857adb8fee13fa56c172bd11262f888c0c648f9fea113e777bb2c7904a81", size = 670419, upload-time = "2026-06-26T19:10:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/51/1e/1d51640cacbfc455dbe9f9a9f594c49e4e244f63b9971a2f4764e46cc53d/greenlet-3.5.3-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:232fec92e823addaf02d9472cf7381e24a1d046a6ced1103c5caa4c21b9dfc1d", size = 668787, upload-time = "2026-06-26T18:32:24.298Z" },
+    { url = "https://files.pythonhosted.org/packages/21/66/4030d5b0b5894500023f003bb054d9bb354dfbd1e186c3a296759172f5f5/greenlet-3.5.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:2421c3564da9429d5586d46ca31ebb26516b5498a802cf65c041a8e8a8980d34", size = 1626305, upload-time = "2026-06-26T19:09:08.281Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/50/5221371c7550108dfa3c378debc41d032aa9c78e89abb01d8011cfc93289/greenlet-3.5.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:e0f0d160f0b2e558e6c75f7930967183255dc9735e5f5b8cae58ee09c9576d8b", size = 1688631, upload-time = "2026-06-26T18:31:51.278Z" },
+    { url = "https://files.pythonhosted.org/packages/68/5d/00d469daae3c65d2bf620b10eee82eb022127d483c6bc8c69fae6f3fbf17/greenlet-3.5.3-cp315-cp315-win_amd64.whl", hash = "sha256:dd99329bbc15ca78dcc583dba05d0b1b0bae01ab6c2174989f5aaee3e41ac930", size = 241027, upload-time = "2026-06-26T18:22:38.203Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e8/883785b44c5780ed71e83d3e4437e710470be17a2e181e8b601e2da0dc4a/greenlet-3.5.3-cp315-cp315-win_arm64.whl", hash = "sha256:499fef2acede88c1864a57bb586b4bf533c81e1b82df7ab93451cdb47dfec227", size = 240085, upload-time = "2026-06-26T18:23:54.217Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/da/4f4a8450962fad137c1c8981a3f1b8919d06c829993d4d476f9c525d5173/greenlet-3.5.3-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:176bc16a721fa5fc294d70b87b4dfa5fbdd251b3da5d5372735ecef9bd7d6d0c", size = 297221, upload-time = "2026-06-26T18:23:27.176Z" },
+    { url = "https://files.pythonhosted.org/packages/57/66/b3bfae3e220a9b63ea539a0eea681800c69ab1aada757eae8789f183e7ce/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:629b614d2b786e89c50440e246f33eea78f58a962d0bdbbcc809e6d13605903f", size = 657221, upload-time = "2026-06-26T19:07:16.973Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/81/b6d4d73a709684fc77e7fa034d7c2fe82cffa9fc920fadcaa659c2626213/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2b2e857ae16f5f72142edf75f9f176fe7526ba19a2841df1420516f83831c9f2", size = 663226, upload-time = "2026-06-26T19:10:13.723Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/07/e210b02b589f16e74ff48b730690e4a34ffe984219fce4f3c1a0e7ec8545/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e515757e2e36bcbf1fad09a46e1557e8b1ae1797d4b44d09da7deed88ad28608", size = 660802, upload-time = "2026-06-26T18:32:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/2e/5303eb3fa06bca089060f479707182a93e360683bc252acf846c3090d34e/greenlet-3.5.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:b363d46ed1ea431825fdb01471bb024fc08399bad1572a616e853c7684415adb", size = 1622157, upload-time = "2026-06-26T19:09:09.527Z" },
+    { url = "https://files.pythonhosted.org/packages/54/70/50de47a488f14df260b50ae34fb5d56016e308b098eab02c878b5223c26a/greenlet-3.5.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:e44da2f5bbdaabaf7d80b73dbb430c7035771e9f244e3c8b769715c9d8fa0a16", size = 1681159, upload-time = "2026-06-26T18:31:52.986Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/13/1055e1dda7882073eda533e2b96c62e55bbd2db7fda6d5ece992febc7071/greenlet-3.5.3-cp315-cp315t-win_amd64.whl", hash = "sha256:8ff8bed3e3baa20a3ea261ce00526f1898ad4801d4886fd2220580ee0ad8fadf", size = 244007, upload-time = "2026-06-26T18:22:04.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/0d/ca7d15afbdc397e3401134c9e1800d51d12b829661786187a4ad08fe484f/greenlet-3.5.3-cp315-cp315t-win_arm64.whl", hash = "sha256:b7068bd09f761f3f5b4d214c2bed063186b2a86148c740b3873e3f56d79bac31", size = 242586, upload-time = "2026-06-26T18:23:37.93Z" },
+]
+
+[[package]]
 name = "groovy"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/52/36/bbdede67400277bef33d3ec0e6a31750da972c469f75966b4930c753218f/groovy-0.1.2.tar.gz", hash = "sha256:25c1dc09b3f9d7e292458aa762c6beb96ea037071bf5e917fc81fb78d2231083", size = 17325, upload-time = "2025-02-28T20:24:56.068Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/28/27/3d6dcadc8a3214d8522c1e7f6a19554e33659be44546d44a2f7572ac7d2a/groovy-0.1.2-py3-none-any.whl", hash = "sha256:7f7975bab18c729a257a8b1ae9dcd70b7cafb1720481beae47719af57c35fa64", size = 14090, upload-time = "2025-02-28T20:24:55.152Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.81.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/b5/1ff353970a87eda4c98251e34d2dfd214abd4982dc89119c9252a2a482d2/grpcio-1.81.1.tar.gz", hash = "sha256:6fa10a767143a5e82e8eaab53918af0cd8909a57a27f8cb2288b80a613ac671b", size = 13026582, upload-time = "2026-06-11T12:46:51.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/d5/f2b159d8eec08be2a855ef698f5b6f7f9fdda022e4dd9e4f5d968affd678/grpcio-1.81.1-cp310-cp310-linux_armv7l.whl", hash = "sha256:6f9a0c9c1cc15c112d1c053064fd032b64917062292c3d70aea280e02ae10b77", size = 6086868, upload-time = "2026-06-11T12:44:19.364Z" },
+    { url = "https://files.pythonhosted.org/packages/80/41/9c95232b94b219ed8b14029d9cd000e0381cafba869c451dda60af84f4ba/grpcio-1.81.1-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:69ef28e54fc85397f91b8c19592b8ef3d81952080366914823bd8572a2958120", size = 12062291, upload-time = "2026-06-11T12:44:27.142Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8b/bd9284bdd665ddf877a3e8bc2930d1bcf6ebdbae7b0da5c783dc26bd6e33/grpcio-1.81.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:15641444eca4a29358107b3dceb74c1c6305c55c822fd199b458aaea4068a7fb", size = 6635242, upload-time = "2026-06-11T12:44:30.741Z" },
+    { url = "https://files.pythonhosted.org/packages/60/24/78fa025517a925f1a17da71c4ef9d5f1c6f9fa65af22dfb523c5c6317a21/grpcio-1.81.1-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:d4b2dddfc219f54f956ccd53cf76a1d338ffe68fc7f2849ec9c7feb9927ff692", size = 7332974, upload-time = "2026-06-11T12:44:33.72Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/11/402295b388dd35861007f8a26a37c2e2f284212d57bdf407c31f36043746/grpcio-1.81.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ca1cc11d82677b9662082e5478b7528e2b7db7beaa6bdff42bd62789d81be399", size = 6836597, upload-time = "2026-06-11T12:44:36.108Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/71/37b10fd4fd579ffade6e695c14e9df5e8cba9e2365b81c131da438b67c34/grpcio-1.81.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:aa2ba7d2ad6df4d80127cea65e5b8d5e2c3adbf153ff4804452836328aca7c54", size = 7440660, upload-time = "2026-06-11T12:44:38.664Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d5/40203f828abc83d458b634666df6df13778032f178c03845ad5a93682388/grpcio-1.81.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:592b5fee597faa91cce2dd294dd7d9a1c83d76c4dbf877e33ec1adb866b2fbed", size = 8443171, upload-time = "2026-06-11T12:44:41.678Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/2c/0ed82ea35b5ec595e10444940c1db8c0e0ef57aa46bc8797d5ff838a219e/grpcio-1.81.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:62481553b1793a27e9b9c3cf9e5bd483ef045ca72462592074b46d42b0c4d9b9", size = 7868905, upload-time = "2026-06-11T12:44:44.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/1f/dcbdc1a68a07cc2b631c3098953794f17d75f93426a019240b90ce5423d6/grpcio-1.81.1-cp310-cp310-win32.whl", hash = "sha256:bb693b1e3d9a2f3fd228e2110daf4b5aeedb36761ca1e4282f74725f6d89f611", size = 4202215, upload-time = "2026-06-11T12:44:47.165Z" },
+    { url = "https://files.pythonhosted.org/packages/75/a1/d7ab9f1f42efcb7d9e6111d38be6b367737a72ea2c534e1f55c81e1b6436/grpcio-1.81.1-cp310-cp310-win_amd64.whl", hash = "sha256:88268ca418cacea64cecb0d1d600d3c6b3a8038fcba02e1e205178c5b1f47661", size = 4936582, upload-time = "2026-06-11T12:44:49.479Z" },
+    { url = "https://files.pythonhosted.org/packages/52/ea/1c2fa386b718ff493225e61cfc052ef400b4d6ffc54cbe261026432624b5/grpcio-1.81.1-cp311-cp311-linux_armv7l.whl", hash = "sha256:d71d30f2d92f67d944631c523713934fee37292469e182ebcd2c1dd8a64ce53f", size = 6093112, upload-time = "2026-06-11T12:44:52.131Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/18/acf45fa8bd1bc5d7b0c2fd3dc4c209379fbd5bb396b440b68a83342226b7/grpcio-1.81.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:b137f4bf3ada9dc44d411478decc6ff09a79ed30b306cd2abaa98408c3588137", size = 12074277, upload-time = "2026-06-11T12:44:55.354Z" },
+    { url = "https://files.pythonhosted.org/packages/48/d7/ee86a60699b7db039f772a2c4a7e4facc7138984ff42c0130933a0063884/grpcio-1.81.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a3acb384427816dd5d470f47e62137b87f74da694faa8a50147012cf40df276a", size = 6640348, upload-time = "2026-06-11T12:44:59.223Z" },
+    { url = "https://files.pythonhosted.org/packages/26/ee/d2de5e47378ffc207d476c230fea3be4d2601edbce9995f4fe45535d4896/grpcio-1.81.1-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:f9a0ebbe45c29b5e5866593c12b78bd9035f0f0f0d4bc8361680cd580d99db49", size = 7331842, upload-time = "2026-06-11T12:45:02.001Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d6/abeda5c2b896a0b341584fe5ac411bbf72e197a9a374c355fb90965e08d2/grpcio-1.81.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0a37165cc80b1a368384b383e63a4c38116a10467ae44c904d2d7468c4470ec2", size = 6842229, upload-time = "2026-06-11T12:45:04.76Z" },
+    { url = "https://files.pythonhosted.org/packages/10/1c/1f0da7d590b4aeee006826ba568d0e419ca14b23e18f901a3da3e9fba613/grpcio-1.81.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6282caffb41ec326d4cb67ca9cf53b739d1b2f975a2acb498c7418e9f7d9a416", size = 7446096, upload-time = "2026-06-11T12:45:07.499Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/81/5c505d508f7c887aa7982d21443a4126597c80d34b0bcf40f9cec576d7f3/grpcio-1.81.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:a35009284d0d3d5c2c9601c164a911b8b4331608d98a9a66d47d97bb2f522b70", size = 8445238, upload-time = "2026-06-11T12:45:10.243Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/b2/524847365122ee509ca17bcc4e092198b700e94af7bfd5bb5e6dd9f3ee66/grpcio-1.81.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1b22c80559854b789a01fd89e8929b3798a156c0829b5282a8939f33ad4115ad", size = 7873989, upload-time = "2026-06-11T12:45:13.102Z" },
+    { url = "https://files.pythonhosted.org/packages/18/fa/07c037c50b006909d1d13a5848774f8aa7b242f70dc03a035c64eea0e6db/grpcio-1.81.1-cp311-cp311-win32.whl", hash = "sha256:428bec0161b48d8cf583c068591bc0016d0d9cfff52462b72b3884861ea768c5", size = 4202223, upload-time = "2026-06-11T12:45:16.166Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ed/6bff15376920942fac6b95b9802752b837437172c9e8fc2d3170546b89cc/grpcio-1.81.1-cp311-cp311-win_amd64.whl", hash = "sha256:30e825f6848d9f18bba350ed6c75c1b02a0b5184474a31db9a32b1fa66fd8c79", size = 4941303, upload-time = "2026-06-11T12:45:18.724Z" },
+    { url = "https://files.pythonhosted.org/packages/85/07/9a979c81738863a738dc23d65177056e71fbb2db817740ed870b33434e7a/grpcio-1.81.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:8b39472beafc0bdcafc4c8c73ad082ebfdb449d566897a61e7acb4fa88089115", size = 6053264, upload-time = "2026-06-11T12:45:21.017Z" },
+    { url = "https://files.pythonhosted.org/packages/75/95/539706ca0d3bd40dbad583dc56fd883da941f37556b629132da5762781b9/grpcio-1.81.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:12b7524c88d4026d3dcb7b0ebe16b6714f3b4af402ddd0f0639ab064a00c87c3", size = 12052560, upload-time = "2026-06-11T12:45:23.652Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/44/f257b7e0bd69c93b06c6cb8ac8d1b901ccb42bedabd83c1a4c77a71f8810/grpcio-1.81.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1e123f9b37edb8375fd74130d1f69c944bbf0a7b06761ae7211154b8759e94d2", size = 6595983, upload-time = "2026-06-11T12:45:26.963Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/f3/19782aa04c960968bef8c5539329d8e3bbc3364e2e46d19eb5e5cc5e43b7/grpcio-1.81.1-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:2c2e2ae6867c2966b8daccc836d54a13218e0007e9a490aeb81dd05be64d22d7", size = 7303455, upload-time = "2026-06-11T12:45:29.707Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/8c/dea020b6d91508cd84463917a63149ec196ee7db505d032ae43fcb3303b9/grpcio-1.81.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:766bc7c9a9c340342f4c864ccbda8e78111e4751f13b895812b9c148fb79e9d0", size = 6809167, upload-time = "2026-06-11T12:45:32.52Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c7/3030dd940408083bd32cd95d634777a71605ade4887154d93e8a89244946/grpcio-1.81.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b259a04a737cb3496be0901328eb8b7552ed8df4865d8c8f1cf1bffcfc0776a3", size = 7412536, upload-time = "2026-06-11T12:45:35.403Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/dd/1172a9e42b168edcafefad6115346ef619a3fc02158bb170e66ced24bcdd/grpcio-1.81.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:85b10a45b8993d195c4f3ff57025b8d1e11834909ee475c403bfa60cb4caefaf", size = 8408276, upload-time = "2026-06-11T12:45:37.78Z" },
+    { url = "https://files.pythonhosted.org/packages/25/7a/71437c7f3596e5246155c515852795a85a1a8d228190212432b13b97a95d/grpcio-1.81.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8ea1936c26b99999b27479853039a7f34713f56c49375ad52b38535ec93a796c", size = 7849660, upload-time = "2026-06-11T12:45:40.627Z" },
+    { url = "https://files.pythonhosted.org/packages/65/40/7debc0da45d2efebafb82da75644be347497fe4ee250514b8cd3b86ae8bf/grpcio-1.81.1-cp312-cp312-win32.whl", hash = "sha256:a185a04039df6cae8648bc8ab6d6fde7bf94f7188ecf7828e76ac52eef1e41d6", size = 4185819, upload-time = "2026-06-11T12:45:43.027Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b9/8fe3ba5ed462067774ebc1f9c7f26aa7ebcc280ddd476be107153de1339e/grpcio-1.81.1-cp312-cp312-win_amd64.whl", hash = "sha256:3ad74f8bb1a18963914c5452d289422830b39459e8776ebbcd207be1fbfb1d94", size = 4930461, upload-time = "2026-06-11T12:45:45.775Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/42/dcc2e4b600538ef18327c0839d56b7d3c3812337c5d710df5877dbb39b1e/grpcio-1.81.1-cp313-cp313-linux_armv7l.whl", hash = "sha256:b10e1ff4756ed27d5a29d7fc79cfce7ef1ff56ad20025b89bac7cf79e09abbbe", size = 6054466, upload-time = "2026-06-11T12:45:48.43Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/4a/a36e03210183a8a7d4c80c3936acee679f4bd77d5861f369db47b2cc5f05/grpcio-1.81.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:819edbdcb42ab8598b494bcf0222684bbb7a3c772bd1b1f0be7e029a6063c28e", size = 12048795, upload-time = "2026-06-11T12:45:54.011Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/d5/d68e30b29098f63beab6fe501100fe82674ff142b32c672532da86a99b3a/grpcio-1.81.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c5bf2dc311127d91230cc79b92188c082634a06cf66c5234db49a43b910183b0", size = 6599094, upload-time = "2026-06-11T12:45:57.799Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b3/e837954d279754f638a11cca5dcf6b24a005efb398984cefaf7735945a54/grpcio-1.81.1-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:e8ca6a1fcdb2943c9cbc1804a1baf3acb6071d72a471591678ded84218006e14", size = 7307182, upload-time = "2026-06-11T12:46:00.568Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/1e/b47957057e729adc6cdf519a47f8be2562b7140e280f1418443eb4022192/grpcio-1.81.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e64dd101d380a115cc5a0c7856788adb535f1a4e21fc543775602f8be95180ae", size = 6810962, upload-time = "2026-06-11T12:46:03.312Z" },
+    { url = "https://files.pythonhosted.org/packages/40/26/569868e364e05b19ec8f969da53d230bcd89c962cd198f7c29943155c4d3/grpcio-1.81.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:98a07f9bf591e3a8919797bee1c53f026ba4acd587e5a4404c8e57c9ec36b2a5", size = 7415698, upload-time = "2026-06-11T12:46:06.005Z" },
+    { url = "https://files.pythonhosted.org/packages/36/0c/5440a0582cb5653fc42a6e262eeb22700943313f8076f9dc927491b20a59/grpcio-1.81.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:c261d74b1a945cf895a9d6eccd1685a8e837531beaab782da4d630a8d12deffb", size = 8407779, upload-time = "2026-06-11T12:46:08.84Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/aa/66fe9f39871d766987d869a03ee0842a026f499c7b1e62decb9e78a8088e/grpcio-1.81.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:58ad1131c300d3c9b933802b3cc4dc69d380822935ba50b28703156ea826fbf7", size = 7844521, upload-time = "2026-06-11T12:46:12.171Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/9e/69bb7194861bcd28fb3193261d4f9c3831b4446993f002cf59068943e7ab/grpcio-1.81.1-cp313-cp313-win32.whl", hash = "sha256:78e29211f26da2fdd0e9c6d2b79f489476140cf7029b6a64808ade7ca4156a42", size = 4182786, upload-time = "2026-06-11T12:46:15.192Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/20/3da8bb0d637feccdc3e1e419bb511ce93651ce7d54164f95de22cc0b8b34/grpcio-1.81.1-cp313-cp313-win_amd64.whl", hash = "sha256:edb59506291b647a30884b1d51a599d605f40b20af4a7dc3d33786a47a31de60", size = 4928648, upload-time = "2026-06-11T12:46:17.823Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/58/19414622b1bf6981bc9c05a365bd548e71876c89000083b3af489251e9c0/grpcio-1.81.1-cp314-cp314-linux_armv7l.whl", hash = "sha256:506f48f2f9c29b143fca3dad7b0d518c188b6c9648c75a2ae6e2d9f2c13a060b", size = 6055336, upload-time = "2026-06-11T12:46:20.557Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f1/2ec88adb92b0eba970dd0e0e7dd086341daa3c75eba4f735f9e44bf684b0/grpcio-1.81.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d865db4a6318e1c1bea83292e0ed231090538fc4ca45425b0f0480eb338bbc6e", size = 12056279, upload-time = "2026-06-11T12:46:24.255Z" },
+    { url = "https://files.pythonhosted.org/packages/41/36/e8c5f8c6ec71de73733695ebc809e98b178b534ec6d8eaa31a7ebab4ad4c/grpcio-1.81.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e2aa72e3ce1770317ef534f63d397b55e130725f5149bd36077c3b539019db27", size = 6608225, upload-time = "2026-06-11T12:46:27.601Z" },
+    { url = "https://files.pythonhosted.org/packages/30/22/96fc577a845ab093326d9ab1adb874bd4936c8cf98ac8ed2f3db13a0a2fb/grpcio-1.81.1-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0490c30c261eded63f3f354979f9dc4502a9fb944cccb60cd9dc85f5a7349854", size = 7306576, upload-time = "2026-06-11T12:46:30.514Z" },
+    { url = "https://files.pythonhosted.org/packages/76/7b/61dab5d5969f28d97fb1009cead1df0a5cd987d3315e1b37f18a4449f8bc/grpcio-1.81.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:410482da976329fe5f4067270401b12cf2bd552ff8020f054ecfaddb5475f9d6", size = 6812165, upload-time = "2026-06-11T12:46:33.699Z" },
+    { url = "https://files.pythonhosted.org/packages/82/78/6e501929d4f5f96462fd82fd9f0f06e5f9612207582b862868d68757b27d/grpcio-1.81.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e3657301562ac3cb8018d30d0d3ebfa39932239f7b5703422057ef14b69949f5", size = 7422962, upload-time = "2026-06-11T12:46:36.511Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/7e/f2157589e66daa78ebb3165942d05a08bdea93b9d11c2bc1e172aef89685/grpcio-1.81.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:24c8e57504c8f45b237e40b99262d181071e5099a07053695b75d97bb53053a0", size = 8408176, upload-time = "2026-06-11T12:46:39.803Z" },
+    { url = "https://files.pythonhosted.org/packages/da/df/c6717fef716e00d235ffb96123baf6dce76d6004f6233fa767c502861460/grpcio-1.81.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b427c19380991a4eaab2f6144b64b99b412043314c6bf4ab544f97bb31ee4190", size = 7846681, upload-time = "2026-06-11T12:46:43.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/84/3502e9f210a6a5c4438c8aca3f88edd2e04f6a27f3d41b26cf0a0024b096/grpcio-1.81.1-cp314-cp314-win32.whl", hash = "sha256:61233fe8951e5c85dff81c2458b6528624760166946b5b47ea150a589168411f", size = 4264615, upload-time = "2026-06-11T12:46:45.741Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b0/4af731ff7492c68a96e4c71bfd0f4590acde92b31c6fe4894e6465c10ff6/grpcio-1.81.1-cp314-cp314-win_amd64.whl", hash = "sha256:3768a5ff1b2125e6f552e561b6b2dca0e64982d8949689b4df145cf8b98d7821", size = 5070275, upload-time = "2026-06-11T12:46:48.486Z" },
+]
+
+[[package]]
+name = "grpcio-tools"
+version = "1.81.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "grpcio", marker = "python_full_version < '3.13'" },
+    { name = "protobuf", marker = "python_full_version < '3.13'" },
+    { name = "setuptools", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/b3/1c5951352d6777fd7f99a0ccee04617fdfd8a5dbf2918a1f58c8b2b280b8/grpcio_tools-1.81.1.tar.gz", hash = "sha256:a22a3870180927fdd84e2b27d079ef5b7f5f8c6110181b6736afc17a463481f1", size = 6236155, upload-time = "2026-06-11T12:51:21.235Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/e1/1fcf884902ae7255d8da224cfa638ea88a46d50f62a33d06d35c8960b029/grpcio_tools-1.81.1-cp310-cp310-linux_armv7l.whl", hash = "sha256:9b6ba8a72cfda576508701a7c0bbeebe6f6f9843320d4f12e74efd19ddccd965", size = 2586261, upload-time = "2026-06-11T12:49:21.447Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/d7/1815110b2d40ec99dbb0a7e6d7eafd591cd1f1e9bf9d3858cd9cf3ffacbd/grpcio_tools-1.81.1-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:ac47a9ea1224df8b653072614e6f0207e9fbfe63fdabaa5918a60ca5fc931b88", size = 5817509, upload-time = "2026-06-11T12:49:25.958Z" },
+    { url = "https://files.pythonhosted.org/packages/23/e8/af99579842b5a555312fa782f32ce0f99bd35b2b7a1243294b2755468857/grpcio_tools-1.81.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eac4bb645ceff0c147cc720a40ae68f97427eaafb4968e866dd8fcc20d3d4831", size = 2634112, upload-time = "2026-06-11T12:49:27.937Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/cd/235ad56ac728c49c17e9218c4daccd5831e6ec7af94236bec0cc66c71c68/grpcio_tools-1.81.1-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:cc410b621dd85193766c12dca2e238696199a27a65d2b31b6f0a4c6c0043ff26", size = 2957950, upload-time = "2026-06-11T12:49:29.619Z" },
+    { url = "https://files.pythonhosted.org/packages/77/3e/9103e8b4610597bf89db49eb112091c91bf5d63ddef2a951e11a4be05f2b/grpcio_tools-1.81.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b62d254c214faa3773eac709376ae25cf7abff1a76ba5fc4dbcd7b14fc4e4ae6", size = 2697765, upload-time = "2026-06-11T12:49:31.702Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/86/beb2a43fbb93570a2305696083f6736566301d957869f463308ec6839f95/grpcio_tools-1.81.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:bd0b68dc76b10b3384b9b6e9f59202b83dcaafd8098eb644759a69316686acf8", size = 3147588, upload-time = "2026-06-11T12:49:33.748Z" },
+    { url = "https://files.pythonhosted.org/packages/af/4d/b0182d9948631cd837a372b6625cf59d6e335d4aab0f425d4b7306619074/grpcio_tools-1.81.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:a28d231455ab6e3558299f7d831a73c8be8ee6b7ec614ecf39eb50c0ed15767f", size = 3708798, upload-time = "2026-06-11T12:49:35.979Z" },
+    { url = "https://files.pythonhosted.org/packages/23/9b/f452a189d399051d85cf82fe2f27a070efaa52512a2c5e3ae6ef1ae99a1f/grpcio_tools-1.81.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:82740248eb6f3b6a38988cb5e64adb7303af9ea5cb4197c8ed08c1fabc767440", size = 3366969, upload-time = "2026-06-11T12:49:37.911Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/48/0075cb4f6ae7db280f461de2dbba700b22ae62e351ae13e6e461cd6804de/grpcio_tools-1.81.1-cp310-cp310-win32.whl", hash = "sha256:801d9d8ab5cddf8f8e064225292f0713427011252a07828a6b54e2ed64d534de", size = 1008713, upload-time = "2026-06-11T12:49:39.791Z" },
+    { url = "https://files.pythonhosted.org/packages/17/bd/7692bc698259e5645b68720e77e7b176d376f6ae0c9db8b5b750a02f1958/grpcio_tools-1.81.1-cp310-cp310-win_amd64.whl", hash = "sha256:3c8611d6e4e859ac5373422ef27c4b7540cf98c9991c9abc6722613ef72b13aa", size = 1174752, upload-time = "2026-06-11T12:49:41.43Z" },
+    { url = "https://files.pythonhosted.org/packages/18/76/14ff87090199a36f914388299a1148d0734a20cea1b0ca8480bae1f373f1/grpcio_tools-1.81.1-cp311-cp311-linux_armv7l.whl", hash = "sha256:8161f398f957a376cae7385ea7c8684f439d460ef702b528912da3bcb31fc515", size = 2586251, upload-time = "2026-06-11T12:49:43.514Z" },
+    { url = "https://files.pythonhosted.org/packages/87/a8/d5aa99de9d8b2dd2a8192c1779796eda8b0d0f1dd915422e0a8a61b80391/grpcio_tools-1.81.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:53ef76cc3b0493ff734a5e8c39d5b519e1822236fcccdfe7677c5e1efd767761", size = 5818063, upload-time = "2026-06-11T12:49:45.975Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/cb/2e9a6dbc6a514dd3cd264fb3bf9217937453a4d45dbc3ca6ca4ee34ba1a7/grpcio_tools-1.81.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:690e6dcaa8b8a7886ce206ba344e2127211597e1a1ddab73df9f3d80c8f6707e", size = 2634061, upload-time = "2026-06-11T12:49:48.13Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/2b/2ccd1a929e6c8ad84a0aa8d66ad9f615b4a8e79d9927373d86aa36b4ba2e/grpcio_tools-1.81.1-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:ad7a997c07bd345e84842e60561e7e2cc090ce6c4e1d2f0407e31b85b40fc49a", size = 2958029, upload-time = "2026-06-11T12:49:50.466Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/67/2da8cd312edc348f44f26f82096b25cdb7d2905cd786acc6bf777b169502/grpcio_tools-1.81.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b6bd163ece4535726e5292b845ed80ae9b2cae73ba091c7d6c66033c430e3857", size = 2698031, upload-time = "2026-06-11T12:49:52.292Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/ba/ad1680fbdf9317c4f1e54c37c96d1f422370df66ac9adbd175c7cb3531d7/grpcio_tools-1.81.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2baa7e735f35b2a648144c03348a126097b13e101d3c242d5edb6ac91437ccbe", size = 3147541, upload-time = "2026-06-11T12:49:54.43Z" },
+    { url = "https://files.pythonhosted.org/packages/57/c1/57cd08eef293d713cb8935295e4f08d8f0013480b2ba3aad1af0271eb7ba/grpcio_tools-1.81.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:1d602b410b2b2addc434cace9ce4fe2035974a3078228f98ffa049a5c90acc2f", size = 3708524, upload-time = "2026-06-11T12:49:56.544Z" },
+    { url = "https://files.pythonhosted.org/packages/52/31/01ea8ca9c82fe2c79b5b594c3ae427d56699bc106b2d91caca129add8b10/grpcio_tools-1.81.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f8cb64f87c45ccca8234fa47e6b21f09e43801ff11b556deecb461b3b3e9f292", size = 3367022, upload-time = "2026-06-11T12:49:59.608Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/35/8140cd175602df3d17215cfb28a7ea55b7a67e2b872be76e1ee4af5c4df9/grpcio_tools-1.81.1-cp311-cp311-win32.whl", hash = "sha256:87b25ca0e27373a4a32a629a4ba976f5764b9887dd50d6fe017d38009a0363e8", size = 1008980, upload-time = "2026-06-11T12:50:01.422Z" },
+    { url = "https://files.pythonhosted.org/packages/be/86/1bd29ab3c52457702b96536f1f208ab27695322d855f95c9666dfb713019/grpcio_tools-1.81.1-cp311-cp311-win_amd64.whl", hash = "sha256:204de03b539a4b08772c6553b92bcc112cbc965e0ac22f909f6d133b8ac33a8c", size = 1174840, upload-time = "2026-06-11T12:50:03.408Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8a/824a9ca20bcdce8a568bb8c9f98bfeb7fad62129235e6d2ae7576fd1250a/grpcio_tools-1.81.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:353b1fafcc739c31ed42271052709595b340d34f27c459beeb78a32938305bb5", size = 2585927, upload-time = "2026-06-11T12:50:05.671Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/35/e5f9f671378b1b89a896150d3e4fa2c6ec61a5e1e9e5107ce4c140ccc931/grpcio_tools-1.81.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:768f584c2423cbeb6cb6867817a39365b987ff16b8259a3adbc6546b9e303a4e", size = 5815665, upload-time = "2026-06-11T12:50:08.178Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/02/631b628e4072e988c669bd8f1b2406ef3c9a4cfcb2625bbf2a308a07b71d/grpcio_tools-1.81.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1680b35a84f4694401819ac4acac42dda6dbc7bb8fc74112fd1a60425a07adf4", size = 2635518, upload-time = "2026-06-11T12:50:10.391Z" },
+    { url = "https://files.pythonhosted.org/packages/de/7c/2e3537e3ea3d1c0ddd6766cf6a7c62b487d89fb005713df2781d5f21483a/grpcio_tools-1.81.1-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:f64e665c8ec639278ecf009beb92cbdcc5994f617c1af3d58036e1f70b1423ec", size = 2958252, upload-time = "2026-06-11T12:50:12.677Z" },
+    { url = "https://files.pythonhosted.org/packages/35/68/14013cb2942bdac354746b643b4c37dd91906da8dce00f41c616e88bf33d/grpcio_tools-1.81.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ba8f1ae82ad199f43448995715445cc623fb20d3882382e4be61f0da8ccb3f0e", size = 2698439, upload-time = "2026-06-11T12:50:15.017Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/45/000c14c0338a7ad36054b9f17ea41842deb7841c05c067dd36cc831bc0f4/grpcio_tools-1.81.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b7b6d1e986d5923751bfe2b5cca9c4cb3d5653446e4fa4aacd438033e2dc360a", size = 3152160, upload-time = "2026-06-11T12:50:17.3Z" },
+    { url = "https://files.pythonhosted.org/packages/41/97/881930ca3967d2c8a95649bea8ebc991a7cf2331bc96679fd3600450dccc/grpcio_tools-1.81.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:7f208c207aca639dcb34648d3826c38d7cf3485118fb2065117e9fc4827406b3", size = 3710468, upload-time = "2026-06-11T12:50:19.479Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/b5/67baeba7366162652cdc1dbd962289accde07241bc8f42f6f02b305efcc6/grpcio_tools-1.81.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:724ecb69af63d2f6d4ccea3e6fa0ca110ed9c5824d48c2f887c631bbb03c1c3c", size = 3370797, upload-time = "2026-06-11T12:50:21.501Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/5d/34f2dce2125ccb107e32b57f5a9c1257edcc0793b0d2fef1e8b13a6bac3c/grpcio_tools-1.81.1-cp312-cp312-win32.whl", hash = "sha256:895a6782cec86beac71ccebb4b9848259c6f04a3028b8e42fa8d40cfe5146593", size = 1008453, upload-time = "2026-06-11T12:50:23.358Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/be/09da8256ec8d2a5ce8a1acc51cbbc4ca52a462d78ed3412778440a56502e/grpcio_tools-1.81.1-cp312-cp312-win_amd64.whl", hash = "sha256:0265fd1386b7458302f79542558345880d484f8fa92ae196c0c0268242c5f23a", size = 1174857, upload-time = "2026-06-11T12:50:25.685Z" },
+    { url = "https://files.pythonhosted.org/packages/76/90/5faa8b26e03495e5117f93bef8293cbada4af136362745dad7d1813ef0b0/grpcio_tools-1.81.1-cp313-cp313-linux_armv7l.whl", hash = "sha256:3d604b4fd114b79ebb9f865bf3e04fd3ae93c704e1fad96f7fd03b0865c263b7", size = 2586071, upload-time = "2026-06-11T12:50:28.4Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/9a/85dc589fa6ae2439451eaa81a1578de31e29c676980d38bef7549b8a1f45/grpcio_tools-1.81.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:3389e705460efa3f3758141ba5520e6743b131c9576197c944fb9cbe49048126", size = 5813299, upload-time = "2026-06-11T12:50:31.295Z" },
+    { url = "https://files.pythonhosted.org/packages/77/fd/c53994e58a837e6eefe48f53eb3492afc04f2b8af255df4adb37d14378f8/grpcio_tools-1.81.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8a17d8ceeb6a855fadf39f5171c80a382d97c4db98d5943eca553497fdebf84b", size = 2634668, upload-time = "2026-06-11T12:50:33.938Z" },
+    { url = "https://files.pythonhosted.org/packages/34/32/de988e86688686a2117e7ce6ce9eff4f638c929bb55b0afe60d6fbd2e45c/grpcio_tools-1.81.1-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:43baf71dc60fd653062da2e95e95c73b35dd130be8f9fa3d544c3af3f808a290", size = 2957930, upload-time = "2026-06-11T12:50:36.726Z" },
+    { url = "https://files.pythonhosted.org/packages/72/97/3f18a0ea32b5f809d21961dbd0bc382b589a4c3d501e3d67c345d5456ed3/grpcio_tools-1.81.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:136e90906af0df51ad929713244ba812d0dbb1844b4f467d5d86bdb054698f90", size = 2697760, upload-time = "2026-06-11T12:50:39.108Z" },
+    { url = "https://files.pythonhosted.org/packages/49/c0/dbf5cbc877290ff7504a59959a8af4fdcfdaa1e84237948405ccf1aa82a6/grpcio_tools-1.81.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bd6c3bf3ea6a61eb58c54368d72ada591f2a270f3a31a32e8536e773337e76d9", size = 3151456, upload-time = "2026-06-11T12:50:41.983Z" },
+    { url = "https://files.pythonhosted.org/packages/de/ea/16fe2dc83140a59e5c0a0b9dc2693dd36bfaa6bd835724b4ec66a68eab7b/grpcio_tools-1.81.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2c306c307f8f74cddc4056fdbb6f1da55de087a21120efbd02bd915daa5a52fd", size = 3710469, upload-time = "2026-06-11T12:50:44.596Z" },
+    { url = "https://files.pythonhosted.org/packages/22/7d/df987d7d81e7ad2f7516d9e9d56ff29c54dbc6d8587e425688dca9a28e49/grpcio_tools-1.81.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bdbdc927be2e0ea13c32564a72ee31d712a716fb6f8c0d53d37a77d8277c272c", size = 3370488, upload-time = "2026-06-11T12:50:47.199Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/c5/5a63444d694ea47bf670138208f71830cc1759c402c8818092b28ab2dc5f/grpcio_tools-1.81.1-cp313-cp313-win32.whl", hash = "sha256:9d383724bcd67244b6def9e9164c640ee9380c0b7534ee7545a6fb0022a59afe", size = 1008229, upload-time = "2026-06-11T12:50:49.527Z" },
+    { url = "https://files.pythonhosted.org/packages/00/75/3945e26d5c94ae6ed9be5caef73d4d66c47dc8cfdd7b4995efaf942754e0/grpcio_tools-1.81.1-cp313-cp313-win_amd64.whl", hash = "sha256:f3eb15849979ca7bb864ce81a74d68b0f225a7f111ed3fe212bfc08cf9812b10", size = 1174523, upload-time = "2026-06-11T12:50:51.755Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/08/e581ad42ae517a61172285047e4d710e2ac75f2f1915f7c91f284254e6d5/grpcio_tools-1.81.1-cp314-cp314-linux_armv7l.whl", hash = "sha256:7d168ea26390717d0462c0d0408331dc98a60fc7f7e6118afac9b73f5a66d87c", size = 2585944, upload-time = "2026-06-11T12:50:54.528Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c8/200d90ebad685af7eea5ff7e0360c504dd01ec053fe0f1f9c4abe3ea2d5a/grpcio_tools-1.81.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:43c528655b226375013036692d8db4cd59060c1f41dd62c77f4d17b69f6ce828", size = 5813492, upload-time = "2026-06-11T12:50:57.291Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/c0/60da2a1af37aa8eb47308cec24d9f7709a8976fdec3a53fd35b56b358326/grpcio_tools-1.81.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a9c6fcc68c9d5a208967bfe4fd3224d3c3be9a950c3e827e8f4b17e15c2dc555", size = 2634991, upload-time = "2026-06-11T12:50:59.767Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/7f/dede28b579ae9bf9079ba1aa913e8088d1dc0cdbe21c85caa22f0790cad2/grpcio_tools-1.81.1-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:a987c85dcbe1b32066d7acd46266d1a428aecbd629331bf5b853e74c835bf876", size = 2957913, upload-time = "2026-06-11T12:51:02.31Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/38/4de2118adb58ec7ffba65ec623b5836db769665c192517cbf187db3f6145/grpcio_tools-1.81.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a882382507bb5ec6d7edc9648053dfd3bc8f9285cde56a6fa9b9a83b4bd07f1c", size = 2697709, upload-time = "2026-06-11T12:51:05.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/e1/762ced51059e4f694fd337ecae491581d42a4e61dcb0415d8c5c60e6ddcb/grpcio_tools-1.81.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7746e508d4239a02f7e93638be5bc0ebb0120ddb796f7506aaae9d47a4599d97", size = 3151884, upload-time = "2026-06-11T12:51:07.593Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d8/9823090dc801e7229944874e7429c3b98e741ac778d8dc373f60240e1c43/grpcio_tools-1.81.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:fc3d2a41a7a4467fa03b391394fffada9291fe8feebc8679b526f6bc36942b25", size = 3710404, upload-time = "2026-06-11T12:51:10.172Z" },
+    { url = "https://files.pythonhosted.org/packages/64/4e/4eae98d02148cb6f9f452f09942afba407afa6851e6c1fddc5ae9ec0b4ed/grpcio_tools-1.81.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:21bb3ba90e6d8df1ff663d4ee39a4e5b25a64e8ed4902476ca9ded0954d3917a", size = 3370525, upload-time = "2026-06-11T12:51:12.678Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/3e/2206e597a128da6a03a6106d2eaf2c3e72c7d80843d4be933e3a3d10d02a/grpcio_tools-1.81.1-cp314-cp314-win32.whl", hash = "sha256:3dca56016d90a710c4d9861bae793dc089c1430a90c79ce672e948ddb65fa539", size = 1030582, upload-time = "2026-06-11T12:51:14.906Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/f2/bbeef86c687225b7bbc7c0acdfbd25c8bcaa3f5b1c941db053e5c3d9e859/grpcio_tools-1.81.1-cp314-cp314-win_amd64.whl", hash = "sha256:cb08172b7b629e75cb33866928d319a3196540a725eaab628ba721007140f1af", size = 1207490, upload-time = "2026-06-11T12:51:17.598Z" },
 ]
 
 [[package]]
@@ -946,6 +1498,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/42/4b/53951592882d9c23080c7644542fda34a3813104e9e11fa1a7d82d419cb8/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7716d62015477a70ea272d2d68cd7cad140f61c52ee452e133e139abfe2c17ba", size = 4429392, upload-time = "2026-03-31T22:40:03.492Z" },
     { url = "https://files.pythonhosted.org/packages/8a/21/75a6c175b4e79662ad8e62f46a40ce341d8d6b206b06b4320d07d55b188c/hf_xet-1.4.3-cp37-abi3-win_amd64.whl", hash = "sha256:6b591fcad34e272a5b02607485e4f2a1334aebf1bc6d16ce8eb1eb8978ac2021", size = 3677359, upload-time = "2026-03-31T22:40:13.619Z" },
     { url = "https://files.pythonhosted.org/packages/8a/7c/44314ecd0e89f8b2b51c9d9e5e7a60a9c1c82024ac471d415860557d3cd8/hf_xet-1.4.3-cp37-abi3-win_arm64.whl", hash = "sha256:7c2c7e20bcfcc946dc67187c203463f5e932e395845d098cc2a93f5b67ca0b47", size = 3533664, upload-time = "2026-03-31T22:40:12.152Z" },
+]
+
+[[package]]
+name = "httmock"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/35/d881561984239dcf507625ec86f9653ba5526213ed94138a9ea6b0305169/httmock-1.4.0.tar.gz", hash = "sha256:44eaf4bb59cc64cd6f5d8bf8700b46aa3097cc5651b9bc85c527dfbc71792f41", size = 4795, upload-time = "2020-10-28T12:01:30.325Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/99/f950e23335affb58ae116aaf32565258a732b2b570aa961764df2ac0540d/httmock-1.4.0-py3-none-any.whl", hash = "sha256:13e6c63f135a928e15d386af789a2890efb03e0e280f29bdc9961f3f0dc34cb9", size = 4754, upload-time = "2020-10-28T12:01:29.1Z" },
 ]
 
 [[package]]
@@ -997,6 +1561,15 @@ wheels = [
 ]
 
 [[package]]
+name = "humanize"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/66/a3921783d54be8a6870ac4ccffcd15c4dc0dd7fcce51c6d63b8c63935276/humanize-4.15.0.tar.gz", hash = "sha256:1dd098483eb1c7ee8e32eb2e99ad1910baefa4b75c3aff3a82f4d78688993b10", size = 83599, upload-time = "2025-12-20T20:16:13.19Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/7b/bca5613a0c3b542420cf92bd5e5fb8ebd5435ce1011a091f66bb7693285e/humanize-4.15.0-py3-none-any.whl", hash = "sha256:b1186eb9f5a9749cd9cb8565aee77919dd7c8d076161cf44d70e59e3301e1769", size = 132203, upload-time = "2025-12-20T20:16:11.67Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.18"
 source = { registry = "https://pypi.org/simple" }
@@ -1027,6 +1600,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/5f/07f93b0e5a94b69a65eb108290ae0544210affeb24ec20cf219fe60b4e8e/import-ipynb-0.2.tar.gz", hash = "sha256:0a6db02db7973a35ed1bf007b837288b13374897282218e226d01a1eaecaff85", size = 5376, upload-time = "2024-10-09T06:04:53.734Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/62/e0b830773060d2a390aa923dcc8afc680d798bdbdadb6394f760fac62517/import_ipynb-0.2-py3-none-any.whl", hash = "sha256:cb9e41c65dd81ebaa8e1e3e1b591276f910fbaac9238960d6798aad28d4c323f", size = 4005, upload-time = "2024-10-09T06:04:52.598Z" },
+]
+
+[[package]]
+name = "importlib-resources"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/06/b56dfa750b44e86157093bc8fca0ab81dccbf5260510de4eaf1cb69b5b99/importlib_resources-7.1.0.tar.gz", hash = "sha256:0722d4c6212489c530f2a145a34c0a7a3b4721bc96a15fada5930e2a0b760708", size = 44985, upload-time = "2026-04-12T16:36:09.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl", hash = "sha256:1bd7b48b4088eddb2cd16382150bb515af0bd2c70128194392725f82ad2c96a1", size = 37232, upload-time = "2026-04-12T16:36:08.219Z" },
 ]
 
 [[package]]
@@ -1132,6 +1714,107 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c", size = 8074, upload-time = "2025-01-17T11:24:33.271Z" },
+]
+
+[[package]]
+name = "jax"
+version = "0.4.38"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jaxlib", marker = "python_full_version < '3.13'" },
+    { name = "ml-dtypes", marker = "python_full_version < '3.13'" },
+    { name = "numpy", marker = "python_full_version < '3.13'" },
+    { name = "opt-einsum", marker = "python_full_version < '3.13'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/e5/c4aa9644bb96b7f6747bd7c9f8cda7665ca5e194fa2542b2dea3ff730701/jax-0.4.38.tar.gz", hash = "sha256:43bae65881628319e0a2148e8f81a202fbc2b8d048e35c7cb1df2416672fa4a8", size = 1930034, upload-time = "2024-12-17T23:03:47.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/49/b4418a7a892c0dd64442bbbeef54e1cdfe722dfc5a7bf0d611d3f5f90e99/jax-0.4.38-py3-none-any.whl", hash = "sha256:78987306f7041ea8500d99df1a17c33ed92620c2268c4c3677fb24e06712be64", size = 2236864, upload-time = "2024-12-17T23:03:44.433Z" },
+]
+
+[[package]]
+name = "jaxlib"
+version = "0.4.38"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ml-dtypes", marker = "python_full_version < '3.13'" },
+    { name = "numpy", marker = "python_full_version < '3.13'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/d4/e6a0881a88b8f17491c2ee271fd77c348b0221d9e2ec92dad23a2c9e41bc/jaxlib-0.4.38-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:55c19b9d3f33a6fc59f644aa5a21fba02639ccdd776cb4a9b5526625f57839ff", size = 99663603, upload-time = "2024-12-17T23:04:08.864Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6d/11569ce873f04c82ec22e58d822f4187dccae1d400c0d6dd05ed314d5328/jaxlib-0.4.38-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:30b2f52cb50d74734af2f477c2533a7a583e3bb7b2c8acdeb361ee77d940577a", size = 79475708, upload-time = "2024-12-17T23:04:21.67Z" },
+    { url = "https://files.pythonhosted.org/packages/72/61/1de2405d13089c83b1ad87ec0266479c9d00080659dae2474892ae356306/jaxlib-0.4.38-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:ee19c163a8fdf0839d4c18b88a5fbfb4e731ba7c437416d3e5483e570bb764e4", size = 93219045, upload-time = "2024-12-17T23:04:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/24/0829decf233c6af9efe7c53888ae8ac72395e0979869cd9cee487e35dac3/jaxlib-0.4.38-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:61aeccb9a27c67fdb8450f6357240019cd4511cb9d62a44e4764756d384853ad", size = 101732107, upload-time = "2024-12-17T23:04:49.106Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/04/120c4caac6151f7297fedf9dd776362aa2d417d3f87bda826050b4da45e8/jaxlib-0.4.38-cp310-cp310-win_amd64.whl", hash = "sha256:d6ab745a89d0fb737a36fe1d8b86659e3fffe6ee8303b20651b26193d5edc0ef", size = 64223924, upload-time = "2024-12-17T23:05:04.362Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/6a/b9fba73eb5e758e40a514919e096a039d27dc0ab4776a6cc977f5153a55f/jaxlib-0.4.38-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:b67fdeabd6dfed08b7768f3bdffb521160085f8305669bd197beef61d08de08b", size = 99679916, upload-time = "2024-12-17T23:05:19.908Z" },
+    { url = "https://files.pythonhosted.org/packages/44/2a/3458130d44d44038fd6974e7c43948f68408f685063203b82229b9b72c1a/jaxlib-0.4.38-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3fb0eaae7369157afecbead50aaf29e73ffddfa77a2335d721bd9794f3c510e4", size = 79488377, upload-time = "2024-12-17T23:05:31.031Z" },
+    { url = "https://files.pythonhosted.org/packages/94/96/7d9a0b9f35af4727df44b68ade4c6f15163840727d1cb47251b1ea515e30/jaxlib-0.4.38-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:43db58c4c427627296366a56c10318e1f00f503690e17f94bb4344293e1995e0", size = 93241543, upload-time = "2024-12-17T23:05:42.246Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/2d/68f85037e60c981b37b18b23ace458c677199dea4722ddce541b48ddfc63/jaxlib-0.4.38-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:2751ff7037d6a997d0be0e77cc4be381c5a9f9bb8b314edb755c13a6fd969f45", size = 101751923, upload-time = "2024-12-17T23:05:55.321Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/24/a9c571c8a189f58e0b54b14d53fc7f5a0a06e4f1d7ab9edcf8d1d91d07e7/jaxlib-0.4.38-cp311-cp311-win_amd64.whl", hash = "sha256:35226968fc9de6873d1571670eac4117f5ed80e955f7a1775204d1044abe16c6", size = 64255189, upload-time = "2024-12-17T23:06:06.683Z" },
+    { url = "https://files.pythonhosted.org/packages/49/df/08b94c593c0867c7eaa334592807ba74495de4be90580f360db8b96221dc/jaxlib-0.4.38-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:3fefea985f0415816f3bbafd3f03a437050275ef9bac9a72c1314e1644ac57c1", size = 99737849, upload-time = "2024-12-17T23:06:20.406Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/b1/c9d2a7ba9ebeabb7ac37082f4c466364f475dc7550a79358c0f0aa89fdf2/jaxlib-0.4.38-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f33bcafe32c97a562ecf6894d7c41674c80c0acdedfa5423d49af51147149874", size = 79509242, upload-time = "2024-12-17T23:06:33.73Z" },
+    { url = "https://files.pythonhosted.org/packages/53/25/dd670d8bdf3799ece76d12cfe6a6a250ea256057aa4b0fcace4753a99d2d/jaxlib-0.4.38-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:496f45b0e001a2341309cd0c74af0b670537dced79c168cb230cfcc773f0aa86", size = 93251503, upload-time = "2024-12-17T23:06:48.243Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/cc/37fce5162f6b9070203fd76cc0f298d9b3bfdf01939a78935a6078d63621/jaxlib-0.4.38-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:dad6c0a96567c06d083c0469fec40f201210b099365bd698be31a6d2ec88fd59", size = 101792792, upload-time = "2024-12-17T23:07:01.615Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/7a/8515950a60a4ea5b13cc98fc0a42e36553b2db5a6eedc00d3bd7836f77b5/jaxlib-0.4.38-cp312-cp312-win_amd64.whl", hash = "sha256:966cdec36cfa978f5b4582bcb4147fe511725b94c1a752dac3a5f52ce46b6fa3", size = 64288223, upload-time = "2024-12-17T23:07:15.024Z" },
+    { url = "https://files.pythonhosted.org/packages/91/03/aee503c7077c6dbbd568842303426c6ec1cef9bff330c418c9e71906cccd/jaxlib-0.4.38-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:41e55ae5818a882e5789e848f6f16687ac132bcfbb5a5fa114a5d18b78d05f2d", size = 99739026, upload-time = "2024-12-17T23:07:27.542Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/bf/fbbf61da319611d88e11c691d5a2077039208ded05e1731dea940f824a59/jaxlib-0.4.38-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6fe326b8af366387dd47ccf312583b2b17fed12712c9b74a648b18a13cbdbabf", size = 79508735, upload-time = "2024-12-17T23:07:42.037Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/0b/8cbff0b6d62a4694351c49baf53b7ed8deb8a6854d129408c38158e11676/jaxlib-0.4.38-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:248cca3771ebf24b070f49701364ceada33e6139445b06c782cca5ac5ad92bf4", size = 93251882, upload-time = "2024-12-17T23:07:56.85Z" },
+    { url = "https://files.pythonhosted.org/packages/15/57/7f0283273b69c417071bcd2f4c2ed076479ec5ffc22a647f13c21da8d071/jaxlib-0.4.38-cp313-cp313-manylinux2014_x86_64.whl", hash = "sha256:2ce77ba8cda9259a4bca97afc1c722e4291a6c463a63f8d372c6edc85117d625", size = 101791137, upload-time = "2024-12-17T23:08:10.361Z" },
+    { url = "https://files.pythonhosted.org/packages/de/de/d6c4d234cd426b97459cb070af90792b48643967a0d28641379ee9e10fc9/jaxlib-0.4.38-cp313-cp313-win_amd64.whl", hash = "sha256:4103db0b3a38a5dc132741237453c24d8547290a22079ba1b577d6c88c95300a", size = 64288459, upload-time = "2024-12-17T23:08:25.039Z" },
+]
+
+[[package]]
+name = "jaxopt"
+version = "0.8.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jax", marker = "python_full_version < '3.13'" },
+    { name = "jaxlib", marker = "python_full_version < '3.13'" },
+    { name = "numpy", marker = "python_full_version < '3.13'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/da/ff7d7fbd13b8ed5e8458e80308d075fc649062b9f8676d3fc56f2dc99a82/jaxopt-0.8.5.tar.gz", hash = "sha256:2790bd68ef132b216c083a8bc7a2704eceb35a92c0fc0a1e652e79dfb1e9e9ab", size = 121709, upload-time = "2025-04-14T17:59:01.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/d8/55e0901103c93d57bab3b932294c216f0cbd49054187ce29f8f13808d530/jaxopt-0.8.5-py3-none-any.whl", hash = "sha256:ff221d1a86908ec759eb1e219ee1d12bf208a70707e961bf7401076fe7cf4d5e", size = 172434, upload-time = "2025-04-14T17:59:00.342Z" },
+]
+
+[[package]]
+name = "jaxtyping"
+version = "0.3.7"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "wadler-lindig", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/40/a2ea3ce0e3e5f540eb970de7792c90fa58fef1b27d34c83f9fa94fea4729/jaxtyping-0.3.7.tar.gz", hash = "sha256:3bd7d9beb7d3cb01a89f93f90581c6f4fff3e5c5dc3c9307e8f8687a040d10c4", size = 45721, upload-time = "2026-01-30T14:18:47.409Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/42/caf65e9a0576a3abadc537e2f831701ba9081f21317fb3be87d64451587a/jaxtyping-0.3.7-py3-none-any.whl", hash = "sha256:303ab8599edf412eeb40bf06c863e3168fa186cf0e7334703fa741ddd7046e66", size = 56101, upload-time = "2026-01-30T14:18:45.954Z" },
+]
+
+[[package]]
+name = "jaxtyping"
+version = "0.3.11"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "wadler-lindig", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/c1/091b8852bd7cbf50bd655543c8506033cf4029300c67f8c176c1286879a9/jaxtyping-0.3.11.tar.gz", hash = "sha256:b09c14acf6686feb9e0df5b0d8c6e7c5b6f8d36bf059ee54cd522a186c2ef050", size = 46489, upload-time = "2026-06-13T18:35:23.167Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/38/c66bbdc5047f4776c2bd3e47e5295a350e3fa44d5b8942105e71c2a876a0/jaxtyping-0.3.11-py3-none-any.whl", hash = "sha256:8a4bedc4e3f963fa82df41bd13c7ebc2bad925601eb48614c65798f21329d4e3", size = 56593, upload-time = "2026-06-13T18:35:22.01Z" },
 ]
 
 [[package]]
@@ -1527,6 +2210,124 @@ wheels = [
 ]
 
 [[package]]
+name = "ml-dtypes"
+version = "0.5.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/4a/c27b42ed9b1c7d13d9ba8b6905dece787d6259152f2309338aed29b2447b/ml_dtypes-0.5.4.tar.gz", hash = "sha256:8ab06a50fb9bf9666dd0fe5dfb4676fa2b0ac0f31ecff72a6c3af8e22c063453", size = 692314, upload-time = "2025-11-17T22:32:31.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/3a/c5b855752a70267ff729c349e650263adb3c206c29d28cc8ea7ace30a1d5/ml_dtypes-0.5.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b95e97e470fe60ed493fd9ae3911d8da4ebac16bd21f87ffa2b7c588bf22ea2c", size = 679735, upload-time = "2025-11-17T22:31:31.367Z" },
+    { url = "https://files.pythonhosted.org/packages/41/79/7433f30ee04bd4faa303844048f55e1eb939131c8e5195a00a96a0939b64/ml_dtypes-0.5.4-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b4b801ebe0b477be666696bda493a9be8356f1f0057a57f1e35cd26928823e5a", size = 5051883, upload-time = "2025-11-17T22:31:33.658Z" },
+    { url = "https://files.pythonhosted.org/packages/10/b1/8938e8830b0ee2e167fc75a094dea766a1152bde46752cd9bfc57ee78a82/ml_dtypes-0.5.4-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:388d399a2152dd79a3f0456a952284a99ee5c93d3e2f8dfe25977511e0515270", size = 5030369, upload-time = "2025-11-17T22:31:35.595Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/a3/51886727bd16e2f47587997b802dd56398692ce8c6c03c2e5bb32ecafe26/ml_dtypes-0.5.4-cp310-cp310-win_amd64.whl", hash = "sha256:4ff7f3e7ca2972e7de850e7b8fcbb355304271e2933dd90814c1cb847414d6e2", size = 210738, upload-time = "2025-11-17T22:31:37.43Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/5e/712092cfe7e5eb667b8ad9ca7c54442f21ed7ca8979745f1000e24cf8737/ml_dtypes-0.5.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6c7ecb74c4bd71db68a6bea1edf8da8c34f3d9fe218f038814fd1d310ac76c90", size = 679734, upload-time = "2025-11-17T22:31:39.223Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/cf/912146dfd4b5c0eea956836c01dcd2fce6c9c844b2691f5152aca196ce4f/ml_dtypes-0.5.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bc11d7e8c44a65115d05e2ab9989d1e045125d7be8e05a071a48bc76eb6d6040", size = 5056165, upload-time = "2025-11-17T22:31:41.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/80/19189ea605017473660e43762dc853d2797984b3c7bf30ce656099add30c/ml_dtypes-0.5.4-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:19b9a53598f21e453ea2fbda8aa783c20faff8e1eeb0d7ab899309a0053f1483", size = 5034975, upload-time = "2025-11-17T22:31:42.758Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/24/70bd59276883fdd91600ca20040b41efd4902a923283c4d6edcb1de128d2/ml_dtypes-0.5.4-cp311-cp311-win_amd64.whl", hash = "sha256:7c23c54a00ae43edf48d44066a7ec31e05fdc2eee0be2b8b50dd1903a1db94bb", size = 210742, upload-time = "2025-11-17T22:31:44.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/c9/64230ef14e40aa3f1cb254ef623bf812735e6bec7772848d19131111ac0d/ml_dtypes-0.5.4-cp311-cp311-win_arm64.whl", hash = "sha256:557a31a390b7e9439056644cb80ed0735a6e3e3bb09d67fd5687e4b04238d1de", size = 160709, upload-time = "2025-11-17T22:31:46.557Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b8/3c70881695e056f8a32f8b941126cf78775d9a4d7feba8abcb52cb7b04f2/ml_dtypes-0.5.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a174837a64f5b16cab6f368171a1a03a27936b31699d167684073ff1c4237dac", size = 676927, upload-time = "2025-11-17T22:31:48.182Z" },
+    { url = "https://files.pythonhosted.org/packages/54/0f/428ef6881782e5ebb7eca459689448c0394fa0a80bea3aa9262cba5445ea/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a7f7c643e8b1320fd958bf098aa7ecf70623a42ec5154e3be3be673f4c34d900", size = 5028464, upload-time = "2025-11-17T22:31:50.135Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/cb/28ce52eb94390dda42599c98ea0204d74799e4d8047a0eb559b6fd648056/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9ad459e99793fa6e13bd5b7e6792c8f9190b4e5a1b45c63aba14a4d0a7f1d5ff", size = 5009002, upload-time = "2025-11-17T22:31:52.001Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/f0/0cfadd537c5470378b1b32bd859cf2824972174b51b873c9d95cfd7475a5/ml_dtypes-0.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:c1a953995cccb9e25a4ae19e34316671e4e2edaebe4cf538229b1fc7109087b7", size = 212222, upload-time = "2025-11-17T22:31:53.742Z" },
+    { url = "https://files.pythonhosted.org/packages/16/2e/9acc86985bfad8f2c2d30291b27cd2bb4c74cea08695bd540906ed744249/ml_dtypes-0.5.4-cp312-cp312-win_arm64.whl", hash = "sha256:9bad06436568442575beb2d03389aa7456c690a5b05892c471215bfd8cf39460", size = 160793, upload-time = "2025-11-17T22:31:55.358Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a1/4008f14bbc616cfb1ac5b39ea485f9c63031c4634ab3f4cf72e7541f816a/ml_dtypes-0.5.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8c760d85a2f82e2bed75867079188c9d18dae2ee77c25a54d60e9cc79be1bc48", size = 676888, upload-time = "2025-11-17T22:31:56.907Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b7/dff378afc2b0d5a7d6cd9d3209b60474d9819d1189d347521e1688a60a53/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce756d3a10d0c4067172804c9cc276ba9cc0ff47af9078ad439b075d1abdc29b", size = 5036993, upload-time = "2025-11-17T22:31:58.497Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/33/40cd74219417e78b97c47802037cf2d87b91973e18bb968a7da48a96ea44/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:533ce891ba774eabf607172254f2e7260ba5f57bdd64030c9a4fcfbd99815d0d", size = 5010956, upload-time = "2025-11-17T22:31:59.931Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/8b/200088c6859d8221454825959df35b5244fa9bdf263fd0249ac5fb75e281/ml_dtypes-0.5.4-cp313-cp313-win_amd64.whl", hash = "sha256:f21c9219ef48ca5ee78402d5cc831bd58ea27ce89beda894428bc67a52da5328", size = 212224, upload-time = "2025-11-17T22:32:01.349Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/75/dfc3775cb36367816e678f69a7843f6f03bd4e2bcd79941e01ea960a068e/ml_dtypes-0.5.4-cp313-cp313-win_arm64.whl", hash = "sha256:35f29491a3e478407f7047b8a4834e4640a77d2737e0b294d049746507af5175", size = 160798, upload-time = "2025-11-17T22:32:02.864Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/74/e9ddb35fd1dd43b1106c20ced3f53c2e8e7fc7598c15638e9f80677f81d4/ml_dtypes-0.5.4-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:304ad47faa395415b9ccbcc06a0350800bc50eda70f0e45326796e27c62f18b6", size = 702083, upload-time = "2025-11-17T22:32:04.08Z" },
+    { url = "https://files.pythonhosted.org/packages/74/f5/667060b0aed1aa63166b22897fdf16dca9eb704e6b4bbf86848d5a181aa7/ml_dtypes-0.5.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6a0df4223b514d799b8a1629c65ddc351b3efa833ccf7f8ea0cf654a61d1e35d", size = 5354111, upload-time = "2025-11-17T22:32:05.546Z" },
+    { url = "https://files.pythonhosted.org/packages/40/49/0f8c498a28c0efa5f5c95a9e374c83ec1385ca41d0e85e7cf40e5d519a21/ml_dtypes-0.5.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:531eff30e4d368cb6255bc2328d070e35836aa4f282a0fb5f3a0cd7260257298", size = 5366453, upload-time = "2025-11-17T22:32:07.115Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/27/12607423d0a9c6bbbcc780ad19f1f6baa2b68b18ce4bddcdc122c4c68dc9/ml_dtypes-0.5.4-cp313-cp313t-win_amd64.whl", hash = "sha256:cb73dccfc991691c444acc8c0012bee8f2470da826a92e3a20bb333b1a7894e6", size = 225612, upload-time = "2025-11-17T22:32:08.615Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/80/5a5929e92c72936d5b19872c5fb8fc09327c1da67b3b68c6a13139e77e20/ml_dtypes-0.5.4-cp313-cp313t-win_arm64.whl", hash = "sha256:3bbbe120b915090d9dd1375e4684dd17a20a2491ef25d640a908281da85e73f1", size = 164145, upload-time = "2025-11-17T22:32:09.782Z" },
+    { url = "https://files.pythonhosted.org/packages/72/4e/1339dc6e2557a344f5ba5590872e80346f76f6cb2ac3dd16e4666e88818c/ml_dtypes-0.5.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:2b857d3af6ac0d39db1de7c706e69c7f9791627209c3d6dedbfca8c7e5faec22", size = 673781, upload-time = "2025-11-17T22:32:11.364Z" },
+    { url = "https://files.pythonhosted.org/packages/04/f9/067b84365c7e83bda15bba2b06c6ca250ce27b20630b1128c435fb7a09aa/ml_dtypes-0.5.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:805cef3a38f4eafae3a5bf9ebdcdb741d0bcfd9e1bd90eb54abd24f928cd2465", size = 5036145, upload-time = "2025-11-17T22:32:12.783Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/bb/82c7dcf38070b46172a517e2334e665c5bf374a262f99a283ea454bece7c/ml_dtypes-0.5.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14a4fd3228af936461db66faccef6e4f41c1d82fcc30e9f8d58a08916b1d811f", size = 5010230, upload-time = "2025-11-17T22:32:14.38Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/93/2bfed22d2498c468f6bcd0d9f56b033eaa19f33320389314c19ef6766413/ml_dtypes-0.5.4-cp314-cp314-win_amd64.whl", hash = "sha256:8c6a2dcebd6f3903e05d51960a8058d6e131fe69f952a5397e5dbabc841b6d56", size = 221032, upload-time = "2025-11-17T22:32:15.763Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a3/9c912fe6ea747bb10fe2f8f54d027eb265db05dfb0c6335e3e063e74e6e8/ml_dtypes-0.5.4-cp314-cp314-win_arm64.whl", hash = "sha256:5a0f68ca8fd8d16583dfa7793973feb86f2fbb56ce3966daf9c9f748f52a2049", size = 163353, upload-time = "2025-11-17T22:32:16.932Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/02/48aa7d84cc30ab4ee37624a2fd98c56c02326785750cd212bc0826c2f15b/ml_dtypes-0.5.4-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:bfc534409c5d4b0bf945af29e5d0ab075eae9eecbb549ff8a29280db822f34f9", size = 702085, upload-time = "2025-11-17T22:32:18.175Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/e7/85cb99fe80a7a5513253ec7faa88a65306be071163485e9a626fce1b6e84/ml_dtypes-0.5.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2314892cdc3fcf05e373d76d72aaa15fda9fb98625effa73c1d646f331fcecb7", size = 5355358, upload-time = "2025-11-17T22:32:19.7Z" },
+    { url = "https://files.pythonhosted.org/packages/79/2b/a826ba18d2179a56e144aef69e57fb2ab7c464ef0b2111940ee8a3a223a2/ml_dtypes-0.5.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d2ffd05a2575b1519dc928c0b93c06339eb67173ff53acb00724502cda231cf", size = 5366332, upload-time = "2025-11-17T22:32:21.193Z" },
+    { url = "https://files.pythonhosted.org/packages/84/44/f4d18446eacb20ea11e82f133ea8f86e2bf2891785b67d9da8d0ab0ef525/ml_dtypes-0.5.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4381fe2f2452a2d7589689693d3162e876b3ddb0a832cde7a414f8e1adf7eab1", size = 236612, upload-time = "2025-11-17T22:32:22.579Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/3f/3d42e9a78fe5edf792a83c074b13b9b770092a4fbf3462872f4303135f09/ml_dtypes-0.5.4-cp314-cp314t-win_arm64.whl", hash = "sha256:11942cbf2cf92157db91e5022633c0d9474d4dfd813a909383bd23ce828a4b7d", size = 168825, upload-time = "2025-11-17T22:32:23.766Z" },
+]
+
+[[package]]
+name = "msgpack"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/f9/c0a1c127f9049db9155afc316952ea571720dd01833ff5e4d7e8e6352dbb/msgpack-1.2.1.tar.gz", hash = "sha256:04c721c2c7448767e9e3f2520a475663d8ee0f09c31890f6d2bd70fd636a9647", size = 183960, upload-time = "2026-06-18T16:13:52.594Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/16/f70100614b69feb3ade7285f08c9c52d6cda0a5c03f3f5e2facd63acb211/msgpack-1.2.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8c7b398c56ff125feae96c2737abfec5595f1fa0aa186df60c56040b8accb95c", size = 82926, upload-time = "2026-06-18T16:12:31.531Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/3c/08ecd5cdfe4e2de43aec79062028ad0f7b2d9b1fea5430068c198ba570da/msgpack-1.2.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1548006a91aa93c5da81f3bdcebc1a0d10cea2d25969754fbe848da622b2b895", size = 82730, upload-time = "2026-06-18T16:12:32.894Z" },
+    { url = "https://files.pythonhosted.org/packages/19/9f/a70c9cb1a04ecc134005149367dcfe35d167284e8f65035a1e4156ad17b5/msgpack-1.2.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1dabedcd0f23559f3596428c6589c1cd8c6eaed3a0d720795b07b0225d769203", size = 400729, upload-time = "2026-06-18T16:12:34.052Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/7f/5ce020168cf0439041526e95aa068c722c016aee21624e331aeabeee2e8e/msgpack-1.2.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:83efa1c898e0fc5380fc0cabbf75164c52e3b5cbb45973710d75821928380c73", size = 407625, upload-time = "2026-06-18T16:12:35.239Z" },
+    { url = "https://files.pythonhosted.org/packages/79/70/fb7668ce0386819303047057aef6fc1da73b584291d9cff82b821744e2ef/msgpack-1.2.1-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:01e2dd6c9b19d333a00282330cc8a73d38d8dabc306dc5b42cd668c3ac82e833", size = 377891, upload-time = "2026-06-18T16:12:36.684Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/dc/9ebe654a73c3aed2e40aa6b52e3c2a02b5f53ef0085fa235a45d5b367f87/msgpack-1.2.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:350cb813d0af6e65d2f7ef0d729f7ff5be5a8bce03665892f43e5883d4ecc1b8", size = 391987, upload-time = "2026-06-18T16:12:37.839Z" },
+    { url = "https://files.pythonhosted.org/packages/42/eb/b67cf64218a2fa25e1c671fe1d3dbb06cbeb973e71bc4b822da079862d0b/msgpack-1.2.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:ee1d9ed27d0497b848923746cf762ed2e7db24f4be7eec8e5cbe8c766aa707b7", size = 374603, upload-time = "2026-06-18T16:12:39.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/2e/9ee200cde32fd1a0101b4006202fde554c1860adfb9bf7bff31ea4c08df8/msgpack-1.2.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:633727297ed063441fd1cda2288865487f33ad14eeb8831afb5f0c396a62cfce", size = 405121, upload-time = "2026-06-18T16:12:40.524Z" },
+    { url = "https://files.pythonhosted.org/packages/43/b6/f10117be7ca7a51e8feed699a907b8e663a8cd66e115ae6b4fb30cc7945c/msgpack-1.2.1-cp310-cp310-win32.whl", hash = "sha256:298872ecf9e61950f1c6af4ca969b859ee91783bb920ef6e6172697d0c8aad74", size = 64088, upload-time = "2026-06-18T16:12:41.762Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/93/89976c696fb0224662239d952c47b4d1661b34d79a332ef5584facaa8579/msgpack-1.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:2ff164c1b0bcb740b073b99e945234d0212852fa378e44a208c425379140dbeb", size = 70113, upload-time = "2026-06-18T16:12:42.78Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/6b/e9b1cdc042c4458801d2545ed782a95f3d6ba8e270cce8745b8603c7f748/msgpack-1.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:29a3f6e9667868429d8240dfd063ea5ffdc1321c13d783aa23827a38de0dcb22", size = 82812, upload-time = "2026-06-18T16:12:45.022Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/3a/dd518a1bf78ed1e9ad8afe57307c079a00eafe4b3068932a27ca1ea56b4f/msgpack-1.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:aded5bdf32609dc7987a49bbbd15a8ef096193f96dd8bbeb791de729e650acf5", size = 82739, upload-time = "2026-06-18T16:12:46.025Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e0/7ba9e1542bf0771a27b8b37c1316e3f95ae9d748fd765284655c476ad4ef/msgpack-1.2.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:146ee4e9ce80b365c6d4c47073da9da7bcec473e58194ceee5dd7620ace77e06", size = 414233, upload-time = "2026-06-18T16:12:47.029Z" },
+    { url = "https://files.pythonhosted.org/packages/03/8d/671d81534ea0e2b0e8a121be100020da09eb78861fe3aa8f3ef7dcd3bed1/msgpack-1.2.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a28d076ca7c82b9c8728ad90b7147489449557038bed50e4241eb832395169b4", size = 423843, upload-time = "2026-06-18T16:12:48.19Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/b6/e5c737515ed1f166664b87601b532f58cbb73d8aa6a90b99f7c2c5037e8e/msgpack-1.2.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7d31c0ac0c640f877804c67cb2bc9f4e23dc2db97e96c2e67fa27d38283b41f8", size = 390772, upload-time = "2026-06-18T16:12:49.624Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/46/62ed8c2e87d7021eab19921594d961ef3aa3794eec76c716dc30f3bfd433/msgpack-1.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8ff92d7feeaf5bc26c51495b69e2f99ed97ab79346fb6555f44be7dd2ac6503b", size = 409559, upload-time = "2026-06-18T16:12:50.936Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ff/59aa3887b860bbf43532835e192b1c388a17590d6068ae4f8b2bc74c906e/msgpack-1.2.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:779197a6513bab3c3632265e3d0f7cb3227e62510841a6f34f1eaa37efbb345e", size = 387838, upload-time = "2026-06-18T16:12:52.161Z" },
+    { url = "https://files.pythonhosted.org/packages/09/11/f8563e471093420cf6478cb3271a0175d8402b82d879783d4035d2d03360/msgpack-1.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:67f6dd22fa72a93752643f07889796d62739a13415ee630169a8ce764f86cf9f", size = 421732, upload-time = "2026-06-18T16:12:53.556Z" },
+    { url = "https://files.pythonhosted.org/packages/57/cf/e673683c4c6c90c1022b24c65af4b03eda72b182a1176ef6449069d66acc/msgpack-1.2.1-cp311-cp311-win32.whl", hash = "sha256:91054a783328e0ea7954b8771095705c8d2243b814743fbaadf14552c9c52c5d", size = 64091, upload-time = "2026-06-18T16:12:54.821Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/07/ca212739d179f9083bff2c7c08c24101c3555a334fadc2b876b18768a3ae/msgpack-1.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2eda0b7ebb1283a98d3e4492ac933c8af6aff59fd3df1c3ed024f536af4b1dc8", size = 70462, upload-time = "2026-06-18T16:12:55.898Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/be/6798347b425e26f35db82e69dd83c09716c856a3714e7bffc4c0860fd830/msgpack-1.2.1-cp311-cp311-win_arm64.whl", hash = "sha256:6ee967f7c7e1df2890c671ff2ee51a28ded0efc95da3e507176dee881ce36c66", size = 65059, upload-time = "2026-06-18T16:12:57.053Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/dd/9e8cbd8f5582ca4b590336f2b91ee5662f6a6ca562b565abaf696a0f81ff/msgpack-1.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2ef59c659f289eddf8aa6623823f19fa2f40a4029266889eac7a2505dd210c35", size = 83531, upload-time = "2026-06-18T16:12:58.249Z" },
+    { url = "https://files.pythonhosted.org/packages/50/2e/ebdb85a8da151397a2790363676b7ed7c125924fe618e4c6d8befb0cc62c/msgpack-1.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d3567748a5107cb40cdf66a275430c2f87c07777698f4bfd25c35f44d533258c", size = 82657, upload-time = "2026-06-18T16:12:59.396Z" },
+    { url = "https://files.pythonhosted.org/packages/26/aa/753ad8b007b464e1d8aa0c8e650b9c5f4f725e658fc5ac8a7635c55b7f6e/msgpack-1.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60926b75d00c8e816ef98f3034f484a8bc64242d66839cef4cf7e503142316a0", size = 410634, upload-time = "2026-06-18T16:13:00.383Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/fd/6adabd4f6d5e686f97dd02ce7fce3fe4cf672cbac36b8f67ff4040e8ad8b/msgpack-1.2.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:020e881a764b20d8d7ca1a54fc01b8175519d108e3c3f194fddc200bda95951a", size = 419989, upload-time = "2026-06-18T16:13:01.776Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cc/85039b7b0eb168aaad7383a23c97e291a11f08351cb45a606ce865e4e3f1/msgpack-1.2.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4202c74688ca06591f78cb18988228bd4cca2cc75d57b60008372892d2f1e6e6", size = 377544, upload-time = "2026-06-18T16:13:03.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/bf/35963899493b32030c85fc513b723ae66144ac70c11ebc52e889e16e3d99/msgpack-1.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8b267ce94efb76fbd1b3373511420074ee3187f0f7811bf394531de13294735a", size = 400842, upload-time = "2026-06-18T16:13:05.012Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/df/8e2ac970c8f99264cd9997d1c73df5466bc19da3301d7dc5500862a9b089/msgpack-1.2.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:e4f1d0f8f98ade9634e01fb704a408f9336c0a8f1117b369f5db83dc7551d8b1", size = 374108, upload-time = "2026-06-18T16:13:06.232Z" },
+    { url = "https://files.pythonhosted.org/packages/17/dd/fa8bd265110dfa51c20cb529f9e6d240a16fafe7e645004c6af2d01353ba/msgpack-1.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f02cf17a6ca1abe29b5f980644f7551f94d71f2011509b26d8625ce038f0df64", size = 414939, upload-time = "2026-06-18T16:13:07.478Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b9/8377a5ad8953fc0437c70cc98d9ae29f27fe5ac5109fbec0812085865735/msgpack-1.2.1-cp312-cp312-win32.whl", hash = "sha256:0c0d9802354507bcba62af19c17918e3eb437cc25e6f50657d511b5856a77aac", size = 64504, upload-time = "2026-06-18T16:13:08.822Z" },
+    { url = "https://files.pythonhosted.org/packages/57/7f/ce1e377df7e62461fefd9eb23bfb93a4a523f40a517b377b8f844d836828/msgpack-1.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:5c24aa15d5963051e1a5c62b12c50cd705992502b5ec1f3bece6046f33c9fc24", size = 71421, upload-time = "2026-06-18T16:13:09.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/32/ebfe84c9929f08f188d56c7a2fd913406a9ddad76a634697c1c43b8112e6/msgpack-1.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:4227224aaec8f7fbcbfbd4272319347b2bb4030366502600f8c45588c5187b07", size = 64775, upload-time = "2026-06-18T16:13:11.056Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ac/dcddcab6f6c20ecb387ca5e980371cdb3f87ff69aeca388be97eebc4c074/msgpack-1.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0a70e3cf2804a300d921bb0940426e35f4e489a23adfb77a808892241db0a064", size = 83151, upload-time = "2026-06-18T16:13:12.173Z" },
+    { url = "https://files.pythonhosted.org/packages/64/71/fbcfa83a1d6a9c6091942d1cfd070962244664b87427a9a49a6897b1b219/msgpack-1.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:491cc39455ca765fad51fb451bf2915eb2cf41192ab5801ce8d67c1d614fe056", size = 82351, upload-time = "2026-06-18T16:13:13.194Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/10/ddf7b06db879e8792d13934ddda09ff20bd2a583fd84c9b59aae9b0e650b/msgpack-1.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f310233ef7fb9c14e201c93639fe5f5260b005f56f0b29048e999c30935596cc", size = 407518, upload-time = "2026-06-18T16:13:14.233Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d3/36a46a8ed992b781acbc05928bd5bee3c810cb0c3563bf81a7b0c04a1a76/msgpack-1.2.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:787c9bebb5833e8f6fc8abca3c0597683d8d87f56a8842b6b89c75a5f3176e2d", size = 416405, upload-time = "2026-06-18T16:13:15.435Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/84/e8e9598b557c0ba6ddae901a73780a4c75ac667dddf59414b1e56a42fb34/msgpack-1.2.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dc871b997a9370d855b7394465f2f350e847a5b806dd38dcc9c989e7d87da155", size = 376257, upload-time = "2026-06-18T16:13:17.022Z" },
+    { url = "https://files.pythonhosted.org/packages/40/16/738fe6d875ad7e2a9429c165322a4ec088f4f273cdfae63d96a89c467961/msgpack-1.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:85f57e960d877f2977f6430896191b04a21f8901b3b4baf2e4604329f4db5402", size = 397469, upload-time = "2026-06-18T16:13:18.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/be/6d5952df75a7f24f35833af764c3a6860780364cb3a0030beb8099e1b2b4/msgpack-1.2.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1233ee2dd0cefba127583de50ea654677277047d238303521db35def3d7b2e7c", size = 372802, upload-time = "2026-06-18T16:13:19.685Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/39/e2ef7dbf0473bcb8dc7c50bf782a892d67414877b63e47fc88eb189ef5e6/msgpack-1.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e3dc2feb0876209d9c38aa56cb1de169bd6c4348f1aa48271f241226590993e6", size = 411273, upload-time = "2026-06-18T16:13:21.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c5/133f4512a56e983a93445c836c9d94d88f3bc2e0980ff4b9e577bd8416ce/msgpack-1.2.1-cp313-cp313-win32.whl", hash = "sha256:6d09badf350af2be9d189184e04e64cf54ad93569ab3d96fca58bd3e84aad707", size = 64471, upload-time = "2026-06-18T16:13:22.293Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/98/577e10b055096a7dd40732358cabaf7180a20c79ed1dcdbb618e4b9deac7/msgpack-1.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:33f14fba63278b714efe6ad07e50ea5f03d91537aa6a1c5f1ceca4cf44013ca9", size = 71274, upload-time = "2026-06-18T16:13:23.455Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/ee/0c0048e7cfbef23c6a94791b8959ab28155232e7956de8a305b5ff588f05/msgpack-1.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:afc5febcd4c99effbc02b528e49d6fd0760b2b7d48c05239e345a5fa6e743d9a", size = 64795, upload-time = "2026-06-18T16:13:24.687Z" },
+    { url = "https://files.pythonhosted.org/packages/77/58/cce442852c6b9e1639c7c8ac8fd9143121cb32dab0f308df4d1426a8eb9c/msgpack-1.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:05f340e47e7e47d2da8db9b53e1bb1d294369e9ef45a747441309f6650b8351d", size = 83610, upload-time = "2026-06-18T16:13:25.724Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5c/15b4c7a0182f75ffa90751958ba36a9c01cafee367d49a3edc10ed140b01/msgpack-1.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:810b916696c86ef0deb3b74588480224df4c1b071136c34183e4a2a4284d7ac7", size = 83138, upload-time = "2026-06-18T16:13:26.781Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a6/99e58722feaffc5f2fbcc0c8c0d1451ab9f84097f7af87291b46af2390f4/msgpack-1.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ca0dacff965c47afdc3749a8469d7302a8f801d6a28758d55120d75e66ce6889", size = 406090, upload-time = "2026-06-18T16:13:28.072Z" },
+    { url = "https://files.pythonhosted.org/packages/19/03/8c63e8cf52958534ef688625965ab04c269a6cadd8caef16758b380a821a/msgpack-1.2.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e2bf9280bceb5efca998435904b5d3e9fdbcc11d90dc9df30aec7973252b720", size = 412106, upload-time = "2026-06-18T16:13:29.427Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d2/155d9e71b40e41fd934bc0c48b9b2770f22263e1ac20aad8e29fdca7be3f/msgpack-1.2.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aa6c4be5d1c02a42b066ca6ddb71adf36432868fdcdb6ee87e634e86e0674190", size = 374851, upload-time = "2026-06-18T16:13:30.631Z" },
+    { url = "https://files.pythonhosted.org/packages/98/48/deaf2326262a8d5ea3295ce9649912ecd3f551ba7ec8e33c665d2ba583f3/msgpack-1.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec0e675d59150a6269ddc9139087c722292664a37d071a849c05c473350f1f2d", size = 396168, upload-time = "2026-06-18T16:13:31.977Z" },
+    { url = "https://files.pythonhosted.org/packages/10/2a/b4410f906c2ec0008f1608d3ab5143afc3ad3f4e6da0fed3ea2231d0bef4/msgpack-1.2.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:dd3bfe82d53edfe4b7fc9a7ec9761e23a7a5b1dac22264505af428253c29ed24", size = 371959, upload-time = "2026-06-18T16:13:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/59/86/1edc67270099a528fa2093ea60fe191233cd238e4bd30cfacf7db79fc959/msgpack-1.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5ad5467fc3f68b5468e06c5f788d712e9f8ffc8b0cd1bcb160c105c1ee92dae7", size = 408457, upload-time = "2026-06-18T16:13:34.567Z" },
+    { url = "https://files.pythonhosted.org/packages/82/90/8b630fef07d8c5ab457b71ff2c217910c83d333c7a68472c186e87cc504a/msgpack-1.2.1-cp314-cp314-win32.whl", hash = "sha256:98b58bdb89c46190e4609bb36abe17c6d4105ad13f9c5f8f6f64d320f8ced3fb", size = 65942, upload-time = "2026-06-18T16:13:36.056Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f1/467b81e98b24dd3885d7b1857728797b4ffc76a7a7483af4fb321a07de3c/msgpack-1.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:74847557e28ce71bd3c438a447ca90e4b507e997ddbdef8a12a7b283b86c156b", size = 72627, upload-time = "2026-06-18T16:13:37.079Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/1d/5d8c4c89985feb6acefb82a09e501c60392261856d2408d20bfe4f0360b1/msgpack-1.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:b50b727bd652bdc37d950336c848ef20ec54a4cafc38dce19b1cd86ad625d0f7", size = 66908, upload-time = "2026-06-18T16:13:38.23Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/02/ad2afb678b4de94496cd432b581759b756a92c1192d8c767edd6b132efdc/msgpack-1.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:8d00f177ca88a77c1cf848d204a38f249751650b601cb6532acc68805d8a8273", size = 86000, upload-time = "2026-06-18T16:13:39.44Z" },
+    { url = "https://files.pythonhosted.org/packages/54/74/0b797484013128837f3b1cbb6cea019277c4de4e377dc512b4d9a0f92940/msgpack-1.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5bb9c386f0a329c035ddbab4b72d1028bf9627add8dda41070288563d57ed1b1", size = 86544, upload-time = "2026-06-18T16:13:40.447Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/b4/b774d7eb95561739907fec675582f83203cf41c597a418c2589b4bfb8e9d/msgpack-1.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20466cca18c49c7292a8984bc15d65857b171e7264bdcb5f96baf8be238791fc", size = 427661, upload-time = "2026-06-18T16:13:41.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/f9/3243191dc9937e00756c8bc1b0272fed8f23758e43df2a3b46f533e5090f/msgpack-1.2.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:196300e7e5d6e74d50f1607ab9c06c4a1484c383cd22defd727902591f7e8dde", size = 426375, upload-time = "2026-06-18T16:13:42.936Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c7/1693111db9944ba4ad4b67a1e788400d78a0b6af7a6523dc7e4e58f8274b/msgpack-1.2.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:575957e79cd51903a4e8495a242442949641e08f1efd5197b43bebd3ea7682b4", size = 380495, upload-time = "2026-06-18T16:13:44.306Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/2b/92f86956a0c13e8662f7e2ad630c4eb4db07497b967589bd5245e018b2c1/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8c2ed1e48cc0f460bf3c7780e7137ff21a4e18433451916f2442c1b21036cd7d", size = 410897, upload-time = "2026-06-18T16:13:45.629Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ea/1479f72d200313a76fc2f823a79d1e07ed052ab7b8a0280640aa7b95de42/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5f6277e5f783c36786a145e0247fc189a03f35f84b251646e53592d2bc12b355", size = 378519, upload-time = "2026-06-18T16:13:46.998Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/4d/fa006060ffa1011d32bfae826fe766fe73e02982183601633b7121058ab3/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f9389552ecf4784886345ead0647e4edc96bee37cbab05b75540f542f766c48c", size = 419815, upload-time = "2026-06-18T16:13:48.205Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/aab6c946570496b78e67804721f3d5e2d62a93081b9b37df77764ef56347/msgpack-1.2.1-cp314-cp314t-win32.whl", hash = "sha256:c1c79a604a2969a868a78b6ebd27a887e00c624f14f66b3038e0590cb23332d1", size = 70914, upload-time = "2026-06-18T16:13:49.385Z" },
+    { url = "https://files.pythonhosted.org/packages/13/0a/e608956488a2af014cfe6e3d665e090b8ee42aa14b07f8f95b8880d66b09/msgpack-1.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f12038a35fabd52e56a3547bab42401af49a45caa6dd00b34c44de235bc93ee2", size = 77999, upload-time = "2026-06-18T16:13:50.467Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/8a/27e2e57055176e366a46b85d02d68e7a5bcfbdd8474c9706375d965f24d3/msgpack-1.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:0adcf06ffde0777c0e1a9b771a2b1c4226ba1bbf748c8efcc02fcdeca3299107", size = 71160, upload-time = "2026-06-18T16:13:51.498Z" },
+]
+
+[[package]]
 name = "munch"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1557,6 +2358,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6d/fd/91545e604bc3dad7dca9ed03284086039b294c6b3d75c0d2fa45f9e9caf3/nbformat-5.10.4.tar.gz", hash = "sha256:322168b14f937a5d11362988ecac2a4952d3d8e3a2cbeb2319584631226d5b3a", size = 142749, upload-time = "2024-04-04T11:20:37.371Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl", hash = "sha256:3b48d6c8fbca4b299bf3982ea7db1af21580e4fec269ad087b9e81588891200b", size = 78454, upload-time = "2024-04-04T11:20:34.895Z" },
+]
+
+[[package]]
+name = "nest-asyncio"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
 ]
 
 [[package]]
@@ -1607,6 +2417,58 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ce/49/c29f6e30d8662d2e94fef17739ea7309cc76aba269922ae999e4cc07f268/nvidia_ml_py-13.595.45.tar.gz", hash = "sha256:c9f34897fe0441ff35bc8f35baf80f830a20b0f4e6ce71e0a325bc0e66acf079", size = 50780, upload-time = "2026-03-19T16:59:44.956Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/24/fc256107d23597fa33d319505ce77160fa1a2349c096d01901ffc7cb7fc4/nvidia_ml_py-13.595.45-py3-none-any.whl", hash = "sha256:b65a7977f503d56154b14d683710125ef93594adb63fbf7e559336e3318f1376", size = 51776, upload-time = "2026-03-19T16:59:43.603Z" },
+]
+
+[[package]]
+name = "opt-einsum"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/b9/2ac072041e899a52f20cf9510850ff58295003aa75525e58343591b0cbfb/opt_einsum-3.4.0.tar.gz", hash = "sha256:96ca72f1b886d148241348783498194c577fa30a8faac108586b14f1ba4473ac", size = 63004, upload-time = "2024-09-26T14:33:24.483Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl", hash = "sha256:69bb92469f86a1565195ece4ac0323943e83477171b91d24c35afe028a90d7cd", size = 71932, upload-time = "2024-09-26T14:33:23.039Z" },
+]
+
+[[package]]
+name = "optax"
+version = "0.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py", marker = "python_full_version < '3.13'" },
+    { name = "chex", marker = "python_full_version < '3.13'" },
+    { name = "etils", version = "1.13.0", source = { registry = "https://pypi.org/simple" }, extra = ["epy"], marker = "python_full_version < '3.11'" },
+    { name = "etils", version = "1.14.0", source = { registry = "https://pypi.org/simple" }, extra = ["epy"], marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "jax", marker = "python_full_version < '3.13'" },
+    { name = "jaxlib", marker = "python_full_version < '3.13'" },
+    { name = "numpy", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/b5/f88a0d851547b2e6b2c7e7e6509ad66236b3e7019f1f095bb03dbaa61fa1/optax-0.2.4.tar.gz", hash = "sha256:4e05d3d5307e6dde4c319187ae36e6cd3a0c035d4ed25e9e992449a304f47336", size = 229717, upload-time = "2024-11-12T21:52:17.439Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/24/28d0bb21600a78e46754947333ec9a297044af884d360092eb8561575fe9/optax-0.2.4-py3-none-any.whl", hash = "sha256:db35c04e50b52596662efb002334de08c2a0a74971e4da33f467e84fac08886a", size = 319212, upload-time = "2024-11-12T21:52:15.446Z" },
+]
+
+[[package]]
+name = "orbax-checkpoint"
+version = "0.11.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py", marker = "python_full_version < '3.13'" },
+    { name = "etils", version = "1.13.0", source = { registry = "https://pypi.org/simple" }, extra = ["epath", "epy"], marker = "python_full_version < '3.11'" },
+    { name = "etils", version = "1.14.0", source = { registry = "https://pypi.org/simple" }, extra = ["epath", "epy"], marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "humanize", marker = "python_full_version < '3.13'" },
+    { name = "jax", marker = "python_full_version < '3.13'" },
+    { name = "msgpack", marker = "python_full_version < '3.13'" },
+    { name = "nest-asyncio", marker = "python_full_version < '3.13'" },
+    { name = "numpy", marker = "python_full_version < '3.13'" },
+    { name = "protobuf", marker = "python_full_version < '3.13'" },
+    { name = "pyyaml", marker = "python_full_version < '3.13'" },
+    { name = "simplejson", marker = "python_full_version < '3.13'" },
+    { name = "tensorstore", version = "0.1.78", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "tensorstore", version = "0.1.84", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/b4/262439a3fe00064b53a5182c0149447304f5a2d5a328a92d64390c18d189/orbax_checkpoint-0.11.5.tar.gz", hash = "sha256:8331ff594980a241ba43eb59dd683e5b590b339cff32a7b72d78cb5a350030b4", size = 249258, upload-time = "2025-02-11T19:33:45.364Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/80/e659696b5b1c2ced427efedd2d9d29c1bc31d841ac8a031215aa38f6b2ae/orbax_checkpoint-0.11.5-py3-none-any.whl", hash = "sha256:b55a7a254ea0ab18237e8234a6ca8bf5522f589fcc2ac698cf6893d5e7ae3500", size = 342800, upload-time = "2025-02-11T19:33:43.507Z" },
 ]
 
 [[package]]
@@ -2006,6 +2868,18 @@ wheels = [
 ]
 
 [[package]]
+name = "portpicker"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "psutil", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/d0/cda2fc582f09510c84cd6b7d7b9e22a02d4e45dbad2b2ef1c6edd7847e00/portpicker-1.6.0.tar.gz", hash = "sha256:bd507fd6f96f65ee02781f2e674e9dc6c99bbfa6e3c39992e3916204c9d431fa", size = 25676, upload-time = "2023-08-15T04:37:08.865Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/2d/440e4d7041fff89f28f483733eb617127aa866135c2dc719e05893f089e1/portpicker-1.6.0-py3-none-any.whl", hash = "sha256:b2787a41404cf7edbe29b07b9e0ed863b09f2665dcc01c1eb0c2261c1e7d0755", size = 16613, upload-time = "2023-08-15T04:37:07.327Z" },
+]
+
+[[package]]
 name = "pre-commit"
 version = "4.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2034,6 +2908,24 @@ wheels = [
 ]
 
 [[package]]
+name = "prometheus-api-client"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dateparser" },
+    { name = "httmock" },
+    { name = "matplotlib" },
+    { name = "numpy" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
+    { name = "pandas", version = "3.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/18/893d14d805164b6bd479aff7659a9cbf249628006dc4369058609029b9e1/prometheus_api_client-0.6.0.tar.gz", hash = "sha256:80822f1bb599febcab27c5ba2924b1c236d01f9b0df0308f91b5087937a6ad3e", size = 26004, upload-time = "2025-04-18T04:24:45.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/24/0c06c1d10aada3f9b44174c743e48d25e19f953ee9de5caf2c30099c342d/prometheus_api_client-0.6.0-py3-none-any.whl", hash = "sha256:137fa4576a76177547c4d7bb43e2a457df95f5bd81afe782896ba77ab87ebaf6", size = 30170, upload-time = "2025-04-18T04:24:43.639Z" },
+]
+
+[[package]]
 name = "prompt-toolkit"
 version = "3.0.52"
 source = { registry = "https://pypi.org/simple" }
@@ -2043,6 +2935,49 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
 ]
 
 [[package]]
@@ -2530,6 +3465,142 @@ wheels = [
 ]
 
 [[package]]
+name = "regex"
+version = "2026.5.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/0e/49aee608ad09480e7fd276898c99ec6192985fa331abe4eb3a986094490b/regex-2026.5.9.tar.gz", hash = "sha256:a8234aa23ec39894bfe4a3f1b85616a7032481964a13ac6fc9f10de4f6fca270", size = 416074, upload-time = "2026-05-09T23:15:19.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ed/0ad2c8edf634918eb4484365d3819fa7bd7f58daf807fe7fb21812c316e5/regex-2026.5.9-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a9e1328e17c84c1a5d22ec9f785ecef4a967fab9a42b6a8dc3bcbebd0a0c9e44", size = 489438, upload-time = "2026-05-09T23:11:29.374Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a9/4ed972ad263963b860b7c3e86e0e1bcc791def47b43b8c8efe57e710f139/regex-2026.5.9-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bfe1ce50cbfb569d74e1e4337da6468961f31dbea55fd85aa5de59c0947a805a", size = 291270, upload-time = "2026-05-09T23:11:33.254Z" },
+    { url = "https://files.pythonhosted.org/packages/16/81/075930d9fa28c4ea1f53398dd015ee7c882f623539759113cda1257f4b82/regex-2026.5.9-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:15ee42209947f4ca045412eae98416317238163618ace2a8e54f99586a466733", size = 289198, upload-time = "2026-05-09T23:11:35.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/c8/5cdfbf0b5dc6599e1b6131eff43262e5275d4ec3469ce10216061659aadb/regex-2026.5.9-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b4bb445ff3f725f59df8f6014edb547ee928ec7023a774f6a39a3f953038cbb2", size = 784765, upload-time = "2026-05-09T23:11:37.689Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ca/ae5fd6edc59b7f84b904b31d6ec39a860cbcecd10f64bd5a062ca83a4864/regex-2026.5.9-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:446ddd671e43ab535810c4b21cff7104945c701d4a14d1e6d1cd6f4e445a8bea", size = 852115, upload-time = "2026-05-09T23:11:39.973Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/ce/a91cf555afb51f3b74a182e24ba073b91ea7bb64592fc4b315c111bb19fd/regex-2026.5.9-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7b92817338591505f282cf3864c145244b1edcf5381d237038df955001091538", size = 899503, upload-time = "2026-05-09T23:11:42.48Z" },
+    { url = "https://files.pythonhosted.org/packages/55/7f/725a0a2b245a4cf0c4bab29d0e97c74285d94136a65d1b55a6459a583502/regex-2026.5.9-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6b8a143aca6c39b446ea8092cde25cc8fe9304d4f5fecfbc1a9dbb0282703c2", size = 794093, upload-time = "2026-05-09T23:11:44.681Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/2a/996efbd59ce6b5d4a09e3af6180ceb62af171f4a9a6fb557d2f0ae0d462b/regex-2026.5.9-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0f03aa6898aaaac4592479821df16e68e8d0e29e903e65d8f2dfb2f19028a989", size = 786234, upload-time = "2026-05-09T23:11:46.882Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/0a/8731e8b8806174c9cdd5903f80a14990331c1f42fc4209b540952e9e010d/regex-2026.5.9-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ed457d8e98ae812ed7732bef7bf78de78e834eae0372a74e23ca90ef21d910f9", size = 769895, upload-time = "2026-05-09T23:11:49.324Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/0b/932473194bd563f342a412ae2ffbbd6da608306a2bc4e99249a41c2b0b92/regex-2026.5.9-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:71b61c5bfe1c806332defc42ad6c780b3c55f661986d7f40283a3a88274b4c00", size = 774991, upload-time = "2026-05-09T23:11:51.261Z" },
+    { url = "https://files.pythonhosted.org/packages/98/80/9523d196010031df25f7177ee0a467efbee436324038e5d99def17a57515/regex-2026.5.9-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:3b1e39888c5e0c7d92cea4fc777396c4a90363b05de75d02eb459a4752200808", size = 848790, upload-time = "2026-05-09T23:11:53.232Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/07/56987b35e89edf47e4a38cf2845aeee476bfa688a6bdbd3e820cda461dc1/regex-2026.5.9-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:6ba42b2e7e7f46cf68cc6a5ca36fa07959f9bbd9c6bdcc47b6ee76549a590248", size = 757679, upload-time = "2026-05-09T23:11:55.82Z" },
+    { url = "https://files.pythonhosted.org/packages/04/2a/ff713fff0c566507c06a4ce2dc0ae8e7eeebc88811a95fc81cf1e7d534dd/regex-2026.5.9-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:c010eb8caca74bdb40c07498d7ece26b4428fd3f04aa8a72c9ac6f79e8faaac6", size = 837116, upload-time = "2026-05-09T23:11:57.934Z" },
+    { url = "https://files.pythonhosted.org/packages/77/90/df6d982b03e3614785c6937ba51b57f6733d97d2ee1c9bc7531dbfab3a54/regex-2026.5.9-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a6a563446a41adc451393dc6b8e6ad87979efaee3c8738690a8d1b08ebead1b4", size = 782081, upload-time = "2026-05-09T23:11:59.607Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/8a/4e88a5f7c3e98489aac4dd23142723d907b2a595b4a6abcbacabefeded09/regex-2026.5.9-cp310-cp310-win32.whl", hash = "sha256:954cc214c04663ee6d266fc61739cad83054683048de65c5bd1d640ad28098ac", size = 266247, upload-time = "2026-05-09T23:12:01.116Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/40/4b224cb0582b2dca1786726e6cdabe26abbf757d7f6718332f186da155d2/regex-2026.5.9-cp310-cp310-win_amd64.whl", hash = "sha256:b310768746dd314ea6e2ff4cc89ef215426813396ff4e94ee8e6f7096c8b6e03", size = 278416, upload-time = "2026-05-09T23:12:03.2Z" },
+    { url = "https://files.pythonhosted.org/packages/12/4d/014fbe803204cab0947ee428f09f658a29632053dde1d3c6176bb4f0fd4c/regex-2026.5.9-cp310-cp310-win_arm64.whl", hash = "sha256:19c16ceb4a267a8789e25733e583983eeab9f0f8664e66b0bd1c5d21f14c2d4b", size = 270413, upload-time = "2026-05-09T23:12:04.649Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/dc/c1f2df4027e82fc54b5a473e4b250f5139faca49a0fbe29a48668d228f34/regex-2026.5.9-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ccf5249114cc3e772ecdd88a98a86eca0fd74c61ce32a94743758c083fc05d48", size = 489445, upload-time = "2026-05-09T23:12:06.111Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d2/59f01110660081cce9c0bc30ebd0b5ee250dacf658e3248ed92f01e0e8ee/regex-2026.5.9-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:46f1326ca6e65b0879d23ca302c0f2415aad42ff0309b9c818e7949fe19a41d8", size = 291271, upload-time = "2026-05-09T23:12:07.731Z" },
+    { url = "https://files.pythonhosted.org/packages/58/b6/14b2c84ff90ddb370c81d27503f4a0fcf071496416f4855f6cc8c5d81c35/regex-2026.5.9-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ef31cbfe458e21c6122ba8150ff060e0c7789ed0d26eb423f25472584920b555", size = 289212, upload-time = "2026-05-09T23:12:09.266Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d0/4db86529117320de0c84afd90e70bb47434625875e34fcef9d8c127c5b16/regex-2026.5.9-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:992604d02e6d9c6d786c24a706a71ecffe1020fc1ef264044474cd81fa2c3919", size = 792310, upload-time = "2026-05-09T23:12:11.416Z" },
+    { url = "https://files.pythonhosted.org/packages/07/78/fe4800cd322f862ecffd2d553409b20d80650e5ed71b9d178f853d020b82/regex-2026.5.9-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c9411dd64ca95477225734a93dfc8583b51916b8d5942f99d6cac21e09965451", size = 861721, upload-time = "2026-05-09T23:12:13.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d0/b3618a895dd8feb897c61bb2954edd265e1767d82a01d53065d5871127a3/regex-2026.5.9-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3dd4a3ff360dfb836fecdb93a4598f9d6e2ac81e3e397125145c6221bf58cf4c", size = 906460, upload-time = "2026-05-09T23:12:15.443Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6f/1481597e859ef19508b345eec4afd1416ed6e6b459c75a64026ef193aecf/regex-2026.5.9-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2a661a7d270a61f7cf460caee8b9fa2d5ef9e5c681234bcb9e0fe14f488e7dfc", size = 799843, upload-time = "2026-05-09T23:12:16.892Z" },
+    { url = "https://files.pythonhosted.org/packages/73/59/955734c803f59108deccba3597ae440c76b62a652733c0006e6243758420/regex-2026.5.9-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f079e50a0d3cc3cd5091fa9ff45869a2e6b2cd35895731edafb0327901a8d86d", size = 773610, upload-time = "2026-05-09T23:12:19.127Z" },
+    { url = "https://files.pythonhosted.org/packages/68/8f/70c04a236d651c81881dac42ef8538bddda6121434509d0a22d9e601503b/regex-2026.5.9-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4ebe8f0b5ec5a5024dc4a4c59f444c4e9afc5f2abdbb8962065b75d27fb971f9", size = 781645, upload-time = "2026-05-09T23:12:20.806Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/96/05c7434d88185e5d27fe54aeb74df86bd77cd79f52f0b4eae54faa8fea70/regex-2026.5.9-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:97cf3bc1b7d7d2306772ec07366c80d9df00ff79e79cea32898883a646d2fae2", size = 854473, upload-time = "2026-05-09T23:12:22.465Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c1/6e3d8202d981f3117004bf341ee74893ba4ba8a9fbaf4b94615846550a08/regex-2026.5.9-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:0f9eede6a5cbdc02d4978090186390936e1776a7d1359b21e41014c609880bcf", size = 763311, upload-time = "2026-05-09T23:12:24.351Z" },
+    { url = "https://files.pythonhosted.org/packages/93/c7/e7737f1526b3fb32bd4c337fd6c71c3ebb5c8296fc34d11197e0955d2e35/regex-2026.5.9-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:01f0f5f55f4b64dacec85dc116d3c05fd23ad3ff037bbc73a2085775953c2611", size = 844593, upload-time = "2026-05-09T23:12:26.341Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/27/0daffb1a535bb39f422c3d200f4ab023c71110ad66a32b366bee708baba0/regex-2026.5.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1268eddd8486dc561d08eee1156e40aa3a8fe10f4bdec8fa653b455fcbffd12c", size = 789167, upload-time = "2026-05-09T23:12:27.975Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fc/294fe4fac4f2ed67207b17471815870c1c45b3a489e08e0ac96daea16ef6/regex-2026.5.9-cp311-cp311-win32.whl", hash = "sha256:8676474c07469d6f33dd1085ca2cd45f65785f32518f2b20e36d9953ca07f994", size = 266249, upload-time = "2026-05-09T23:12:30.141Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/b0/8dce459f6245bcf8f6e9f23ac9569f1a0f15c131cc0745e82b43226204cf/regex-2026.5.9-cp311-cp311-win_amd64.whl", hash = "sha256:246de9d60aa3f8538b519834dd95cbf276ea263d6a7bd5a3666dc3fa0230505b", size = 278423, upload-time = "2026-05-09T23:12:31.676Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8d/f9aeff6ad63a3ef720386f2907e6d34a35a510a6e498ebad28b0fb3f6ab6/regex-2026.5.9-cp311-cp311-win_arm64.whl", hash = "sha256:d726ca3f0d76969bf1e8e477d160d3d666bbf999f6860bd314889e5345782046", size = 270420, upload-time = "2026-05-09T23:12:33.194Z" },
+    { url = "https://files.pythonhosted.org/packages/50/9b/6550044bc44e17c84d312c031c2ec42fbdb6a4ec4e29093be3a172d08772/regex-2026.5.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:57eeeb05db7979413dec5438f2db21d7ecbba787cde7a711df1a6f6df672aa06", size = 490451, upload-time = "2026-05-09T23:12:34.72Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/95/fc7ba4303b5a0f92446a12ee6778ef2c6c799233f5060042a31bf390cfe9/regex-2026.5.9-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:398c521292f4c7fb807001dcd54694d3a1fcafc179a36ad9cc56f98df85930b6", size = 292112, upload-time = "2026-05-09T23:12:36.285Z" },
+    { url = "https://files.pythonhosted.org/packages/54/4b/ee27938d1b2c443e89a9a10e00d2d19aa5ee300cd3d61140644e93bb083e/regex-2026.5.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f7a7c26137296beba7784de6eba69c6a93a63ccebc385e4962fe67e267a91225", size = 289599, upload-time = "2026-05-09T23:12:38.089Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/dd/ba103dc19614e25f3880800ca67ce093d6e21b325d72b8383c7bf906e9fa/regex-2026.5.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6441cc660d76107934a09c22167200839a0e89604a6297f78a974e66e931d2c0", size = 796732, upload-time = "2026-05-09T23:12:40.062Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e7/f035b4fd858b050b0080bf302968dc0f59ba34e391872d54936758e6844e/regex-2026.5.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:91328f1c23d47595ca3ef0a7557fa129c5a23404b775c770697d2f35b33e0107", size = 865440, upload-time = "2026-05-09T23:12:42.059Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/51/8cd301ecc899aea28124357f729f4272f44de7806fc7ca02490bfbe253e8/regex-2026.5.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:93a7860539414dddaefba2b40f8771765ae17949d4c7182b876ce429e11a8309", size = 912329, upload-time = "2026-05-09T23:12:44.373Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/1e/3fbe2fa1e8cebd62f3bb7d3321cff1640aca2e240b51d9bd624aad949260/regex-2026.5.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dd2810d22146b6d838acc5ec15602cb6b47920aa4e33015df3868eedfd20bab8", size = 801239, upload-time = "2026-05-09T23:12:46.268Z" },
+    { url = "https://files.pythonhosted.org/packages/17/2f/6f6008682bf2cf98040a0d3153a8e557b6ab728d7713d045cee4ce544ab8/regex-2026.5.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:daff2bdbaf1d23e52fdff7c0b7bc2048b68f978df6a4d107ac981f94caef2e66", size = 777054, upload-time = "2026-05-09T23:12:48.051Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2b/eee0d20a6842ba04df4b8847a920b57ef56853f14ef85405473e586b605a/regex-2026.5.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4eeb011098fcb77af513dcef521a3dbecbf8849b1e38940759d293b7a93f5026", size = 785098, upload-time = "2026-05-09T23:12:49.851Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/98/6fc1e6410feefb92159edaed5041992bfe390e8d26c721865434acbca558/regex-2026.5.9-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:ea9c8ecfa1b73c73b626534d6626e5340d429630943672b8480724f44e84b962", size = 860095, upload-time = "2026-05-09T23:12:51.666Z" },
+    { url = "https://files.pythonhosted.org/packages/18/a3/bd855e0f2cb1a978ecf6fa6bb69632dd9c3f6ea3b81cde62fde14c9daec7/regex-2026.5.9-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:cd2846168eb9ee3c513902bc8225409cb1caab31d04728b145171fa1625d9621", size = 765762, upload-time = "2026-05-09T23:12:53.413Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/66/0ae8c092e60b14c79d24f8e0b7f0aea5bfbffdcab00b5483d13404d3c3a5/regex-2026.5.9-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:39617fb0cde9c0e6306dc70e3bfc096f3da793219879f7ae7aa341a69fbdcf6d", size = 852100, upload-time = "2026-05-09T23:12:55.256Z" },
+    { url = "https://files.pythonhosted.org/packages/21/de/8dfde60fc1b21c946a893ba273403b72617edb261370cb1087099a83f088/regex-2026.5.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fd03c4f0e33280d15cae17159b899245d6b7c53d21def19b263b39655061f5ce", size = 789479, upload-time = "2026-05-09T23:12:57.573Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/1c/bdcc98f9a4af4fdd166c74941174619ccff4726d3ce32faa8e9a2ecd38dd/regex-2026.5.9-cp312-cp312-win32.whl", hash = "sha256:164eba9b755ea6f244b0d881196fbc1fac09714e9782c9e2732b813142033c8e", size = 266699, upload-time = "2026-05-09T23:12:59.14Z" },
+    { url = "https://files.pythonhosted.org/packages/78/87/240d36864f9e48ace85f72e79ced97ceb7f27ce87739a947dcb834b4e6bc/regex-2026.5.9-cp312-cp312-win_amd64.whl", hash = "sha256:86f40a5d6444db30a125c9c9177e6b25dad981cbc37451fd838f145e6edac92e", size = 277783, upload-time = "2026-05-09T23:13:00.789Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/b5/7b30f312b0669dff5beebe5b0989dc2d1a312b1a44fab852199c387a5b96/regex-2026.5.9-cp312-cp312-win_arm64.whl", hash = "sha256:96f5f58b54a063d7ea9dca08e1cf57bfe10499c4d579ee672da284f57f5f0070", size = 270513, upload-time = "2026-05-09T23:13:02.426Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/da/797e91ecec6f84135da778ddce78c20e0af5d2a15c26f87a81bc3eadb6db/regex-2026.5.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d626b84406444b165fc0ba981604edea39f0588ff1f92baa23fe50799ea9afdb", size = 490303, upload-time = "2026-05-09T23:13:04.382Z" },
+    { url = "https://files.pythonhosted.org/packages/44/da/bf30abaaa737b58f4a4b8c4a03659e02fd92092c822e0197ed9e0daab917/regex-2026.5.9-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d7bdc0ab8f3dd7e1b4f9ab88634e13374669db86bb3c72e8292f07ae313f539f", size = 292019, upload-time = "2026-05-09T23:13:06.022Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e7/d0eaf5713828417b9e5648cf81fa9bacd4961f6ab98c380c2034f8716e35/regex-2026.5.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a8820737949116ffff55fe18f9fc644530063ba6ebfcb8314239416e78f1347c", size = 289468, upload-time = "2026-05-09T23:13:08.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9b/b3fdd62b003baa1a9b593cd8c8699c9651c2e80cc21a5c715707983c42d7/regex-2026.5.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0fbdbac82cb3e4450d0ccde7d7a35607f4cb2dd9fba4b8b69bfaf8c9fa6aed", size = 796749, upload-time = "2026-05-09T23:13:10.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/30/66ab84588765f5b4b271a9ca09ef7ce2b87caa95176ec3d2ad65d7bc4902/regex-2026.5.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:57e8915c7986aa33d25e4d3629cef711cd2863f2961b10409f0c04cb8b7d9020", size = 865445, upload-time = "2026-05-09T23:13:12.523Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/89/f05169e8588aac365f35ffc7f3bc3184f095ef4cfded7cfaa3c7fd5dbd89/regex-2026.5.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:508f56a89ba9cb26e4168cbc37dbd60a28d82430a9e18ad1d25fe0883c314ca2", size = 912322, upload-time = "2026-05-09T23:13:14.281Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e1/c93444052cf41581f3c884ab3fb5823daf0992f11cd4388d4275ca610558/regex-2026.5.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6d189041f15691cfa2b6c4290448ec221244d225b3f5fe9e7771b34ffcdf6e2", size = 801269, upload-time = "2026-05-09T23:13:16.569Z" },
+    { url = "https://files.pythonhosted.org/packages/50/fe/0cf96b882f540e62e8b9956599798203d599c44cf4c77917ca27400ff69b/regex-2026.5.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e82db382b44d0111b22601c509c89f64434816c9e0eef9d1989cda8cc6ff1c04", size = 777085, upload-time = "2026-05-09T23:13:18.675Z" },
+    { url = "https://files.pythonhosted.org/packages/23/5c/d78d4924e7fc875557b9e9b768423925fdfaac5549d06da7810019a9bd26/regex-2026.5.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2acfb48634f64996b57f90f39afa692ff362162722581921fe92239a59960f3c", size = 785153, upload-time = "2026-05-09T23:13:20.525Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e0/5214774090e7b4524dcea3e3c4aa74141d43043f8beb49c1599db1c8b53a/regex-2026.5.9-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d29eebfc9525db68cad3c97eedd7f754fa265aa5cd0cf4f863b2421e1b48fc9f", size = 860164, upload-time = "2026-05-09T23:13:22.263Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/e1/4a57a83350319b1271f0d7a249b8672513ed928b237a741631270de6caea/regex-2026.5.9-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:debb893095e944091c16e641a6e33c1b0f4cb61ab945ec5afbf53ce7068834d8", size = 765731, upload-time = "2026-05-09T23:13:24.277Z" },
+    { url = "https://files.pythonhosted.org/packages/12/f4/499e74a20c156fc75836ee04a72a38d1a063978f600937f9760467beb1b0/regex-2026.5.9-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:d659eee77986549c9ea45b861c7567e44d6287c3dc9a4565478853f7b9fe2ff6", size = 852062, upload-time = "2026-05-09T23:13:26.125Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/92/7eebc0d0a01e78629695f342ba17e0deaff8fb45e79cc0d7b98287da6e3e/regex-2026.5.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2efa205e6d98b24d1f3ab395c11aa15cdf10935bca283d0285e0499c284fba21", size = 789577, upload-time = "2026-05-09T23:13:27.814Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a4/018e71f7d2ad48c1ebe6d3ae0026f9b7cb4802fd15c7cc02fdf724355102/regex-2026.5.9-cp313-cp313-win32.whl", hash = "sha256:f3844f134e834076677dd369976e9f5068679fcb8e50102fdf6b7ac96a3ec127", size = 266691, upload-time = "2026-05-09T23:13:29.549Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/1d/861a93719fb9ee7dbfc3761b3797b7a3e112a5d42c6129459d2d741be9b5/regex-2026.5.9-cp313-cp313-win_amd64.whl", hash = "sha256:3527bb4942d2c14552155406cdedd906567456821848aed1cb4933a391bf5eca", size = 277747, upload-time = "2026-05-09T23:13:31.859Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/c6/0a2436ae4da1ba76e51cb98943c6838a9a721faa40ebe2dce07694ae34e3/regex-2026.5.9-cp313-cp313-win_arm64.whl", hash = "sha256:56a33f191f17d8c417f99945ebdc1e691d3af9605d86ec68c7e54a57e3e17af6", size = 270500, upload-time = "2026-05-09T23:13:33.525Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e9/d21346f7b60ed58789371358ed66b09d00f832e1bd7c06e55d9da5679882/regex-2026.5.9-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:01f28d868834624c934b8d2e0aa1c8341337e37831f4a012f18a5afcba4cbaf3", size = 494172, upload-time = "2026-05-09T23:13:35.935Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/43/fd1177a2032037c681baecdb3422ee4e1424aec4e4f470ef47793d325274/regex-2026.5.9-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:48036f6374aaa79eb3b754ec29c61d1c6b1606749d705a13f8854fa2539671f6", size = 293952, upload-time = "2026-05-09T23:13:38.307Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7d/9fbf919768368d3f8a4f6c692cf2aa61e482b2b81ec6a298ace4cbf02480/regex-2026.5.9-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b96350aa424e79d4fd6b567b344dcbe2b2d6bfc48dfe7717587e1fa6d43da6ff", size = 292314, upload-time = "2026-05-09T23:13:40.353Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6c/e41bfeecb589716843e7c4df09ba46ff2a42961457afece19059d85caeef/regex-2026.5.9-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f3af7a4903c5c04a11a196a5aa75cdd7dd3f8508132f9fb3259d9f5908e3b88", size = 811681, upload-time = "2026-05-09T23:13:42.543Z" },
+    { url = "https://files.pythonhosted.org/packages/87/83/a5c1c525fba0aa656e88ad0face0b1829788ef4c2fb6b26df58aa1151b84/regex-2026.5.9-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7e87577720152d2caae19fe2baaf1f8d5ca12091e9e229f03915c37d1e4b9178", size = 871135, upload-time = "2026-05-09T23:13:44.326Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d4/80882e799e440dd878b0979cbebf8fa4d54624a332c83037c7a701649e3f/regex-2026.5.9-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c8b9b9d294cfea3cd19c718ade7cc93492b2c4991abd9a68d0b3477ae6d8e100", size = 917265, upload-time = "2026-05-09T23:13:47.295Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ff/8db60211e2286e396aad7dc7725356c502bff0901ea05bd6cdc2e1a042b9/regex-2026.5.9-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:728d8bfd28a8845c8b6bc5dc7ce010453d206396786c0765c2740cb65f37791e", size = 816311, upload-time = "2026-05-09T23:13:49.885Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/47/742ef579c61730f8d268e5cf1f9ce0e37e2ea041ad0f5644724f2378e463/regex-2026.5.9-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7e30b874d341fac767d7df5a0870540541c2c054b80cfaac116e8d367a8a7ff2", size = 785498, upload-time = "2026-05-09T23:13:52.25Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ab/cb0999802dcb0fb95b1ab005e8d4163d8afdd67efc2cb6b6630ac13f8cb1/regex-2026.5.9-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fd190e88a895a8901325fad284a3f74ea52b1da8525b76cc811fa9b1edf0ce2b", size = 801348, upload-time = "2026-05-09T23:13:54.127Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/62/8ca59a24c55bc34d166eefaf3717bd77772f329fdbf984d86581e0a3571c/regex-2026.5.9-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:8e76e8161ad00694cfce6767d5dea860c6391ac5b83e5c3a39661e696f11fc7e", size = 866493, upload-time = "2026-05-09T23:13:56.067Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/3d/30f2ae62cef3278bb5bb821f467277a55fb73f01032cf85997e15e8289a8/regex-2026.5.9-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ddda5340e6c01a293027dd46232fa79eaff1b48058ce7a98f572b6445b088041", size = 772811, upload-time = "2026-05-09T23:13:57.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ae/7d2089bcd78ad0c0161bc684339df50032acb438a7bd3305e7ddb1193cec/regex-2026.5.9-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:205109e96b3cf5adf8f4cd62bedde9487feb282b9497a3535451e5a24cd706a0", size = 856584, upload-time = "2026-05-09T23:13:59.679Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/29/92ff47f75990131ea4f24ba17819e5a9d141e10819807e09addd73409af6/regex-2026.5.9-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dfbe4579b9f08036aa7d101d1835437a20783574ac66327e6b29b4018a138081", size = 803453, upload-time = "2026-05-09T23:14:01.978Z" },
+    { url = "https://files.pythonhosted.org/packages/04/99/eff29f1037dcab36702c9ee5d6858cf1ce2336ea8ea2987f64245b99ea5e/regex-2026.5.9-cp313-cp313t-win32.whl", hash = "sha256:ed2c9e8068b614c574d8d30e543d617cf5379b0535d46f97ef00e904745a08b5", size = 269951, upload-time = "2026-05-09T23:14:03.661Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/9d/8870b8981d27b22cda77bb26a5ac7ebfa9c7d9e0dea195a834a82380e748/regex-2026.5.9-cp313-cp313t-win_amd64.whl", hash = "sha256:b46b0f094dc1d3b90356c85a0bd2c9bafc4a6a190b9d6f8ddd5a033b6e088ed4", size = 281240, upload-time = "2026-05-09T23:14:05.56Z" },
+    { url = "https://files.pythonhosted.org/packages/72/b1/3379415e8f135c13ac551353397cc4fe97b4978f3cac73c5fcbcded548b8/regex-2026.5.9-cp313-cp313t-win_arm64.whl", hash = "sha256:872acc074bd29ffc9913ecdfedf6ea77502312ca44a4aa0d3779089c6069d8de", size = 272383, upload-time = "2026-05-09T23:14:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/13/3e/9c3cd292d8808b3645a2ce517e200179b6d0e903f176300bd8b542e14de5/regex-2026.5.9-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:1bd7587a2948b4085195d5a3374eaf4a425dc3e55784c038175355ecf3bbbf8a", size = 490376, upload-time = "2026-05-09T23:14:09.64Z" },
+    { url = "https://files.pythonhosted.org/packages/60/70/d43ee8a2ca0a8b68d167f21658b85520ac0574617c7f320367c5047f7556/regex-2026.5.9-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:dea2e88e1cce4522496cce630e11e67b98b7076620bc4336c3f674bc21a375f4", size = 291964, upload-time = "2026-05-09T23:14:11.424Z" },
+    { url = "https://files.pythonhosted.org/packages/21/91/9d50b433828d8e74196904e168a43abf1e6e88b2a15d47ed742456720c37/regex-2026.5.9-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2099f7e7ff7b6aa3192312650a56e91cc091e49d50b04e4f6f8b6e28b3b27f1c", size = 289682, upload-time = "2026-05-09T23:14:13.123Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/b835e3cafbb9d977736912436259ff551d60919f7d7b3d37d46659c63564/regex-2026.5.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecd353045824e4477562a2ac718c25799cdaaa41f7aa925a806a8a3e6848a5b9", size = 796996, upload-time = "2026-05-09T23:14:14.923Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/a6/9f992d00019166b9de01c546dd4549bc679f2a68df11b877740b0760b7c2/regex-2026.5.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:65c8c8c37377794bd5b2f3ebe51919042bf17aec802e23c833d89782ed0c78af", size = 866089, upload-time = "2026-05-09T23:14:17.757Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/08/4d32af657e049b19cb62b02e46e38fe1518797bfb2203ee93a510b21b0dc/regex-2026.5.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5b73ab8afcf66c622db143d1c6fda4e58e4d537ee4f125229ad47b1ab80f34c0", size = 911530, upload-time = "2026-05-09T23:14:20.353Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/27/2af43dd1dc201d1fecefda64a45f4ad0995855b92724f795a777b402ee69/regex-2026.5.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0de5cf193997384ed2ca6f1cd4f78055b255d93d82d5a8cd6ba0d11c10b167e4", size = 800643, upload-time = "2026-05-09T23:14:22.265Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/dd/23a249047013b5321d4a60c4d2437462086f601b061776a525e5fba2a59f/regex-2026.5.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d641a8c9a61618047796d572a39a79b26167b0411d2c3031937b2fe2d081e2cf", size = 777223, upload-time = "2026-05-09T23:14:24.179Z" },
+    { url = "https://files.pythonhosted.org/packages/94/6a/e85ed9538cd19586d0465076a4578a12e093ce776d15f3f8ce92733a8dd6/regex-2026.5.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:24b2355ef5cc9aa5b8f07d17704face1c166fdcc2290fa7bd6e6c925655a8346", size = 785760, upload-time = "2026-05-09T23:14:26.065Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/c4/f25473209438638e947c55f9156fd8f236f74169229028cc99116380868e/regex-2026.5.9-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:a24852d3c29ad9e47593593d8a247c44ccc3d0548ef12c822d6ed0810affe676", size = 860891, upload-time = "2026-05-09T23:14:28.17Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/f7/f4f86e3c74419c37370e91f150ae0c2ef7d34b2e0e4cdd5da046a02e4022/regex-2026.5.9-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:916714069da19329ef7de197dcbc77bb3104145c7c2c864dbfbe318f46b88b14", size = 765891, upload-time = "2026-05-09T23:14:30.06Z" },
+    { url = "https://files.pythonhosted.org/packages/26/70/704d8e13765939146b1cd0ef4e2feb71d7929727d2290f026eed10095955/regex-2026.5.9-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:fa411799ca8da32a8d38d020a88faa5b6f91657d284761352940ecf9f7c3bbdd", size = 851380, upload-time = "2026-05-09T23:14:32.123Z" },
+    { url = "https://files.pythonhosted.org/packages/26/29/1a13582a8460038edc38e49f64ceb0dd7c60f5caba77571f4bf6601965d9/regex-2026.5.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1e6da47d679b7010ef27556b6e0f99771b744936db1792a10ceac6547ae1503e", size = 789350, upload-time = "2026-05-09T23:14:34.799Z" },
+    { url = "https://files.pythonhosted.org/packages/73/56/3dcafe34fc72e271d62ad9a291801e88a1457bb251c132f15fcc2e5aad1a/regex-2026.5.9-cp314-cp314-win32.whl", hash = "sha256:98bd73080e8756255137e1bd3f3f00295bbc5aa383c0e0f973920e9134d7c4ad", size = 272130, upload-time = "2026-05-09T23:14:36.729Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9c/02eebf0be95efe416c664db7fb8b6b05b7a0b06a7544f2884f2558b0526f/regex-2026.5.9-cp314-cp314-win_amd64.whl", hash = "sha256:ff8d372ac2acdc048d1c19916f27ee61bc5722728458ba6ca5052f2c72d51763", size = 280999, upload-time = "2026-05-09T23:14:39.126Z" },
+    { url = "https://files.pythonhosted.org/packages/70/5a/1dd1abee76cb7a846a0bcf42fdc87e5720c3c33c24f3e37814310a513d9f/regex-2026.5.9-cp314-cp314-win_arm64.whl", hash = "sha256:e1d93bf647916292e8edcec150c07ddf3dc50179ccaf770c04a7f9e452155372", size = 273500, upload-time = "2026-05-09T23:14:41.059Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c1/c5f619b0057a7965cb78ec559c1d7a45ce8c99a35bea95483d64959a93d9/regex-2026.5.9-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:83d0ee4a57d1c87cb549e195ec300b8f0ec3a82eba66d835e4e2ed8634fe4499", size = 494269, upload-time = "2026-05-09T23:14:42.869Z" },
+    { url = "https://files.pythonhosted.org/packages/05/2c/5d01f1aee33de4bbe60c8452945bfc8477ca7c5ae4450f6bfe711036cb36/regex-2026.5.9-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:d3d7eb5c9a7f6df82ed3cfac9beb93882a5cbcb5b8b157b56cb2b3b276574ac1", size = 293954, upload-time = "2026-05-09T23:14:44.822Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/fe/e8988b2ae2108c6ef71bd4aa8d87fbe257976dd0810e826cd75f701c68b6/regex-2026.5.9-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:075160bf16658e16d35233300b8453aac25de4cbea808d22348b6979668e924d", size = 292405, upload-time = "2026-05-09T23:14:47.211Z" },
+    { url = "https://files.pythonhosted.org/packages/79/34/d2b0937faa7859263f7f0a3c6b103a1296306be6952dc173d0154e9a2f49/regex-2026.5.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45375819235558a4ff1c4971dc32881f022613abdb180128f5cb4768c1765a1c", size = 811855, upload-time = "2026-05-09T23:14:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fe/daf53a47457a8486db66c66c01ceb9c2303eecee3f87197f1e77eb1a736d/regex-2026.5.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ead4b163ac30a29574510cd4b3e2e985ac5290c05fc7095557d6a5f403fc31b5", size = 871189, upload-time = "2026-05-09T23:14:51.555Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/75/058fc4470cbfbf57d800aff1a0022b929a3f9fa553ee10a0cdf2070eb31f/regex-2026.5.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8c6e4218fbdfbcd4f6c19efca40930d24a621bf4b48cb76bc6640543bd28ef20", size = 917485, upload-time = "2026-05-09T23:14:53.633Z" },
+    { url = "https://files.pythonhosted.org/packages/88/e7/179cfda3a28bc843b5c6cfe7f79f23489c791ed95f151083803660878432/regex-2026.5.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6351571c8a42b505eb555c0dc47d740d0fb66977dc142919eea6f4325b7c56a0", size = 816369, upload-time = "2026-05-09T23:14:56.198Z" },
+    { url = "https://files.pythonhosted.org/packages/41/90/6f0cc422071688266d344fca8462d787cba0a2c144acb25721f9a61ec265/regex-2026.5.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:002205cafd2a9e78c6290c7d1df277bf3277b3b7a30e0b4bb0dac2e2e3f7cb2d", size = 785869, upload-time = "2026-05-09T23:14:58.602Z" },
+    { url = "https://files.pythonhosted.org/packages/02/67/a31f1760f09c27b251ef39e9beb541f462cf977381d067faa764c2c0e393/regex-2026.5.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8abd33fef90b2a9efac5557d6033ca82d1195ed3a15fea5af15ba7b463c6a63b", size = 801427, upload-time = "2026-05-09T23:15:00.642Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/c4/1a80654597b6bc1e1ea0494824c31200e8a956abe290afae9b19a166a148/regex-2026.5.9-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:31037c82eccb44b7ea2e9e221d7c01429430e989a1f4b91ea5a855f6017b509a", size = 866482, upload-time = "2026-05-09T23:15:03.384Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/960724e06482c08466ff5611e242e86f80062949cdf6b4b9cc317b9dd93d/regex-2026.5.9-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5604dfd046dc37eca90250fc3be938b076c8059fa772ac0ed6f499b0f0fb0415", size = 773022, upload-time = "2026-05-09T23:15:05.625Z" },
+    { url = "https://files.pythonhosted.org/packages/50/a8/a9979c3e7918280e93159ebcab5ef1a65116dd4f3bd6091be0eae4a126e8/regex-2026.5.9-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:0e1b1b4e496afbb24f4a62aba855ee4f88f25578927697b340702e48c9ee6bc2", size = 856642, upload-time = "2026-05-09T23:15:07.966Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/d4/a9b732f2f0072c0ab12227483abb24fffcb9f73f8a2b203df0a6d0434735/regex-2026.5.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:be3372b9df6ddecff6486d37e19095a7b4973137caf5512407a89f4455361f41", size = 803552, upload-time = "2026-05-09T23:15:10.215Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/fe/1b3113817447a1d4155e4ac76d2e072f42c0bcba2f43fa8a0e756ea2cd91/regex-2026.5.9-cp314-cp314t-win32.whl", hash = "sha256:3ddd90103f9e5c471c49c7852ecc1fe27c7e45eb99e977aefe7caa4e779f4f58", size = 275746, upload-time = "2026-05-09T23:15:12.609Z" },
+    { url = "https://files.pythonhosted.org/packages/92/73/93d42045302636c91f2e5ef588b65b84b01428f28ec77de256b1dfdfbe5c/regex-2026.5.9-cp314-cp314t-win_amd64.whl", hash = "sha256:ca518ed29c46eecba6010b15f1b9a479314d2de409536e71b6a13aa04e3b8a77", size = 285685, upload-time = "2026-05-09T23:15:15.086Z" },
+    { url = "https://files.pythonhosted.org/packages/da/80/35b4c33c804a165a7f55289afda3ea9e3eb6d15800341a2d66455c0f1f30/regex-2026.5.9-cp314-cp314t-win_arm64.whl", hash = "sha256:5e41809d2683fcde7d5a8c87a6567ba1fb1ce0de9f31bff578de00a4b2d76daa", size = 275713, upload-time = "2026-05-09T23:15:16.98Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
 name = "rich"
 version = "14.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2874,12 +3945,142 @@ wheels = [
 ]
 
 [[package]]
+name = "simplejson"
+version = "4.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/2a/54837395a3487c725669428d513293612a48d82b95a0642c936932e5d898/simplejson-4.1.1.tar.gz", hash = "sha256:c08eb9f7a90f77ae470e19a07472e9a79ebc0d1c2315d86a72767665bd5ba79f", size = 118860, upload-time = "2026-04-24T19:24:59.819Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/da/3ba5e87e917094961e7b51b541c88f735f1ca37d580ac78a9302b468f64e/simplejson-4.1.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7f61eefab86235c800e7f4e37d977080ec424bb2bf0b74e95a2d17ecb48eac0a", size = 111675, upload-time = "2026-04-24T19:22:30.344Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/8a/d0c08f4b8934b64469a63d461a68a01d5cc32faf313400dda2bdc1075a29/simplejson-4.1.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4484960512db9c8124bfa91e0d8a9f9c302338f1c5454e74c21d7d022df10f46", size = 90544, upload-time = "2026-04-24T19:22:32.095Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/2d/7832ed91cf4900f86c783d589bfac53358abfccb278f1c8b55eec167b395/simplejson-4.1.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b75c7ef874dbb350f41827cdf3cee23f5257bdcb0df46d4c01b34badb62dcfe8", size = 90895, upload-time = "2026-04-24T19:22:34.412Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/d6/a2a7a482fa43aaeaefc001491d381960f5e685ee4645343e0e037cebb57c/simplejson-4.1.1-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c7494c75b95171194f965ea609e97081837a26494d91dcc046ad27dd9c3503e2", size = 168660, upload-time = "2026-04-24T19:22:35.717Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/06/7a6482f336338dbdb6ca6d3099b2fdc1c74c47eea3c6511975751e9198df/simplejson-4.1.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1778e09a6e4bb4ef304627915dc4a838569d9e6b737c787925b4e98244bbbc16", size = 167264, upload-time = "2026-04-24T19:22:37.415Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/43/039982e956b06c6b019d48bdf9d4ec06f298adf6136552ad1979b94be0fd/simplejson-4.1.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:67e43e7c0555e10de6d83e1408035652fad28c983516e38c4e3a9a748c9af129", size = 176909, upload-time = "2026-04-24T19:22:38.872Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/f5/e3ad592d089922abce2c2ea377548953ac55ffcbe061d600f01b9db2e6b6/simplejson-4.1.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:93bf6653420258372444de90194dab8de8ff13d74b5d4263a5fefbbe8b8d2060", size = 165930, upload-time = "2026-04-24T19:22:40.575Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/b9/f830b648ae04601e6813306535d8e0a4c178d6453cec539b85dafdac80ed/simplejson-4.1.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:0662cfe0482c9796bd097213b27f006815bfdc9b671264c3c0b7fc0e72b71d00", size = 174710, upload-time = "2026-04-24T19:22:42.437Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3e/82c8997c4ef2ef6c832fbfc3bb2ed14a212616a284100af03b552ea7e072/simplejson-4.1.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a9ab55d2459f6d0fdf9984a7a0fb0280dae12979f4fcc3171f5096a4fcf5fafe", size = 167685, upload-time = "2026-04-24T19:22:44.023Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/03/80e67a6c63fe812094c681917a5c5d403e34904d200570416863fe2e8328/simplejson-4.1.1-cp310-cp310-win32.whl", hash = "sha256:dfb84ace97acbdf1916c5a675387493fc5a7f67c2e15d4a7687143f8c73024d4", size = 88317, upload-time = "2026-04-24T19:22:45.547Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/05/d4fa2c024d566bddff732a2aa437faa4cbee15ee277e2a855faf91a9d906/simplejson-4.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:8eb821ef27f688f59ed4a93b17a666a7ebacf8dd65fecaa2b3c531a3aea62eaf", size = 90461, upload-time = "2026-04-24T19:22:47.447Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/25/39013ffe279d90093ec1c848565b3683c586906c10fa55d9000ec29d046b/simplejson-4.1.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2867c64d92abd1992c15666fae198203093f593e43d6b81adf176bae530d493a", size = 111538, upload-time = "2026-04-24T19:22:49.051Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/ae/2c272971c8a87e2539c54a98eb6ff037bee1e2e93943c3986cf7500a4f3a/simplejson-4.1.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4c47c46e16c8ea9e4850061e6ed5aa2b9cd2074cb2274bfd9c138cba15ce7453", size = 90594, upload-time = "2026-04-24T19:22:50.408Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/a2/6eebfb99dedc139f549200f61ade6d1890ac5707c5d427bdfa6fe39c9313/simplejson-4.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e294e33dbf316a9bbdd4030d46503c9b0f19470ae7ad6af5bae6c426bc2e869f", size = 90718, upload-time = "2026-04-24T19:22:51.694Z" },
+    { url = "https://files.pythonhosted.org/packages/80/7e/c9e6c0c4ad8415e64dad0c47f619b556b02680a41631b4dbc281d55dc54d/simplejson-4.1.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7ce252b28fddbdd83db5bd7d93dad2a8a591d7ada098afec9c1b23d6b722a7a4", size = 180901, upload-time = "2026-04-24T19:22:53.025Z" },
+    { url = "https://files.pythonhosted.org/packages/34/09/69e331e3994b1ed9be6ce9ace4ade704e7ed503edf869929ca7bb404eda8/simplejson-4.1.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c44ef6b02a4eb67ed17a72342341792149b3ff46f15426c26e970e49addf327", size = 178133, upload-time = "2026-04-24T19:22:54.574Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/40/ed806f24afef295c1032448f5ff6f6f2979392d5645ddb9f4fed7f38194d/simplejson-4.1.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:82bfca2b85a34178c25829c703f0a9e9f113a5af7539285bd3efb583a0bf1ba3", size = 188155, upload-time = "2026-04-24T19:22:56.044Z" },
+    { url = "https://files.pythonhosted.org/packages/38/94/8d6f515b827b0f7881a49c8c1ac6920b7ae9428939ef04238c973278b42a/simplejson-4.1.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0e4b23f71dd781f8830f1663dc01a4944d3dbf87a1f93d78fba1cf64722d0ccf", size = 176225, upload-time = "2026-04-24T19:22:57.981Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/fd/6dffb4956563d48bbe46b91ff341adae34920e94008fd6b8d728072abfc7/simplejson-4.1.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:82fee635d7b73ad801030b05a75fbd34a098da0c2ecf600667a03636d09e1e42", size = 185535, upload-time = "2026-04-24T19:22:59.618Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d2/a509ee37763e79aec75d68f8521db1440306edeba3b8b4064ab4ee8bf1d9/simplejson-4.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:68e62eda21192c5ea9bb92d571ca46a4477fef48762f50d433de2b4253051551", size = 179302, upload-time = "2026-04-24T19:23:01.324Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/23/5b343bfd2a79d3b6818e4db3586c405a001a090d4c89d336e31273ce7177/simplejson-4.1.1-cp311-cp311-win32.whl", hash = "sha256:ffd3d82294b47f5ec64050021ace95fd62628a0c1cc8bbf4d06d2d1fb697e055", size = 88408, upload-time = "2026-04-24T19:23:02.808Z" },
+    { url = "https://files.pythonhosted.org/packages/38/04/df9b37aedbd524dca20840d25ebe01d6ae486b89792aeff5d15b9c4114f7/simplejson-4.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:78a3fe0995be42bed62a26aa78e0e0b4d87c6545785346b9cc898f3389569a35", size = 90526, upload-time = "2026-04-24T19:23:04.408Z" },
+    { url = "https://files.pythonhosted.org/packages/60/25/e90998fe8e480eb43b966c09e835379887d427567ebd496563d3b1e16b19/simplejson-4.1.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:19040a17154dc03d289bab68d73ce0a6a0be01de30c584bbdd93490bead14b22", size = 112414, upload-time = "2026-04-24T19:23:06.084Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/a0/abd4785f36c3400f1fbb21f517be39295a750a714f04b7ee175adf6ef580/simplejson-4.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a94ebaecdbaa80d9551a3ec6bf0c9302fc8b53ab6c1b2bfd498a1df4cb28158d", size = 91120, upload-time = "2026-04-24T19:23:07.877Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/78/fc060d2e3b13c6ec59288574b8efac64075e316b2afba4396a56b2422f78/simplejson-4.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:67341c95c0a168ab4a6d1e807e50463f1c8da932c3286d81e201266c427061fa", size = 91055, upload-time = "2026-04-24T19:23:09.264Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/b6/156a8de1e1b47694f0e7de6675866936608d45dc68388fd017d36f8693be/simplejson-4.1.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:45ec18e337fec538b7e902d489505c450b2454653d1290f3f50385e6fd8aa607", size = 190297, upload-time = "2026-04-24T19:23:11.226Z" },
+    { url = "https://files.pythonhosted.org/packages/86/1c/e4d0eab695be3eb21d0f46bce820752031f03e7113f9c80a9b3c73ee7157/simplejson-4.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:820c69a4710400e9b248d5670647d60be58824369282d3925e516b3ff1a7cd82", size = 187002, upload-time = "2026-04-24T19:23:12.982Z" },
+    { url = "https://files.pythonhosted.org/packages/76/0e/7f5a59d29426b062d5928fb88b403c3f797129d53be7102f955dbe51aa44/simplejson-4.1.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e708d373a10e4378ef2d59f8361850c7150fd907ed49efe49bc5492160476d1", size = 195146, upload-time = "2026-04-24T19:23:14.517Z" },
+    { url = "https://files.pythonhosted.org/packages/78/18/9943db224dd4d5fa3c090c3e56a94c37b254338c83995ec5680285111c40/simplejson-4.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:980fc33353f81fd12d8c49d44f8c2760d1dc8192285e627c5180d141035b228a", size = 183931, upload-time = "2026-04-24T19:23:16.742Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/08/9a690da9a766161c06c627d805362cf159f1abe480969372b2897649b955/simplejson-4.1.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:de2ed102fff88dacf543699f53ee3a533cc11539a39baa176b7e09dd783069d6", size = 192228, upload-time = "2026-04-24T19:23:18.33Z" },
+    { url = "https://files.pythonhosted.org/packages/05/88/bd8aad36b451ffb0e0a3f721d695a88befa6d1ac7d1e02ae788ca7ff4029/simplejson-4.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2785ff8edc0e28bf773a32543a6bbed46351453c997b3f6709c744e3c2f7eabb", size = 187808, upload-time = "2026-04-24T19:23:21.165Z" },
+    { url = "https://files.pythonhosted.org/packages/04/ee/14f91db0d1f481533b651dafbf8cd0da088d9817f7af30c68f7f19f9c847/simplejson-4.1.1-cp312-cp312-win32.whl", hash = "sha256:2e0d5ead6d14610467ec356ec1f6b5d8a56aa216abaad8d41c8b873b16cf313f", size = 88512, upload-time = "2026-04-24T19:23:22.764Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c4/90de06b2d8737c68c05ff9274113f854dbf6a5f28b7a955212111672cb57/simplejson-4.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:63a5451f557d6be48a231bae932458655c620902b868170b2f1c8afed496f6b4", size = 90748, upload-time = "2026-04-24T19:23:24.494Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a9/47b445eeb559c9593453a0648e0fd6d08e8adff64dd5e5ced66726da8a09/simplejson-4.1.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:dff52fc7af272e84fc21cc5a06c927c823ca6ae00af14f3b0d7707b42775ed98", size = 113160, upload-time = "2026-04-24T19:23:26.033Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/65/cb72db31523c164dea5dc55b02dad065a40c478856bc7534b279d2b51906/simplejson-4.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:971aed0647ad6e840a3943bec812fcda5f2d26a5497a4981d1fb49aa4f9a396c", size = 91521, upload-time = "2026-04-24T19:23:27.572Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e5/54cb7c50ad5fdc1e0a86b7df4b135c2cbd5c4623605aa94466659098e8da/simplejson-4.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:249e2e220aa6d9b9d936bde84eb7bf79d5b6c5a8273c6e411f8b1635a9073f2d", size = 91407, upload-time = "2026-04-24T19:23:28.991Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2e/21a3ede87f0bf82d6c7bcb90480d50a6490eb974c6ab20881188e440957c/simplejson-4.1.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8e5cdd6a5d52299f345c15ab5678cc4249e24f383f361d986afbc3c7072a6b6b", size = 192451, upload-time = "2026-04-24T19:23:30.56Z" },
+    { url = "https://files.pythonhosted.org/packages/59/df/9903edd3102bf0b5984edfcb90c88612330996efa3b4fbf8a971d6e17839/simplejson-4.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:642cec364e0676e2d5a73fa4d31d0c7c55886997caa2fde24e8292ca44d32728", size = 189015, upload-time = "2026-04-24T19:23:32.647Z" },
+    { url = "https://files.pythonhosted.org/packages/98/cd/33230927a780e1398b857e3944abb914556994d252b1d765ae40d112cb25/simplejson-4.1.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:76fe296ca1df23d290033f10aaacf534fd1b3e3007e7f9ff8aa68b21413aaa78", size = 196658, upload-time = "2026-04-24T19:23:34.563Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/84/2c5a7444eb53e9a86d3738299bffddd9f53aeed799ded2f45368221fdb19/simplejson-4.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8f0ad25b7dc4e0fb23858355819f2e994f1a5badcdcde8737eac7921c2f1ed2a", size = 185967, upload-time = "2026-04-24T19:23:36.191Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/68/454378e06d059cd412a7ed5d87fb6d29fd5b60f13a4d89fc1f764ff434df/simplejson-4.1.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:a59ebd0533f03fd06ff0c42ba0f02d93cbcdd7944922bf3b93911327a95b901f", size = 193940, upload-time = "2026-04-24T19:23:38.151Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/d5/a15bf915f623a2c5a079d6e3be8256fdb8ef06f110669493a09b9d6933e0/simplejson-4.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bccbf4419676b517939852e5aeff2af6aee4dc046881c67a1581fa6f1cb01abd", size = 189795, upload-time = "2026-04-24T19:23:40.139Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/c9/37212ae7dc4b607f0978c408e8633f05c810884e054c33113184c6c2c8a2/simplejson-4.1.1-cp313-cp313-win32.whl", hash = "sha256:6c845363eb5fd166fb7c72243da38f4fcfde666ede7fdf2cc6fd7762894626f7", size = 88773, upload-time = "2026-04-24T19:23:41.754Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/a5/c7a0a47883a9015b54c9d8a4b62f2aba17bd4335b1787b9b8a0fc2fa6d52/simplejson-4.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:104d8324c34f25b4b90800bc5fa363780cbc3d8496aef061cba7ce1af9162270", size = 90888, upload-time = "2026-04-24T19:23:43.11Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/18/4a118a6a92eb33bb08c8e2fe7ec85cb96f0673491bb2b829930831ee4fbe/simplejson-4.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ed7473602b6625de793b6acba49aa949f144a475f538792067e4cf2fda2071f5", size = 110492, upload-time = "2026-04-24T19:23:44.957Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f4/84d160e9fa8cada1e0a9381cae4fa81eecd573577a5b34366d8ced59bdf7/simplejson-4.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:225c9caa324c5b554d009fb9cac22aee7711e71bd96f487938c659af467e828e", size = 90152, upload-time = "2026-04-24T19:23:46.355Z" },
+    { url = "https://files.pythonhosted.org/packages/68/31/9a5432c433a7671107182cdc9a20ea78a70f99c4e5334aa54b6d4d0d79ed/simplejson-4.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:95407269340c7f22f09776ea7b717a52cf56cfcf119b5e45f66faa4a26445bea", size = 90115, upload-time = "2026-04-24T19:23:47.743Z" },
+    { url = "https://files.pythonhosted.org/packages/78/91/3635cdb13318cb0a328abaa69e2b91251caad39d6779aa308098f341f6cb/simplejson-4.1.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3851658d642c1184d2023f0e6c9ce44a21eb1629e74e7c84ef956b128841fe12", size = 184036, upload-time = "2026-04-24T19:23:49.472Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ba/149b6ec5393f6849d98c59cadba888b710a8ef4b805ab91e11a566960d40/simplejson-4.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:95a3bb0f78e85f4937f99092239f2011ce06f0f2d803df5c299cc05abbeae008", size = 180543, upload-time = "2026-04-24T19:23:51.023Z" },
+    { url = "https://files.pythonhosted.org/packages/df/7c/a5d968d0b527a748b667e62bea94309ccbcb1e2b108e8f0cf8547efaa12b/simplejson-4.1.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bbfdaa7c0603f75b7b14b211b7f2be44696d4e26833ad2d91d5c87bf5fb9a920", size = 188725, upload-time = "2026-04-24T19:23:52.995Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e3/6a8d11181d587ef00e2db9112357e6832111e56dd56b01b5c11758a1965d/simplejson-4.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:39e3c584071dced8c21b4689f0254303521daeb9b5bc1f4289755d71fa3cb0d3", size = 177492, upload-time = "2026-04-24T19:23:54.581Z" },
+    { url = "https://files.pythonhosted.org/packages/67/e3/8b0eb8b06e8198cfbd1270487da163d0093df05cc4f557350cd65e2f7e79/simplejson-4.1.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:036a27bd0469b9d79557cbddb392969f876cd7f278cfbd0fba81534927a06575", size = 185281, upload-time = "2026-04-24T19:23:56.13Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/5f/64990f07ec9e2cb1a814c674e2e21b5693207f74ac70eb72151b847ea4e6/simplejson-4.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b70bfd2f67f3351baba08aa3ae9233c83f21fd95ae5e6b3d0ecb8c647929112f", size = 181848, upload-time = "2026-04-24T19:23:57.92Z" },
+    { url = "https://files.pythonhosted.org/packages/61/a5/bbc1bc0447f339f79f99ab8c37f7f037cb2f1f93af75d6a4d553096bb0c3/simplejson-4.1.1-cp314-cp314-win32.whl", hash = "sha256:37233c72ce88d06acb92747347742b3c07871eba6789f060c179c9302dde8efe", size = 88761, upload-time = "2026-04-24T19:23:59.397Z" },
+    { url = "https://files.pythonhosted.org/packages/18/72/ec1b5cbdcb140c132e6c7bdf99bd73e4f675439e77126c88f472fcffa09c/simplejson-4.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:cc0442dea71cd9cbf30a0b8b9929ab5aa6c02c0443a3d977351e6ec5bada4388", size = 91018, upload-time = "2026-04-24T19:24:00.85Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/97/4fa437f68ff72219bac3bf3d050de9c6265691f3a170e16954bd69d7cddd/simplejson-4.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:c996a4d38290c515af347740659ce095b425449c164a5c9fa3977caa6eff5dbe", size = 113919, upload-time = "2026-04-24T19:24:02.287Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/83/59de041d09eb4a9577f7015d7263c32095dfb7fde49717dff62145d89809/simplejson-4.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:c65c763fb20d7ca113c1c14dce2fc04a0fc3a57aceff533d6fdac707c7bffb40", size = 91904, upload-time = "2026-04-24T19:24:03.812Z" },
+    { url = "https://files.pythonhosted.org/packages/03/8e/46bb345d540f6eb31427d984a4e518cdb182d0621814fee4fee045e8815b/simplejson-4.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0da5c9f57206ee7ef280ff7f1d924937b0a64f9a271a5ef371a2ecdbebba7421", size = 91752, upload-time = "2026-04-24T19:24:05.622Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e2/1b2ce97f068835eb3d253c116a4df7a3f436b7bf2fb5ff1ba29287e8b0ec/simplejson-4.1.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ea3426e786425d10e9e82f8a6eda74a7d6eb10d99165ac3d0d3bbcb65c0ea343", size = 214021, upload-time = "2026-04-24T19:24:07.447Z" },
+    { url = "https://files.pythonhosted.org/packages/48/70/d93e556df6a0786298644a7c08304fcbeddc248325f23f38acbebeb21165/simplejson-4.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d75cea7a1025edd7e439b2966b3d977c45b5b899e2adaf422811b3ac702ed9fb", size = 213530, upload-time = "2026-04-24T19:24:09.289Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a5/c93bf305b9f00d7259e09e713d60e75bd0f7f53da970f716ab90491770e7/simplejson-4.1.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:63c2ada8e58f266491f19eed2eeeb7c25c6141e52f8f9e820f6bb94156cf8dbc", size = 218282, upload-time = "2026-04-24T19:24:10.991Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/20/a9b5d2e27ec44b069ee251bd55544fc76929a067107b1050001566ba86f3/simplejson-4.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d1fffb56305c5b475ee746cf9e04f97423ba5aaacd292dc1255bd75b1d3b124b", size = 209249, upload-time = "2026-04-24T19:24:12.662Z" },
+    { url = "https://files.pythonhosted.org/packages/97/e4/e06ee682ed5df67592181f5ecb062e35878967e27f5b6e087237d4548d95/simplejson-4.1.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:a6525ec733f43d0541206cffa64fd2aad5a7ae3eb76566aff49cd4db6382209a", size = 213963, upload-time = "2026-04-24T19:24:14.302Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/9f/1e160e4cd8cdbf062bf6a454cdf814dc7a48eb47e566fdb8f80ccb202605/simplejson-4.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:861e393260508efa64d8805a8e49c416c3484907e3f146ce966c69552b49b9a3", size = 210474, upload-time = "2026-04-24T19:24:15.917Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/e6/cecd913df322df5bbe7ebb8ba39e0708e505a165553900da8a7761026d6f/simplejson-4.1.1-cp314-cp314t-win32.whl", hash = "sha256:d083b89d30948a751d3d97476c2ed91e4caaa24a1a1459bdbadb8876242c71fe", size = 91134, upload-time = "2026-04-24T19:24:17.635Z" },
+    { url = "https://files.pythonhosted.org/packages/97/73/f540dde99cc1d393bd062ab3b5735b777561a5d8f8a5f2e241164444d77a/simplejson-4.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:4cbb299d0528ec0447fe366d8c9641860e28f997a62730690fef905f1f41046e", size = 94467, upload-time = "2026-04-24T19:24:19.109Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/6a/8b74c52ffd33dbbde00fe7251fee6a0acdc8cea33f7a43805aed258fb79b/simplejson-4.1.1-py3-none-any.whl", hash = "sha256:2ce92b3748f02423e26d2bfb636fb9d7a8f67c8f5854dcae69d350d123b2eee2", size = 69195, upload-time = "2026-04-24T19:24:57.962Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sqlalchemy"
+version = "2.0.51"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "(python_full_version < '3.13' and platform_machine == 'AMD64') or (python_full_version < '3.13' and platform_machine == 'WIN32') or (python_full_version < '3.13' and platform_machine == 'aarch64') or (python_full_version < '3.13' and platform_machine == 'amd64') or (python_full_version < '3.13' and platform_machine == 'ppc64le') or (python_full_version < '3.13' and platform_machine == 'win32') or (python_full_version < '3.13' and platform_machine == 'x86_64')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/f1/a7a892f18d4d224e6b26f706531eafccc41e37594d37d304786969ee13cb/sqlalchemy-2.0.51.tar.gz", hash = "sha256:804dccd8a4a6242c4e30ad961e540e18a588f6527202f2d6791b01845d59fdc9", size = 9912201, upload-time = "2026-06-15T15:41:20.012Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/76/b3ea1d8842e7b62c718a88d302809003d65ed82011460ca48907dde658c4/sqlalchemy-2.0.51-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0e8203d2fbd5c6254692ef0a72c740d75b2f3c7ca345404f4c1a4604813c77c0", size = 2162087, upload-time = "2026-06-15T16:05:15.795Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/22/f19552eb7876774d50cfd025337ef5d67acc10cd8f29adab7716cf47c352/sqlalchemy-2.0.51-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1af05726b3d0cdba1c55284bf408fd3b792e690fe2399bfb8304565551cda652", size = 3244579, upload-time = "2026-06-15T16:10:36.165Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/97/e4a2eb5a8ec5cd3c2a0615a2f15f0afca89ac039229599b9ed0c0ed28e5e/sqlalchemy-2.0.51-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2e54ff2dd657f2e3e0fbf2b097db1182f7bfea263eca4353f00065bae2a67c3d", size = 3243515, upload-time = "2026-06-15T16:12:22.627Z" },
+    { url = "https://files.pythonhosted.org/packages/74/c6/5900ec624fab3360aa2ec59b99bb2046dd79799e310bb78a0514eaa4038e/sqlalchemy-2.0.51-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:1e47b1199c2e832e325eacabc8d32d2487f58c9358f97e9a00f5eb93c5680d84", size = 3195492, upload-time = "2026-06-15T16:10:38.097Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/41/2ee3c4e1ac4fd22309349823fe13f33febeab1a71db1d7e9d60293a07dcb/sqlalchemy-2.0.51-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c68568f3facf8f66fa76c60e0ced69b67666ffa9941d1d0a3756fda196049080", size = 3215782, upload-time = "2026-06-15T16:12:24.051Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/1c/3bd72c341f1cb5faed5a7457ea840228a46be51cfbaf31a9db72fc963f11/sqlalchemy-2.0.51-cp310-cp310-win32.whl", hash = "sha256:0592bdadf86ddcabfd72d9ab66ea8a5d8d2cc6be1cc51fa7e66c03868ac5eac1", size = 2122119, upload-time = "2026-06-15T16:13:26.915Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/63/b6dfdd646abf91c3bedb13727226a5e765e5f8365e898d43818e6672fa46/sqlalchemy-2.0.51-cp310-cp310-win_amd64.whl", hash = "sha256:740cf6f35351b1ac3d82369152acf1d51d37e3dcf85d4dc0a22ca01410eabe2a", size = 2145158, upload-time = "2026-06-15T16:13:28.386Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/69/a67c69e5f28fc9c99d6f7bd60bd50e91f2fed2423e3b30fb228fa00e51f3/sqlalchemy-2.0.51-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1aa10c0daee6705294d181daadaa793221e1a59ed55000a3fab1d42b088ce4ba", size = 2161838, upload-time = "2026-06-15T16:05:17.144Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a4/c8c22b8438bddc0a030157c6ec0f6ef97b3c38effa444bdab2a27af04090/sqlalchemy-2.0.51-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a5b2ed6d828f1f09bd812861f4f59ca3bc3803f9df871f4555187f0faf018604", size = 3319402, upload-time = "2026-06-15T16:10:40.002Z" },
+    { url = "https://files.pythonhosted.org/packages/90/54/44012d32fd77d991256d2ff793ba3807c51d40cb27a85b4796224f6744df/sqlalchemy-2.0.51-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:436728ce18a80f6951a1e11cc6112c2ede9faf20766f1a26195a7c441ca12dbd", size = 3319675, upload-time = "2026-06-15T16:12:25.658Z" },
+    { url = "https://files.pythonhosted.org/packages/29/a5/de0592acaf5906cd7430874392d6f7e8b4a7c8437610953ee2d1501c0b44/sqlalchemy-2.0.51-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:dc261707bf5739aea8a541593f3cc1d463c2701fb05fbcbba0ce031b69a21260", size = 3270777, upload-time = "2026-06-15T16:10:42.125Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/14/a44c90739c780b362238e4ac3cb19dd0ca40d13e6ddc5daa112166ddab4f/sqlalchemy-2.0.51-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a6d26094615306d116dd5e4a51b0304c99dd2356fc569eed6922a80a6bd3b265", size = 3293940, upload-time = "2026-06-15T16:12:27.156Z" },
+    { url = "https://files.pythonhosted.org/packages/65/eb/fbd0f206a330e66f8c602a99c37c4e731f107faed62954b41b01f16dd9d9/sqlalchemy-2.0.51-cp311-cp311-win32.whl", hash = "sha256:ca8435d13829b92f4a97362d91975154a4015db3a2634154e1754e9a915e6b86", size = 2121183, upload-time = "2026-06-15T16:13:29.905Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fd/005bf80f3cf6e5c62b5dd68616280f51cd012c60840fa74781b3ed7b1623/sqlalchemy-2.0.51-cp311-cp311-win_amd64.whl", hash = "sha256:4a011ea4510683319ce4ed274b56ee05194b39b6da9d09ca7a39388f0fa84dcc", size = 2145796, upload-time = "2026-06-15T16:13:31.283Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/70/e868bc5412acd101a8280f25c95f10eeae0771c4eb806b02491142810ee8/sqlalchemy-2.0.51-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7d78702b26ba1c18b2d0fb2ea940ba7f17a9581b42e8361ff93920ebbee1235a", size = 2160291, upload-time = "2026-06-15T16:08:48.918Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/1c/71ee0f8a6b9d7316a1ccd30430b4c62b6c2e36adc96017a4e3a72dce49d6/sqlalchemy-2.0.51-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:581921d849d6e6f994d560389192955e80e2950e18fcdfe2ccea863e01158e6e", size = 3343835, upload-time = "2026-06-15T16:19:42.613Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/7c/7ab9f9aadc5944fdd06612484ed7918fe376ad871a5f50404dc1536e0194/sqlalchemy-2.0.51-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1d21ce524ab86c23046e992a5b81cb54c21079c6df6e78b8fc77d77cac70a6b9", size = 3358470, upload-time = "2026-06-15T16:26:38.011Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/7d/ff77169fee6186de145a7f2b87006c39638391130abbab2b1f63ac6ea583/sqlalchemy-2.0.51-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c5d98a2709840027f5a347c3af0a7c3d5f6c1ff93af2ca1c54494e23cba8f389", size = 3289874, upload-time = "2026-06-15T16:19:45.212Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/3b/6c505903710d781b55bc3141ee34a062bf9745a6b5bc7333305b9ed63b33/sqlalchemy-2.0.51-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1181256e0f16479691b5616d36375dc2620ad8332b25978763c3d206ad3f3f1d", size = 3321692, upload-time = "2026-06-15T16:26:39.747Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/b7/c5ffe50aa2f4d947c9250e1519d939260329a07fe6272edfccd784b3d007/sqlalchemy-2.0.51-cp312-cp312-win32.whl", hash = "sha256:9f380393be5abeb6815f68fd39271b95127173511b6706b0a630a9995d53f8f5", size = 2119674, upload-time = "2026-06-15T16:23:09.543Z" },
+    { url = "https://files.pythonhosted.org/packages/25/dc/46a65916af68a06ef6b972c6050ba4c8f97070fe3fb33097d34229d9bef6/sqlalchemy-2.0.51-cp312-cp312-win_amd64.whl", hash = "sha256:2cf39aabdf48e87c1c2c2ed6d20d33ffa0733b3071ce9c5f66357947dd009080", size = 2146670, upload-time = "2026-06-15T16:23:11.048Z" },
+    { url = "https://files.pythonhosted.org/packages/54/fe/a210d52fd1a90ecfae8a78e9d8b27e18d733d60818a8bf250ff690b75120/sqlalchemy-2.0.51-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7c2056838b6685b72fdb36c99996cf862753461a62f2e84f4196371d3b2d6a07", size = 2157184, upload-time = "2026-06-15T16:08:50.374Z" },
+    { url = "https://files.pythonhosted.org/packages/17/6b/2dce8369b199cb855110e056032f94a9f66dacc2237d3d39c115a86eac56/sqlalchemy-2.0.51-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:483b11bd46bf35fc14c52faf338b04300c9e6ce554bce9b11be85bfec3bc3195", size = 3284735, upload-time = "2026-06-15T16:19:46.934Z" },
+    { url = "https://files.pythonhosted.org/packages/53/ff/dbc495b8a14da840faffb353857a72d4190113cac33727906fb997047f0f/sqlalchemy-2.0.51-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1bed1ee8b01da6088210aa9412023326fb98a599ba502e6118308601dcbef77f", size = 3302756, upload-time = "2026-06-15T16:26:41.336Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/d5/fde8f4dddcf518ee15ab35a7c6a28acc32c8ba548d1d2aa451f96e6dbb0b/sqlalchemy-2.0.51-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:72ca54c952107ba5cd58854b67a5a6268631289d21651a1235396f3b98b47400", size = 3232055, upload-time = "2026-06-15T16:19:49.286Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d1/43d3a0ac955a58601c24fa23038b1c55ee3a1ec02c0f96ebb1eae2bcf614/sqlalchemy-2.0.51-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b3e693d15533a45cd5906f0589f9c35090bef6ef45bf1e8195c424aa0ae06a8d", size = 3269850, upload-time = "2026-06-15T16:26:43.017Z" },
+    { url = "https://files.pythonhosted.org/packages/94/df/de669c7054cd47c4439ac34b1b2ee8b804a794791fbb10720e997a2c87c7/sqlalchemy-2.0.51-cp313-cp313-win32.whl", hash = "sha256:b93ab07b5292dbe7e6b8da89475275e7042744283921344b56105f3eeb0f828b", size = 2117721, upload-time = "2026-06-15T16:23:12.36Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/8a/403c51d064196bae20a0bc2476577f83a3f8dd299719a97417086b7f2ec5/sqlalchemy-2.0.51-cp313-cp313-win_amd64.whl", hash = "sha256:0f053118c30e53161857a953e4de667d90e274980dccbe5dd3829bbbeece72a5", size = 2143615, upload-time = "2026-06-15T16:23:13.906Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/49/a739be2e1d02a96a658eb71ab45d921c874249252358ad24a5bffdd02525/sqlalchemy-2.0.51-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6ea306caaae6bd5afd0a46050003c88f6bf33227377a49298c498c3cb88ff491", size = 2158999, upload-time = "2026-06-15T16:08:51.759Z" },
+    { url = "https://files.pythonhosted.org/packages/23/6b/2e0e38cf75c8780eca78d9b2e78164f8bcfd70125e5caa588ff5cbb9c9f4/sqlalchemy-2.0.51-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c45a496d6bc05dec41dcd4c3a2b183723f47473255c159cd80b503c8f246424d", size = 3282539, upload-time = "2026-06-15T16:19:51.065Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a1/e77854cb5336fd37dc3c6ae3b71de242c98caac5725120be0b526b31cbd0/sqlalchemy-2.0.51-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4004ada0aafe8ae1991b2cd1d99c6d9146126e123bd6f883c260d974aa012e54", size = 3287545, upload-time = "2026-06-15T16:26:44.735Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/ab/9e17272fd4dac8df3b83c4fbe52b998a1c9d89a843c8c35ff29b74ff7364/sqlalchemy-2.0.51-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0f6bcad487aee1c638d707235682fc96f741de00663619881ab235400d03289e", size = 3230929, upload-time = "2026-06-15T16:19:52.625Z" },
+    { url = "https://files.pythonhosted.org/packages/02/3c/52f408ea701781caee975606beccc48845f2aee8711ac29843d612c0306c/sqlalchemy-2.0.51-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:39a76529db6305693d8d4affa58ad5b5e2e18edd62daea628b29b97930b3513d", size = 3252888, upload-time = "2026-06-15T16:26:46.454Z" },
+    { url = "https://files.pythonhosted.org/packages/24/16/3efd2ee6bc4ca4693a30a1dd17a91b606cae15d517d2a4746611d9b73ce8/sqlalchemy-2.0.51-cp314-cp314-win32.whl", hash = "sha256:08a204d8b5638717c26a24df18fcf40af45a6b22e35b70b1d62f0113c2e278e8", size = 2120551, upload-time = "2026-06-15T16:23:15.629Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/78/55b12e70f45bccc40d9e483925c065027b3b98ea4cbbdf6f8c2546feaf6c/sqlalchemy-2.0.51-cp314-cp314-win_amd64.whl", hash = "sha256:96747bfbadb055466e5b46d572618170046b45ce5a4879167f50d70a5319a499", size = 2146318, upload-time = "2026-06-15T16:23:17.108Z" },
+    { url = "https://files.pythonhosted.org/packages/21/db/a9574ed40fed418924b1b1a3e54f47ee3963053b3d3d325a0d36b41f2c08/sqlalchemy-2.0.51-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:e5ea1a213be1fcd5e49d9904c3b9939211ded90bc2a64e93f4c01963474285de", size = 2178920, upload-time = "2026-06-15T15:59:56.285Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/90/a1bb5c7cbba76b7bc1fbd586d0a5479a7bc9c27b4a8298f22ec9423b2bb3/sqlalchemy-2.0.51-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7c6b36ed71f41942bdcd2ad2522be46bfce09d5705be5640ecf19bbc7660e4b7", size = 3566534, upload-time = "2026-06-15T15:58:35.024Z" },
+    { url = "https://files.pythonhosted.org/packages/15/4b/481f1fed30e0e9e8dd24aecbb49f29eb57fe7657ece5cf06ee9b84bb97d8/sqlalchemy-2.0.51-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0c2c62877097e1a0db401fba5cb4debee33265e5b2a55c4ccb489c02c53b4f72", size = 3535844, upload-time = "2026-06-15T16:02:43.973Z" },
+    { url = "https://files.pythonhosted.org/packages/02/71/0aa64aeda645510af0a43f7d9ee70932f0d1dc4263aed34c50ee891d9df3/sqlalchemy-2.0.51-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0378d055e9e8cd6ce4d8dff683bdd3d7d413533c4ee51d67a2b1e0f9eacc0f23", size = 3475355, upload-time = "2026-06-15T15:58:36.592Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/6061db32316446135a3abae5f308d144ab988a34234726042da3e58b1c63/sqlalchemy-2.0.51-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6e46fc36029eff666391e0531e5387b62ce6c4f1d8e50b3fb3099eaca1b42522", size = 3486591, upload-time = "2026-06-15T16:02:45.346Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/c9/f14fdf71bb8957e0c7e39db69bbdf12b5c80f4ef775fdfa127bf4e0d6760/sqlalchemy-2.0.51-cp314-cp314t-win32.whl", hash = "sha256:9161cfc9efce70d1715f47d6ff40f79c6778c00d53be4fbc09d70301e4b83ba7", size = 2151313, upload-time = "2026-06-15T16:03:39.127Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c6/673e618e6f4f297e126d9b56ea2f6478708f6c1af4e3223835c22e2c3697/sqlalchemy-2.0.51-cp314-cp314t-win_amd64.whl", hash = "sha256:159bb6ba32059f57ad7375a8f50d844dd2f19d14954ecf820cd33e20debd46b2", size = 2186280, upload-time = "2026-06-15T16:03:40.569Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/22/dbf013a12ec759e54a34a119e9e217435b3f71b2dd5c61a7ade0a25dae87/sqlalchemy-2.0.51-py3-none-any.whl", hash = "sha256:bb024d8b621d0be75f4f44ecc7c950450026e76d66dc8f791bb5331d7fed59d5", size = 1944334, upload-time = "2026-06-15T16:09:22.418Z" },
 ]
 
 [[package]]
@@ -2929,6 +4130,131 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/80/cc/44f2d81d8f9093aad81c3467a5bf5718d2b5f786e887b6e4adcfc17ec6b9/tcolorpy-0.1.7.tar.gz", hash = "sha256:0fbf6bf238890bbc2e32662aa25736769a29bf6d880328f310c910a327632614", size = 299437, upload-time = "2024-12-29T15:24:23.847Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/05/a2/ed023f2edd1e011b4d99b6727bce8253842d66c3fbf9ed0a26fc09a92571/tcolorpy-0.1.7-py3-none-any.whl", hash = "sha256:26a59d52027e175a37e0aba72efc99dda43f074db71f55b316d3de37d3251378", size = 8096, upload-time = "2024-12-29T15:24:21.33Z" },
+]
+
+[[package]]
+name = "tensorflow-probability"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py", marker = "python_full_version < '3.13'" },
+    { name = "cloudpickle", marker = "python_full_version < '3.13'" },
+    { name = "decorator", marker = "python_full_version < '3.13'" },
+    { name = "dm-tree", marker = "python_full_version < '3.13'" },
+    { name = "gast", marker = "python_full_version < '3.13'" },
+    { name = "numpy", marker = "python_full_version < '3.13'" },
+    { name = "six", marker = "python_full_version < '3.13'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/b6/e116761ceeb880b7ad4c6a7e1203538754dd7dda42538f08d6daaf8dfa4d/tensorflow_probability-0.25.0-py2.py3-none-any.whl", hash = "sha256:f3f4d6431656c0122906888afe1b67b4400e82bd7f254b45b92e6c5b84ea8e3e", size = 6979403, upload-time = "2024-11-08T16:25:57.238Z" },
+]
+
+[package.optional-dependencies]
+jax = [
+    { name = "jax", marker = "python_full_version < '3.13'" },
+    { name = "jaxlib", marker = "python_full_version < '3.13'" },
+]
+
+[[package]]
+name = "tensorstore"
+version = "0.1.78"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "ml-dtypes", marker = "python_full_version < '3.11'" },
+    { name = "numpy", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/ee/05eb424437f4db63331c90e4605025eedc0f71da3faff97161d5d7b405af/tensorstore-0.1.78.tar.gz", hash = "sha256:e26074ffe462394cf54197eb76d6569b500f347573cd74da3f4dd5f510a4ad7c", size = 6913502, upload-time = "2025-10-06T17:44:29.649Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/1e/77eff7bb320f72a9cb6e9a19eee4d78bee4a6ac1c28ceef60df28b4ab670/tensorstore-0.1.78-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:f1bc58164ad964d9cc298d20b62ca704ab6241639a21015e47ce6ea5b5cae27f", size = 15710776, upload-time = "2025-10-06T17:43:47.469Z" },
+    { url = "https://files.pythonhosted.org/packages/55/df/f74f8004b246006ae03c90c28e32d71eb8a86a5b325d2d84dda327babdcc/tensorstore-0.1.78-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1910101ea85b6507958da28628ef53712c5311df19a795f449604f82bae6a24b", size = 13771121, upload-time = "2025-10-06T17:43:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b8/ab0d0b2afc53f47fbfd95c10d9ae21d393019aca45c8513657b8d7002f1f/tensorstore-0.1.78-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e92195db0c8c3ca749f24b1e930ab93382ac27430ac4ad2e3f53fc8f739323f", size = 18154513, upload-time = "2025-10-06T17:43:51.694Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ea/c1b4cc6a089a39f63e8d189a55c715e393995628b12b4c8560b3ae4874ba/tensorstore-0.1.78-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90570b867f9100f7405e4116c73910d0bd283a101500ea5680c5a8a881ea05c6", size = 20048971, upload-time = "2025-10-06T17:43:54.358Z" },
+    { url = "https://files.pythonhosted.org/packages/58/2a/7167087885b12473f20ae4fddb9a8feeed6bd44ea8d42c73ae29ad3d1591/tensorstore-0.1.78-cp310-cp310-win_amd64.whl", hash = "sha256:4de9d4ee93d712cb665890af0738f4d74cac3b9b9a0492d477a3ee63fbbf445b", size = 12707793, upload-time = "2025-10-06T17:43:56.405Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b1/45070c393586306cef44c7bfc47ed2eddfb8930e648aaa847f615e3ae797/tensorstore-0.1.78-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:1c91e7ff93561612bd9868f3ee56702b0e4fecb45079a4c152dff9a6aa751913", size = 15712387, upload-time = "2025-10-06T17:43:58.458Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d8/c045da71460301f37704e1ab1eec9e7e480dc711dbd281d86dc3d792c50e/tensorstore-0.1.78-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:781e123d392b2d9115e94b01849797a4540f54cd6d34c6ee32b9491f2f2a399c", size = 13773158, upload-time = "2025-10-06T17:44:00.285Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e8/2b0d48100816649ec516fca31d02ad8028c090324e77b1c309c09a172350/tensorstore-0.1.78-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e650d363ad43754626a828a242785e6359a59fedb171276e9a0c66c0bd963cd4", size = 18154388, upload-time = "2025-10-06T17:44:02.428Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/a1/d9be82de18afe764c0fc7fb21b3d3bb0ad12845d202861fff7189afdb99d/tensorstore-0.1.78-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:33fed0ffa7a42ad24ce203486cf039f81b211723b45bd54859ba237a9d3aedb9", size = 20050304, upload-time = "2025-10-06T17:44:04.673Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/fc/b980958f91a9780e4dbc1038da723d2ad91307dbe30563359606f78926e5/tensorstore-0.1.78-cp311-cp311-win_amd64.whl", hash = "sha256:c02df3d8de4703d9ee42c8f620b2288f41c19a0fd5ffa907b72a736678e22188", size = 12708115, upload-time = "2025-10-06T17:44:06.574Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/5f/5853c04bebaed2d3c0ada9245328ffe3fff8b0f0f1c64f4776f67b42033f/tensorstore-0.1.78-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:ce375a8f6621cdb94638b9cdc5266519db16a58353d4c6920e8b9d6bdd419e21", size = 15727539, upload-time = "2025-10-06T17:44:08.631Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/e2/f67fcca8f90258c1cf1326aa366fe10f559f4c60102f53fdcc6614159c45/tensorstore-0.1.78-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:82f68fa5a3b4c84365a667ea0a7465a53d5d969c4d3909ac990f314d1569ffc3", size = 13780753, upload-time = "2025-10-06T17:44:10.488Z" },
+    { url = "https://files.pythonhosted.org/packages/57/de/95013db6ef3b6a14b4237b95184c21becdf56d16605bf42903bb141f729e/tensorstore-0.1.78-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5dc0bd6361d73e3f67d70980f96f4e8bcbd8e810b5475a01333ca9c37f0785a5", size = 18157446, upload-time = "2025-10-06T17:44:12.831Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/75/6e7cef68cab3a672c6668cc80c399ae6626a498a3ef04b35b3704b41e9cc/tensorstore-0.1.78-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:75a17cef99f05fad9cc6fda37f1a1868d5f1502fd577af13174382931481c948", size = 20060211, upload-time = "2025-10-06T17:44:15.189Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/46/4ff3e395c44348c7442523c8ddd8ccc72d9ac81838e7a8f6afdd92131c3e/tensorstore-0.1.78-cp312-cp312-win_amd64.whl", hash = "sha256:56271d4652a7cb445879089f620af47801c091765d35a005505d6bfb8d00c535", size = 12711274, upload-time = "2025-10-06T17:44:17.586Z" },
+    { url = "https://files.pythonhosted.org/packages/18/36/cfb5a2acf9005896c88f80b93c2aee42f00fab9d0045369fef6e1b297242/tensorstore-0.1.78-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:8a1d0ae7996c80f2e623be5b8cfbc32a307d08dfef3d2dcb455f592908ecd46d", size = 15727334, upload-time = "2025-10-06T17:44:19.93Z" },
+    { url = "https://files.pythonhosted.org/packages/54/cd/d1bcc3aab5be4298616dbc060b5aa2012b686270aaa16a9579c7945d0a1c/tensorstore-0.1.78-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:311846cfb2d644cd4a7861005e521a79816093e76d7924c83de5d06ca323067e", size = 13780722, upload-time = "2025-10-06T17:44:21.822Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/3b/b0bb4440a9d67859b1abb367e436c62b0a27991dd7109f20be9dabff488f/tensorstore-0.1.78-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:630538a66eb9964bd2975c4e09ae83be9984f2e4ebd5f7969983137bfda92071", size = 18157269, upload-time = "2025-10-06T17:44:23.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/d6/d95cde18ca2475bf317051b2be168cc963c5cfcd67e9c59786326ccdca53/tensorstore-0.1.78-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6886bec93b8ba22f83c4dc9e7c1ee20b11025ea9a5a839de21d0cbf7fd7aada2", size = 20060053, upload-time = "2025-10-06T17:44:25.942Z" },
+    { url = "https://files.pythonhosted.org/packages/db/a2/dbd1af0e97d5d549051309d72c6e3f2fe81fae636f9db3692d21adc9c731/tensorstore-0.1.78-cp313-cp313-win_amd64.whl", hash = "sha256:e0073de8fa3074bc4cc92ced0210310fd89851899faf42a5ba256f0ba87d095c", size = 12711250, upload-time = "2025-10-06T17:44:27.926Z" },
+]
+
+[[package]]
+name = "tensorstore"
+version = "0.1.84"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "ml-dtypes", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/18/c8e8b4faffab1a434b6c013d54cf7f5b754a6849429d9dbb718297705796/tensorstore-0.1.84.tar.gz", hash = "sha256:3cb091dfde68600e6d8f03a389ccc92ffa7c0798a0c600d1013c0138d7163e6b", size = 7208048, upload-time = "2026-05-16T06:17:58.448Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/2f/7630705a1db3a349f162552c7a34f4e74c06bf9800d73c233eb939305f6e/tensorstore-0.1.84-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:6103311700359e9f552e8560d16eecf1548b87e2f8a6a766b9f6a65c8722f879", size = 16556656, upload-time = "2026-05-16T06:17:01.065Z" },
+    { url = "https://files.pythonhosted.org/packages/09/2b/fbba516c549fc868d9b9c74e3e593157825b08db0103dcfcde1ae994d1f4/tensorstore-0.1.84-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:340fe971f1808d7060f2273b8eee352780bcb65e5035f78163fa9b8930aa795a", size = 14900174, upload-time = "2026-05-16T06:17:03.647Z" },
+    { url = "https://files.pythonhosted.org/packages/55/6d/fe5013aa1b8e8e6a73213285f29a059bfcbefcfebafc937694823bdc5a00/tensorstore-0.1.84-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:34352f8ba6e5efba5feb18917d68da1a92bbff80e64c3fd06d3d1af4b343821a", size = 19341729, upload-time = "2026-05-16T06:17:06.242Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c5/65e7dfc4108451f5317aca47a7c339954d0b7601ed4db4481a2f80ee2da1/tensorstore-0.1.84-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ae74451ab5cc8a0cd9e51926adf04f4dfdbd8ad5ac31ac71f1caa7bdfb2828d", size = 20952887, upload-time = "2026-05-16T06:17:08.653Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/dc/11a487107c5b73684aeaa4667693d5e73b96bc3ad7211db4a03f6049bf65/tensorstore-0.1.84-cp311-cp311-win_amd64.whl", hash = "sha256:4c9b084b0b44c36eaa9b9c51c3347474cd3c94fda12344fb507e6629357615bf", size = 13391569, upload-time = "2026-05-16T06:17:11.307Z" },
+    { url = "https://files.pythonhosted.org/packages/46/8a/1b5231e965257c3ee7d4615cb49a0fac53a71a1c34b293bcf524bb7c6d13/tensorstore-0.1.84-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:915371fc2c27540e8b69c573b7a06217fb8d161ec231cedfa9f3d264615a326d", size = 16571584, upload-time = "2026-05-16T06:17:13.283Z" },
+    { url = "https://files.pythonhosted.org/packages/88/5d/52e52aa00a5ae3ebe1116ca52ac9f47ef98e94f6c4e411649cd3d1bb79cc/tensorstore-0.1.84-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4477eabe26e2f5131f1b1a3444cd9167fe69fabc29579eab8259d218399b9e6b", size = 14905169, upload-time = "2026-05-16T06:17:15.638Z" },
+    { url = "https://files.pythonhosted.org/packages/61/36/f88b4bf267902f12cd2ca33aff10fabd6839dd1ce7d51876ebefa98aaf2c/tensorstore-0.1.84-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ace00cf2e45dc5d64fe3a10c2cbef61343915683808a10a3e081233566a7231", size = 19345134, upload-time = "2026-05-16T06:17:17.984Z" },
+    { url = "https://files.pythonhosted.org/packages/18/7c/b7b24e10e5cb0213c85204d53fcd60d0568d986ea0001a00a815e14e01e1/tensorstore-0.1.84-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:64c8039558d5607b73903948fce058725731df410c5c196cf58b3fc6222395b5", size = 20968745, upload-time = "2026-05-16T06:17:20.569Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/36/33ad454a2b667a93b35e74595a351dbf9b8693440bd68665990663b79164/tensorstore-0.1.84-cp312-cp312-win_amd64.whl", hash = "sha256:08e7ec5b35db5d4c4b6a867be8500448f9bd4e0c9d5a52d7f0b460650622baf6", size = 13398458, upload-time = "2026-05-16T06:17:22.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/27/3c637c0f987866f6fb92cf96ee4d40eee4b5ab699135803ada851f2a56ad/tensorstore-0.1.84-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:9337d96693b4a0e555fbe63bb228e3e2e681a80e4d371f351fb67810f197f74e", size = 16571472, upload-time = "2026-05-16T06:17:24.885Z" },
+    { url = "https://files.pythonhosted.org/packages/41/83/4f3c6ef9bed01f384036c2030b3901cf075bbc8eff6e4529e502f0283ab5/tensorstore-0.1.84-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:028455cccdc05c31f194048cf459a26669b26d38f0516caf9213e7219b1ee79a", size = 14905288, upload-time = "2026-05-16T06:17:26.753Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/28/03e46405ba7c616e7a1ec5425a8f4a1b3f4d6ec2be359cb2f248199849e4/tensorstore-0.1.84-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50afb06c57a509091015af6a85da6f483a7f5ad0372284dd95d5513d877336e4", size = 19344890, upload-time = "2026-05-16T06:17:28.956Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/c6/82669e70cef67c803852285ba6f59d7e3d102983c0ab4be8269c14756677/tensorstore-0.1.84-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ea53a851ea86aad3d99c14a790c85468d6324be14c7ac211f1f0265e8fab707", size = 20968230, upload-time = "2026-05-16T06:17:31.374Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/12/97d8ad183e3130e168f2feb860edd68f1b72e57f29268d980f3b70e34cd0/tensorstore-0.1.84-cp313-cp313-win_amd64.whl", hash = "sha256:fe9bf1c7fef69884a91222179550f9b5ba6c1454f9534429221824d9b15c00ec", size = 13398858, upload-time = "2026-05-16T06:17:33.658Z" },
+    { url = "https://files.pythonhosted.org/packages/39/bd/fda828e7915ddb61704a6f4568b5b7ce9fe607c33b7535cf51b4fd900b38/tensorstore-0.1.84-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:97e767a64415297f019dd1e4b9af6a23d72e126e2a2d05cf41083253abe81428", size = 16576451, upload-time = "2026-05-16T06:17:35.993Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/99/2e72fcb19404de43f9412880c542a8ef8651bd30183c85454d6ca14ebe56/tensorstore-0.1.84-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7d01775985fcaa2b0f100349766a953c5086e92e746bf395e936151d4d8f9ac", size = 14907896, upload-time = "2026-05-16T06:17:38.458Z" },
+    { url = "https://files.pythonhosted.org/packages/25/d4/9a3964cdfdc5a15df6d0485694de9684c13990a5b0f5d88bfa365e0a2936/tensorstore-0.1.84-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b2ff5d5536a8a9b1596c51b9075cc9d40b4c4ea4e6cc03c0480111dbe5d956d", size = 19347021, upload-time = "2026-05-16T06:17:41.316Z" },
+    { url = "https://files.pythonhosted.org/packages/43/19/70532cb2bf2f6fc3bf252f850bfb528b26eeb9c30c3cafffb075cbb7c77a/tensorstore-0.1.84-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c9108ae6c29adc90b72ca267ba2b577386c5e410ea2f8e87eabce5ebdad327e", size = 20970345, upload-time = "2026-05-16T06:17:43.874Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/22/a523e7576c83a6c35bd1415e5f4530b0f1e448c099d7e22684f55792755c/tensorstore-0.1.84-cp314-cp314-win_amd64.whl", hash = "sha256:4096220f4b9a2411c3751597dd8ced2f671d7a217575613c915191e19d5ea150", size = 13787429, upload-time = "2026-05-16T06:17:46.135Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/23/40b0a0a91973431770ac09a8b69039bd7a051169f6707b63a1c51ad36782/tensorstore-0.1.84-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:70284a7225d94adad5989de7f9238638ec9fec2bdd8c0fdb86d567f16d59e615", size = 16652804, upload-time = "2026-05-16T06:17:49.226Z" },
+    { url = "https://files.pythonhosted.org/packages/01/99/2ea3b37864adb2e9f6e724c6959ab2b7f56aa4dad01964d4b32adf211e68/tensorstore-0.1.84-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:98e10cae5b3fc0828967b8ddf36242b3b26ac8bc79880bc3e36346063259212a", size = 14990904, upload-time = "2026-05-16T06:17:51.464Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/26/fe72887d7b91e832bef3033d244c4c548993d1b6fb19177dff3895659c12/tensorstore-0.1.84-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98edbc57d453ba8ebcf0d19bc28e4de6de95922bee2eca0805955b0833b8ce26", size = 19365698, upload-time = "2026-05-16T06:17:53.748Z" },
+    { url = "https://files.pythonhosted.org/packages/37/74/35a1d41343f86f6e2ef135e81f6b8107b9f16c777a3e8be9e3fbce541d18/tensorstore-0.1.84-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bd20de85c1b83dd3ca94db24e7bd449bdb055590a1b162b05691f6b81fff00f", size = 20986107, upload-time = "2026-05-16T06:17:56.571Z" },
+]
+
+[[package]]
+name = "tfp-nightly"
+version = "0.26.0.dev20260626"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py", marker = "python_full_version < '3.13'" },
+    { name = "cloudpickle", marker = "python_full_version < '3.13'" },
+    { name = "decorator", marker = "python_full_version < '3.13'" },
+    { name = "dm-tree", marker = "python_full_version < '3.13'" },
+    { name = "gast", marker = "python_full_version < '3.13'" },
+    { name = "numpy", marker = "python_full_version < '3.13'" },
+    { name = "six", marker = "python_full_version < '3.13'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/5c/e24a6f85b2038cbf209844944774102bb37e3a1e67ae524c71a7aad0e0a6/tfp_nightly-0.26.0.dev20260626-py2.py3-none-any.whl", hash = "sha256:57d024ecbc1da39e33af522f98bdfc95cb118af04e27a0b3391618f29be546ee", size = 6975580, upload-time = "2026-06-26T08:45:22.208Z" },
+]
+
+[package.optional-dependencies]
+jax = [
+    { name = "jax", marker = "python_full_version < '3.13'" },
+    { name = "jaxlib", marker = "python_full_version < '3.13'" },
 ]
 
 [[package]]
@@ -2995,6 +4321,15 @@ wheels = [
 ]
 
 [[package]]
+name = "toolz"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/d6/114b492226588d6ff54579d95847662fc69196bdeec318eb45393b24c192/toolz-1.1.0.tar.gz", hash = "sha256:27a5c770d068c110d9ed9323f24f1543e83b2f300a687b7891c1a6d56b697b5b", size = 52613, upload-time = "2025-10-17T04:03:21.661Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl", hash = "sha256:15ccc861ac51c53696de0a5d6d4607f99c210739caf987b5d2054f3efed429d8", size = 58093, upload-time = "2025-10-17T04:03:20.435Z" },
+]
+
+[[package]]
 name = "tornado"
 version = "6.5.5"
 source = { registry = "https://pypi.org/simple" }
@@ -3030,6 +4365,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "typeguard"
+version = "2.13.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/38/c61bfcf62a7b572b5e9363a802ff92559cb427ee963048e1442e3aef7490/typeguard-2.13.3.tar.gz", hash = "sha256:00edaa8da3a133674796cf5ea87d9f4b4c367d77476e185e80251cc13dfbb8c4", size = 40604, upload-time = "2021-12-10T21:09:39.158Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/bb/d43e5c75054e53efce310e79d63df0ac3f25e34c926be5dffb7d283fb2a8/typeguard-2.13.3-py3-none-any.whl", hash = "sha256:5e3e3be01e887e7eafae5af63d1f36c849aaa94e3a0112097312aabfa16284f1", size = 17605, upload-time = "2021-12-10T21:09:37.844Z" },
 ]
 
 [[package]]
@@ -3097,6 +4441,27 @@ wheels = [
 ]
 
 [[package]]
+name = "tzlocal"
+version = "5.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/55/15e2340963d2bfedcc6042da3911438fd336f8ae96b65bdbe3a29766da0c/tzlocal-5.4.3.tar.gz", hash = "sha256:3a8c9bc18cf47e1dcde252ea0e6a72a6cde320a400b6ac6db1f1f8cccd553c00", size = 30873, upload-time = "2026-06-17T04:17:41.764Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/28/fc144409c71569e928585f8f3c629d80d1ca3ef40175e9222f01588f98c9/tzlocal-5.4.3-py3-none-any.whl", hash = "sha256:24ce97bb58e2a973f7640ec2553ab4e6f6d5a0d0d1aa9dc43bca21d89e1feb82", size = 18039, upload-time = "2026-06-17T04:17:40.027Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
 name = "uv"
 version = "0.11.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3153,6 +4518,15 @@ wheels = [
 ]
 
 [[package]]
+name = "wadler-lindig"
+version = "0.1.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/67/cbae4bf7683a64755c2c1778c418fea96d00e34395bb91743f08bd951571/wadler_lindig-0.1.7.tar.gz", hash = "sha256:81d14d3fe77d441acf3ebd7f4aefac20c74128bf460e84b512806dccf7b2cd55", size = 15842, upload-time = "2025-06-18T07:00:42.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/96/04e7b441807b26b794da5b11e59ed7f83b2cf8af202bd7eba8ad2fa6046e/wadler_lindig-0.1.7-py3-none-any.whl", hash = "sha256:e3ec83835570fd0a9509f969162aeb9c65618f998b1f42918cfc8d45122fe953", size = 20516, upload-time = "2025-06-18T07:00:41.684Z" },
+]
+
+[[package]]
 name = "wcwidth"
 version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3162,10 +4536,105 @@ wheels = [
 ]
 
 [[package]]
+name = "wrapt"
+version = "2.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/a4/282c8e64300a59fc834518a54bf0afabb4ff9218b5fa76958b450459a844/wrapt-2.2.2.tar.gz", hash = "sha256:0788e321027c999bf221b667bd4a54aaefd1a36283749a860ac3eb77daed0302", size = 129068, upload-time = "2026-06-20T23:49:44.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/8b/59781d0fe7b0adfbea37f600857de4be68921e454aeecf1a11bda35cdccc/wrapt-2.2.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:055e6fcfaa28e58c6a8c247d48b92be9d56f818b7068aa4f22b15b3343a09931", size = 80556, upload-time = "2026-06-20T23:47:28.473Z" },
+    { url = "https://files.pythonhosted.org/packages/94/dc/66c61aca927230c9cf97a3cb005c803971a1076ff9f7d61085d035c20085/wrapt-2.2.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8374eb6b1a58809211e84ff835a182bb17ab2807a5bfef23204c8cff38178a00", size = 81648, upload-time = "2026-06-20T23:47:30.504Z" },
+    { url = "https://files.pythonhosted.org/packages/23/1b/545eee1c18f3af4cf140bb5822b6ef81ebe569df0a63ac109973103a30a5/wrapt-2.2.2-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:656593bb3f5529f03d27af4136c4d7b11990e470bcbc6fefa5ef218695bece55", size = 152956, upload-time = "2026-06-20T23:47:31.867Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a7/6f42a3d03e44dc612a5dcff324e7366075a7857f0be2d49a8cb8a68279b8/wrapt-2.2.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dfb00cb7bb22099e2f64b7340fb96113639aa7260c0972af3797ace2297b936c", size = 154771, upload-time = "2026-06-20T23:47:33.352Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/55/4d76175aaa97523c38f1d28f79d18ab41a1b116814158a818bc0eba00571/wrapt-2.2.2-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e7f10ee0bd53673bfd52b67cbce83336fe6cad90d2377b03baf66491d2bbfb91", size = 149460, upload-time = "2026-06-20T23:47:34.712Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9b/12e23264d8f4735e8483262f95c5a6b03c3665fd2a84bdf99a45b6a2f4ec/wrapt-2.2.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:4402f57c5f0d0579599858ffbdd9bf4e3f0972f51096f2bd6cc7dab6b76ee49e", size = 153648, upload-time = "2026-06-20T23:47:36.092Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a3/bcd5ec37289dcd85ecd4d15395a6a6063d60bc45ff94a9d77814e1e54d64/wrapt-2.2.2-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:3a4eb7964ff4643d333c84f880bcf554652b2a1050aebc54ae696327f61acfaf", size = 148502, upload-time = "2026-06-20T23:47:37.623Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/be/716d708f607fa70f8a6eb47dff8ee945d5278dfc89ffeeff33039d052e63/wrapt-2.2.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e542b7c5af91e2123a8aabf19894319d5ec4268d2a9ffd2f239386133fc47746", size = 152238, upload-time = "2026-06-20T23:47:39.118Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/c0/1a48e7e54501274f5d906f18372221b13183b0afbb5b8bb4c7ca0392c0b4/wrapt-2.2.2-cp310-cp310-win32.whl", hash = "sha256:6e7e45b43d3c774d244fe7264378f5a3f0f383bc55a54a9866434e524540110f", size = 77278, upload-time = "2026-06-20T23:47:40.476Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/82/9cd69a1af288fbdedf01a10e3c8a0b6890b08c7f3f96d36a213699dbcd94/wrapt-2.2.2-cp310-cp310-win_amd64.whl", hash = "sha256:955f1d6e72a352e478de8d8b503abe301c5e139a141b62eb0923bd694995025f", size = 80131, upload-time = "2026-06-20T23:47:41.785Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/73/8db7e27daef37ae70a53ea62bef7fe80cc51a8b5e9e9181a8be6eb9a999c/wrapt-2.2.2-cp310-cp310-win_arm64.whl", hash = "sha256:b89d8d73c82db2bb7e6090b3afd7973f980d24e905cc34394eab60b884b3bf67", size = 79615, upload-time = "2026-06-20T23:47:43.109Z" },
+    { url = "https://files.pythonhosted.org/packages/27/15/0c2d55168707465abfc41f33c0b23d792a5fa9b65c26983606940900a120/wrapt-2.2.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f1a2ff355ece6a111ca7a20dc86df6659c9205d3fcee674ca34f2a2854fd4e73", size = 80782, upload-time = "2026-06-20T23:47:44.367Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/b5/5c0b093eb48f8a062ef6267d3cb36e9bb1b88440181f6545a383c60efdf8/wrapt-2.2.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:55b9a899e6fff5444f229d30aa6e9ac92d2216d9d60f33c771b5d76a760d5f8e", size = 81678, upload-time = "2026-06-20T23:47:45.857Z" },
+    { url = "https://files.pythonhosted.org/packages/34/f3/de70937472dd3e8a4e6811192f9c6075efdffd4a2cd9b4596bf160f89668/wrapt-2.2.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a2d78c363f97d8bd718ee40432c66395685e9e98528ccaa423c3355d1715a26d", size = 159671, upload-time = "2026-06-20T23:47:47.345Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ec/40aed2330e7f02ecf74386ffcfef9ccb7108c6a430f15b6a252b663b1bed/wrapt-2.2.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d619e1eed9bd4f6ed9f24cd61971aa086fa86505289628d464bcf8a2c2e3f328", size = 160785, upload-time = "2026-06-20T23:47:48.759Z" },
+    { url = "https://files.pythonhosted.org/packages/45/04/aa5309beed5344b00220ae6b3b24055852192656194c27947bee1736306a/wrapt-2.2.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:518b0c5e323511ec56a38894802ddd5e1222626484e68efe63f201854ad788e5", size = 153699, upload-time = "2026-06-20T23:47:50.177Z" },
+    { url = "https://files.pythonhosted.org/packages/01/df/2def7e99d1fe87eea413f95f671924cdddcb08823b1ffd212748dfa6d062/wrapt-2.2.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4bccea5cdecffa9dd70e343741f0e41e0a16619313d04b72f78bb525162ebcd0", size = 159695, upload-time = "2026-06-20T23:47:51.602Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f6/a906d01a2ce12157bad2404957b3e2140da354b8a70b2fa48bbf282871c0/wrapt-2.2.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:209112cafd963710a05d199aae431d79a28bc76eb8e6d1bbbb8ad24340722cae", size = 152813, upload-time = "2026-06-20T23:47:53.03Z" },
+    { url = "https://files.pythonhosted.org/packages/02/49/bc0086292d239575b4c08f4cf8a4079fa58abbad58ec23abf84833a283ed/wrapt-2.2.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e5a5290e4bf2f332fc29ce72ffb9a2fff678aaac047e2e9f5f7165cd7792e099", size = 158809, upload-time = "2026-06-20T23:47:54.391Z" },
+    { url = "https://files.pythonhosted.org/packages/55/83/8fbd034de1f3e907edaa18786d5dd8f6932874edee0826c7cecb5cab03a1/wrapt-2.2.2-cp311-cp311-win32.whl", hash = "sha256:5499236ad1dc116012e2a5dd943f3f31af12fce452128e2bbcbd55a7d3d4d14c", size = 77414, upload-time = "2026-06-20T23:47:55.882Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/9c/23695baa331c6de4e874c3d78b8e0bed92e1d2a274e665b29858f6841672/wrapt-2.2.2-cp311-cp311-win_amd64.whl", hash = "sha256:8636809939152be6ae20a6cef0fed9fe60f411b47847d0426a826884b469e971", size = 80368, upload-time = "2026-06-20T23:47:57.237Z" },
+    { url = "https://files.pythonhosted.org/packages/08/49/40cefc342bf89b234a4490d741290fce781774b831aefb39c25471da96c9/wrapt-2.2.2-cp311-cp311-win_arm64.whl", hash = "sha256:5d0a142f7af07caeb5e5da87493162a7b8efa19ba919e550a746f7446e13fb30", size = 79489, upload-time = "2026-06-20T23:47:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/85/180b40628b23772692a0c76e8030114e1c0ae068470ed531919f0a5f2a4a/wrapt-2.2.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8417fd3c674d3c8023d080292d29301531a12daf8bd938dd419710dd2f464f2b", size = 81484, upload-time = "2026-06-20T23:47:59.924Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f2/21c90f2a16689702e2aaff45795b11018dff2c9b1242bac10d225483f676/wrapt-2.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e7070c7472582e31af3dfc2622b2381a0df7435110a9388ed8db5ffbce67efb", size = 82151, upload-time = "2026-06-20T23:48:01.303Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/b3/7e6e9fcf4fe7e1b69a49fe6cc5a44e8224bab6283c5233c97e132f14908e/wrapt-2.2.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2e096c9d39a59b35b63c9aacfbbbec2088ff51ff1fc31051acc60a07f42f273a", size = 169828, upload-time = "2026-06-20T23:48:02.719Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/43/894f132d857ed5a9904d937baf368badcbe5ea9e436e2f1930fe21c9f1f0/wrapt-2.2.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d1a6050405bf334be33bf66296f113563622972a34900ae6fa60fd283a1a900", size = 171544, upload-time = "2026-06-20T23:48:04.266Z" },
+    { url = "https://files.pythonhosted.org/packages/29/de/3c833e03725b477e9ea34028224dd21a48781830101e4e036f77e8b6b102/wrapt-2.2.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10adb01371408c6de504a6658b9886480f1a4919a83752748a387a504a21df79", size = 160663, upload-time = "2026-06-20T23:48:05.708Z" },
+    { url = "https://files.pythonhosted.org/packages/33/be/27edce350b24e3054d9d047f65f16d4c4d4c1f3f31c4278a1f8a95c723c8/wrapt-2.2.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3442eee2a5798f9b451f1b2cd7518ce8b7e28a2a364696c414460a0e295c012a", size = 169387, upload-time = "2026-06-20T23:48:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c4/9fd9679af8bf38e146652c7f47b6b352c3e5795b4ad1c0b7f94e15ac2aa7/wrapt-2.2.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6c99012a22f735a85eed7c4b86a3e99c30fdd57d9e115b2b45f796264b58d0bf", size = 158849, upload-time = "2026-06-20T23:48:08.91Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/c2/aa6c0c2206803068c6859dabe01f8c84c43744da93d4c67b8946d21655ee/wrapt-2.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3b686cfc008776a3952d6213cb296ed7f45d782a8453936406faa89eac0835ab", size = 168147, upload-time = "2026-06-20T23:48:10.374Z" },
+    { url = "https://files.pythonhosted.org/packages/42/63/3eb25da41049d20ae18fcab2dd8b056e02387c4bfa626cbdfb7c3b872e4f/wrapt-2.2.2-cp312-cp312-win32.whl", hash = "sha256:ef2cce266b5b0b07e19fa82e59673b81142b7a3607c8ed1254113d048ed668da", size = 77734, upload-time = "2026-06-20T23:48:11.769Z" },
+    { url = "https://files.pythonhosted.org/packages/da/09/0390e008a305360948fa9ce69507d041ac12cb2ee5d28e34467e2ee79391/wrapt-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:abf8c20a2d72ee69e16328b3c91342c446e723bfe48bfcc4dded3b9722ac027f", size = 80585, upload-time = "2026-06-20T23:48:13.117Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b3/84c445c66969f2d3457276b183a48c91097d59bbef9af6c075366b0f8c36/wrapt-2.2.2-cp312-cp312-win_arm64.whl", hash = "sha256:c6c64c5d02578bc4c4bca4f0aef1504de933c1d5b4ac2710b9131111459506c8", size = 79553, upload-time = "2026-06-20T23:48:14.5Z" },
+    { url = "https://files.pythonhosted.org/packages/43/fc/f32f4b22c6511173c11d9e541ab4e7d8467a0f1b3455acaf784115d31ff8/wrapt-2.2.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9e8b648270c613720a202d9a45ebabc33261b22c3a839b115ac5bce8c0bb0d69", size = 81296, upload-time = "2026-06-20T23:48:15.881Z" },
+    { url = "https://files.pythonhosted.org/packages/72/06/4d117d5d77a9344776c0248b24dae3d3dd2f58e5f765fa08cf887072e719/wrapt-2.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6fb7e94e8fe3e4c3067bb1653a91cce7c5e83acc119fdd41501b1bf74654617", size = 81841, upload-time = "2026-06-20T23:48:17.262Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ff/63ad96f98eb58a742b1a20d80f21da88924405910149950b912368150468/wrapt-2.2.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb18fc51e813df0d9c98049e3bf2298a5495a648602040e21fa3c7329371159e", size = 167882, upload-time = "2026-06-20T23:48:18.764Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1f/8bb62d8933df7acf3247194e6e9fc68edf9d2fa203252c89c94b319dd472/wrapt-2.2.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94b00b00f806eb3ef2abe9049ed45994a81ee9284884d96e6b8314927c6cea3d", size = 167411, upload-time = "2026-06-20T23:48:20.315Z" },
+    { url = "https://files.pythonhosted.org/packages/17/09/8789dcb09ee1de715727db7521aabbb68ffa68dfade3a49468440cfced49/wrapt-2.2.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:62415fd095bc590b842b6d092f2b5d9ccbaeb7e0b28535c03dcea2718b48636b", size = 158607, upload-time = "2026-06-20T23:48:21.728Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/66e02562d53ee67d841f175e38e3c993c2d78a3e104c576cad61c028b43c/wrapt-2.2.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a41e758d80dc0ab8c210f641ac892009d356cf1f955d97db544c8dd317b4d14c", size = 166367, upload-time = "2026-06-20T23:48:23.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a3/832ac4e41222fb263b3042d42c2f08d305db7d0f0c9b1d3a271a9eede8f6/wrapt-2.2.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b84cd4058001c9727b0e9980b7a9e66325b5ca748b1b578e822cade1bc6b304f", size = 157176, upload-time = "2026-06-20T23:48:24.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/01/1bd5e4d2df9c0178989ac8da9186543465388588ee2ef153e2591accebef/wrapt-2.2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:26fc73a1b15e0946d2942b9a4426d162b51676338327dc067ccd8d2d76385f94", size = 167025, upload-time = "2026-06-20T23:48:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/69/583ed25291ab53e1ec117135fb1c33425e2f46d2bc8f29c17f7a94cf4274/wrapt-2.2.2-cp313-cp313-win32.whl", hash = "sha256:3c4095803491f6ef72128914c28ec05bbad9758433bb35f6715a3e9c8e46fb2d", size = 77605, upload-time = "2026-06-20T23:48:27.643Z" },
+    { url = "https://files.pythonhosted.org/packages/29/68/e69fc6d06e1523c68e0d00f95c9aed1158ce9908ee41603f7f2eae3d5db6/wrapt-2.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:2cb07f414fab25dbe6b5c7398e1491423a5c81a6209533639969a6c928d474a4", size = 80508, upload-time = "2026-06-20T23:48:29.013Z" },
+    { url = "https://files.pythonhosted.org/packages/55/21/fe7a393d9e5dc0923bed8f5d857e9dcff210f1fa0888c02cc8f3ffaa55aa/wrapt-2.2.2-cp313-cp313-win_arm64.whl", hash = "sha256:1fc7691f070220215cccb2a20836b9adbaecb8ff22ad47abe63de5f110994fac", size = 79565, upload-time = "2026-06-20T23:48:30.429Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e5/c120d13bf5091164f68c3c1657e84f16f57e71d978421b626393ac5bd7eb/wrapt-2.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ec8f83949028366531383603139403cac7a826e4011955813cdd640017845ce5", size = 83264, upload-time = "2026-06-20T23:48:31.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b0/d4a1eb97e0e286625bdf21bc7f702637f9607787ffbbdb5ec14d50c79dbf/wrapt-2.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4b481fb0c40d9fd90a5809911208da700987d373a20a4709dc9e3944af7a6bec", size = 83791, upload-time = "2026-06-20T23:48:33.482Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1e/f060df47755e87b57684cee7bfc1362b204df55fac96ffebc0631b697b79/wrapt-2.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0065a3b657cec06813b4241d2462ccec287f6863103d7445b725fb3a889736f9", size = 203399, upload-time = "2026-06-20T23:48:34.97Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/de/2316a757a1abb6453700b79d83e532146dcef2611348282d4d8889792161/wrapt-2.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30f7424af5c5c345b7f26490e097f74a2ef45b3d08b664dc33571aee3bd3b56c", size = 210461, upload-time = "2026-06-20T23:48:36.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/29/d1160785ae18ca2495a6d82a21154103d74f656c9fd457fb35f6b11b965a/wrapt-2.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:07fdcb012821859168641acf68afad61ef9783cf37100af85f152550e9677194", size = 195313, upload-time = "2026-06-20T23:48:38.175Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/2d/7caa9598ae61a9cf0989cc501739cbeeb7d650ab3193cca1407b9af0c6ab/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f90038ab58fafb584801ca62d72384d7d5225d93c76f7b773c22fae545bd8066", size = 206116, upload-time = "2026-06-20T23:48:39.804Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/02/281ea1088b8650d865f311b35cf86fd21df89128e2909714f1161e01c9d0/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c5d7825491bfa2d08b97e9557768987952c7b9ae687d06c3320b40a37ccb7f20", size = 192668, upload-time = "2026-06-20T23:48:41.346Z" },
+    { url = "https://files.pythonhosted.org/packages/be/7d/976e2d5b4b5c5babda40974edd54d0a5585cb60132ed86b46f4b80239b16/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ad520e6daa9bbf136f14de735474dbec7dcc0891f718e1d274ce8dc92e645af", size = 198891, upload-time = "2026-06-20T23:48:43.056Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b7/e47651797c097f75a37e2ce86dcf04048ff576f3a674f7c558df7b5e9622/wrapt-2.2.2-cp313-cp313t-win32.whl", hash = "sha256:25904acb9475f46c24fe0423dbc8fda8cc5fbc282ab3dc6e72e919748c53f4e9", size = 78537, upload-time = "2026-06-20T23:48:44.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/6f/9fa5d59fb06d890defb5a8f727ce6a14d2932c8760153f96956628559fee/wrapt-2.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:305d4c247d61c4115794a169141823c62f719525ddb90b23aa332741c77d2c28", size = 82005, upload-time = "2026-06-20T23:48:46.391Z" },
+    { url = "https://files.pythonhosted.org/packages/15/80/4c7bd9873d1f9f7d138d93556b500469dbe24f42710b877519c2b9eb380d/wrapt-2.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c20279cd1a29800815d7b2d6338b60a6c6e78263f9d6e62e0eda251ba9cae2d0", size = 80762, upload-time = "2026-06-20T23:48:47.964Z" },
+    { url = "https://files.pythonhosted.org/packages/24/05/7fd9c3f83b2c74cbfc572a0b88aa37431e04bd8aed70d2c0efd3464206de/wrapt-2.2.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0e64826f920c42d9d9f87e8cc09ffae66c51ede12d59061a5a426deb9aa71745", size = 81341, upload-time = "2026-06-20T23:48:49.39Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/68/1bfa43100dd90d4ef74a05897b86275cf57e1313ca14aae2545bc9f872c9/wrapt-2.2.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dcaa5e1451bd8751d7bd1568dfa3321c78092a52a7ecb5d1a0f18a5791e1fd00", size = 81921, upload-time = "2026-06-20T23:48:50.986Z" },
+    { url = "https://files.pythonhosted.org/packages/74/eb/df7b7f0b631dbbc750f39be27d8b55f65777d8ac86da80e12be41a644c4b/wrapt-2.2.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0abfd648dac9ac9c5b3aa9b523d27f1789046640b58dcd5652a720ddb325e1fc", size = 167713, upload-time = "2026-06-20T23:48:52.598Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9a/d1bd36f6d088c8e652a9383cabbd49af30b8c576302a7eccddbab6963e3f/wrapt-2.2.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f4bfd8d1eb438153eff8b8cfe87f032ba65731e1ce06138b5090f745a33f6f95", size = 166779, upload-time = "2026-06-20T23:48:54.33Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ae/24ffacd4187fac2740a1972093929e836dea092d42c87d728cd98fee11a6/wrapt-2.2.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c427c9d06d859848a69f0d928fe28b5c33a941b2265d10a0e1f15cd244f1ee33", size = 158407, upload-time = "2026-06-20T23:48:55.944Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ed/974427668249a356051e8d67d47fa54ef6c777f0fcf3bae9d292c047d4b6/wrapt-2.2.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4250b43d1a129d947e083c4dc6baf333c9bb34edd26f912d5b0457841fc858ab", size = 166594, upload-time = "2026-06-20T23:48:57.617Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/5f/e1d7c6e4523f78db2fbd7826babd0348da1d5e0834c4f918b9ab5757dfae/wrapt-2.2.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:173e5bb5ca350a6e0abab60b7ec7cdd7992a814cb14b4de670a28f067f105663", size = 157068, upload-time = "2026-06-20T23:48:59.171Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c1/7ebd1027f00700c0b0233b20aceef2b4784294ed64971424c4a78e069e34/wrapt-2.2.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aa14b01804bce36c6d63d7b6a4f55df390f29f8648cc13a1f40b166f4d54680d", size = 166470, upload-time = "2026-06-20T23:49:00.737Z" },
+    { url = "https://files.pythonhosted.org/packages/99/eb/974e471a6a978b8180186b8a9dc5ae3361ce269a967190b709b8ce17abfb/wrapt-2.2.2-cp314-cp314-win32.whl", hash = "sha256:58f9f8d637c9a6e245c6ef5b109b67ec187d2faed23d1405656b51d96e0a5b56", size = 78062, upload-time = "2026-06-20T23:49:02.327Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ec/e1281156cdc7a66693838ad7a0865ad641c74abd337a957d668b575aaffb/wrapt-2.2.2-cp314-cp314-win_amd64.whl", hash = "sha256:385cb1866f20479e83299af585375bfa0a4b0c6c9907a981483ea782ea8ae406", size = 80832, upload-time = "2026-06-20T23:49:03.837Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7d/1b6b5ddd94005a2dac97a4490c9838f3154977850d633abcb65b30089437/wrapt-2.2.2-cp314-cp314-win_arm64.whl", hash = "sha256:8ffbeaea6771a6eba6e6eeb09767864995726bc8240bb54baf88a9bb1db34d5c", size = 80029, upload-time = "2026-06-20T23:49:05.237Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/33/9ebcf8aafe91c601127cbd93708c16aa8f688f34a10bf004046803ecdc4f/wrapt-2.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:09f811d43f6f33ec7515f0be76b159569f4057ab54d3e079c3204dddb90afa2a", size = 83357, upload-time = "2026-06-20T23:49:06.632Z" },
+    { url = "https://files.pythonhosted.org/packages/39/38/ec45b635153327b52e52732a0ea980e5f00b7efba65f9e018828f1e69daa/wrapt-2.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a795d3c06e5fbf9ea2f13196180b77aeab1b4685917256ee0d014cc163d90063", size = 83794, upload-time = "2026-06-20T23:49:08.098Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ea/1a89e6d3b7a83c3affe5c09cde77792c947e63e4bc85ad84cd5bb9abb0d8/wrapt-2.2.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:45c2f2768e790c9f8db90f239ef23a2af8e7570f25a35619ef902df4a738447f", size = 203362, upload-time = "2026-06-20T23:49:09.811Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d8/3b58763d9863b5a73771c0d97110f9595d248db454009e07e1535ee905a4/wrapt-2.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbf00ee0cb55ec24e2b0995a71942b85b21a066db8f3f46e1dbfdb9433ffba81", size = 210449, upload-time = "2026-06-20T23:49:11.521Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/6f/17fd9e053103d8be148d20d5d7505facc72d5fe1f9127973904ceaed79cf/wrapt-2.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2252f77663651b89255895f58cc6ac08fcb206d4371813e5af61bb62d4f7689c", size = 195349, upload-time = "2026-06-20T23:49:13.346Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/04/d0d1ccaaa12cb7dccf28a23f0279a608ba498f71e81d949d5ed54bcfd5c1/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2cd7181ab1c31192ff5219269830744b5a62020b3a6d433588c4f1c95b8f8bff", size = 206099, upload-time = "2026-06-20T23:49:15.051Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/e8aa07b619890a2aa6cde1931b1887abb08820721b564a5f80b7ca3f3aa0/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6fe35fd51b74867d8b80174c277bd6bbf6a73e443f908129dc531c4b688a20d5", size = 192728, upload-time = "2026-06-20T23:49:16.854Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f0/1819fb50f0d3c9bd758d8a83b56f1b470dee8b5b8eac8702b7c137cea9d4/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:11d95fc2fbad3163596c39d440e6f21ca9fccece74b56e30a37ac2fca786a07c", size = 198842, upload-time = "2026-06-20T23:49:18.504Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7c/e88313f16a99930b899ef970d91c281544a470749a359decad994483bbda/wrapt-2.2.2-cp314-cp314t-win32.whl", hash = "sha256:d8a15813215f33fa83667bfc978b300e35669ea8bb424e970a1426bcb7bc6cca", size = 79059, upload-time = "2026-06-20T23:49:20.107Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/4f/ac12fda57a55068a094ec42851fb0a40e8489d8941863d517452de62e507/wrapt-2.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d09db0f7e8357060d3c38fc22a018aba683a796bf184360fd1a58f6fc180dc77", size = 82462, upload-time = "2026-06-20T23:49:21.631Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/df732dac86d9b2027c56bd163dbc883e037b16c3469614752e148d219c61/wrapt-2.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f32fe639c39561ccc187bcae17e9271be0eb45f1c2952510d2f29b33ab577347", size = 81182, upload-time = "2026-06-20T23:49:23.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d2/6317eb6d4554855bbf12d61857774af34747bf88a42c19bf306de67e2fa3/wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048", size = 61460, upload-time = "2026-06-20T23:49:42.966Z" },
+]
+
+[[package]]
 name = "xyzservices"
 version = "2026.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f6/08/3cb9f67a8d48021aca2a02292cc26eecd71d949ae70ad66420a8730cc302/xyzservices-2026.3.0.tar.gz", hash = "sha256:d226866a5d8e9fef337034d8da37a8298f0a1d9d1489b4018e69579eb321fea4", size = 1135736, upload-time = "2026-03-30T14:42:25.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/a9/d23012099dc88ec69a29c6407b41d89681cb674c2043cd5b467c7e299c08/xyzservices-2026.3.0-py3-none-any.whl", hash = "sha256:503183d4b322bfebc3c50cdd21192aa3e81e36c5efbf9133d54ae82143e0576b", size = 94101, upload-time = "2026-03-30T14:42:24.608Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
 ]


### PR DESCRIPTION
#### Overview:

Backports #1244 to release/0.10.0.

#### Details:

- Cherry-picks source commit a3a070349c04795ab5ff375e269f0ede6664575f.
- Contains exactly one commit based directly on release/0.10.0.
- The backport patch is identical to the original merged patch and preserves its DCO sign-offs.

#### Validation:

- Targeted CLI, Spica, and generator tests: 294 passed, 3 skipped
- Wheel build: passed; all 16 Spica package files included
- Real Spica E2E: left to the dedicated opt-in CI job
- git diff --check: passed

#### Where should the reviewer start?

See the original PR: https://github.com/ai-dynamo/aiconfigurator/pull/1244

#### Related Issues:

- Relates to #1244
