### PR TITLE
fix(generator): emit --served-model-name for vLLM workers (cherry-pick #1293)

### DIFF
--- a/src/aiconfigurator/generator/builders/k8s_builder.py
+++ b/src/aiconfigurator/generator/builders/k8s_builder.py
@@ -307,13 +307,13 @@ def _populate_vllm(context: dict[str, Any], resolved_facts: Any = None) -> list[
             volume_mounts = [{"name": "model-cache", "mountPath": model_cache_mount}]
 
         args: list[str] = ["--model", str(svc_cfg.get("model_path"))]
-        # served-model-name: the vllm cli_args templates now emit
-        # `--served-model-name <ServiceConfig.served_model_name>` as the FIRST
-        # cli_args token (guarded on a non-empty value), so extending with
-        # cli_args_list places it directly after --model — same relative
-        # placement as the sglang worker script. Do NOT also insert it here:
-        # cli_args_list is the rendered template output, and an explicit
-        # insertion would duplicate the flag.
+        # served-model-name: emit it here (directly after --model), matching the
+        # sglang/trtllm workers. The vllm cli_args templates do NOT emit this
+        # service-level flag, so without this the deployed model advertises only
+        # the HF model id and requests using the configured alias 404.
+        served_model_name = svc_cfg.get("served_model_name")
+        if served_model_name:
+            args.extend(["--served-model-name", str(served_model_name)])
         args.extend(cli_args_list or [])
         if enable_router:
             port = svc_cfg.get("dyn_vllm_kv_event_port") or 20081

--- a/src/aiconfigurator/generator/config/backend_templates/vllm/run.sh.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/vllm/run.sh.j2
@@ -10,6 +10,7 @@ trap 'echo "Cleaning up..."; kill 0 2>/dev/null || true' EXIT INT TERM
 export PYTHONHASHSEED=0
 {% endif %}
 export MODEL_PATH=${MODEL_PATH:-"{{ ServiceConfig.model_path }}"}
+export SERVED_MODEL_NAME=${SERVED_MODEL_NAME:-"{{ ServiceConfig.served_model_name }}"}
 export HF_TOKEN=${HF_TOKEN:-"{{ ServiceConfig.hf_token }}"}
 python3 -m dynamo.frontend {% if frontend_args %}{{ frontend_args }} {% elif enable_router %}--router-mode kv --router-reset-states {% endif %}--http-port "{{ ServiceConfig.port }}" 2>&1 | sed "s/^/[Frontend] /" &
 
@@ -38,6 +39,7 @@ for ((w=0; w<AGG_WORKERS; w++)); do
     VLLM_NIXL_SIDE_CHANNEL_PORT=$SIDE_CHANNEL_PORT \
     {{ _device_env }} python3 -m dynamo.vllm \
     --model "$MODEL_PATH" \
+    {% if ServiceConfig.served_model_name %}--served-model-name "$SERVED_MODEL_NAME" {% endif %}\
     {% if enable_router %}--kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${EVENT_PORT}\",\"enable_kv_cache_events\":true}" {% endif %}\
     {{ agg_cli_args }} {% if kvbm_enabled %}--kv-transfer-config '{"kv_connector":"DynamoConnector","kv_connector_module_path":"kvbm.vllm_integration.connector","kv_role":"kv_both"}' {% endif %}2>&1 | sed "s/^/[Worker $w] /" ) &
 done
@@ -70,6 +72,7 @@ for ((w=0; w<PREFILL_WORKERS; w++)); do
   {{ _device_env }} \
     python3 -m dynamo.vllm \
       --model "$MODEL_PATH" \
+      {% if ServiceConfig.served_model_name %}--served-model-name "$SERVED_MODEL_NAME" {% endif %}\
       {% if enable_router %}--kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${EVENT_PORT}\",\"enable_kv_cache_events\":true}" {% endif %}\
       {{ prefill_cli_args }} --is-prefill-worker --kv-transfer-config '{% if kvbm_enabled %}{"kv_connector":"PdConnector","kv_role":"kv_both","kv_connector_extra_config":{"connectors":[{"kv_connector":"DynamoConnector","kv_connector_module_path":"kvbm.vllm_integration.connector","kv_role":"kv_both"},{"kv_connector":"NixlConnector","kv_role":"kv_both"}]},"kv_connector_module_path":"kvbm.vllm_integration.connector"}{% else %}{"kv_connector":"NixlConnector","kv_role":"kv_both"}{% endif %}' 2>&1 | sed "s/^/[Prefill $w] /" ) &
 done
@@ -90,6 +93,7 @@ for ((w=0; w<DECODE_WORKERS; w++)); do
   {{ _device_env }} \
     python3 -m dynamo.vllm \
       --model "$MODEL_PATH" \
+      {% if ServiceConfig.served_model_name %}--served-model-name "$SERVED_MODEL_NAME" {% endif %}\
       {% if enable_router %}--kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${EVENT_PORT}\",\"enable_kv_cache_events\":true}" {% endif %}\
       {{ decode_cli_args }} --is-decode-worker --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' 2>&1 | sed "s/^/[Decode $w] /" ) &
 done

