### PR TITLE
fix(cli): apply DeepSeek-V3/Kimi context FMHA rule in estimate path

### DIFF
--- a/docs/cli_user_guide.md
+++ b/docs/cli_user_guide.md
@@ -126,7 +126,7 @@ aiconfigurator cli estimate --model-path Qwen/Qwen3-32B --system h200_sxm --tp-s
 - `--moe-ep-size` (alias `--ep`): MoE expert parallelism size (auto-inferred if omitted)
 - `--gemm-quant-mode`: GEMM quantization mode (auto-inferred from model config if omitted)
 - `--kvcache-quant-mode`: KV cache quantization mode (auto-inferred if omitted)
-- `--fmha-quant-mode`: FMHA quantization mode (auto-inferred if omitted)
+- `--fmha-quant-mode`: FMHA quantization mode (auto-inferred if omitted). DeepSeek-V3 / Kimi-K2.5 context attention (MLA prefill) has no fp8 FMHA data — auto-inferred fp8 is downgraded to `bfloat16` for context-touching estimates (agg, prefill, static, static_ctx, AFD prefill), while decode/generation keeps fp8. Explicitly passing `fp8` for a context estimate is rejected with a clear error.
 - `--moe-quant-mode`: MoE quantization mode (auto-inferred if omitted)
 - `--comm-quant-mode`: Communication quantization mode (auto-inferred; default `half`)
 - `--prefix`: Prefix cache length (subset of ISL already cached per request). Default: `0`

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -26,7 +26,7 @@ from aiconfigurator.cli.report_and_save import save_results
 from aiconfigurator.sdk.config import ModelConfig
 from aiconfigurator.sdk.config_builders import apply_nextn as _apply_nextn
 from aiconfigurator.sdk.config_builders import build_model_config as _build_model_config
-from aiconfigurator.sdk.models import check_is_moe
+from aiconfigurator.sdk.models import check_is_moe, resolve_context_fmha_compat
 from aiconfigurator.sdk.task_v2 import Task
 
 # Default per-phase latency-correction scales for single-point disagg estimates.
@@ -1146,6 +1146,9 @@ def _run_agg_estimate(
         comm_quant_mode,
     )
     _apply_nextn(model_config, nextn, nextn_accept_rates)
