### PR TITLE
fix(sdk): preserve multimodal fields in agg sweep point config

### DIFF
--- a/src/aiconfigurator/sdk/sweep.py
+++ b/src/aiconfigurator/sdk/sweep.py
@@ -283,7 +283,6 @@ def _sweep_one_parallel_agg(
     osl = runtime_config.osl
     ttft_target = runtime_config.ttft
     tpot_target = runtime_config.tpot
-    prefix = runtime_config.prefix
 
     b_list = [b for b in _DEFAULT_AGG_BATCH_SCHEDULE if b <= max_batch_size]
     ctx_tokens_list = _agg_ctx_tokens_list(isl, ctx_stride, enable_chunked_prefill)
@@ -310,14 +309,13 @@ def _sweep_one_parallel_agg(
                     continue
                 capped_b.append(gen_tokens)
 
-            point_rt = config.RuntimeConfig(
-                batch_size=b,
-                isl=isl,
-                osl=osl,
-                prefix=prefix,
-                seq_imbalance_correction_scale=runtime_config.seq_imbalance_correction_scale,
-                engine_step_backend=runtime_config.engine_step_backend,
-            )
+            # Deep-copy the full runtime_config (mirrors the disagg path below) so
+            # every field is preserved per batch point. Explicit field-by-field
+            # construction silently dropped multimodal fields (image_height/width,
+            # num_images_per_request, num_image_tokens), zeroing the image encoder
+            # workload in agg while disagg stayed correct (NVBug 6401839).
+            point_rt = copy.deepcopy(runtime_config)
+            point_rt.batch_size = b
 
             backend_kwargs: dict[str, Any] = {}
             if max_seq_len is not None:

--- a/tests/unit/sdk/sweep/test_sweep.py
+++ b/tests/unit/sdk/sweep/test_sweep.py
@@ -106,6 +106,63 @@ def test_sweep_agg_classifies_no_result_outcomes(monkeypatch, memory_states, exp
         )
 
 
+def test_sweep_agg_point_config_preserves_multimodal_fields(monkeypatch):
+    """Regression for NVBug 6401839: the agg per-batch RuntimeConfig must carry
+    every multimodal field from the base runtime_config. The old field-by-field
+    construction dropped image_height/width, num_images_per_request, and
+    num_image_tokens, zeroing the image encoder workload in agg while disagg
+    (which deep-copies) stayed correct."""
+    captured: list[config.RuntimeConfig] = []
+
+    def _record(*, runtime_config, **_kwargs):
+        captured.append(runtime_config)
+        summary = MagicMock()
+        summary.check_oom.return_value = False
+        summary.check_kv_cache_oom.return_value = False
+        summary.get_result_dict.return_value = {"ttft": 1.0, "tpot": 1.0}
+        summary.get_per_ops_source.return_value = {}
+        return summary
+
+    monkeypatch.setattr(sweep, "get_backend", lambda _backend_name: MagicMock())
+    monkeypatch.setattr(sweep, "get_model", lambda **_kwargs: MagicMock())
+    monkeypatch.setattr(sweep, "predict_agg_worker", _record)
+
+    base_rt = config.RuntimeConfig(
+        isl=256,
+        osl=256,
+        ttft=1e9,
+        tpot=1e9,
+        image_height=1024,
+        image_width=1024,
+        num_images_per_request=2,
+        num_image_tokens=333,
+        seq_imbalance_correction_scale=1.5,
+        engine_step_backend="rust",
+    )
+
+    sweep.sweep_agg(
+        model_path="test-model",
+        runtime_config=base_rt,
+        database=MagicMock(),
+        backend_name="trtllm",
+        model_config=config.ModelConfig(),
+        parallel_config_list=[(1, 1, 1, 1, 1, 1)],
+        max_batch_size=1,
+        ctx_stride=1024,
+    )
+
+    assert captured, "expected at least one agg point to be evaluated"
+    for point_rt in captured:
+        assert point_rt.image_height == 1024
+        assert point_rt.image_width == 1024
+        assert point_rt.num_images_per_request == 2
+        assert point_rt.num_image_tokens == 333
+        # Non-multimodal fields must survive too (the deep-copy carries them all).
+        assert point_rt.seq_imbalance_correction_scale == 1.5
+        assert point_rt.engine_step_backend == "rust"
+        assert point_rt.batch_size == 1
+
+
 # ---------------------------------------------------------------------------
 # sweep_disagg validation
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
`aiconfigurator cli default` dropped the Qwen3-VL image workload during the **aggregated** sweep: image agg `best_config_topn.csv` was byte-for-byte identical to text-only and reported `encoder_latency=0` / `encoder_memory=0.0`, making the agg throughput/capacity recommendation unreliable. The disagg path from the same command was correct.

## Root cause
`_sweep_one_parallel_agg` (`src/aiconfigurator/sdk/sweep.py`) constructed a fresh `RuntimeConfig` for every batch point and copied only text-workload fields:

```python
point_rt = config.RuntimeConfig(
    batch_size=b, isl=isl, osl=osl, prefix=prefix,
    seq_imbalance_correction_scale=runtime_config.seq_imbalance_correction_scale,
    engine_step_backend=runtime_config.engine_step_backend,
)
```

`image_height`, `image_width`, `num_images_per_request`, and `num_image_tokens` reverted to dataclass defaults, so `base_backend` resolved zero visual tokens and skipped encoder modeling. The disagg path uses `copy.deepcopy(runtime_config)` and was unaffected — which is exactly why disagg reported nonzero encoder cost on the same run.

## Fix
Deep-copy the full `runtime_config` per batch point (mirroring the disagg path), so every current and future runtime field is preserved:

```python
point_rt = copy.deepcopy(runtime_config)
point_rt.batch_size = b
```

This is also the most faithful-to-legacy behavior: the legacy `find_best_agg_result_under_constraints` passed the full `runtime_config` per point. `run_agg` reads `isl/osl/prefix/batch_size` and the image fields but not `ttft/tpot`, so carrying the extra fields does not change results.

## Verification
- Existing sweep parity + unit tests pass (57 tests).
- New regression test `test_sweep_agg_point_config_preserves_multimodal_fields` asserts the agg point config keeps all multimodal fields (including the `num_image_tokens` override); it fails on the old code (`image_height=0`) and passes with the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed aggregate sweep runs so per-point runtime settings now preserve all existing configuration fields, including multimodal image-related settings.
  * Prevented aggregate workloads from losing image encoder configuration during sweep execution.

* **Tests**
  * Added a regression test to verify per-point sweep configurations keep multimodal and other runtime fields intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->