### PR TITLE
fix(rust-core): validate engine-spec schema version before decoding op payloads

### DIFF
--- a/rust/aiconfigurator-core/src/config.rs
+++ b/rust/aiconfigurator-core/src/config.rs
@@ -15,7 +15,13 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 
 pub const ENGINE_CONFIG_SCHEMA_VERSION: u32 = 1;
-pub const ENGINE_SPEC_SCHEMA_VERSION: u32 = 1;
+// Bumped to 2 for the 0.10.0 op-payload layout change (context-parallelism +
+// perf-DB refactor added serialized fields such as `seq_split` / `cp_size` to
+// `OpSpec`). bincode op payloads are positional, so a producer/consumer skew is
+// only distinguishable by this version — `EngineSpec::from_bincode` reads and
+// checks it before decoding the op lists. Bump whenever an `OpSpec` field
+// changes; keep in lockstep with `sdk/engine.py::ENGINE_SPEC_SCHEMA_VERSION`.
+pub const ENGINE_SPEC_SCHEMA_VERSION: u32 = 2;
 
 /// Static engine identity and setup information carried by an
 /// [`crate::engine::spec::EngineSpec`].

--- a/rust/aiconfigurator-core/src/engine/spec.rs
+++ b/rust/aiconfigurator-core/src/engine/spec.rs
@@ -691,4 +691,106 @@ mod tests {
             ),
         }
     }
+
+    /// Canonical valid spec used by the handshake tests below.
+    fn handshake_spec() -> EngineSpec {
+        EngineSpec::new(
+            sample_engine_config(),
+            vec![OpSpec::Gemm(gemm()), OpSpec::ContextAttention(context_attention())],
+            vec![OpSpec::GenerationAttention(generation_attention())],
+        )
+    }
+
+    /// Round-trip preserves the stamped schema version end to end.
+    #[test]
+    fn from_bincode_round_trips_and_preserves_version() {
+        let spec = handshake_spec();
+        let decoded =
+            EngineSpec::from_bincode(&spec.to_bincode().expect("to_bincode")).expect("from_bincode");
+        assert_eq!(decoded, spec);
+        assert_eq!(decoded.schema_version, ENGINE_SPEC_SCHEMA_VERSION);
+    }
+
+    /// A buffer too short to even hold the 4-byte version prefix must fail at the
+    /// prefix stage, not deep in the (absent) payload.
+    #[test]
+    fn from_bincode_rejects_empty_buffer() {
+        match EngineSpec::from_bincode(&[]) {
+            Err(AicError::EngineSpec(msg)) => {
+                assert!(
+                    msg.contains("schema_version prefix"),
+                    "message should name the prefix stage, got: {msg}"
+                );
+            }
+            other => panic!("expected EngineSpec prefix error, got {other:?}"),
+        }
+    }
+
+    /// The version gate fires even when the op payload is fully intact — the
+    /// rejection is driven by the version alone, not by a decode failure.
+    #[test]
+    fn from_bincode_version_gate_fires_with_intact_payload() {
+        let mut bytes = handshake_spec().to_bincode().expect("to_bincode");
+        let foreign = ENGINE_SPEC_SCHEMA_VERSION + 7;
+        bytes[..4].copy_from_slice(&foreign.to_le_bytes()); // only the prefix changes
+
+        match EngineSpec::from_bincode(&bytes) {
+            Err(AicError::UnsupportedSchemaVersion { kind, got, expected }) => {
+                assert_eq!(kind, "EngineSpec");
+                assert_eq!(got, foreign);
+                assert_eq!(expected, ENGINE_SPEC_SCHEMA_VERSION);
+            }
+            other => panic!("expected UnsupportedSchemaVersion, got {other:?}"),
+        }
+    }
+
+    /// A correct version but an undecodable op payload is NOT a version skew: it
+    /// must surface as an op-payload-stage `EngineSpec` error (op-layout drift
+    /// within a version, or corruption), naming the stage and the version.
+    #[test]
+    fn from_bincode_matching_version_corrupt_ops_names_op_payload_stage() {
+        let mut bytes = handshake_spec().to_bincode().expect("to_bincode");
+        // Leave the version prefix intact; corrupt the trailing op payload.
+        bytes.truncate(bytes.len() - 8);
+
+        match EngineSpec::from_bincode(&bytes) {
+            Err(AicError::EngineSpec(msg)) => {
+                assert!(
+                    msg.contains("op payloads"),
+                    "message should name the op-payload stage, got: {msg}"
+                );
+                assert!(
+                    msg.contains(&ENGINE_SPEC_SCHEMA_VERSION.to_string()),
+                    "message should cite the matching version, got: {msg}"
+                );
+            }
+            other => panic!("expected EngineSpec op-payload error, got {other:?}"),
+        }
+    }
+
+    /// A well-formed wire buffer whose embedded `engine_json` is not valid JSON
+    /// must fail at the engine-JSON stage (after the version gate and op decode
+    /// both pass), naming that stage.
+    #[test]
+    fn from_bincode_invalid_engine_json_names_json_stage() {
+        // Hand-build a wire buffer with the current version, empty op lists, and
+        // a deliberately malformed `engine_json`.
+        let wire = BincodeWire {
+            schema_version: ENGINE_SPEC_SCHEMA_VERSION,
+            engine_json: "this is not json".to_string(),
+            context_ops: vec![],
+            generation_ops: vec![],
+        };
+        let bytes = bincode::serialize(&wire).expect("serialize wire");
+
+        match EngineSpec::from_bincode(&bytes) {
+            Err(AicError::EngineSpec(msg)) => {
+                assert!(
+                    msg.contains("engine JSON"),
+                    "message should name the engine-JSON stage, got: {msg}"
+                );
+            }
+            other => panic!("expected EngineSpec engine-JSON error, got {other:?}"),
+        }
+    }
 }

