### PR TITLE
fix: generator parameter propagation fixes across the generation paths

### DIFF
--- a/src/aiconfigurator/generator/builders/dgd_model.py
+++ b/src/aiconfigurator/generator/builders/dgd_model.py
@@ -22,6 +22,7 @@ dicts/lists passed through verbatim.
 from __future__ import annotations
 
 import copy
+import re
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -29,6 +30,33 @@ import yaml
 
 DGD_API_VERSION = "nvidia.com/v1alpha1"
 DGD_KIND = "DynamoGraphDeployment"
+
+# Boolean tokens of go-yaml (YAML 1.1), which Kubernetes uses for YAML-to-JSON
+# conversion. PyYAML's own resolver omits the single letters y/Y/n/N, so it
+# emits the string "y" as a plain scalar that the API server decodes as the
+# JSON boolean true — the DGD admission webhook then rejects the manifest
+# because EnvVar.value must be a string. Quote every token in the go-yaml set.
+_YAML11_BOOL_TOKENS = re.compile(
+    r"^(?:y|Y|n|N|yes|Yes|YES|no|No|NO|true|True|TRUE"
+    r"|false|False|FALSE|on|On|ON|off|Off|OFF)$"
+)
+
+
+class _K8sSafeDumper(yaml.SafeDumper):
+    """SafeDumper that keeps YAML-1.1 boolean-like strings quoted for K8s."""
+
+
+def _represent_str_k8s(dumper: yaml.SafeDumper, data: str) -> yaml.ScalarNode:
+    style = "'" if _YAML11_BOOL_TOKENS.match(data) else None
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data, style=style)
+
+
+_K8sSafeDumper.add_representer(str, _represent_str_k8s)
+
+
+def k8s_safe_dump(data: Any) -> str:
+    """Serialize a K8s manifest dict without losing string types to YAML 1.1."""
+    return yaml.dump(data, Dumper=_K8sSafeDumper, sort_keys=False)
 
 
 def _put(out: dict[str, Any], key: str, value: Any) -> None:
@@ -221,7 +249,7 @@ class DGD:
         return out
 
     def to_yaml(self) -> str:
-        return yaml.safe_dump(self.to_dict(), sort_keys=False)
+        return k8s_safe_dump(self.to_dict())
 
 
 @dataclass
@@ -268,7 +296,7 @@ class ConfigMapDoc:
         return out
 
     def to_yaml(self) -> str:
-        return yaml.safe_dump(self.to_dict(), sort_keys=False)
+        return k8s_safe_dump(self.to_dict())
 
 
 @dataclass
@@ -327,7 +355,7 @@ class ComputeDomainDoc:
         return out
 
     def to_yaml(self) -> str:
-        return yaml.safe_dump(self.to_dict(), sort_keys=False)
+        return k8s_safe_dump(self.to_dict())
 
 
 def dgd_documents_to_yaml(docs: list[Any]) -> str:

