### PR TITLE
fix(generator): preserve disagg system name in Task bridge

### DIFF
--- a/src/aiconfigurator/generator/module_bridge.py
+++ b/src/aiconfigurator/generator/module_bridge.py
@@ -275,8 +275,25 @@ def task_config_to_generator_config(
     )
 
     params = _deep_merge(params, overrides.get("Params"))
-    # Expose SDK's system identifier to templates via NodeConfig.system_name
-    params.setdefault("NodeConfig", {})["system_name"] = task_config.system_name
+    # Expose SDK's system identifier to templates via NodeConfig.system_name.
+    # Use primary_system_name: for disagg, the shared top-level system_name is
+    # empty (phase-specific prefill/decode systems carry the value), so reading
+    # system_name here would blank NodeConfig and drop all hardware facts.
+    #
+    # NodeConfig.system_name (and the hardware facts derived from it) is global,
+    # while disagg prefill/decode can request different systems. Heterogeneous
+    # placement is out of scope here, so fail fast rather than silently applying
+    # the prefill system's node selectors/env to both workers.
+    system_name = task_config.primary_system_name
+    if task_config.serving_mode == "disagg":
+        prefill_system = getattr(task_config, "prefill_system_name", system_name)
+        decode_system = getattr(task_config, "decode_system_name", system_name)
+        if prefill_system != decode_system:
+            raise ValueError(
+                "Generator artifacts currently require matching prefill/decode systems; "
+                f"got prefill={prefill_system!r}, decode={decode_system!r}"
+            )
+    params.setdefault("NodeConfig", {})["system_name"] = system_name
     rule_name = overrides.get("rule")
     if rule_name:
         params["rule"] = rule_name

--- a/tests/unit/generator/test_module_bridge_system_name.py
+++ b/tests/unit/generator/test_module_bridge_system_name.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The bridge must preserve the requested system into NodeConfig.
+
+Task v2 stores the disagg system selection in phase-specific fields; the shared
+top-level ``system_name`` is empty for disagg. The bridge must read
+``primary_system_name`` so hardware facts (node selectors, NCCL/UCX env) resolve
+for disaggregated deployments instead of silently placing workers anywhere.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from aiconfigurator.generator.module_bridge import task_config_to_generator_config
+
+
+def _task(
+    *,
+    serving_mode: str,
+    system_name: str,
+    primary_system_name: str,
+    prefill_system_name: str | None = None,
+    decode_system_name: str | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        primary_backend_name="vllm",
+        primary_system_name=primary_system_name,
+        primary_backend_version="0.20.1",
+        primary_model_path="Qwen/Qwen3-32B-FP8",
+        prefix=0,
+        is_moe=False,
+        nextn=0,
+        nextn_accept_rates=[],
+        serving_mode=serving_mode,
+        total_gpus=0,
+        system_name=system_name,
+        # Disagg phase-specific systems; default to the primary so homogeneous
+        # cases don't trip the heterogeneous-placement guard.
+        prefill_system_name=prefill_system_name if prefill_system_name is not None else primary_system_name,
+        decode_system_name=decode_system_name if decode_system_name is not None else primary_system_name,
+        isl=1024,
+        osl=256,
+        ttft=2000.0,
+        tpot=50.0,
+    )
+
+
+def test_disagg_preserves_system_name_from_primary():
+    # Disagg: top-level system_name is empty; prefill/decode carry the value.
+    task = _task(serving_mode="disagg", system_name="", primary_system_name="gb200")
+    row = pd.Series({"(p)workers": 1, "(p)tp": 1, "(d)workers": 1, "(d)tp": 1})
+
+    result = task_config_to_generator_config(task, row, num_gpus_per_node=4)
+
+    assert result["NodeConfig"]["system_name"] == "gb200"
+
+
+def test_agg_preserves_system_name():
+    # Agg: primary_system_name is the top-level system_name.
+    task = _task(serving_mode="agg", system_name="h200_sxm", primary_system_name="h200_sxm")
+    row = pd.Series({"workers": 1, "tp": 1})
+
+    result = task_config_to_generator_config(task, row, num_gpus_per_node=8)
+
+    assert result["NodeConfig"]["system_name"] == "h200_sxm"
+
+
+def test_disagg_heterogeneous_systems_raise():
+    # NodeConfig.system_name is global; differing prefill/decode systems would
+    # silently apply the prefill placement to both -> fail fast instead.
+    task = _task(
+        serving_mode="disagg",
+        system_name="",
+        primary_system_name="gb200",
+        prefill_system_name="gb200",
+        decode_system_name="h200_sxm",
+    )
+    row = pd.Series({"(p)workers": 1, "(p)tp": 1, "(d)workers": 1, "(d)tp": 1})
+
+    with pytest.raises(ValueError, match="matching prefill/decode systems"):
+        task_config_to_generator_config(task, row, num_gpus_per_node=4)


### PR DESCRIPTION
#### Overview:

The Task→generator bridge set `NodeConfig.system_name` from the shared top-level `task_config.system_name`. For disaggregated Task v2 requests that field is empty (the selected system lives in `prefill_system_name`/`decode_system_name`), so `NodeConfig.system_name` came out blank, `request_resolution` found no system, and hardware facts (node selectors, NCCL/UCX env) were dropped — workers could schedule on the wrong architecture (e.g. a `--system gb200` request ran on H200).

#### Details:

- Read `task_config.primary_system_name` instead, which returns the top-level system for agg and the prefill-side system for disagg.
- Same-system disagg only; heterogeneous prefill/decode placement remains a separate future concern (as noted in the bug report).

#### Where should the reviewer start?

- `src/aiconfigurator/generator/module_bridge.py` — one-line change near the end of `task_config_to_generator_config`.
- `tests/unit/generator/test_module_bridge_system_name.py`.

#### Note:


#### Related Issues:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected system name propagation into generated template node configuration, preventing missing system details in disaggregated setups.
  * Improved disaggregated validation to ensure prefill and decode system identifiers are consistent; mismatches now return a clear error.
* **Tests**
  * Added/updated unit tests covering aggregated vs. disaggregated behavior to verify node system naming and the new mismatch error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->