### PR TITLE
chore: bump version 0.9.0 -> 0.10.0 on release/0.10.0 (#1271)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "aiconfigurator"
-version = "0.9.0"
+version = "0.10.0"
 authors = [
     { name = "NVIDIA Inc.", email = "sw-dl-dynamo@nvidia.com" },
 ]
@@ -40,7 +40,7 @@ license-files = ["LICENSE"]
 requires-python = ">=3.10"
 
 dependencies = [
-    "aiconfigurator-core==0.9.0",
+    "aiconfigurator-core==0.10.0",
     "jinja2>=3.1.0",
     "packaging>=20.0",
     "matplotlib>=3.9.4",

--- a/rust/aiconfigurator-core/Cargo.toml
+++ b/rust/aiconfigurator-core/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "aiconfigurator-core"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "Rust-native core latency estimator for AIConfigurator"
 license = "Apache-2.0"

--- a/src/aiconfigurator-core/pyproject.toml
+++ b/src/aiconfigurator-core/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "aiconfigurator-core"
-version = "0.9.0"
+version = "0.10.0"
 authors = [
     { name = "NVIDIA Inc.", email = "sw-dl-dynamo@nvidia.com" },
 ]


### PR DESCRIPTION
The release/0.10.0 branch still declared version 0.9.0 in pyproject.toml, rust/aiconfigurator-core/Cargo.toml, src/aiconfigurator-core/pyproject.toml, and the aiconfigurator-core dependency pin. This bumps all four so the branch produces correctly-versioned 0.10.0 artifacts (python wheels + aiconfigurator-core crate/extension).

#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
