### PR TITLE
feat(rust-core): add context-parallelism and catch up with latest perf DB refactors; make Spica tests non-blocking (cherry-pick #1313)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -9,6 +9,7 @@ on:
     types:
       - opened
       - synchronize
+  workflow_dispatch:
 
 jobs:
   cargo-deny:
@@ -108,7 +109,16 @@ jobs:
 
   spica-thorough-e2e:
     name: Build and Test (Spica thorough e2e)
-    if: github.event_name == 'pull_request'
+    # Manual-only. This job builds a PINNED Dynamo (`aic-forward-pass`) against
+    # aiconfigurator-core, so it passes only when Dynamo's pinned mocker matches
+    # aic-core's current Rust API. Branches that evolve aic-core (e.g. new
+    # EngineConfig/ParallelMapping fields for context parallelism) break the
+    # pinned mocker's struct literals until Dynamo is updated and its pin bumped
+    # -- an expected failure the aiconfigurator PR cannot self-fix. Running it on
+    # every PR showed a confusing red check for that expected skew, so it is
+    # gated to manual `workflow_dispatch` runs. Trigger it from the Actions tab
+    # ("Run workflow") when validating the Dynamo replay path.
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -184,3 +194,44 @@ jobs:
           path: ${{ runner.temp }}/spica-thorough-e2e-results
           if-no-files-found: warn
           retention-days: 30
+
+  rust-engine-step-parity:
+    name: Rust/Python engine-step parity
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+          lfs: true
+          fetch-depth: 0
+      - name: Git LFS Pull
+        # The parity suite reads the collected perf parquet tables under
+        # src/aiconfigurator/systems/data (stored via Git LFS).
+        run: git lfs pull
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.12'
+      - name: Install AIC and test dependencies
+        run: |
+          python -m pip install uv
+          uv sync --extra dev
+          uv pip install --python .venv/bin/python maturin
+      - name: Build the aiconfigurator_core Rust extension
+        # The AICONFIGURATOR_RUST_CORE_AUTOBUILD env var is a no-op; the compiled
+        # aiconfigurator_core extension must be built explicitly with maturin so
+        # the parity suite exercises the current Rust source. On release/0.10.0 the
+        # maturin project is the core-wheel package at src/aiconfigurator-core (its
+        # [tool.maturin] manifest-path points at rust/aiconfigurator-core/Cargo.toml);
+        # the repo-root pyproject.toml still uses setuptools on this branch, so
+        # maturin must run from the core package dir, not the repo root.
+        working-directory: src/aiconfigurator-core
+        run: |
+          VIRTUAL_ENV="${GITHUB_WORKSPACE}/.venv" \
+            "${GITHUB_WORKSPACE}/.venv/bin/maturin" develop --release
+      - name: Run Rust/Python engine-step parity suite
+        run: |
+          "${GITHUB_WORKSPACE}/.venv/bin/pytest" -q -rx \
+            rust/aiconfigurator-core/parity_tests/test_engine_step_parity.py

--- a/rust/aiconfigurator-core/README.md
+++ b/rust/aiconfigurator-core/README.md
@@ -1,57 +1,146 @@
 # AIConfigurator Rust Core
 
-Phase 1 Rust core for estimating forward-pass latency from AIC model metadata and perf files.
+Rust-native core that estimates prefill, decode, and forward-pass latency from
+AIC model metadata and perf files, without re-entering Python on the hot path.
 
-This crate intentionally does not change the existing Python SDK. It gives Rust callers, especially Dynamo Mocker, a reusable estimator that loads metadata once and then serves per-iteration estimates without Python/GIL overhead.
+This crate intentionally does not change the existing Python SDK. It gives Rust
+callers — especially the Dynamo Mocker and planner — a reusable estimator that
+loads metadata once and then serves per-iteration latency estimates with the
+GIL never acquired.
 
-The v1 input is a per-attention-DP-rank list of AIC-owned Rust `ForwardPassMetrics`, aligned with Dynamo FPM v1. That keeps this first iteration close to existing Dynamo telemetry while avoiding a direct AIC dependency on Dynamo crates.
+## How it works
+
+The **compiled-engine path is the only supported entry point**. Python's
+`compile_engine` walks the model once and emits an `EngineSpec` (the op lists
+plus an `EngineConfig` identity); the Rust `Engine` then executes that spec over
+the loaded perf database natively.
+
+> Note that "compile" here produces a serialized `EngineSpec` (an op-list plan),
+not a native binary. Python builds the spec as JSON, it is re-encoded to bincode
+bytes as the Python → Rust wire format, and the Rust `Engine` deserializes and
+interprets it — closer to a compiled query plan than a compiled executable. The
+one-time compile just resolves the model into a fixed, serializable op list so
+the hot path never re-walks the model or re-enters Python.
+
+- `build_aic_engine(...)` is the Rust → Python (`compile_engine`) → Rust build
+  entry point for callers in other crates (the Dynamo Mocker,
+  `tests/embedded_round_trip.rs`). It embeds a Python interpreter only for the
+  one-time compile step.
+- The returned `AicEngine` exposes GIL-free inherent methods
+  (`prefill_latency_ms`, `decode_latency_ms`) for the pure-Rust hot path, plus
+  `#[pymethods]` wrappers and an FPM-aggregate `estimate_forward_pass_time_ms`
+  for Python callers.
+- `ForwardPassPerfModel` layers online correction, a regression fallback, and
+  readiness/diagnostics on top of the compiled `Engine`, and is re-exported for
+  native embedders and exposed to Python as `RustForwardPassPerfModel`.
 
 ```rust
-use aiconfigurator_core::{
-    create_engine_step_estimator, BackendKind, DataType, EngineConfig, ForwardPassMetrics,
-    ScheduledRequestMetrics, ENGINE_CONFIG_SCHEMA_VERSION,
-};
+use aiconfigurator_core::build_aic_engine;
 
-let estimator = create_engine_step_estimator(EngineConfig {
-    schema_version: ENGINE_CONFIG_SCHEMA_VERSION,
-    model_name: "Qwen/Qwen3-8B".to_string(),
-    model_arch: None,
-    system_name: "h100_sxm".to_string(),
-    backend: BackendKind::Vllm,
-    backend_version: Some("0.19.0".to_string()),
-    tp_size: 1,
-    pp_size: 1,
-    moe_tp_size: None,
-    moe_ep_size: None,
-    attention_dp_size: None,
-    weight_dtype: Some(DataType::Bfloat16),
-    moe_dtype: None,
-    activation_dtype: Some(DataType::Bfloat16),
-    kv_cache_dtype: Some(DataType::Bfloat16),
-    kv_block_size: None,
-    extra: Default::default(),
-})?;
+// Rust -> Python (compile_engine) -> Rust (Engine build + perf-DB load).
+let engine = build_aic_engine(
+    "Qwen/Qwen3-8B",
+    "b200_sxm",
+    "vllm",
+    Some("0.19.0"),
+    8,       // tp_size
+    1,       // pp_size
+    1,       // attention_dp_size
+    Some(1), // moe_tp_size
+    Some(8), // moe_ep_size
+    None,    // gemm_quant_mode   (inferred by compile_engine when None)
+    None,    // moe_quant_mode
+    None,    // kvcache_quant_mode
+    None,    // fmha_quant_mode
+    None,    // comm_quant_mode
+    0,       // nextn (MTP depth; 0 disables)
+    None,    // nextn_accept_rates
+    None,    // kv_block_size
+    None,    // systems_path (None uses the bundled data root)
+)?;
 
-let latency = estimator.forward_pass_time(&[ForwardPassMetrics {
-    scheduled_requests: ScheduledRequestMetrics {
-        num_decode_requests: 1,
-        sum_decode_kv_tokens: 2048,
-        ..Default::default()
-    },
-    ..Default::default()
-}])?;
+// Pure-Rust hot path: no `py` token, so the GIL is never acquired here.
+let prefill = engine.prefill_latency_ms(/* bs */ 1, /* isl */ 1024, /* prefix */ 0)?;
+let decode = engine.decode_latency_ms(/* bs */ 1, /* isl */ 1024, /* osl */ 2)?;
 ```
 
-Current scope:
+The `EngineConfig` identity carried by the spec groups its fields into cohesive
+sub-structs — `ParallelMapping` (`tp_size`, `pp_size`, `attention_dp_size`,
+`moe_tp_size`, `moe_ep_size`, `cp_size`), `QuantizationConfig`, and an optional
+`SpeculativeConfig` (`nextn`, `nextn_accept_rates`) — all `#[serde(flatten)]`-ed
+so the wire JSON stays the flat object Python emits.
 
-- Prefill, decode, and mixed prefill plus decode steps for all model families represented in AIC's checked-in model configs.
-- FPM v1 aggregate scheduled request fields per attention-DP rank as the estimator input.
+## Supported vs. not supported
+
+**Supported today**
+
+- **Silicon mode.** Latency is computed from the collected perf `.parquet`
+  tables. Ops that are inherently analytical (memory-bound element-wise, some
+  communication) compute their formula and tag their result `Empirical` / `Sol`,
+  but that is per-op provenance, not a separate run mode — there is no global
+  `db_mode` selector in the Rust core.
+- **KV-cache memory estimation.** The `estimate_kv_cache` API (a native estimate
+  with an optional naive fallback via `allow_naive_fallback`), run once at
+  startup, separate from the latency hot path.
+- **Shared-layer source inheritance.** Sibling / cross-version silicon rows are
+  resolved by Python and carried on the spec (`perf_db_sources`), so Rust queries
+  the same rows Python does.
+
+**Not supported**
+
+- **Hybrid mode.** Python's silicon-plus-empirical gap-filling — falling back to
+  an analytical estimate when a specific silicon shape or table is missing — is
+  not implemented. A missing table or shape **errors** rather than being
+  estimated. This is why the parity gate uses error-symmetry: both sides erroring
+  on the same input counts as a match (see [Parity](#parity)).
+- **Pure empirical / SOL modes.** The Rust core does not run a whole model
+  analytically; it interprets collected silicon data.
+- Model- and feature-level gaps (DSA/dsv4 context parallelism, FPM v2, …) are
+  listed under [Known limits](#known-limits).
+
+## Current scope
+
+- Prefill, decode, and mixed prefill-plus-decode steps for the model families
+  represented in AIC's checked-in model configs (dense GQA and MoE).
+- MLA attention (context + generation) and DeepSeek-family models, including MTP
+  speculative decoding (`nextn`).
+- Context parallelism: dense GQA/MoE (seq-split token-major ops + zigzag
+  `ContextAttention`) and MLA prefill (zigzag `ContextMLA`).
+- MoE attention-DP token scaling (SGLang all-gathers DP-sharded tokens before
+  the MoE) and DSA generation boundary-utilization extrapolation, both matched
+  to Python.
+- Shared-layer perf-data sources: sibling / cross-version rows are resolved in
+  Python (`sdk/engine.py::_compute_perf_db_sources`) and carried on the spec as
+  `perf_db_sources`, so the Rust core inherits the same silicon rows Python
+  resolves for the shared layer.
+- FPM v1 aggregate scheduled-request fields per attention-DP rank as the
+  estimator input, aligned with Dynamo FPM v1.
 - AIC-style Hugging Face model config JSON files.
-- AIC `gemm_perf.txt`, `context_attention_perf.txt`, `generation_attention_perf.txt`, `moe_perf.txt`, `context_mla_perf.txt`, and `generation_mla_perf.txt` CSV files.
-- Explicit Git LFS pointer detection for perf data that has not been pulled locally.
-- A minimal C ABI used by Python tests to opt into the Rust estimator without requiring PyO3 or changing the default Python SDK path.
+- AIC perf `.parquet` files (`gemm_perf`, `context_attention_perf`,
+  `generation_attention_perf`, `moe_perf`, `mla_context_module_perf`,
+  `mla_generation_module_perf`, `dsa_*_module_perf`, communication tables, …),
+  with explicit Git LFS pointer detection for data that has not been pulled.
+- A PyO3 hot-path pyclass (`AicEngine`) plus a minimal C ABI so Python tests can
+  opt into the Rust estimator without changing the default Python SDK path.
 
-Known Phase 1 limits:
+## Parity
 
-- Request-level FPM v2 fields, KV block modeling, exact Python parity for every specialized op, P2P pipeline composition, WideEP accuracy work, and production Python bindings are intentionally left for later PRs.
-- Tests use fixture perf files so they can run without the large AIC perf databases.
+Rust output is held to the Python SDK by the engine-step parity gate
+(`parity_tests/test_engine_step_parity.py`, run on PRs). The contract is a 1%
+tolerance with error-symmetry: both sides erroring is a pass; one side erroring
+is a fail. Rust loaders and operators deliberately mirror Python's exact
+semantics (e.g. the dsv4 loader's last-source-wins overwrite), so parity-shaped
+code should not be "cleaned up" in ways that diverge from the pinned reference.
+
+## Known limits
+
+- Full context-parallel modeling for DSA (DeepSeek-V3.2) and dsv4
+  (DeepSeek-V4-Flash) is blocked on missing sparse mqa/topk/dsa perf tables; the
+  dense and MLA CP paths are complete.
+- Request-level FPM v2 fields and further WideEP accuracy work are left for later
+  PRs.
+- Unit and integration tests use fixture perf files so they can run without the
+  large AIC perf databases. `cargo test` targets that embed Python (e.g.
+  `embedded_round_trip`, `memory_round_trip`) require a Python interpreter and
+  run under the maturin/pytest harness; CI exercises the crate via pytest and
+  `cargo-deny`, not `cargo test`.

--- a/rust/aiconfigurator-core/parity_tests/test_engine_step_parity.py
+++ b/rust/aiconfigurator-core/parity_tests/test_engine_step_parity.py
@@ -41,6 +41,7 @@ class EngineStepParityCase:
     attention_dp_size: int = 1
     moe_tp_size: int = 1
     moe_ep_size: int = 8
+    cp_size: int = 1
     agg_batch_size: int = 2
     agg_ctx_tokens: int | None = None
     disagg_prefill_batch_size: int = 1
@@ -277,6 +278,22 @@ SMOKE_CASES = [
             backend_version="0.5.10",
         ),
         id="deepseek-v32-b200-sglang-0510-isl1024-osl2",
+    ),
+    # Attention-DP coverage: sglang all-gathers the DP-sharded tokens before
+    # the MoE, so MoE compute scales by attention_dp_size. Every other MoE case
+    # runs at attention_dp=1, which left the Rust MoE token scaling untested;
+    # this Qwen3-235B config (tp1 dp8 etp4 ep2) exercises attention_dp>1.
+    pytest.param(
+        EngineStepParityCase(
+            model_path="Qwen/Qwen3-235B-A22B",
+            backend_name="sglang",
+            backend_version="0.5.10",
+            tp_size=1,
+            attention_dp_size=8,
+            moe_tp_size=4,
+            moe_ep_size=2,
+        ),
+        id="qwen3-235b-b200-sglang-0510-adp8-etp4ep2",
     ),
     # Phase 4 D7-G: shape-variation coverage. All previous cases run at
     # `(batch=1, isl=1024, osl=2)` (plus one prefix variant). The four
@@ -703,6 +720,7 @@ def _python_mixed_step_ms(case: EngineStepParityCase) -> float:
         attention_dp_size=case.attention_dp_size,
         moe_tp_size=case.moe_tp_size,
         moe_ep_size=case.moe_ep_size,
+        cp_size=case.cp_size,
     )
     model = _quiet_call(get_model, case.model_path, model_config, case.backend_name)
     backend = get_backend(case.backend_name)
@@ -741,6 +759,7 @@ def _rust_mixed_step_ms(case: EngineStepParityCase) -> float:
         attention_dp_size=case.attention_dp_size,
         moe_tp_size=case.moe_tp_size,
         moe_ep_size=case.moe_ep_size,
+        cp_size=case.cp_size,
     )
     model = _quiet_call(get_model, case.model_path, model_config, case.backend_name)
     shape = _mix_step_shape(case)
@@ -909,4 +928,80 @@ class TestRustEngineStepDisaggParity:
         _prepare_rust_core(monkeypatch)
 
         reason = _parity_mismatch_reason(_disagg_comparison_metrics(case))
+        assert reason is None, reason
+
+
+# Context-parallelism (CP) parity cases. CP is SGLang-only and shards prefill
+# sequence tokens: token-major ops divide their per-rank token count by cp
+# (seq_split), ContextAttention models rank-0's zigzag chunk split, and
+# MoEDispatch all-gathers (pre) / reduce-scatters (combine) the CP-sharded
+# tokens. sglang CP requires tp_size=1 and attention_dp_size=1, so the width
+# (tp*dp*cp) is carried entirely by cp and matched by moe_tp*moe_ep.
+#
+# Validated on the mix-step surface: the prefill chunk exercises the CP ops
+# (context attention, GEMMs, comm, MoE dispatch). Without the Rust CP support
+# these cases drift (Rust would evaluate the cp>1 config as cp=1); with it the
+# Python and Rust engine steps match within PARITY_RTOL.
+CP_CASES = [
+    pytest.param(
+        EngineStepParityCase(
+            model_path="Qwen/Qwen3-235B-A22B",
+            system_name="b200_sxm",
+            backend_name="sglang",
+            backend_version="0.5.10",
+            tp_size=1,
+            attention_dp_size=1,
+            moe_tp_size=8,
+            moe_ep_size=1,
+            cp_size=8,
+        ),
+        id="qwen3-235b-a22b-b200-sglang-0510-cp8",
+    ),
+    pytest.param(
+        EngineStepParityCase(
+            model_path="Qwen/Qwen3-235B-A22B",
+            system_name="b200_sxm",
+            backend_name="sglang",
+            backend_version="0.5.10",
+            tp_size=1,
+            attention_dp_size=1,
+            moe_tp_size=4,
+            moe_ep_size=1,
+            cp_size=4,
+        ),
+        id="qwen3-235b-a22b-b200-sglang-0510-cp4",
+    ),
+    # MLA context-parallelism: Kimi is MLA with bfloat16 FMHA (collected on
+    # sglang), so it exercises the ContextMLA cp zigzag sharding. (DeepSeek-R1
+    # would need the uncollected fp8-FMHA context-MLA slice; DSA/dsv4 CP need
+    # uncollected sparse mqa/topk tables — both out of scope until collected.)
+    pytest.param(
+        EngineStepParityCase(
+            model_path="moonshotai/Kimi-K2.5",
+            system_name="b200_sxm",
+            backend_name="sglang",
+            backend_version="0.5.10",
+            tp_size=1,
+            attention_dp_size=1,
+            moe_tp_size=8,
+            moe_ep_size=1,
+            cp_size=8,
+        ),
+        id="kimi-k25-b200-sglang-0510-cp8",
+    ),
+]
+
+
+class TestRustEngineStepCpMixedStepParity:
+    """CP parity on the mix-step surface (CP ops run in the prefill chunk)."""
+
+    @pytest.mark.parametrize("case", CP_CASES)
+    def test_cp_parity(
+        self,
+        case: EngineStepParityCase,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _prepare_rust_core(monkeypatch)
+
+        reason = _parity_mismatch_reason(_mixed_step_comparison_metrics(case))
         assert reason is None, reason

--- a/rust/aiconfigurator-core/src/config.rs
+++ b/rust/aiconfigurator-core/src/config.rs
@@ -54,8 +54,40 @@ pub struct EngineConfig {
     #[serde(flatten)]
     pub speculative: Option<SpeculativeConfig>,
 
+    /// Shared-layer (sibling/cross-version) perf-data sources per op-file
+    /// basename (e.g. `gemm_perf.parquet`), resolved in Python
+    /// (`sdk/engine.py::_compute_perf_db_sources`) so the Rust core inherits the
+    /// SAME rows Python does under SILICON/HYBRID. Each entry is
+    /// `(abs_path, Option<kernel_source_allowlist>)` in priority order — the
+    /// first source containing a shape wins (mirrors Python
+    /// `_read_filtered_rows` + skip-on-key-conflict). Absent/empty = fall back
+    /// to the single primary `data_root` (back-compat with pre-shared-layer
+    /// specs).
+    #[serde(default)]
+    pub perf_db_sources: PerfDbSources,
+
     #[serde(default)]
     pub extra: BTreeMap<String, String>,
+}
+
+/// Per-op-file ordered source list, keyed by op-file basename. See
+/// [`EngineConfig::perf_db_sources`].
+pub type PerfDbSources = BTreeMap<String, Vec<PerfSource>>;
+
+/// One perf-data source: an absolute file path plus an optional
+/// `kernel_source` allowlist. `None` admits every row (the primary source);
+/// `Some(set)` keeps only rows whose `kernel_source` is in the set (sibling
+/// inheritance). Wire form is a 2-element JSON array `[path, [ks...] | null]`.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct PerfSource(pub PathBuf, pub Option<Vec<String>>);
+
+impl PerfSource {
+    pub fn path(&self) -> &std::path::Path {
+        &self.0
+    }
+    pub fn kernel_sources(&self) -> Option<&[String]> {
+        self.1.as_deref()
+    }
 }
 
 /// Parallelism layout. Flattened into [`EngineConfig`] so the flat wire keys
@@ -70,6 +102,12 @@ pub struct ParallelMapping {
     pub moe_tp_size: Option<u32>,
     #[serde(default)]
     pub moe_ep_size: Option<u32>,
+    /// Context-parallel size. Part of the engine identity so cp variants get
+    /// distinct compiled handles. `None`/1 means no CP. The per-op CP math is
+    /// carried on the ops themselves (seq_split / cp_size / attn_cp_size), not
+    /// re-derived from this field.
+    #[serde(default)]
+    pub cp_size: Option<u32>,
 }
 
 /// Precision/quantization dtypes. Flattened into [`EngineConfig`]. Field

--- a/rust/aiconfigurator-core/src/engine/runtime.rs
+++ b/rust/aiconfigurator-core/src/engine/runtime.rs
@@ -164,11 +164,12 @@ impl Engine {
         // The spec's own `systems_path` wins when present; otherwise fall back
         // to the `systems_root` argument.
         let systems_root = spec.engine.systems_path.as_deref().unwrap_or(systems_root);
-        let db = PerfDatabase::load(
+        let db = PerfDatabase::load_with_sources(
             systems_root,
             &spec.engine.system_name,
             spec.engine.backend.as_str(),
             version,
+            &spec.engine.perf_db_sources,
         )?;
         Engine::build(spec, Arc::new(db))
     }
@@ -530,6 +531,7 @@ mod tests {
                 name: "rmsnorm".into(),
                 scale_factor: 1.0,
                 bytes_per_token: 8192.0,
+                seq_split: 1,
             }),
             Op::Gemm(GemmOp {
                 name: "qkv_gemm".into(),
@@ -539,6 +541,7 @@ mod tests {
                 quant_mode: GemmQuantMode::Fp8Block,
                 scale_num_tokens: 0,
                 low_precision_input: false,
+                seq_split: 1,
             }),
             Op::ContextAttention(ContextAttentionOp {
                 name: "context_attention".into(),
@@ -550,6 +553,7 @@ mod tests {
                 kv_cache_dtype: KvCacheQuantMode::Fp8,
                 fmha_quant_mode: FmhaQuantMode::Bfloat16,
                 use_qk_norm: false,
+                cp_size: 1,
             }),
         ]
     }
@@ -560,6 +564,7 @@ mod tests {
                 name: "rmsnorm".into(),
                 scale_factor: 1.0,
                 bytes_per_token: 8192.0,
+                seq_split: 1,
             }),
             Op::GenerationAttention(GenerationAttentionOp {
                 name: "generation_attention".into(),
@@ -588,6 +593,7 @@ mod tests {
                 attention_dp_size: Some(1),
                 moe_tp_size: Some(1),
                 moe_ep_size: Some(8),
+                cp_size: None,
             },
             quantization: QuantizationConfig {
                 weight_dtype: None,
@@ -599,6 +605,7 @@ mod tests {
                 nextn: Some(n),
                 nextn_accept_rates: None,
             }),
+            perf_db_sources: Default::default(),
             extra: BTreeMap::new(),
         }
     }

--- a/rust/aiconfigurator-core/src/engine/spec.rs
+++ b/rust/aiconfigurator-core/src/engine/spec.rs
@@ -152,6 +152,7 @@ mod tests {
             quant_mode: GemmQuantMode::Fp8,
             scale_num_tokens: 0,
             low_precision_input: true,
+                seq_split: 1,
         }
     }
 
@@ -162,6 +163,7 @@ mod tests {
             vocab_size: 128_256,
             hidden_size: 4096,
             quant_mode: GemmQuantMode::Bfloat16,
+            seq_split: 1,
         }
     }
 
@@ -170,6 +172,7 @@ mod tests {
             name: "rmsnorm".into(),
             scale_factor: 1.5,
             bytes_per_token: 8192.0,
+            seq_split: 1,
         }
     }
 
@@ -184,6 +187,7 @@ mod tests {
             kv_cache_dtype: KvCacheQuantMode::Fp8,
             fmha_quant_mode: FmhaQuantMode::Bfloat16,
             use_qk_norm: true,
+            cp_size: 1,
         }
     }
 
@@ -216,6 +220,7 @@ mod tests {
             num_heads: 128,
             kv_cache_dtype: KvCacheQuantMode::Bfloat16,
             fmha_quant_mode: FmhaQuantMode::Bfloat16,
+            cp_size: 1,
         }
     }
 
@@ -259,6 +264,7 @@ mod tests {
             num_experts: 256,
             moe_tp_size: 1,
             moe_ep_size: 8,
+            attention_dp_size: 1,
             quant_mode: MoeQuantMode::Fp8Block,
             workload_distribution: "power_law_1.2".into(),
             is_gated: true,
@@ -280,6 +286,8 @@ mod tests {
             flavor: DispatchFlavor::TrtllmAlltoall,
             comm_quant: CommQuantMode::Half,
             moe_quant: MoeQuantMode::Fp8Block,
+            attn_cp_size: 1,
+            is_context: false,
         }
     }
 
@@ -290,6 +298,7 @@ mod tests {
             hidden_size: 4096,
             tp_size: 8,
             quant: CommQuantMode::Half,
+            seq_split: 1,
         }
     }
 
@@ -297,10 +306,11 @@ mod tests {
         NcclOp {
             name: "nccl_all_reduce".into(),
             scale_factor: 1.0,
-            hidden_size: 4096,
+            hidden_size: 4096.0,
             num_gpus: 8,
             dtype: CommQuantMode::Half,
             operation: "all_reduce".into(),
+            seq_split: 1,
         }
     }
 
@@ -310,6 +320,7 @@ mod tests {
             scale_factor: 1.0,
             pp_size: 4,
             hidden_size: 4096,
+            seq_split: 1,
         }
     }
 
@@ -549,6 +560,7 @@ mod tests {
                 attention_dp_size: Some(8),
                 moe_tp_size: Some(1),
                 moe_ep_size: Some(8),
+                cp_size: None,
             },
             quantization: QuantizationConfig {
                 weight_dtype: Some(DataType::Fp8),
@@ -560,6 +572,7 @@ mod tests {
                 nextn: Some(1),
                 nextn_accept_rates: Some(vec![0.85, 0.3, 0.0, 0.0, 0.0]),
             }),
+            perf_db_sources: Default::default(),
             extra: BTreeMap::new(),
         }
     }

