### PR TITLE
fix(cli): report invalid Spica --thorough-config without a traceback

### DIFF
--- a/src/aiconfigurator/cli/spica/helper.py
+++ b/src/aiconfigurator/cli/spica/helper.py
@@ -1743,14 +1743,50 @@ def _spica_extra_input_lines(config: Any, config_path: str | None) -> list[str]:
     return lines
 
 
+def _format_spica_validation_error(exc) -> str:
+    """Render a Pydantic ValidationError as a concise ``loc: msg`` summary."""
+    parts = []
+    for err in exc.errors():
+        loc = ".".join(str(item) for item in err.get("loc", ()))
+        msg = err.get("msg", "")
+        parts.append(f"{loc}: {msg}" if loc else msg)
+    return "; ".join(parts) if parts else str(exc)
+
+
 def _load_spica_config(args, smart_search_config_cls):
+    # A missing/malformed --thorough-config file, or a config that fails schema
+    # validation, is an expected user error. Convert the underlying OSError /
+    # yaml.YAMLError / pydantic.ValidationError into a concise CLI message
+    # instead of leaking a raw Python/Pydantic traceback; keep the stack at
+    # DEBUG (--log-level DEBUG) for diagnosis. Applies to both the native
+    # --thorough-config path and the CLI-derived config path.
+    import pydantic
+
     config_path = getattr(args, "thorough_config", None)
     if config_path:
-        return smart_search_config_cls.from_yaml(config_path), config_path
+        try:
+            return smart_search_config_cls.from_yaml(config_path), config_path
+        except OSError as exc:
+            logger.debug("Could not read Spica config %s", config_path, exc_info=True)
+            raise SystemExit(f"Error: could not read Spica config {config_path}: {exc}") from None
+        except yaml.YAMLError as exc:
+            logger.debug("Malformed Spica YAML %s", config_path, exc_info=True)
+            raise SystemExit(f"Error: malformed Spica YAML {config_path}: {exc}") from None
+        except pydantic.ValidationError as exc:
+            logger.debug("Invalid Spica config %s", config_path, exc_info=True)
+            raise SystemExit(
+                f"Error: invalid Spica config {config_path}: {_format_spica_validation_error(exc)}"
+            ) from None
 
     backends = [backend.value for backend in common.BackendName] if args.backend == "auto" else [args.backend]
     config_data = _build_spica_thorough_config_data(args, backends)
-    return smart_search_config_cls.model_validate(config_data), None
+    try:
+        return smart_search_config_cls.model_validate(config_data), None
+    except pydantic.ValidationError as exc:
+        logger.debug("Invalid Spica config derived from CLI arguments", exc_info=True)
+        raise SystemExit(
+            f"Error: invalid Spica config derived from CLI arguments: {_format_spica_validation_error(exc)}"
+        ) from None
 
 
 def _install_dynamo_planner_bridge_compat() -> None:

--- a/tests/unit/cli/test_cli_workflow.py
+++ b/tests/unit/cli/test_cli_workflow.py
@@ -32,6 +32,7 @@ from aiconfigurator.cli.spica.helper import (
     _build_spica_thorough_config_data,
     _build_spica_trace_result_bundle,
     _build_spica_trace_search_space,
+    _load_spica_config,
     _save_spica_trace_artifacts,
     _spica_candidates_to_result_df,
     _spica_extra_input_lines,
@@ -1621,3 +1622,63 @@ class TestInclusiveTpot:
         df = self._make_df(ttft=500.0, tpot=20.0, osl=1)
         result = _apply_inclusive_tpot(df)
         assert abs(result["tpot"].iloc[0] - 500.0) < 1e-9
+
+
+class TestLoadSpicaConfigErrorHandling:
+    """--thorough-config file errors surface as concise CLI errors, not tracebacks.
+
+    The fake SmartSearchConfig mirrors Spica's real ``from_yaml`` (read_text ->
+    yaml.safe_load -> model_validate) so the test exercises the actual exception
+    types (OSError / yaml.YAMLError / pydantic.ValidationError) that
+    ``_load_spica_config`` must catch.
+    """
+
+    @staticmethod
+    def _fake_config_cls():
+        import pydantic
+
+        class _FakeSmartSearchConfig(pydantic.BaseModel):
+            hardware_sku: str
+
+            @classmethod
+            def from_yaml(cls, path):
+                from pathlib import Path
+
+                data = yaml.safe_load(Path(path).read_text())
+                return cls.model_validate(data)
+
+        return _FakeSmartSearchConfig
+
+    def test_missing_config_file_raises_concise_error(self, tmp_path):
+        args = argparse.Namespace(thorough_config=str(tmp_path / "does_not_exist.yaml"))
+        with pytest.raises(SystemExit) as excinfo:
+            _load_spica_config(args, self._fake_config_cls())
+        message = str(excinfo.value)
+        assert "could not read Spica config" in message
+        assert "Traceback" not in message
+        assert excinfo.value.__cause__ is None
+
+    def test_malformed_yaml_raises_concise_error(self, tmp_path):
+        config_path = tmp_path / "malformed.yaml"
+        config_path.write_text("hardware_sku: [unterminated\n")
+        args = argparse.Namespace(thorough_config=str(config_path))
+        with pytest.raises(SystemExit) as excinfo:
+            _load_spica_config(args, self._fake_config_cls())
+        message = str(excinfo.value)
+        assert "malformed Spica YAML" in message
+        assert "Traceback" not in message
+        assert excinfo.value.__cause__ is None
+
+    def test_missing_required_field_raises_concise_error(self, tmp_path):
+        # Valid YAML, but omits the required field -> ValidationError.
+        config_path = tmp_path / "invalid.yaml"
+        config_path.write_text("some_other_field: 1\n")
+        args = argparse.Namespace(thorough_config=str(config_path))
+        with pytest.raises(SystemExit) as excinfo:
+            _load_spica_config(args, self._fake_config_cls())
+        message = str(excinfo.value)
+        assert "invalid Spica config" in message
+        assert "hardware_sku" in message  # the concise loc: msg reason is preserved
+        assert "Field required" in message
+        assert "Traceback" not in message
+        assert excinfo.value.__cause__ is None


### PR DESCRIPTION
#### Overview:

`aiconfigurator cli default --thorough-config <file>` dumped a full Python/Pydantic traceback when the given Spica config file was missing, contained malformed YAML, or failed schema validation (for example, an omitted required field such as `search_space.hardware_sku`). These are expected, actionable user errors — the CLI now exits non-zero with a single concise `Error: ...` line instead of leaking internal stack frames.

#### Details:

The Spica thorough adapter's `_load_spica_config()` called `SmartSearchConfig.from_yaml()` (and `model_validate()` for the CLI-derived path) without handling the exception families that Spica deliberately lets propagate: `OSError` (unreadable file), `yaml.YAMLError` (malformed YAML), and `pydantic.ValidationError` (schema violation). Those reached the console entry point as a raw traceback.

This PR catches all three in `_load_spica_config()` — on both the native `--thorough-config` path and the CLI-derived config path — and converts them to a concise message via `raise SystemExit(...) from None` (exit 1, no traceback / no exception chain):

- `Error: could not read Spica config <path>: ...`
- `Error: malformed Spica YAML <path>: ...`
- `Error: invalid Spica config <path>: <loc>: <msg>`

`ValidationError` is rendered as a compact `loc: msg` summary so the actionable reason is preserved (e.g. `search_space.hardware_sku: Field required`). The full stack remains available at `--log-level DEBUG`, matching the expected-CLI-error convention introduced in #1282.

Verified end-to-end against all three repro inputs: each exits 1 with the concise reason and zero `Traceback` lines; the standalone `python -m spica` control was already traceback-free, and this brings the AIC adapter in line with it.

#### Where should the reviewer start?

- `src/aiconfigurator/cli/spica/helper.py` — `_load_spica_config()` and the new `_format_spica_validation_error()` helper.
- `tests/unit/cli/test_cli_workflow.py` — `TestLoadSpicaConfigErrorHandling` (missing file / malformed YAML / missing required field; each asserts non-zero exit, accurate reason, no traceback). The fake config mirrors Spica's real `from_yaml` so the tests exercise the actual exception types.

#### Related Issues:

- Relates to the AIConfigurator 0.10.0 CLI release-blocker triage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI error handling when loading configuration files.
  * Users now see concise, readable error messages for missing files, malformed YAML, and invalid or incomplete configuration values.
  * Error details are preserved in the message, while raw tracebacks are no longer shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->