### PR TITLE
fix(sdk): preserve multimodal fields in agg sweep point config (cherry-pick #1280)

### DIFF
--- a/src/aiconfigurator/sdk/sweep.py
+++ b/src/aiconfigurator/sdk/sweep.py
@@ -283,7 +283,6 @@ def _sweep_one_parallel_agg(
     osl = runtime_config.osl
     ttft_target = runtime_config.ttft
     tpot_target = runtime_config.tpot
-    prefix = runtime_config.prefix
 
     b_list = [b for b in _DEFAULT_AGG_BATCH_SCHEDULE if b <= max_batch_size]
     ctx_tokens_list = _agg_ctx_tokens_list(isl, ctx_stride, enable_chunked_prefill)
@@ -310,14 +309,13 @@ def _sweep_one_parallel_agg(
                     continue
                 capped_b.append(gen_tokens)
 
-            point_rt = config.RuntimeConfig(
-                batch_size=b,
-                isl=isl,
-                osl=osl,
-                prefix=prefix,
-                seq_imbalance_correction_scale=runtime_config.seq_imbalance_correction_scale,
-                engine_step_backend=runtime_config.engine_step_backend,
-            )
+            # Deep-copy the full runtime_config (mirrors the disagg path below) so
+            # every field is preserved per batch point. Explicit field-by-field
+            # construction silently dropped multimodal fields (image_height/width,
+            # num_images_per_request, num_image_tokens), zeroing the image encoder
+            # workload in agg while disagg stayed correct (NVBug 6401839).
+            point_rt = copy.deepcopy(runtime_config)
+            point_rt.batch_size = b
 
             backend_kwargs: dict[str, Any] = {}
             if max_seq_len is not None:

--- a/tests/unit/sdk/sweep/test_sweep.py
+++ b/tests/unit/sdk/sweep/test_sweep.py
@@ -106,6 +106,63 @@ def test_sweep_agg_classifies_no_result_outcomes(monkeypatch, memory_states, exp
         )
 
 
+def test_sweep_agg_point_config_preserves_multimodal_fields(monkeypatch):
+    """Regression for NVBug 6401839: the agg per-batch RuntimeConfig must carry
+    every multimodal field from the base runtime_config. The old field-by-field
+    construction dropped image_height/width, num_images_per_request, and
+    num_image_tokens, zeroing the image encoder workload in agg while disagg
+    (which deep-copies) stayed correct."""
+    captured: list[config.RuntimeConfig] = []
+
+    def _record(*, runtime_config, **_kwargs):
+        captured.append(runtime_config)
+        summary = MagicMock()
+        summary.check_oom.return_value = False
+        summary.check_kv_cache_oom.return_value = False
+        summary.get_result_dict.return_value = {"ttft": 1.0, "tpot": 1.0}
+        summary.get_per_ops_source.return_value = {}
+        return summary
+
+    monkeypatch.setattr(sweep, "get_backend", lambda _backend_name: MagicMock())
+    monkeypatch.setattr(sweep, "get_model", lambda **_kwargs: MagicMock())
+    monkeypatch.setattr(sweep, "predict_agg_worker", _record)
+
+    base_rt = config.RuntimeConfig(
+        isl=256,
+        osl=256,
+        ttft=1e9,
+        tpot=1e9,
+        image_height=1024,
+        image_width=1024,
+        num_images_per_request=2,
+        num_image_tokens=333,
+        seq_imbalance_correction_scale=1.5,
+        engine_step_backend="rust",
+    )
+
+    sweep.sweep_agg(
+        model_path="test-model",
+        runtime_config=base_rt,
+        database=MagicMock(),
+        backend_name="trtllm",
+        model_config=config.ModelConfig(),
+        parallel_config_list=[(1, 1, 1, 1, 1, 1)],
+        max_batch_size=1,
+        ctx_stride=1024,
+    )
+
+    assert captured, "expected at least one agg point to be evaluated"
+    for point_rt in captured:
+        assert point_rt.image_height == 1024
+        assert point_rt.image_width == 1024
+        assert point_rt.num_images_per_request == 2
+        assert point_rt.num_image_tokens == 333
+        # Non-multimodal fields must survive too (the deep-copy carries them all).
+        assert point_rt.seq_imbalance_correction_scale == 1.5
+        assert point_rt.engine_step_backend == "rust"
+        assert point_rt.batch_size == 1
+
+
 # ---------------------------------------------------------------------------
 # sweep_disagg validation
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
#### Overview:

Backports #1280 to release/0.10.0.

#### Details:

- Cherry-picks the fix commit ad71f6d9cbb97d5de2ddc7b62aa1ffc932ebfa1f.
- Contains exactly one commit based directly on release/0.10.0.
- The backport patch is identical to the original patch and preserves DCO compliance.

#### Fix summary:

The aggregated sweep built each per-batch RuntimeConfig field-by-field and copied only text-workload fields, so image_height/width, num_images_per_request, and num_image_tokens reverted to defaults — zeroing the image encoder workload in agg (encoder_latency=0 / encoder_memory=0.0), while disagg (which deep-copies) stayed correct. Deep-copy the full runtime_config per batch point so every runtime field is preserved.

#### Validation:

- tests/unit/sdk/sweep/test_sweep.py: 48 passed (incl. the new multimodal-field regression test).

#### Where should the reviewer start?

See the original PR: https://github.com/ai-dynamo/aiconfigurator/pull/1280

#### Related Issues:

- Relates to #1280
