### PR TITLE
refactor(sdk): data-driven FMHA quant resolution — retire model-specific rules

### DIFF
--- a/rust/aiconfigurator-core/src/operators/mla.rs
+++ b/rust/aiconfigurator-core/src/operators/mla.rs
@@ -184,12 +184,13 @@ impl MlaModuleOp {
         batch_size: u32,
         s: u32,
     ) -> Result<PerformanceResult, AicError> {
+        // No fmha arg: the generation module table has no fmha axis (decode
+        // compute dtype follows the kv-cache dtype).
         let latency = db.mla.query_generation_module(
             batch_size,
             s,
             self.num_heads,
             self.kv_cache_dtype,
-            self.fmha_quant_mode,
             self.gemm_quant_mode,
         )?;
         Ok(PerformanceResult::new(latency, Source::Silicon)

--- a/rust/aiconfigurator-core/src/perf_database/mla.rs
+++ b/rust/aiconfigurator-core/src/perf_database/mla.rs
@@ -832,6 +832,12 @@ mod tests {
             .join("src/aiconfigurator/systems/data/gb200/trtllm/1.3.0rc10")
     }
 
+    fn h200_trtllm_data_root() -> PathBuf {
+        PathBuf::from(REPO_ROOT_HINT)
+            .join("../..")
+            .join("src/aiconfigurator/systems/data/h200_sxm/trtllm/1.3.0rc10")
+    }
+
     fn load_spec(name: &str) -> SystemSpec {
         let systems_yaml = PathBuf::from(REPO_ROOT_HINT)
             .join("../..")
@@ -893,6 +899,28 @@ mod tests {
                 // interpolation-range error is acceptable for this smoke check.
             }
             Err(other) => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn module_level_generation_mla_fp8_kv_anchor() {
+        // Exact-value pins for fp8-KV decode: dropping the degenerate fmha
+        // axis makes the generation module table live for fp8-checkpoint
+        // V3/R1/Kimi decode (was: FallbackOp -> granular path). h200 ships
+        // NATIVE (kv=fp8, gemm=fp8_block) rows, so this anchor holds under
+        // single-primary loading. Values minted from this Rust path on the
+        // PR branch.
+        let table = MlaTable::new(h200_trtllm_data_root(), load_spec("h200_sxm"));
+        let cases: &[(u32, u32, f64)] = &[(8, 4097, 0.0693), (64, 4096, 0.1146884765625)];
+        for &(b, s, expected) in cases {
+            let got = table
+                .query_generation_module(b, s, 16, KvCacheQuantMode::Fp8, GemmQuantMode::Fp8Block)
+                .unwrap();
+            let rel = ((got - expected) / expected.max(1e-12)).abs();
+            assert!(
+                rel < 1e-9,
+                "gen_mla_module_fp8kv(b={b}, s={s}): got {got:.16}, expected {expected:.16}"
+            );
         }
     }
 

--- a/rust/aiconfigurator-core/src/perf_database/mla.rs
+++ b/rust/aiconfigurator-core/src/perf_database/mla.rs
@@ -62,7 +62,7 @@ pub struct MlaTable {
     generation: OnceLock<Result<GenerationMlaGrids, AicError>>,
     bmm: OnceLock<Result<BmmGrids, AicError>>,
     context_module: OnceLock<Result<ModuleGrids, AicError>>,
-    generation_module: OnceLock<Result<ModuleGrids, AicError>>,
+    generation_module: OnceLock<Result<GenModuleGrids, AicError>>,
 }
 
 struct ContextMlaGrids {
@@ -73,10 +73,17 @@ struct GenerationMlaGrids {
     by_keys: BTreeMap<KvOnlyKey, Node>,
 }
 
-/// Module-level MLA grids, shared between context and generation variants
-/// (the same nested layout; distinct CSV files supply the data).
+/// Module-level context MLA grids (fmha is a real axis for context).
 struct ModuleGrids {
     by_keys: BTreeMap<ModuleKey, Node>,
+}
+
+/// Module-level generation MLA grids, keyed on (kv, gemm) only: the parquet's
+/// `mla_dtype` column is degenerate (collectors hardcode `bfloat16`; decode
+/// compute dtype follows the kv-cache dtype) and is dropped, mirroring
+/// Python's `load_generation_mla_module_data`.
+struct GenModuleGrids {
+    by_keys: BTreeMap<GenModuleKey, Node>,
 }
 
 struct BmmGrids {
@@ -98,6 +105,12 @@ struct KvOnlyKey {
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 struct ModuleKey {
     fmha_quant: String,
+    kv_quant: String,
+    gemm_quant: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct GenModuleKey {
     kv_quant: String,
     gemm_quant: String,
 }
@@ -285,19 +298,18 @@ impl MlaTable {
         )
     }
 
-    /// Module-level generation MLA latency in ms.
+    /// Module-level generation MLA latency in ms. No fmha axis: decode
+    /// compute dtype follows the kv-cache dtype (see [`GenModuleGrids`]).
     pub fn query_generation_module(
         &self,
         b: u32,
         s: u32,
         num_heads: u32,
         kv_quant: KvCacheQuantMode,
-        fmha_quant: FmhaQuantMode,
         gemm_quant: GemmQuantMode,
     ) -> Result<f64, AicError> {
         let grids = self.load_generation_module()?;
-        let key = ModuleKey {
-            fmha_quant: fmha_quant.name().to_string(),
+        let key = GenModuleKey {
             kv_quant: kv_quant.name().to_string(),
             gemm_quant: gemm_quant.name().to_string(),
         };
@@ -307,7 +319,7 @@ impl MlaTable {
         let spec = &self.system_spec;
         // Generation module SOL = generation MLA SOL + BMM pre/post terms
         // (Python's module get_sol folds the BMM into sol_math/sol_mem before
-        // the max). fmha_quant only keys the table slice, not the SOL.
+        // the max).
         let sol =
             move |c: &[f64]| generation_mla_module_sol_ms(spec, kv_quant, gemm_quant, c[0], c[1], c[2]);
         let cfg = OpInterpConfig::grid(GENERATION_AXES, &sol);
@@ -337,14 +349,14 @@ impl MlaTable {
 
     fn load_context_module(&self) -> Result<&ModuleGrids, AicError> {
         let cell = self.context_module.get_or_init(|| {
-            load_module_parquet(&self.mla_context_module_sources, true)
+            load_context_module_parquet(&self.mla_context_module_sources)
         });
         cell.as_ref().map_err(clone_err)
     }
 
-    fn load_generation_module(&self) -> Result<&ModuleGrids, AicError> {
+    fn load_generation_module(&self) -> Result<&GenModuleGrids, AicError> {
         let cell = self.generation_module.get_or_init(|| {
-            load_module_parquet(&self.mla_generation_module_sources, false)
+            load_generation_module_parquet(&self.mla_generation_module_sources)
         });
         cell.as_ref().map_err(clone_err)
     }
@@ -606,7 +618,7 @@ fn load_op_gen_parquet(sources: &[PerfSource]) -> Result<GenerationMlaGrids, Aic
     Ok(GenerationMlaGrids { by_keys })
 }
 
-fn load_module_parquet(sources: &[PerfSource], is_context: bool) -> Result<ModuleGrids, AicError> {
+fn load_context_module_parquet(sources: &[PerfSource]) -> Result<ModuleGrids, AicError> {
     let mut raw: BTreeMap<ModuleKey, Grid3<f64>> = BTreeMap::new();
     let mut any_source = false;
     for source in sources {
@@ -622,7 +634,6 @@ fn load_module_parquet(sources: &[PerfSource], is_context: bool) -> Result<Modul
         let num_heads_col = reader.col("num_heads")?;
         let batch_size_col = reader.col("batch_size")?;
         let isl_col = reader.col("isl")?;
-        let step_col = reader.col("step")?;
         let latency_col = reader.col("latency")?;
         let ks_col = reader.col_optional("kernel_source");
         for row in reader.rows()? {
@@ -640,40 +651,27 @@ fn load_module_parquet(sources: &[PerfSource], is_context: bool) -> Result<Modul
             let isl = row.u32(isl_col)?;
             let latency = row.f64(latency_col)?;
             // Last-wins parity with Python `load_context_mla_module_data`
-            // (`operations/mla.py:1804`) and `load_generation_mla_module_data`
-            // (`operations/mla.py:1847`). Unlike the legacy CSV loaders and most
-            // other Python perf-DB loaders (GEMM, attention, MoE, MHC, wideep)
-            // which guard with `try/except KeyError` for first-wins semantics,
-            // these two MLA-module parquet loaders use direct assignment and
-            // therefore last-wins. (Python DSA is neither: it is two-phase —
-            // last-row-wins within a file, first-source-wins across sources;
-            // see `operations/dsa.py:1461-1502` and `dsa.rs::load_dsa_parquet`.)
-            // Some perf-DB parquet shards (notably
-            // b300_sxm/vllm/0.19.0 `mla_generation_module_perf.parquet`) contain
-            // duplicate (num_heads, batch_size, sequence_tokens) rows; first-wins
-            // here caused a constant +0.247ms/step decode drift on b300 because
+            // and `load_generation_mla_module_data`. Unlike the legacy CSV
+            // loaders and most other Python perf-DB loaders (GEMM, attention,
+            // MoE, MHC, wideep) which guard with `try/except KeyError` for
+            // first-wins semantics, these two MLA-module parquet loaders use
+            // direct assignment and therefore last-wins. (Python DSA is
+            // neither: it is two-phase — last-row-wins within a file,
+            // first-source-wins across sources; see
+            // `operations/dsa.py:1461-1502` and `dsa.rs::load_dsa_parquet`.)
+            // Some perf-DB parquet shards (notably b300_sxm/vllm/0.19.0
+            // `mla_generation_module_perf.parquet`) contain duplicate
+            // (num_heads, batch_size, sequence_tokens) rows; first-wins here
+            // caused a constant +0.247ms/step decode drift on b300 because
             // Rust picked the slightly-higher latency for ~184 affected keys.
-            if is_context {
-                let inner = raw
-                    .entry(key)
-                    .or_default()
-                    .entry(num_heads)
-                    .or_default()
-                    .entry(isl)
-                    .or_default();
-                inner.insert(batch_size, latency);
-            } else {
-                // Generation module: (num_heads, b, s) axis order.
-                let sequence_tokens = isl + row.u32(step_col)?;
-                let inner = raw
-                    .entry(key)
-                    .or_default()
-                    .entry(num_heads)
-                    .or_default()
-                    .entry(batch_size)
-                    .or_default();
-                inner.insert(sequence_tokens, latency);
-            }
+            let inner = raw
+                .entry(key)
+                .or_default()
+                .entry(num_heads)
+                .or_default()
+                .entry(isl)
+                .or_default();
+            inner.insert(batch_size, latency);
         }
     }
     if !any_source || raw.is_empty() {
@@ -688,6 +686,67 @@ fn load_module_parquet(sources: &[PerfSource], is_context: bool) -> Result<Modul
         .map(|(key, grid)| (key, grid3_to_node(&grid)))
         .collect();
     Ok(ModuleGrids { by_keys })
+}
+
+fn load_generation_module_parquet(sources: &[PerfSource]) -> Result<GenModuleGrids, AicError> {
+    let mut raw: BTreeMap<GenModuleKey, Grid3<f64>> = BTreeMap::new();
+    let mut any_source = false;
+    for source in sources {
+        let path = source.path();
+        if !path.exists() {
+            continue;
+        }
+        any_source = true;
+        let reader = PerfReader::open(path)?;
+        // The `mla_dtype` column is intentionally not read: it is degenerate
+        // for generation (collectors hardcode `bfloat16`; decode compute
+        // dtype follows the kv-cache dtype).
+        let kv_cache_dtype_col = reader.col("kv_cache_dtype")?;
+        let gemm_type_col = reader.col("gemm_type")?;
+        let num_heads_col = reader.col("num_heads")?;
+        let batch_size_col = reader.col("batch_size")?;
+        let isl_col = reader.col("isl")?;
+        let step_col = reader.col("step")?;
+        let latency_col = reader.col("latency")?;
+        let ks_col = reader.col_optional("kernel_source");
+        for row in reader.rows()? {
+            let row = row?;
+            if !kernel_source_ok(source.kernel_sources(), ks_col, &row)? {
+                continue;
+            }
+            let key = GenModuleKey {
+                kv_quant: row.str_owned(kv_cache_dtype_col)?,
+                gemm_quant: row.str_owned(gemm_type_col)?,
+            };
+            let num_heads = row.u32(num_heads_col)?;
+            let batch_size = row.u32(batch_size_col)?;
+            let isl = row.u32(isl_col)?;
+            let latency = row.f64(latency_col)?;
+            // Generation module: (num_heads, b, s) axis order. Last-wins on
+            // duplicate rows -- see the note in `load_context_module_parquet`.
+            let sequence_tokens = isl + row.u32(step_col)?;
+            let inner = raw
+                .entry(key)
+                .or_default()
+                .entry(num_heads)
+                .or_default()
+                .entry(batch_size)
+                .or_default();
+            inner.insert(sequence_tokens, latency);
+        }
+    }
+    if !any_source || raw.is_empty() {
+        return Err(AicError::PerfDatabase(format!(
+            "no MLA module rows loaded from {} source(s) (first: {})",
+            sources.len(),
+            sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
+        )));
+    }
+    let by_keys = raw
+        .into_iter()
+        .map(|(key, grid)| (key, grid3_to_node(&grid)))
+        .collect();
+    Ok(GenModuleGrids { by_keys })
 }
 
 fn load_bmm_parquet(sources: &[PerfSource]) -> Result<BmmGrids, AicError> {
@@ -825,7 +884,6 @@ mod tests {
             1024,
             128,
             KvCacheQuantMode::Bfloat16,
-            FmhaQuantMode::Bfloat16,
             GemmQuantMode::Bfloat16,
         );
         match result {
@@ -953,7 +1011,6 @@ mod tests {
                     s,
                     128,
                     KvCacheQuantMode::Bfloat16,
-                    FmhaQuantMode::Bfloat16,
                     GemmQuantMode::Bfloat16,
                 )
                 .unwrap();

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -26,7 +26,7 @@ from aiconfigurator.cli.report_and_save import save_results
 from aiconfigurator.sdk.config import ModelConfig
 from aiconfigurator.sdk.config_builders import apply_nextn as _apply_nextn
 from aiconfigurator.sdk.config_builders import build_model_config as _build_model_config
-from aiconfigurator.sdk.models import check_is_moe, resolve_context_fmha_compat
+from aiconfigurator.sdk.models import check_is_moe, resolve_context_fmha_by_data
 from aiconfigurator.sdk.task_v2 import Task
 
 # Default per-phase latency-correction scales for single-point disagg estimates.
@@ -1146,9 +1146,11 @@ def _run_agg_estimate(
         comm_quant_mode,
     )
     _apply_nextn(model_config, nextn, nextn_accept_rates)
-    # Agg workers run context attention → apply the V3/Kimi context FMHA rule
+    # Agg workers run context attention → resolve fmha against the perf data
     # before building the model (mirrors the sweep/task_v2 path).
-    resolve_context_fmha_compat(model_config, model_path, is_context_role=True)
+    resolve_context_fmha_by_data(
+        model_config, model_path, load_database(system_name), backend_name, is_context_role=True
+    )
     runtime_config = RuntimeConfig(
         isl=isl,
         osl=osl,
@@ -1278,8 +1280,14 @@ def _run_static_estimate(
     )
     _apply_nextn(model_config, nextn, nextn_accept_rates)
     # static / static_ctx run context attention; static_gen is generation-only
-    # and legitimately keeps fp8 FMHA. Apply the V3/Kimi context rule accordingly.
-    resolve_context_fmha_compat(model_config, model_path, is_context_role=static_mode != "static_gen")
+    # and legitimately keeps fp8 FMHA. Resolve fmha against the perf data accordingly.
+    resolve_context_fmha_by_data(
+        model_config,
+        model_path,
+        load_database(system_name),
+        backend_name,
+        is_context_role=static_mode != "static_gen",
+    )
 
     runtime_config = RuntimeConfig(
         batch_size=batch_size,
@@ -1426,9 +1434,11 @@ def _run_disagg_estimate(
     # configs so a single ``--nextn N`` reaches each side of the disagg pair.
     _apply_nextn(prefill_model_config, nextn, nextn_accept_rates)
     _apply_nextn(decode_model_config, nextn, nextn_accept_rates)
-    # Prefill runs context attention → V3/Kimi context FMHA rule applies. Decode
+    # Prefill runs context attention → resolve fmha against the perf data. Decode
     # is generation-only and keeps fp8, so it needs no adjustment.
-    resolve_context_fmha_compat(prefill_model_config, model_path, is_context_role=True)
+    resolve_context_fmha_by_data(
+        prefill_model_config, model_path, load_database(system_name), backend_name, is_context_role=True
+    )
 
     runtime_config = RuntimeConfig(
         isl=isl,
@@ -1708,10 +1718,12 @@ def _run_afd_estimate(
     _apply_nextn(a_model_config, nextn, nextn_accept_rates)
     _apply_nextn(f_model_config, nextn, nextn_accept_rates)
     # The A-worker runs context attention whenever the phase covers prefill
-    # ("prefill" or "both"); apply the V3/Kimi context FMHA rule then. The
+    # ("prefill" or "both"); resolve fmha against the perf data then. The
     # F-worker is FFN/MoE only and never touches FMHA. The decode-phase static
     # complement is a static_ctx call handled in _run_static_estimate.
-    resolve_context_fmha_compat(a_model_config, model_path, is_context_role=afd_phase in ("prefill", "both"))
+    resolve_context_fmha_by_data(
+        a_model_config, model_path, database, backend_name, is_context_role=afd_phase in ("prefill", "both")
+    )
 
     afd_config = AFDConfig(
         n_a_nodes=n_a_nodes,

--- a/src/aiconfigurator/cli/exps/deepseek_disagg_mixed_wideep_trtllm.yaml
+++ b/src/aiconfigurator/cli/exps/deepseek_disagg_mixed_wideep_trtllm.yaml
@@ -35,7 +35,7 @@ exp_disagg_prefill_wideep_decode_standard:
   prefill_gemm_quant_mode: nvfp4
   prefill_moe_quant_mode: nvfp4
   prefill_kvcache_quant_mode: fp8
-  prefill_fmha_quant_mode: fp8
+  prefill_fmha_quant_mode: bfloat16
   prefill_comm_quant_mode: half
   prefill_num_gpu_candidates:
   - 4
@@ -190,7 +190,7 @@ exp_disagg_both_wideep:
   prefill_gemm_quant_mode: nvfp4
   prefill_moe_quant_mode: nvfp4
   prefill_kvcache_quant_mode: fp8
-  prefill_fmha_quant_mode: fp8
+  prefill_fmha_quant_mode: bfloat16
   prefill_comm_quant_mode: half
   prefill_num_gpu_candidates:
   - 4

--- a/src/aiconfigurator/sdk/models/__init__.py
+++ b/src/aiconfigurator/sdk/models/__init__.py
@@ -34,10 +34,11 @@ from aiconfigurator.sdk.models.helpers import (
     _architecture_to_model_family,
     _get_model_info,
     _infer_quant_modes_from_raw_config,
+    attention_op_keys,
     calc_expectation,
     check_is_moe,
     get_model_family,
-    resolve_context_fmha_compat,
+    resolve_context_fmha_by_data,
 )
 
 # Auto-import every other module in this package so ``@register_model``
@@ -160,9 +161,10 @@ __all__ = [
     "_architecture_to_model_family",
     "_get_model_info",
     "_infer_quant_modes_from_raw_config",
+    "attention_op_keys",
     "calc_expectation",
     "check_is_moe",
     "get_model",
     "get_model_family",
-    "resolve_context_fmha_compat",
+    "resolve_context_fmha_by_data",
 ]

--- a/src/aiconfigurator/sdk/models/helpers.py
+++ b/src/aiconfigurator/sdk/models/helpers.py
@@ -293,6 +293,7 @@ def _apply_model_quant_defaults(
 ) -> None:
     # Clone original model_config to track if any modifications were made
     original_config = dataclasses.replace(model_config)
+    fmha_was_unset = model_config.fmha_quant_mode is None
 
     inferred = _infer_quant_modes_from_raw_config(raw_config, architecture)
     applied: list[str] = []
@@ -315,23 +316,30 @@ def _apply_model_quant_defaults(
     if applied:
         logger.debug("Using model-provided quantization defaults: %s", ", ".join(applied))
 
-    # DSA module (DeepSeek-V3.2 / GLM-5): DSA perf tables only have bfloat16 FMHA currently.
-    if (
-        architecture in ("DeepseekV32ForCausalLM", "GlmMoeDsaForCausalLM")
-        and backend_name in ("trtllm", "sglang")
-        and model_config.fmha_quant_mode == common.FMHAQuantMode.fp8
-    ):
-        model_config.fmha_quant_mode = common.FMHAQuantMode.bfloat16
+    # Legacy FMHA guards for direct get_model() callers that bypass Task /
+    # estimate-path resolution.  They apply ONLY when fmha arrived unset (i.e.
+    # this function inferred it from the checkpoint just above): a value that
+    # arrived already resolved is owned by Task._resolve_quant_modes or
+    # resolve_context_fmha_by_data, whose data-driven decision must not be
+    # overridden here.
+    if fmha_was_unset:
+        # DSA module (DeepSeek-V3.2 / GLM-5): DSA perf tables only have bfloat16 FMHA currently.
+        if (
+            architecture in ("DeepseekV32ForCausalLM", "GlmMoeDsaForCausalLM")
+            and backend_name in ("trtllm", "sglang")
+            and model_config.fmha_quant_mode == common.FMHAQuantMode.fp8
+        ):
+            model_config.fmha_quant_mode = common.FMHAQuantMode.bfloat16
 
-    # DeepSeek-V4 compressed attention collectors record the attention module as
-    # BF16 even when projections/KV cache are quantized.
-    if architecture == "DeepseekV4ForCausalLM" and model_config.fmha_quant_mode == common.FMHAQuantMode.fp8:
-        model_config.fmha_quant_mode = common.FMHAQuantMode.bfloat16
+        # DeepSeek-V4 compressed attention collectors record the attention module as
+        # BF16 even when projections/KV cache are quantized.
+        if architecture == "DeepseekV4ForCausalLM" and model_config.fmha_quant_mode == common.FMHAQuantMode.fp8:
+            model_config.fmha_quant_mode = common.FMHAQuantMode.bfloat16
 
-    # FIXME: temporary workaround for Qwen3 32B FP8, only bfloat16+fp8kvcache is supported
-    # VLLM perf tables only include bfloat16 FMHA; fall back to bfloat16 for estimation.
-    if backend_name == "vllm" and model_config.fmha_quant_mode == common.FMHAQuantMode.fp8:
-        model_config.fmha_quant_mode = common.FMHAQuantMode.bfloat16
+        # FIXME: temporary workaround for Qwen3 32B FP8, only bfloat16+fp8kvcache is supported
+        # VLLM perf tables only include bfloat16 FMHA; fall back to bfloat16 for estimation.
+        if backend_name == "vllm" and model_config.fmha_quant_mode == common.FMHAQuantMode.fp8:
+            model_config.fmha_quant_mode = common.FMHAQuantMode.bfloat16
 
     # Only log if model_config was modified
     if original_config != model_config:
@@ -382,10 +390,16 @@ def resolve_context_fmha_by_data(
     if not is_context_role:
         return
 
+    from aiconfigurator.sdk.perf_database import context_fmha_supported_modes
+
     info = _get_model_info(model_path)
     family = _architecture_to_model_family(info["architecture"])
+    inferred = _infer_quant_modes_from_raw_config(info.get("raw_config", {}), info.get("architecture"))
+    # Joint (fmha, kv) capability: use the kv mode this estimate will actually
+    # run with (explicit wins, else the checkpoint inference).
+    kv_mode = model_config.kvcache_quant_mode or inferred.get("kvcache_quant_mode")
     ctx_op, _ = attention_op_keys(family, backend_name)
-    supported = (getattr(database, "supported_quant_mode", {}) or {}).get(ctx_op, []) or []
+    supported = context_fmha_supported_modes(database, ctx_op, kv_mode)
     if not supported or common.FMHAQuantMode.fp8.name in supported:
         return
 
@@ -399,7 +413,6 @@ def resolve_context_fmha_by_data(
 
     # Not user-explicit: mirror what get_model would infer, and downgrade only
     # when that inference would pick fp8 (bf16 checkpoints need no change).
-    inferred = _infer_quant_modes_from_raw_config(info.get("raw_config", {}), info.get("architecture"))
     if inferred.get("fmha_quant_mode") == common.FMHAQuantMode.fp8 and common.FMHAQuantMode.bfloat16.name in supported:
         model_config.fmha_quant_mode = common.FMHAQuantMode.bfloat16
         logger.warning(

--- a/src/aiconfigurator/sdk/models/helpers.py
+++ b/src/aiconfigurator/sdk/models/helpers.py
@@ -50,8 +50,15 @@ def attention_op_keys(model_family: str, backend_name: str, enable_wideep: bool 
     if model_family == "DEEPSEEKV32":
         return "dsa_context_module", "dsa_generation_module"
     if model_family in ("DEEPSEEK", "KIMIK25") and backend_name != "vllm":
-        if backend_name == "sglang" and enable_wideep:
-            return "wideep_context_mla", "wideep_generation_mla"
+        if enable_wideep:
+            if backend_name == "sglang":
+                return "wideep_context_mla", "wideep_generation_mla"
+            # trtllm wideep context queries the granular context_mla table
+            # directly (plain ContextMLA op, no module primary), so its
+            # capability key is the granular-only slice set: the merged
+            # context_mla list may contain module-only slices (incl.
+            # cross-framework shared-layer rows) this path can never hit.
+            return "context_mla_granular", "generation_mla"
         return "context_mla", "generation_mla"
     return "context_attention", "generation_attention"
 
@@ -375,7 +382,9 @@ def resolve_context_fmha_by_data(
     if not is_context_role:
         return
 
-    ctx_op, _ = attention_op_keys(get_model_family(model_path), backend_name)
+    info = _get_model_info(model_path)
+    family = _architecture_to_model_family(info["architecture"])
+    ctx_op, _ = attention_op_keys(family, backend_name)
     supported = (getattr(database, "supported_quant_mode", {}) or {}).get(ctx_op, []) or []
     if not supported or common.FMHAQuantMode.fp8.name in supported:
         return
@@ -390,7 +399,6 @@ def resolve_context_fmha_by_data(
 
     # Not user-explicit: mirror what get_model would infer, and downgrade only
     # when that inference would pick fp8 (bf16 checkpoints need no change).
-    info = _get_model_info(model_path)
     inferred = _infer_quant_modes_from_raw_config(info.get("raw_config", {}), info.get("architecture"))
     if inferred.get("fmha_quant_mode") == common.FMHAQuantMode.fp8 and common.FMHAQuantMode.bfloat16.name in supported:
         model_config.fmha_quant_mode = common.FMHAQuantMode.bfloat16

--- a/src/aiconfigurator/sdk/models/helpers.py
+++ b/src/aiconfigurator/sdk/models/helpers.py
@@ -35,15 +35,25 @@ _MOE_MODEL_FAMILIES = {
     "MINIMAXM3",
 }
 
-# DeepSeek-V3 / Kimi-K2.5 context attention (MLA prefill) has no fp8 FMHA perf
-# data — only bf16. The generation (decode) path keeps fp8. This mirrors the
-# role-aware rule in ``task_v2.Task._resolve_quant_modes`` so the single-point
-# CLI estimate path resolves quant modes the same way the sweep (task_v2)
-# already does. See NVBug 6401867.
-_CONTEXT_FP8_FMHA_UNSUPPORTED_ARCHS = (
-    "DeepseekV3ForCausalLM",
-    "KimiK25ForConditionalGeneration",
-)
+
+def attention_op_keys(model_family: str, backend_name: str, enable_wideep: bool = False) -> tuple[str, str]:
+    """(context_op, generation_op) support-matrix keys for a model family /
+    backend / wideep combination.
+
+    Single source of truth shared by ``task_v2.Task`` (resolve-time FMHA
+    fallback + validate) and the estimate-path FMHA guard
+    (:func:`resolve_context_fmha_by_data`). Every context op keys on fmha at
+    the top level; every generation op keys on kv dtype.
+    """
+    if model_family == "DEEPSEEKV4":
+        return "deepseek_v4_context_module", "deepseek_v4_generation_module"
+    if model_family == "DEEPSEEKV32":
+        return "dsa_context_module", "dsa_generation_module"
+    if model_family in ("DEEPSEEK", "KIMIK25") and backend_name != "vllm":
+        if backend_name == "sglang" and enable_wideep:
+            return "wideep_context_mla", "wideep_generation_mla"
+        return "context_mla", "generation_mla"
+    return "context_attention", "generation_attention"
 
 
 @cache
@@ -329,54 +339,67 @@ def _apply_model_quant_defaults(
         )
 
 
-def resolve_context_fmha_compat(
+def resolve_context_fmha_by_data(
     model_config: config.ModelConfig,
     model_path: str,
+    database,
+    backend_name: str,
     *,
     is_context_role: bool,
 ) -> None:
-    """Apply the DeepSeek-V3 / Kimi context-role FMHA compatibility rule.
+    """Data-driven context-FMHA guard for the estimate path (no Task involved).
 
-    Must be called BEFORE ``get_model`` so the downgrade lands before the model
-    (and its attention ops) are built. ``_apply_model_quant_defaults`` cannot own
-    this rule because it is role-agnostic: decode/generation attention keeps fp8,
-    only context attention (agg / prefill / static_ctx) must fall back to bf16.
+    Must be called BEFORE ``get_model`` so the resolution lands before the
+    model (and its attention ops) are built. Mirrors the resolve-time fallback
+    in ``task_v2.Task._resolve_quant_modes``, driven by the perf DB's
+    fmha-keyed context table instead of a hand-written architecture list:
 
-    Behavior (mirrors ``task_v2``):
-    * Non-context roles, or non-V3/Kimi architectures: no-op.
-    * fmha auto-inferred to fp8 → downgrade to bfloat16 (unblocks the estimate).
-    * fmha explicitly set to fp8 by the user → raise a concise ``ValueError``
-      instead of letting a missing-perf-data traceback surface downstream.
+    * Generation-only roles: no-op (no generation table keys on fmha).
+    * fp8 slice present, or no DB information for the op: no-op.
+    * fmha explicitly set to fp8 with no fp8 slice: raise a concise
+      ``ValueError`` instead of a missing-perf-data traceback downstream.
+    * fmha auto-inferred to fp8 with no fp8 slice but a bf16 one: downgrade
+      to bfloat16 with a warning (predictions are conservative if the
+      deployed engine runs fp8 FMHA).
 
     Args:
         model_config: ModelConfig whose ``fmha_quant_mode`` may be adjusted
             in place. A non-None value is treated as a user-explicit request.
-        model_path: HF model path used to resolve architecture and quant config.
+        model_path: HF model path used to resolve family and quant config.
+        database: the role's loaded perf database (its
+            ``supported_quant_mode`` is consulted).
+        backend_name: backend the estimate targets (selects the context op).
         is_context_role: True for context-attention roles (agg, prefill,
             static, static_ctx, AFD prefill); False for generation-only roles.
     """
     if not is_context_role:
         return
 
-    info = _get_model_info(model_path)
-    architecture = info.get("architecture")
-    if architecture not in _CONTEXT_FP8_FMHA_UNSUPPORTED_ARCHS:
+    ctx_op, _ = attention_op_keys(get_model_family(model_path), backend_name)
+    supported = (getattr(database, "supported_quant_mode", {}) or {}).get(ctx_op, []) or []
+    if not supported or common.FMHAQuantMode.fp8.name in supported:
         return
 
-    explicit = model_config.fmha_quant_mode is not None
-    if explicit:
+    if model_config.fmha_quant_mode is not None:
         if model_config.fmha_quant_mode == common.FMHAQuantMode.fp8:
             raise ValueError(
-                f"{architecture} context attention (MLA prefill) does not support fp8 FMHA. "
+                f"fmha_quant_mode=fp8 has no {ctx_op!r} perf data for this system/backend/version. "
                 "Use --fmha-quant-mode bfloat16, or omit --fmha-quant-mode to auto-select it."
             )
         return
 
     # Not user-explicit: mirror what get_model would infer, and downgrade only
     # when that inference would pick fp8 (bf16 checkpoints need no change).
-    inferred = _infer_quant_modes_from_raw_config(info.get("raw_config", {}), architecture)
-    if inferred.get("fmha_quant_mode") == common.FMHAQuantMode.fp8:
+    info = _get_model_info(model_path)
+    inferred = _infer_quant_modes_from_raw_config(info.get("raw_config", {}), info.get("architecture"))
+    if inferred.get("fmha_quant_mode") == common.FMHAQuantMode.fp8 and common.FMHAQuantMode.bfloat16.name in supported:
         model_config.fmha_quant_mode = common.FMHAQuantMode.bfloat16
+        logger.warning(
+            "fmha_quant_mode=fp8 (inferred from the model checkpoint) has no %r perf data; "
+            "falling back to bfloat16 FMHA data. Predictions are conservative if the deployed "
+            "engine runs fp8 FMHA; set fmha_quant_mode explicitly to override.",
+            ctx_op,
+        )
 
 
 def get_model_family(model_path: str) -> str:

--- a/src/aiconfigurator/sdk/operations/dsv4.py
+++ b/src/aiconfigurator/sdk/operations/dsv4.py
@@ -1241,6 +1241,15 @@ class GenerationDeepSeekV4AttentionModule(_BaseDeepSeekV4AttentionModule):
     ) -> PerformanceResult | tuple[float, float, float]:
         """Verbatim port of legacy ``PerfDatabase.query_generation_deepseek_v4_attention_module``."""
         cls.load_data(database)
+        # Decode attention compute dtype follows the kv-cache dtype; the fmha
+        # label is inert for generation (the table keys on kv dtype).  Derive
+        # the SOL dtype from kv so label changes cannot move decode SOL --
+        # mirrors query_generation_mla's get_sol.
+        fmha_quant_mode = (
+            common.FMHAQuantMode.fp8
+            if kvcache_quant_mode == common.KVCacheQuantMode.fp8
+            else common.FMHAQuantMode.bfloat16
+        )
 
         def get_sol(b_: int = b, s_: int = s) -> tuple[float, float, float]:
             return _deepseek_v4_attention_sol(

--- a/src/aiconfigurator/sdk/operations/mla.py
+++ b/src/aiconfigurator/sdk/operations/mla.py
@@ -1055,6 +1055,15 @@ class WideEPGenerationMLA(Operation):
         database_mode: common.DatabaseMode | None = None,
     ):
         """Query WideEP generation MLA table. Verbatim port of the legacy body."""
+        # Decode attention compute dtype follows the kv-cache dtype; the fmha
+        # label is inert for generation (kernel tables key on kv dtype).
+        # Derive the SOL dtype from kv so label changes cannot move decode SOL
+        # -- mirrors query_generation_mla's get_sol.
+        fmha_quant_mode = (
+            common.FMHAQuantMode.fp8
+            if kvcache_quant_mode == common.KVCacheQuantMode.fp8
+            else common.FMHAQuantMode.bfloat16
+        )
 
         def get_sol(
             b: int,

--- a/src/aiconfigurator/sdk/operations/mla.py
+++ b/src/aiconfigurator/sdk/operations/mla.py
@@ -824,7 +824,6 @@ class MLAModule(Operation):
         s: int,
         num_heads: int,
         kv_cache_dtype: common.KVCacheQuantMode,
-        fmha_quant_mode: common.FMHAQuantMode = common.FMHAQuantMode.bfloat16,
         gemm_quant_mode: common.GEMMQuantMode = common.GEMMQuantMode.bfloat16,
         database_mode: common.DatabaseMode | None = None,
     ):
@@ -868,7 +867,6 @@ class MLAModule(Operation):
                 wrapper.raise_if_not_loaded()
                 return util_empirical.require_data_slice(
                     wrapper,
-                    fmha_quant_mode,
                     kv_cache_dtype,
                     gemm_quant_mode,
                 )
@@ -879,7 +877,6 @@ class MLAModule(Operation):
                     database.system,
                     database.backend,
                     database.version,
-                    fmha_quant_mode.name,
                     kv_cache_dtype.name,
                     gemm_quant_mode.name,
                 ),
@@ -908,7 +905,6 @@ class MLAModule(Operation):
             data_wrapper.raise_if_not_loaded()
             mla_dict = util_empirical.require_data_slice(
                 data_wrapper,
-                fmha_quant_mode,
                 kv_cache_dtype,
                 gemm_quant_mode,
             )
@@ -960,7 +956,6 @@ class MLAModule(Operation):
                 s=s,
                 num_heads=self._num_heads,
                 kv_cache_dtype=self._kvcache_quant_mode,
-                fmha_quant_mode=self._fmha_quant_mode,
                 gemm_quant_mode=self._gemm_quant_mode,
             )
 
@@ -1891,16 +1886,19 @@ def load_generation_mla_module_data(mla_module_file: str):
     batch_size, isl, tp_size, step, latency [, power]
 
     Dict structure:
-        data[fmha_quant_mode][kv_cache_quant_mode][gemm_quant_mode][num_heads][b][s]
+        data[kv_cache_quant_mode][gemm_quant_mode][num_heads][b][s]
+
+    The ``mla_dtype`` column is ignored: decode MLA compute dtype follows the
+    KV cache dtype (collectors hardcode ``bfloat16`` in that column), so it is
+    not a real axis — mirroring ``load_generation_mla_data``, which likewise
+    drops it.
     """
     rows = _read_filtered_rows(mla_module_file)
     if rows is None:
         logger.debug(f"MLA generation module data file {mla_module_file} not found.")
         return None
 
-    mla_data = defaultdict(
-        lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict()))))
-    )
+    mla_data = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict()))))
 
     has_power = len(rows) > 0 and "power" in rows[0]
 
@@ -1912,11 +1910,10 @@ def load_generation_mla_module_data(mla_module_file: str):
         power = float(row.get("power", 0.0)) if has_power else 0.0
         energy = power * latency
 
-        fmha_mode = common.FMHAQuantMode[row["mla_dtype"]]
         gemm_mode = common.GEMMQuantMode[row["gemm_type"]]
         kv_dtype = common.KVCacheQuantMode[row["kv_cache_dtype"]]
 
-        mla_data[fmha_mode][kv_dtype][gemm_mode][num_heads][b][s] = {
+        mla_data[kv_dtype][gemm_mode][num_heads][b][s] = {
             "latency": latency,
             "power": power,
             "energy": energy,

--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -1075,6 +1075,7 @@ class _LazySupportMatrix:
             "context_attention",
             "generation_attention",
             "context_mla",
+            "context_mla_granular",
             "generation_mla",
             "dsa_context_module",
             "dsa_generation_module",
@@ -1094,6 +1095,7 @@ class _LazySupportMatrix:
             "context_attention",
             "generation_attention",
             "context_mla",
+            "context_mla_granular",
             "generation_mla",
             "dsa_context_module",
             "dsa_generation_module",
@@ -1108,6 +1110,7 @@ class _LazySupportMatrix:
             "context_attention",
             "generation_attention",
             "context_mla",
+            "context_mla_granular",
             "generation_mla",
             "dsa_context_module",
             "dsa_generation_module",
@@ -1196,6 +1199,15 @@ class _LazySupportMatrix:
                 getattr(db, "_context_mla_data", None),
                 getattr(db, "_context_mla_module_data", None),
             )
+
+        if key == "context_mla_granular":
+            # Granular-table-only capability: the trtllm wideep context path
+            # queries the granular context_mla table directly (no module
+            # primary), so module-only slices must not count for it.
+            from aiconfigurator.sdk.operations.mla import ContextMLA
+
+            ContextMLA.load_data(db)
+            return _enum_key_names(getattr(db, "_context_mla_data", None))
 
         if key == "generation_mla":
             from aiconfigurator.sdk.operations.mla import GenerationMLA, MLAModule
@@ -1528,6 +1540,7 @@ class PerfDatabase:
                     getattr(self, "_context_mla_data", None),
                     getattr(self, "_context_mla_module_data", None),
                 ),
+                "context_mla_granular": _enum_key_names(getattr(self, "_context_mla_data", None)),
                 "generation_mla": _generation_mla_kv_modes(),
                 "dsa_context_module": _enum_key_names(getattr(self, "_context_dsa_module_data", None)),
                 "dsa_generation_module": _enum_key_names(getattr(self, "_generation_dsa_module_data", None)),
@@ -1555,6 +1568,7 @@ class PerfDatabase:
                     getattr(self, "_context_mla_data", None),
                     getattr(self, "_context_mla_module_data", None),
                 ),
+                "context_mla_granular": _enum_key_names(getattr(self, "_context_mla_data", None)),
                 "generation_mla": _generation_mla_kv_modes(),
                 "dsa_context_module": _enum_key_names(getattr(self, "_context_dsa_module_data", None)),
                 "dsa_generation_module": _enum_key_names(getattr(self, "_generation_dsa_module_data", None)),
@@ -1577,6 +1591,7 @@ class PerfDatabase:
                     getattr(self, "_context_mla_data", None),
                     getattr(self, "_context_mla_module_data", None),
                 ),
+                "context_mla_granular": _enum_key_names(getattr(self, "_context_mla_data", None)),
                 "generation_mla": _generation_mla_kv_modes(),
                 "dsa_context_module": _enum_key_names(getattr(self, "_context_dsa_module_data", None)),
                 "dsa_generation_module": _enum_key_names(getattr(self, "_generation_dsa_module_data", None)),

--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -1202,18 +1202,12 @@ class _LazySupportMatrix:
 
             GenerationMLA.load_data(db)
             MLAModule.load_data(db)
-            # Granular data is keyed [kv_cache]...; module data is keyed
-            # [fmha][kv_cache][gemm]... so kv modes are at the second level there.
-            kv_modes: set[str] = set()
-            granular = getattr(db, "_generation_mla_data", None)
-            if granular:
-                kv_modes.update(_enum_key_names(granular))
-            module = getattr(db, "_generation_mla_module_data", None)
-            if module:
-                for fmha_mode in module:
-                    for kv_mode in module[fmha_mode]:
-                        kv_modes.add(kv_mode.name if hasattr(kv_mode, "name") else str(kv_mode))
-            return sorted(kv_modes)
+            # Both granular and module data key on kv_cache_dtype at the top
+            # level (generation MLA has no fmha axis).
+            return _merge_key_names(
+                getattr(db, "_generation_mla_data", None),
+                getattr(db, "_generation_mla_module_data", None),
+            )
 
         if key == "dsa_context_module":
             from aiconfigurator.sdk.operations.dsa import ContextDSAModule
@@ -1487,22 +1481,13 @@ class PerfDatabase:
         def _generation_mla_kv_modes() -> list[str]:
             """Collect kv_cache_dtype names for generation MLA from both sources.
 
-            Granular data is keyed [kv_cache]... so top-level keys are kv modes.
-            Module data is keyed [fmha][kv_cache][gemm]... so kv modes are
-            at the second level.
+            Both granular and module data key on kv_cache_dtype at the top
+            level (generation MLA has no fmha axis).
             """
-            kv_modes: set[str] = set()
-            # Granular: top-level keys are kv_cache_dtype
-            granular = getattr(self, "_generation_mla_data", None)
-            if granular:
-                kv_modes.update(_enum_key_names(granular))
-            # Module: kv_cache_dtype is at the second level
-            module = getattr(self, "_generation_mla_module_data", None)
-            if module:
-                for fmha_mode in module:
-                    for kv_mode in module[fmha_mode]:
-                        kv_modes.add(kv_mode.name if hasattr(kv_mode, "name") else str(kv_mode))
-            return sorted(kv_modes)
+            return _merge_key_names(
+                getattr(self, "_generation_mla_data", None),
+                getattr(self, "_generation_mla_module_data", None),
+            )
 
         def _dsv4_megamoe_modes(data: dict | None) -> list[str]:
             """Collect MoE quant-mode names from DSv4 MegaMoE data.
@@ -2069,7 +2054,6 @@ class PerfDatabase:
         s: int,
         num_heads: int,
         kv_cache_dtype: common.KVCacheQuantMode,
-        fmha_quant_mode: common.FMHAQuantMode = common.FMHAQuantMode.bfloat16,
         gemm_quant_mode: common.GEMMQuantMode = common.GEMMQuantMode.bfloat16,
         database_mode: common.DatabaseMode | None = None,
     ) -> PerformanceResult | tuple[float, float, float]:
@@ -2082,7 +2066,6 @@ class PerfDatabase:
             s,
             num_heads,
             kv_cache_dtype,
-            fmha_quant_mode,
             gemm_quant_mode,
             database_mode,
         )

--- a/src/aiconfigurator/sdk/perf_database.py
+++ b/src/aiconfigurator/sdk/perf_database.py
@@ -155,6 +155,54 @@ def has_perf_data_not_available_cause(error: BaseException) -> bool:
     return False
 
 
+# Instance attribute(s) holding the raw table(s) behind each fmha-keyed context
+# op. Every listed table is keyed [fmha][kv_cache]... at its top two levels, so
+# joint (fmha, kv) slice presence can be checked uniformly. Ops absent from
+# this map (e.g. wideep_context_mla: [kernel_source][quant], no kv axis) fall
+# back to the flat supported list.
+_CONTEXT_FMHA_OP_TABLES: dict[str, tuple[str, ...]] = {
+    "context_attention": ("_context_attention_data",),
+    "context_mla": ("_context_mla_data", "_context_mla_module_data"),
+    "context_mla_granular": ("_context_mla_data",),
+    "dsa_context_module": ("_context_dsa_module_data",),
+    "deepseek_v4_context_module": ("_context_deepseek_v4_attention_module_data",),
+}
+
+
+def context_fmha_supported_modes(database, ctx_op: str, kv_cache_mode) -> list[str]:
+    """FMHA mode names with perf data for ``ctx_op``, restricted to slices that
+    exist JOINTLY with ``kv_cache_mode``.
+
+    The flat ``supported_quant_mode[ctx_op]`` list unions fmha keys across kv
+    slices (and across granular+module tables for ``context_mla``), so an fmha
+    mode collected only under a different kv dtype — e.g. the fp8 fmha slice
+    that exists solely under kv=fp8 — would look available for a bf16-kv role
+    and then miss at query time.  Returns ``[]`` when there is no information
+    (missing op/table); falls back to the flat list when the op has no kv axis
+    or the database exposes no raw tables (test stubs).
+    """
+    supported = getattr(database, "supported_quant_mode", {}) or {}
+    flat = supported.get(ctx_op, []) or []  # triggers the lazy load of the op's table(s)
+    if not flat:
+        return []
+    table_attrs = _CONTEXT_FMHA_OP_TABLES.get(ctx_op)
+    if table_attrs is None or kv_cache_mode is None:
+        return list(flat)
+    modes: set[str] = set()
+    saw_table = False
+    for attr in table_attrs:
+        data = getattr(database, attr, None)
+        if not data:
+            continue
+        saw_table = True
+        for fmha_key in data:
+            if kv_cache_mode in data[fmha_key]:
+                modes.add(fmha_key.name if hasattr(fmha_key, "name") else str(fmha_key))
+    if not saw_table:
+        return list(flat)
+    return sorted(modes)
+
+
 @functools.cache
 def _load_op_kernel_source_manifest_entries(systems_root: str) -> dict[str, tuple[dict, ...]]:
     """Load `<systems_root>/op_kernel_source_manifest.yaml` and group entries by op_file.

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -38,6 +38,7 @@ from typing import Any, Literal
 from aiconfigurator.sdk import common, config
 from aiconfigurator.sdk.models import (
     _infer_quant_modes_from_raw_config,
+    attention_op_keys,
     check_is_moe,
     get_model_family,
 )
@@ -717,8 +718,8 @@ class Task:
                 self._set_role_attr(role, "moe_quant_mode", common.MoEQuantMode.w4a8_mxfp4_mxfp8)
 
         # Track whether fmha came from an explicit field (vs HF/fallback): the
-        # V3/Kimi context downgrade must NOT fire on an EXPLICIT fp8 -- v1 keeps it
-        # (its `not explicit_fmha_mode` guard) and lets validate fail fast.
+        # data-driven fallback below must NOT fire on an EXPLICIT fp8 -- explicit
+        # values are the user's contract and validate fails fast on them.
         fmha_explicit: dict[str, bool] = {}
         for role in roles:
             for key in _QUANT_ENUM_TABLES:
@@ -747,53 +748,16 @@ class Task:
                 resolved = from_hf if from_hf is not None else fallback
                 self._set_role_attr(role, key, resolved)
 
-        # Backend / architecture FMHA fp8->bf16 fixups (mirror v1: the V3/Kimi rule
-        # lives in validate_context => context-only; the V3.2/GLM-DSA, V4 and vLLM
-        # rules live in _apply_model_quant_defaults => every role incl. decode).
-        # These encode KERNEL CAPABILITY facts -- the deployed engine runs bf16
-        # FMHA for these arch/backend combos regardless of checkpoint quant -- so
-        # they apply even when no perf DB is packaged (synthetic what-if systems).
-        # Unknown models do NOT need a new rule here: the data-driven fallback
-        # below downgrades any remaining inferred fp8 that has no perf data.
-        # The explicit-fp8 asymmetry is deliberate: only the V3/Kimi rule spares
-        # an explicit fp8 (v1's `not explicit_fmha_mode` guard); the DSA/V4/vLLM
-        # rules override even an explicit fp8, keeping v1 profile YAMLs
-        # (`profiles: [fp8]`) deployable on these combos.
-        for role in roles:
-            backend_name = self._role_attr(role, "backend_name")
-            # DeepSeek-V3/Kimi context attention (MLA prefill) does not support fp8 FMHA,
-            # so downgrade to bfloat16 -- but ONLY for context-attention roles (agg, prefill).
-            # The decode role uses generation attention, which keeps fp8.
-            if (
-                role != "decode"
-                and not fmha_explicit.get(role, False)
-                and self._architecture in ("DeepseekV3ForCausalLM", "KimiK25ForConditionalGeneration")
-                and self._role_attr(role, "fmha_quant_mode") == common.FMHAQuantMode.fp8
-            ):
-                self._set_role_attr(role, "fmha_quant_mode", common.FMHAQuantMode.bfloat16)
-            # DSA module (DeepSeek-V3.2 / GLM-5): DSA perf tables only carry bf16 FMHA.
-            if (
-                self._architecture in ("DeepseekV32ForCausalLM", "GlmMoeDsaForCausalLM")
-                and backend_name in ("trtllm", "sglang")
-                and self._role_attr(role, "fmha_quant_mode") == common.FMHAQuantMode.fp8
-            ):
-                self._set_role_attr(role, "fmha_quant_mode", common.FMHAQuantMode.bfloat16)
-            # DeepSeek-V4 compressed attention is recorded as bf16 in the perf tables.
-            if (
-                self._architecture == "DeepseekV4ForCausalLM"
-                and self._role_attr(role, "fmha_quant_mode") == common.FMHAQuantMode.fp8
-            ):
-                self._set_role_attr(role, "fmha_quant_mode", common.FMHAQuantMode.bfloat16)
-            # vLLM perf tables only include bf16 FMHA.
-            if backend_name == "vllm" and self._role_attr(role, "fmha_quant_mode") == common.FMHAQuantMode.fp8:
-                self._set_role_attr(role, "fmha_quant_mode", common.FMHAQuantMode.bfloat16)
-
-        # Data-driven fallback for whatever inferred fp8 remains: if the role's
-        # perf DB has no fp8 slice in its fmha-keyed context-attention table,
-        # fall back to bfloat16 with a warning instead of failing validate
-        # later.  bf16-as-fp8 is conservative: same kv-cache dtype, attention
-        # math modeled at bf16 throughput.  Explicit user fp8 is never
-        # overridden by this tier -- validate stays fail-fast for it.
+        # Data-driven FMHA resolution: if an inferred fp8 has no fp8 slice in
+        # the role's fmha-keyed context-attention table, fall back to bfloat16
+        # with a warning instead of failing validate later.  bf16-as-fp8 is
+        # conservative: same kv-cache dtype, attention math modeled at bf16
+        # throughput.  The data IS the capability statement -- there are no
+        # per-model downgrade rules; when fp8 slices land for a combo (e.g.
+        # DSA on Blackwell vLLM), the inference survives and uses them.
+        # Explicit user fp8 is never overridden -- validate stays fail-fast
+        # for it (including v1 profile-derived values).  Systems with no
+        # packaged data keep the checkpoint inference untouched.
         #
         # Context-using roles only: NO generation table keys on fmha (decode
         # compute dtype follows the kv-cache dtype; the generation MLA module
@@ -827,18 +791,13 @@ class Task:
     def _attention_op_keys(self, role: str) -> tuple[str, str]:
         """(context_op, generation_op) support-matrix keys for this role's model
         family / backend / wideep combination (shared by the resolve-time FMHA
-        fallback and ``_check_role_against_db``)."""
-        backend = self._role_attr(role, "backend_name")
-        fam = self._model_family
-        if fam == "DEEPSEEKV4":
-            return "deepseek_v4_context_module", "deepseek_v4_generation_module"
-        if fam == "DEEPSEEKV32":
-            return "dsa_context_module", "dsa_generation_module"
-        if fam in ("DEEPSEEK", "KIMIK25") and backend != "vllm":
-            if backend == "sglang" and bool(self._role_attr(role, "enable_wideep")):
-                return "wideep_context_mla", "wideep_generation_mla"
-            return "context_mla", "generation_mla"
-        return "context_attention", "generation_attention"
+        fallback and ``_check_role_against_db``; mapping lives in
+        ``models.attention_op_keys``)."""
+        return attention_op_keys(
+            self._model_family,
+            self._role_attr(role, "backend_name"),
+            bool(self._role_attr(role, "enable_wideep")),
+        )
 
     def _try_load_role_database(self, role: str):
         """Load the role's perf DB, returning None when the perf data is

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -750,9 +750,17 @@ class Task:
         # Backend / architecture FMHA fp8->bf16 fixups (mirror v1: the V3/Kimi rule
         # lives in validate_context => context-only; the V3.2/GLM-DSA, V4 and vLLM
         # rules live in _apply_model_quant_defaults => every role incl. decode).
+        # These encode KERNEL CAPABILITY facts -- the deployed engine runs bf16
+        # FMHA for these arch/backend combos regardless of checkpoint quant -- so
+        # they apply even when no perf DB is packaged (synthetic what-if systems).
+        # Unknown models do NOT need a new rule here: the data-driven fallback
+        # below downgrades any remaining inferred fp8 that has no perf data.
+        # The explicit-fp8 asymmetry is deliberate: only the V3/Kimi rule spares
+        # an explicit fp8 (v1's `not explicit_fmha_mode` guard); the DSA/V4/vLLM
+        # rules override even an explicit fp8, keeping v1 profile YAMLs
+        # (`profiles: [fp8]`) deployable on these combos.
         for role in roles:
             backend_name = self._role_attr(role, "backend_name")
-            fmha = self._role_attr(role, "fmha_quant_mode")
             # DeepSeek-V3/Kimi context attention (MLA prefill) does not support fp8 FMHA,
             # so downgrade to bfloat16 -- but ONLY for context-attention roles (agg, prefill).
             # The decode role uses generation attention, which keeps fp8.
@@ -760,7 +768,7 @@ class Task:
                 role != "decode"
                 and not fmha_explicit.get(role, False)
                 and self._architecture in ("DeepseekV3ForCausalLM", "KimiK25ForConditionalGeneration")
-                and fmha == common.FMHAQuantMode.fp8
+                and self._role_attr(role, "fmha_quant_mode") == common.FMHAQuantMode.fp8
             ):
                 self._set_role_attr(role, "fmha_quant_mode", common.FMHAQuantMode.bfloat16)
             # DSA module (DeepSeek-V3.2 / GLM-5): DSA perf tables only carry bf16 FMHA.
@@ -779,6 +787,106 @@ class Task:
             # vLLM perf tables only include bf16 FMHA.
             if backend_name == "vllm" and self._role_attr(role, "fmha_quant_mode") == common.FMHAQuantMode.fp8:
                 self._set_role_attr(role, "fmha_quant_mode", common.FMHAQuantMode.bfloat16)
+
+        # Data-driven fallback for whatever inferred fp8 remains: if the role's
+        # perf DB has no fp8 slice in its fmha-keyed context-attention table,
+        # fall back to bfloat16 with a warning instead of failing validate
+        # later.  bf16-as-fp8 is conservative: same kv-cache dtype, attention
+        # math modeled at bf16 throughput.  Explicit user fp8 is never
+        # overridden by this tier -- validate stays fail-fast for it.
+        #
+        # Decode roles are consulted only for the (non-wideep) MLA family:
+        # its generation *module* table is the one generation table keyed on
+        # fmha.  Every other generation table keys on kv dtype, so an fp8
+        # label is inert there -- and validate likewise checks fmha only for
+        # context-using roles -- hence skipping avoids a data-gap warning
+        # about data the role never reads.  For MLA decode the context table
+        # stands proxy for capability; TODO: the generation MLA module
+        # table's top-level key IS fmha, so decode could read it directly
+        # should the context/generation labels ever diverge.
+        for role in roles:
+            if fmha_explicit.get(role, False):
+                continue
+            if self._role_attr(role, "fmha_quant_mode") != common.FMHAQuantMode.fp8:
+                continue
+            if role == "decode" and self._attention_op_keys(role) != ("context_mla", "generation_mla"):
+                continue
+            supported = self._context_fmha_supported_modes(role)
+            if not supported or common.FMHAQuantMode.fp8.name in supported:
+                continue  # fp8 data present, or no DB to consult -> keep fp8
+            if common.FMHAQuantMode.bfloat16.name not in supported:
+                continue  # no bf16 slice either (e.g. wideep fp8_block-only tables) -> let validate report
+            self._set_role_attr(role, "fmha_quant_mode", common.FMHAQuantMode.bfloat16)
+            ctx_op, _ = self._attention_op_keys(role)
+            field = "fmha_quant_mode" if self.serving_mode == "agg" else f"{role}_fmha_quant_mode"
+            msg = (
+                f"{role} fmha_quant_mode=fp8 (inferred from the model checkpoint) has no "
+                f"{ctx_op!r} perf data for system={self._role_attr(role, 'system_name')!r}, "
+                f"backend={self._role_attr(role, 'backend_name')!r}, "
+                f"version={self._role_attr(role, 'backend_version')!r}; falling back to bfloat16 "
+                f"FMHA data. Predictions are conservative if the deployed engine runs fp8 FMHA; "
+                f"set {field} explicitly to override."
+            )
+            if self._architecture in ("DeepseekV3ForCausalLM", "KimiK25ForConditionalGeneration"):
+                # Known capability: MLA decode tables are bf16-labeled by design
+                # (the kernel's fp8 work is captured under the kv-cache dtype), so
+                # this is an exact relabel, not a data gap worth warning about.
+                logger.debug(msg)
+            else:
+                logger.warning(msg)
+
+    def _attention_op_keys(self, role: str) -> tuple[str, str]:
+        """(context_op, generation_op) support-matrix keys for this role's model
+        family / backend / wideep combination (shared by the resolve-time FMHA
+        fallback and ``_check_role_against_db``)."""
+        backend = self._role_attr(role, "backend_name")
+        fam = self._model_family
+        if fam == "DEEPSEEKV4":
+            return "deepseek_v4_context_module", "deepseek_v4_generation_module"
+        if fam == "DEEPSEEKV32":
+            return "dsa_context_module", "dsa_generation_module"
+        if fam in ("DEEPSEEK", "KIMIK25") and backend != "vllm":
+            if backend == "sglang" and bool(self._role_attr(role, "enable_wideep")):
+                return "wideep_context_mla", "wideep_generation_mla"
+            return "context_mla", "generation_mla"
+        return "context_attention", "generation_attention"
+
+    def _try_load_role_database(self, role: str):
+        """Load the role's perf DB, returning None when the perf data is
+        unavailable (missing system/backend/version data).  Programmer errors
+        propagate; only data-availability failures are swallowed."""
+        from aiconfigurator.sdk.perf_database import (
+            PerfDataNotAvailableError,
+            has_perf_data_not_available_cause,
+        )
+
+        system = self._role_attr(role, "system_name")
+        backend = self._role_attr(role, "backend_name")
+        version = self._role_attr(role, "backend_version")
+        if not (system and backend and version):
+            return None
+        try:
+            return self._load_database(system, backend, version)
+        except (PerfDataNotAvailableError, FileNotFoundError) as exc:
+            logger.debug("perf DB unavailable for %s role (%s/%s/%s): %s", role, system, backend, version, exc)
+            return None
+        except Exception as exc:
+            # Match the legacy "DB error" envelope (e.g. wrapped FileNotFoundError
+            # inside RuntimeError) without swallowing programmer typos.
+            if not has_perf_data_not_available_cause(exc):
+                raise
+            logger.debug("perf DB unavailable for %s role (%s/%s/%s): %s", role, system, backend, version, exc)
+            return None
+
+    def _context_fmha_supported_modes(self, role: str) -> list[str]:
+        """FMHA modes with perf data for this role's fmha-keyed context-attention
+        op.  Returns [] when the DB (or the op's table) is unavailable, meaning
+        "no information" -- callers must not read that as "nothing supported"."""
+        database = self._try_load_role_database(role)
+        if database is None:
+            return []
+        supported = getattr(database, "supported_quant_mode", {}) or {}
+        return supported.get(self._attention_op_keys(role)[0], []) or []
 
     def _resolve_search_space(self) -> None:
         roles = ["agg"] if self.serving_mode == "agg" else ["prefill", "decode"]
@@ -1180,10 +1288,6 @@ class Task:
     ) -> None:
         """For one role, fetch its perf DB and verify each quant mode is supported."""
         from aiconfigurator.sdk.errors import UnsupportedWideepConfigError
-        from aiconfigurator.sdk.perf_database import (
-            PerfDataNotAvailableError,
-            has_perf_data_not_available_cause,
-        )
 
         system = self._role_attr(role, "system_name")
         backend = self._role_attr(role, "backend_name")
@@ -1191,19 +1295,8 @@ class Task:
         if not (system and backend and version):
             return  # nothing to validate against
 
-        try:
-            database = self._load_database(system, backend, version)
-        except (PerfDataNotAvailableError, FileNotFoundError) as exc:
-            # DB unavailable; let sweep surface the real error later.
-            logger.debug("validate: skipping DB-side quant check (DB unavailable): %s", exc)
-            database = None
-        except Exception as exc:
-            # Match the legacy "DB error" envelope (e.g. wrapped FileNotFoundError
-            # inside RuntimeError) without swallowing programmer typos.
-            if not has_perf_data_not_available_cause(exc):
-                raise
-            logger.debug("validate: skipping DB-side quant check (DB unavailable): %s", exc)
-            database = None
+        # DB unavailable; let sweep surface the real error later.
+        database = self._try_load_role_database(role)
 
         if database is None:
             # In SILICON mode the DB must exist; fp8_static is derived from
@@ -1220,23 +1313,11 @@ class Task:
             return
 
         supported: dict = getattr(database, "supported_quant_mode", {}) or {}
-        enable_wideep = bool(self._role_attr(role, "enable_wideep"))
         moe_backend = self.moe_backend  # shared across roles
         is_moe = self._is_moe
-        fam = self._model_family
 
         # Pick the attention-module op keys for this (model family, backend, wideep).
-        if fam == "DEEPSEEKV4":
-            ctx_op, gen_op = "deepseek_v4_context_module", "deepseek_v4_generation_module"
-        elif fam == "DEEPSEEKV32":
-            ctx_op, gen_op = "dsa_context_module", "dsa_generation_module"
-        elif fam in ("DEEPSEEK", "KIMIK25") and backend != "vllm":
-            if backend == "sglang" and enable_wideep:
-                ctx_op, gen_op = "wideep_context_mla", "wideep_generation_mla"
-            else:
-                ctx_op, gen_op = "context_mla", "generation_mla"
-        else:
-            ctx_op, gen_op = "context_attention", "generation_attention"
+        ctx_op, gen_op = self._attention_op_keys(role)
 
         # supported_quant_mode is a DATA-PRESENCE list (which quants the DB carries
         # tables for), not a backend-capability list. In SILICON that equals what we

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -828,13 +828,21 @@ class Task:
 
     def _context_fmha_supported_modes(self, role: str) -> list[str]:
         """FMHA modes with perf data for this role's fmha-keyed context-attention
-        op.  Returns [] when the DB (or the op's table) is unavailable, meaning
-        "no information" -- callers must not read that as "nothing supported"."""
+        op, jointly with the role's resolved kv-cache mode (an fmha slice that
+        exists only under a different kv dtype cannot serve this role's
+        queries).  Returns [] when the DB (or the op's table) is unavailable,
+        meaning "no information" -- callers must not read that as "nothing
+        supported"."""
+        from aiconfigurator.sdk.perf_database import context_fmha_supported_modes
+
         database = self._try_load_role_database(role)
         if database is None:
             return []
-        supported = getattr(database, "supported_quant_mode", {}) or {}
-        return supported.get(self._attention_op_keys(role)[0], []) or []
+        return context_fmha_supported_modes(
+            database,
+            self._attention_op_keys(role)[0],
+            self._role_attr(role, "kvcache_quant_mode"),
+        )
 
     def _resolve_search_space(self) -> None:
         roles = ["agg"] if self.serving_mode == "agg" else ["prefill", "decode"]

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -795,31 +795,27 @@ class Task:
         # math modeled at bf16 throughput.  Explicit user fp8 is never
         # overridden by this tier -- validate stays fail-fast for it.
         #
-        # Decode roles are consulted only for the (non-wideep) MLA family:
-        # its generation *module* table is the one generation table keyed on
-        # fmha.  Every other generation table keys on kv dtype, so an fp8
-        # label is inert there -- and validate likewise checks fmha only for
-        # context-using roles -- hence skipping avoids a data-gap warning
-        # about data the role never reads.  For MLA decode the context table
-        # stands proxy for capability; TODO: the generation MLA module
-        # table's top-level key IS fmha, so decode could read it directly
-        # should the context/generation labels ever diverge.
+        # Context-using roles only: NO generation table keys on fmha (decode
+        # compute dtype follows the kv-cache dtype; the generation MLA module
+        # loader drops the degenerate mla_dtype column), so an fp8 label is
+        # inert on decode -- and validate likewise checks fmha only for
+        # context-using roles.
         for role in roles:
+            if role == "decode":
+                continue
             if fmha_explicit.get(role, False):
                 continue
             if self._role_attr(role, "fmha_quant_mode") != common.FMHAQuantMode.fp8:
-                continue
-            if role == "decode" and self._attention_op_keys(role) != ("context_mla", "generation_mla"):
                 continue
             supported = self._context_fmha_supported_modes(role)
             if not supported or common.FMHAQuantMode.fp8.name in supported:
                 continue  # fp8 data present, or no DB to consult -> keep fp8
             if common.FMHAQuantMode.bfloat16.name not in supported:
-                continue  # no bf16 slice either (e.g. wideep fp8_block-only tables) -> let validate report
+                continue  # no bf16 slice either -> let validate report the gap
             self._set_role_attr(role, "fmha_quant_mode", common.FMHAQuantMode.bfloat16)
             ctx_op, _ = self._attention_op_keys(role)
             field = "fmha_quant_mode" if self.serving_mode == "agg" else f"{role}_fmha_quant_mode"
-            msg = (
+            logger.warning(
                 f"{role} fmha_quant_mode=fp8 (inferred from the model checkpoint) has no "
                 f"{ctx_op!r} perf data for system={self._role_attr(role, 'system_name')!r}, "
                 f"backend={self._role_attr(role, 'backend_name')!r}, "
@@ -827,13 +823,6 @@ class Task:
                 f"FMHA data. Predictions are conservative if the deployed engine runs fp8 FMHA; "
                 f"set {field} explicitly to override."
             )
-            if self._architecture in ("DeepseekV3ForCausalLM", "KimiK25ForConditionalGeneration"):
-                # Known capability: MLA decode tables are bf16-labeled by design
-                # (the kernel's fp8 work is captured under the kv-cache dtype), so
-                # this is an exact relabel, not a data gap worth warning about.
-                logger.debug(msg)
-            else:
-                logger.warning(msg)
 
     def _attention_op_keys(self, role: str) -> tuple[str, str]:
         """(context_op, generation_op) support-matrix keys for this role's model

--- a/tests/unit/sdk/database/test_data_loaders.py
+++ b/tests/unit/sdk/database/test_data_loaders.py
@@ -1083,7 +1083,7 @@ def test_load_generation_mla_module_data_nonexistent(tmp_path):
 def test_load_generation_mla_module_data_basic(tmp_path):
     """
     Test loading generation MLA module data.
-    Structure: data[fmha_quant_mode][kv_cache_quant_mode][gemm_quant_mode][num_heads][b][s]
+    Structure: data[kv_cache_quant_mode][gemm_quant_mode][num_heads][b][s]
     s = isl + step
     """
     csv_file = tmp_path / "mla_generation_module_perf.txt"
@@ -1099,17 +1099,17 @@ def test_load_generation_mla_module_data_basic(tmp_path):
 
     data = load_generation_mla_module_data(str(csv_file))
 
-    fmha = FMHAQuantMode.bfloat16
     kv = KVCacheQuantMode.fp8
     gemm = GEMMQuantMode.fp8_block
 
-    assert fmha in data
-    assert kv in data[fmha]
-    assert gemm in data[fmha][kv]
-    assert 16 in data[fmha][kv][gemm]  # num_heads
-    assert 4 in data[fmha][kv][gemm][16]  # b
-    assert 256 in data[fmha][kv][gemm][16][4]  # s = isl(1) + step(255)
-    assert data[fmha][kv][gemm][16][4][256]["latency"] == pytest.approx(0.135)
+    # The mla_dtype column is dropped: generation module data keys on
+    # kv_cache_dtype at the top level (decode compute follows kv dtype).
+    assert kv in data
+    assert gemm in data[kv]
+    assert 16 in data[kv][gemm]  # num_heads
+    assert 4 in data[kv][gemm][16]  # b
+    assert 256 in data[kv][gemm][16][4]  # s = isl(1) + step(255)
+    assert data[kv][gemm][16][4][256]["latency"] == pytest.approx(0.135)
 
 
 def test_load_generation_mla_module_data_multiple_quant_modes(tmp_path):
@@ -1129,10 +1129,10 @@ def test_load_generation_mla_module_data_multiple_quant_modes(tmp_path):
 
     data = load_generation_mla_module_data(str(csv_file))
 
-    # bfloat16/bfloat16/bfloat16 combo
-    entry1 = data[FMHAQuantMode.bfloat16][KVCacheQuantMode.bfloat16][GEMMQuantMode.bfloat16][128][1][257]
+    # bfloat16/bfloat16 combo
+    entry1 = data[KVCacheQuantMode.bfloat16][GEMMQuantMode.bfloat16][128][1][257]
     assert entry1["latency"] == pytest.approx(0.13)
 
-    # bfloat16/fp8/fp8_block combo
-    entry2 = data[FMHAQuantMode.bfloat16][KVCacheQuantMode.fp8][GEMMQuantMode.fp8_block][128][1][257]
+    # fp8/fp8_block combo
+    entry2 = data[KVCacheQuantMode.fp8][GEMMQuantMode.fp8_block][128][1][257]
     assert entry2["latency"] == pytest.approx(0.10)

--- a/tests/unit/sdk/database/test_fallback_op.py
+++ b/tests/unit/sdk/database/test_fallback_op.py
@@ -238,7 +238,6 @@ class TestMLAModule:
             s=4000,
             num_heads=16,
             kv_cache_dtype=common.KVCacheQuantMode.fp8,
-            fmha_quant_mode=common.FMHAQuantMode.bfloat16,
             gemm_quant_mode=common.GEMMQuantMode.fp8_block,
         )
         mock_db.query_context_mla_module.assert_not_called()

--- a/tests/unit/sdk/database/test_generation_mla_module_pins.py
+++ b/tests/unit/sdk/database/test_generation_mla_module_pins.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Exact-value pins for the generation MLA module table on fp8-KV decode.
+
+Dropping the degenerate fmha axis makes the module table live for
+fp8-checkpoint DeepSeek-V3/R1/Kimi decode (previously the fp8 fmha label
+missed the fmha-keyed table and FallbackOp silently composed the granular
+path).  That moves decode predictions by tens of percent on every system
+shipping mla_generation_module data, so these pins hold the module-table
+numbers still: any drift here is a data or interpolation change, not noise.
+Values minted on the PR branch via ``get_database`` (production loading,
+shared layer included) in SILICON mode.
+"""
+
+import pytest
+
+from aiconfigurator.sdk import common
+from aiconfigurator.sdk.perf_database import get_database
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    ("system", "b", "s", "num_heads", "gemm", "expected_ms"),
+    [
+        ("gb200", 8, 4097, 128, common.GEMMQuantMode.bfloat16, 0.1536000000000000),
+        ("gb200", 8, 3000, 128, common.GEMMQuantMode.bfloat16, 0.1519930664062500),
+        ("gb200", 64, 4096, 128, common.GEMMQuantMode.bfloat16, 0.1999953125000000),
+        ("h200_sxm", 64, 4096, 16, common.GEMMQuantMode.fp8_block, 0.1904882812500000),
+    ],
+)
+def test_generation_mla_module_fp8_kv_exact_values(system, b, s, num_heads, gemm, expected_ms):
+    db = get_database(system, "trtllm", "1.3.0rc10")
+    db.set_default_database_mode(common.DatabaseMode.SILICON)
+    result = db.query_generation_mla_module(
+        b=b,
+        s=s,
+        num_heads=num_heads,
+        kv_cache_dtype=common.KVCacheQuantMode.fp8,
+        gemm_quant_mode=gemm,
+    )
+    assert float(result) == pytest.approx(expected_ms, rel=1e-9)

--- a/tests/unit/sdk/models/test_context_fmha_compat.py
+++ b/tests/unit/sdk/models/test_context_fmha_compat.py
@@ -1,19 +1,22 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Regression tests for the DeepSeek-V3 / Kimi context-role FMHA rule.
+"""Regression tests for the estimate-path data-driven context-FMHA guard.
 
 NVBug 6401867: the single-point ``cli estimate`` / AFD path resolved fp8 FMHA
 for DeepSeek-V3 context MLA (no perf data) and crashed with a
-PerfDataNotAvailableError traceback. ``resolve_context_fmha_compat`` mirrors the
-role-aware downgrade that ``task_v2`` (the sweep path) already applies.
+PerfDataNotAvailableError traceback. ``resolve_context_fmha_by_data`` mirrors
+the resolve-time data fallback that ``task_v2`` (the sweep path) applies: the
+perf DB's fmha-keyed context table decides, not a hand-written model list.
 """
+
+from types import SimpleNamespace
 
 import pytest
 
 import aiconfigurator.sdk.models.helpers as helpers
 from aiconfigurator.sdk import common, config
-from aiconfigurator.sdk.models import resolve_context_fmha_compat
+from aiconfigurator.sdk.models import resolve_context_fmha_by_data
 
 pytestmark = pytest.mark.unit
 
@@ -40,20 +43,41 @@ def _mc(fmha=None):
     return config.ModelConfig(fmha_quant_mode=fmha)
 
 
-def test_context_role_inferred_fp8_downgrades_to_bf16(fake_model_info):
-    """Auto-inferred fp8 FMHA on a V3 context role falls back to bf16."""
+def _db(**supported):
+    """Database stub exposing only supported_quant_mode."""
+    return SimpleNamespace(supported_quant_mode=supported)
+
+
+# V3 on trtllm consults the "context_mla" op key.
+_BF16_ONLY_DB = _db(context_mla=["bfloat16"])
+_FP8_DB = _db(context_mla=["bfloat16", "fp8"])
+_NO_INFO_DB = _db()
+
+
+def test_context_role_inferred_fp8_downgrades_to_bf16(fake_model_info, caplog):
+    """Auto-inferred fp8 FMHA with a bf16-only context table falls back to bf16."""
     fake_model_info("DeepseekV3ForCausalLM", _V3_FP8_RAW)
     mc = _mc(fmha=None)
-    resolve_context_fmha_compat(mc, "deepseek-ai/DeepSeek-V3", is_context_role=True)
+    with caplog.at_level("WARNING"):
+        resolve_context_fmha_by_data(mc, "deepseek-ai/DeepSeek-V3", _BF16_ONLY_DB, "trtllm", is_context_role=True)
     assert mc.fmha_quant_mode == common.FMHAQuantMode.bfloat16
+    assert any("falling back to bfloat16" in r.message for r in caplog.records)
+
+
+def test_context_role_inferred_fp8_kept_when_data_exists(fake_model_info):
+    """With an fp8 slice in the context table, the inference survives (left to get_model)."""
+    fake_model_info("DeepseekV3ForCausalLM", _V3_FP8_RAW)
+    mc = _mc(fmha=None)
+    resolve_context_fmha_by_data(mc, "deepseek-ai/DeepSeek-V3", _FP8_DB, "trtllm", is_context_role=True)
+    assert mc.fmha_quant_mode is None
 
 
 def test_context_role_explicit_fp8_raises(fake_model_info):
-    """Explicit fp8 FMHA on a V3 context role raises a concise error, no traceback."""
+    """Explicit fp8 FMHA with no fp8 slice raises a concise error, no traceback."""
     fake_model_info("DeepseekV3ForCausalLM", _V3_FP8_RAW)
     mc = _mc(fmha=common.FMHAQuantMode.fp8)
-    with pytest.raises(ValueError, match="does not support fp8 FMHA"):
-        resolve_context_fmha_compat(mc, "deepseek-ai/DeepSeek-V3", is_context_role=True)
+    with pytest.raises(ValueError, match="has no 'context_mla' perf data"):
+        resolve_context_fmha_by_data(mc, "deepseek-ai/DeepSeek-V3", _BF16_ONLY_DB, "trtllm", is_context_role=True)
 
 
 def test_generation_role_keeps_fp8(fake_model_info):
@@ -61,11 +85,11 @@ def test_generation_role_keeps_fp8(fake_model_info):
     fake_model_info("DeepseekV3ForCausalLM", _V3_FP8_RAW)
     # Explicit fp8 must NOT raise for a gen role.
     mc = _mc(fmha=common.FMHAQuantMode.fp8)
-    resolve_context_fmha_compat(mc, "deepseek-ai/DeepSeek-V3", is_context_role=False)
+    resolve_context_fmha_by_data(mc, "deepseek-ai/DeepSeek-V3", _BF16_ONLY_DB, "trtllm", is_context_role=False)
     assert mc.fmha_quant_mode == common.FMHAQuantMode.fp8
     # Auto-inferred case: helper leaves it for get_model to resolve to fp8.
     mc_auto = _mc(fmha=None)
-    resolve_context_fmha_compat(mc_auto, "deepseek-ai/DeepSeek-V3", is_context_role=False)
+    resolve_context_fmha_by_data(mc_auto, "deepseek-ai/DeepSeek-V3", _BF16_ONLY_DB, "trtllm", is_context_role=False)
     assert mc_auto.fmha_quant_mode is None
 
 
@@ -73,21 +97,36 @@ def test_context_role_explicit_bf16_is_untouched(fake_model_info):
     """An explicit non-fp8 request is respected (no error, no change)."""
     fake_model_info("KimiK25ForConditionalGeneration", _V3_FP8_RAW)
     mc = _mc(fmha=common.FMHAQuantMode.bfloat16)
-    resolve_context_fmha_compat(mc, "moonshotai/Kimi-K2.5", is_context_role=True)
+    resolve_context_fmha_by_data(mc, "moonshotai/Kimi-K2.5", _BF16_ONLY_DB, "trtllm", is_context_role=True)
     assert mc.fmha_quant_mode == common.FMHAQuantMode.bfloat16
 
 
-def test_non_v3_architecture_is_untouched(fake_model_info):
-    """Architectures without the context-fp8 limitation are left to get_model."""
-    fake_model_info("Qwen3MoeForCausalLM", _V3_FP8_RAW)
+def test_no_db_information_is_untouched(fake_model_info):
+    """Without table info (synthetic what-if system), the inference is kept."""
+    fake_model_info("DeepseekV3ForCausalLM", _V3_FP8_RAW)
     mc = _mc(fmha=None)
-    resolve_context_fmha_compat(mc, "Qwen/Qwen3-235B", is_context_role=True)
+    resolve_context_fmha_by_data(mc, "deepseek-ai/DeepSeek-V3", _NO_INFO_DB, "trtllm", is_context_role=True)
     assert mc.fmha_quant_mode is None
+    # Explicit fp8 is also left for the query path to surface (no early raise).
+    mc_explicit = _mc(fmha=common.FMHAQuantMode.fp8)
+    resolve_context_fmha_by_data(mc_explicit, "deepseek-ai/DeepSeek-V3", _NO_INFO_DB, "trtllm", is_context_role=True)
+    assert mc_explicit.fmha_quant_mode == common.FMHAQuantMode.fp8
 
 
 def test_bf16_v3_checkpoint_needs_no_downgrade(fake_model_info):
     """A bf16 V3 checkpoint infers no fp8, so the helper is a no-op."""
     fake_model_info("DeepseekV3ForCausalLM", _V3_BF16_RAW)
     mc = _mc(fmha=None)
-    resolve_context_fmha_compat(mc, "deepseek-ai/DeepSeek-V3-bf16", is_context_role=True)
+    resolve_context_fmha_by_data(mc, "deepseek-ai/DeepSeek-V3-bf16", _BF16_ONLY_DB, "trtllm", is_context_role=True)
     assert mc.fmha_quant_mode is None
+
+
+def test_generic_arch_consults_context_attention(fake_model_info, caplog):
+    """Non-MLA families consult the generic context_attention table."""
+    fake_model_info("Qwen3MoeForCausalLM", {"quant_algo": "fp8"})
+    db = _db(context_attention=["bfloat16"])
+    mc = _mc(fmha=None)
+    with caplog.at_level("WARNING"):
+        resolve_context_fmha_by_data(mc, "Qwen/Qwen3-235B", db, "sglang", is_context_role=True)
+    assert mc.fmha_quant_mode == common.FMHAQuantMode.bfloat16
+    assert any("context_attention" in r.message for r in caplog.records)

--- a/tests/unit/sdk/task_v2/test_task_config.py
+++ b/tests/unit/sdk/task_v2/test_task_config.py
@@ -512,6 +512,29 @@ def test_deepseek_v32_v4_context_fmha_downgrade_is_data_driven():
         assert t.decode_fmha_quant_mode == common.FMHAQuantMode.fp8
 
 
+def test_wideep_trtllm_context_fmha_capability_uses_granular_table(caplog):
+    """trtllm wideep context queries the granular context_mla table directly, so
+    the fmha fallback must key capability off the granular slices -- the merged
+    context_mla list can contain module-only fp8 rows inherited cross-framework
+    via the shared layer (gb200: vllm module data), which the wideep path can
+    never hit.  Regression for the deepseek_wideep_trtllm.yaml e2e failure.
+    """
+    import logging
+
+    from aiconfigurator.sdk import common
+
+    with caplog.at_level(logging.WARNING):
+        t = Task(
+            serving_mode="agg",
+            model_path="deepseek-ai/DeepSeek-V3",
+            system_name="gb200",
+            backend_name="trtllm",
+            enable_wideep=True,
+        )
+    assert t.fmha_quant_mode == common.FMHAQuantMode.bfloat16
+    assert any("context_mla_granular" in r.message for r in caplog.records)
+
+
 def test_nextn_default_respects_hf_then_family_fallback():
     """nextn: HF num_nextn_predict_layers wins (incl. explicit 0, e.g. Kimi-K2.5);
     field absent -> family-based fallback (Qwen3.5 -> 1, DeepSeek -> 1).

--- a/tests/unit/sdk/task_v2/test_task_config.py
+++ b/tests/unit/sdk/task_v2/test_task_config.py
@@ -384,23 +384,109 @@ def test_sweep_disagg_require_same_tp_sglang_non_wideep():
     assert mk("trtllm")["require_same_tp"] is False
 
 
-def test_deepseek_decode_keeps_fp8_fmha_prefill_downgrades():
-    """DeepSeek context attention (prefill) downgrades fp8 FMHA to bf16; decode
-    (generation attention) keeps fp8. Matches v1, which gates this on validate_context.
+def test_deepseek_prefill_and_decode_fmha_downgrade_to_bf16(caplog):
+    """DeepSeek context attention (prefill) downgrades fp8 FMHA to bf16 via the
+    V3/Kimi capability rule; decode is downgraded by the data-driven fallback
+    (the MLA perf tables carry no fp8 fmha slice), so the resolved config and
+    the queried data slices agree.  Known-capability downgrades stay silent
+    (debug, not warning) -- a V3 run must not warn on every task.
     """
+    import logging
+
     from aiconfigurator.sdk import common
 
-    t = Task(
-        serving_mode="disagg",
-        prefill_model_path="deepseek-ai/DeepSeek-V3",
-        prefill_system_name="h200_sxm",
-        prefill_backend_name="sglang",
-        decode_model_path="deepseek-ai/DeepSeek-V3",
-        decode_system_name="h200_sxm",
-        decode_backend_name="sglang",
-    )
+    with caplog.at_level(logging.WARNING):
+        t = Task(
+            serving_mode="disagg",
+            prefill_model_path="deepseek-ai/DeepSeek-V3",
+            prefill_system_name="h200_sxm",
+            prefill_backend_name="sglang",
+            decode_model_path="deepseek-ai/DeepSeek-V3",
+            decode_system_name="h200_sxm",
+            decode_backend_name="sglang",
+        )
+    assert t.prefill_fmha_quant_mode == common.FMHAQuantMode.bfloat16
+    assert t.decode_fmha_quant_mode == common.FMHAQuantMode.bfloat16
+    assert not any("falling back to bfloat16 FMHA" in r.message for r in caplog.records)
+
+
+def test_fmha_data_fallback_unknown_arch_downgrades_with_warning(caplog):
+    """A checkpoint-inferred fp8 FMHA on a platform whose context-attention table
+    has no fp8 slice (a100: no fp8 hardware) falls back to bfloat16 with a warning,
+    instead of leaving a mode that validate would reject.  The same model on a
+    platform WITH fp8 data (h200) keeps fp8 and does not warn.
+    """
+    import logging
+
+    from aiconfigurator.sdk import common
+
+    with caplog.at_level(logging.WARNING):
+        t = Task(
+            serving_mode="agg",
+            model_path="Qwen/Qwen3-32B-FP8-Static-PerTensor",
+            system_name="a100_sxm",
+            backend_name="sglang",
+        )
+    assert t.fmha_quant_mode == common.FMHAQuantMode.bfloat16
+    assert any("falling back to bfloat16 FMHA" in r.message for r in caplog.records)
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        t2 = Task(
+            serving_mode="agg",
+            model_path="Qwen/Qwen3-32B-FP8-Static-PerTensor",
+            system_name="h200_sxm",
+            backend_name="trtllm",
+        )
+    assert t2.fmha_quant_mode == common.FMHAQuantMode.fp8
+    assert not any("falling back to bfloat16 FMHA" in r.message for r in caplog.records)
+
+
+def test_fmha_data_fallback_skips_generation_only_decode(caplog):
+    """A generic-attention decode role never reads fmha data (generation tables
+    key on kv dtype; validate checks fmha only for context roles), so the
+    fallback must not warn about or downgrade decode even on a system whose
+    context table lacks fp8.  The prefill role on the same system DOES fall back.
+    """
+    import logging
+
+    from aiconfigurator.sdk import common
+
+    with caplog.at_level(logging.WARNING):
+        t = Task(
+            serving_mode="disagg",
+            prefill_model_path="Qwen/Qwen3-32B-FP8-Static-PerTensor",
+            prefill_system_name="a100_sxm",
+            prefill_backend_name="sglang",
+            decode_model_path="Qwen/Qwen3-32B-FP8-Static-PerTensor",
+            decode_system_name="a100_sxm",
+            decode_backend_name="sglang",
+        )
     assert t.prefill_fmha_quant_mode == common.FMHAQuantMode.bfloat16
     assert t.decode_fmha_quant_mode == common.FMHAQuantMode.fp8
+    fallback_msgs = [r.message for r in caplog.records if "falling back to bfloat16 FMHA" in r.message]
+    assert len(fallback_msgs) == 1 and fallback_msgs[0].startswith("prefill ")
+
+
+def test_fmha_data_fallback_without_bf16_slice_left_untouched(monkeypatch, caplog):
+    """When the context table has fmha data but neither fp8 nor bf16 slices
+    (e.g. wideep tables carry only fp8_block), the fallback must leave the
+    inferred fp8 alone -- there is nothing safe to fall back to, so validate
+    reports the gap instead."""
+    import logging
+
+    from aiconfigurator.sdk import common
+
+    monkeypatch.setattr(Task, "_context_fmha_supported_modes", lambda self, role: ["fp8_block"])
+    with caplog.at_level(logging.WARNING):
+        t = Task(
+            serving_mode="agg",
+            model_path="Qwen/Qwen3-32B-FP8-Static-PerTensor",
+            system_name="a100_sxm",
+            backend_name="sglang",
+        )
+    assert t.fmha_quant_mode == common.FMHAQuantMode.fp8
+    assert not any("falling back to bfloat16 FMHA" in r.message for r in caplog.records)
 
 
 def test_deepseek_v32_v4_downgrade_fmha_all_roles():

--- a/tests/unit/sdk/task_v2/test_task_config.py
+++ b/tests/unit/sdk/task_v2/test_task_config.py
@@ -416,6 +416,11 @@ def test_fmha_data_fallback_unknown_arch_downgrades_with_warning(caplog):
     has no fp8 slice (a100: no fp8 hardware) falls back to bfloat16 with a warning,
     instead of leaving a mode that validate would reject.  The same model on a
     platform WITH fp8 data (h200) keeps fp8 and does not warn.
+
+    kv is pinned to bfloat16 on a100: capability is judged jointly with the kv
+    mode, and a100's only slice is (bf16 fmha, bf16 kv) -- with an fp8 kv there
+    is nothing to fall back to and the inference is kept for validate to
+    report.
     """
     import logging
 
@@ -427,9 +432,23 @@ def test_fmha_data_fallback_unknown_arch_downgrades_with_warning(caplog):
             model_path="Qwen/Qwen3-32B-FP8-Static-PerTensor",
             system_name="a100_sxm",
             backend_name="sglang",
+            kvcache_quant_mode=common.KVCacheQuantMode.bfloat16,
         )
     assert t.fmha_quant_mode == common.FMHAQuantMode.bfloat16
     assert any("falling back to bfloat16 FMHA" in r.message for r in caplog.records)
+
+    # With the inferred fp8 kv, no a100 slice can serve at all -> keep fp8
+    # (validate reports the gap); no misleading "falling back" warning.
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        t_kv_fp8 = Task(
+            serving_mode="agg",
+            model_path="Qwen/Qwen3-32B-FP8-Static-PerTensor",
+            system_name="a100_sxm",
+            backend_name="sglang",
+        )
+    assert t_kv_fp8.fmha_quant_mode == common.FMHAQuantMode.fp8
+    assert not any("falling back to bfloat16 FMHA" in r.message for r in caplog.records)
 
     caplog.clear()
     with caplog.at_level(logging.WARNING):
@@ -459,9 +478,11 @@ def test_fmha_data_fallback_skips_generation_only_decode(caplog):
             prefill_model_path="Qwen/Qwen3-32B-FP8-Static-PerTensor",
             prefill_system_name="a100_sxm",
             prefill_backend_name="sglang",
+            prefill_kvcache_quant_mode=common.KVCacheQuantMode.bfloat16,
             decode_model_path="Qwen/Qwen3-32B-FP8-Static-PerTensor",
             decode_system_name="a100_sxm",
             decode_backend_name="sglang",
+            decode_kvcache_quant_mode=common.KVCacheQuantMode.bfloat16,
         )
     assert t.prefill_fmha_quant_mode == common.FMHAQuantMode.bfloat16
     assert t.decode_fmha_quant_mode == common.FMHAQuantMode.fp8
@@ -510,6 +531,48 @@ def test_deepseek_v32_v4_context_fmha_downgrade_is_data_driven():
         )
         assert t.prefill_fmha_quant_mode == common.FMHAQuantMode.bfloat16
         assert t.decode_fmha_quant_mode == common.FMHAQuantMode.fp8
+
+
+def test_get_model_preserves_task_resolved_fmha():
+    """get_model()'s legacy FMHA guards fire only when fmha arrives unset: a
+    Task-resolved fp8 (data-backed -- b200 vLLM ships native fp8 dsa_context
+    slices) must survive model build.  Review regression: the guards in
+    _apply_model_quant_defaults used to re-downgrade on the value, silently
+    undoing the data-driven resolution at every sweep point."""
+    from aiconfigurator.sdk import common
+    from aiconfigurator.sdk.models import get_model
+
+    t = Task(
+        serving_mode="agg",
+        model_path="deepseek-ai/DeepSeek-V3.2",
+        system_name="b200_sxm",
+        backend_name="vllm",
+    )
+    assert t.fmha_quant_mode == common.FMHAQuantMode.fp8
+    mc = t.build_model_config(role="agg")
+    mc.tp_size = 8
+    mc.moe_ep_size = 8
+    mc.moe_tp_size = 1
+    get_model("deepseek-ai/DeepSeek-V3.2", mc, "vllm")
+    assert mc.fmha_quant_mode == common.FMHAQuantMode.fp8
+
+
+def test_fmha_fallback_uses_joint_fmha_kv_capability(caplog):
+    """Capability is judged jointly with the role's kv mode: on b200 trtllm the
+    fp8 context_mla slice exists only under kv=fp8 (shared-layer module rows),
+    so inferred fp8 fmha survives with kv=fp8 but must downgrade with an
+    explicit bf16 kv -- the flat per-op list would keep fp8 and crash at query
+    time (review finding)."""
+    import logging
+
+    from aiconfigurator.sdk import common
+
+    base = dict(serving_mode="agg", model_path="deepseek-ai/DeepSeek-V3", system_name="b200_sxm", backend_name="trtllm")
+    assert Task(**base).fmha_quant_mode == common.FMHAQuantMode.fp8  # kv inferred fp8 -> joint slice present
+    with caplog.at_level(logging.WARNING):
+        t = Task(**base, kvcache_quant_mode=common.KVCacheQuantMode.bfloat16)
+    assert t.fmha_quant_mode == common.FMHAQuantMode.bfloat16
+    assert any("falling back to bfloat16 FMHA" in r.message for r in caplog.records)
 
 
 def test_wideep_trtllm_context_fmha_capability_uses_granular_table(caplog):

--- a/tests/unit/sdk/task_v2/test_task_config.py
+++ b/tests/unit/sdk/task_v2/test_task_config.py
@@ -386,10 +386,10 @@ def test_sweep_disagg_require_same_tp_sglang_non_wideep():
 
 def test_deepseek_prefill_downgrades_decode_keeps_fp8_fmha(caplog):
     """DeepSeek context attention (prefill) downgrades fp8 FMHA to bf16 via the
-    V3/Kimi capability rule.  Decode keeps the checkpoint-inferred fp8 label:
-    no generation table keys on fmha (the generation MLA module table has no
-    fmha axis), so the label is inert for decode modeling and the data-driven
-    fallback skips decode roles -- no warning either way.
+    data fallback (the packaged context_mla tables carry no fp8 slice), with
+    one warning for the task.  Decode keeps the checkpoint-inferred fp8 label:
+    no generation table keys on fmha, so the label is inert for decode modeling
+    and the fallback skips decode roles.
     """
     import logging
 
@@ -407,7 +407,8 @@ def test_deepseek_prefill_downgrades_decode_keeps_fp8_fmha(caplog):
         )
     assert t.prefill_fmha_quant_mode == common.FMHAQuantMode.bfloat16
     assert t.decode_fmha_quant_mode == common.FMHAQuantMode.fp8
-    assert not any("falling back to bfloat16 FMHA" in r.message for r in caplog.records)
+    fallback_msgs = [r.message for r in caplog.records if "falling back to bfloat16 FMHA" in r.message]
+    assert len(fallback_msgs) == 1 and fallback_msgs[0].startswith("prefill ")
 
 
 def test_fmha_data_fallback_unknown_arch_downgrades_with_warning(caplog):
@@ -489,10 +490,11 @@ def test_fmha_data_fallback_without_bf16_slice_left_untouched(monkeypatch, caplo
     assert not any("falling back to bfloat16 FMHA" in r.message for r in caplog.records)
 
 
-def test_deepseek_v32_v4_downgrade_fmha_all_roles():
-    """DeepSeek-V3.2 / V4 use bf16 FMHA on EVERY role incl. decode (DSA / compressed
-    attention perf tables only carry bf16). Mirrors v1 _apply_model_quant_defaults,
-    which is unconditional (unlike the context-only V3/Kimi rule).
+def test_deepseek_v32_v4_context_fmha_downgrade_is_data_driven():
+    """DeepSeek-V3.2 / V4 context fmha resolves bf16 on sglang b200 because the
+    dsa/dsv4 context module tables there carry only bf16 slices -- decided by
+    the data fallback, not a hand-written model rule.  Decode keeps the fp8
+    label (no generation table keys on fmha).
     """
     from aiconfigurator.sdk import common
 
@@ -507,7 +509,7 @@ def test_deepseek_v32_v4_downgrade_fmha_all_roles():
             decode_backend_name="sglang",
         )
         assert t.prefill_fmha_quant_mode == common.FMHAQuantMode.bfloat16
-        assert t.decode_fmha_quant_mode == common.FMHAQuantMode.bfloat16
+        assert t.decode_fmha_quant_mode == common.FMHAQuantMode.fp8
 
 
 def test_nextn_default_respects_hf_then_family_fallback():
@@ -955,8 +957,9 @@ def test_run_dispatches_to_sweep_agg(monkeypatch):
     )
     result = t.run(validate=False)  # this test isolates dispatch; validate() is covered separately
     assert result == "agg-result"
-    # DB loaded for the (system, backend, version) triple
-    assert captured["dbs"] == [("h200_sxm", t.backend_name, t.backend_version)]
+    # DB loaded for the (system, backend, version) triple (the resolve-time
+    # fmha fallback loads the same view earlier; dispatch adds one more).
+    assert set(captured["dbs"]) == {("h200_sxm", t.backend_name, t.backend_version)}
     assert captured["agg_kwargs"]["model_path"] == "deepseek-ai/DeepSeek-V3"
     assert captured["agg_kwargs"]["database"] == f"db-h200_sxm-{t.backend_name}-{t.backend_version}"
 

--- a/tests/unit/sdk/task_v2/test_task_config.py
+++ b/tests/unit/sdk/task_v2/test_task_config.py
@@ -384,12 +384,12 @@ def test_sweep_disagg_require_same_tp_sglang_non_wideep():
     assert mk("trtllm")["require_same_tp"] is False
 
 
-def test_deepseek_prefill_and_decode_fmha_downgrade_to_bf16(caplog):
+def test_deepseek_prefill_downgrades_decode_keeps_fp8_fmha(caplog):
     """DeepSeek context attention (prefill) downgrades fp8 FMHA to bf16 via the
-    V3/Kimi capability rule; decode is downgraded by the data-driven fallback
-    (the MLA perf tables carry no fp8 fmha slice), so the resolved config and
-    the queried data slices agree.  Known-capability downgrades stay silent
-    (debug, not warning) -- a V3 run must not warn on every task.
+    V3/Kimi capability rule.  Decode keeps the checkpoint-inferred fp8 label:
+    no generation table keys on fmha (the generation MLA module table has no
+    fmha axis), so the label is inert for decode modeling and the data-driven
+    fallback skips decode roles -- no warning either way.
     """
     import logging
 
@@ -406,7 +406,7 @@ def test_deepseek_prefill_and_decode_fmha_downgrade_to_bf16(caplog):
             decode_backend_name="sglang",
         )
     assert t.prefill_fmha_quant_mode == common.FMHAQuantMode.bfloat16
-    assert t.decode_fmha_quant_mode == common.FMHAQuantMode.bfloat16
+    assert t.decode_fmha_quant_mode == common.FMHAQuantMode.fp8
     assert not any("falling back to bfloat16 FMHA" in r.message for r in caplog.records)
 
 


### PR DESCRIPTION
## Summary

FMHA capability facts move from hand-written code rules into the perf data itself. Four commits, one story (plus review fixes):

1. **`feat(sdk)`: data-driven FMHA fp8→bf16 fallback at task resolve time** — a checkpoint-inferred fp8 FMHA now consults the role's fmha-keyed context-attention table at `Task` resolve time, **jointly with the role's resolved kv-cache mode**: joint fp8 slice present → keep fp8; only a joint bf16 slice → downgrade with one warning per task; no joint slice / no DB info → keep the inference for validate to report. Explicit user fp8 is never overridden (validate stays fail-fast).

2. **`refactor(sdk,rust)`: drop the degenerate fmha axis from the generation MLA module table** — collectors hardcode `mla_dtype="bfloat16"` for generation (decode compute dtype follows the kv-cache dtype), yet the loader used it as a lookup key, so an fp8 label made every module lookup miss and silently pushed V3/Kimi decode through `FallbackOp` to the granular path. Python and Rust loaders now key `[kv][gemm]`. After this, **no generation table anywhere keys on fmha**; DSV4/WideEP generation SOL now also derives its compute dtype from kv (the `query_generation_mla` precedent), making the decode fmha label inert end-to-end.

3. **`refactor(sdk,cli)`: retire all five model-specific FMHA downgrade rules** — V3/Kimi context, DSA, DSV4, vLLM in `_resolve_quant_modes`, plus the estimate path's arch list (`resolve_context_fmha_compat` → data-driven `resolve_context_fmha_by_data`). The legacy copies in `_apply_model_quant_defaults` now fire **only when fmha arrives unset** (direct `get_model()` callers) and never override a resolved value. `models.attention_op_keys` is the single (family, backend, wideep) → op-key map; trtllm-wideep context maps to a granular-only capability key (`context_mla_granular`) because that path queries the granular table directly.

## Behavior changes vs main (all disclosed, all pinned or warned)

| Scenario | Before (main) | After (PR) |
|---|---|---|
| DSV3.2 / GLM-5 on Blackwell vLLM, inferred fp8 | forced bf16 by the vLLM rule | **keeps fp8** and models with the packaged **native** fp8 `dsa_context` slices (regression test pins the built op's mode) |
| **DeepSeek-V3/R1/Kimi prefill on Blackwell + RTX-Pro TRT-LLM, inferred fp8 (kv=fp8)** | forced bf16 by the V3/Kimi rule | **keeps fp8**: the loaded DB's `context_mla` module table carries fp8 rows inherited cross-framework from vLLM via the shared layer (raw trtllm files are bf16-only). Probed fp8-vs-bf16 module rows differ ≤0.05% at sampled points; `FallbackOp` primary serves them |
| **fp8-checkpoint V3/R1/Kimi decode on systems shipping `mla_generation_module` data** | fp8 label missed the fmha-keyed module table → `FallbackOp` silently composed the granular path | **module table hit** (kv-keyed): block-level decode latency moves by tens of percent (h200 b=64 s=4096 tp=8 probe: 6.86 → 11.62 ms, +69%). The module table is the designed primary (fused end-to-end measurement). Exact-value pins added in Python (production loading, gb200+h200) and Rust (single-primary, h200 native fp8-kv rows) |
| inferred fp8 fmha + bf16 kv on systems whose fp8 slice exists only under kv=fp8 | passed flat validate, then `PerfDataNotAvailableError` at query time | joint (fmha × kv) capability check downgrades to bf16 at resolve (regression test) |
| DSV4 / WideEP decode SOL (EMPIRICAL/HYBRID only) | consumed the fmha label (rule-forced bf16) | derives compute dtype from kv (fp8-kv → fp8 factors), label-independent |
| V3/Kimi/DSA/DSV4/vLLM combos with bf16-only joint slices, inferred fp8 | silent rule downgrade | same downgrade, now with **one warning per task** naming the missing op/system/backend |
| Explicit fp8 (incl. v1 `profiles: [fp8]` YAMLs) with no joint fp8 slice | silently downgraded (DSA/DSV4/vLLM) | **fail-fast at validate**. `deepseek_disagg_mixed_wideep_trtllm.yaml` updated accordingly (its explicit prefill fp8 crashed at sweep time on main) |
| Dataless (synthetic what-if) systems, inferred fp8 | forced bf16 | keeps the checkpoint inference (current kernels do run fp8 context FMHA: TRT-LLM ≥1.3 MLA, SGLang `trtllm_mla` on SM100) |

## Verification

- Python: 1509 unit tests green (sdk + cli), including regression tests for: model-build preserving Task-resolved fmha, joint fmha×kv capability, trtllm-wideep granular capability (the `deepseek_wideep_trtllm.yaml` e2e failure), and exact-value decode-module pins.
- Rust: `cargo test -p aiconfigurator-core mla` 12/12 including the `mla_queries_match_python_v2_engine` parity anchors (bf16, unchanged) and a new fp8-kv generation-module anchor.
- Packaged-data audit (two layers, both verified): **raw files** — no native fp8 in any trtllm context table; native fp8 exists in Blackwell-vLLM `dsa_context` and h200-trtllm `mla_generation_module` (kv=fp8). **Loaded DBs** — Blackwell/RTX-Pro trtllm `context_mla` additionally carries shared-layer fp8 rows inherited from vLLM (low-fidelity, warned at load). Capability follows the loaded DB because that is what queries hit.
- Known pre-existing issue surfaced by the pins (out of scope): cross-source **last-wins** in the MLA module loaders lets shared-layer vLLM rows override native trtllm rows on overlapping coordinates (h200 gen-module point: native 0.1147 ms vs production-merged 0.1905 ms).
- Accuracy-regression baselines will flag the two disclosed numeric changes (DSA-on-Blackwell-vLLM, V3-family decode module) — expected, this PR is the cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Context workload FMHA mode resolution is now driven by performance-database data for more accurate automatic selection.
* **Bug Fixes**
  * Improved FP8→BF16 fallback when FP8 context-FMHA perf data is missing, while respecting explicitly requested settings.
  * Generation-only estimation no longer applies context-FMHA handling.
  * MLA generation-module lookups and caching no longer depend on the FMHA quant axis.
* **Documentation / Tests**
  * Updated SDK helpers and unit tests for the revised MLA perf data loading and query signatures, including new pinned generation-module latency coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->