### PR TITLE
feat: add and harden Generator FPM deployment target

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ aiconfigurator cli support --model-path Qwen/Qwen3-32B-FP8 --system h200_sxm
 - Use `support` to verify if AIC supports a model/hardware combination for agg and disagg modes.
 - `--model` is an alias for `--model-path` in the CLI.
 - Use `--backend` to specify the inference backend: `trtllm` (default), `vllm`, or `sglang`.
-- Use `--deployment-target` to specify the deployment platform: `dynamo-j2` (default, Jinja2 templates), `dynamo-python` (Dynamo Python config modifiers), or `llm-d` (llm-d Helm values). Backends vllm and sglang support llm-d; trtllm is Dynamo-only.
+- Use `--deployment-target` to specify the artifact platform: `dynamo-j2` (default, typed Dynamo manifests), `dynamo-python`, `llm-d-helm`, `llm-d-kustomize`, or `fpm`. FPM V1 supports one aggregated vLLM worker group and emits exactly two artifacts: a reusable keepalive Pod or LeaderWorkerSet, and `run.sh`; see the [Generator overview](docs/generator_overview.md#fpm-v1-target).
 - Use `exp`, pass in exp.yaml by `--yaml-path` to customize your experiments and even a heterogenous one.
-- Use `--save-dir DIR` to generate deployment configuration files (Dynamo K8s manifests or llm-d Helm values, depending on `--deployment-target`).
+- Use `--save-dir DIR` to generate deployment artifacts for the selected target (Dynamo manifests, llm-d values/overlays, or an FPM resource workload + script).
 - Use `--database-mode` to control performance estimation mode: `SILICON` (default, uses collected silicon data), `HYBRID` (uses silicon data when available, otherwise SOL+empirical), `EMPIRICAL` (SOL+empirical for all), or `SOL` (speed-of-light only). Please be careful, only `SILICON` mode's result is reproducible. Other modes are for research purpose
 - Use `--systems-paths` to override where system YAMLs and data are loaded from (comma-separated; `default` maps to the built-in systems path). First match wins for identical system/backend/version.
 - Use `-h` for more options and customization.

--- a/docs/cli_user_guide.md
+++ b/docs/cli_user_guide.md
@@ -15,7 +15,7 @@ These flags are shared across modes (a few are sweep-only, as noted):
 - `--save-dir DIR`: Directory to write results and generated deployment artifacts. (`default`, `exp`, `generate`, `estimate`)
 - `--top-n N`: Number of top configurations to output — per experiment in `exp` mode, or per serving mode (agg/disagg) in `default` mode. Default: `5`. (`default`, `exp`, `generate`, `estimate`)
 - `--systems-paths`: System search paths (comma-separated). Use `default` for the built-in systems path; the first match wins for an identical system/backend/version. (`default`, `exp`, `generate`, `estimate`)
-- `--deployment-target`: Generated-artifact platform — `dynamo-j2` (default), `dynamo-python`, or `llm-d`. See [Deployment Target Selection](#default-mode). (`default`, `exp`, `generate`, `estimate`)
+- `--deployment-target`: Generated-artifact platform — `dynamo-j2` (default), `dynamo-python`, `llm-d-helm`, `llm-d-kustomize`, or `fpm`. See [Deployment Target Selection](#deployment-target-selection). (`default`, `exp`, `generate`, `estimate`)
 - `--engine-step-backend`: Experimental static-latency backend — `python` (default) or `rust` (routes static step estimates through the Rust FPM estimator). (`default`, `exp`, `generate`, `estimate`)
 
 The `support` mode accepts only `--log-level`, `--debug`, and `--no-color` from this list. Generator-artifact flags (`--generator-config`, `--generator-set`, `--generator-help`, `--generator-help-backend`, `--generated-config-version`, `--generator-dynamo-version`) are documented under [Default mode](#default-mode).
@@ -686,6 +686,7 @@ results/Qwen_Qwen3-32B-FP8_h200_sxm_trtllm_isl4000_osl1000_ttft1000_tpot20_90449
 By default, we output the top 5 configs we have found. You can get the configs and scripts to deploy under each experiment's folder. The generated files depend on your `--deployment-target`:
 - **Dynamo** (default): `k8s_deploy.yaml` for Kubernetes deployment, plus engine configs (`agg_config.yaml`, `prefill_config.yaml`, `decode_config.yaml`) and run scripts (`node_0_run.sh`)
 - **llm-d**: `llm-d-values.yaml` for Helm deployment with the llm-d-modelservice chart
+- **FPM V1**: exactly `k8s_deploy.yaml` (a reusable keepalive Pod or LeaderWorkerSet) and `run.sh` (the complete rank-aware vLLM launch)
 
 For benchmarking, see the [Benchmark Artifacts](#benchmark-artifacts) section below. Refer to [deployment guide](dynamo_deployment_guide.md) for Dynamo deployments or the [README llm-d section](../README.md#deploying-to-llm-d-platform) for llm-d deployments.
 
@@ -694,11 +695,79 @@ For benchmarking, see the [Benchmark Artifacts](#benchmark-artifacts) section be
 **Deployment Target Selection**
 
 Use `--deployment-target` to choose which orchestration platform to deploy to:
-- `dynamo-j2` (default): Generates Dynamo Kubernetes manifests using Jinja2 templates
+- `dynamo-j2` (default): Generates typed Dynamo Kubernetes manifests
 - `dynamo-python`: Generates Dynamo Kubernetes manifests using Dynamo's Python config modifiers (requires `dynamo` package)
-- `llm-d`: Generates Helm values for the llm-d-modelservice chart
+- `llm-d-helm`: Generates Helm values for the llm-d-modelservice chart
+- `llm-d-kustomize`: Generates Kustomize overlays for llm-d modelserver guides
+- `fpm`: Generates a reusable Kubernetes resource workload and a complete FPM launch script, `run.sh`
 
-The backend (`--backend trtllm/vllm/sglang`) and deployment target are orthogonal choices. Note that TRT-LLM only supports Dynamo platforms, while vLLM and SGLang support all three options.
+The backend (`--backend trtllm/vllm/sglang`) and deployment target are generally orthogonal choices. Note that TRT-LLM only supports Dynamo platforms. FPM V1 is the exception: it supports only vLLM aggregated mode with exactly one worker replica; that worker may span multiple nodes. Router/planner configurations and invalid FPM topologies fail closed.
+
+#### FPM V1 resource workload and run script
+
+Use `--deployment-target fpm` when a collector or agent should reserve Kubernetes resources and execute generated FPM launches in them. A generator config can add tokenized vLLM arguments, concrete environment variables, and resource-workload overlays:
+
+```yaml
+WorkerConfig:
+  agg_workers: 1
+Workers:
+  agg:
+    extra_cli_args:
+      - --scheduler-cls
+      - InstrumentedScheduler
+      - --benchmark-mode
+      - agg
+      - --dump-config-to
+      - "/results/resolved-config-node{node_rank}.json"
+K8sConfig:
+  fpm_shared_memory_size: 200Gi
+  fpm_resource_labels:
+    fpm.nvidia.com/run-id: glm52-example
+    fpm.nvidia.com/stage: probe
+  worker_extra_pod_spec:
+    mainContainer:
+      resources:
+        requests:
+          memory: 448Gi
+          ephemeral-storage: 30Gi
+  extra_env:
+    - name: FPM_RUN_ID
+      value: glm52-example
+    - name: DYN_FPM_BENCHMARK_OUTPUT_PATH
+      value: /results/glm52-example.json
+```
+
+`Workers.agg.extra_cli_args` must be a `list[str]`, and the final command must include `--benchmark-mode agg`. `K8sConfig.extra_env` accepts concrete `{name, value}` entries only; `valueFrom`, `envFrom`, and Secret-derived values are not supported. The normal rule, mapping, and versioned-template pipeline still builds the base command before the extra arguments are appended. If both `--benchmark-output-path` and `DYN_FPM_BENCHMARK_OUTPUT_PATH` are supplied, they must be identical. If neither is supplied, the generator adds `/results/benchmark.json` to both the command and environment.
+
+`K8sConfig.fpm_shared_memory_size` controls the generated `/dev/shm` `emptyDir` limit, while `K8sConfig.fpm_resource_labels` adds labels to the workload and its Pods. Container memory, ephemeral-storage, and other requests or limits can be supplied under `K8sConfig.worker_extra_pod_spec.mainContainer.resources`; the Generator-resolved per-node GPU count cannot be changed there. Matching user-provided `results` or `dshm` volume-and-mount pairs are preserved instead of replaced.
+
+The generated artifact directory contains only:
+
+```text
+artifacts/
+├── k8s_deploy.yaml
+└── run.sh
+```
+
+For a single-node topology, `k8s_deploy.yaml` is a keepalive Pod. For a multinode topology, it is a keepalive `LeaderWorkerSet` whose size and per-node GPU limit come from the resolved topology. Both forms contain the requested image, per-node GPU limit, preserved custom resources, volumes, and mounts, but no engine arguments or engine/FPM environment variables. By default they mount Pod-local `emptyDir` storage at `/results`. `run.sh` contains the environment exports and the complete resolved `python3 -m dynamo.vllm ...` command.
+
+`Workers.agg.gpus_per_worker` is the total GPU count for the one worker replica. When that topology exceeds `NodeConfig.num_gpus_per_node`, the generator emits an LWS and divides the GPU limit across its Pods. The total must divide evenly across the resolved node count, and `TP * PP * DP` must match it. Multinode DP must divide evenly across nodes and uses the `mp` data-parallel backend. The target cluster must have the LeaderWorkerSet API and controller installed before applying a multinode artifact.
+
+For one node, apply the Pod, wait for it to become ready, and stream the script into it:
+
+```bash
+kubectl apply -f artifacts/k8s_deploy.yaml
+kubectl wait --for=condition=Ready pod/<pod> --timeout=10m
+kubectl exec -i <pod> -- bash -s < artifacts/run.sh
+```
+
+For multiple nodes, the collector stages inputs first and then starts the same `run.sh` concurrently on every LWS Pod. The script requires the controller-injected `LWS_WORKER_INDEX` and `LWS_LEADER_ADDRESS` values to add the rank, master, headless, or local-DP arguments required by that node. Multinode values passed to `--dump-config-to` must contain `{node_rank}`; the default is `/results/resolved-config-node{node_rank}.json`. This placeholder applies only to `--dump-config-to`, not to environment values or arbitrary CLI arguments. Callers must not pass Generator-owned orchestration options such as `--nnodes`, `--node-rank`, `--headless`, or `--data-parallel-size-local` in `extra_cli_args`. On multinode runs, leave `DYN_FPM_WORKER_ID` unset so the script derives `<FPM_RUN_ID>-node<N>`, unless the collector supplies a distinct value to each process.
+
+With DP greater than one, DP rank 0 uses the configured benchmark output path and later DP ranks use `_dp<N>` before the extension. Each node waits for all results in its local rank range. A result counts as complete only when it is non-empty JSON with `schema_version: 2`, `status: passed`, and the expected `config.dp_rank`; a failed result terminates the script. The collector still owns staging the complete runtime bundle (scheduler code, cases, capacity, run-spec, runtime contracts, and validators) on every Pod, strict schema/metric validation, result download/aggregation/evidence, exit coordination, and cleanup.
+
+Every execution starts a new engine and reloads the model. `run.sh` refuses to overwrite any expected benchmark output, so each run must use new paths. With the default `/results` `emptyDir`, results remain only for the lifetime of the Pod. FPM V1 does not keep the engine or GPU-resident model alive between executions. Selecting any other deployment target preserves the existing generator output and behavior.
+
+The current vLLM template matrix tops out at `0.20.1`. You may pass reference `0.24.0`-only flags through `extra_cli_args`, but the generator has not yet validated those flags against a `0.24.0` runtime image.
 
 **Generator Dynamo version** (applies to Dynamo deployments only)
 - Use `--generator-dynamo-version 0.7.1` to select the Dynamo release. This affects both the generated backend config version and the default K8s image tag.
@@ -946,7 +1015,7 @@ See `src/aiconfigurator/cli/exps/database_mode_comparison.yaml` for an example c
 
 ### Benchmark Artifacts
 
-When `--save-dir` is used, each `topN` directory includes two benchmark helpers alongside the deployment artifacts:
+For non-FPM deployment targets, each `topN` directory includes two benchmark helpers alongside the deployment artifacts when `--save-dir` is used. The FPM target emits only `k8s_deploy.yaml` and `run.sh`, so it does not include these helpers.
 
 - **`bench_run.sh`** -- A shell script for bare-metal benchmarking. It loops over a concurrency array and calls [`aiperf profile`](https://github.com/ai-dynamo/aiperf) for each level. Before running it, make sure the deployed service is reachable at the endpoint printed in the script, and that `aiperf` is installed (`pip install aiperf`). Usage:
   ```bash

--- a/docs/dynamo_deployment_guide.md
+++ b/docs/dynamo_deployment_guide.md
@@ -1,6 +1,6 @@
 # Dynamo Deployment with Aiconfigurator Guide
 
-> **Note:** This guide covers Dynamo platform deployments (`--deployment-target dynamo-j2` or `dynamo-python`). For llm-d platform deployments, see the [llm-d deployment examples in the README](../README.md#deploying-to-llm-d-platform).
+> **Note:** This guide covers Dynamo platform deployments (`--deployment-target dynamo-j2` or `dynamo-python`). For llm-d platform deployments, see the [llm-d deployment examples in the README](../README.md#deploying-to-llm-d-platform). The separate FPM V1 resource-workload workflow is summarized in [Section 6](#6-fpm-v1-resource-workload-workflow).
 
 This guide walks through   
 - installing aiconfigurator
@@ -485,3 +485,31 @@ Use `--generator-set K8sConfig.<field>=value` (or place the same keys inside `--
 
 
 ---
+
+## 6. FPM V1 Resource Workload Workflow
+
+`--deployment-target fpm` is a separate target for vLLM aggregated deployments with exactly one worker replica. It emits a Pod for a single-node topology and a `LeaderWorkerSet` when the resolved worker spans multiple nodes. Router/planner configurations and invalid FPM topologies fail closed. It does not change the output of `dynamo-j2`, `dynamo-python`, or llm-d targets.
+
+FPM V1 emits exactly two artifacts:
+
+```text
+artifacts/
+├── k8s_deploy.yaml   # keepalive Pod or LeaderWorkerSet
+└── run.sh            # rank-aware environment exports and complete vLLM command
+```
+
+The workload requests the generated image, per-node GPU limit, preserved custom resources, volumes, and mounts, but contains no engine arguments or engine/FPM environment variables. Add tokenized launch arguments through `Workers.agg.extra_cli_args: list[str]` and concrete `{name, value}` environment entries through `K8sConfig.extra_env`; the generator places both in `run.sh`. `--benchmark-mode agg` is required. `K8sConfig.fpm_shared_memory_size`, `K8sConfig.fpm_resource_labels`, and `K8sConfig.worker_extra_pod_spec.mainContainer.resources` configure generated shared memory, workload/Pod labels, and non-GPU resource requests or limits. `valueFrom`, `envFrom`, and Secret-derived environment values are not supported in V1.
+
+For a single-node Pod, an agent can create the resource once and execute a generated script in it:
+
+```bash
+kubectl apply -f artifacts/k8s_deploy.yaml
+kubectl wait --for=condition=Ready pod/<pod> --timeout=10m
+kubectl exec -i <pod> -- bash -s < artifacts/run.sh
+```
+
+For a multinode LWS, the collector stages the complete runtime bundle on every Pod and starts the same script concurrently across them. `run.sh` requires `LWS_WORKER_INDEX` and `LWS_LEADER_ADDRESS` from the LWS controller and appends the required model- or data-parallel coordination arguments. A multinode `--dump-config-to` path must contain `{node_rank}`; this substitution applies only to that option. For DP, each node waits for its local result files and checks `schema_version: 2`, `status: passed`, and the expected `config.dp_rank` before stopping its engine. Strict validation, result collection/aggregation/evidence, exit coordination, and cleanup remain collector responsibilities.
+
+Each collection still starts a new engine and reloads the model. `run.sh` stops result-producing engines after their local completion gate; the collector coordinates headless followers and final cleanup. The script refuses to overwrite any expected benchmark output, so use unique paths for every run. By default `/results` is backed by Pod-local `emptyDir`, and those results disappear when the Pod is deleted; a matching user-provided volume and mount are preserved. Persistent engines and reuse of a GPU-resident model are outside the V1 scope. A target cluster needs the LeaderWorkerSet API and controller for multinode artifacts. See the [CLI User Guide](cli_user_guide.md#fpm-v1-resource-workload-and-run-script) for the full input example.
+
+The current vLLM template matrix tops out at `0.20.1`; reference `0.24.0`-only flags may be passed through, but their runtime compatibility is not yet validated by the generator.

--- a/docs/generator_overview.md
+++ b/docs/generator_overview.md
@@ -10,7 +10,7 @@ flowchart TD
   C --> D[<b>Rule plugins</b><br/>rule_plugin/*.rule]
   D --> E[<b>Parameter mapping</b><br/>config/backend_config_mapping.yaml]
   E --> F[<b>Template rendering</b><br/>config/backend_templates/backend/...]
-  F --> G[<b>Generated artifacts</b><br/>k8s_deploy.yaml OR llm-d-values.yaml,<br/>run_*.sh,<br/>engine configs/cli args]
+  F --> G[<b>Generated artifacts</b><br/>k8s_deploy.yaml OR llm-d-values.yaml,<br/>run_*.sh OR FPM run.sh,<br/>engine configs/cli args]
 ```
 
 ### Key Components
@@ -93,7 +93,7 @@ You can use the generator in two ways: AIConfigurator CLI or standalone (code/CL
     --save-dir ./results
   ```
   Notes:
-  - Use `--deployment-target` to choose the orchestration platform: `dynamo-j2` (default, Jinja2 templates), `dynamo-python` (Python config modifiers), or `llm-d` (Helm values).
+  - Use `--deployment-target` to choose the orchestration platform: `dynamo-j2` (default, typed Dynamo manifests), `dynamo-python` (Python config modifiers), `llm-d-helm`/`llm-d-kustomize`, or `fpm` (a reusable resource workload plus `run.sh`).
   - For Dynamo deployments: Use `--generator-dynamo-version 0.7.1` to select the Dynamo release. This affects both the generated backend config version and the default K8s image tag. If not provided, defaults to `1.0.0`.
   - For llm-d deployments: Container image versions are specified via `LlmdConfig.vllm_image` or `LlmdConfig.sglang_image` (defaults to `latest` tags).
   - If `--generated-config-version` is provided, it overrides the generated backend version for any deployment target.
@@ -173,9 +173,44 @@ You can use the generator in two ways: AIConfigurator CLI or standalone (code/CL
 - Deployment manifests:
   - **Dynamo**: Kubernetes manifest (`k8s_deploy.yaml`) with images, namespace, volumes, engine args (inline or ConfigMap), and role-specific settings.
   - **llm-d**: Helm values (`llm-d-values.yaml`) for the llm-d-modelservice chart with model artifacts, parallelism, and container configurations.
-- Benchmark helpers:
-  - `bench_run.sh` and `k8s_bench.yaml` are generated alongside deployment artifacts for running `aiperf` benchmarks.
+  - **FPM V1**: exactly `k8s_deploy.yaml` and `run.sh`; see [FPM V1 Target](#fpm-v1-target).
+- Benchmark helpers (non-FPM targets):
+  - `bench_run.sh` and `k8s_bench.yaml` are generated alongside normal deployment artifacts for running `aiperf` benchmarks. The FPM target emits neither helper.
   - `concurrency_array` is built from a base list (`1 2 8 16 32 64 128`) plus `BenchConfig.estimated_concurrency` and its +/-5% neighbors when the estimate is available.
+
+### FPM V1 Target
+
+`--deployment-target fpm` supports vLLM aggregated mode with exactly one worker replica. It emits a keepalive Pod when the resolved topology fits on one node and a `LeaderWorkerSet` when it spans multiple nodes. Router/planner configurations and invalid FPM topologies fail closed. Other deployment targets keep their existing behavior.
+
+`Workers.agg.gpus_per_worker` is the total GPU count for the worker replica; a value larger than `NodeConfig.num_gpus_per_node` produces a multinode worker and therefore an LWS. The resolved `TP * PP * DP` must equal that total, which must divide evenly across the resolved node count. Multinode DP must also divide evenly across nodes and uses the `mp` data-parallel backend. A cluster that runs a multinode artifact must have the LeaderWorkerSet API and controller installed.
+
+The FPM overlay accepts `Workers.agg.extra_cli_args` as a `list[str]` and concrete `K8sConfig.extra_env` entries in `{name, value}` form. Rules, mappings, and versioned templates still produce the base vLLM command; `extra_cli_args` are appended to that resolved command. `--benchmark-mode agg` is required. `valueFrom`, `envFrom`, and Secret-derived environment values are not supported in V1. The generator owns multinode coordination arguments such as `--nnodes`, `--node-rank`, `--headless`, and the local data-parallel rank arguments, so callers must not pass those through the overlay.
+
+The target emits only:
+
+```text
+artifacts/
+├── k8s_deploy.yaml   # keepalive Pod or LeaderWorkerSet; resources and mounts only
+└── run.sh            # rank-aware exports plus the complete resolved vLLM command
+```
+
+The resource workload contains no engine arguments or engine/FPM environment variables. It preserves the generated image, per-node GPU limit, custom resources, volumes, and mounts. `K8sConfig.fpm_shared_memory_size` sets the generated `/dev/shm` `emptyDir` limit, `K8sConfig.fpm_resource_labels` adds workload and Pod labels, and `K8sConfig.worker_extra_pod_spec.mainContainer.resources` supplies requests or limits such as memory and ephemeral storage. The resolved per-node GPU count cannot be overridden by this resource overlay. By default `/results` is a Pod-local `emptyDir`; matching user-provided `results` or `dshm` volume-and-mount pairs are preserved.
+
+On multiple nodes, `run.sh` requires the LWS controller-injected `LWS_WORKER_INDEX` and `LWS_LEADER_ADDRESS` values and adds the required model-parallel or data-parallel coordination arguments. A custom `--dump-config-to` path must contain `{node_rank}` for a multinode topology; the script replaces it with the current node rank. Without that option, the generator uses `/results/resolved-config-node{node_rank}.json` on multiple nodes and `/results/resolved-config-node0.json` on one node. This placeholder substitution applies only to `--dump-config-to`, not to environment values or other CLI arguments.
+
+For data parallelism, DP rank 0 writes the configured base output (for example, `benchmark.json`) and later DP ranks write suffixed files such as `benchmark_dp1.json`. Each node waits for its local DP rank range. Before stopping its engine, the script verifies that every expected result is non-empty JSON with `schema_version: 2`, `status: passed`, and the expected `config.dp_rank`. This is a completion and identity gate, not full FPM result validation.
+
+The FPM collector or agent remains responsible for staging the complete runtime bundle—scheduler code, cases, capacity, run-spec, runtime contracts, and validators—on every Pod; starting `run.sh` concurrently on all Pods in an LWS; coordinating exit status; strictly validating, downloading, aggregating, and recording evidence for the results; and cleaning up the workload. For a single-node Pod, the basic execution flow is:
+
+```bash
+kubectl apply -f artifacts/k8s_deploy.yaml
+kubectl wait --for=condition=Ready pod/<pod> --timeout=10m
+kubectl exec -i <pod> -- bash -s < artifacts/run.sh
+```
+
+Each collection run starts a new engine, so the model is still loaded on every run. The script stops a result-producing engine after its expected files pass the completion gate; the collector coordinates headless followers and final cleanup. The script refuses to overwrite any expected benchmark output path, so use distinct paths for each run. Reusing the resource workload avoids re-requesting resources, but V1 does not provide a persistent engine or in-GPU model reuse.
+
+The current vLLM template matrix tops out at `0.20.1`. Flags required only by the reference `0.24.0` runtime can be passed through as tokens, but their runtime compatibility is not yet validated by the generator.
 
 ### TRT-LLM Deployment Notes
 When deploying with TRT-LLM, the generated run scripts (`run_x.sh`) reference engine config files at `/workspace/engine_configs/`. Before executing the run scripts, you must:

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -137,11 +137,11 @@ def _build_common_cli_experiments_parser() -> argparse.ArgumentParser:
     common_parser.add_argument(
         "--deployment-target",
         type=str,
-        choices=["dynamo-j2", "dynamo-python", "llm-d-helm", "llm-d-kustomize"],
+        choices=["dynamo-j2", "dynamo-python", "llm-d-helm", "llm-d-kustomize", "fpm"],
         default="dynamo-j2",
-        help="Deployment target platform. Options: dynamo-j2 (default, Jinja2 templates), "
+        help="Deployment target platform. Options: dynamo-j2 (default, typed Dynamo manifests), "
         "dynamo-python (Dynamo Python config modifiers), llm-d-helm (llm-d Helm values), "
-        "llm-d-kustomize (llm-d Kustomize overlays).",
+        "llm-d-kustomize (llm-d Kustomize overlays), fpm (reusable resource Pod + run.sh).",
     )
     common_parser.add_argument(
         "--engine-step-backend",
@@ -2304,6 +2304,25 @@ def _validate_default_mode_inputs(args) -> None:
         )
 
 
+def _validate_fpm_sweep_tasks(args, tasks: dict[str, Task]) -> None:
+    """Reject task shapes that can only fail after an expensive FPM sweep."""
+    if getattr(args, "deployment_target", "dynamo-j2") != "fpm":
+        return
+
+    unsupported: list[str] = []
+    for name, task in tasks.items():
+        serving_mode = getattr(task, "serving_mode", None)
+        backend = getattr(task, "primary_backend_name", None)
+        if serving_mode != "agg" or backend != common.BackendName.vllm.value:
+            unsupported.append(f"{name} ({serving_mode or 'unknown'}/{backend or 'unknown'})")
+
+    if unsupported:
+        raise SystemExit(
+            "--deployment-target fpm supports only vLLM aggregated tasks; "
+            "unsupported task(s): " + ", ".join(unsupported)
+        )
+
+
 def main(args):
     setup_logging(
         level=_resolve_cli_log_level(args),
@@ -2348,6 +2367,8 @@ def main(args):
     if args.mode == "default":
         _validate_default_mode_inputs(args)
         if getattr(args, "thorough_sweep", False) or getattr(args, "thorough_config", None):
+            if getattr(args, "deployment_target", "dynamo-j2") == "fpm":
+                raise SystemExit("--deployment-target fpm does not support Spica thorough sweeps")
             run_spica_thorough_default(args)
             return
 
@@ -2414,6 +2435,8 @@ def main(args):
             raise SystemExit(1)
     else:
         raise SystemExit(f"Unsupported mode: {args.mode}")
+
+    _validate_fpm_sweep_tasks(args, tasks)
 
     execute_kwargs: dict = {}
     if getattr(args, "strict_sla", False):

--- a/src/aiconfigurator/generator/aggregators.py
+++ b/src/aiconfigurator/generator/aggregators.py
@@ -283,10 +283,12 @@ def generate_config_from_input_dict(
     for role in ("prefill", "decode", "agg", "encode"):
         role_in = workers_in.get(role, {}) or {}
         if isinstance(role_in, dict):
-            # `extra_engine_args` is a user passthrough, not a mapped param, so
-            # it must survive the allowed-keys filter to reach the renderer.
+            # User passthrough fields are not mapped params, so they must
+            # survive the allowed-keys filter to reach their target renderer.
             filtered = {
-                k: v for k, v in role_in.items() if (not allowed_keys or k in allowed_keys or k == "extra_engine_args")
+                k: v
+                for k, v in role_in.items()
+                if (not allowed_keys or k in allowed_keys or k in {"extra_engine_args", "extra_cli_args"})
             }
             if filtered:
                 for k, v in filtered.items():

--- a/src/aiconfigurator/generator/api.py
+++ b/src/aiconfigurator/generator/api.py
@@ -274,8 +274,9 @@ def generate_backend_artifacts(
         templates_dir: Optional directory containing templates
         output_dir: Optional directory to save generated files
         backend_version: Optional version string for version-specific template selection
-        deployment_target: Deployment platform ('dynamo-j2', 'dynamo-python', 'llm-d-helm', or 'llm-d-kustomize').
-            'dynamo-j2' uses Jinja2 templates, 'dynamo-python' uses Dynamo's Python config modifiers,
+        deployment_target: Deployment platform ('dynamo-j2', 'dynamo-python', 'llm-d-helm',
+            'llm-d-kustomize', or 'fpm').
+            'dynamo-j2' uses typed Dynamo builders, 'dynamo-python' uses Dynamo's Python config modifiers,
             'llm-d-helm' generates Helm values for llm-d-modelservice chart, and 'llm-d-kustomize'
             generates Kustomize overlays for llm-d modelserver guides.
         use_dynamo_generator: If True, use Dynamo's Python config modifiers
@@ -314,6 +315,7 @@ def generate_backend_artifacts(
             output_dir=os.path.abspath(output_dir),
             prefer_disagg=prefer_disagg,
             has_agg_role=has_agg,
+            preserve_run_sh=deployment_target == "fpm",
         )
         try:
             writer.write(artifacts)
@@ -670,7 +672,8 @@ def generate_naive_config(
             template versions and runtime image defaults.
         generator_overrides: Optional generator config overrides from
             --generator-config and --generator-set.
-        deployment_target: Deployment platform ('dynamo-j2', 'dynamo-python', or 'llm-d').
+        deployment_target: Deployment platform ('dynamo-j2', 'dynamo-python',
+            'llm-d-helm', 'llm-d-kustomize', or 'fpm').
 
     Returns:
         Dictionary containing:
@@ -771,6 +774,7 @@ def generate_naive_config(
             output_dir=os.path.abspath(actual_output_dir),
             prefer_disagg=prefer_disagg,
             has_agg_role=has_agg,
+            preserve_run_sh=deployment_target == "fpm",
         )
         try:
             writer.write(artifacts)

--- a/src/aiconfigurator/generator/artifacts.py
+++ b/src/aiconfigurator/generator/artifacts.py
@@ -16,6 +16,7 @@ class ArtifactWriter:
     output_dir: str
     prefer_disagg: bool
     has_agg_role: bool
+    preserve_run_sh: bool = False
 
     def write(self, artifacts: dict[str, str]) -> None:
         os.makedirs(self.output_dir, exist_ok=True)
@@ -40,7 +41,7 @@ class ArtifactWriter:
             mapped = self._map_engine_name(artifact_name)
             return os.path.join(self.output_dir, mapped)
         if artifact_name == "run.sh":
-            mapped = "run_x.sh"
+            mapped = "run.sh" if self.preserve_run_sh else "run_x.sh"
         else:
             mapped = artifact_name
         return os.path.join(self.output_dir, mapped)

--- a/src/aiconfigurator/generator/builders/fpm_builder.py
+++ b/src/aiconfigurator/generator/builders/fpm_builder.py
@@ -76,7 +76,7 @@ def build_fpm_artifacts(
     args.extend(extra_cli_args)
 
     env = _collect_concrete_env(worker, main_container)
-    _require_cli_option(args, "--benchmark-mode", expected="agg")
+    benchmark_mode = _require_fpm_benchmark_mode(args)
     topology = _resolve_topology(context, worker, args)
     if topology["data_parallel_size"] > 1 and _cli_option_value(args, "--data-parallel-backend") is None:
         args.extend(["--data-parallel-backend", "mp"])
@@ -88,6 +88,7 @@ def build_fpm_artifacts(
     run_script = _render_run_script(
         command + args,
         env,
+        benchmark_mode,
         benchmark_output_path,
         wait_timeout_seconds,
         topology,
@@ -330,6 +331,15 @@ def _require_cli_option(args: list[str], flag: str, *, expected: str | None = No
         raise ValueError(f"FPM V1 requires {flag} {expected}")
 
 
+def _require_fpm_benchmark_mode(args: list[str]) -> str:
+    mode = _cli_option_value(args, "--benchmark-mode")
+    if mode is None:
+        raise ValueError("FPM V1 requires --benchmark-mode")
+    if mode not in {"prefill", "decode"}:
+        raise ValueError("FPM V1 requires --benchmark-mode prefill or decode")
+    return mode
+
+
 def _last_env_value(env: list[tuple[str, str]], name: str) -> str | None:
     for env_name, value in reversed(env):
         if env_name == name:
@@ -376,6 +386,7 @@ def _benchmark_wait_timeout_seconds(args: list[str]) -> int:
 def _render_run_script(
     command: list[str],
     env: list[tuple[str, str]],
+    benchmark_mode: str,
     benchmark_output_path: str,
     wait_timeout_seconds: int,
     topology: dict[str, int],
@@ -408,6 +419,7 @@ def _render_run_script(
             "  exit 2",
             "fi",
             'export DYN_FPM_WORKER_ID="${DYN_FPM_WORKER_ID:-${FPM_RUN_ID:-fpm}-node${node_rank}}"',
+            f"benchmark_mode={shlex.quote(benchmark_mode)}",
             f"benchmark_output_path={shlex.quote(benchmark_output_path)}",
             f"wait_timeout_seconds={wait_timeout_seconds}",
             f"engine_command=({' '.join(shlex.quote(token) for token in command)})",
@@ -462,13 +474,19 @@ def _render_run_script(
             "done",
             "",
             "check_result_files() {",
-            '  python3 - "$local_dp_start" "${expected_results[@]}" <<\'PY\'',
+            '  python3 - "$local_dp_start" "$benchmark_mode" "${expected_results[@]}" <<\'PY\'',
             "import json",
             "import pathlib",
             "import sys",
             "",
             "start_rank = int(sys.argv[1])",
-            "for offset, raw_path in enumerate(sys.argv[2:]):",
+            "expected_mode = sys.argv[2]",
+            "",
+            "def invalid(path, message):",
+            '    print(f"Invalid FPM benchmark result {path}: {message}", file=sys.stderr)',
+            "    raise SystemExit(20)",
+            "",
+            "for offset, raw_path in enumerate(sys.argv[3:]):",
             "    path = pathlib.Path(raw_path)",
             "    if not path.is_file() or path.stat().st_size == 0:",
             "        raise SystemExit(10)",
@@ -476,18 +494,54 @@ def _render_run_script(
             '        value = json.loads(path.read_text(encoding="utf-8"))',
             "    except (OSError, json.JSONDecodeError):",
             "        raise SystemExit(10)",
-            '    if value.get("schema_version") != 2 or value.get("status") != "passed":',
-            '        print(f"Invalid FPM benchmark result {path}: "',
-            "              f\"schema_version={value.get('schema_version')!r} \"",
-            "              f\"status={value.get('status')!r} errors={value.get('errors')!r}\",",
-            "              file=sys.stderr)",
-            "        raise SystemExit(20)",
+            '    if (value.get("schema_version") != 1 or value.get("status") != "complete"',
+            '            or value.get("valid") is not True):',
+            "        invalid(path,",
+            "                f\"schema_version={value.get('schema_version')!r} \"",
+            "                f\"status={value.get('status')!r} valid={value.get('valid')!r} \"",
+            "                f\"skipped_points={value.get('skipped_points')!r}\")",
+            '    config = value.get("config")',
+            '    actual_mode = config.get("mode") if isinstance(config, dict) else None',
+            "    if actual_mode != expected_mode:",
+            '        invalid(path, f"benchmark mode {actual_mode!r} "',
+            '                      f"!= {expected_mode!r}")',
+            '    coverage = value.get("coverage")',
+            "    if not isinstance(coverage, dict):",
+            '        invalid(path, "coverage must be an object")',
+            '    expected_points = coverage.get("expected_points")',
+            '    completed_points = coverage.get("completed_points")',
+            '    skipped_points = coverage.get("skipped_points")',
+            "    if (type(expected_points) is not int or expected_points <= 0",
+            "            or type(completed_points) is not int or completed_points != expected_points",
+            "            or type(skipped_points) is not int or skipped_points != 0):",
+            '        invalid(path, f"invalid coverage {coverage!r}")',
+            '    results = value.get("results")',
+            "    result_count = len(results) if isinstance(results, list) else None",
+            "    if not isinstance(results, list) or len(results) != completed_points:",
+            '        invalid(path, f"results count does not match coverage: "',
+            '                      f"{type(results).__name__}({result_count!r}) "',
+            '                      f"!= {completed_points}")',
             "    expected_rank = start_rank + offset",
-            '    if (value.get("config") or {}).get("dp_rank") != expected_rank:',
-            '        print(f"FPM benchmark DP rank mismatch for {path}: "',
-            "              f\"{(value.get('config') or {}).get('dp_rank')!r} != {expected_rank}\",",
-            "              file=sys.stderr)",
-            "        raise SystemExit(20)",
+            "    observed_ranks = set()",
+            "    for result in results:",
+            "        if not isinstance(result, dict):",
+            '            invalid(path, "result entry must be an object")',
+            '        point = result.get("point")',
+            '        point_type = point.get("point_type") if isinstance(point, dict) else None',
+            "        if point_type != expected_mode:",
+            '            invalid(path, f"point type {point_type!r} "',
+            '                          f"!= {expected_mode!r}")',
+            '        fpms = result.get("fpms")',
+            "        if not isinstance(fpms, list) or not fpms:",
+            '            invalid(path, "each result must contain at least one FPM sample")',
+            "        for fpm in fpms:",
+            '            rank = fpm.get("dp_rank") if isinstance(fpm, dict) else None',
+            "            if type(rank) is not int:",
+            '                invalid(path, f"invalid FPM dp_rank {rank!r}")',
+            "            observed_ranks.add(rank)",
+            "    if observed_ranks != {expected_rank}:",
+            '        invalid(path, f"FPM dp_ranks {sorted(observed_ranks)!r} "',
+            '                      f"!= [{expected_rank}]")',
             "PY",
             "}",
             "",

--- a/src/aiconfigurator/generator/builders/fpm_builder.py
+++ b/src/aiconfigurator/generator/builders/fpm_builder.py
@@ -1,0 +1,896 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Build the artifacts used for FPM collection.
+
+The FPM resource Pod or LeaderWorkerSet deliberately does not launch an engine.
+It reserves the same infrastructure as the normal vLLM worker and stays alive
+while a collector streams the generated ``run.sh`` into it.
+"""
+
+from __future__ import annotations
+
+import copy
+import re
+import shlex
+from typing import Any
+
+from .dgd_model import DGD, DGDService, MainContainer, _dump_k8s_yaml
+from .k8s_builder import build_dgd
+
+_ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_MISSING = object()
+_NODE_RANK_SENTINEL = "__FPM_NODE_RANK__"
+_FPM_OWNED_ORCHESTRATION_FLAGS = frozenset(
+    {
+        "--nnodes",
+        "--node-rank",
+        "--master-addr",
+        "--master-port",
+        "--headless",
+        "--data-parallel-size-local",
+        "--data-parallel-start-rank",
+        "--data-parallel-address",
+        "--data-parallel-rpc-port",
+        "--data-parallel-hybrid-lb",
+    }
+)
+
+
+def build_fpm_artifacts(
+    context: dict[str, Any],
+    backend: str,
+    resolved_facts: Any = None,
+    param_values: dict[str, Any] | None = None,
+) -> dict[str, str]:
+    """Return a reusable resource workload and a complete FPM engine script.
+
+    The existing DGD builder remains the source of truth for infrastructure.
+    This function lowers its one aggregated worker to a Pod (single node) or a
+    LeaderWorkerSet (multiple nodes), while moving every concrete environment
+    variable and the engine command into ``run.sh``.
+    """
+    if backend != "vllm":
+        raise ValueError("FPM V1 supports only the vllm backend")
+
+    dyn_config = context.get("DynConfig") or {}
+    if not isinstance(dyn_config, dict) or dyn_config.get("mode") != "agg":
+        raise ValueError("FPM V1 supports only DynConfig.mode=agg")
+    unsupported_dyn_features = [
+        key for key in ("enable_router", "router_mode", "router_config", "planner_config") if dyn_config.get(key)
+    ]
+    if unsupported_dyn_features:
+        fields = ", ".join(f"DynConfig.{key}" for key in unsupported_dyn_features)
+        raise ValueError(f"FPM V1 does not support router or planner configuration: {fields}")
+
+    extra_cli_args = _extract_extra_cli_args(param_values)
+    _reject_owned_orchestration_args(extra_cli_args)
+    worker = _build_worker(context, backend, resolved_facts)
+    main_container = _require_main_container(worker)
+
+    command = list(main_container.command or [])
+    args = list(main_container.args or [])
+    if command[:3] != ["python3", "-m", "dynamo.vllm"]:
+        raise ValueError("FPM V1 requires the normal vLLM worker command")
+    if not all(isinstance(token, str) for token in command + args):
+        raise ValueError("The resolved vLLM command must contain only string tokens")
+    args.extend(extra_cli_args)
+
+    env = _collect_concrete_env(worker, main_container)
+    _require_cli_option(args, "--benchmark-mode", expected="agg")
+    topology = _resolve_topology(context, worker, args)
+    if topology["data_parallel_size"] > 1 and _cli_option_value(args, "--data-parallel-backend") is None:
+        args.extend(["--data-parallel-backend", "mp"])
+    if topology["data_parallel_size"] > 1:
+        _require_cli_option(args, "--data-parallel-backend", expected="mp")
+    _ensure_dump_config_path(args, topology["node_count"])
+    benchmark_output_path = _ensure_benchmark_output_path(args, env)
+    wait_timeout_seconds = _benchmark_wait_timeout_seconds(args)
+    run_script = _render_run_script(
+        command + args,
+        env,
+        benchmark_output_path,
+        wait_timeout_seconds,
+        topology,
+    )
+    workload = _lower_worker_to_resource(
+        context,
+        worker,
+        main_container,
+        topology,
+        efa_resource_name=_efa_resource_name(resolved_facts),
+    )
+
+    return {
+        "k8s_deploy.yaml": _dump_k8s_yaml(workload),
+        "run.sh": run_script,
+    }
+
+
+def _extract_extra_cli_args(param_values: dict[str, Any] | None) -> list[str]:
+    if param_values is None:
+        return []
+    if not isinstance(param_values, dict):
+        raise TypeError("param_values must be a mapping")
+
+    params = param_values.get("params") or {}
+    if not isinstance(params, dict):
+        raise TypeError("param_values.params must be a mapping")
+    agg = params.get("agg") or {}
+    if not isinstance(agg, dict):
+        raise TypeError("param_values.params.agg must be a mapping")
+
+    value = agg.get("extra_cli_args", _MISSING)
+    if value is _MISSING:
+        return []
+    if not isinstance(value, list) or not all(isinstance(token, str) for token in value):
+        raise ValueError("params.agg.extra_cli_args must be a list[str]")
+    return list(value)
+
+
+def _reject_owned_orchestration_args(args: list[str]) -> None:
+    for token in args:
+        for flag in _FPM_OWNED_ORCHESTRATION_FLAGS:
+            if token == flag or token.startswith(f"{flag}="):
+                raise ValueError(f"FPM owns orchestration option {flag}; do not pass it through extra_cli_args")
+
+
+def _ensure_dump_config_path(args: list[str], node_count: int) -> None:
+    flag = "--dump-config-to"
+    occurrences: list[tuple[int, bool]] = []
+    for index, token in enumerate(args):
+        if token == flag:
+            if index + 1 >= len(args) or args[index + 1].startswith("--"):
+                raise ValueError(f"{flag} requires a value")
+            occurrences.append((index + 1, False))
+        elif token.startswith(f"{flag}="):
+            occurrences.append((index, True))
+    if len(occurrences) > 1:
+        raise ValueError(f"FPM accepts at most one {flag} option")
+
+    default = (
+        "/results/resolved-config-node{node_rank}.json" if node_count > 1 else "/results/resolved-config-node0.json"
+    )
+    if not occurrences:
+        value = default
+        args.extend([flag, value])
+        occurrences.append((len(args) - 1, False))
+
+    index, joined = occurrences[0]
+    value = args[index].split("=", 1)[1] if joined else args[index]
+    if node_count > 1 and "{node_rank}" not in value:
+        raise ValueError(f"Multinode FPM {flag} must contain the {{node_rank}} placeholder")
+    if node_count == 1:
+        value = value.replace("{node_rank}", "0")
+    else:
+        value = value.replace("{node_rank}", _NODE_RANK_SENTINEL)
+    args[index] = f"{flag}={value}" if joined else value
+
+
+def _build_worker(context: dict[str, Any], backend: str, resolved_facts: Any) -> DGDService:
+    docs = build_dgd(context, backend, resolved_facts=resolved_facts)
+    dgd_docs = [doc for doc in docs if isinstance(doc, DGD)]
+    if len(dgd_docs) != 1:
+        raise ValueError("FPM V1 requires exactly one DynamoGraphDeployment document")
+
+    workers = [(name, service) for name, service in dgd_docs[0].services.items() if service.component_type == "worker"]
+    if len(workers) != 1 or workers[0][0] != "VllmWorker":
+        raise ValueError("FPM V1 requires exactly one aggregated VllmWorker")
+
+    worker = workers[0][1]
+    if worker.replicas != 1:
+        raise ValueError("FPM V1 requires worker replicas=1")
+    return worker
+
+
+def _positive_cli_int(args: list[str], flag: str, *, default: int = 1) -> int:
+    raw = _cli_option_value(args, flag)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{flag} must be a positive integer") from exc
+    if value <= 0:
+        raise ValueError(f"{flag} must be a positive integer")
+    return value
+
+
+def _worker_gpu_limit(resources: dict[str, Any] | None) -> int:
+    if not isinstance(resources, dict):
+        raise TypeError("The resolved vLLM worker has no resources")
+    limits = resources.get("limits")
+    if not isinstance(limits, dict):
+        raise TypeError("The resolved vLLM worker has no GPU limits")
+    raw = limits.get("gpu")
+    if raw is None:
+        custom = limits.get("custom")
+        if isinstance(custom, dict):
+            raw = custom.get("nvidia.com/gpu")
+    try:
+        value = int(raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("The resolved vLLM worker has an invalid GPU limit") from exc
+    if value <= 0:
+        raise ValueError("The resolved vLLM worker GPU limit must be positive")
+    return value
+
+
+def _resolve_topology(context: dict[str, Any], worker: DGDService, args: list[str]) -> dict[str, int]:
+    total_gpus = _worker_gpu_limit(worker.resources)
+    multinode = worker.multinode
+    if multinode is None:
+        node_count = 1
+    elif isinstance(multinode, dict):
+        try:
+            node_count = int(multinode.get("nodeCount"))
+        except (TypeError, ValueError) as exc:
+            raise ValueError("FPM multinode.nodeCount must be a positive integer") from exc
+        if node_count <= 1:
+            raise ValueError("FPM multinode.nodeCount must be greater than one")
+    else:
+        raise TypeError("FPM worker.multinode must be a mapping")
+
+    if total_gpus % node_count:
+        raise ValueError("FPM total GPU count must be divisible by node count")
+    gpus_per_node = total_gpus // node_count
+    configured_gpus_per_node = int((context.get("NodeConfig") or {}).get("num_gpus_per_node") or gpus_per_node)
+    if node_count > 1 and gpus_per_node > configured_gpus_per_node:
+        raise ValueError("FPM per-node GPU count exceeds NodeConfig.num_gpus_per_node")
+
+    tensor_parallel_size = _positive_cli_int(args, "--tensor-parallel-size")
+    pipeline_parallel_size = _positive_cli_int(args, "--pipeline-parallel-size")
+    data_parallel_size = _positive_cli_int(args, "--data-parallel-size")
+    expected_gpus = tensor_parallel_size * pipeline_parallel_size * data_parallel_size
+    if expected_gpus != total_gpus:
+        raise ValueError(
+            "FPM topology does not match the resolved GPU count: "
+            f"tp({tensor_parallel_size}) * pp({pipeline_parallel_size}) * dp({data_parallel_size}) "
+            f"!= gpus({total_gpus})"
+        )
+
+    if data_parallel_size > 1:
+        if data_parallel_size % node_count:
+            raise ValueError("FPM data parallel size must be divisible by node count")
+        local_data_parallel_size = data_parallel_size // node_count
+    else:
+        local_data_parallel_size = 1
+    if (
+        data_parallel_size > 1
+        and local_data_parallel_size * tensor_parallel_size * pipeline_parallel_size > gpus_per_node
+    ):
+        raise ValueError("FPM local parallel topology exceeds the per-node GPU count")
+
+    return {
+        "node_count": node_count,
+        "total_gpus": total_gpus,
+        "gpus_per_node": gpus_per_node,
+        "tensor_parallel_size": tensor_parallel_size,
+        "pipeline_parallel_size": pipeline_parallel_size,
+        "data_parallel_size": data_parallel_size,
+        "local_data_parallel_size": local_data_parallel_size,
+    }
+
+
+def _require_main_container(worker: DGDService) -> MainContainer:
+    pod_spec = worker.extra_pod_spec
+    if pod_spec is None or pod_spec.main_container is None:
+        raise ValueError("The resolved vLLM worker has no main container")
+    return pod_spec.main_container
+
+
+def _collect_concrete_env(worker: DGDService, main_container: MainContainer) -> list[tuple[str, str]]:
+    # build_dgd sets the operator-only envFromSecret="hf-token-secret" on
+    # every vLLM worker. FPM V1 intentionally accepts only concrete values:
+    # it cannot safely materialize a Secret into run.sh, and rejecting that
+    # built-in marker would make every FPM render fail.
+    resolved: list[tuple[str, str]] = []
+    entries = list(worker.envs or []) + list(main_container.env or [])
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise TypeError("FPM environment entries must be mappings")
+        if "valueFrom" in entry:
+            raise ValueError("FPM V1 does not support valueFrom environment entries")
+
+        name = entry.get("name")
+        if not isinstance(name, str) or not _ENV_NAME_RE.fullmatch(name):
+            raise ValueError(f"Invalid shell environment variable name: {name!r}")
+        if "value" not in entry or entry["value"] is None:
+            raise ValueError(f"Environment variable {name} must have a concrete value")
+
+        value = entry["value"]
+        if isinstance(value, bool):
+            resolved.append((name, "true" if value else "false"))
+        elif isinstance(value, (str, int, float)):
+            resolved.append((name, str(value)))
+        else:
+            raise TypeError(f"Environment variable {name} must have a scalar value")
+    return resolved
+
+
+def _cli_option_value(args: list[str], flag: str) -> str | None:
+    value: str | None = None
+    for index, token in enumerate(args):
+        if token == flag:
+            if index + 1 >= len(args):
+                raise ValueError(f"{flag} requires a value")
+            candidate = args[index + 1]
+            if candidate.startswith("--"):
+                raise ValueError(f"{flag} requires a value")
+            value = candidate
+        elif token.startswith(f"{flag}="):
+            value = token.split("=", 1)[1]
+    return value
+
+
+def _require_cli_option(args: list[str], flag: str, *, expected: str | None = None) -> None:
+    value = _cli_option_value(args, flag)
+    if value is None:
+        raise ValueError(f"FPM V1 requires {flag}")
+    if expected is not None and value != expected:
+        raise ValueError(f"FPM V1 requires {flag} {expected}")
+
+
+def _last_env_value(env: list[tuple[str, str]], name: str) -> str | None:
+    for env_name, value in reversed(env):
+        if env_name == name:
+            return value
+    return None
+
+
+def _ensure_benchmark_output_path(args: list[str], env: list[tuple[str, str]]) -> str:
+    flag = "--benchmark-output-path"
+    cli_value = _cli_option_value(args, flag)
+    env_value = _last_env_value(env, "DYN_FPM_BENCHMARK_OUTPUT_PATH")
+    if cli_value is not None and env_value is not None and cli_value != env_value:
+        raise ValueError(f"{flag} and DYN_FPM_BENCHMARK_OUTPUT_PATH must resolve to the same path")
+    value = cli_value if cli_value is not None else env_value
+
+    if value is None:
+        value = "/results/benchmark.json"
+    if not value:
+        raise ValueError(f"{flag} must not be empty")
+    if cli_value is None:
+        # Waiting for an output path that the engine does not know about would
+        # hang forever.  Make the V1 default explicit in the resolved command.
+        args.extend([flag, value])
+    if env_value is None:
+        env.append(("DYN_FPM_BENCHMARK_OUTPUT_PATH", value))
+    return value
+
+
+def _benchmark_wait_timeout_seconds(args: list[str]) -> int:
+    raw = _cli_option_value(args, "--benchmark-timeout")
+    if raw is None:
+        return 7800
+    try:
+        benchmark_timeout = int(raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("--benchmark-timeout must be an integer number of seconds") from exc
+    if benchmark_timeout <= 0:
+        raise ValueError("--benchmark-timeout must be positive")
+    # Give the engine time to initialize and flush the final result after its
+    # own collector deadline expires.
+    return benchmark_timeout + 600
+
+
+def _render_run_script(
+    command: list[str],
+    env: list[tuple[str, str]],
+    benchmark_output_path: str,
+    wait_timeout_seconds: int,
+    topology: dict[str, int],
+) -> str:
+    lines = [
+        "#!/usr/bin/env bash",
+        "set -Eeuo pipefail",
+        "",
+        "ulimit -l unlimited || true",
+        "ulimit -n 1048576 || true",
+    ]
+    for name, value in env:
+        lines.append(f"export {name}={shlex.quote(value)}")
+
+    lines.extend(
+        [
+            "",
+            f"node_count={topology['node_count']}",
+            f"data_parallel_size={topology['data_parallel_size']}",
+            f"local_data_parallel_size={topology['local_data_parallel_size']}",
+            "if (( node_count > 1 )); then",
+            '  node_rank="${LWS_WORKER_INDEX:?LWS_WORKER_INDEX is required for multinode FPM}"',
+            '  master_addr="${LWS_LEADER_ADDRESS:?LWS_LEADER_ADDRESS is required for multinode FPM}"',
+            "else",
+            '  node_rank="${LWS_WORKER_INDEX:-0}"',
+            '  master_addr="${LWS_LEADER_ADDRESS:-127.0.0.1}"',
+            "fi",
+            'if ! [[ "$node_rank" =~ ^[0-9]+$ ]] || (( node_rank >= node_count )); then',
+            '  echo "Invalid FPM node rank: $node_rank (node_count=$node_count)" >&2',
+            "  exit 2",
+            "fi",
+            'export DYN_FPM_WORKER_ID="${DYN_FPM_WORKER_ID:-${FPM_RUN_ID:-fpm}-node${node_rank}}"',
+            f"benchmark_output_path={shlex.quote(benchmark_output_path)}",
+            f"wait_timeout_seconds={wait_timeout_seconds}",
+            f"engine_command=({' '.join(shlex.quote(token) for token in command)})",
+            'for index in "${!engine_command[@]}"; do',
+            f'  engine_command[$index]="${{engine_command[$index]//{_NODE_RANK_SENTINEL}/$node_rank}}"',
+            "done",
+            "",
+            "if (( node_count > 1 )); then",
+            "  if (( data_parallel_size > 1 )); then",
+            '    engine_command+=(--data-parallel-size-local "$local_data_parallel_size")',
+            '    engine_command+=(--data-parallel-start-rank "$((node_rank * local_data_parallel_size))")',
+            '    engine_command+=(--data-parallel-address "$master_addr" --data-parallel-rpc-port 29510)',
+            "    engine_command+=(--data-parallel-hybrid-lb)",
+            "  else",
+            '    engine_command+=(--nnodes "$node_count" --node-rank "$node_rank")',
+            '    engine_command+=(--master-addr "$master_addr" --master-port 29500)',
+            "    if (( node_rank > 0 )); then",
+            '      exec "${engine_command[@]}" --headless',
+            "    fi",
+            "  fi",
+            "fi",
+            "",
+            "benchmark_path_for_dp_rank() {",
+            "  local dp_rank=$1",
+            '  local directory=""',
+            '  local filename="$benchmark_output_path"',
+            '  if [[ "$benchmark_output_path" == */* ]]; then',
+            '    directory="${benchmark_output_path%/*}/"',
+            '    filename="${benchmark_output_path##*/}"',
+            "  fi",
+            "  if (( dp_rank == 0 )); then",
+            '    printf "%s\\n" "$benchmark_output_path"',
+            '  elif [[ "$filename" == *.* ]]; then',
+            '    printf "%s%s_dp%s.%s\\n" "$directory" "${filename%.*}" "$dp_rank" "${filename##*.}"',
+            "  else",
+            '    printf "%s%s_dp%s\\n" "$directory" "$filename" "$dp_rank"',
+            "  fi",
+            "}",
+            "",
+            "expected_results=()",
+            "local_dp_start=$((node_rank * local_data_parallel_size))",
+            "local_dp_end=$((local_dp_start + local_data_parallel_size))",
+            "for ((dp_rank=local_dp_start; dp_rank<local_dp_end; dp_rank++)); do",
+            '  expected_results+=("$(benchmark_path_for_dp_rank "$dp_rank")")',
+            "done",
+            'for path in "${expected_results[@]}"; do',
+            '  if [[ -e "$path" || -L "$path" ]]; then',
+            '    echo "Refusing to overwrite existing benchmark output: $path" >&2',
+            "    exit 1",
+            "  fi",
+            '  mkdir -p -- "$(dirname -- "$path")"',
+            "done",
+            "",
+            "check_result_files() {",
+            '  python3 - "$local_dp_start" "${expected_results[@]}" <<\'PY\'',
+            "import json",
+            "import pathlib",
+            "import sys",
+            "",
+            "start_rank = int(sys.argv[1])",
+            "for offset, raw_path in enumerate(sys.argv[2:]):",
+            "    path = pathlib.Path(raw_path)",
+            "    if not path.is_file() or path.stat().st_size == 0:",
+            "        raise SystemExit(10)",
+            "    try:",
+            '        value = json.loads(path.read_text(encoding="utf-8"))',
+            "    except (OSError, json.JSONDecodeError):",
+            "        raise SystemExit(10)",
+            '    if value.get("schema_version") != 2 or value.get("status") != "passed":',
+            '        print(f"Invalid FPM benchmark result {path}: "',
+            "              f\"schema_version={value.get('schema_version')!r} \"",
+            "              f\"status={value.get('status')!r} errors={value.get('errors')!r}\",",
+            "              file=sys.stderr)",
+            "        raise SystemExit(20)",
+            "    expected_rank = start_rank + offset",
+            '    if (value.get("config") or {}).get("dp_rank") != expected_rank:',
+            '        print(f"FPM benchmark DP rank mismatch for {path}: "',
+            "              f\"{(value.get('config') or {}).get('dp_rank')!r} != {expected_rank}\",",
+            "              file=sys.stderr)",
+            "        raise SystemExit(20)",
+            "PY",
+            "}",
+            "",
+            'engine_pid=""',
+            "engine_shutdown_grace_seconds=30",
+            "terminate_engine() {",
+            "  local pid=$1",
+            '  kill -TERM -- "-$pid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null || true',
+            "  local shutdown_deadline=$((SECONDS + engine_shutdown_grace_seconds))",
+            '  while kill -0 "$pid" 2>/dev/null || kill -0 -- "-$pid" 2>/dev/null; do',
+            "    if (( SECONDS >= shutdown_deadline )); then",
+            '      echo "Engine did not stop within ${engine_shutdown_grace_seconds}s; sending SIGKILL" >&2',
+            '      kill -KILL -- "-$pid" 2>/dev/null || true',
+            '      kill -KILL "$pid" 2>/dev/null || true',
+            "      break",
+            "    fi",
+            "    sleep 1",
+            "  done",
+            '  wait "$pid" 2>/dev/null || true',
+            "}",
+            "cleanup() {",
+            "  local status=$?",
+            "  trap - EXIT INT TERM",
+            '  if [[ -n "${engine_pid:-}" ]]; then',
+            '    terminate_engine "$engine_pid"',
+            "  fi",
+            '  exit "$status"',
+            "}",
+            "trap cleanup EXIT",
+            "trap 'exit 130' INT",
+            "trap 'exit 143' TERM",
+            "",
+            "python3 -c 'import os, sys; os.setsid(); os.execvp(sys.argv[1], sys.argv[1:])' \"${engine_command[@]}\" &",
+            "engine_pid=$!",
+            "deadline=$((SECONDS + wait_timeout_seconds))",
+            "",
+            "while true; do",
+            "  set +e",
+            "  check_result_files",
+            "  result_status=$?",
+            "  set -e",
+            "  if (( result_status == 0 )); then",
+            "    break",
+            "  fi",
+            "  if (( result_status == 20 )); then",
+            "    exit 1",
+            "  fi",
+            '  if ! kill -0 "$engine_pid" 2>/dev/null; then',
+            "    set +e",
+            '    wait "$engine_pid"',
+            "    engine_status=$?",
+            "    set -e",
+            '    terminate_engine "$engine_pid"',
+            '    engine_pid=""',
+            '    echo "Engine exited before writing all FPM benchmark outputs" >&2',
+            '    if (( engine_status == 0 )); then exit 1; else exit "$engine_status"; fi',
+            "  fi",
+            "  if (( SECONDS >= deadline )); then",
+            '    echo "Timed out waiting for all FPM benchmark outputs" >&2',
+            "    exit 124",
+            "  fi",
+            "  sleep 2",
+            "done",
+            "",
+            'terminate_engine "$engine_pid"',
+            'engine_pid=""',
+            "trap - EXIT INT TERM",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _lower_worker_to_resource(
+    context: dict[str, Any],
+    worker: DGDService,
+    main_container: MainContainer,
+    topology: dict[str, int],
+    *,
+    efa_resource_name: str | None,
+) -> dict[str, Any]:
+    k8s = context.get("K8sConfig") or {}
+    if not isinstance(k8s, dict):
+        raise TypeError("K8sConfig must be a mapping")
+    pod_spec = _lower_worker_pod_spec(
+        worker,
+        main_container,
+        topology["gpus_per_node"],
+        shared_memory_size=k8s.get("fpm_shared_memory_size"),
+        compute_domain_name=(f"{context.get('name')}-compute-domain-channel" if topology["node_count"] > 1 else None),
+        efa_resource_name=efa_resource_name,
+    )
+    metadata = _resource_metadata(context)
+    if topology["node_count"] == 1:
+        return {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": metadata,
+            "spec": pod_spec,
+        }
+
+    if len(metadata["name"]) > 50:
+        raise ValueError("FPM LeaderWorkerSet names must be at most 50 characters")
+    pod_labels = copy.deepcopy(metadata["labels"])
+    pod_template = {
+        "metadata": {"labels": pod_labels},
+        "spec": pod_spec,
+    }
+    return {
+        "apiVersion": "leaderworkerset.x-k8s.io/v1",
+        "kind": "LeaderWorkerSet",
+        "metadata": metadata,
+        "spec": {
+            "replicas": 1,
+            "startupPolicy": "LeaderCreated",
+            "networkConfig": {"subdomainPolicy": "Shared"},
+            "leaderWorkerTemplate": {
+                "size": topology["node_count"],
+                "restartPolicy": "None",
+                "leaderTemplate": copy.deepcopy(pod_template),
+                "workerTemplate": copy.deepcopy(pod_template),
+            },
+        },
+    }
+
+
+def _resource_metadata(context: dict[str, Any]) -> dict[str, Any]:
+    k8s = context.get("K8sConfig") or {}
+    if not isinstance(k8s, dict):
+        raise TypeError("K8sConfig must be a mapping")
+    name = context.get("name")
+    if not isinstance(name, str) or not name:
+        raise ValueError("FPM resource workload requires a non-empty context name")
+
+    labels = {
+        "app.kubernetes.io/name": name,
+        "app.kubernetes.io/component": "fpm-resource",
+    }
+    extra_labels = k8s.get("fpm_resource_labels") or {}
+    if not isinstance(extra_labels, dict):
+        raise TypeError("K8sConfig.fpm_resource_labels must be a mapping")
+    for label_name, label_value in extra_labels.items():
+        if not isinstance(label_name, str) or not isinstance(label_value, str):
+            raise TypeError("FPM resource label names and values must be strings")
+        if label_name in labels and labels[label_name] != label_value:
+            raise ValueError(f"K8sConfig.fpm_resource_labels cannot replace reserved label {label_name}")
+        labels[label_name] = label_value
+
+    metadata: dict[str, Any] = {
+        "name": name,
+        "labels": labels,
+    }
+    namespace = k8s.get("k8s_namespace")
+    if namespace:
+        metadata["namespace"] = namespace
+    return metadata
+
+
+def _drop_compute_domain_claims(pod_spec: dict[str, Any], expected_template_name: str | None) -> None:
+    claims = pod_spec.pop("resourceClaims", None) or []
+    if not isinstance(claims, list):
+        raise TypeError("Pod resourceClaims must be a list")
+    expected = (
+        [
+            {
+                "name": "compute-domain-channel",
+                "resourceClaimTemplateName": expected_template_name,
+            }
+        ]
+        if expected_template_name is not None
+        else []
+    )
+    if claims != expected:
+        raise ValueError("FPM does not support user-provided Pod resourceClaims")
+
+
+def _lower_worker_pod_spec(
+    worker: DGDService,
+    main_container: MainContainer,
+    gpus_per_node: int,
+    *,
+    shared_memory_size: Any = None,
+    compute_domain_name: str | None = None,
+    efa_resource_name: str | None = None,
+) -> dict[str, Any]:
+    extra_pod_spec = worker.extra_pod_spec
+    if extra_pod_spec is None:
+        raise ValueError("The resolved vLLM worker has no extraPodSpec")
+
+    pod_spec = extra_pod_spec.to_dict()
+    pod_spec.pop("mainContainer", None)
+    _drop_compute_domain_claims(pod_spec, compute_domain_name)
+
+    container = main_container.to_dict()
+    if container.get("envFrom"):
+        raise ValueError("FPM V1 does not support mainContainer.envFrom")
+    resource_override = container.get("resources")
+    for key in (
+        "command",
+        "args",
+        "env",
+        "envFrom",
+        "startupProbe",
+        "livenessProbe",
+        "readinessProbe",
+        "lifecycle",
+        "resources",
+    ):
+        container.pop(key, None)
+    if not container.get("image"):
+        raise ValueError("The resolved vLLM worker has no container image")
+
+    volumes = copy.deepcopy(pod_spec.get("volumes") or [])
+    volume_mounts = copy.deepcopy(container.get("volumeMounts") or [])
+    if not isinstance(volumes, list):
+        raise TypeError("Worker volumes must be a list")
+    if not isinstance(volume_mounts, list):
+        raise TypeError("Worker volumeMounts must be a list")
+    _add_volume_mount(
+        volumes,
+        volume_mounts,
+        name="results",
+        mount_path="/results",
+        volume_source={"emptyDir": {}},
+    )
+
+    # A vLLM resource pod always needs a real /dev/shm mount; when the normal
+    # DGD resolved a hardware-specific size, preserve it as sizeLimit.
+    shared_memory = worker.shared_memory
+    empty_dir: dict[str, Any] = {"medium": "Memory"}
+    if shared_memory_size is not None:
+        if not isinstance(shared_memory_size, str) or not shared_memory_size:
+            raise ValueError("K8sConfig.fpm_shared_memory_size must be a non-empty string")
+        empty_dir["sizeLimit"] = shared_memory_size
+    elif shared_memory is not None:
+        if not isinstance(shared_memory, dict):
+            raise ValueError("sharedMemory must be a mapping")
+        size = shared_memory.get("size")
+        if size:
+            empty_dir["sizeLimit"] = size
+    _add_volume_mount(
+        volumes,
+        volume_mounts,
+        name="dshm",
+        mount_path="/dev/shm",
+        volume_source={"emptyDir": empty_dir},
+    )
+
+    container.update(
+        {
+            "name": "fpm-resource",
+            "resources": _merge_container_resources(
+                _lower_resources(
+                    worker.resources,
+                    gpu_limit=gpus_per_node,
+                    allow_compute_domain_claim=compute_domain_name is not None,
+                    efa_resource_name=efa_resource_name,
+                ),
+                resource_override,
+                expected_gpu_limit=gpus_per_node,
+                efa_resource_name=efa_resource_name,
+            ),
+            "volumeMounts": volume_mounts,
+            "command": ["/bin/bash", "-lc"],
+            "args": ["exec sleep infinity"],
+        }
+    )
+    pod_spec["volumes"] = volumes
+    pod_spec["containers"] = [container]
+    pod_spec["restartPolicy"] = "Always"
+    return pod_spec
+
+
+def _lower_resources(
+    resources: dict[str, Any] | None,
+    *,
+    gpu_limit: int,
+    allow_compute_domain_claim: bool,
+    efa_resource_name: str | None,
+) -> dict[str, Any]:
+    if not isinstance(resources, dict):
+        raise TypeError("The resolved vLLM worker has no resources")
+    claims = resources.get("claims") or []
+    if not isinstance(claims, list):
+        raise TypeError("resources.claims must be a list")
+    expected_claims = [{"name": "compute-domain-channel"}] if allow_compute_domain_claim else []
+    if claims != expected_claims:
+        raise ValueError("FPM does not support user-provided resource claims")
+
+    lowered: dict[str, Any] = {}
+    for section_name in ("limits", "requests"):
+        section = resources.get(section_name)
+        if section is None:
+            continue
+        if not isinstance(section, dict):
+            raise TypeError(f"resources.{section_name} must be a mapping")
+        section = copy.deepcopy(section)
+        custom = section.pop("custom", None)
+        gpu = section.pop("gpu", None)
+        if gpu is not None:
+            section["nvidia.com/gpu"] = str(gpu_limit)
+        if custom is not None:
+            if not isinstance(custom, dict):
+                raise TypeError(f"resources.{section_name}.custom must be a mapping")
+            if efa_resource_name is not None and efa_resource_name in custom:
+                custom[efa_resource_name] = str(gpu_limit)
+            section.update(copy.deepcopy(custom))
+        if section:
+            lowered[section_name] = section
+
+    limits = lowered.get("limits") or {}
+    if "nvidia.com/gpu" not in limits:
+        raise ValueError("FPM resource Pod requires a GPU limit")
+    return lowered
+
+
+def _merge_container_resources(
+    base: dict[str, Any],
+    override: Any,
+    *,
+    expected_gpu_limit: int,
+    efa_resource_name: str | None,
+) -> dict[str, Any]:
+    if override is None:
+        return base
+    if not isinstance(override, dict):
+        raise TypeError("worker_extra_pod_spec.mainContainer.resources must be a mapping")
+
+    merged = copy.deepcopy(base)
+    for section_name, section_override in override.items():
+        if section_name not in ("limits", "requests"):
+            raise ValueError(f"Unsupported container resource section: {section_name}")
+        if not isinstance(section_override, dict):
+            raise TypeError(f"mainContainer.resources.{section_name} must be a mapping")
+        section = merged.setdefault(section_name, {})
+        for name, value in section_override.items():
+            if name == "nvidia.com/gpu":
+                try:
+                    requested_gpu = int(value)
+                except (TypeError, ValueError) as exc:
+                    raise ValueError("nvidia.com/gpu must be an integer") from exc
+                if requested_gpu != expected_gpu_limit:
+                    raise ValueError("worker_extra_pod_spec cannot override the Generator-resolved per-node GPU count")
+                value = str(expected_gpu_limit)
+            elif efa_resource_name is not None and name == efa_resource_name:
+                try:
+                    requested_efa = int(value)
+                except (TypeError, ValueError) as exc:
+                    raise ValueError(f"{efa_resource_name} must be an integer") from exc
+                if requested_efa != expected_gpu_limit:
+                    raise ValueError("worker_extra_pod_spec cannot override the Generator-resolved per-node EFA count")
+                value = str(expected_gpu_limit)
+            section[name] = copy.deepcopy(value)
+    return merged
+
+
+def _efa_resource_name(resolved_facts: Any) -> str | None:
+    transport = getattr(resolved_facts, "transport", None)
+    if not isinstance(transport, dict):
+        return None
+    pod = transport.get("pod")
+    if pod is None:
+        return None
+    if not isinstance(pod, dict):
+        raise TypeError("Resolved transport pod facts must be a mapping")
+    resource_name = pod.get("efa_resource")
+    if resource_name is None:
+        return None
+    if not isinstance(resource_name, str) or not resource_name:
+        raise ValueError("Resolved transport efa_resource must be a non-empty string")
+    return resource_name
+
+
+def _add_volume_mount(
+    volumes: list[Any],
+    volume_mounts: list[Any],
+    *,
+    name: str,
+    mount_path: str,
+    volume_source: dict[str, Any],
+) -> None:
+    matching_volume = None
+    for volume in volumes:
+        if isinstance(volume, dict) and volume.get("name") == name:
+            matching_volume = volume
+            break
+
+    matching_mount = None
+    for mount in volume_mounts:
+        if not isinstance(mount, dict):
+            raise TypeError("Worker volumeMount entries must be mappings")
+        if mount.get("name") == name or mount.get("mountPath") == mount_path:
+            if mount.get("name") == name and mount.get("mountPath") == mount_path:
+                matching_mount = mount
+                break
+            raise ValueError(f"worker_extra_pod_spec conflicts with reserved mount {mount_path}")
+
+    if matching_volume is not None or matching_mount is not None:
+        if matching_volume is None or matching_mount is None:
+            raise ValueError(
+                f"worker_extra_pod_spec must define both volume {name} and mount {mount_path} when overriding it"
+            )
+        return
+
+    volumes.append({"name": name, **copy.deepcopy(volume_source)})
+    volume_mounts.append({"name": name, "mountPath": mount_path})

--- a/src/aiconfigurator/generator/builders/k8s_builder.py
+++ b/src/aiconfigurator/generator/builders/k8s_builder.py
@@ -226,7 +226,7 @@ def _populate_vllm(context: dict[str, Any], resolved_facts: Any = None) -> list[
     model_cache_input = str(k8s.get("k8s_model_cache") or "").strip()
     use_model_cache = model_cache_input != ""
     model_cache_pvc = model_cache_input if use_model_cache else "model-cache"
-    model_cache_mount = "/workspace/model_cache"
+    model_cache_mount = str(k8s.get("k8s_pvc_mount_path") or "/workspace/model_cache")
     enable_router = bool(dyn.get("enable_router") or False)
     etcd_endpoints = k8s.get("k8s_etcd_endpoints")
     hf_home = k8s.get("k8s_hf_home")
@@ -533,7 +533,7 @@ def _populate_sglang(context: dict[str, Any], resolved_facts: Any = None) -> lis
     model_cache_input = str(k8s.get("k8s_model_cache") or "").strip()
     use_model_cache = model_cache_input != ""
     model_cache_pvc = model_cache_input if use_model_cache else "model-cache"
-    model_cache_mount = "/workspace/model_cache"
+    model_cache_mount = str(k8s.get("k8s_pvc_mount_path") or "/workspace/model_cache")
     etcd_endpoints = k8s.get("k8s_etcd_endpoints")
     hf_home = k8s.get("k8s_hf_home")
     image_pull_secret = k8s.get("k8s_image_pull_secret")
@@ -827,7 +827,7 @@ def _populate_trtllm(context: dict[str, Any], resolved_facts: Any = None) -> lis
     model_cache_input = str(k8s.get("k8s_model_cache") or "").strip()
     use_model_cache = model_cache_input != ""
     model_cache_pvc = model_cache_input if use_model_cache else "model-cache"
-    model_cache_mount = "/workspace/model_cache"
+    model_cache_mount = str(k8s.get("k8s_pvc_mount_path") or "/workspace/model_cache")
     runtime_working_dir = context.get("working_dir") or "/workspace/"
     etcd_endpoints = k8s.get("k8s_etcd_endpoints")
     hf_home = k8s.get("k8s_hf_home")

--- a/src/aiconfigurator/generator/config/deployment_config.yaml
+++ b/src/aiconfigurator/generator/config/deployment_config.yaml
@@ -128,6 +128,11 @@ inputs:
     required: false
   - key: K8sConfig.frontend_extra_pod_spec
     required: false
+  # FPM-only resource-workload controls. Other deployment targets ignore them.
+  - key: K8sConfig.fpm_shared_memory_size
+    required: false
+  - key: K8sConfig.fpm_resource_labels
+    required: false
 
   # Worker config
   - key: WorkerConfig.prefill_workers

--- a/src/aiconfigurator/generator/main.py
+++ b/src/aiconfigurator/generator/main.py
@@ -63,6 +63,12 @@ def main(argv: Optional[list[str]] = None):
     )
     p_art.add_argument("--templates-dir", help="Templates directory override")
     p_art.add_argument("--version", help="Backend version for template selection")
+    p_art.add_argument(
+        "--deployment-target",
+        choices=["dynamo-j2", "dynamo-python", "llm-d-helm", "llm-d-kustomize", "fpm"],
+        default="dynamo-j2",
+        help="Artifact target. 'fpm' emits a reusable resource Pod and run.sh.",
+    )
     p_art.add_argument("--output", help="Directory to save generated artifacts")
     args = parser.parse_args(argv)
 
@@ -89,6 +95,7 @@ def main(argv: Optional[list[str]] = None):
             templates_dir=args.templates_dir,
             output_dir=args.output,
             backend_version=args.version,
+            deployment_target=args.deployment_target,
         )
         print(json.dumps(artifacts, ensure_ascii=False, indent=2))
         return

--- a/src/aiconfigurator/generator/rendering/engine.py
+++ b/src/aiconfigurator/generator/rendering/engine.py
@@ -252,7 +252,8 @@ def render_backend_templates(
         backend: Backend name (e.g., 'trtllm', 'vllm', 'sglang')
         templates_dir: Directory containing backend-specific template directories
         version: Version string (e.g., '1.1.0rc5'). If None, uses default templates
-        deployment_target: Deployment platform ('dynamo-j2', 'dynamo-python', 'llm-d-helm', or 'llm-d-kustomize')
+        deployment_target: Deployment platform ('dynamo-j2', 'dynamo-python', 'llm-d-helm',
+            'llm-d-kustomize', or 'fpm')
         resolved_facts: Optional ``ResolvedFacts`` (typed ``Any`` to avoid an import
             cycle). When it carries a matched model profile, model ``defaults:``
             cli flags are appended (facts-default precedence: fill-if-absent) at the
@@ -705,6 +706,23 @@ def render_backend_templates(
                 rendered_templates["llm-d-values.yaml"] = rendered
             except Exception as e:
                 logger.warning(f"Failed to render template llm-d-values.yaml.j2: {e}")
+    elif deployment_target == "fpm":
+        # FPM is deliberately isolated from the normal DGD/run-script path. It
+        # emits exactly two artifacts: a reusable, keepalive resource Pod and a
+        # complete engine launch script. The builder consumes the same fully
+        # resolved vLLM context as the normal typed K8s builder, so rule/mapping/
+        # versioned-template output remains the source of the base argv.
+        from aiconfigurator.generator.builders.fpm_builder import build_fpm_artifacts
+
+        fpm_context = _assemble_k8s_context(context, has_engine_templates)
+        if _context_sink is not None:
+            _context_sink(fpm_context)
+        return build_fpm_artifacts(
+            fpm_context,
+            backend,
+            resolved_facts=resolved_facts,
+            param_values=param_values,
+        )
     elif deployment_target == "dynamo-python":
         # Dynamo deployment using Dynamo's Python config modifiers
         try:

--- a/tests/unit/cli/test_cli_workflow.py
+++ b/tests/unit/cli/test_cli_workflow.py
@@ -22,6 +22,7 @@ import yaml
 from aiconfigurator.cli.main import (
     _execute_tasks,
     _resolve_cli_log_level,
+    _validate_fpm_sweep_tasks,
     build_default_tasks,
     build_experiment_tasks,
     configure_parser,
@@ -195,6 +196,51 @@ class TestCLIIntegration:
         mock_builder.assert_called_once()
         mock_execute.assert_called_once_with({"agg": mock_task_config}, mode, top_n=5)
 
+    def test_fpm_sweep_validation_accepts_vllm_aggregated_tasks(self):
+        args = argparse.Namespace(deployment_target="fpm")
+        tasks = {
+            "agg": argparse.Namespace(
+                serving_mode="agg",
+                primary_backend_name="vllm",
+            )
+        }
+
+        _validate_fpm_sweep_tasks(args, tasks)
+
+    @patch("aiconfigurator.cli.main._execute_tasks")
+    @patch("aiconfigurator.cli.main.build_experiment_tasks")
+    def test_cli_fpm_rejects_incompatible_tasks_before_sweep(
+        self,
+        mock_build_exp,
+        mock_execute,
+        cli_args_factory,
+        mock_exp_yaml_path,
+    ):
+        mock_build_exp.return_value = {
+            "disagg": argparse.Namespace(
+                serving_mode="disagg",
+                primary_backend_name="vllm",
+            ),
+            "agg_trtllm": argparse.Namespace(
+                serving_mode="agg",
+                primary_backend_name="trtllm",
+            ),
+        }
+        args = cli_args_factory(
+            mode="exp",
+            extra_args=[
+                "--yaml-path",
+                str(mock_exp_yaml_path),
+                "--deployment-target",
+                "fpm",
+            ],
+        )
+
+        with pytest.raises(SystemExit, match="supports only vLLM aggregated tasks"):
+            cli_main(args)
+
+        mock_execute.assert_not_called()
+
     @patch("aiconfigurator.cli.main.run_spica_thorough_default")
     @patch("aiconfigurator.cli.main._execute_tasks")
     @patch("aiconfigurator.cli.main.build_default_tasks")
@@ -212,6 +258,26 @@ class TestCLIIntegration:
 
         mock_run_spica.assert_called_once_with(args)
         mock_build_default.assert_not_called()
+        mock_execute.assert_not_called()
+
+    @patch("aiconfigurator.cli.main.run_spica_thorough_default")
+    @patch("aiconfigurator.cli.main._execute_tasks")
+    def test_cli_fpm_rejects_thorough_sweep_before_spica(
+        self,
+        mock_execute,
+        mock_run_spica,
+        cli_args_factory,
+    ):
+        args = cli_args_factory(
+            mode="default",
+            thorough_sweep=True,
+            deployment_target="fpm",
+        )
+
+        with pytest.raises(SystemExit, match="does not support Spica thorough sweeps"):
+            cli_main(args)
+
+        mock_run_spica.assert_not_called()
         mock_execute.assert_not_called()
 
     @patch("aiconfigurator.cli.main.run_spica_thorough_default")
@@ -761,7 +827,7 @@ class TestCLIIntegration:
         assert planner_config["prefill_engine_num_gpu"] == 1
         assert planner_config["decode_engine_num_gpu"] == 2
 
-    @pytest.mark.parametrize("deployment_target", ["dynamo-python", "llm-d-helm", "llm-d-kustomize"])
+    @pytest.mark.parametrize("deployment_target", ["dynamo-python", "llm-d-helm", "llm-d-kustomize", "fpm"])
     def test_spica_artifacts_fail_closed_when_target_drops_native_features(self, deployment_target):
         generator_config = {
             "DynConfig": {

--- a/tests/unit/generator/test_fpm_artifacts.py
+++ b/tests/unit/generator/test_fpm_artifacts.py
@@ -1,0 +1,1213 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public-contract tests for the reusable-Pod FPM artifact target."""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import shlex
+import signal
+import stat
+import subprocess
+import time
+
+import pytest
+import yaml
+
+from aiconfigurator.generator.aggregators import generate_config_from_input_dict
+from aiconfigurator.generator.api import generate_backend_artifacts
+from aiconfigurator.generator.main import main as generator_main
+from aiconfigurator.generator.rendering.engine import render_backend_templates
+
+pytestmark = pytest.mark.unit
+
+_BACKEND_VERSION = "0.20.1"
+_COMPILATION_CONFIG = json.dumps(
+    {
+        "cudagraph_mode": "FULL",
+        "max_capture_size": 1024,
+        "compile_sizes": [1, 2, 4, 8],
+    }
+)
+
+
+def _params() -> dict:
+    return {
+        "ServiceConfig": {
+            "model_path": "/workspace/model_cache/GLM-5",
+            "served_model_path": "/workspace/model_cache/GLM-5",
+            "served_model_name": "glm52-fpm",
+            "include_frontend": False,
+        },
+        "K8sConfig": {
+            "name_prefix": "glm52-fpm",
+            "k8s_namespace": "default",
+            "k8s_image": "nvcr.io/nvidia/ai-dynamo/vllm-runtime:test",
+            "k8s_pvc_name": "model-cache-pvc",
+            "k8s_pvc_mount_path": "/workspace/model_cache",
+            "k8s_model_path_in_pvc": "GLM-5",
+            # Normalized backward-compatible aliases consumed by the typed
+            # vLLM K8s builder, which remains FPM's infrastructure source.
+            "k8s_model_cache": "model-cache-pvc",
+            "k8s_hf_home": "/workspace/model_cache/GLM-5",
+            "extra_env": [
+                {"name": "FPM_RUN_ID", "value": "glm52-fpm-a3-example"},
+                {"name": "FPM_STAGE", "value": "aligned validation"},
+                {"name": "DYN_FPM_BENCHMARK_OUTPUT_PATH", "value": "/results/benchmark.json"},
+                {"name": "NCCL_DEBUG", "value": "INFO"},
+            ],
+        },
+        "DynConfig": {"mode": "agg"},
+        "WorkerConfig": {
+            "agg_workers": 1,
+            "agg_gpus_per_worker": 4,
+            "prefill_workers": 0,
+            "decode_workers": 0,
+        },
+        "NodeConfig": {"system_name": "b200_sxm", "num_gpus_per_node": 8},
+        "SlaConfig": {"isl": 1024, "osl": 256},
+        "ModelConfig": {"is_moe": True, "prefix": 0, "nextn": 0},
+        "BenchConfig": {},
+        "params": {
+            "agg": {
+                "tensor_parallel_size": 4,
+                "pipeline_parallel_size": 1,
+                "data_parallel_size": 1,
+                "gpus_per_worker": 4,
+                "max_batch_size": 64,
+                "max_num_tokens": 4096,
+                "max_seq_len": 8192,
+                "tokens_per_block": 64,
+                "trust_remote_code": True,
+                "extra_cli_args": [
+                    "--scheduler-cls",
+                    "fpm.scheduler.InstrumentedScheduler",
+                    "--benchmark-mode",
+                    "agg",
+                    "--compilation-config",
+                    _COMPILATION_CONFIG,
+                ],
+            }
+        },
+    }
+
+
+def _render(params: dict | None = None, backend: str = "vllm") -> dict[str, str]:
+    return render_backend_templates(
+        copy.deepcopy(params or _params()),
+        backend,
+        version=_BACKEND_VERSION,
+        deployment_target="fpm",
+    )
+
+
+def _pod(artifacts: dict[str, str]) -> dict:
+    document = yaml.safe_load(artifacts["k8s_deploy.yaml"])
+    assert isinstance(document, dict)
+    return document
+
+
+def _main_container(pod: dict) -> dict:
+    containers = pod["spec"]["containers"]
+    assert len(containers) == 1
+    return containers[0]
+
+
+def _export_value(script: str, name: str) -> str:
+    prefix = f"{name}="
+    for line in script.splitlines():
+        try:
+            tokens = shlex.split(line, comments=True)
+        except ValueError:
+            continue
+        if not tokens or tokens[0] != "export":
+            continue
+        for assignment in tokens[1:]:
+            if assignment.startswith(prefix):
+                return assignment[len(prefix) :]
+    raise AssertionError(f"missing export for {name}")
+
+
+def test_fpm_render_returns_only_resource_pod_and_run_script():
+    artifacts = _render()
+
+    assert set(artifacts) == {"k8s_deploy.yaml", "run.sh"}
+
+
+def test_fpm_pinned_vllm_024_uses_floor_template_and_preserves_fpm_overlay():
+    artifacts = render_backend_templates(
+        copy.deepcopy(_params()),
+        "vllm",
+        version="0.24.0",
+        deployment_target="fpm",
+    )
+
+    assert yaml.safe_load(artifacts["k8s_deploy.yaml"])["kind"] == "Pod"
+    assert "--tensor-parallel-size 4" in artifacts["run.sh"]
+    assert "--scheduler-cls fpm.scheduler.InstrumentedScheduler" in artifacts["run.sh"]
+    assert "--dump-config-to /results/resolved-config-node0.json" in artifacts["run.sh"]
+
+
+def test_fpm_resource_pod_is_keepalive_only_and_preserves_resources():
+    artifacts = _render()
+    pod = _pod(artifacts)
+    container = _main_container(pod)
+
+    assert pod["apiVersion"] == "v1"
+    assert pod["kind"] == "Pod"
+    keepalive = " ".join([*container.get("command", []), *container.get("args", [])])
+    assert "sleep" in keepalive
+    assert "infinity" in keepalive
+
+    assert int(container["resources"]["limits"]["nvidia.com/gpu"]) == 4
+    assert pod["spec"]["nodeSelector"]["nvidia.com/gpu.product"] == "NVIDIA-B200"
+    assert not container.get("env")
+    assert not container.get("envFrom")
+    assert "dynamo.vllm" not in keepalive
+    assert "--scheduler-cls" not in keepalive
+    assert "--benchmark-mode" not in keepalive
+
+    volumes = {volume["name"]: volume for volume in pod["spec"]["volumes"]}
+    mounts = {mount["mountPath"]: mount["name"] for mount in container["volumeMounts"]}
+
+    model_volume = volumes[mounts["/workspace/model_cache"]]
+    assert model_volume["persistentVolumeClaim"]["claimName"] == "model-cache-pvc"
+    assert volumes[mounts["/results"]]["emptyDir"] == {}
+    assert volumes[mounts["/dev/shm"]]["emptyDir"]["medium"] == "Memory"
+    assert volumes[mounts["/dev/shm"]]["emptyDir"]["sizeLimit"] == "64Gi"
+
+
+def test_fpm_resource_overlays_preserve_requests_mount_path_shm_and_labels():
+    params = _params()
+    params["K8sConfig"].update(
+        {
+            "k8s_pvc_mount_path": "/model-cache",
+            "fpm_shared_memory_size": "200Gi",
+            "fpm_resource_labels": {
+                "fpm.nvidia.com/run-id": "glm52-fpm-a3-example",
+                "fpm.nvidia.com/stage": "probe",
+            },
+            "worker_extra_pod_spec": {
+                "mainContainer": {
+                    "resources": {
+                        "requests": {
+                            "memory": "448Gi",
+                            "ephemeral-storage": "30Gi",
+                        }
+                    }
+                }
+            },
+        }
+    )
+
+    pod = _pod(_render(params))
+    container = _main_container(pod)
+    requests = container["resources"]["requests"]
+    assert requests["memory"] == "448Gi"
+    assert requests["ephemeral-storage"] == "30Gi"
+    assert container["resources"]["limits"]["nvidia.com/gpu"] == "4"
+    assert {mount["mountPath"] for mount in container["volumeMounts"]} >= {
+        "/model-cache",
+        "/results",
+        "/dev/shm",
+    }
+    volumes = {volume["name"]: volume for volume in pod["spec"]["volumes"]}
+    assert volumes["dshm"]["emptyDir"] == {"medium": "Memory", "sizeLimit": "200Gi"}
+    assert pod["metadata"]["labels"]["fpm.nvidia.com/run-id"] == "glm52-fpm-a3-example"
+    assert pod["metadata"]["labels"]["fpm.nvidia.com/stage"] == "probe"
+
+
+def test_fpm_resource_overlay_cannot_change_resolved_gpu_count():
+    params = _params()
+    params["K8sConfig"]["worker_extra_pod_spec"] = {"mainContainer": {"resources": {"limits": {"nvidia.com/gpu": "8"}}}}
+
+    with pytest.raises(ValueError, match="per-node GPU count"):
+        _render(params)
+
+
+def test_fpm_run_script_contains_resolved_args_passthrough_and_exports():
+    script = _render()["run.sh"]
+
+    # Service-level fields plus the normal versioned vLLM template/rule output.
+    assert "python3 -m dynamo.vllm" in script
+    assert "--model /workspace/model_cache/GLM-5" in script
+    assert "--served-model-name glm52-fpm" in script
+    assert "--tensor-parallel-size 4" in script
+    assert "--block-size 64" in script
+
+    # FPM-only argv is appended without losing token boundaries. The JSON has
+    # spaces and nested values specifically to catch unsafe string joining.
+    assert "--scheduler-cls fpm.scheduler.InstrumentedScheduler" in script
+    assert "--benchmark-mode agg" in script
+    assert f"--compilation-config {shlex.quote(_COMPILATION_CONFIG)}" in script
+    assert script.count(_COMPILATION_CONFIG) == 1
+
+    assert _export_value(script, "FPM_RUN_ID") == "glm52-fpm-a3-example"
+    assert _export_value(script, "FPM_STAGE") == "aligned validation"
+    assert _export_value(script, "DYN_FPM_BENCHMARK_OUTPUT_PATH") == "/results/benchmark.json"
+    assert _export_value(script, "NCCL_DEBUG") == "INFO"
+    assert _export_value(script, "NCCL_CUMEM_ENABLE") == "1"
+    assert "ulimit -n 1048576" in script
+    assert "wait_timeout_seconds=7800" in script
+
+    syntax = subprocess.run(
+        ["bash", "-n"],
+        input=script,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert syntax.returncode == 0, syntax.stderr
+
+
+def test_fpm_preserves_duplicate_environment_export_order():
+    params = _params()
+    params["K8sConfig"]["extra_env"].extend(
+        [
+            {"name": "NCCL_DEBUG", "value": "WARN"},
+            {"name": "NCCL_DEBUG", "value": "TRACE"},
+        ]
+    )
+
+    exports = [line for line in _render(params)["run.sh"].splitlines() if line.startswith("export NCCL_DEBUG=")]
+
+    assert exports == ["export NCCL_DEBUG=INFO", "export NCCL_DEBUG=WARN", "export NCCL_DEBUG=TRACE"]
+
+
+def test_fpm_keeps_cli_and_environment_output_paths_aligned():
+    params = _params()
+    params["K8sConfig"]["extra_env"] = [
+        entry for entry in params["K8sConfig"]["extra_env"] if entry["name"] != "DYN_FPM_BENCHMARK_OUTPUT_PATH"
+    ]
+    params["params"]["agg"]["extra_cli_args"].extend(["--benchmark-output-path", "/results/custom.json"])
+
+    script = _render(params)["run.sh"]
+
+    assert _export_value(script, "DYN_FPM_BENCHMARK_OUTPUT_PATH") == "/results/custom.json"
+
+
+def test_fpm_rejects_conflicting_output_paths():
+    params = _params()
+    params["params"]["agg"]["extra_cli_args"].extend(["--benchmark-output-path", "/results/different.json"])
+
+    with pytest.raises(ValueError, match="same path"):
+        _render(params)
+
+
+def _assert_process_stopped(pid_path) -> None:
+    process_pid = int(pid_path.read_text())
+    exit_deadline = time.monotonic() + 2
+    while time.monotonic() < exit_deadline:
+        try:
+            os.kill(process_pid, 0)
+        except ProcessLookupError:
+            return
+        time.sleep(0.05)
+
+    try:
+        os.kill(process_pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return
+    pytest.fail(f"process {process_pid} survived FPM run.sh cleanup")
+
+
+@pytest.mark.parametrize(
+    "empty_cli_args",
+    [
+        ["--benchmark-output-path", ""],
+        ["--benchmark-output-path="],
+    ],
+)
+def test_fpm_rejects_explicit_empty_cli_output_path(empty_cli_args):
+    params = _params()
+    params["K8sConfig"]["extra_env"] = [
+        entry for entry in params["K8sConfig"]["extra_env"] if entry["name"] != "DYN_FPM_BENCHMARK_OUTPUT_PATH"
+    ]
+    params["params"]["agg"]["extra_cli_args"].extend(empty_cli_args)
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        _render(params)
+
+
+def test_fpm_rejects_explicit_empty_environment_output_path():
+    params = _params()
+    for entry in params["K8sConfig"]["extra_env"]:
+        if entry["name"] == "DYN_FPM_BENCHMARK_OUTPUT_PATH":
+            entry["value"] = ""
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        _render(params)
+
+
+def test_fpm_api_writes_exact_filenames_and_executable_script(tmp_path):
+    artifacts = generate_backend_artifacts(
+        copy.deepcopy(_params()),
+        "vllm",
+        output_dir=str(tmp_path),
+        backend_version=_BACKEND_VERSION,
+        deployment_target="fpm",
+    )
+
+    assert set(artifacts) == {"k8s_deploy.yaml", "run.sh"}
+    assert {path.name for path in tmp_path.iterdir()} == {"k8s_deploy.yaml", "run.sh"}
+    assert not (tmp_path / "run_x.sh").exists()
+    assert (tmp_path / "run.sh").stat().st_mode & stat.S_IXUSR
+    assert yaml.safe_load((tmp_path / "k8s_deploy.yaml").read_text())["kind"] == "Pod"
+
+
+def test_fpm_run_script_completes_and_stops_fake_engine(tmp_path):
+    output_path = tmp_path / "benchmark.json"
+    params = _params()
+    for entry in params["K8sConfig"]["extra_env"]:
+        if entry["name"] == "DYN_FPM_BENCHMARK_OUTPUT_PATH":
+            entry["value"] = str(output_path)
+
+    fake_package = tmp_path / "fake-package" / "dynamo" / "vllm"
+    fake_package.mkdir(parents=True)
+    (fake_package.parent / "__init__.py").write_text("")
+    (fake_package / "__init__.py").write_text("")
+    (fake_package / "__main__.py").write_text(
+        """\
+import json
+import pathlib
+import signal
+import sys
+import time
+
+flag = "--benchmark-output-path"
+index = sys.argv.index(flag)
+path = pathlib.Path(sys.argv[index + 1])
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text(json.dumps({"schema_version": 2, "status": "passed", "config": {"dp_rank": 0}}))
+signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+while True:
+    time.sleep(0.1)
+"""
+    )
+    script_path = tmp_path / "run.sh"
+    script_path.write_text(_render(params)["run.sh"])
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(tmp_path / "fake-package")
+
+    completed = subprocess.run(
+        ["bash", str(script_path)],
+        text=True,
+        capture_output=True,
+        env=env,
+        timeout=10,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert json.loads(output_path.read_text()) == {
+        "schema_version": 2,
+        "status": "passed",
+        "config": {"dp_rank": 0},
+    }
+
+    repeated = subprocess.run(
+        ["bash", str(script_path)],
+        text=True,
+        capture_output=True,
+        env=env,
+        timeout=10,
+        check=False,
+    )
+    assert repeated.returncode == 1
+    assert "Refusing to overwrite" in repeated.stderr
+
+
+def test_fpm_run_script_waits_for_every_single_node_dp_result(tmp_path):
+    output_path = tmp_path / "benchmark.json"
+    params = _params()
+    params["params"]["agg"].update(
+        {
+            "tensor_parallel_size": 1,
+            "data_parallel_size": 4,
+            "gpus_per_worker": 4,
+        }
+    )
+    for entry in params["K8sConfig"]["extra_env"]:
+        if entry["name"] == "DYN_FPM_BENCHMARK_OUTPUT_PATH":
+            entry["value"] = str(output_path)
+
+    fake_package = tmp_path / "fake-package" / "dynamo" / "vllm"
+    fake_package.mkdir(parents=True)
+    (fake_package.parent / "__init__.py").write_text("")
+    (fake_package / "__init__.py").write_text("")
+    (fake_package / "__main__.py").write_text(
+        """\
+import json
+import pathlib
+import signal
+import sys
+import time
+
+output_flag = sys.argv.index("--benchmark-output-path")
+base = pathlib.Path(sys.argv[output_flag + 1])
+dp_flag = sys.argv.index("--data-parallel-size")
+dp_size = int(sys.argv[dp_flag + 1])
+base.parent.mkdir(parents=True, exist_ok=True)
+for rank in range(dp_size):
+    path = base if rank == 0 else base.with_name(f"{base.stem}_dp{rank}{base.suffix}")
+    path.write_text(json.dumps({
+        "schema_version": 2,
+        "status": "passed",
+        "config": {"dp_rank": rank},
+        "rank": rank,
+    }))
+    time.sleep(1)
+signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+while True:
+    time.sleep(0.1)
+"""
+    )
+    script_path = tmp_path / "run.sh"
+    script_path.write_text(_render(params)["run.sh"])
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(tmp_path / "fake-package")
+
+    completed = subprocess.run(
+        ["bash", str(script_path)],
+        text=True,
+        capture_output=True,
+        env=env,
+        timeout=12,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert [
+        json.loads((output_path if rank == 0 else tmp_path / f"benchmark_dp{rank}.json").read_text())["rank"]
+        for rank in range(4)
+    ] == [0, 1, 2, 3]
+
+
+def test_fpm_run_script_rejects_terminal_failed_result(tmp_path):
+    output_path = tmp_path / "benchmark.json"
+    params = _params()
+    for entry in params["K8sConfig"]["extra_env"]:
+        if entry["name"] == "DYN_FPM_BENCHMARK_OUTPUT_PATH":
+            entry["value"] = str(output_path)
+
+    fake_package = tmp_path / "fake-package" / "dynamo" / "vllm"
+    fake_package.mkdir(parents=True)
+    (fake_package.parent / "__init__.py").write_text("")
+    (fake_package / "__init__.py").write_text("")
+    (fake_package / "__main__.py").write_text(
+        """\
+import json
+import pathlib
+import signal
+import sys
+import time
+
+index = sys.argv.index("--benchmark-output-path")
+path = pathlib.Path(sys.argv[index + 1])
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text(json.dumps({
+    "schema_version": 2,
+    "status": "failed",
+    "config": {"dp_rank": 0},
+    "errors": ["boom"],
+}))
+signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+while True:
+    time.sleep(0.1)
+"""
+    )
+    script_path = tmp_path / "run.sh"
+    script_path.write_text(_render(params)["run.sh"])
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(tmp_path / "fake-package")
+
+    completed = subprocess.run(
+        ["bash", str(script_path)],
+        text=True,
+        capture_output=True,
+        env=env,
+        timeout=8,
+        check=False,
+    )
+
+    assert completed.returncode == 1
+    assert "status='failed'" in completed.stderr
+    assert "boom" in completed.stderr
+
+
+@pytest.mark.parametrize(
+    ("result_status", "expected_returncode"),
+    [
+        ("passed", 0),
+        ("failed", 1),
+    ],
+)
+def test_fpm_run_script_bounds_stubborn_engine_shutdown(
+    tmp_path,
+    result_status,
+    expected_returncode,
+):
+    output_path = tmp_path / "benchmark.json"
+    pid_path = tmp_path / "engine.pid"
+    child_pid_path = tmp_path / "engine-child.pid"
+    params = _params()
+    for entry in params["K8sConfig"]["extra_env"]:
+        if entry["name"] == "DYN_FPM_BENCHMARK_OUTPUT_PATH":
+            entry["value"] = str(output_path)
+
+    fake_package = tmp_path / "fake-package" / "dynamo" / "vllm"
+    fake_package.mkdir(parents=True)
+    (fake_package.parent / "__init__.py").write_text("")
+    (fake_package / "__init__.py").write_text("")
+    (fake_package / "__main__.py").write_text(
+        f"""\
+import json
+import os
+import pathlib
+import signal
+import subprocess
+import sys
+import time
+
+signal.signal(signal.SIGTERM, signal.SIG_IGN)
+pathlib.Path(os.environ["FAKE_ENGINE_PID_PATH"]).write_text(str(os.getpid()))
+child = subprocess.Popen([
+    sys.executable,
+    "-c",
+    "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(3600)",
+])
+pathlib.Path(os.environ["FAKE_ENGINE_CHILD_PID_PATH"]).write_text(str(child.pid))
+index = sys.argv.index("--benchmark-output-path")
+path = pathlib.Path(sys.argv[index + 1])
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text(json.dumps({{
+    "schema_version": 2,
+    "status": "{result_status}",
+    "config": {{"dp_rank": 0}},
+}}))
+while True:
+    time.sleep(0.1)
+"""
+    )
+    script_path = tmp_path / "run.sh"
+    script = _render(params)["run.sh"].replace(
+        "engine_shutdown_grace_seconds=30",
+        "engine_shutdown_grace_seconds=1",
+    )
+    script_path.write_text(script)
+    env = dict(os.environ)
+    env.update(
+        {
+            "PYTHONPATH": str(tmp_path / "fake-package"),
+            "FAKE_ENGINE_PID_PATH": str(pid_path),
+            "FAKE_ENGINE_CHILD_PID_PATH": str(child_pid_path),
+        }
+    )
+
+    started = time.monotonic()
+    completed = subprocess.run(
+        ["bash", str(script_path)],
+        text=True,
+        capture_output=True,
+        env=env,
+        timeout=8,
+        check=False,
+    )
+    elapsed = time.monotonic() - started
+
+    assert completed.returncode == expected_returncode
+    assert elapsed < 7
+    assert "Engine did not stop within 1s; sending SIGKILL" in completed.stderr
+    for process_pid_path in (pid_path, child_pid_path):
+        _assert_process_stopped(process_pid_path)
+
+
+def test_fpm_run_script_cleans_process_group_when_engine_parent_exits(tmp_path):
+    output_path = tmp_path / "benchmark.json"
+    child_pid_path = tmp_path / "engine-child.pid"
+    params = _params()
+    for entry in params["K8sConfig"]["extra_env"]:
+        if entry["name"] == "DYN_FPM_BENCHMARK_OUTPUT_PATH":
+            entry["value"] = str(output_path)
+
+    fake_package = tmp_path / "fake-package" / "dynamo" / "vllm"
+    fake_package.mkdir(parents=True)
+    (fake_package.parent / "__init__.py").write_text("")
+    (fake_package / "__init__.py").write_text("")
+    (fake_package / "__main__.py").write_text(
+        """\
+import os
+import pathlib
+import signal
+import subprocess
+import sys
+
+child = subprocess.Popen(
+    [
+        sys.executable,
+        "-c",
+        "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(3600)",
+    ],
+    stdin=subprocess.DEVNULL,
+    stdout=subprocess.DEVNULL,
+    stderr=subprocess.DEVNULL,
+)
+pathlib.Path(os.environ["FAKE_ENGINE_CHILD_PID_PATH"]).write_text(str(child.pid))
+raise SystemExit(23)
+"""
+    )
+    script_path = tmp_path / "run.sh"
+    script = _render(params)["run.sh"].replace(
+        "engine_shutdown_grace_seconds=30",
+        "engine_shutdown_grace_seconds=1",
+    )
+    script_path.write_text(script)
+    env = dict(os.environ)
+    env.update(
+        {
+            "PYTHONPATH": str(tmp_path / "fake-package"),
+            "FAKE_ENGINE_CHILD_PID_PATH": str(child_pid_path),
+        }
+    )
+
+    try:
+        completed = subprocess.run(
+            ["bash", str(script_path)],
+            text=True,
+            capture_output=True,
+            env=env,
+            timeout=8,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        if child_pid_path.exists():
+            os.kill(int(child_pid_path.read_text()), signal.SIGKILL)
+        raise
+
+    assert completed.returncode == 23
+    assert "Engine exited before writing all FPM benchmark outputs" in completed.stderr
+    assert "Engine did not stop within 1s; sending SIGKILL" in completed.stderr
+    _assert_process_stopped(child_pid_path)
+
+
+def test_default_and_explicit_normal_targets_remain_identical():
+    params = _params()
+    params["K8sConfig"].pop("extra_env")
+    params["params"]["agg"].pop("extra_cli_args")
+
+    default = render_backend_templates(copy.deepcopy(params), "vllm", version=_BACKEND_VERSION)
+    explicit = render_backend_templates(
+        copy.deepcopy(params),
+        "vllm",
+        version=_BACKEND_VERSION,
+        deployment_target="dynamo-j2",
+    )
+
+    assert explicit == default
+    assert "k8s_deploy.yaml" in explicit
+    assert "run_0.sh" in explicit
+    assert "run.sh" not in explicit
+
+
+def test_legacy_yaml_normalization_preserves_extra_cli_args():
+    raw = {
+        "ServiceConfig": {"model_path": "/models/glm52", "served_model_name": "glm52"},
+        "DynConfig": {"mode": "agg"},
+        "Workers": {
+            "agg": {
+                "tensor_parallel_size": 4,
+                "extra_cli_args": ["--scheduler-cls", "fpm.scheduler.InstrumentedScheduler"],
+            }
+        },
+    }
+
+    normalized = generate_config_from_input_dict(raw, backend="vllm")
+
+    assert normalized["params"]["agg"]["extra_cli_args"] == raw["Workers"]["agg"]["extra_cli_args"]
+
+
+def test_render_artifacts_cli_accepts_fpm_target(tmp_path, capsys):
+    config = {
+        "ServiceConfig": {
+            "model_path": "/workspace/model_cache/GLM-5",
+            "served_model_name": "glm52-fpm",
+        },
+        "K8sConfig": {
+            "name_prefix": "glm52-fpm",
+            "k8s_namespace": "default",
+            "k8s_image": "nvcr.io/nvidia/ai-dynamo/vllm-runtime:test",
+            "extra_env": [
+                {"name": "DYN_FPM_BENCHMARK_OUTPUT_PATH", "value": "/results/benchmark.json"},
+            ],
+        },
+        "DynConfig": {"mode": "agg"},
+        "WorkerConfig": {"agg_workers": 1},
+        "NodeConfig": {"num_gpus_per_node": 8},
+        "Workers": {
+            "agg": {
+                "tensor_parallel_size": 4,
+                "pipeline_parallel_size": 1,
+                "gpus_per_worker": 4,
+                "max_batch_size": 64,
+                "max_num_tokens": 4096,
+                "max_seq_len": 8192,
+                "tokens_per_block": 64,
+                "extra_cli_args": ["--benchmark-mode", "agg"],
+            }
+        },
+    }
+    config_path = tmp_path / "fpm-request.yaml"
+    output_dir = tmp_path / "artifacts"
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False))
+
+    generator_main(
+        [
+            "render-artifacts",
+            "--backend",
+            "vllm",
+            "--version",
+            _BACKEND_VERSION,
+            "--deployment-target",
+            "fpm",
+            "--config",
+            str(config_path),
+            "--output",
+            str(output_dir),
+        ]
+    )
+    capsys.readouterr()
+
+    assert {path.name for path in output_dir.iterdir()} == {"k8s_deploy.yaml", "run.sh"}
+
+
+def _disagg_params() -> dict:
+    params = _params()
+    agg = params["params"].pop("agg")
+    params["params"]["prefill"] = copy.deepcopy(agg)
+    params["params"]["decode"] = copy.deepcopy(agg)
+    params["DynConfig"]["mode"] = "disagg"
+    params["WorkerConfig"].update(
+        {
+            "agg_workers": 0,
+            "prefill_workers": 1,
+            "decode_workers": 1,
+            "prefill_gpus_per_worker": 4,
+            "decode_gpus_per_worker": 4,
+        }
+    )
+    return params
+
+
+@pytest.mark.parametrize(
+    ("backend", "params"),
+    [
+        pytest.param("sglang", _params(), id="non-vllm"),
+        pytest.param("vllm", _disagg_params(), id="disaggregated"),
+    ],
+)
+def test_fpm_rejects_unsupported_backend_or_mode(backend, params):
+    with pytest.raises(ValueError):
+        _render(params, backend=backend)
+
+
+def test_fpm_rejects_multiple_workers():
+    params = _params()
+    params["WorkerConfig"]["agg_workers"] = 2
+
+    with pytest.raises(ValueError):
+        _render(params)
+
+
+def test_fpm_multinode_worker_emits_keepalive_leaderworkerset_and_rank_aware_script():
+    params = _params()
+    params["WorkerConfig"]["agg_gpus_per_worker"] = 16
+    params["params"]["agg"]["gpus_per_worker"] = 16
+    params["params"]["agg"]["tensor_parallel_size"] = 16
+
+    artifacts = _render(params)
+    workload = yaml.safe_load(artifacts["k8s_deploy.yaml"])
+
+    assert workload["apiVersion"] == "leaderworkerset.x-k8s.io/v1"
+    assert workload["kind"] == "LeaderWorkerSet"
+    group = workload["spec"]["leaderWorkerTemplate"]
+    assert group["size"] == 2
+    for template_name in ("leaderTemplate", "workerTemplate"):
+        container = group[template_name]["spec"]["containers"][0]
+        assert container["resources"]["limits"]["nvidia.com/gpu"] == "8"
+        assert container["command"] == ["/bin/bash", "-lc"]
+        assert container["args"] == ["exec sleep infinity"]
+
+    script = artifacts["run.sh"]
+    assert 'node_rank="${LWS_WORKER_INDEX:?LWS_WORKER_INDEX is required for multinode FPM}"' in script
+    assert 'master_addr="${LWS_LEADER_ADDRESS:?LWS_LEADER_ADDRESS is required for multinode FPM}"' in script
+    assert '--nnodes "$node_count" --node-rank "$node_rank"' in script
+    assert 'exec "${engine_command[@]}" --headless' in script
+
+
+def test_fpm_multinode_efa_resource_matches_per_node_gpu_count():
+    params = _params()
+    params["K8sConfig"]["transport"] = "efa"
+    params["K8sConfig"]["worker_extra_pod_spec"] = {
+        "mainContainer": {
+            "resources": {
+                "limits": {"example.com/unrelated": "1"},
+            }
+        }
+    }
+    params["WorkerConfig"]["agg_gpus_per_worker"] = 16
+    params["params"]["agg"].update({"gpus_per_worker": 16, "tensor_parallel_size": 16})
+
+    workload = yaml.safe_load(_render(params)["k8s_deploy.yaml"])
+    group = workload["spec"]["leaderWorkerTemplate"]
+
+    for template_name in ("leaderTemplate", "workerTemplate"):
+        limits = group[template_name]["spec"]["containers"][0]["resources"]["limits"]
+        assert limits["nvidia.com/gpu"] == "8"
+        assert limits["vpc.amazonaws.com/efa"] == "8"
+        assert limits["example.com/unrelated"] == "1"
+
+
+def test_fpm_efa_resource_overlay_cannot_change_resolved_per_node_count():
+    params = _params()
+    params["K8sConfig"]["transport"] = "efa"
+    params["K8sConfig"]["worker_extra_pod_spec"] = {
+        "mainContainer": {
+            "resources": {
+                "limits": {"vpc.amazonaws.com/efa": "16"},
+            }
+        }
+    }
+    params["WorkerConfig"]["agg_gpus_per_worker"] = 16
+    params["params"]["agg"].update({"gpus_per_worker": 16, "tensor_parallel_size": 16})
+
+    with pytest.raises(ValueError, match="per-node EFA count"):
+        _render(params)
+
+
+def test_fpm_multinode_dump_config_override_requires_rank_placeholder():
+    params = _params()
+    params["WorkerConfig"]["agg_gpus_per_worker"] = 16
+    params["params"]["agg"].update({"gpus_per_worker": 16, "tensor_parallel_size": 16})
+    params["params"]["agg"]["extra_cli_args"].extend(["--dump-config-to", "/results/resolved-config.json"])
+
+    with pytest.raises(ValueError, match="node_rank"):
+        _render(params)
+
+
+def test_fpm_multinode_rejects_name_too_long_for_lws_revision_labels():
+    params = _params()
+    params["K8sConfig"]["name_prefix"] = "f" * 51
+    params["WorkerConfig"]["agg_gpus_per_worker"] = 16
+    params["params"]["agg"].update({"gpus_per_worker": 16, "tensor_parallel_size": 16})
+
+    with pytest.raises(ValueError, match="at most 50"):
+        _render(params)
+
+
+def test_fpm_multinode_requires_lws_runtime_environment(tmp_path):
+    params = _params()
+    params["WorkerConfig"]["agg_gpus_per_worker"] = 16
+    params["params"]["agg"].update({"gpus_per_worker": 16, "tensor_parallel_size": 16})
+    script_path = tmp_path / "run.sh"
+    script_path.write_text(_render(params)["run.sh"])
+
+    completed = subprocess.run(
+        ["bash", str(script_path)],
+        text=True,
+        capture_output=True,
+        timeout=5,
+        check=False,
+    )
+
+    assert completed.returncode != 0
+    assert "LWS_WORKER_INDEX is required" in completed.stderr
+
+
+def test_fpm_multinode_model_parallel_follower_receives_rank_and_headless(tmp_path):
+    args_path = tmp_path / "engine-args.json"
+    params = _params()
+    params["WorkerConfig"]["agg_gpus_per_worker"] = 16
+    params["params"]["agg"].update({"gpus_per_worker": 16, "tensor_parallel_size": 16})
+
+    fake_package = tmp_path / "fake-package" / "dynamo" / "vllm"
+    fake_package.mkdir(parents=True)
+    (fake_package.parent / "__init__.py").write_text("")
+    (fake_package / "__init__.py").write_text("")
+    (fake_package / "__main__.py").write_text(
+        """\
+import json
+import os
+import pathlib
+import sys
+
+pathlib.Path(os.environ["FAKE_ARGS_PATH"]).write_text(json.dumps(sys.argv[1:]))
+"""
+    )
+    script_path = tmp_path / "run.sh"
+    script_path.write_text(_render(params)["run.sh"])
+    env = dict(os.environ)
+    env.update(
+        {
+            "PYTHONPATH": str(tmp_path / "fake-package"),
+            "FAKE_ARGS_PATH": str(args_path),
+            "LWS_WORKER_INDEX": "1",
+            "LWS_LEADER_ADDRESS": "leader.example",
+        }
+    )
+
+    completed = subprocess.run(
+        ["bash", str(script_path)],
+        text=True,
+        capture_output=True,
+        env=env,
+        timeout=5,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    engine_args = json.loads(args_path.read_text())
+    assert engine_args[engine_args.index("--nnodes") + 1] == "2"
+    assert engine_args[engine_args.index("--node-rank") + 1] == "1"
+    assert engine_args[engine_args.index("--master-addr") + 1] == "leader.example"
+    assert engine_args[engine_args.index("--dump-config-to") + 1].endswith("resolved-config-node1.json")
+    assert engine_args[-1] == "--headless"
+
+
+def test_fpm_multinode_dp_rank_executes_local_result_range(tmp_path):
+    output_path = tmp_path / "run.v1" / "metrics.final.json"
+    args_path = tmp_path / "engine-args.json"
+    params = _params()
+    params["WorkerConfig"]["agg_gpus_per_worker"] = 16
+    params["params"]["agg"].update(
+        {
+            "gpus_per_worker": 16,
+            "tensor_parallel_size": 1,
+            "data_parallel_size": 16,
+        }
+    )
+    for entry in params["K8sConfig"]["extra_env"]:
+        if entry["name"] == "DYN_FPM_BENCHMARK_OUTPUT_PATH":
+            entry["value"] = str(output_path)
+
+    fake_package = tmp_path / "fake-package" / "dynamo" / "vllm"
+    fake_package.mkdir(parents=True)
+    (fake_package.parent / "__init__.py").write_text("")
+    (fake_package / "__init__.py").write_text("")
+    (fake_package / "__main__.py").write_text(
+        """\
+import json
+import os
+import pathlib
+import signal
+import sys
+import time
+
+pathlib.Path(os.environ["FAKE_ARGS_PATH"]).write_text(json.dumps(sys.argv[1:]))
+output = pathlib.Path(sys.argv[sys.argv.index("--benchmark-output-path") + 1])
+local = int(sys.argv[sys.argv.index("--data-parallel-size-local") + 1])
+start = int(sys.argv[sys.argv.index("--data-parallel-start-rank") + 1])
+output.parent.mkdir(parents=True, exist_ok=True)
+for rank in range(start, start + local):
+    path = output if rank == 0 else output.with_name(f"{output.stem}_dp{rank}{output.suffix}")
+    path.write_text(json.dumps({
+        "schema_version": 2,
+        "status": "passed",
+        "config": {"dp_rank": rank},
+    }))
+signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+while True:
+    time.sleep(0.1)
+"""
+    )
+    script_path = tmp_path / "run.sh"
+    script_path.write_text(_render(params)["run.sh"])
+    env = dict(os.environ)
+    env.update(
+        {
+            "PYTHONPATH": str(tmp_path / "fake-package"),
+            "FAKE_ARGS_PATH": str(args_path),
+            "LWS_WORKER_INDEX": "1",
+            "LWS_LEADER_ADDRESS": "leader.example",
+        }
+    )
+
+    completed = subprocess.run(
+        ["bash", str(script_path)],
+        text=True,
+        capture_output=True,
+        env=env,
+        timeout=8,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    engine_args = json.loads(args_path.read_text())
+    assert engine_args[engine_args.index("--data-parallel-size-local") + 1] == "8"
+    assert engine_args[engine_args.index("--data-parallel-start-rank") + 1] == "8"
+    assert engine_args[engine_args.index("--data-parallel-address") + 1] == "leader.example"
+    assert engine_args[engine_args.index("--dump-config-to") + 1].endswith("resolved-config-node1.json")
+    assert engine_args[-1] == "--data-parallel-hybrid-lb"
+    assert "--headless" not in engine_args
+    assert {path.name for path in output_path.parent.glob("metrics.final_dp*.json")} == {
+        f"metrics.final_dp{rank}.json" for rank in range(8, 16)
+    }
+
+
+@pytest.mark.parametrize(
+    "flag",
+    sorted(
+        [
+            "--nnodes",
+            "--node-rank",
+            "--master-addr",
+            "--master-port",
+            "--headless",
+            "--data-parallel-size-local",
+            "--data-parallel-start-rank",
+            "--data-parallel-address",
+            "--data-parallel-rpc-port",
+            "--data-parallel-hybrid-lb",
+        ]
+    ),
+)
+def test_fpm_rejects_passthrough_of_generator_owned_orchestration_flags(flag):
+    params = _params()
+    params["params"]["agg"]["extra_cli_args"].append(flag)
+
+    with pytest.raises(ValueError, match="owns orchestration option"):
+        _render(params)
+
+
+def test_fpm_rejects_value_from_environment_entry():
+    params = _params()
+    params["K8sConfig"]["extra_env"].append(
+        {
+            "name": "POD_NAME",
+            "valueFrom": {
+                "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "metadata.name",
+                }
+            },
+        }
+    )
+
+    with pytest.raises(ValueError):
+        _render(params)
+
+
+def test_fpm_rejects_env_from_environment_sources():
+    params = _params()
+    params["K8sConfig"]["worker_extra_pod_spec"] = {
+        "mainContainer": {
+            "envFrom": [{"secretRef": {"name": "fpm-secret"}}],
+        }
+    }
+
+    with pytest.raises(ValueError, match="envFrom"):
+        _render(params)
+
+
+def test_fpm_rejects_user_resource_claims():
+    params = _params()
+    params["K8sConfig"]["worker_extra_pod_spec"] = {
+        "resourceClaims": [
+            {
+                "name": "compute-domain-channel",
+                "resourceClaimTemplateName": "user-owned",
+            }
+        ]
+    }
+
+    with pytest.raises(ValueError, match="resourceClaims"):
+        _render(params)
+
+
+def test_fpm_requires_mp_data_parallel_backend():
+    params = _params()
+    params["params"]["agg"].update(
+        {
+            "tensor_parallel_size": 1,
+            "data_parallel_size": 4,
+            "gpus_per_worker": 4,
+        }
+    )
+    params["params"]["agg"]["extra_cli_args"].extend(["--data-parallel-backend", "ray"])
+
+    with pytest.raises(ValueError, match="data-parallel-backend mp"):
+        _render(params)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("enable_router", True),
+        ("router_mode", "kv"),
+        ("router_config", {"router_reset_states": True}),
+        ("planner_config", {"environment": "kubernetes"}),
+    ],
+)
+def test_fpm_rejects_router_and_planner_configuration(field, value):
+    params = _params()
+    params["DynConfig"][field] = value
+
+    with pytest.raises(ValueError, match="router or planner"):
+        _render(params)
+
+
+def test_fpm_requires_benchmark_mode():
+    params = _params()
+    args = params["params"]["agg"]["extra_cli_args"]
+    index = args.index("--benchmark-mode")
+    del args[index : index + 2]
+
+    with pytest.raises(ValueError, match="--benchmark-mode"):
+        _render(params)
+
+
+def test_fpm_requires_aggregated_benchmark_mode():
+    params = _params()
+    args = params["params"]["agg"]["extra_cli_args"]
+    index = args.index("--benchmark-mode")
+    args[index + 1] = "disagg"
+
+    with pytest.raises(ValueError, match="--benchmark-mode agg"):
+        _render(params)
+
+
+def test_fpm_rejects_another_flag_in_a_required_value_position():
+    params = _params()
+    args = params["params"]["agg"]["extra_cli_args"]
+    index = args.index("--benchmark-mode")
+    args[index + 1] = "--scheduler-cls"
+
+    with pytest.raises(ValueError, match="requires a value"):
+        _render(params)
+
+
+def test_fpm_uses_benchmark_timeout_with_startup_grace():
+    params = _params()
+    params["params"]["agg"]["extra_cli_args"].extend(["--benchmark-timeout", "3600"])
+
+    assert "wait_timeout_seconds=4200" in _render(params)["run.sh"]
+
+
+@pytest.mark.parametrize("timeout", ["zero", "0", "-1"])
+def test_fpm_rejects_invalid_benchmark_timeout(timeout):
+    params = _params()
+    params["params"]["agg"]["extra_cli_args"].extend(["--benchmark-timeout", timeout])
+
+    with pytest.raises(ValueError, match="benchmark-timeout"):
+        _render(params)
+
+
+@pytest.mark.parametrize("invalid", ["--scheduler-cls InstrumentedScheduler", {"--scheduler-cls": "x"}, None])
+def test_fpm_rejects_non_list_extra_cli_args(invalid):
+    params = _params()
+    params["params"]["agg"]["extra_cli_args"] = invalid
+
+    with pytest.raises((TypeError, ValueError)):
+        _render(params)

--- a/tests/unit/generator/test_fpm_artifacts.py
+++ b/tests/unit/generator/test_fpm_artifacts.py
@@ -34,6 +34,40 @@ _COMPILATION_CONFIG = json.dumps(
 )
 
 
+def _benchmark_result(
+    dp_rank: int = 0,
+    *,
+    mode: str = "prefill",
+    valid: bool = True,
+    schema_version: int = 1,
+    status: str = "complete",
+) -> dict:
+    completed_points = 1 if valid else 0
+    skipped_points = 0 if valid else 1
+    return {
+        "schema_version": schema_version,
+        "status": status,
+        "valid": valid,
+        "coverage": {
+            "expected_points": 1,
+            "completed_points": completed_points,
+            "skipped_points": skipped_points,
+        },
+        "config": {"mode": mode},
+        "results": (
+            [
+                {
+                    "point": {"point_type": mode},
+                    "fpms": [{"dp_rank": dp_rank}],
+                }
+            ]
+            if valid
+            else []
+        ),
+        "skipped_points": [] if valid else [{"reason": "boom"}],
+    }
+
+
 def _params() -> dict:
     return {
         "ServiceConfig": {
@@ -86,7 +120,7 @@ def _params() -> dict:
                     "--scheduler-cls",
                     "fpm.scheduler.InstrumentedScheduler",
                     "--benchmark-mode",
-                    "agg",
+                    "prefill",
                     "--compilation-config",
                     _COMPILATION_CONFIG,
                 ],
@@ -241,7 +275,7 @@ def test_fpm_run_script_contains_resolved_args_passthrough_and_exports():
     # FPM-only argv is appended without losing token boundaries. The JSON has
     # spaces and nested values specifically to catch unsafe string joining.
     assert "--scheduler-cls fpm.scheduler.InstrumentedScheduler" in script
-    assert "--benchmark-mode agg" in script
+    assert "--benchmark-mode prefill" in script
     assert f"--compilation-config {shlex.quote(_COMPILATION_CONFIG)}" in script
     assert script.count(_COMPILATION_CONFIG) == 1
 
@@ -360,6 +394,7 @@ def test_fpm_api_writes_exact_filenames_and_executable_script(tmp_path):
 
 def test_fpm_run_script_completes_and_stops_fake_engine(tmp_path):
     output_path = tmp_path / "benchmark.json"
+    result = _benchmark_result()
     params = _params()
     for entry in params["K8sConfig"]["extra_env"]:
         if entry["name"] == "DYN_FPM_BENCHMARK_OUTPUT_PATH":
@@ -370,7 +405,7 @@ def test_fpm_run_script_completes_and_stops_fake_engine(tmp_path):
     (fake_package.parent / "__init__.py").write_text("")
     (fake_package / "__init__.py").write_text("")
     (fake_package / "__main__.py").write_text(
-        """\
+        f"""\
 import json
 import pathlib
 import signal
@@ -381,7 +416,7 @@ flag = "--benchmark-output-path"
 index = sys.argv.index(flag)
 path = pathlib.Path(sys.argv[index + 1])
 path.parent.mkdir(parents=True, exist_ok=True)
-path.write_text(json.dumps({"schema_version": 2, "status": "passed", "config": {"dp_rank": 0}}))
+path.write_text({json.dumps(result)!r})
 signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
 while True:
     time.sleep(0.1)
@@ -402,11 +437,7 @@ while True:
     )
 
     assert completed.returncode == 0, completed.stderr
-    assert json.loads(output_path.read_text()) == {
-        "schema_version": 2,
-        "status": "passed",
-        "config": {"dp_rank": 0},
-    }
+    assert json.loads(output_path.read_text()) == result
 
     repeated = subprocess.run(
         ["bash", str(script_path)],
@@ -454,9 +485,13 @@ base.parent.mkdir(parents=True, exist_ok=True)
 for rank in range(dp_size):
     path = base if rank == 0 else base.with_name(f"{base.stem}_dp{rank}{base.suffix}")
     path.write_text(json.dumps({
-        "schema_version": 2,
-        "status": "passed",
-        "config": {"dp_rank": rank},
+        "schema_version": 1,
+        "status": "complete",
+        "valid": True,
+        "coverage": {"expected_points": 1, "completed_points": 1, "skipped_points": 0},
+        "config": {"mode": "prefill"},
+        "results": [{"point": {"point_type": "prefill"}, "fpms": [{"dp_rank": rank}]}],
+        "skipped_points": [],
         "rank": rank,
     }))
     time.sleep(1)
@@ -488,6 +523,7 @@ while True:
 
 def test_fpm_run_script_rejects_terminal_failed_result(tmp_path):
     output_path = tmp_path / "benchmark.json"
+    result = _benchmark_result(valid=False)
     params = _params()
     for entry in params["K8sConfig"]["extra_env"]:
         if entry["name"] == "DYN_FPM_BENCHMARK_OUTPUT_PATH":
@@ -498,7 +534,7 @@ def test_fpm_run_script_rejects_terminal_failed_result(tmp_path):
     (fake_package.parent / "__init__.py").write_text("")
     (fake_package / "__init__.py").write_text("")
     (fake_package / "__main__.py").write_text(
-        """\
+        f"""\
 import json
 import pathlib
 import signal
@@ -508,12 +544,7 @@ import time
 index = sys.argv.index("--benchmark-output-path")
 path = pathlib.Path(sys.argv[index + 1])
 path.parent.mkdir(parents=True, exist_ok=True)
-path.write_text(json.dumps({
-    "schema_version": 2,
-    "status": "failed",
-    "config": {"dp_rank": 0},
-    "errors": ["boom"],
-}))
+path.write_text({json.dumps(result)!r})
 signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
 while True:
     time.sleep(0.1)
@@ -534,23 +565,76 @@ while True:
     )
 
     assert completed.returncode == 1
-    assert "status='failed'" in completed.stderr
+    assert "valid=False" in completed.stderr
     assert "boom" in completed.stderr
 
 
 @pytest.mark.parametrize(
-    ("result_status", "expected_returncode"),
+    ("result", "expected_message"),
     [
-        ("passed", 0),
-        ("failed", 1),
+        (_benchmark_result(schema_version=2), "schema_version=2"),
+        (_benchmark_result(mode="decode"), "benchmark mode 'decode' != 'prefill'"),
+        (_benchmark_result(dp_rank=1), "FPM dp_ranks [1] != [0]"),
+    ],
+)
+def test_fpm_run_script_rejects_mismatched_result_identity(tmp_path, result, expected_message):
+    output_path = tmp_path / "benchmark.json"
+    params = _params()
+    for entry in params["K8sConfig"]["extra_env"]:
+        if entry["name"] == "DYN_FPM_BENCHMARK_OUTPUT_PATH":
+            entry["value"] = str(output_path)
+
+    fake_package = tmp_path / "fake-package" / "dynamo" / "vllm"
+    fake_package.mkdir(parents=True)
+    (fake_package.parent / "__init__.py").write_text("")
+    (fake_package / "__init__.py").write_text("")
+    (fake_package / "__main__.py").write_text(
+        f"""\
+import pathlib
+import signal
+import sys
+import time
+
+path = pathlib.Path(sys.argv[sys.argv.index("--benchmark-output-path") + 1])
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text({json.dumps(result)!r})
+signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+while True:
+    time.sleep(0.1)
+"""
+    )
+    script_path = tmp_path / "run.sh"
+    script_path.write_text(_render(params)["run.sh"])
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(tmp_path / "fake-package")
+
+    completed = subprocess.run(
+        ["bash", str(script_path)],
+        text=True,
+        capture_output=True,
+        env=env,
+        timeout=8,
+        check=False,
+    )
+
+    assert completed.returncode == 1
+    assert expected_message in completed.stderr
+
+
+@pytest.mark.parametrize(
+    ("result_valid", "expected_returncode"),
+    [
+        (True, 0),
+        (False, 1),
     ],
 )
 def test_fpm_run_script_bounds_stubborn_engine_shutdown(
     tmp_path,
-    result_status,
+    result_valid,
     expected_returncode,
 ):
     output_path = tmp_path / "benchmark.json"
+    result = _benchmark_result(valid=result_valid)
     pid_path = tmp_path / "engine.pid"
     child_pid_path = tmp_path / "engine-child.pid"
     params = _params()
@@ -583,11 +667,7 @@ pathlib.Path(os.environ["FAKE_ENGINE_CHILD_PID_PATH"]).write_text(str(child.pid)
 index = sys.argv.index("--benchmark-output-path")
 path = pathlib.Path(sys.argv[index + 1])
 path.parent.mkdir(parents=True, exist_ok=True)
-path.write_text(json.dumps({{
-    "schema_version": 2,
-    "status": "{result_status}",
-    "config": {{"dp_rank": 0}},
-}}))
+path.write_text({json.dumps(result)!r})
 while True:
     time.sleep(0.1)
 """
@@ -755,7 +835,7 @@ def test_render_artifacts_cli_accepts_fpm_target(tmp_path, capsys):
                 "max_num_tokens": 4096,
                 "max_seq_len": 8192,
                 "tokens_per_block": 64,
-                "extra_cli_args": ["--benchmark-mode", "agg"],
+                "extra_cli_args": ["--benchmark-mode", "prefill"],
             }
         },
     }
@@ -1013,9 +1093,13 @@ output.parent.mkdir(parents=True, exist_ok=True)
 for rank in range(start, start + local):
     path = output if rank == 0 else output.with_name(f"{output.stem}_dp{rank}{output.suffix}")
     path.write_text(json.dumps({
-        "schema_version": 2,
-        "status": "passed",
-        "config": {"dp_rank": rank},
+        "schema_version": 1,
+        "status": "complete",
+        "valid": True,
+        "coverage": {"expected_points": 1, "completed_points": 1, "skipped_points": 0},
+        "config": {"mode": "prefill"},
+        "results": [{"point": {"point_type": "prefill"}, "fpms": [{"dp_rank": rank}]}],
+        "skipped_points": [],
     }))
 signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
 while True:
@@ -1168,13 +1252,24 @@ def test_fpm_requires_benchmark_mode():
         _render(params)
 
 
-def test_fpm_requires_aggregated_benchmark_mode():
+@pytest.mark.parametrize("benchmark_mode", ["prefill", "decode"])
+def test_fpm_accepts_phase_specific_benchmark_mode(benchmark_mode):
     params = _params()
     args = params["params"]["agg"]["extra_cli_args"]
     index = args.index("--benchmark-mode")
-    args[index + 1] = "disagg"
+    args[index + 1] = benchmark_mode
 
-    with pytest.raises(ValueError, match="--benchmark-mode agg"):
+    assert f"--benchmark-mode {benchmark_mode}" in _render(params)["run.sh"]
+
+
+@pytest.mark.parametrize("benchmark_mode", ["agg", "disagg", "unknown"])
+def test_fpm_rejects_non_phase_benchmark_mode(benchmark_mode):
+    params = _params()
+    args = params["params"]["agg"]["extra_cli_args"]
+    index = args.index("--benchmark-mode")
+    args[index + 1] = benchmark_mode
+
+    with pytest.raises(ValueError, match="--benchmark-mode prefill or decode"):
         _render(params)
 
 


### PR DESCRIPTION
Summary:
- Reconstruct PR #1328 as a single baseline commit on the upstream main snapshot used for review.
- Add a separate minimal follow-up commit that accepts pure `prefill`/`decode` benchmark modes and aligns `run.sh` with Dynamo's merged schema-v1 result contract.
- Validate terminal status, coverage, workload identity, nested per-FPM `dp_rank`, and bounded engine process-group cleanup.
- Keep the change as a Draft for Generator owners to review and modify collaboratively; this does not supersede #1328 without owner coordination.

Test plan:
- `pytest tests/unit/generator/test_fpm_artifacts.py`: 68 passed.
- Full Generator suite: 212 passed, 4 skipped.
- CLI FPM selection: 4 passed, 67 deselected.
- `ruff check`, `ruff format --check`, and `git diff --check`: passed.
- Real Kubernetes smoke test: GLM-5.2 NVFP4 on 4x B200, TP4/PP1/DP1, one pure-prefill point; schema v1 result was complete/valid with nested `dp_rank=0`, `run.sh` exited 0, engine children were removed, and owned resources were deleted.

Notes:
- Commit 1 is the PR #1328 baseline; commit 2 contains the contract-alignment changes for focused review.
- The branch is one data-only upstream-main commit behind (`62633bb`); that commit does not overlap the Generator files changed here.

Relates to #1328


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FPM V1 as a deployment target for supported vLLM aggregated workloads.
  * FPM generates Kubernetes deployment resources and a launch script, with single- and multi-node support.
  * Added CLI support for selecting deployment targets, including Helm and Kustomize options.
  * Added FPM-specific resource settings and improved model-cache mount configuration.

* **Bug Fixes**
  * Preserved user-provided extra CLI arguments during configuration generation.

* **Documentation**
  * Expanded CLI, deployment, generator, and artifact documentation with supported targets, outputs, and FPM usage constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->