### PR TITLE
feat(sdk): model EPD (encoder disaggregation) for VL disagg sweep

### DIFF
--- a/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
+++ b/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
@@ -249,7 +249,7 @@ class BaseBackend:
         RuntimeConfig + VisionEncoderConfig.
 
         Resolution order:
-            1. image_height + image_width (computed from patch/merge sizes)
+            1. image_height + image_width (smart-resized, then patch/merge sizes)
             2. num_image_tokens (explicit per-image override)
 
         Returns ``(tokens_post_merge_per_image, pre_merge_per_image)``.
@@ -257,11 +257,16 @@ class BaseBackend:
         """
         has_image_dims = runtime_config.image_height > 0 and runtime_config.image_width > 0
         if has_image_dims:
+            # Upstream VL processors (Qwen smart_resize) round each raw
+            # dimension to the *nearest* multiple of patch_size * merge_size
+            # before patchify; plain floor under-counts tokens for
+            # non-aligned inputs.  The processor's min/max_pixels rescaling
+            # is a preprocessor knob AIC does not model.
             img_stride = enc_cfg.patch_size * enc_cfg.spatial_merge_size
-            tokens_per_image = (runtime_config.image_height // img_stride) * (runtime_config.image_width // img_stride)
-            pre_merge_per_image = (runtime_config.image_height // enc_cfg.patch_size) * (
-                runtime_config.image_width // enc_cfg.patch_size
-            )
+            h_bar = max(img_stride, round(runtime_config.image_height / img_stride) * img_stride)
+            w_bar = max(img_stride, round(runtime_config.image_width / img_stride) * img_stride)
+            tokens_per_image = (h_bar // img_stride) * (w_bar // img_stride)
+            pre_merge_per_image = (h_bar // enc_cfg.patch_size) * (w_bar // enc_cfg.patch_size)
         elif runtime_config.num_image_tokens > 0:
             tokens_per_image = runtime_config.num_image_tokens
             pre_merge_per_image = tokens_per_image * (enc_cfg.spatial_merge_size**2)

--- a/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
+++ b/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
@@ -406,6 +406,31 @@ class BaseBackend:
             return None
         return latency_dict, energy_dict, source_dict
 
+    def run_encoder_static(
+        self,
+        model: BaseModel,
+        database: PerfDatabase,
+        runtime_config: RuntimeConfig,
+        batch_size: int,
+        latency_correction_scale: float = 1.0,
+    ) -> tuple[float, float, dict[str, float]]:
+        """Encoder-only static evaluation for a disaggregated encode (EPD) worker.
+
+        Runs just the vision-encoder phase for one batch of ``batch_size``
+        requests (each carrying ``runtime_config.num_images_per_request``
+        images) and returns ``(latency_ms, power_w, memory_dict)``.
+        ``latency_ms`` is 0.0 when the model has no encoder ops or the
+        workload has no image input.  ``power_w`` is the phase-average power
+        (energy / latency; invariant to the latency correction).
+        """
+        encoder_latency_dict, encoder_energy_wms_dict, _, _ = self._run_encoder_phase(
+            model, database, runtime_config, batch_size
+        )
+        raw_latency = sum(encoder_latency_dict.values())
+        power_w = sum(encoder_energy_wms_dict.values()) / raw_latency if raw_latency > 0 else 0.0
+        memory = self._get_encoder_component_memory_for_runtime(model, runtime_config, batch_size)
+        return raw_latency * latency_correction_scale, power_w, memory
+
     def _run_context_phase(
         self,
         model: BaseModel,
@@ -670,7 +695,9 @@ class BaseBackend:
         This shares the same latency breakdown path as ``run_static`` but skips
         building an ``InferenceSummary``.
         """
-        if mode == "static_gen":
+        # Workers without encoder ops (text-only models, or EPD language-only
+        # prefill workers) still count vision tokens in the LLM context.
+        if mode == "static_gen" or not model.encoder_ops:
             encoder_latency = 0.0
             img_ctx_tokens = self._visual_context_tokens(model, runtime_config)
         else:
@@ -748,7 +775,9 @@ class BaseBackend:
             runtime_config.prefix,
         )
 
-        if mode == "static_gen":
+        # Workers without encoder ops (text-only models, or EPD language-only
+        # prefill workers) still count vision tokens in the LLM context.
+        if mode == "static_gen" or not model.encoder_ops:
             encoder_latency_dict, encoder_energy_wms_dict = defaultdict(float), defaultdict(float)
             encoder_source_dict = {}
             img_ctx_tokens = self._visual_context_tokens(model, runtime_config)

--- a/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
+++ b/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
@@ -235,6 +235,22 @@ class BaseBackend:
         return post_merge * runtime_config.num_images_per_request
 
     @staticmethod
+    def effective_prefill_isl(model_path: str, runtime_config: RuntimeConfig) -> int:
+        """Text ISL + vision context tokens for one request.
+
+        Single source for the effective prefill ISL: every token/batch budget
+        derived from it must divide by this same value, never a recomputed one.
+        """
+        from aiconfigurator_core.sdk.utils import get_model_config_from_model_path
+
+        try:
+            enc_cfg = get_model_config_from_model_path(model_path).get("extra_params")
+        except Exception:
+            logger.debug("Could not resolve model config for the effective ISL; using text ISL", exc_info=True)
+            enc_cfg = None
+        return runtime_config.isl + BaseBackend._visual_context_tokens_from_encoder_config(enc_cfg, runtime_config)
+
+    @staticmethod
     def _visual_context_tokens(model: BaseModel, runtime_config: RuntimeConfig) -> int:
         return BaseBackend._visual_context_tokens_from_encoder_config(
             getattr(model, "encoder_config", None), runtime_config
@@ -418,22 +434,29 @@ class BaseBackend:
         runtime_config: RuntimeConfig,
         batch_size: int,
         latency_correction_scale: float = 1.0,
-    ) -> tuple[float, float, dict[str, float]]:
+    ) -> tuple[float, float, dict[str, float], float]:
         """Encoder-only static evaluation for a disaggregated encode (EPD) worker.
 
         Runs just the vision-encoder phase for one batch of ``batch_size``
-        requests and returns ``(latency_ms, power_w, memory_dict)``.
-        ``model`` may be any object carrying ``encoder_ops``,
-        ``encoder_config`` and ``config`` (e.g. ``EncoderOnlyModel``);
-        ``power_w`` is the phase-average power, invariant to the correction.
+        requests and returns ``(latency_ms, power_w, memory_dict,
+        power_coverage)``.  ``model`` may be any object carrying
+        ``encoder_ops``, ``encoder_config`` and ``config`` (e.g.
+        ``EncoderOnlyModel``); ``power_w`` is the phase-average power,
+        invariant to the correction.  ``power_coverage`` is the
+        latency-weighted fraction of ops with recorded energy, mirroring
+        ``InferenceSummary.get_power_data_coverage``.
         """
         encoder_latency_dict, encoder_energy_wms_dict, _, _ = self._run_encoder_phase(
             model, database, runtime_config, batch_size
         )
         raw_latency = sum(encoder_latency_dict.values())
         power_w = sum(encoder_energy_wms_dict.values()) / raw_latency if raw_latency > 0 else 0.0
+        covered_latency = sum(
+            latency for op, latency in encoder_latency_dict.items() if encoder_energy_wms_dict.get(op, 0.0) > 0
+        )
+        power_coverage = covered_latency / raw_latency if raw_latency > 0 else 0.0
         memory = self._get_encoder_component_memory_for_runtime(model, runtime_config, batch_size)
-        return raw_latency * latency_correction_scale, power_w, memory
+        return raw_latency * latency_correction_scale, power_w, memory, power_coverage
 
     def _run_context_phase(
         self,

--- a/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
+++ b/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
@@ -421,6 +421,12 @@ class BaseBackend:
     ) -> tuple[float, float, dict[str, float]]:
         """Encoder-only static evaluation for a disaggregated encode (EPD) worker.
 
+        ``model`` may be any object carrying ``encoder_ops``,
+        ``encoder_config`` and the ``config`` parallelism fields
+        (``tp_size`` / ``enable_encoder_dp``), e.g.
+        ``models.vit_ops.EncoderOnlyModel`` -- the encoder phase reads
+        nothing else from it.
+
         Runs just the vision-encoder phase for one batch of ``batch_size``
         requests (each carrying ``runtime_config.num_images_per_request``
         images) and returns ``(latency_ms, power_w, memory_dict)``.

--- a/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
+++ b/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
@@ -421,18 +421,11 @@ class BaseBackend:
     ) -> tuple[float, float, dict[str, float]]:
         """Encoder-only static evaluation for a disaggregated encode (EPD) worker.
 
-        ``model`` may be any object carrying ``encoder_ops``,
-        ``encoder_config`` and the ``config`` parallelism fields
-        (``tp_size`` / ``enable_encoder_dp``), e.g.
-        ``models.vit_ops.EncoderOnlyModel`` -- the encoder phase reads
-        nothing else from it.
-
         Runs just the vision-encoder phase for one batch of ``batch_size``
-        requests (each carrying ``runtime_config.num_images_per_request``
-        images) and returns ``(latency_ms, power_w, memory_dict)``.
-        ``latency_ms`` is 0.0 when the model has no encoder ops or the
-        workload has no image input.  ``power_w`` is the phase-average power
-        (energy / latency; invariant to the latency correction).
+        requests and returns ``(latency_ms, power_w, memory_dict)``.
+        ``model`` may be any object carrying ``encoder_ops``,
+        ``encoder_config`` and ``config`` (e.g. ``EncoderOnlyModel``);
+        ``power_w`` is the phase-average power, invariant to the correction.
         """
         encoder_latency_dict, encoder_energy_wms_dict, _, _ = self._run_encoder_phase(
             model, database, runtime_config, batch_size

--- a/aic-core/src/aiconfigurator_core/sdk/common.py
+++ b/aic-core/src/aiconfigurator_core/sdk/common.py
@@ -900,6 +900,7 @@ ColumnsDisagg = [
     "(e)workers",
     "(e)tp",
     "(e)pp",
+    "(e)bs",
     "(e)parallel",
     "(e)memory",
     "power_w",  # NEW: E2E weighted average power in watts

--- a/aic-core/src/aiconfigurator_core/sdk/common.py
+++ b/aic-core/src/aiconfigurator_core/sdk/common.py
@@ -838,6 +838,18 @@ ColumnsAgg = [
     "power_w",  # NEW: E2E weighted average power in watts
 ]
 
+# E+agg (enable_epd) rows: ColumnsAgg plus the rate-matched cell columns
+# ((a)workers agg workers paired with an (e)* encode pool).
+ColumnsAggEpd = ColumnsAgg + [
+    "(a)workers",
+    "(e)workers",
+    "(e)tp",
+    "(e)pp",
+    "(e)bs",
+    "(e)parallel",
+    "(e)memory",
+]
+
 """
 Columns for disaggregated inference summary dataframe
 """

--- a/aic-core/src/aiconfigurator_core/sdk/config.py
+++ b/aic-core/src/aiconfigurator_core/sdk/config.py
@@ -32,6 +32,10 @@ class ModelConfig:
     # this in their op pipeline; GLM-5 DSA ignores it (handled in ContextDSAModule).
     cp_style: str = "none"
     workload_distribution: str = "power_law"
+    # EPD: when False, this worker does not host the vision encoder (a
+    # language-only prefill worker, e.g. SGLang --language-only). Vision
+    # tokens still extend its context; the ViT ops are simply not built.
+    encoder_colocated: bool = True
     # quantization options
     # MTP speculative decoding: draft length (compute/verification cost only).
     # Accepted-token progress belongs to the upper prediction/simulation layer.

--- a/aic-core/src/aiconfigurator_core/sdk/config.py
+++ b/aic-core/src/aiconfigurator_core/sdk/config.py
@@ -32,10 +32,11 @@ class ModelConfig:
     # this in their op pipeline; GLM-5 DSA ignores it (handled in ContextDSAModule).
     cp_style: str = "none"
     workload_distribution: str = "power_law"
-    # EPD: when False, this worker does not host the vision encoder (a
-    # language-only prefill worker, e.g. SGLang --language-only). Vision
-    # tokens still extend its context; the ViT ops are simply not built.
-    encoder_colocated: bool = True
+    # EPD: this worker hosts only the language model -- the vision encoder
+    # is served elsewhere (mirrors SGLang --language-only).  Like tp_size,
+    # this describes the deployed worker, not the model: vision tokens still
+    # extend the context; the ViT ops are simply not hosted here.
+    language_only: bool = False
     # quantization options
     # MTP speculative decoding: draft length (compute/verification cost only).
     # Accepted-token progress belongs to the upper prediction/simulation layer.

--- a/aic-core/src/aiconfigurator_core/sdk/models/blocks/vit.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/blocks/vit.py
@@ -53,6 +53,8 @@ are responsible for choosing a projector_dims layout that is TP-correct.
 
 from __future__ import annotations
 
+import dataclasses
+
 import aiconfigurator_core.sdk.operations as ops
 from aiconfigurator_core.sdk import common
 
@@ -221,3 +223,21 @@ def build_encoder_ops(enc_cfg: common.VisionEncoderConfig, tp_size: int, enable_
             )
         )
     return result
+
+
+@dataclasses.dataclass
+class EncoderOnlyModel:
+    """Vision-encoder-only model for a disaggregated encode (EPD) worker.
+
+    Mirrors an encoder-only instance (e.g. SGLang ``--encoder-only``): the
+    worker hosts just the ViT + projector, so only ViT-side constraints
+    govern its tensor parallelism -- LLM-side rules (KV-head divisibility,
+    MoE width identities) do not apply and must not reject it.  Duck-types
+    the slice of ``BaseModel`` the encoder phase reads: ``encoder_ops``,
+    ``encoder_config``, and the ``config`` parallelism fields
+    (``tp_size`` / ``enable_encoder_dp``) that shard the image batch.
+    """
+
+    encoder_ops: list
+    encoder_config: common.VisionEncoderConfig
+    config: object

--- a/aic-core/src/aiconfigurator_core/sdk/models/blocks/vit.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/blocks/vit.py
@@ -232,9 +232,13 @@ class EncoderOnlyModel:
     Mirrors an encoder-only instance (e.g. SGLang ``--encoder-only``); only
     ViT-side rules govern its tensor parallelism.  Duck-types the slice of
     ``BaseModel`` the encoder phase reads: ``encoder_ops``,
-    ``encoder_config`` and ``config``.
+    ``encoder_config`` and ``config``.  The empty LM op lists satisfy the
+    compiled engine's spec-build contract (read unconditionally before any
+    ad-hoc op-list evaluation).
     """
 
     encoder_ops: list
     encoder_config: common.VisionEncoderConfig
     config: object
+    context_ops: list = dataclasses.field(default_factory=list)
+    generation_ops: list = dataclasses.field(default_factory=list)

--- a/aic-core/src/aiconfigurator_core/sdk/models/blocks/vit.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/blocks/vit.py
@@ -229,13 +229,10 @@ def build_encoder_ops(enc_cfg: common.VisionEncoderConfig, tp_size: int, enable_
 class EncoderOnlyModel:
     """Vision-encoder-only model for a disaggregated encode (EPD) worker.
 
-    Mirrors an encoder-only instance (e.g. SGLang ``--encoder-only``): the
-    worker hosts just the ViT + projector, so only ViT-side constraints
-    govern its tensor parallelism -- LLM-side rules (KV-head divisibility,
-    MoE width identities) do not apply and must not reject it.  Duck-types
-    the slice of ``BaseModel`` the encoder phase reads: ``encoder_ops``,
-    ``encoder_config``, and the ``config`` parallelism fields
-    (``tp_size`` / ``enable_encoder_dp``) that shard the image batch.
+    Mirrors an encoder-only instance (e.g. SGLang ``--encoder-only``); only
+    ViT-side rules govern its tensor parallelism.  Duck-types the slice of
+    ``BaseModel`` the encoder phase reads: ``encoder_ops``,
+    ``encoder_config`` and ``config``.
     """
 
     encoder_ops: list

--- a/aic-core/src/aiconfigurator_core/sdk/models/qwen3vl.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/qwen3vl.py
@@ -50,7 +50,12 @@ class Qwen3VLModel(LLAMAModel):
         if encoder_config is None:
             return
         self.encoder_config = encoder_config
-        self.encoder_ops.extend(build_encoder_ops(encoder_config, self.config.tp_size, self.config.enable_encoder_dp))
+        # EPD language-only workers keep encoder_config (vision tokens still
+        # extend the LLM context) but never host the ViT ops.
+        if self.config.encoder_colocated:
+            self.encoder_ops.extend(
+                build_encoder_ops(encoder_config, self.config.tp_size, self.config.enable_encoder_dp)
+            )
 
 
 @register_model("QWEN3VL_MOE")
@@ -89,4 +94,7 @@ class Qwen3VLMoEModel(MOEModel):
         if encoder_config is None:
             return
         self.encoder_config = encoder_config
-        self.encoder_ops.extend(build_encoder_ops(encoder_config, self.config.tp_size, self.config.enable_encoder_dp))
+        if self.config.encoder_colocated:
+            self.encoder_ops.extend(
+                build_encoder_ops(encoder_config, self.config.tp_size, self.config.enable_encoder_dp)
+            )

--- a/aic-core/src/aiconfigurator_core/sdk/models/qwen3vl.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/qwen3vl.py
@@ -52,7 +52,7 @@ class Qwen3VLModel(LLAMAModel):
         self.encoder_config = encoder_config
         # EPD language-only workers keep encoder_config (vision tokens still
         # extend the LLM context) but never host the ViT ops.
-        if self.config.encoder_colocated:
+        if not self.config.language_only:
             self.encoder_ops.extend(
                 build_encoder_ops(encoder_config, self.config.tp_size, self.config.enable_encoder_dp)
             )
@@ -94,7 +94,7 @@ class Qwen3VLMoEModel(MOEModel):
         if encoder_config is None:
             return
         self.encoder_config = encoder_config
-        if self.config.encoder_colocated:
+        if not self.config.language_only:
             self.encoder_ops.extend(
                 build_encoder_ops(encoder_config, self.config.tp_size, self.config.enable_encoder_dp)
             )

--- a/docs/advanced_tuning.md
+++ b/docs/advanced_tuning.md
@@ -172,6 +172,23 @@ And for prefill, for typical ISL larger than 1000, it's almost saturating the co
 ## agg config
 It's same for agg. You can treat agg as a prefill or decode worker.
 
+## EPD (encoder disaggregation) config
+For vision-language workloads (image inputs set), `enable_epd: true` serves the vision encoder from a dedicated
+encode-worker pool instead of colocated with the LM workers — agg becomes E+agg, disagg becomes E+P+D. The encode
+pool is rate-matched against the LM pools; result rows carry `(e)workers`/`(e)tp`/`(e)bs` columns. Optional knobs
+(all require `enable_epd`; keys are Task field names, not CLI flags):
+
+- `encoder_tp_candidates`: encode-worker TP sizes to sweep (default `[1, 2, 4, 8]`)
+- `encoder_batch_candidates`: encode batch sizes to sweep (default `[1, 2, 4, 8]`; capped at 8, SGLang's
+  `SGLANG_ENCODER_MAX_BATCH_SIZE` default)
+- `max_encoder_workers`: encode-worker cap per rate-matched cell (default 32)
+- `encoder_latency_correction`: encode-latency correction scale (default 1.0)
+- `encoder_system_name`: system (GPU type) for a heterogeneous encode pool; backend and version follow the P/agg side
+- `rate_match_encoder_degradation`: encode-pool rate-matching degradation (default 0.9, alongside the
+  prefill/decode factors)
+
+See the `vl_epd_agg` experiment in `src/aiconfigurator/cli/example.yaml` for a complete template.
+
 ## Practical suggestion
 In order to save search time, you need to reduce the search space by choosing fewer parallel options. Say for `*_num_gpu_candidates` here, it's DeepSeek V3 with 671B model 
 parameters. With fp8_block, the rough estimation of the model weights is 671GB. You can not hold it on 4/2/1 gpus, you can modify it to `[8]` only. 

--- a/docs/cli_user_guide.md
+++ b/docs/cli_user_guide.md
@@ -213,6 +213,14 @@ result = cli_estimate(
 )
 ```
 
+#### EPD single point (`--enable-epd`)
+
+For vision-language models with image inputs, `--enable-epd` overlays a fixed encode-worker pool on an `agg` or `disagg` estimate (other estimate modes reject it):
+
+- `--encoder-tp`: Encode-worker TP (required with `--enable-epd`).
+- `--encoder-batch-size`: Encode batch size. Default: `1` (maximum: 8).
+- `--encoder-num-workers`: Encode workers in the pool. Default: `1`.
+
 #### Static estimate modes (`static`, `static_ctx`, `static_gen`)
 
 `agg` and `disagg` model continuous (in-flight) batching. The three `static` modes instead run a **single forward pass** through the model — no IFB scheduling — and report the per-phase latency and memory layout for that one pass. They are the quickest way to see where time and memory go for a given shape and parallelism.
@@ -433,6 +441,15 @@ Beyond `--ttft`, `--tpot`, `--isl`, `--osl`, and `--prefix`, `default` mode acce
 - `--image-height`, `--image-width`: Image dimensions in pixels. Default: `0` (disabled — the request is modeled as text-only).
 - `--num-images`: Number of images per request. Default: `1`.
 - `--disable-encoder-dp`: Model the vision encoder as TP-sharded instead of the default data-parallel. Also available in `estimate` mode (alongside the image flags above).
+
+**Encoder disaggregation (EPD)** — serve the vision encoder from a dedicated encode-worker pool rate-matched against the LM workers (agg becomes E+agg, disagg becomes E+P+D). Requires image inputs; the LM workers are modeled language-only. Result rows carry `(e)workers`/`(e)tp`/`(e)bs` columns.
+
+- `--enable-epd`: Sweep dedicated encode workers alongside the LM sweep.
+- `--encoder-tp`: Encode-worker TP sizes to sweep. Default: `1 2 4 8`.
+- `--encoder-system`: System (GPU type) for the encode pool. Defaults to the LM-side system; backend and version always follow the P/agg side.
+- `--encoder-latency-correction`: Latency correction scale for encode workers. Default: `1.0`.
+
+Encode batch sizes are swept over `1 2 4 8`, capped at 8 (SGLang's `SGLANG_ENCODER_MAX_BATCH_SIZE` default); explicit candidates above the cap are rejected. Further knobs (`encoder_batch_candidates`, `max_encoder_workers`, `rate_match_encoder_degradation`) are Task fields for `exp`-mode YAML — see [Advanced Tuning](advanced_tuning.md). EPD rows are excluded from generator artifacts (see [Generator Overview](generator_overview.md)).
 
 The SLA, precision, and speculative-decoding flags (`--strict-sla`, `--request-latency`, `--inclusive-tpot`, `--nextn`, `--nextn-accepted`, `--database-mode`) have dedicated subsections below. Shared flags such as `--save-dir`, `--top-n`, and `--systems-paths` are described in [Common Arguments](#common-arguments-all-modes).
 

--- a/docs/generator_overview.md
+++ b/docs/generator_overview.md
@@ -177,6 +177,7 @@ You can use the generator in two ways: AIConfigurator CLI or standalone (code/CL
 - Benchmark helpers (non-FPM targets):
   - `bench_run.sh` and `k8s_bench.yaml` are generated alongside normal deployment artifacts for running `aiperf` benchmarks. The FPM target emits neither helper.
   - `concurrency_array` is built from a base list (`1 2 8 16 32 64 128`) plus `BenchConfig.estimated_concurrency` and its +/-5% neighbors when the estimate is available.
+- EPD rows are fail-closed: rows recommending a dedicated encode pool (`(e)workers > 0`, from `enable_epd`) skip all generator artifacts with a warning — the bridge does not map the encode pool into a deployment topology yet, and LM-only configs would contradict the recommendation. Performance tables and CSVs still contain these rows.
 
 ### FPM V1 Target
 

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -168,6 +168,9 @@ def cli_default(
     image_width: int = 0,
     num_images: int = 1,
     enable_encoder_dp: bool = True,
+    enable_epd: bool = False,
+    encoder_tp: list[int] | None = None,
+    encoder_system: str | None = None,
     ttft: float = 2000.0,
     tpot: float = 30.0,
     request_latency: float | None = None,
@@ -227,6 +230,12 @@ def cli_default(
             Used to filter batch sizes that would exceed KV cache capacity.
         max_seq_len: TRT-LLM ``--max_seq_len`` setting. Controls how many KV blocks are
             pre-allocated per sequence. Defaults to ``isl + osl`` when ``None``.
+        enable_epd: VL models -- serve the vision encoder from a dedicated
+            encode-worker pool (agg becomes E+agg, disagg becomes E+P+D).
+            Requires an image workload (image_height/image_width).
+        encoder_tp: EPD encode-worker TP sizes to sweep (default [1, 2, 4, 8]).
+        encoder_system: System (GPU type) for the encode workers; defaults to
+            the prefill/agg side's system.
         top_n: Number of top configurations to return for each mode (agg/disagg). Default is 5.
         save_dir: Directory to save results. If None, results are not saved to disk.
         generator_set: List of inline generator overrides in KEY=VALUE format (e.g.,
@@ -294,6 +303,9 @@ def cli_default(
         image_width=image_width,
         num_images=num_images,
         enable_encoder_dp=enable_encoder_dp,
+        enable_epd=enable_epd,
+        encoder_tp=encoder_tp,
+        encoder_system=encoder_system,
         ttft=ttft,
         tpot=tpot,
         request_latency=request_latency,

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -904,9 +904,22 @@ def _apply_power_coverage_gate(summary, result_dict: dict) -> dict:
     power is unavailable without treating the whole estimate as failed.
     """
     gated = dict(result_dict)
-    coverage = summary.get_power_data_coverage()
-    gated["power_coverage"] = coverage
-    if coverage < POWER_DATA_COVERAGE_THRESHOLD:
+    gated["power_coverage"] = summary.get_power_data_coverage()
+    return apply_row_power_coverage_gate(gated)
+
+
+def apply_row_power_coverage_gate(row: dict) -> dict:
+    """Hide ``power_w`` when ``power_coverage`` is missing, non-finite, or
+    below the coverage threshold (fail-closed)."""
+    import math
+
+    gated = dict(row)
+    coverage = gated.get("power_coverage")
+    if (
+        not isinstance(coverage, (int, float))
+        or not math.isfinite(coverage)
+        or coverage < POWER_DATA_COVERAGE_THRESHOLD
+    ):
         gated["power_w"] = None
     return gated
 

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -171,6 +171,7 @@ def cli_default(
     enable_epd: bool = False,
     encoder_tp: list[int] | None = None,
     encoder_system: str | None = None,
+    encoder_latency_correction: float = 1.0,
     ttft: float = 2000.0,
     tpot: float = 30.0,
     request_latency: float | None = None,
@@ -236,6 +237,8 @@ def cli_default(
         encoder_tp: EPD encode-worker TP sizes to sweep (default [1, 2, 4, 8]).
         encoder_system: System (GPU type) for the encode workers; defaults to
             the prefill/agg side's system.
+        encoder_latency_correction: Latency correction scale for the encode
+            workers.  Default 1.0.
         top_n: Number of top configurations to return for each mode (agg/disagg). Default is 5.
         save_dir: Directory to save results. If None, results are not saved to disk.
         generator_set: List of inline generator overrides in KEY=VALUE format (e.g.,
@@ -306,6 +309,7 @@ def cli_default(
         enable_epd=enable_epd,
         encoder_tp=encoder_tp,
         encoder_system=encoder_system,
+        encoder_latency_correction=encoder_latency_correction,
         ttft=ttft,
         tpot=tpot,
         request_latency=request_latency,

--- a/src/aiconfigurator/cli/example.yaml
+++ b/src/aiconfigurator/cli/example.yaml
@@ -192,3 +192,32 @@ disagg_full:
   # modeling queueing-under-concurrency in the deployed system.
   # Used by both the constraint-mode search and ``pick_autoscale``.
   autoscale_ttft_correction_factor: 1.8
+
+
+# ============================================================
+# Vision-language + EPD (encoder disaggregation)
+# ============================================================
+# enable_epd serves the vision encoder from a dedicated encode-worker
+# pool (agg -> E+agg, disagg -> E+P+D) instead of colocated.  Keys are
+# Task field names (encoder_tp_candidates), not CLI flags (--encoder-tp).
+vl_epd_agg:
+  serving_mode: agg
+  model_path: Qwen/Qwen3-VL-30B-A3B-Instruct
+  system_name: h100_sxm
+  backend_name: vllm
+  total_gpus: 8
+  isl: 2000
+  osl: 200
+  ttft: 300.0
+  tpot: 20.0
+  image_height: 768
+  image_width: 768
+  num_images_per_request: 8
+  enable_epd: true
+
+  # Optional encoder knobs (all require enable_epd):
+  # encoder_tp_candidates: [1, 2, 4, 8]
+  # encoder_batch_candidates: [1, 2, 4, 8]
+  # max_encoder_workers: 32
+  # encoder_latency_correction: 1.0
+  # encoder_system_name: h200_sxm   # hetero encode pool

--- a/src/aiconfigurator/cli/example.yaml
+++ b/src/aiconfigurator/cli/example.yaml
@@ -221,3 +221,4 @@ vl_epd_agg:
   # max_encoder_workers: 32
   # encoder_latency_correction: 1.0
   # encoder_system_name: h200_sxm   # hetero encode pool
+  # rate_match_encoder_degradation: 0.9   # encode-pool rate-matching loss

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -439,6 +439,12 @@ def _add_default_mode_arguments(parser):
         "Defaults to the prefill/agg side's system.",
     )
     parser.add_argument(
+        "--encoder-latency-correction",
+        type=float,
+        default=1.0,
+        help="Latency correction scale for EPD encode workers (requires --enable-epd). Default: 1.0.",
+    )
+    parser.add_argument(
         "--ttft",
         type=float,
         default=2000.0,
@@ -1469,6 +1475,7 @@ def build_default_tasks(
     enable_epd: bool = False,
     encoder_tp: list[int] | None = None,
     encoder_system: str | None = None,
+    encoder_latency_correction: float = 1.0,
     ttft: float = 2000.0,
     tpot: float = 30.0,
     request_latency: float | None = None,
@@ -1696,6 +1703,7 @@ def build_default_tasks(
             enable_epd=enable_epd,
             encoder_tp_candidates=encoder_tp,
             encoder_system_name=encoder_system,
+            encoder_latency_correction=encoder_latency_correction,
             **global_kwargs,
         )
 
@@ -1715,6 +1723,7 @@ def build_default_tasks(
             enable_epd=enable_epd,
             encoder_tp_candidates=encoder_tp,
             encoder_system_name=encoder_system,
+            encoder_latency_correction=encoder_latency_correction,
             **global_kwargs,
         )
 
@@ -2894,6 +2903,7 @@ def main(args):
             enable_epd=args.enable_epd,
             encoder_tp=args.encoder_tp,
             encoder_system=args.encoder_system,
+            encoder_latency_correction=args.encoder_latency_correction,
             ttft=args.ttft,
             tpot=args.tpot,
             request_latency=args.request_latency,

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -849,6 +849,30 @@ def _add_estimate_mode_arguments(parser):
         "(vLLM mm_encoder_tp_mode='data' / SGLang --mm-enable-dp-encoder semantics).",
     )
     parser.add_argument(
+        "--enable-epd",
+        action="store_true",
+        help="EPD single point: overlay a fixed encode-worker pool on the agg/disagg point; "
+        "the LM side becomes language-only. Supports --estimate-mode agg/disagg.",
+    )
+    parser.add_argument(
+        "--encoder-tp",
+        type=int,
+        default=None,
+        help="EPD encode-worker TP (required with --enable-epd).",
+    )
+    parser.add_argument(
+        "--encoder-batch-size",
+        type=int,
+        default=1,
+        help="EPD encode-worker batch size. Default: 1.",
+    )
+    parser.add_argument(
+        "--encoder-num-workers",
+        type=int,
+        default=1,
+        help="EPD encode workers in the pool. Default: 1.",
+    )
+    parser.add_argument(
         "--batch-size",
         "--bs",
         dest="batch_size",
@@ -2403,6 +2427,104 @@ def _print_per_ops_latency(per_ops_data: dict) -> None:
             _print_per_ops_section("AFD Transfer (per layer, a2f + f2a)", directional)
 
 
+def _run_estimate_epd(args, estimate_mode: str) -> None:
+    """EPD single-point estimate via Task.run_single_* (dedicated encode pool)."""
+    from aiconfigurator.sdk.task_v2 import Task
+
+    if estimate_mode not in ("agg", "disagg"):
+        raise SystemExit("--enable-epd supports --estimate-mode agg or disagg only.")
+    workload = dict(
+        enable_epd=True,
+        backend_version=args.backend_version,
+        database_mode=args.database_mode,
+        isl=args.isl,
+        osl=args.osl,
+        image_height=args.image_height,
+        image_width=args.image_width,
+        num_images_per_request=args.num_images,
+        gemm_quant_mode=args.gemm_quant_mode,
+        moe_quant_mode=args.moe_quant_mode,
+        kvcache_quant_mode=args.kvcache_quant_mode,
+        fmha_quant_mode=args.fmha_quant_mode,
+        comm_quant_mode=args.comm_quant_mode,
+        nextn=args.nextn,
+        nextn_accepted=args.nextn_accepted,
+    )
+    encoder_kwargs = dict(
+        encoder_tp=args.encoder_tp,
+        encoder_batch_size=args.encoder_batch_size,
+        encoder_num_workers=args.encoder_num_workers,
+    )
+    if estimate_mode == "agg":
+        task = Task.from_cli(
+            serving_mode="agg",
+            model_path=args.model_path,
+            system_name=args.system,
+            backend_name=args.backend,
+            **workload,
+        )
+        row = task.run_single_agg(
+            tp=args.tp_size,
+            pp=args.pp_size,
+            dp=args.attention_dp_size,
+            moe_tp=args.moe_tp_size,
+            moe_ep=args.moe_ep_size,
+            batch_size=args.batch_size,
+            ctx_tokens=args.ctx_tokens,
+            **encoder_kwargs,
+        )
+    else:
+        task = Task.from_cli(
+            serving_mode="disagg",
+            prefill_model_path=args.model_path,
+            decode_model_path=args.model_path,
+            prefill_system_name=args.system,
+            decode_system_name=args.decode_system or args.system,
+            prefill_backend_name=args.backend,
+            decode_backend_name=args.backend,
+            **workload,
+        )
+        row = task.run_single_disagg(
+            prefill_tp=args.prefill_tp_size,
+            prefill_pp=args.prefill_pp_size or 1,
+            prefill_dp=args.prefill_attention_dp_size or 1,
+            prefill_moe_tp=args.prefill_moe_tp_size or 1,
+            prefill_moe_ep=args.prefill_moe_ep_size or 1,
+            prefill_batch_size=args.prefill_batch_size,
+            prefill_num_workers=args.prefill_num_workers,
+            decode_tp=args.decode_tp_size,
+            decode_pp=args.decode_pp_size or 1,
+            decode_dp=args.decode_attention_dp_size or 1,
+            decode_moe_tp=args.decode_moe_tp_size or 1,
+            decode_moe_ep=args.decode_moe_ep_size or 1,
+            decode_batch_size=args.decode_batch_size,
+            decode_num_workers=args.decode_num_workers,
+            **encoder_kwargs,
+        )
+    logger.info("EPD %s single-point estimate:", estimate_mode)
+    keys = (
+        "ttft",
+        "tpot",
+        "encoder_latency",
+        "request_latency",
+        "seq/s",
+        "tokens/s/gpu",
+        "num_total_gpus",
+        "(a)workers",
+        "(p)workers",
+        "(d)workers",
+        "(e)workers",
+        "(e)tp",
+        "(e)bs",
+        "(e)memory",
+        "power_w",
+    )
+    for key in keys:
+        if key in row:
+            value = row[key]
+            logger.info("  %-16s %s", key, f"{value:.3f}" if isinstance(value, float) else value)
+
+
 def _run_estimate_mode(args):
     """Run the estimate mode to predict TTFT, TPOT, and power for a single config."""
     from aiconfigurator.cli.api import cli_estimate
@@ -2420,6 +2542,10 @@ def _run_estimate_mode(args):
     )
 
     _resolve_and_validate_nextn(args)
+
+    if args.enable_epd:
+        _run_estimate_epd(args, estimate_mode)
+        return
 
     # Resolve --detail before running the estimate so time detail can compare
     # against a second SOL-mode result.

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -2427,19 +2427,10 @@ def _print_per_ops_latency(per_ops_data: dict) -> None:
             _print_per_ops_section("AFD Transfer (per layer, a2f + f2a)", directional)
 
 
-_ESTIMATE_QUANT_ENUMS = {
-    "gemm_quant_mode": common.GEMMQuantMode,
-    "moe_quant_mode": common.MoEQuantMode,
-    "kvcache_quant_mode": common.KVCacheQuantMode,
-    "fmha_quant_mode": common.FMHAQuantMode,
-    "comm_quant_mode": common.CommQuantMode,
-}
-
-
 def _run_estimate_epd(args, estimate_mode: str) -> None:
     """EPD single-point estimate via Task.run_single_* (dedicated encode pool)."""
-    from aiconfigurator.cli.api import POWER_DATA_COVERAGE_THRESHOLD
-    from aiconfigurator.sdk.task_v2 import Task
+    from aiconfigurator.cli.api import apply_row_power_coverage_gate
+    from aiconfigurator.sdk.task_v2 import _QUANT_ENUM_TABLES, Task
 
     if estimate_mode not in ("agg", "disagg"):
         raise SystemExit("--enable-epd supports --estimate-mode agg or disagg only.")
@@ -2461,9 +2452,7 @@ def _run_estimate_epd(args, estimate_mode: str) -> None:
         nextn=args.nextn,
         nextn_accepted=args.nextn_accepted,
     )
-    workload.update(
-        {name: enum[getattr(args, name)] for name, enum in _ESTIMATE_QUANT_ENUMS.items() if getattr(args, name)}
-    )
+    workload.update({name: getattr(args, name) for name in _QUANT_ENUM_TABLES if getattr(args, name, None)})
     encoder_kwargs = dict(
         encoder_tp=args.encoder_tp,
         encoder_batch_size=args.encoder_batch_size,
@@ -2496,6 +2485,11 @@ def _run_estimate_epd(args, estimate_mode: str) -> None:
         def _role(value, shared):
             return value if value is not None else shared
 
+        # Shared quant/version args map to the per-role fields: disagg Tasks
+        # reject top-level worker fields and silently ignore backend_version.
+        role_shared = {"backend_version": workload.pop("backend_version", None)}
+        for name in [k for k in workload if k.endswith("quant_mode")]:
+            role_shared[name] = workload.pop(name)
         task = Task.from_cli(
             serving_mode="disagg",
             prefill_model_path=args.model_path,
@@ -2504,6 +2498,8 @@ def _run_estimate_epd(args, estimate_mode: str) -> None:
             decode_system_name=args.decode_system or args.system,
             prefill_backend_name=args.backend,
             decode_backend_name=args.backend,
+            **{f"prefill_{k}": v for k, v in role_shared.items()},
+            **{f"decode_{k}": v for k, v in role_shared.items()},
             **workload,
         )
         row = task.run_single_disagg(
@@ -2523,6 +2519,7 @@ def _run_estimate_epd(args, estimate_mode: str) -> None:
             decode_num_workers=args.decode_num_workers,
             **encoder_kwargs,
         )
+    row = apply_row_power_coverage_gate(row)
     logger.info("EPD %s single-point estimate:", estimate_mode)
     keys = (
         "ttft",
@@ -2545,8 +2542,8 @@ def _run_estimate_epd(args, estimate_mode: str) -> None:
         if key not in row:
             continue
         value = row[key]
-        if key == "power_w" and row.get("power_coverage", 1.0) < POWER_DATA_COVERAGE_THRESHOLD:
-            logger.info("  %-16s unavailable (%.0f%% power-data coverage)", key, row["power_coverage"] * 100)
+        if key == "power_w" and value is None:
+            logger.info("  %-16s unavailable (%.0f%% power-data coverage)", key, row.get("power_coverage", 0.0) * 100)
             continue
         logger.info("  %-16s %s", key, f"{value:.3f}" if isinstance(value, float) else value)
 

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -418,6 +418,20 @@ def _add_default_mode_arguments(parser):
         "(vLLM mm_encoder_tp_mode='data' / SGLang --mm-enable-dp-encoder semantics).",
     )
     parser.add_argument(
+        "--enable-epd",
+        action="store_true",
+        help="EPD (vision-language models): run the vision encoder on dedicated encode workers "
+        "instead of colocated with prefill. Turns the disagg experiment into EPD; requires an "
+        "image workload (--image-height/--image-width).",
+    )
+    parser.add_argument(
+        "--encoder-tp",
+        type=int,
+        nargs="+",
+        default=None,
+        help="EPD encode-worker TP sizes to sweep (requires --enable-epd). Default: 1 2 4 8.",
+    )
+    parser.add_argument(
         "--ttft",
         type=float,
         default=2000.0,
@@ -1445,6 +1459,8 @@ def build_default_tasks(
     image_width: int = 0,
     num_images: int = 1,
     enable_encoder_dp: bool = True,
+    enable_epd: bool = False,
+    encoder_tp: list[int] | None = None,
     ttft: float = 2000.0,
     tpot: float = 30.0,
     request_latency: float | None = None,
@@ -1685,6 +1701,8 @@ def build_default_tasks(
             decode_backend_version=backend_version,
             prefill_enable_chunked_prefill=enable_chunked_prefill,
             moe_backend=moe_backend_value,
+            enable_epd=enable_epd,
+            encoder_tp_candidates=encoder_tp,
             **global_kwargs,
         )
 
@@ -2861,6 +2879,8 @@ def main(args):
             image_width=args.image_width,
             num_images=args.num_images,
             enable_encoder_dp=not args.disable_encoder_dp,
+            enable_epd=args.enable_epd,
+            encoder_tp=args.encoder_tp,
             ttft=args.ttft,
             tpot=args.tpot,
             request_latency=args.request_latency,

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -2427,8 +2427,18 @@ def _print_per_ops_latency(per_ops_data: dict) -> None:
             _print_per_ops_section("AFD Transfer (per layer, a2f + f2a)", directional)
 
 
+_ESTIMATE_QUANT_ENUMS = {
+    "gemm_quant_mode": common.GEMMQuantMode,
+    "moe_quant_mode": common.MoEQuantMode,
+    "kvcache_quant_mode": common.KVCacheQuantMode,
+    "fmha_quant_mode": common.FMHAQuantMode,
+    "comm_quant_mode": common.CommQuantMode,
+}
+
+
 def _run_estimate_epd(args, estimate_mode: str) -> None:
     """EPD single-point estimate via Task.run_single_* (dedicated encode pool)."""
+    from aiconfigurator.cli.api import POWER_DATA_COVERAGE_THRESHOLD
     from aiconfigurator.sdk.task_v2 import Task
 
     if estimate_mode not in ("agg", "disagg"):
@@ -2437,18 +2447,22 @@ def _run_estimate_epd(args, estimate_mode: str) -> None:
         enable_epd=True,
         backend_version=args.backend_version,
         database_mode=args.database_mode,
+        transfer_policy=args.transfer_policy,
         isl=args.isl,
         osl=args.osl,
+        prefix=args.prefix,
         image_height=args.image_height,
         image_width=args.image_width,
         num_images_per_request=args.num_images,
-        gemm_quant_mode=args.gemm_quant_mode,
-        moe_quant_mode=args.moe_quant_mode,
-        kvcache_quant_mode=args.kvcache_quant_mode,
-        fmha_quant_mode=args.fmha_quant_mode,
-        comm_quant_mode=args.comm_quant_mode,
+        free_gpu_memory_fraction=args.free_gpu_memory_fraction,
+        max_seq_len=args.max_seq_len,
+        engine_step_backend=args.engine_step_backend,
+        forward_model=args.forward_model,
         nextn=args.nextn,
         nextn_accepted=args.nextn_accepted,
+    )
+    workload.update(
+        {name: enum[getattr(args, name)] for name, enum in _ESTIMATE_QUANT_ENUMS.items() if getattr(args, name)}
     )
     encoder_kwargs = dict(
         encoder_tp=args.encoder_tp,
@@ -2474,6 +2488,14 @@ def _run_estimate_epd(args, estimate_mode: str) -> None:
             **encoder_kwargs,
         )
     else:
+        # Required disagg params and shared-arg fallbacks mirror cli_estimate.
+        for name in ("prefill_batch_size", "prefill_num_workers", "decode_batch_size", "decode_num_workers"):
+            if getattr(args, name) is None:
+                raise SystemExit(f"{name} is required for disagg mode.")
+
+        def _role(value, shared):
+            return value if value is not None else shared
+
         task = Task.from_cli(
             serving_mode="disagg",
             prefill_model_path=args.model_path,
@@ -2485,18 +2507,18 @@ def _run_estimate_epd(args, estimate_mode: str) -> None:
             **workload,
         )
         row = task.run_single_disagg(
-            prefill_tp=args.prefill_tp_size,
-            prefill_pp=args.prefill_pp_size or 1,
-            prefill_dp=args.prefill_attention_dp_size or 1,
-            prefill_moe_tp=args.prefill_moe_tp_size or 1,
-            prefill_moe_ep=args.prefill_moe_ep_size or 1,
+            prefill_tp=_role(args.prefill_tp_size, args.tp_size),
+            prefill_pp=_role(args.prefill_pp_size, args.pp_size),
+            prefill_dp=_role(args.prefill_attention_dp_size, args.attention_dp_size),
+            prefill_moe_tp=_role(args.prefill_moe_tp_size, args.moe_tp_size),
+            prefill_moe_ep=_role(args.prefill_moe_ep_size, args.moe_ep_size),
             prefill_batch_size=args.prefill_batch_size,
             prefill_num_workers=args.prefill_num_workers,
-            decode_tp=args.decode_tp_size,
-            decode_pp=args.decode_pp_size or 1,
-            decode_dp=args.decode_attention_dp_size or 1,
-            decode_moe_tp=args.decode_moe_tp_size or 1,
-            decode_moe_ep=args.decode_moe_ep_size or 1,
+            decode_tp=_role(args.decode_tp_size, args.tp_size),
+            decode_pp=_role(args.decode_pp_size, args.pp_size),
+            decode_dp=_role(args.decode_attention_dp_size, args.attention_dp_size),
+            decode_moe_tp=_role(args.decode_moe_tp_size, args.moe_tp_size),
+            decode_moe_ep=_role(args.decode_moe_ep_size, args.moe_ep_size),
             decode_batch_size=args.decode_batch_size,
             decode_num_workers=args.decode_num_workers,
             **encoder_kwargs,
@@ -2520,9 +2542,13 @@ def _run_estimate_epd(args, estimate_mode: str) -> None:
         "power_w",
     )
     for key in keys:
-        if key in row:
-            value = row[key]
-            logger.info("  %-16s %s", key, f"{value:.3f}" if isinstance(value, float) else value)
+        if key not in row:
+            continue
+        value = row[key]
+        if key == "power_w" and row.get("power_coverage", 1.0) < POWER_DATA_COVERAGE_THRESHOLD:
+            logger.info("  %-16s unavailable (%.0f%% power-data coverage)", key, row["power_coverage"] * 100)
+            continue
+        logger.info("  %-16s %s", key, f"{value:.3f}" if isinstance(value, float) else value)
 
 
 def _run_estimate_mode(args):
@@ -2981,6 +3007,11 @@ def main(args):
             or getattr(args, "target_concurrency", None) is not None
         )
         if getattr(args, "total_gpus", None) is None and has_load_target:
+            if args.enable_epd or args.encoder_tp or args.encoder_system or args.encoder_latency_correction != 1.0:
+                raise SystemExit(
+                    "--enable-epd/encoder_* flags are not supported by the auto-recommend routing "
+                    "(load target without --total-gpus); pass --total-gpus to run the EPD sweep."
+                )
             _run_recommend(args)
             return
         if has_load_target:

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -432,6 +432,13 @@ def _add_default_mode_arguments(parser):
         help="EPD encode-worker TP sizes to sweep (requires --enable-epd). Default: 1 2 4 8.",
     )
     parser.add_argument(
+        "--encoder-system",
+        type=str,
+        default=None,
+        help="System (GPU type) for EPD encode workers (requires --enable-epd). "
+        "Defaults to the prefill/agg side's system.",
+    )
+    parser.add_argument(
         "--ttft",
         type=float,
         default=2000.0,
@@ -1461,6 +1468,7 @@ def build_default_tasks(
     enable_encoder_dp: bool = True,
     enable_epd: bool = False,
     encoder_tp: list[int] | None = None,
+    encoder_system: str | None = None,
     ttft: float = 2000.0,
     tpot: float = 30.0,
     request_latency: float | None = None,
@@ -1687,6 +1695,7 @@ def build_default_tasks(
             moe_backend=moe_backend_value,
             enable_epd=enable_epd,
             encoder_tp_candidates=encoder_tp,
+            encoder_system_name=encoder_system,
             **global_kwargs,
         )
 
@@ -1705,6 +1714,7 @@ def build_default_tasks(
             moe_backend=moe_backend_value,
             enable_epd=enable_epd,
             encoder_tp_candidates=encoder_tp,
+            encoder_system_name=encoder_system,
             **global_kwargs,
         )
 
@@ -2883,6 +2893,7 @@ def main(args):
             enable_encoder_dp=not args.disable_encoder_dp,
             enable_epd=args.enable_epd,
             encoder_tp=args.encoder_tp,
+            encoder_system=args.encoder_system,
             ttft=args.ttft,
             tpot=args.tpot,
             request_latency=args.request_latency,

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -421,8 +421,8 @@ def _add_default_mode_arguments(parser):
         "--enable-epd",
         action="store_true",
         help="EPD (vision-language models): run the vision encoder on dedicated encode workers "
-        "instead of colocated with prefill. Turns the disagg experiment into EPD; requires an "
-        "image workload (--image-height/--image-width).",
+        "instead of colocated. Turns the disagg experiment into E+P+D and the agg experiment "
+        "into E+agg; requires an image workload (--image-height/--image-width).",
     )
     parser.add_argument(
         "--encoder-tp",
@@ -1685,6 +1685,8 @@ def build_default_tasks(
             backend_version=backend_version,
             enable_chunked_prefill=enable_chunked_prefill,
             moe_backend=moe_backend_value,
+            enable_epd=enable_epd,
+            encoder_tp_candidates=encoder_tp,
             **global_kwargs,
         )
 

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -863,13 +863,13 @@ def _add_estimate_mode_arguments(parser):
     parser.add_argument(
         "--encoder-batch-size",
         type=int,
-        default=1,
+        default=None,
         help="EPD encode-worker batch size. Default: 1.",
     )
     parser.add_argument(
         "--encoder-num-workers",
         type=int,
-        default=1,
+        default=None,
         help="EPD encode workers in the pool. Default: 1.",
     )
     parser.add_argument(
@@ -1578,6 +1578,8 @@ def build_default_tasks(
         modes_to_sweep = {"agg", "disagg", "afd"}
     else:
         modes_to_sweep = {serving_mode}
+    if enable_epd and not (modes_to_sweep & {"agg", "disagg"}):
+        raise ValueError("enable_epd requires an agg or disagg experiment; 'afd' does not support EPD.")
     needs_disagg = "disagg" in modes_to_sweep
 
     backends_to_sweep = [b.value for b in common.BackendName] if backend == "auto" else [backend]
@@ -2455,8 +2457,8 @@ def _run_estimate_epd(args, estimate_mode: str) -> None:
     workload.update({name: getattr(args, name) for name in _QUANT_ENUM_TABLES if getattr(args, name, None)})
     encoder_kwargs = dict(
         encoder_tp=args.encoder_tp,
-        encoder_batch_size=args.encoder_batch_size,
-        encoder_num_workers=args.encoder_num_workers,
+        encoder_batch_size=1 if args.encoder_batch_size is None else args.encoder_batch_size,
+        encoder_num_workers=1 if args.encoder_num_workers is None else args.encoder_num_workers,
     )
     if estimate_mode == "agg":
         task = Task.from_cli(
@@ -2551,6 +2553,11 @@ def _run_estimate_epd(args, estimate_mode: str) -> None:
 def _run_estimate_mode(args):
     """Run the estimate mode to predict TTFT, TPOT, and power for a single config."""
     from aiconfigurator.cli.api import cli_estimate
+
+    if not args.enable_epd and any(
+        v is not None for v in (args.encoder_tp, args.encoder_batch_size, args.encoder_num_workers)
+    ):
+        raise SystemExit("--encoder-tp/--encoder-batch-size/--encoder-num-workers require --enable-epd.")
 
     estimate_mode = args.estimate_mode
 

--- a/src/aiconfigurator/cli/report_and_save.py
+++ b/src/aiconfigurator/cli/report_and_save.py
@@ -78,8 +78,8 @@ def _format_power(power_w: object) -> str:
     return "" if pd.isna(power_w) else f"{float(power_w):.1f}W"
 
 
-def _composed_worker_gpus(row: dict, role: str) -> int:
-    """Per-worker GPU count from a composed disagg row's ``(p)``/``(d)`` columns.
+def _composed_worker_gpus(row: dict, role: str = "") -> int:
+    """Per-worker GPU count from ``(p)``/``(d)``-prefixed or plain columns.
 
     Iterates :data:`aiconfigurator.sdk.picking.WORKER_GPU_DIMS` so every
     parallelism dimension lands here automatically; columns a row predates
@@ -87,7 +87,7 @@ def _composed_worker_gpus(row: dict, role: str) -> int:
     """
     gpus = 1
     for dim in WORKER_GPU_DIMS:
-        gpus *= parallel_dim(row.get(f"({role}){dim}"))
+        gpus *= parallel_dim(row.get(f"({role}){dim}" if role else dim))
     return gpus
 
 
@@ -392,7 +392,7 @@ def _plot_worker_setup_table(
             e_workers = int(row.get("(e)workers", 0) or 0)
             if e_workers:
                 # E+agg cell: (a)workers language-only agg workers + encode pool.
-                worker_gpus = row["pp"] * row["tp"] * row["dp"]
+                worker_gpus = _composed_worker_gpus(row)
                 gpus_replica = (
                     f"{row['num_total_gpus']} "
                     f"(={a_workers}x{worker_gpus}+{e_workers}x{int(row.get('(e)tp', 0) or 0)}(e))"

--- a/src/aiconfigurator/cli/report_and_save.py
+++ b/src/aiconfigurator/cli/report_and_save.py
@@ -146,6 +146,13 @@ def _plot_worker_setup_table(
         top_configs["replicas"] = total_gpus // top_configs["num_total_gpus"]
         top_configs["total_gpus_used"] = top_configs["num_total_gpus"] * top_configs["replicas"]
 
+    def _power_cell(row) -> str:
+        # power_w == 0.0 on an EPD row is the no-data sentinel (incomplete
+        # encoder energy data), not a real 0 W estimate.
+        if (row.get("(e)workers") or 0) > 0 and row["power_w"] < 1.0:
+            return "n/a"
+        return _format_power(row["power_w"])
+
     ranking_label = "total_gpus_needed" if "replicas_needed" in top_configs.columns else "tokens/s/gpu"
     buf.append(f"\n{exp_name} Top Configurations: (Ranked by {ranking_label})")
     table = PrettyTable()
@@ -332,7 +339,7 @@ def _plot_worker_setup_table(
                     ]
                 )
             if show_power:
-                row_data.append(_format_power(row["power_w"]))
+                row_data.append(_power_cell(row))
             table.add_row(row_data)
     else:  # agg
         field_names = [
@@ -418,7 +425,7 @@ def _plot_worker_setup_table(
                     ]
                 )
             if show_power:
-                row_data.append(_format_power(row["power_w"]))
+                row_data.append(_power_cell(row))
             table.add_row(row_data)
 
     buf.append(table.get_string())
@@ -1050,17 +1057,8 @@ def save_results(
                             afd_artifact_warning_emitted = True
                         continue
 
-                    result_df = result_df.drop(labels=["_task_key"], errors="ignore")
-                    cfg = task_config_to_generator_config(
-                        task_config=row_task,
-                        result_df=result_df,
-                        generator_overrides=generator_overrides,
-                    )
-
                     top_config_dir = os.path.join(exp_dir, f"top{i + 1}")
                     safe_mkdir(top_config_dir, exist_ok=True)
-                    with open(os.path.join(top_config_dir, "generator_config.yaml"), "w") as f:
-                        yaml.safe_dump(cfg, f, sort_keys=False)
 
                     # Per-op PerformanceResult.source breakdown, pulled through
                     # the InferenceSummary.
@@ -1069,6 +1067,28 @@ def save_results(
                     if i < len(best_config_per_ops_source) and best_config_per_ops_source[i] is not None:
                         with open(os.path.join(top_config_dir, "per_ops_source.json"), "w") as f:
                             json.dump(best_config_per_ops_source[i], f, indent=2, sort_keys=True)
+
+                    enc_workers = result_df.get("(e)workers", 0)
+                    if pd.notna(enc_workers) and enc_workers > 0:
+                        logger.warning(
+                            "%s top%d is an EPD row ((e)workers=%d): generator artifacts skipped -- "
+                            "the generator bridge does not map the dedicated encode pool yet, and the "
+                            "emitted deploy configs would contradict the recommendation.",
+                            exp_name,
+                            i + 1,
+                            int(enc_workers),
+                        )
+                        continue
+
+                    result_df = result_df.drop(labels=["_task_key"], errors="ignore")
+                    cfg = task_config_to_generator_config(
+                        task_config=row_task,
+                        result_df=result_df,
+                        generator_overrides=generator_overrides,
+                    )
+
+                    with open(os.path.join(top_config_dir, "generator_config.yaml"), "w") as f:
+                        yaml.safe_dump(cfg, f, sort_keys=False)
 
                     try:
                         deployment_target = getattr(args, "deployment_target", "dynamo-j2")

--- a/src/aiconfigurator/cli/report_and_save.py
+++ b/src/aiconfigurator/cli/report_and_save.py
@@ -158,6 +158,11 @@ def _plot_worker_setup_table(
 
     top_configs["cluster_request_rate"] = top_configs["request_rate"] * top_configs["replicas"]
 
+    # EPD rows carry a dedicated encode-worker pool; show it only when present.
+    has_encoder_pool = (
+        is_disagg and "(e)workers" in top_configs.columns and (top_configs["(e)workers"].fillna(0) > 0).any()
+    )
+
     if is_afd:
         field_names = [
             "Rank",
@@ -240,6 +245,8 @@ def _plot_worker_setup_table(
             "(d)parallel",
             "(d)bs",
         ]
+        if has_encoder_pool:
+            field_names.extend(["(e)workers", "(e)tp", "(e)bs"])
         if show_power:
             field_names.append("power_w")
         table.field_names = field_names
@@ -287,7 +294,11 @@ def _plot_worker_setup_table(
                     f"{p_gpus} (={_cli_underline(str(row['(p)tp']))}x{_cli_underline(str(row['(p)pp']))}{p_cp_factor})"
                 )
                 d_gpus_worker = f"{d_gpus} (={_cli_underline(str(row['(d)tp']))}x{_cli_underline(str(row['(d)pp']))})"
-            gpus_replica_str = f"{row['num_total_gpus']} (={row['(p)workers']}x{p_gpus}+{row['(d)workers']}x{d_gpus})"
+            e_workers = int(row.get("(e)workers", 0) or 0)
+            encoder_term = f"+{e_workers}x{int(row.get('(e)tp', 0) or 0)}(e)" if e_workers else ""
+            gpus_replica_str = (
+                f"{row['num_total_gpus']} (={row['(p)workers']}x{p_gpus}+{row['(d)workers']}x{d_gpus}{encoder_term})"
+            )
             row_data = [
                 i + 1,
                 row["backend"],
@@ -313,6 +324,14 @@ def _plot_worker_setup_table(
                     row["(d)bs"],
                 ]
             )
+            if has_encoder_pool:
+                row_data.extend(
+                    [
+                        e_workers,
+                        int(row.get("(e)tp", 0) or 0),
+                        int(row.get("(e)bs", 0) or 0),
+                    ]
+                )
             if show_power:
                 row_data.append(_format_power(row["power_w"]))
             table.add_row(row_data)

--- a/src/aiconfigurator/cli/report_and_save.py
+++ b/src/aiconfigurator/cli/report_and_save.py
@@ -158,10 +158,9 @@ def _plot_worker_setup_table(
 
     top_configs["cluster_request_rate"] = top_configs["request_rate"] * top_configs["replicas"]
 
-    # EPD rows carry a dedicated encode-worker pool; show it only when present.
-    has_encoder_pool = (
-        is_disagg and "(e)workers" in top_configs.columns and (top_configs["(e)workers"].fillna(0) > 0).any()
-    )
+    # EPD rows (disagg E+P+D or agg E+agg) carry a dedicated encode-worker
+    # pool; show it only when present.
+    has_encoder_pool = "(e)workers" in top_configs.columns and (top_configs["(e)workers"].fillna(0) > 0).any()
 
     if is_afd:
         field_names = [
@@ -352,6 +351,8 @@ def _plot_worker_setup_table(
             "parallel",
             "bs",
         ]
+        if has_encoder_pool:
+            field_names.extend(["(a)workers", "(e)workers", "(e)tp", "(e)bs"])
         if show_power:
             field_names.append("power_w")
         table.field_names = field_names
@@ -380,6 +381,17 @@ def _plot_worker_setup_table(
                 i + 1,
                 row["backend"],
             ]
+            a_workers = int(row.get("(a)workers", 0) or 0)
+            e_workers = int(row.get("(e)workers", 0) or 0)
+            if e_workers:
+                # E+agg cell: (a)workers language-only agg workers + encode pool.
+                worker_gpus = row["pp"] * row["tp"] * row["dp"]
+                gpus_replica = (
+                    f"{row['num_total_gpus']} "
+                    f"(={a_workers}x{worker_gpus}+{e_workers}x{int(row.get('(e)tp', 0) or 0)}(e))"
+                )
+            else:
+                gpus_replica = row["num_total_gpus"]
             row_data.extend(
                 [
                     _cli_bold(f"{row['tokens/s/gpu_cluster']:.2f}"),
@@ -390,12 +402,21 @@ def _plot_worker_setup_table(
                     f"{display_concurrency} (={row['concurrency']}x{row['replicas']})",
                     f"{display_total_gpus} ({row['total_gpus_used']}={row['replicas']}x{row['num_total_gpus']})",
                     row["replicas"],
-                    row["num_total_gpus"],
+                    gpus_replica,
                     gpus_worker,
                     parallel,
                     row["bs"],
                 ]
             )
+            if has_encoder_pool:
+                row_data.extend(
+                    [
+                        a_workers,
+                        e_workers,
+                        int(row.get("(e)tp", 0) or 0),
+                        int(row.get("(e)bs", 0) or 0),
+                    ]
+                )
             if show_power:
                 row_data.append(_format_power(row["power_w"]))
             table.add_row(row_data)

--- a/src/aiconfigurator/generator/module_bridge.py
+++ b/src/aiconfigurator/generator/module_bridge.py
@@ -91,6 +91,14 @@ def task_config_to_generator_config(
             in the generated config.
     """
 
+    # Fail closed: rendering an EPD row would emit a deploy config that
+    # contradicts the recommendation.
+    if getattr(task_config, "enable_epd", False) or _safe_int(_series_val(result_df, "(e)workers", 0), 0) > 0:
+        raise ValueError(
+            "EPD results are not supported by the generator bridge yet: the dedicated "
+            "encode pool ((a)/(e) columns) is not mapped into deployment configs."
+        )
+
     overrides = copy.deepcopy(generator_overrides or {})
 
     # Encoder parallelism is deployment-relevant only when the task models an
@@ -248,9 +256,9 @@ def task_config_to_generator_config(
     if decode_params:
         decode_workers = _safe_int(worker_count_overrides.get("decode_workers"), decode_workers)
 
-    # Multimodal EPD: the encode worker is not produced by the SDK sweep (the
-    # encoder is modeled colocated with prefill). Inject it from explicit
-    # overrides -- --generator-set Workers.encode.* + WorkerConfig.encode_workers.
+    # Multimodal encode workers: the default sweep models the encoder colocated
+    # with prefill/agg, so no encode worker is derived here.  Inject explicit
+    # workers via --generator-set Workers.encode.* + WorkerConfig.encode_workers.
     # Absent -> no encode worker, output unchanged.
     encode_override = worker_overrides.get("encode")
     encode_params = None

--- a/src/aiconfigurator/sdk/inference_session.py
+++ b/src/aiconfigurator/sdk/inference_session.py
@@ -21,7 +21,7 @@ from aiconfigurator.sdk.picking import (
 )
 from aiconfigurator.sdk.speculative import SpeculativeDecodingProfile
 from aiconfigurator.sdk.step_estimate import MixedStepInput, StepEstimate
-from aiconfigurator.sdk.utils import enumerate_ttft_tpot_constraints, get_model_config_from_model_path
+from aiconfigurator.sdk.utils import enumerate_ttft_tpot_constraints
 
 logger = logging.getLogger(__name__)
 warnings.filterwarnings("ignore", category=FutureWarning)
@@ -826,14 +826,7 @@ class DisaggInferenceSession:
         else:
             decode_batch_size_range = [i for i in decode_batch_size_list_default if i <= decode_max_num_tokens]
 
-        try:
-            enc_cfg = get_model_config_from_model_path(model_path).get("extra_params")
-        except Exception:
-            logger.debug("Could not resolve model config for VL effective ISL; using text ISL", exc_info=True)
-            enc_cfg = None
-        prefill_effective_isl = runtime_config.isl + BaseBackend._visual_context_tokens_from_encoder_config(
-            enc_cfg, runtime_config
-        )
+        prefill_effective_isl = BaseBackend.effective_prefill_isl(model_path, runtime_config)
         if prefill_max_num_tokens < prefill_effective_isl:
             logger.warning("prefill_max_num_tokens is less than effective prefill ISL, set to effective prefill ISL")
             prefill_max_num_tokens = prefill_effective_isl

--- a/src/aiconfigurator/sdk/picking.py
+++ b/src/aiconfigurator/sdk/picking.py
@@ -191,6 +191,7 @@ def _build_disagg_summary_dict(
         "(e)workers": 0,
         "(e)tp": 0,
         "(e)pp": 0,
+        "(e)bs": 0,
         "(e)parallel": "",
         "(e)memory": encoder_memory,
         "power_w": disagg_power_avg,

--- a/src/aiconfigurator/sdk/sweep.py
+++ b/src/aiconfigurator/sdk/sweep.py
@@ -51,6 +51,7 @@ from aiconfigurator.sdk.errors import (
     PerfDataNotAvailableError,
 )
 from aiconfigurator.sdk.models import get_model
+from aiconfigurator.sdk.models.vit_ops import EncoderOnlyModel, build_encoder_ops
 from aiconfigurator.sdk.perf_database import PerfDatabase
 from aiconfigurator.sdk.picking import parallel_dim, worker_gpus
 from aiconfigurator.sdk.predict import predict_agg_worker, predict_disagg_worker
@@ -505,7 +506,6 @@ def sweep_agg(
         # encoder, ``encoder_database``); it defaults to the agg side.
         encoder_candidates = _get_encoder_worker_candidates(
             model_path=model_path,
-            model_config=model_config,
             tp_list=encoder_tp_list or _DEFAULT_ENCODER_TP_LIST,
             b_list=encoder_batch_list or _DEFAULT_ENCODER_BATCH_SCHEDULE,
             runtime_config=runtime_config,
@@ -781,7 +781,6 @@ def _get_disagg_worker_candidates(
 def _get_encoder_worker_candidates(
     *,
     model_path: str,
-    model_config: config.ModelConfig,
     tp_list: list[int],
     b_list: list[int],
     runtime_config: config.RuntimeConfig,
@@ -793,34 +792,48 @@ def _get_encoder_worker_candidates(
 
     An encode (E) worker runs only the vision encoder (ViT + projector) with
     its own tensor parallelism, mirroring an encoder-only instance that loads
-    no LLM weights (e.g. SGLang ``--encoder-only``).  A worker encodes one
-    batch of ``b`` requests (each with ``num_images_per_request`` images) in
-    ``encoder_latency`` ms, so its throughput is ``b / encoder_latency``.
-    Per tp, batch points that do not improve throughput over a smaller batch
-    are dominated (same rate at worse latency) and dropped.
+    no LLM weights (e.g. SGLang ``--encoder-only``).  The worker model is
+    built directly from the encoder config: constructing the full LLM here
+    would waste work and, worse, let LLM-side parallelism rules (KV-head
+    divisibility, MoE width identities) reject a tp the ViT itself supports.
+    The ViT is weight-sharded over the worker's tp (encoder DP off): that is
+    the encoder-instance default of both engines (vLLM
+    ``mm_encoder_tp_mode="weights"``, SGLang ``mm_enable_dp_encoder=False``,
+    each independent of the disaggregation flags) -- the DP layout's benefit
+    (replicas over a colocated worker's LLM-sized tp group) is expressed in
+    EPD by sweeping multiple small-tp encode workers instead.
+    A worker encodes one batch of ``b`` requests (each with
+    ``num_images_per_request`` images) in ``encoder_latency`` ms, so its
+    throughput is ``b / encoder_latency``.  Per tp, batch points that do not
+    improve throughput over a smaller batch are dominated (same rate at
+    worse latency) and dropped.
 
     Returns row dicts with keys
     ``encoder_latency / seq/s / num_total_gpus / tp / bs / memory``.
     """
     backend = get_backend(backend_name)
+    enc_cfg = get_model_config_from_model_path(model_path).get("extra_params")
+    if not isinstance(enc_cfg, common.VisionEncoderConfig):
+        # Config error, not a typing mistake: "no VisionEncoderConfig" means
+        # the model is not a VL model, so EPD cannot apply to it.
+        raise ValueError(  # noqa: TRY004
+            f"EPD (encoder disaggregation) requested but model {model_path!r} has no vision encoder."
+        )
     rows: list[dict] = []
     for etp in tp_list:
-        point_mc = copy.deepcopy(model_config)
-        point_mc.tp_size = etp
-        point_mc.pp_size = 1
-        point_mc.attention_dp_size = 1
-        point_mc.cp_size = 1
-        point_mc.moe_tp_size = etp
-        point_mc.moe_ep_size = 1
-        point_mc.language_only = False  # the encode worker itself hosts the ViT
         try:
-            model = get_model(model_path=model_path, model_config=point_mc, backend_name=backend_name)
+            encoder_ops = build_encoder_ops(enc_cfg, etp, enable_encoder_dp=False)
         except ValueError as e:
-            # e.g. ViT heads / FFN not divisible by this tp.
-            logger.debug("sweep_disagg/encoder: tp=%s rejected: %s", etp, e)
+            # ViT-side constraint: heads / FFN width not divisible by this tp.
+            logger.debug("EPD encoder: tp=%s rejected: %s", etp, e)
             continue
-        if not getattr(model, "encoder_ops", None):
-            raise ValueError(f"EPD (encoder disaggregation) requested but model {model_path!r} has no vision encoder.")
+        model = EncoderOnlyModel(
+            encoder_ops=encoder_ops,
+            encoder_config=enc_cfg,
+            # The ModelConfig slice the encoder phase reads; enable_encoder_dp
+            # stays off so the image batch is not ceil-sharded across ranks.
+            config=config.ModelConfig(tp_size=etp, enable_encoder_dp=False),
+        )
         best_seq_s = 0.0
         for b in b_list:
             latency, power_w, memory = backend.run_encoder_static(
@@ -847,7 +860,7 @@ def _get_encoder_worker_candidates(
                 }
             )
     if not rows:
-        raise NoFeasibleConfigError("sweep_disagg/encoder: no encode-worker candidate for any encoder tp.")
+        raise NoFeasibleConfigError("EPD encoder: no encode-worker candidate for any encoder tp.")
     return rows
 
 
@@ -1246,7 +1259,6 @@ def sweep_disagg(
         # encoder, ``encoder_database``); it defaults to the prefill side.
         encoder_candidates = _get_encoder_worker_candidates(
             model_path=model_path,
-            model_config=prefill_model_config,
             tp_list=encoder_tp_list or _DEFAULT_ENCODER_TP_LIST,
             b_list=encoder_batch_list or _DEFAULT_ENCODER_BATCH_SCHEDULE,
             runtime_config=runtime_config,

--- a/src/aiconfigurator/sdk/sweep.py
+++ b/src/aiconfigurator/sdk/sweep.py
@@ -455,6 +455,7 @@ def sweep_agg(
     encoder_batch_list: list[int] | None = None,
     encoder_latency_correction: float = 1.0,
     encoder_database: PerfDatabase | None = None,
+    num_gpu_list: list[int] | None = None,
     predictor: Any = None,
     speculative_profile: SpeculativeDecodingProfile | None = None,
 ) -> pd.DataFrame:
@@ -477,9 +478,13 @@ def sweep_agg(
     aggregated.  The agg worker becomes language-only (vision tokens stay in
     context, no ViT hosted); each row is then a rate-matched cell of
     ``(a)workers`` agg workers plus ``(e)workers`` encode workers, with the
-    encode batch latency added to TTFT.  Default (``enable_epd=False``) keeps
-    the encoder inline (colocated): its latency is part of the agg worker's
-    TTFT and its weights part of the worker's memory.
+    encode batch latency added to TTFT.  ``num_gpu_list`` is the allowed
+    per-cell (per-replica) GPU counts for those cells, exactly as in
+    ``sweep_disagg``; it is unused outside EPD (a plain agg row is a single
+    worker whose GPU count is already gated by the parallel candidates).
+    Default (``enable_epd=False``) keeps the encoder inline (colocated): its
+    latency is part of the agg worker's TTFT and its weights part of the
+    worker's memory.
 
     Args:
         model_path: HuggingFace model path or local path.
@@ -533,6 +538,9 @@ def sweep_agg(
         )
         model_config = copy.deepcopy(model_config)
         model_config.language_only = True
+    # Per-cell (per-replica) GPU budget for the E+agg rate matching, same
+    # semantics as sweep_disagg's num_gpu_list.
+    epd_num_gpu_set: set[int] = set(num_gpu_list) if num_gpu_list else set()
 
     for parallel_config in parallel_config_list:
         tp_size, pp_size, dp_size, moe_tp_size, moe_ep_size, cp_size = parallel_config
@@ -614,6 +622,7 @@ def sweep_agg(
                         point_df,
                         encoder_candidates,
                         ttft_target=point_rt.ttft,
+                        num_gpu_set=epd_num_gpu_set,
                     )
                 if len(point_df) == 0:
                     continue
@@ -900,11 +909,14 @@ def _overlay_encoder_stage(
     corrected wholesale, so the disaggregated encode stage must be too),
     while the agg path keeps 1.0 (run_agg adds the inline encoder outside
     its queueing factor).  The ``encoder_latency`` column stays the raw
-    stage latency, like the inline rows.  ``seq/s`` is unchanged: the
-    encode pool is sized to at least the rate-matched throughput; its GPUs
-    only dilute the per-GPU metrics.  ``power_w`` is re-weighted over the
-    three-phase timeline (encode + prefill + decode); the prefill phase
-    reuses the colocated worker's average power as an approximation.
+    stage latency, like the inline rows.  Three-pool rate matching: when
+    the encode pool's degraded capacity is below the row throughput (the
+    matcher may pick an encode-bound cell), ``seq/s`` is capped at that
+    capacity and the rate-derived columns rescale with it; per-request
+    latency columns are unaffected (the batch latency does not depend on
+    the pool size).  ``power_w`` is re-weighted over the three-phase
+    timeline (encode + prefill + decode); the prefill phase reuses the
+    colocated worker's average power as an approximation.
     """
     row = dict(disagg_dict)
     encoder_latency = encoder_worker["encoder_latency"]
@@ -921,6 +933,13 @@ def _overlay_encoder_stage(
     row["encoder_latency"] = encoder_latency
     row["ttft"] = prefill_ttft + encoder_ttft_share
     row["request_latency"] = row["request_latency"] + encoder_ttft_share
+    # Same association order as the matchers ((seq/s x deg) x workers) so
+    # the capped value is bit-identical to the capacity the argmax used.
+    encoder_capacity = encoder_worker["seq/s"] * _RATE_MATCH_ENCODER_DEGRADATION * encoder_num_worker
+    if 0 < encoder_capacity < row["seq/s"]:
+        row["tokens/s"] = row["tokens/s"] * (encoder_capacity / row["seq/s"])
+        row["seq/s"] = encoder_capacity
+        row["request_rate"] = encoder_capacity
     num_total_gpus = row["num_total_gpus"] + encoder_worker["num_total_gpus"] * encoder_num_worker
     row["seq/s/gpu"] = row["seq/s"] / num_total_gpus
     row["tokens/s/gpu"] = row["tokens/s"] / num_total_gpus
@@ -939,16 +958,23 @@ def _rate_match_agg_epd(
     encoder_records: list[dict],
     *,
     ttft_target: float,
+    num_gpu_set: set[int] | None = None,
 ) -> pd.DataFrame:
     """Rate-match the encode pool against language-only agg workers (E+agg).
 
     The agg counterpart of the disagg encoder rate matching + ``_overlay_encoder_stage``:
     for each (agg row, encode-worker choice) whose encode latency still fits
-    the TTFT budget, pick the cell of ``a`` agg workers + ``e`` encode workers
-    (``e`` = smallest count that does not bottleneck the agg throughput, the
-    EPD disagg convention) maximizing throughput-per-GPU; ties keep the
-    smaller cell.  The returned rows are per-cell — ``(a)workers`` agg workers
-    — so the downstream replicas logic scales whole cells.
+    the TTFT budget, sweep cells of ``a`` agg workers + ``e`` encode workers
+    -- ``e`` up to the first count that no longer binds (larger pools are
+    dominated), smaller counts making the encode pool the rate-matched
+    bottleneck (cell throughput = min of the two pools, applied by the
+    overlay).  ``num_gpu_set`` is the per-replica GPU budget, exactly as in
+    the disagg matching: cells whose total GPU count is not allowed are
+    skipped *before* the argmax, so a feasible small cell is never shadowed
+    by an infeasible better-amortized large one.  Among feasible cells the
+    throughput-per-GPU argmax wins; ties keep the smaller cell.  The
+    returned rows are per-cell — ``(a)workers`` agg workers — so the
+    downstream replicas logic scales whole cells.
     """
     rows: list[dict] = []
     for r in agg_df.to_dict("records"):
@@ -962,11 +988,17 @@ def _rate_match_agg_epd(
             encoder_capacity = float(enc["seq/s"]) * _RATE_MATCH_ENCODER_DEGRADATION
             best: tuple[tuple[float, int], int, int] | None = None
             for a_num in range(1, _MAX_AGG_WORKERS_EPD + 1):
-                e_num = max(1, math.ceil(rate_one * a_num / encoder_capacity))
-                num_gpu = gpus_one * a_num + enc["num_total_gpus"] * e_num
-                key = (rate_one * a_num / num_gpu, -num_gpu)
-                if best is None or key > best[0]:
-                    best = (key, a_num, e_num)
+                agg_rate = rate_one * a_num
+                for e_num in range(1, max(1, math.ceil(agg_rate / encoder_capacity)) + 1):
+                    num_gpu = gpus_one * a_num + enc["num_total_gpus"] * e_num
+                    if num_gpu_set and num_gpu not in num_gpu_set:
+                        continue
+                    cell_rate = min(agg_rate, encoder_capacity * e_num)
+                    key = (cell_rate / num_gpu, -num_gpu)
+                    if best is None or key > best[0]:
+                        best = (key, a_num, e_num)
+            if best is None:
+                continue
             _, a_num, e_num = best
             cell = dict(r)
             cell["(a)workers"] = a_num
@@ -975,9 +1007,11 @@ def _rate_match_agg_epd(
             cell["request_rate"] = cell["seq/s"]
             cell["concurrency"] = r["concurrency"] * a_num
             cell["num_total_gpus"] = gpus_one * a_num
-            # per-GPU metrics are recomputed by the overlay with the encode
-            # pool GPUs included; the agg worker covers both the prefill and
-            # decode phases of the power timeline.
+            # cell rate columns are the uncapped agg-side capacity; the
+            # overlay applies the min() with the encode pool and recomputes
+            # the per-GPU metrics with the encode GPUs included.  The agg
+            # worker covers both the prefill and decode phases of the power
+            # timeline.
             rows.append(
                 _overlay_encoder_stage(
                     cell,
@@ -1365,34 +1399,45 @@ def sweep_disagg(
     ) -> tuple[int, int, int]:
         """Pick (p_num, d_num, e_num) maximizing throughput per GPU.
 
-        The encode pool is the optional third rate-matched pool (EPD): for
-        each (p_num, d_num) it is sized to the smallest worker count that
-        does not bottleneck the rate-matched P/D throughput, so seq/s stays
-        min(p, d) while the encode GPUs count toward the per-GPU objective
-        and the replica GPU budget.  ``encoder_throughput = 0`` (plain PD)
-        drops the encoder terms entirely and returns ``e_num = 0``.
+        The encode pool is the optional third rate-matched pool (EPD),
+        fully symmetric with P and D: its size is swept like theirs and the
+        achieved throughput is the min of the three degraded pool
+        capacities -- the encode pool may itself be the bottleneck, running
+        at its degradation headroom exactly like a binding P or D pool.
+        ``encoder_throughput = 0`` (plain PD) drops the encoder terms
+        entirely and returns ``e_num = 0``.
         """
         prefill_opt, decode_opt, encoder_opt = -1, -1, -1
         throughput_per_gpu_max = 0.0
         encoder_capacity = encoder_throughput * _RATE_MATCH_ENCODER_DEGRADATION
         for d_num in d_num_workers:
             for p_num in p_num_workers:
-                p_corrected = prefill_throughput * p_num * prefill_deg
-                d_corrected = decode_throughput * d_num * decode_deg
-                required = min(p_corrected, d_corrected)
-                e_num = max(1, math.ceil(required / encoder_capacity)) if encoder_capacity > 0 else 0
-                num_gpu = prefill_gpus * p_num + decode_gpus * d_num + encoder_gpus * e_num
-                if num_gpu_set and num_gpu not in num_gpu_set:
-                    continue
                 if max_prefill_gpus is not None and max_decode_gpus is not None:
                     if prefill_gpus * p_num > max_prefill_gpus:
                         continue
                     if decode_gpus * d_num > max_decode_gpus:
                         continue
-                tpg = required / num_gpu
-                if tpg > throughput_per_gpu_max:
-                    throughput_per_gpu_max = tpg
-                    prefill_opt, decode_opt, encoder_opt = p_num, d_num, e_num
+                p_corrected = prefill_throughput * p_num * prefill_deg
+                d_corrected = decode_throughput * d_num * decode_deg
+                pd_required = min(p_corrected, d_corrected)
+                if encoder_capacity > 0:
+                    # Sweep the encode pool up to the first size that no
+                    # longer binds; larger pools are dominated (same
+                    # throughput, more GPUs).  Smaller sizes trade capped
+                    # throughput for GPUs -- and under a per-replica GPU
+                    # budget they are sometimes the only feasible cells.
+                    e_num_candidates = range(1, max(1, math.ceil(pd_required / encoder_capacity)) + 1)
+                else:
+                    e_num_candidates = (0,)
+                for e_num in e_num_candidates:
+                    required = pd_required if e_num == 0 else min(pd_required, encoder_capacity * e_num)
+                    num_gpu = prefill_gpus * p_num + decode_gpus * d_num + encoder_gpus * e_num
+                    if num_gpu_set and num_gpu not in num_gpu_set:
+                        continue
+                    tpg = required / num_gpu
+                    if tpg > throughput_per_gpu_max:
+                        throughput_per_gpu_max = tpg
+                        prefill_opt, decode_opt, encoder_opt = p_num, d_num, e_num
         return prefill_opt, decode_opt, encoder_opt
 
     disagg_df = pd.DataFrame(columns=common.ColumnsDisagg)

--- a/src/aiconfigurator/sdk/sweep.py
+++ b/src/aiconfigurator/sdk/sweep.py
@@ -55,7 +55,7 @@ from aiconfigurator.sdk.perf_database import PerfDatabase
 from aiconfigurator.sdk.picking import parallel_dim, worker_gpus
 from aiconfigurator.sdk.predict import predict_agg_worker, predict_disagg_worker
 from aiconfigurator.sdk.speculative import SpeculativeDecodingProfile
-from aiconfigurator.sdk.utils import enumerate_ttft_tpot_constraints
+from aiconfigurator.sdk.utils import enumerate_ttft_tpot_constraints, get_model_config_from_model_path
 
 logger = logging.getLogger(__name__)
 
@@ -84,11 +84,13 @@ _DEFAULT_DECODE_BATCH_SCHEDULE: list[int] = (
 )
 
 # Default EPD encode-worker search space.  TP mirrors a real encode
-# instance's --tp-size choices; the batch schedule models cross-request
-# image batching (e.g. SGLang's encoder scheduler, default max batch 8),
-# swept wider so the TTFT budget decides what is affordable.
+# instance's --tp-size choices.  The batch schedule models cross-request
+# batching by the encode instance's greedy scheduler and is capped at
+# SGLang's default (SGLANG_ENCODER_MAX_BATCH_SIZE = 8) -- larger batches
+# do not exist in the deployed system, so sweeping them would credit the
+# encode pool with unreachable throughput.
 _DEFAULT_ENCODER_TP_LIST: list[int] = [1, 2, 4, 8]
-_DEFAULT_ENCODER_BATCH_SCHEDULE: list[int] = [1, 2, 4, 8, 16, 32]
+_DEFAULT_ENCODER_BATCH_SCHEDULE: list[int] = [1, 2, 4, 8]
 
 # E+agg: agg-worker replicas explored per rate-matched cell.  Mirrors the
 # disagg worker lists (range(1, 33)); the cell only exists to express the
@@ -303,7 +305,11 @@ def _sweep_one_parallel_agg(
     ``backend.find_best_agg_result_under_constraints``; parity is enforced by
     the integration test.
     """
-    isl = runtime_config.isl
+    # Vision tokens occupy the prefill context, so the ctx-token grid and the
+    # batch/ctx feasibility guards below run on the effective ISL -- same as
+    # the legacy find_best_agg_result_under_constraints (its isl_eff) and as
+    # run_agg's internal accounting.
+    isl = runtime_config.isl + BaseBackend._visual_context_tokens(model, runtime_config)
     osl = runtime_config.osl
     ttft_target = runtime_config.ttft
     tpot_target = runtime_config.tpot
@@ -429,6 +435,7 @@ def sweep_agg(
     encoder_tp_list: list[int] | None = None,
     encoder_batch_list: list[int] | None = None,
     encoder_latency_correction: float = 1.0,
+    encoder_database: PerfDatabase | None = None,
     predictor: Any = None,
     speculative_profile: SpeculativeDecodingProfile | None = None,
 ) -> pd.DataFrame:
@@ -493,19 +500,21 @@ def sweep_agg(
     encoder_candidates: list[dict] | None = None
     if enable_epd:
         # E+agg: enumerate the encode-worker pool once (independent of the
-        # agg parallel choice), then sweep language-only agg workers.
+        # agg parallel choice), then sweep language-only agg workers.  The
+        # encode pool may live on its own system / GPU type (hetero
+        # encoder, ``encoder_database``); it defaults to the agg side.
         encoder_candidates = _get_encoder_worker_candidates(
             model_path=model_path,
             model_config=model_config,
             tp_list=encoder_tp_list or _DEFAULT_ENCODER_TP_LIST,
             b_list=encoder_batch_list or _DEFAULT_ENCODER_BATCH_SCHEDULE,
             runtime_config=runtime_config,
-            database=database,
+            database=encoder_database or database,
             backend_name=backend_name,
             latency_correction=encoder_latency_correction,
         )
         model_config = copy.deepcopy(model_config)
-        model_config.encoder_colocated = False
+        model_config.language_only = True
 
     for parallel_config in parallel_config_list:
         tp_size, pp_size, dp_size, moe_tp_size, moe_ep_size, cp_size = parallel_config
@@ -803,7 +812,7 @@ def _get_encoder_worker_candidates(
         point_mc.cp_size = 1
         point_mc.moe_tp_size = etp
         point_mc.moe_ep_size = 1
-        point_mc.encoder_colocated = True  # the encode worker itself hosts the ViT
+        point_mc.language_only = False  # the encode worker itself hosts the ViT
         try:
             model = get_model(model_path=model_path, model_config=point_mc, backend_name=backend_name)
         except ValueError as e:
@@ -848,31 +857,39 @@ def _overlay_encoder_stage(
     encoder_num_worker: int,
     prefill_power: float = 0.0,
     decode_power: float = 0.0,
+    ttft_scale: float = 1.0,
 ) -> dict:
-    """Overlay the encode stage onto a rate-matched P/D row (EPD).
+    """Overlay the encode stage onto a rate-matched P/D or agg row (EPD).
 
     Encode -> prefill is sequential per request (prefill starts only after
     the full image embedding arrives), so the encode batch latency adds to
-    TTFT and request latency.  ``seq/s`` is unchanged: the encode pool is
-    sized to at least the rate-matched P/D throughput; its GPUs only dilute
-    the per-GPU metrics.  ``power_w`` is re-weighted over the three-phase
-    timeline (encode + prefill + decode); the prefill phase reuses the
-    colocated worker's average power as an approximation.
+    TTFT and request latency.  ``ttft_scale`` keeps the queueing correction
+    symmetric with the non-EPD baseline: the disagg path passes the
+    autoscale TTFT correction factor (its inline-encoder prefill ttft is
+    corrected wholesale, so the disaggregated encode stage must be too),
+    while the agg path keeps 1.0 (run_agg adds the inline encoder outside
+    its queueing factor).  The ``encoder_latency`` column stays the raw
+    stage latency, like the inline rows.  ``seq/s`` is unchanged: the
+    encode pool is sized to at least the rate-matched throughput; its GPUs
+    only dilute the per-GPU metrics.  ``power_w`` is re-weighted over the
+    three-phase timeline (encode + prefill + decode); the prefill phase
+    reuses the colocated worker's average power as an approximation.
     """
     row = dict(disagg_dict)
     encoder_latency = encoder_worker["encoder_latency"]
+    encoder_ttft_share = encoder_latency * ttft_scale
     prefill_ttft = row["ttft"]
     decode_time = row["tpot"] * max(row["osl"] - 1, 0)
-    total_time = encoder_latency + prefill_ttft + decode_time
+    total_time = encoder_ttft_share + prefill_ttft + decode_time
     if total_time > 0:
         row["power_w"] = (
-            encoder_worker.get("power_w", 0.0) * encoder_latency
+            encoder_worker.get("power_w", 0.0) * encoder_ttft_share
             + prefill_power * prefill_ttft
             + decode_power * decode_time
         ) / total_time
     row["encoder_latency"] = encoder_latency
-    row["ttft"] = prefill_ttft + encoder_latency
-    row["request_latency"] = row["request_latency"] + encoder_latency
+    row["ttft"] = prefill_ttft + encoder_ttft_share
+    row["request_latency"] = row["request_latency"] + encoder_ttft_share
     num_total_gpus = row["num_total_gpus"] + encoder_worker["num_total_gpus"] * encoder_num_worker
     row["seq/s/gpu"] = row["seq/s"] / num_total_gpus
     row["tokens/s/gpu"] = row["tokens/s"] / num_total_gpus
@@ -1002,13 +1019,19 @@ def _find_best_disagg_under_constraint(
         )
 
     # EPD: encode -> prefill is sequential per request, so each encode choice
-    # consumes its latency from the TTFT budget.  Plain PD is the single
+    # consumes its latency from the TTFT budget -- under the same queueing
+    # correction as the prefill stage (the inline PD baseline corrects its
+    # whole E+P ttft, so correcting only P here would systematically favor
+    # EPD by the uncorrected encode share).  Plain PD is the single
     # no-encoder choice with the full budget.
     encoder_choices: list[dict | None] = [None]
     if encoder_records:
-        encoder_choices = [e for e in encoder_records if e["encoder_latency"] < ttft_target]
+        encoder_choices = [
+            e for e in encoder_records if e["encoder_latency"] * autoscale_ttft_correction_factor < ttft_target
+        ]
     p_records_per_choice = [
-        _prefill_records(ttft_target - (enc["encoder_latency"] if enc else 0.0)) for enc in encoder_choices
+        _prefill_records(ttft_target - (enc["encoder_latency"] * autoscale_ttft_correction_factor if enc else 0.0))
+        for enc in encoder_choices
     ]
     if not any(p_records_per_choice):
         logger.debug("sweep_disagg: no prefill candidates meet ttft<%sms", ttft_target)
@@ -1079,6 +1102,7 @@ def _find_best_disagg_under_constraint(
                             e_num,
                             prefill_power=p_worker.get("power_w", 0.0),
                             decode_power=d_worker.get("power_w", 0.0),
+                            ttft_scale=autoscale_ttft_correction_factor,
                         )
                     category_results.append(disagg_dict)
         if category_results:
@@ -1127,6 +1151,7 @@ def sweep_disagg(
     encoder_tp_list: list[int] | None = None,
     encoder_batch_list: list[int] | None = None,
     encoder_latency_correction: float = 1.0,
+    encoder_database: PerfDatabase | None = None,
     predictor: Any = None,
     speculative_profile: SpeculativeDecodingProfile | None = None,
     free_gpu_memory_fraction: float | None = None,
@@ -1198,28 +1223,41 @@ def sweep_disagg(
     else:
         decode_batch_range = [b for b in _DEFAULT_DECODE_BATCH_SCHEDULE if b <= decode_max_num_tokens]
 
-    if prefill_max_num_tokens < runtime_config.isl:
-        logger.warning("prefill_max_num_tokens < runtime_config.isl, clamping to isl")
-        prefill_max_num_tokens = runtime_config.isl
-    max_prefill_batch_size = prefill_max_num_tokens // runtime_config.isl
+    # Vision tokens occupy the prefill context, so the per-request cost that
+    # divides the token budget is the effective ISL (mirrors the legacy
+    # DisaggInferenceSession and the agg sweep above).
+    try:
+        _enc_cfg = get_model_config_from_model_path(model_path).get("extra_params")
+    except Exception:
+        logger.debug("Could not resolve model config for VL effective ISL; using text ISL", exc_info=True)
+        _enc_cfg = None
+    prefill_effective_isl = runtime_config.isl + BaseBackend._visual_context_tokens_from_encoder_config(
+        _enc_cfg, runtime_config
+    )
+    if prefill_max_num_tokens < prefill_effective_isl:
+        logger.warning("prefill_max_num_tokens < effective prefill ISL, clamping to effective ISL")
+        prefill_max_num_tokens = prefill_effective_isl
+    max_prefill_batch_size = prefill_max_num_tokens // prefill_effective_isl
     prefill_batch_range = range(1, max_prefill_batch_size + 1)
 
     encoder_candidates: list[dict] | None = None
     if enable_epd:
+        # The encode pool may live on its own system / GPU type (hetero
+        # encoder, ``encoder_database``); it defaults to the prefill side.
         encoder_candidates = _get_encoder_worker_candidates(
             model_path=model_path,
             model_config=prefill_model_config,
             tp_list=encoder_tp_list or _DEFAULT_ENCODER_TP_LIST,
             b_list=encoder_batch_list or _DEFAULT_ENCODER_BATCH_SCHEDULE,
             runtime_config=runtime_config,
-            database=prefill_database,
+            database=encoder_database or prefill_database,
             backend_name=prefill_backend_name,
             latency_correction=encoder_latency_correction,
         )
         # EPD prefill workers are language-only (e.g. SGLang --language-only):
         # vision tokens stay in their context, but they never host the ViT.
         prefill_model_config = copy.deepcopy(prefill_model_config)
-        prefill_model_config.encoder_colocated = False
+        prefill_model_config.language_only = True
 
     prefill_summary_df = _get_disagg_worker_candidates(
         model_path=model_path,

--- a/src/aiconfigurator/sdk/sweep.py
+++ b/src/aiconfigurator/sdk/sweep.py
@@ -413,6 +413,14 @@ def _point_model_config(model_config, parallel_config) -> config.ModelConfig:
     return copy.deepcopy(model_config)
 
 
+def _language_only_config(model_config):
+    """Language-only variant of a template OR per-point builder (both forms
+    ``_point_model_config`` accepts)."""
+    if callable(model_config):
+        return lambda parallel: dataclasses.replace(model_config(parallel), language_only=True)
+    return dataclasses.replace(model_config, language_only=True)
+
+
 def sweep_agg(
     *,
     model_path: str,
@@ -506,8 +514,7 @@ def sweep_agg(
             backend_name=backend_name,
             latency_correction=encoder_latency_correction,
         )
-        model_config = copy.deepcopy(model_config)
-        model_config.language_only = True
+        model_config = _language_only_config(model_config)
     # Per-cell GPU budget for the E+agg rate matching (sweep_disagg semantics).
     epd_num_gpu_set: set[int] = set(num_gpu_list) if num_gpu_list else set()
 
@@ -1303,8 +1310,7 @@ def sweep_disagg(
             latency_correction=encoder_latency_correction,
         )
         # EPD prefill workers are language-only (vision tokens stay in context).
-        prefill_model_config = copy.deepcopy(prefill_model_config)
-        prefill_model_config.language_only = True
+        prefill_model_config = _language_only_config(prefill_model_config)
 
     prefill_summary_df = _get_disagg_worker_candidates(
         model_path=model_path,

--- a/src/aiconfigurator/sdk/sweep.py
+++ b/src/aiconfigurator/sdk/sweep.py
@@ -34,6 +34,7 @@ import copy
 import dataclasses
 import functools
 import logging
+import math
 from collections.abc import Callable
 from typing import Any
 
@@ -869,6 +870,29 @@ def _get_encoder_worker_candidates(
     return rows
 
 
+def _epd_e_num_candidates(
+    lm_required: float,
+    lm_gpus: int,
+    encoder_capacity: float,
+    encoder_gpus: int,
+    num_gpu_set: set[int],
+    bound: int,
+):
+    """Encode-pool sizes that can contribute a cell — exactly what a flat
+    ``1..bound`` sweep would keep: under a per-replica budget only
+    grid-landing counts pass the membership filter (derived here); without
+    one, counts past the first non-binding size can never win the per-GPU
+    argmax.  Ascending order keeps the flat sweep's tie behavior."""
+    if num_gpu_set:
+        counts = (
+            (total - lm_gpus) // encoder_gpus
+            for total in num_gpu_set
+            if total > lm_gpus and (total - lm_gpus) % encoder_gpus == 0
+        )
+        return sorted(e for e in counts if e <= bound)
+    return range(1, min(math.ceil(lm_required / encoder_capacity), bound) + 1)
+
+
 def _overlay_encoder_stage(
     disagg_dict: dict,
     encoder_worker: dict,
@@ -960,7 +984,14 @@ def _rate_match_agg_epd(
             best: tuple[tuple[float, int], int, int] | None = None
             for a_num in range(1, _MAX_AGG_WORKERS_EPD + 1):
                 agg_rate = rate_one * a_num
-                for e_num in range(1, e_workers_bound + 1):
+                for e_num in _epd_e_num_candidates(
+                    agg_rate,
+                    gpus_one * a_num,
+                    encoder_capacity,
+                    enc_worker["num_total_gpus"],
+                    num_gpu_set or set(),
+                    e_workers_bound,
+                ):
                     num_gpu = gpus_one * a_num + enc_worker["num_total_gpus"] * e_num
                     if num_gpu_set and num_gpu not in num_gpu_set:
                         continue
@@ -1383,10 +1414,14 @@ def sweep_disagg(
                 d_corrected = decode_throughput * d_num * decode_deg
                 pd_required = min(p_corrected, d_corrected)
                 if encoder_capacity > 0:
-                    # Full sweep like the P/D worker lists: sizes past the
-                    # first non-binding one are throughput-dominated, but can
-                    # be the only counts that land in num_gpu_set.
-                    e_num_candidates = range(1, e_workers_bound + 1)
+                    e_num_candidates = _epd_e_num_candidates(
+                        pd_required,
+                        prefill_gpus * p_num + decode_gpus * d_num,
+                        encoder_capacity,
+                        encoder_gpus,
+                        num_gpu_set,
+                        e_workers_bound,
+                    )
                 else:
                     e_num_candidates = (0,)
                 for e_num in e_num_candidates:

--- a/src/aiconfigurator/sdk/sweep.py
+++ b/src/aiconfigurator/sdk/sweep.py
@@ -441,6 +441,7 @@ def sweep_agg(
     max_encoder_workers: int | None = None,
     encoder_latency_correction: float = 1.0,
     encoder_database: PerfDatabase | None = None,
+    rate_matching_encoder_degradation: float | None = None,
     num_gpu_list: list[int] | None = None,
     predictor: Any = None,
     speculative_profile: SpeculativeDecodingProfile | None = None,
@@ -501,6 +502,13 @@ def sweep_agg(
     saw_memory_fit = False
     perf_misses = 0
 
+    e_deg = (
+        rate_matching_encoder_degradation
+        if rate_matching_encoder_degradation is not None
+        else _RATE_MATCH_ENCODER_DEGRADATION
+    )
+    if not (math.isfinite(e_deg) and e_deg > 0):
+        raise ValueError(f"rate_matching_encoder_degradation must be a positive finite number, got {e_deg!r}.")
     encoder_candidates: list[dict] | None = None
     if enable_epd:
         # E+agg: enumerate the encode pool once; hetero encoder may use its
@@ -602,6 +610,7 @@ def sweep_agg(
                         num_gpu_set=epd_num_gpu_set,
                         top_k=top_k,
                         max_encoder_workers=max_encoder_workers,
+                        encoder_degradation=e_deg,
                     )
                 if len(point_df) == 0:
                     continue
@@ -807,7 +816,8 @@ def _get_encoder_worker_candidates(
     or exceed the encoder system's GPU memory are dropped.
 
     Returns row dicts with keys
-    ``encoder_latency / seq/s / num_total_gpus / tp / bs / memory``.
+    ``encoder_latency / seq/s / num_total_gpus / tp / bs / memory /
+    power_w / power_coverage``.
     """
     backend = get_backend(backend_name)
     enc_cfg = get_model_config_from_model_path(model_path).get("extra_params")
@@ -831,6 +841,13 @@ def _get_encoder_worker_candidates(
     # The dominance filter below relies on ascending batch order.
     b_schedule = sorted(set(b_list or _DEFAULT_ENCODER_BATCH_SCHEDULE))
     for etp in sorted(set(tp_list or _DEFAULT_ENCODER_TP_LIST)):
+        if min(etp, 8) not in misc_spec["nccl_mem"]:
+            logger.warning(
+                "EPD encoder: tp=%s skipped: no comm data for this world size on this system (supported: %s)",
+                etp,
+                sorted(misc_spec["nccl_mem"]),
+            )
+            continue
         overhead_gib = (misc_spec["nccl_mem"][min(etp, 8)] + other_mem) / (1 << 30)
         try:
             encoder_ops = build_encoder_ops(enc_cfg, etp, enable_encoder_dp=False)
@@ -846,13 +863,18 @@ def _get_encoder_worker_candidates(
         )
         best_seq_s = 0.0
         for b in b_schedule:
-            latency, power_w, memory = backend.run_encoder_static(
+            latency, power_w, memory, power_coverage = backend.run_encoder_static(
                 model, database, runtime_config, b, latency_correction_scale=latency_correction
             )
             if memory.get("total", 0.0) + overhead_gib >= mem_capacity_gib:
                 # Memory grows with batch: larger batches also OOM.
                 saw_oom = True
                 break
+            if not (latency > 0 and math.isfinite(latency)):
+                raise ValueError(
+                    f"EPD encoder: invalid batch latency ({latency}) at tp={etp} bs={b}; "
+                    "the encoder perf data or latency correction is invalid."
+                )
             seq_s = b * 1000.0 / latency
             if seq_s <= best_seq_s:
                 continue
@@ -866,6 +888,7 @@ def _get_encoder_worker_candidates(
                     "bs": b,
                     "memory": round(memory.get("total", 0.0), 3),
                     "power_w": power_w,
+                    "power_coverage": power_coverage,
                 }
             )
     if not rows:
@@ -873,7 +896,10 @@ def _get_encoder_worker_candidates(
             raise InsufficientMemoryError(
                 "EPD encoder: the encode worker does not fit in GPU memory for any (tp, batch)."
             )
-        raise NoFeasibleConfigError("EPD encoder: no encode-worker candidate for any encoder tp.")
+        raise NoFeasibleConfigError(
+            "EPD encoder: no encode-worker candidate for any encoder tp "
+            "(tp must divide the ViT geometry and have comm data on this system; see warnings)."
+        )
     return rows
 
 
@@ -900,6 +926,13 @@ def _epd_e_num_candidates(
     return range(1, min(math.ceil(lm_required / encoder_capacity), bound) + 1)
 
 
+def _degraded_encoder_capacity(seq_s: float, degradation: float, e_num: int = 1) -> float:
+    """Degraded encode-pool capacity.  Keeps the ((seq/s x deg) x workers)
+    association order shared by the matchers and the overlay cap, so the
+    capped value is bit-identical to the capacity the argmax used."""
+    return seq_s * degradation * e_num
+
+
 def _overlay_encoder_stage(
     disagg_dict: dict,
     encoder_worker: dict,
@@ -907,6 +940,7 @@ def _overlay_encoder_stage(
     prefill_power: float = 0.0,
     decode_power: float = 0.0,
     ttft_scale: float = 1.0,
+    encoder_degradation: float = _RATE_MATCH_ENCODER_DEGRADATION,
 ) -> dict:
     """Overlay the encode stage onto a rate-matched P/D or agg row (EPD).
 
@@ -916,7 +950,8 @@ def _overlay_encoder_stage(
     it raw (run_agg adds the inline encoder outside its queueing factor).
     When the degraded encode pool capacity is below the row throughput,
     ``seq/s`` is capped and the rate-derived columns rescale with it;
-    ``power_w`` is re-weighted over the encode + prefill + decode timeline.
+    ``power_w`` (and ``power_coverage``, when the row carries it) is
+    re-weighted over the encode + prefill + decode timeline.
     """
     row = dict(disagg_dict)
     encoder_latency = encoder_worker["encoder_latency"]
@@ -930,12 +965,21 @@ def _overlay_encoder_stage(
             + prefill_power * prefill_ttft
             + decode_power * decode_time
         ) / total_time
+        if "power_coverage" in row:
+            row["power_coverage"] = (
+                encoder_worker.get("power_coverage", 0.0) * encoder_ttft_share
+                + row["power_coverage"] * (prefill_ttft + decode_time)
+            ) / total_time
+        elif not encoder_worker.get("power_coverage", 0.0) >= 1.0:
+            # Sweep rows carry no coverage channel to express a partially
+            # covered encoder, so anything short of full encoder energy data
+            # fails closed to the no-data sentinel instead of silently
+            # understating the blended power.
+            row["power_w"] = 0.0
     row["encoder_latency"] = encoder_latency
     row["ttft"] = prefill_ttft + encoder_ttft_share
     row["request_latency"] = row["request_latency"] + encoder_ttft_share
-    # Same association order as the matchers ((seq/s x deg) x workers) so
-    # the capped value is bit-identical to the capacity the argmax used.
-    encoder_capacity = encoder_worker["seq/s"] * _RATE_MATCH_ENCODER_DEGRADATION * encoder_num_worker
+    encoder_capacity = _degraded_encoder_capacity(encoder_worker["seq/s"], encoder_degradation, encoder_num_worker)
     if 0 < encoder_capacity < row["seq/s"]:
         row["tokens/s"] = row["tokens/s"] * (encoder_capacity / row["seq/s"])
         row["seq/s"] = encoder_capacity
@@ -961,6 +1005,7 @@ def _rate_match_agg_epd(
     num_gpu_set: set[int] | None = None,
     top_k: int = 0,
     max_encoder_workers: int | None = None,
+    encoder_degradation: float = _RATE_MATCH_ENCODER_DEGRADATION,
 ) -> pd.DataFrame:
     """Rate-match the encode pool against language-only agg workers (E+agg).
 
@@ -979,7 +1024,7 @@ def _rate_match_agg_epd(
     e_workers_bound = max_encoder_workers or _MAX_ENCODE_WORKERS
     rows: list[dict] = []
     for enc_worker in encoder_records:
-        encoder_capacity = float(enc_worker["seq/s"]) * _RATE_MATCH_ENCODER_DEGRADATION
+        encoder_capacity = _degraded_encoder_capacity(float(enc_worker["seq/s"]), encoder_degradation)
         paired = 0
         for r in records:
             if enc_worker["encoder_latency"] + r["ttft"] >= ttft_target:
@@ -1025,6 +1070,7 @@ def _rate_match_agg_epd(
                     e_num,
                     prefill_power=r.get("power_w", 0.0),
                     decode_power=r.get("power_w", 0.0),
+                    encoder_degradation=encoder_degradation,
                 )
             )
             paired += 1
@@ -1052,6 +1098,7 @@ def _find_best_disagg_under_constraint(
     match_workers: Any,
     autoscale_ttft_correction_factor: float = _AUTOSCALE_TTFT_CORRECTION_FACTOR,
     encoder_records: list[dict] | None = None,
+    encoder_degradation: float = _RATE_MATCH_ENCODER_DEGRADATION,
 ) -> pd.DataFrame | None:
     """For one (ttft, tpot) pair, filter + rate-match + pick best per decode parallel.
 
@@ -1162,6 +1209,7 @@ def _find_best_disagg_under_constraint(
                             prefill_power=p_worker.get("power_w", 0.0),
                             decode_power=d_worker.get("power_w", 0.0),
                             ttft_scale=autoscale_ttft_correction_factor,
+                            encoder_degradation=encoder_degradation,
                         )
                     category_results.append(disagg_dict)
         if category_results:
@@ -1205,6 +1253,7 @@ def sweep_disagg(
     target_tpot: float | None = None,
     rate_matching_prefill_degradation: float | None = None,
     rate_matching_decode_degradation: float | None = None,
+    rate_matching_encoder_degradation: float | None = None,
     autoscale_ttft_correction_factor: float | None = None,
     enable_epd: bool = False,
     encoder_tp_list: list[int] | None = None,
@@ -1255,6 +1304,16 @@ def sweep_disagg(
         if rate_matching_decode_degradation is not None
         else _RATE_MATCH_DECODE_DEGRADATION
     )
+    e_deg = (
+        rate_matching_encoder_degradation
+        if rate_matching_encoder_degradation is not None
+        else _RATE_MATCH_ENCODER_DEGRADATION
+    )
+    for deg_name, deg_value in (("prefill", p_deg), ("decode", d_deg), ("encoder", e_deg)):
+        if not (math.isfinite(deg_value) and deg_value > 0):
+            raise ValueError(
+                f"rate_matching_{deg_name}_degradation must be a positive finite number, got {deg_value!r}."
+            )
     ttft_corr = (
         autoscale_ttft_correction_factor
         if autoscale_ttft_correction_factor is not None
@@ -1283,14 +1342,7 @@ def sweep_disagg(
     # The token budget divides by the effective ISL (text + vision context
     # tokens); Task._prefill_effective_isl builds the budget the same way,
     # so the caller's batch intent round-trips.
-    try:
-        enc_cfg = get_model_config_from_model_path(model_path).get("extra_params")
-    except Exception:
-        logger.debug("Could not resolve model config for the effective ISL; using text ISL", exc_info=True)
-        enc_cfg = None
-    prefill_effective_isl = runtime_config.isl + BaseBackend._visual_context_tokens_from_encoder_config(
-        enc_cfg, runtime_config
-    )
+    prefill_effective_isl = BaseBackend.effective_prefill_isl(model_path, runtime_config)
     if prefill_max_num_tokens < prefill_effective_isl:
         logger.warning("prefill_max_num_tokens < effective prefill ISL, clamping to effective ISL")
         prefill_max_num_tokens = prefill_effective_isl
@@ -1408,7 +1460,7 @@ def sweep_disagg(
         """
         prefill_opt, decode_opt, encoder_opt = -1, -1, -1
         throughput_per_gpu_max = 0.0
-        encoder_capacity = encoder_throughput * _RATE_MATCH_ENCODER_DEGRADATION
+        encoder_capacity = _degraded_encoder_capacity(encoder_throughput, e_deg)
         for d_num in d_num_workers:
             for p_num in p_num_workers:
                 if max_prefill_gpus is not None and max_decode_gpus is not None:
@@ -1461,6 +1513,7 @@ def sweep_disagg(
             match_workers=_match_workers,
             autoscale_ttft_correction_factor=ttft_corr,
             encoder_records=encoder_candidates,
+            encoder_degradation=e_deg,
         )
         if partial is not None:
             disagg_df = pd.concat([disagg_df, partial], axis=0, ignore_index=True)

--- a/src/aiconfigurator/sdk/sweep.py
+++ b/src/aiconfigurator/sdk/sweep.py
@@ -112,6 +112,24 @@ _DEFAULT_AGG_BATCH_SCHEDULE: list[int] = (
 )
 
 
+def vl_effective_isl(model_path: str, runtime_config: config.RuntimeConfig) -> int:
+    """Per-request effective ISL: text ISL plus vision context tokens.
+
+    Single source of truth for the VL token accounting shared by ``Task``
+    (which builds token budgets as ``batch x effective_isl``) and
+    ``sweep_disagg`` (which divides the budget by the same value to recover
+    the batch range) -- deriving it in two places would silently break that
+    round trip.  Falls back to the plain text ISL when the model config
+    cannot be resolved or the model / workload has no vision input.
+    """
+    try:
+        enc_cfg = get_model_config_from_model_path(model_path).get("extra_params")
+    except Exception:
+        logger.debug("Could not resolve model config for VL effective ISL; using text ISL", exc_info=True)
+        return runtime_config.isl
+    return runtime_config.isl + BaseBackend._visual_context_tokens_from_encoder_config(enc_cfg, runtime_config)
+
+
 # ---------------------------------------------------------------------------
 # Rate matching (disagg post-processing, inlined for sweep's internal use)
 # ---------------------------------------------------------------------------
@@ -1238,15 +1256,9 @@ def sweep_disagg(
 
     # Vision tokens occupy the prefill context, so the per-request cost that
     # divides the token budget is the effective ISL (mirrors the legacy
-    # DisaggInferenceSession and the agg sweep above).
-    try:
-        _enc_cfg = get_model_config_from_model_path(model_path).get("extra_params")
-    except Exception:
-        logger.debug("Could not resolve model config for VL effective ISL; using text ISL", exc_info=True)
-        _enc_cfg = None
-    prefill_effective_isl = runtime_config.isl + BaseBackend._visual_context_tokens_from_encoder_config(
-        _enc_cfg, runtime_config
-    )
+    # DisaggInferenceSession and the agg sweep above).  Task builds the
+    # budget with the same helper, so the caller's batch intent round-trips.
+    prefill_effective_isl = vl_effective_isl(model_path, runtime_config)
     if prefill_max_num_tokens < prefill_effective_isl:
         logger.warning("prefill_max_num_tokens < effective prefill ISL, clamping to effective ISL")
         prefill_max_num_tokens = prefill_effective_isl

--- a/src/aiconfigurator/sdk/sweep.py
+++ b/src/aiconfigurator/sdk/sweep.py
@@ -529,8 +529,8 @@ def sweep_agg(
         # encoder, ``encoder_database``); it defaults to the agg side.
         encoder_candidates = _get_encoder_worker_candidates(
             model_path=model_path,
-            tp_list=encoder_tp_list or _DEFAULT_ENCODER_TP_LIST,
-            b_list=encoder_batch_list or _DEFAULT_ENCODER_BATCH_SCHEDULE,
+            tp_list=encoder_tp_list,
+            b_list=encoder_batch_list,
             runtime_config=runtime_config,
             database=encoder_database or database,
             backend_name=backend_name,
@@ -602,7 +602,10 @@ def sweep_agg(
                     backend=backend,
                     database=database,
                     runtime_config=point_rt,
-                    top_k=top_k,
+                    # EPD defers the top_k cut to the encoder pairing: cutting
+                    # the language-only rows here would let high-throughput
+                    # rows without encode headroom shadow the pairable ones.
+                    top_k=0 if encoder_candidates is not None else top_k,
                     max_batch_size=max_batch_size,
                     ctx_stride=ctx_stride,
                     enable_chunked_prefill=enable_chunked_prefill,
@@ -623,6 +626,7 @@ def sweep_agg(
                         encoder_candidates,
                         ttft_target=point_rt.ttft,
                         num_gpu_set=epd_num_gpu_set,
+                        top_k=top_k,
                     )
                 if len(point_df) == 0:
                     continue
@@ -808,8 +812,8 @@ def _get_disagg_worker_candidates(
 def _get_encoder_worker_candidates(
     *,
     model_path: str,
-    tp_list: list[int],
-    b_list: list[int],
+    tp_list: list[int] | None,
+    b_list: list[int] | None,
     runtime_config: config.RuntimeConfig,
     database: PerfDatabase,
     backend_name: str,
@@ -829,6 +833,8 @@ def _get_encoder_worker_candidates(
     each independent of the disaggregation flags) -- the DP layout's benefit
     (replicas over a colocated worker's LLM-sized tp group) is expressed in
     EPD by sweeping multiple small-tp encode workers instead.
+    ``tp_list`` / ``b_list`` fall back to :data:`_DEFAULT_ENCODER_TP_LIST` /
+    :data:`_DEFAULT_ENCODER_BATCH_SCHEDULE` when None.
     A worker encodes one batch of ``b`` requests (each with
     ``num_images_per_request`` images) in ``encoder_latency`` ms, so its
     throughput is ``b / encoder_latency``.  Per tp, batch points that do not
@@ -846,8 +852,15 @@ def _get_encoder_worker_candidates(
         raise ValueError(  # noqa: TRY004
             f"EPD (encoder disaggregation) requested but model {model_path!r} has no vision encoder."
         )
+    if BaseBackend._visual_context_tokens_from_encoder_config(enc_cfg, runtime_config) <= 0:
+        raise ValueError(
+            "EPD (encoder disaggregation) requested but the workload has no image input; "
+            "set image_height/image_width (or num_image_tokens) and num_images_per_request."
+        )
     rows: list[dict] = []
-    for etp in tp_list:
+    # The dominance filter below relies on ascending batch order.
+    b_schedule = sorted(set(b_list or _DEFAULT_ENCODER_BATCH_SCHEDULE))
+    for etp in sorted(set(tp_list or _DEFAULT_ENCODER_TP_LIST)):
         try:
             encoder_ops = build_encoder_ops(enc_cfg, etp, enable_encoder_dp=False)
         except ValueError as e:
@@ -862,15 +875,10 @@ def _get_encoder_worker_candidates(
             config=config.ModelConfig(tp_size=etp, enable_encoder_dp=False),
         )
         best_seq_s = 0.0
-        for b in b_list:
+        for b in b_schedule:
             latency, power_w, memory = backend.run_encoder_static(
                 model, database, runtime_config, b, latency_correction_scale=latency_correction
             )
-            if latency <= 0.0:
-                raise ValueError(
-                    "EPD (encoder disaggregation) requested but the workload has no image input; "
-                    "set image_height/image_width (or num_image_tokens) and num_images_per_request."
-                )
             seq_s = b * 1000.0 / latency
             if seq_s <= best_seq_s:
                 continue
@@ -959,12 +967,19 @@ def _rate_match_agg_epd(
     *,
     ttft_target: float,
     num_gpu_set: set[int] | None = None,
+    top_k: int = 0,
 ) -> pd.DataFrame:
     """Rate-match the encode pool against language-only agg workers (E+agg).
 
     The agg counterpart of the disagg encoder rate matching + ``_overlay_encoder_stage``:
-    for each (agg row, encode-worker choice) whose encode latency still fits
-    the TTFT budget, sweep cells of ``a`` agg workers + ``e`` encode workers
+    for each encode-worker choice, pair the agg rows whose encode latency
+    still fits the TTFT budget -- best throughput first, up to ``top_k``
+    rows per choice (0 = uncapped), mirroring the per-choice
+    ``_prefill_records`` re-filter in the disagg path.  The caller hands
+    over the full SLA-feasible row set: a top_k cut on the language-only
+    rows *before* this pairing would let high-throughput rows without
+    encode headroom shadow the (possibly only) pairable rows.  For each
+    pairing, sweep cells of ``a`` agg workers + ``e`` encode workers
     -- ``e`` up to the first count that no longer binds (larger pools are
     dominated), smaller counts making the encode pool the rate-matched
     bottleneck (cell throughput = min of the two pools, applied by the
@@ -976,16 +991,18 @@ def _rate_match_agg_epd(
     returned rows are per-cell — ``(a)workers`` agg workers — so the
     downstream replicas logic scales whole cells.
     """
+    records = agg_df.sort_values(by="seq/s", ascending=False).to_dict("records")
     rows: list[dict] = []
-    for r in agg_df.to_dict("records"):
-        rate_one = float(r["seq/s"])
-        gpus_one = int(r["num_total_gpus"])
-        if rate_one <= 0:
-            continue
-        for enc in encoder_records:
+    for enc in encoder_records:
+        encoder_capacity = float(enc["seq/s"]) * _RATE_MATCH_ENCODER_DEGRADATION
+        paired = 0
+        for r in records:
             if enc["encoder_latency"] + r["ttft"] >= ttft_target:
                 continue
-            encoder_capacity = float(enc["seq/s"]) * _RATE_MATCH_ENCODER_DEGRADATION
+            rate_one = float(r["seq/s"])
+            gpus_one = int(r["num_total_gpus"])
+            if rate_one <= 0:
+                continue
             best: tuple[tuple[float, int], int, int] | None = None
             for a_num in range(1, _MAX_AGG_WORKERS_EPD + 1):
                 agg_rate = rate_one * a_num
@@ -1021,6 +1038,9 @@ def _rate_match_agg_epd(
                     decode_power=r.get("power_w", 0.0),
                 )
             )
+            paired += 1
+            if top_k and paired >= top_k:
+                break
     if not rows:
         return pd.DataFrame(columns=list(agg_df.columns))
     return pd.DataFrame(rows)
@@ -1294,8 +1314,8 @@ def sweep_disagg(
         # encoder, ``encoder_database``); it defaults to the prefill side.
         encoder_candidates = _get_encoder_worker_candidates(
             model_path=model_path,
-            tp_list=encoder_tp_list or _DEFAULT_ENCODER_TP_LIST,
-            b_list=encoder_batch_list or _DEFAULT_ENCODER_BATCH_SCHEDULE,
+            tp_list=encoder_tp_list,
+            b_list=encoder_batch_list,
             runtime_config=runtime_config,
             database=encoder_database or prefill_database,
             backend_name=prefill_backend_name,

--- a/src/aiconfigurator/sdk/sweep.py
+++ b/src/aiconfigurator/sdk/sweep.py
@@ -815,11 +815,15 @@ def _get_encoder_worker_candidates(
         )
     rows: list[dict] = []
     saw_oom = False
-    # Same OOM gate as the P/D candidates (set_memory_and_check_oom).
+    # Same OOM gate as the P/D candidates (set_memory_and_check_oom), charging
+    # the same framework overhead as _get_memory_usage (nccl_mem + other_mem).
     mem_capacity_gib = database.system_spec["gpu"]["mem_capacity"] / (1 << 30)
+    misc_spec = database.system_spec["misc"]
+    other_mem = misc_spec["other_mem"] * (1.0 + backend.OTHERS_OVERHEAD_FRAC)
     # The dominance filter below relies on ascending batch order.
     b_schedule = sorted(set(b_list or _DEFAULT_ENCODER_BATCH_SCHEDULE))
     for etp in sorted(set(tp_list or _DEFAULT_ENCODER_TP_LIST)):
+        overhead_gib = (misc_spec["nccl_mem"][min(etp, 8)] + other_mem) / (1 << 30)
         try:
             encoder_ops = build_encoder_ops(enc_cfg, etp, enable_encoder_dp=False)
         except ValueError as e:
@@ -837,7 +841,7 @@ def _get_encoder_worker_candidates(
             latency, power_w, memory = backend.run_encoder_static(
                 model, database, runtime_config, b, latency_correction_scale=latency_correction
             )
-            if memory.get("total", 0.0) >= mem_capacity_gib:
+            if memory.get("total", 0.0) + overhead_gib >= mem_capacity_gib:
                 # Memory grows with batch: larger batches also OOM.
                 saw_oom = True
                 break

--- a/src/aiconfigurator/sdk/sweep.py
+++ b/src/aiconfigurator/sdk/sweep.py
@@ -34,6 +34,7 @@ import copy
 import dataclasses
 import functools
 import logging
+import math
 from collections.abc import Callable
 from typing import Any
 
@@ -63,6 +64,9 @@ logger = logging.getLogger(__name__)
 # (locked in via parity test; do not change without updating picking.py too).
 _RATE_MATCH_PREFILL_DEGRADATION = 0.9
 _RATE_MATCH_DECODE_DEGRADATION = 0.92
+# EPD: the encode pool suffers the same pipeline-bubble class of loss as
+# prefill (imperfect batch packing under bursty arrivals).
+_RATE_MATCH_ENCODER_DEGRADATION = 0.9
 
 # TTFT pre-correction for queueing under concurrency, sourced from
 # picking._AUTOSCALE_TTFT_CORRECTION_FACTOR (locked by integration parity test).
@@ -78,6 +82,13 @@ _MAX_PREFILL_WORKERS = 32
 _DEFAULT_DECODE_BATCH_SCHEDULE: list[int] = (
     list(range(1, 16, 1)) + list(range(16, 32, 2)) + list(range(32, 128, 4)) + list(range(128, 512, 8)) + [512]
 )
+
+# Default EPD encode-worker search space.  TP mirrors a real encode
+# instance's --tp-size choices; the batch schedule models cross-request
+# image batching (e.g. SGLang's encoder scheduler, default max batch 8),
+# swept wider so the TTFT budget decides what is affordable.
+_DEFAULT_ENCODER_TP_LIST: list[int] = [1, 2, 4, 8]
+_DEFAULT_ENCODER_BATCH_SCHEDULE: list[int] = [1, 2, 4, 8, 16, 32]
 
 # Default batch-size schedule used by sweep_agg.  Mirrors the schedule in
 # the legacy ``backend.find_best_agg_result_under_constraints`` so results
@@ -198,10 +209,12 @@ def _rate_match_dict(
         "(d)version": d.get("version", ""),
         "(d)system": d.get("system", ""),
         # Encoder is colocated with prefill for VL; text-only models leave these
-        # visibility fields at zero/empty.
+        # visibility fields at zero/empty.  EPD overlays them via
+        # _overlay_encoder_stage.
         "(e)workers": 0,
         "(e)tp": 0,
         "(e)pp": 0,
+        "(e)bs": 0,
         "(e)parallel": "",
         "(e)memory": encoder_memory,
         "power_w": disagg_power_avg,
@@ -706,6 +719,128 @@ def _get_disagg_worker_candidates(
     return pd.concat(result_rows, axis=0, ignore_index=True)
 
 
+# ---------------------------------------------------------------------------
+# EPD (encoder disaggregation) helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_encoder_worker_candidates(
+    *,
+    model_path: str,
+    model_config: config.ModelConfig,
+    tp_list: list[int],
+    b_list: list[int],
+    runtime_config: config.RuntimeConfig,
+    database: PerfDatabase,
+    backend_name: str,
+    latency_correction: float,
+) -> list[dict]:
+    """Enumerate (tp, batch) encode-worker candidates for EPD.
+
+    An encode (E) worker runs only the vision encoder (ViT + projector) with
+    its own tensor parallelism, mirroring an encoder-only instance that loads
+    no LLM weights (e.g. SGLang ``--encoder-only``).  A worker encodes one
+    batch of ``b`` requests (each with ``num_images_per_request`` images) in
+    ``encoder_latency`` ms, so its throughput is ``b / encoder_latency``.
+    Per tp, batch points that do not improve throughput over a smaller batch
+    are dominated (same rate at worse latency) and dropped.
+
+    Returns row dicts with keys
+    ``encoder_latency / seq/s / num_total_gpus / tp / bs / memory``.
+    """
+    backend = get_backend(backend_name)
+    rows: list[dict] = []
+    for etp in tp_list:
+        point_mc = copy.deepcopy(model_config)
+        point_mc.tp_size = etp
+        point_mc.pp_size = 1
+        point_mc.attention_dp_size = 1
+        point_mc.cp_size = 1
+        point_mc.moe_tp_size = etp
+        point_mc.moe_ep_size = 1
+        point_mc.encoder_colocated = True  # the encode worker itself hosts the ViT
+        try:
+            model = get_model(model_path=model_path, model_config=point_mc, backend_name=backend_name)
+        except ValueError as e:
+            # e.g. ViT heads / FFN not divisible by this tp.
+            logger.debug("sweep_disagg/encoder: tp=%s rejected: %s", etp, e)
+            continue
+        if not getattr(model, "encoder_ops", None):
+            raise ValueError(f"EPD (encoder disaggregation) requested but model {model_path!r} has no vision encoder.")
+        best_seq_s = 0.0
+        for b in b_list:
+            latency, power_w, memory = backend.run_encoder_static(
+                model, database, runtime_config, b, latency_correction_scale=latency_correction
+            )
+            if latency <= 0.0:
+                raise ValueError(
+                    "EPD (encoder disaggregation) requested but the workload has no image input; "
+                    "set image_height/image_width (or num_image_tokens) and num_images_per_request."
+                )
+            seq_s = b * 1000.0 / latency
+            if seq_s <= best_seq_s:
+                continue
+            best_seq_s = seq_s
+            rows.append(
+                {
+                    "encoder_latency": round(latency, 3),
+                    "seq/s": seq_s,
+                    "num_total_gpus": etp,
+                    "tp": etp,
+                    "bs": b,
+                    "memory": round(memory.get("total", 0.0), 3),
+                    "power_w": power_w,
+                }
+            )
+    if not rows:
+        raise NoFeasibleConfigError("sweep_disagg/encoder: no encode-worker candidate for any encoder tp.")
+    return rows
+
+
+def _overlay_encoder_stage(
+    disagg_dict: dict,
+    encoder_worker: dict,
+    encoder_num_worker: int,
+    prefill_power: float = 0.0,
+    decode_power: float = 0.0,
+) -> dict:
+    """Overlay the encode stage onto a rate-matched P/D row (EPD).
+
+    Encode -> prefill is sequential per request (prefill starts only after
+    the full image embedding arrives), so the encode batch latency adds to
+    TTFT and request latency.  ``seq/s`` is unchanged: the encode pool is
+    sized to at least the rate-matched P/D throughput; its GPUs only dilute
+    the per-GPU metrics.  ``power_w`` is re-weighted over the three-phase
+    timeline (encode + prefill + decode); the prefill phase reuses the
+    colocated worker's average power as an approximation.
+    """
+    row = dict(disagg_dict)
+    encoder_latency = encoder_worker["encoder_latency"]
+    prefill_ttft = row["ttft"]
+    decode_time = row["tpot"] * max(row["osl"] - 1, 0)
+    total_time = encoder_latency + prefill_ttft + decode_time
+    if total_time > 0:
+        row["power_w"] = (
+            encoder_worker.get("power_w", 0.0) * encoder_latency
+            + prefill_power * prefill_ttft
+            + decode_power * decode_time
+        ) / total_time
+    row["encoder_latency"] = encoder_latency
+    row["ttft"] = prefill_ttft + encoder_latency
+    row["request_latency"] = row["request_latency"] + encoder_latency
+    num_total_gpus = row["num_total_gpus"] + encoder_worker["num_total_gpus"] * encoder_num_worker
+    row["seq/s/gpu"] = row["seq/s"] / num_total_gpus
+    row["tokens/s/gpu"] = row["tokens/s"] / num_total_gpus
+    row["num_total_gpus"] = num_total_gpus
+    row["(e)workers"] = encoder_num_worker
+    row["(e)tp"] = encoder_worker["tp"]
+    row["(e)pp"] = 1
+    row["(e)bs"] = encoder_worker["bs"]
+    row["(e)parallel"] = f"tp{encoder_worker['tp']}"
+    row["(e)memory"] = encoder_worker["memory"]
+    return row
+
+
 def _find_best_disagg_under_constraint(
     *,
     ttft_target: float,
@@ -723,6 +858,8 @@ def _find_best_disagg_under_constraint(
     decode_degradation: float,
     match_workers: Any,
     autoscale_ttft_correction_factor: float = _AUTOSCALE_TTFT_CORRECTION_FACTOR,
+    encoder_records: list[dict] | None = None,
+    match_workers_epd: Any = None,
 ) -> pd.DataFrame | None:
     """For one (ttft, tpot) pair, filter + rate-match + pick best per decode parallel.
 
@@ -738,21 +875,41 @@ def _find_best_disagg_under_constraint(
     pair instead of one bool: the constraint it models (sglang KV transfer
     layout) is lifted per pair by a large-EP side, which is a property of the
     pair's parallel configs, not of the task.
+
+    When ``encoder_records`` is given (EPD), each encode-worker choice spends
+    its batch latency out of the TTFT budget before the prefill filter, and
+    ``match_workers_epd`` sizes the encode pool into the rate matching; the
+    per-decode-parallel best is picked across encode choices as well.
     """
     requires_same_tp = (
         require_same_tp if callable(require_same_tp) else (lambda _p, _d, _flag=bool(require_same_tp): _flag)
     )
 
     p_corrected = prefill_summary_df.assign(ttft=prefill_summary_df["ttft"] * autoscale_ttft_correction_factor)
-    p_candidates = p_corrected[p_corrected["ttft"] < ttft_target]
-    if len(p_candidates) == 0:
+
+    def _prefill_records(ttft_budget: float) -> list[dict]:
+        candidates = p_corrected[p_corrected["ttft"] < ttft_budget]
+        if len(candidates) == 0:
+            return []
+        return (
+            candidates.sort_values(by=["seq/s/gpu", "global_bs"], ascending=[False, True])
+            .reset_index(drop=True)
+            .head(_MAX_PREFILL_WORKERS)
+            .to_dict("records")
+        )
+
+    # EPD: encode -> prefill is sequential per request, so each encode choice
+    # consumes its latency from the TTFT budget.  Plain PD is the single
+    # no-encoder choice with the full budget.
+    encoder_choices: list[dict | None] = [None]
+    if encoder_records:
+        encoder_choices = [e for e in encoder_records if e["encoder_latency"] < ttft_target]
+    p_records_per_choice = [
+        _prefill_records(ttft_target - (enc["encoder_latency"] if enc else 0.0)) for enc in encoder_choices
+    ]
+    if not any(p_records_per_choice):
         logger.debug("sweep_disagg: no prefill candidates meet ttft<%sms", ttft_target)
         return None
-    p_candidates = (
-        p_candidates.sort_values(by=["seq/s/gpu", "global_bs"], ascending=[False, True])
-        .reset_index(drop=True)
-        .head(_MAX_PREFILL_WORKERS)
-    )
 
     d_candidates = decode_summary_df[
         (decode_summary_df["tpot"] < tpot_target * _DECODE_FILTER_RATIO_MAX)
@@ -763,7 +920,6 @@ def _find_best_disagg_under_constraint(
         return None
 
     all_category_results: list[dict] = []
-    p_records = p_candidates.to_dict("records")
 
     for parallel_value, parallel_group in d_candidates.groupby("parallel"):
         group_sorted = (
@@ -773,33 +929,55 @@ def _find_best_disagg_under_constraint(
         )
         decode_records = group_sorted.to_dict("records")
         category_results: list[dict] = []
-        for d_worker in decode_records:
-            d_throughput = float(d_worker["seq/s"])
-            d_gpus = d_worker["num_total_gpus"]
-            for p_worker in p_records:
-                if p_worker["tp"] != d_worker["tp"] and requires_same_tp(p_worker, d_worker):
-                    continue
-                p_throughput = float(p_worker["seq/s"])
-                p_gpus = p_worker["num_total_gpus"]
-                p_num, d_num = match_workers(
-                    prefill_throughput=p_throughput,
-                    prefill_gpus=p_gpus,
-                    decode_throughput=d_throughput,
-                    decode_gpus=d_gpus,
-                    prefill_deg=prefill_degradation,
-                    decode_deg=decode_degradation,
-                )
-                if p_num == -1 or d_num == -1:
-                    continue
-                disagg_dict = _rate_match_dict(
-                    p_worker,
-                    p_num,
-                    d_worker,
-                    d_num,
-                    prefill_degradation=prefill_degradation,
-                    decode_degradation=decode_degradation,
-                )
-                category_results.append(disagg_dict)
+        for enc, p_records in zip(encoder_choices, p_records_per_choice, strict=True):
+            for d_worker in decode_records:
+                d_throughput = float(d_worker["seq/s"])
+                d_gpus = d_worker["num_total_gpus"]
+                for p_worker in p_records:
+                    if p_worker["tp"] != d_worker["tp"] and requires_same_tp(p_worker, d_worker):
+                        continue
+                    p_throughput = float(p_worker["seq/s"])
+                    p_gpus = p_worker["num_total_gpus"]
+                    if enc is None:
+                        p_num, d_num = match_workers(
+                            prefill_throughput=p_throughput,
+                            prefill_gpus=p_gpus,
+                            decode_throughput=d_throughput,
+                            decode_gpus=d_gpus,
+                            prefill_deg=prefill_degradation,
+                            decode_deg=decode_degradation,
+                        )
+                        e_num = 0
+                    else:
+                        p_num, d_num, e_num = match_workers_epd(
+                            prefill_throughput=p_throughput,
+                            prefill_gpus=p_gpus,
+                            decode_throughput=d_throughput,
+                            decode_gpus=d_gpus,
+                            encoder_throughput=float(enc["seq/s"]),
+                            encoder_gpus=enc["num_total_gpus"],
+                            prefill_deg=prefill_degradation,
+                            decode_deg=decode_degradation,
+                        )
+                    if p_num == -1 or d_num == -1:
+                        continue
+                    disagg_dict = _rate_match_dict(
+                        p_worker,
+                        p_num,
+                        d_worker,
+                        d_num,
+                        prefill_degradation=prefill_degradation,
+                        decode_degradation=decode_degradation,
+                    )
+                    if enc is not None:
+                        disagg_dict = _overlay_encoder_stage(
+                            disagg_dict,
+                            enc,
+                            e_num,
+                            prefill_power=p_worker.get("power_w", 0.0),
+                            decode_power=d_worker.get("power_w", 0.0),
+                        )
+                    category_results.append(disagg_dict)
         if category_results:
             best = max(category_results, key=lambda x: (x["tokens/s/gpu"], -x["num_total_gpus"]))
             all_category_results.append(best)
@@ -842,6 +1020,10 @@ def sweep_disagg(
     rate_matching_prefill_degradation: float | None = None,
     rate_matching_decode_degradation: float | None = None,
     autoscale_ttft_correction_factor: float | None = None,
+    enable_epd: bool = False,
+    encoder_tp_list: list[int] | None = None,
+    encoder_batch_list: list[int] | None = None,
+    encoder_latency_correction: float = 1.0,
     predictor: Any = None,
     speculative_profile: SpeculativeDecodingProfile | None = None,
     free_gpu_memory_fraction: float | None = None,
@@ -855,6 +1037,15 @@ def sweep_disagg(
     The two databases / backends are accepted independently to support
     hetero-disagg (prefill and decode on different systems).
 
+    ``enable_epd`` switches VL disagg into EPD: the vision encoder runs on
+    dedicated encode workers, enumerated over
+    ``encoder_tp_list x encoder_batch_list`` (defaults
+    :data:`_DEFAULT_ENCODER_TP_LIST` / :data:`_DEFAULT_ENCODER_BATCH_SCHEDULE`)
+    on the prefill database/backend.  Prefill workers become language-only
+    (vision tokens stay in context, no ViT hosted), TTFT gains the encode
+    batch latency, and the encode pool joins the worker rate matching
+    (``(e)*`` columns in the output).
+
     Returns:
         DataFrame (possibly empty) with schema ``common.ColumnsDisagg``.
 
@@ -867,6 +1058,8 @@ def sweep_disagg(
         raise ValueError(f"max_prefill_gpus must be > 0, got {max_prefill_gpus}")
     if max_decode_gpus is not None and max_decode_gpus <= 0:
         raise ValueError(f"max_decode_gpus must be > 0, got {max_decode_gpus}")
+    if enable_epd and autoscale:
+        raise ValueError("EPD (enable_epd) is not supported with autoscale.")
 
     p_deg = (
         rate_matching_prefill_degradation
@@ -907,6 +1100,23 @@ def sweep_disagg(
         prefill_max_num_tokens = runtime_config.isl
     max_prefill_batch_size = prefill_max_num_tokens // runtime_config.isl
     prefill_batch_range = range(1, max_prefill_batch_size + 1)
+
+    encoder_candidates: list[dict] | None = None
+    if enable_epd:
+        encoder_candidates = _get_encoder_worker_candidates(
+            model_path=model_path,
+            model_config=prefill_model_config,
+            tp_list=encoder_tp_list or _DEFAULT_ENCODER_TP_LIST,
+            b_list=encoder_batch_list or _DEFAULT_ENCODER_BATCH_SCHEDULE,
+            runtime_config=runtime_config,
+            database=prefill_database,
+            backend_name=prefill_backend_name,
+            latency_correction=encoder_latency_correction,
+        )
+        # EPD prefill workers are language-only (e.g. SGLang --language-only):
+        # vision tokens stay in their context, but they never host the ViT.
+        prefill_model_config = copy.deepcopy(prefill_model_config)
+        prefill_model_config.encoder_colocated = False
 
     prefill_summary_df = _get_disagg_worker_candidates(
         model_path=model_path,
@@ -1015,6 +1225,46 @@ def sweep_disagg(
                     prefill_opt, decode_opt = p_num, d_num
         return prefill_opt, decode_opt
 
+    # EPD variant: for each (p_num, d_num), size the encode pool to the
+    # smallest worker count that does not bottleneck the rate-matched P/D
+    # throughput -- so seq/s stays min(p, d) while the encode GPUs count
+    # toward the per-GPU objective and the replica GPU budget.  Unbounded
+    # cache: the key space is the (p, d, e) candidate cross-product, which
+    # exceeds the default lru size but stays small in memory.
+    @functools.cache
+    def _match_workers_epd(
+        prefill_throughput: float,
+        prefill_gpus: int,
+        decode_throughput: float,
+        decode_gpus: int,
+        encoder_throughput: float,
+        encoder_gpus: int,
+        prefill_deg: float,
+        decode_deg: float,
+    ) -> tuple[int, int, int]:
+        prefill_opt, decode_opt, encoder_opt = -1, -1, -1
+        throughput_per_gpu_max = 0.0
+        encoder_capacity = encoder_throughput * _RATE_MATCH_ENCODER_DEGRADATION
+        for d_num in d_num_workers:
+            for p_num in p_num_workers:
+                p_corrected = prefill_throughput * p_num * prefill_deg
+                d_corrected = decode_throughput * d_num * decode_deg
+                required = min(p_corrected, d_corrected)
+                e_num = max(1, math.ceil(required / encoder_capacity))
+                num_gpu = prefill_gpus * p_num + decode_gpus * d_num + encoder_gpus * e_num
+                if num_gpu_set and num_gpu not in num_gpu_set:
+                    continue
+                if max_prefill_gpus is not None and max_decode_gpus is not None:
+                    if prefill_gpus * p_num > max_prefill_gpus:
+                        continue
+                    if decode_gpus * d_num > max_decode_gpus:
+                        continue
+                tpg = required / num_gpu
+                if tpg > throughput_per_gpu_max:
+                    throughput_per_gpu_max = tpg
+                    prefill_opt, decode_opt, encoder_opt = p_num, d_num, e_num
+        return prefill_opt, decode_opt, encoder_opt
+
     disagg_df = pd.DataFrame(columns=common.ColumnsDisagg)
     for ttft_c, tpot_c in constraint_pairs:
         logger.debug("sweep_disagg: finding best for ttft=%sms tpot=%sms", ttft_c, tpot_c)
@@ -1034,6 +1284,8 @@ def sweep_disagg(
             decode_degradation=d_deg,
             match_workers=_match_workers,
             autoscale_ttft_correction_factor=ttft_corr,
+            encoder_records=encoder_candidates,
+            match_workers_epd=_match_workers_epd,
         )
         if partial is not None:
             disagg_df = pd.concat([disagg_df, partial], axis=0, ignore_index=True)

--- a/src/aiconfigurator/sdk/sweep.py
+++ b/src/aiconfigurator/sdk/sweep.py
@@ -90,6 +90,11 @@ _DEFAULT_DECODE_BATCH_SCHEDULE: list[int] = (
 _DEFAULT_ENCODER_TP_LIST: list[int] = [1, 2, 4, 8]
 _DEFAULT_ENCODER_BATCH_SCHEDULE: list[int] = [1, 2, 4, 8, 16, 32]
 
+# E+agg: agg-worker replicas explored per rate-matched cell.  Mirrors the
+# disagg worker lists (range(1, 33)); the cell only exists to express the
+# integer agg:encode worker ratio.
+_MAX_AGG_WORKERS_EPD = 32
+
 # Default batch-size schedule used by sweep_agg.  Mirrors the schedule in
 # the legacy ``backend.find_best_agg_result_under_constraints`` so results
 # stay byte-identical.
@@ -420,6 +425,10 @@ def sweep_agg(
     enable_chunked_prefill: bool = False,
     free_gpu_memory_fraction: float | None = None,
     max_seq_len: int | None = None,
+    enable_epd: bool = False,
+    encoder_tp_list: list[int] | None = None,
+    encoder_batch_list: list[int] | None = None,
+    encoder_latency_correction: float = 1.0,
     predictor: Any = None,
     speculative_profile: SpeculativeDecodingProfile | None = None,
 ) -> pd.DataFrame:
@@ -435,6 +444,16 @@ def sweep_agg(
     Per-tpot sweeping (``runtime_config.tpot`` may be a list) and
     request-latency-derived constraints are handled here as in the legacy
     proxy.
+
+    ``enable_epd`` switches VL agg into E+agg: the vision encoder runs on
+    dedicated encode workers (same candidate space as EPD disagg,
+    ``encoder_tp_list x encoder_batch_list``) while prefill+decode stay
+    aggregated.  The agg worker becomes language-only (vision tokens stay in
+    context, no ViT hosted); each row is then a rate-matched cell of
+    ``(a)workers`` agg workers plus ``(e)workers`` encode workers, with the
+    encode batch latency added to TTFT.  Default (``enable_epd=False``) keeps
+    the encoder inline (colocated): its latency is part of the agg worker's
+    TTFT and its weights part of the worker's memory.
 
     Args:
         model_path: HuggingFace model path or local path.
@@ -470,6 +489,23 @@ def sweep_agg(
     saw_model_fit = False
     saw_memory_fit = False
     perf_misses = 0
+
+    encoder_candidates: list[dict] | None = None
+    if enable_epd:
+        # E+agg: enumerate the encode-worker pool once (independent of the
+        # agg parallel choice), then sweep language-only agg workers.
+        encoder_candidates = _get_encoder_worker_candidates(
+            model_path=model_path,
+            model_config=model_config,
+            tp_list=encoder_tp_list or _DEFAULT_ENCODER_TP_LIST,
+            b_list=encoder_batch_list or _DEFAULT_ENCODER_BATCH_SCHEDULE,
+            runtime_config=runtime_config,
+            database=database,
+            backend_name=backend_name,
+            latency_correction=encoder_latency_correction,
+        )
+        model_config = copy.deepcopy(model_config)
+        model_config.encoder_colocated = False
 
     for parallel_config in parallel_config_list:
         tp_size, pp_size, dp_size, moe_tp_size, moe_ep_size, cp_size = parallel_config
@@ -543,6 +579,15 @@ def sweep_agg(
                 saw_model_fit |= point_saw_model_fit
                 saw_memory_fit |= point_saw_memory_fit
                 perf_misses += point_perf_misses
+                if encoder_candidates is not None and len(point_df) > 0:
+                    # E+agg: the per-point ttft filter above ran on the
+                    # language-only ttft (a superset — adding the encode
+                    # latency only tightens it); pair exactly here.
+                    point_df = _rate_match_agg_epd(
+                        point_df,
+                        encoder_candidates,
+                        ttft_target=point_rt.ttft,
+                    )
                 if len(point_df) == 0:
                     continue
                 if len(results_df) == 0:
@@ -839,6 +884,64 @@ def _overlay_encoder_stage(
     row["(e)parallel"] = f"tp{encoder_worker['tp']}"
     row["(e)memory"] = encoder_worker["memory"]
     return row
+
+
+def _rate_match_agg_epd(
+    agg_df: pd.DataFrame,
+    encoder_records: list[dict],
+    *,
+    ttft_target: float,
+) -> pd.DataFrame:
+    """Rate-match the encode pool against language-only agg workers (E+agg).
+
+    The agg counterpart of ``_match_workers_epd`` + ``_overlay_encoder_stage``:
+    for each (agg row, encode-worker choice) whose encode latency still fits
+    the TTFT budget, pick the cell of ``a`` agg workers + ``e`` encode workers
+    (``e`` = smallest count that does not bottleneck the agg throughput, the
+    EPD disagg convention) maximizing throughput-per-GPU; ties keep the
+    smaller cell.  The returned rows are per-cell — ``(a)workers`` agg workers
+    — so the downstream replicas logic scales whole cells.
+    """
+    rows: list[dict] = []
+    for r in agg_df.to_dict("records"):
+        rate_one = float(r["seq/s"])
+        gpus_one = int(r["num_total_gpus"])
+        if rate_one <= 0:
+            continue
+        for enc in encoder_records:
+            if enc["encoder_latency"] + r["ttft"] >= ttft_target:
+                continue
+            encoder_capacity = float(enc["seq/s"]) * _RATE_MATCH_ENCODER_DEGRADATION
+            best: tuple[tuple[float, int], int, int] | None = None
+            for a_num in range(1, _MAX_AGG_WORKERS_EPD + 1):
+                e_num = max(1, math.ceil(rate_one * a_num / encoder_capacity))
+                num_gpu = gpus_one * a_num + enc["num_total_gpus"] * e_num
+                key = (rate_one * a_num / num_gpu, -num_gpu)
+                if best is None or key > best[0]:
+                    best = (key, a_num, e_num)
+            _, a_num, e_num = best
+            cell = dict(r)
+            cell["(a)workers"] = a_num
+            cell["seq/s"] = rate_one * a_num
+            cell["tokens/s"] = float(r["tokens/s"]) * a_num
+            cell["request_rate"] = cell["seq/s"]
+            cell["concurrency"] = r["concurrency"] * a_num
+            cell["num_total_gpus"] = gpus_one * a_num
+            # per-GPU metrics are recomputed by the overlay with the encode
+            # pool GPUs included; the agg worker covers both the prefill and
+            # decode phases of the power timeline.
+            rows.append(
+                _overlay_encoder_stage(
+                    cell,
+                    enc,
+                    e_num,
+                    prefill_power=r.get("power_w", 0.0),
+                    decode_power=r.get("power_w", 0.0),
+                )
+            )
+    if not rows:
+        return pd.DataFrame(columns=list(agg_df.columns))
+    return pd.DataFrame(rows)
 
 
 def _find_best_disagg_under_constraint(

--- a/src/aiconfigurator/sdk/sweep.py
+++ b/src/aiconfigurator/sdk/sweep.py
@@ -85,10 +85,12 @@ _DEFAULT_DECODE_BATCH_SCHEDULE: list[int] = (
     list(range(1, 16, 1)) + list(range(16, 32, 2)) + list(range(32, 128, 4)) + list(range(128, 512, 8)) + [512]
 )
 
-# Default EPD encode-worker search space; the batch schedule is capped at
-# SGLang's default (SGLANG_ENCODER_MAX_BATCH_SIZE = 8).
+# Default EPD encode-worker search space; batches are capped at SGLang's
+# default (SGLANG_ENCODER_MAX_BATCH_SIZE = 8) — explicit candidates above
+# the cap would claim throughput the reference deployment cannot form.
 _DEFAULT_ENCODER_TP_LIST: list[int] = [1, 2, 4, 8]
 _DEFAULT_ENCODER_BATCH_SCHEDULE: list[int] = [1, 2, 4, 8]
+_MAX_ENCODER_BATCH = 8
 
 # E+agg: agg-worker replicas explored per rate-matched cell (mirrors the
 # disagg worker lists, range(1, 33)).
@@ -840,6 +842,12 @@ def _get_encoder_worker_candidates(
     other_mem = misc_spec["other_mem"] * (1.0 + backend.OTHERS_OVERHEAD_FRAC)
     # The dominance filter below relies on ascending batch order.
     b_schedule = sorted(set(b_list or _DEFAULT_ENCODER_BATCH_SCHEDULE))
+    if b_schedule[-1] > _MAX_ENCODER_BATCH:
+        raise ValueError(
+            f"encoder batch candidates {[b for b in b_schedule if b > _MAX_ENCODER_BATCH]} exceed "
+            f"the supported maximum {_MAX_ENCODER_BATCH} (SGLang's SGLANG_ENCODER_MAX_BATCH_SIZE "
+            "default); modeling a raised deployment cap needs an explicit knob."
+        )
     for etp in sorted(set(tp_list or _DEFAULT_ENCODER_TP_LIST)):
         if min(etp, 8) not in misc_spec["nccl_mem"]:
             logger.warning(
@@ -1015,10 +1023,11 @@ def _rate_match_agg_epd(
     SLA-feasible row set so a pre-cut cannot shadow the pairable rows.
     Each pairing sweeps cells of ``a`` agg + ``e`` encode workers (cell
     throughput = min of the two pools, applied by the overlay); cells whose
-    GPU total is not in ``num_gpu_set`` are skipped before the
-    throughput-per-GPU argmax, and ties keep the smaller cell.  Returned
-    rows are per-cell (``common.ColumnsAggEpd`` plus passthrough columns),
-    so the downstream replicas logic scales whole cells.
+    GPU total is not in ``num_gpu_set`` are skipped, and the nondominated
+    (cell gpus, cell rate) frontier is emitted — one row per surviving cell
+    size — so the cluster-aware picker sees every packing alternative.
+    Returned rows are per-cell (``common.ColumnsAggEpd`` plus passthrough
+    columns), so the downstream replicas logic scales whole cells.
     """
     records = agg_df.sort_values(by="seq/s", ascending=False).to_dict("records")
     e_workers_bound = max_encoder_workers or _MAX_ENCODE_WORKERS
@@ -1033,7 +1042,11 @@ def _rate_match_agg_epd(
             gpus_one = int(r["num_total_gpus"])
             if rate_one <= 0:
                 continue
-            best: tuple[tuple[float, int], int, int] | None = None
+            # Downstream picking packs whole cells (floor(total_gpus /
+            # cell_gpus)), so a single per-cell-efficiency argmax could
+            # discard the packed winner; keep the best rate per cell size
+            # and emit the nondominated (gpus, rate) frontier.
+            best_per_gpus: dict[int, tuple[float, int, int]] = {}
             for a_num in range(1, _MAX_AGG_WORKERS_EPD + 1):
                 agg_rate = rate_one * a_num
                 for e_num in _epd_e_num_candidates(
@@ -1048,31 +1061,40 @@ def _rate_match_agg_epd(
                     if num_gpu_set and num_gpu not in num_gpu_set:
                         continue
                     cell_rate = min(agg_rate, encoder_capacity * e_num)
-                    key = (cell_rate / num_gpu, -num_gpu)
-                    if best is None or key > best[0]:
-                        best = (key, a_num, e_num)
-            if best is None:
+                    incumbent = best_per_gpus.get(num_gpu)
+                    if incumbent is None or cell_rate > incumbent[0]:
+                        best_per_gpus[num_gpu] = (cell_rate, a_num, e_num)
+            if not best_per_gpus:
                 continue
-            _, a_num, e_num = best
-            cell = dict(r)
-            cell["(a)workers"] = a_num
-            cell["seq/s"] = rate_one * a_num
-            cell["tokens/s"] = float(r["tokens/s"]) * a_num
-            cell["request_rate"] = cell["seq/s"]
-            cell["concurrency"] = r["concurrency"] * a_num
-            cell["num_total_gpus"] = gpus_one * a_num
-            # Cell rate columns are the uncapped agg-side capacity; the
-            # overlay applies the min() with the encode pool.
-            rows.append(
-                _overlay_encoder_stage(
-                    cell,
-                    enc_worker,
-                    e_num,
-                    prefill_power=r.get("power_w", 0.0),
-                    decode_power=r.get("power_w", 0.0),
-                    encoder_degradation=encoder_degradation,
+            kept: list[tuple[int, float]] = []
+            for num_gpu in sorted(best_per_gpus):
+                cell_rate, a_num, e_num = best_per_gpus[num_gpu]
+                # Dominated at every cluster size: no rate gain over a
+                # smaller cell, or a proportional repeat of one.
+                if kept and cell_rate <= kept[-1][1]:
+                    continue
+                if any(num_gpu % gpus == 0 and cell_rate <= (num_gpu // gpus) * rate for gpus, rate in kept):
+                    continue
+                kept.append((num_gpu, cell_rate))
+                cell = dict(r)
+                cell["(a)workers"] = a_num
+                cell["seq/s"] = rate_one * a_num
+                cell["tokens/s"] = float(r["tokens/s"]) * a_num
+                cell["request_rate"] = cell["seq/s"]
+                cell["concurrency"] = r["concurrency"] * a_num
+                cell["num_total_gpus"] = gpus_one * a_num
+                # Cell rate columns are the uncapped agg-side capacity; the
+                # overlay applies the min() with the encode pool.
+                rows.append(
+                    _overlay_encoder_stage(
+                        cell,
+                        enc_worker,
+                        e_num,
+                        prefill_power=r.get("power_w", 0.0),
+                        decode_power=r.get("power_w", 0.0),
+                        encoder_degradation=encoder_degradation,
+                    )
                 )
-            )
             paired += 1
             if top_k and paired >= top_k:
                 break

--- a/src/aiconfigurator/sdk/sweep.py
+++ b/src/aiconfigurator/sdk/sweep.py
@@ -429,6 +429,7 @@ def sweep_agg(
     enable_epd: bool = False,
     encoder_tp_list: list[int] | None = None,
     encoder_batch_list: list[int] | None = None,
+    max_encoder_workers: int | None = None,
     encoder_latency_correction: float = 1.0,
     encoder_database: PerfDatabase | None = None,
     num_gpu_list: list[int] | None = None,
@@ -451,7 +452,8 @@ def sweep_agg(
     ``enable_epd`` switches VL agg into E+agg: the vision encoder runs on
     dedicated encode workers while the agg workers become language-only, and
     each row is a rate-matched cell of ``(a)workers`` agg plus ``(e)workers``
-    encode workers with the encode batch latency added to TTFT.
+    encode workers with the encode batch latency added to TTFT — rows then
+    carry ``common.ColumnsAggEpd`` instead of ``common.ColumnsAgg``.
     ``num_gpu_list`` is the allowed per-cell GPU counts (as in
     ``sweep_disagg``); it is unused outside EPD.
 
@@ -591,6 +593,7 @@ def sweep_agg(
                         ttft_target=point_rt.ttft,
                         num_gpu_set=epd_num_gpu_set,
                         top_k=top_k,
+                        max_encoder_workers=max_encoder_workers,
                     )
                 if len(point_df) == 0:
                     continue
@@ -922,6 +925,7 @@ def _rate_match_agg_epd(
     ttft_target: float,
     num_gpu_set: set[int] | None = None,
     top_k: int = 0,
+    max_encoder_workers: int | None = None,
 ) -> pd.DataFrame:
     """Rate-match the encode pool against language-only agg workers (E+agg).
 
@@ -933,9 +937,11 @@ def _rate_match_agg_epd(
     throughput = min of the two pools, applied by the overlay); cells whose
     GPU total is not in ``num_gpu_set`` are skipped before the
     throughput-per-GPU argmax, and ties keep the smaller cell.  Returned
-    rows are per-cell, so the downstream replicas logic scales whole cells.
+    rows are per-cell (``common.ColumnsAggEpd`` plus passthrough columns),
+    so the downstream replicas logic scales whole cells.
     """
     records = agg_df.sort_values(by="seq/s", ascending=False).to_dict("records")
+    e_workers_bound = max_encoder_workers or _MAX_ENCODE_WORKERS
     rows: list[dict] = []
     for enc_worker in encoder_records:
         encoder_capacity = float(enc_worker["seq/s"]) * _RATE_MATCH_ENCODER_DEGRADATION
@@ -950,7 +956,7 @@ def _rate_match_agg_epd(
             best: tuple[tuple[float, int], int, int] | None = None
             for a_num in range(1, _MAX_AGG_WORKERS_EPD + 1):
                 agg_rate = rate_one * a_num
-                for e_num in range(1, _MAX_ENCODE_WORKERS + 1):
+                for e_num in range(1, e_workers_bound + 1):
                     num_gpu = gpus_one * a_num + enc_worker["num_total_gpus"] * e_num
                     if num_gpu_set and num_gpu not in num_gpu_set:
                         continue
@@ -982,9 +988,8 @@ def _rate_match_agg_epd(
             paired += 1
             if top_k and paired >= top_k:
                 break
-    if not rows:
-        return pd.DataFrame(columns=list(agg_df.columns))
-    return pd.DataFrame(rows)
+    columns = common.ColumnsAggEpd + [c for c in agg_df.columns if c not in common.ColumnsAggEpd]
+    return pd.DataFrame(rows, columns=columns)
 
 
 def _find_best_disagg_under_constraint(
@@ -1162,6 +1167,7 @@ def sweep_disagg(
     enable_epd: bool = False,
     encoder_tp_list: list[int] | None = None,
     encoder_batch_list: list[int] | None = None,
+    max_encoder_workers: int | None = None,
     encoder_latency_correction: float = 1.0,
     encoder_database: PerfDatabase | None = None,
     predictor: Any = None,
@@ -1214,6 +1220,7 @@ def sweep_disagg(
     )
     p_num_workers = prefill_num_worker_list or []
     d_num_workers = decode_num_worker_list or []
+    e_workers_bound = max_encoder_workers or _MAX_ENCODE_WORKERS
     if not p_num_workers or not d_num_workers:
         raise ValueError(
             "sweep_disagg requires non-empty prefill_num_worker_list and decode_num_worker_list. "
@@ -1236,11 +1243,12 @@ def sweep_disagg(
     # so the caller's batch intent round-trips.
     try:
         enc_cfg = get_model_config_from_model_path(model_path).get("extra_params")
-        vision_tokens = BaseBackend._visual_context_tokens_from_encoder_config(enc_cfg, runtime_config)
     except Exception:
         logger.debug("Could not resolve model config for the effective ISL; using text ISL", exc_info=True)
-        vision_tokens = 0
-    prefill_effective_isl = runtime_config.isl + vision_tokens
+        enc_cfg = None
+    prefill_effective_isl = runtime_config.isl + BaseBackend._visual_context_tokens_from_encoder_config(
+        enc_cfg, runtime_config
+    )
     if prefill_max_num_tokens < prefill_effective_isl:
         logger.warning("prefill_max_num_tokens < effective prefill ISL, clamping to effective ISL")
         prefill_max_num_tokens = prefill_effective_isl
@@ -1374,7 +1382,7 @@ def sweep_disagg(
                     # Full sweep like the P/D worker lists: sizes past the
                     # first non-binding one are throughput-dominated, but can
                     # be the only counts that land in num_gpu_set.
-                    e_num_candidates = range(1, _MAX_ENCODE_WORKERS + 1)
+                    e_num_candidates = range(1, e_workers_bound + 1)
                 else:
                     e_num_candidates = (0,)
                 for e_num in e_num_candidates:

--- a/src/aiconfigurator/sdk/sweep.py
+++ b/src/aiconfigurator/sdk/sweep.py
@@ -942,7 +942,7 @@ def _rate_match_agg_epd(
 ) -> pd.DataFrame:
     """Rate-match the encode pool against language-only agg workers (E+agg).
 
-    The agg counterpart of ``_match_workers_epd`` + ``_overlay_encoder_stage``:
+    The agg counterpart of the disagg encoder rate matching + ``_overlay_encoder_stage``:
     for each (agg row, encode-worker choice) whose encode latency still fits
     the TTFT budget, pick the cell of ``a`` agg workers + ``e`` encode workers
     (``e`` = smallest count that does not bottleneck the agg throughput, the
@@ -1010,7 +1010,6 @@ def _find_best_disagg_under_constraint(
     match_workers: Any,
     autoscale_ttft_correction_factor: float = _AUTOSCALE_TTFT_CORRECTION_FACTOR,
     encoder_records: list[dict] | None = None,
-    match_workers_epd: Any = None,
 ) -> pd.DataFrame | None:
     """For one (ttft, tpot) pair, filter + rate-match + pick best per decode parallel.
 
@@ -1018,7 +1017,7 @@ def _find_best_disagg_under_constraint(
     DisaggInferenceSession.find_best_disagg_result_under_constraints.
 
     ``match_workers`` is supplied by the caller (``sweep_disagg``) so its
-    ``lru_cache`` is shared across all (ttft, tpot) pairs -- its result is
+    cache is shared across all (ttft, tpot) pairs -- its result is
     independent of the target, so a per-pair cache would recompute identical
     matches.
 
@@ -1028,9 +1027,10 @@ def _find_best_disagg_under_constraint(
     pair's parallel configs, not of the task.
 
     When ``encoder_records`` is given (EPD), each encode-worker choice spends
-    its batch latency out of the TTFT budget before the prefill filter, and
-    ``match_workers_epd`` sizes the encode pool into the rate matching; the
-    per-decode-parallel best is picked across encode choices as well.
+    its batch latency out of the TTFT budget before the prefill filter and
+    joins the worker rate matching as the third pool (``match_workers``
+    encoder arguments); the per-decode-parallel best is picked across encode
+    choices as well.
     """
     requires_same_tp = (
         require_same_tp if callable(require_same_tp) else (lambda _p, _d, _flag=bool(require_same_tp): _flag)
@@ -1095,27 +1095,16 @@ def _find_best_disagg_under_constraint(
                         continue
                     p_throughput = float(p_worker["seq/s"])
                     p_gpus = p_worker["num_total_gpus"]
-                    if enc is None:
-                        p_num, d_num = match_workers(
-                            prefill_throughput=p_throughput,
-                            prefill_gpus=p_gpus,
-                            decode_throughput=d_throughput,
-                            decode_gpus=d_gpus,
-                            prefill_deg=prefill_degradation,
-                            decode_deg=decode_degradation,
-                        )
-                        e_num = 0
-                    else:
-                        p_num, d_num, e_num = match_workers_epd(
-                            prefill_throughput=p_throughput,
-                            prefill_gpus=p_gpus,
-                            decode_throughput=d_throughput,
-                            decode_gpus=d_gpus,
-                            encoder_throughput=float(enc["seq/s"]),
-                            encoder_gpus=enc["num_total_gpus"],
-                            prefill_deg=prefill_degradation,
-                            decode_deg=decode_degradation,
-                        )
+                    p_num, d_num, e_num = match_workers(
+                        prefill_throughput=p_throughput,
+                        prefill_gpus=p_gpus,
+                        decode_throughput=d_throughput,
+                        decode_gpus=d_gpus,
+                        prefill_deg=prefill_degradation,
+                        decode_deg=decode_degradation,
+                        encoder_throughput=float(enc["seq/s"]) if enc else 0.0,
+                        encoder_gpus=enc["num_total_gpus"] if enc else 0,
+                    )
                     if p_num == -1 or d_num == -1:
                         continue
                     disagg_dict = _rate_match_dict(
@@ -1358,10 +1347,12 @@ def sweep_disagg(
 
     # Worker-count rate matching depends only on per-worker throughput/GPUs and the
     # (constant) worker-count lists + GPU budget -- NOT on the (ttft, tpot) target.
-    # Define it once here so the lru_cache is shared across every constraint pair.
+    # Define it once here so the cache is shared across every constraint pair.
     # Nesting it inside _find_best_disagg_under_constraint rebuilt the cache per pair
     # and recomputed identical matches (the dominant cost of the disagg sweep).
-    @functools.lru_cache(maxsize=8192)
+    # Unbounded cache: the key space is the (p, d[, e]) candidate cross-product,
+    # which can exceed a default lru size but stays small in memory.
+    @functools.cache
     def _match_workers(
         prefill_throughput: float,
         prefill_gpus: int,
@@ -1369,44 +1360,18 @@ def sweep_disagg(
         decode_gpus: int,
         prefill_deg: float,
         decode_deg: float,
-    ) -> tuple[int, int]:
-        prefill_opt, decode_opt = -1, -1
-        throughput_per_gpu_max = 0.0
-        for d_num in d_num_workers:
-            for p_num in p_num_workers:
-                num_gpu = prefill_gpus * p_num + decode_gpus * d_num
-                if num_gpu_set and num_gpu not in num_gpu_set:
-                    continue
-                if max_prefill_gpus is not None and max_decode_gpus is not None:
-                    if prefill_gpus * p_num > max_prefill_gpus:
-                        continue
-                    if decode_gpus * d_num > max_decode_gpus:
-                        continue
-                p_corrected = prefill_throughput * p_num * prefill_deg
-                d_corrected = decode_throughput * d_num * decode_deg
-                tpg = min(p_corrected, d_corrected) / num_gpu
-                if tpg > throughput_per_gpu_max:
-                    throughput_per_gpu_max = tpg
-                    prefill_opt, decode_opt = p_num, d_num
-        return prefill_opt, decode_opt
-
-    # EPD variant: for each (p_num, d_num), size the encode pool to the
-    # smallest worker count that does not bottleneck the rate-matched P/D
-    # throughput -- so seq/s stays min(p, d) while the encode GPUs count
-    # toward the per-GPU objective and the replica GPU budget.  Unbounded
-    # cache: the key space is the (p, d, e) candidate cross-product, which
-    # exceeds the default lru size but stays small in memory.
-    @functools.cache
-    def _match_workers_epd(
-        prefill_throughput: float,
-        prefill_gpus: int,
-        decode_throughput: float,
-        decode_gpus: int,
-        encoder_throughput: float,
-        encoder_gpus: int,
-        prefill_deg: float,
-        decode_deg: float,
+        encoder_throughput: float = 0.0,
+        encoder_gpus: int = 0,
     ) -> tuple[int, int, int]:
+        """Pick (p_num, d_num, e_num) maximizing throughput per GPU.
+
+        The encode pool is the optional third rate-matched pool (EPD): for
+        each (p_num, d_num) it is sized to the smallest worker count that
+        does not bottleneck the rate-matched P/D throughput, so seq/s stays
+        min(p, d) while the encode GPUs count toward the per-GPU objective
+        and the replica GPU budget.  ``encoder_throughput = 0`` (plain PD)
+        drops the encoder terms entirely and returns ``e_num = 0``.
+        """
         prefill_opt, decode_opt, encoder_opt = -1, -1, -1
         throughput_per_gpu_max = 0.0
         encoder_capacity = encoder_throughput * _RATE_MATCH_ENCODER_DEGRADATION
@@ -1415,7 +1380,7 @@ def sweep_disagg(
                 p_corrected = prefill_throughput * p_num * prefill_deg
                 d_corrected = decode_throughput * d_num * decode_deg
                 required = min(p_corrected, d_corrected)
-                e_num = max(1, math.ceil(required / encoder_capacity))
+                e_num = max(1, math.ceil(required / encoder_capacity)) if encoder_capacity > 0 else 0
                 num_gpu = prefill_gpus * p_num + decode_gpus * d_num + encoder_gpus * e_num
                 if num_gpu_set and num_gpu not in num_gpu_set:
                     continue
@@ -1450,7 +1415,6 @@ def sweep_disagg(
             match_workers=_match_workers,
             autoscale_ttft_correction_factor=ttft_corr,
             encoder_records=encoder_candidates,
-            match_workers_epd=_match_workers_epd,
         )
         if partial is not None:
             disagg_df = pd.concat([disagg_df, partial], axis=0, ignore_index=True)

--- a/src/aiconfigurator/sdk/sweep.py
+++ b/src/aiconfigurator/sdk/sweep.py
@@ -34,7 +34,6 @@ import copy
 import dataclasses
 import functools
 import logging
-import math
 from collections.abc import Callable
 from typing import Any
 
@@ -65,8 +64,7 @@ logger = logging.getLogger(__name__)
 # (locked in via parity test; do not change without updating picking.py too).
 _RATE_MATCH_PREFILL_DEGRADATION = 0.9
 _RATE_MATCH_DECODE_DEGRADATION = 0.92
-# EPD: the encode pool suffers the same pipeline-bubble class of loss as
-# prefill (imperfect batch packing under bursty arrivals).
+# EPD: the encode pool takes the same class of loss as prefill.
 _RATE_MATCH_ENCODER_DEGRADATION = 0.9
 
 # TTFT pre-correction for queueing under concurrency, sourced from
@@ -78,24 +76,21 @@ _DECODE_FILTER_RATIO_MIN = 0.0
 _DECODE_FILTER_RATIO_MAX = 1.0
 _MAX_DECODE_WORKERS_PER_CATEGORY = 16
 _MAX_PREFILL_WORKERS = 32
+# EPD encode-pool size sweep bound, mirroring the P/D worker-list bounds.
+_MAX_ENCODE_WORKERS = 32
 
 # Default decode batch-size schedule for disagg worker enumeration.
 _DEFAULT_DECODE_BATCH_SCHEDULE: list[int] = (
     list(range(1, 16, 1)) + list(range(16, 32, 2)) + list(range(32, 128, 4)) + list(range(128, 512, 8)) + [512]
 )
 
-# Default EPD encode-worker search space.  TP mirrors a real encode
-# instance's --tp-size choices.  The batch schedule models cross-request
-# batching by the encode instance's greedy scheduler and is capped at
-# SGLang's default (SGLANG_ENCODER_MAX_BATCH_SIZE = 8) -- larger batches
-# do not exist in the deployed system, so sweeping them would credit the
-# encode pool with unreachable throughput.
+# Default EPD encode-worker search space; the batch schedule is capped at
+# SGLang's default (SGLANG_ENCODER_MAX_BATCH_SIZE = 8).
 _DEFAULT_ENCODER_TP_LIST: list[int] = [1, 2, 4, 8]
 _DEFAULT_ENCODER_BATCH_SCHEDULE: list[int] = [1, 2, 4, 8]
 
-# E+agg: agg-worker replicas explored per rate-matched cell.  Mirrors the
-# disagg worker lists (range(1, 33)); the cell only exists to express the
-# integer agg:encode worker ratio.
+# E+agg: agg-worker replicas explored per rate-matched cell (mirrors the
+# disagg worker lists, range(1, 33)).
 _MAX_AGG_WORKERS_EPD = 32
 
 # Default batch-size schedule used by sweep_agg.  Mirrors the schedule in
@@ -110,24 +105,6 @@ _DEFAULT_AGG_BATCH_SCHEDULE: list[int] = (
     + list(range(512, 1024, 256))
     + [1024]
 )
-
-
-def vl_effective_isl(model_path: str, runtime_config: config.RuntimeConfig) -> int:
-    """Per-request effective ISL: text ISL plus vision context tokens.
-
-    Single source of truth for the VL token accounting shared by ``Task``
-    (which builds token budgets as ``batch x effective_isl``) and
-    ``sweep_disagg`` (which divides the budget by the same value to recover
-    the batch range) -- deriving it in two places would silently break that
-    round trip.  Falls back to the plain text ISL when the model config
-    cannot be resolved or the model / workload has no vision input.
-    """
-    try:
-        enc_cfg = get_model_config_from_model_path(model_path).get("extra_params")
-    except Exception:
-        logger.debug("Could not resolve model config for VL effective ISL; using text ISL", exc_info=True)
-        return runtime_config.isl
-    return runtime_config.isl + BaseBackend._visual_context_tokens_from_encoder_config(enc_cfg, runtime_config)
 
 
 # ---------------------------------------------------------------------------
@@ -234,8 +211,7 @@ def _rate_match_dict(
         "(d)backend": d.get("backend", ""),
         "(d)version": d.get("version", ""),
         "(d)system": d.get("system", ""),
-        # Encoder is colocated with prefill for VL; text-only models leave these
-        # visibility fields at zero/empty.  EPD overlays them via
+        # Colocated-encoder visibility fields; EPD overwrites them via
         # _overlay_encoder_stage.
         "(e)workers": 0,
         "(e)tp": 0,
@@ -473,18 +449,11 @@ def sweep_agg(
     proxy.
 
     ``enable_epd`` switches VL agg into E+agg: the vision encoder runs on
-    dedicated encode workers (same candidate space as EPD disagg,
-    ``encoder_tp_list x encoder_batch_list``) while prefill+decode stay
-    aggregated.  The agg worker becomes language-only (vision tokens stay in
-    context, no ViT hosted); each row is then a rate-matched cell of
-    ``(a)workers`` agg workers plus ``(e)workers`` encode workers, with the
-    encode batch latency added to TTFT.  ``num_gpu_list`` is the allowed
-    per-cell (per-replica) GPU counts for those cells, exactly as in
-    ``sweep_disagg``; it is unused outside EPD (a plain agg row is a single
-    worker whose GPU count is already gated by the parallel candidates).
-    Default (``enable_epd=False``) keeps the encoder inline (colocated): its
-    latency is part of the agg worker's TTFT and its weights part of the
-    worker's memory.
+    dedicated encode workers while the agg workers become language-only, and
+    each row is a rate-matched cell of ``(a)workers`` agg plus ``(e)workers``
+    encode workers with the encode batch latency added to TTFT.
+    ``num_gpu_list`` is the allowed per-cell GPU counts (as in
+    ``sweep_disagg``); it is unused outside EPD.
 
     Args:
         model_path: HuggingFace model path or local path.
@@ -523,10 +492,8 @@ def sweep_agg(
 
     encoder_candidates: list[dict] | None = None
     if enable_epd:
-        # E+agg: enumerate the encode-worker pool once (independent of the
-        # agg parallel choice), then sweep language-only agg workers.  The
-        # encode pool may live on its own system / GPU type (hetero
-        # encoder, ``encoder_database``); it defaults to the agg side.
+        # E+agg: enumerate the encode pool once; hetero encoder may use its
+        # own database (defaults to the agg side).
         encoder_candidates = _get_encoder_worker_candidates(
             model_path=model_path,
             tp_list=encoder_tp_list,
@@ -538,8 +505,7 @@ def sweep_agg(
         )
         model_config = copy.deepcopy(model_config)
         model_config.language_only = True
-    # Per-cell (per-replica) GPU budget for the E+agg rate matching, same
-    # semantics as sweep_disagg's num_gpu_list.
+    # Per-cell GPU budget for the E+agg rate matching (sweep_disagg semantics).
     epd_num_gpu_set: set[int] = set(num_gpu_list) if num_gpu_list else set()
 
     for parallel_config in parallel_config_list:
@@ -602,9 +568,8 @@ def sweep_agg(
                     backend=backend,
                     database=database,
                     runtime_config=point_rt,
-                    # EPD defers the top_k cut to the encoder pairing: cutting
-                    # the language-only rows here would let high-throughput
-                    # rows without encode headroom shadow the pairable ones.
+                    # EPD defers the top_k cut to the encoder pairing (a cut
+                    # here could shadow the only pairable rows).
                     top_k=0 if encoder_candidates is not None else top_k,
                     max_batch_size=max_batch_size,
                     ctx_stride=ctx_stride,
@@ -618,9 +583,8 @@ def sweep_agg(
                 saw_memory_fit |= point_saw_memory_fit
                 perf_misses += point_perf_misses
                 if encoder_candidates is not None and len(point_df) > 0:
-                    # E+agg: the per-point ttft filter above ran on the
-                    # language-only ttft (a superset — adding the encode
-                    # latency only tightens it); pair exactly here.
+                    # The per-point ttft filter ran on the language-only ttft;
+                    # pair exactly here.
                     point_df = _rate_match_agg_epd(
                         point_df,
                         encoder_candidates,
@@ -821,25 +785,15 @@ def _get_encoder_worker_candidates(
 ) -> list[dict]:
     """Enumerate (tp, batch) encode-worker candidates for EPD.
 
-    An encode (E) worker runs only the vision encoder (ViT + projector) with
-    its own tensor parallelism, mirroring an encoder-only instance that loads
-    no LLM weights (e.g. SGLang ``--encoder-only``).  The worker model is
-    built directly from the encoder config: constructing the full LLM here
-    would waste work and, worse, let LLM-side parallelism rules (KV-head
-    divisibility, MoE width identities) reject a tp the ViT itself supports.
-    The ViT is weight-sharded over the worker's tp (encoder DP off): that is
-    the encoder-instance default of both engines (vLLM
-    ``mm_encoder_tp_mode="weights"``, SGLang ``mm_enable_dp_encoder=False``,
-    each independent of the disaggregation flags) -- the DP layout's benefit
-    (replicas over a colocated worker's LLM-sized tp group) is expressed in
-    EPD by sweeping multiple small-tp encode workers instead.
-    ``tp_list`` / ``b_list`` fall back to :data:`_DEFAULT_ENCODER_TP_LIST` /
-    :data:`_DEFAULT_ENCODER_BATCH_SCHEDULE` when None.
-    A worker encodes one batch of ``b`` requests (each with
-    ``num_images_per_request`` images) in ``encoder_latency`` ms, so its
-    throughput is ``b / encoder_latency``.  Per tp, batch points that do not
-    improve throughput over a smaller batch are dominated (same rate at
-    worse latency) and dropped.
+    An encode (E) worker runs only the vision encoder (ViT + projector),
+    mirroring an encoder-only instance that loads no LLM weights (e.g.
+    SGLang ``--encoder-only``), so only ViT-side rules constrain its tp.
+    The ViT is weight-sharded over the worker's tp (encoder DP off, the
+    engines' encoder-instance default); the DP layout's benefit is expressed
+    by sweeping multiple small-tp workers instead.  A worker encodes one
+    batch of ``b`` requests in ``encoder_latency`` ms (throughput
+    ``b / encoder_latency``); batch points that do not improve throughput
+    or exceed the encoder system's GPU memory are dropped.
 
     Returns row dicts with keys
     ``encoder_latency / seq/s / num_total_gpus / tp / bs / memory``.
@@ -847,8 +801,7 @@ def _get_encoder_worker_candidates(
     backend = get_backend(backend_name)
     enc_cfg = get_model_config_from_model_path(model_path).get("extra_params")
     if not isinstance(enc_cfg, common.VisionEncoderConfig):
-        # Config error, not a typing mistake: "no VisionEncoderConfig" means
-        # the model is not a VL model, so EPD cannot apply to it.
+        # Not a VL model -> EPD cannot apply (config error, not a type bug).
         raise ValueError(  # noqa: TRY004
             f"EPD (encoder disaggregation) requested but model {model_path!r} has no vision encoder."
         )
@@ -858,6 +811,9 @@ def _get_encoder_worker_candidates(
             "set image_height/image_width (or num_image_tokens) and num_images_per_request."
         )
     rows: list[dict] = []
+    saw_oom = False
+    # Same OOM gate as the P/D candidates (set_memory_and_check_oom).
+    mem_capacity_gib = database.system_spec["gpu"]["mem_capacity"] / (1 << 30)
     # The dominance filter below relies on ascending batch order.
     b_schedule = sorted(set(b_list or _DEFAULT_ENCODER_BATCH_SCHEDULE))
     for etp in sorted(set(tp_list or _DEFAULT_ENCODER_TP_LIST)):
@@ -870,8 +826,7 @@ def _get_encoder_worker_candidates(
         model = EncoderOnlyModel(
             encoder_ops=encoder_ops,
             encoder_config=enc_cfg,
-            # The ModelConfig slice the encoder phase reads; enable_encoder_dp
-            # stays off so the image batch is not ceil-sharded across ranks.
+            # The ModelConfig slice the encoder phase reads (DP off).
             config=config.ModelConfig(tp_size=etp, enable_encoder_dp=False),
         )
         best_seq_s = 0.0
@@ -879,6 +834,10 @@ def _get_encoder_worker_candidates(
             latency, power_w, memory = backend.run_encoder_static(
                 model, database, runtime_config, b, latency_correction_scale=latency_correction
             )
+            if memory.get("total", 0.0) >= mem_capacity_gib:
+                # Memory grows with batch: larger batches also OOM.
+                saw_oom = True
+                break
             seq_s = b * 1000.0 / latency
             if seq_s <= best_seq_s:
                 continue
@@ -895,6 +854,10 @@ def _get_encoder_worker_candidates(
                 }
             )
     if not rows:
+        if saw_oom:
+            raise InsufficientMemoryError(
+                "EPD encoder: the encode worker does not fit in GPU memory for any (tp, batch)."
+            )
         raise NoFeasibleConfigError("EPD encoder: no encode-worker candidate for any encoder tp.")
     return rows
 
@@ -909,22 +872,13 @@ def _overlay_encoder_stage(
 ) -> dict:
     """Overlay the encode stage onto a rate-matched P/D or agg row (EPD).
 
-    Encode -> prefill is sequential per request (prefill starts only after
-    the full image embedding arrives), so the encode batch latency adds to
-    TTFT and request latency.  ``ttft_scale`` keeps the queueing correction
-    symmetric with the non-EPD baseline: the disagg path passes the
-    autoscale TTFT correction factor (its inline-encoder prefill ttft is
-    corrected wholesale, so the disaggregated encode stage must be too),
-    while the agg path keeps 1.0 (run_agg adds the inline encoder outside
-    its queueing factor).  The ``encoder_latency`` column stays the raw
-    stage latency, like the inline rows.  Three-pool rate matching: when
-    the encode pool's degraded capacity is below the row throughput (the
-    matcher may pick an encode-bound cell), ``seq/s`` is capped at that
-    capacity and the rate-derived columns rescale with it; per-request
-    latency columns are unaffected (the batch latency does not depend on
-    the pool size).  ``power_w`` is re-weighted over the three-phase
-    timeline (encode + prefill + decode); the prefill phase reuses the
-    colocated worker's average power as an approximation.
+    Encode -> prefill is sequential per request, so the encode batch latency
+    adds to TTFT and request latency.  ``ttft_scale`` mirrors each baseline:
+    disagg corrects the encode stage like its prefill ttft (x1.8), agg adds
+    it raw (run_agg adds the inline encoder outside its queueing factor).
+    When the degraded encode pool capacity is below the row throughput,
+    ``seq/s`` is capped and the rate-derived columns rescale with it;
+    ``power_w`` is re-weighted over the encode + prefill + decode timeline.
     """
     row = dict(disagg_dict)
     encoder_latency = encoder_worker["encoder_latency"]
@@ -971,33 +925,23 @@ def _rate_match_agg_epd(
 ) -> pd.DataFrame:
     """Rate-match the encode pool against language-only agg workers (E+agg).
 
-    The agg counterpart of the disagg encoder rate matching + ``_overlay_encoder_stage``:
-    for each encode-worker choice, pair the agg rows whose encode latency
+    For each encode-worker choice, pair the agg rows whose encode latency
     still fits the TTFT budget -- best throughput first, up to ``top_k``
-    rows per choice (0 = uncapped), mirroring the per-choice
-    ``_prefill_records`` re-filter in the disagg path.  The caller hands
-    over the full SLA-feasible row set: a top_k cut on the language-only
-    rows *before* this pairing would let high-throughput rows without
-    encode headroom shadow the (possibly only) pairable rows.  For each
-    pairing, sweep cells of ``a`` agg workers + ``e`` encode workers
-    -- ``e`` up to the first count that no longer binds (larger pools are
-    dominated), smaller counts making the encode pool the rate-matched
-    bottleneck (cell throughput = min of the two pools, applied by the
-    overlay).  ``num_gpu_set`` is the per-replica GPU budget, exactly as in
-    the disagg matching: cells whose total GPU count is not allowed are
-    skipped *before* the argmax, so a feasible small cell is never shadowed
-    by an infeasible better-amortized large one.  Among feasible cells the
-    throughput-per-GPU argmax wins; ties keep the smaller cell.  The
-    returned rows are per-cell — ``(a)workers`` agg workers — so the
-    downstream replicas logic scales whole cells.
+    rows per choice (0 = uncapped); the caller hands over the full
+    SLA-feasible row set so a pre-cut cannot shadow the pairable rows.
+    Each pairing sweeps cells of ``a`` agg + ``e`` encode workers (cell
+    throughput = min of the two pools, applied by the overlay); cells whose
+    GPU total is not in ``num_gpu_set`` are skipped before the
+    throughput-per-GPU argmax, and ties keep the smaller cell.  Returned
+    rows are per-cell, so the downstream replicas logic scales whole cells.
     """
     records = agg_df.sort_values(by="seq/s", ascending=False).to_dict("records")
     rows: list[dict] = []
-    for enc in encoder_records:
-        encoder_capacity = float(enc["seq/s"]) * _RATE_MATCH_ENCODER_DEGRADATION
+    for enc_worker in encoder_records:
+        encoder_capacity = float(enc_worker["seq/s"]) * _RATE_MATCH_ENCODER_DEGRADATION
         paired = 0
         for r in records:
-            if enc["encoder_latency"] + r["ttft"] >= ttft_target:
+            if enc_worker["encoder_latency"] + r["ttft"] >= ttft_target:
                 continue
             rate_one = float(r["seq/s"])
             gpus_one = int(r["num_total_gpus"])
@@ -1006,8 +950,8 @@ def _rate_match_agg_epd(
             best: tuple[tuple[float, int], int, int] | None = None
             for a_num in range(1, _MAX_AGG_WORKERS_EPD + 1):
                 agg_rate = rate_one * a_num
-                for e_num in range(1, max(1, math.ceil(agg_rate / encoder_capacity)) + 1):
-                    num_gpu = gpus_one * a_num + enc["num_total_gpus"] * e_num
+                for e_num in range(1, _MAX_ENCODE_WORKERS + 1):
+                    num_gpu = gpus_one * a_num + enc_worker["num_total_gpus"] * e_num
                     if num_gpu_set and num_gpu not in num_gpu_set:
                         continue
                     cell_rate = min(agg_rate, encoder_capacity * e_num)
@@ -1024,15 +968,12 @@ def _rate_match_agg_epd(
             cell["request_rate"] = cell["seq/s"]
             cell["concurrency"] = r["concurrency"] * a_num
             cell["num_total_gpus"] = gpus_one * a_num
-            # cell rate columns are the uncapped agg-side capacity; the
-            # overlay applies the min() with the encode pool and recomputes
-            # the per-GPU metrics with the encode GPUs included.  The agg
-            # worker covers both the prefill and decode phases of the power
-            # timeline.
+            # Cell rate columns are the uncapped agg-side capacity; the
+            # overlay applies the min() with the encode pool.
             rows.append(
                 _overlay_encoder_stage(
                     cell,
-                    enc,
+                    enc_worker,
                     e_num,
                     prefill_power=r.get("power_w", 0.0),
                     decode_power=r.get("power_w", 0.0),
@@ -1082,9 +1023,7 @@ def _find_best_disagg_under_constraint(
 
     When ``encoder_records`` is given (EPD), each encode-worker choice spends
     its batch latency out of the TTFT budget before the prefill filter and
-    joins the worker rate matching as the third pool (``match_workers``
-    encoder arguments); the per-decode-parallel best is picked across encode
-    choices as well.
+    joins the worker rate matching as the third pool.
     """
     requires_same_tp = (
         require_same_tp if callable(require_same_tp) else (lambda _p, _d, _flag=bool(require_same_tp): _flag)
@@ -1103,20 +1042,19 @@ def _find_best_disagg_under_constraint(
             .to_dict("records")
         )
 
-    # EPD: encode -> prefill is sequential per request, so each encode choice
-    # consumes its latency from the TTFT budget -- under the same queueing
-    # correction as the prefill stage (the inline PD baseline corrects its
-    # whole E+P ttft, so correcting only P here would systematically favor
-    # EPD by the uncorrected encode share).  Plain PD is the single
-    # no-encoder choice with the full budget.
+    # Each encode choice spends its corrected (x1.8) latency out of the TTFT
+    # budget -- same correction as prefill, mirroring the inline PD baseline
+    # whose whole E+P ttft is corrected.  [None] = plain PD, full budget.
     encoder_choices: list[dict | None] = [None]
     if encoder_records:
         encoder_choices = [
             e for e in encoder_records if e["encoder_latency"] * autoscale_ttft_correction_factor < ttft_target
         ]
     p_records_per_choice = [
-        _prefill_records(ttft_target - (enc["encoder_latency"] * autoscale_ttft_correction_factor if enc else 0.0))
-        for enc in encoder_choices
+        _prefill_records(
+            ttft_target - (enc_worker["encoder_latency"] * autoscale_ttft_correction_factor if enc_worker else 0.0)
+        )
+        for enc_worker in encoder_choices
     ]
     if not any(p_records_per_choice):
         logger.debug("sweep_disagg: no prefill candidates meet ttft<%sms", ttft_target)
@@ -1140,7 +1078,7 @@ def _find_best_disagg_under_constraint(
         )
         decode_records = group_sorted.to_dict("records")
         category_results: list[dict] = []
-        for enc, p_records in zip(encoder_choices, p_records_per_choice, strict=True):
+        for enc_worker, p_records in zip(encoder_choices, p_records_per_choice, strict=True):
             for d_worker in decode_records:
                 d_throughput = float(d_worker["seq/s"])
                 d_gpus = d_worker["num_total_gpus"]
@@ -1156,8 +1094,8 @@ def _find_best_disagg_under_constraint(
                         decode_gpus=d_gpus,
                         prefill_deg=prefill_degradation,
                         decode_deg=decode_degradation,
-                        encoder_throughput=float(enc["seq/s"]) if enc else 0.0,
-                        encoder_gpus=enc["num_total_gpus"] if enc else 0,
+                        encoder_throughput=float(enc_worker["seq/s"]) if enc_worker else 0.0,
+                        encoder_gpus=enc_worker["num_total_gpus"] if enc_worker else 0,
                     )
                     if p_num == -1 or d_num == -1:
                         continue
@@ -1169,10 +1107,10 @@ def _find_best_disagg_under_constraint(
                         prefill_degradation=prefill_degradation,
                         decode_degradation=decode_degradation,
                     )
-                    if enc is not None:
+                    if enc_worker is not None:
                         disagg_dict = _overlay_encoder_stage(
                             disagg_dict,
-                            enc,
+                            enc_worker,
                             e_num,
                             prefill_power=p_worker.get("power_w", 0.0),
                             decode_power=d_worker.get("power_w", 0.0),
@@ -1240,13 +1178,9 @@ def sweep_disagg(
     hetero-disagg (prefill and decode on different systems).
 
     ``enable_epd`` switches VL disagg into EPD: the vision encoder runs on
-    dedicated encode workers, enumerated over
-    ``encoder_tp_list x encoder_batch_list`` (defaults
-    :data:`_DEFAULT_ENCODER_TP_LIST` / :data:`_DEFAULT_ENCODER_BATCH_SCHEDULE`)
-    on the prefill database/backend.  Prefill workers become language-only
-    (vision tokens stay in context, no ViT hosted), TTFT gains the encode
-    batch latency, and the encode pool joins the worker rate matching
-    (``(e)*`` columns in the output).
+    dedicated encode workers, prefill workers become language-only, TTFT
+    gains the encode batch latency, and the encode pool joins the worker
+    rate matching (``(e)*`` columns in the output).
 
     Returns:
         DataFrame (possibly empty) with schema ``common.ColumnsDisagg``.
@@ -1297,11 +1231,16 @@ def sweep_disagg(
     else:
         decode_batch_range = [b for b in _DEFAULT_DECODE_BATCH_SCHEDULE if b <= decode_max_num_tokens]
 
-    # Vision tokens occupy the prefill context, so the per-request cost that
-    # divides the token budget is the effective ISL (mirrors the legacy
-    # DisaggInferenceSession and the agg sweep above).  Task builds the
-    # budget with the same helper, so the caller's batch intent round-trips.
-    prefill_effective_isl = vl_effective_isl(model_path, runtime_config)
+    # The token budget divides by the effective ISL (text + vision context
+    # tokens); Task._prefill_effective_isl builds the budget the same way,
+    # so the caller's batch intent round-trips.
+    try:
+        enc_cfg = get_model_config_from_model_path(model_path).get("extra_params")
+        vision_tokens = BaseBackend._visual_context_tokens_from_encoder_config(enc_cfg, runtime_config)
+    except Exception:
+        logger.debug("Could not resolve model config for the effective ISL; using text ISL", exc_info=True)
+        vision_tokens = 0
+    prefill_effective_isl = runtime_config.isl + vision_tokens
     if prefill_max_num_tokens < prefill_effective_isl:
         logger.warning("prefill_max_num_tokens < effective prefill ISL, clamping to effective ISL")
         prefill_max_num_tokens = prefill_effective_isl
@@ -1310,8 +1249,7 @@ def sweep_disagg(
 
     encoder_candidates: list[dict] | None = None
     if enable_epd:
-        # The encode pool may live on its own system / GPU type (hetero
-        # encoder, ``encoder_database``); it defaults to the prefill side.
+        # Hetero encoder: encoder_database defaults to the prefill side.
         encoder_candidates = _get_encoder_worker_candidates(
             model_path=model_path,
             tp_list=encoder_tp_list,
@@ -1321,8 +1259,7 @@ def sweep_disagg(
             backend_name=prefill_backend_name,
             latency_correction=encoder_latency_correction,
         )
-        # EPD prefill workers are language-only (e.g. SGLang --language-only):
-        # vision tokens stay in their context, but they never host the ViT.
+        # EPD prefill workers are language-only (vision tokens stay in context).
         prefill_model_config = copy.deepcopy(prefill_model_config)
         prefill_model_config.language_only = True
 
@@ -1399,13 +1336,10 @@ def sweep_disagg(
         tpot_values = runtime_config.tpot if isinstance(runtime_config.tpot, list) else [runtime_config.tpot]
         constraint_pairs = [(runtime_config.ttft, tpot) for tpot in tpot_values]
 
-    # Worker-count rate matching depends only on per-worker throughput/GPUs and the
-    # (constant) worker-count lists + GPU budget -- NOT on the (ttft, tpot) target.
-    # Define it once here so the cache is shared across every constraint pair.
-    # Nesting it inside _find_best_disagg_under_constraint rebuilt the cache per pair
-    # and recomputed identical matches (the dominant cost of the disagg sweep).
-    # Unbounded cache: the key space is the (p, d[, e]) candidate cross-product,
-    # which can exceed a default lru size but stays small in memory.
+    # Worker-count matching is independent of the (ttft, tpot) target, so the
+    # cache is defined once here and shared across constraint pairs (the
+    # matching is the dominant cost of the disagg sweep).  Unbounded: the
+    # (p, d[, e]) key cross-product can exceed a default lru size.
     @functools.cache
     def _match_workers(
         prefill_throughput: float,
@@ -1419,13 +1353,9 @@ def sweep_disagg(
     ) -> tuple[int, int, int]:
         """Pick (p_num, d_num, e_num) maximizing throughput per GPU.
 
-        The encode pool is the optional third rate-matched pool (EPD),
-        fully symmetric with P and D: its size is swept like theirs and the
-        achieved throughput is the min of the three degraded pool
-        capacities -- the encode pool may itself be the bottleneck, running
-        at its degradation headroom exactly like a binding P or D pool.
-        ``encoder_throughput = 0`` (plain PD) drops the encoder terms
-        entirely and returns ``e_num = 0``.
+        The encode pool is the optional third rate-matched pool (EPD): the
+        achieved throughput is the min of the degraded pool capacities.
+        ``encoder_throughput = 0`` (plain PD) returns ``e_num = 0``.
         """
         prefill_opt, decode_opt, encoder_opt = -1, -1, -1
         throughput_per_gpu_max = 0.0
@@ -1441,12 +1371,10 @@ def sweep_disagg(
                 d_corrected = decode_throughput * d_num * decode_deg
                 pd_required = min(p_corrected, d_corrected)
                 if encoder_capacity > 0:
-                    # Sweep the encode pool up to the first size that no
-                    # longer binds; larger pools are dominated (same
-                    # throughput, more GPUs).  Smaller sizes trade capped
-                    # throughput for GPUs -- and under a per-replica GPU
-                    # budget they are sometimes the only feasible cells.
-                    e_num_candidates = range(1, max(1, math.ceil(pd_required / encoder_capacity)) + 1)
+                    # Full sweep like the P/D worker lists: sizes past the
+                    # first non-binding one are throughput-dominated, but can
+                    # be the only counts that land in num_gpu_set.
+                    e_num_candidates = range(1, _MAX_ENCODE_WORKERS + 1)
                 else:
                     e_num_candidates = (0,)
                 for e_num in e_num_candidates:

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import copy
 import dataclasses
 import logging
+import math
 import warnings
 from collections.abc import Iterator, Mapping
 from dataclasses import dataclass, field
@@ -628,6 +629,8 @@ class Task:
     # the practical efficiency loss.  Calibrated against silicon (V1 default).
     rate_match_prefill_degradation: float = 0.9
     rate_match_decode_degradation: float = 0.92
+    # Encode pool (EPD) takes the same class of loss as prefill.
+    rate_match_encoder_degradation: float = 0.9
     # TTFT pre-correction applied to prefill candidates before the SLA filter,
     # accounting for queueing-under-concurrency in the deployed system.
     # Used by both ``_find_best_disagg_under_constraint`` and
@@ -770,8 +773,15 @@ class Task:
 
     @classmethod
     def from_cli(cls, **kwargs: Any) -> Task:
-        """Construct from CLI kwargs.  Filters None to let __post_init__ defaults run."""
-        return cls(**{k: v for k, v in kwargs.items() if v is not None})
+        """Construct from CLI kwargs.  Filters None to let __post_init__ defaults
+        run; quant_mode strings resolve to enums as in ``from_yaml``."""
+        return cls(
+            **{
+                k: (_resolve_quant_str(k, v) if k.endswith("quant_mode") else v)
+                for k, v in kwargs.items()
+                if v is not None
+            }
+        )
 
     # =====================================================================
     # Convenience read-only views (primary = prefill side in disagg)
@@ -1928,17 +1938,10 @@ class Task:
         return rt
 
     def _prefill_effective_isl(self) -> int:
-        """Text ISL + vision context tokens (must match sweep_disagg's
-        effective-ISL computation so the batch intent in
-        ``prefill_max_num_tokens`` round-trips)."""
+        """Text ISL + vision context tokens for one request."""
         from aiconfigurator.sdk.backends.base_backend import BaseBackend
 
-        runtime_config = self.build_runtime_config()
-        try:
-            enc_cfg = get_model_config_from_model_path(self.primary_model_path).get("extra_params")
-        except Exception:
-            return runtime_config.isl
-        return runtime_config.isl + BaseBackend._visual_context_tokens_from_encoder_config(enc_cfg, runtime_config)
+        return BaseBackend.effective_prefill_isl(self.primary_model_path, self.build_runtime_config())
 
     def build_model_config(
         self,
@@ -2067,16 +2070,8 @@ class Task:
             raise ValueError(f"attention_backend must be 'flashinfer' or 'fa3', got {self.attention_backend!r}.")
         if self.wideep_num_slots is not None and self.wideep_num_slots <= 0:
             raise ValueError(f"wideep_num_slots must be a positive integer, got {self.wideep_num_slots!r}.")
-        # encoder_* fields are pure knobs; only enable_epd switches EPD on.
-        encoder_knobs_set = (
-            self.encoder_tp_candidates
-            or self.encoder_batch_candidates
-            or self.encoder_system_name
-            or self.max_encoder_workers is not None
-            or self.encoder_latency_correction != 1.0
-        )
-        if encoder_knobs_set and not self.enable_epd:
-            raise ValueError("encoder_* settings require enable_epd=True.")
+        self._check_encoder_knobs_require_epd()
+        self._validate_rate_match_degradations()
         if self.enable_epd:
             for name in ("encoder_tp_candidates", "encoder_batch_candidates"):
                 values = getattr(self, name)
@@ -2084,8 +2079,7 @@ class Task:
                     raise ValueError(f"{name} must be a list of positive ints, got {values!r}.")
             if self.max_encoder_workers is not None and self.max_encoder_workers <= 0:
                 raise ValueError(f"max_encoder_workers must be > 0, got {self.max_encoder_workers!r}.")
-            if self.encoder_latency_correction <= 0:
-                raise ValueError(f"encoder_latency_correction must be > 0, got {self.encoder_latency_correction!r}.")
+            self._validate_epd_knob_values()
         if self.serving_mode == "agg":
             self._validate_agg()
         elif self.serving_mode == "disagg":
@@ -2497,6 +2491,7 @@ class Task:
             "max_encoder_workers": self.max_encoder_workers,
             "encoder_latency_correction": self.encoder_latency_correction,
             "encoder_database": encoder_database,
+            "rate_matching_encoder_degradation": self.rate_match_encoder_degradation,
             # Per-cell (per-replica) budget for the E+agg rate matching; a
             # plain agg row is a single worker and ignores it.
             "num_gpu_list": self._replica_num_gpu_list() if self.enable_epd else None,
@@ -2541,6 +2536,7 @@ class Task:
             "num_gpu_list": self._replica_num_gpu_list(),
             "rate_matching_prefill_degradation": self.rate_match_prefill_degradation,
             "rate_matching_decode_degradation": self.rate_match_decode_degradation,
+            "rate_matching_encoder_degradation": self.rate_match_encoder_degradation,
             "autoscale_ttft_correction_factor": self.autoscale_ttft_correction_factor,
             "require_same_tp": self._require_same_tp_gate(),
             "enable_epd": self.enable_epd,
@@ -2735,13 +2731,42 @@ class Task:
     # Single-point evaluation (subsumes cli_estimate)
     # =====================================================================
 
+    def _check_encoder_knobs_require_epd(self) -> None:
+        # encoder_* fields are pure knobs; only enable_epd switches EPD on.
+        encoder_knobs_set = (
+            self.encoder_tp_candidates
+            or self.encoder_batch_candidates
+            or self.encoder_system_name
+            or self.max_encoder_workers is not None
+            or self.encoder_latency_correction != 1.0
+            or self.rate_match_encoder_degradation != 0.9
+        )
+        if encoder_knobs_set and not self.enable_epd:
+            raise ValueError("encoder_* settings require enable_epd=True.")
+
+    def _validate_rate_match_degradations(self) -> None:
+        for name in ("rate_match_prefill_degradation", "rate_match_decode_degradation"):
+            value = getattr(self, name)
+            if not math.isfinite(value) or value <= 0:
+                raise ValueError(f"{name} must be a positive finite number, got {value!r}.")
+
+    def _validate_epd_knob_values(self) -> None:
+        """Value-domain checks for the EPD scalar knobs; kept separate because
+        some entry points skip the full ``validate``."""
+        for name in ("encoder_latency_correction", "rate_match_encoder_degradation"):
+            value = getattr(self, name)
+            if not math.isfinite(value) or value <= 0:
+                raise ValueError(f"{name} must be a positive finite number, got {value!r}.")
+
     def _validate_single_point_epd_args(
         self, api_name: str, encoder_tp: int | None, encoder_batch_size: int, encoder_num_workers: int
     ) -> None:
         if not self.enable_epd:
+            self._check_encoder_knobs_require_epd()
             if encoder_tp is not None or encoder_batch_size != 1 or encoder_num_workers != 1:
                 raise ValueError("encoder_* arguments require enable_epd=True.")
             return
+        self._validate_epd_knob_values()
         if encoder_tp is None:
             raise ValueError(f"{api_name} with enable_epd requires encoder_tp for the encode worker.")
         for name, value in (
@@ -2789,6 +2814,7 @@ class Task:
             encoder_num_workers,
             prefill_power=prefill_power,
             decode_power=decode_power,
+            encoder_degradation=self.rate_match_encoder_degradation,
         )
 
     def run_single_agg(
@@ -2940,6 +2966,7 @@ class Task:
             RuntimeError: on OOM in either phase.
         """
         self._validate_single_point_epd_args("run_single_disagg", encoder_tp, encoder_batch_size, encoder_num_workers)
+        self._validate_rate_match_degradations()
         if self.serving_mode != "disagg":
             raise ValueError(
                 f"run_single_disagg requires serving_mode='disagg', got {self.serving_mode!r}; "
@@ -3023,8 +3050,21 @@ class Task:
         # --- Rate-match the pair ---
         p_dict = p_summary.get_summary_df().iloc[0].to_dict()
         d_dict = d_summary.get_summary_df().iloc[0].to_dict()
-        row = _rate_match_dict(p_dict, prefill_num_workers, d_dict, decode_num_workers)
-        row["power_coverage"] = min(p_summary.get_power_data_coverage(), d_summary.get_power_data_coverage())
+        row = _rate_match_dict(
+            p_dict,
+            prefill_num_workers,
+            d_dict,
+            decode_num_workers,
+            prefill_degradation=self.rate_match_prefill_degradation,
+            decode_degradation=self.rate_match_decode_degradation,
+        )
+        # Time-weighted over the P + D phases, matching the weights the
+        # encoder overlay applies when it blends in the encoder coverage.
+        decode_time = row["tpot"] * max(row["osl"] - 1, 0)
+        lm_time = row["ttft"] + decode_time
+        p_cov = p_summary.get_power_data_coverage()
+        d_cov = d_summary.get_power_data_coverage()
+        row["power_coverage"] = (p_cov * row["ttft"] + d_cov * decode_time) / lm_time if lm_time > 0 else 0.0
         if not self.enable_epd:
             return row
         return self._overlay_single_point_encoder(

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -882,6 +882,8 @@ class Task:
         workers model the engines' encoder-instance default (weight-sharded
         ViT), and language-only P/agg workers host no ViT to shard."""
         if self.enable_epd:
+            if self.serving_mode not in ("agg", "disagg"):
+                raise ValueError(f"enable_epd requires serving_mode 'agg' or 'disagg', got {self.serving_mode!r}.")
             self.enable_encoder_dp = False
 
     def _validate_megamoe_backend_support(self) -> None:

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -507,9 +507,8 @@ class Task:
     image_height: int = 0
     image_width: int = 0
     num_images_per_request: int = 1
-    # Vision encoder data parallelism (ModelConfig default).  Pinned off under
-    # enable_epd by _normalize_epd_encoder_dp: EPD encode workers model the
-    # engines' encoder-instance default (weight-sharded ViT).
+    # Vision encoder data parallelism (ModelConfig default); pinned off under
+    # enable_epd by _normalize_epd_encoder_dp.
     enable_encoder_dp: bool = True
     ttft: float = 1000.0
     tpot: float = 50.0
@@ -636,21 +635,15 @@ class Task:
     autoscale_ttft_correction_factor: float = 1.8
 
     # ====== 8.6 EPD: encoder disaggregation (VL models) ======
-    # enable_epd runs the vision encoder on dedicated encode workers, swept
-    # over tp x batch.  serving_mode='disagg' gives E+P+D; serving_mode='agg'
-    # gives E+agg (encoder disaggregated, prefill+decode aggregated).  The
-    # P/agg workers become language-only (vision tokens stay in context, no
-    # ViT hosted); TTFT adds the encode batch latency; the encode pool joins
-    # the worker rate matching.  Default (False) keeps the encoder inline
-    # (colocated) in both serving modes.
+    # enable_epd runs the vision encoder on dedicated encode workers:
+    # disagg -> E+P+D, agg -> E+agg.  P/agg workers become language-only and
+    # the encode pool joins the rate matching.
     enable_epd: bool = False
     encoder_tp_candidates: list[int] | None = None  # None -> [1, 2, 4, 8]
     encoder_batch_candidates: list[int] | None = None  # None -> default schedule
     encoder_latency_correction: float = 1.0
-    # Encode workers may run on a different system (GPU type) than the
-    # P/agg side (hetero encoder, mirroring prefill_/decode_system_name);
-    # backend and version follow the prefill/agg side.  None inherits the
-    # P/agg system too.
+    # Hetero encoder: encode workers on their own system (GPU type);
+    # backend/version follow the P/agg side.  None inherits the P/agg system.
     encoder_system_name: str | None = None
 
     # ====== 8.5 Predictor strategy ======
@@ -872,15 +865,9 @@ class Task:
             self.moe_backend = "deepep_moe"
 
     def _normalize_epd_encoder_dp(self) -> None:
-        """enable_epd pins the colocated encoder-DP knob off.
-
-        EPD encode workers model the engines' encoder-instance default
-        parallelism -- a weight-sharded ViT over the worker's tp (vLLM
-        ``mm_encoder_tp_mode="weights"``, SGLang ``mm_enable_dp_encoder=False``,
-        both independent of their disaggregation flags) -- and the
-        language-only P/agg workers host no ViT, so the colocated DP layout
-        has nothing to act on.  Pinning the field keeps the task state and
-        any rendered engine args consistent with what the sweep modeled."""
+        """enable_epd pins the colocated encoder-DP knob off: EPD encode
+        workers model the engines' encoder-instance default (weight-sharded
+        ViT), and language-only P/agg workers host no ViT to shard."""
         if self.enable_epd:
             self.enable_encoder_dp = False
 
@@ -1591,8 +1578,7 @@ class Task:
             if getattr(self, name) is None:
                 setattr(self, name, values)
 
-        # E+agg cells are replicas: resolve the same per-replica GPU budget
-        # defaults as disagg replicas (same fields, same code).
+        # E+agg cells are replicas: same per-replica budget defaults as disagg.
         if self.enable_epd:
             self._resolve_replica_budget()
 
@@ -1939,16 +1925,17 @@ class Task:
         return rt
 
     def _prefill_effective_isl(self) -> int:
-        """Text ISL + per-request vision context tokens (plain ISL for
-        text-only workloads or when the model config cannot be resolved).
+        """Text ISL + vision context tokens (must match sweep_disagg's
+        effective-ISL computation so the batch intent in
+        ``prefill_max_num_tokens`` round-trips)."""
+        from aiconfigurator.sdk.backends.base_backend import BaseBackend
 
-        Delegates to :func:`sweep.vl_effective_isl` -- the same implementation
-        sweep_disagg divides its token budget by, so the batch intent encoded
-        in ``prefill_max_num_tokens`` round-trips exactly.
-        """
-        from aiconfigurator.sdk.sweep import vl_effective_isl
-
-        return vl_effective_isl(self.primary_model_path, self.build_runtime_config())
+        runtime_config = self.build_runtime_config()
+        try:
+            enc_cfg = get_model_config_from_model_path(self.primary_model_path).get("extra_params")
+        except Exception:
+            return runtime_config.isl
+        return runtime_config.isl + BaseBackend._visual_context_tokens_from_encoder_config(enc_cfg, runtime_config)
 
     def build_model_config(
         self,
@@ -2077,9 +2064,7 @@ class Task:
             raise ValueError(f"attention_backend must be 'flashinfer' or 'fa3', got {self.attention_backend!r}.")
         if self.wideep_num_slots is not None and self.wideep_num_slots <= 0:
             raise ValueError(f"wideep_num_slots must be a positive integer, got {self.wideep_num_slots!r}.")
-        # EPD is switched on explicitly and only by enable_epd (both serving
-        # modes); every other encoder_* field is a pure search-space /
-        # placement / calibration knob and must not act as an implicit switch.
+        # encoder_* fields are pure knobs; only enable_epd switches EPD on.
         encoder_knobs_set = (
             self.encoder_tp_candidates
             or self.encoder_batch_candidates
@@ -2088,6 +2073,13 @@ class Task:
         )
         if encoder_knobs_set and not self.enable_epd:
             raise ValueError("encoder_* settings require enable_epd=True.")
+        if self.enable_epd:
+            for name in ("encoder_tp_candidates", "encoder_batch_candidates"):
+                values = getattr(self, name)
+                if values and any(not isinstance(v, int) or v <= 0 for v in values):
+                    raise ValueError(f"{name} must be a list of positive ints, got {values!r}.")
+            if self.encoder_latency_correction <= 0:
+                raise ValueError(f"encoder_latency_correction must be > 0, got {self.encoder_latency_correction!r}.")
         if self.serving_mode == "agg":
             self._validate_agg()
         elif self.serving_mode == "disagg":
@@ -2722,7 +2714,14 @@ class Task:
         P/agg-side database."""
         if not (self.enable_epd and self.encoder_system_name):
             return None
-        return self._load_database(self.encoder_system_name, default_backend, default_version)
+        database = self._load_database(self.encoder_system_name, default_backend, default_version)
+        if database is None:
+            raise ValueError(
+                f"encoder_system_name={self.encoder_system_name!r}: no perf database for "
+                f"backend={default_backend!r} version={default_version!r} (encoder follows "
+                "the P/agg-side backend/version)."
+            )
+        return database
 
     # =====================================================================
     # Single-point evaluation (subsumes cli_estimate)

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -1908,14 +1908,15 @@ class Task:
 
     def _prefill_effective_isl(self) -> int:
         """Text ISL + per-request vision context tokens (plain ISL for
-        text-only workloads or when the model config cannot be resolved)."""
-        from aiconfigurator.sdk.backends.base_backend import BaseBackend
+        text-only workloads or when the model config cannot be resolved).
 
-        try:
-            enc_cfg = get_model_config_from_model_path(self.primary_model_path).get("extra_params")
-        except Exception:
-            return self.isl
-        return self.isl + BaseBackend._visual_context_tokens_from_encoder_config(enc_cfg, self.build_runtime_config())
+        Delegates to :func:`sweep.vl_effective_isl` -- the same implementation
+        sweep_disagg divides its token budget by, so the batch intent encoded
+        in ``prefill_max_num_tokens`` round-trips exactly.
+        """
+        from aiconfigurator.sdk.sweep import vl_effective_isl
+
+        return vl_effective_isl(self.primary_model_path, self.build_runtime_config())
 
     def build_model_config(
         self,

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -507,7 +507,9 @@ class Task:
     image_height: int = 0
     image_width: int = 0
     num_images_per_request: int = 1
-    # Vision encoder data parallelism (ModelConfig default).
+    # Vision encoder data parallelism (ModelConfig default).  Pinned off under
+    # enable_epd by _normalize_epd_encoder_dp: EPD encode workers model the
+    # engines' encoder-instance default (weight-sharded ViT).
     enable_encoder_dp: bool = True
     ttft: float = 1000.0
     tpot: float = 50.0
@@ -836,6 +838,7 @@ class Task:
             raise ValueError("nextn='auto' requires a model path to resolve num_nextn_predict_layers.")
         self._resolve_backend_version()
         self._normalize_wideep_moe_backend()
+        self._normalize_epd_encoder_dp()
         self._resolve_quant_modes()
         # The search space is resolved BEFORE the data-driven FMHA fallback:
         # the attention-op keys the fallback consults depend on whether any
@@ -867,6 +870,19 @@ class Task:
         )
         if wideep:
             self.moe_backend = "deepep_moe"
+
+    def _normalize_epd_encoder_dp(self) -> None:
+        """enable_epd pins the colocated encoder-DP knob off.
+
+        EPD encode workers model the engines' encoder-instance default
+        parallelism -- a weight-sharded ViT over the worker's tp (vLLM
+        ``mm_encoder_tp_mode="weights"``, SGLang ``mm_enable_dp_encoder=False``,
+        both independent of their disaggregation flags) -- and the
+        language-only P/agg workers host no ViT, so the colocated DP layout
+        has nothing to act on.  Pinning the field keeps the task state and
+        any rendered engine args consistent with what the sweep modeled."""
+        if self.enable_epd:
+            self.enable_encoder_dp = False
 
     def _validate_megamoe_backend_support(self) -> None:
         """v1 _validate_megamoe_backend_support: megamoe is sglang + DeepSeek-V4-Pro + Blackwell only."""

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -2884,6 +2884,7 @@ class Task:
         result = summary.get_result_dict()
         if result is None:
             raise RuntimeError("run_single_agg produced no result; configuration may be invalid.")
+        result["power_coverage"] = summary.get_power_data_coverage()
         if not self.enable_epd:
             return result
         result["(a)workers"] = 1
@@ -3023,6 +3024,7 @@ class Task:
         p_dict = p_summary.get_summary_df().iloc[0].to_dict()
         d_dict = d_summary.get_summary_df().iloc[0].to_dict()
         row = _rate_match_dict(p_dict, prefill_num_workers, d_dict, decode_num_workers)
+        row["power_coverage"] = min(p_summary.get_power_data_coverage(), d_summary.get_power_data_coverage())
         if not self.enable_epd:
             return row
         return self._overlay_single_point_encoder(

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -2735,11 +2735,22 @@ class Task:
     # Single-point evaluation (subsumes cli_estimate)
     # =====================================================================
 
-    def _validate_single_point_epd_args(self, api_name: str, encoder_tp: int | None) -> None:
-        if self.enable_epd and encoder_tp is None:
+    def _validate_single_point_epd_args(
+        self, api_name: str, encoder_tp: int | None, encoder_batch_size: int, encoder_num_workers: int
+    ) -> None:
+        if not self.enable_epd:
+            if encoder_tp is not None or encoder_batch_size != 1 or encoder_num_workers != 1:
+                raise ValueError("encoder_* arguments require enable_epd=True.")
+            return
+        if encoder_tp is None:
             raise ValueError(f"{api_name} with enable_epd requires encoder_tp for the encode worker.")
-        if encoder_tp is not None and not self.enable_epd:
-            raise ValueError("encoder_tp requires enable_epd=True.")
+        for name, value in (
+            ("encoder_tp", encoder_tp),
+            ("encoder_batch_size", encoder_batch_size),
+            ("encoder_num_workers", encoder_num_workers),
+        ):
+            if not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive int, got {value!r}.")
 
     def _overlay_single_point_encoder(
         self,
@@ -2824,7 +2835,7 @@ class Task:
                 :meth:`run_single_disagg` instead.
             RuntimeError: on OOM at this config point.
         """
-        self._validate_single_point_epd_args("run_single_agg", encoder_tp)
+        self._validate_single_point_epd_args("run_single_agg", encoder_tp, encoder_batch_size, encoder_num_workers)
         if self.serving_mode != "agg":
             raise ValueError(
                 f"run_single_agg requires serving_mode='agg', got {self.serving_mode!r}; "
@@ -2927,7 +2938,7 @@ class Task:
             ValueError: if called on an agg Task.
             RuntimeError: on OOM in either phase.
         """
-        self._validate_single_point_epd_args("run_single_disagg", encoder_tp)
+        self._validate_single_point_epd_args("run_single_disagg", encoder_tp, encoder_batch_size, encoder_num_workers)
         if self.serving_mode != "disagg":
             raise ValueError(
                 f"run_single_disagg requires serving_mode='disagg', got {self.serving_mode!r}; "

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -1575,13 +1575,10 @@ class Task:
             if getattr(self, name) is None:
                 setattr(self, name, values)
 
-        # E+agg cells are replicas: give them the same per-replica GPU budget
-        # defaults as disagg replicas (same fields, same vocabulary).
+        # E+agg cells are replicas: resolve the same per-replica GPU budget
+        # defaults as disagg replicas (same fields, same code).
         if self.enable_epd:
-            if self.num_gpu_per_replica is None:
-                self.num_gpu_per_replica = [1, 2, 4, 8] + list(range(16, 129, 8))
-            if self.max_gpu_per_replica is None:
-                self.max_gpu_per_replica = 128
+            self._resolve_replica_budget()
 
         # CP auto-sweep for validated families (sglang); [1] otherwise. agg runs
         # prefill in-worker, so cp applies; decode-cp=1 is enforced in iter_parallel.
@@ -1714,14 +1711,19 @@ class Task:
             if self.max_gpu_per_replica is None:
                 self.max_gpu_per_replica = 512
         else:
-            if self.num_gpu_per_replica is None:
-                self.num_gpu_per_replica = [1, 2, 4, 8] + list(range(16, 129, 8))
-            if self.max_gpu_per_replica is None:
-                self.max_gpu_per_replica = 128
+            self._resolve_replica_budget()
         if self.max_prefill_workers is None:
             self.max_prefill_workers = 32
         if self.max_decode_workers is None:
             self.max_decode_workers = 32
+
+    def _resolve_replica_budget(self) -> None:
+        """Default per-replica GPU budget, shared by disagg replicas and
+        (under enable_epd) E+agg cells — an E+agg cell is a replica."""
+        if self.num_gpu_per_replica is None:
+            self.num_gpu_per_replica = [1, 2, 4, 8] + list(range(16, 129, 8))
+        if self.max_gpu_per_replica is None:
+            self.max_gpu_per_replica = 128
 
     def _resolve_afd_search(self) -> None:
         """Resolve AFD search space: enumerate candidate topologies.
@@ -2061,8 +2063,13 @@ class Task:
             raise ValueError(f"wideep_num_slots must be a positive integer, got {self.wideep_num_slots!r}.")
         # EPD is switched on explicitly and only by enable_epd (both serving
         # modes); every other encoder_* field is a pure search-space /
-        # placement knob and must not act as an implicit switch.
-        encoder_knobs_set = self.encoder_tp_candidates or self.encoder_batch_candidates or self.encoder_system_name
+        # placement / calibration knob and must not act as an implicit switch.
+        encoder_knobs_set = (
+            self.encoder_tp_candidates
+            or self.encoder_batch_candidates
+            or self.encoder_system_name
+            or self.encoder_latency_correction != 1.0
+        )
         if encoder_knobs_set and not self.enable_epd:
             raise ValueError("encoder_* settings require enable_epd=True.")
         if self.serving_mode == "agg":

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -2077,6 +2077,14 @@ class Task:
                 values = getattr(self, name)
                 if values and any(not isinstance(v, int) or v <= 0 for v in values):
                     raise ValueError(f"{name} must be a list of positive ints, got {values!r}.")
+            if self.encoder_batch_candidates:
+                from aiconfigurator.sdk.sweep import _MAX_ENCODER_BATCH
+
+                if max(self.encoder_batch_candidates) > _MAX_ENCODER_BATCH:
+                    raise ValueError(
+                        f"encoder_batch_candidates must be <= {_MAX_ENCODER_BATCH} (SGLang's "
+                        f"SGLANG_ENCODER_MAX_BATCH_SIZE default), got {self.encoder_batch_candidates!r}."
+                    )
             if self.max_encoder_workers is not None and self.max_encoder_workers <= 0:
                 raise ValueError(f"max_encoder_workers must be > 0, got {self.max_encoder_workers!r}.")
             self._validate_epd_knob_values()
@@ -2776,6 +2784,13 @@ class Task:
         ):
             if not isinstance(value, int) or value <= 0:
                 raise ValueError(f"{name} must be a positive int, got {value!r}.")
+        from aiconfigurator.sdk.sweep import _MAX_ENCODER_BATCH
+
+        if encoder_batch_size > _MAX_ENCODER_BATCH:
+            raise ValueError(
+                f"encoder_batch_size must be <= {_MAX_ENCODER_BATCH} (SGLang's "
+                f"SGLANG_ENCODER_MAX_BATCH_SIZE default), got {encoder_batch_size}."
+            )
 
     def _overlay_single_point_encoder(
         self,

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -630,6 +630,16 @@ class Task:
     # ``picking.pick_autoscale``; default 1.8 locked by parity test.
     autoscale_ttft_correction_factor: float = 1.8
 
+    # ====== 8.6 EPD: encoder disaggregation (VL models, disagg only) ======
+    # enable_epd runs the vision encoder on dedicated encode workers, swept
+    # over tp x batch on the prefill database.  Prefill workers become
+    # language-only (vision tokens stay in context, no ViT hosted); TTFT adds
+    # the encode batch latency; the encode pool joins the worker rate matching.
+    enable_epd: bool = False
+    encoder_tp_candidates: list[int] | None = None  # None -> [1, 2, 4, 8]
+    encoder_batch_candidates: list[int] | None = None  # None -> default schedule
+    encoder_latency_correction: float = 1.0
+
     # ====== 8.5 Predictor strategy ======
     # Optional Predictor that decides how each single config point is
     # predicted.  None (default) uses sdk.predictor.AnalyticPredictor --
@@ -2030,6 +2040,8 @@ class Task:
             raise ValueError("agg mode requires model_path")
         if not self.system_name:
             raise ValueError("agg mode requires system_name")
+        if self.enable_epd:
+            raise ValueError("enable_epd (EPD) requires serving_mode='disagg'.")
         # fp8_static is not hard-gated to trtllm: it is derived from the dynamic
         # fp8 GEMM minus compute_scale/scale_matrix overhead and works on any
         # backend whose perf DB carries those tables.  _validate_database_quant_modes
@@ -2051,6 +2063,8 @@ class Task:
             )
         if not self.prefill_system_name or not self.decode_system_name:
             raise ValueError("disagg mode requires both prefill_system_name and decode_system_name.")
+        if (self.encoder_tp_candidates or self.encoder_batch_candidates) and not self.enable_epd:
+            raise ValueError("encoder_tp_candidates/encoder_batch_candidates require enable_epd=True.")
         # fp8_static is not hard-gated to trtllm (see _validate_agg); the
         # per-role DB check in _validate_database_quant_modes governs support.
 
@@ -2451,6 +2465,10 @@ class Task:
             "rate_matching_decode_degradation": self.rate_match_decode_degradation,
             "autoscale_ttft_correction_factor": self.autoscale_ttft_correction_factor,
             "require_same_tp": self._require_same_tp_gate(),
+            "enable_epd": self.enable_epd,
+            "encoder_tp_list": self.encoder_tp_candidates,
+            "encoder_batch_list": self.encoder_batch_candidates,
+            "encoder_latency_correction": self.encoder_latency_correction,
         }
 
     def sweep_afd_kwargs(self, *, database) -> dict[str, Any]:

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -641,6 +641,9 @@ class Task:
     enable_epd: bool = False
     encoder_tp_candidates: list[int] | None = None  # None -> [1, 2, 4, 8]
     encoder_batch_candidates: list[int] | None = None  # None -> default schedule
+    # Encode-pool size bound per rate-matched cell (None -> 32, mirroring
+    # max_prefill_workers/max_decode_workers).
+    max_encoder_workers: int | None = None
     encoder_latency_correction: float = 1.0
     # Hetero encoder: encode workers on their own system (GPU type);
     # backend/version follow the P/agg side.  None inherits the P/agg system.
@@ -2069,6 +2072,7 @@ class Task:
             self.encoder_tp_candidates
             or self.encoder_batch_candidates
             or self.encoder_system_name
+            or self.max_encoder_workers is not None
             or self.encoder_latency_correction != 1.0
         )
         if encoder_knobs_set and not self.enable_epd:
@@ -2078,6 +2082,8 @@ class Task:
                 values = getattr(self, name)
                 if values and any(not isinstance(v, int) or v <= 0 for v in values):
                     raise ValueError(f"{name} must be a list of positive ints, got {values!r}.")
+            if self.max_encoder_workers is not None and self.max_encoder_workers <= 0:
+                raise ValueError(f"max_encoder_workers must be > 0, got {self.max_encoder_workers!r}.")
             if self.encoder_latency_correction <= 0:
                 raise ValueError(f"encoder_latency_correction must be > 0, got {self.encoder_latency_correction!r}.")
         if self.serving_mode == "agg":
@@ -2488,6 +2494,7 @@ class Task:
             "enable_epd": self.enable_epd,
             "encoder_tp_list": self.encoder_tp_candidates,
             "encoder_batch_list": self.encoder_batch_candidates,
+            "max_encoder_workers": self.max_encoder_workers,
             "encoder_latency_correction": self.encoder_latency_correction,
             "encoder_database": encoder_database,
             # Per-cell (per-replica) budget for the E+agg rate matching; a
@@ -2539,6 +2546,7 @@ class Task:
             "enable_epd": self.enable_epd,
             "encoder_tp_list": self.encoder_tp_candidates,
             "encoder_batch_list": self.encoder_batch_candidates,
+            "max_encoder_workers": self.max_encoder_workers,
             "encoder_latency_correction": self.encoder_latency_correction,
             "encoder_database": encoder_database,
         }
@@ -2727,6 +2735,51 @@ class Task:
     # Single-point evaluation (subsumes cli_estimate)
     # =====================================================================
 
+    def _validate_single_point_epd_args(self, api_name: str, encoder_tp: int | None) -> None:
+        if self.enable_epd and encoder_tp is None:
+            raise ValueError(f"{api_name} with enable_epd requires encoder_tp for the encode worker.")
+        if encoder_tp is not None and not self.enable_epd:
+            raise ValueError("encoder_tp requires enable_epd=True.")
+
+    def _overlay_single_point_encoder(
+        self,
+        row: dict,
+        *,
+        runtime_config,
+        database,
+        backend_name: str,
+        backend_version: str | None,
+        encoder_tp: int,
+        encoder_batch_size: int,
+        encoder_num_workers: int,
+        prefill_power: float,
+        decode_power: float,
+    ) -> dict:
+        """Overlay one fixed encode worker onto a single-point row.
+
+        Reuses the sweep's candidate path (singleton lists) so the VRAM gate
+        and workload validation apply; single-point rows carry raw ttft, so
+        the encode stage joins uncorrected (overlay's default ttft_scale)."""
+        from aiconfigurator.sdk.sweep import _get_encoder_worker_candidates, _overlay_encoder_stage
+
+        encoder_database = self._load_encoder_database(backend_name, backend_version) or database
+        enc_worker = _get_encoder_worker_candidates(
+            model_path=self.primary_model_path,
+            tp_list=[encoder_tp],
+            b_list=[encoder_batch_size],
+            runtime_config=runtime_config,
+            database=encoder_database,
+            backend_name=backend_name,
+            latency_correction=self.encoder_latency_correction,
+        )[0]
+        return _overlay_encoder_stage(
+            row,
+            enc_worker,
+            encoder_num_workers,
+            prefill_power=prefill_power,
+            decode_power=decode_power,
+        )
+
     def run_single_agg(
         self,
         *,
@@ -2737,8 +2790,17 @@ class Task:
         moe_ep: int = 1,
         batch_size: int,
         ctx_tokens: int | None = None,
+        encoder_tp: int | None = None,
+        encoder_batch_size: int = 1,
+        encoder_num_workers: int = 1,
     ) -> dict:
         """Evaluate one fixed agg config point and return its row dict.
+
+        With ``enable_epd`` the point is one E+agg cell: a language-only agg
+        worker plus ``encoder_num_workers`` encode workers of ``encoder_tp``
+        x ``encoder_batch_size`` (required with enable_epd).  The encode
+        latency joins TTFT raw, matching this row's uncorrected convention;
+        the row then carries ``common.ColumnsAggEpd``.
 
         Subsumes the per-point use case that ``cli/api.cli_estimate``
         handles today (40 separate kwargs, custom model/backend wiring).
@@ -2762,6 +2824,7 @@ class Task:
                 :meth:`run_single_disagg` instead.
             RuntimeError: on OOM at this config point.
         """
+        self._validate_single_point_epd_args("run_single_agg", encoder_tp)
         if self.serving_mode != "agg":
             raise ValueError(
                 f"run_single_agg requires serving_mode='agg', got {self.serving_mode!r}; "
@@ -2772,6 +2835,8 @@ class Task:
         from aiconfigurator.sdk.predict import predict_agg_worker
 
         model_config = self.build_model_config(role="agg", parallel=(tp, pp, dp, moe_tp, moe_ep, 1))
+        if self.enable_epd:
+            model_config.language_only = True
         model_config.tp_size = tp
         model_config.pp_size = pp
         model_config.attention_dp_size = dp if self._is_moe else 1
@@ -2808,7 +2873,21 @@ class Task:
         result = summary.get_result_dict()
         if result is None:
             raise RuntimeError("run_single_agg produced no result; configuration may be invalid.")
-        return result
+        if not self.enable_epd:
+            return result
+        result["(a)workers"] = 1
+        return self._overlay_single_point_encoder(
+            result,
+            runtime_config=runtime_config,
+            database=database,
+            backend_name=self.backend_name,
+            backend_version=self.backend_version,
+            encoder_tp=encoder_tp,
+            encoder_batch_size=encoder_batch_size,
+            encoder_num_workers=encoder_num_workers,
+            prefill_power=result.get("power_w", 0.0),
+            decode_power=result.get("power_w", 0.0),
+        )
 
     def run_single_disagg(
         self,
@@ -2827,12 +2906,18 @@ class Task:
         decode_moe_ep: int = 1,
         decode_batch_size: int,
         decode_num_workers: int = 1,
+        encoder_tp: int | None = None,
+        encoder_batch_size: int = 1,
+        encoder_num_workers: int = 1,
     ) -> dict:
         """Evaluate one fixed disagg config point and return its row dict.
 
         Subsumes the disagg per-point use case from ``cli_estimate``.
         Reads workload + model_path + quant from the Task; per-role
-        parallelism, batch_size, and num_workers come from args.
+        parallelism, batch_size, and num_workers come from args.  With
+        ``enable_epd`` the prefill worker is language-only and the encode
+        stage (``encoder_tp`` x ``encoder_batch_size``, required with
+        enable_epd) overlays the rate-matched pair.
 
         Returns:
             Row dict in ``common.ColumnsDisagg`` schema (one rate-matched
@@ -2842,6 +2927,7 @@ class Task:
             ValueError: if called on an agg Task.
             RuntimeError: on OOM in either phase.
         """
+        self._validate_single_point_epd_args("run_single_disagg", encoder_tp)
         if self.serving_mode != "disagg":
             raise ValueError(
                 f"run_single_disagg requires serving_mode='disagg', got {self.serving_mode!r}; "
@@ -2856,6 +2942,8 @@ class Task:
         p_mc = self.build_model_config(
             role="prefill", parallel=(prefill_tp, prefill_pp, prefill_dp, prefill_moe_tp, prefill_moe_ep, 1)
         )
+        if self.enable_epd:
+            p_mc.language_only = True
         p_mc.tp_size = prefill_tp
         p_mc.pp_size = prefill_pp
         p_mc.attention_dp_size = prefill_dp if self._is_moe else 1
@@ -2923,7 +3011,21 @@ class Task:
         # --- Rate-match the pair ---
         p_dict = p_summary.get_summary_df().iloc[0].to_dict()
         d_dict = d_summary.get_summary_df().iloc[0].to_dict()
-        return _rate_match_dict(p_dict, prefill_num_workers, d_dict, decode_num_workers)
+        row = _rate_match_dict(p_dict, prefill_num_workers, d_dict, decode_num_workers)
+        if not self.enable_epd:
+            return row
+        return self._overlay_single_point_encoder(
+            row,
+            runtime_config=p_rt,
+            database=p_db,
+            backend_name=self.prefill_backend_name,
+            backend_version=self.prefill_backend_version,
+            encoder_tp=encoder_tp,
+            encoder_batch_size=encoder_batch_size,
+            encoder_num_workers=encoder_num_workers,
+            prefill_power=p_dict.get("power_w", 0.0),
+            decode_power=d_dict.get("power_w", 0.0),
+        )
 
     def _run_afd_single_point(self, database):
         """Run a single pinned-topology AFD estimate via AFDInferenceSession."""

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -630,11 +630,14 @@ class Task:
     # ``picking.pick_autoscale``; default 1.8 locked by parity test.
     autoscale_ttft_correction_factor: float = 1.8
 
-    # ====== 8.6 EPD: encoder disaggregation (VL models, disagg only) ======
+    # ====== 8.6 EPD: encoder disaggregation (VL models) ======
     # enable_epd runs the vision encoder on dedicated encode workers, swept
-    # over tp x batch on the prefill database.  Prefill workers become
-    # language-only (vision tokens stay in context, no ViT hosted); TTFT adds
-    # the encode batch latency; the encode pool joins the worker rate matching.
+    # over tp x batch.  serving_mode='disagg' gives E+P+D; serving_mode='agg'
+    # gives E+agg (encoder disaggregated, prefill+decode aggregated).  The
+    # P/agg workers become language-only (vision tokens stay in context, no
+    # ViT hosted); TTFT adds the encode batch latency; the encode pool joins
+    # the worker rate matching.  Default (False) keeps the encoder inline
+    # (colocated) in both serving modes.
     enable_epd: bool = False
     encoder_tp_candidates: list[int] | None = None  # None -> [1, 2, 4, 8]
     encoder_batch_candidates: list[int] | None = None  # None -> default schedule
@@ -2025,6 +2028,10 @@ class Task:
             raise ValueError(f"attention_backend must be 'flashinfer' or 'fa3', got {self.attention_backend!r}.")
         if self.wideep_num_slots is not None and self.wideep_num_slots <= 0:
             raise ValueError(f"wideep_num_slots must be a positive integer, got {self.wideep_num_slots!r}.")
+        # EPD is switched on explicitly and only by enable_epd (both serving
+        # modes); the encoder candidate lists are pure search-space knobs.
+        if (self.encoder_tp_candidates or self.encoder_batch_candidates) and not self.enable_epd:
+            raise ValueError("encoder_tp_candidates/encoder_batch_candidates require enable_epd=True.")
         if self.serving_mode == "agg":
             self._validate_agg()
         elif self.serving_mode == "disagg":
@@ -2040,8 +2047,6 @@ class Task:
             raise ValueError("agg mode requires model_path")
         if not self.system_name:
             raise ValueError("agg mode requires system_name")
-        if self.enable_epd:
-            raise ValueError("enable_epd (EPD) requires serving_mode='disagg'.")
         # fp8_static is not hard-gated to trtllm: it is derived from the dynamic
         # fp8 GEMM minus compute_scale/scale_matrix overhead and works on any
         # backend whose perf DB carries those tables.  _validate_database_quant_modes
@@ -2063,8 +2068,6 @@ class Task:
             )
         if not self.prefill_system_name or not self.decode_system_name:
             raise ValueError("disagg mode requires both prefill_system_name and decode_system_name.")
-        if (self.encoder_tp_candidates or self.encoder_batch_candidates) and not self.enable_epd:
-            raise ValueError("encoder_tp_candidates/encoder_batch_candidates require enable_epd=True.")
         # fp8_static is not hard-gated to trtllm (see _validate_agg); the
         # per-role DB check in _validate_database_quant_modes governs support.
 
@@ -2416,6 +2419,10 @@ class Task:
             "enable_chunked_prefill": self.enable_chunked_prefill,
             "free_gpu_memory_fraction": self.free_gpu_memory_fraction,
             "max_seq_len": self.max_seq_len,
+            "enable_epd": self.enable_epd,
+            "encoder_tp_list": self.encoder_tp_candidates,
+            "encoder_batch_list": self.encoder_batch_candidates,
+            "encoder_latency_correction": self.encoder_latency_correction,
         }
 
     def sweep_disagg_kwargs(self, *, prefill_database, decode_database) -> dict[str, Any]:

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -642,6 +642,11 @@ class Task:
     encoder_tp_candidates: list[int] | None = None  # None -> [1, 2, 4, 8]
     encoder_batch_candidates: list[int] | None = None  # None -> default schedule
     encoder_latency_correction: float = 1.0
+    # Encode workers may run on a different system (GPU type) than the
+    # P/agg side (hetero encoder, mirroring prefill_/decode_system_name);
+    # backend and version follow the prefill/agg side.  None inherits the
+    # P/agg system too.
+    encoder_system_name: str | None = None
 
     # ====== 8.5 Predictor strategy ======
     # Optional Predictor that decides how each single config point is
@@ -1901,6 +1906,17 @@ class Task:
             rt.batch_size = batch_size
         return rt
 
+    def _prefill_effective_isl(self) -> int:
+        """Text ISL + per-request vision context tokens (plain ISL for
+        text-only workloads or when the model config cannot be resolved)."""
+        from aiconfigurator.sdk.backends.base_backend import BaseBackend
+
+        try:
+            enc_cfg = get_model_config_from_model_path(self.primary_model_path).get("extra_params")
+        except Exception:
+            return self.isl
+        return self.isl + BaseBackend._visual_context_tokens_from_encoder_config(enc_cfg, self.build_runtime_config())
+
     def build_model_config(
         self,
         *,
@@ -2029,9 +2045,11 @@ class Task:
         if self.wideep_num_slots is not None and self.wideep_num_slots <= 0:
             raise ValueError(f"wideep_num_slots must be a positive integer, got {self.wideep_num_slots!r}.")
         # EPD is switched on explicitly and only by enable_epd (both serving
-        # modes); the encoder candidate lists are pure search-space knobs.
-        if (self.encoder_tp_candidates or self.encoder_batch_candidates) and not self.enable_epd:
-            raise ValueError("encoder_tp_candidates/encoder_batch_candidates require enable_epd=True.")
+        # modes); every other encoder_* field is a pure search-space /
+        # placement knob and must not act as an implicit switch.
+        encoder_knobs_set = self.encoder_tp_candidates or self.encoder_batch_candidates or self.encoder_system_name
+        if encoder_knobs_set and not self.enable_epd:
+            raise ValueError("encoder_* settings require enable_epd=True.")
         if self.serving_mode == "agg":
             self._validate_agg()
         elif self.serving_mode == "disagg":
@@ -2395,7 +2413,7 @@ class Task:
     # sweep.py kwargs builders
     # =====================================================================
 
-    def sweep_agg_kwargs(self, *, database) -> dict[str, Any]:
+    def sweep_agg_kwargs(self, *, database, encoder_database=None) -> dict[str, Any]:
         """Return the exact kwargs needed for sweep.sweep_agg.
 
         Caller is responsible for loading the perf database (so it can be
@@ -2423,9 +2441,10 @@ class Task:
             "encoder_tp_list": self.encoder_tp_candidates,
             "encoder_batch_list": self.encoder_batch_candidates,
             "encoder_latency_correction": self.encoder_latency_correction,
+            "encoder_database": encoder_database,
         }
 
-    def sweep_disagg_kwargs(self, *, prefill_database, decode_database) -> dict[str, Any]:
+    def sweep_disagg_kwargs(self, *, prefill_database, decode_database, encoder_database=None) -> dict[str, Any]:
         """Return the exact kwargs needed for sweep.sweep_disagg."""
         if self.serving_mode != "disagg":
             raise ValueError(f"sweep_disagg_kwargs requires serving_mode='disagg', got {self.serving_mode!r}")
@@ -2463,7 +2482,12 @@ class Task:
             "decode_parallel_config_list": decode_parallel,
             "decode_latency_correction": self.decode_latency_correction,
             "free_gpu_memory_fraction": self.free_gpu_memory_fraction,
-            "prefill_max_num_tokens": max(self.prefill_max_batch_size, 1) * self.isl,
+            # Token budget for prefill_max_batch_size requests: VL requests
+            # spend effective-ISL tokens (text + vision) of the engine's
+            # max_num_tokens each, so the budget is derived from it too --
+            # sweep_disagg divides by the same effective ISL, preserving the
+            # user's batch intent for VL and text alike.
+            "prefill_max_num_tokens": max(self.prefill_max_batch_size, 1) * self._prefill_effective_isl(),
             "decode_max_num_tokens": self.decode_max_batch_size,
             "prefill_num_worker_list": prefill_worker_list,
             "decode_num_worker_list": decode_worker_list,
@@ -2476,6 +2500,7 @@ class Task:
             "encoder_tp_list": self.encoder_tp_candidates,
             "encoder_batch_list": self.encoder_batch_candidates,
             "encoder_latency_correction": self.encoder_latency_correction,
+            "encoder_database": encoder_database,
         }
 
     def sweep_afd_kwargs(self, *, database) -> dict[str, Any]:
@@ -2608,8 +2633,9 @@ class Task:
             if autoscale:
                 raise ValueError("autoscale is only supported in disagg mode")
             database = self._load_database(self.system_name, self.backend_name, self.backend_version)
+            encoder_database = self._load_encoder_database(self.backend_name, self.backend_version)
             return sweep_agg(
-                **self.sweep_agg_kwargs(database=database),
+                **self.sweep_agg_kwargs(database=database, encoder_database=encoder_database),
                 predictor=self.predictor,
                 speculative_profile=self.build_speculative_profile(),
             )
@@ -2628,13 +2654,27 @@ class Task:
             decode_database = self._load_database(
                 self.decode_system_name, self.decode_backend_name, self.decode_backend_version
             )
+            encoder_database = self._load_encoder_database(self.prefill_backend_name, self.prefill_backend_version)
             return sweep_disagg(
-                **self.sweep_disagg_kwargs(prefill_database=prefill_database, decode_database=decode_database),
+                **self.sweep_disagg_kwargs(
+                    prefill_database=prefill_database,
+                    decode_database=decode_database,
+                    encoder_database=encoder_database,
+                ),
                 autoscale=autoscale,
                 predictor=self.predictor,
                 speculative_profile=self.build_speculative_profile(),
             )
         raise ValueError(f"Invalid serving_mode: {self.serving_mode!r}")
+
+    def _load_encoder_database(self, default_backend: str, default_version: str | None):
+        """Load the encode-pool perf DB when EPD places it on its own system
+        (GPU type); backend/version follow the P/agg side.  None when EPD is
+        off or no encoder system is set -- the sweep then reuses the
+        P/agg-side database."""
+        if not (self.enable_epd and self.encoder_system_name):
+            return None
+        return self._load_database(self.encoder_system_name, default_backend, default_version)
 
     # =====================================================================
     # Single-point evaluation (subsumes cli_estimate)

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -611,6 +611,9 @@ class Task:
     decode_cp_candidates: list[int] | None = None
 
     # ====== 8. Disagg orchestration ======
+    # Per-replica GPU budget (allowed replica sizes / size ceiling).  Disagg
+    # replicas always obey it; with enable_epd it also budgets the E+agg
+    # cells (an E+agg cell is a replica), with the same defaults.
     num_gpu_per_replica: list[int] | None = None
     max_gpu_per_replica: int | None = None
     max_prefill_workers: int | None = None
@@ -1553,6 +1556,9 @@ class Task:
             if self.total_gpus < 0:
                 raise ValueError(f"total_gpus of agg must be no smaller than 0, got {self.total_gpus}")
             self.agg_num_gpu_candidates = [n for n in self.agg_num_gpu_candidates if n <= self.total_gpus]
+            # E+agg cells are replicas: clamp their budget like disagg below.
+            if self.enable_epd and self.max_gpu_per_replica is not None:
+                self.max_gpu_per_replica = min(self.total_gpus, self.max_gpu_per_replica)
         else:
             if self.total_gpus < 2:
                 raise ValueError(f"total_gpus must be greater than 2 for disagg, got {self.total_gpus}")
@@ -1568,6 +1574,14 @@ class Task:
         def _set(name: str, values: list[int]) -> None:
             if getattr(self, name) is None:
                 setattr(self, name, values)
+
+        # E+agg cells are replicas: give them the same per-replica GPU budget
+        # defaults as disagg replicas (same fields, same vocabulary).
+        if self.enable_epd:
+            if self.num_gpu_per_replica is None:
+                self.num_gpu_per_replica = [1, 2, 4, 8] + list(range(16, 129, 8))
+            if self.max_gpu_per_replica is None:
+                self.max_gpu_per_replica = 128
 
         # CP auto-sweep for validated families (sglang); [1] otherwise. agg runs
         # prefill in-worker, so cp applies; decode-cp=1 is enforced in iter_parallel.
@@ -2414,6 +2428,24 @@ class Task:
     # sweep.py kwargs builders
     # =====================================================================
 
+    def _replica_num_gpu_list(self) -> list[int] | None:
+        """Allowed per-replica GPU counts for the sweep's rate matching.
+
+        Mirror v1 get_working_list(num_gpu_per_replica, max_gpu_per_replica):
+        an explicit list is filtered by the cap; a None list (WideEP) becomes
+        range(1, cap+1) so the replica size stays bounded (the sweep gates by
+        this list, not a max ceiling).  Used by disagg replicas and, under
+        enable_epd, by the E+agg cells.
+        """
+        if self.num_gpu_per_replica:
+            num_gpu_list = self.num_gpu_per_replica
+            if self.max_gpu_per_replica is not None:
+                num_gpu_list = [n for n in num_gpu_list if n <= self.max_gpu_per_replica]
+            return num_gpu_list
+        if self.max_gpu_per_replica is not None:
+            return list(range(1, self.max_gpu_per_replica + 1))
+        return None
+
     def sweep_agg_kwargs(self, *, database, encoder_database=None) -> dict[str, Any]:
         """Return the exact kwargs needed for sweep.sweep_agg.
 
@@ -2443,6 +2475,9 @@ class Task:
             "encoder_batch_list": self.encoder_batch_candidates,
             "encoder_latency_correction": self.encoder_latency_correction,
             "encoder_database": encoder_database,
+            # Per-cell (per-replica) budget for the E+agg rate matching; a
+            # plain agg row is a single worker and ignores it.
+            "num_gpu_list": self._replica_num_gpu_list() if self.enable_epd else None,
         }
 
     def sweep_disagg_kwargs(self, *, prefill_database, decode_database, encoder_database=None) -> dict[str, Any]:
@@ -2454,17 +2489,6 @@ class Task:
         # Derive worker count ranges from replica constraints (legacy semantics).
         prefill_worker_list = list(range(1, (self.max_prefill_workers or 32) + 1))
         decode_worker_list = list(range(1, (self.max_decode_workers or 32) + 1))
-        # Mirror v1 get_working_list(num_gpu_per_replica, max_gpu_per_replica): an explicit
-        # list is filtered by the cap; a None list (WideEP) becomes range(1, cap+1) so the
-        # replica size stays bounded (v2 sweep gates by this list, not a max ceiling).
-        if self.num_gpu_per_replica:
-            num_gpu_list = self.num_gpu_per_replica
-            if self.max_gpu_per_replica is not None:
-                num_gpu_list = [n for n in num_gpu_list if n <= self.max_gpu_per_replica]
-        elif self.max_gpu_per_replica is not None:
-            num_gpu_list = list(range(1, self.max_gpu_per_replica + 1))
-        else:
-            num_gpu_list = None
         runtime_config = self.build_runtime_config()
         if self.pareto_sweep:
             runtime_config.tpot = _LEGACY_TPOT_SWEEP
@@ -2492,7 +2516,7 @@ class Task:
             "decode_max_num_tokens": self.decode_max_batch_size,
             "prefill_num_worker_list": prefill_worker_list,
             "decode_num_worker_list": decode_worker_list,
-            "num_gpu_list": num_gpu_list,
+            "num_gpu_list": self._replica_num_gpu_list(),
             "rate_matching_prefill_degradation": self.rate_match_prefill_degradation,
             "rate_matching_decode_degradation": self.rate_match_decode_degradation,
             "autoscale_ttft_correction_factor": self.autoscale_ttft_correction_factor,

--- a/tests/unit/cli/test_epd_cli_gates.py
+++ b/tests/unit/cli/test_epd_cli_gates.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""EPD CLI misuse must fail loud, and EPD report arithmetic must stay
+consistent with the row totals."""
+
+import argparse
+
+import pandas as pd
+import pytest
+
+from aiconfigurator.cli.main import _run_estimate_mode, build_default_tasks
+from aiconfigurator.cli.report_and_save import _plot_worker_setup_table
+
+pytestmark = pytest.mark.unit
+
+
+def test_epd_agg_worker_table_gpu_decomposition_includes_cp():
+    config_df = pd.DataFrame(
+        [
+            {
+                "backend": "sglang",
+                "tokens/s/gpu": 10.0,
+                "tokens/s/user": 1.0,
+                "request_rate": 1.0,
+                "ttft": 100.0,
+                "tpot": 10.0,
+                "request_latency": 200.0,
+                "concurrency": 1,
+                "bs": 8,
+                "tp": 1,
+                "pp": 1,
+                "dp": 1,
+                "cp": 2,
+                "num_total_gpus": 8,
+                "(a)workers": 3,
+                "(e)workers": 1,
+                "(e)tp": 2,
+                "(e)bs": 4,
+            }
+        ]
+    )
+
+    table = _plot_worker_setup_table(
+        "agg",
+        config_df,
+        total_gpus=8,
+        tpot_target=50.0,
+        top=1,
+        is_moe=False,
+        request_latency_target=None,
+        show_power=False,
+    )
+
+    # 3 agg workers x (tp*pp*dp*cp = 2 GPUs) + 1 encode worker x 2 = 8.
+    assert "8 (=3x2+1x2(e))" in table
+
+
+def test_estimate_encoder_flags_require_enable_epd():
+    args = argparse.Namespace(enable_epd=False, encoder_tp=4, encoder_batch_size=None, encoder_num_workers=None)
+    with pytest.raises(SystemExit, match="require --enable-epd"):
+        _run_estimate_mode(args)
+
+
+def test_default_afd_serving_mode_rejects_enable_epd():
+    with pytest.raises(ValueError, match="'afd' does not support EPD"):
+        build_default_tasks(
+            model_path="Qwen/Qwen3-VL-8B-Instruct",
+            total_gpus=8,
+            system="h200_sxm",
+            backend="sglang",
+            serving_mode="afd",
+            enable_epd=True,
+        )

--- a/tests/unit/cli/test_epd_generator_guard.py
+++ b/tests/unit/cli/test_epd_generator_guard.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""EPD rows must not silently produce generator artifacts: the generator
+bridge does not map the dedicated encode pool yet, so the emitted deploy
+configs would contradict the recommendation."""
+
+import argparse
+import logging
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from aiconfigurator.cli.main import build_default_tasks
+from aiconfigurator.cli.report_and_save import save_results
+
+pytestmark = pytest.mark.unit
+
+
+def test_epd_rows_skip_generator_artifacts(tmp_path, caplog):
+    tasks = build_default_tasks(
+        model_path="nvidia/GLM-5.2-NVFP4",
+        total_gpus=1,
+        system="gb200",
+        backend="vllm",
+        backend_version="0.11.0",
+        database_mode="SOL",
+    )
+
+    def _row(e_workers: float) -> dict:
+        return {
+            "tp": 1,
+            "pp": 1,
+            "dp": 1,
+            "ttft": 100.0,
+            "tpot": 10.0,
+            "tokens/s/gpu": 100.0,
+            "power_w": 0.0,
+            "(e)workers": e_workers,
+        }
+
+    args = argparse.Namespace(inclusive_tpot=False, deployment_target="dynamo-j2")
+    caplog.set_level(logging.WARNING)
+    with (
+        patch(
+            "aiconfigurator.cli.report_and_save.get_default_dynamo_version_mapping",
+            return_value=("1.0.0", {"vllm": "0.11.0"}),
+        ),
+        patch(
+            "aiconfigurator.cli.report_and_save.task_config_to_generator_config",
+            return_value={},
+        ) as bridge,
+    ):
+        save_results(
+            args=args,
+            best_configs={"agg": pd.DataFrame([_row(2.0), _row(0.0)])},
+            pareto_fronts={"agg": None},
+            tasks=tasks,
+            save_dir=str(tmp_path),
+            backend="vllm",
+        )
+
+    assert bridge.call_count == 1  # only the non-EPD row reaches the bridge
+    assert "generator artifacts skipped" in caplog.text

--- a/tests/unit/cli/test_power_coverage_gate.py
+++ b/tests/unit/cli/test_power_coverage_gate.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-from aiconfigurator.cli.api import _apply_power_coverage_gate
+from aiconfigurator.cli.api import _apply_power_coverage_gate, apply_row_power_coverage_gate
 from aiconfigurator.sdk.config import RuntimeConfig
 from aiconfigurator.sdk.inference_summary import InferenceSummary
 
@@ -48,3 +48,10 @@ def test_sufficient_power_coverage_preserves_power() -> None:
 
     assert gated["power_w"] == 450.0
     assert gated["power_coverage"] == pytest.approx(0.9)
+
+
+def test_row_gate_applies_same_rule_to_prestamped_rows() -> None:
+    assert apply_row_power_coverage_gate({"power_w": 450.0, "power_coverage": 0.95})["power_w"] == 450.0
+    # Fail-closed: no evidence (missing / NaN coverage) hides the power too.
+    assert apply_row_power_coverage_gate({"power_w": 450.0})["power_w"] is None
+    assert apply_row_power_coverage_gate({"power_w": 450.0, "power_coverage": float("nan")})["power_w"] is None

--- a/tests/unit/generator/test_module_bridge_image_workload.py
+++ b/tests/unit/generator/test_module_bridge_image_workload.py
@@ -17,6 +17,8 @@ import pytest
 
 from aiconfigurator.generator.module_bridge import task_config_to_generator_config
 
+pytestmark = pytest.mark.unit
+
 
 def _task(
     *,

--- a/tests/unit/generator/test_module_bridge_image_workload.py
+++ b/tests/unit/generator/test_module_bridge_image_workload.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pandas as pd
+import pytest
 
 from aiconfigurator.generator.module_bridge import task_config_to_generator_config
 
@@ -45,6 +46,17 @@ def _task(
         num_images_per_request=num_images_per_request,
         enable_encoder_dp=enable_encoder_dp,
     )
+
+
+def test_epd_rows_fail_closed():
+    # The bridge does not map the dedicated encode pool ((a)/(e) columns);
+    # direct callers must get a loud error, not a contradicting config.
+    task = _task(image_height=1024, image_width=1024, num_images_per_request=1)
+    with pytest.raises(ValueError, match="encode pool"):
+        task_config_to_generator_config(task, pd.Series({"workers": 1, "tp": 1, "(e)workers": 2}))
+    task.enable_epd = True
+    with pytest.raises(ValueError, match="encode pool"):
+        task_config_to_generator_config(task, pd.Series({"workers": 1, "tp": 1}))
 
 
 def test_image_workload_populates_bench_config():

--- a/tests/unit/sdk/backends/test_encoder.py
+++ b/tests/unit/sdk/backends/test_encoder.py
@@ -550,3 +550,31 @@ class TestEncoderMemoryInSummary:
         assert enc_mem["kvcache"] == 0.0
         assert enc_mem["weights"] > 0.0
         assert enc_mem["activations"] > 0.0
+
+
+class TestSmartResizeTokenResolution:
+    """_encoder_pre_merge_per_visual mirrors the upstream VL processor's
+    smart_resize: raw H/W round to the *nearest* multiple of
+    patch_size x spatial_merge_size (plain floor under-counted tokens for
+    non-aligned inputs)."""
+
+    def test_non_aligned_dims_round_to_nearest_factor(self):
+        from aiconfigurator.sdk.backends.base_backend import BaseBackend
+
+        enc_cfg = common.VisionEncoderConfig(
+            depth=27,
+            hidden_size=1152,
+            num_heads=16,
+            intermediate_size=4304,
+            patch_size=16,
+            temporal_patch_size=2,
+            spatial_merge_size=2,
+            out_hidden_size=5120,
+        )
+        # 500 rounds to 512 (nearest multiple of 32; floor gave 480):
+        # post-merge 16^2, pre-merge (512/16)^2.
+        rc = RuntimeConfig(isl=1, osl=1, image_height=500, image_width=500, num_images_per_request=1)
+        assert BaseBackend._encoder_pre_merge_per_visual(rc, enc_cfg) == (256, 1024)
+        # Aligned dims are untouched.
+        rc_aligned = RuntimeConfig(isl=1, osl=1, image_height=448, image_width=448, num_images_per_request=1)
+        assert BaseBackend._encoder_pre_merge_per_visual(rc_aligned, enc_cfg) == (196, 784)

--- a/tests/unit/sdk/sweep/test_sweep.py
+++ b/tests/unit/sdk/sweep/test_sweep.py
@@ -298,10 +298,12 @@ def test_sweep_disagg_epd_composes_encoder_stage(monkeypatch):
     """EPD end-to-end semantics on synthetic candidates.
 
     Pins the three EPD invariants: (1) enable_epd flips the prefill workers
-    to language-only (encoder_colocated=False -> pure ttft 60 instead of the
-    colocated 100), (2) TTFT composes sequentially as encode latency +
-    corrected prefill ttft, (3) the encode pool is sized into the rate
-    matching and its GPUs dilute the per-GPU metrics.
+    to language-only (pure ttft 60 instead of the inline-encoder 100),
+    (2) TTFT composes sequentially with the same queueing correction applied
+    to both stages (corr x encode latency + corr x prefill ttft -- symmetric
+    with the inline PD path, whose full E+P ttft is corrected), (3) the
+    encode pool is sized into the rate matching and its GPUs dilute the
+    per-GPU metrics.
     """
     import pandas as pd
 
@@ -347,8 +349,8 @@ def test_sweep_disagg_epd_composes_encoder_stage(monkeypatch):
         base.update(overrides)
         return base
 
-    # Colocated prefill (PD): ttft = 40ms encoder + 60ms context.  Language-only
-    # prefill (EPD, encoder_colocated=False): the same worker without the ViT.
+    # Inline-encoder prefill (PD): ttft = 40ms encoder + 60ms context.
+    # Language-only prefill (EPD): the same worker without the ViT.
     colocated_prefill_df = pd.DataFrame([_worker_row()])
     pure_prefill_df = pd.DataFrame(
         [
@@ -381,7 +383,7 @@ def test_sweep_disagg_epd_composes_encoder_stage(monkeypatch):
     def _fake_candidates(*, role, model_config, **_kwargs):
         if role == "decode":
             return decode_df.copy()
-        return (colocated_prefill_df if model_config.encoder_colocated else pure_prefill_df).copy()
+        return (pure_prefill_df if model_config.language_only else colocated_prefill_df).copy()
 
     monkeypatch.setattr(sweep, "_get_disagg_worker_candidates", _fake_candidates)
     monkeypatch.setattr(
@@ -411,15 +413,19 @@ def test_sweep_disagg_epd_composes_encoder_stage(monkeypatch):
         rate_matching_decode_degradation=1.0,
     )
 
-    # Plain PD: encoder stays colocated (ttft 100 * 1.8 correction).
+    # Plain PD: the inline encoder is part of the corrected prefill ttft
+    # (1.8 x (40 encoder + 60 context) = 180).
     pd_row = sweep_disagg(**common_kwargs).iloc[0]
     assert pd_row["(e)workers"] == 0
     assert pd_row["ttft"] == pytest.approx(180.0)
     assert pd_row["encoder_latency"] == pytest.approx(40.0)
 
-    # EPD: language-only prefill ttft = 60 -> corrected 108; + encode batch 50 = 158.
+    # EPD: language-only prefill ttft = 60 -> corrected 108; the encode stage
+    # carries the same correction (1.8 x 50 = 90) so the PD comparison stays
+    # apples-to-apples: ttft = 90 + 108 = 198.
     epd_row = sweep_disagg(**common_kwargs, enable_epd=True, encoder_tp_list=[2]).iloc[0]
-    assert epd_row["ttft"] == pytest.approx(158.0)
+    assert epd_row["ttft"] == pytest.approx(198.0)
+    # encoder_latency stays the raw stage latency, like the inline PD row.
     assert epd_row["encoder_latency"] == pytest.approx(50.0)
     # Rate matching: p 16.667/w (4 gpus), d 20/w (8 gpus), e 80/w * 0.9 deg (2 gpus)
     # -> optimum (4p, 3d, 1e): seq/s 60, gpus 16+24+2=42.
@@ -428,18 +434,20 @@ def test_sweep_disagg_epd_composes_encoder_stage(monkeypatch):
     assert epd_row["seq/s"] == pytest.approx(60.0)
     assert epd_row["tokens/s/gpu"] == pytest.approx(6000.0 / 42, abs=1e-3)
     assert (epd_row["(e)tp"], epd_row["(e)bs"], epd_row["(e)parallel"]) == (2, 4, "tp2")
-    # request latency = corrected prefill ttft + tpot*(osl-1) + encode latency.
-    assert epd_row["request_latency"] == pytest.approx(108.0 + 8.0 * 99 + 50.0)
+    # request latency = corrected prefill ttft + tpot*(osl-1) + corrected encode stage.
+    assert epd_row["request_latency"] == pytest.approx(108.0 + 8.0 * 99 + 90.0)
 
 
 def test_sweep_agg_epd_composes_encoder_stage(monkeypatch):
     """E+agg end-to-end semantics on synthetic candidates.
 
     Pins the E+agg invariants: (1) enable_epd flips the agg workers to
-    language-only (encoder_colocated=False) while the default keeps the
-    encoder inline, (2) TTFT composes sequentially as encode latency + agg
-    ttft, (3) the cell rate match picks the best integer agg:encode worker
-    ratio (encode pool sized to not bottleneck, GPUs dilute per-GPU metrics).
+    language-only while the default keeps the encoder inline, (2) TTFT
+    composes sequentially as raw encode latency + agg ttft (mirroring
+    run_agg's inline convention, which adds the encoder before its queueing
+    factor), (3) the cell rate match picks the best integer agg:encode
+    worker ratio (encode pool sized to not bottleneck, GPUs dilute per-GPU
+    metrics).
     """
     import pandas as pd
 
@@ -490,7 +498,7 @@ def test_sweep_agg_epd_composes_encoder_stage(monkeypatch):
     captured: dict = {}
 
     def _fake_get_model(*, model_path, model_config, backend_name):
-        captured["encoder_colocated"] = model_config.encoder_colocated
+        captured["language_only"] = model_config.language_only
         return MagicMock()
 
     monkeypatch.setattr(sweep, "get_model", _fake_get_model)
@@ -517,13 +525,13 @@ def test_sweep_agg_epd_composes_encoder_stage(monkeypatch):
 
     # Default: encoder stays inline (colocated); rows pass through untouched.
     agg_df = sweep.sweep_agg(**common_kwargs)
-    assert captured["encoder_colocated"] is True
+    assert captured["language_only"] is False
     assert "(e)workers" not in agg_df.columns
     assert agg_df.iloc[0]["ttft"] == pytest.approx(100.0)
 
     # E+agg: language-only agg workers + encode pool.
     epd_df = sweep.sweep_agg(**common_kwargs, enable_epd=True, encoder_tp_list=[2])
-    assert captured["encoder_colocated"] is False
+    assert captured["language_only"] is True
     row = epd_df.iloc[0]
     # TTFT = agg ttft + encode batch latency; request latency follows.
     assert row["ttft"] == pytest.approx(150.0)

--- a/tests/unit/sdk/sweep/test_sweep.py
+++ b/tests/unit/sdk/sweep/test_sweep.py
@@ -294,6 +294,144 @@ def test_sweep_disagg_rejects_invalid_max_decode_gpus():
         )
 
 
+def test_sweep_disagg_epd_composes_encoder_stage(monkeypatch):
+    """EPD end-to-end semantics on synthetic candidates.
+
+    Pins the three EPD invariants: (1) enable_epd flips the prefill workers
+    to language-only (encoder_colocated=False -> pure ttft 60 instead of the
+    colocated 100), (2) TTFT composes sequentially as encode latency +
+    corrected prefill ttft, (3) the encode pool is sized into the rate
+    matching and its GPUs dilute the per-GPU metrics.
+    """
+    import pandas as pd
+
+    def _worker_row(**overrides) -> dict:
+        base = {
+            "model": "m",
+            "isl": 1000,
+            "osl": 100,
+            "prefix": 0,
+            "concurrency": 1,
+            "request_rate": 0.0,
+            "bs": 1,
+            "global_bs": 1,
+            "ttft": 100.0,
+            "tpot": 0.0,
+            "seq/s": 10.0,
+            "seq/s/gpu": 2.5,
+            "tokens/s": 10.0,
+            "tokens/s/gpu": 2.5,
+            "tokens/s/user": 0.0,
+            "request_latency": 100.0,
+            "encoder_latency": 40.0,
+            "encoder_memory": 1.5,
+            "num_total_gpus": 4,
+            "tp": 4,
+            "pp": 1,
+            "dp": 1,
+            "moe_tp": 1,
+            "moe_ep": 1,
+            "cp": 1,
+            "parallel": "tp4pp1dp1",
+            "gemm": "fp8",
+            "kvcache": "fp8",
+            "fmha": "fp8",
+            "moe": "fp8",
+            "comm": "half",
+            "memory": 30.0,
+            "backend": "sglang",
+            "version": "0.5.10",
+            "system": "h200_sxm",
+            "power_w": 500.0,
+        }
+        base.update(overrides)
+        return base
+
+    # Colocated prefill (PD): ttft = 40ms encoder + 60ms context.  Language-only
+    # prefill (EPD, encoder_colocated=False): the same worker without the ViT.
+    colocated_prefill_df = pd.DataFrame([_worker_row()])
+    pure_prefill_df = pd.DataFrame(
+        [
+            _worker_row(
+                ttft=60.0,
+                request_latency=60.0,
+                encoder_latency=0.0,
+                encoder_memory=0.0,
+                **{"seq/s": 1000.0 / 60, "seq/s/gpu": 250.0 / 60, "tokens/s": 1000.0 / 60, "tokens/s/gpu": 250.0 / 60},
+            )
+        ]
+    )
+    decode_df = pd.DataFrame(
+        [
+            _worker_row(
+                bs=32,
+                global_bs=32,
+                concurrency=32,
+                ttft=0.0,
+                tpot=8.0,
+                **{"seq/s": 20.0, "seq/s/gpu": 2.5, "tokens/s/user": 125.0},
+                encoder_latency=0.0,
+                num_total_gpus=8,
+                tp=8,
+                parallel="tp8pp1dp1",
+            )
+        ]
+    )
+
+    def _fake_candidates(*, role, model_config, **_kwargs):
+        if role == "decode":
+            return decode_df.copy()
+        return (colocated_prefill_df if model_config.encoder_colocated else pure_prefill_df).copy()
+
+    monkeypatch.setattr(sweep, "_get_disagg_worker_candidates", _fake_candidates)
+    monkeypatch.setattr(
+        sweep,
+        "_get_encoder_worker_candidates",
+        lambda **_kwargs: [
+            {"encoder_latency": 50.0, "seq/s": 80.0, "num_total_gpus": 2, "tp": 2, "bs": 4, "memory": 1.5}
+        ],
+    )
+
+    common_kwargs = dict(
+        model_path="m",
+        runtime_config=config.RuntimeConfig(isl=1000, osl=100, ttft=200.0, tpot=10.0),
+        prefill_database=MagicMock(),
+        prefill_backend_name="sglang",
+        prefill_model_config=config.ModelConfig(),
+        prefill_parallel_config_list=[(4, 1, 1, 1, 1, 1)],
+        prefill_latency_correction=1.0,
+        decode_database=MagicMock(),
+        decode_backend_name="sglang",
+        decode_model_config=config.ModelConfig(),
+        decode_parallel_config_list=[(8, 1, 1, 1, 1, 1)],
+        decode_latency_correction=1.0,
+        prefill_num_worker_list=[1, 2, 3, 4],
+        decode_num_worker_list=[1, 2, 3, 4],
+        rate_matching_prefill_degradation=1.0,
+        rate_matching_decode_degradation=1.0,
+    )
+
+    # Plain PD: encoder stays colocated (ttft 100 * 1.8 correction).
+    pd_row = sweep_disagg(**common_kwargs).iloc[0]
+    assert pd_row["(e)workers"] == 0
+    assert pd_row["ttft"] == pytest.approx(180.0)
+    assert pd_row["encoder_latency"] == pytest.approx(40.0)
+
+    # EPD: language-only prefill ttft = 60 -> corrected 108; + encode batch 50 = 158.
+    epd_row = sweep_disagg(**common_kwargs, enable_epd=True, encoder_tp_list=[2]).iloc[0]
+    assert epd_row["ttft"] == pytest.approx(158.0)
+    assert epd_row["encoder_latency"] == pytest.approx(50.0)
+    # Rate matching: p 16.667/w (4 gpus), d 20/w (8 gpus), e 80/w * 0.9 deg (2 gpus)
+    # -> optimum (4p, 3d, 1e): seq/s 60, gpus 16+24+2=42.
+    assert (epd_row["(p)workers"], epd_row["(d)workers"], epd_row["(e)workers"]) == (4, 3, 1)
+    assert epd_row["num_total_gpus"] == 42
+    assert epd_row["seq/s"] == pytest.approx(60.0)
+    assert epd_row["tokens/s/gpu"] == pytest.approx(6000.0 / 42, abs=1e-3)
+    assert (epd_row["(e)tp"], epd_row["(e)bs"], epd_row["(e)parallel"]) == (2, 4, "tp2")
+    # request latency = corrected prefill ttft + tpot*(osl-1) + encode latency.
+    assert epd_row["request_latency"] == pytest.approx(108.0 + 8.0 * 99 + 50.0)
+
+
 def test_sweep_disagg_rejects_empty_num_worker_lists():
     """Empty worker lists silently skipped the rate-match inner loop in earlier
     versions; now fail loud to avoid surprising zero-result sweeps."""

--- a/tests/unit/sdk/sweep/test_sweep.py
+++ b/tests/unit/sdk/sweep/test_sweep.py
@@ -440,6 +440,43 @@ def test_sweep_disagg_epd_composes_encoder_stage(monkeypatch):
     assert epd_row["request_latency"] == pytest.approx(108.0 + 8.0 * 99 + 90.0)
 
 
+def test_sweep_agg_epd_language_only_pin_survives_config_builder(monkeypatch):
+    """Task hands sweep_* a per-point ModelConfig builder, not an instance;
+    the EPD language-only pin must apply to what the builder produces."""
+    captured: dict = {}
+
+    def _fake_get_model(*, model_path, model_config, backend_name):
+        captured["language_only"] = model_config.language_only
+        return MagicMock()
+
+    monkeypatch.setattr(sweep, "get_model", _fake_get_model)
+    monkeypatch.setattr(sweep, "get_backend", lambda name: MagicMock())
+    monkeypatch.setattr(
+        sweep,
+        "_sweep_one_parallel_agg",
+        lambda **_kwargs: (pd.DataFrame(), True, True, 0),
+    )
+    monkeypatch.setattr(
+        sweep,
+        "_get_encoder_worker_candidates",
+        lambda **_kwargs: [
+            {"encoder_latency": 50.0, "seq/s": 80.0, "num_total_gpus": 2, "tp": 2, "bs": 4, "memory": 1.5}
+        ],
+    )
+    with pytest.raises(NoFeasibleConfigError):
+        sweep.sweep_agg(
+            model_path="m",
+            runtime_config=config.RuntimeConfig(isl=1000, osl=100, ttft=200.0, tpot=10.0),
+            database=MagicMock(),
+            backend_name="sglang",
+            model_config=lambda parallel: config.ModelConfig(),
+            parallel_config_list=[(4, 1, 1, 1, 1, 1)],
+            enable_epd=True,
+            encoder_tp_list=[2],
+        )
+    assert captured["language_only"] is True
+
+
 def test_sweep_agg_epd_composes_encoder_stage(monkeypatch):
     """E+agg end-to-end semantics on synthetic candidates.
 

--- a/tests/unit/sdk/sweep/test_sweep.py
+++ b/tests/unit/sdk/sweep/test_sweep.py
@@ -294,6 +294,50 @@ def test_sweep_disagg_rejects_invalid_max_decode_gpus():
         )
 
 
+def _worker_row(**overrides) -> dict:
+    """Synthetic ColumnsStatic-shaped disagg worker row shared by the EPD tests."""
+    base = {
+        "model": "m",
+        "isl": 1000,
+        "osl": 100,
+        "prefix": 0,
+        "concurrency": 1,
+        "request_rate": 0.0,
+        "bs": 1,
+        "global_bs": 1,
+        "ttft": 100.0,
+        "tpot": 0.0,
+        "seq/s": 10.0,
+        "seq/s/gpu": 2.5,
+        "tokens/s": 10.0,
+        "tokens/s/gpu": 2.5,
+        "tokens/s/user": 0.0,
+        "request_latency": 100.0,
+        "encoder_latency": 40.0,
+        "encoder_memory": 1.5,
+        "num_total_gpus": 4,
+        "tp": 4,
+        "pp": 1,
+        "dp": 1,
+        "moe_tp": 1,
+        "moe_ep": 1,
+        "cp": 1,
+        "parallel": "tp4pp1dp1",
+        "gemm": "fp8",
+        "kvcache": "fp8",
+        "fmha": "fp8",
+        "moe": "fp8",
+        "comm": "half",
+        "memory": 30.0,
+        "backend": "sglang",
+        "version": "0.5.10",
+        "system": "h200_sxm",
+        "power_w": 500.0,
+    }
+    base.update(overrides)
+    return base
+
+
 def test_sweep_disagg_epd_composes_encoder_stage(monkeypatch):
     """EPD end-to-end semantics on synthetic candidates.
 
@@ -306,48 +350,6 @@ def test_sweep_disagg_epd_composes_encoder_stage(monkeypatch):
     per-GPU metrics.
     """
     import pandas as pd
-
-    def _worker_row(**overrides) -> dict:
-        base = {
-            "model": "m",
-            "isl": 1000,
-            "osl": 100,
-            "prefix": 0,
-            "concurrency": 1,
-            "request_rate": 0.0,
-            "bs": 1,
-            "global_bs": 1,
-            "ttft": 100.0,
-            "tpot": 0.0,
-            "seq/s": 10.0,
-            "seq/s/gpu": 2.5,
-            "tokens/s": 10.0,
-            "tokens/s/gpu": 2.5,
-            "tokens/s/user": 0.0,
-            "request_latency": 100.0,
-            "encoder_latency": 40.0,
-            "encoder_memory": 1.5,
-            "num_total_gpus": 4,
-            "tp": 4,
-            "pp": 1,
-            "dp": 1,
-            "moe_tp": 1,
-            "moe_ep": 1,
-            "cp": 1,
-            "parallel": "tp4pp1dp1",
-            "gemm": "fp8",
-            "kvcache": "fp8",
-            "fmha": "fp8",
-            "moe": "fp8",
-            "comm": "half",
-            "memory": 30.0,
-            "backend": "sglang",
-            "version": "0.5.10",
-            "system": "h200_sxm",
-            "power_w": 500.0,
-        }
-        base.update(overrides)
-        return base
 
     # Inline-encoder prefill (PD): ttft = 40ms encoder + 60ms context.
     # Language-only prefill (EPD): the same worker without the ViT.
@@ -524,25 +526,26 @@ def test_sweep_agg_epd_composes_encoder_stage(monkeypatch):
     # Default: encoder stays inline (colocated); rows pass through untouched.
     agg_df = sweep.sweep_agg(**common_kwargs)
     assert captured["language_only"] is False
-    assert "(e)workers" not in agg_df.columns
     assert agg_df.iloc[0]["ttft"] == pytest.approx(100.0)
 
     # E+agg: language-only agg workers + encode pool.
     epd_df = sweep.sweep_agg(**common_kwargs, enable_epd=True, encoder_tp_list=[2])
     assert captured["language_only"] is True
     row = epd_df.iloc[0]
-    # TTFT = agg ttft + encode batch latency; request latency follows.
+    # TTFT = agg ttft + raw encode batch latency (run_agg's inline convention).
     assert row["ttft"] == pytest.approx(150.0)
     assert row["encoder_latency"] == pytest.approx(50.0)
-    assert row["request_latency"] == pytest.approx(100.0 + 8.0 * 99 + 50.0)
     # Cell match: agg 10/w (4 gpus) vs encode capacity 80*0.9=72 (2 gpus)
     # -> optimum (7 agg, 1 e): seq/s 70, gpus 28+2=30 (ties keep the smaller cell).
     assert (row["(a)workers"], row["(e)workers"]) == (7, 1)
     assert row["num_total_gpus"] == 30
     assert row["seq/s"] == pytest.approx(70.0)
-    assert row["tokens/s/gpu"] == pytest.approx(7000.0 / 30, abs=1e-3)
     assert row["concurrency"] == 32 * 7
-    assert (row["(e)tp"], row["(e)bs"]) == (2, 4)
+
+    # Replica budget: num_gpu_list=[6] leaves exactly one feasible cell.
+    row = sweep.sweep_agg(**common_kwargs, enable_epd=True, encoder_tp_list=[2], num_gpu_list=[6]).iloc[0]
+    assert (row["(a)workers"], row["(e)workers"]) == (1, 1)
+    assert row["num_total_gpus"] == 6
 
 
 def test_sweep_disagg_epd_encoder_pool_sizing_under_replica_budget(monkeypatch):
@@ -555,47 +558,20 @@ def test_sweep_disagg_epd_encoder_pool_sizing_under_replica_budget(monkeypatch):
     """
     import pandas as pd
 
-    def _row(**overrides) -> dict:
-        base = {
-            "model": "m",
-            "isl": 1000,
-            "osl": 100,
-            "prefix": 0,
-            "concurrency": 1,
-            "request_rate": 0.0,
-            "bs": 1,
-            "global_bs": 1,
-            "ttft": 60.0,
-            "tpot": 0.0,
-            "seq/s": 10.0,
-            "seq/s/gpu": 10.0,
-            "tokens/s": 10.0,
-            "tokens/s/gpu": 10.0,
-            "tokens/s/user": 0.0,
-            "request_latency": 60.0,
-            "encoder_latency": 0.0,
-            "encoder_memory": 0.0,
-            "num_total_gpus": 1,
-            "tp": 1,
-            "pp": 1,
-            "dp": 1,
-            "moe_tp": 1,
-            "moe_ep": 1,
-            "cp": 1,
-            "parallel": "tp1pp1dp1",
-            "gemm": "fp8",
-            "kvcache": "fp8",
-            "fmha": "fp8",
-            "moe": "fp8",
-            "comm": "half",
-            "memory": 30.0,
-            "power_w": 500.0,
-        }
-        base.update(overrides)
-        return base
-
-    prefill_df = pd.DataFrame([_row()])
-    decode_df = pd.DataFrame([_row(bs=32, global_bs=32, concurrency=32, ttft=0.0, tpot=8.0)])
+    # Language-only 1-GPU workers riding the shared row builder.
+    lm = dict(
+        ttft=60.0,
+        request_latency=60.0,
+        encoder_latency=0.0,
+        encoder_memory=0.0,
+        num_total_gpus=1,
+        tp=1,
+        parallel="tp1pp1dp1",
+    )
+    prefill_df = pd.DataFrame([_worker_row(**lm)])
+    decode_df = pd.DataFrame(
+        [_worker_row(**{**lm, "bs": 32, "global_bs": 32, "concurrency": 32, "ttft": 0.0, "tpot": 8.0})]
+    )
 
     monkeypatch.setattr(
         sweep,
@@ -686,6 +662,7 @@ def test_encoder_worker_candidates_gated_by_gpu_memory(monkeypatch):
     )
     monkeypatch.setattr(sweep, "get_model_config_from_model_path", lambda _path: {"extra_params": enc_cfg})
     backend = MagicMock()
+    backend.OTHERS_OVERHEAD_FRAC = 0.0
     memory_by_batch = {1: 10.0, 2: 15.0, 4: 25.0}
     backend.run_encoder_static.side_effect = lambda model, database, rc, b, latency_correction_scale=1.0: (
         50.0,
@@ -695,7 +672,10 @@ def test_encoder_worker_candidates_gated_by_gpu_memory(monkeypatch):
     monkeypatch.setattr(sweep, "get_backend", lambda _name: backend)
 
     database = MagicMock()
-    database.system_spec = {"gpu": {"mem_capacity": 20 * (1 << 30)}}
+    database.system_spec = {
+        "gpu": {"mem_capacity": 20 * (1 << 30)},
+        "misc": {"nccl_mem": {1: 0}, "other_mem": 5 * (1 << 30)},
+    }
     rows = sweep._get_encoder_worker_candidates(
         model_path="m",
         tp_list=[1],
@@ -707,59 +687,9 @@ def test_encoder_worker_candidates_gated_by_gpu_memory(monkeypatch):
         backend_name="sglang",
         latency_correction=1.0,
     )
-    # batch 4 hits the 20 GiB gate and stops the schedule; 1 and 2 survive.
-    assert [r["bs"] for r in rows] == [1, 2]
-
-
-def test_sweep_agg_epd_respects_replica_budget(monkeypatch):
-    """E+agg cell selection under num_gpu_list, with an encode-bound cell.
-
-    agg worker 10 seq/s x 4 GPUs; encode worker 8 seq/s x 2 GPUs (degraded
-    capacity 7.2).  Unbudgeted, the argmax grows the cell to amortize the
-    encode ceil; num_gpu_list=[6] leaves exactly one feasible cell — 1 agg +
-    1 encode — which is encode-bound: seq/s = 7.2.
-    """
-    import pandas as pd
-
-    # Only the keys the (agg x encode) matcher and the encoder overlay read.
-    agg_row = {
-        "osl": 100,
-        "concurrency": 32,
-        "ttft": 100.0,
-        "tpot": 8.0,
-        "request_latency": 892.0,
-        "seq/s": 10.0,
-        "tokens/s": 1000.0,
-        "num_total_gpus": 4,
-    }
-
-    monkeypatch.setattr(sweep, "get_model", lambda **_kwargs: MagicMock())
-    monkeypatch.setattr(sweep, "get_backend", lambda name: MagicMock())
-    monkeypatch.setattr(sweep, "_sweep_one_parallel_agg", lambda **_kwargs: (pd.DataFrame([agg_row]), True, True))
-    monkeypatch.setattr(
-        sweep,
-        "_get_encoder_worker_candidates",
-        lambda **_kwargs: [
-            {"encoder_latency": 50.0, "seq/s": 8.0, "num_total_gpus": 2, "tp": 2, "bs": 4, "memory": 1.5}
-        ],
-    )
-
-    row = sweep.sweep_agg(
-        model_path="m",
-        runtime_config=config.RuntimeConfig(isl=1000, osl=100, ttft=200.0, tpot=10.0),
-        database=MagicMock(),
-        backend_name="sglang",
-        model_config=config.ModelConfig(),
-        parallel_config_list=[(4, 1, 1, 1, 1, 1)],
-        enable_epd=True,
-        encoder_tp_list=[2],
-        num_gpu_list=[6],
-    ).iloc[0]
-
-    assert (row["(a)workers"], row["(e)workers"]) == (1, 1)
-    assert row["num_total_gpus"] == 6
-    # Encode pool binds: 8 * 1 * 0.9 = 7.2 < 10.
-    assert row["seq/s"] == pytest.approx(7.2)
+    # The gate charges the framework overhead too: batch 2 (15 + 5 other_mem
+    # >= 20 GiB) stops the schedule; only batch 1 survives.
+    assert [r["bs"] for r in rows] == [1]
 
 
 def test_sweep_agg_epd_top_k_defers_to_encoder_pairing(monkeypatch):
@@ -781,11 +711,13 @@ def test_sweep_agg_epd_top_k_defers_to_encoder_pairing(monkeypatch):
             "num_total_gpus": 4,
         }
 
-    captured: dict = {}
-
     def _fake_sweep_one(**kwargs):
-        captured["top_k"] = kwargs["top_k"]
-        return pd.DataFrame([_row(ttft=180.0, seq_s=50.0), _row(ttft=60.0, seq_s=10.0)]), True, True
+        # Honors top_k like the real sweep (seq/s-descending cut), so the
+        # outcome below fails if sweep_agg ever cuts before the pairing.
+        df = pd.DataFrame([_row(ttft=180.0, seq_s=50.0), _row(ttft=60.0, seq_s=10.0)])
+        if kwargs["top_k"] > 0:
+            df = df.head(kwargs["top_k"])
+        return df, True, True, 0
 
     monkeypatch.setattr(sweep, "get_model", lambda **_kwargs: MagicMock())
     monkeypatch.setattr(sweep, "get_backend", lambda name: MagicMock())
@@ -810,9 +742,8 @@ def test_sweep_agg_epd_top_k_defers_to_encoder_pairing(monkeypatch):
         encoder_tp_list=[2],
     )
 
-    # The language-only rows reach the pairing uncut ...
-    assert captured["top_k"] == 0
-    # ... and the pairable row (ttft 60 + encode 50) wins the per-choice slot.
+    # The pairable row (ttft 60 + encode 50) wins the per-choice slot; a cut
+    # before the pairing would have dropped it (fake returns rows seq/s-desc).
     assert len(df) == 1
     assert df.iloc[0]["ttft"] == pytest.approx(110.0)
 

--- a/tests/unit/sdk/sweep/test_sweep.py
+++ b/tests/unit/sdk/sweep/test_sweep.py
@@ -652,6 +652,19 @@ def test_sweep_disagg_epd_encoder_pool_sizing_under_replica_budget(monkeypatch):
     assert row["num_total_gpus"] == 4
     assert row["seq/s"] == pytest.approx(10.0)
 
+    # max_encoder_workers=1 pins the pool: without it this encoder (capacity
+    # 5.4/worker) would size to e=2 for seq/s 10; capped, the cell is E-bound.
+    monkeypatch.setattr(
+        sweep,
+        "_get_encoder_worker_candidates",
+        lambda **_kwargs: [
+            {"encoder_latency": 50.0, "seq/s": 6.0, "num_total_gpus": 1, "tp": 1, "bs": 4, "memory": 1.0}
+        ],
+    )
+    row = sweep_disagg(**kwargs, prefill_num_worker_list=[1], decode_num_worker_list=[1], max_encoder_workers=1).iloc[0]
+    assert (row["(p)workers"], row["(d)workers"], row["(e)workers"]) == (1, 1, 1)
+    assert row["seq/s"] == pytest.approx(5.4)
+
 
 def test_encoder_worker_candidates_gated_by_gpu_memory(monkeypatch):
     """_get_encoder_worker_candidates drops (tp, batch) points that exceed the

--- a/tests/unit/sdk/sweep/test_sweep.py
+++ b/tests/unit/sdk/sweep/test_sweep.py
@@ -545,15 +545,13 @@ def test_sweep_agg_epd_composes_encoder_stage(monkeypatch):
     assert (row["(e)tp"], row["(e)bs"]) == (2, 4)
 
 
-def test_sweep_disagg_epd_encoder_can_bottleneck_under_replica_budget(monkeypatch):
-    """Three-pool rate matching under a per-replica GPU budget.
+def test_sweep_disagg_epd_encoder_pool_sizing_under_replica_budget(monkeypatch):
+    """E-pool sizing under a per-replica GPU budget: bottleneck and padding.
 
-    p/d workers of 10 seq/s x 1 GPU each; encode worker 10 seq/s x 1 GPU
-    (degraded capacity 9).  Sizing the encode pool to never bottleneck needs
-    2 encode workers, but that cell (1p+1d+2e = 4 GPUs) is outside
-    num_gpu_list=[3]; the only feasible cell is 1p1d1e with the encode pool
-    as the rate-matched bottleneck: seq/s = 9 (min of the three pools), not
-    the P/D-matched 10.  A ceil-only sizing would emit nothing here.
+    Small pools trade capped throughput for GPUs (num_gpu_list=[3] forces
+    1p1d1e with the encode pool binding at 9 seq/s); over-provisioned pools
+    can be the only counts landing on the grid (num_gpu_list=[4] pads a
+    never-binding encoder to e=2, throughput uncapped).
     """
     import pandas as pd
 
@@ -612,7 +610,7 @@ def test_sweep_disagg_epd_encoder_can_bottleneck_under_replica_budget(monkeypatc
         ],
     )
 
-    row = sweep_disagg(
+    kwargs = dict(
         model_path="m",
         runtime_config=config.RuntimeConfig(isl=1000, osl=100, ttft=200.0, tpot=10.0),
         prefill_database=MagicMock(),
@@ -625,20 +623,79 @@ def test_sweep_disagg_epd_encoder_can_bottleneck_under_replica_budget(monkeypatc
         decode_model_config=config.ModelConfig(),
         decode_parallel_config_list=[(1, 1, 1, 1, 1, 1)],
         decode_latency_correction=1.0,
-        prefill_num_worker_list=[1, 2],
-        decode_num_worker_list=[1, 2],
-        num_gpu_list=[3],
         rate_matching_prefill_degradation=1.0,
         rate_matching_decode_degradation=1.0,
         enable_epd=True,
         encoder_tp_list=[1],
-    ).iloc[0]
+    )
+    row = sweep_disagg(**kwargs, prefill_num_worker_list=[1, 2], decode_num_worker_list=[1, 2], num_gpu_list=[3]).iloc[
+        0
+    ]
 
     assert (row["(p)workers"], row["(d)workers"], row["(e)workers"]) == (1, 1, 1)
     assert row["num_total_gpus"] == 3
     # Encode pool binds: 10 * 1 * 0.9 = 9 < min(p, d) = 10.
     assert row["seq/s"] == pytest.approx(9.0)
     assert row["tokens/s/gpu"] == pytest.approx(900.0 / 3, abs=1e-3)
+
+    # Padding: a fast encode worker never binds at e=1, but only e=2 lands on
+    # the [4] grid.
+    monkeypatch.setattr(
+        sweep,
+        "_get_encoder_worker_candidates",
+        lambda **_kwargs: [
+            {"encoder_latency": 50.0, "seq/s": 100.0, "num_total_gpus": 1, "tp": 1, "bs": 4, "memory": 1.0}
+        ],
+    )
+    row = sweep_disagg(**kwargs, prefill_num_worker_list=[1], decode_num_worker_list=[1], num_gpu_list=[4]).iloc[0]
+    assert (row["(p)workers"], row["(d)workers"], row["(e)workers"]) == (1, 1, 2)
+    assert row["num_total_gpus"] == 4
+    assert row["seq/s"] == pytest.approx(10.0)
+
+
+def test_encoder_worker_candidates_gated_by_gpu_memory(monkeypatch):
+    """_get_encoder_worker_candidates drops (tp, batch) points that exceed the
+    encoder system's GPU memory."""
+    from aiconfigurator.sdk import common
+
+    enc_cfg = common.VisionEncoderConfig(
+        depth=2,
+        hidden_size=64,
+        num_heads=4,
+        intermediate_size=128,
+        patch_size=16,
+        temporal_patch_size=1,
+        spatial_merge_size=2,
+        out_hidden_size=64,
+        projector_dims=((64, 64),),
+        projector_n_instances=1,
+        partial_rotary_factor=0.0,
+    )
+    monkeypatch.setattr(sweep, "get_model_config_from_model_path", lambda _path: {"extra_params": enc_cfg})
+    backend = MagicMock()
+    memory_by_batch = {1: 10.0, 2: 15.0, 4: 25.0}
+    backend.run_encoder_static.side_effect = lambda model, database, rc, b, latency_correction_scale=1.0: (
+        50.0,
+        100.0,
+        {"total": memory_by_batch[b]},
+    )
+    monkeypatch.setattr(sweep, "get_backend", lambda _name: backend)
+
+    database = MagicMock()
+    database.system_spec = {"gpu": {"mem_capacity": 20 * (1 << 30)}}
+    rows = sweep._get_encoder_worker_candidates(
+        model_path="m",
+        tp_list=[1],
+        b_list=None,
+        runtime_config=config.RuntimeConfig(
+            isl=1000, osl=100, ttft=200.0, tpot=10.0, image_height=256, image_width=256, num_images_per_request=1
+        ),
+        database=database,
+        backend_name="sglang",
+        latency_correction=1.0,
+    )
+    # batch 4 hits the 20 GiB gate and stops the schedule; 1 and 2 survive.
+    assert [r["bs"] for r in rows] == [1, 2]
 
 
 def test_sweep_agg_epd_respects_replica_budget(monkeypatch):

--- a/tests/unit/sdk/sweep/test_sweep.py
+++ b/tests/unit/sdk/sweep/test_sweep.py
@@ -432,6 +432,113 @@ def test_sweep_disagg_epd_composes_encoder_stage(monkeypatch):
     assert epd_row["request_latency"] == pytest.approx(108.0 + 8.0 * 99 + 50.0)
 
 
+def test_sweep_agg_epd_composes_encoder_stage(monkeypatch):
+    """E+agg end-to-end semantics on synthetic candidates.
+
+    Pins the E+agg invariants: (1) enable_epd flips the agg workers to
+    language-only (encoder_colocated=False) while the default keeps the
+    encoder inline, (2) TTFT composes sequentially as encode latency + agg
+    ttft, (3) the cell rate match picks the best integer agg:encode worker
+    ratio (encode pool sized to not bottleneck, GPUs dilute per-GPU metrics).
+    """
+    import pandas as pd
+
+    agg_row = {
+        "model": "m",
+        "isl": 1000,
+        "osl": 100,
+        "prefix": 0,
+        "concurrency": 32,
+        "request_rate": 10.0,
+        "bs": 32,
+        "global_bs": 32,
+        "ttft": 100.0,
+        "tpot": 8.0,
+        "request_latency": 100.0 + 8.0 * 99,
+        "encoder_latency": 0.0,
+        "encoder_memory": 0.0,
+        "seq/s": 10.0,
+        "seq/s/gpu": 2.5,
+        "tokens/s": 1000.0,
+        "tokens/s/gpu": 250.0,
+        "tokens/s/user": 125.0,
+        "num_total_gpus": 4,
+        "tp": 4,
+        "pp": 1,
+        "dp": 1,
+        "moe_tp": 1,
+        "moe_ep": 1,
+        "cp": 1,
+        "parallel": "tp4pp1dp1",
+        "gemm": "fp8",
+        "kvcache": "fp8",
+        "fmha": "fp8",
+        "moe": "fp8",
+        "comm": "half",
+        "memory": 30.0,
+        "backend": "sglang",
+        "version": "0.5.10",
+        "system": "h200_sxm",
+        "power_w": 500.0,
+        "balance_score": 1.0,
+        "num_ctx_reqs": 1,
+        "num_gen_reqs": 31,
+        "num_tokens": 1000,
+        "ctx_tokens": 1000,
+        "gen_tokens": 31,
+    }
+    captured: dict = {}
+
+    def _fake_get_model(*, model_path, model_config, backend_name):
+        captured["encoder_colocated"] = model_config.encoder_colocated
+        return MagicMock()
+
+    monkeypatch.setattr(sweep, "get_model", _fake_get_model)
+    monkeypatch.setattr(sweep, "get_backend", lambda name: MagicMock())
+    monkeypatch.setattr(
+        sweep, "_sweep_one_parallel_agg", lambda **_kwargs: (pd.DataFrame([agg_row]), True, True)
+    )
+    monkeypatch.setattr(
+        sweep,
+        "_get_encoder_worker_candidates",
+        lambda **_kwargs: [
+            {"encoder_latency": 50.0, "seq/s": 80.0, "num_total_gpus": 2, "tp": 2, "bs": 4, "memory": 1.5}
+        ],
+    )
+
+    common_kwargs = dict(
+        model_path="m",
+        runtime_config=config.RuntimeConfig(isl=1000, osl=100, ttft=200.0, tpot=10.0),
+        database=MagicMock(),
+        backend_name="sglang",
+        model_config=config.ModelConfig(),
+        parallel_config_list=[(4, 1, 1, 1, 1, 1)],
+    )
+
+    # Default: encoder stays inline (colocated); rows pass through untouched.
+    agg_df = sweep.sweep_agg(**common_kwargs)
+    assert captured["encoder_colocated"] is True
+    assert "(e)workers" not in agg_df.columns
+    assert agg_df.iloc[0]["ttft"] == pytest.approx(100.0)
+
+    # E+agg: language-only agg workers + encode pool.
+    epd_df = sweep.sweep_agg(**common_kwargs, enable_epd=True, encoder_tp_list=[2])
+    assert captured["encoder_colocated"] is False
+    row = epd_df.iloc[0]
+    # TTFT = agg ttft + encode batch latency; request latency follows.
+    assert row["ttft"] == pytest.approx(150.0)
+    assert row["encoder_latency"] == pytest.approx(50.0)
+    assert row["request_latency"] == pytest.approx(100.0 + 8.0 * 99 + 50.0)
+    # Cell match: agg 10/w (4 gpus) vs encode capacity 80*0.9=72 (2 gpus)
+    # -> optimum (7 agg, 1 e): seq/s 70, gpus 28+2=30 (ties keep the smaller cell).
+    assert (row["(a)workers"], row["(e)workers"]) == (7, 1)
+    assert row["num_total_gpus"] == 30
+    assert row["seq/s"] == pytest.approx(70.0)
+    assert row["tokens/s/gpu"] == pytest.approx(7000.0 / 30, abs=1e-3)
+    assert row["concurrency"] == 32 * 7
+    assert (row["(e)tp"], row["(e)bs"], row["(e)parallel"]) == (2, 4, "tp2")
+
+
 def test_sweep_disagg_rejects_empty_num_worker_lists():
     """Empty worker lists silently skipped the rate-match inner loop in earlier
     versions; now fail loud to avoid surprising zero-result sweeps."""

--- a/tests/unit/sdk/sweep/test_sweep.py
+++ b/tests/unit/sdk/sweep/test_sweep.py
@@ -433,7 +433,7 @@ def test_sweep_disagg_epd_composes_encoder_stage(monkeypatch):
     assert epd_row["num_total_gpus"] == 42
     assert epd_row["seq/s"] == pytest.approx(60.0)
     assert epd_row["tokens/s/gpu"] == pytest.approx(6000.0 / 42, abs=1e-3)
-    assert (epd_row["(e)tp"], epd_row["(e)bs"], epd_row["(e)parallel"]) == (2, 4, "tp2")
+    assert (epd_row["(e)tp"], epd_row["(e)bs"]) == (2, 4)
     # request latency = corrected prefill ttft + tpot*(osl-1) + corrected encode stage.
     assert epd_row["request_latency"] == pytest.approx(108.0 + 8.0 * 99 + 90.0)
 
@@ -503,9 +503,7 @@ def test_sweep_agg_epd_composes_encoder_stage(monkeypatch):
 
     monkeypatch.setattr(sweep, "get_model", _fake_get_model)
     monkeypatch.setattr(sweep, "get_backend", lambda name: MagicMock())
-    monkeypatch.setattr(
-        sweep, "_sweep_one_parallel_agg", lambda **_kwargs: (pd.DataFrame([agg_row]), True, True)
-    )
+    monkeypatch.setattr(sweep, "_sweep_one_parallel_agg", lambda **_kwargs: (pd.DataFrame([agg_row]), True, True, 0))
     monkeypatch.setattr(
         sweep,
         "_get_encoder_worker_candidates",
@@ -544,7 +542,209 @@ def test_sweep_agg_epd_composes_encoder_stage(monkeypatch):
     assert row["seq/s"] == pytest.approx(70.0)
     assert row["tokens/s/gpu"] == pytest.approx(7000.0 / 30, abs=1e-3)
     assert row["concurrency"] == 32 * 7
-    assert (row["(e)tp"], row["(e)bs"], row["(e)parallel"]) == (2, 4, "tp2")
+    assert (row["(e)tp"], row["(e)bs"]) == (2, 4)
+
+
+def test_sweep_disagg_epd_encoder_can_bottleneck_under_replica_budget(monkeypatch):
+    """Three-pool rate matching under a per-replica GPU budget.
+
+    p/d workers of 10 seq/s x 1 GPU each; encode worker 10 seq/s x 1 GPU
+    (degraded capacity 9).  Sizing the encode pool to never bottleneck needs
+    2 encode workers, but that cell (1p+1d+2e = 4 GPUs) is outside
+    num_gpu_list=[3]; the only feasible cell is 1p1d1e with the encode pool
+    as the rate-matched bottleneck: seq/s = 9 (min of the three pools), not
+    the P/D-matched 10.  A ceil-only sizing would emit nothing here.
+    """
+    import pandas as pd
+
+    def _row(**overrides) -> dict:
+        base = {
+            "model": "m",
+            "isl": 1000,
+            "osl": 100,
+            "prefix": 0,
+            "concurrency": 1,
+            "request_rate": 0.0,
+            "bs": 1,
+            "global_bs": 1,
+            "ttft": 60.0,
+            "tpot": 0.0,
+            "seq/s": 10.0,
+            "seq/s/gpu": 10.0,
+            "tokens/s": 10.0,
+            "tokens/s/gpu": 10.0,
+            "tokens/s/user": 0.0,
+            "request_latency": 60.0,
+            "encoder_latency": 0.0,
+            "encoder_memory": 0.0,
+            "num_total_gpus": 1,
+            "tp": 1,
+            "pp": 1,
+            "dp": 1,
+            "moe_tp": 1,
+            "moe_ep": 1,
+            "cp": 1,
+            "parallel": "tp1pp1dp1",
+            "gemm": "fp8",
+            "kvcache": "fp8",
+            "fmha": "fp8",
+            "moe": "fp8",
+            "comm": "half",
+            "memory": 30.0,
+            "power_w": 500.0,
+        }
+        base.update(overrides)
+        return base
+
+    prefill_df = pd.DataFrame([_row()])
+    decode_df = pd.DataFrame([_row(bs=32, global_bs=32, concurrency=32, ttft=0.0, tpot=8.0)])
+
+    monkeypatch.setattr(
+        sweep,
+        "_get_disagg_worker_candidates",
+        lambda *, role, **_kwargs: (decode_df if role == "decode" else prefill_df).copy(),
+    )
+    monkeypatch.setattr(
+        sweep,
+        "_get_encoder_worker_candidates",
+        lambda **_kwargs: [
+            {"encoder_latency": 50.0, "seq/s": 10.0, "num_total_gpus": 1, "tp": 1, "bs": 4, "memory": 1.0}
+        ],
+    )
+
+    row = sweep_disagg(
+        model_path="m",
+        runtime_config=config.RuntimeConfig(isl=1000, osl=100, ttft=200.0, tpot=10.0),
+        prefill_database=MagicMock(),
+        prefill_backend_name="sglang",
+        prefill_model_config=config.ModelConfig(),
+        prefill_parallel_config_list=[(1, 1, 1, 1, 1, 1)],
+        prefill_latency_correction=1.0,
+        decode_database=MagicMock(),
+        decode_backend_name="sglang",
+        decode_model_config=config.ModelConfig(),
+        decode_parallel_config_list=[(1, 1, 1, 1, 1, 1)],
+        decode_latency_correction=1.0,
+        prefill_num_worker_list=[1, 2],
+        decode_num_worker_list=[1, 2],
+        num_gpu_list=[3],
+        rate_matching_prefill_degradation=1.0,
+        rate_matching_decode_degradation=1.0,
+        enable_epd=True,
+        encoder_tp_list=[1],
+    ).iloc[0]
+
+    assert (row["(p)workers"], row["(d)workers"], row["(e)workers"]) == (1, 1, 1)
+    assert row["num_total_gpus"] == 3
+    # Encode pool binds: 10 * 1 * 0.9 = 9 < min(p, d) = 10.
+    assert row["seq/s"] == pytest.approx(9.0)
+    assert row["tokens/s/gpu"] == pytest.approx(900.0 / 3, abs=1e-3)
+
+
+def test_sweep_agg_epd_respects_replica_budget(monkeypatch):
+    """E+agg cell selection under num_gpu_list, with an encode-bound cell.
+
+    agg worker 10 seq/s x 4 GPUs; encode worker 8 seq/s x 2 GPUs (degraded
+    capacity 7.2).  Unbudgeted, the argmax grows the cell to amortize the
+    encode ceil; num_gpu_list=[6] leaves exactly one feasible cell — 1 agg +
+    1 encode — which is encode-bound: seq/s = 7.2.
+    """
+    import pandas as pd
+
+    # Only the keys the (agg x encode) matcher and the encoder overlay read.
+    agg_row = {
+        "osl": 100,
+        "concurrency": 32,
+        "ttft": 100.0,
+        "tpot": 8.0,
+        "request_latency": 892.0,
+        "seq/s": 10.0,
+        "tokens/s": 1000.0,
+        "num_total_gpus": 4,
+    }
+
+    monkeypatch.setattr(sweep, "get_model", lambda **_kwargs: MagicMock())
+    monkeypatch.setattr(sweep, "get_backend", lambda name: MagicMock())
+    monkeypatch.setattr(sweep, "_sweep_one_parallel_agg", lambda **_kwargs: (pd.DataFrame([agg_row]), True, True))
+    monkeypatch.setattr(
+        sweep,
+        "_get_encoder_worker_candidates",
+        lambda **_kwargs: [
+            {"encoder_latency": 50.0, "seq/s": 8.0, "num_total_gpus": 2, "tp": 2, "bs": 4, "memory": 1.5}
+        ],
+    )
+
+    row = sweep.sweep_agg(
+        model_path="m",
+        runtime_config=config.RuntimeConfig(isl=1000, osl=100, ttft=200.0, tpot=10.0),
+        database=MagicMock(),
+        backend_name="sglang",
+        model_config=config.ModelConfig(),
+        parallel_config_list=[(4, 1, 1, 1, 1, 1)],
+        enable_epd=True,
+        encoder_tp_list=[2],
+        num_gpu_list=[6],
+    ).iloc[0]
+
+    assert (row["(a)workers"], row["(e)workers"]) == (1, 1)
+    assert row["num_total_gpus"] == 6
+    # Encode pool binds: 8 * 1 * 0.9 = 7.2 < 10.
+    assert row["seq/s"] == pytest.approx(7.2)
+
+
+def test_sweep_agg_epd_top_k_defers_to_encoder_pairing(monkeypatch):
+    """The top_k cut must happen per encode pairing, not on the language-only
+    rows: with top_k=1 the higher-throughput row (no encode headroom,
+    50 + 180 >= 200) would otherwise shadow the only pairable row."""
+    import pandas as pd
+
+    # Only the keys the (agg x encode) matcher and the encoder overlay read.
+    def _row(ttft: float, seq_s: float) -> dict:
+        return {
+            "osl": 100,
+            "concurrency": 32,
+            "ttft": ttft,
+            "tpot": 8.0,
+            "request_latency": ttft + 8.0 * 99,
+            "seq/s": seq_s,
+            "tokens/s": seq_s * 100,
+            "num_total_gpus": 4,
+        }
+
+    captured: dict = {}
+
+    def _fake_sweep_one(**kwargs):
+        captured["top_k"] = kwargs["top_k"]
+        return pd.DataFrame([_row(ttft=180.0, seq_s=50.0), _row(ttft=60.0, seq_s=10.0)]), True, True
+
+    monkeypatch.setattr(sweep, "get_model", lambda **_kwargs: MagicMock())
+    monkeypatch.setattr(sweep, "get_backend", lambda name: MagicMock())
+    monkeypatch.setattr(sweep, "_sweep_one_parallel_agg", _fake_sweep_one)
+    monkeypatch.setattr(
+        sweep,
+        "_get_encoder_worker_candidates",
+        lambda **_kwargs: [
+            {"encoder_latency": 50.0, "seq/s": 8.0, "num_total_gpus": 2, "tp": 2, "bs": 4, "memory": 1.5}
+        ],
+    )
+
+    df = sweep.sweep_agg(
+        model_path="m",
+        runtime_config=config.RuntimeConfig(isl=1000, osl=100, ttft=200.0, tpot=10.0),
+        database=MagicMock(),
+        backend_name="sglang",
+        model_config=config.ModelConfig(),
+        parallel_config_list=[(4, 1, 1, 1, 1, 1)],
+        top_k=1,
+        enable_epd=True,
+        encoder_tp_list=[2],
+    )
+
+    # The language-only rows reach the pairing uncut ...
+    assert captured["top_k"] == 0
+    # ... and the pairable row (ttft 60 + encode 50) wins the per-choice slot.
+    assert len(df) == 1
+    assert df.iloc[0]["ttft"] == pytest.approx(110.0)
 
 
 def test_sweep_disagg_rejects_empty_num_worker_lists():

--- a/tests/unit/sdk/sweep/test_sweep.py
+++ b/tests/unit/sdk/sweep/test_sweep.py
@@ -705,6 +705,7 @@ def test_encoder_worker_candidates_gated_by_gpu_memory(monkeypatch):
         50.0,
         100.0,
         {"total": memory_by_batch[b]},
+        1.0,
     )
     monkeypatch.setattr(sweep, "get_backend", lambda _name: backend)
 
@@ -727,6 +728,130 @@ def test_encoder_worker_candidates_gated_by_gpu_memory(monkeypatch):
     # The gate charges the framework overhead too: batch 2 (15 + 5 other_mem
     # >= 20 GiB) stops the schedule; only batch 1 survives.
     assert [r["bs"] for r in rows] == [1]
+
+
+def _encoder_candidates_env(monkeypatch, *, latency: float = 50.0):
+    """Fixture env for _get_encoder_worker_candidates: real encoder ops,
+    mocked perf query, nccl_mem table with keys {1, 2} only."""
+    from aiconfigurator.sdk import common
+
+    enc_cfg = common.VisionEncoderConfig(
+        depth=2,
+        hidden_size=64,
+        num_heads=4,
+        intermediate_size=128,
+        patch_size=16,
+        temporal_patch_size=1,
+        spatial_merge_size=2,
+        out_hidden_size=64,
+        projector_dims=((64, 64),),
+        projector_n_instances=1,
+        partial_rotary_factor=0.0,
+    )
+    monkeypatch.setattr(sweep, "get_model_config_from_model_path", lambda _path: {"extra_params": enc_cfg})
+    backend = MagicMock()
+    backend.OTHERS_OVERHEAD_FRAC = 0.0
+    backend.run_encoder_static.side_effect = lambda model, database, rc, b, latency_correction_scale=1.0: (
+        latency,
+        100.0,
+        {"total": 1.0},
+        1.0,
+    )
+    monkeypatch.setattr(sweep, "get_backend", lambda _name: backend)
+    database = MagicMock()
+    database.system_spec = {
+        "gpu": {"mem_capacity": 20 * (1 << 30)},
+        "misc": {"nccl_mem": {1: 0, 2: 0}, "other_mem": 0},
+    }
+    return database
+
+
+_ENC_RC = config.RuntimeConfig(
+    isl=1000, osl=100, ttft=200.0, tpot=10.0, image_height=256, image_width=256, num_images_per_request=1
+)
+
+
+def test_encoder_tp_without_comm_data_is_skipped_not_crashed(monkeypatch):
+    """tp values absent from the system's nccl_mem table are skipped with a
+    warning instead of raising a raw KeyError; all-skipped fails loud."""
+    database = _encoder_candidates_env(monkeypatch)
+    rows = sweep._get_encoder_worker_candidates(
+        model_path="m",
+        tp_list=[2, 3],
+        b_list=[1],
+        runtime_config=_ENC_RC,
+        database=database,
+        backend_name="sglang",
+        latency_correction=1.0,
+    )
+    assert [r["tp"] for r in rows] == [2]
+    with pytest.raises(NoFeasibleConfigError):
+        sweep._get_encoder_worker_candidates(
+            model_path="m",
+            tp_list=[3],
+            b_list=[1],
+            runtime_config=_ENC_RC,
+            database=database,
+            backend_name="sglang",
+            latency_correction=1.0,
+        )
+
+
+def test_encoder_zero_latency_fails_loud(monkeypatch):
+    """A non-positive batch latency (corrupt perf data or zero correction)
+    raises instead of ZeroDivisionError / silently skewing the sweep."""
+    database = _encoder_candidates_env(monkeypatch, latency=0.0)
+    with pytest.raises(ValueError, match="invalid batch latency"):
+        sweep._get_encoder_worker_candidates(
+            model_path="m",
+            tp_list=[1],
+            b_list=[1],
+            runtime_config=_ENC_RC,
+            database=database,
+            backend_name="sglang",
+            latency_correction=1.0,
+        )
+
+
+def test_overlay_encoder_stage_degradation_knob_and_coverage_blend():
+    """The overlay honors a custom encoder degradation and re-weights
+    power_coverage with the same time weights as power_w; rows without a
+    coverage key must not gain one."""
+    row = {
+        "ttft": 100.0,
+        "tpot": 10.0,
+        "osl": 11,
+        "request_latency": 200.0,
+        "seq/s": 10.0,
+        "tokens/s": 1000.0,
+        "request_rate": 10.0,
+        "num_total_gpus": 4,
+        "power_w": 0.0,
+        "power_coverage": 1.0,
+    }
+    enc = {
+        "encoder_latency": 50.0,
+        "seq/s": 8.0,
+        "num_total_gpus": 1,
+        "tp": 1,
+        "bs": 2,
+        "memory": 1.0,
+        "power_w": 0.0,
+        "power_coverage": 0.0,
+    }
+    out = sweep._overlay_encoder_stage(row, enc, 1, encoder_degradation=0.5)
+    assert out["seq/s"] == pytest.approx(4.0)  # 8.0 x 0.5 x 1 caps the row's 10.0
+    # decode_time = 10 x (11 - 1); coverage = (0 x 50 + 1.0 x 200) / 250.
+    assert out["power_coverage"] == pytest.approx(0.8)
+    # Sweep rows (no coverage channel): anything short of full encoder
+    # energy data zeroes the blended power instead of understating it.
+    bare = {k: v for k, v in row.items() if k != "power_coverage"}
+    for partial in (0.99, float("nan")):
+        zeroed = sweep._overlay_encoder_stage(bare, dict(enc, power_coverage=partial), 1, prefill_power=100.0)
+        assert "power_coverage" not in zeroed
+        assert zeroed["power_w"] == 0.0
+    covered = sweep._overlay_encoder_stage(bare, dict(enc, power_coverage=1.0), 1, prefill_power=100.0)
+    assert covered["power_w"] > 0.0
 
 
 def test_sweep_agg_epd_top_k_defers_to_encoder_pairing(monkeypatch):

--- a/tests/unit/sdk/sweep/test_sweep.py
+++ b/tests/unit/sdk/sweep/test_sweep.py
@@ -813,6 +813,76 @@ def test_encoder_zero_latency_fails_loud(monkeypatch):
         )
 
 
+def test_encoder_batch_candidates_capped_at_sglang_max(monkeypatch):
+    """The batch cap (8) holds at every entry: explicit candidates at the
+    helper, Task validation, and the single-point arguments."""
+    from aiconfigurator.sdk.task_v2 import Task
+
+    database = _encoder_candidates_env(monkeypatch)
+    rows = sweep._get_encoder_worker_candidates(
+        model_path="m",
+        tp_list=[1],
+        b_list=[1, 8],
+        runtime_config=_ENC_RC,
+        database=database,
+        backend_name="sglang",
+        latency_correction=1.0,
+    )
+    assert max(r["bs"] for r in rows) == 8
+    with pytest.raises(ValueError, match="exceed the supported maximum"):
+        sweep._get_encoder_worker_candidates(
+            model_path="m",
+            tp_list=[1],
+            b_list=[9, 16],
+            runtime_config=_ENC_RC,
+            database=database,
+            backend_name="sglang",
+            latency_correction=1.0,
+        )
+    with pytest.raises(ValueError, match="encoder_batch_candidates must be <="):
+        Task(enable_epd=True, encoder_batch_candidates=[9]).validate()
+    with pytest.raises(ValueError, match="encoder_batch_size must be <="):
+        Task(enable_epd=True).run_single_agg(tp=1, batch_size=1, encoder_tp=1, encoder_batch_size=9)
+
+
+def test_rate_match_agg_epd_keeps_cluster_packing_winner():
+    """A larger cell can lose on per-cell efficiency yet win once whole cells
+    are packed into the cluster; the emitted frontier must retain it
+    (1a+2e = 16 GPUs @ 10/s vs 2a+2e = 24 GPUs @ 12/s, total_gpus = 24)."""
+    agg_row = {
+        "ttft": 100.0,
+        "tpot": 10.0,
+        "osl": 100,
+        "request_latency": 200.0,
+        "seq/s": 10.0,
+        "tokens/s": 1000.0,
+        "request_rate": 10.0,
+        "concurrency": 8,
+        "num_total_gpus": 8,
+        "power_w": 0.0,
+    }
+    enc_worker = {
+        "encoder_latency": 10.0,
+        "seq/s": 6.0,
+        "num_total_gpus": 4,
+        "tp": 4,
+        "bs": 1,
+        "memory": 1.0,
+    }
+    df = sweep._rate_match_agg_epd(
+        pd.DataFrame([agg_row]),
+        [enc_worker],
+        ttft_target=1000.0,
+        num_gpu_set={16, 24},
+        encoder_degradation=1.0,
+    )
+    cells = {int(r["num_total_gpus"]): float(r["seq/s"]) for r in df.to_dict("records")}
+    assert cells == {16: 10.0, 24: 12.0}
+    total_gpus = 24
+    packed = {gpus: (total_gpus // gpus) * rate for gpus, rate in cells.items()}
+    assert packed[24] > packed[16]
+
+
 def test_overlay_encoder_stage_degradation_knob_and_coverage_blend():
     """The overlay honors a custom encoder degradation and re-weights
     power_coverage with the same time weights as power_w; rows without a
@@ -906,8 +976,9 @@ def test_sweep_agg_epd_top_k_defers_to_encoder_pairing(monkeypatch):
 
     # The pairable row (ttft 60 + encode 50) wins the per-choice slot; a cut
     # before the pairing would have dropped it (fake returns rows seq/s-desc).
-    assert len(df) == 1
-    assert df.iloc[0]["ttft"] == pytest.approx(110.0)
+    # Every emitted frontier cell derives from that one pairable base row.
+    assert len(df) > 0
+    assert df["ttft"].eq(110.0).all()
 
 
 def test_sweep_disagg_rejects_empty_num_worker_lists():

--- a/tests/unit/sdk/task_v2/test_epd_real_database.py
+++ b/tests/unit/sdk/task_v2/test_epd_real_database.py
@@ -15,6 +15,8 @@ import pytest
 from aiconfigurator.sdk import config
 from aiconfigurator.sdk.task_v2 import Task
 
+pytestmark = pytest.mark.unit
+
 _MODEL = "Qwen/Qwen3-VL-8B-Instruct"
 _SYSTEM = "h200_sxm"
 _BACKEND = "sglang"

--- a/tests/unit/sdk/task_v2/test_epd_real_database.py
+++ b/tests/unit/sdk/task_v2/test_epd_real_database.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""EPD single-point evaluation against a real packaged perf database.
+
+Synthetic databases route the engine step to the Python path, so only a
+real database exercises the default compiled-engine path where the encode
+worker's ``EncoderOnlyModel`` must satisfy the full-engine spec contract.
+"""
+
+import json
+
+import pytest
+
+from aiconfigurator.sdk import config
+from aiconfigurator.sdk.task_v2 import Task
+
+_MODEL = "Qwen/Qwen3-VL-8B-Instruct"
+_SYSTEM = "h200_sxm"
+_BACKEND = "sglang"
+_WORKLOAD = dict(
+    isl=2048,
+    osl=256,
+    image_height=768,
+    image_width=768,
+    num_images_per_request=2,
+)
+
+
+def test_encoder_only_model_satisfies_engine_spec_contract():
+    from aiconfigurator_core.sdk.engine import build_engine_spec_json
+    from aiconfigurator_core.sdk.models.vit_ops import EncoderOnlyModel
+
+    model = EncoderOnlyModel(
+        encoder_ops=[],
+        encoder_config=None,
+        config=config.ModelConfig(tp_size=2, enable_encoder_dp=False),
+    )
+    spec = json.loads(
+        build_engine_spec_json(
+            model,
+            model_path="epd-encoder-only",
+            system=_SYSTEM,
+            backend=_BACKEND,
+            backend_version=None,
+            kv_block_size=None,
+            systems_path=None,
+            nextn=0,
+        )
+    )
+    assert spec["context_ops"] == []
+    assert spec["generation_ops"] == []
+
+
+@pytest.mark.parametrize("engine_step_backend", [None, "rust"])
+def test_run_single_agg_epd_real_database(engine_step_backend):
+    task = Task(
+        serving_mode="agg",
+        model_path=_MODEL,
+        system_name=_SYSTEM,
+        backend_name=_BACKEND,
+        enable_epd=True,
+        engine_step_backend=engine_step_backend,
+        **_WORKLOAD,
+    )
+    row = task.run_single_agg(tp=1, batch_size=1, encoder_tp=1)
+    assert row["(e)workers"] == 1
+    assert row["encoder_latency"] > 0
+    assert row["ttft"] > row["encoder_latency"]
+
+
+@pytest.mark.parametrize("engine_step_backend", [None, "rust"])
+def test_run_single_disagg_epd_real_database(engine_step_backend):
+    task = Task(
+        serving_mode="disagg",
+        prefill_model_path=_MODEL,
+        decode_model_path=_MODEL,
+        prefill_system_name=_SYSTEM,
+        decode_system_name=_SYSTEM,
+        prefill_backend_name=_BACKEND,
+        decode_backend_name=_BACKEND,
+        enable_epd=True,
+        engine_step_backend=engine_step_backend,
+        **_WORKLOAD,
+    )
+    row = task.run_single_disagg(
+        prefill_tp=1,
+        decode_tp=1,
+        decode_batch_size=8,
+        encoder_tp=1,
+    )
+    assert row["(e)workers"] == 1
+    assert row["encoder_latency"] > 0
+    assert row["ttft"] > row["encoder_latency"]

--- a/tests/unit/sdk/task_v2/test_task_config.py
+++ b/tests/unit/sdk/task_v2/test_task_config.py
@@ -38,6 +38,16 @@ def test_enable_epd_pins_encoder_dp_off():
     assert Task(enable_epd=True).enable_encoder_dp is False
 
 
+def test_run_single_epd_arg_validation():
+    task = Task(enable_epd=True)
+    with pytest.raises(ValueError, match="requires encoder_tp"):
+        task.run_single_agg(tp=1, batch_size=1)
+    with pytest.raises(ValueError, match="requires encoder_tp"):
+        task.run_single_disagg(prefill_tp=1, decode_tp=1, decode_batch_size=1)
+    with pytest.raises(ValueError, match="requires enable_epd"):
+        Task().run_single_agg(tp=1, batch_size=1, encoder_tp=2)
+
+
 def test_agg_with_model_resolves_identity_and_backend():
     t = Task(
         serving_mode="agg",

--- a/tests/unit/sdk/task_v2/test_task_config.py
+++ b/tests/unit/sdk/task_v2/test_task_config.py
@@ -45,6 +45,17 @@ def test_run_single_epd_arg_validation():
         Task(enable_epd=True).run_single_agg(tp=1, batch_size=1, encoder_tp=1, encoder_num_workers=0)
     with pytest.raises(ValueError, match="require enable_epd"):
         Task().run_single_agg(tp=1, batch_size=1, encoder_tp=2)
+    with pytest.raises(ValueError, match="positive finite"):
+        Task(enable_epd=True, rate_match_encoder_degradation=-1.0).run_single_agg(tp=1, batch_size=1, encoder_tp=1)
+    with pytest.raises(ValueError, match="require enable_epd"):
+        Task(rate_match_encoder_degradation=0.7).run_single_agg(tp=1, batch_size=1)
+    with pytest.raises(ValueError, match="positive finite"):
+        Task(rate_match_prefill_degradation=-1.0).run_single_disagg(prefill_tp=1, decode_tp=1, decode_batch_size=1)
+
+
+def test_from_cli_resolves_quant_strings():
+    t = Task.from_cli(gemm_quant_mode="fp8", prefill_kvcache_quant_mode=None)
+    assert t.gemm_quant_mode is common.GEMMQuantMode.fp8
 
 
 def test_agg_with_model_resolves_identity_and_backend():

--- a/tests/unit/sdk/task_v2/test_task_config.py
+++ b/tests/unit/sdk/task_v2/test_task_config.py
@@ -1453,6 +1453,7 @@ def _build_fake_summary(result_dict: dict | None = None, oom: bool = False):
     import pandas as pd
 
     s.get_summary_df.return_value = pd.DataFrame([result_dict or {"tokens/s/gpu": 100.0, "ttft": 50.0, "tpot": 20.0}])
+    s.get_power_data_coverage.return_value = 1.0
     return s
 
 

--- a/tests/unit/sdk/task_v2/test_task_config.py
+++ b/tests/unit/sdk/task_v2/test_task_config.py
@@ -30,6 +30,14 @@ def test_default_task_config_is_agg_with_default_workload():
     assert t.tpot == 50.0
 
 
+def test_enable_epd_pins_encoder_dp_off():
+    # EPD encode workers model the engines' encoder-instance default
+    # (weight-sharded ViT); the colocated encoder-DP default stays True
+    # only outside EPD.
+    assert Task().enable_encoder_dp is True
+    assert Task(enable_epd=True).enable_encoder_dp is False
+
+
 def test_agg_with_model_resolves_identity_and_backend():
     t = Task(
         serving_mode="agg",

--- a/tests/unit/sdk/task_v2/test_task_config.py
+++ b/tests/unit/sdk/task_v2/test_task_config.py
@@ -38,6 +38,13 @@ def test_enable_epd_pins_encoder_dp_off():
     assert Task(enable_epd=True).enable_encoder_dp is False
 
 
+def test_enable_epd_rejects_afd_serving_mode():
+    # sweep_afd carries no EPD parameters; accepting the combination would
+    # silently run a plain AFD sweep with every encoder knob dropped.
+    with pytest.raises(ValueError, match="serving_mode 'agg' or 'disagg'"):
+        Task(serving_mode="afd", enable_epd=True)
+
+
 def test_run_single_epd_arg_validation():
     with pytest.raises(ValueError, match="requires encoder_tp"):
         Task(enable_epd=True).run_single_agg(tp=1, batch_size=1)

--- a/tests/unit/sdk/task_v2/test_task_config.py
+++ b/tests/unit/sdk/task_v2/test_task_config.py
@@ -39,12 +39,11 @@ def test_enable_epd_pins_encoder_dp_off():
 
 
 def test_run_single_epd_arg_validation():
-    task = Task(enable_epd=True)
     with pytest.raises(ValueError, match="requires encoder_tp"):
-        task.run_single_agg(tp=1, batch_size=1)
-    with pytest.raises(ValueError, match="requires encoder_tp"):
-        task.run_single_disagg(prefill_tp=1, decode_tp=1, decode_batch_size=1)
-    with pytest.raises(ValueError, match="requires enable_epd"):
+        Task(enable_epd=True).run_single_agg(tp=1, batch_size=1)
+    with pytest.raises(ValueError, match="positive int"):
+        Task(enable_epd=True).run_single_agg(tp=1, batch_size=1, encoder_tp=1, encoder_num_workers=0)
+    with pytest.raises(ValueError, match="require enable_epd"):
         Task().run_single_agg(tp=1, batch_size=1, encoder_tp=2)
 
 


### PR DESCRIPTION
#### Overview:

Adds EPD (encoder/prefill/decode disaggregation) modeling for vision-language models, mirroring how real EPD deployments work (SGLang `--encoder-only` / language-only instances). One switch, both serving modes: `--enable-epd` turns the disagg experiment into **E+P+D** and the agg experiment into **E+agg**.

#### Details:

**Topology**

* `--enable-epd` (Task field `enable_epd`): the vision encoder runs on dedicated encode workers instead of colocated with prefill/agg.
* **Encode (E) workers** are encoder-only instances built directly from the encoder config (`EncoderOnlyModel`, no LLM weights; it satisfies the compiled-engine spec contract with empty LM op lists, so the default Rust engine path works). ViT weight-sharded over the worker's TP with encoder DP off — the encoder-instance default of both engines (vLLM  `mm_encoder_tp_mode="weights"`, SGLang `mm_enable_dp_encoder=False`). `enable_epd` pins the Task-level encoder-DP knob off accordingly; the DP layout's benefit is expressed by sweeping multiple small-TP encode workers instead.
* **P/agg workers become language-only** (`ModelConfig.language_only=True`): vision tokens still extend the context, but no ViT compute/memory lands on the LM worker.

**Search space & rate matching**

* Encode-worker candidates: encoder TP (default `1/2/4/8`) × batch (default `1/2/4/8`); per-worker throughput = batch / encode latency. Batch is capped at 8 (SGLang's `SGLANG_ENCODER_MAX_BATCH_SIZE` default) and enforced fail-loud at Task validation, the candidate helper, and the single-point args. Candidates are OOM-gated against the encoder system's GPU memory with the same framework overhead the P/D checks charge.
* **3-pool rate matching**: cell throughput = min of the degraded E/P/D pool capacities — the encode pool can itself be the bottleneck. Pool size is swept up to `max_encoder_workers` (default 32, mirroring the P/D worker lists); over-provisioned pools are enumerated too, since they can be the only counts that land on an exact per-replica GPU grid. Encode GPUs count toward the per-GPU objective and the replica GPU budget.
* **E+agg**: each row is a rate-matched cell of `(a)workers` language-only agg workers plus `(e)workers` encode workers (`common.ColumnsAggEpd` schema). Per encoder choice, the best rate for every admissible cell GPU count is kept as a nondominated (cell gpus, cell rate) frontier, so the cluster-aware floor-packing picker — not a per-cell efficiency score — makes the final call. Disagg rows fill the existing `(e)*` columns (+ new `(e)bs`).

**TTFT composition**

* Encode → prefill is sequential per request: each encode choice spends its batch latency out of the TTFT budget before the LM-side SLA filter.
* The queueing correction mirrors each baseline: disagg corrects the encode stage like its prefill TTFT (×1.8, since the inline baseline corrects its combined E+P TTFT); agg adds the raw encode latency (run_agg adds the inline encoder outside its queueing factor) — so EPD-vs-baseline comparisons stay apples-to-apples in both modes.

**Knobs & APIs**

* Task: `encoder_tp_candidates`, `encoder_batch_candidates`, `max_encoder_workers`, `encoder_latency_correction`, `encoder_system_name` (hetero encoder: encode pool on its own GPU type; missing perf DB fails loud instead of silently falling back). All encoder knobs require `enable_epd`.
* CLI: `--enable-epd`, `--encoder-tp`, `--encoder-system`, `--encoder-latency-correction`.
* **Single-point evaluation**: `run_single_agg` / `run_single_disagg` accept `encoder_tp` / `encoder_batch_size` / `encoder_num_workers` to spot-check one fixed EPD cell (raw-TTFT convention, args validated fail-loud).
* Docs: `docs/cli_user_guide.md` (CLI controls, default + estimate modes), `docs/advanced_tuning.md` (Task tuning fields), `docs/generator_overview.md` (EPD rows are fail-closed in the generator).

**Behavior with EPD off**

* Text-only paths are byte-identical to main (locked by the rate-match parity test).
* Two **in-scope VL fidelity fixes** apply regardless of EPD (before/after on packaged h200_sxm/sglang, Qwen3-VL-8B):

<!-- linear:table-colwidths:160,160,160,160,160 -->
| Fix | Case | main | this PR | Why |
| -- | -- | -- | -- | -- |
| Smart-resize rounding (floor → round) | 1010×1010 estimate | 961 tok/img; TTFT 431.58 ms | 1024 tok/img; TTFT 441.14 ms | HF `smart_resize` rounds each side to the *nearest* multiple of 32; flooring undercounts the tokens the deployed preprocessor produces. 32-aligned resolutions and text-only: unchanged. |
| Plain-agg ctx grid on effective ISL | default agg sweep, 768²×2 imgs | ctx grid 2048; top1 2177.01 tok/s/gpu | ctx grid 3200; top1 2101.66 tok/s/gpu | Vision embeddings occupy LLM context — the engine prefills 3200 tokens/request; the text-only grid understated per-iteration prefill work (legacy `find_best_agg` behavior restored). |

Disagg pareto rows are unchanged (only the new empty `(e)bs` schema column differs).

**Not modeled (out of scope for this PR)**

* E→P embedding transfer time and encode-side queueing/host CPU overhead.

## Usage

```bash
aiconfigurator cli default --model-path Qwen/Qwen3-VL-8B-Instruct \
  --total-gpus 32 --system h200_sxm --backend sglang \
  --isl 2000 --osl 200 --ttft 250 --tpot 20 \
  --image-height 1344 --image-width 1344 --num-images 2 \
  --enable-epd
```

#### Where should the reviewer start?

* `src/aiconfigurator/sdk/sweep.py` — the EPD section: `_get_encoder_worker_candidates` (candidate enumeration + VRAM gate), `_overlay_encoder_stage` (single composition point for both topologies), `_rate_match_agg_epd` (E+agg frontier), and the 3-pool `_match_workers` closure in `sweep_disagg`.
* `src/aiconfigurator/sdk/task_v2.py` — `enable_epd` + encoder knobs, `_normalize_epd_encoder_dp`, and the `run_single_*` EPD path.
* `aic-core`: `models/blocks/vit.py` (`EncoderOnlyModel`, `build_encoder_ops`; `vit_ops.py` is now a compatibility shim) and `backends/base_backend.py` (`run_encoder_static`);`common.py` (`ColumnsAggEpd`, `(e)bs`).
* Real-database regressions: `tests/unit/sdk/task_v2/test_epd_real_database.py` (default-Rust path, agg + disagg).

#### Related Issues:

* Closes ai-dynamo/aiconfigurator#1546

## Summary by CodeRabbit

* **New Features**
  * Added optional dedicated vision encoder workers for vision-language inference.
  * Added controls for encoder tensor parallelism, batch sizing, latency adjustment, and GPU system selection.
  * Added encoder-aware aggregated and disaggregated performance sweeps, including worker matching and resource reporting.
  * Extended CLI and Python APIs with encoder configuration options.
* **Bug Fixes**
  * Improved visual token estimation by rounding image dimensions correctly.
  * Workers without vision encoders now handle vision context consistently.
  * Reports now include encoder worker details and batch sizes when applicable.