### PR TITLE
fix(generator): keep system identity in naive NodeConfig (cherry-pick #1296)

### DIFF
--- a/src/aiconfigurator/generator/naive.py
+++ b/src/aiconfigurator/generator/naive.py
@@ -420,6 +420,7 @@ def build_naive_generator_params(
     }
     node_config = {
         "num_gpus_per_node": gpus_per_node,
+        "system_name": system_name,
     }
     model_config = {
         "is_moe": is_moe,
@@ -510,6 +511,12 @@ def build_naive_generator_params(
         )
 
     params["ModelConfig"] = model_config
+    # collect_generator_params rebuilds NodeConfig with only num_gpus_per_node,
+    # dropping system_name (and any NodeConfig override). Merge the full
+    # node_config back so the system identity survives; run.sh reads
+    # NodeConfig.system_name to pick the device env var (e.g. B60 needs
+    # ONEAPI_DEVICE_SELECTOR instead of CUDA_VISIBLE_DEVICES).
+    params["NodeConfig"] = _deep_merge_dicts(params.get("NodeConfig", {}), node_config)
     if llmd_config:
         params["LlmdConfig"] = llmd_config
     params["backend"] = backend_name

--- a/tests/unit/generator/test_naive_node_config_system_name.py
+++ b/tests/unit/generator/test_naive_node_config_system_name.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Naive generation must keep the system identity in NodeConfig.
+
+collect_generator_params rebuilds NodeConfig with only num_gpus_per_node, so the
+requested system was dropped from NodeConfig.system_name. The vLLM run.sh reads
+that field to pick the device env var (B60 needs ONEAPI_DEVICE_SELECTOR, not
+CUDA_VISIBLE_DEVICES), so it must survive into the generated params.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from aiconfigurator.generator.naive import build_naive_generator_params
+
+_SYS_CFG = {"gpus_per_node": 8, "vram_per_gpu": 141 * 1024**3}
+
+
+@pytest.fixture(autouse=True)
+def _mock_naive_env():
+    with (
+        patch("aiconfigurator.generator.naive._estimate_model_weight_bytes", return_value=15 * 1024**3),
+        patch("aiconfigurator.generator.naive._get_system_config", return_value=_SYS_CFG),
+    ):
+        yield
+
+
+def test_node_config_carries_requested_system():
+    result = build_naive_generator_params(
+        model_name="Qwen/Qwen3-8B",
+        total_gpus=1,
+        system_name="b60",
+        backend_name="vllm",
+    )
+    assert result["NodeConfig"]["system_name"] == "b60"
+    # num_gpus_per_node still present (was the only field before the fix).
+    assert "num_gpus_per_node" in result["NodeConfig"]
+
+
+def test_node_config_override_still_propagates():
+    result = build_naive_generator_params(
+        model_name="Qwen/Qwen3-8B",
+        total_gpus=1,
+        system_name="b60",
+        backend_name="vllm",
+        generator_overrides={"NodeConfig": {"system_name": "h200_sxm"}},
+    )
+    assert result["NodeConfig"]["system_name"] == "h200_sxm"
+
+
+def test_non_b60_system_is_preserved():
+    result = build_naive_generator_params(
+        model_name="Qwen/Qwen3-8B",
+        total_gpus=1,
+        system_name="h200_sxm",
+        backend_name="vllm",
+    )
+    assert result["NodeConfig"]["system_name"] == "h200_sxm"


### PR DESCRIPTION
#### Overview:

Backports #1296 to release/0.10.0.

#### Details:

- Cherry-picks the fix commit 658729199c428b327aac5c90f2efdfe83f2514af.
- Contains exactly one commit based directly on release/0.10.0; patch identical to the original, DCO preserved.

#### Where should the reviewer start?

See the original PR: https://github.com/ai-dynamo/aiconfigurator/pull/1296

#### Related Issues:

- Relates to #1296