### PR TITLE
feat(rust-core): context-parallelism support for engine-step (Phase 1: dense GQA + MoE)

### DIFF
--- a/rust/aiconfigurator-core/parity_tests/test_engine_step_parity.py
+++ b/rust/aiconfigurator-core/parity_tests/test_engine_step_parity.py
@@ -41,6 +41,7 @@ class EngineStepParityCase:
     attention_dp_size: int = 1
     moe_tp_size: int = 1
     moe_ep_size: int = 8
+    cp_size: int = 1
     agg_batch_size: int = 2
     agg_ctx_tokens: int | None = None
     disagg_prefill_batch_size: int = 1
@@ -703,6 +704,7 @@ def _python_mixed_step_ms(case: EngineStepParityCase) -> float:
         attention_dp_size=case.attention_dp_size,
         moe_tp_size=case.moe_tp_size,
         moe_ep_size=case.moe_ep_size,
+        cp_size=case.cp_size,
     )
     model = _quiet_call(get_model, case.model_path, model_config, case.backend_name)
     backend = get_backend(case.backend_name)
@@ -741,6 +743,7 @@ def _rust_mixed_step_ms(case: EngineStepParityCase) -> float:
         attention_dp_size=case.attention_dp_size,
         moe_tp_size=case.moe_tp_size,
         moe_ep_size=case.moe_ep_size,
+        cp_size=case.cp_size,
     )
     model = _quiet_call(get_model, case.model_path, model_config, case.backend_name)
     shape = _mix_step_shape(case)
@@ -909,4 +912,62 @@ class TestRustEngineStepDisaggParity:
         _prepare_rust_core(monkeypatch)
 
         reason = _parity_mismatch_reason(_disagg_comparison_metrics(case))
+        assert reason is None, reason
+
+
+# Context-parallelism (CP) parity cases. CP is SGLang-only and shards prefill
+# sequence tokens: token-major ops divide their per-rank token count by cp
+# (seq_split), ContextAttention models rank-0's zigzag chunk split, and
+# MoEDispatch all-gathers (pre) / reduce-scatters (combine) the CP-sharded
+# tokens. sglang CP requires tp_size=1 and attention_dp_size=1, so the width
+# (tp*dp*cp) is carried entirely by cp and matched by moe_tp*moe_ep.
+#
+# Validated on the mix-step surface: the prefill chunk exercises the CP ops
+# (context attention, GEMMs, comm, MoE dispatch). Without the Rust CP support
+# these cases drift (Rust would evaluate the cp>1 config as cp=1); with it the
+# Python and Rust engine steps match within PARITY_RTOL.
+CP_CASES = [
+    pytest.param(
+        EngineStepParityCase(
+            model_path="Qwen/Qwen3-235B-A22B",
+            system_name="b200_sxm",
+            backend_name="sglang",
+            backend_version="0.5.10",
+            tp_size=1,
+            attention_dp_size=1,
+            moe_tp_size=8,
+            moe_ep_size=1,
+            cp_size=8,
+        ),
+        id="qwen3-235b-a22b-b200-sglang-0510-cp8",
+    ),
+    pytest.param(
+        EngineStepParityCase(
+            model_path="Qwen/Qwen3-235B-A22B",
+            system_name="b200_sxm",
+            backend_name="sglang",
+            backend_version="0.5.10",
+            tp_size=1,
+            attention_dp_size=1,
+            moe_tp_size=4,
+            moe_ep_size=1,
+            cp_size=4,
+        ),
+        id="qwen3-235b-a22b-b200-sglang-0510-cp4",
+    ),
+]
+
+
+class TestRustEngineStepCpMixedStepParity:
+    """CP parity on the mix-step surface (CP ops run in the prefill chunk)."""
+
+    @pytest.mark.parametrize("case", CP_CASES)
+    def test_cp_parity(
+        self,
+        case: EngineStepParityCase,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _prepare_rust_core(monkeypatch)
+
+        reason = _parity_mismatch_reason(_mixed_step_comparison_metrics(case))
         assert reason is None, reason

--- a/rust/aiconfigurator-core/src/config.rs
+++ b/rust/aiconfigurator-core/src/config.rs
@@ -70,6 +70,12 @@ pub struct ParallelMapping {
     pub moe_tp_size: Option<u32>,
     #[serde(default)]
     pub moe_ep_size: Option<u32>,
+    /// Context-parallel size. Part of the engine identity so cp variants get
+    /// distinct compiled handles. `None`/1 means no CP. The per-op CP math is
+    /// carried on the ops themselves (seq_split / cp_size / attn_cp_size), not
+    /// re-derived from this field.
+    #[serde(default)]
+    pub cp_size: Option<u32>,
 }
 
 /// Precision/quantization dtypes. Flattened into [`EngineConfig`]. Field

--- a/rust/aiconfigurator-core/src/engine/runtime.rs
+++ b/rust/aiconfigurator-core/src/engine/runtime.rs
@@ -530,6 +530,7 @@ mod tests {
                 name: "rmsnorm".into(),
                 scale_factor: 1.0,
                 bytes_per_token: 8192.0,
+                seq_split: 1,
             }),
             Op::Gemm(GemmOp {
                 name: "qkv_gemm".into(),
@@ -539,6 +540,7 @@ mod tests {
                 quant_mode: GemmQuantMode::Fp8Block,
                 scale_num_tokens: 0,
                 low_precision_input: false,
+                seq_split: 1,
             }),
             Op::ContextAttention(ContextAttentionOp {
                 name: "context_attention".into(),
@@ -550,6 +552,7 @@ mod tests {
                 kv_cache_dtype: KvCacheQuantMode::Fp8,
                 fmha_quant_mode: FmhaQuantMode::Bfloat16,
                 use_qk_norm: false,
+                cp_size: 1,
             }),
         ]
     }
