### PR TITLE
fix(sdk): respect effective perf-data exception chain (cherry-pick #1270)

### DIFF
--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -139,7 +139,7 @@ def build_no_databases_message() -> str:
 
 
 def has_perf_data_not_available_cause(error: BaseException) -> bool:
-    """Return True when an exception or chained cause is a structured perf-data miss."""
+    """Return True when an exception's effective chain has a structured perf-data miss."""
     seen: set[int] = set()
     stack: list[BaseException] = [error]
     while stack:
@@ -151,7 +151,7 @@ def has_perf_data_not_available_cause(error: BaseException) -> bool:
         seen.add(id(current))
         if current.__cause__ is not None:
             stack.append(current.__cause__)
-        if current.__context__ is not None:
+        elif not current.__suppress_context__ and current.__context__ is not None:
             stack.append(current.__context__)
     return False
 

--- a/tests/unit/sdk/database/test_perf_database_errors.py
+++ b/tests/unit/sdk/database/test_perf_database_errors.py
@@ -17,12 +17,43 @@ from aiconfigurator.sdk.performance_result import PerformanceResult
 pytestmark = pytest.mark.unit
 
 
-def test_perf_data_cause_detection_traverses_cause_and_context() -> None:
+def test_perf_data_cause_detection_accepts_direct_error() -> None:
+    error = PerfDataNotAvailableError("missing perf data")
+
+    assert has_perf_data_not_available_cause(error)
+
+
+def test_perf_data_cause_detection_accepts_explicit_cause() -> None:
+    error = RuntimeError("outer")
+    error.__cause__ = PerfDataNotAvailableError("missing perf data")
+
+    assert has_perf_data_not_available_cause(error)
+
+
+def test_perf_data_cause_detection_accepts_implicit_context() -> None:
+    error = RuntimeError("outer")
+    error.__context__ = PerfDataNotAvailableError("missing perf data")
+
+    assert has_perf_data_not_available_cause(error)
+
+
+def test_perf_data_cause_detection_prefers_explicit_cause() -> None:
     error = RuntimeError("outer")
     error.__cause__ = RuntimeError("explicit cause")
     error.__context__ = PerfDataNotAvailableError("missing perf data")
 
-    assert has_perf_data_not_available_cause(error)
+    assert not has_perf_data_not_available_cause(error)
+
+
+def test_perf_data_cause_detection_ignores_suppressed_context() -> None:
+    try:
+        try:
+            raise PerfDataNotAvailableError("missing perf data")
+        except PerfDataNotAvailableError:
+            raise KeyError("real bug while handling perf-data miss") from None
+    except KeyError as error:
+        assert error.__suppress_context__
+        assert not has_perf_data_not_available_cause(error)
 
 
 def test_perf_data_cause_detection_avoids_cycles() -> None:


### PR DESCRIPTION
#### Overview:

Backports #1270 to release/0.10.0.

#### Details:

- Cherry-picks the main-branch commit 9ab3535732fa4770b0c990bfce7cd6e81387b380.
- Contains exactly one commit based directly on release/0.10.0.
- This is a logical follow-up to #1239, but its patch is independently applicable and is not stacked on that backport.
- The backport patch is identical to the original merged patch and preserves DCO compliance.

#### Validation:

- tests/unit/sdk/database/test_perf_database_errors.py: 14 passed
- git diff --check: passed

#### Where should the reviewer start?

See the original PR: https://github.com/ai-dynamo/aiconfigurator/pull/1270

#### Related Issues:

- Relates to #1270
