### PR TITLE
fix(cli): convert estimate-mode validation errors to concise CLI errors

### DIFF
--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -2258,7 +2258,14 @@ def main(args):
 
     # Handle estimate mode separately (single-point estimation)
     if args.mode == "estimate":
-        _run_estimate_mode(args)
+        # Invalid sizing/parameters surface as ValueError from the SDK
+        # validation path (e.g. AFD f_moe_ep_size not dividing f_tp_size).
+        # Convert to a concise CLI error instead of a full traceback,
+        # matching the set_systems_paths convention above.
+        try:
+            _run_estimate_mode(args)
+        except ValueError as exc:
+            raise SystemExit("Error: " + str(exc)) from exc
         return
 
     if args.mode == "default":

--- a/tests/unit/cli/test_afd_phase_completion.py
+++ b/tests/unit/cli/test_afd_phase_completion.py
@@ -804,3 +804,32 @@ def test_cli_estimate_afd_phase_both_with_combined_with_pd_raises(monkeypatch):
         api.cli_estimate(
             **_afd_cli_estimate_kwargs(afd_phase="both", afd_combined_with_pd=True),
         )
+
+
+def test_cli_main_estimate_value_error_exits_without_traceback(monkeypatch):
+    """Estimate-mode validation errors surface as a concise CLI error.
+
+    Invalid AFD sizing (e.g. ``f_moe_ep_size`` not dividing ``f_tp_size``)
+    raises ``ValueError`` deep in the SDK. ``cli.main.main`` must convert it
+    to ``SystemExit`` so the user sees the actionable message instead of a
+    full Python traceback.
+    """
+    from types import SimpleNamespace
+
+    import aiconfigurator.cli.main as cli_main
+    import aiconfigurator.sdk.perf_database as perf_database
+
+    monkeypatch.setattr(perf_database, "set_systems_paths", lambda _paths: None)
+    monkeypatch.setattr(
+        cli_main,
+        "_run_estimate_mode",
+        lambda _args: (_ for _ in ()).throw(ValueError("f_moe_ep_size (7) must be a positive divisor")),
+    )
+
+    args = SimpleNamespace(mode="estimate", systems_paths=None, top_n=5, no_color=True)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(args)
+
+    # SystemExit carries the plain message (no traceback, exit code 1).
+    assert "f_moe_ep_size (7) must be a positive divisor" in str(exc_info.value)


### PR DESCRIPTION
## Problem

`aiconfigurator cli estimate` with invalid sizing surfaces SDK validation
errors as a full Python traceback instead of a concise CLI message.

For example, AFD estimate where `f_moe_ep_size` does not divide `f_tp_size`
raises a `ValueError` deep in the SDK. Because estimate mode calls
`_run_estimate_mode(args)` directly, the actionable message is delivered
through an unhandled exception — the user sees internal stack frames and the
process exits via an uncaught `ValueError`.

## Fix

Wrap `_run_estimate_mode(args)` in a narrow `ValueError` → `SystemExit`
conversion, matching the existing `set_systems_paths` convention a few lines
above. The user now sees a clean `Error: ...` line (exit code 1, no traceback)
while the actionable validation message is preserved.

## Test

Added `test_cli_main_estimate_value_error_exits_without_traceback`, which
asserts that a `ValueError` raised from estimate mode is converted to
`SystemExit` carrying the plain message. Full `test_afd_phase_completion.py`
suite passes (15/15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI error handling in estimate mode so validation errors now exit cleanly with a concise message instead of showing a traceback.
  * The original error text is preserved to help users understand what went wrong.
* **Tests**
  * Added coverage to verify the CLI exits with the expected user-friendly error message when estimate mode validation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->