--- a/tests/unit/generator/test_vllm_served_model_name.py
+++ b/tests/unit/generator/test_vllm_served_model_name.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""vLLM workers must advertise the configured served model name.
+
+The vLLM cli_args templates do not emit ``--served-model-name`` (unlike the
+sglang/trtllm run scripts), so the k8s worker args and the run.sh launcher must
+carry this service-level flag; otherwise the deployed model only answers to the
+HF model id and requests using the configured alias 404.
+"""
+
+from __future__ import annotations
+
+import copy
+import shlex
+
+import yaml
+
+from aiconfigurator.generator.api import generate_backend_artifacts
+
+_BACKEND_VERSION = "0.20.1"
+
+_PARAMS = {
+    "ServiceConfig": {
+        "model_path": "Qwen/Qwen3-32B-FP8",
+        "served_model_path": "Qwen/Qwen3-32B-FP8",
+        "served_model_name": "Qwen3-32B-FP8",
+        "include_frontend": True,
+    },
+    "K8sConfig": {"name_prefix": "test", "k8s_namespace": "default"},
+    "DynConfig": {"mode": "agg"},
+    "WorkerConfig": {"agg_workers": 1, "agg_gpus_per_worker": 1, "prefill_workers": 0, "decode_workers": 0},
+    "NodeConfig": {"num_gpus_per_node": 8},
+    "SlaConfig": {"isl": 1024, "osl": 256},
+    "ModelConfig": {"is_moe": False, "prefix": 0, "nextn": 0},
+    "BenchConfig": {},
+    "params": {
+        "agg": {
+            "tensor_parallel_size": 1,
+            "pipeline_parallel_size": 1,
+            "data_parallel_size": 1,
+            "max_batch_size": 64,
+            "max_num_tokens": 4096,
+            "max_seq_len": 4096,
+        }
+    },
+}
+
+
+def _render():
+    return generate_backend_artifacts(
+        copy.deepcopy(_PARAMS),
+        "vllm",
+        backend_version=_BACKEND_VERSION,
+        deployment_target="dynamo-j2",
+    )
+
+
+def test_k8s_worker_args_carry_served_model_name():
+    artifacts = _render()
+    k8s = yaml.safe_load(artifacts["k8s_deploy.yaml"])
+    services = k8s["spec"]["services"]
+    worker = next(svc for name, svc in services.items() if name != "Frontend")
+    args = worker["extraPodSpec"]["mainContainer"]["args"]
+
+    assert "--served-model-name" in args
+    assert args[args.index("--served-model-name") + 1] == "Qwen3-32B-FP8"
+
+
+def test_run_script_carries_served_model_name():
+    artifacts = _render()
+    run_script = next(v for k, v in artifacts.items() if k.startswith("run_") and k.endswith(".sh"))
+
+    assert 'export SERVED_MODEL_NAME=${SERVED_MODEL_NAME:-"Qwen3-32B-FP8"}' in run_script
+    assert '--served-model-name "$SERVED_MODEL_NAME"' in run_script
+
+
+def test_served_model_name_appears_once_per_worker():
+    # The templates own only --model; the builder owns --served-model-name.
+    # Guard against a future duplicate if a template starts emitting it too.
+    artifacts = _render()
+    k8s = yaml.safe_load(artifacts["k8s_deploy.yaml"])
+    services = k8s["spec"]["services"]
+    worker = next(svc for name, svc in services.items() if name != "Frontend")
+    args = worker["extraPodSpec"]["mainContainer"]["args"]
+    assert args.count("--served-model-name") == 1
+
+    run_script = next(v for k, v in artifacts.items() if k.startswith("run_") and k.endswith(".sh"))
+    # One worker loop in agg mode -> exactly one occurrence in the rendered script.
+    assert run_script.count("--served-model-name") == 1
+    # Sanity: the run script is shell-parseable.
+    shlex.split(run_script.split("python3 -m dynamo.vllm", 1)[0])
+
+
+def test_empty_served_model_name_omits_flag():
+    # An empty served_model_name must NOT emit `--served-model-name ""` (which
+    # vLLM treats as an explicit empty alias -> 404), matching the k8s builder's
+    # `if served_model_name` guard. Both the k8s worker args and run.sh must
+    # fall back to `--model` only.
+    params = copy.deepcopy(_PARAMS)
+    params["ServiceConfig"]["served_model_name"] = ""
+
+    artifacts = generate_backend_artifacts(
+        params, "vllm", backend_version=_BACKEND_VERSION, deployment_target="dynamo-j2"
+    )
+
+    k8s = yaml.safe_load(artifacts["k8s_deploy.yaml"])
+    services = k8s["spec"]["services"]
+    worker = next(svc for name, svc in services.items() if name != "Frontend")
+    assert "--served-model-name" not in worker["extraPodSpec"]["mainContainer"]["args"]
+
+    run_script = next(v for k, v in artifacts.items() if k.startswith("run_") and k.endswith(".sh"))
+    assert "--served-model-name" not in run_script


### PR DESCRIPTION
#### Overview:

Backports #1293 to release/0.10.0.

#### Details:

- Cherry-picks the fix commit 5b3c7cf2bc56898fde5c0b4824ae335f35d0c8ec.
- Contains exactly one commit based directly on release/0.10.0; patch identical to the original, DCO preserved.

#### Where should the reviewer start?

See the original PR: https://github.com/ai-dynamo/aiconfigurator/pull/1293

#### Related Issues:

- Relates to #1293