### PR TITLE
docs(attributions): add Rust crate attributions + fix Python deps for…

### DIFF
--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f0f2c8cd9077aa4f0186288bb264b4dd47e99838b3de9b4547b5e31c74ce72e2
-size 1449933
+oid sha256:2f62a6fd85a6209feedfe10b77f0558bdeea81fff3cb0133e360b9c38baab749
+size 1452089

--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c738fb502dd5ca0afdb72bca0e53924b8aeac3246177e47c5ad68230328e0625
-size 203847
+oid sha256:f0f2c8cd9077aa4f0186288bb264b4dd47e99838b3de9b4547b5e31c74ce72e2
+size 1449933


### PR DESCRIPTION
… 0.10.0

The 0.10.0 wheel now statically links the aiconfigurator_core Rust extension (_aiconfigurator_core.abi3.so), pulling 103 crates into the shipped artifact. None were previously attributed. Adds a Rust section generated from the wheel's bundled CycloneDX SBOM plus crates.io license files (all permissive: MIT / Apache-2.0 / BSD-3-Clause / CC0-1.0; no copyleft). r-efi and thrift ship no license file in-crate, so canonical MIT/Apache-2.0 text is included.

Also fixes Python entries that violated pyproject constraints:
- numpy 2.3.2 -> 1.26.4 (constraint is numpy~=1.26.4)
- gradio 4.44.1 -> 6.8.0 ([webapp] pins gradio==6.8.0) And adds three missing declared base deps: packaging, pydantic, pyarrow.


(cherry picked from commit 438e90018e7d4b3cbfe030d0fb2f78878ee4075f)

#### Overview:

> **Why the file diff looks empty:** `ATTRIBUTIONS.md` is Git-LFS-tracked, so GitHub renders only the LFS pointer change (`oid`/`size`), not the text. This comment is the human-readable summary of the actual content change (**17 → 124** attributed components). To see the full license-text diff locally: `git fetch && git checkout <this branch> && git lfs pull && git diff <base> -- ATTRIBUTIONS.md`.

**Python**
- Added: `packaging` (26.2), `pydantic` (2.13.4), `pyarrow` (24.0.0)
- `numpy` 2.3.2 → **1.26.4** (was a `numpy~=1.26.4` constraint violation)
- `gradio` 4.44.1 → **6.8.0** (`[webapp]` pins `==6.8.0`)

**Vendored C library**
- Added `zstd (C library)` (1.5.7) — BSD-3-Clause (© Meta), statically linked via zstd-sys

**Rust — 103 crates added** (statically linked into `_aiconfigurator_core.abi3.so`, from the wheel's CycloneDX SBOM). All permissive; no copyleft:

`ahash 0.8.12`, `android_system_properties 0.1.5`, … `zstd-sys 2.0.16+zstd.1.5.7`

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the attribution file reference to a new tracked content version (updated LFS pointer metadata).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->