### PR TITLE
chore(codeowners): cover Rust and Spica

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,6 +24,10 @@
 /src/aiconfigurator/model_configs/ @ai-dynamo/aiconfigurator-runtime @ai-dynamo/maintainers-aiconfigurator
 /src/aiconfigurator/webapp/ @ai-dynamo/aiconfigurator-runtime @ai-dynamo/maintainers-aiconfigurator
 
+# Rust core and Spica sweeper
+/rust/aiconfigurator-core/ @ai-dynamo/aiconfigurator-runtime @ai-dynamo/maintainers-aiconfigurator @tedzhouhk @peabrane @dreamtalen
+/spica/ @ai-dynamo/aiconfigurator-runtime @ai-dynamo/maintainers-aiconfigurator @tedzhouhk @peabrane @dreamtalen
+
 # Config generation, CLI, eval, and automation tooling
 /src/aiconfigurator/generator/ @ai-dynamo/aiconfigurator-generators @ai-dynamo/maintainers-aiconfigurator
 /src/aiconfigurator/cli/ @ai-dynamo/aiconfigurator-generators @ai-dynamo/maintainers-aiconfigurator


### PR DESCRIPTION
## Summary

- Add CODEOWNERS coverage for the Rust `aiconfigurator-core` crate and the Spica sweeper.
- Assign the AIConfigurator runtime and maintainer teams, plus `@tedzhouhk`, `@peabrane`, and `@dreamtalen`.

## Validation

- `git diff --check origin/main...HEAD`
- No runtime tests needed (CODEOWNERS-only change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership coverage for the Rust core and sweeper areas, helping route future changes to the appropriate maintainers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->