### PR TITLE
fix(sdk): stop double-counting MTP activation in KV-cache capacity estimate (cherry-pick #1228)

### DIFF
--- a/src/aiconfigurator/sdk/backends/base_backend.py
+++ b/src/aiconfigurator/sdk/backends/base_backend.py
@@ -1535,6 +1535,7 @@ class BaseBackend:
         prefix: int = 0,
         max_seq_len: int | None = None,
         encoder_memory: dict[str, float] | None = None,
+        mtp_activation_scaling: bool = True,
     ) -> dict[str, float]:
         """
         Get the memory usage of the backend.
@@ -1545,6 +1546,13 @@ class BaseBackend:
             max_seq_len: per-slot KV cache pre-allocation budget. Defaults to
                 ``isl + beam_width * osl`` when not supplied.
             encoder_memory: optional colocated encoder component to add to this worker.
+            mtp_activation_scaling: whether to scale activation by ``(nextn + 1)`` for
+                speculative decoding (see the MTP correction below). True for the
+                latency sweep, where ``num_tokens`` is the per-step token count that the
+                multiplier turns into the verified ``nextn + 1`` tokens. False for the
+                KV-cache capacity path, where ``num_tokens`` is the engine's
+                ``max_num_tokens`` budget that already caps total per-forward tokens
+                (draft tokens included), so re-multiplying would double-count.
         """
         weights = 0.0
         for op in model.context_ops:
@@ -1579,8 +1587,13 @@ class BaseBackend:
 
         activations = max(activations, self.MIN_ACTIVATION_BYTES)
 
-        # MTP correction: additional activation memory for draft tokens (applies to all models)
-        if model.config.nextn > 0:
+        # MTP correction: speculative decoding verifies nextn+1 tokens per decode step,
+        # so the decode-phase activation scales with (nextn+1). Suppressed on the
+        # KV-cache capacity path (mtp_activation_scaling=False), where num_tokens is the
+        # engine's max_num_tokens budget that already caps total per-forward tokens
+        # (draft tokens included) -- re-multiplying there double-counts and can drive the
+        # prefill worker's KV budget negative.
+        if mtp_activation_scaling and model.config.nextn > 0:
             activations = activations * (model.config.nextn + 1)
 
         # Backend-level activation overhead (SGLang only by default).

