### PR TITLE
fix(cli): restore legacy --debug flag as deprecated alias

### DIFF
--- a/docs/cli_user_guide.md
+++ b/docs/cli_user_guide.md
@@ -9,7 +9,8 @@ For low-precision models, use a quantized HF ID (for example, `Qwen/Qwen3-32B-FP
 
 These flags are shared across modes (a few are sweep-only, as noted):
 
-- `--debug`: Enable verbose debug logging. (all modes)
+- `--log-level LEVEL`: Set the minimum log level (`CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG`). Priority: `--log-level > AICONFIGURATOR_LOG_LEVEL > --debug > INFO`. (all modes)
+- `--debug`: Deprecated alias for `--log-level DEBUG`, kept for backward compatibility. Prefer `--log-level`. (all modes)
 - `--no-color`: Disable ANSI colors in output. (all modes)
 - `--save-dir DIR`: Directory to write results and generated deployment artifacts. (`default`, `exp`, `generate`, `estimate`)
 - `--top-n N`: Number of top configurations to output — per experiment in `exp` mode, or per serving mode (agg/disagg) in `default` mode. Default: `5`. (`default`, `exp`, `generate`, `estimate`)
@@ -17,7 +18,7 @@ These flags are shared across modes (a few are sweep-only, as noted):
 - `--deployment-target`: Generated-artifact platform — `dynamo-j2` (default), `dynamo-python`, or `llm-d`. See [Deployment Target Selection](#default-mode). (`default`, `exp`, `generate`, `estimate`)
 - `--engine-step-backend`: Experimental static-latency backend — `python` (default) or `rust` (routes static step estimates through the Rust FPM estimator). (`default`, `exp`, `generate`, `estimate`)
 
-The `support` mode accepts only `--debug` and `--no-color` from this list. Generator-artifact flags (`--generator-config`, `--generator-set`, `--generator-help`, `--generator-help-backend`, `--generated-config-version`, `--generator-dynamo-version`) are documented under [Default mode](#default-mode).
+The `support` mode accepts only `--log-level`, `--debug`, and `--no-color` from this list. Generator-artifact flags (`--generator-config`, `--generator-set`, `--generator-help`, `--generator-help-backend`, `--generated-config-version`, `--generator-dynamo-version`) are documented under [Default mode](#default-mode).
 
 ## Defaults and Implicit Behavior
 

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -96,7 +96,12 @@ def _build_common_cli_parser() -> argparse.ArgumentParser:
         type=str.upper,
         default=None,
         choices=["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"],
-        help=("Set the minimum log level. Priority: --log-level > AICONFIGURATOR_LOG_LEVEL > INFO."),
+        help=("Set the minimum log level. Priority: --log-level > AICONFIGURATOR_LOG_LEVEL > --debug > INFO."),
+    )
+    common_parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Deprecated alias for --log-level DEBUG, kept for backward compatibility.",
     )
     common_parser.add_argument(
         "--no-color",
@@ -2255,7 +2260,7 @@ def _run_estimate_mode(args):
 
 
 def _resolve_cli_log_level(args) -> int:
-    """Pick the log level with priority: --log-level > AICONFIGURATOR_LOG_LEVEL > INFO."""
+    """Pick the log level with priority: --log-level > AICONFIGURATOR_LOG_LEVEL > --debug > INFO."""
     cli_level = getattr(args, "log_level", None)
     if cli_level:
         return getattr(logging, cli_level)
@@ -2264,6 +2269,8 @@ def _resolve_cli_log_level(args) -> int:
         resolved = env_level.strip().upper()
         if resolved in {"CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"}:
             return getattr(logging, resolved)
+    if getattr(args, "debug", False):
+        return logging.DEBUG
     return logging.INFO
 
 

--- a/tests/unit/cli/test_argument_parsing.py
+++ b/tests/unit/cli/test_argument_parsing.py
@@ -209,6 +209,23 @@ class TestCLIArgumentParsing:
 
         assert args.log_level == "DEBUG"
 
+    def test_legacy_debug_flag(self, cli_parser):
+        """Legacy --debug is still accepted for backward compatibility."""
+        args = cli_parser.parse_args(
+            [
+                "default",
+                "--model-path",
+                "Qwen/Qwen3-32B",
+                "--total-gpus",
+                "8",
+                "--system",
+                "h200_sxm",
+                "--debug",
+            ]
+        )
+
+        assert args.debug is True
+
     def test_engine_step_backend_flag(self, cli_parser):
         """Test that the experimental engine step backend can be selected."""
         args = cli_parser.parse_args(

--- a/tests/unit/cli/test_cli_workflow.py
+++ b/tests/unit/cli/test_cli_workflow.py
@@ -69,6 +69,21 @@ class TestCLILogLevelResolution:
         args = argparse.Namespace(log_level=None)
         assert _resolve_cli_log_level(args) == logging.INFO
 
+    def test_legacy_debug_flag_resolves_to_debug(self, monkeypatch) -> None:
+        monkeypatch.delenv("AICONFIGURATOR_LOG_LEVEL", raising=False)
+        args = argparse.Namespace(log_level=None, debug=True)
+        assert _resolve_cli_log_level(args) == logging.DEBUG
+
+    def test_env_var_overrides_legacy_debug(self, monkeypatch) -> None:
+        monkeypatch.setenv("AICONFIGURATOR_LOG_LEVEL", "warning")
+        args = argparse.Namespace(log_level=None, debug=True)
+        assert _resolve_cli_log_level(args) == logging.WARNING
+
+    def test_cli_flag_overrides_legacy_debug(self, monkeypatch) -> None:
+        monkeypatch.setenv("AICONFIGURATOR_LOG_LEVEL", "warning")
+        args = argparse.Namespace(log_level="ERROR", debug=True)
+        assert _resolve_cli_log_level(args) == logging.ERROR
+
 
 class TestCLIIntegration:
     """Workflow tests for the CLI orchestration layer (builders/executor/save)."""


### PR DESCRIPTION
## Summary
PR #1230 replaced `--debug` with `--log-level` but promised backward compatibility for `--debug` with precedence `--log-level > AICONFIGURATOR_LOG_LEVEL > --debug > INFO`. The final implementation dropped `--debug` entirely, so argparse rejected it with exit code 2 across **all** CLI modes (`default`, `exp`, `generate`, `estimate`, `support`), breaking existing scripts.

## Changes
- **`src/aiconfigurator/cli/main.py`**
  - `_build_common_cli_parser()`: restore `--debug` as a `store_true` deprecated alias. Since this parser is a parent of all five modes, `--debug` is accepted everywhere again.
  - `_resolve_cli_log_level()`: add `args.debug → DEBUG` fallback *after* the env-var check and *before* the INFO default, matching the promised precedence. Uses `getattr(args, "debug", False)` so it is safe when the attribute is absent.
- **`docs/cli_user_guide.md`**: document `--log-level` as the preferred interface with full precedence; mark `--debug` as a deprecated compatibility alias; update the `support`-mode note.
- **Tests**: parsing test for `--debug`, plus resolver precedence tests (`--debug` alone → DEBUG; env `WARNING` overrides `--debug`; `--log-level ERROR` overrides both).

## Verification
- All 48 CLI unit tests pass.
- Subprocess smoke test: the exact failing command (`cli support ... --no-color --debug`) now exits `0` instead of `2`.
- Confirmed `--debug` sets the root logger to DEBUG; no flag → INFO.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI help docs to describe `--log-level` and its precedence with environment settings and the legacy `--debug` flag.
  * Clarified accepted flags for `support` mode.

* **Bug Fixes**
  * Improved log-level selection so the legacy `--debug` flag works as expected and remains backward compatible.
  * Ensured explicit CLI log-level settings take priority over other sources, with environment values still overriding `--debug` when applicable.

* **Tests**
  * Added coverage for legacy debug flag handling and log-level precedence scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->