--- a/rust/aiconfigurator-core/src/fpm/tests.rs
+++ b/rust/aiconfigurator-core/src/fpm/tests.rs
@@ -34,6 +34,7 @@ fn context_ops() -> Vec<Op> {
             name: "rmsnorm".into(),
             scale_factor: 1.0,
             bytes_per_token: 8192.0,
+                seq_split: 1,
         }),
         Op::Gemm(GemmOp {
             name: "qkv_gemm".into(),
@@ -43,6 +44,7 @@ fn context_ops() -> Vec<Op> {
             quant_mode: GemmQuantMode::Fp8Block,
             scale_num_tokens: 0,
             low_precision_input: false,
+                seq_split: 1,
         }),
         Op::ContextAttention(ContextAttentionOp {
             name: "context_attention".into(),
@@ -54,6 +56,7 @@ fn context_ops() -> Vec<Op> {
             kv_cache_dtype: KvCacheQuantMode::Fp8,
             fmha_quant_mode: FmhaQuantMode::Bfloat16,
             use_qk_norm: false,
+                cp_size: 1,
         }),
     ]
 }
@@ -64,6 +67,7 @@ fn generation_ops() -> Vec<Op> {
             name: "rmsnorm".into(),
             scale_factor: 1.0,
             bytes_per_token: 8192.0,
+                seq_split: 1,
         }),
         Op::GenerationAttention(GenerationAttentionOp {
             name: "generation_attention".into(),
@@ -92,6 +96,7 @@ fn fixture_engine_config() -> EngineConfig {
             attention_dp_size: Some(1),
             moe_tp_size: Some(1),
             moe_ep_size: Some(8),
+                cp_size: None,
         },
         quantization: QuantizationConfig {
             weight_dtype: None,
@@ -100,6 +105,7 @@ fn fixture_engine_config() -> EngineConfig {
             kv_cache_dtype: None,
         },
         speculative: None,
+        perf_db_sources: Default::default(),
         extra: BTreeMap::new(),
     }
 }

--- a/rust/aiconfigurator-core/src/operators/attention.rs
+++ b/rust/aiconfigurator-core/src/operators/attention.rs
@@ -57,6 +57,13 @@ pub struct ContextAttentionOp {
     pub kv_cache_dtype: KvCacheQuantMode,
     pub fmha_quant_mode: FmhaQuantMode,
     pub use_qk_norm: bool,
+    /// Context-parallel factor (Python's `_cp_size`, = `cp_size`). When `>1`,
+    /// prefill FMHA is modeled as rank-0's two zigzag chunks:
+    /// `ctx(c, prefix) + ctx(c, prefix + isl - c)` with `c = ceil(isl / 2cp)`.
+    /// Defaults to 1 (no CP). The fused rope/kv_write/qk_norm extras are still
+    /// added once, not per chunk.
+    #[serde(default = "crate::operators::gemm::default_seq_split")]
+    pub cp_size: u32,
 }
 
 impl ContextAttentionOp {
@@ -78,6 +85,7 @@ impl ContextAttentionOp {
             kv_cache_dtype,
             fmha_quant_mode,
             use_qk_norm: false,
+            cp_size: 1,
         }
     }
 
@@ -89,19 +97,34 @@ impl ContextAttentionOp {
         prefix: u32,
         seq_imbalance_correction_scale: f64,
     ) -> Result<PerformanceResult, AicError> {
-        let full_s = isl + prefix;
-        let table_latency = db.attention.query_context(
-            batch_size,
-            full_s,
-            self.n,
-            self.n_kv,
-            self.head_size,
-            self.window_size,
-            self.kv_cache_dtype,
-            self.fmha_quant_mode,
-        )?;
-        let prefix_factor = prefix_correction(full_s, prefix);
-        let mut latency = table_latency * prefix_factor;
+        // Mirror Python's `ContextAttention._ctx(s, pfx)`: query the table at
+        // the full sequence `s + pfx` and apply the prefix correction for
+        // `pfx`. The Rust table is keyed by the full sequence length.
+        let ctx = |s: u32, pfx: u32| -> Result<f64, AicError> {
+            let full_s = s + pfx;
+            let table = db.attention.query_context(
+                batch_size,
+                full_s,
+                self.n,
+                self.n_kv,
+                self.head_size,
+                self.window_size,
+                self.kv_cache_dtype,
+                self.fmha_quant_mode,
+            )?;
+            Ok(table * prefix_correction(full_s, pfx))
+        };
+
+        // Context parallelism (SGLang AllGather / zigzag): model rank 0's two
+        // balanced chunks. c = ceil(isl / 2cp); rank 0 owns chunk 0 (prefix
+        // unchanged) and chunk 2cp-1 (attends almost the full sequence). Only
+        // the FMHA table term is split; the fused extras below are added once.
+        let mut latency = if self.cp_size > 1 {
+            let c = isl.div_ceil(2 * self.cp_size).max(1);
+            ctx(c, prefix)? + ctx(c, prefix + isl - c)?
+        } else {
+            ctx(isl, prefix)?
+        };
 
         // Fused-op extras (qk_norm optional, rope + kv_write mandatory).
         let q_num = (self.n * self.head_size) as f64;

--- a/rust/aiconfigurator-core/src/operators/communication.rs
+++ b/rust/aiconfigurator-core/src/operators/communication.rs
@@ -29,6 +29,10 @@ pub struct CustomAllReduceOp {
     pub hidden_size: u32,
     pub tp_size: u32,
     pub quant: CommQuantMode,
+    /// CP sequence-shard factor (Python's `_seq_split`, = `cp_size`): the
+    /// per-rank payload is `ceil(num_tokens / seq_split)`. Defaults to 1.
+    #[serde(default = "crate::operators::gemm::default_seq_split")]
+    pub seq_split: u32,
 }
 
 impl CustomAllReduceOp {
@@ -44,6 +48,7 @@ impl CustomAllReduceOp {
             hidden_size,
             tp_size,
             quant: CommQuantMode::Half,
+            seq_split: 1,
         }
     }
 
@@ -60,7 +65,8 @@ impl CustomAllReduceOp {
         if self.tp_size <= 1 {
             return Ok(PerformanceResult::zero());
         }
-        let message_size = (num_tokens as u64) * (self.hidden_size as u64);
+        let per_rank_tokens = num_tokens.div_ceil(self.seq_split.max(1)); // CP: busiest rank
+        let message_size = (per_rank_tokens as u64) * (self.hidden_size as u64);
         let spec = &db.system_spec;
         let per_node = spec.node.num_gpus_per_node;
         let effective_tp = self.tp_size.min(per_node);
@@ -85,17 +91,26 @@ impl CustomAllReduceOp {
 pub struct NcclOp {
     pub name: String,
     pub scale_factor: f64,
-    pub hidden_size: u32,
+    /// Elements moved per token (Python's `_num_elements_per_token`). This is a
+    /// float, not an integer: the CP KV all-gather sizes it as
+    /// `kvcache_bytes_per_token / comm_bytes`, which can be fractional.
+    pub hidden_size: f64,
     pub num_gpus: u32,
     pub dtype: CommQuantMode,
     pub operation: String,
+    /// CP sequence-shard factor (Python's `_seq_split`, = `cp_size`): the
+    /// per-rank payload is `ceil(num_tokens / seq_split)`. Defaults to 1.
+    /// Note the CP KV all-gather (`context_cp_all_gather`) itself keeps
+    /// `seq_split=1` (it moves the full per-token KV), so this is per-op.
+    #[serde(default = "crate::operators::gemm::default_seq_split")]
+    pub seq_split: u32,
 }
 
 impl NcclOp {
     pub fn new(
         name: impl Into<String>,
         scale_factor: f64,
-        hidden_size: u32,
+        hidden_size: f64,
         num_gpus: u32,
         operation: impl Into<String>,
     ) -> Self {
@@ -106,6 +121,7 @@ impl NcclOp {
             num_gpus,
             dtype: CommQuantMode::Half,
             operation: operation.into(),
+            seq_split: 1,
         }
     }
 
@@ -117,7 +133,9 @@ impl NcclOp {
         if self.num_gpus <= 1 {
             return Ok(PerformanceResult::zero());
         }
-        let message_size = (num_tokens as u64) * (self.hidden_size as u64);
+        let per_rank_tokens = num_tokens.div_ceil(self.seq_split.max(1)); // CP: busiest rank
+        // Python: message_size = ceil(x/seq_split) * num_elements_per_token (float).
+        let message_size = ((per_rank_tokens as f64) * self.hidden_size) as u64;
         let max_recorded = db
             .communication
             .nccl_max_num_gpus(self.dtype, &self.operation)?
@@ -149,6 +167,10 @@ pub struct P2POp {
     pub scale_factor: f64,
     pub pp_size: u32,
     pub hidden_size: u32,
+    /// CP sequence-shard factor (Python's `_seq_split`, = `cp_size`): the
+    /// per-rank payload is `ceil(x / seq_split)`. Defaults to 1.
+    #[serde(default = "crate::operators::gemm::default_seq_split")]
+    pub seq_split: u32,
 }
 
 impl P2POp {
@@ -158,6 +180,7 @@ impl P2POp {
             scale_factor: 1.0,
             pp_size,
             hidden_size,
+            seq_split: 1,
         }
     }
 
@@ -166,7 +189,8 @@ impl P2POp {
             return Ok(PerformanceResult::zero());
         }
         let spec = &db.system_spec;
-        let bytes = (x as f64) * (self.hidden_size as f64) * 2.0;
+        let per_rank_tokens = x.div_ceil(self.seq_split.max(1)); // CP: busiest rank
+        let bytes = (per_rank_tokens as f64) * (self.hidden_size as f64) * 2.0;
         let inter_bw = spec.node.inter_node_bw.max(1.0);
         let latency = (bytes / inter_bw + spec.node.p2p_latency) * 1000.0;
         Ok(PerformanceResult::new(latency, Source::Empirical)

--- a/rust/aiconfigurator-core/src/operators/dsa.rs
+++ b/rust/aiconfigurator-core/src/operators/dsa.rs
@@ -89,6 +89,7 @@ impl DsaModuleOp {
         s: u32,
     ) -> Result<PerformanceResult, AicError> {
         let latency = db.dsa.query_generation(
+            &db.system_spec,
             batch_size,
             s,
             self.num_heads,

--- a/rust/aiconfigurator-core/src/operators/elementwise.rs
+++ b/rust/aiconfigurator-core/src/operators/elementwise.rs
@@ -25,6 +25,12 @@ pub struct ElementwiseOp {
     /// Bytes touched per input token. The query multiplies this by the
     /// runtime token count.
     pub bytes_per_token: f64,
+    /// CP sequence-shard factor (Python's `_seq_split`, = `cp_size`): the
+    /// per-rank token count is `ceil(num_tokens / seq_split)`. Defaults to 1.
+    /// (Python's `scale_num_tokens` is folded into `bytes_per_token` by the
+    /// serializer; `seq_split` is applied here to the token count.)
+    #[serde(default = "crate::operators::gemm::default_seq_split")]
+    pub seq_split: u32,
 }
 
 impl ElementwiseOp {
@@ -33,10 +39,12 @@ impl ElementwiseOp {
             name: name.into(),
             scale_factor: 1.0,
             bytes_per_token,
+            seq_split: 1,
         }
     }
 
     pub fn query(&self, db: &PerfDatabase, num_tokens: u32) -> Result<PerformanceResult, AicError> {
+        let num_tokens = num_tokens.div_ceil(self.seq_split.max(1)); // CP: busiest rank
         let bytes = self.bytes_per_token * (num_tokens as f64);
         let latency = mem_op_latency_ms(&db.system_spec, bytes);
         Ok(PerformanceResult::new(latency, Source::Empirical).scaled(self.scale_factor))

--- a/rust/aiconfigurator-core/src/operators/embedding.rs
+++ b/rust/aiconfigurator-core/src/operators/embedding.rs
@@ -23,6 +23,10 @@ pub struct EmbeddingOp {
     pub vocab_size: u32,
     pub hidden_size: u32,
     pub quant_mode: GemmQuantMode,
+    /// CP sequence-shard factor (Python's `_seq_split`, = `cp_size`): the
+    /// per-rank token count is `ceil(num_tokens / seq_split)`. Defaults to 1.
+    #[serde(default = "crate::operators::gemm::default_seq_split")]
+    pub seq_split: u32,
 }
 
 impl EmbeddingOp {
@@ -38,12 +42,14 @@ impl EmbeddingOp {
             vocab_size,
             hidden_size,
             quant_mode,
+            seq_split: 1,
         }
     }
 
     /// Per-token embedding lookup: each token loads one row of size
     /// `hidden_size * dtype_memory` bytes.
     pub fn query(&self, db: &PerfDatabase, num_tokens: u32) -> Result<PerformanceResult, AicError> {
+        let num_tokens = num_tokens.div_ceil(self.seq_split.max(1)); // CP: busiest rank
         let bytes = (num_tokens as f64)
             * (self.hidden_size as f64)
             * self.quant_mode.mapping().memory;

--- a/rust/aiconfigurator-core/src/operators/gemm.rs
+++ b/rust/aiconfigurator-core/src/operators/gemm.rs
@@ -29,6 +29,14 @@ pub struct GemmOp {
     pub quant_mode: GemmQuantMode,
     pub scale_num_tokens: u32,
     pub low_precision_input: bool,
+    /// Context-parallel sequence-shard factor (Python's `_seq_split`, = `cp_size`).
+    /// The per-rank token count is `ceil(m / seq_split)`. Defaults to 1 (no CP).
+    #[serde(default = "default_seq_split")]
+    pub seq_split: u32,
+}
+
+pub(crate) fn default_seq_split() -> u32 {
+    1
 }
 
 impl GemmOp {
@@ -43,6 +51,7 @@ impl GemmOp {
             quant_mode,
             scale_num_tokens: 1,
             low_precision_input: false,
+            seq_split: 1,
         }
     }
 
@@ -62,6 +71,8 @@ impl GemmOp {
         quant_override: Option<GemmQuantMode>,
     ) -> Result<PerformanceResult, AicError> {
         let m = x / self.scale_num_tokens.max(1);
+        // CP: per-rank token count = ceil(m / seq_split) (busiest rank).
+        let m = m.div_ceil(self.seq_split.max(1));
         let quant = quant_override.unwrap_or(self.quant_mode);
 
         let mut latency = db.gemm.query(quant, m, self.n, self.k)?;
@@ -132,6 +143,7 @@ mod tests {
             quant_mode: GemmQuantMode::Bfloat16,
             scale_num_tokens: 1,
             low_precision_input: false,
+            seq_split: 1,
         };
         let result = op.query(&db, 32768, None).expect("query must succeed");
         assert!(
@@ -153,6 +165,7 @@ mod tests {
             quant_mode: GemmQuantMode::Bfloat16,
             scale_num_tokens: 2,
             low_precision_input: false,
+            seq_split: 1,
         };
         let result = op.query(&db, 65536, None).expect("query must succeed");
         assert!(

--- a/rust/aiconfigurator-core/src/operators/mla.rs
+++ b/rust/aiconfigurator-core/src/operators/mla.rs
@@ -32,6 +32,13 @@ pub struct ContextMlaOp {
     pub num_heads: u32,
     pub kv_cache_dtype: KvCacheQuantMode,
     pub fmha_quant_mode: FmhaQuantMode,
+    /// Context-parallel factor (Python `ContextMLA._cp_size`). When `>1`,
+    /// prefill MLA is modeled as SGLang AllGather rank-0's two zigzag chunks:
+    /// `ctx(c, prefix) + ctx(c, prefix + isl - c)` with `c = ceil(isl / 2cp)`,
+    /// mirroring `operators/attention.rs::ContextAttentionOp`. Absent in
+    /// pre-CP specs -> 1 (no sharding).
+    #[serde(default = "crate::operators::gemm::default_seq_split")]
+    pub cp_size: u32,
 }
 
 impl ContextMlaOp {
@@ -47,6 +54,7 @@ impl ContextMlaOp {
             num_heads,
             kv_cache_dtype,
             fmha_quant_mode,
+            cp_size: 1,
         }
     }
 
@@ -57,15 +65,28 @@ impl ContextMlaOp {
         isl: u32,
         prefix: u32,
     ) -> Result<PerformanceResult, AicError> {
-        let full_s = isl + prefix;
-        let raw = db.mla.query_context(
-            batch_size,
-            full_s,
-            self.num_heads,
-            self.kv_cache_dtype,
-            self.fmha_quant_mode,
-        )?;
-        let latency = raw * prefix_correction(full_s, prefix);
+        // ctx(s, pfx): the un-sharded context-MLA query for a sequence chunk of
+        // length `s` at prefix `pfx`, with the prefix correction applied.
+        let ctx = |s: u32, pfx: u32| -> Result<f64, AicError> {
+            let full_s = s + pfx;
+            let raw = db.mla.query_context(
+                batch_size,
+                full_s,
+                self.num_heads,
+                self.kv_cache_dtype,
+                self.fmha_quant_mode,
+            )?;
+            Ok(raw * prefix_correction(full_s, pfx))
+        };
+        // Context parallelism (SGLang AllGather / zigzag): model rank 0's two
+        // balanced chunks, c = ceil(isl / 2cp). Mirrors Python
+        // `ContextMLA.query` and `operators/attention.rs::ContextAttentionOp`.
+        let latency = if self.cp_size > 1 {
+            let c = isl.div_ceil(2 * self.cp_size).max(1);
+            ctx(c, prefix)? + ctx(c, prefix + isl - c)?
+        } else {
+            ctx(isl, prefix)?
+        };
         Ok(PerformanceResult::new(latency, Source::Silicon)
             .clamp_non_negative()
             .scaled(self.scale_factor))

--- a/rust/aiconfigurator-core/src/operators/moe.rs
+++ b/rust/aiconfigurator-core/src/operators/moe.rs
@@ -30,6 +30,12 @@ pub struct MoeOp {
     pub num_experts: u32,
     pub moe_tp_size: u32,
     pub moe_ep_size: u32,
+    /// Attention data-parallel size. sglang all-gathers the DP-sharded tokens
+    /// before the MoE, so the compute sees `num_tokens * attention_dp_size`
+    /// tokens (mirrors Python `MoE.query`: `x = x * attention_dp_size`).
+    /// Absent in pre-existing specs -> treated as 1.
+    #[serde(default)]
+    pub attention_dp_size: u32,
     pub quant_mode: MoeQuantMode,
     pub workload_distribution: String,
     /// Gated FFN (SwiGLU) when true; non-gated (Relu²) when false.
@@ -60,6 +66,7 @@ impl MoeOp {
             num_experts,
             moe_tp_size,
             moe_ep_size,
+            attention_dp_size: 1,
             quant_mode,
             workload_distribution: workload_distribution.into(),
             is_gated: true,
@@ -67,6 +74,12 @@ impl MoeOp {
     }
 
     pub fn query(&self, db: &PerfDatabase, num_tokens: u32) -> Result<PerformanceResult, AicError> {
+        // sglang all-gathers the attention-DP-sharded tokens before the MoE,
+        // so the compute processes the full global token count. Mirror Python
+        // `MoE.query` (`operations/moe.py`): `x = x * attention_dp_size`. Do
+        // this first so the overflow/interpolation logic below keys off the
+        // scaled token count.
+        let num_tokens = num_tokens.saturating_mul(self.attention_dp_size.max(1));
         // SOL-anchored overflow: when `num_tokens` exceeds the largest
         // recorded token point for this (quant, distribution, topology),
         // Python switches to a utilization-anchored estimate instead of

--- a/rust/aiconfigurator-core/src/operators/moe_dispatch.rs
+++ b/rust/aiconfigurator-core/src/operators/moe_dispatch.rs
@@ -56,6 +56,15 @@ pub struct MoEDispatchOp {
     pub flavor: DispatchFlavor,
     pub comm_quant: CommQuantMode,
     pub moe_quant: MoeQuantMode,
+    /// Attention-side context-parallel factor (Python's `_attn_cp_size`,
+    /// = `cp_size`). Under CP (sglang, prefill) the pre-dispatch all-gathers
+    /// / post-dispatch reduce-scatters the CP-sharded tokens. Defaults to 1.
+    #[serde(default = "crate::operators::gemm::default_seq_split")]
+    pub attn_cp_size: u32,
+    /// Whether this is a context (prefill) dispatch. CP dispatch comm only runs
+    /// in prefill; decode replicates attention across CP ranks (no comm).
+    #[serde(default)]
+    pub is_context: bool,
 }
 
 impl MoEDispatchOp {
@@ -85,6 +94,8 @@ impl MoEDispatchOp {
             flavor,
             comm_quant: CommQuantMode::Half,
             moe_quant: MoeQuantMode::Bfloat16,
+            attn_cp_size: 1,
+            is_context: false,
         }
     }
 
@@ -149,7 +160,7 @@ impl MoEDispatchOp {
                             let nccl = NcclOp::new(
                                 &self.name,
                                 1.0,
-                                self.hidden_size,
+                                self.hidden_size as f64,
                                 num_gpus,
                                 op_name,
                             );
@@ -180,10 +191,25 @@ impl MoEDispatchOp {
                                     num_tokens,
                                 )
                             };
-                            let n1 = NcclOp::new(&self.name, 1.0, self.hidden_size, gpus1, op1);
-                            let n2 = NcclOp::new(&self.name, 1.0, self.hidden_size, gpus2, op2);
+                            let n1 = NcclOp::new(&self.name, 1.0, self.hidden_size as f64, gpus1, op1);
+                            let n2 = NcclOp::new(&self.name, 1.0, self.hidden_size as f64, gpus2, op2);
                             n1.query(db, tokens1)?.latency_ms
                                 + n2.query(db, tokens2)?.latency_ms
+                        } else if self.attn_cp_size > 1 {
+                            // Context parallelism (Python moe.py:1390-1401):
+                            //  * prefill: tokens are CP-sharded; all_gather (pre)
+                            //    to assemble the full token set / reduce_scatter
+                            //    (combine) back. volume = num_tokens * hidden.
+                            //  * decode: CP does not run (attention replicated);
+                            //    the selection is local -> no comm.
+                            if self.is_context {
+                                let op_name = if pre { "all_gather" } else { "reduce_scatter" };
+                                let nccl =
+                                    NcclOp::new(&self.name, 1.0, self.hidden_size as f64, num_gpus, op_name);
+                                nccl.query(db, num_tokens)?.latency_ms
+                            } else {
+                                0.0
+                            }
                         } else if attn_tp > 1 {
                             let ar = CustomAllReduceOp::new(
                                 &self.name,
@@ -197,7 +223,7 @@ impl MoEDispatchOp {
                             let nccl = NcclOp::new(
                                 &self.name,
                                 1.0,
-                                self.hidden_size,
+                                self.hidden_size as f64,
                                 num_gpus,
                                 op_name,
                             );

--- a/rust/aiconfigurator-core/src/operators/vision.rs
+++ b/rust/aiconfigurator-core/src/operators/vision.rs
@@ -54,6 +54,7 @@ impl VisionEncoderOp {
             quant_mode: self.gemm_quant,
             scale_num_tokens: 1,
             low_precision_input: false,
+                seq_split: 1,
         };
         let attn = EncoderAttentionOp::new(
             format!("{}.attn", self.name),
@@ -69,6 +70,7 @@ impl VisionEncoderOp {
             quant_mode: self.gemm_quant,
             scale_num_tokens: 1,
             low_precision_input: false,
+                seq_split: 1,
         };
         let ffn1 = GemmOp {
             name: format!("{}.ffn1", self.name),
@@ -78,6 +80,7 @@ impl VisionEncoderOp {
             quant_mode: self.gemm_quant,
             scale_num_tokens: 1,
             low_precision_input: false,
+                seq_split: 1,
         };
         let ffn2 = GemmOp {
             name: format!("{}.ffn2", self.name),
@@ -87,6 +90,7 @@ impl VisionEncoderOp {
             quant_mode: self.gemm_quant,
             scale_num_tokens: 1,
             low_precision_input: false,
+                seq_split: 1,
         };
         let norms = ElementwiseOp::new(
             format!("{}.norms", self.name),

--- a/rust/aiconfigurator-core/src/perf_database/attention.rs
+++ b/rust/aiconfigurator-core/src/perf_database/attention.rs
@@ -29,6 +29,8 @@ use std::sync::OnceLock;
 use crate::common::enums::{FmhaQuantMode, KvCacheQuantMode};
 use crate::common::error::AicError;
 use crate::common::system_spec::SystemSpec;
+use crate::config::{PerfDbSources, PerfSource};
+use super::{kernel_source_ok, resolve_op_sources};
 use super::interpolation::{
     interp_1d, interp_2d_1d_grid, interp_2d_1d_grid_strict, nearest_neighbors, Grid3,
 };
@@ -37,6 +39,12 @@ use crate::perf_database::parquet_loader::PerfReader;
 pub struct AttentionTable {
     data_root: PathBuf,
     system_spec: SystemSpec,
+    /// Ordered, priority-sorted sources for each attention perf file
+    /// (shared-layer aware; see [`PerfSource`]). Single-primary, no-filter by
+    /// default (`AttentionTable::new`).
+    context_sources: Vec<PerfSource>,
+    generation_sources: Vec<PerfSource>,
+    encoder_sources: Vec<PerfSource>,
     context: OnceLock<Result<ContextGrids, AicError>>,
     generation: OnceLock<Result<GenerationGrids, AicError>>,
     encoder: OnceLock<Result<EncoderGrids, AicError>>,
@@ -78,10 +86,36 @@ struct EncoderKey {
 }
 
 impl AttentionTable {
+    /// Construct an empty table for the given data directory. No I/O. Each
+    /// perf file is sourced solely from `data_root/<basename>` with no
+    /// `kernel_source` filter (pre-shared-layer behaviour).
     pub fn new(data_root: PathBuf, system_spec: SystemSpec) -> Self {
+        Self::with_sources(data_root, system_spec, &PerfDbSources::default())
+    }
+
+    /// Construct with shared-layer (sibling/cross-version) sources resolved from
+    /// `perf_db_sources` (Python-supplied). Each attention file falls back to
+    /// its primary `data_root/<basename>` when absent from the map. No I/O.
+    pub fn with_sources(
+        data_root: PathBuf,
+        system_spec: SystemSpec,
+        perf_db_sources: &PerfDbSources,
+    ) -> Self {
+        let context_sources =
+            resolve_op_sources(perf_db_sources, "context_attention_perf.parquet", &data_root);
+        let generation_sources = resolve_op_sources(
+            perf_db_sources,
+            "generation_attention_perf.parquet",
+            &data_root,
+        );
+        let encoder_sources =
+            resolve_op_sources(perf_db_sources, "encoder_attention_perf.parquet", &data_root);
         Self {
             data_root,
             system_spec,
+            context_sources,
+            generation_sources,
+            encoder_sources,
             context: OnceLock::new(),
             generation: OnceLock::new(),
             encoder: OnceLock::new(),
@@ -187,16 +221,14 @@ impl AttentionTable {
 
     fn load_context(&self) -> Result<&ContextGrids, AicError> {
         let cell = self.context.get_or_init(|| {
-            load_context_parquet(&self.data_root.join("context_attention_perf.parquet"))
+            load_context_parquet(&self.context_sources)
         });
         cell.as_ref().map_err(clone_err)
     }
 
     fn load_generation(&self) -> Result<&GenerationGrids, AicError> {
         let cell = self.generation.get_or_init(|| {
-            let mut grids = load_generation_parquet(
-                &self.data_root.join("generation_attention_perf.parquet"),
-            )?;
+            let mut grids = load_generation_parquet(&self.generation_sources)?;
             // Mirror Python `GenerationAttention.load_data` order:
             //   1. clamp to SOL (`_correct_sol`)
             //   2. densify the grid (`_extrapolate` -> `extrapolate_data_grid`)
@@ -215,7 +247,7 @@ impl AttentionTable {
 
     fn load_encoder(&self) -> Result<&EncoderGrids, AicError> {
         let cell = self.encoder.get_or_init(|| {
-            load_encoder_parquet(&self.data_root.join("encoder_attention_perf.parquet"))
+            load_encoder_parquet(&self.encoder_sources)
         });
         cell.as_ref().map_err(clone_err)
     }
@@ -230,92 +262,125 @@ fn normalize_kv(n: u32, n_kv: u32) -> u32 {
     }
 }
 
-fn load_context_parquet(path: &Path) -> Result<ContextGrids, AicError> {
-    let reader = PerfReader::open(path)?;
-    let batch_size_col = reader.col("batch_size")?;
-    let isl_col = reader.col("isl")?;
-    let num_heads_col = reader.col("num_heads")?;
-    let num_kv_col = reader.col("num_key_value_heads")?;
-    let head_dim_col = reader.col("head_dim")?;
-    let attn_dtype_col = reader.col("attn_dtype")?;
-    let kv_cache_dtype_col = reader.col("kv_cache_dtype")?;
-    let latency_col = reader.col("latency")?;
-    let window_size_col = reader.col_optional("window_size");
-
+/// Load the context-attention table from an ordered, priority-sorted source
+/// list. Sources are read in order; the first source containing a key wins
+/// (`or_insert`). Missing files are skipped; an error is returned only when no
+/// source yields rows.
+fn load_context_parquet(sources: &[PerfSource]) -> Result<ContextGrids, AicError> {
     let mut by_keys: BTreeMap<ContextKey, Grid3<f64>> = BTreeMap::new();
-    for row in reader.rows()? {
-        let row = row?;
-        let num_heads = row.u32(num_heads_col)?;
-        let num_kv = row.u32(num_kv_col)?;
-        let key = ContextKey {
-            fmha_quant: row.str_owned(attn_dtype_col)?,
-            kv_quant: row.str_owned(kv_cache_dtype_col)?,
-            n_kv_lookup: normalize_kv(num_heads, num_kv),
-            head_size: row.u32(head_dim_col)?,
-            window_size: row.u32_optional(window_size_col)?.unwrap_or(0),
-        };
-        // First-wins parity with Python `load_context_attention_data`.
-        by_keys
-            .entry(key)
-            .or_default()
-            .entry(num_heads)
-            .or_default()
-            .entry(row.u32(isl_col)?)
-            .or_default()
-            .entry(row.u32(batch_size_col)?)
-            .or_insert(row.f64(latency_col)?);
+    let mut any_source = false;
+    for source in sources {
+        let path = source.path();
+        if !path.exists() {
+            continue;
+        }
+        any_source = true;
+        let reader = PerfReader::open(path)?;
+        let batch_size_col = reader.col("batch_size")?;
+        let isl_col = reader.col("isl")?;
+        let num_heads_col = reader.col("num_heads")?;
+        let num_kv_col = reader.col("num_key_value_heads")?;
+        let head_dim_col = reader.col("head_dim")?;
+        let attn_dtype_col = reader.col("attn_dtype")?;
+        let kv_cache_dtype_col = reader.col("kv_cache_dtype")?;
+        let latency_col = reader.col("latency")?;
+        let window_size_col = reader.col_optional("window_size");
+        let ks_col = reader.col_optional("kernel_source");
+        for row in reader.rows()? {
+            let row = row?;
+            if !kernel_source_ok(source.kernel_sources(), ks_col, &row)? {
+                continue;
+            }
+            let num_heads = row.u32(num_heads_col)?;
+            let num_kv = row.u32(num_kv_col)?;
+            let key = ContextKey {
+                fmha_quant: row.str_owned(attn_dtype_col)?,
+                kv_quant: row.str_owned(kv_cache_dtype_col)?,
+                n_kv_lookup: normalize_kv(num_heads, num_kv),
+                head_size: row.u32(head_dim_col)?,
+                window_size: row.u32_optional(window_size_col)?.unwrap_or(0),
+            };
+            // First-wins parity with Python `load_context_attention_data`,
+            // extended across shared-layer sources (earlier source wins).
+            by_keys
+                .entry(key)
+                .or_default()
+                .entry(num_heads)
+                .or_default()
+                .entry(row.u32(isl_col)?)
+                .or_default()
+                .entry(row.u32(batch_size_col)?)
+                .or_insert(row.f64(latency_col)?);
+        }
     }
-    if by_keys.is_empty() {
+    if !any_source || by_keys.is_empty() {
         return Err(AicError::PerfDatabase(format!(
-            "no context-attention rows loaded from {}",
-            path.display()
+            "no context-attention rows loaded from {} source(s) (first: {})",
+            sources.len(),
+            sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
         )));
     }
     Ok(ContextGrids { by_keys })
 }
 
-fn load_generation_parquet(path: &Path) -> Result<GenerationGrids, AicError> {
-    let reader = PerfReader::open(path)?;
-    let batch_size_col = reader.col("batch_size")?;
-    let isl_col = reader.col("isl")?;
-    let num_heads_col = reader.col("num_heads")?;
-    let num_kv_col = reader.col("num_key_value_heads")?;
-    let head_dim_col = reader.col("head_dim")?;
-    let kv_cache_dtype_col = reader.col("kv_cache_dtype")?;
-    let step_col = reader.col("step")?;
-    let latency_col = reader.col("latency")?;
-    let window_size_col = reader.col_optional("window_size");
-
+/// Load the generation-attention table from an ordered, priority-sorted source
+/// list. Same first-wins-across-sources + missing-file-skip semantics as
+/// [`load_context_parquet`].
+fn load_generation_parquet(sources: &[PerfSource]) -> Result<GenerationGrids, AicError> {
     let mut by_keys: BTreeMap<GenerationKey, Grid3<f64>> = BTreeMap::new();
-    for row in reader.rows()? {
-        let row = row?;
-        let num_heads = row.u32(num_heads_col)?;
-        let num_kv = row.u32(num_kv_col)?;
-        let key = GenerationKey {
-            kv_quant: row.str_owned(kv_cache_dtype_col)?,
-            n_kv_lookup: normalize_kv(num_heads, num_kv),
-            head_size: row.u32(head_dim_col)?,
-            window_size: row.u32_optional(window_size_col)?.unwrap_or(0),
-        };
-        let sequence_tokens = row.u32(isl_col)? + row.u32(step_col)?;
-        // First-wins parity with Python `load_generation_attention_data`.
-        // Grid axis order is `[n][b][s]` to match Python's `interp_3d(n, b, s)`
-        // (1-D over n, bilinear over (b, s)). Nesting: num_heads -> batch_size
-        // -> sequence_tokens.
-        by_keys
-            .entry(key)
-            .or_default()
-            .entry(num_heads)
-            .or_default()
-            .entry(row.u32(batch_size_col)?)
-            .or_default()
-            .entry(sequence_tokens)
-            .or_insert(row.f64(latency_col)?);
+    let mut any_source = false;
+    for source in sources {
+        let path = source.path();
+        if !path.exists() {
+            continue;
+        }
+        any_source = true;
+        let reader = PerfReader::open(path)?;
+        let batch_size_col = reader.col("batch_size")?;
+        let isl_col = reader.col("isl")?;
+        let num_heads_col = reader.col("num_heads")?;
+        let num_kv_col = reader.col("num_key_value_heads")?;
+        let head_dim_col = reader.col("head_dim")?;
+        let kv_cache_dtype_col = reader.col("kv_cache_dtype")?;
+        let step_col = reader.col("step")?;
+        let latency_col = reader.col("latency")?;
+        let window_size_col = reader.col_optional("window_size");
+        let ks_col = reader.col_optional("kernel_source");
+        for row in reader.rows()? {
+            let row = row?;
+            if !kernel_source_ok(source.kernel_sources(), ks_col, &row)? {
+                continue;
+            }
+            let num_heads = row.u32(num_heads_col)?;
+            let num_kv = row.u32(num_kv_col)?;
+            let key = GenerationKey {
+                kv_quant: row.str_owned(kv_cache_dtype_col)?,
+                n_kv_lookup: normalize_kv(num_heads, num_kv),
+                head_size: row.u32(head_dim_col)?,
+                window_size: row.u32_optional(window_size_col)?.unwrap_or(0),
+            };
+            let sequence_tokens = row.u32(isl_col)? + row.u32(step_col)?;
+            // First-wins parity with Python `load_generation_attention_data`,
+            // extended across shared-layer sources.
+            // Grid axis order is `[n][b][s]` to match Python's `interp_3d(n, b, s)`
+            // (1-D over n, bilinear over (b, s)). Nesting: num_heads -> batch_size
+            // -> sequence_tokens.
+            by_keys
+                .entry(key)
+                .or_default()
+                .entry(num_heads)
+                .or_default()
+                .entry(row.u32(batch_size_col)?)
+                .or_default()
+                .entry(sequence_tokens)
+                .or_insert(row.f64(latency_col)?);
+        }
     }
-    if by_keys.is_empty() {
+    if !any_source || by_keys.is_empty() {
         return Err(AicError::PerfDatabase(format!(
-            "no generation-attention rows loaded from {}",
-            path.display()
+            "no generation-attention rows loaded from {} source(s) (first: {})",
+            sources.len(),
+            sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
         )));
     }
     Ok(GenerationGrids { by_keys })
@@ -537,37 +602,53 @@ fn kv_cache_quant_by_name(name: &str) -> Option<KvCacheQuantMode> {
     })
 }
 
-fn load_encoder_parquet(path: &Path) -> Result<EncoderGrids, AicError> {
-    let reader = PerfReader::open(path)?;
-    let batch_size_col = reader.col("batch_size")?;
-    let isl_col = reader.col("isl")?;
-    let num_heads_col = reader.col("num_heads")?;
-    let head_dim_col = reader.col("head_dim")?;
-    let attn_dtype_col = reader.col("attn_dtype")?;
-    let latency_col = reader.col("latency")?;
-
+/// Load the encoder-attention table from an ordered, priority-sorted source
+/// list. Same first-wins-across-sources + missing-file-skip semantics as
+/// [`load_context_parquet`].
+fn load_encoder_parquet(sources: &[PerfSource]) -> Result<EncoderGrids, AicError> {
     let mut by_keys: BTreeMap<EncoderKey, Grid3<f64>> = BTreeMap::new();
-    for row in reader.rows()? {
-        let row = row?;
-        let key = EncoderKey {
-            fmha_quant: row.str_owned(attn_dtype_col)?,
-            head_size: row.u32(head_dim_col)?,
-        };
-        // First-wins parity with Python `load_encoder_attention_data`.
-        by_keys
-            .entry(key)
-            .or_default()
-            .entry(row.u32(num_heads_col)?)
-            .or_default()
-            .entry(row.u32(isl_col)?)
-            .or_default()
-            .entry(row.u32(batch_size_col)?)
-            .or_insert(row.f64(latency_col)?);
+    let mut any_source = false;
+    for source in sources {
+        let path = source.path();
+        if !path.exists() {
+            continue;
+        }
+        any_source = true;
+        let reader = PerfReader::open(path)?;
+        let batch_size_col = reader.col("batch_size")?;
+        let isl_col = reader.col("isl")?;
+        let num_heads_col = reader.col("num_heads")?;
+        let head_dim_col = reader.col("head_dim")?;
+        let attn_dtype_col = reader.col("attn_dtype")?;
+        let latency_col = reader.col("latency")?;
+        let ks_col = reader.col_optional("kernel_source");
+        for row in reader.rows()? {
+            let row = row?;
+            if !kernel_source_ok(source.kernel_sources(), ks_col, &row)? {
+                continue;
+            }
+            let key = EncoderKey {
+                fmha_quant: row.str_owned(attn_dtype_col)?,
+                head_size: row.u32(head_dim_col)?,
+            };
+            // First-wins parity with Python `load_encoder_attention_data`,
+            // extended across shared-layer sources.
+            by_keys
+                .entry(key)
+                .or_default()
+                .entry(row.u32(num_heads_col)?)
+                .or_default()
+                .entry(row.u32(isl_col)?)
+                .or_default()
+                .entry(row.u32(batch_size_col)?)
+                .or_insert(row.f64(latency_col)?);
+        }
     }
-    if by_keys.is_empty() {
+    if !any_source || by_keys.is_empty() {
         return Err(AicError::PerfDatabase(format!(
-            "no encoder-attention rows loaded from {}",
-            path.display()
+            "no encoder-attention rows loaded from {} source(s) (first: {})",
+            sources.len(),
+            sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
         )));
     }
     Ok(EncoderGrids { by_keys })
@@ -760,17 +841,22 @@ mod tests {
     }
 
     #[test]
-    fn encoder_attention_absent_on_vllm_b200_errors_clearly() {
-        // vLLM b200 doesn't ship encoder_attention_perf.txt; expect a clear
-        // IO error from the lazy loader.
+    fn encoder_attention_loads_on_vllm_b200() {
+        // b200_sxm/vllm/0.19.0 ships encoder_attention_perf.parquet (added in
+        // #1210, "add non causal attention data"), so the lazy loader resolves
+        // the table and the query returns a real latency. (This case used to
+        // assert a clean error back when the file was absent; the fixture now
+        // exercises the encoder load path instead. The missing-data error path
+        // is covered by `gemm_missing_data_root_errors_on_query` and
+        // `compute_scale_absent_on_vllm_b200_errors_clearly`.)
         let table = AttentionTable::new(b200_vllm_data_root(), b200_sxm_spec());
-        let err = table
+        let latency = table
             .query_encoder(1, 1024, 16, 64, FmhaQuantMode::Bfloat16)
-            .unwrap_err();
-        match err {
-            AicError::Io { .. } | AicError::PerfDatabase(_) => {}
-            other => panic!("unexpected error variant: {other:?}"),
-        }
+            .expect("encoder query must succeed once encoder data is present");
+        assert!(
+            latency > 0.0,
+            "expected a positive encoder latency, got {latency}"
+        );
     }
 
     #[test]

--- a/rust/aiconfigurator-core/src/perf_database/communication.rs
+++ b/rust/aiconfigurator-core/src/perf_database/communication.rs
@@ -25,6 +25,8 @@ use std::sync::OnceLock;
 
 use crate::common::enums::CommQuantMode;
 use crate::common::error::AicError;
+use crate::config::{PerfDbSources, PerfSource};
+use super::{kernel_source_ok, resolve_op_sources};
 use super::interpolation::{interp_1d, nearest_neighbors};
 use crate::perf_database::parquet_loader::PerfReader;
 
@@ -42,6 +44,11 @@ pub struct CommunicationTable {
     /// when the system YAML has no `misc.oneccl_version` declared (most
     /// systems — OneCCL is the XPU fallback path).
     oneccl_root: Option<PathBuf>,
+    /// Ordered, priority-sorted sources for `custom_allreduce_perf.parquet`
+    /// (shared-layer aware; see [`PerfSource`]). Single-primary, no-filter by
+    /// default (`CommunicationTable::new`). NCCL/OneCCL remain framework-agnostic
+    /// and are loaded directly from `nccl_root` / `oneccl_root`.
+    custom_allreduce_sources: Vec<PerfSource>,
     custom_allreduce: OnceLock<Result<CustomAllReduceGrids, AicError>>,
     nccl: OnceLock<Result<NcclGrids, AicError>>,
     oneccl: OnceLock<Result<NcclGrids, AicError>>,
@@ -69,10 +76,28 @@ impl CommunicationTable {
         nccl_root: Option<PathBuf>,
         oneccl_root: Option<PathBuf>,
     ) -> Self {
+        Self::with_sources(data_root, nccl_root, oneccl_root, &PerfDbSources::default())
+    }
+
+    /// Construct with shared-layer (sibling/cross-version) sources resolved from
+    /// `perf_db_sources` (Python-supplied) for `custom_allreduce_perf.parquet`.
+    /// The file falls back to its primary `data_root/custom_allreduce_perf.parquet`
+    /// when absent from the map. NCCL/OneCCL are framework-agnostic and are NOT
+    /// shared-layer sourced — they load directly from `nccl_root` / `oneccl_root`.
+    /// No I/O.
+    pub fn with_sources(
+        data_root: PathBuf,
+        nccl_root: Option<PathBuf>,
+        oneccl_root: Option<PathBuf>,
+        perf_db_sources: &PerfDbSources,
+    ) -> Self {
+        let custom_allreduce_sources =
+            resolve_op_sources(perf_db_sources, "custom_allreduce_perf.parquet", &data_root);
         Self {
             data_root,
             nccl_root,
             oneccl_root,
+            custom_allreduce_sources,
             custom_allreduce: OnceLock::new(),
             nccl: OnceLock::new(),
             oneccl: OnceLock::new(),
@@ -166,7 +191,7 @@ impl CommunicationTable {
 
     fn load_custom_allreduce(&self) -> Result<&CustomAllReduceGrids, AicError> {
         let cell = self.custom_allreduce.get_or_init(|| {
-            load_custom_allreduce_parquet(&self.data_root.join("custom_allreduce_perf.parquet"))
+            load_custom_allreduce_parquet(&self.custom_allreduce_sources)
         });
         cell.as_ref().map_err(clone_err)
     }
@@ -215,45 +240,59 @@ fn interp_message_size(by_size: &BTreeMap<u64, f64>, message_size: u64) -> Resul
     Ok(interp_1d(lo as f64, hi as f64, y_lo, y_hi, query as f64))
 }
 
-fn load_custom_allreduce_parquet(path: &Path) -> Result<CustomAllReduceGrids, AicError> {
-    let reader = PerfReader::open(path)?;
-    let num_gpus_col = reader.col("num_gpus")?;
-    let message_size_col = reader.col("message_size")?;
-    let latency_col = reader.col("latency")?;
-    let kernel_source_col = reader.col_optional("kernel_source");
-    let backend_col = reader.col_optional("backend");
-
-    // Mirror Python/legacy: skip "_eager" kernel sources on systems other
-    // than b60. We can't see the system name from here, so apply the filter
-    // by path prefix.
-    let path_str = path.to_string_lossy();
-    let is_b60 = path_str.contains("/b60/");
-
+fn load_custom_allreduce_parquet(sources: &[PerfSource]) -> Result<CustomAllReduceGrids, AicError> {
     let mut by_keys: BTreeMap<(String, u32), BTreeMap<u64, f64>> = BTreeMap::new();
-    for row in reader.rows()? {
-        let row = row?;
-        if !is_b60 {
-            let kernel = row.str_optional(kernel_source_col)?.unwrap_or("");
-            let backend = row.str_optional(backend_col)?.unwrap_or("");
-            if kernel.ends_with("_eager") || backend.ends_with("_eager") {
+    let mut any_source = false;
+    for source in sources {
+        let path = source.path();
+        if !path.exists() {
+            continue;
+        }
+        any_source = true;
+        let reader = PerfReader::open(path)?;
+        let num_gpus_col = reader.col("num_gpus")?;
+        let message_size_col = reader.col("message_size")?;
+        let latency_col = reader.col("latency")?;
+        let kernel_source_col = reader.col_optional("kernel_source");
+        let backend_col = reader.col_optional("backend");
+        let ks_col = reader.col_optional("kernel_source");
+
+        // Mirror Python/legacy: skip "_eager" kernel sources on systems other
+        // than b60. We can't see the system name from here, so apply the filter
+        // by path prefix.
+        let path_str = path.to_string_lossy();
+        let is_b60 = path_str.contains("/b60/");
+
+        for row in reader.rows()? {
+            let row = row?;
+            if !kernel_source_ok(source.kernel_sources(), ks_col, &row)? {
                 continue;
             }
+            if !is_b60 {
+                let kernel = row.str_optional(kernel_source_col)?.unwrap_or("");
+                let backend = row.str_optional(backend_col)?.unwrap_or("");
+                if kernel.ends_with("_eager") || backend.ends_with("_eager") {
+                    continue;
+                }
+            }
+            // Match Python's `load_custom_allreduce_data`: every row is stored
+            // under `CommQuantMode.half` regardless of the CSV's
+            // `allreduce_dtype` column (Python has a `TODO` here but the
+            // behavior is stable in production).
+            // First-wins parity with Python `load_custom_allreduce_data`,
+            // extended across shared-layer sources (earlier source wins).
+            by_keys
+                .entry(("half".to_string(), row.u32(num_gpus_col)?))
+                .or_default()
+                .entry(row.u64(message_size_col)?)
+                .or_insert(row.f64(latency_col)?);
         }
-        // Match Python's `load_custom_allreduce_data`: every row is stored
-        // under `CommQuantMode.half` regardless of the CSV's
-        // `allreduce_dtype` column (Python has a `TODO` here but the
-        // behavior is stable in production).
-        // First-wins parity with Python `load_custom_allreduce_data`.
-        by_keys
-            .entry(("half".to_string(), row.u32(num_gpus_col)?))
-            .or_default()
-            .entry(row.u64(message_size_col)?)
-            .or_insert(row.f64(latency_col)?);
     }
-    if by_keys.is_empty() {
+    if !any_source || by_keys.is_empty() {
         return Err(AicError::PerfDatabase(format!(
-            "no custom_allreduce rows loaded from {}",
-            path.display()
+            "no rows loaded from {} source(s) (first: {})",
+            sources.len(),
+            sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
         )));
     }
     Ok(CustomAllReduceGrids { by_keys })

--- a/rust/aiconfigurator-core/src/perf_database/dsa.rs
+++ b/rust/aiconfigurator-core/src/perf_database/dsa.rs
@@ -21,6 +21,10 @@ use std::sync::OnceLock;
 
 use crate::common::enums::{FmhaQuantMode, GemmQuantMode, KvCacheQuantMode};
 use crate::common::error::AicError;
+use crate::common::system_spec::SystemSpec;
+use crate::config::{PerfDbSources, PerfSource};
+use super::gemm::tc_flops_for_compute;
+use super::{kernel_source_ok, resolve_op_sources};
 use super::interpolation::{
     interp_1d, interp_2d_1d_grid_extrapolate_inner, interp_2d_1d_grid_strict,
     interp_context_topk_piecewise, nearest_neighbors, Grid3,
@@ -29,6 +33,11 @@ use crate::perf_database::parquet_loader::PerfReader;
 
 pub struct DsaTable {
     data_root: PathBuf,
+    /// Ordered, priority-sorted sources for the context/generation DSA perf
+    /// files (shared-layer aware; see [`PerfSource`]). Single-primary,
+    /// no-filter by default (`DsaTable::new`).
+    context_sources: Vec<PerfSource>,
+    generation_sources: Vec<PerfSource>,
     context: OnceLock<Result<DsaGrids, AicError>>,
     generation: OnceLock<Result<DsaGrids, AicError>>,
     /// Lazy per-`(DsaKey, prefix)` Grid3 caches with the exact shape
@@ -63,9 +72,28 @@ pub struct DsaKey {
 }
 
 impl DsaTable {
+    /// Construct an empty table for the given data directory. No I/O. Each
+    /// perf file is sourced solely from `data_root/<basename>` with no
+    /// `kernel_source` filter (pre-shared-layer behaviour).
     pub fn new(data_root: PathBuf) -> Self {
+        Self::with_sources(data_root, &PerfDbSources::default())
+    }
+
+    /// Construct with shared-layer (sibling/cross-version) sources resolved from
+    /// `perf_db_sources` (Python-supplied). Each DSA file falls back to its
+    /// primary `data_root/<basename>` when absent from the map. No I/O.
+    pub fn with_sources(data_root: PathBuf, perf_db_sources: &PerfDbSources) -> Self {
+        let context_sources =
+            resolve_op_sources(perf_db_sources, "dsa_context_module_perf.parquet", &data_root);
+        let generation_sources = resolve_op_sources(
+            perf_db_sources,
+            "dsa_generation_module_perf.parquet",
+            &data_root,
+        );
         Self {
             data_root,
+            context_sources,
+            generation_sources,
             context: OnceLock::new(),
             generation: OnceLock::new(),
             context_prefix_grids: OnceLock::new(),
@@ -137,6 +165,7 @@ impl DsaTable {
     /// from the CSV; query interpolates over (num_heads, batch, seq).
     pub fn query_generation(
         &self,
+        spec: &SystemSpec,
         b: u32,
         sequence_tokens: u32,
         num_heads: u32,
@@ -157,11 +186,51 @@ impl DsaTable {
             .get(&key)
             .ok_or_else(|| missing("generation DSA module", &self.data_root, format!("{key:?}")))?;
         // Grid axis order: outer = num_heads, middle = seq_tokens, inner = batch.
-        // Uses the extrapolating variant because Python pre-extends both
-        // axes via `_extrapolate` before interpolation; linear extrapolation
-        // here from the boundary pair gives the same numeric result for the
-        // out-of-envelope queries that show up on sparser backend tables
-        // (e.g. SGLang DSv32 at low num_heads).
+        //
+        // Boundary-utilization reconstruction (mirrors Python
+        // `_query_generation_dsa_module_table::boundary_util_value` — the SILICON
+        // out-of-envelope path added alongside the hybrid/empirical rework): for
+        // the EXACT (num_heads, b) slice,
+        // when the requested sequence is OUTSIDE the measured envelope, freeze the
+        // boundary row's SOL utilization instead of extrapolating latency:
+        //   latency = boundary_latency * SOL(b, s) / SOL(b, boundary_s)
+        // The decode measurement grid is sparse on the seq axis for small batch
+        // (e.g. SGLang DeepSeek-V3.2 b=1 collects only up to step 128), so a
+        // production decode at s = isl + step lands out-of-envelope and a plain
+        // latency extrapolation drifts from Python.
+        if let Some(head_slice) = grid.get(&num_heads) {
+            let mut curve: Vec<(u32, f64)> = head_slice
+                .iter()
+                .filter_map(|(&seq, by_batch)| by_batch.get(&b).map(|&lat| (seq, lat)))
+                .collect();
+            if !curve.is_empty() {
+                curve.sort_by_key(|&(seq, _)| seq);
+                let (min_s, min_lat) = curve[0];
+                let (max_s, max_lat) = *curve.last().unwrap();
+                if sequence_tokens < min_s || sequence_tokens > max_s {
+                    let (boundary_s, boundary_lat) = if sequence_tokens < min_s {
+                        (min_s, min_lat)
+                    } else {
+                        (max_s, max_lat)
+                    };
+                    if boundary_lat > 0.0 {
+                        let dims = dsa_model_dims(architecture);
+                        let kv_mem = kv_quant.mapping().memory;
+                        let gq = gemm_quant.mapping();
+                        let sol_q = generation_dsa_sol(
+                            spec, &dims, b, sequence_tokens, num_heads, kv_mem, gq.compute, gq.memory,
+                        );
+                        let sol_b = generation_dsa_sol(
+                            spec, &dims, b, boundary_s, num_heads, kv_mem, gq.compute, gq.memory,
+                        );
+                        if sol_q > 0.0 && sol_b > 0.0 {
+                            return Ok(boundary_lat * sol_q / sol_b);
+                        }
+                    }
+                }
+            }
+        }
+        // In-envelope (or missing exact slice): fall back to grid interpolation.
         interp_2d_1d_grid_extrapolate_inner(grid, num_heads, sequence_tokens, b)
     }
 
@@ -175,14 +244,14 @@ impl DsaTable {
     fn load_context(&self) -> Result<&DsaGrids, AicError> {
         let cell = self
             .context
-            .get_or_init(|| load_dsa_parquet(&self.data_root.join("dsa_context_module_perf.parquet")));
+            .get_or_init(|| load_dsa_parquet(&self.context_sources));
         cell.as_ref().map_err(clone_err)
     }
 
     fn load_generation(&self) -> Result<&DsaGrids, AicError> {
         let cell = self
             .generation
-            .get_or_init(|| load_dsa_parquet(&self.data_root.join("dsa_generation_module_perf.parquet")));
+            .get_or_init(|| load_dsa_parquet(&self.generation_sources));
         cell.as_ref().map_err(clone_err)
     }
 
@@ -367,45 +436,64 @@ fn lookup_at_batch(
     Some(interp_1d(sl as f64, sr as f64, left, right, isl as f64))
 }
 
-fn load_dsa_parquet(path: &Path) -> Result<DsaGrids, AicError> {
-    let reader = PerfReader::open(path)?;
-    let arch_col = reader.col("architecture")?;
-    let mla_dtype_col = reader.col("mla_dtype")?;
-    let kv_cache_dtype_col = reader.col("kv_cache_dtype")?;
-    let gemm_type_col = reader.col("gemm_type")?;
-    let num_heads_col = reader.col("num_heads")?;
-    let batch_size_col = reader.col("batch_size")?;
-    let isl_col = reader.col("isl")?;
-    let step_col = reader.col("step")?;
-    let latency_col = reader.col("latency")?;
-
+/// Load a DSA module table from an ordered, priority-sorted source list. Sources
+/// are read in order; the first source containing a key wins (`or_insert`),
+/// mirroring Python's `_read_filtered_rows` concatenation + `load_dsa_module_data`
+/// skip-on-key-conflict. Missing files are skipped (a sibling declared in the
+/// manifest need not exist for every system); an error is returned only when no
+/// source yields rows. Shared by both the context and generation DSA files.
+fn load_dsa_parquet(sources: &[PerfSource]) -> Result<DsaGrids, AicError> {
     let mut by_keys: BTreeMap<DsaKey, BTreeMap<u32, BTreeMap<u32, BTreeMap<u32, BTreeMap<u32, f64>>>>> =
         BTreeMap::new();
-    for row in reader.rows()? {
-        let row = row?;
-        let key = DsaKey {
-            architecture: row.str_owned(arch_col)?,
-            fmha_quant: row.str_owned(mla_dtype_col)?,
-            kv_quant: row.str_owned(kv_cache_dtype_col)?,
-            gemm_quant: row.str_owned(gemm_type_col)?,
-        };
-        // First-wins parity with Python `load_dsa_module_data`.
-        by_keys
-            .entry(key)
-            .or_default()
-            .entry(row.u32(num_heads_col)?)
-            .or_default()
-            .entry(row.u32(step_col)?)
-            .or_default()
-            .entry(row.u32(isl_col)?)
-            .or_default()
-            .entry(row.u32(batch_size_col)?)
-            .or_insert(row.f64(latency_col)?);
+    let mut any_source = false;
+    for source in sources {
+        let path = source.path();
+        if !path.exists() {
+            continue;
+        }
+        any_source = true;
+        let reader = PerfReader::open(path)?;
+        let arch_col = reader.col("architecture")?;
+        let mla_dtype_col = reader.col("mla_dtype")?;
+        let kv_cache_dtype_col = reader.col("kv_cache_dtype")?;
+        let gemm_type_col = reader.col("gemm_type")?;
+        let num_heads_col = reader.col("num_heads")?;
+        let batch_size_col = reader.col("batch_size")?;
+        let isl_col = reader.col("isl")?;
+        let step_col = reader.col("step")?;
+        let latency_col = reader.col("latency")?;
+        let ks_col = reader.col_optional("kernel_source");
+        for row in reader.rows()? {
+            let row = row?;
+            if !kernel_source_ok(source.kernel_sources(), ks_col, &row)? {
+                continue;
+            }
+            let key = DsaKey {
+                architecture: row.str_owned(arch_col)?,
+                fmha_quant: row.str_owned(mla_dtype_col)?,
+                kv_quant: row.str_owned(kv_cache_dtype_col)?,
+                gemm_quant: row.str_owned(gemm_type_col)?,
+            };
+            // First-wins parity with Python `load_dsa_module_data`, extended
+            // across shared-layer sources (earlier source wins).
+            by_keys
+                .entry(key)
+                .or_default()
+                .entry(row.u32(num_heads_col)?)
+                .or_default()
+                .entry(row.u32(step_col)?)
+                .or_default()
+                .entry(row.u32(isl_col)?)
+                .or_default()
+                .entry(row.u32(batch_size_col)?)
+                .or_insert(row.f64(latency_col)?);
+        }
     }
-    if by_keys.is_empty() {
+    if !any_source || by_keys.is_empty() {
         return Err(AicError::PerfDatabase(format!(
-            "no DSA module rows loaded from {}",
-            path.display()
+            "no DSA module rows loaded from {} source(s) (first: {})",
+            sources.len(),
+            sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
         )));
     }
     Ok(DsaGrids { by_keys })
@@ -420,6 +508,114 @@ fn missing(table: &str, data_root: &Path, descriptor: String) -> AicError {
 
 fn clone_err(err: &AicError) -> AicError {
     AicError::PerfDatabase(err.to_string())
+}
+
+/// Per-architecture DSA model dimensions. Mirrors Python
+/// `sdk/operations/dsa.py::DSA_MODEL_DIMS`. Only the fields the generation
+/// SOL formula needs are carried.
+struct DsaDims {
+    hidden_size: f64,
+    q_lora_rank: f64,
+    kv_lora_rank: f64,
+    qk_nope_head_dim: f64,
+    qk_rope_head_dim: f64,
+    v_head_dim: f64,
+    index_topk: f64,
+    index_head_dim: f64,
+    index_n_heads: f64,
+}
+
+/// Look up DSA dims by architecture, defaulting to DeepSeek-V3.2 (matches
+/// Python `DEFAULT_DSA_ARCHITECTURE`).
+fn dsa_model_dims(architecture: &str) -> DsaDims {
+    match architecture {
+        "GlmMoeDsaForCausalLM" => DsaDims {
+            hidden_size: 6144.0,
+            q_lora_rank: 2048.0,
+            kv_lora_rank: 512.0,
+            qk_nope_head_dim: 192.0,
+            qk_rope_head_dim: 64.0,
+            v_head_dim: 256.0,
+            index_topk: 2048.0,
+            index_head_dim: 128.0,
+            index_n_heads: 32.0,
+        },
+        // "DeepseekV32ForCausalLM" and default.
+        _ => DsaDims {
+            hidden_size: 7168.0,
+            q_lora_rank: 1536.0,
+            kv_lora_rank: 512.0,
+            qk_nope_head_dim: 128.0,
+            qk_rope_head_dim: 64.0,
+            v_head_dim: 128.0,
+            index_topk: 2048.0,
+            index_head_dim: 128.0,
+            index_n_heads: 64.0,
+        },
+    }
+}
+
+/// Bytes per token in the FP8 indexer KV cache, including one scale per 128
+/// values. Mirrors Python `common.indexer_cache_entry_bytes`.
+fn indexer_cache_entry_bytes(index_head_dim: f64) -> f64 {
+    let d = index_head_dim;
+    d + ((d + 127.0) / 128.0).floor() * 4.0
+}
+
+/// Speed-of-light latency (ms) for the generation DSA module at one decode
+/// step. Mirrors Python `_query_generation_dsa_module_table::get_sol`
+/// (1 token per request; indexer uses FP8 flops, sparse attention uses BF16).
+/// `gemm_compute`/`gemm_memory` come from the GEMM quant mapping; `kv_memory`
+/// from the KV-cache quant mapping.
+#[allow(clippy::too_many_arguments)]
+fn generation_dsa_sol(
+    spec: &SystemSpec,
+    dims: &DsaDims,
+    b: u32,
+    s: u32,
+    num_heads: u32,
+    kv_memory: f64,
+    gemm_compute: f64,
+    gemm_memory: f64,
+) -> f64 {
+    let tokens = b as f64;
+    let s_f = s as f64;
+    let nh = num_heads as f64;
+    let qk_head_dim = dims.qk_nope_head_dim + dims.qk_rope_head_dim;
+    let attn_head_dim = dims.kv_lora_rank + dims.qk_rope_head_dim;
+    let proj_out = dims.q_lora_rank + dims.kv_lora_rank + dims.qk_rope_head_dim + dims.index_head_dim;
+    let effective_kv = s_f.min(dims.index_topk);
+
+    let gemm_group_ops = 2.0 * tokens * dims.hidden_size * proj_out
+        + 2.0 * tokens * dims.q_lora_rank * nh * qk_head_dim
+        + 2.0 * tokens * dims.q_lora_rank * dims.index_n_heads * dims.index_head_dim
+        + 2.0 * tokens * dims.hidden_size * dims.index_n_heads
+        + 2.0 * tokens * nh * dims.v_head_dim * dims.hidden_size
+        + 2.0 * nh * tokens * dims.qk_nope_head_dim * dims.kv_lora_rank
+        + 2.0 * nh * tokens * dims.kv_lora_rank * dims.v_head_dim;
+    let indexer_logits_ops = 2.0 * tokens * dims.index_n_heads * dims.index_head_dim * s_f;
+    let sparse_attn_ops = 2.0 * tokens * nh * (attn_head_dim + dims.kv_lora_rank) * effective_kv;
+
+    let gemm_weight_bytes = (dims.hidden_size * proj_out
+        + dims.q_lora_rank * nh * qk_head_dim
+        + dims.q_lora_rank * dims.index_n_heads * dims.index_head_dim
+        + dims.hidden_size * dims.index_n_heads
+        + nh * dims.v_head_dim * dims.hidden_size)
+        * gemm_memory;
+    let indexer_cache_bytes = tokens * s_f * indexer_cache_entry_bytes(dims.index_head_dim);
+    let kv_cache_bytes = tokens * effective_kv * attn_head_dim * kv_memory;
+    let total_mem = gemm_weight_bytes + indexer_cache_bytes + kv_cache_bytes;
+
+    let gemm_flops = tc_flops_for_compute(spec, gemm_compute);
+    let indexer_fp8_flops = tc_flops_for_compute(spec, 2.0); // FP8
+    let attn_flops = tc_flops_for_compute(spec, 1.0); // BF16
+
+    let sol_math = (gemm_group_ops / gemm_flops
+        + indexer_logits_ops / indexer_fp8_flops
+        + sparse_attn_ops / attn_flops)
+        * 1000.0;
+    let sol_mem = total_mem / spec.gpu.mem_bw * 1000.0;
+    sol_math.max(sol_mem)
 }
 
 #[cfg(test)]

--- a/rust/aiconfigurator-core/src/perf_database/dsv4.rs
+++ b/rust/aiconfigurator-core/src/perf_database/dsv4.rs
@@ -26,13 +26,15 @@
 //! backends without DSV4 data.
 
 use std::collections::BTreeMap;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::OnceLock;
 
 use serde::{Deserialize, Serialize};
 
 use crate::common::enums::{FmhaQuantMode, GemmQuantMode, KvCacheQuantMode};
 use crate::common::error::AicError;
+use crate::config::{PerfDbSources, PerfSource};
+use super::{kernel_source_ok, resolve_op_sources};
 use super::interpolation::{interp_1d, nearest_neighbors};
 use crate::perf_database::parquet_loader::PerfReader;
 
@@ -60,7 +62,17 @@ type ByStep = BTreeMap<u32, ByIsl>;
 type ByNative = BTreeMap<u32, ByStep>;
 
 pub struct Dsv4Table {
+    // dsv4 errors key off the per-source path, not data_root, so the field is
+    // retained for struct parity with the other perf tables but not read here.
+    #[allow(dead_code)]
     data_root: PathBuf,
+    /// Ordered, priority-sorted sources for each of the four DSV4 module perf
+    /// files (shared-layer aware; see [`PerfSource`]). Single-primary,
+    /// no-filter by default (`Dsv4Table::new`).
+    csa_context_sources: Vec<PerfSource>,
+    hca_context_sources: Vec<PerfSource>,
+    csa_generation_sources: Vec<PerfSource>,
+    hca_generation_sources: Vec<PerfSource>,
     csa_context: OnceLock<Result<ModuleGrids, AicError>>,
     hca_context: OnceLock<Result<ModuleGrids, AicError>>,
     csa_generation: OnceLock<Result<ModuleGrids, AicError>>,
@@ -80,9 +92,37 @@ struct ModuleKey {
 }
 
 impl Dsv4Table {
+    /// Construct an empty table for the given data directory. No I/O. Each
+    /// perf file is sourced solely from `data_root/<basename>` with no
+    /// `kernel_source` filter (pre-shared-layer behaviour).
     pub fn new(data_root: PathBuf) -> Self {
+        Self::with_sources(data_root, &PerfDbSources::default())
+    }
+
+    /// Construct with shared-layer (sibling/cross-version) sources resolved from
+    /// `perf_db_sources` (Python-supplied). Each DSV4 file falls back to its
+    /// primary `data_root/<basename>` when absent from the map. No I/O.
+    pub fn with_sources(data_root: PathBuf, perf_db_sources: &PerfDbSources) -> Self {
+        let csa_context_sources =
+            resolve_op_sources(perf_db_sources, "dsv4_csa_context_module_perf.parquet", &data_root);
+        let hca_context_sources =
+            resolve_op_sources(perf_db_sources, "dsv4_hca_context_module_perf.parquet", &data_root);
+        let csa_generation_sources = resolve_op_sources(
+            perf_db_sources,
+            "dsv4_csa_generation_module_perf.parquet",
+            &data_root,
+        );
+        let hca_generation_sources = resolve_op_sources(
+            perf_db_sources,
+            "dsv4_hca_generation_module_perf.parquet",
+            &data_root,
+        );
         Self {
             data_root,
+            csa_context_sources,
+            hca_context_sources,
+            csa_generation_sources,
+            hca_generation_sources,
             csa_context: OnceLock::new(),
             hca_context: OnceLock::new(),
             csa_generation: OnceLock::new(),
@@ -178,27 +218,27 @@ impl Dsv4Table {
     }
 
     fn load_csa_context(&self) -> Result<&ModuleGrids, AicError> {
-        let cell = self.csa_context.get_or_init(|| {
-            load_module_parquet(&self.data_root.join("dsv4_csa_context_module_perf.parquet"))
-        });
+        let cell = self
+            .csa_context
+            .get_or_init(|| load_module_parquet(&self.csa_context_sources));
         cell.as_ref().map_err(clone_err)
     }
     fn load_hca_context(&self) -> Result<&ModuleGrids, AicError> {
-        let cell = self.hca_context.get_or_init(|| {
-            load_module_parquet(&self.data_root.join("dsv4_hca_context_module_perf.parquet"))
-        });
+        let cell = self
+            .hca_context
+            .get_or_init(|| load_module_parquet(&self.hca_context_sources));
         cell.as_ref().map_err(clone_err)
     }
     fn load_csa_generation(&self) -> Result<&ModuleGrids, AicError> {
-        let cell = self.csa_generation.get_or_init(|| {
-            load_module_parquet(&self.data_root.join("dsv4_csa_generation_module_perf.parquet"))
-        });
+        let cell = self
+            .csa_generation
+            .get_or_init(|| load_module_parquet(&self.csa_generation_sources));
         cell.as_ref().map_err(clone_err)
     }
     fn load_hca_generation(&self) -> Result<&ModuleGrids, AicError> {
-        let cell = self.hca_generation.get_or_init(|| {
-            load_module_parquet(&self.data_root.join("dsv4_hca_generation_module_perf.parquet"))
-        });
+        let cell = self
+            .hca_generation
+            .get_or_init(|| load_module_parquet(&self.hca_generation_sources));
         cell.as_ref().map_err(clone_err)
     }
 }
@@ -399,54 +439,73 @@ fn normalize_dsv4_dtype(name: &str) -> String {
     }
 }
 
-fn load_module_parquet(path: &Path) -> Result<ModuleGrids, AicError> {
-    let reader = PerfReader::open(path)?;
-    let arch_col = reader.col("architecture")?;
-    let mla_dtype_col = reader.col("mla_dtype")?;
-    let kv_cache_dtype_col = reader.col("kv_cache_dtype")?;
-    let gemm_type_col = reader.col("gemm_type")?;
-    let num_heads_col = reader.col("num_heads")?;
-    let batch_size_col = reader.col("batch_size")?;
-    let isl_col = reader.col("isl")?;
-    let step_col = reader.col("step")?;
-    let latency_col = reader.col("latency")?;
-
+/// Load a DSV4 module table from an ordered, priority-sorted source list.
+/// Sources are read in order; missing files are skipped (a sibling declared in
+/// the manifest need not exist for every system). Within the DSV4 dict the
+/// tp_size axis is collapsed with last-write-wins, so a later source overwrites
+/// an earlier one at a shared cell (mirroring Python's flat-dict overwrite). An
+/// error is returned only when no source yields rows.
+fn load_module_parquet(sources: &[PerfSource]) -> Result<ModuleGrids, AicError> {
     let mut by_keys: BTreeMap<ModuleKey, ByNative> = BTreeMap::new();
-    for row in reader.rows()? {
-        let row = row?;
-        let key = ModuleKey {
-            architecture: row.str_owned(arch_col)?,
-            // CSV columns use sglang dtype naming; the query side builds keys
-            // from the enum `.name()` (canonical short names). Normalize on
-            // load to match Python `_dsv4_normalize_dtype`, which aliases
-            // `fp8_e4m3` -> `fp8` for `mla_dtype` (fmha) and `kv_cache_dtype`
-            // (kv). `gemm_type` is intentionally left untouched, matching
-            // Python (e.g. `fp8_block` is a real value that must pass through).
-            fmha_quant: normalize_dsv4_dtype(&row.str_owned(mla_dtype_col)?),
-            kv_quant: normalize_dsv4_dtype(&row.str_owned(kv_cache_dtype_col)?),
-            gemm_quant: row.str_owned(gemm_type_col)?,
-        };
-        // Last-wins parity with Python `load_*_dsv4_kind_module_data`, which
-        // assigns `data[...][b][s] = {...}` per row keyed on
-        // `(num_heads, compress_ratio, step, isl, batch)` but NOT on `tp_size`,
-        // so a later row (here: a higher tp_size, since the file is
-        // gemm-then-tp-ascending) overwrites the earlier one. We drop the tp
-        // axis and let `BTreeMap::insert` overwrite; do NOT use `or_insert`.
-        by_keys
-            .entry(key)
-            .or_default()
-            .entry(row.u32(num_heads_col)?) // CSV `num_heads` column (head axis)
-            .or_default()
-            .entry(row.u32(step_col)?)
-            .or_default()
-            .entry(row.u32(isl_col)?)
-            .or_default()
-            .insert(row.u32(batch_size_col)?, row.f64(latency_col)?);
+    let mut any_source = false;
+    for source in sources {
+        let path = source.path();
+        if !path.exists() {
+            continue;
+        }
+        any_source = true;
+        let reader = PerfReader::open(path)?;
+        let arch_col = reader.col("architecture")?;
+        let mla_dtype_col = reader.col("mla_dtype")?;
+        let kv_cache_dtype_col = reader.col("kv_cache_dtype")?;
+        let gemm_type_col = reader.col("gemm_type")?;
+        let num_heads_col = reader.col("num_heads")?;
+        let batch_size_col = reader.col("batch_size")?;
+        let isl_col = reader.col("isl")?;
+        let step_col = reader.col("step")?;
+        let latency_col = reader.col("latency")?;
+        let ks_col = reader.col_optional("kernel_source");
+
+        for row in reader.rows()? {
+            let row = row?;
+            if !kernel_source_ok(source.kernel_sources(), ks_col, &row)? {
+                continue;
+            }
+            let key = ModuleKey {
+                architecture: row.str_owned(arch_col)?,
+                // CSV columns use sglang dtype naming; the query side builds keys
+                // from the enum `.name()` (canonical short names). Normalize on
+                // load to match Python `_dsv4_normalize_dtype`, which aliases
+                // `fp8_e4m3` -> `fp8` for `mla_dtype` (fmha) and `kv_cache_dtype`
+                // (kv). `gemm_type` is intentionally left untouched, matching
+                // Python (e.g. `fp8_block` is a real value that must pass through).
+                fmha_quant: normalize_dsv4_dtype(&row.str_owned(mla_dtype_col)?),
+                kv_quant: normalize_dsv4_dtype(&row.str_owned(kv_cache_dtype_col)?),
+                gemm_quant: row.str_owned(gemm_type_col)?,
+            };
+            // Last-wins parity with Python `load_*_dsv4_kind_module_data`, which
+            // assigns `data[...][b][s] = {...}` per row keyed on
+            // `(num_heads, compress_ratio, step, isl, batch)` but NOT on `tp_size`,
+            // so a later row (here: a higher tp_size, since the file is
+            // gemm-then-tp-ascending) overwrites the earlier one. We drop the tp
+            // axis and let `BTreeMap::insert` overwrite; do NOT use `or_insert`.
+            by_keys
+                .entry(key)
+                .or_default()
+                .entry(row.u32(num_heads_col)?) // CSV `num_heads` column (head axis)
+                .or_default()
+                .entry(row.u32(step_col)?)
+                .or_default()
+                .entry(row.u32(isl_col)?)
+                .or_default()
+                .insert(row.u32(batch_size_col)?, row.f64(latency_col)?);
+        }
     }
-    if by_keys.is_empty() {
+    if !any_source || by_keys.is_empty() {
         return Err(AicError::PerfDatabase(format!(
-            "no DSV4 module rows loaded from {}",
-            path.display()
+            "no DSV4 module rows loaded from {} source(s) (first: {})",
+            sources.len(),
+            sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
         )));
     }
     Ok(ModuleGrids { by_keys })

--- a/rust/aiconfigurator-core/src/perf_database/gemm.rs
+++ b/rust/aiconfigurator-core/src/perf_database/gemm.rs
@@ -21,6 +21,8 @@ use std::sync::OnceLock;
 use crate::common::enums::GemmQuantMode;
 use crate::common::error::AicError;
 use crate::common::system_spec::SystemSpec;
+use crate::config::{PerfDbSources, PerfSource};
+use super::{kernel_source_ok, resolve_op_sources};
 use super::interpolation::{interp_1d, interp_2d_1d_grid, nearest_neighbors, Grid3};
 use crate::perf_database::parquet_loader::PerfReader;
 
@@ -36,6 +38,12 @@ use crate::perf_database::parquet_loader::PerfReader;
 pub struct GemmTable {
     data_root: PathBuf,
     system_spec: SystemSpec,
+    /// Ordered, priority-sorted sources for each of the three GEMM-family perf
+    /// files (shared-layer aware; see [`PerfSource`]). Single-primary,
+    /// no-filter by default (`GemmTable::new`).
+    gemm_sources: Vec<PerfSource>,
+    compute_scale_sources: Vec<PerfSource>,
+    scale_matrix_sources: Vec<PerfSource>,
     gemm: OnceLock<Result<GemmGrids, AicError>>,
     compute_scale: OnceLock<Result<TwoDGrids, AicError>>,
     scale_matrix: OnceLock<Result<TwoDGrids, AicError>>,
@@ -52,11 +60,32 @@ struct TwoDGrids {
 }
 
 impl GemmTable {
-    /// Construct an empty table for the given data directory. No I/O.
+    /// Construct an empty table for the given data directory. No I/O. Each
+    /// perf file is sourced solely from `data_root/<basename>` with no
+    /// `kernel_source` filter (pre-shared-layer behaviour).
     pub fn new(data_root: PathBuf, system_spec: SystemSpec) -> Self {
+        Self::with_sources(data_root, system_spec, &PerfDbSources::default())
+    }
+
+    /// Construct with shared-layer (sibling/cross-version) sources resolved from
+    /// `perf_db_sources` (Python-supplied). Each GEMM-family file falls back to
+    /// its primary `data_root/<basename>` when absent from the map. No I/O.
+    pub fn with_sources(
+        data_root: PathBuf,
+        system_spec: SystemSpec,
+        perf_db_sources: &PerfDbSources,
+    ) -> Self {
+        let gemm_sources = resolve_op_sources(perf_db_sources, "gemm_perf.parquet", &data_root);
+        let compute_scale_sources =
+            resolve_op_sources(perf_db_sources, "computescale_perf.parquet", &data_root);
+        let scale_matrix_sources =
+            resolve_op_sources(perf_db_sources, "scale_matrix_perf.parquet", &data_root);
         Self {
             data_root,
             system_spec,
+            gemm_sources,
+            compute_scale_sources,
+            scale_matrix_sources,
             gemm: OnceLock::new(),
             compute_scale: OnceLock::new(),
             scale_matrix: OnceLock::new(),
@@ -154,7 +183,7 @@ impl GemmTable {
 
     fn load_gemm(&self) -> Result<&GemmGrids, AicError> {
         let cell = self.gemm.get_or_init(|| {
-            let mut grids = load_gemm_parquet(&self.data_root.join("gemm_perf.parquet"))?;
+            let mut grids = load_gemm_parquet(&self.gemm_sources)?;
             // Mirror Python `GEMM._correct_sol`: clamp every stored grid
             // entry to `>= SOL`. SOL is deterministic from the system spec
             // and (m, n, k, quant); on currently-aligned surfaces this is
@@ -173,16 +202,16 @@ impl GemmTable {
     }
 
     fn load_compute_scale(&self) -> Result<&TwoDGrids, AicError> {
-        let cell = self.compute_scale.get_or_init(|| {
-            load_two_d_parquet(&self.data_root.join("computescale_perf.parquet"))
-        });
+        let cell = self
+            .compute_scale
+            .get_or_init(|| load_two_d_parquet(&self.compute_scale_sources));
         cell.as_ref().map_err(|err| clone_err(err))
     }
 
     fn load_scale_matrix(&self) -> Result<&TwoDGrids, AicError> {
-        let cell = self.scale_matrix.get_or_init(|| {
-            load_two_d_parquet(&self.data_root.join("scale_matrix_perf.parquet"))
-        });
+        let cell = self
+            .scale_matrix
+            .get_or_init(|| load_two_d_parquet(&self.scale_matrix_sources));
         cell.as_ref().map_err(|err| clone_err(err))
     }
 }
@@ -217,7 +246,7 @@ pub(crate) fn gemm_sol_latency_ms(
     sol_math.max(sol_mem)
 }
 
-fn tc_flops_for_compute(spec: &SystemSpec, compute_factor: f64) -> f64 {
+pub(crate) fn tc_flops_for_compute(spec: &SystemSpec, compute_factor: f64) -> f64 {
     let bf16 = spec.gpu.bfloat16_tc_flops.unwrap_or(0.0);
     let direct = match compute_factor as u32 {
         1 => spec.gpu.bfloat16_tc_flops,
@@ -366,67 +395,102 @@ fn query_two_d(
     ))
 }
 
-fn load_gemm_parquet(path: &Path) -> Result<GemmGrids, AicError> {
-    let reader = PerfReader::open(path)?;
-    let gemm_dtype_col = reader.col("gemm_dtype")?;
-    let m_col = reader.col("m")?;
-    let n_col = reader.col("n")?;
-    let k_col = reader.col("k")?;
-    let latency_col = reader.col("latency")?;
-
+/// Load the GEMM table from an ordered, priority-sorted source list. Sources are
+/// read in order; the first source containing a shape wins (`or_insert`),
+/// mirroring Python's `_read_filtered_rows` concatenation + `load_gemm_data`
+/// skip-on-key-conflict. Missing files are skipped (a sibling declared in the
+/// manifest need not exist for every system); an error is returned only when no
+/// source yields rows.
+fn load_gemm_parquet(sources: &[PerfSource]) -> Result<GemmGrids, AicError> {
     let mut by_quant: BTreeMap<String, Grid3<f64>> = BTreeMap::new();
-    for row in reader.rows()? {
-        let row = row?;
-        let dtype = row.str(gemm_dtype_col)?;
-        // Skip quant modes AIC does not model in the perf path (matches the
-        // legacy perf.rs behavior).
-        if dtype == "awq" || dtype == "gptq" {
+    let mut any_source = false;
+    for source in sources {
+        let path = source.path();
+        if !path.exists() {
             continue;
         }
-        let dtype = dtype.to_string();
-        // First-wins parity with Python's `load_gemm_data` try/except KeyError.
-        by_quant
-            .entry(dtype)
-            .or_default()
-            .entry(row.u32(m_col)?)
-            .or_default()
-            .entry(row.u32(n_col)?)
-            .or_default()
-            .entry(row.u32(k_col)?)
-            .or_insert(row.f64(latency_col)?);
+        any_source = true;
+        let reader = PerfReader::open(path)?;
+        let gemm_dtype_col = reader.col("gemm_dtype")?;
+        let m_col = reader.col("m")?;
+        let n_col = reader.col("n")?;
+        let k_col = reader.col("k")?;
+        let latency_col = reader.col("latency")?;
+        let ks_col = reader.col_optional("kernel_source");
+        for row in reader.rows()? {
+            let row = row?;
+            if !kernel_source_ok(source.kernel_sources(), ks_col, &row)? {
+                continue;
+            }
+            let dtype = row.str(gemm_dtype_col)?;
+            // Skip quant modes AIC does not model in the perf path (matches the
+            // legacy perf.rs behavior).
+            if dtype == "awq" || dtype == "gptq" {
+                continue;
+            }
+            let dtype = dtype.to_string();
+            // First-wins parity with Python's `load_gemm_data` try/except
+            // KeyError, extended across shared-layer sources (earlier source wins).
+            by_quant
+                .entry(dtype)
+                .or_default()
+                .entry(row.u32(m_col)?)
+                .or_default()
+                .entry(row.u32(n_col)?)
+                .or_default()
+                .entry(row.u32(k_col)?)
+                .or_insert(row.f64(latency_col)?);
+        }
     }
-    if by_quant.is_empty() {
+    if !any_source || by_quant.is_empty() {
         return Err(AicError::PerfDatabase(format!(
-            "no GEMM rows loaded from {}",
-            path.display()
+            "no GEMM rows loaded from {} source(s) (first: {})",
+            sources.len(),
+            sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
         )));
     }
     Ok(GemmGrids { by_quant })
 }
 
-fn load_two_d_parquet(path: &Path) -> Result<TwoDGrids, AicError> {
-    let reader = PerfReader::open(path)?;
-    let quant_dtype_col = reader.col("quant_dtype")?;
-    let m_col = reader.col("m")?;
-    let k_col = reader.col("k")?;
-    let latency_col = reader.col("latency")?;
-
+/// Load a 2-D (compute_scale / scale_matrix) table from an ordered source list.
+/// Same first-wins-across-sources + missing-file-skip semantics as
+/// [`load_gemm_parquet`].
+fn load_two_d_parquet(sources: &[PerfSource]) -> Result<TwoDGrids, AicError> {
     let mut by_quant: BTreeMap<String, BTreeMap<u32, BTreeMap<u32, f64>>> = BTreeMap::new();
-    for row in reader.rows()? {
-        let row = row?;
-        // First-wins parity (compute_scale / scale_matrix tables in Python).
-        by_quant
-            .entry(row.str_owned(quant_dtype_col)?)
-            .or_default()
-            .entry(row.u32(m_col)?)
-            .or_default()
-            .entry(row.u32(k_col)?)
-            .or_insert(row.f64(latency_col)?);
+    let mut any_source = false;
+    for source in sources {
+        let path = source.path();
+        if !path.exists() {
+            continue;
+        }
+        any_source = true;
+        let reader = PerfReader::open(path)?;
+        let quant_dtype_col = reader.col("quant_dtype")?;
+        let m_col = reader.col("m")?;
+        let k_col = reader.col("k")?;
+        let latency_col = reader.col("latency")?;
+        let ks_col = reader.col_optional("kernel_source");
+        for row in reader.rows()? {
+            let row = row?;
+            if !kernel_source_ok(source.kernel_sources(), ks_col, &row)? {
+                continue;
+            }
+            // First-wins parity (compute_scale / scale_matrix tables in Python),
+            // extended across shared-layer sources.
+            by_quant
+                .entry(row.str_owned(quant_dtype_col)?)
+                .or_default()
+                .entry(row.u32(m_col)?)
+                .or_default()
+                .entry(row.u32(k_col)?)
+                .or_insert(row.f64(latency_col)?);
+        }
     }
-    if by_quant.is_empty() {
+    if !any_source || by_quant.is_empty() {
         return Err(AicError::PerfDatabase(format!(
-            "no rows loaded from {}",
-            path.display()
+            "no rows loaded from {} source(s) (first: {})",
+            sources.len(),
+            sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
         )));
     }
     Ok(TwoDGrids { by_quant })
@@ -456,6 +520,79 @@ mod tests {
             .join("../..")
             .join("src/aiconfigurator/systems/b200_sxm.yaml");
         SystemSpec::load(&systems_yaml).expect("b200_sxm.yaml must parse")
+    }
+
+    fn b200_gemm_parquet(backend: &str, version: &str) -> PathBuf {
+        PathBuf::from(REPO_ROOT_HINT)
+            .join("../..")
+            .join(format!(
+                "src/aiconfigurator/systems/data/b200_sxm/{backend}/{version}/gemm_perf.parquet"
+            ))
+    }
+
+    fn gemm_shape_count(grids: &GemmGrids) -> usize {
+        grids
+            .by_quant
+            .values()
+            .flat_map(|by_m| by_m.values())
+            .flat_map(|by_n| by_n.values())
+            .map(|by_k| by_k.len())
+            .sum()
+    }
+
+    /// Shared-layer sibling merge: sources are read in priority order, later
+    /// sources only add shapes the earlier ones lack (first-wins), and a
+    /// per-source `kernel_source` allowlist gates which sibling rows are
+    /// admitted. Mirrors Python `_read_filtered_rows` + `load_gemm_data`.
+    #[test]
+    fn shared_layer_merges_siblings_with_kernel_source_filter_and_first_wins() {
+        // trtllm 1.3.0rc10 primary + 1.2.0rc5 sibling — the real shape Python's
+        // `_compute_perf_db_sources` emits for this backend.
+        let primary = b200_gemm_parquet("trtllm", "1.3.0rc10");
+        let sibling = b200_gemm_parquet("trtllm", "1.2.0rc5");
+
+        let primary_only = load_gemm_parquet(&[PerfSource(primary.clone(), None)]).unwrap();
+
+        // Sibling admitted unfiltered: never drops a primary shape, only adds.
+        let merged =
+            load_gemm_parquet(&[PerfSource(primary.clone(), None), PerfSource(sibling.clone(), None)])
+                .unwrap();
+        assert!(
+            gemm_shape_count(&merged) >= gemm_shape_count(&primary_only),
+            "unfiltered sibling must not drop shapes"
+        );
+
+        // First-wins: every primary (quant,m,n,k) keeps the PRIMARY latency even
+        // though the sibling also carries rows.
+        for (q, by_m) in &primary_only.by_quant {
+            for (m, by_n) in by_m {
+                for (n, by_k) in by_n {
+                    for (k, v) in by_k {
+                        let got = merged
+                            .by_quant
+                            .get(q)
+                            .and_then(|x| x.get(m))
+                            .and_then(|x| x.get(n))
+                            .and_then(|x| x.get(k))
+                            .copied();
+                        assert_eq!(got, Some(*v), "first source must win at ({q},{m},{n},{k})");
+                    }
+                }
+            }
+        }
+
+        // A `kernel_source` allowlist that matches nothing drops every sibling
+        // row, so the merged table equals primary-only.
+        let blocked = load_gemm_parquet(&[
+            PerfSource(primary.clone(), None),
+            PerfSource(sibling.clone(), Some(vec!["__no_such_kernel_source__".to_string()])),
+        ])
+        .unwrap();
+        assert_eq!(
+            gemm_shape_count(&blocked),
+            gemm_shape_count(&primary_only),
+            "a non-matching kernel_source filter must exclude all sibling rows"
+        );
     }
 
     #[test]

--- a/rust/aiconfigurator-core/src/perf_database/mhc.rs
+++ b/rust/aiconfigurator-core/src/perf_database/mhc.rs
@@ -14,15 +14,21 @@
 //! `_query_mhc_table`, which key `data[op_name][hc_mult][hidden_size]`.
 
 use std::collections::BTreeMap;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::OnceLock;
 
 use crate::common::error::AicError;
+use crate::config::{PerfDbSources, PerfSource};
+use super::{kernel_source_ok, resolve_op_sources};
 use super::interpolation::{interp_1d, nearest_neighbors};
 use crate::perf_database::parquet_loader::PerfReader;
 
 pub struct MhcTable {
     data_root: PathBuf,
+    /// Ordered, priority-sorted sources for the mHC perf file (shared-layer
+    /// aware; see [`PerfSource`]). Single-primary, no-filter by default
+    /// (`MhcTable::new`).
+    mhc_sources: Vec<PerfSource>,
     module: OnceLock<Result<MhcGrids, AicError>>,
 }
 
@@ -39,9 +45,23 @@ struct MhcKey {
 }
 
 impl MhcTable {
+    /// Construct an empty table for the given data directory. No I/O. The
+    /// perf file is sourced solely from `data_root/mhc_module_perf.parquet`
+    /// with no `kernel_source` filter (pre-shared-layer behaviour).
     pub fn new(data_root: PathBuf) -> Self {
+        Self::with_sources(data_root, &PerfDbSources::default())
+    }
+
+    /// Construct with shared-layer (sibling/cross-version) sources resolved from
+    /// `perf_db_sources` (Python-supplied). The mHC file falls back to its
+    /// primary `data_root/mhc_module_perf.parquet` when absent from the map.
+    /// No I/O.
+    pub fn with_sources(data_root: PathBuf, perf_db_sources: &PerfDbSources) -> Self {
+        let mhc_sources =
+            resolve_op_sources(perf_db_sources, "mhc_module_perf.parquet", &data_root);
         Self {
             data_root,
+            mhc_sources,
             module: OnceLock::new(),
         }
     }
@@ -103,43 +123,63 @@ impl MhcTable {
     fn load(&self) -> Result<&MhcGrids, AicError> {
         let cell = self
             .module
-            .get_or_init(|| load_mhc_parquet(&self.data_root.join("mhc_module_perf.parquet")));
+            .get_or_init(|| load_mhc_parquet(&self.mhc_sources));
         cell.as_ref().map_err(clone_err)
     }
 }
 
-fn load_mhc_parquet(path: &Path) -> Result<MhcGrids, AicError> {
-    let reader = PerfReader::open(path)?;
-    let arch_col = reader.col("architecture")?;
-    let op_name_col = reader.col("op_name")?;
-    let num_tokens_col = reader.col("num_tokens")?;
-    let hc_mult_col = reader.col("hc_mult")?;
-    let hidden_size_col = reader.col("hidden_size")?;
-    let latency_col = reader.col("latency")?;
-
+/// Load the mHC module table from an ordered, priority-sorted source list.
+/// Sources are read in order (shared-layer aware). Missing files are skipped (a
+/// sibling declared in the manifest need not exist for every system); an error
+/// is returned only when no source yields rows.
+fn load_mhc_parquet(sources: &[PerfSource]) -> Result<MhcGrids, AicError> {
     let mut by_keys: BTreeMap<MhcKey, BTreeMap<u32, f64>> = BTreeMap::new();
-    for row in reader.rows()? {
-        let row = row?;
-        let key = MhcKey {
-            // `op_name` (pre/post) is part of the key — without it the pre and
-            // post rows for the same (arch, hc_mult, hidden_size, num_tokens)
-            // collide and `post` silently reads `pre`'s latency.
-            op_name: row.str_owned(op_name_col)?,
-            architecture: row.str_owned(arch_col)?,
-            hc_mult: row.u32(hc_mult_col)?,
-            hidden_size: row.u32(hidden_size_col)?,
-        };
-        // Last-wins parity with Python `load_mhc_module_data`, which assigns
-        // `mhc_data[op][hc_mult][hidden_size][num_tokens] = {...}` per row.
-        by_keys
-            .entry(key)
-            .or_default()
-            .insert(row.u32(num_tokens_col)?, row.f64(latency_col)?);
+    let mut any_source = false;
+    for source in sources {
+        let path = source.path();
+        if !path.exists() {
+            continue;
+        }
+        any_source = true;
+        let reader = PerfReader::open(path)?;
+        let arch_col = reader.col("architecture")?;
+        let op_name_col = reader.col("op_name")?;
+        let num_tokens_col = reader.col("num_tokens")?;
+        let hc_mult_col = reader.col("hc_mult")?;
+        let hidden_size_col = reader.col("hidden_size")?;
+        let latency_col = reader.col("latency")?;
+        let ks_col = reader.col_optional("kernel_source");
+
+        for row in reader.rows()? {
+            let row = row?;
+            if !kernel_source_ok(source.kernel_sources(), ks_col, &row)? {
+                continue;
+            }
+            let key = MhcKey {
+                // `op_name` (pre/post) is part of the key — without it the pre and
+                // post rows for the same (arch, hc_mult, hidden_size, num_tokens)
+                // collide and `post` silently reads `pre`'s latency.
+                op_name: row.str_owned(op_name_col)?,
+                architecture: row.str_owned(arch_col)?,
+                hc_mult: row.u32(hc_mult_col)?,
+                hidden_size: row.u32(hidden_size_col)?,
+            };
+            // Last-wins parity with Python `load_mhc_module_data`, which assigns
+            // `mhc_data[op][hc_mult][hidden_size][num_tokens] = {...}` per row.
+            by_keys
+                .entry(key)
+                .or_default()
+                .insert(row.u32(num_tokens_col)?, row.f64(latency_col)?);
+        }
     }
-    if by_keys.is_empty() {
+    if !any_source || by_keys.is_empty() {
         return Err(AicError::PerfDatabase(format!(
-            "no MHC module rows loaded from {}",
-            path.display()
+            "no MHC module rows loaded from {} source(s) (first: {})",
+            sources.len(),
+            sources
+                .first()
+                .map(|s| s.path().display().to_string())
+                .unwrap_or_default()
         )));
     }
     Ok(MhcGrids { by_keys })

--- a/rust/aiconfigurator-core/src/perf_database/mla.rs
+++ b/rust/aiconfigurator-core/src/perf_database/mla.rs
@@ -20,11 +20,21 @@ use std::sync::OnceLock;
 
 use crate::common::enums::{FmhaQuantMode, GemmQuantMode, KvCacheQuantMode};
 use crate::common::error::AicError;
+use crate::config::{PerfDbSources, PerfSource};
+use super::{kernel_source_ok, resolve_op_sources};
 use super::interpolation::{interp_1d, interp_2d_1d_grid, nearest_neighbors, Grid3};
 use crate::perf_database::parquet_loader::PerfReader;
 
 pub struct MlaTable {
     data_root: PathBuf,
+    /// Ordered, priority-sorted sources for each MLA-family perf file
+    /// (shared-layer aware; see [`PerfSource`]). Single-primary, no-filter by
+    /// default (`MlaTable::new`).
+    context_mla_sources: Vec<PerfSource>,
+    generation_mla_sources: Vec<PerfSource>,
+    mla_bmm_sources: Vec<PerfSource>,
+    mla_context_module_sources: Vec<PerfSource>,
+    mla_generation_module_sources: Vec<PerfSource>,
     context: OnceLock<Result<ContextMlaGrids, AicError>>,
     generation: OnceLock<Result<GenerationMlaGrids, AicError>>,
     bmm: OnceLock<Result<BmmGrids, AicError>>,
@@ -76,9 +86,37 @@ struct BmmKey {
 }
 
 impl MlaTable {
+    /// Construct an empty table for the given data directory. No I/O. Each
+    /// perf file is sourced solely from `data_root/<basename>` with no
+    /// `kernel_source` filter (pre-shared-layer behaviour).
     pub fn new(data_root: PathBuf) -> Self {
+        Self::with_sources(data_root, &PerfDbSources::default())
+    }
+
+    /// Construct with shared-layer (sibling/cross-version) sources resolved from
+    /// `perf_db_sources` (Python-supplied). Each MLA-family file falls back to
+    /// its primary `data_root/<basename>` when absent from the map. No I/O.
+    pub fn with_sources(data_root: PathBuf, perf_db_sources: &PerfDbSources) -> Self {
+        let context_mla_sources =
+            resolve_op_sources(perf_db_sources, "context_mla_perf.parquet", &data_root);
+        let generation_mla_sources =
+            resolve_op_sources(perf_db_sources, "generation_mla_perf.parquet", &data_root);
+        let mla_bmm_sources =
+            resolve_op_sources(perf_db_sources, "mla_bmm_perf.parquet", &data_root);
+        let mla_context_module_sources =
+            resolve_op_sources(perf_db_sources, "mla_context_module_perf.parquet", &data_root);
+        let mla_generation_module_sources = resolve_op_sources(
+            perf_db_sources,
+            "mla_generation_module_perf.parquet",
+            &data_root,
+        );
         Self {
             data_root,
+            context_mla_sources,
+            generation_mla_sources,
+            mla_bmm_sources,
+            mla_context_module_sources,
+            mla_generation_module_sources,
             context: OnceLock::new(),
             generation: OnceLock::new(),
             bmm: OnceLock::new(),
@@ -225,208 +263,256 @@ impl MlaTable {
     fn load_context(&self) -> Result<&ContextMlaGrids, AicError> {
         let cell = self
             .context
-            .get_or_init(|| load_op_parquet(&self.data_root.join("context_mla_perf.parquet"), true));
+            .get_or_init(|| load_op_parquet(&self.context_mla_sources, true));
         cell.as_ref().map_err(clone_err)
     }
 
     fn load_generation(&self) -> Result<&GenerationMlaGrids, AicError> {
-        let cell = self.generation.get_or_init(|| {
-            load_op_gen_parquet(&self.data_root.join("generation_mla_perf.parquet"))
-        });
+        let cell = self
+            .generation
+            .get_or_init(|| load_op_gen_parquet(&self.generation_mla_sources));
         cell.as_ref().map_err(clone_err)
     }
 
     fn load_bmm(&self) -> Result<&BmmGrids, AicError> {
         let cell = self
             .bmm
-            .get_or_init(|| load_bmm_parquet(&self.data_root.join("mla_bmm_perf.parquet")));
+            .get_or_init(|| load_bmm_parquet(&self.mla_bmm_sources));
         cell.as_ref().map_err(clone_err)
     }
 
     fn load_context_module(&self) -> Result<&ModuleGrids, AicError> {
         let cell = self.context_module.get_or_init(|| {
-            load_module_parquet(&self.data_root.join("mla_context_module_perf.parquet"), true)
+            load_module_parquet(&self.mla_context_module_sources, true)
         });
         cell.as_ref().map_err(clone_err)
     }
 
     fn load_generation_module(&self) -> Result<&ModuleGrids, AicError> {
         let cell = self.generation_module.get_or_init(|| {
-            load_module_parquet(&self.data_root.join("mla_generation_module_perf.parquet"), false)
+            load_module_parquet(&self.mla_generation_module_sources, false)
         });
         cell.as_ref().map_err(clone_err)
     }
 }
 
-fn load_op_parquet(path: &Path, is_context: bool) -> Result<ContextMlaGrids, AicError> {
-    let reader = PerfReader::open(path)?;
-    let mla_dtype_col = reader.col("mla_dtype")?;
-    let kv_cache_dtype_col = reader.col("kv_cache_dtype")?;
-    let num_heads_col = reader.col("num_heads")?;
-    let batch_size_col = reader.col("batch_size")?;
-    let isl_col = reader.col("isl")?;
-    let step_col = reader.col("step")?;
-    let latency_col = reader.col("latency")?;
-
+fn load_op_parquet(sources: &[PerfSource], is_context: bool) -> Result<ContextMlaGrids, AicError> {
     let mut by_keys: BTreeMap<ContextKey, Grid3<f64>> = BTreeMap::new();
-    for row in reader.rows()? {
-        let row = row?;
-        let key = ContextKey {
-            fmha_quant: row.str_owned(mla_dtype_col)?,
-            kv_quant: row.str_owned(kv_cache_dtype_col)?,
-        };
-        let isl = row.u32(isl_col)?;
-        let y_axis = if is_context { isl } else { isl + row.u32(step_col)? };
-        // First-wins parity with Python `load_mla_data` (context branch).
-        by_keys
-            .entry(key)
-            .or_default()
-            .entry(row.u32(num_heads_col)?)
-            .or_default()
-            .entry(y_axis)
-            .or_default()
-            .entry(row.u32(batch_size_col)?)
-            .or_insert(row.f64(latency_col)?);
+    let mut any_source = false;
+    for source in sources {
+        let path = source.path();
+        if !path.exists() {
+            continue;
+        }
+        any_source = true;
+        let reader = PerfReader::open(path)?;
+        let mla_dtype_col = reader.col("mla_dtype")?;
+        let kv_cache_dtype_col = reader.col("kv_cache_dtype")?;
+        let num_heads_col = reader.col("num_heads")?;
+        let batch_size_col = reader.col("batch_size")?;
+        let isl_col = reader.col("isl")?;
+        let step_col = reader.col("step")?;
+        let latency_col = reader.col("latency")?;
+        let ks_col = reader.col_optional("kernel_source");
+        for row in reader.rows()? {
+            let row = row?;
+            if !kernel_source_ok(source.kernel_sources(), ks_col, &row)? {
+                continue;
+            }
+            let key = ContextKey {
+                fmha_quant: row.str_owned(mla_dtype_col)?,
+                kv_quant: row.str_owned(kv_cache_dtype_col)?,
+            };
+            let isl = row.u32(isl_col)?;
+            let y_axis = if is_context { isl } else { isl + row.u32(step_col)? };
+            // First-wins parity with Python `load_mla_data` (context branch).
+            by_keys
+                .entry(key)
+                .or_default()
+                .entry(row.u32(num_heads_col)?)
+                .or_default()
+                .entry(y_axis)
+                .or_default()
+                .entry(row.u32(batch_size_col)?)
+                .or_insert(row.f64(latency_col)?);
+        }
     }
-    if by_keys.is_empty() {
+    if !any_source || by_keys.is_empty() {
         return Err(AicError::PerfDatabase(format!(
-            "no MLA op rows loaded from {}",
-            path.display()
+            "no rows loaded from {} source(s) (first: {})",
+            sources.len(),
+            sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
         )));
     }
     Ok(ContextMlaGrids { by_keys })
 }
 
-fn load_op_gen_parquet(path: &Path) -> Result<GenerationMlaGrids, AicError> {
-    let reader = PerfReader::open(path)?;
-    let kv_cache_dtype_col = reader.col("kv_cache_dtype")?;
-    let num_heads_col = reader.col("num_heads")?;
-    let batch_size_col = reader.col("batch_size")?;
-    let isl_col = reader.col("isl")?;
-    let step_col = reader.col("step")?;
-    let latency_col = reader.col("latency")?;
-
+fn load_op_gen_parquet(sources: &[PerfSource]) -> Result<GenerationMlaGrids, AicError> {
     let mut by_keys: BTreeMap<KvOnlyKey, Grid3<f64>> = BTreeMap::new();
-    for row in reader.rows()? {
-        let row = row?;
-        let key = KvOnlyKey {
-            kv_quant: row.str_owned(kv_cache_dtype_col)?,
-        };
-        let sequence_tokens = row.u32(isl_col)? + row.u32(step_col)?;
-        // Python uses (num_heads, b, s) axis order for generation MLA.
-        // First-wins parity with Python `load_mla_data` (generation branch).
-        by_keys
-            .entry(key)
-            .or_default()
-            .entry(row.u32(num_heads_col)?)
-            .or_default()
-            .entry(row.u32(batch_size_col)?)
-            .or_default()
-            .entry(sequence_tokens)
-            .or_insert(row.f64(latency_col)?);
+    let mut any_source = false;
+    for source in sources {
+        let path = source.path();
+        if !path.exists() {
+            continue;
+        }
+        any_source = true;
+        let reader = PerfReader::open(path)?;
+        let kv_cache_dtype_col = reader.col("kv_cache_dtype")?;
+        let num_heads_col = reader.col("num_heads")?;
+        let batch_size_col = reader.col("batch_size")?;
+        let isl_col = reader.col("isl")?;
+        let step_col = reader.col("step")?;
+        let latency_col = reader.col("latency")?;
+        let ks_col = reader.col_optional("kernel_source");
+        for row in reader.rows()? {
+            let row = row?;
+            if !kernel_source_ok(source.kernel_sources(), ks_col, &row)? {
+                continue;
+            }
+            let key = KvOnlyKey {
+                kv_quant: row.str_owned(kv_cache_dtype_col)?,
+            };
+            let sequence_tokens = row.u32(isl_col)? + row.u32(step_col)?;
+            // Python uses (num_heads, b, s) axis order for generation MLA.
+            // First-wins parity with Python `load_mla_data` (generation branch).
+            by_keys
+                .entry(key)
+                .or_default()
+                .entry(row.u32(num_heads_col)?)
+                .or_default()
+                .entry(row.u32(batch_size_col)?)
+                .or_default()
+                .entry(sequence_tokens)
+                .or_insert(row.f64(latency_col)?);
+        }
     }
-    if by_keys.is_empty() {
+    if !any_source || by_keys.is_empty() {
         return Err(AicError::PerfDatabase(format!(
-            "no generation MLA rows loaded from {}",
-            path.display()
+            "no rows loaded from {} source(s) (first: {})",
+            sources.len(),
+            sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
         )));
     }
     Ok(GenerationMlaGrids { by_keys })
 }
 
-fn load_module_parquet(path: &Path, is_context: bool) -> Result<ModuleGrids, AicError> {
-    let reader = PerfReader::open(path)?;
-    let mla_dtype_col = reader.col("mla_dtype")?;
-    let kv_cache_dtype_col = reader.col("kv_cache_dtype")?;
-    let gemm_type_col = reader.col("gemm_type")?;
-    let num_heads_col = reader.col("num_heads")?;
-    let batch_size_col = reader.col("batch_size")?;
-    let isl_col = reader.col("isl")?;
-    let step_col = reader.col("step")?;
-    let latency_col = reader.col("latency")?;
-
+fn load_module_parquet(sources: &[PerfSource], is_context: bool) -> Result<ModuleGrids, AicError> {
     let mut by_keys: BTreeMap<ModuleKey, Grid3<f64>> = BTreeMap::new();
-    for row in reader.rows()? {
-        let row = row?;
-        let key = ModuleKey {
-            fmha_quant: row.str_owned(mla_dtype_col)?,
-            kv_quant: row.str_owned(kv_cache_dtype_col)?,
-            gemm_quant: row.str_owned(gemm_type_col)?,
-        };
-        let num_heads = row.u32(num_heads_col)?;
-        let batch_size = row.u32(batch_size_col)?;
-        let isl = row.u32(isl_col)?;
-        let latency = row.f64(latency_col)?;
-        // Last-wins parity with Python `load_context_mla_module_data`
-        // (`operations/mla.py:1804`) and `load_generation_mla_module_data`
-        // (`operations/mla.py:1847`). Unlike the legacy CSV loaders and every
-        // other Python perf-DB loader (GEMM, attention, MoE, MHC, DSA, wideep)
-        // which guard with `try/except KeyError` for first-wins semantics,
-        // these two MLA-module parquet loaders use direct assignment and
-        // therefore last-wins. Some perf-DB parquet shards (notably
-        // b300_sxm/vllm/0.19.0 `mla_generation_module_perf.parquet`) contain
-        // duplicate (num_heads, batch_size, sequence_tokens) rows; first-wins
-        // here caused a constant +0.247ms/step decode drift on b300 because
-        // Rust picked the slightly-higher latency for ~184 affected keys.
-        if is_context {
-            let inner = by_keys
-                .entry(key)
-                .or_default()
-                .entry(num_heads)
-                .or_default()
-                .entry(isl)
-                .or_default();
-            inner.insert(batch_size, latency);
-        } else {
-            // Generation module: (num_heads, b, s) axis order.
-            let sequence_tokens = isl + row.u32(step_col)?;
-            let inner = by_keys
-                .entry(key)
-                .or_default()
-                .entry(num_heads)
-                .or_default()
-                .entry(batch_size)
-                .or_default();
-            inner.insert(sequence_tokens, latency);
+    let mut any_source = false;
+    for source in sources {
+        let path = source.path();
+        if !path.exists() {
+            continue;
+        }
+        any_source = true;
+        let reader = PerfReader::open(path)?;
+        let mla_dtype_col = reader.col("mla_dtype")?;
+        let kv_cache_dtype_col = reader.col("kv_cache_dtype")?;
+        let gemm_type_col = reader.col("gemm_type")?;
+        let num_heads_col = reader.col("num_heads")?;
+        let batch_size_col = reader.col("batch_size")?;
+        let isl_col = reader.col("isl")?;
+        let step_col = reader.col("step")?;
+        let latency_col = reader.col("latency")?;
+        let ks_col = reader.col_optional("kernel_source");
+        for row in reader.rows()? {
+            let row = row?;
+            if !kernel_source_ok(source.kernel_sources(), ks_col, &row)? {
+                continue;
+            }
+            let key = ModuleKey {
+                fmha_quant: row.str_owned(mla_dtype_col)?,
+                kv_quant: row.str_owned(kv_cache_dtype_col)?,
+                gemm_quant: row.str_owned(gemm_type_col)?,
+            };
+            let num_heads = row.u32(num_heads_col)?;
+            let batch_size = row.u32(batch_size_col)?;
+            let isl = row.u32(isl_col)?;
+            let latency = row.f64(latency_col)?;
+            // Last-wins parity with Python `load_context_mla_module_data`
+            // (`operations/mla.py:1804`) and `load_generation_mla_module_data`
+            // (`operations/mla.py:1847`). Unlike the legacy CSV loaders and every
+            // other Python perf-DB loader (GEMM, attention, MoE, MHC, DSA, wideep)
+            // which guard with `try/except KeyError` for first-wins semantics,
+            // these two MLA-module parquet loaders use direct assignment and
+            // therefore last-wins. Some perf-DB parquet shards (notably
+            // b300_sxm/vllm/0.19.0 `mla_generation_module_perf.parquet`) contain
+            // duplicate (num_heads, batch_size, sequence_tokens) rows; first-wins
+            // here caused a constant +0.247ms/step decode drift on b300 because
+            // Rust picked the slightly-higher latency for ~184 affected keys.
+            if is_context {
+                let inner = by_keys
+                    .entry(key)
+                    .or_default()
+                    .entry(num_heads)
+                    .or_default()
+                    .entry(isl)
+                    .or_default();
+                inner.insert(batch_size, latency);
+            } else {
+                // Generation module: (num_heads, b, s) axis order.
+                let sequence_tokens = isl + row.u32(step_col)?;
+                let inner = by_keys
+                    .entry(key)
+                    .or_default()
+                    .entry(num_heads)
+                    .or_default()
+                    .entry(batch_size)
+                    .or_default();
+                inner.insert(sequence_tokens, latency);
+            }
         }
     }
-    if by_keys.is_empty() {
+    if !any_source || by_keys.is_empty() {
         return Err(AicError::PerfDatabase(format!(
-            "no MLA module rows loaded from {}",
-            path.display()
+            "no rows loaded from {} source(s) (first: {})",
+            sources.len(),
+            sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
         )));
     }
     Ok(ModuleGrids { by_keys })
 }
 
-fn load_bmm_parquet(path: &Path) -> Result<BmmGrids, AicError> {
-    let reader = PerfReader::open(path)?;
-    let op_name_col = reader.col("op_name")?;
-    let bmm_dtype_col = reader.col("bmm_dtype")?;
-    let num_tokens_col = reader.col("num_tokens")?;
-    let num_heads_col = reader.col("num_heads")?;
-    let latency_col = reader.col("latency")?;
-
+fn load_bmm_parquet(sources: &[PerfSource]) -> Result<BmmGrids, AicError> {
     let mut by_keys: BTreeMap<BmmKey, BTreeMap<u32, BTreeMap<u32, f64>>> = BTreeMap::new();
-    for row in reader.rows()? {
-        let row = row?;
-        let key = BmmKey {
-            bmm_quant: row.str_owned(bmm_dtype_col)?,
-            pre_or_post: row.str_owned(op_name_col)?,
-        };
-        // First-wins parity with Python `load_mla_bmm_data`.
-        by_keys
-            .entry(key)
-            .or_default()
-            .entry(row.u32(num_heads_col)?)
-            .or_default()
-            .entry(row.u32(num_tokens_col)?)
-            .or_insert(row.f64(latency_col)?);
+    let mut any_source = false;
+    for source in sources {
+        let path = source.path();
+        if !path.exists() {
+            continue;
+        }
+        any_source = true;
+        let reader = PerfReader::open(path)?;
+        let op_name_col = reader.col("op_name")?;
+        let bmm_dtype_col = reader.col("bmm_dtype")?;
+        let num_tokens_col = reader.col("num_tokens")?;
+        let num_heads_col = reader.col("num_heads")?;
+        let latency_col = reader.col("latency")?;
+        let ks_col = reader.col_optional("kernel_source");
+        for row in reader.rows()? {
+            let row = row?;
+            if !kernel_source_ok(source.kernel_sources(), ks_col, &row)? {
+                continue;
+            }
+            let key = BmmKey {
+                bmm_quant: row.str_owned(bmm_dtype_col)?,
+                pre_or_post: row.str_owned(op_name_col)?,
+            };
+            // First-wins parity with Python `load_mla_bmm_data`.
+            by_keys
+                .entry(key)
+                .or_default()
+                .entry(row.u32(num_heads_col)?)
+                .or_default()
+                .entry(row.u32(num_tokens_col)?)
+                .or_insert(row.f64(latency_col)?);
+        }
     }
-    if by_keys.is_empty() {
+    if !any_source || by_keys.is_empty() {
         return Err(AicError::PerfDatabase(format!(
-            "no MLA BMM rows loaded from {}",
-            path.display()
+            "no rows loaded from {} source(s) (first: {})",
+            sources.len(),
+            sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
         )));
     }
     Ok(BmmGrids { by_keys })

--- a/rust/aiconfigurator-core/src/perf_database/mod.rs
+++ b/rust/aiconfigurator-core/src/perf_database/mod.rs
@@ -14,6 +14,40 @@ use std::path::{Path, PathBuf};
 
 use crate::common::error::AicError;
 use crate::common::system_spec::SystemSpec;
+use crate::config::{PerfDbSources, PerfSource};
+
+/// Resolve the ordered source list for one op-file basename: the Python-supplied
+/// shared-layer sources when present, else a single primary `data_root/<basename>`
+/// with no `kernel_source` filter (identical to the pre-shared-layer default).
+pub(crate) fn resolve_op_sources(
+    perf_db_sources: &PerfDbSources,
+    basename: &str,
+    data_root: &Path,
+) -> Vec<PerfSource> {
+    match perf_db_sources.get(basename) {
+        Some(sources) if !sources.is_empty() => sources.clone(),
+        _ => vec![PerfSource(data_root.join(basename), None)],
+    }
+}
+
+/// Whether a row's `kernel_source` passes a source's filter, mirroring Python
+/// `_read_filtered_rows`: `None` admits every row; a `Some` allowlist keeps only
+/// rows whose `kernel_source` value is in the set (a row missing the column is
+/// dropped, since Python's `row.get("kernel_source") in ks_filter` is `False`
+/// for `None`). Shared by every op table's multi-source loader.
+pub(crate) fn kernel_source_ok(
+    filter: Option<&[String]>,
+    ks_col: Option<usize>,
+    row: &parquet_loader::PerfRow,
+) -> Result<bool, AicError> {
+    match filter {
+        None => Ok(true),
+        Some(allow) => match row.str_optional(ks_col)? {
+            Some(ks) => Ok(allow.iter().any(|a| a == ks)),
+            None => Ok(false),
+        },
+    }
+}
 
 pub mod attention;
 pub mod communication;
@@ -82,6 +116,23 @@ impl PerfDatabase {
         backend: &str,
         version: &str,
     ) -> Result<Self, AicError> {
+        Self::load_with_sources(systems_root, system, backend, version, &PerfDbSources::default())
+    }
+
+    /// Like [`PerfDatabase::load`], but honours the shared-layer
+    /// (sibling/cross-version) `perf_db_sources` resolved in Python
+    /// (`sdk/engine.py::_compute_perf_db_sources`). For op files present in the
+    /// map, the ordered source list (with per-source `kernel_source` filters) is
+    /// used instead of the single primary file so Rust inherits the same rows
+    /// Python does under SILICON/HYBRID. Op files absent from the map fall back
+    /// to the primary `data_root` (identical to [`PerfDatabase::load`]).
+    pub fn load_with_sources(
+        systems_root: &Path,
+        system: &str,
+        backend: &str,
+        version: &str,
+        perf_db_sources: &PerfDbSources,
+    ) -> Result<Self, AicError> {
         let system_yaml = systems_root.join(format!("{system}.yaml"));
         let spec = SystemSpec::load(&system_yaml)?;
         let system_data_root = systems_root.join(&spec.data_dir);
@@ -112,19 +163,29 @@ impl PerfDatabase {
             system: system.to_string(),
             backend: backend.to_string(),
             version: version.to_string(),
-            gemm: GemmTable::new(data_root.clone(), spec.clone()),
-            attention: AttentionTable::new(data_root.clone(), spec.clone()),
+            // Every op table resolves its own file basenames from
+            // `perf_db_sources` via `with_sources` (shared-layer aware); an
+            // absent basename falls back to the primary `data_root` file.
+            // NCCL/OneCCL are framework-agnostic and never inherit siblings, so
+            // their roots stay as the direct system-wide dirs.
+            gemm: GemmTable::with_sources(data_root.clone(), spec.clone(), perf_db_sources),
+            attention: AttentionTable::with_sources(data_root.clone(), spec.clone(), perf_db_sources),
             system_spec: spec,
-            mla: MlaTable::new(data_root.clone()),
-            moe: MoeTable::new(data_root.clone()),
-            communication: CommunicationTable::new(data_root.clone(), nccl_root, oneccl_root),
-            dsa: DsaTable::new(data_root.clone()),
-            dsv4: Dsv4Table::new(data_root.clone()),
-            mhc: MhcTable::new(data_root.clone()),
-            wideep: WideEpTable::new(data_root.clone()),
-            wideep_mla: WideEpMlaTable::new(data_root.clone()),
-            wideep_moe: WideEpMoeTable::new(data_root.clone()),
-            state_space: StateSpaceTable::new(data_root.clone()),
+            mla: MlaTable::with_sources(data_root.clone(), perf_db_sources),
+            moe: MoeTable::with_sources(data_root.clone(), perf_db_sources),
+            communication: CommunicationTable::with_sources(
+                data_root.clone(),
+                nccl_root,
+                oneccl_root,
+                perf_db_sources,
+            ),
+            dsa: DsaTable::with_sources(data_root.clone(), perf_db_sources),
+            dsv4: Dsv4Table::with_sources(data_root.clone(), perf_db_sources),
+            mhc: MhcTable::with_sources(data_root.clone(), perf_db_sources),
+            wideep: WideEpTable::with_sources(data_root.clone(), perf_db_sources),
+            wideep_mla: WideEpMlaTable::with_sources(data_root.clone(), perf_db_sources),
+            wideep_moe: WideEpMoeTable::with_sources(data_root.clone(), perf_db_sources),
+            state_space: StateSpaceTable::with_sources(data_root.clone(), perf_db_sources),
             data_root,
         })
     }

--- a/rust/aiconfigurator-core/src/perf_database/moe.rs
+++ b/rust/aiconfigurator-core/src/perf_database/moe.rs
@@ -21,16 +21,22 @@
 //! `perf_database::wideep`, `wideep_mla`, and `wideep_moe`.
 
 use std::collections::BTreeMap;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::OnceLock;
 
 use crate::common::enums::MoeQuantMode;
 use crate::common::error::AicError;
+use crate::config::{PerfDbSources, PerfSource};
+use super::{kernel_source_ok, resolve_op_sources};
 use super::interpolation::{interp_1d, nearest_neighbors};
 use crate::perf_database::parquet_loader::PerfReader;
 
 pub struct MoeTable {
     data_root: PathBuf,
+    /// Ordered, priority-sorted sources for the MoE perf file (shared-layer
+    /// aware; see [`PerfSource`]). Single-primary, no-filter by default
+    /// (`MoeTable::new`).
+    moe_sources: Vec<PerfSource>,
     moe: OnceLock<Result<LoadedMoeGrids, AicError>>,
 }
 
@@ -61,9 +67,21 @@ struct MoeKey {
 }
 
 impl MoeTable {
+    /// Construct an empty table for the given data directory. No I/O. The MoE
+    /// perf file is sourced solely from `data_root/moe_perf.parquet` with no
+    /// `kernel_source` filter (pre-shared-layer behaviour).
     pub fn new(data_root: PathBuf) -> Self {
+        Self::with_sources(data_root, &PerfDbSources::default())
+    }
+
+    /// Construct with shared-layer (sibling/cross-version) sources resolved from
+    /// `perf_db_sources` (Python-supplied). The MoE file falls back to its
+    /// primary `data_root/moe_perf.parquet` when absent from the map. No I/O.
+    pub fn with_sources(data_root: PathBuf, perf_db_sources: &PerfDbSources) -> Self {
+        let moe_sources = resolve_op_sources(perf_db_sources, "moe_perf.parquet", &data_root);
         Self {
             data_root,
+            moe_sources,
             moe: OnceLock::new(),
         }
     }
@@ -258,61 +276,80 @@ impl MoeTable {
     fn load(&self) -> Result<&LoadedMoeGrids, AicError> {
         let cell = self
             .moe
-            .get_or_init(|| load_moe_parquet(&self.data_root.join("moe_perf.parquet")));
+            .get_or_init(|| load_moe_parquet(&self.moe_sources));
         cell.as_ref().map_err(clone_err)
     }
 }
 
-fn load_moe_parquet(path: &Path) -> Result<LoadedMoeGrids, AicError> {
-    let reader = PerfReader::open(path)?;
-    let moe_dtype_col = reader.col("moe_dtype")?;
-    let num_tokens_col = reader.col("num_tokens")?;
-    let hidden_size_col = reader.col("hidden_size")?;
-    let inter_size_col = reader.col("inter_size")?;
-    let topk_col = reader.col("topk")?;
-    let num_experts_col = reader.col("num_experts")?;
-    let moe_tp_size_col = reader.col("moe_tp_size")?;
-    let moe_ep_size_col = reader.col("moe_ep_size")?;
-    let distribution_col = reader.col("distribution")?;
-    let latency_col = reader.col("latency")?;
-    // Optional in older perf-DB versions; when absent every row falls into
-    // the `default` grid (matching the pre-split behavior).
-    let kernel_source_col = reader.col_optional("kernel_source");
-
+/// Load the MoE table from an ordered, priority-sorted source list. Sources are
+/// read in order; the first source containing a `(shape, num_tokens)` tuple wins
+/// (`or_insert`), mirroring Python's `_read_filtered_rows` concatenation +
+/// `load_moe_data` skip-on-key-conflict. Missing files are skipped (a sibling
+/// declared in the manifest need not exist for every system); an error is
+/// returned only when no source yields rows.
+fn load_moe_parquet(sources: &[PerfSource]) -> Result<LoadedMoeGrids, AicError> {
     let mut default_keys: BTreeMap<MoeKey, BTreeMap<u32, f64>> = BTreeMap::new();
     let mut low_latency_keys: BTreeMap<MoeKey, BTreeMap<u32, f64>> = BTreeMap::new();
-    for row in reader.rows()? {
-        let row = row?;
-        let key = MoeKey {
-            quant: row.str_owned(moe_dtype_col)?,
-            distribution: row.str_owned(distribution_col)?,
-            topk: row.u32(topk_col)?,
-            num_experts: row.u32(num_experts_col)?,
-            hidden_size: row.u32(hidden_size_col)?,
-            inter_size: row.u32(inter_size_col)?,
-            moe_tp_size: row.u32(moe_tp_size_col)?,
-            moe_ep_size: row.u32(moe_ep_size_col)?,
-        };
-        let kernel_source = row.str_optional(kernel_source_col)?.unwrap_or("");
-        let target = if kernel_source == "moe_torch_flow_min_latency" {
-            &mut low_latency_keys
-        } else {
-            &mut default_keys
-        };
-        // Python's `load_moe_data` wraps the leaf insert in a try/except KeyError
-        // and skips on conflict, i.e. it keeps the FIRST occurrence of each
-        // (shape, num_tokens) tuple. Some perf files contain duplicate rows
-        // (same kernel_source, same shape) — preserving first-wins parity here.
-        target
-            .entry(key)
-            .or_default()
-            .entry(row.u32(num_tokens_col)?)
-            .or_insert(row.f64(latency_col)?);
+    let mut any_source = false;
+    for source in sources {
+        let path = source.path();
+        if !path.exists() {
+            continue;
+        }
+        any_source = true;
+        let reader = PerfReader::open(path)?;
+        let moe_dtype_col = reader.col("moe_dtype")?;
+        let num_tokens_col = reader.col("num_tokens")?;
+        let hidden_size_col = reader.col("hidden_size")?;
+        let inter_size_col = reader.col("inter_size")?;
+        let topk_col = reader.col("topk")?;
+        let num_experts_col = reader.col("num_experts")?;
+        let moe_tp_size_col = reader.col("moe_tp_size")?;
+        let moe_ep_size_col = reader.col("moe_ep_size")?;
+        let distribution_col = reader.col("distribution")?;
+        let latency_col = reader.col("latency")?;
+        // Optional in older perf-DB versions; when absent every row falls into
+        // the `default` grid (matching the pre-split behavior). The same column
+        // gates the per-source shared-layer `kernel_source` allowlist.
+        let kernel_source_col = reader.col_optional("kernel_source");
+        for row in reader.rows()? {
+            let row = row?;
+            if !kernel_source_ok(source.kernel_sources(), kernel_source_col, &row)? {
+                continue;
+            }
+            let key = MoeKey {
+                quant: row.str_owned(moe_dtype_col)?,
+                distribution: row.str_owned(distribution_col)?,
+                topk: row.u32(topk_col)?,
+                num_experts: row.u32(num_experts_col)?,
+                hidden_size: row.u32(hidden_size_col)?,
+                inter_size: row.u32(inter_size_col)?,
+                moe_tp_size: row.u32(moe_tp_size_col)?,
+                moe_ep_size: row.u32(moe_ep_size_col)?,
+            };
+            let kernel_source = row.str_optional(kernel_source_col)?.unwrap_or("");
+            let target = if kernel_source == "moe_torch_flow_min_latency" {
+                &mut low_latency_keys
+            } else {
+                &mut default_keys
+            };
+            // Python's `load_moe_data` wraps the leaf insert in a try/except KeyError
+            // and skips on conflict, i.e. it keeps the FIRST occurrence of each
+            // (shape, num_tokens) tuple. Some perf files contain duplicate rows
+            // (same kernel_source, same shape) — preserving first-wins parity here,
+            // extended across shared-layer sources (earlier source wins).
+            target
+                .entry(key)
+                .or_default()
+                .entry(row.u32(num_tokens_col)?)
+                .or_insert(row.f64(latency_col)?);
+        }
     }
-    if default_keys.is_empty() && low_latency_keys.is_empty() {
+    if !any_source || (default_keys.is_empty() && low_latency_keys.is_empty()) {
         return Err(AicError::PerfDatabase(format!(
-            "no MoE rows loaded from {}",
-            path.display()
+            "no rows loaded from {} source(s) (first: {})",
+            sources.len(),
+            sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
         )));
     }
     Ok(LoadedMoeGrids {

--- a/rust/aiconfigurator-core/src/perf_database/state_space.rs
+++ b/rust/aiconfigurator-core/src/perf_database/state_space.rs
@@ -16,11 +16,18 @@ use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 use crate::common::error::AicError;
+use crate::config::{PerfDbSources, PerfSource};
+use super::{kernel_source_ok, resolve_op_sources};
 use super::interpolation::{interp_1d, nearest_neighbors};
 use crate::perf_database::parquet_loader::PerfReader;
 
 pub struct StateSpaceTable {
     data_root: PathBuf,
+    /// Ordered, priority-sorted sources for each state-space perf file
+    /// (shared-layer aware; see [`PerfSource`]). Single-primary, no-filter by
+    /// default (`StateSpaceTable::new`).
+    mamba2_sources: Vec<PerfSource>,
+    gdn_sources: Vec<PerfSource>,
     mamba2: OnceLock<Result<Mamba2Grids, AicError>>,
     gdn: OnceLock<Result<GdnGrids, AicError>>,
 }
@@ -67,9 +74,24 @@ struct GdnKey {
 }
 
 impl StateSpaceTable {
+    /// Construct an empty table for the given data directory. No I/O. Each
+    /// perf file is sourced solely from `data_root/<basename>` with no
+    /// `kernel_source` filter (pre-shared-layer behaviour).
     pub fn new(data_root: PathBuf) -> Self {
+        Self::with_sources(data_root, &PerfDbSources::default())
+    }
+
+    /// Construct with shared-layer (sibling/cross-version) sources resolved from
+    /// `perf_db_sources` (Python-supplied). Each state-space file falls back to
+    /// its primary `data_root/<basename>` when absent from the map. No I/O.
+    pub fn with_sources(data_root: PathBuf, perf_db_sources: &PerfDbSources) -> Self {
+        let mamba2_sources =
+            resolve_op_sources(perf_db_sources, "mamba2_perf.parquet", &data_root);
+        let gdn_sources = resolve_op_sources(perf_db_sources, "gdn_perf.parquet", &data_root);
         Self {
             data_root,
+            mamba2_sources,
+            gdn_sources,
             mamba2: OnceLock::new(),
             gdn: OnceLock::new(),
         }
@@ -205,14 +227,14 @@ impl StateSpaceTable {
     fn load_mamba2(&self) -> Result<&Mamba2Grids, AicError> {
         let cell = self
             .mamba2
-            .get_or_init(|| load_mamba2_parquet(&self.data_root.join("mamba2_perf.parquet")));
+            .get_or_init(|| load_mamba2_parquet(&self.mamba2_sources));
         cell.as_ref().map_err(clone_err)
     }
 
     fn load_gdn(&self) -> Result<&GdnGrids, AicError> {
         let cell = self
             .gdn
-            .get_or_init(|| load_gdn_parquet(&self.data_root.join("gdn_perf.parquet")));
+            .get_or_init(|| load_gdn_parquet(&self.gdn_sources));
         cell.as_ref().map_err(clone_err)
     }
 }
@@ -289,89 +311,124 @@ fn bs_seq_interp(
     )))
 }
 
-fn load_mamba2_parquet(path: &Path) -> Result<Mamba2Grids, AicError> {
-    let reader = PerfReader::open(path)?;
-    let kernel_source_col = reader.col("kernel_source")?;
-    let phase_col = reader.col("phase")?;
-    let batch_size_col = reader.col("batch_size")?;
-    let seq_len_col = reader.col("seq_len")?;
-    let d_model_col = reader.col("d_model")?;
-    let d_state_col = reader.col("d_state")?;
-    let d_conv_col = reader.col("d_conv")?;
-    let nheads_col = reader.col("nheads")?;
-    let head_dim_col = reader.col("head_dim")?;
-    let n_groups_col = reader.col("n_groups")?;
-    let chunk_size_col = reader.col("chunk_size")?;
-    let latency_col = reader.col("latency")?;
-
+/// Load the Mamba2 table from an ordered, priority-sorted source list. Sources
+/// are read in order; the first source containing a `(key, bs, seq)` wins
+/// (`or_insert`), mirroring Python's `_read_filtered_rows` concatenation +
+/// `load_mamba2_data` skip-on-key-conflict. Missing files are skipped (a sibling
+/// declared in the manifest need not exist for every system); an error is
+/// returned only when no source yields rows.
+fn load_mamba2_parquet(sources: &[PerfSource]) -> Result<Mamba2Grids, AicError> {
     let mut by_keys: BTreeMap<Mamba2Key, BTreeMap<(u32, u32), f64>> = BTreeMap::new();
-    for row in reader.rows()? {
-        let row = row?;
-        let key = Mamba2Key {
-            kernel_source: row.str_owned(kernel_source_col)?,
-            phase: row.str_owned(phase_col)?,
-            d_model: row.u32(d_model_col)?,
-            d_state: row.u32(d_state_col)?,
-            d_conv: row.u32(d_conv_col)?,
-            nheads: row.u32(nheads_col)?,
-            head_dim: row.u32(head_dim_col)?,
-            n_groups: row.u32(n_groups_col)?,
-            chunk_size: row.u32(chunk_size_col)?,
-        };
-        // First-wins parity with Python `load_mamba2_data`.
-        by_keys
-            .entry(key)
-            .or_default()
-            .entry((row.u32(batch_size_col)?, row.u32(seq_len_col)?))
-            .or_insert(row.f64(latency_col)?);
+    let mut any_source = false;
+    for source in sources {
+        let path = source.path();
+        if !path.exists() {
+            continue;
+        }
+        any_source = true;
+        let reader = PerfReader::open(path)?;
+        let kernel_source_col = reader.col("kernel_source")?;
+        let phase_col = reader.col("phase")?;
+        let batch_size_col = reader.col("batch_size")?;
+        let seq_len_col = reader.col("seq_len")?;
+        let d_model_col = reader.col("d_model")?;
+        let d_state_col = reader.col("d_state")?;
+        let d_conv_col = reader.col("d_conv")?;
+        let nheads_col = reader.col("nheads")?;
+        let head_dim_col = reader.col("head_dim")?;
+        let n_groups_col = reader.col("n_groups")?;
+        let chunk_size_col = reader.col("chunk_size")?;
+        let latency_col = reader.col("latency")?;
+        let ks_col = reader.col_optional("kernel_source");
+        for row in reader.rows()? {
+            let row = row?;
+            if !kernel_source_ok(source.kernel_sources(), ks_col, &row)? {
+                continue;
+            }
+            let key = Mamba2Key {
+                kernel_source: row.str_owned(kernel_source_col)?,
+                phase: row.str_owned(phase_col)?,
+                d_model: row.u32(d_model_col)?,
+                d_state: row.u32(d_state_col)?,
+                d_conv: row.u32(d_conv_col)?,
+                nheads: row.u32(nheads_col)?,
+                head_dim: row.u32(head_dim_col)?,
+                n_groups: row.u32(n_groups_col)?,
+                chunk_size: row.u32(chunk_size_col)?,
+            };
+            // First-wins parity with Python `load_mamba2_data`, extended across
+            // shared-layer sources (earlier source wins).
+            by_keys
+                .entry(key)
+                .or_default()
+                .entry((row.u32(batch_size_col)?, row.u32(seq_len_col)?))
+                .or_insert(row.f64(latency_col)?);
+        }
     }
-    if by_keys.is_empty() {
+    if !any_source || by_keys.is_empty() {
         return Err(AicError::PerfDatabase(format!(
-            "no Mamba2 rows loaded from {}",
-            path.display()
+            "no Mamba2 rows loaded from {} source(s) (first: {})",
+            sources.len(),
+            sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
         )));
     }
     Ok(Mamba2Grids { by_keys })
 }
 
-fn load_gdn_parquet(path: &Path) -> Result<GdnGrids, AicError> {
-    let reader = PerfReader::open(path)?;
-    let kernel_source_col = reader.col("kernel_source")?;
-    let phase_col = reader.col("phase")?;
-    let batch_size_col = reader.col("batch_size")?;
-    let seq_len_col = reader.col("seq_len")?;
-    let d_model_col = reader.col("d_model")?;
-    let d_conv_col = reader.col("d_conv")?;
-    let num_k_heads_col = reader.col("num_k_heads")?;
-    let head_k_dim_col = reader.col("head_k_dim")?;
-    let num_v_heads_col = reader.col("num_v_heads")?;
-    let head_v_dim_col = reader.col("head_v_dim")?;
-    let latency_col = reader.col("latency")?;
-
+/// Load the GDN table from an ordered, priority-sorted source list. Same
+/// first-wins-across-sources + missing-file-skip semantics as
+/// [`load_mamba2_parquet`].
+fn load_gdn_parquet(sources: &[PerfSource]) -> Result<GdnGrids, AicError> {
     let mut by_keys: BTreeMap<GdnKey, BTreeMap<(u32, u32), f64>> = BTreeMap::new();
-    for row in reader.rows()? {
-        let row = row?;
-        let key = GdnKey {
-            kernel_source: row.str_owned(kernel_source_col)?,
-            phase: row.str_owned(phase_col)?,
-            d_model: row.u32(d_model_col)?,
-            d_conv: row.u32(d_conv_col)?,
-            num_k_heads: row.u32(num_k_heads_col)?,
-            head_k_dim: row.u32(head_k_dim_col)?,
-            num_v_heads: row.u32(num_v_heads_col)?,
-            head_v_dim: row.u32(head_v_dim_col)?,
-        };
-        // First-wins parity with Python `load_gdn_data`.
-        by_keys
-            .entry(key)
-            .or_default()
-            .entry((row.u32(batch_size_col)?, row.u32(seq_len_col)?))
-            .or_insert(row.f64(latency_col)?);
+    let mut any_source = false;
+    for source in sources {
+        let path = source.path();
+        if !path.exists() {
+            continue;
+        }
+        any_source = true;
+        let reader = PerfReader::open(path)?;
+        let kernel_source_col = reader.col("kernel_source")?;
+        let phase_col = reader.col("phase")?;
+        let batch_size_col = reader.col("batch_size")?;
+        let seq_len_col = reader.col("seq_len")?;
+        let d_model_col = reader.col("d_model")?;
+        let d_conv_col = reader.col("d_conv")?;
+        let num_k_heads_col = reader.col("num_k_heads")?;
+        let head_k_dim_col = reader.col("head_k_dim")?;
+        let num_v_heads_col = reader.col("num_v_heads")?;
+        let head_v_dim_col = reader.col("head_v_dim")?;
+        let latency_col = reader.col("latency")?;
+        let ks_col = reader.col_optional("kernel_source");
+        for row in reader.rows()? {
+            let row = row?;
+            if !kernel_source_ok(source.kernel_sources(), ks_col, &row)? {
+                continue;
+            }
+            let key = GdnKey {
+                kernel_source: row.str_owned(kernel_source_col)?,
+                phase: row.str_owned(phase_col)?,
+                d_model: row.u32(d_model_col)?,
+                d_conv: row.u32(d_conv_col)?,
+                num_k_heads: row.u32(num_k_heads_col)?,
+                head_k_dim: row.u32(head_k_dim_col)?,
+                num_v_heads: row.u32(num_v_heads_col)?,
+                head_v_dim: row.u32(head_v_dim_col)?,
+            };
+            // First-wins parity with Python `load_gdn_data`, extended across
+            // shared-layer sources (earlier source wins).
+            by_keys
+                .entry(key)
+                .or_default()
+                .entry((row.u32(batch_size_col)?, row.u32(seq_len_col)?))
+                .or_insert(row.f64(latency_col)?);
+        }
     }
-    if by_keys.is_empty() {
+    if !any_source || by_keys.is_empty() {
         return Err(AicError::PerfDatabase(format!(
-            "no GDN rows loaded from {}",
-            path.display()
+            "no GDN rows loaded from {} source(s) (first: {})",
+            sources.len(),
+            sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
         )));
     }
     Ok(GdnGrids { by_keys })

--- a/rust/aiconfigurator-core/src/perf_database/wideep.rs
+++ b/rust/aiconfigurator-core/src/perf_database/wideep.rs
@@ -26,11 +26,22 @@ use std::sync::OnceLock;
 
 use crate::common::enums::MoeQuantMode;
 use crate::common::error::AicError;
+use crate::config::{PerfDbSources, PerfSource};
+use super::{kernel_source_ok, resolve_op_sources};
 use super::interpolation::{interp_1d, nearest_neighbors};
 use crate::perf_database::parquet_loader::PerfReader;
 
 pub struct WideEpTable {
     data_root: PathBuf,
+    /// Ordered, priority-sorted sources per distinct perf-file basename
+    /// (shared-layer aware; see [`PerfSource`]). Single-primary, no-filter by
+    /// default (`WideEpTable::new`).
+    context_moe_sources: Vec<PerfSource>,
+    generation_moe_sources: Vec<PerfSource>,
+    moe_sources: Vec<PerfSource>,
+    alltoall_sources: Vec<PerfSource>,
+    deepep_normal_sources: Vec<PerfSource>,
+    deepep_ll_sources: Vec<PerfSource>,
     context_moe: OnceLock<Result<MoeGrids, AicError>>,
     generation_moe: OnceLock<Result<MoeGrids, AicError>>,
     trtllm_wideep_moe: OnceLock<Result<MoeGrids, AicError>>,
@@ -83,9 +94,42 @@ pub struct DispatchPoint {
 }
 
 impl WideEpTable {
+    /// Construct an empty table for the given data directory. No I/O. Each
+    /// perf file is sourced solely from `data_root/<basename>` with no
+    /// `kernel_source` filter (pre-shared-layer behaviour).
     pub fn new(data_root: PathBuf) -> Self {
+        Self::with_sources(data_root, &PerfDbSources::default())
+    }
+
+    /// Construct with shared-layer (sibling/cross-version) sources resolved from
+    /// `perf_db_sources` (Python-supplied). Each perf file falls back to its
+    /// primary `data_root/<basename>` when absent from the map. No I/O.
+    pub fn with_sources(data_root: PathBuf, perf_db_sources: &PerfDbSources) -> Self {
+        let context_moe_sources =
+            resolve_op_sources(perf_db_sources, "wideep_context_moe_perf.parquet", &data_root);
+        let generation_moe_sources = resolve_op_sources(
+            perf_db_sources,
+            "wideep_generation_moe_perf.parquet",
+            &data_root,
+        );
+        let moe_sources = resolve_op_sources(perf_db_sources, "wideep_moe_perf.parquet", &data_root);
+        let alltoall_sources =
+            resolve_op_sources(perf_db_sources, "trtllm_alltoall_perf.parquet", &data_root);
+        let deepep_normal_sources = resolve_op_sources(
+            perf_db_sources,
+            "wideep_deepep_normal_perf.parquet",
+            &data_root,
+        );
+        let deepep_ll_sources =
+            resolve_op_sources(perf_db_sources, "wideep_deepep_ll_perf.parquet", &data_root);
         Self {
             data_root,
+            context_moe_sources,
+            generation_moe_sources,
+            moe_sources,
+            alltoall_sources,
+            deepep_normal_sources,
+            deepep_ll_sources,
             context_moe: OnceLock::new(),
             generation_moe: OnceLock::new(),
             trtllm_wideep_moe: OnceLock::new(),
@@ -238,37 +282,37 @@ impl WideEpTable {
     fn load_context_moe(&self) -> Result<&MoeGrids, AicError> {
         let cell = self
             .context_moe
-            .get_or_init(|| load_moe_parquet(&self.data_root.join("wideep_context_moe_perf.parquet")));
+            .get_or_init(|| load_moe_parquet(&self.context_moe_sources));
         cell.as_ref().map_err(clone_err)
     }
     fn load_generation_moe(&self) -> Result<&MoeGrids, AicError> {
         let cell = self
             .generation_moe
-            .get_or_init(|| load_moe_parquet(&self.data_root.join("wideep_generation_moe_perf.parquet")));
+            .get_or_init(|| load_moe_parquet(&self.generation_moe_sources));
         cell.as_ref().map_err(clone_err)
     }
     fn load_trtllm_wideep_moe(&self) -> Result<&MoeGrids, AicError> {
         let cell = self
             .trtllm_wideep_moe
-            .get_or_init(|| load_moe_parquet(&self.data_root.join("wideep_moe_perf.parquet")));
+            .get_or_init(|| load_moe_parquet(&self.moe_sources));
         cell.as_ref().map_err(clone_err)
     }
     fn load_trtllm_alltoall(&self) -> Result<&MoeGrids, AicError> {
         let cell = self
             .trtllm_alltoall
-            .get_or_init(|| load_moe_parquet(&self.data_root.join("trtllm_alltoall_perf.parquet")));
+            .get_or_init(|| load_moe_parquet(&self.alltoall_sources));
         cell.as_ref().map_err(clone_err)
     }
     fn load_deepep_normal(&self) -> Result<&DispatchGrids, AicError> {
-        let cell = self.deepep_normal.get_or_init(|| {
-            load_deepep_normal_parquet(&self.data_root.join("wideep_deepep_normal_perf.parquet"))
-        });
+        let cell = self
+            .deepep_normal
+            .get_or_init(|| load_deepep_normal_parquet(&self.deepep_normal_sources));
         cell.as_ref().map_err(clone_err)
     }
     fn load_deepep_ll(&self) -> Result<&DispatchGrids, AicError> {
         let cell = self
             .deepep_ll
-            .get_or_init(|| load_deepep_ll_parquet(&self.data_root.join("wideep_deepep_ll_perf.parquet")));
+            .get_or_init(|| load_deepep_ll_parquet(&self.deepep_ll_sources));
         cell.as_ref().map_err(clone_err)
     }
 }
@@ -362,128 +406,203 @@ fn dispatch_lookup(
     })
 }
 
-fn load_moe_parquet(path: &Path) -> Result<MoeGrids, AicError> {
-    let reader = PerfReader::open(path)?;
-    let moe_dtype_col = reader.col("moe_dtype")?;
-    let num_tokens_col = reader.col("num_tokens")?;
-    let hidden_size_col = reader.col("hidden_size")?;
-    // `inter_size` / `moe_tp_size` are absent in `trtllm_alltoall_perf.parquet`;
-    // shared with the wideep_*_moe parquets which carry them. Optional lookup
-    // mirrors the prior `Option<u32>` deserialization plus `unwrap_or` default.
-    let inter_size_col = reader.col_optional("inter_size");
-    let topk_col = reader.col("topk")?;
-    let num_experts_col = reader.col("num_experts")?;
-    let moe_tp_size_col = reader.col_optional("moe_tp_size");
-    let moe_ep_size_col = reader.col("moe_ep_size")?;
-    let distribution_col = reader.col("distribution")?;
-    let latency_col = reader.col("latency")?;
-
+/// Load a MoE-shape table from an ordered, priority-sorted source list. Sources
+/// are read in order; the first source containing a `(key, num_tokens)` wins
+/// (`or_insert`), mirroring Python's `_read_filtered_rows` concatenation +
+/// `load_wideep_*_moe_data` skip-on-key-conflict. Missing files are skipped; an
+/// error is returned only when no source yields rows. Reused for the
+/// context/generation/wideep-moe/alltoall parquets.
+fn load_moe_parquet(sources: &[PerfSource]) -> Result<MoeGrids, AicError> {
     let mut by_keys: BTreeMap<MoeKey, BTreeMap<u32, f64>> = BTreeMap::new();
-    for row in reader.rows()? {
-        let row = row?;
-        let key = MoeKey {
-            quant: row.str_owned(moe_dtype_col)?,
-            distribution: row.str_owned(distribution_col)?,
-            topk: row.u32(topk_col)?,
-            num_experts: row.u32(num_experts_col)?,
-            hidden_size: row.u32(hidden_size_col)?,
-            inter_size: row.u32_optional(inter_size_col)?.unwrap_or(0),
-            moe_tp_size: row.u32_optional(moe_tp_size_col)?.unwrap_or(1),
-            moe_ep_size: row.u32(moe_ep_size_col)?,
-        };
-        // First-wins parity with Python `load_wideep_*_moe_data`.
-        by_keys
-            .entry(key)
-            .or_default()
-            .entry(row.u32(num_tokens_col)?)
-            .or_insert(row.f64(latency_col)?);
+    let mut any_source = false;
+    for source in sources {
+        let path = source.path();
+        if !path.exists() {
+            continue;
+        }
+        any_source = true;
+        let reader = PerfReader::open(path)?;
+        let moe_dtype_col = reader.col("moe_dtype")?;
+        let num_tokens_col = reader.col("num_tokens")?;
+        let hidden_size_col = reader.col("hidden_size")?;
+        // `inter_size` / `moe_tp_size` are absent in `trtllm_alltoall_perf.parquet`;
+        // shared with the wideep_*_moe parquets which carry them. Optional lookup
+        // mirrors the prior `Option<u32>` deserialization plus `unwrap_or` default.
+        let inter_size_col = reader.col_optional("inter_size");
+        let topk_col = reader.col("topk")?;
+        let num_experts_col = reader.col("num_experts")?;
+        let moe_tp_size_col = reader.col_optional("moe_tp_size");
+        let moe_ep_size_col = reader.col("moe_ep_size")?;
+        let distribution_col = reader.col("distribution")?;
+        let latency_col = reader.col("latency")?;
+        let ks_col = reader.col_optional("kernel_source");
+        for row in reader.rows()? {
+            let row = row?;
+            if !kernel_source_ok(source.kernel_sources(), ks_col, &row)? {
+                continue;
+            }
+            let key = MoeKey {
+                quant: row.str_owned(moe_dtype_col)?,
+                distribution: row.str_owned(distribution_col)?,
+                topk: row.u32(topk_col)?,
+                num_experts: row.u32(num_experts_col)?,
+                hidden_size: row.u32(hidden_size_col)?,
+                inter_size: row.u32_optional(inter_size_col)?.unwrap_or(0),
+                moe_tp_size: row.u32_optional(moe_tp_size_col)?.unwrap_or(1),
+                moe_ep_size: row.u32(moe_ep_size_col)?,
+            };
+            // First-wins parity with Python `load_wideep_*_moe_data`, extended
+            // across shared-layer sources (earlier source wins).
+            by_keys
+                .entry(key)
+                .or_default()
+                .entry(row.u32(num_tokens_col)?)
+                .or_insert(row.f64(latency_col)?);
+        }
     }
-    if by_keys.is_empty() {
+    if !any_source || by_keys.is_empty() {
         return Err(AicError::PerfDatabase(format!(
-            "no MoE-shape rows loaded from {}",
-            path.display()
+            "no MoE-shape rows loaded from {} source(s) (first: {})",
+            sources.len(),
+            sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
         )));
     }
     Ok(MoeGrids { by_keys })
 }
 
-fn load_deepep_normal_parquet(path: &Path) -> Result<DispatchGrids, AicError> {
-    let reader = PerfReader::open(path)?;
-    let node_num_col = reader.col("node_num")?;
-    let hidden_size_col = reader.col("hidden_size")?;
-    let num_token_col = reader.col("num_token")?;
-    let num_topk_col = reader.col("num_topk")?;
-    let num_experts_col = reader.col("num_experts")?;
-    let dispatch_transmit_us_col = reader.col_optional("dispatch_transmit_us");
-    let dispatch_notify_us_col = reader.col_optional("dispatch_notify_us");
-    let combine_transmit_us_col = reader.col_optional("combine_transmit_us");
-    let combine_notify_us_col = reader.col_optional("combine_notify_us");
-
+/// Load the DeepEP-normal dispatch table from an ordered source list. Missing
+/// files are skipped; an error is returned only when no source yields rows.
+///
+/// Two-level merge semantics: WITHIN a source, `.insert()` keeps the LAST row
+/// for a `(key, num_token)` — byte-identical to the pre-shared-layer loader,
+/// which collapsed the `dispatch_sms` dimension (absent from `DispatchKey`) to
+/// whichever row came last. ACROSS sources, the per-source map is folded in with
+/// `or_insert`, so the FIRST (highest-priority) source wins — matching the gemm
+/// shared-layer contract and Python's concat-then-skip-on-conflict. Do not
+/// collapse to a plain per-row `or_insert`: it would flip the within-file
+/// last-wins and regress single-primary parity.
+fn load_deepep_normal_parquet(sources: &[PerfSource]) -> Result<DispatchGrids, AicError> {
     let mut by_keys: BTreeMap<DispatchKey, BTreeMap<u32, DispatchPoint>> = BTreeMap::new();
-    for row in reader.rows()? {
-        let row = row?;
-        let key = DispatchKey {
-            node_num: row.u32(node_num_col)?,
-            hidden_size: row.u32(hidden_size_col)?,
-            num_topk: row.u32(num_topk_col)?,
-            num_experts: row.u32(num_experts_col)?,
-        };
-        by_keys.entry(key).or_default().insert(
-            row.u32(num_token_col)?,
-            DispatchPoint {
-                dispatch_transmit_us: row.f64_optional(dispatch_transmit_us_col)?.unwrap_or(0.0),
-                dispatch_notify_us: row.f64_optional(dispatch_notify_us_col)?.unwrap_or(0.0),
-                combine_transmit_us: row.f64_optional(combine_transmit_us_col)?.unwrap_or(0.0),
-                combine_notify_us: row.f64_optional(combine_notify_us_col)?.unwrap_or(0.0),
-                combine_avg_t_us: 0.0,
-                dispatch_avg_t_us: 0.0,
-            },
-        );
+    let mut any_source = false;
+    for source in sources {
+        let path = source.path();
+        if !path.exists() {
+            continue;
+        }
+        any_source = true;
+        let reader = PerfReader::open(path)?;
+        let node_num_col = reader.col("node_num")?;
+        let hidden_size_col = reader.col("hidden_size")?;
+        let num_token_col = reader.col("num_token")?;
+        let num_topk_col = reader.col("num_topk")?;
+        let num_experts_col = reader.col("num_experts")?;
+        let dispatch_transmit_us_col = reader.col_optional("dispatch_transmit_us");
+        let dispatch_notify_us_col = reader.col_optional("dispatch_notify_us");
+        let combine_transmit_us_col = reader.col_optional("combine_transmit_us");
+        let combine_notify_us_col = reader.col_optional("combine_notify_us");
+        let ks_col = reader.col_optional("kernel_source");
+        // Per-source last-wins (byte-identical to the original single-file loader).
+        let mut source_map: BTreeMap<DispatchKey, BTreeMap<u32, DispatchPoint>> = BTreeMap::new();
+        for row in reader.rows()? {
+            let row = row?;
+            if !kernel_source_ok(source.kernel_sources(), ks_col, &row)? {
+                continue;
+            }
+            let key = DispatchKey {
+                node_num: row.u32(node_num_col)?,
+                hidden_size: row.u32(hidden_size_col)?,
+                num_topk: row.u32(num_topk_col)?,
+                num_experts: row.u32(num_experts_col)?,
+            };
+            source_map.entry(key).or_default().insert(
+                row.u32(num_token_col)?,
+                DispatchPoint {
+                    dispatch_transmit_us: row.f64_optional(dispatch_transmit_us_col)?.unwrap_or(0.0),
+                    dispatch_notify_us: row.f64_optional(dispatch_notify_us_col)?.unwrap_or(0.0),
+                    combine_transmit_us: row.f64_optional(combine_transmit_us_col)?.unwrap_or(0.0),
+                    combine_notify_us: row.f64_optional(combine_notify_us_col)?.unwrap_or(0.0),
+                    combine_avg_t_us: 0.0,
+                    dispatch_avg_t_us: 0.0,
+                },
+            );
+        }
+        // Fold into the global map: earlier (higher-priority) source wins.
+        for (key, tokens) in source_map {
+            let dest = by_keys.entry(key).or_default();
+            for (token, point) in tokens {
+                dest.entry(token).or_insert(point);
+            }
+        }
     }
-    if by_keys.is_empty() {
+    if !any_source || by_keys.is_empty() {
         return Err(AicError::PerfDatabase(format!(
-            "no DeepEP-normal rows loaded from {}",
-            path.display()
+            "no DeepEP-normal rows loaded from {} source(s) (first: {})",
+            sources.len(),
+            sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
         )));
     }
     Ok(DispatchGrids { by_keys })
 }
 
-fn load_deepep_ll_parquet(path: &Path) -> Result<DispatchGrids, AicError> {
-    let reader = PerfReader::open(path)?;
-    let node_num_col = reader.col("node_num")?;
-    let hidden_size_col = reader.col("hidden_size")?;
-    let num_token_col = reader.col("num_token")?;
-    let num_topk_col = reader.col("num_topk")?;
-    let num_experts_col = reader.col("num_experts")?;
-    let combine_avg_t_us_col = reader.col_optional("combine_avg_t_us");
-    let dispatch_avg_t_us_col = reader.col_optional("dispatch_avg_t_us");
-
+/// Load the DeepEP low-latency dispatch table from an ordered source list. Same
+/// two-level merge (within-file last-wins, cross-source first-wins) and
+/// missing-file-skip semantics as [`load_deepep_normal_parquet`].
+fn load_deepep_ll_parquet(sources: &[PerfSource]) -> Result<DispatchGrids, AicError> {
     let mut by_keys: BTreeMap<DispatchKey, BTreeMap<u32, DispatchPoint>> = BTreeMap::new();
-    for row in reader.rows()? {
-        let row = row?;
-        let key = DispatchKey {
-            node_num: row.u32(node_num_col)?,
-            hidden_size: row.u32(hidden_size_col)?,
-            num_topk: row.u32(num_topk_col)?,
-            num_experts: row.u32(num_experts_col)?,
-        };
-        by_keys.entry(key).or_default().insert(
-            row.u32(num_token_col)?,
-            DispatchPoint {
-                dispatch_transmit_us: 0.0,
-                dispatch_notify_us: 0.0,
-                combine_transmit_us: 0.0,
-                combine_notify_us: 0.0,
-                combine_avg_t_us: row.f64_optional(combine_avg_t_us_col)?.unwrap_or(0.0),
-                dispatch_avg_t_us: row.f64_optional(dispatch_avg_t_us_col)?.unwrap_or(0.0),
-            },
-        );
+    let mut any_source = false;
+    for source in sources {
+        let path = source.path();
+        if !path.exists() {
+            continue;
+        }
+        any_source = true;
+        let reader = PerfReader::open(path)?;
+        let node_num_col = reader.col("node_num")?;
+        let hidden_size_col = reader.col("hidden_size")?;
+        let num_token_col = reader.col("num_token")?;
+        let num_topk_col = reader.col("num_topk")?;
+        let num_experts_col = reader.col("num_experts")?;
+        let combine_avg_t_us_col = reader.col_optional("combine_avg_t_us");
+        let dispatch_avg_t_us_col = reader.col_optional("dispatch_avg_t_us");
+        let ks_col = reader.col_optional("kernel_source");
+        // Per-source last-wins (byte-identical to the original single-file loader).
+        let mut source_map: BTreeMap<DispatchKey, BTreeMap<u32, DispatchPoint>> = BTreeMap::new();
+        for row in reader.rows()? {
+            let row = row?;
+            if !kernel_source_ok(source.kernel_sources(), ks_col, &row)? {
+                continue;
+            }
+            let key = DispatchKey {
+                node_num: row.u32(node_num_col)?,
+                hidden_size: row.u32(hidden_size_col)?,
+                num_topk: row.u32(num_topk_col)?,
+                num_experts: row.u32(num_experts_col)?,
+            };
+            source_map.entry(key).or_default().insert(
+                row.u32(num_token_col)?,
+                DispatchPoint {
+                    dispatch_transmit_us: 0.0,
+                    dispatch_notify_us: 0.0,
+                    combine_transmit_us: 0.0,
+                    combine_notify_us: 0.0,
+                    combine_avg_t_us: row.f64_optional(combine_avg_t_us_col)?.unwrap_or(0.0),
+                    dispatch_avg_t_us: row.f64_optional(dispatch_avg_t_us_col)?.unwrap_or(0.0),
+                },
+            );
+        }
+        // Fold into the global map: earlier (higher-priority) source wins.
+        for (key, tokens) in source_map {
+            let dest = by_keys.entry(key).or_default();
+            for (token, point) in tokens {
+                dest.entry(token).or_insert(point);
+            }
+        }
     }
-    if by_keys.is_empty() {
+    if !any_source || by_keys.is_empty() {
         return Err(AicError::PerfDatabase(format!(
-            "no DeepEP-LL rows loaded from {}",
-            path.display()
+            "no DeepEP-LL rows loaded from {} source(s) (first: {})",
+            sources.len(),
+            sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
         )));
     }
     Ok(DispatchGrids { by_keys })

--- a/rust/aiconfigurator-core/src/perf_database/wideep_mla.rs
+++ b/rust/aiconfigurator-core/src/perf_database/wideep_mla.rs
@@ -39,6 +39,8 @@ use std::sync::OnceLock;
 
 use crate::common::enums::{FmhaQuantMode, KvCacheQuantMode};
 use crate::common::error::AicError;
+use crate::config::{PerfDbSources, PerfSource};
+use super::{kernel_source_ok, resolve_op_sources};
 use super::interpolation::{interp_2d_1d_grid_extrapolate_inner, Grid3};
 use crate::perf_database::parquet_loader::PerfReader;
 
@@ -46,6 +48,11 @@ use crate::perf_database::parquet_loader::PerfReader;
 /// query.
 pub struct WideEpMlaTable {
     data_root: PathBuf,
+    /// Ordered, priority-sorted sources for each WideEP MLA perf file
+    /// (shared-layer aware; see [`PerfSource`]). Single-primary, no-filter by
+    /// default (`WideEpMlaTable::new`).
+    context_sources: Vec<PerfSource>,
+    generation_sources: Vec<PerfSource>,
     context: OnceLock<Result<WideEpContextMlaGrids, AicError>>,
     generation: OnceLock<Result<WideEpGenerationMlaGrids, AicError>>,
 }
@@ -77,9 +84,28 @@ pub struct GenerationKey {
 }
 
 impl WideEpMlaTable {
+    /// Construct an empty table for the given data directory. No I/O. Each
+    /// perf file is sourced solely from `data_root/<basename>` with no
+    /// `kernel_source` filter (pre-shared-layer behaviour).
     pub fn new(data_root: PathBuf) -> Self {
+        Self::with_sources(data_root, &PerfDbSources::default())
+    }
+
+    /// Construct with shared-layer (sibling/cross-version) sources resolved from
+    /// `perf_db_sources` (Python-supplied). Each WideEP MLA file falls back to
+    /// its primary `data_root/<basename>` when absent from the map. No I/O.
+    pub fn with_sources(data_root: PathBuf, perf_db_sources: &PerfDbSources) -> Self {
+        let context_sources =
+            resolve_op_sources(perf_db_sources, "wideep_context_mla_perf.parquet", &data_root);
+        let generation_sources = resolve_op_sources(
+            perf_db_sources,
+            "wideep_generation_mla_perf.parquet",
+            &data_root,
+        );
         Self {
             data_root,
+            context_sources,
+            generation_sources,
             context: OnceLock::new(),
             generation: OnceLock::new(),
         }
@@ -144,91 +170,126 @@ impl WideEpMlaTable {
     }
 
     fn load_context(&self) -> Result<&WideEpContextMlaGrids, AicError> {
-        let cell = self.context.get_or_init(|| {
-            load_context_parquet(&self.data_root.join("wideep_context_mla_perf.parquet"))
-        });
+        let cell = self
+            .context
+            .get_or_init(|| load_context_parquet(&self.context_sources));
         cell.as_ref().map_err(clone_err)
     }
 
     fn load_generation(&self) -> Result<&WideEpGenerationMlaGrids, AicError> {
-        let cell = self.generation.get_or_init(|| {
-            load_generation_parquet(&self.data_root.join("wideep_generation_mla_perf.parquet"))
-        });
+        let cell = self
+            .generation
+            .get_or_init(|| load_generation_parquet(&self.generation_sources));
         cell.as_ref().map_err(clone_err)
     }
 }
 
-fn load_context_parquet(path: &Path) -> Result<WideEpContextMlaGrids, AicError> {
-    let reader = PerfReader::open(path)?;
-    let kernel_source_col = reader.col("kernel_source")?;
-    let mla_dtype_col = reader.col("mla_dtype")?;
-    let kv_cache_dtype_col = reader.col("kv_cache_dtype")?;
-    let num_heads_col = reader.col("num_heads")?;
-    let batch_size_col = reader.col("batch_size")?;
-    let isl_col = reader.col("isl")?;
-    let latency_col = reader.col("latency")?;
-
+/// Load the WideEP context MLA table from an ordered, priority-sorted source
+/// list. Sources are read in order; the first source containing a shape wins
+/// (`or_insert`), mirroring Python's `_read_filtered_rows` concatenation +
+/// `load_wideep_context_mla_data` skip-on-key-conflict. Missing files are
+/// skipped (a sibling declared in the manifest need not exist for every
+/// system); an error is returned only when no source yields rows.
+fn load_context_parquet(sources: &[PerfSource]) -> Result<WideEpContextMlaGrids, AicError> {
     let mut by_keys: BTreeMap<ContextKey, Grid3<f64>> = BTreeMap::new();
-    for row in reader.rows()? {
-        let row = row?;
-        let key = ContextKey {
-            kernel_source: row.str_owned(kernel_source_col)?,
-            fmha_quant: row.str_owned(mla_dtype_col)?,
-            kv_quant: row.str_owned(kv_cache_dtype_col)?,
-        };
-        // First-wins parity with Python `load_wideep_context_mla_data`.
-        by_keys
-            .entry(key)
-            .or_default()
-            .entry(row.u32(num_heads_col)?)
-            .or_default()
-            .entry(row.u32(isl_col)?)
-            .or_default()
-            .entry(row.u32(batch_size_col)?)
-            .or_insert(row.f64(latency_col)?);
+    let mut any_source = false;
+    for source in sources {
+        let path = source.path();
+        if !path.exists() {
+            continue;
+        }
+        any_source = true;
+        let reader = PerfReader::open(path)?;
+        let kernel_source_col = reader.col("kernel_source")?;
+        let mla_dtype_col = reader.col("mla_dtype")?;
+        let kv_cache_dtype_col = reader.col("kv_cache_dtype")?;
+        let num_heads_col = reader.col("num_heads")?;
+        let batch_size_col = reader.col("batch_size")?;
+        let isl_col = reader.col("isl")?;
+        let latency_col = reader.col("latency")?;
+        let ks_col = reader.col_optional("kernel_source");
+        for row in reader.rows()? {
+            let row = row?;
+            if !kernel_source_ok(source.kernel_sources(), ks_col, &row)? {
+                continue;
+            }
+            let key = ContextKey {
+                kernel_source: row.str_owned(kernel_source_col)?,
+                fmha_quant: row.str_owned(mla_dtype_col)?,
+                kv_quant: row.str_owned(kv_cache_dtype_col)?,
+            };
+            // First-wins parity with Python `load_wideep_context_mla_data`,
+            // extended across shared-layer sources (earlier source wins).
+            by_keys
+                .entry(key)
+                .or_default()
+                .entry(row.u32(num_heads_col)?)
+                .or_default()
+                .entry(row.u32(isl_col)?)
+                .or_default()
+                .entry(row.u32(batch_size_col)?)
+                .or_insert(row.f64(latency_col)?);
+        }
     }
-    if by_keys.is_empty() {
+    if !any_source || by_keys.is_empty() {
         return Err(AicError::PerfDatabase(format!(
-            "no WideEP context MLA rows loaded from {}",
-            path.display()
+            "no WideEP context MLA rows loaded from {} source(s) (first: {})",
+            sources.len(),
+            sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
         )));
     }
     Ok(WideEpContextMlaGrids { by_keys })
 }
 
-fn load_generation_parquet(path: &Path) -> Result<WideEpGenerationMlaGrids, AicError> {
-    let reader = PerfReader::open(path)?;
-    let kernel_source_col = reader.col("kernel_source")?;
-    let kv_cache_dtype_col = reader.col("kv_cache_dtype")?;
-    let num_heads_col = reader.col("num_heads")?;
-    let batch_size_col = reader.col("batch_size")?;
-    let isl_col = reader.col("isl")?;
-    let step_col = reader.col("step")?;
-    let latency_col = reader.col("latency")?;
-
+/// Load the WideEP generation MLA table from an ordered source list. Same
+/// first-wins-across-sources + missing-file-skip semantics as
+/// [`load_context_parquet`].
+fn load_generation_parquet(sources: &[PerfSource]) -> Result<WideEpGenerationMlaGrids, AicError> {
     let mut by_keys: BTreeMap<GenerationKey, Grid3<f64>> = BTreeMap::new();
-    for row in reader.rows()? {
-        let row = row?;
-        let key = GenerationKey {
-            kernel_source: row.str_owned(kernel_source_col)?,
-            kv_quant: row.str_owned(kv_cache_dtype_col)?,
-        };
-        // Python collapses `s = isl + step` into the seq axis.
-        let seq = row.u32(isl_col)? + row.u32(step_col)?;
-        by_keys
-            .entry(key)
-            .or_default()
-            .entry(row.u32(num_heads_col)?)
-            .or_default()
-            .entry(row.u32(batch_size_col)?)
-            .or_default()
-            .entry(seq)
-            .or_insert(row.f64(latency_col)?);
+    let mut any_source = false;
+    for source in sources {
+        let path = source.path();
+        if !path.exists() {
+            continue;
+        }
+        any_source = true;
+        let reader = PerfReader::open(path)?;
+        let kernel_source_col = reader.col("kernel_source")?;
+        let kv_cache_dtype_col = reader.col("kv_cache_dtype")?;
+        let num_heads_col = reader.col("num_heads")?;
+        let batch_size_col = reader.col("batch_size")?;
+        let isl_col = reader.col("isl")?;
+        let step_col = reader.col("step")?;
+        let latency_col = reader.col("latency")?;
+        let ks_col = reader.col_optional("kernel_source");
+        for row in reader.rows()? {
+            let row = row?;
+            if !kernel_source_ok(source.kernel_sources(), ks_col, &row)? {
+                continue;
+            }
+            let key = GenerationKey {
+                kernel_source: row.str_owned(kernel_source_col)?,
+                kv_quant: row.str_owned(kv_cache_dtype_col)?,
+            };
+            // Python collapses `s = isl + step` into the seq axis.
+            let seq = row.u32(isl_col)? + row.u32(step_col)?;
+            // First-wins parity, extended across shared-layer sources.
+            by_keys
+                .entry(key)
+                .or_default()
+                .entry(row.u32(num_heads_col)?)
+                .or_default()
+                .entry(row.u32(batch_size_col)?)
+                .or_default()
+                .entry(seq)
+                .or_insert(row.f64(latency_col)?);
+        }
     }
-    if by_keys.is_empty() {
+    if !any_source || by_keys.is_empty() {
         return Err(AicError::PerfDatabase(format!(
-            "no WideEP generation MLA rows loaded from {}",
-            path.display()
+            "no WideEP generation MLA rows loaded from {} source(s) (first: {})",
+            sources.len(),
+            sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
         )));
     }
     Ok(WideEpGenerationMlaGrids { by_keys })

--- a/rust/aiconfigurator-core/src/perf_database/wideep_moe.rs
+++ b/rust/aiconfigurator-core/src/perf_database/wideep_moe.rs
@@ -27,16 +27,22 @@
 //! variants used by the TRT-LLM WideEP path).
 
 use std::collections::BTreeMap;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::OnceLock;
 
 use crate::common::enums::MoeQuantMode;
 use crate::common::error::AicError;
+use crate::config::{PerfDbSources, PerfSource};
+use super::{kernel_source_ok, resolve_op_sources};
 use super::interpolation::{interp_1d, nearest_neighbors};
 use crate::perf_database::parquet_loader::PerfReader;
 
 pub struct WideEpMoeTable {
     data_root: PathBuf,
+    /// Ordered, priority-sorted sources for the WideEP MoE compute perf file
+    /// (shared-layer aware; see [`PerfSource`]). Single-primary, no-filter by
+    /// default (`WideEpMoeTable::new`).
+    wideep_moe_sources: Vec<PerfSource>,
     compute: OnceLock<Result<WideEpMoeGrids, AicError>>,
 }
 
@@ -65,9 +71,22 @@ pub struct WideEpMoeKey {
 const DEFAULT_KERNEL_SOURCE: &str = "moe_torch_flow";
 
 impl WideEpMoeTable {
+    /// Construct an empty table for the given data directory. No I/O. The perf
+    /// file is sourced solely from `data_root/wideep_moe_perf.parquet` with no
+    /// `kernel_source` filter (pre-shared-layer behaviour).
     pub fn new(data_root: PathBuf) -> Self {
+        Self::with_sources(data_root, &PerfDbSources::default())
+    }
+
+    /// Construct with shared-layer (sibling/cross-version) sources resolved from
+    /// `perf_db_sources` (Python-supplied). Falls back to the primary
+    /// `data_root/wideep_moe_perf.parquet` when absent from the map. No I/O.
+    pub fn with_sources(data_root: PathBuf, perf_db_sources: &PerfDbSources) -> Self {
+        let wideep_moe_sources =
+            resolve_op_sources(perf_db_sources, "wideep_moe_perf.parquet", &data_root);
         Self {
             data_root,
+            wideep_moe_sources,
             compute: OnceLock::new(),
         }
     }
@@ -176,58 +195,76 @@ impl WideEpMoeTable {
     fn load_compute(&self) -> Result<&WideEpMoeGrids, AicError> {
         let cell = self
             .compute
-            .get_or_init(|| load_compute_parquet(&self.data_root.join("wideep_moe_perf.parquet")));
+            .get_or_init(|| load_compute_parquet(&self.wideep_moe_sources));
         cell.as_ref().map_err(clone_err)
     }
 }
 
-fn load_compute_parquet(path: &Path) -> Result<WideEpMoeGrids, AicError> {
-    let reader = PerfReader::open(path)?;
-    let kernel_source_col = reader.col_optional("kernel_source");
-    let moe_dtype_col = reader.col("moe_dtype")?;
-    let num_tokens_col = reader.col("num_tokens")?;
-    let hidden_size_col = reader.col("hidden_size")?;
-    let inter_size_col = reader.col("inter_size")?;
-    let topk_col = reader.col("topk")?;
-    let num_experts_col = reader.col("num_experts")?;
-    let num_slots_col = reader.col("num_slots")?;
-    let moe_tp_size_col = reader.col("moe_tp_size")?;
-    let moe_ep_size_col = reader.col("moe_ep_size")?;
-    let distribution_col = reader.col("distribution")?;
-    let latency_col = reader.col("latency")?;
-
+/// Load the WideEP MoE compute table from an ordered, priority-sorted source
+/// list. Sources are read in order; the first source containing a key wins
+/// (`or_insert`). Missing files are skipped (a sibling declared in the manifest
+/// need not exist for every system); an error is returned only when no source
+/// yields rows.
+fn load_compute_parquet(sources: &[PerfSource]) -> Result<WideEpMoeGrids, AicError> {
     let mut by_keys: BTreeMap<WideEpMoeKey, BTreeMap<u32, f64>> = BTreeMap::new();
-    for row in reader.rows()? {
-        let row = row?;
-        // `kernel_source` is optional/nullable in the perf file; default to
-        // "moe_torch_flow" when absent, matching Python's loader.
-        let kernel_source = row
-            .str_optional(kernel_source_col)?
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| DEFAULT_KERNEL_SOURCE.to_string());
-        let key = WideEpMoeKey {
-            kernel_source,
-            quant: row.str_owned(moe_dtype_col)?,
-            distribution: row.str_owned(distribution_col)?,
-            topk: row.u32(topk_col)?,
-            num_experts: row.u32(num_experts_col)?,
-            hidden_size: row.u32(hidden_size_col)?,
-            inter_size: row.u32(inter_size_col)?,
-            num_slots: row.u32(num_slots_col)?,
-            moe_tp_size: row.u32(moe_tp_size_col)?,
-            moe_ep_size: row.u32(moe_ep_size_col)?,
-        };
-        // First-wins parity with Python loader.
-        by_keys
-            .entry(key)
-            .or_default()
-            .entry(row.u32(num_tokens_col)?)
-            .or_insert(row.f64(latency_col)?);
+    let mut any_source = false;
+    for source in sources {
+        let path = source.path();
+        if !path.exists() {
+            continue;
+        }
+        any_source = true;
+        let reader = PerfReader::open(path)?;
+        let kernel_source_col = reader.col_optional("kernel_source");
+        let moe_dtype_col = reader.col("moe_dtype")?;
+        let num_tokens_col = reader.col("num_tokens")?;
+        let hidden_size_col = reader.col("hidden_size")?;
+        let inter_size_col = reader.col("inter_size")?;
+        let topk_col = reader.col("topk")?;
+        let num_experts_col = reader.col("num_experts")?;
+        let num_slots_col = reader.col("num_slots")?;
+        let moe_tp_size_col = reader.col("moe_tp_size")?;
+        let moe_ep_size_col = reader.col("moe_ep_size")?;
+        let distribution_col = reader.col("distribution")?;
+        let latency_col = reader.col("latency")?;
+
+        for row in reader.rows()? {
+            let row = row?;
+            if !kernel_source_ok(source.kernel_sources(), kernel_source_col, &row)? {
+                continue;
+            }
+            // `kernel_source` is optional/nullable in the perf file; default to
+            // "moe_torch_flow" when absent, matching Python's loader.
+            let kernel_source = row
+                .str_optional(kernel_source_col)?
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| DEFAULT_KERNEL_SOURCE.to_string());
+            let key = WideEpMoeKey {
+                kernel_source,
+                quant: row.str_owned(moe_dtype_col)?,
+                distribution: row.str_owned(distribution_col)?,
+                topk: row.u32(topk_col)?,
+                num_experts: row.u32(num_experts_col)?,
+                hidden_size: row.u32(hidden_size_col)?,
+                inter_size: row.u32(inter_size_col)?,
+                num_slots: row.u32(num_slots_col)?,
+                moe_tp_size: row.u32(moe_tp_size_col)?,
+                moe_ep_size: row.u32(moe_ep_size_col)?,
+            };
+            // First-wins parity with Python loader, extended across shared-layer
+            // sources (earlier source wins).
+            by_keys
+                .entry(key)
+                .or_default()
+                .entry(row.u32(num_tokens_col)?)
+                .or_insert(row.f64(latency_col)?);
+        }
     }
-    if by_keys.is_empty() {
+    if !any_source || by_keys.is_empty() {
         return Err(AicError::PerfDatabase(format!(
-            "no WideEP MoE compute rows loaded from {}",
-            path.display()
+            "no WideEP MoE compute rows loaded from {} source(s) (first: {})",
+            sources.len(),
+            sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
         )));
     }
     Ok(WideEpMoeGrids { by_keys })

--- a/rust/aiconfigurator-core/src/py.rs
+++ b/rust/aiconfigurator-core/src/py.rs
@@ -692,6 +692,7 @@ mod tests {
                 name: "rmsnorm".into(),
                 scale_factor: 1.0,
                 bytes_per_token: 8192.0,
+                seq_split: 1,
             }),
             Op::Gemm(GemmOp {
                 name: "qkv_gemm".into(),
@@ -701,6 +702,7 @@ mod tests {
                 quant_mode: GemmQuantMode::Fp8Block,
                 scale_num_tokens: 0,
                 low_precision_input: false,
+                seq_split: 1,
             }),
             Op::ContextAttention(ContextAttentionOp {
                 name: "context_attention".into(),
@@ -712,6 +714,7 @@ mod tests {
                 kv_cache_dtype: KvCacheQuantMode::Fp8,
                 fmha_quant_mode: FmhaQuantMode::Bfloat16,
                 use_qk_norm: false,
+                cp_size: 1,
             }),
         ]
     }
@@ -724,6 +727,7 @@ mod tests {
                 name: "rmsnorm".into(),
                 scale_factor: 1.0,
                 bytes_per_token: 8192.0,
+                seq_split: 1,
             }),
             Op::GenerationAttention(GenerationAttentionOp {
                 name: "generation_attention".into(),
@@ -752,6 +756,7 @@ mod tests {
                 attention_dp_size: Some(1),
                 moe_tp_size: Some(1),
                 moe_ep_size: Some(8),
+                cp_size: None,
             },
             quantization: QuantizationConfig {
                 weight_dtype: None,
@@ -760,6 +765,7 @@ mod tests {
                 kv_cache_dtype: None,
             },
             speculative: None,
+            perf_db_sources: Default::default(),
             extra: BTreeMap::new(),
         }
     }

--- a/rust/aiconfigurator-core/tests/memory_round_trip.rs
+++ b/rust/aiconfigurator-core/tests/memory_round_trip.rs
@@ -95,6 +95,7 @@ fn request(tolerance_fraction: Option<f64>) -> KvCacheEstimateRequest {
                 attention_dp_size: Some(1),
                 moe_tp_size: None,
                 moe_ep_size: None,
+                cp_size: None,
             },
             quantization: QuantizationConfig {
                 weight_dtype: None,
@@ -103,6 +104,7 @@ fn request(tolerance_fraction: Option<f64>) -> KvCacheEstimateRequest {
                 kv_cache_dtype: None,
             },
             speculative: None,
+            perf_db_sources: BTreeMap::new(),
             extra: BTreeMap::new(),
         },
         max_num_tokens: 8192,

--- a/src/aiconfigurator/sdk/engine.py
+++ b/src/aiconfigurator/sdk/engine.py
@@ -34,6 +34,7 @@ The live ``rust_engine_step.py`` helpers build on this path.
 from __future__ import annotations
 
 import json
+import os
 from typing import Any
 
 import aiconfigurator_core
@@ -123,6 +124,7 @@ def _gemm(op: GEMM) -> dict:
         "quant_mode": _quant_name(op._quant_mode),
         "scale_num_tokens": op._scale_num_tokens,
         "low_precision_input": op._low_precision_input,
+        "seq_split": op._seq_split,
     }
 
 
@@ -136,6 +138,7 @@ def _embedding(op: Embedding) -> dict:
         # query ignores it (memory-only op). Bfloat16 is the neutral value the
         # Rust builders use for embeddings.
         "quant_mode": "bfloat16",
+        "seq_split": op._seq_split,
     }
 
 
@@ -149,6 +152,7 @@ def _elementwise(op: ElementWise) -> dict:
         "name": op._name,
         "scale_factor": op._scale_factor,
         "bytes_per_token": float(bytes_per_token),
+        "seq_split": op._seq_split,
     }
 
 
@@ -163,6 +167,7 @@ def _context_attention(op: ContextAttention) -> dict:
         "kv_cache_dtype": _quant_name(op._kvcache_quant_mode),
         "fmha_quant_mode": _quant_name(op._fmha_quant_mode),
         "use_qk_norm": op._use_qk_norm,
+        "cp_size": op._cp_size,
     }
 
 
@@ -195,6 +200,7 @@ def _context_mla(op: ContextMLA) -> dict:
         "num_heads": op._num_heads,
         "kv_cache_dtype": _quant_name(op._kvcache_quant_mode),
         "fmha_quant_mode": _quant_name(op._fmha_quant_mode),
+        "cp_size": op._cp_size,
     }
 
 
@@ -238,6 +244,7 @@ def _moe(op: MoE) -> dict:
         "num_experts": op._num_experts,
         "moe_tp_size": op._moe_tp_size,
         "moe_ep_size": op._moe_ep_size,
+        "attention_dp_size": op._attention_dp_size,
         "quant_mode": _quant_name(op._quant_mode),
         "workload_distribution": op._workload_distribution,
         "is_gated": op._is_gated,
@@ -282,6 +289,8 @@ def _moe_dispatch(op: MoEDispatch, *, backend: str) -> dict:
         "flavor": _dispatch_flavor(backend),
         "comm_quant": "half",
         "moe_quant": _quant_name(quant) if quant is not None else "bfloat16",
+        "attn_cp_size": op._attn_cp_size,
+        "is_context": op._is_context,
     }
 
 
@@ -292,6 +301,7 @@ def _custom_all_reduce(op: CustomAllReduce) -> dict:
         "hidden_size": op._h,
         "tp_size": op._tp_size,
         "quant": "half",
+        "seq_split": op._seq_split,
     }
 
 
@@ -303,6 +313,7 @@ def _nccl(op: NCCL) -> dict:
         "num_gpus": op._num_gpus,
         "dtype": "half",
         "operation": op._nccl_op,
+        "seq_split": op._seq_split,
     }
 
 
@@ -312,6 +323,7 @@ def _p2p(op: P2P) -> dict:
         "scale_factor": op._scale_factor,
         "pp_size": op._pp_size,
         "hidden_size": op._h,
+        "seq_split": op._seq_split,
     }
 
 
@@ -563,6 +575,38 @@ def _to_opspec(op: Any, *, backend: str, architecture: str, database: Any) -> di
 # --------------------------------------------------------------------------- #
 
 
+def _compute_perf_db_sources(database: Any) -> dict:
+    """Resolve the shared-layer (sibling/cross-version) source list per op file
+    from the Python ``database``, so the Rust core can load the SAME rows Python
+    does under SILICON/HYBRID.
+
+    Returns ``{op_file_basename: [[abs_path, [kernel_sources] | None], ...]}``.
+    ``_build_op_sources`` returns just ``[(primary, None)]`` when the shared
+    layer is off or an op has no inheritable siblings, so the Rust side falls
+    back to its primary ``data_root`` behaviour for those. Returns ``{}`` when a
+    database is unavailable or introspection fails (Rust then uses its
+    single-``data_root`` default). Discovery stays here (single source of truth)
+    rather than being reimplemented in Rust.
+    """
+    if database is None:
+        return {}
+    try:
+        from aiconfigurator.sdk.common import PerfDataFilename
+
+        system_data_root = os.path.join(database.systems_root, database.system_spec["data_dir"])
+        data_dir = os.path.join(system_data_root, database.backend, database.version)
+        out: dict[str, list] = {}
+        for filename_enum in PerfDataFilename:
+            primary_path = os.path.join(data_dir, filename_enum.value)
+            sources = database._build_op_sources(filename_enum, primary_path, system_data_root)
+            out[filename_enum.value] = [
+                [os.path.abspath(path), (sorted(ks) if ks is not None else None)] for path, ks in sources
+            ]
+        return out
+    except Exception:
+        return {}
+
+
 def _engine_config_dict(
     *,
     model: Any,
@@ -574,6 +618,7 @@ def _engine_config_dict(
     systems_path: str | None,
     nextn: int,
     nextn_accept_rates: list[float] | None,
+    database: Any = None,
 ) -> dict:
     """Build the ``EngineConfig`` JSON (matches the Rust modularised struct).
 
@@ -609,11 +654,16 @@ def _engine_config_dict(
         "attention_dp_size": _opt_int(getattr(cfg, "attention_dp_size", None)),
         "moe_tp_size": _opt_int(getattr(cfg, "moe_tp_size", None)),
         "moe_ep_size": _opt_int(getattr(cfg, "moe_ep_size", None)),
+        "cp_size": _opt_int(getattr(cfg, "cp_size", None)),
         # QuantizationConfig (flattened)
         "weight_dtype": _rust_quant_to_dtype(getattr(cfg, "gemm_quant_mode", None)),
         "moe_dtype": _rust_moe_quant_to_dtype(getattr(cfg, "moe_quant_mode", None)),
         "activation_dtype": _rust_quant_to_dtype(getattr(cfg, "fmha_quant_mode", None)),
         "kv_cache_dtype": _rust_quant_to_dtype(getattr(cfg, "kvcache_quant_mode", None)),
+        # Shared-layer (sibling/cross-version) per-op perf-data sources, resolved
+        # in Python so the Rust core inherits the same rows. Empty/absent = Rust
+        # uses its single-``data_root`` default (back-compat with old specs).
+        "perf_db_sources": _compute_perf_db_sources(database),
         "extra": {},
     }
     # SpeculativeConfig (flattened, Option<>): emit nextn/nextn_accept_rates at
@@ -752,6 +802,7 @@ def build_engine_spec_json(
             systems_path=systems_path,
             nextn=nextn,
             nextn_accept_rates=nextn_accept_rates,
+            database=database,
         ),
         "context_ops": context_ops,
         "generation_ops": generation_ops,

--- a/src/aiconfigurator/sdk/rust_engine_step.py
+++ b/src/aiconfigurator/sdk/rust_engine_step.py
@@ -396,6 +396,8 @@ def _engine_config_json(model: Any, database: Any) -> str:
         "moe_tp_size": _optional_int(getattr(model_config, "moe_tp_size", None)),
         "moe_ep_size": _optional_int(getattr(model_config, "moe_ep_size", None)),
         "attention_dp_size": _optional_int(getattr(model_config, "attention_dp_size", None)),
+        # Part of the engine identity so cp variants get distinct cached handles.
+        "cp_size": _optional_int(getattr(model_config, "cp_size", None)),
         "weight_dtype": _quant_to_dtype(getattr(model_config, "gemm_quant_mode", None)),
         "moe_dtype": _moe_quant_to_dtype(getattr(model_config, "moe_quant_mode", None)),
         "activation_dtype": _quant_to_dtype(getattr(model_config, "fmha_quant_mode", None)),


### PR DESCRIPTION
#### Overview:

Backports #1313 to `release/0.10.0`. Brings the Rust engine-step core up to parity with the Python reference: context-parallelism support, the latest perf-DB refactors (shared-layer inheritance, DSA boundary-utilization, MoE attention-DP token scaling), a Rust/Python engine-step parity CI gate, and gates the flaky Spica thorough-e2e job to manual runs.

#### Details:

Cherry-pick of the squashed commit from #1313. The Rust source and the parity suite apply **cleanly** and are unchanged from #1313.

**One release-specific deviation** (flagged per backport policy): the new `rust-engine-step-parity` CI job builds `aiconfigurator_core` via `maturin develop` from the core-wheel package dir `src/aiconfigurator-core/` (whose `[tool.maturin] manifest-path` points at `rust/aiconfigurator-core/Cargo.toml`) instead of from the repo root. On `main`, #1283 made the repo-root `pyproject.toml` a maturin project; on `release/0.10.0` the root is still `setuptools` (the root-wheel repackaging, backport #1300, is not yet merged here), so building from root would fail. Only the CI build step's `working-directory` + its comment differ from #1313.

**Validation on `release/0.10.0`:** `cargo check --tests` clean; core builds from `src/aiconfigurator-core/`; the full engine-step parity suite passes **227/227** locally.

#### Where should the reviewer start?

- `.github/workflows/build-test.yml` — the `rust-engine-step-parity` job's build step (the only deviation from #1313).
- `rust/aiconfigurator-core/src/perf_database/` and `src/operators/attention.rs`, `mla.rs` — the core parity changes.

#### Related Issues:

- Relates to #1313