### PR TITLE
fix(generator): quote boolean-like env values in DGD YAML (cherry-pick #1292)

### DIFF
--- a/src/aiconfigurator/generator/builders/dgd_model.py
+++ b/src/aiconfigurator/generator/builders/dgd_model.py
@@ -31,6 +31,59 @@ DGD_API_VERSION = "nvidia.com/v1alpha1"
 DGD_KIND = "DynamoGraphDeployment"
 
 
+# Strings that a YAML 1.1 parser (used by Kubernetes' YAML->JSON conversion)
+# resolves to a boolean. PyYAML's SafeDumper already quotes most of these
+# because its own resolver treats them as booleans, but it leaves the bare
+# `y`/`Y`/`n`/`N` forms unquoted. Kubernetes then unmarshals `value: y` as a
+# bool and the DGD admission webhook rejects the manifest because
+# `EnvVar.value` must be a string. Force-quote the full YAML 1.1 boolean set so
+# every emitted scalar keeps its string type regardless of PyYAML version.
+_YAML_BOOLISH_STRINGS = frozenset(
+    {
+        "y",
+        "Y",
+        "yes",
+        "Yes",
+        "YES",
+        "n",
+        "N",
+        "no",
+        "No",
+        "NO",
+        "true",
+        "True",
+        "TRUE",
+        "false",
+        "False",
+        "FALSE",
+        "on",
+        "On",
+        "ON",
+        "off",
+        "Off",
+        "OFF",
+    }
+)
+
+
+class _K8sSafeDumper(yaml.SafeDumper):
+    """SafeDumper that keeps Kubernetes-sensitive strings as strings."""
+
+
+def _represent_str(dumper: yaml.SafeDumper, data: str):
+    if data in _YAML_BOOLISH_STRINGS:
+        return dumper.represent_scalar("tag:yaml.org,2002:str", data, style='"')
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data)
+
+
+_K8sSafeDumper.add_representer(str, _represent_str)
+
+
+def _dump_k8s_yaml(data: Any) -> str:
+    """Serialize a k8s document, quoting YAML 1.1 boolean-like strings."""
+    return yaml.dump(data, Dumper=_K8sSafeDumper, sort_keys=False)
+
+
 def _put(out: dict[str, Any], key: str, value: Any) -> None:
     """Insert ``key`` only when the typed field is actually set (non-None)."""
     if value is not None:
@@ -221,7 +274,7 @@ class DGD:
         return out
 
     def to_yaml(self) -> str:
-        return yaml.safe_dump(self.to_dict(), sort_keys=False)
+        return _dump_k8s_yaml(self.to_dict())
 
 
 @dataclass
@@ -268,7 +321,7 @@ class ConfigMapDoc:
         return out
 
     def to_yaml(self) -> str:
-        return yaml.safe_dump(self.to_dict(), sort_keys=False)
+        return _dump_k8s_yaml(self.to_dict())
 
 
 @dataclass
@@ -327,7 +380,7 @@ class ComputeDomainDoc:
         return out
 
     def to_yaml(self) -> str:
-        return yaml.safe_dump(self.to_dict(), sort_keys=False)
+        return _dump_k8s_yaml(self.to_dict())
 
 
 def dgd_documents_to_yaml(docs: list[Any]) -> str:

--- a/tests/unit/generator/test_dgd_yaml_serialization.py
+++ b/tests/unit/generator/test_dgd_yaml_serialization.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""DGD YAML serialization must keep boolean-like env values as strings.
+
+Kubernetes converts the generated YAML to JSON with a YAML 1.1 parser before the
+DGD admission webhook validates it. A bare scalar such as ``value: y`` is read as
+a boolean and rejected because ``EnvVar.value`` must be a string, so every
+boolean-like string the generator emits must stay quoted.
+"""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from aiconfigurator.generator.builders.dgd_model import DGD
+
+# Tokens a YAML 1.1 parser resolves to a boolean (Kubernetes' behavior).
+BOOLISH_TOKENS = ["y", "Y", "n", "N", "yes", "no", "on", "off", "true", "false", "YES", "Off"]
+
+
+def _dgd_with_env_value(value: str) -> DGD:
+    doc = {
+        "apiVersion": "nvidia.com/v1alpha1",
+        "kind": "DynamoGraphDeployment",
+        "metadata": {"name": "dynamo-agg"},
+        "spec": {
+            "services": {
+                "Worker": {
+                    "extraPodSpec": {
+                        "mainContainer": {
+                            "env": [{"name": "UCX_CUDA_IPC_ENABLE_MNNVL", "value": value}],
+                        }
+                    }
+                }
+            }
+        },
+    }
+    return DGD.from_dict(doc)
+
+
+@pytest.mark.parametrize("token", BOOLISH_TOKENS)
+def test_boolean_like_env_value_is_quoted(token: str):
+    text = _dgd_with_env_value(token).to_yaml()
+
+    # The scalar must be quoted, never emitted bare (a bare token is read as bool).
+    assert f"value: {token}\n" not in text
+    assert f'value: "{token}"' in text
+
+    # And it must round-trip back as a string.
+    reloaded = yaml.safe_load(text)
+    env = reloaded["spec"]["services"]["Worker"]["extraPodSpec"]["mainContainer"]["env"][0]
+    assert env["value"] == token
+    assert isinstance(env["value"], str)
+
+
+def test_plain_strings_are_not_quoted():
+    # Non-boolean strings keep the compact plain style (no gratuitous quoting).
+    text = _dgd_with_env_value("/workspace/model_cache").to_yaml()
+    assert "value: /workspace/model_cache\n" in text


### PR DESCRIPTION
#### Overview:

Backports #1292 to release/0.10.0.

#### Details:

- Cherry-picks the fix commit 08638cba1ef7d66744f8fad86893f8803e70b094.
- Contains exactly one commit based directly on release/0.10.0; patch identical to the original, DCO preserved.

#### Where should the reviewer start?

See the original PR: https://github.com/ai-dynamo/aiconfigurator/pull/1292

#### Related Issues:

- Relates to #1292