@@ -560,6 +563,7 @@ mod tests {
                 name: "rmsnorm".into(),
                 scale_factor: 1.0,
                 bytes_per_token: 8192.0,
+                seq_split: 1,
             }),
             Op::GenerationAttention(GenerationAttentionOp {
                 name: "generation_attention".into(),
@@ -588,6 +592,7 @@ mod tests {
                 attention_dp_size: Some(1),
                 moe_tp_size: Some(1),
                 moe_ep_size: Some(8),
+                cp_size: None,
             },
             quantization: QuantizationConfig {
                 weight_dtype: None,

--- a/rust/aiconfigurator-core/src/engine/spec.rs
+++ b/rust/aiconfigurator-core/src/engine/spec.rs
@@ -152,6 +152,7 @@ mod tests {
             quant_mode: GemmQuantMode::Fp8,
             scale_num_tokens: 0,
             low_precision_input: true,
+                seq_split: 1,
         }
     }
 
@@ -162,6 +163,7 @@ mod tests {
             vocab_size: 128_256,
             hidden_size: 4096,
             quant_mode: GemmQuantMode::Bfloat16,
+            seq_split: 1,
         }
     }
 
@@ -170,6 +172,7 @@ mod tests {
             name: "rmsnorm".into(),
             scale_factor: 1.5,
             bytes_per_token: 8192.0,
+            seq_split: 1,
         }
     }
 
@@ -184,6 +187,7 @@ mod tests {
             kv_cache_dtype: KvCacheQuantMode::Fp8,
             fmha_quant_mode: FmhaQuantMode::Bfloat16,
             use_qk_norm: true,
+            cp_size: 1,
         }
     }
 
@@ -280,6 +284,8 @@ mod tests {
             flavor: DispatchFlavor::TrtllmAlltoall,
             comm_quant: CommQuantMode::Half,
             moe_quant: MoeQuantMode::Fp8Block,
+            attn_cp_size: 1,
+            is_context: false,
         }
     }
 
@@ -290,6 +296,7 @@ mod tests {
             hidden_size: 4096,
             tp_size: 8,
             quant: CommQuantMode::Half,
+            seq_split: 1,
         }
     }
 
@@ -297,10 +304,11 @@ mod tests {
         NcclOp {
             name: "nccl_all_reduce".into(),
             scale_factor: 1.0,
-            hidden_size: 4096,
+            hidden_size: 4096.0,
             num_gpus: 8,
             dtype: CommQuantMode::Half,
             operation: "all_reduce".into(),
+            seq_split: 1,
         }
     }
 
@@ -310,6 +318,7 @@ mod tests {
             scale_factor: 1.0,
             pp_size: 4,
             hidden_size: 4096,
+            seq_split: 1,
         }
     }
 
@@ -549,6 +558,7 @@ mod tests {
                 attention_dp_size: Some(8),
                 moe_tp_size: Some(1),
                 moe_ep_size: Some(8),
+                cp_size: None,
             },
             quantization: QuantizationConfig {
                 weight_dtype: Some(DataType::Fp8),

--- a/rust/aiconfigurator-core/src/fpm/tests.rs
+++ b/rust/aiconfigurator-core/src/fpm/tests.rs
@@ -34,6 +34,7 @@ fn context_ops() -> Vec<Op> {
             name: "rmsnorm".into(),
             scale_factor: 1.0,
             bytes_per_token: 8192.0,
+                seq_split: 1,
         }),
         Op::Gemm(GemmOp {
             name: "qkv_gemm".into(),
@@ -43,6 +44,7 @@ fn context_ops() -> Vec<Op> {
             quant_mode: GemmQuantMode::Fp8Block,
             scale_num_tokens: 0,
             low_precision_input: false,
+                seq_split: 1,
         }),
         Op::ContextAttention(ContextAttentionOp {
             name: "context_attention".into(),
@@ -54,6 +56,7 @@ fn context_ops() -> Vec<Op> {
             kv_cache_dtype: KvCacheQuantMode::Fp8,
             fmha_quant_mode: FmhaQuantMode::Bfloat16,
             use_qk_norm: false,
+                cp_size: 1,
         }),
     ]
 }
