### PR TITLE
fix: update b60 intra node bandwidth and p2p latency

### DIFF
--- a/src/aiconfigurator/systems/b60.yaml
+++ b/src/aiconfigurator/systems/b60.yaml
@@ -15,9 +15,9 @@ gpu:
 node:
   num_gpus_per_node: 8 # check your # cards with sycl-ls
   inter_node_bw: 50000000000 # Byte/s per GPU, single direction, 1:1 CX7 per node, 50GB/s
-  intra_node_bw: 32000000000    # PCIe bw without NVLink, Byte/s per GPU, single direction
+  intra_node_bw: 28400000000    # PCIe bw without NVLink, Byte/s per GPU, single direction, limited by line rate and TLP header
   pcie_bw: 32000000000  # Byte/s, single direction, pcie 5.0 (4GB/s) x8 (8 lane for b60)
-  p2p_latency: 0.00001  # 10us some nonofficial correction based on observations, you should try to modify based on your own observations
+  p2p_latency: 0.000002  # 2us PCIe round-trip latency measured on B60 operated by GPU kernels
 
 # TODO fix this with oneccl, use for memory usage computation
 misc:


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
Unidirectional PCIe bandwidth should be no better than 28.4GBps due to the line rate and TLP header. PCIe round-trip latency is measured to be around 2us on B60 operated by GPU kernels.

#### Details:

<!-- Describe the changes made in this PR. -->
As above

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->
NA

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

NA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated GPU communication timing and bandwidth values for a specific system profile, which may improve scheduling and performance behavior in related workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->