### PR TITLE
fix(cli): convert estimate-mode validation errors to concise CLI errors (cherry-pick #1273)

### DIFF
--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -2258,7 +2258,14 @@ def main(args):
 
     # Handle estimate mode separately (single-point estimation)
     if args.mode == "estimate":
-        _run_estimate_mode(args)
+        # Invalid sizing/parameters surface as ValueError from the SDK
+        # validation path (e.g. AFD f_moe_ep_size not dividing f_tp_size).
+        # Convert to a concise CLI error instead of a full traceback,
+        # matching the set_systems_paths convention above.
+        try:
+            _run_estimate_mode(args)
+        except ValueError as exc:
+            raise SystemExit("Error: " + str(exc)) from exc
         return
 
     if args.mode == "default":

--- a/tests/unit/cli/test_afd_phase_completion.py
+++ b/tests/unit/cli/test_afd_phase_completion.py
@@ -804,3 +804,32 @@ def test_cli_estimate_afd_phase_both_with_combined_with_pd_raises(monkeypatch):
         api.cli_estimate(
             **_afd_cli_estimate_kwargs(afd_phase="both", afd_combined_with_pd=True),
         )
+
+
+def test_cli_main_estimate_value_error_exits_without_traceback(monkeypatch):
+    """Estimate-mode validation errors surface as a concise CLI error.
+
+    Invalid AFD sizing (e.g. ``f_moe_ep_size`` not dividing ``f_tp_size``)
+    raises ``ValueError`` deep in the SDK. ``cli.main.main`` must convert it
+    to ``SystemExit`` so the user sees the actionable message instead of a
+    full Python traceback.
+    """
+    from types import SimpleNamespace
+
+    import aiconfigurator.cli.main as cli_main
+    import aiconfigurator.sdk.perf_database as perf_database
+
+    monkeypatch.setattr(perf_database, "set_systems_paths", lambda _paths: None)
+    monkeypatch.setattr(
+        cli_main,
+        "_run_estimate_mode",
+        lambda _args: (_ for _ in ()).throw(ValueError("f_moe_ep_size (7) must be a positive divisor")),
+    )
+
+    args = SimpleNamespace(mode="estimate", systems_paths=None, top_n=5, no_color=True)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(args)
+
+    # SystemExit carries the plain message (no traceback, exit code 1).
+    assert "f_moe_ep_size (7) must be a positive divisor" in str(exc_info.value)


### PR DESCRIPTION
#### Overview:

Backports #1273 to release/0.10.0.

#### Details:

- Cherry-picks the main-branch squash commit d5a49a9cdfa3b35169369304b9438054feea2acc.
- Contains exactly one commit based directly on the current release/0.10.0 tip.
- The backport patch is identical to the original merged patch and preserves its DCO sign-off.
- No other post-release commits are required.

#### Validation:

- tests/unit/cli/test_afd_phase_completion.py: 15 passed
- Ruff check: passed
- Ruff format check: passed
- git diff --check: passed

#### Where should the reviewer start?

See the original PR: https://github.com/ai-dynamo/aiconfigurator/pull/1273

#### Related Issues:

- Relates to #1273
