### PR TITLE
fix(cli): report expected data/compatibility errors without tracebacks (cherry-pick #1282)

### DIFF
--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -27,7 +27,7 @@ from aiconfigurator.sdk import common, perf_database
 from aiconfigurator.sdk.errors import (
     NoFeasibleConfigError,
     UnsupportedWideepConfigError,
-    is_expected_no_result_cause,
+    is_expected_cli_error,
 )
 from aiconfigurator.sdk.models import check_is_moe
 from aiconfigurator.sdk.task_v2 import Task
@@ -1520,8 +1520,14 @@ def build_experiment_tasks(
         try:
             task_config = {**exp_config, "database_mode": database_mode}
             tasks[exp_name] = Task.from_yaml(task_config, **overrides)
-        except Exception:
-            logger.exception("Failed to build Task for experiment '%s'", exp_name)
+        except Exception as exc:
+            if is_expected_cli_error(exc):
+                # Expected config/compatibility rejection (e.g. MegaMoE requires a
+                # Blackwell system): report cleanly and keep the traceback at DEBUG.
+                logger.log(logging.ERROR, "Failed to build Task for experiment '%s': %s", exp_name, exc)
+                logger.debug("Traceback for experiment %s", exp_name, exc_info=True)
+            else:
+                logger.exception("Failed to build Task for experiment '%s'", exp_name)
 
     return tasks
 
@@ -1597,10 +1603,13 @@ def _execute_tasks(
             logger.warning(msg)
             failure_messages.append(msg)
         except Exception as exc:
-            if is_expected_no_result_cause(exc) or perf_database.has_perf_data_not_available_cause(exc):
-                # Expected failure (no feasible config / OOM / KV-cache capacity, or
-                # a per-op perf-data miss): report cleanly without a scary traceback.
+            if is_expected_cli_error(exc):
+                # Expected failure (no feasible config / OOM / KV-cache capacity,
+                # a per-op perf-data miss, or an unsupported quant/compatibility
+                # config): report cleanly. Keep the traceback at DEBUG for
+                # diagnosis via --log-level DEBUG.
                 logger.log(logging.ERROR, "Error running experiment %s: %s", exp_name, exc)
+                logger.debug("Traceback for experiment %s", exp_name, exc_info=True)
             else:
                 logger.exception("Error running experiment %s", exp_name)
             failure_messages.append(f"Experiment {exp_name} failed: {exc}")
@@ -2314,14 +2323,19 @@ def main(args):
 
     # Handle estimate mode separately (single-point estimation)
     if args.mode == "estimate":
-        # Invalid sizing/parameters surface as ValueError from the SDK
-        # validation path (e.g. AFD f_moe_ep_size not dividing f_tp_size).
-        # Convert to a concise CLI error instead of a full traceback,
-        # matching the set_systems_paths convention above.
+        # Expected user errors surface from the SDK as ValueError (invalid
+        # sizing/parameters, unsupported quant/compatibility) or as a perf-data
+        # coverage miss (PerfDataNotAvailableError / EmpiricalNotImplementedError).
+        # Convert them to a concise CLI error instead of a full traceback; keep
+        # the traceback at DEBUG (--log-level DEBUG) and let genuine bugs
+        # (KeyError, OOM RuntimeError, …) propagate unchanged.
         try:
             _run_estimate_mode(args)
-        except ValueError as exc:
-            raise SystemExit("Error: " + str(exc)) from exc
+        except Exception as exc:
+            if is_expected_cli_error(exc):
+                logger.debug("Traceback for estimate mode", exc_info=True)
+                raise SystemExit("Error: " + str(exc)) from exc
+            raise
         return
 
     if args.mode == "default":

--- a/src/aiconfigurator/sdk/errors.py
+++ b/src/aiconfigurator/sdk/errors.py
@@ -67,14 +67,13 @@ class EmpiricalNotImplementedError(RuntimeError):
     """
 
 
-def is_expected_no_result_cause(error: BaseException) -> bool:
-    """Return True when ``error`` or its effective chain has a NoResultsError.
+def _chain_has(error: BaseException, types: tuple[type[BaseException], ...]) -> bool:
+    """Return True when ``error`` or its effective chain contains one of ``types``.
 
     Follows an explicit ``__cause__`` or an unsuppressed ``__context__`` so a
-    generic wrapper such as
-    ``RuntimeError(...) from InsufficientMemoryError(...)`` is recognized as an
-    expected no-result outcome, while a wrapper around a genuine bug (e.g. an
-    unexpected ``KeyError``) returns False and keeps its traceback.
+    generic wrapper such as ``RuntimeError(...) from InsufficientMemoryError(...)``
+    is classified by the underlying cause, while a wrapper around a genuine bug
+    (e.g. an unexpected ``KeyError``) is not matched and keeps its traceback.
     """
     seen: set[int] = set()
     stack: list[BaseException] = [error]
@@ -82,7 +81,7 @@ def is_expected_no_result_cause(error: BaseException) -> bool:
         current = stack.pop()
         if id(current) in seen:
             continue
-        if isinstance(current, NoResultsError):
+        if isinstance(current, types):
             return True
         seen.add(id(current))
         if current.__cause__ is not None:
@@ -90,3 +89,34 @@ def is_expected_no_result_cause(error: BaseException) -> bool:
         elif not current.__suppress_context__ and current.__context__ is not None:
             stack.append(current.__context__)
     return False
+
+
+def is_expected_no_result_cause(error: BaseException) -> bool:
+    """Return True when ``error`` or its effective chain has a NoResultsError."""
+    return _chain_has(error, (NoResultsError,))
+
+
+def is_expected_cli_error(error: BaseException) -> bool:
+    """Return True when ``error`` is an *expected*, user-actionable CLI failure.
+
+    Expected = the user's inputs/environment can't be served and the message
+    already says why: SLA-infeasible / OOM / KV-cache (``NoResultsError``), a
+    perf-data coverage gap (``PerfDataNotAvailableError`` /
+    ``EmpiricalNotImplementedError``), or a configuration / compatibility
+    rejection (``ValueError`` — the whole SDK raises this by convention for
+    unsupported quant modes, invalid parallelism, hardware requirements, etc.).
+
+    Such errors should be reported as a concise ``Error: <message>`` line, not a
+    Python traceback. Genuine programming defects (``KeyError``,
+    ``AttributeError``, ``TypeError``, ``RuntimeError`` such as OOM, …) are NOT
+    matched and keep their traceback so real bugs stay visible. Callers should
+    still emit the full traceback at DEBUG level (``exc_info=True``) so
+    ``--log-level DEBUG`` can recover it when diagnosing.
+
+    Walks the exception chain, so a wrapper raised ``from`` an expected cause is
+    still recognized.
+    """
+    return _chain_has(
+        error,
+        (NoResultsError, PerfDataNotAvailableError, EmpiricalNotImplementedError, ValueError),
+    )

--- a/tests/unit/sdk/test_errors.py
+++ b/tests/unit/sdk/test_errors.py
@@ -18,10 +18,12 @@ two contracts verified here:
 import pytest
 
 from aiconfigurator.sdk.errors import (
+    EmpiricalNotImplementedError,
     InsufficientMemoryError,
     KVCacheCapacityError,
     NoFeasibleConfigError,
     NoResultsError,
+    is_expected_cli_error,
     is_expected_no_result_cause,
 )
 from aiconfigurator.sdk.perf_database import PerfDataNotAvailableError
@@ -110,3 +112,59 @@ def test_recognizer_avoids_cycles() -> None:
     nested.__context__ = error
 
     assert not is_expected_no_result_cause(error)
+
+
+# ---------------------------------------------------------------------------
+# is_expected_cli_error — the shared CLI classifier (NVBug 6401889)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        NoFeasibleConfigError("sla"),
+        InsufficientMemoryError("oom"),
+        KVCacheCapacityError("kv"),
+        PerfDataNotAvailableError("missing silicon data"),
+        EmpiricalNotImplementedError("no basis"),
+        ValueError("Unsupported gemm quant mode 'fp8_static'"),
+    ],
+)
+def test_cli_classifier_accepts_expected_user_errors(exc) -> None:
+    """SLA/OOM/KV, perf-data misses, and config/compatibility ValueErrors are concise."""
+    assert is_expected_cli_error(exc)
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        KeyError("bug"),
+        AttributeError("bug"),
+        TypeError("bug"),
+        RuntimeError("OOM: model does not fit"),  # plain RuntimeError (e.g. OOM) keeps traceback
+        IndexError("bug"),
+    ],
+)
+def test_cli_classifier_rejects_programming_errors(exc) -> None:
+    """Genuine defects (and OOM RuntimeError) are NOT concise — they keep tracebacks."""
+    assert not is_expected_cli_error(exc)
+
+
+def test_cli_classifier_accepts_wrapper_chained_from_expected_cause() -> None:
+    # A ValueError (unsupported quant) wrapped by a generic RuntimeError is still expected.
+    try:
+        raise RuntimeError("task failed") from ValueError("Unsupported quant mode")
+    except RuntimeError as exc:
+        assert is_expected_cli_error(exc)
+    # Same for a perf-data miss surfaced through a wrapper.
+    try:
+        raise RuntimeError("task failed") from PerfDataNotAvailableError("miss")
+    except RuntimeError as exc:
+        assert is_expected_cli_error(exc)
+
+
+def test_cli_classifier_rejects_wrapper_around_real_bug() -> None:
+    try:
+        raise RuntimeError("task failed") from KeyError("unexpected")
+    except RuntimeError as exc:
+        assert not is_expected_cli_error(exc)


