### PR TITLE
fix: report expected "no results" sweep outcomes cleanly (cherry-pick #1239)

### DIFF
--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -23,7 +23,11 @@ from aiconfigurator.generator.api import (
 )
 from aiconfigurator.logging_utils import setup_logging
 from aiconfigurator.sdk import common, perf_database
-from aiconfigurator.sdk.errors import NoFeasibleConfigError, UnsupportedWideepConfigError
+from aiconfigurator.sdk.errors import (
+    NoFeasibleConfigError,
+    UnsupportedWideepConfigError,
+    is_expected_no_result_cause,
+)
 from aiconfigurator.sdk.models import check_is_moe
 from aiconfigurator.sdk.task_v2 import Task
 from aiconfigurator.sdk.utils import ListFlowDumper, get_model_config_from_model_path
@@ -1564,7 +1568,9 @@ def _execute_tasks(
             logger.warning(msg)
             failure_messages.append(msg)
         except Exception as exc:
-            if perf_database.has_perf_data_not_available_cause(exc):
+            if is_expected_no_result_cause(exc) or perf_database.has_perf_data_not_available_cause(exc):
+                # Expected failure (no feasible config / OOM / KV-cache capacity, or
+                # a per-op perf-data miss): report cleanly without a scary traceback.
                 logger.log(logging.ERROR, "Error running experiment %s: %s", exp_name, exc)
             else:
                 logger.exception("Error running experiment %s", exp_name)

--- a/src/aiconfigurator/sdk/errors.py
+++ b/src/aiconfigurator/sdk/errors.py
@@ -4,8 +4,36 @@
 """Shared SDK exception types."""
 
 
-class NoFeasibleConfigError(RuntimeError):
+class NoResultsError(RuntimeError):
+    """Base class for *expected* "the sweep produced no results" outcomes.
+
+    These are not bugs: they mean a sweep ran to completion but every parallel
+    configuration was ruled out for an understood reason (SLA infeasible, OOM,
+    KV-cache capacity). They carry an actionable message and should be reported
+    cleanly (no Python traceback), unlike a genuine crash.
+
+    A per-op data miss (``PerfDataNotAvailableError``) is deliberately NOT in
+    this family -- it can be skipped on one config while others still produce
+    results -- and has its own recognizer ``has_perf_data_not_available_cause``.
+
+    Subclasses ``RuntimeError`` so existing ``except RuntimeError`` / ``except
+    Exception`` callers (e.g. the per-config sweep catch, support-matrix) keep
+    catching them unchanged. Recognize the whole family via
+    :func:`is_expected_no_result_cause`, which walks the exception chain so a
+    generic wrapper raised ``from`` one of these is still classified correctly.
+    """
+
+
+class NoFeasibleConfigError(NoResultsError):
     """Raised when no configuration satisfies user-provided SLA constraints."""
+
+
+class InsufficientMemoryError(NoResultsError):
+    """Raised when the model does not fit in GPU memory for any parallel config."""
+
+
+class KVCacheCapacityError(NoResultsError):
+    """Raised when the requested batch size exceeds KV-cache capacity for all configs."""
 
 
 class UnsupportedWideepConfigError(ValueError):
@@ -16,7 +44,14 @@ class UnsupportedWideepConfigError(ValueError):
 
 
 class PerfDataNotAvailableError(RuntimeError):
-    """Raised when required performance data is missing for a requested mode."""
+    """Raised when required performance data is missing or unsupported for a requested mode.
+
+    This is a *per-op* data-miss raised deep inside a single config's evaluation
+    (and in non-sweep paths like validate / single-point estimate), so it is
+    deliberately NOT a :class:`NoResultsError`: a miss on one config can be
+    skipped while other configs still produce results. Recognize it via
+    ``has_perf_data_not_available_cause`` in ``perf_database``.
+    """
 
 
 class EmpiricalNotImplementedError(RuntimeError):
@@ -30,3 +65,28 @@ class EmpiricalNotImplementedError(RuntimeError):
     than as a fabricated number. Genuinely table-less ops (mem / p2p /
     element-wise) keep their own analytic formulas and never reach here.
     """
+
+
+def is_expected_no_result_cause(error: BaseException) -> bool:
+    """Return True when ``error`` or its effective chain has a NoResultsError.
+
+    Follows an explicit ``__cause__`` or an unsuppressed ``__context__`` so a
+    generic wrapper such as
+    ``RuntimeError(...) from InsufficientMemoryError(...)`` is recognized as an
+    expected no-result outcome, while a wrapper around a genuine bug (e.g. an
+    unexpected ``KeyError``) returns False and keeps its traceback.
+    """
+    seen: set[int] = set()
+    stack: list[BaseException] = [error]
+    while stack:
+        current = stack.pop()
+        if id(current) in seen:
+            continue
+        if isinstance(current, NoResultsError):
+            return True
+        seen.add(id(current))
+        if current.__cause__ is not None:
+            stack.append(current.__cause__)
+        elif not current.__suppress_context__ and current.__context__ is not None:
+            stack.append(current.__context__)
+    return False

--- a/src/aiconfigurator/sdk/sweep.py
+++ b/src/aiconfigurator/sdk/sweep.py
@@ -41,7 +41,11 @@ import pandas as pd
 from aiconfigurator.sdk import common, config
 from aiconfigurator.sdk.backends.base_backend import BaseBackend
 from aiconfigurator.sdk.backends.factory import get_backend
-from aiconfigurator.sdk.errors import NoFeasibleConfigError
+from aiconfigurator.sdk.errors import (
+    InsufficientMemoryError,
+    KVCacheCapacityError,
+    NoFeasibleConfigError,
+)
 from aiconfigurator.sdk.models import get_model
 from aiconfigurator.sdk.perf_database import PerfDatabase
 from aiconfigurator.sdk.predict import predict_agg_worker, predict_disagg_worker
@@ -261,7 +265,7 @@ def _sweep_one_parallel_agg(
     free_gpu_memory_fraction: float | None,
     max_seq_len: int | None,
     predictor: Any = None,
-) -> tuple[pd.DataFrame, bool]:
+) -> tuple[pd.DataFrame, bool, bool]:
     """Sweep batch_size x ctx_tokens for one fixed parallel choice.
 
     Caller is responsible for constructing ``model`` and ``backend`` and
@@ -270,9 +274,10 @@ def _sweep_one_parallel_agg(
     a full recomputation per tpot, ~80x slowdown for an 80-element tpot
     sweep.
 
-    Returns ``(rows_df, all_oom)``.  Logic faithfully reproduces the
-    body of the legacy ``backend.find_best_agg_result_under_constraints``;
-    parity is enforced by the integration test.
+    Returns ``(rows_df, saw_model_fit, saw_memory_fit)``.  Logic faithfully
+    reproduces the body of the legacy
+    ``backend.find_best_agg_result_under_constraints``; parity is enforced by
+    the integration test.
     """
     isl = runtime_config.isl
     osl = runtime_config.osl
@@ -286,7 +291,8 @@ def _sweep_one_parallel_agg(
     results_dict_list: list[dict] = []
     results_per_ops_source: list[dict | None] = []
     capped_b: list[int] = []
-    all_oom = True
+    saw_model_fit = False
+    saw_memory_fit = False
 
     for b in b_list:
         for ctx_tokens in ctx_tokens_list:
@@ -329,23 +335,26 @@ def _sweep_one_parallel_agg(
                 **backend_kwargs,
             )
 
-            if summary.check_oom() or summary.check_kv_cache_oom():
+            model_oom = summary.check_oom()
+            kv_cache_oom = summary.check_kv_cache_oom()
+            saw_model_fit |= not model_oom
+            saw_memory_fit |= not model_oom and not kv_cache_oom
+            if model_oom or kv_cache_oom:
                 break  # ctx_tokens monotonic → larger will also OOM
-            all_oom = False
             result_dict = summary.get_result_dict()
             if result_dict and result_dict["tpot"] <= tpot_target and result_dict["ttft"] <= ttft_target:
                 results_dict_list.append(result_dict)
                 results_per_ops_source.append(summary.get_per_ops_source())
 
     if not results_dict_list:
-        return pd.DataFrame(columns=common.ColumnsAgg), all_oom
+        return pd.DataFrame(columns=common.ColumnsAgg), saw_model_fit, saw_memory_fit
 
     df = pd.DataFrame(results_dict_list, columns=common.ColumnsAgg).round(3)
     df["_per_ops_source"] = results_per_ops_source
     df = df.sort_values(by="seq/s", ascending=False).round(3)
     if top_k > 0:
         df = df.head(top_k)
-    return df, all_oom
+    return df, saw_model_fit, saw_memory_fit
 
 
 def sweep_agg(
@@ -399,13 +408,15 @@ def sweep_agg(
         Deduped, sorted feasible-candidate DataFrame with schema ``common.ColumnsAgg``.
 
     Raises:
-        RuntimeError: When all configs OOM or no point meets SLA.
+        InsufficientMemoryError: When the model does not fit in any config.
+        KVCacheCapacityError: When the model fits but the KV cache does not.
         NoFeasibleConfigError: When SLA cannot be satisfied at any point.
+        RuntimeError: When no results are produced and a configuration raises.
     """
     results_df = pd.DataFrame(columns=common.ColumnsAgg)
     exceptions: list[Exception] = []
-    all_configs_oom = True
-    all_kv_cache_oom = True
+    saw_model_fit = False
+    saw_memory_fit = False
 
     for parallel_config in parallel_config_list:
         tp_size, pp_size, dp_size, moe_tp_size, moe_ep_size, cp_size = parallel_config
@@ -465,7 +476,7 @@ def sweep_agg(
                 continue
 
             for point_rt in runtime_configs_to_evaluate:
-                point_df, all_oom = _sweep_one_parallel_agg(
+                point_df, point_saw_model_fit, point_saw_memory_fit = _sweep_one_parallel_agg(
                     model=model,
                     backend=backend,
                     database=database,
@@ -478,12 +489,8 @@ def sweep_agg(
                     max_seq_len=max_seq_len,
                     predictor=predictor,
                 )
-                if not all_oom:
-                    all_configs_oom = False
-                # KV cache OOM is detected per-summary inside; we conservatively
-                # mark "not all KV cache OOM" whenever we produced any row.
-                if len(point_df) > 0:
-                    all_kv_cache_oom = False
+                saw_model_fit |= point_saw_model_fit
+                saw_memory_fit |= point_saw_memory_fit
                 if len(point_df) == 0:
                     continue
                 if len(results_df) == 0:
@@ -512,13 +519,13 @@ def sweep_agg(
         raise RuntimeError(
             f"sweep_agg: no results for any parallel configuration. Last exception: {exceptions[-1]}"
         ) from exceptions[-1]
-    if all_configs_oom:
-        raise RuntimeError(
+    if not saw_model_fit:
+        raise InsufficientMemoryError(
             "sweep_agg: no results — model does not fit in GPU memory for any parallel config. "
             "Try increasing --total-gpus, using a quantized model, or a system with more VRAM per GPU."
         )
-    if all_kv_cache_oom:
-        raise RuntimeError(
+    if not saw_memory_fit:
+        raise KVCacheCapacityError(
             "sweep_agg: no results — requested batch_size exceeds KV cache capacity for all configs. "
             "Try reducing batch_size, increasing free_gpu_memory_fraction, or a system with more VRAM."
         )
@@ -621,7 +628,7 @@ def _get_disagg_worker_candidates(
                 f"sweep_disagg/{role}: no results for any parallel config. Last exception: {exceptions[-1]}"
             ) from exceptions[-1]
         if all_configs_oom:
-            raise RuntimeError(
+            raise InsufficientMemoryError(
                 f"sweep_disagg/{role}: no results — model does not fit in GPU memory for any parallel config. "
                 "Try increasing GPU budget, using a quantized model, or a system with more VRAM per GPU."
             )

--- a/tests/unit/sdk/sweep/test_sweep.py
+++ b/tests/unit/sdk/sweep/test_sweep.py
@@ -3,13 +3,21 @@
 
 """Unit tests for sweep.py helpers and sweep_disagg placeholder.
 
-sweep_agg end-to-end correctness is validated by the integration
-parity test (tests/integration/test_task_v1_v2_parity.py) against the
-legacy CLI path; mocking it at unit level provides little signal.
+Sweep output correctness is validated by the integration parity test
+(``tests/integration/test_task_v1_v2_parity.py``) against the legacy CLI path;
+the unit coverage here targets local control flow and terminal classification.
 """
+
+from unittest.mock import MagicMock
 
 import pytest
 
+from aiconfigurator.sdk import config, sweep
+from aiconfigurator.sdk.errors import (
+    InsufficientMemoryError,
+    KVCacheCapacityError,
+    NoFeasibleConfigError,
+)
 from aiconfigurator.sdk.sweep import (
     _DEFAULT_AGG_BATCH_SCHEDULE,
     _agg_ctx_tokens_list,
@@ -57,6 +65,45 @@ def test_default_agg_batch_schedule_is_monotonic_and_capped():
     assert sorted(_DEFAULT_AGG_BATCH_SCHEDULE) == _DEFAULT_AGG_BATCH_SCHEDULE
     assert _DEFAULT_AGG_BATCH_SCHEDULE[0] == 1
     assert _DEFAULT_AGG_BATCH_SCHEDULE[-1] == 1024
+
+
+# ---------------------------------------------------------------------------
+# sweep_agg no-result classification
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("memory_states", "expected_error"),
+    [
+        ([(True, False), (True, False)], InsufficientMemoryError),
+        ([(False, True), (True, False)], KVCacheCapacityError),
+        ([(False, False), (True, False)], NoFeasibleConfigError),
+    ],
+)
+def test_sweep_agg_classifies_no_result_outcomes(monkeypatch, memory_states, expected_error):
+    summaries = []
+    for model_oom, kv_cache_oom in memory_states:
+        summary = MagicMock()
+        summary.check_oom.return_value = model_oom
+        summary.check_kv_cache_oom.return_value = kv_cache_oom
+        summary.get_result_dict.return_value = {"ttft": 2.0, "tpot": 2.0}
+        summaries.append(summary)
+
+    monkeypatch.setattr(sweep, "get_backend", lambda _backend_name: MagicMock())
+    monkeypatch.setattr(sweep, "get_model", lambda **_kwargs: MagicMock())
+    monkeypatch.setattr(sweep, "predict_agg_worker", MagicMock(side_effect=summaries))
+
+    with pytest.raises(expected_error):
+        sweep.sweep_agg(
+            model_path="test-model",
+            runtime_config=config.RuntimeConfig(isl=1024, osl=1, ttft=1.0, tpot=1.0),
+            database=MagicMock(),
+            backend_name="trtllm",
+            model_config=config.ModelConfig(),
+            parallel_config_list=[(1, 1, 1, 1, 1, 1), (2, 1, 1, 2, 1, 1)],
+            max_batch_size=1,
+            ctx_stride=1024,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/sdk/test_errors.py
+++ b/tests/unit/sdk/test_errors.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the NoResultsError taxonomy and its chain-walking recognizer.
+
+The CLI experiment handler (cli/main.py) and any downstream sweep driver rely on
+two contracts verified here:
+
+1. Every *expected* "no results" exception is-a ``NoResultsError`` (so a single
+   ``isinstance`` check classifies it) AND is-a ``RuntimeError`` (so existing
+   ``except RuntimeError`` / ``except Exception`` catches keep working).
+2. ``is_expected_no_result_cause`` recognizes the family through the exception
+   chain, so a generic wrapper raised ``from`` a family member is treated as a
+   clean outcome -- while a wrapper around a genuine bug is NOT, preserving its
+   traceback.
+"""
+
+import pytest
+
+from aiconfigurator.sdk.errors import (
+    InsufficientMemoryError,
+    KVCacheCapacityError,
+    NoFeasibleConfigError,
+    NoResultsError,
+    is_expected_no_result_cause,
+)
+from aiconfigurator.sdk.perf_database import PerfDataNotAvailableError
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    "exc_type",
+    [NoFeasibleConfigError, InsufficientMemoryError, KVCacheCapacityError],
+)
+def test_expected_no_result_types_are_noresults_and_runtimeerror(exc_type) -> None:
+    # is-a NoResultsError -> a single isinstance classifies it cleanly.
+    assert issubclass(exc_type, NoResultsError)
+    # is-a RuntimeError -> backward-compatible with existing broad catches.
+    assert issubclass(exc_type, RuntimeError)
+
+
+def test_perf_data_miss_is_not_a_no_results_error() -> None:
+    # A per-op data miss can be skipped while other configs still produce
+    # results, so it is deliberately NOT in the NoResultsError family (it keeps
+    # its own recognizer, has_perf_data_not_available_cause).
+    assert not issubclass(PerfDataNotAvailableError, NoResultsError)
+    assert issubclass(PerfDataNotAvailableError, RuntimeError)
+    assert not is_expected_no_result_cause(PerfDataNotAvailableError("miss"))
+
+
+def test_recognizer_accepts_direct_family_member() -> None:
+    assert is_expected_no_result_cause(InsufficientMemoryError("oom"))
+
+
+def test_recognizer_accepts_generic_wrapper_chained_from_family_member() -> None:
+    # Mirrors sweep.py: ``raise RuntimeError(...) from exceptions[-1]`` where the
+    # last per-config failure was a NoResultsError-family member.
+    try:
+        raise RuntimeError("no results for any config") from InsufficientMemoryError("oom")
+    except RuntimeError as exc:
+        assert is_expected_no_result_cause(exc)
+
+
+def test_recognizer_accepts_implicit_expected_context() -> None:
+    inner = InsufficientMemoryError("expected no-result")
+    outer = RuntimeError("wrapper")
+    outer.__context__ = inner
+
+    assert is_expected_no_result_cause(outer)
+
+
+def test_recognizer_prefers_explicit_cause_over_expected_context() -> None:
+    try:
+        try:
+            raise InsufficientMemoryError("expected no-result")
+        except InsufficientMemoryError:
+            raise RuntimeError("wrapper") from KeyError("real bug")
+    except RuntimeError as exc:
+        assert not is_expected_no_result_cause(exc)
+
+
+def test_recognizer_ignores_suppressed_expected_context() -> None:
+    try:
+        try:
+            raise InsufficientMemoryError("expected no-result")
+        except InsufficientMemoryError:
+            raise KeyError("real bug while handling expected result") from None
+    except KeyError as exc:
+        assert exc.__suppress_context__
+        assert not is_expected_no_result_cause(exc)
+
+
+def test_recognizer_rejects_wrapper_around_real_bug() -> None:
+    # A genuine bug surfacing as the last exception must keep its traceback.
+    try:
+        raise RuntimeError("no results for any config") from KeyError("unexpected")
+    except RuntimeError as exc:
+        assert not is_expected_no_result_cause(exc)
+
+
+def test_recognizer_rejects_plain_runtimeerror() -> None:
+    assert not is_expected_no_result_cause(RuntimeError("something else"))
+
+
+def test_recognizer_avoids_cycles() -> None:
+    error = RuntimeError("outer")
+    nested = RuntimeError("nested")
+    error.__cause__ = nested
+    nested.__context__ = error
+
+    assert not is_expected_no_result_cause(error)


### PR DESCRIPTION
#### Overview:

Backports #1239 to release/0.10.0.

#### Details:

- Cherry-picks the main-branch commit b706a37d5565b4dcf4679762335bcd22359f2dee.
- Contains exactly one commit based directly on release/0.10.0.
- The backport patch is identical to the original merged patch and preserves DCO compliance.

#### Validation:

- Focused SDK error and sweep tests: 59 passed
- Broader SDK and CLI experiment suite, excluding an unrelated optional-torch module: 1,235 passed, 3 skipped
- git diff --check: passed

#### Where should the reviewer start?

See the original PR: https://github.com/ai-dynamo/aiconfigurator/pull/1239

#### Related Issues:

- Relates to #1239