--- a/src/aiconfigurator/sdk/memory.py
+++ b/src/aiconfigurator/sdk/memory.py
@@ -268,13 +268,15 @@ class KVCacheEstimator:
     ) -> KVCacheEstimator:
         """Build the model/backend/perf-DB and the non-KV memory breakdown.
 
-        Reuses the exact AIC machinery the latency path uses: ``_build_model_config``
-        + ``_apply_nextn`` (so speculative/MTP requests scale activation memory) +
-        ``get_model`` (quant inferred inside ``get_model``), ``get_backend``, and
+        Reuses the exact AIC machinery the latency path uses: ``build_model_config``
+        + ``apply_nextn`` (so the built model is spec-decode aware) + ``get_model``
+        (quant inferred inside ``get_model``), ``get_backend``, and
         ``perf_database.get_database``. Calls ``BaseBackend._get_memory_usage`` with
-        ``num_tokens = max_num_tokens`` (so activations track
-        ``BuildConfig.max_num_tokens`` the way TRT-LLM's
-        ``_memory_usage_kwargs_for_agg`` does); ``isl``/``osl``/``max_seq_len`` only
+        ``num_tokens = max_num_tokens`` and ``mtp_activation_scaling=False`` (so
+        activations track ``BuildConfig.max_num_tokens`` -- the engine's per-iteration
+        token budget that already bounds draft tokens -- the way TRT-LLM's
+        ``_memory_usage_kwargs_for_agg`` does, without re-applying the ``(nextn+1)``
+        decode multiplier); ``isl``/``osl``/``max_seq_len`` only
         feed the discarded ``kvcache`` key, so they are set to a neutral ``1``. Note
         ``max_batch_size`` does NOT affect non-KV memory (activations use
         ``num_tokens``, KV is recomputed per token), but it is accepted to mirror the
@@ -297,10 +299,10 @@ class KVCacheEstimator:
             moe_quant_mode=moe_quant_mode,
             comm_quant_mode=comm_quant_mode,
         )
-        # Apply nextn/MTP onto the config BEFORE get_model: _get_memory_usage reads
-        # model.config.nextn to scale activation memory for speculative decoding, so
-        # skipping this would size non-KV memory as if nextn=0 and overstate the KV
-        # budget. Mirrors the agg/disagg/static estimate paths in cli.api.
+        # Apply nextn/MTP onto the config BEFORE get_model so the built model is
+        # spec-decode aware (e.g. for any draft-module weights). This does NOT scale
+        # the capacity activation by (nextn+1); that multiplier is suppressed below
+        # (see mtp_activation_scaling). Mirrors the agg/disagg/static estimate paths.
         apply_nextn(model_config, nextn, nextn_accept_rates)
         model = get_model(model_path, model_config, backend)
         backend_obj = get_backend(backend)
@@ -309,6 +311,16 @@ class KVCacheEstimator:
         # num_tokens = max_num_tokens -> activations track BuildConfig.max_num_tokens
         # (TRT-LLM `_memory_usage_kwargs_for_agg`). With num_tokens > 0 passed
         # explicitly, isl/osl/max_seq_len only feed the discarded `kvcache` key.
+        #
+        # mtp_activation_scaling=False: max_num_tokens is the engine's per-iteration
+        # token budget, which already caps total per-forward tokens INCLUDING the nextn
+        # draft tokens. The latency sweep's (nextn+1) activation multiplier would
+        # double-count here -- it inflated the prefill worker's non-KV memory past GPU
+        # capacity and drove the KV budget negative once the draft length grew
+        # (AIC-1110). With it suppressed the breakdown is nextn-independent: the draft
+        # module's marginal weight/KV cost (~nextn extra layers) is not separately
+        # modeled, so the estimate slightly OVERSTATES available KV (an optimistic
+        # approximation) -- but far closer to reality than the gross prior over-count.
         memory = backend_obj._get_memory_usage(
             model,
             database,
@@ -319,6 +331,7 @@ class KVCacheEstimator:
             num_tokens=int(max_num_tokens),
             prefix=0,
             max_seq_len=1,
+            mtp_activation_scaling=False,
         )
 
         weights_bytes = float(memory["weights"]) * _ONE_GIB

--- a/tests/integration/test_memory_estimation.py
+++ b/tests/integration/test_memory_estimation.py
@@ -201,3 +201,59 @@ def test_estimate_num_gpu_blocks_floor_conversion(case):
     assert blocks_tol == adj_tokens // _BLOCK_SIZE
     assert blocks_tol <= blocks_raw
     assert math.floor(adj_tokens / _BLOCK_SIZE) == blocks_tol
+
+
+# Regression: AIC-1110 — Kimi-K2.5 + GB200 DEP4 prefill worker with Eagle (nextn).
+# A prefill/context worker never verifies nextn+1 tokens, so the MTP draft only adds
+# its own ~nextn draft-layer activation (a few %), NOT a full (nextn+1)x of the whole
+# context activation. The blanket `activations *= (nextn+1)` in _get_memory_usage
+# inflated prefill non-KV memory past GPU capacity, so estimate_kv_cache raised
+# "no KV budget" once the draft length grew — the worker could not start.
+_EAGLE_PREFILL_CASE = dict(
+    model_path="moonshotai/Kimi-K2.5",
+    system="gb200",
+    backend="trtllm",
+    backend_version="1.3.0rc10",
+    # A realistic long-context prefill chunk (the reporter's agentic workload runs up
+    # to ~200k ISL); the over-count scales with the chunk, so it surfaces here at a
+    # modest draft length rather than only at nextn>=4 with an 8k chunk.
+    max_num_tokens=16384,
+    max_batch_size=1,
+    memory_fraction_kind="of_free",
+    memory_fraction_value=0.9,
+    tp_size=1,
+    pp_size=1,
+    attention_dp_size=4,
+    moe_tp_size=1,
+    moe_ep_size=4,
+    gemm_quant_mode="nvfp4",
+    moe_quant_mode="nvfp4",
+    kvcache_quant_mode="fp8",
+)
+
+
+@pytest.mark.parametrize("nextn", [1, 2, 3])
+def test_eagle_prefill_kv_budget_nonnegative_kimi_gb200(nextn):
+    """AIC-1110: a feasible Eagle draft length must not drive the prefill KV budget negative.
+
+    Also pins the post-fix invariant: because ``max_num_tokens`` already bounds the
+    per-forward tokens (draft tokens included), the capacity breakdown is independent
+    of ``nextn`` -- the activation must match the ``nextn=0`` baseline exactly, not be
+    scaled by ``(nextn+1)`` as the latency sweep does.
+    """
+    try:
+        baseline = memory.estimate_kv_cache(**_EAGLE_PREFILL_CASE, nextn=0)
+        est = memory.estimate_kv_cache(**_EAGLE_PREFILL_CASE, nextn=nextn)
+    except ValueError as exc:
+        # A genuinely-missing perf DB / model soft-skips; the "no KV budget" regression
+        # (any other ValueError) is re-raised by the helper and fails the test.
+        _skip_if_fixture_unavailable(exc)
+
+    # Non-negative budget for any feasible draft length (the reported failure).
+    assert est["total_kv_size_bytes"] > 0
+    assert est["total_kv_size_tokens"] > 0
+
+    # nextn-independence: activation (and hence the whole non-KV breakdown and budget)
+    # must not grow with the draft length on the capacity path.
+    assert est["memory_breakdown"]["activations_bytes"] == baseline["memory_breakdown"]["activations_bytes"]
+    assert est["total_kv_size_bytes"] == baseline["total_kv_size_bytes"]


### PR DESCRIPTION
#### Overview:

Backports #1228 to release/0.10.0.

#### Details:

- Cherry-picks source commit 2cd0c07f2dd8ef0efa7e3ba4cfafe04d7b087413.
- Contains exactly one commit based directly on release/0.10.0.
- The backport patch is identical to the original merged patch and preserves its DCO sign-offs.

#### Validation:

- tests/integration/test_memory_estimation.py: 10 passed
- git diff --check: passed

#### Where should the reviewer start?

See the original PR: https://github.com/ai-dynamo/aiconfigurator/pull/1228

#### Related Issues:

- Relates to #1228
