### PR TITLE
docs(attributions): add Rust crate attributions + fix Python deps for…

### DIFF
--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f0f2c8cd9077aa4f0186288bb264b4dd47e99838b3de9b4547b5e31c74ce72e2
-size 1449933
+oid sha256:2f62a6fd85a6209feedfe10b77f0558bdeea81fff3cb0133e360b9c38baab749
+size 1452089

--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c738fb502dd5ca0afdb72bca0e53924b8aeac3246177e47c5ad68230328e0625
-size 203847
+oid sha256:f0f2c8cd9077aa4f0186288bb264b4dd47e99838b3de9b4547b5e31c74ce72e2
+size 1449933


### PR DESCRIPTION
… 0.10.0

The 0.10.0 wheel now statically links the aiconfigurator_core Rust extension (_aiconfigurator_core.abi3.so), pulling 103 crates into the shipped artifact. None were previously attributed. Adds a Rust section generated from the wheel's bundled CycloneDX SBOM plus crates.io license files (all permissive: MIT / Apache-2.0 / BSD-3-Clause / CC0-1.0; no copyleft). r-efi and thrift ship no license file in-crate, so canonical MIT/Apache-2.0 text is included.

Also fixes Python entries that violated pyproject constraints:
- numpy 2.3.2 -> 1.26.4 (constraint is numpy~=1.26.4)
- gradio 4.44.1 -> 6.8.0 ([webapp] pins gradio==6.8.0) And adds three missing declared base deps: packaging, pydantic, pyarrow.

#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