--- a/rust/aiconfigurator-core/src/engine/spec.rs
+++ b/rust/aiconfigurator-core/src/engine/spec.rs
@@ -98,16 +98,30 @@ impl EngineSpec {
     }
 
     /// Deserialize from the bincode wire format produced by [`Self::to_bincode`].
+    ///
+    /// The `schema_version` prefix is read and validated **before** the
+    /// variable-layout op payloads are decoded. bincode is not self-describing,
+    /// so a producer/consumer op-layout skew (e.g. a newer producer that added
+    /// serialized fields to an `OpSpec`) would otherwise fail deep inside the
+    /// payload with a generic `bincode decode: io error`, masking the real
+    /// cause. Reading the leading version first lets a version mismatch surface
+    /// as a clear [`AicError::UnsupportedSchemaVersion`] instead.
     pub fn from_bincode(bytes: &[u8]) -> Result<Self, AicError> {
-        let wire: BincodeWire = bincode::deserialize(bytes)
-            .map_err(|e| AicError::EngineSpec(format!("bincode decode: {e}")))?;
-        if wire.schema_version != ENGINE_SPEC_SCHEMA_VERSION {
+        // `schema_version` is the first field of `BincodeWire`, so it is the
+        // first value in the byte stream. Decode just it and gate on it before
+        // touching the op lists (which is where a layout skew would fail).
+        let mut cursor = std::io::Cursor::new(bytes);
+        let schema_version: u32 = bincode::deserialize_from(&mut cursor)
+            .map_err(|e| AicError::EngineSpec(format!("bincode decode schema version: {e}")))?;
+        if schema_version != ENGINE_SPEC_SCHEMA_VERSION {
             return Err(AicError::UnsupportedSchemaVersion {
                 kind: "EngineSpec",
-                got: wire.schema_version,
+                got: schema_version,
                 expected: ENGINE_SPEC_SCHEMA_VERSION,
             });
         }
+        let wire: BincodeWire = bincode::deserialize(bytes)
+            .map_err(|e| AicError::EngineSpec(format!("bincode decode: {e}")))?;
         let engine: EngineConfig = serde_json::from_str(&wire.engine_json)
             .map_err(|e| AicError::EngineSpec(format!("engine JSON decode: {e}")))?;
         Ok(Self {
@@ -624,5 +638,42 @@ mod tests {
         let bytes = spec.to_bincode().expect("to_bincode");
         let decoded = EngineSpec::from_bincode(&bytes).expect("from_bincode");
         assert_eq!(spec, decoded);
+    }
+
+    /// A version skew combined with an op-layout change must surface as a clear
+    /// [`AicError::UnsupportedSchemaVersion`], NOT a generic bincode I/O error.
+    ///
+    /// This reproduces the cross-version failure mode: a producer at a different
+    /// schema version emits op payloads whose layout the consumer cannot decode.
+    /// We simulate it by stamping a foreign version into the leading prefix and
+    /// truncating the op payload. `from_bincode` must read + reject the version
+    /// *before* it attempts to decode the (now-undecodable) op lists.
+    #[test]
+    fn version_skew_reports_unsupported_before_payload_decode() {
+        let spec = EngineSpec::new(
+            sample_engine_config(),
+            vec![OpSpec::Gemm(gemm()), OpSpec::ContextAttention(context_attention())],
+            vec![OpSpec::GenerationAttention(generation_attention())],
+        );
+        let mut bytes = spec.to_bincode().expect("to_bincode");
+
+        // Overwrite the 4-byte little-endian `schema_version` prefix with a
+        // version this consumer does not speak.
+        let foreign = ENGINE_SPEC_SCHEMA_VERSION + 1;
+        bytes[..4].copy_from_slice(&foreign.to_le_bytes());
+        // Corrupt the op payload so a decode-first implementation fails there
+        // with a generic bincode I/O error instead of reaching the version gate.
+        bytes.truncate(bytes.len() - 8);
+
+        match EngineSpec::from_bincode(&bytes) {
+            Err(AicError::UnsupportedSchemaVersion { kind, got, expected }) => {
+                assert_eq!(kind, "EngineSpec");
+                assert_eq!(got, foreign);
+                assert_eq!(expected, ENGINE_SPEC_SCHEMA_VERSION);
+            }
+            other => panic!(
+                "expected UnsupportedSchemaVersion before payload decode, got {other:?}"
+            ),
+        }
     }
 }

--- a/rust/aiconfigurator-core/src/engine/spec.rs
+++ b/rust/aiconfigurator-core/src/engine/spec.rs
@@ -111,8 +111,13 @@ impl EngineSpec {
         // first value in the byte stream. Decode just it and gate on it before
         // touching the op lists (which is where a layout skew would fail).
         let mut cursor = std::io::Cursor::new(bytes);
-        let schema_version: u32 = bincode::deserialize_from(&mut cursor)
-            .map_err(|e| AicError::EngineSpec(format!("bincode decode schema version: {e}")))?;
+        let schema_version: u32 = bincode::deserialize_from(&mut cursor).map_err(|e| {
+            AicError::EngineSpec(format!(
+                "bincode decode of the leading schema_version prefix failed \
+                 (payload is {} bytes; too short or not an EngineSpec wire buffer): {e}",
+                bytes.len()
+            ))
+        })?;
         if schema_version != ENGINE_SPEC_SCHEMA_VERSION {
             return Err(AicError::UnsupportedSchemaVersion {
                 kind: "EngineSpec",
@@ -120,10 +125,20 @@ impl EngineSpec {
                 expected: ENGINE_SPEC_SCHEMA_VERSION,
             });
         }
-        let wire: BincodeWire = bincode::deserialize(bytes)
-            .map_err(|e| AicError::EngineSpec(format!("bincode decode: {e}")))?;
-        let engine: EngineConfig = serde_json::from_str(&wire.engine_json)
-            .map_err(|e| AicError::EngineSpec(format!("engine JSON decode: {e}")))?;
+        let wire: BincodeWire = bincode::deserialize(bytes).map_err(|e| {
+            AicError::EngineSpec(format!(
+                "bincode decode of the op payloads failed at matching \
+                 schema_version {schema_version} — this indicates op-layout drift \
+                 within the same version (an OpSpec changed without a \
+                 ENGINE_SPEC_SCHEMA_VERSION bump) or a corrupt payload, not a \
+                 version skew: {e}"
+            ))
+        })?;
+        let engine: EngineConfig = serde_json::from_str(&wire.engine_json).map_err(|e| {
+            AicError::EngineSpec(format!(
+                "engine JSON decode failed at schema_version {schema_version}: {e}"
+            ))
+        })?;
         Ok(Self {
             schema_version: wire.schema_version,
             engine,

--- a/src/aiconfigurator/sdk/engine.py
+++ b/src/aiconfigurator/sdk/engine.py
@@ -85,7 +85,11 @@ from aiconfigurator.sdk.rust_engine_step import (
 
 # Schema versions must match the Rust crate constants
 # (`ENGINE_SPEC_SCHEMA_VERSION` / `ENGINE_CONFIG_SCHEMA_VERSION` in `lib.rs`).
-ENGINE_SPEC_SCHEMA_VERSION = 1
+# ENGINE_SPEC bumped to 2 for the 0.10.0 op-payload layout change (CP + perf-DB
+# refactor added serialized `OpSpec` fields); the Rust consumer gates on this
+# version before decoding the positional op lists. Keep in lockstep with the
+# Rust `ENGINE_SPEC_SCHEMA_VERSION`.
+ENGINE_SPEC_SCHEMA_VERSION = 2
 ENGINE_CONFIG_SCHEMA_VERSION = 1
 
 


### PR DESCRIPTION
#### Overview:

Hardens the `EngineSpec` bincode wire format so a producer/consumer version skew fails with a clear, actionable error instead of an opaque `bincode decode: io error`.

Context: when an older embedded `aiconfigurator-core` consumer is paired with a newer AIC Python producer (different `OpSpec` layout), `EngineSpec::from_bincode` decoded the entire positional op payload *before* checking `schema_version`. bincode is not self-describing, so the op-layout mismatch failed deep inside the payload with a generic io error — masking the real cause (a version mismatch). This surfaced downstream as `AIC: failed to build the Rust engine ...: engine spec wire-format error: bincode decode: io error`.

This is defense-in-depth for the wire format. The environment that triggered the report also needs the *consumer* to be repinned to the matching core revision + its `EngineConfig`/`ParallelMapping` initializers updated for the new 0.10.0 fields — that lives in the embedding project, not here.

#### Details:

1. **Read the version before the payload.** `from_bincode` now decodes and validates the leading `schema_version` prefix first (it is the first field of the wire struct), returning a clear `UnsupportedSchemaVersion` on mismatch, before it decodes the variable-layout op lists. The wire bytes are unchanged. Adds a regression test that stamps a foreign version + truncates the op payload and asserts `UnsupportedSchemaVersion` (previously produced the generic io error; red on `main`).

2. **Bump `ENGINE_SPEC_SCHEMA_VERSION` 1 → 2.** The op payload layout genuinely changed in 0.10.0 (context-parallelism + perf-DB refactor added serialized `OpSpec` fields such as `seq_split` / `cp_size`) but the spec version stayed at 1, so old-layout and new-layout producers were indistinguishable. Bumping the mirrored Rust (`config.rs`) and Python (`sdk/engine.py`) constants gives the version gate teeth.

> **Coordination note:** after this bump, an embedding project that pins an older core but installs the new (final) wheel will hard-fail the version gate *by design*. Such consumers must repin their embedded core to the matching release **in lockstep** with adopting the new wheel.

#### Where should the reviewer start?

- `rust/aiconfigurator-core/src/engine/spec.rs` — `from_bincode` reorder + regression test.
- `rust/aiconfigurator-core/src/config.rs` + `src/aiconfigurator/sdk/engine.py` — the mirrored version bump (kept in lockstep).

#### Related Issues:

- N/A (no public GitHub issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the engine schema version to `2` to align with the latest op-payload layout.
  * Improved engine spec decoding by validating the schema version before decoding payloads, so version mismatches are detected earlier and reported with clearer “unsupported schema version” errors.
* **Tests**
  * Added a regression test to verify schema version skew reports the expected unsupported-version error (instead of a generic decode failure).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->