### PR TITLE
fix(sdk): respect effective perf-data exception chain

### DIFF
--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -139,7 +139,7 @@ def build_no_databases_message() -> str:
 
 
 def has_perf_data_not_available_cause(error: BaseException) -> bool:
-    """Return True when an exception or chained cause is a structured perf-data miss."""
+    """Return True when an exception's effective chain has a structured perf-data miss."""
     seen: set[int] = set()
     stack: list[BaseException] = [error]
     while stack:
@@ -151,7 +151,7 @@ def has_perf_data_not_available_cause(error: BaseException) -> bool:
         seen.add(id(current))
         if current.__cause__ is not None:
             stack.append(current.__cause__)
-        if current.__context__ is not None:
+        elif not current.__suppress_context__ and current.__context__ is not None:
             stack.append(current.__context__)
     return False
 

--- a/tests/unit/sdk/database/test_perf_database_errors.py
+++ b/tests/unit/sdk/database/test_perf_database_errors.py
@@ -17,12 +17,43 @@ from aiconfigurator.sdk.performance_result import PerformanceResult
 pytestmark = pytest.mark.unit
 
 
-def test_perf_data_cause_detection_traverses_cause_and_context() -> None:
+def test_perf_data_cause_detection_accepts_direct_error() -> None:
+    error = PerfDataNotAvailableError("missing perf data")
+
+    assert has_perf_data_not_available_cause(error)
+
+
+def test_perf_data_cause_detection_accepts_explicit_cause() -> None:
+    error = RuntimeError("outer")
+    error.__cause__ = PerfDataNotAvailableError("missing perf data")
+
+    assert has_perf_data_not_available_cause(error)
+
+
+def test_perf_data_cause_detection_accepts_implicit_context() -> None:
+    error = RuntimeError("outer")
+    error.__context__ = PerfDataNotAvailableError("missing perf data")
+
+    assert has_perf_data_not_available_cause(error)
+
+
+def test_perf_data_cause_detection_prefers_explicit_cause() -> None:
     error = RuntimeError("outer")
     error.__cause__ = RuntimeError("explicit cause")
     error.__context__ = PerfDataNotAvailableError("missing perf data")
 
-    assert has_perf_data_not_available_cause(error)
+    assert not has_perf_data_not_available_cause(error)
+
+
+def test_perf_data_cause_detection_ignores_suppressed_context() -> None:
+    try:
+        try:
+            raise PerfDataNotAvailableError("missing perf data")
+        except PerfDataNotAvailableError:
+            raise KeyError("real bug while handling perf-data miss") from None
+    except KeyError as error:
+        assert error.__suppress_context__
+        assert not has_perf_data_not_available_cause(error)
 
 
 def test_perf_data_cause_detection_avoids_cycles() -> None:


### PR DESCRIPTION
## Summary

Follow Python effective exception-chain semantics when detecting `PerfDataNotAvailableError`:

- prefer an explicit `__cause__`
- otherwise traverse only an unsuppressed `__context__`
- retain tracebacks for genuine errors raised while handling a perf-data miss

The regression coverage now includes direct errors, explicit causes, implicit contexts, explicit-cause precedence, `raise ... from None`, and cycles.

Follow-up to #1239 and the deferred review finding in https://github.com/ai-dynamo/aiconfigurator/pull/1239#discussion_r3500448934.

## Testing

- `pytest -m unit`: 1727 passed, 39 skipped
- `pytest tests/unit/sdk/database/test_perf_database_errors.py`: 14 passed
- `pytest tests/unit/cli/test_cli_workflow.py`: 55 passed
- `ruff check` and `ruff format --check` on changed files
- `git diff --check`