### PR TITLE
fix(generator): preserve LlmdConfig overrides in Task bridge (cherry-pick #1297)

### DIFF
--- a/src/aiconfigurator/generator/module_bridge.py
+++ b/src/aiconfigurator/generator/module_bridge.py
@@ -281,6 +281,13 @@ def task_config_to_generator_config(
     if rule_name:
         params["rule"] = rule_name
     params["ModelConfig"] = model_cfg
+    # Preserve LlmdConfig overrides (e.g. vllm_image, kustomize_base_path) so the
+    # llm-d artifacts honor them. The bridge handles the other config sections
+    # explicitly but omitted this one, so the llm-d templates fell back to their
+    # defaults. Matches the naive generator's behavior.
+    llmd_config = copy.deepcopy(overrides.get("LlmdConfig") or {})
+    if llmd_config:
+        params["LlmdConfig"] = llmd_config
     return params
 
 

--- a/tests/unit/generator/test_module_bridge_llmd_config.py
+++ b/tests/unit/generator/test_module_bridge_llmd_config.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The bridge must preserve LlmdConfig overrides for llm-d artifacts.
+
+cli default / cli sweep go through the Task->generator bridge. It handled the
+other config sections explicitly but dropped LlmdConfig, so llm-d artifacts
+ignored user-selected image / kustomize base and fell back to template defaults.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pandas as pd
+
+from aiconfigurator.generator.module_bridge import task_config_to_generator_config
+
+
+def _task() -> SimpleNamespace:
+    return SimpleNamespace(
+        primary_backend_name="vllm",
+        primary_system_name="h200_sxm",
+        primary_backend_version="0.20.1",
+        primary_model_path="Qwen/Qwen3-32B",
+        prefix=0,
+        is_moe=False,
+        nextn=0,
+        nextn_accept_rates=[],
+        serving_mode="disagg",
+        total_gpus=0,
+        system_name="h200_sxm",
+        isl=4000,
+        osl=1000,
+        ttft=2000.0,
+        tpot=50.0,
+    )
+
+
+def test_llmd_config_overrides_are_preserved():
+    overrides = {
+        "LlmdConfig": {
+            "vllm_image": "nvcr.io/nvstaging/ai-dynamo/vllm-runtime:1.3.0-rc1",
+            "kustomize_base_path": "./guides/pd-disaggregation/modelserver/gpu/vllm/base",
+        }
+    }
+    row = pd.Series({"(p)workers": 1, "(p)tp": 1, "(d)workers": 1, "(d)tp": 1})
+
+    result = task_config_to_generator_config(_task(), row, generator_overrides=overrides, num_gpus_per_node=8)
+
+    assert result["LlmdConfig"] == overrides["LlmdConfig"]
+
+
+def test_llmd_config_absent_when_not_requested():
+    row = pd.Series({"(p)workers": 1, "(p)tp": 1, "(d)workers": 1, "(d)tp": 1})
+
+    result = task_config_to_generator_config(_task(), row, num_gpus_per_node=8)
+
+    assert "LlmdConfig" not in result


### PR DESCRIPTION
#### Overview:

Backports #1297 to release/0.10.0.

#### Details:

- Cherry-picks the fix commit 638ed65550c8b261e339bca97d4f13c3bf2ade47.
- Contains exactly one commit based directly on release/0.10.0; patch identical to the original, DCO preserved.

#### Where should the reviewer start?

See the original PR: https://github.com/ai-dynamo/aiconfigurator/pull/1297

#### Related Issues:

- Relates to #1297