### PR TITLE
fix(generator): carry multimodal image workload into BenchConfig

### DIFF
--- a/src/aiconfigurator/generator/module_bridge.py
+++ b/src/aiconfigurator/generator/module_bridge.py
@@ -252,7 +252,27 @@ def task_config_to_generator_config(
         "tpot": _safe_float(_series_val(result_df, "tpot", task_config.tpot), task_config.tpot),
     }
     sla_cfg = _deep_merge(sla_cfg, overrides.get("SlaConfig"))
-    bench_cfg = overrides.get("BenchConfig")
+
+    # Seed BenchConfig from the Task's multimodal image workload so image args
+    # reach bench_run.sh / k8s_bench.yaml. Without this, image_batch_size falls
+    # back to the schema default 0 and the templates emit a text-only benchmark
+    # even for image workloads. Explicit BenchConfig overrides win via merge.
+    image_height = getattr(task_config, "image_height", 0) or 0
+    image_width = getattr(task_config, "image_width", 0) or 0
+    # Default only a missing/None image count to 1. A deliberate
+    # num_images_per_request=0 ("disable the image encoder", used with 448x448
+    # dimensions by the web UI) must survive so the templates omit image args.
+    image_batch_size = getattr(task_config, "num_images_per_request", None)
+    if image_batch_size is None:
+        image_batch_size = 1
+    bench_cfg: dict[str, Any] = {}
+    if image_height > 0 and image_width > 0:
+        bench_cfg = {
+            "image_batch_size": image_batch_size,
+            "image_width_mean": image_width,
+            "image_height_mean": image_height,
+        }
+    bench_cfg = _deep_merge(bench_cfg, overrides.get("BenchConfig"))
 
     params = collect_generator_params(
         service=service_cfg,

--- a/tests/unit/generator/test_module_bridge_image_workload.py
+++ b/tests/unit/generator/test_module_bridge_image_workload.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The bridge must carry the Task's multimodal image workload into BenchConfig.
+
+Image dimensions live on the Task (image_height/image_width/num_images_per_request)
+but the bridge previously built BenchConfig only from explicit overrides, so
+image_batch_size fell back to 0 and the benchmark artifacts ran text-only.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pandas as pd
+
+from aiconfigurator.generator.module_bridge import task_config_to_generator_config
+
+
+def _task(*, image_height: int, image_width: int, num_images_per_request: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        primary_backend_name="vllm",
+        primary_system_name="h200_sxm",
+        primary_backend_version="0.20.1",
+        primary_model_path="Qwen/Qwen3-VL-4B-Instruct",
+        prefix=0,
+        is_moe=False,
+        nextn=0,
+        nextn_accept_rates=[],
+        serving_mode="agg",
+        total_gpus=0,
+        system_name="h200_sxm",
+        isl=256,
+        osl=256,
+        ttft=2000.0,
+        tpot=50.0,
+        image_height=image_height,
+        image_width=image_width,
+        num_images_per_request=num_images_per_request,
+    )
+
+
+def test_image_workload_populates_bench_config():
+    task = _task(image_height=1024, image_width=1024, num_images_per_request=1)
+    row = pd.Series({"workers": 1, "tp": 1})
+
+    result = task_config_to_generator_config(task, row, num_gpus_per_node=4)
+
+    bench = result["BenchConfig"]
+    assert bench["image_batch_size"] == 1
+    assert bench["image_width_mean"] == 1024
+    assert bench["image_height_mean"] == 1024
+
+
+def test_explicit_bench_override_wins():
+    task = _task(image_height=1024, image_width=1024, num_images_per_request=1)
+    row = pd.Series({"workers": 1, "tp": 1})
+
+    result = task_config_to_generator_config(
+        task,
+        row,
+        generator_overrides={"BenchConfig": {"image_batch_size": 4}},
+        num_gpus_per_node=4,
+    )
+
+    assert result["BenchConfig"]["image_batch_size"] == 4
+    # Task-derived dimensions still fill the unspecified fields.
+    assert result["BenchConfig"]["image_width_mean"] == 1024
+
+
+def test_text_only_workload_keeps_image_disabled():
+    task = _task(image_height=0, image_width=0, num_images_per_request=1)
+    row = pd.Series({"workers": 1, "tp": 1})
+
+    result = task_config_to_generator_config(task, row, num_gpus_per_node=4)
+
+    assert result["BenchConfig"]["image_batch_size"] == 0
+    assert not result["BenchConfig"].get("image_width_mean")
+
+
+def test_explicit_zero_image_count_disables_encoder_even_with_dimensions():
+    # num_images_per_request=0 with dimensions set = "disable the image encoder"
+    # (used with 448x448 by the web UI). The zero must survive (not become 1),
+    # so image_batch_size stays 0 and the benchmark templates omit image args.
+    task = _task(image_height=448, image_width=448, num_images_per_request=0)
+    row = pd.Series({"workers": 1, "tp": 1})
+
+    result = task_config_to_generator_config(task, row, num_gpus_per_node=4)
+
+    assert result["BenchConfig"]["image_batch_size"] == 0


### PR DESCRIPTION
#### Overview:

For Qwen3-VL image workloads (`--image-height/--image-width/--num-images`), the image config was preserved in `exp_config.yaml` but lost entering the generator bridge. The bridge built `BenchConfig` only from explicit overrides, so `image_batch_size` fell back to the schema default `0` and `bench_run.sh` / `k8s_bench.yaml` ran a text-only benchmark.

#### Details:

- Seed `BenchConfig` from the Task image fields (`image_height`, `image_width`, `num_images_per_request`) when both dimensions are set.
- Deep-merge explicit `BenchConfig` overrides afterward so user values still win.
- Fields read via `getattr` so text-only and duck-typed callers are unaffected (`image_batch_size` stays 0).

#### Where should the reviewer start?

- `src/aiconfigurator/generator/module_bridge.py` — `bench_cfg` seeding block.
- `tests/unit/generator/test_module_bridge_image_workload.py` — image, override-wins, and text-only cases.

#### Note:


#### Related Issues:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image-based workloads now auto-populate generated benchmark configuration with image batch size and dimension mean values (when image height and width are positive).

* **Bug Fixes**
  * Benchmark configuration overrides are now deep-merged on top of image-derived defaults, preserving derived fields not explicitly overridden.
  * Text-only and zero-image cases keep image batch settings at zero and avoid adding image dimension mean values.

* **Tests**
  * Added unit tests covering default propagation, override precedence, and zero-image/text-only edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->