### PR TITLE
fix(cli): report invalid Spica --thorough-config without a traceback (cherry-pick #1315)

### DIFF
--- a/src/aiconfigurator/cli/spica/helper.py
+++ b/src/aiconfigurator/cli/spica/helper.py
@@ -1722,14 +1722,50 @@ def _spica_extra_input_lines(config: Any, config_path: str | None) -> list[str]:
     return lines
 
 
+def _format_spica_validation_error(exc) -> str:
+    """Render a Pydantic ValidationError as a concise ``loc: msg`` summary."""
+    parts = []
+    for err in exc.errors():
+        loc = ".".join(str(item) for item in err.get("loc", ()))
+        msg = err.get("msg", "")
+        parts.append(f"{loc}: {msg}" if loc else msg)
+    return "; ".join(parts) if parts else str(exc)
+
+
 def _load_spica_config(args, smart_search_config_cls):
+    # A missing/malformed --thorough-config file, or a config that fails schema
+    # validation, is an expected user error. Convert the underlying OSError /
+    # yaml.YAMLError / pydantic.ValidationError into a concise CLI message
+    # instead of leaking a raw Python/Pydantic traceback; keep the stack at
+    # DEBUG (--log-level DEBUG) for diagnosis. Applies to both the native
+    # --thorough-config path and the CLI-derived config path.
+    import pydantic
+
     config_path = getattr(args, "thorough_config", None)
     if config_path:
-        return smart_search_config_cls.from_yaml(config_path), config_path
+        try:
+            return smart_search_config_cls.from_yaml(config_path), config_path
+        except OSError as exc:
+            logger.debug("Could not read Spica config %s", config_path, exc_info=True)
+            raise SystemExit(f"Error: could not read Spica config {config_path}: {exc}") from None
+        except yaml.YAMLError as exc:
+            logger.debug("Malformed Spica YAML %s", config_path, exc_info=True)
+            raise SystemExit(f"Error: malformed Spica YAML {config_path}: {exc}") from None
+        except pydantic.ValidationError as exc:
+            logger.debug("Invalid Spica config %s", config_path, exc_info=True)
+            raise SystemExit(
+                f"Error: invalid Spica config {config_path}: {_format_spica_validation_error(exc)}"
+            ) from None
 
     backends = [backend.value for backend in common.BackendName] if args.backend == "auto" else [args.backend]
     config_data = _build_spica_thorough_config_data(args, backends)
-    return smart_search_config_cls.model_validate(config_data), None
+    try:
+        return smart_search_config_cls.model_validate(config_data), None
+    except pydantic.ValidationError as exc:
+        logger.debug("Invalid Spica config derived from CLI arguments", exc_info=True)
+        raise SystemExit(
+            f"Error: invalid Spica config derived from CLI arguments: {_format_spica_validation_error(exc)}"
+        ) from None
 
 
 def _install_dynamo_planner_bridge_compat() -> None:

--- a/tests/unit/cli/test_cli_workflow.py
+++ b/tests/unit/cli/test_cli_workflow.py
@@ -32,6 +32,7 @@ from aiconfigurator.cli.spica.helper import (
     _build_spica_thorough_config_data,
     _build_spica_trace_result_bundle,
     _build_spica_trace_search_space,
+    _load_spica_config,
     _save_spica_trace_artifacts,
     _spica_candidates_to_result_df,
     _spica_generated_backend_version,
@@ -1554,3 +1555,63 @@ class TestInclusiveTpot:
         df = self._make_df(ttft=500.0, tpot=20.0, osl=1)
         result = _apply_inclusive_tpot(df)
         assert abs(result["tpot"].iloc[0] - 500.0) < 1e-9
+
+
+class TestLoadSpicaConfigErrorHandling:
+    """--thorough-config file errors surface as concise CLI errors, not tracebacks.
+
+    The fake SmartSearchConfig mirrors Spica's real ``from_yaml`` (read_text ->
+    yaml.safe_load -> model_validate) so the test exercises the actual exception
+    types (OSError / yaml.YAMLError / pydantic.ValidationError) that
+    ``_load_spica_config`` must catch.
+    """
+
+    @staticmethod
+    def _fake_config_cls():
+        import pydantic
+
+        class _FakeSmartSearchConfig(pydantic.BaseModel):
+            hardware_sku: str
+
+            @classmethod
+            def from_yaml(cls, path):
+                from pathlib import Path
+
+                data = yaml.safe_load(Path(path).read_text())
+                return cls.model_validate(data)
+
+        return _FakeSmartSearchConfig
+
+    def test_missing_config_file_raises_concise_error(self, tmp_path):
+        args = argparse.Namespace(thorough_config=str(tmp_path / "does_not_exist.yaml"))
+        with pytest.raises(SystemExit) as excinfo:
+            _load_spica_config(args, self._fake_config_cls())
+        message = str(excinfo.value)
+        assert "could not read Spica config" in message
+        assert "Traceback" not in message
+        assert excinfo.value.__cause__ is None
+
+    def test_malformed_yaml_raises_concise_error(self, tmp_path):
+        config_path = tmp_path / "malformed.yaml"
+        config_path.write_text("hardware_sku: [unterminated\n")
+        args = argparse.Namespace(thorough_config=str(config_path))
+        with pytest.raises(SystemExit) as excinfo:
+            _load_spica_config(args, self._fake_config_cls())
+        message = str(excinfo.value)
+        assert "malformed Spica YAML" in message
+        assert "Traceback" not in message
+        assert excinfo.value.__cause__ is None
+
+    def test_missing_required_field_raises_concise_error(self, tmp_path):
+        # Valid YAML, but omits the required field -> ValidationError.
+        config_path = tmp_path / "invalid.yaml"
+        config_path.write_text("some_other_field: 1\n")
+        args = argparse.Namespace(thorough_config=str(config_path))
+        with pytest.raises(SystemExit) as excinfo:
+            _load_spica_config(args, self._fake_config_cls())
+        message = str(excinfo.value)
+        assert "invalid Spica config" in message
+        assert "hardware_sku" in message  # the concise loc: msg reason is preserved
+        assert "Field required" in message
+        assert "Traceback" not in message
+        assert excinfo.value.__cause__ is None


### PR DESCRIPTION
#### Overview:

Backports #1315 to `release/0.10.0`.

`aiconfigurator cli default --thorough-config <file>` leaked a full Python/Pydantic traceback for an invalid Spica config (missing file, malformed YAML, or a missing required field such as `search_space.hardware_sku`). This is a 0.10.0 release-blocker fix.

#### Details:

Clean cherry-pick of the squashed commit from #1315 (the `_load_spica_config` region is identical on `main` and `release/0.10.0`). `_load_spica_config()` now catches the `OSError` / `yaml.YAMLError` / `pydantic.ValidationError` that Spica's `from_yaml` propagates — on both the `--thorough-config` and CLI-derived paths — and exits 1 with a concise `Error: ...` message (`SystemExit(...) from None`, no traceback); full stack stays at `--log-level DEBUG`.

The three CLI regressions (`TestLoadSpicaConfigErrorHandling`) pass on `release/0.10.0`.

#### Where should the reviewer start?

- `src/aiconfigurator/cli/spica/helper.py` — `_load_spica_config()` + `_format_spica_validation_error()`.

#### Related Issues:

- Relates to #1315