### PR TITLE
fix(sdk): skip MoE workspace for dense Gemma 4

### DIFF
--- a/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
+++ b/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
@@ -1572,7 +1572,7 @@ class BaseBackend:
 
         # MoE block-scale dispatch workspace (only for families that pay this cost).
         # 128 = block scale; 4 = float bytes.
-        if family in self.MOE_WORKSPACE_FAMILIES:
+        if family in self.MOE_WORKSPACE_FAMILIES and model._num_experts:
             moe_h = self._moe_workspace_width(model, family, h)
             activations += (
                 num_tokens

--- a/tests/unit/sdk/test_utils.py
+++ b/tests/unit/sdk/test_utils.py
@@ -7,11 +7,13 @@ Unit tests for SDK utility functions.
 Tests HuggingFace config parsing and model config retrieval.
 """
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 
 from aiconfigurator.sdk import common, config
+from aiconfigurator.sdk.backends.base_backend import BaseBackend
 from aiconfigurator.sdk.models import Gemma4MixModel, HybridMoEModel
 from aiconfigurator.sdk.utils import (
     _parse_hf_config_json,
@@ -829,6 +831,26 @@ class TestGemma4MixModelBuilder:
         )
         gen_names = {op._name for op in model.generation_ops}
         assert not any("moe" in n.lower() or "router" in n.lower() for n in gen_names)
+
+        database = SimpleNamespace(
+            system_spec={
+                "misc": {
+                    "nccl_mem": {1: 0},
+                    "other_mem": 0,
+                }
+            }
+        )
+        memory = BaseBackend()._get_memory_usage(
+            model,
+            database,
+            batch_size=1,
+            beam_width=1,
+            isl=1,
+            osl=1,
+        )
+
+        assert memory["activations"] == pytest.approx(BaseBackend.MIN_ACTIVATION_BYTES / (1 << 30))
+        assert memory["total"] > 0
 
     def test_dense_variant_rejects_moe_ep_gt_1(self):
         """Dense Gemma 4 has no experts, so any moe_ep_size > 1 must be rejected

--- a/tests/unit/sdk/test_utils.py
+++ b/tests/unit/sdk/test_utils.py
@@ -634,6 +634,41 @@ class TestGemma4MixModelBuilder:
         model.set_gemma4_config(cfg)
         return model
 
+    @staticmethod
+    def _make_dense_model():
+        """Build a dense Gemma 4 variant (e.g. gemma-4-31B-it: topk=0, num_experts=None):
+        every layer is just shared dense MLP + attention, no routed-MoE block."""
+        layer_types = (["sliding_attention"] * 5 + ["full_attention"]) * 2  # 12 layers
+        cfg = common.Gemma4MixConfig(
+            layer_types=tuple(layer_types),
+            swa_num_kv_heads=16,
+            swa_head_dim=256,
+            global_num_kv_heads=4,
+            global_head_dim=512,
+            sliding_window_size=1024,
+            attention_k_eq_v=True,
+        )
+        model = Gemma4MixModel(
+            0,  # topk = 0 (dense)
+            None,  # num_experts = None (dense)
+            21504,  # moe_inter_size (unused for dense, but kept aligned with HF config)
+            "google/gemma-4-31B-it",
+            "GEMMA4MIX",
+            "Gemma4ForConditionalGeneration",
+            len(layer_types),
+            32,
+            16,
+            256,
+            5376,
+            21504,
+            262144,
+            262144,
+            TestGemma4MixModelBuilder._make_model_config(),  # tp=1, moe_tp=1, moe_ep=1
+            None,
+        )
+        model.set_gemma4_config(cfg)
+        return model
+
     def test_builds_both_layer_recipes(self):
         """30-layer 5:1 SWA:global pattern emits both recipes with shared-MLP + MoE ops."""
         model = self._make_model(self._make_model_config())
@@ -790,35 +825,7 @@ class TestGemma4MixModelBuilder:
 
         Regression test for the assertion crash when num_experts is None.
         """
-        layer_types = (["sliding_attention"] * 5 + ["full_attention"]) * 2  # 12 layers
-        cfg = common.Gemma4MixConfig(
-            layer_types=tuple(layer_types),
-            swa_num_kv_heads=16,
-            swa_head_dim=256,
-            global_num_kv_heads=4,
-            global_head_dim=512,
-            sliding_window_size=1024,
-            attention_k_eq_v=True,
-        )
-        model = Gemma4MixModel(
-            0,  # topk = 0 (dense)
-            None,  # num_experts = None (dense)
-            21504,  # moe_inter_size (unused for dense, but kept aligned with HF config)
-            "google/gemma-4-31B-it",
-            "GEMMA4MIX",
-            "Gemma4ForConditionalGeneration",
-            len(layer_types),
-            32,
-            16,
-            256,
-            5376,
-            21504,
-            262144,
-            262144,
-            self._make_model_config(),  # tp=1, moe_tp=1, moe_ep=1
-            None,
-        )
-        model.set_gemma4_config(cfg)
+        model = self._make_dense_model()
 
         op_names = {op._name for op in model.context_ops}
         # Shared dense MLP ops MUST be present.
@@ -831,6 +838,11 @@ class TestGemma4MixModelBuilder:
         )
         gen_names = {op._name for op in model.generation_ops}
         assert not any("moe" in n.lower() or "router" in n.lower() for n in gen_names)
+
+    def test_dense_variant_memory_usage_no_crash(self):
+        """Dense Gemma 4 (num_experts=None) must flow through _get_memory_usage without
+        crashing on the missing MoE workspace; activations fall back to MIN_ACTIVATION_BYTES."""
+        model = self._make_dense_model()
 
         database = SimpleNamespace(
             system_spec={


### PR DESCRIPTION

#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

Reproduce with:

  aiconfigurator cli default --model-path google/gemma-4-31B-it --total-gpus 2 --system h100_sxm --database-mode SOL --top-n 1

Before this fix, both agg and disagg reject every parallel configuration after memory accounting raises:

  TypeError: unsupported operand type(s) for *: 'float' and 'NoneType'

Dense Gemma 4 variants have topk=0 and num_experts=None, but shared GEMMA4MIX memory accounting multiplied by num_experts. Only charge MoE dispatch workspace when routed experts are present.


#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory usage estimates for mixture-of-experts models by excluding unnecessary workspace overhead when no experts are configured.
  * Corrected activation and total memory calculations for dense model variants, resulting in more accurate backend resource estimates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->