### PR TITLE
fix(sdk): extend the DeepSeek-V4 sglang MoE kernel remap to V4-Flash

### DIFF
--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -726,13 +726,19 @@ class Task:
                 from_hf = base.get(key)
                 if key == "fmha_quant_mode":
                     fmha_explicit[role] = explicit is not None
-                # DeepSeek-V4-Pro on sglang uses arch-specific MoE kernels. This acts at
-                # the HF-base layer so an explicit field still overrides it. Skip megamoe,
-                # which keys its own quant table. Mirrors legacy V1 dsv4pro-moe-arch.
+                # Native DeepSeek-V4 checkpoints on sglang use arch-specific MoE
+                # kernels (collector kernel_source sglang_mxfp4_flashinfer_trtllm_moe /
+                # sglang_flashinfer_cutlass_moe; the loader files those rows under the
+                # dedicated quant modes). This acts at the HF-base layer so an explicit
+                # field still overrides it. Skip megamoe, which keys its own quant
+                # table, and the sgl-project *-FP8 requant artifacts, whose MoE runs
+                # fp8_block. Mirrors legacy V1 dsv4pro-moe-arch; extended to V4-Flash,
+                # whose serving selects the same kernels per platform.
                 if (
                     key == "moe_quant_mode"
                     and self._role_attr(role, "backend_name") == "sglang"
-                    and self._role_attr(role, "model_path") == "deepseek-ai/DeepSeek-V4-Pro"
+                    and self._role_attr(role, "model_path")
+                    in ("deepseek-ai/DeepSeek-V4-Pro", "deepseek-ai/DeepSeek-V4-Flash")
                     and self.moe_backend != "megamoe"
                 ):
                     sysn = self._role_attr(role, "system_name")

--- a/tests/unit/sdk/task_v2/test_task_config.py
+++ b/tests/unit/sdk/task_v2/test_task_config.py
@@ -466,24 +466,33 @@ def test_moe_backend_flows_into_model_config():
     assert t.build_model_config(role="agg").moe_backend == "deepep_moe"
 
 
-def test_dsv4_pro_sglang_moe_remap():
-    """DeepSeek-V4-Pro on sglang remaps MoE to the arch-specific kernel (v1 dsv4pro-moe-arch):
-    Blackwell -> w4a8_mxfp4_mxfp8_trtllm. megamoe and non-sglang backends are exempt.
+def test_dsv4_native_sglang_moe_remap():
+    """Native DeepSeek-V4 (Pro AND Flash) on sglang remaps MoE to the arch-specific
+    kernel (v1 dsv4pro-moe-arch): Blackwell -> w4a8_mxfp4_mxfp8_trtllm; on Hopper
+    the native FP4-expert checkpoints are rejected outright. megamoe, non-sglang
+    backends, and the sgl-project FP8 requant artifacts are exempt.
     """
     from aiconfigurator.sdk import common
 
-    def moe(be, **kw):
+    def moe(be, mp="deepseek-ai/DeepSeek-V4-Pro", system="b200_sxm", **kw):
         return Task(
             serving_mode="agg",
-            model_path="deepseek-ai/DeepSeek-V4-Pro",
-            system_name="b200_sxm",
+            model_path=mp,
+            system_name=system,
             backend_name=be,
             **kw,
         ).moe_quant_mode
 
-    assert moe("sglang") == common.MoEQuantMode.w4a8_mxfp4_mxfp8_trtllm
+    for mp in ("deepseek-ai/DeepSeek-V4-Pro", "deepseek-ai/DeepSeek-V4-Flash"):
+        assert moe("sglang", mp=mp) == common.MoEQuantMode.w4a8_mxfp4_mxfp8_trtllm
+        # Native FP4-expert checkpoints are rejected outright on Hopper.
+        with pytest.raises(ValueError, match="native FP4 routed-expert"):
+            moe("sglang", mp=mp, system="h200_sxm")
+        assert moe("trtllm", mp=mp) != common.MoEQuantMode.w4a8_mxfp4_mxfp8_trtllm
+    # megamoe keys its own quant table (packaged data exists only for V4-Pro).
     assert moe("sglang", moe_backend="megamoe") != common.MoEQuantMode.w4a8_mxfp4_mxfp8_trtllm
-    assert moe("trtllm") != common.MoEQuantMode.w4a8_mxfp4_mxfp8_trtllm
+    # FP8 requant artifacts keep their own (fp8_block-family) resolution.
+    assert moe("sglang", mp="sgl-project/DeepSeek-V4-Flash-FP8") != common.MoEQuantMode.w4a8_mxfp4_mxfp8_trtllm
 
 
 def test_pareto_sweep_controls_tpot_grid():


### PR DESCRIPTION
## Summary

The arch-specific MoE quant remap for DeepSeek-V4 on sglang (legacy `dsv4pro-moe-arch`) was gated on the exact model path `deepseek-ai/DeepSeek-V4-Pro`. `deepseek-ai/DeepSeek-V4-Flash` therefore resolved plain `w4a8_mxfp4_mxfp8`, while the loader files the collected rows for its geometry (kernel_source `sglang_mxfp4_flashinfer_trtllm_moe`, per the routing comment in `operations/moe.py`) under `w4a8_mxfp4_mxfp8_trtllm` — every MoE lookup missed, and the support matrix demoted Flash to HYBRID_PASS despite complete silicon data.

## Fix

Gate the remap on the native-checkpoint path set {V4-Pro, V4-Flash}:
- sgl-project `*-FP8` requant artifacts stay exempt (their MoE runs `fp8_block`)
- Hopper still rejects native FP4-expert checkpoints outright (`_validate_deepseek_v4_hardware`)
- megamoe keeps its own quant table

## Verification

- On the sglang 0.5.14 b200 dataset (PR #1304's collection): the failing lookup `(hidden=4096, inter=2048, topk=6, experts=256, w4a8_mxfp4_mxfp8, power_law_1.01)` has 2,835 matching rows filed under the `_trtllm` mode — data was complete, only the selection missed.
- With this fix, DeepSeek-V4-Flash agg on b200_sxm/sglang/0.5.14 is pure silicon PASS (was HYBRID_PASS).
- `tests/unit/sdk/task_v2`: 98 passed; the remap test now covers Flash, the Hopper rejection, and the FP8-artifact exemption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved quantization handling for DeepSeek-V4-Pro and DeepSeek-V4-Flash models when using the sglang backend.
  - Added system-aware support for supported Blackwell and Hopper configurations.
  - Preserved explicit quantization settings and existing Megatron MoE backend behavior.
  - Added validation to reject unsupported native FP4-expert configurations on Hopper systems.
  - Maintained correct FP8-family quantization handling for DeepSeek-V4-Flash FP8 checkpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->