@@ -64,6 +67,7 @@ fn generation_ops() -> Vec<Op> {
             name: "rmsnorm".into(),
             scale_factor: 1.0,
             bytes_per_token: 8192.0,
+                seq_split: 1,
         }),
         Op::GenerationAttention(GenerationAttentionOp {
             name: "generation_attention".into(),
@@ -92,6 +96,7 @@ fn fixture_engine_config() -> EngineConfig {
             attention_dp_size: Some(1),
             moe_tp_size: Some(1),
             moe_ep_size: Some(8),
+                cp_size: None,
         },
         quantization: QuantizationConfig {
             weight_dtype: None,

--- a/rust/aiconfigurator-core/src/operators/attention.rs
+++ b/rust/aiconfigurator-core/src/operators/attention.rs
@@ -57,6 +57,13 @@ pub struct ContextAttentionOp {
     pub kv_cache_dtype: KvCacheQuantMode,
     pub fmha_quant_mode: FmhaQuantMode,
     pub use_qk_norm: bool,
+    /// Context-parallel factor (Python's `_cp_size`, = `cp_size`). When `>1`,
+    /// prefill FMHA is modeled as rank-0's two zigzag chunks:
+    /// `ctx(c, prefix) + ctx(c, prefix + isl - c)` with `c = ceil(isl / 2cp)`.
+    /// Defaults to 1 (no CP). The fused rope/kv_write/qk_norm extras are still
+    /// added once, not per chunk.
+    #[serde(default = "crate::operators::gemm::default_seq_split")]
+    pub cp_size: u32,
 }
 
 impl ContextAttentionOp {
@@ -78,6 +85,7 @@ impl ContextAttentionOp {
             kv_cache_dtype,
             fmha_quant_mode,
             use_qk_norm: false,
+            cp_size: 1,
         }
     }
 
@@ -89,19 +97,34 @@ impl ContextAttentionOp {
         prefix: u32,
         seq_imbalance_correction_scale: f64,
     ) -> Result<PerformanceResult, AicError> {
-        let full_s = isl + prefix;
-        let table_latency = db.attention.query_context(
-            batch_size,
-            full_s,
-            self.n,
-            self.n_kv,
-            self.head_size,
-            self.window_size,
-            self.kv_cache_dtype,
-            self.fmha_quant_mode,
-        )?;
-        let prefix_factor = prefix_correction(full_s, prefix);
-        let mut latency = table_latency * prefix_factor;
+        // Mirror Python's `ContextAttention._ctx(s, pfx)`: query the table at
+        // the full sequence `s + pfx` and apply the prefix correction for
+        // `pfx`. The Rust table is keyed by the full sequence length.
+        let ctx = |s: u32, pfx: u32| -> Result<f64, AicError> {
+            let full_s = s + pfx;
+            let table = db.attention.query_context(
+                batch_size,
+                full_s,
+                self.n,
+                self.n_kv,
+                self.head_size,
+                self.window_size,
+                self.kv_cache_dtype,
+                self.fmha_quant_mode,
+            )?;
+            Ok(table * prefix_correction(full_s, pfx))
+        };
+
+        // Context parallelism (SGLang AllGather / zigzag): model rank 0's two
+        // balanced chunks. c = ceil(isl / 2cp); rank 0 owns chunk 0 (prefix
+        // unchanged) and chunk 2cp-1 (attends almost the full sequence). Only
+        // the FMHA table term is split; the fused extras below are added once.
+        let mut latency = if self.cp_size > 1 {
+            let c = isl.div_ceil(2 * self.cp_size).max(1);
+            ctx(c, prefix)? + ctx(c, prefix + isl - c)?
+        } else {
+            ctx(isl, prefix)?
+        };
 
         // Fused-op extras (qk_norm optional, rope + kv_write mandatory).
         let q_num = (self.n * self.head_size) as f64;

--- a/rust/aiconfigurator-core/src/operators/communication.rs
+++ b/rust/aiconfigurator-core/src/operators/communication.rs
@@ -29,6 +29,10 @@ pub struct CustomAllReduceOp {
     pub hidden_size: u32,
     pub tp_size: u32,
     pub quant: CommQuantMode,
+    /// CP sequence-shard factor (Python's `_seq_split`, = `cp_size`): the
+    /// per-rank payload is `ceil(num_tokens / seq_split)`. Defaults to 1.
+    #[serde(default = "crate::operators::gemm::default_seq_split")]
+    pub seq_split: u32,
 }
 
 impl CustomAllReduceOp {
@@ -44,6 +48,7 @@ impl CustomAllReduceOp {
             hidden_size,
             tp_size,
             quant: CommQuantMode::Half,
+            seq_split: 1,
         }
     }
 
@@ -60,7 +65,8 @@ impl CustomAllReduceOp {
         if self.tp_size <= 1 {
             return Ok(PerformanceResult::zero());
         }
-        let message_size = (num_tokens as u64) * (self.hidden_size as u64);
+        let per_rank_tokens = num_tokens.div_ceil(self.seq_split.max(1)); // CP: busiest rank
+        let message_size = (per_rank_tokens as u64) * (self.hidden_size as u64);
         let spec = &db.system_spec;
         let per_node = spec.node.num_gpus_per_node;
         let effective_tp = self.tp_size.min(per_node);
@@ -85,17 +91,26 @@ impl CustomAllReduceOp {
 pub struct NcclOp {
     pub name: String,
     pub scale_factor: f64,
-    pub hidden_size: u32,
+    /// Elements moved per token (Python's `_num_elements_per_token`). This is a
+    /// float, not an integer: the CP KV all-gather sizes it as
+    /// `kvcache_bytes_per_token / comm_bytes`, which can be fractional.
+    pub hidden_size: f64,
     pub num_gpus: u32,
     pub dtype: CommQuantMode,
     pub operation: String,
+    /// CP sequence-shard factor (Python's `_seq_split`, = `cp_size`): the
+    /// per-rank payload is `ceil(num_tokens / seq_split)`. Defaults to 1.
+    /// Note the CP KV all-gather (`context_cp_all_gather`) itself keeps
+    /// `seq_split=1` (it moves the full per-token KV), so this is per-op.
+    #[serde(default = "crate::operators::gemm::default_seq_split")]
+    pub seq_split: u32,
 }
 
 impl NcclOp {
     pub fn new(
         name: impl Into<String>,
         scale_factor: f64,
-        hidden_size: u32,
+        hidden_size: f64,
         num_gpus: u32,
         operation: impl Into<String>,
     ) -> Self {
@@ -106,6 +121,7 @@ impl NcclOp {
             num_gpus,
             dtype: CommQuantMode::Half,
             operation: operation.into(),
+            seq_split: 1,
         }
     }
 
@@ -117,7 +133,9 @@ impl NcclOp {
         if self.num_gpus <= 1 {
             return Ok(PerformanceResult::zero());
         }
-        let message_size = (num_tokens as u64) * (self.hidden_size as u64);
+        let per_rank_tokens = num_tokens.div_ceil(self.seq_split.max(1)); // CP: busiest rank
+        // Python: message_size = ceil(x/seq_split) * num_elements_per_token (float).
+        let message_size = ((per_rank_tokens as f64) * self.hidden_size) as u64;
         let max_recorded = db
             .communication
             .nccl_max_num_gpus(self.dtype, &self.operation)?
@@ -149,6 +167,10 @@ pub struct P2POp {
     pub scale_factor: f64,
     pub pp_size: u32,
     pub hidden_size: u32,
+    /// CP sequence-shard factor (Python's `_seq_split`, = `cp_size`): the
+    /// per-rank payload is `ceil(x / seq_split)`. Defaults to 1.
+    #[serde(default = "crate::operators::gemm::default_seq_split")]
+    pub seq_split: u32,
 }
 
 impl P2POp {
@@ -158,6 +180,7 @@ impl P2POp {
             scale_factor: 1.0,
             pp_size,
             hidden_size,
+            seq_split: 1,
         }
     }
 
@@ -166,7 +189,8 @@ impl P2POp {
             return Ok(PerformanceResult::zero());
         }
         let spec = &db.system_spec;
-        let bytes = (x as f64) * (self.hidden_size as f64) * 2.0;
+        let per_rank_tokens = x.div_ceil(self.seq_split.max(1)); // CP: busiest rank
+        let bytes = (per_rank_tokens as f64) * (self.hidden_size as f64) * 2.0;
         let inter_bw = spec.node.inter_node_bw.max(1.0);
         let latency = (bytes / inter_bw + spec.node.p2p_latency) * 1000.0;
         Ok(PerformanceResult::new(latency, Source::Empirical)

--- a/rust/aiconfigurator-core/src/operators/elementwise.rs
+++ b/rust/aiconfigurator-core/src/operators/elementwise.rs
@@ -25,6 +25,12 @@ pub struct ElementwiseOp {
     /// Bytes touched per input token. The query multiplies this by the
     /// runtime token count.
     pub bytes_per_token: f64,
+    /// CP sequence-shard factor (Python's `_seq_split`, = `cp_size`): the
+    /// per-rank token count is `ceil(num_tokens / seq_split)`. Defaults to 1.
+    /// (Python's `scale_num_tokens` is folded into `bytes_per_token` by the
+    /// serializer; `seq_split` is applied here to the token count.)
+    #[serde(default = "crate::operators::gemm::default_seq_split")]
+    pub seq_split: u32,
 }
 
 impl ElementwiseOp {
@@ -33,10 +39,12 @@ impl ElementwiseOp {
             name: name.into(),
             scale_factor: 1.0,
             bytes_per_token,
+            seq_split: 1,
         }
     }
 
     pub fn query(&self, db: &PerfDatabase, num_tokens: u32) -> Result<PerformanceResult, AicError> {
+        let num_tokens = num_tokens.div_ceil(self.seq_split.max(1)); // CP: busiest rank
         let bytes = self.bytes_per_token * (num_tokens as f64);
         let latency = mem_op_latency_ms(&db.system_spec, bytes);
         Ok(PerformanceResult::new(latency, Source::Empirical).scaled(self.scale_factor))

--- a/rust/aiconfigurator-core/src/operators/embedding.rs
+++ b/rust/aiconfigurator-core/src/operators/embedding.rs
@@ -23,6 +23,10 @@ pub struct EmbeddingOp {
     pub vocab_size: u32,
     pub hidden_size: u32,
     pub quant_mode: GemmQuantMode,
+    /// CP sequence-shard factor (Python's `_seq_split`, = `cp_size`): the
+    /// per-rank token count is `ceil(num_tokens / seq_split)`. Defaults to 1.
+    #[serde(default = "crate::operators::gemm::default_seq_split")]
+    pub seq_split: u32,
 }
 
 impl EmbeddingOp {
@@ -38,12 +42,14 @@ impl EmbeddingOp {
             vocab_size,
             hidden_size,
             quant_mode,
+            seq_split: 1,
         }
     }
 
     /// Per-token embedding lookup: each token loads one row of size
     /// `hidden_size * dtype_memory` bytes.
     pub fn query(&self, db: &PerfDatabase, num_tokens: u32) -> Result<PerformanceResult, AicError> {
+        let num_tokens = num_tokens.div_ceil(self.seq_split.max(1)); // CP: busiest rank
         let bytes = (num_tokens as f64)
             * (self.hidden_size as f64)
             * self.quant_mode.mapping().memory;

--- a/rust/aiconfigurator-core/src/operators/gemm.rs
+++ b/rust/aiconfigurator-core/src/operators/gemm.rs
@@ -29,6 +29,14 @@ pub struct GemmOp {
     pub quant_mode: GemmQuantMode,
     pub scale_num_tokens: u32,
     pub low_precision_input: bool,
+    /// Context-parallel sequence-shard factor (Python's `_seq_split`, = `cp_size`).
+    /// The per-rank token count is `ceil(m / seq_split)`. Defaults to 1 (no CP).
+    #[serde(default = "default_seq_split")]
+    pub seq_split: u32,
+}
+
+pub(crate) fn default_seq_split() -> u32 {
+    1
 }
 
 impl GemmOp {
@@ -43,6 +51,7 @@ impl GemmOp {
             quant_mode,
             scale_num_tokens: 1,
             low_precision_input: false,
+            seq_split: 1,
         }
     }
 
@@ -62,6 +71,8 @@ impl GemmOp {
         quant_override: Option<GemmQuantMode>,
     ) -> Result<PerformanceResult, AicError> {
         let m = x / self.scale_num_tokens.max(1);
+        // CP: per-rank token count = ceil(m / seq_split) (busiest rank).
+        let m = m.div_ceil(self.seq_split.max(1));
         let quant = quant_override.unwrap_or(self.quant_mode);
 
         let mut latency = db.gemm.query(quant, m, self.n, self.k)?;
@@ -132,6 +143,7 @@ mod tests {
             quant_mode: GemmQuantMode::Bfloat16,
             scale_num_tokens: 1,
             low_precision_input: false,
+            seq_split: 1,
         };
         let result = op.query(&db, 32768, None).expect("query must succeed");
         assert!(
@@ -153,6 +165,7 @@ mod tests {
             quant_mode: GemmQuantMode::Bfloat16,
             scale_num_tokens: 2,
             low_precision_input: false,
+            seq_split: 1,
         };
         let result = op.query(&db, 65536, None).expect("query must succeed");
         assert!(

--- a/rust/aiconfigurator-core/src/operators/moe_dispatch.rs
+++ b/rust/aiconfigurator-core/src/operators/moe_dispatch.rs
@@ -56,6 +56,15 @@ pub struct MoEDispatchOp {
     pub flavor: DispatchFlavor,
     pub comm_quant: CommQuantMode,
     pub moe_quant: MoeQuantMode,
+    /// Attention-side context-parallel factor (Python's `_attn_cp_size`,
+    /// = `cp_size`). Under CP (sglang, prefill) the pre-dispatch all-gathers
+    /// / post-dispatch reduce-scatters the CP-sharded tokens. Defaults to 1.
+    #[serde(default = "crate::operators::gemm::default_seq_split")]
+    pub attn_cp_size: u32,
+    /// Whether this is a context (prefill) dispatch. CP dispatch comm only runs
+    /// in prefill; decode replicates attention across CP ranks (no comm).
+    #[serde(default)]
+    pub is_context: bool,
 }
 
 impl MoEDispatchOp {
@@ -85,6 +94,8 @@ impl MoEDispatchOp {
             flavor,
             comm_quant: CommQuantMode::Half,
             moe_quant: MoeQuantMode::Bfloat16,
+            attn_cp_size: 1,
+            is_context: false,
         }
     }
 
@@ -149,7 +160,7 @@ impl MoEDispatchOp {
                             let nccl = NcclOp::new(
                                 &self.name,
                                 1.0,
-                                self.hidden_size,
+                                self.hidden_size as f64,
                                 num_gpus,
                                 op_name,
                             );
@@ -180,10 +191,25 @@ impl MoEDispatchOp {
                                     num_tokens,
                                 )
                             };
-                            let n1 = NcclOp::new(&self.name, 1.0, self.hidden_size, gpus1, op1);
-                            let n2 = NcclOp::new(&self.name, 1.0, self.hidden_size, gpus2, op2);
+                            let n1 = NcclOp::new(&self.name, 1.0, self.hidden_size as f64, gpus1, op1);
+                            let n2 = NcclOp::new(&self.name, 1.0, self.hidden_size as f64, gpus2, op2);
                             n1.query(db, tokens1)?.latency_ms
                                 + n2.query(db, tokens2)?.latency_ms
+                        } else if self.attn_cp_size > 1 {
+                            // Context parallelism (Python moe.py:1390-1401):
+                            //  * prefill: tokens are CP-sharded; all_gather (pre)
+                            //    to assemble the full token set / reduce_scatter
+                            //    (combine) back. volume = num_tokens * hidden.
+                            //  * decode: CP does not run (attention replicated);
+                            //    the selection is local -> no comm.
+                            if self.is_context {
+                                let op_name = if pre { "all_gather" } else { "reduce_scatter" };
+                                let nccl =
+                                    NcclOp::new(&self.name, 1.0, self.hidden_size as f64, num_gpus, op_name);
+                                nccl.query(db, num_tokens)?.latency_ms
+                            } else {
+                                0.0
+                            }
                         } else if attn_tp > 1 {
                             let ar = CustomAllReduceOp::new(
                                 &self.name,
@@ -197,7 +223,7 @@ impl MoEDispatchOp {
                             let nccl = NcclOp::new(
                                 &self.name,
                                 1.0,
-                                self.hidden_size,
+                                self.hidden_size as f64,
                                 num_gpus,
                                 op_name,
                             );

--- a/rust/aiconfigurator-core/src/operators/vision.rs
+++ b/rust/aiconfigurator-core/src/operators/vision.rs
@@ -54,6 +54,7 @@ impl VisionEncoderOp {
             quant_mode: self.gemm_quant,
             scale_num_tokens: 1,
             low_precision_input: false,
+                seq_split: 1,
         };
         let attn = EncoderAttentionOp::new(
             format!("{}.attn", self.name),
@@ -69,6 +70,7 @@ impl VisionEncoderOp {
             quant_mode: self.gemm_quant,
             scale_num_tokens: 1,
             low_precision_input: false,
+                seq_split: 1,
         };
         let ffn1 = GemmOp {
             name: format!("{}.ffn1", self.name),
@@ -78,6 +80,7 @@ impl VisionEncoderOp {
             quant_mode: self.gemm_quant,
             scale_num_tokens: 1,
             low_precision_input: false,
+                seq_split: 1,
         };
         let ffn2 = GemmOp {
             name: format!("{}.ffn2", self.name),
@@ -87,6 +90,7 @@ impl VisionEncoderOp {
             quant_mode: self.gemm_quant,
             scale_num_tokens: 1,
             low_precision_input: false,
+                seq_split: 1,
         };
         let norms = ElementwiseOp::new(
             format!("{}.norms", self.name),

--- a/rust/aiconfigurator-core/src/py.rs
+++ b/rust/aiconfigurator-core/src/py.rs
@@ -692,6 +692,7 @@ mod tests {
                 name: "rmsnorm".into(),
                 scale_factor: 1.0,
                 bytes_per_token: 8192.0,
+                seq_split: 1,
             }),
             Op::Gemm(GemmOp {
                 name: "qkv_gemm".into(),
@@ -701,6 +702,7 @@ mod tests {
                 quant_mode: GemmQuantMode::Fp8Block,
                 scale_num_tokens: 0,
                 low_precision_input: false,
+                seq_split: 1,
             }),
             Op::ContextAttention(ContextAttentionOp {
                 name: "context_attention".into(),
@@ -712,6 +714,7 @@ mod tests {
                 kv_cache_dtype: KvCacheQuantMode::Fp8,
                 fmha_quant_mode: FmhaQuantMode::Bfloat16,
                 use_qk_norm: false,
+                cp_size: 1,
             }),
         ]
     }
@@ -724,6 +727,7 @@ mod tests {
                 name: "rmsnorm".into(),
                 scale_factor: 1.0,
                 bytes_per_token: 8192.0,
+                seq_split: 1,
             }),
             Op::GenerationAttention(GenerationAttentionOp {
                 name: "generation_attention".into(),
@@ -752,6 +756,7 @@ mod tests {
                 attention_dp_size: Some(1),
                 moe_tp_size: Some(1),
                 moe_ep_size: Some(8),
+                cp_size: None,
             },
             quantization: QuantizationConfig {
                 weight_dtype: None,

--- a/src/aiconfigurator/sdk/engine.py
+++ b/src/aiconfigurator/sdk/engine.py
@@ -123,6 +123,7 @@ def _gemm(op: GEMM) -> dict:
         "quant_mode": _quant_name(op._quant_mode),
         "scale_num_tokens": op._scale_num_tokens,
         "low_precision_input": op._low_precision_input,
+        "seq_split": op._seq_split,
     }
 
 
@@ -136,6 +137,7 @@ def _embedding(op: Embedding) -> dict:
         # query ignores it (memory-only op). Bfloat16 is the neutral value the
         # Rust builders use for embeddings.
         "quant_mode": "bfloat16",
+        "seq_split": op._seq_split,
     }
 
 
@@ -149,6 +151,7 @@ def _elementwise(op: ElementWise) -> dict:
         "name": op._name,
         "scale_factor": op._scale_factor,
         "bytes_per_token": float(bytes_per_token),
+        "seq_split": op._seq_split,
     }
 
 
@@ -163,6 +166,7 @@ def _context_attention(op: ContextAttention) -> dict:
         "kv_cache_dtype": _quant_name(op._kvcache_quant_mode),
         "fmha_quant_mode": _quant_name(op._fmha_quant_mode),
         "use_qk_norm": op._use_qk_norm,
+        "cp_size": op._cp_size,
     }
 
 
@@ -282,6 +286,8 @@ def _moe_dispatch(op: MoEDispatch, *, backend: str) -> dict:
         "flavor": _dispatch_flavor(backend),
         "comm_quant": "half",
         "moe_quant": _quant_name(quant) if quant is not None else "bfloat16",
+        "attn_cp_size": op._attn_cp_size,
+        "is_context": op._is_context,
     }
 
 
@@ -292,6 +298,7 @@ def _custom_all_reduce(op: CustomAllReduce) -> dict:
         "hidden_size": op._h,
         "tp_size": op._tp_size,
         "quant": "half",
+        "seq_split": op._seq_split,
     }
 
 
@@ -303,6 +310,7 @@ def _nccl(op: NCCL) -> dict:
         "num_gpus": op._num_gpus,
         "dtype": "half",
         "operation": op._nccl_op,
+        "seq_split": op._seq_split,
     }
 
 
@@ -312,6 +320,7 @@ def _p2p(op: P2P) -> dict:
         "scale_factor": op._scale_factor,
         "pp_size": op._pp_size,
         "hidden_size": op._h,
+        "seq_split": op._seq_split,
     }
 
 
@@ -609,6 +618,7 @@ def _engine_config_dict(
         "attention_dp_size": _opt_int(getattr(cfg, "attention_dp_size", None)),
         "moe_tp_size": _opt_int(getattr(cfg, "moe_tp_size", None)),
         "moe_ep_size": _opt_int(getattr(cfg, "moe_ep_size", None)),
+        "cp_size": _opt_int(getattr(cfg, "cp_size", None)),
         # QuantizationConfig (flattened)
         "weight_dtype": _rust_quant_to_dtype(getattr(cfg, "gemm_quant_mode", None)),
         "moe_dtype": _rust_moe_quant_to_dtype(getattr(cfg, "moe_quant_mode", None)),

--- a/src/aiconfigurator/sdk/rust_engine_step.py
+++ b/src/aiconfigurator/sdk/rust_engine_step.py
@@ -396,6 +396,8 @@ def _engine_config_json(model: Any, database: Any) -> str:
         "moe_tp_size": _optional_int(getattr(model_config, "moe_tp_size", None)),
         "moe_ep_size": _optional_int(getattr(model_config, "moe_ep_size", None)),
         "attention_dp_size": _optional_int(getattr(model_config, "attention_dp_size", None)),
+        # Part of the engine identity so cp variants get distinct cached handles.
+        "cp_size": _optional_int(getattr(model_config, "cp_size", None)),
         "weight_dtype": _quant_to_dtype(getattr(model_config, "gemm_quant_mode", None)),
         "moe_dtype": _moe_quant_to_dtype(getattr(model_config, "moe_quant_mode", None)),
         "activation_dtype": _quant_to_dtype(getattr(model_config, "fmha_quant_mode", None)),


### PR DESCRIPTION
#### Overview:

The Python SDK models context parallelism (CP) as a first-class prefill dimension (`cp ∈ {1,2,4,8}`), but the Rust engine-step path dropped it entirely — the spec serializers never emitted the per-op CP fields, so a `cp>1` config was evaluated as `cp=1`. On the `--engine-step-backend rust` path this made the optimizer pick a different serving mode / parallelism than Python for CP-capable models (the reported Qwen3-235B/SGLang case: Python picks disagg `cp8`, Rust can't express CP so it picks `cp1` agg).

This is **Phase 1** of CP support: the dense-GQA + MoE prefill path (SGLang-only — the only backend that supports CP).

#### Details:

**Serialize the per-op CP fields** (`sdk/engine.py`):
- token-major ops carry `seq_split` (GEMM, ElementWise, Embedding, CustomAllReduce, NCCL, P2P)
- ContextAttention carries `cp_size`; MoEDispatch carries `attn_cp_size` + `is_context`
- `cp_size` also joins the `EngineConfig` identity (`config.rs` + `engine.py` + `rust_engine_step.py` cache key) so cp variants get distinct compiled handles

**Apply the CP math in the Rust ops** (mirrors Python exactly):
- token-major ops divide the per-rank token count: `ceil(x / seq_split)` (applied *after* `scale_num_tokens`, matching Python's order)
- ContextAttention splits **only** the FMHA table term into rank-0's two zigzag chunks (`c = ceil(isl / 2cp)`); the rope/kv_write/qk_norm extras stay added once
- MoEDispatch (sglang) all-gathers (pre) / reduce-scatters (combine) the CP-sharded tokens in the prefill path
- `NcclOp.hidden_size` is now `f64` (Python's `num_elements_per_token` is fractional for the CP KV all-gather)

The dense-CP KV all-gather already flows through as a normal `NCCL` op (no Rust change), and CP gives no KV-memory change (`_cp_kv_memory_divisor = 1`), so **decode/generation is untouched**.

#### Validation:

- New CP mix-step parity cases (`Qwen3-235B/SGLang cp8` & `cp4`) in `test_engine_step_parity.py`: Python and Rust match within the 1% release tolerance.
- Full engine-step parity suite unchanged: **177 passed / 45 failed** (the 45 are pre-existing non-CP drift across Kimi/DeepSeek/Qwen3.5 — a separate issue, not addressed here; confirmed identical on a clean tree). `cp=1` output is byte-identical (per-op decomposition verified).
- Rust unit tests unchanged (123 pass / 7 pre-existing env+PyO3-init failures, identical on clean tree).

**Validation boundary (honest scoping):** this proves op-level parity on the mix-step surface — the Rust engine-step now computes `cp>1` to within 1% of Python. It does not run the full Qwen3-235B 64-GPU sweep, so "Rust now recommends disagg-cp8" is proxy-validated (the sweep ranks on these very numbers), not directly re-run. CP coverage is on a dedicated mix-step test class; the static/agg/disagg surfaces (which go through `cli_estimate`, no `cp` param) don't yet guard CP.

#### Where should the reviewer start?

- `rust/aiconfigurator-core/src/operators/attention.rs` — the zigzag split (only the table term splits).
- `rust/aiconfigurator-core/src/operators/moe_dispatch.rs` — the sglang CP comm branch.
- `src/aiconfigurator/sdk/engine.py` — the per-op serializer additions.
- `rust/aiconfigurator-core/parity_tests/test_engine_step_parity.py` — `CP_CASES` + `TestRustEngineStepCpMixedStepParity`.

#### Follow-up (not in this PR):

- Phase 2: MLA CP (`ContextMLA`) — covers DeepSeek-R1 (the 109% max-drift case).
- Phase 3: DSA (`ContextDSAModule`, V3.2) and dsv4 (V4) CP.
- The 45 pre-existing non-CP parity failures (separate root cause).

#### Related Issues:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for context-parallel settings in engine configuration and operation specs, including new fields for attention, GEMM, communication, embedding, and dispatch paths.
  * Engine caching now distinguishes configurations with different context-parallel sizes.

* **Bug Fixes**
  * Improved latency calculations so mixed execution paths better reflect sharded token handling.
  * Added parity coverage to verify Rust and Python results stay aligned for context-parallel scenarios.

* **Tests**
  * Expanded test fixtures and parity tests to cover the new configuration fields and context-parallel cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->