--- a/src/aiconfigurator/generator/module_bridge.py
+++ b/src/aiconfigurator/generator/module_bridge.py
@@ -256,12 +256,16 @@ def task_config_to_generator_config(
     # benchmark doesn't silently degrade to text-only (the schema default
     # image_batch_size: 0 disables every image block in the bench templates).
     # Explicit --generator-set BenchConfig.* overrides keep highest precedence.
+    # getattr: duck-typed callers (spica's argparse.Namespace) lack the
+    # optional Task fields.
     bench_cfg: dict[str, Any] = {}
-    if task_config.image_height > 0 and task_config.image_width > 0:
+    image_height = _safe_int(getattr(task_config, "image_height", 0), 0)
+    image_width = _safe_int(getattr(task_config, "image_width", 0), 0)
+    if image_height > 0 and image_width > 0:
         bench_cfg = {
-            "image_batch_size": task_config.num_images_per_request,
-            "image_width_mean": task_config.image_width,
-            "image_height_mean": task_config.image_height,
+            "image_batch_size": _safe_int(getattr(task_config, "num_images_per_request", 1), 1),
+            "image_width_mean": image_width,
+            "image_height_mean": image_height,
         }
     bench_cfg = _deep_merge(bench_cfg, overrides.get("BenchConfig"))
 
@@ -292,8 +296,10 @@ def task_config_to_generator_config(
     # NodeConfig.system_name blank and facts resolution silently skipped all
     # hardware placement/env for disagg DGDs.
     if task_config.serving_mode != "agg":
-        prefill_system = task_config.prefill_system_name
-        decode_system = task_config.decode_system_name
+        # getattr: duck-typed callers (spica) carry only the primary_* views,
+        # not the per-role disagg fields.
+        prefill_system = getattr(task_config, "prefill_system_name", "")
+        decode_system = getattr(task_config, "decode_system_name", "")
         if prefill_system and decode_system and prefill_system != decode_system:
             # NodeConfig carries a single system: emitting prefill facts for
             # decode workers would silently misplace them. Reject until the
@@ -303,7 +309,9 @@ def task_config_to_generator_config(
                 f"prefill_system_name={prefill_system!r} != decode_system_name={decode_system!r}. "
                 "Generate per-system deployments separately or use matching systems."
             )
-    params.setdefault("NodeConfig", {})["system_name"] = task_config.primary_system_name
+    params.setdefault("NodeConfig", {})["system_name"] = getattr(
+        task_config, "primary_system_name", None
+    ) or getattr(task_config, "system_name", "")
     # Explicit --generator-set NodeConfig.* overrides win over derived values
     # (same precedence as the naive path); previously they were dropped.
     node_overrides = overrides.get("NodeConfig")

--- a/src/aiconfigurator/generator/module_bridge.py
+++ b/src/aiconfigurator/generator/module_bridge.py
@@ -304,6 +304,11 @@ def task_config_to_generator_config(
                 "Generate per-system deployments separately or use matching systems."
             )
     params.setdefault("NodeConfig", {})["system_name"] = task_config.primary_system_name
+    # Explicit --generator-set NodeConfig.* overrides win over derived values
+    # (same precedence as the naive path); previously they were dropped.
+    node_overrides = overrides.get("NodeConfig")
+    if isinstance(node_overrides, dict) and node_overrides:
+        params["NodeConfig"] = _deep_merge(params["NodeConfig"], node_overrides)
     rule_name = overrides.get("rule")
     if rule_name:
         params["rule"] = rule_name

--- a/src/aiconfigurator/generator/module_bridge.py
+++ b/src/aiconfigurator/generator/module_bridge.py
@@ -252,7 +252,18 @@ def task_config_to_generator_config(
         "tpot": _safe_float(_series_val(result_df, "tpot", task_config.tpot), task_config.tpot),
     }
     sla_cfg = _deep_merge(sla_cfg, overrides.get("SlaConfig"))
-    bench_cfg = overrides.get("BenchConfig")
+    # Seed BenchConfig from the Task's multimodal image workload so a VL
+    # benchmark doesn't silently degrade to text-only (the schema default
+    # image_batch_size: 0 disables every image block in the bench templates).
+    # Explicit --generator-set BenchConfig.* overrides keep highest precedence.
+    bench_cfg: dict[str, Any] = {}
+    if task_config.image_height > 0 and task_config.image_width > 0:
+        bench_cfg = {
+            "image_batch_size": task_config.num_images_per_request,
+            "image_width_mean": task_config.image_width,
+            "image_height_mean": task_config.image_height,
+        }
+    bench_cfg = _deep_merge(bench_cfg, overrides.get("BenchConfig"))
 
     params = collect_generator_params(
         service=service_cfg,

--- a/src/aiconfigurator/generator/module_bridge.py
+++ b/src/aiconfigurator/generator/module_bridge.py
@@ -275,8 +275,24 @@ def task_config_to_generator_config(
     )
 
     params = _deep_merge(params, overrides.get("Params"))
-    # Expose SDK's system identifier to templates via NodeConfig.system_name
-    params.setdefault("NodeConfig", {})["system_name"] = task_config.system_name
+    # Expose SDK's system identifier to templates via NodeConfig.system_name.
+    # Task v2 prefix discipline keeps the top-level system_name empty for
+    # disagg, so read primary_system_name (prefill side) — the raw field left
+    # NodeConfig.system_name blank and facts resolution silently skipped all
+    # hardware placement/env for disagg DGDs.
+    if task_config.serving_mode != "agg":
+        prefill_system = task_config.prefill_system_name
+        decode_system = task_config.decode_system_name
+        if prefill_system and decode_system and prefill_system != decode_system:
+            # NodeConfig carries a single system: emitting prefill facts for
+            # decode workers would silently misplace them. Reject until the
+            # generator supports per-role hardware profiles.
+            raise ValueError(
+                "Disaggregated generation does not support heterogeneous systems yet: "
+                f"prefill_system_name={prefill_system!r} != decode_system_name={decode_system!r}. "
+                "Generate per-system deployments separately or use matching systems."
+            )
+    params.setdefault("NodeConfig", {})["system_name"] = task_config.primary_system_name
     rule_name = overrides.get("rule")
     if rule_name:
         params["rule"] = rule_name

--- a/src/aiconfigurator/generator/module_bridge.py
+++ b/src/aiconfigurator/generator/module_bridge.py
@@ -309,9 +309,9 @@ def task_config_to_generator_config(
                 f"prefill_system_name={prefill_system!r} != decode_system_name={decode_system!r}. "
                 "Generate per-system deployments separately or use matching systems."
             )
-    params.setdefault("NodeConfig", {})["system_name"] = getattr(
-        task_config, "primary_system_name", None
-    ) or getattr(task_config, "system_name", "")
+    params.setdefault("NodeConfig", {})["system_name"] = getattr(task_config, "primary_system_name", None) or getattr(
+        task_config, "system_name", ""
+    )
     # Explicit --generator-set NodeConfig.* overrides win over derived values
     # (same precedence as the naive path); previously they were dropped.
     node_overrides = overrides.get("NodeConfig")

--- a/src/aiconfigurator/generator/module_bridge.py
+++ b/src/aiconfigurator/generator/module_bridge.py
@@ -309,6 +309,12 @@ def task_config_to_generator_config(
         params["rule"] = rule_name
     if "preserve_engine_limits" in overrides:
         params["preserve_engine_limits"] = bool(overrides["preserve_engine_limits"])
+    # Preserve the LlmdConfig section for the llm-d deployment targets (same
+    # semantics as the naive path: only emitted when non-empty). Dropping it
+    # made llm-d artifacts silently fall back to template defaults.
+    llmd_config = overrides.get("LlmdConfig")
+    if isinstance(llmd_config, dict) and llmd_config:
+        params["LlmdConfig"] = copy.deepcopy(llmd_config)
     params["ModelConfig"] = model_cfg
     return params
 

--- a/src/aiconfigurator/generator/naive.py
+++ b/src/aiconfigurator/generator/naive.py
@@ -420,6 +420,10 @@ def build_naive_generator_params(
     }
     node_config = {
         "num_gpus_per_node": gpus_per_node,
+        # Templates branch on NodeConfig.system_name (e.g. the vllm run.sh
+        # B60 ONEAPI vs CUDA device selector); K8sConfig.system_name alone
+        # only feeds facts resolution for the k8s artifacts.
+        "system_name": system_name,
     }
     model_config = {
         "is_moe": is_moe,
@@ -508,6 +512,11 @@ def build_naive_generator_params(
             backend=backend_name,
             generator_dynamo_version=effective_dynamo_version,
         )
+
+    # collect_generator_params rebuilds NodeConfig from the num_gpus_per_node
+    # scalar only; merge the full local node_config back so the system
+    # identity and explicit NodeConfig.* overrides survive into the output.
+    params["NodeConfig"] = _deep_merge_dicts(params.get("NodeConfig", {}), node_config)
 
     params["ModelConfig"] = model_config
     if llmd_config:

--- a/tests/unit/generator/test_dgd_yaml_serialization.py
+++ b/tests/unit/generator/test_dgd_yaml_serialization.py
@@ -29,10 +29,28 @@ from aiconfigurator.generator.builders.dgd_model import (
 # The go-yaml (YAML 1.1) implicit boolean tokens. PyYAML quotes the multi-letter
 # ones on its own; the single letters y/Y/n/N are the regression trigger.
 GO_YAML_BOOL_TOKENS = [
-    "y", "Y", "n", "N",
-    "yes", "Yes", "YES", "no", "No", "NO",
-    "true", "True", "TRUE", "false", "False", "FALSE",
-    "on", "On", "ON", "off", "Off", "OFF",
+    "y",
+    "Y",
+    "n",
+    "N",
+    "yes",
+    "Yes",
+    "YES",
+    "no",
+    "No",
+    "NO",
+    "true",
+    "True",
+    "TRUE",
+    "false",
+    "False",
+    "FALSE",
+    "on",
+    "On",
+    "ON",
+    "off",
+    "Off",
+    "OFF",
 ]
 
 _UNQUOTED_BOOL_LIKE = re.compile(

--- a/tests/unit/generator/test_dgd_yaml_serialization.py
+++ b/tests/unit/generator/test_dgd_yaml_serialization.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""K8s-safe YAML serialization of the typed DGD document models.
+
+Kubernetes converts manifests YAML->JSON with go-yaml (full YAML 1.1), whose
+implicit boolean token set includes the single letters y/Y/n/N that PyYAML's
+resolver omits. PyYAML therefore emits the Python string "y" as the plain
+scalar ``y``, which the API server decodes as the JSON boolean ``true`` and
+the DGD admission webhook rejects (EnvVar.value must be a string). These
+tests pin that every boolean-like string survives serialization as a quoted
+scalar in every emitted K8s document type.
+"""
+
+import re
+
+import pytest
+import yaml
+
+from aiconfigurator.generator.builders.dgd_model import (
+    DGD,
+    ComputeDomainDoc,
+    ConfigMapDoc,
+    DGDService,
+    ExtraPodSpec,
+    MainContainer,
+    dgd_documents_to_yaml,
+)
+
+# The go-yaml (YAML 1.1) implicit boolean tokens. PyYAML quotes the multi-letter
+# ones on its own; the single letters y/Y/n/N are the regression trigger.
+GO_YAML_BOOL_TOKENS = [
+    "y", "Y", "n", "N",
+    "yes", "Yes", "YES", "no", "No", "NO",
+    "true", "True", "TRUE", "false", "False", "FALSE",
+    "on", "On", "ON", "off", "Off", "OFF",
+]
+
+_UNQUOTED_BOOL_LIKE = re.compile(
+    r":\s+(?:y|Y|n|N|yes|Yes|YES|no|No|NO|true|True|TRUE"
+    r"|false|False|FALSE|on|On|ON|off|Off|OFF)\s*$",
+    re.MULTILINE,
+)
+
+
+def _dgd_with_env(value: str) -> DGD:
+    container = MainContainer(
+        image="nvcr.io/nvstaging/ai-dynamo/sglang-runtime:1.3.0-rc1",
+        env=[{"name": "UCX_CUDA_IPC_ENABLE_MNNVL", "value": value}],
+    )
+    service = DGDService(
+        component_type="worker",
+        replicas=1,
+        extra_pod_spec=ExtraPodSpec(main_container=container),
+    )
+    return DGD(name="dynamo-agg", namespace="qchi-aic", services={"SGLangWorker": service})
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("token", GO_YAML_BOOL_TOKENS)
+def test_dgd_env_bool_like_value_is_quoted(token):
+    out = _dgd_with_env(token).to_yaml()
+    assert not _UNQUOTED_BOOL_LIKE.search(out), (
+        f"boolean-like env value {token!r} emitted as a plain scalar; "
+        "Kubernetes YAML-to-JSON would decode it as a boolean"
+    )
+    doc = yaml.safe_load(out)
+    env = doc["spec"]["services"]["SGLangWorker"]["extraPodSpec"]["mainContainer"]["env"]
+    assert env[0]["value"] == token
+    assert isinstance(env[0]["value"], str)
+
+
+@pytest.mark.unit
+def test_dgd_regular_strings_stay_plain():
+    out = _dgd_with_env("1").to_yaml()
+    # Non-ambiguous strings must not pick up gratuitous quoting.
+    assert "image: nvcr.io/nvstaging/ai-dynamo/sglang-runtime:1.3.0-rc1" in out
+    assert "name: dynamo-agg" in out
+    assert "componentType: worker" in out
+
+
+@pytest.mark.unit
+def test_dgd_round_trip_preserves_env_value():
+    dgd = _dgd_with_env("y")
+    reparsed = DGD.from_dict(yaml.safe_load(dgd.to_yaml()))
+    assert reparsed.to_dict() == dgd.to_dict()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("token", ["y", "n", "on"])
+def test_configmap_data_bool_like_value_is_quoted(token):
+    doc = ConfigMapDoc(name="engine-configs", namespace="qchi-aic", data={"FLAG": token})
+    out = doc.to_yaml()
+    assert not _UNQUOTED_BOOL_LIKE.search(out)
+    assert yaml.safe_load(out)["data"]["FLAG"] == token
+
+
+@pytest.mark.unit
+def test_compute_domain_serialization_unaffected():
+    doc = ComputeDomainDoc(
+        name="dynamo-agg-compute-domain",
+        namespace="qchi-aic",
+        channel_name="dynamo-agg-channel",
+        num_nodes=2,
+    )
+    parsed = yaml.safe_load(doc.to_yaml())
+    assert parsed["spec"]["numNodes"] == 2
+    assert parsed["spec"]["channel"]["resourceClaimTemplate"]["name"] == "dynamo-agg-channel"
+
+
+@pytest.mark.unit
+def test_multi_doc_stream_quotes_bool_like_values():
+    docs = [
+        _dgd_with_env("y"),
+        ConfigMapDoc(name="engine-configs", data={"FLAG": "n"}),
+    ]
+    out = dgd_documents_to_yaml(docs)
+    assert not _UNQUOTED_BOOL_LIKE.search(out)
+    loaded = list(yaml.safe_load_all(out))
+    assert len(loaded) == 2

--- a/tests/unit/generator/test_module_bridge_bench_image.py
+++ b/tests/unit/generator/test_module_bridge_bench_image.py
@@ -59,9 +59,7 @@ def test_text_only_task_keeps_images_disabled():
 @pytest.mark.unit
 def test_explicit_bench_overrides_win_over_task_workload():
     task = _task(image_height=1024, image_width=1024, num_images_per_request=1)
-    bench = _bridge(task, {"BenchConfig": {"image_batch_size": 4, "image_width_mean": 512}})[
-        "BenchConfig"
-    ]
+    bench = _bridge(task, {"BenchConfig": {"image_batch_size": 4, "image_width_mean": 512}})["BenchConfig"]
     assert bench["image_batch_size"] == 4
     assert bench["image_width_mean"] == 512
     assert bench["image_height_mean"] == 1024
@@ -71,9 +69,7 @@ def test_explicit_bench_overrides_win_over_task_workload():
 def test_image_arguments_reach_benchmark_artifacts():
     task = _task(image_height=1024, image_width=1024, num_images_per_request=1)
     cfg = _bridge(task)
-    artifacts = generate_backend_artifacts(
-        cfg, "vllm", backend_version="0.20.1", deployment_target="dynamo-j2"
-    )
+    artifacts = generate_backend_artifacts(cfg, "vllm", backend_version="0.20.1", deployment_target="dynamo-j2")
     bench_artifacts = {k: v for k, v in artifacts.items() if "bench" in k}
     assert bench_artifacts, f"expected benchmark artifacts, got {sorted(artifacts)}"
     for name, content in bench_artifacts.items():
@@ -84,9 +80,7 @@ def test_image_arguments_reach_benchmark_artifacts():
 @pytest.mark.unit
 def test_text_only_benchmark_artifacts_omit_image_arguments():
     cfg = _bridge(_task())
-    artifacts = generate_backend_artifacts(
-        cfg, "vllm", backend_version="0.20.1", deployment_target="dynamo-j2"
-    )
+    artifacts = generate_backend_artifacts(cfg, "vllm", backend_version="0.20.1", deployment_target="dynamo-j2")
     for name, content in artifacts.items():
         if "bench" in name:
             assert "BENCH_IMAGE_BATCH_SIZE" not in content, f"{name}: unexpected image block"

--- a/tests/unit/generator/test_module_bridge_bench_image.py
+++ b/tests/unit/generator/test_module_bridge_bench_image.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Multimodal image workload propagation from Task v2 into BenchConfig.
+
+The Task carries the image workload as first-class fields (image_height,
+image_width, num_images_per_request) and the search uses them, but the bridge
+built BenchConfig purely from explicit --generator-set overrides. Without an
+override, the schema default image_batch_size: 0 disabled every image block in
+bench_run.sh / k8s_bench.yaml, so a requested VL benchmark silently ran
+text-only.
+"""
+
+import pandas as pd
+import pytest
+
+from aiconfigurator.generator.api import generate_backend_artifacts
+from aiconfigurator.generator.module_bridge import task_config_to_generator_config
+from aiconfigurator.sdk.task_v2 import Task
+
+
+def _task(**workload) -> Task:
+    return Task(
+        serving_mode="agg",
+        model_path="Qwen/Qwen3-VL-4B-Instruct",
+        system_name="h200_sxm",
+        backend_name="vllm",
+        isl=256,
+        osl=256,
+        ttft=2000.0,
+        tpot=50.0,
+        **workload,
+    )
+
+
+def _bridge(task: Task, overrides: dict | None = None) -> dict:
+    return task_config_to_generator_config(
+        task_config=task, result_df=pd.Series({"tp": 1}), generator_overrides=overrides
+    )
+
+
+@pytest.mark.unit
+def test_image_workload_propagates_to_bench_config():
+    task = _task(image_height=1024, image_width=1024, num_images_per_request=1)
+    bench = _bridge(task)["BenchConfig"]
+    assert bench["image_batch_size"] == 1
+    assert bench["image_width_mean"] == 1024
+    assert bench["image_height_mean"] == 1024
+
+
+@pytest.mark.unit
+def test_text_only_task_keeps_images_disabled():
+    bench = _bridge(_task())["BenchConfig"]
+    assert bench["image_batch_size"] == 0
+    assert not bench.get("image_width_mean")
+    assert not bench.get("image_height_mean")
+
+
+@pytest.mark.unit
+def test_explicit_bench_overrides_win_over_task_workload():
+    task = _task(image_height=1024, image_width=1024, num_images_per_request=1)
+    bench = _bridge(task, {"BenchConfig": {"image_batch_size": 4, "image_width_mean": 512}})[
+        "BenchConfig"
+    ]
+    assert bench["image_batch_size"] == 4
+    assert bench["image_width_mean"] == 512
+    assert bench["image_height_mean"] == 1024
+
+
+@pytest.mark.unit
+def test_image_arguments_reach_benchmark_artifacts():
+    task = _task(image_height=1024, image_width=1024, num_images_per_request=1)
+    cfg = _bridge(task)
+    artifacts = generate_backend_artifacts(
+        cfg, "vllm", backend_version="0.20.1", deployment_target="dynamo-j2"
+    )
+    bench_artifacts = {k: v for k, v in artifacts.items() if "bench" in k}
+    assert bench_artifacts, f"expected benchmark artifacts, got {sorted(artifacts)}"
+    for name, content in bench_artifacts.items():
+        assert "BENCH_IMAGE_BATCH_SIZE" in content, f"{name}: image block missing"
+        assert "1024" in content, f"{name}: image dimensions missing"
+
+
+@pytest.mark.unit
+def test_text_only_benchmark_artifacts_omit_image_arguments():
+    cfg = _bridge(_task())
+    artifacts = generate_backend_artifacts(
+        cfg, "vllm", backend_version="0.20.1", deployment_target="dynamo-j2"
+    )
+    for name, content in artifacts.items():
+        if "bench" in name:
+            assert "BENCH_IMAGE_BATCH_SIZE" not in content, f"{name}: unexpected image block"

--- a/tests/unit/generator/test_module_bridge_ducktyped_task.py
+++ b/tests/unit/generator/test_module_bridge_ducktyped_task.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Duck-typed task compatibility for the Task-to-generator bridge.
+
+The spica replay path (cli/spica/helper.py:_spica_generator_task) feeds the
+bridge an argparse.Namespace that mimics a Task with a fixed field set — it
+has primary_* views, serving_mode, and workload/SLA scalars, but none of the
+optional Task fields (multimodal image workload, per-role disagg system
+names). New bridge reads of Task attributes must therefore stay defensive
+(getattr with defaults), or the spica path crashes with AttributeError.
+"""
+
+import argparse
+
+import pandas as pd
+import pytest
+
+from aiconfigurator.generator.module_bridge import task_config_to_generator_config
+
+
+def _spica_like_namespace(serving_mode: str) -> argparse.Namespace:
+    # Mirrors the exact field set of cli/spica/helper.py:_spica_generator_task.
+    return argparse.Namespace(
+        primary_backend_name="sglang",
+        primary_system_name="h200_sxm",
+        primary_backend_version="0.5.11",
+        primary_model_path="Qwen/Qwen3-32B",
+        prefix=0,
+        is_moe=False,
+        nextn=0,
+        nextn_accept_rates=[0.85, 0.8, 0.6, 0.0, 0.0],
+        serving_mode=serving_mode,
+        total_gpus=8,
+        system_name="h200_sxm",
+        isl=1024,
+        osl=256,
+        ttft=2000.0,
+        tpot=50.0,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("serving_mode", ["agg", "disagg"])
+def test_bridge_accepts_spica_namespace(serving_mode):
+    row = pd.Series({"tp": 1, "(p)tp": 1, "(d)tp": 1})
+    cfg = task_config_to_generator_config(
+        task_config=_spica_like_namespace(serving_mode), result_df=row
+    )
+    assert cfg["NodeConfig"]["system_name"] == "h200_sxm"
+    # No image fields on the namespace -> image workload must stay disabled.
+    assert cfg["BenchConfig"].get("image_batch_size", 0) == 0

--- a/tests/unit/generator/test_module_bridge_ducktyped_task.py
+++ b/tests/unit/generator/test_module_bridge_ducktyped_task.py
@@ -44,9 +44,7 @@ def _spica_like_namespace(serving_mode: str) -> argparse.Namespace:
 @pytest.mark.parametrize("serving_mode", ["agg", "disagg"])
 def test_bridge_accepts_spica_namespace(serving_mode):
     row = pd.Series({"tp": 1, "(p)tp": 1, "(d)tp": 1})
-    cfg = task_config_to_generator_config(
-        task_config=_spica_like_namespace(serving_mode), result_df=row
-    )
+    cfg = task_config_to_generator_config(task_config=_spica_like_namespace(serving_mode), result_df=row)
     assert cfg["NodeConfig"]["system_name"] == "h200_sxm"
     # No image fields on the namespace -> image workload must stay disabled.
     assert cfg["BenchConfig"].get("image_batch_size", 0) == 0

--- a/tests/unit/generator/test_module_bridge_llmd_config.py
+++ b/tests/unit/generator/test_module_bridge_llmd_config.py
@@ -66,9 +66,7 @@ def test_absent_llmd_override_leaves_section_out():
 @pytest.mark.unit
 def test_llmd_kustomize_artifacts_use_overridden_image_and_base():
     cfg = _bridge(_LLMD_OVERRIDES)
-    artifacts = generate_backend_artifacts(
-        cfg, "vllm", backend_version="0.20.1", deployment_target="llm-d-kustomize"
-    )
+    artifacts = generate_backend_artifacts(cfg, "vllm", backend_version="0.20.1", deployment_target="llm-d-kustomize")
     assert set(artifacts) >= {"kustomization.yaml", "patch-decode.yaml", "patch-prefill.yaml"}
 
     kustomization = yaml.safe_load(artifacts["kustomization.yaml"])
@@ -82,9 +80,7 @@ def test_llmd_kustomize_artifacts_use_overridden_image_and_base():
 @pytest.mark.unit
 def test_llmd_helm_values_use_overridden_image():
     cfg = _bridge(_LLMD_OVERRIDES)
-    artifacts = generate_backend_artifacts(
-        cfg, "vllm", backend_version="0.20.1", deployment_target="llm-d-helm"
-    )
+    artifacts = generate_backend_artifacts(cfg, "vllm", backend_version="0.20.1", deployment_target="llm-d-helm")
     values = artifacts["llm-d-values.yaml"]
     assert _IMAGE in values
     assert "vllm/vllm-openai:latest" not in values

--- a/tests/unit/generator/test_module_bridge_llmd_config.py
+++ b/tests/unit/generator/test_module_bridge_llmd_config.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""LlmdConfig override propagation through the Task-to-generator bridge.
+
+The naive path preserves the LlmdConfig section from --generator-set
+overrides, but task_config_to_generator_config (used by cli default/sweep)
+never read it, so llm-d-kustomize/llm-d-helm artifacts silently fell back to
+the template defaults (vllm/vllm-openai:latest image and the default
+Kustomize base) no matter what the user requested.
+"""
+
+import pandas as pd
+import pytest
+import yaml
+
+from aiconfigurator.generator.api import generate_backend_artifacts
+from aiconfigurator.generator.module_bridge import task_config_to_generator_config
+from aiconfigurator.sdk.task_v2 import Task
+
+_IMAGE = "nvcr.io/nvstaging/ai-dynamo/vllm-runtime:1.3.0-rc1"
+_BASE = "./guides/pd-disaggregation/modelserver/gpu/vllm/base"
+_LLMD_OVERRIDES = {
+    "LlmdConfig": {
+        "vllm_image": _IMAGE,
+        "kustomize_base_path": _BASE,
+    }
+}
+
+
+def _disagg_task() -> Task:
+    return Task(
+        serving_mode="disagg",
+        prefill_model_path="Qwen/Qwen3-32B",
+        prefill_system_name="h200_sxm",
+        prefill_backend_name="vllm",
+        decode_model_path="Qwen/Qwen3-32B",
+        decode_system_name="h200_sxm",
+        decode_backend_name="vllm",
+        isl=4000,
+        osl=1000,
+        ttft=2000.0,
+        tpot=50.0,
+    )
+
+
+def _bridge(overrides: dict | None = None) -> dict:
+    return task_config_to_generator_config(
+        task_config=_disagg_task(),
+        result_df=pd.Series({"(p)tp": 1, "(d)tp": 1}),
+        generator_overrides=overrides,
+    )
+
+
+@pytest.mark.unit
+def test_llmd_config_overrides_survive_bridge():
+    cfg = _bridge(_LLMD_OVERRIDES)
+    assert cfg["LlmdConfig"] == {"vllm_image": _IMAGE, "kustomize_base_path": _BASE}
+
+
+@pytest.mark.unit
+def test_absent_llmd_override_leaves_section_out():
+    assert "LlmdConfig" not in _bridge()
+
+
+@pytest.mark.unit
+def test_llmd_kustomize_artifacts_use_overridden_image_and_base():
+    cfg = _bridge(_LLMD_OVERRIDES)
+    artifacts = generate_backend_artifacts(
+        cfg, "vllm", backend_version="0.20.1", deployment_target="llm-d-kustomize"
+    )
+    assert set(artifacts) >= {"kustomization.yaml", "patch-decode.yaml", "patch-prefill.yaml"}
+
+    kustomization = yaml.safe_load(artifacts["kustomization.yaml"])
+    assert kustomization["resources"] == [_BASE]
+
+    for patch_name in ("patch-decode.yaml", "patch-prefill.yaml"):
+        container = yaml.safe_load(artifacts[patch_name])["spec"]["template"]["spec"]["containers"][0]
+        assert container["image"] == _IMAGE, f"{patch_name}: image not overridden"
+
+
+@pytest.mark.unit
+def test_llmd_helm_values_use_overridden_image():
+    cfg = _bridge(_LLMD_OVERRIDES)
+    artifacts = generate_backend_artifacts(
+        cfg, "vllm", backend_version="0.20.1", deployment_target="llm-d-helm"
+    )
+    values = artifacts["llm-d-values.yaml"]
+    assert _IMAGE in values
+    assert "vllm/vllm-openai:latest" not in values

--- a/tests/unit/generator/test_module_bridge_system_name.py
+++ b/tests/unit/generator/test_module_bridge_system_name.py
@@ -104,3 +104,17 @@ def test_disagg_gb200_hardware_facts_reach_dgd():
         env = {e["name"]: e.get("value") for e in (pod.get("mainContainer") or {}).get("env") or []}
         assert "NCCL_MNNVL_ENABLE" in env, f"{name}: missing GB200 NCCL facts"
         assert "UCX_CUDA_IPC_ENABLE_MNNVL" in env, f"{name}: missing GB200 UCX facts"
+
+
+@pytest.mark.unit
+def test_explicit_node_config_overrides_win():
+    """--generator-set NodeConfig.* must survive the bridge and take precedence
+    over derived values (same precedence as the naive path)."""
+    task = _disagg_task("gb200", "gb200")
+    cfg = task_config_to_generator_config(
+        task_config=task,
+        result_df=_result_row(),
+        generator_overrides={"NodeConfig": {"system_name": "custom-system", "num_gpus_per_node": 4}},
+    )
+    assert cfg["NodeConfig"]["system_name"] == "custom-system"
+    assert cfg["NodeConfig"]["num_gpus_per_node"] == 4

--- a/tests/unit/generator/test_module_bridge_system_name.py
+++ b/tests/unit/generator/test_module_bridge_system_name.py
@@ -85,16 +85,10 @@ def test_disagg_gb200_hardware_facts_reach_dgd():
     placement and NCCL/UCX environment on disagg workers in the raw DGD."""
     task = _disagg_task("gb200", "gb200")
     cfg = task_config_to_generator_config(task_config=task, result_df=_result_row())
-    artifacts = generate_backend_artifacts(
-        cfg, "sglang", backend_version="0.5.11", deployment_target="dynamo-j2"
-    )
+    artifacts = generate_backend_artifacts(cfg, "sglang", backend_version="0.5.11", deployment_target="dynamo-j2")
     dgd = yaml.safe_load(artifacts["k8s_deploy.yaml"])
 
-    workers = {
-        name: svc
-        for name, svc in dgd["spec"]["services"].items()
-        if svc.get("componentType") == "worker"
-    }
+    workers = {name: svc for name, svc in dgd["spec"]["services"].items() if svc.get("componentType") == "worker"}
     assert workers, "expected disagg worker services in the DGD"
     for name, svc in workers.items():
         pod = svc.get("extraPodSpec") or {}

--- a/tests/unit/generator/test_module_bridge_system_name.py
+++ b/tests/unit/generator/test_module_bridge_system_name.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""System-name propagation from Task v2 into generator params.
+
+Task v2's prefix discipline keeps the top-level ``system_name`` empty for
+disagg tasks (the values live in ``prefill_system_name``/``decode_system_name``),
+so the bridge must read ``primary_system_name``. Reading the raw field left
+``NodeConfig.system_name`` empty, facts resolution returned None, and disagg
+DGDs shipped with no nodeSelector/tolerations/NCCL env — a ``--system gb200``
+SGLang deployment silently scheduled onto amd64 H200 nodes.
+"""
+
+import pandas as pd
+import pytest
+import yaml
+
+from aiconfigurator.generator.api import generate_backend_artifacts
+from aiconfigurator.generator.module_bridge import task_config_to_generator_config
+from aiconfigurator.sdk.task_v2 import Task
+
+MODEL = "Qwen/Qwen3-32B"
+
+
+def _disagg_task(prefill_system: str, decode_system: str) -> Task:
+    return Task(
+        serving_mode="disagg",
+        prefill_model_path=MODEL,
+        prefill_system_name=prefill_system,
+        prefill_backend_name="sglang",
+        decode_model_path=MODEL,
+        decode_system_name=decode_system,
+        decode_backend_name="sglang",
+        isl=1024,
+        osl=256,
+        ttft=2000.0,
+        tpot=50.0,
+    )
+
+
+def _result_row() -> pd.Series:
+    return pd.Series(
+        {
+            "(p)workers": 1,
+            "(p)tp": 1,
+            "(d)workers": 1,
+            "(d)tp": 1,
+        }
+    )
+
+
+@pytest.mark.unit
+def test_disagg_system_name_propagates_to_node_config():
+    task = _disagg_task("gb200", "gb200")
+    cfg = task_config_to_generator_config(task_config=task, result_df=_result_row())
+    assert cfg["NodeConfig"]["system_name"] == "gb200"
+
+
+@pytest.mark.unit
+def test_agg_system_name_still_propagates():
+    task = Task(
+        serving_mode="agg",
+        model_path=MODEL,
+        system_name="h200_sxm",
+        backend_name="sglang",
+        isl=1024,
+        osl=256,
+        ttft=2000.0,
+        tpot=50.0,
+    )
+    cfg = task_config_to_generator_config(task_config=task, result_df=pd.Series({"tp": 1}))
+    assert cfg["NodeConfig"]["system_name"] == "h200_sxm"
+
+
+@pytest.mark.unit
+def test_heterogeneous_disagg_systems_rejected():
+    task = _disagg_task("gb200", "h200_sxm")
+    with pytest.raises(ValueError, match=r"heterogeneous"):
+        task_config_to_generator_config(task_config=task, result_df=_result_row())
+
+
+@pytest.mark.unit
+def test_disagg_gb200_hardware_facts_reach_dgd():
+    """End-to-end through the generator: the resolved system must produce GB200
+    placement and NCCL/UCX environment on disagg workers in the raw DGD."""
+    task = _disagg_task("gb200", "gb200")
+    cfg = task_config_to_generator_config(task_config=task, result_df=_result_row())
+    artifacts = generate_backend_artifacts(
+        cfg, "sglang", backend_version="0.5.11", deployment_target="dynamo-j2"
+    )
+    dgd = yaml.safe_load(artifacts["k8s_deploy.yaml"])
+
+    workers = {
+        name: svc
+        for name, svc in dgd["spec"]["services"].items()
+        if svc.get("componentType") == "worker"
+    }
+    assert workers, "expected disagg worker services in the DGD"
+    for name, svc in workers.items():
+        pod = svc.get("extraPodSpec") or {}
+        selector = pod.get("nodeSelector") or {}
+        assert selector.get("kubernetes.io/arch") == "arm64", f"{name}: missing arm64 selector"
+        assert selector.get("nvidia.com/gpu.product") == "NVIDIA-GB200", f"{name}: missing GB200 selector"
+        env = {e["name"]: e.get("value") for e in (pod.get("mainContainer") or {}).get("env") or []}
+        assert "NCCL_MNNVL_ENABLE" in env, f"{name}: missing GB200 NCCL facts"
+        assert "UCX_CUDA_IPC_ENABLE_MNNVL" in env, f"{name}: missing GB200 UCX facts"

--- a/tests/unit/generator/test_naive_node_config.py
+++ b/tests/unit/generator/test_naive_node_config.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""NodeConfig propagation through the naive generation path.
+
+naive.py built a local node_config (with user NodeConfig overrides merged in)
+but forwarded only the num_gpus_per_node scalar into
+collect_generator_params(), which rebuilds NodeConfig from that one value.
+Both the system identity and explicit --generator-set NodeConfig.* overrides
+were therefore dropped: a --system b60 run rendered run_0.sh with
+CUDA_VISIBLE_DEVICES instead of the B60 ONEAPI_DEVICE_SELECTOR (the template
+branches on NodeConfig.system_name), while the K8s facts stayed correct
+because they resolve from the separate K8sConfig.system_name.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from aiconfigurator.generator.api import generate_backend_artifacts
+from aiconfigurator.generator.naive import build_naive_generator_params
+
+_SYSTEM_CONFIGS = {
+    "b60": {"gpus_per_node": 8, "vram_per_gpu": 24 * 1024**3},
+    "h200_sxm": {"gpus_per_node": 8, "vram_per_gpu": 141 * 1024**3},
+}
+
+
+def _naive_params(system_name: str, mode: str = "agg", overrides: dict | None = None) -> dict:
+    with (
+        patch(
+            "aiconfigurator.generator.naive._get_system_config",
+            side_effect=lambda name: dict(_SYSTEM_CONFIGS[name]),
+        ),
+        patch(
+            "aiconfigurator.generator.naive._estimate_model_weight_bytes",
+            return_value=10 * 1024**3,
+        ),
+    ):
+        return build_naive_generator_params(
+            model_name="Qwen/Qwen3-8B",
+            total_gpus=2,
+            system_name=system_name,
+            backend_name="vllm",
+            mode=mode,
+            generator_overrides=overrides,
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("mode", ["agg", "disagg"])
+def test_system_name_propagates_to_node_config(mode):
+    params = _naive_params("b60", mode=mode)
+    assert params["NodeConfig"]["system_name"] == "b60"
+    assert params["NodeConfig"]["num_gpus_per_node"] == 8
+
+
+@pytest.mark.unit
+def test_node_config_overrides_propagate():
+    params = _naive_params(
+        "h200_sxm",
+        overrides={"NodeConfig": {"system_name": "custom-system", "num_gpus_per_node": 4}},
+    )
+    assert params["NodeConfig"]["system_name"] == "custom-system"
+    assert params["NodeConfig"]["num_gpus_per_node"] == 4
+
+
+@pytest.mark.unit
+def test_b60_run_script_uses_oneapi_device_selector():
+    params = _naive_params("b60")
+    artifacts = generate_backend_artifacts(
+        params, "vllm", backend_version="0.20.1", deployment_target="dynamo-j2"
+    )
+    run_scripts = {k: v for k, v in artifacts.items() if k.startswith("run_")}
+    assert run_scripts, f"expected run scripts, got {sorted(artifacts)}"
+    for name, content in run_scripts.items():
+        assert "ONEAPI_DEVICE_SELECTOR" in content, f"{name}: missing B60 device selector"
+        assert "CUDA_VISIBLE_DEVICES" not in content, f"{name}: unexpected CUDA selector"
+
+
+@pytest.mark.unit
+def test_non_b60_run_script_keeps_cuda_device_selector():
+    params = _naive_params("h200_sxm")
+    artifacts = generate_backend_artifacts(
+        params, "vllm", backend_version="0.20.1", deployment_target="dynamo-j2"
+    )
+    run_scripts = {k: v for k, v in artifacts.items() if k.startswith("run_")}
+    assert run_scripts
+    for name, content in run_scripts.items():
+        assert "CUDA_VISIBLE_DEVICES" in content, f"{name}: missing CUDA selector"
+        assert "ONEAPI_DEVICE_SELECTOR" not in content, f"{name}: unexpected B60 selector"

--- a/tests/unit/generator/test_naive_node_config.py
+++ b/tests/unit/generator/test_naive_node_config.py
@@ -68,9 +68,7 @@ def test_node_config_overrides_propagate():
 @pytest.mark.unit
 def test_b60_run_script_uses_oneapi_device_selector():
     params = _naive_params("b60")
-    artifacts = generate_backend_artifacts(
-        params, "vllm", backend_version="0.20.1", deployment_target="dynamo-j2"
-    )
+    artifacts = generate_backend_artifacts(params, "vllm", backend_version="0.20.1", deployment_target="dynamo-j2")
     run_scripts = {k: v for k, v in artifacts.items() if k.startswith("run_")}
     assert run_scripts, f"expected run scripts, got {sorted(artifacts)}"
     for name, content in run_scripts.items():
@@ -81,9 +79,7 @@ def test_b60_run_script_uses_oneapi_device_selector():
 @pytest.mark.unit
 def test_non_b60_run_script_keeps_cuda_device_selector():
     params = _naive_params("h200_sxm")
-    artifacts = generate_backend_artifacts(
-        params, "vllm", backend_version="0.20.1", deployment_target="dynamo-j2"
-    )
+    artifacts = generate_backend_artifacts(params, "vllm", backend_version="0.20.1", deployment_target="dynamo-j2")
     run_scripts = {k: v for k, v in artifacts.items() if k.startswith("run_")}
     assert run_scripts
     for name, content in run_scripts.items():


### PR DESCRIPTION
#### Overview:

Fixes five generator bugs found while validating generated artifacts on real clusters, plus two follow-up hardenings. Four share one root-cause pattern: values correct in the CLI / Task input are silently dropped on the way into generator params, so artifacts fall back to defaults without any error. They land as one PR because the fixes overlap in the same function of `module_bridge.py` and the disagg-system fix depends on the YAML quoting fix, so a single ordered branch keeps every commit deployable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DGD-related Kubernetes YAML now automatically quotes string values that resemble booleans, preserving them as strings.
  * Multimodal image workload settings (when provided) now carry through into generated benchmark/config outputs.

* **Bug Fixes**
  * Improved generator bridging to preserve and validate system-name behavior across aggregation and disaggregation flows, including rejection of mismatched prefill/decode system names.
  * Generator overrides are applied more consistently, with correct propagation of node settings and optional Llmd configuration.

* **Tests**
  * Added coverage for YAML quoting, image propagation, system-name validation, and override precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->