+    # Agg workers run context attention → apply the V3/Kimi context FMHA rule
+    # before building the model (mirrors the sweep/task_v2 path).
+    resolve_context_fmha_compat(model_config, model_path, is_context_role=True)
     runtime_config = RuntimeConfig(
         isl=isl,
         osl=osl,
@@ -1274,6 +1277,9 @@ def _run_static_estimate(
         comm_quant_mode,
     )
     _apply_nextn(model_config, nextn, nextn_accept_rates)
+    # static / static_ctx run context attention; static_gen is generation-only
+    # and legitimately keeps fp8 FMHA. Apply the V3/Kimi context rule accordingly.
+    resolve_context_fmha_compat(model_config, model_path, is_context_role=static_mode != "static_gen")
 
     runtime_config = RuntimeConfig(
         batch_size=batch_size,
@@ -1420,6 +1426,9 @@ def _run_disagg_estimate(
     # configs so a single ``--nextn N`` reaches each side of the disagg pair.
     _apply_nextn(prefill_model_config, nextn, nextn_accept_rates)
     _apply_nextn(decode_model_config, nextn, nextn_accept_rates)
+    # Prefill runs context attention → V3/Kimi context FMHA rule applies. Decode
+    # is generation-only and keeps fp8, so it needs no adjustment.
+    resolve_context_fmha_compat(prefill_model_config, model_path, is_context_role=True)
 
     runtime_config = RuntimeConfig(
         isl=isl,
@@ -1698,6 +1707,11 @@ def _run_afd_estimate(
     # MTP transfer amplification once the serving semantics are finalized.
     _apply_nextn(a_model_config, nextn, nextn_accept_rates)
     _apply_nextn(f_model_config, nextn, nextn_accept_rates)
+    # The A-worker runs context attention whenever the phase covers prefill
+    # ("prefill" or "both"); apply the V3/Kimi context FMHA rule then. The
+    # F-worker is FFN/MoE only and never touches FMHA. The decode-phase static
+    # complement is a static_ctx call handled in _run_static_estimate.
+    resolve_context_fmha_compat(a_model_config, model_path, is_context_role=afd_phase in ("prefill", "both"))
 
     afd_config = AFDConfig(
         n_a_nodes=n_a_nodes,

--- a/src/aiconfigurator/sdk/models/__init__.py
+++ b/src/aiconfigurator/sdk/models/__init__.py
@@ -37,6 +37,7 @@ from aiconfigurator.sdk.models.helpers import (
     calc_expectation,
     check_is_moe,
     get_model_family,
+    resolve_context_fmha_compat,
 )
 
 # Auto-import every other module in this package so ``@register_model``
@@ -163,4 +164,5 @@ __all__ = [
     "check_is_moe",
     "get_model",
     "get_model_family",
+    "resolve_context_fmha_compat",
 ]

--- a/src/aiconfigurator/sdk/models/helpers.py
+++ b/src/aiconfigurator/sdk/models/helpers.py
@@ -35,6 +35,16 @@ _MOE_MODEL_FAMILIES = {
     "MINIMAXM3",
 }
 
+# DeepSeek-V3 / Kimi-K2.5 context attention (MLA prefill) has no fp8 FMHA perf
+# data — only bf16. The generation (decode) path keeps fp8. This mirrors the
+# role-aware rule in ``task_v2.Task._resolve_quant_modes`` so the single-point
+# CLI estimate path resolves quant modes the same way the sweep (task_v2)
+# already does. See NVBug 6401867.
+_CONTEXT_FP8_FMHA_UNSUPPORTED_ARCHS = (
+    "DeepseekV3ForCausalLM",
+    "KimiK25ForConditionalGeneration",
+)
+
 
 @cache
 def _get_model_info(model_path: str) -> dict:
@@ -317,6 +327,56 @@ def _apply_model_quant_defaults(
             model_config.fmha_quant_mode,
             model_config.comm_quant_mode,
         )
+
+
+def resolve_context_fmha_compat(
+    model_config: config.ModelConfig,
+    model_path: str,
+    *,
+    is_context_role: bool,
+) -> None:
+    """Apply the DeepSeek-V3 / Kimi context-role FMHA compatibility rule.
+
+    Must be called BEFORE ``get_model`` so the downgrade lands before the model
+    (and its attention ops) are built. ``_apply_model_quant_defaults`` cannot own
+    this rule because it is role-agnostic: decode/generation attention keeps fp8,
+    only context attention (agg / prefill / static_ctx) must fall back to bf16.
+
+    Behavior (mirrors ``task_v2``):
+    * Non-context roles, or non-V3/Kimi architectures: no-op.
+    * fmha auto-inferred to fp8 → downgrade to bfloat16 (unblocks the estimate).
+    * fmha explicitly set to fp8 by the user → raise a concise ``ValueError``
+      instead of letting a missing-perf-data traceback surface downstream.
+
+    Args:
+        model_config: ModelConfig whose ``fmha_quant_mode`` may be adjusted
+            in place. A non-None value is treated as a user-explicit request.
+        model_path: HF model path used to resolve architecture and quant config.
+        is_context_role: True for context-attention roles (agg, prefill,
+            static, static_ctx, AFD prefill); False for generation-only roles.
+    """
+    if not is_context_role:
+        return
+
+    info = _get_model_info(model_path)
+    architecture = info.get("architecture")
+    if architecture not in _CONTEXT_FP8_FMHA_UNSUPPORTED_ARCHS:
+        return
+
+    explicit = model_config.fmha_quant_mode is not None
+    if explicit:
+        if model_config.fmha_quant_mode == common.FMHAQuantMode.fp8:
+            raise ValueError(
+                f"{architecture} context attention (MLA prefill) does not support fp8 FMHA. "
+                "Use --fmha-quant-mode bfloat16, or omit --fmha-quant-mode to auto-select it."
+            )
+        return
+
+    # Not user-explicit: mirror what get_model would infer, and downgrade only
+    # when that inference would pick fp8 (bf16 checkpoints need no change).
+    inferred = _infer_quant_modes_from_raw_config(info.get("raw_config", {}), architecture)
+    if inferred.get("fmha_quant_mode") == common.FMHAQuantMode.fp8:
+        model_config.fmha_quant_mode = common.FMHAQuantMode.bfloat16
 
 
 def get_model_family(model_path: str) -> str:

--- a/tests/unit/sdk/models/test_context_fmha_compat.py
+++ b/tests/unit/sdk/models/test_context_fmha_compat.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for the DeepSeek-V3 / Kimi context-role FMHA rule.
+
+NVBug 6401867: the single-point ``cli estimate`` / AFD path resolved fp8 FMHA
+for DeepSeek-V3 context MLA (no perf data) and crashed with a
+PerfDataNotAvailableError traceback. ``resolve_context_fmha_compat`` mirrors the
+role-aware downgrade that ``task_v2`` (the sweep path) already applies.
+"""
+
+import pytest
+
+import aiconfigurator.sdk.models.helpers as helpers
+from aiconfigurator.sdk import common, config
+from aiconfigurator.sdk.models import resolve_context_fmha_compat
+
+pytestmark = pytest.mark.unit
+
+# DeepSeek-V3 ships fp8_block weights → inference resolves FMHA to fp8.
+_V3_FP8_RAW = {"quant_algo": "fp8_block"}
+_V3_BF16_RAW = {"quant_algo": None}
+
+
+@pytest.fixture
+def fake_model_info(monkeypatch):
+    """Patch _get_model_info so the helper resolves a chosen (arch, raw_config)."""
+
+    def _install(architecture, raw_config):
+        monkeypatch.setattr(
+            helpers,
+            "_get_model_info",
+            lambda _model_path: {"architecture": architecture, "raw_config": raw_config},
+        )
+
+    return _install
+
+
+def _mc(fmha=None):
+    return config.ModelConfig(fmha_quant_mode=fmha)
+
+
+def test_context_role_inferred_fp8_downgrades_to_bf16(fake_model_info):
+    """Auto-inferred fp8 FMHA on a V3 context role falls back to bf16."""
+    fake_model_info("DeepseekV3ForCausalLM", _V3_FP8_RAW)
+    mc = _mc(fmha=None)
+    resolve_context_fmha_compat(mc, "deepseek-ai/DeepSeek-V3", is_context_role=True)
+    assert mc.fmha_quant_mode == common.FMHAQuantMode.bfloat16
+
+
+def test_context_role_explicit_fp8_raises(fake_model_info):
+    """Explicit fp8 FMHA on a V3 context role raises a concise error, no traceback."""
+    fake_model_info("DeepseekV3ForCausalLM", _V3_FP8_RAW)
+    mc = _mc(fmha=common.FMHAQuantMode.fp8)
+    with pytest.raises(ValueError, match="does not support fp8 FMHA"):
+        resolve_context_fmha_compat(mc, "deepseek-ai/DeepSeek-V3", is_context_role=True)
+
+
+def test_generation_role_keeps_fp8(fake_model_info):
+    """Generation-only roles (static_gen / decode) keep fp8 — no downgrade, no error."""
+    fake_model_info("DeepseekV3ForCausalLM", _V3_FP8_RAW)
+    # Explicit fp8 must NOT raise for a gen role.
+    mc = _mc(fmha=common.FMHAQuantMode.fp8)
+    resolve_context_fmha_compat(mc, "deepseek-ai/DeepSeek-V3", is_context_role=False)
+    assert mc.fmha_quant_mode == common.FMHAQuantMode.fp8
+    # Auto-inferred case: helper leaves it for get_model to resolve to fp8.
+    mc_auto = _mc(fmha=None)
+    resolve_context_fmha_compat(mc_auto, "deepseek-ai/DeepSeek-V3", is_context_role=False)
+    assert mc_auto.fmha_quant_mode is None
+
+
+def test_context_role_explicit_bf16_is_untouched(fake_model_info):
+    """An explicit non-fp8 request is respected (no error, no change)."""
+    fake_model_info("KimiK25ForConditionalGeneration", _V3_FP8_RAW)
+    mc = _mc(fmha=common.FMHAQuantMode.bfloat16)
+    resolve_context_fmha_compat(mc, "moonshotai/Kimi-K2.5", is_context_role=True)
+    assert mc.fmha_quant_mode == common.FMHAQuantMode.bfloat16
+
+
+def test_non_v3_architecture_is_untouched(fake_model_info):
+    """Architectures without the context-fp8 limitation are left to get_model."""
+    fake_model_info("Qwen3MoeForCausalLM", _V3_FP8_RAW)
+    mc = _mc(fmha=None)
+    resolve_context_fmha_compat(mc, "Qwen/Qwen3-235B", is_context_role=True)
+    assert mc.fmha_quant_mode is None
+
+
+def test_bf16_v3_checkpoint_needs_no_downgrade(fake_model_info):
+    """A bf16 V3 checkpoint infers no fp8, so the helper is a no-op."""
+    fake_model_info("DeepseekV3ForCausalLM", _V3_BF16_RAW)
+    mc = _mc(fmha=None)
+    resolve_context_fmha_compat(mc, "deepseek-ai/DeepSeek-V3-bf16", is_context_role=True)
+    assert mc.fmha_quant_mode is None


### PR DESCRIPTION
## Summary
When quantization flags are omitted and left to auto-inference, the single-point `cli estimate` / AFD path resolved **fp8 FMHA** for DeepSeek-V3 (and Kimi-K2.5) context MLA, then exited with an unhandled `PerfDataNotAvailableError` traceback — the SILICON database has no fp8 FMHA context-MLA slice.

## Root cause
The sweep path (`cli default` → `task_v2._resolve_quant_modes`) already downgrades auto-inferred fp8 FMHA to bf16 **for context-attention roles only** (decode keeps fp8, because gen-MLA fp8 data exists). The single-point estimate path resolves quant via `get_model → _apply_model_quant_defaults`, which is **role-agnostic** and never applied that context-specific rule. So every context-touching estimate for V3/Kimi (agg, static, static_ctx, disagg prefill, AFD prefill, and the AFD-decode static_ctx complement) crashed.

## Fix
Add `resolve_context_fmha_compat()` next to the existing quant resolver in `sdk/models/helpers.py` and call it before `get_model` at the four context-touching estimate sites in `cli/api.py`:

- **Auto-inferred fp8 + context role → downgrade to bfloat16** (unblocks the estimate), mirroring `task_v2`.
- **Decode / static_gen → untouched** (keeps fp8).
- **Explicit `--fmha-quant-mode fp8` + context role → concise `ValueError`** (surfaced as a clean `Error: ...` line) instead of a missing-perf-data traceback.

The working sweep path (`task_v2`), `get_model`, and `_apply_model_quant_defaults` are left unchanged; the V3.2 / V4 / vLLM role-agnostic downgrades still resolve through the existing path.

## Verification (h200_sxm / trtllm / 1.3.0rc10, SILICON)
The reporter's repro and related paths now behave correctly:

| Scenario | Before | After |
|---|---|---|
| AFD prefill (`--no-afd-combined-with-pd`) | exit 1, PerfData traceback | exit 0, A-worker `fmha=bfloat16` |
| AFD decode (default combined → static_ctx complement) | exit 1, PerfData traceback | exit 0, complement `fmha=bfloat16` |
| `static_ctx` | (would crash) | exit 0, `fmha=bfloat16` |
| `static_gen` | — | exit 0, `fmha=fp8` (kept) |
| `disagg` | (would crash) | exit 0, prefill `bf16` / decode `fp8` |
| Explicit `--fmha-quant-mode fp8` (context) | PerfData traceback | concise `Error:` line, exit 1 |

Unit tests (`tests/unit/sdk/models/test_context_fmha_compat.py`) cover the context/gen × inferred/explicit matrix plus non-V3 and bf16-checkpoint no-ops. Full `tests/unit/sdk/models`, `tests/unit/cli`, and `tests/unit/sdk/task_v2` suites pass.

## Note
A genuinely oversized config still surfaces a normal OOM `RuntimeError` (pre-existing, out of scope) — that is orthogonal to this fix (the OOM occurs at `fmha=bfloat16`, after the fp8 issue is resolved).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for safer FMHA quantization handling for certain context-attention workloads.

* **Bug Fixes**
  * Context estimates now automatically switch unsupported FP8 FMHA settings to `bfloat16` for affected models.
  * Explicitly requesting FP8 in those context cases now returns a clear error.
  * Generation-only paths keep existing FP8 behavior unchanged.

* **Documentation**
  * Updated CLI guidance to explain the new estimate-mode behavior for context and decode workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->