### PR TITLE
fix(packaging): emit aiconfigurator-core sdist for non-linux-x86_64 installs (backport of #1311)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ Let's get started.
 
 ### Install from PyPI
 
+> **Supported platforms.** Pre-built binary wheels are published for **Linux x86-64
+> only** — `aiconfigurator-core` ships a native (Rust/PyO3) extension. On other
+> platforms (macOS, Linux aarch64), `pip` falls back to the `aiconfigurator-core`
+> **source distribution**, which builds the extension from source and therefore
+> requires a **Rust toolchain** and a C compiler (see
+> [Build and Install from Source](#build-and-install-from-source) for
+> prerequisites). Without those tools, install on non-Linux-x86-64 platforms will
+> fail.
+
 ```bash
 pip3 install aiconfigurator
 ```
@@ -47,7 +56,12 @@ git lfs pull
 # 3. Create and activate a virtual environment
 python3 -m venv myenv && source myenv/bin/activate # (requires Python 3.9 or later)
 
-# 4. Install aiconfigurator-core, then aiconfigurator
+# 4. Install a Rust toolchain + C compiler (needed to build the aiconfigurator-core
+#    native extension from source; required on macOS and Linux aarch64, and for any
+#    source/sdist install). Skip if you already have `cargo` and a C linker.
+#    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh   # then restart your shell
+
+# 5. Install aiconfigurator-core, then aiconfigurator
 pip3 install ./src/aiconfigurator-core
 pip3 install .
 ```

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,7 +38,14 @@ RUN set -e; \
         echo "Run 'git lfs install && git lfs pull' in the source tree before building." >&2; \
         exit 1; \
     fi
+# Build the native `aiconfigurator-core` wheel AND an sdist. The wheel is
+# linux_x86_64-only (native PyO3 extension); the sdist is the fallback that lets
+# `pip install` build from source on other platforms (macOS, Linux aarch64) when
+# a Rust toolchain is present. Without it, ARM64/macOS users cannot install AIC
+# via the documented pip command. The upper `aiconfigurator` wheel is
+# py3-none-any, so it needs no sdist.
 RUN cd src/aiconfigurator-core && uv build --wheel --out-dir /workspace/dist && \
+    uv build --sdist --out-dir /workspace/dist && \
     cd /workspace && uv build --wheel --out-dir /workspace/dist
 
 FROM base AS runtime


### PR DESCRIPTION
#### Overview:

Backports the sdist-fallback fix to `release/0.10.0`. Origin PR on `main`: #1311.

`aiconfigurator-core` is a native (Rust/PyO3) extension published only as a
`linux_x86_64` wheel, so on macOS / Linux aarch64 the documented
`pip3 install aiconfigurator` fails (the upper wheel resolves but its
`aiconfigurator-core==0.10.0` dependency has no compatible distribution).

#### Adapted backport (not a literal cherry-pick):

`main` diverged via #1283 (native extension moved into the root `aiconfigurator`
wheel; core became a pure-Python metapackage). On `release/0.10.0` the native
artifact is still the **`aiconfigurator-core`** wheel, so this PR builds the
**core** sdist (`cd src/aiconfigurator-core && uv build --sdist`), whereas #1311
builds the root sdist. Same fix, adapted to each branch's layout.

#### Details:

- **Docker build stage** also emits the `aiconfigurator-core` sdist into `dist/`.
  The upper `aiconfigurator` wheel is `py3-none-any` and needs no sdist. In-container
  runtime/test stages install `*.whl` only, so the sdist is inert there.
- **README**: supported-platforms note before `pip3 install` + Rust-toolchain
  prerequisite in the source-build section.

#### Validation:

Built the core sdist and installed from source into a clean venv on **macOS arm64**
(the reported platform): compiles via maturin/cargo, installs, `import
aiconfigurator_core` succeeds, `_build_smoke()` returns `1`. sdist includes the
full Rust crate + Python SDK + data payload.

#### Deliverable boundary:

No in-repo publish workflow — publishing to the index is manual/external. This PR
makes the release build **produce** the core sdist; the release owner publishes it.