### PR DESCRIPTION
#### Overview:

Backports #1282 to release/0.10.0.

#### Details:

- Cherry-picks the fix commit bb5bbaaf8875f665f1333361851b47598e80b4e6.
- Contains exactly one commit based directly on release/0.10.0.
- The backport patch is identical to the original patch and preserves DCO compliance.

#### Fix summary:

Three CLI paths printed full tracebacks for expected user errors — estimate (missing perf data), Task execution in default/exp (unsupported quant/compatibility), and Task construction in exp (e.g. MegaMoE requires Blackwell). Adds a shared classifier `is_expected_cli_error()` (walks the exception chain for NoResultsError / PerfDataNotAvailableError / EmpiricalNotImplementedError / ValueError) and wires all three sites to render a concise `Error: <message>` (exit 1) with the full traceback kept at DEBUG (recoverable via `--log-level DEBUG`). Genuine defects (KeyError, AttributeError, TypeError, OOM RuntimeError, ...) keep their tracebacks. The change is a strict superset of the prior concise-handling.

Note: Task.from_yaml schema/field ValueErrors from bad YAML now also render concise (better UX); the DEBUG traceback covers the code-side case.

#### Validation:

- tests/unit/sdk/test_errors.py: 25 passed.
- e2e on release/0.10.0: default unsupported-fp8_static exits 1 with a concise reason and zero tracebacks.

#### Where should the reviewer start?

See the original PR: https://github.com/ai-dynamo/aiconfigurator/pull/1282

#### Related Issues:

- Relates to #1282
