### PR TITLE
feat: support OSS-backed model deployment

### DIFF
--- a/docker/Dockerfile.service
+++ b/docker/Dockerfile.service
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+FROM ghcr.io/astral-sh/uv:0.11.3 AS uv
+FROM registry.k8s.io/kubectl:v1.31.0 AS kubectl
+
+FROM python:3.12-slim-bookworm AS build
+
+COPY --from=uv /uv /usr/local/bin/uv
+WORKDIR /build
+COPY pyproject.toml uv.lock README.md LICENSE ./
+COPY src/ ./src/
+
+# Do not publish an image with Git LFS pointer stubs instead of performance data.
+RUN set -eu; \
+    bad="$(grep -rlE '^version https://git-lfs' /build/src/aiconfigurator/systems 2>/dev/null || true)"; \
+    if [ -n "$bad" ]; then \
+      echo "ERROR: Git LFS objects are not materialized:" >&2; \
+      echo "$bad" >&2; \
+      exit 1; \
+    fi; \
+    uv build --wheel --out-dir /dist
+
+FROM python:3.12-slim-bookworm AS runtime
+
+ARG AIC_MODEL_S3_BUCKET=aiplat
+ARG AWS_ENDPOINT_URL=https://oss-s3.haiercash.com
+ARG AWS_DEFAULT_REGION=cn-east-1
+
+COPY --from=uv /uv /usr/local/bin/uv
+COPY --from=kubectl /bin/kubectl /usr/local/bin/kubectl
+COPY --from=build /dist /wheelhouse
+
+RUN set -eu; \
+    wheel="$(find /wheelhouse -name '*.whl' -print -quit)"; \
+    uv pip install --system "${wheel}[service]"; \
+    rm -rf /wheelhouse; \
+    useradd --create-home --uid 10001 aiconfigurator; \
+    mkdir -p /data/model-configs /tmp/aiconfigurator-service; \
+    chown -R aiconfigurator:aiconfigurator /data/model-configs /tmp/aiconfigurator-service
+
+ENV AIC_MODEL_SOURCE=s3 \
+    AIC_MODEL_S3_BUCKET=${AIC_MODEL_S3_BUCKET} \
+    AWS_ENDPOINT_URL=${AWS_ENDPOINT_URL} \
+    AWS_ENDPOINT_URL_S3=${AWS_ENDPOINT_URL} \
+    AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} \
+    AWS_REGION=${AWS_DEFAULT_REGION} \
+    AWS_EC2_METADATA_DISABLED=true \
+    PYTHONUNBUFFERED=1 \
+    MPLCONFIGDIR=/tmp/matplotlib
+
+USER aiconfigurator
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/healthz', timeout=3)" || exit 1
+
+ENTRYPOINT ["aiconfigurator-service"]
+CMD ["--host", "0.0.0.0", "--port", "8000", "--systems-paths", "default"]

--- a/docs/dynamo_deployment_guide.md
+++ b/docs/dynamo_deployment_guide.md
@@ -483,5 +483,41 @@ Use `--generator-set K8sConfig.<field>=value` (or place the same keys inside `--
 * `K8sConfig.k8s_image=<image>` - runtime image. Default **nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0**.
 * `K8sConfig.k8s_image_pull_secret=<secret>` - optional pull secret name.
 
+### S3-compatible OSS models with ModelExpress (vLLM)
+
+The service UI can use an S3-compatible object store as its model catalog. Model
+directories must use this layout and contain `config.json`:
+
+```text
+s3://<bucket>/<namespace>/<model_name>/<model_version>/config.json
+```
+
+Configure model discovery in the AIConfigurator service process:
+
+```bash
+export AIC_MODEL_S3_BUCKET=aiplat
+export AWS_ENDPOINT_URL=https://oss-s3.haiercash.com
+export AWS_DEFAULT_REGION=cn-east-1
+export AWS_ACCESS_KEY_ID=...
+export AWS_SECRET_ACCESS_KEY=...
+```
+
+When the UI enables OSS deployment, the vLLM manifest downloads model metadata
+to an `emptyDir` and loads safetensors through ModelExpress/ModelStreamer. The
+runtime image must include `modelexpress`, `runai-model-streamer`, `boto3`, and
+the custom S3 endpoint fix required by the target object store.
+
+Relevant generator settings are:
+
+* `K8sConfig.oss_enabled=true`
+* `K8sConfig.oss_endpoint_url=<S3-compatible endpoint>`
+* `K8sConfig.oss_region=<region>`
+* `K8sConfig.oss_secret_name=<Kubernetes Secret name>`
+* `K8sConfig.oss_model_express_url=<ModelExpress service URL>`
+* `K8sConfig.oss_streamer_concurrency=<parallel readers>`
+
+The referenced Secret must contain `AWS_ACCESS_KEY_ID` and
+`AWS_SECRET_ACCESS_KEY`. Credentials are never embedded in generated manifests.
+
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ license-files = ["LICENSE"]
 requires-python = ">=3.10"
 
 dependencies = [
+    "boto3>=1.35.0",
     "jinja2>=3.1.0",
     "packaging>=20.0",
     "matplotlib>=3.9.4",
@@ -59,6 +60,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "uv",
+    "httpx>=0.28.0",
     "ruff==0.14.1",
     "pre-commit==4.3.0",
     "pytest>=8.3.5",
@@ -90,6 +92,7 @@ build-backend = "setuptools.build_meta"
 
 [project.scripts]
 aiconfigurator = "aiconfigurator.main:main"
+aiconfigurator-service = "aiconfigurator.service.main:main"
 
 [tool.setuptools.package-data]
 "aiconfigurator.cli" = ["*.yaml", "exps/*.yaml"]
@@ -103,6 +106,7 @@ aiconfigurator = "aiconfigurator.main:main"
     "model_configs/*.json",
 ]
 "aiconfigurator.webapp.components.profiling" = ["styles.css", "js/*.js"]
+"aiconfigurator.service" = ["static/*.html"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/aiconfigurator/generator/aggregators.py
+++ b/src/aiconfigurator/generator/aggregators.py
@@ -70,7 +70,9 @@ def collect_generator_params(
     enable_router = coerce_bool(dyn_cfg.get("enable_router"))
     mode_tag = "agg" if mode_value == "agg" else "disagg"
     name_prefix = k8s.get("name_prefix") or "dynamo"
-    name = f"{name_prefix}-{mode_tag}{('-router' if enable_router else '')}"
+    explicit_name = k8s.get("name")
+    explicit_name = explicit_name.strip() if isinstance(explicit_name, str) else ""
+    name = explicit_name or f"{name_prefix}-{mode_tag}{('-router' if enable_router else '')}"
     use_engine_cm = k8s.get("k8s_engine_mode", "inline") == "configmap"
     # PVC config: new unified names with backward compat fallbacks
     _pvc_name_raw = k8s.get("k8s_pvc_name") or k8s.get("k8s_model_cache")

--- a/src/aiconfigurator/generator/config/backend_templates/vllm/k8s_deploy.yaml.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/vllm/k8s_deploy.yaml.j2
@@ -9,11 +9,16 @@
 {%- set k8s_model_cache_pvc = (model_cache_input if k8s_use_model_cache else 'model-cache') -%}
 {%- set k8s_model_cache_mount = '/workspace/model_cache' -%}
 {%- set enable_router = DynConfig.enable_router | default(false) -%}
+{%- set oss_enabled = K8sConfig.oss_enabled | default(false) -%}
+{%- set served_model_name = ServiceConfig.served_model_name | default(ServiceConfig.model_path.split('/')[-2], true) -%}
+{%- set oss_metadata_dir = '/tmp/' ~ served_model_name ~ '-meta' -%}
 
 {%- macro render_worker(component_name, role, replicas, gpu, cli_args_list) -%}
     {%- set parsed_args = cli_args_list | default([]) -%}
 {{ "    " ~ component_name ~ ":" }}
+      {% if not oss_enabled %}
       envFromSecret: hf-token-secret
+      {% endif %}
       {% if K8sConfig.k8s_hf_home or K8sConfig.k8s_etcd_endpoints %}
       envs:
         {% if K8sConfig.k8s_etcd_endpoints %}
@@ -34,7 +39,21 @@
         limits:
           gpu: "{{ gpu }}"
       extraPodSpec:
-        {% if k8s_use_model_cache %}
+        {% if oss_enabled and K8sConfig.worker_node_selector %}
+        nodeSelector:
+          {% for key, value in K8sConfig.worker_node_selector.items() %}
+          {{ key }}: {{ value | tojson }}
+          {% endfor %}
+        {% endif %}
+        {% if oss_enabled %}
+        volumes:
+          - name: triton-cache
+            emptyDir: {}
+          - name: xdg-cache
+            emptyDir: {}
+          - name: model-meta
+            emptyDir: {}
+        {% elif k8s_use_model_cache %}
         volumes:
           - name: model-cache
             persistentVolumeClaim:
@@ -48,11 +67,123 @@
           image: {{ K8sConfig.k8s_image }}
           workingDir: {{ runtime_working_dir }}
           imagePullPolicy: IfNotPresent
-          {% if k8s_use_model_cache %}
+          {% if oss_enabled %}
+          volumeMounts:
+            - name: triton-cache
+              mountPath: /tmp/triton
+            - name: xdg-cache
+              mountPath: /tmp/.cache
+            - name: model-meta
+              mountPath: {{ oss_metadata_dir }}
+          env:
+            - name: TRITON_CACHE_DIR
+              value: /tmp/triton
+            - name: XDG_CACHE_HOME
+              value: /tmp/.cache
+            - name: HOME
+              value: /tmp
+            - name: VLLM_PLUGINS
+              value: modelexpress
+            - name: MODEL_NAME
+              value: {{ served_model_name | tojson }}
+            - name: MX_MODEL_URI
+              value: {{ ServiceConfig.model_path | tojson }}
+            - name: MODEL_EXPRESS_URL
+              value: {{ K8sConfig.oss_model_express_url | tojson }}
+            - name: DYN_REGISTER_MODEL_PATH
+              value: {{ oss_metadata_dir | tojson }}
+            - name: MODEL_EXPRESS_NO_SHARED_STORAGE
+              value: "1"
+            - name: RUNAI_STREAMER_CONCURRENCY
+              value: {{ K8sConfig.oss_streamer_concurrency | string | tojson }}
+            - name: RUNAI_STREAMER_S3_USE_VIRTUAL_ADDRESSING
+              value: "0"
+            - name: RUNAI_STREAMER_DIST
+              value: "0"
+            - name: RUNAI_STREAMER_MEMORY_LIMIT
+              value: "0"
+            - name: AWS_ENDPOINT_URL
+              value: {{ K8sConfig.oss_endpoint_url | tojson }}
+            - name: AWS_ENDPOINT_URL_S3
+              value: {{ K8sConfig.oss_endpoint_url | tojson }}
+            - name: AWS_S3_FORCE_PATH_STYLE
+              value: "true"
+            - name: AWS_DEFAULT_REGION
+              value: {{ K8sConfig.oss_region | tojson }}
+            - name: AWS_REGION
+              value: {{ K8sConfig.oss_region | tojson }}
+            - name: AWS_EC2_METADATA_DISABLED
+              value: "true"
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ K8sConfig.oss_secret_name }}
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ K8sConfig.oss_secret_name }}
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: OTEL_EXPORT_ENABLED
+              value: "false"
+          {% elif k8s_use_model_cache %}
           volumeMounts:
             - name: model-cache
               mountPath: {{ k8s_model_cache_mount }}
           {% endif %}
+          {% if oss_enabled %}
+          command:
+            - /bin/bash
+            - -lc
+          args:
+            - |
+              set -euo pipefail
+              META_DIR={{ oss_metadata_dir | tojson }}
+              mkdir -p "${META_DIR}"
+              python3 - <<'PY'
+              import os
+              from urllib.parse import urlparse
+              import boto3
+
+              uri = os.environ["MX_MODEL_URI"]
+              parsed = urlparse(uri)
+              bucket = parsed.netloc
+              prefix = parsed.path.lstrip("/").rstrip("/")
+              meta_dir = os.environ["DYN_REGISTER_MODEL_PATH"]
+              s3 = boto3.client(
+                  "s3",
+                  endpoint_url=os.environ["AWS_ENDPOINT_URL"],
+                  region_name=os.environ["AWS_REGION"],
+              )
+              for name in ("config.json", "tokenizer.json", "tokenizer_config.json", "generation_config.json"):
+                  try:
+                      s3.download_file(bucket, f"{prefix}/{name}", os.path.join(meta_dir, name))
+                  except Exception:
+                      if name == "generation_config.json":
+                          continue
+                      raise
+              PY
+              worker_cmd=(
+                python3 -m dynamo.vllm
+                --model "${MX_MODEL_URI}"
+                --tokenizer "${META_DIR}"
+                --hf-config-path "${META_DIR}"
+                --served-model-name {{ served_model_name | tojson }}
+                --load-format modelexpress
+              )
+              {% for arg in parsed_args %}
+              worker_cmd+=( {{ arg | tojson }} )
+              {% endfor %}
+              {% if enable_router %}
+              worker_cmd+=( --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:{{ ServiceConfig.dyn_vllm_kv_event_port | default(20081, true) }}","enable_kv_cache_events":true}' )
+              {% endif %}
+              {% if role == 'prefill' %}
+              worker_cmd+=( --is-prefill-worker --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' )
+              {% elif role == 'decode' %}
+              worker_cmd+=( --is-decode-worker --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' )
+              {% endif %}
+              exec "${worker_cmd[@]}"
+          {% else %}
           command:
             - python3
             - -m
@@ -76,6 +207,7 @@
             - --kv-transfer-config
             - '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
             {% endif %}
+          {% endif %}
 {%- endmacro %}
 
 apiVersion: nvidia.com/v1alpha1
@@ -84,12 +216,26 @@ metadata:
   name: {{ name }}
   namespace: {{ K8sConfig.k8s_namespace }}
 spec:
+  envs: []
   services:
     Frontend:
+      {% if not oss_enabled %}
       envFromSecret: hf-token-secret
+      {% endif %}
       componentType: frontend
       replicas: {{ frontend_replicas | default(1) }}
       extraPodSpec:
+        {% if oss_enabled and K8sConfig.frontend_node_selector %}
+        nodeSelector:
+          {% for key, value in K8sConfig.frontend_node_selector.items() %}
+          {{ key }}: {{ value | tojson }}
+          {% endfor %}
+        {% endif %}
+        {% if oss_enabled %}
+        volumes:
+          - name: frontend-meta
+            emptyDir: {}
+        {% endif %}
         {% if K8sConfig.k8s_image_pull_secret %}
         imagePullSecrets:
           - name: {{ K8sConfig.k8s_image_pull_secret }}
@@ -97,6 +243,80 @@ spec:
         mainContainer:
           image: {{ K8sConfig.k8s_image }}
           imagePullPolicy: IfNotPresent
+          {% if oss_enabled %}
+          workingDir: /workspace/components/backends/vllm
+          volumeMounts:
+            - name: frontend-meta
+              mountPath: {{ oss_metadata_dir }}
+          env:
+            - name: MODEL_NAME
+              value: {{ served_model_name | tojson }}
+            - name: MX_MODEL_URI
+              value: {{ ServiceConfig.model_path | tojson }}
+            - name: DYN_MODEL_NAME
+              value: {{ served_model_name | tojson }}
+            - name: DYN_MODEL_PATH
+              value: {{ oss_metadata_dir | tojson }}
+            - name: AWS_ENDPOINT_URL
+              value: {{ K8sConfig.oss_endpoint_url | tojson }}
+            - name: AWS_ENDPOINT_URL_S3
+              value: {{ K8sConfig.oss_endpoint_url | tojson }}
+            - name: AWS_S3_FORCE_PATH_STYLE
+              value: "true"
+            - name: AWS_DEFAULT_REGION
+              value: {{ K8sConfig.oss_region | tojson }}
+            - name: AWS_REGION
+              value: {{ K8sConfig.oss_region | tojson }}
+            - name: AWS_EC2_METADATA_DISABLED
+              value: "true"
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ K8sConfig.oss_secret_name }}
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ K8sConfig.oss_secret_name }}
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: OTEL_EXPORT_ENABLED
+              value: "false"
+          command:
+            - /bin/bash
+            - -lc
+          args:
+            - |
+              set -euo pipefail
+              META_DIR={{ oss_metadata_dir | tojson }}
+              mkdir -p "${META_DIR}"
+              python3 - <<'PY'
+              import os
+              from urllib.parse import urlparse
+              import boto3
+
+              uri = os.environ["MX_MODEL_URI"]
+              parsed = urlparse(uri)
+              bucket = parsed.netloc
+              prefix = parsed.path.lstrip("/").rstrip("/")
+              meta_dir = os.environ["DYN_MODEL_PATH"]
+              s3 = boto3.client(
+                  "s3",
+                  endpoint_url=os.environ["AWS_ENDPOINT_URL"],
+                  region_name=os.environ["AWS_REGION"],
+              )
+              for name in ("config.json", "tokenizer.json", "tokenizer_config.json", "generation_config.json"):
+                  try:
+                      s3.download_file(bucket, f"{prefix}/{name}", os.path.join(meta_dir, name))
+                  except Exception:
+                      if name == "generation_config.json":
+                          continue
+                      raise
+              PY
+              exec python3 -m dynamo.frontend \
+                --model-name {{ served_model_name | tojson }} \
+                --model-path "${META_DIR}" \
+                --router-mode round-robin
+          {% endif %}
       {% if enable_router or K8sConfig.k8s_hf_home or K8sConfig.k8s_etcd_endpoints %}
       envs:
         {% if K8sConfig.k8s_etcd_endpoints %}

--- a/src/aiconfigurator/generator/config/deployment_config.yaml
+++ b/src/aiconfigurator/generator/config/deployment_config.yaml
@@ -20,7 +20,10 @@ inputs:
     default: ""
   - key: ServiceConfig.served_model_name
     required: true
-    default: "ServiceConfig.model_name or ServiceConfig.served_model_path or ServiceConfig.model_path"
+    default: >-
+      ServiceConfig.model_name or
+      (ServiceConfig.model_path.split('/')[-2] if ServiceConfig.model_path.startswith('s3://') else
+      (ServiceConfig.served_model_path or ServiceConfig.model_path))
   - key: ServiceConfig.model_name
     required: false
     default: "ServiceConfig.served_model_name"
@@ -60,6 +63,9 @@ inputs:
     default: false
 
   # K8sConfig
+  - key: K8sConfig.name
+    required: false
+    default: ""
   - key: K8sConfig.name_prefix
     required: false
     default: "dynamo"
@@ -71,7 +77,10 @@ inputs:
     default: &default_trtllm_image '"nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:" ~ generator_dynamo_version'
     backend_defaults:
       trtllm: *default_trtllm_image
-      vllm: '"nvcr.io/nvidia/ai-dynamo/vllm-runtime:" ~ generator_dynamo_version'
+      vllm: >-
+        "parties-hub.haiercash.com/nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1-mx-pip-0.4.1-s3fix6"
+        if ServiceConfig.model_path.startswith("s3://") else
+        ("nvcr.io/nvidia/ai-dynamo/vllm-runtime:" ~ generator_dynamo_version)
       sglang: '"nvcr.io/nvidia/ai-dynamo/sglang-runtime:" ~ generator_dynamo_version'
   - key: K8sConfig.k8s_image_pull_secret
     required: false
@@ -99,6 +108,37 @@ inputs:
   - key: K8sConfig.k8s_hf_home
     required: false
     default: ""
+  # S3-compatible OSS + ModelExpress settings (vLLM only)
+  - key: K8sConfig.oss_enabled
+    required: false
+    default: "ServiceConfig.model_path.startswith('s3://') if ServiceConfig.model_path else false"
+    backends: ["vllm"]
+  - key: K8sConfig.oss_endpoint_url
+    required: false
+    default: "https://oss-s3.haiercash.com"
+    backends: ["vllm"]
+  - key: K8sConfig.oss_region
+    required: false
+    default: "cn-east-1"
+    backends: ["vllm"]
+  - key: K8sConfig.oss_secret_name
+    required: false
+    default: "oss-s3-secret"
+    backends: ["vllm"]
+  - key: K8sConfig.oss_model_express_url
+    required: false
+    default: "http://model-express-modelexpress.model-express.svc.cluster.local:8001"
+    backends: ["vllm"]
+  - key: K8sConfig.oss_streamer_concurrency
+    required: false
+    default: 4
+    backends: ["vllm"]
+  - key: K8sConfig.frontend_node_selector
+    required: false
+    default: {}
+  - key: K8sConfig.worker_node_selector
+    required: false
+    default: {}
 
   # Worker config
   - key: WorkerConfig.prefill_workers

--- a/src/aiconfigurator/generator/rendering/engine.py
+++ b/src/aiconfigurator/generator/rendering/engine.py
@@ -31,6 +31,36 @@ _CONFIG_DIR = (_BASE_DIR.parent / "config").resolve()
 _TEMPLATE_ROOT = _CONFIG_DIR / "backend_templates"
 _BACKEND_MAPPING_FILE = str((_CONFIG_DIR / "backend_config_mapping.yaml").resolve())
 
+_VLLM_SAFE_K8S_FLAGS = frozenset(
+    {
+        "--data-parallel-size",
+        "--enable-expert-parallel",
+        "--kv-cache-dtype",
+        "--max-model-len",
+        "--max-num-batched-tokens",
+        "--no-enable-prefix-caching",
+        "--pipeline-parallel-size",
+        "--skip-tokenizer-init",
+        "--speculative-config",
+        "--tensor-parallel-size",
+        "--trust-remote-code",
+    }
+)
+
+
+def _filter_vllm_k8s_cli_args(cli_args: list[str]) -> list[str]:
+    """Keep only topology, safety, and explicitly requested vLLM arguments."""
+    filtered: list[str] = []
+    index = 0
+    while index < len(cli_args):
+        next_index = index + 1
+        while next_index < len(cli_args) and not cli_args[next_index].startswith("--"):
+            next_index += 1
+        if cli_args[index] in _VLLM_SAFE_K8S_FLAGS:
+            filtered.extend(cli_args[index:next_index])
+        index = next_index
+    return filtered
+
 
 def _parse_template_version(version: str | None) -> Version | None:
     if version is None:
@@ -505,6 +535,13 @@ def render_backend_templates(
     context["decode_gpu"] = decode_gpu
     context["agg_gpu"] = agg_gpu
 
+    k8s_context = context
+    if backend == "vllm" and deployment_target in ("dynamo-j2", "dynamo-python"):
+        k8s_context = dict(context)
+        for worker in worker_plan:
+            list_key = f"{worker}_cli_args_list"
+            k8s_context[list_key] = _filter_vllm_k8s_cli_args(list(context.get(list_key) or []))
+
     # Render auxiliary templates based on deployment target
     if deployment_target == "llm-d":
         # llm-d deployment: render Helm values for llm-d-modelservice chart
@@ -519,7 +556,7 @@ def render_backend_templates(
     elif deployment_target == "dynamo-python":
         # Dynamo deployment using Dynamo's Python config modifiers
         try:
-            rendered_templates["k8s_deploy.yaml"] = _generate_k8s_via_dynamo(param_values, backend, context)
+            rendered_templates["k8s_deploy.yaml"] = _generate_k8s_via_dynamo(param_values, backend, k8s_context)
         except Exception as e:
             logger.warning(f"Failed to generate k8s config via Dynamo: {e}")
     else:
@@ -527,7 +564,6 @@ def render_backend_templates(
         k8s_aux = template_path / "k8s_deploy.yaml.j2"
         if k8s_aux.exists():
             try:
-                k8s_context = context
                 # For backends with extra_engine_args templates (trtllm),
                 # suppress cli_args_list so the k8s template uses the
                 # --extra-engine-args file approach instead of inlining

--- a/src/aiconfigurator/sdk/common.py
+++ b/src/aiconfigurator/sdk/common.py
@@ -387,15 +387,19 @@ def get_supported_architectures() -> set[str]:
     return {row["Architecture"] for row in matrix if row["Status"] == "PASS"}
 
 
-@cache
 def get_default_models() -> set[str]:
     """
-    Get the set of default HuggingFace model IDs.
+    Get models from the configured source.
 
     Returns:
-        set[str]: Set of unique HuggingFace model IDs from the support matrix
-            plus locally cached default model configs.
+        set[str]: Versioned S3 model URIs in OSS mode, otherwise the built-in
+            HuggingFace model IDs.
     """
+    from aiconfigurator.sdk.s3_models import get_configured_s3_model_uris, is_s3_model_source_configured
+
+    if is_s3_model_source_configured():
+        return set(get_configured_s3_model_uris())
+
     models = {row["HuggingFaceID"] for row in get_support_matrix()}
     models.update(DefaultHFModels)
     return models

--- a/src/aiconfigurator/sdk/s3_models.py
+++ b/src/aiconfigurator/sdk/s3_models.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Discover and read Hugging Face model layouts stored in S3-compatible OSS."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from functools import cache
+from typing import Any
+from urllib.parse import urlparse
+
+
+class S3ModelError(ValueError):
+    """Raised when an OSS model cannot be discovered or read."""
+
+
+@dataclass(frozen=True)
+class S3ModelLocation:
+    bucket: str
+    namespace: str
+    model_name: str
+    model_version: str
+
+    @property
+    def prefix(self) -> str:
+        return f"{self.namespace}/{self.model_name}/{self.model_version}"
+
+    @property
+    def uri(self) -> str:
+        return f"s3://{self.bucket}/{self.prefix}"
+
+
+def _boto3():
+    try:
+        import boto3
+    except ModuleNotFoundError as exc:
+        raise S3ModelError(
+            "Reading models from S3-compatible OSS requires boto3. Install aiconfigurator with the service extra."
+        ) from exc
+    return boto3
+
+
+@cache
+def get_s3_client():
+    """Build an S3 client from the standard AWS environment contract."""
+    from botocore.config import Config
+
+    endpoint = (
+        os.environ.get("AWS_ENDPOINT_URL_S3") or os.environ.get("AWS_ENDPOINT_URL") or "https://oss-s3.haiercash.com"
+    )
+    region = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION") or "cn-east-1"
+    return _boto3().client(
+        "s3",
+        endpoint_url=endpoint,
+        region_name=region,
+        config=Config(s3={"addressing_style": "path"}),
+    )
+
+
+def parse_s3_model_uri(uri: str) -> S3ModelLocation:
+    """Parse ``s3://bucket/namespace/model/version`` into its model coordinates."""
+    parsed = urlparse(uri)
+    parts = [part for part in parsed.path.split("/") if part]
+    if parsed.scheme != "s3" or not parsed.netloc or len(parts) != 3:
+        raise S3ModelError(f"Invalid OSS model URI {uri!r}; expected s3://bucket/namespace/model_name/model_version")
+    return S3ModelLocation(parsed.netloc, parts[0], parts[1], parts[2])
+
+
+def list_s3_models(bucket: str | None = None) -> list[S3ModelLocation]:
+    """List versioned models by finding ``config.json`` objects under a bucket."""
+    bucket = (bucket or os.environ.get("AIC_MODEL_S3_BUCKET") or "aiplat").strip()
+    if not bucket:
+        return []
+    request: dict[str, Any] = {"Bucket": bucket}
+
+    models: set[S3ModelLocation] = set()
+    client = get_s3_client()
+    while True:
+        try:
+            response = client.list_objects_v2(**request)
+        except Exception as exc:
+            raise S3ModelError(f"Failed to list models in s3://{bucket}: {exc}") from exc
+        for item in response.get("Contents", []):
+            key = str(item.get("Key", "")).strip("/")
+            if not key.endswith("/config.json"):
+                continue
+            model_prefix = key[: -len("/config.json")]
+            parts = model_prefix.split("/")
+            if len(parts) != 3:
+                continue
+            models.add(S3ModelLocation(bucket, parts[0], parts[1], parts[2]))
+        token = response.get("NextContinuationToken")
+        if not token:
+            break
+        request["ContinuationToken"] = token
+
+    by_version = sorted(models, key=lambda item: item.model_version, reverse=True)
+    return sorted(by_version, key=lambda item: (item.namespace.lower(), item.model_name.lower()))
+
+
+@cache
+def load_s3_json(model_uri: str, filename: str, *, required: bool = True) -> dict | None:
+    """Load one JSON metadata file from a versioned OSS model directory."""
+    location = parse_s3_model_uri(model_uri)
+    key = f"{location.prefix}/{filename}"
+    try:
+        response = get_s3_client().get_object(Bucket=location.bucket, Key=key)
+        return json.loads(response["Body"].read())
+    except Exception as exc:
+        if not required:
+            return None
+        raise S3ModelError(f"Failed to read s3://{location.bucket}/{key}: {exc}") from exc
+
+
+def get_configured_s3_model_uris() -> list[str]:
+    """Return OSS-backed model choices when an OSS bucket is configured."""
+    return [model.uri for model in list_s3_models()]
+
+
+def is_s3_model_source_configured() -> bool:
+    return os.environ.get("AIC_MODEL_SOURCE", "s3").strip().lower() == "s3"

--- a/src/aiconfigurator/sdk/utils.py
+++ b/src/aiconfigurator/sdk/utils.py
@@ -1099,6 +1099,13 @@ def _load_model_config_from_model_path(model_path: str) -> dict:
         ValueError: If the model config cannot be found
         HuggingFaceDownloadError: If fetching from HuggingFace fails
     """
+    if model_path.startswith("s3://"):
+        from aiconfigurator.sdk.s3_models import load_s3_json
+
+        config = load_s3_json(model_path, "config.json") or {}
+        hf_quant_config = load_s3_json(model_path, "hf_quant_config.json", required=False)
+        return _attach_inferred_quant_fields(_attach_hf_quant_config(config, hf_quant_config))
+
     # Check if it's a local path
     if os.path.isdir(model_path):
         config = _load_local_config(model_path)

--- a/src/aiconfigurator/service/__init__.py
+++ b/src/aiconfigurator/service/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from .app import create_app
+
+__all__ = ["create_app"]

--- a/src/aiconfigurator/service/app.py
+++ b/src/aiconfigurator/service/app.py
@@ -1,0 +1,1045 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import copy
+import logging
+import os
+import shutil
+import subprocess
+import threading
+import time
+import uuid
+from dataclasses import asdict, is_dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import orjson
+import yaml
+from fastapi import FastAPI, HTTPException, Query, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import FileResponse, JSONResponse
+
+from aiconfigurator import __version__
+from aiconfigurator.cli.api import CLIResult, cli_default
+from aiconfigurator.generator.api import generate_backend_artifacts, prepare_generator_params
+from aiconfigurator.generator.module_bridge import task_config_to_generator_config
+from aiconfigurator.sdk.common import get_default_models
+from aiconfigurator.sdk.perf_database import (
+    get_database,
+    get_supported_databases,
+    get_systems_paths,
+    set_systems_paths,
+)
+from aiconfigurator.sdk.task import TaskConfig
+from aiconfigurator.sdk.utils import HuggingFaceDownloadError
+
+from .models import (
+    AggregateArtifactRequest,
+    ApplyDeploymentRequest,
+    ArtifactRequest,
+    DeleteDeploymentRequest,
+    DGDPreviewRequest,
+    EstimateRequest,
+)
+
+logger = logging.getLogger(__name__)
+_STATIC_DIR = Path(__file__).resolve().parent / "static"
+_DEFAULT_RUN_STORE = Path("/tmp/aiconfigurator-service/runs.json")
+_DEFAULT_MODEL_CONFIGS_ROOT = Path("/data/model-configs")
+_SYSTEMS_PATHS_LOCK = threading.Lock()
+_RUN_STORE_LOCK = threading.Lock()
+_TRANSIENT_RUNS: dict[str, Any] = {}
+
+
+class APIError(Exception):
+    def __init__(self, status_code: int, code: str, message: str, details: dict[str, Any] | None = None):
+        self.status_code = status_code
+        self.code = code
+        self.message = message
+        self.details = details or {}
+        super().__init__(message)
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(title="AIConfigurator Service", version=__version__)
+
+    @app.middleware("http")
+    async def add_trace_id(request: Request, call_next):
+        trace_id = request.headers.get("x-trace-id") or str(uuid.uuid4())
+        request.state.trace_id = trace_id
+        try:
+            response = await call_next(request)
+        except Exception:
+            logger.exception("Unhandled error", extra={"trace_id": trace_id, "path": request.url.path})
+            raise
+        response.headers["x-trace-id"] = trace_id
+        return response
+
+    @app.exception_handler(APIError)
+    async def api_error_handler(request: Request, exc: APIError):
+        return _error_response(request, exc.status_code, exc.code, exc.message, exc.details)
+
+    @app.exception_handler(RequestValidationError)
+    async def validation_error_handler(request: Request, exc: RequestValidationError):
+        return _error_response(
+            request,
+            400,
+            "invalid_request",
+            "Request validation failed.",
+            {"errors": exc.errors()},
+        )
+
+    @app.exception_handler(HTTPException)
+    async def http_error_handler(request: Request, exc: HTTPException):
+        detail = exc.detail if isinstance(exc.detail, dict) else {"detail": exc.detail}
+        return _error_response(request, exc.status_code, "http_error", "HTTP error.", detail)
+
+    @app.get("/healthz")
+    def healthz():
+        return {"status": "ok", "version": __version__}
+
+    @app.get("/demo")
+    def demo_page():
+        return FileResponse(_STATIC_DIR / "index.html")
+
+    @app.get("/readyz")
+    def readyz():
+        supported = get_supported_databases()
+        if not supported:
+            raise APIError(500, "not_ready", "No supported databases are available.")
+        return {"status": "ready", "systems": len(supported)}
+
+    @app.get("/api/v1/options")
+    def options(
+        system: str | None = Query(default=None),
+        backend: str | None = Query(default=None),
+        version: str | None = Query(default=None),
+    ):
+        supported = get_supported_databases()
+        payload: dict[str, Any] = {
+            "models": sorted(get_default_models()),
+            "local_model_configs": _list_local_model_configs(),
+            "supported_databases": supported,
+            "systems": sorted(supported.keys()),
+            "backends": sorted({backend_name for item in supported.values() for backend_name in item}),
+        }
+        if system and backend and version:
+            database = get_database(system, backend, version)
+            if database is None:
+                raise APIError(
+                    422,
+                    "unsupported_backend_version",
+                    "No database found for the requested system/backend/version.",
+                    {"system": system, "backend": backend, "version": version},
+                )
+            payload["quant_modes"] = copy.deepcopy(database.supported_quant_mode)
+        return payload
+
+    @app.post("/api/v1/estimate")
+    def estimate(request: EstimateRequest):
+        result = _run_estimate(request)
+        return _serialize_cli_result(result, request)
+
+    @app.post("/api/v1/generate-k8s-deployment")
+    def generate_k8s_deployment(request: ArtifactRequest):
+        if request.estimate_request is not None and request.direct_generator_params is None:
+            payload = _generate_top1_deployments(request)
+            _attach_and_store_jid(payload, request)
+            return payload
+        params, estimate_result = _resolve_generator_params(request)
+        artifacts = _render_artifacts(request, params)
+        payload = {
+            "backend": request.backend,
+            "backend_version": request.backend_version,
+            "artifact_name": "k8s_deploy.yaml",
+            "content": _require_artifact(artifacts, "k8s_deploy.yaml"),
+            "extras": _pick_artifacts(artifacts, {"run.sh"}),
+            "generator_params": params,
+        }
+        if estimate_result is not None:
+            payload["estimate"] = _serialize_cli_result(estimate_result, request.estimate_request)
+        _attach_and_store_jid(payload, request)
+        return payload
+
+    @app.post("/api/v1/generate-k8s-benchmark")
+    def generate_k8s_benchmark(request: ArtifactRequest):
+        params, estimate_result = _resolve_generator_params(request)
+        artifacts = _render_artifacts(request, params)
+        payload = {
+            "backend": request.backend,
+            "backend_version": request.backend_version,
+            "artifact_name": "k8s_bench.yaml",
+            "content": _require_artifact(artifacts, "k8s_bench.yaml"),
+            "extras": _pick_artifacts(artifacts, {"bench_run.sh"}),
+            "generator_params": params,
+        }
+        if estimate_result is not None:
+            payload["estimate"] = _serialize_cli_result(estimate_result, request.estimate_request)
+        return payload
+
+    @app.post("/api/v1/generate-artifacts")
+    def generate_artifacts(request: AggregateArtifactRequest):
+        params, estimate_result = _resolve_generator_params(request)
+        artifacts = _render_artifacts(request, params)
+        output: dict[str, Any] = {
+            "backend": request.backend,
+            "backend_version": request.backend_version,
+            "generator_params": params,
+            "artifacts": {},
+        }
+        if "deployment" in request.artifact_types:
+            output["artifacts"]["deployment"] = {
+                "artifact_name": "k8s_deploy.yaml",
+                "content": _require_artifact(artifacts, "k8s_deploy.yaml"),
+                "extras": _pick_artifacts(artifacts, {"run.sh"}),
+            }
+        if "benchmark" in request.artifact_types:
+            output["artifacts"]["benchmark"] = {
+                "artifact_name": "k8s_bench.yaml",
+                "content": _require_artifact(artifacts, "k8s_bench.yaml"),
+                "extras": _pick_artifacts(artifacts, {"bench_run.sh"}),
+            }
+        if estimate_result is not None:
+            output["estimate"] = _serialize_cli_result(estimate_result, request.estimate_request)
+        return output
+
+    @app.post("/api/v1/apply-k8s-deployment")
+    def apply_k8s_deployment(request: ApplyDeploymentRequest):
+        return _apply_k8s_deployment(request)
+
+    @app.post("/api/v1/delete-k8s-deployment")
+    def delete_k8s_deployment(request: DeleteDeploymentRequest):
+        return _delete_k8s_deployment(request)
+
+    @app.get("/api/v1/runs/{jid}")
+    def get_run(jid: str):
+        record = _load_run_record(jid)
+        if record is None:
+            raise APIError(404, "run_not_found", "No run record found for the requested jid.", {"jid": jid})
+        return record
+
+    @app.get("/api/v1/deployment-records")
+    def deployment_records():
+        records = []
+        for jid, record in _load_run_records().items():
+            payload = record.get("payload") or {}
+            deployed = payload.get("deployed_dgd") or {}
+            if not deployed:
+                continue
+            request = record.get("request") or {}
+            estimate_request = request.get("estimate_request") or {}
+            generator_overrides = request.get("generator_overrides") or {}
+            service_config = generator_overrides.get("service_config") or {}
+            k8s_config = generator_overrides.get("k8s_config") or {}
+            records.append(
+                {
+                    "jid": jid,
+                    "created_at": record.get("created_at"),
+                    "model_path": estimate_request.get("model_path")
+                    or service_config.get("model_path")
+                    or (request.get("direct_generator_params") or {}).get("ServiceConfig", {}).get("model_path"),
+                    "served_model_name": service_config.get("served_model_name"),
+                    "backend": request.get("backend") or payload.get("backend"),
+                    "backend_version": request.get("backend_version") or payload.get("backend_version"),
+                    "system": estimate_request.get("system"),
+                    "namespace": k8s_config.get("k8s_namespace"),
+                    "deployment_name": k8s_config.get("name"),
+                    "recommended_mode": payload.get("recommended_mode"),
+                    "deployed_dgd_id": deployed.get("dgd_id"),
+                    "deployed_mode": deployed.get("mode"),
+                    "deployed_row_index": deployed.get("row_index"),
+                    "deployed_at": deployed.get("deployed_at"),
+                    "has_deployment": bool(deployed),
+                }
+            )
+        records.sort(key=lambda item: item.get("deployed_at") or item.get("created_at") or "", reverse=True)
+        return {"records": records}
+
+    @app.post("/api/v1/runs/{jid}/dgd")
+    def preview_dgd(jid: str, request: DGDPreviewRequest):
+        return _preview_dgd_from_run(jid, request)
+
+    return app
+
+
+def _list_local_model_configs() -> list[dict[str, str]]:
+    """List mounted model config directories that contain config.json."""
+    root = Path(os.environ.get("AICONFIGURATOR_MODEL_CONFIGS_ROOT", str(_DEFAULT_MODEL_CONFIGS_ROOT)))
+    if not root.is_dir():
+        return []
+    configs: list[dict[str, str]] = []
+    for child in sorted(root.iterdir(), key=lambda item: item.name.lower()):
+        if child.is_dir() and (child / "config.json").is_file():
+            configs.append({"label": child.name, "value": str(child)})
+    return configs
+
+
+def _error_response(
+    request: Request,
+    status_code: int,
+    code: str,
+    message: str,
+    details: dict[str, Any] | None = None,
+) -> JSONResponse:
+    trace_id = getattr(request.state, "trace_id", None)
+    body = {"code": code, "message": message, "details": details or {}, "trace_id": trace_id}
+    return JSONResponse(
+        status_code=status_code,
+        content=orjson.loads(orjson.dumps(body)),
+    )
+
+
+def _run_estimate(request: EstimateRequest) -> CLIResult:
+    try:
+        if request.systems_paths:
+            with _SYSTEMS_PATHS_LOCK:
+                previous_systems_paths = get_systems_paths()
+                try:
+                    set_systems_paths(request.systems_paths)
+                    _validate_estimate_request(request)
+                    return _run_cli_default(request)
+                finally:
+                    set_systems_paths(previous_systems_paths)
+        _validate_estimate_request(request)
+        return _run_cli_default(request)
+    except APIError:
+        raise
+    except RuntimeError as exc:
+        raise _map_runtime_error(exc) from exc
+    except SystemExit as exc:
+        raise _map_system_exit(exc, request) from exc
+    except HuggingFaceDownloadError as exc:
+        raise APIError(400, "invalid_model_path", str(exc)) from exc
+    except ValueError as exc:
+        raise APIError(400, "invalid_request", str(exc)) from exc
+
+
+def _run_cli_default(request: EstimateRequest) -> CLIResult:
+    return cli_default(
+        model_path=request.model_path,
+        total_gpus=request.total_gpus,
+        system=request.system,
+        decode_system=request.decode_system,
+        backend=request.backend,
+        backend_version=request.backend_version,
+        database_mode=request.database_mode,
+        isl=request.isl,
+        osl=request.osl,
+        ttft=request.ttft,
+        tpot=request.tpot,
+        request_latency=request.request_latency,
+        prefix=request.prefix,
+        strict_sla=request.strict_sla,
+        free_gpu_memory_fraction=request.free_gpu_memory_fraction,
+        max_seq_len=request.max_seq_len,
+        top_n=request.top_n,
+    )
+
+
+def _validate_estimate_request(request: EstimateRequest) -> None:
+    if request.backend == "auto":
+        return
+
+    _require_database(request.system, request.backend, request.backend_version, role="worker")
+    if request.decode_system is not None and request.decode_system != request.system:
+        _require_database(request.decode_system, request.backend, request.backend_version, role="decode_worker")
+
+
+def _require_database(system: str, backend: str, version: str | None, *, role: str) -> None:
+    database = get_database(system=system, backend=backend, version=version)
+    if database is None:
+        raise APIError(
+            422,
+            "unsupported_backend_version",
+            "No usable database found for the requested system/backend/version.",
+            {"system": system, "backend": backend, "version": version, "role": role},
+        )
+
+
+def _serialize_cli_result(result: CLIResult, request: EstimateRequest | None) -> dict[str, Any]:
+    comparison = _build_mode_comparison(result)
+    return {
+        "normalized_input": request.model_dump(exclude_none=True) if request is not None else None,
+        "chosen_exp": result.chosen_exp,
+        "recommended_mode": comparison["recommended_mode"],
+        "mode_comparison": comparison["modes"],
+        "best_throughputs": result.best_throughputs,
+        "best_latencies": result.best_latencies,
+        "best_configs": {name: _df_to_records(df) for name, df in result.best_configs.items()},
+        "pareto_fronts": {name: _df_to_records(df) for name, df in result.pareto_fronts.items()},
+    }
+
+
+def _generate_top1_deployments(request: ArtifactRequest) -> dict[str, Any]:
+    assert request.estimate_request is not None
+    estimate_result = _run_estimate(request.estimate_request)
+    artifacts_by_mode: dict[str, Any] = {}
+    for mode in _iter_available_modes(estimate_result):
+        params = _generator_params_from_estimate_result(estimate_result, request, mode, 0)
+        artifacts = _render_artifacts(request, params)
+        artifacts_by_mode[mode] = {
+            "artifact_name": "k8s_deploy.yaml",
+            "content": _require_artifact(artifacts, "k8s_deploy.yaml"),
+            "extras": _pick_artifacts(artifacts, {"run.sh"}),
+            "generator_params": params,
+        }
+
+    comparison = _build_mode_comparison(estimate_result)
+    recommended_mode = comparison["recommended_mode"]
+    estimate_payload = _serialize_cli_result(estimate_result, request.estimate_request)
+    payload: dict[str, Any] = {
+        "backend": request.backend,
+        "backend_version": request.backend_version,
+        "recommended_mode": recommended_mode,
+        "mode_comparison": comparison["modes"],
+        "candidates_by_mode": _build_candidates_by_mode(estimate_payload),
+        "artifacts_by_mode": artifacts_by_mode,
+        "estimate": estimate_payload,
+    }
+    if recommended_mode and recommended_mode in artifacts_by_mode:
+        recommended_artifact = artifacts_by_mode[recommended_mode]
+        payload["artifact_name"] = recommended_artifact["artifact_name"]
+        payload["content"] = recommended_artifact["content"]
+        payload["extras"] = recommended_artifact["extras"]
+        payload["generator_params"] = recommended_artifact["generator_params"]
+    return payload
+
+
+def _attach_and_store_jid(payload: dict[str, Any], request: ArtifactRequest) -> None:
+    jid = _new_jid()
+    payload["jid"] = jid
+    payload["run_store"] = str(_run_store_path())
+    _attach_dgd_ids(payload, jid)
+    _cache_transient_run(jid, request, payload)
+
+
+def _attach_dgd_ids(payload: dict[str, Any], jid: str) -> None:
+    for mode, candidates in (payload.get("candidates_by_mode") or {}).items():
+        for candidate in candidates:
+            row_index = candidate.get("row_index", 0)
+            candidate["dgd_id"] = _dgd_id(jid, mode, row_index)
+    for mode, artifact in (payload.get("artifacts_by_mode") or {}).items():
+        artifact["mode"] = mode
+        artifact["row_index"] = 0
+        artifact["dgd_id"] = _dgd_id(jid, mode, 0)
+    if "content" in payload and "dgd_id" not in payload:
+        mode = payload.get("recommended_mode") or payload.get("selected_mode") or "direct"
+        payload["mode"] = mode
+        payload["row_index"] = payload.get("row_index", 0)
+        payload["dgd_id"] = _dgd_id(jid, mode, payload["row_index"])
+
+
+def _dgd_id(jid: str, mode: str, row_index: int) -> str:
+    return f"{jid}:{mode}:{row_index}"
+
+
+def _build_candidates_by_mode(estimate_payload: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
+    candidates: dict[str, list[dict[str, Any]]] = {}
+    for mode, rows in (estimate_payload.get("best_configs") or {}).items():
+        candidates[mode] = [
+            {
+                "mode": mode,
+                "row_index": index,
+                "summary": row,
+            }
+            for index, row in enumerate(rows)
+        ]
+    return candidates
+
+
+def _new_jid() -> str:
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    return f"aic-{timestamp}-{uuid.uuid4().hex[:8]}"
+
+
+def _run_store_path() -> Path:
+    configured = os.environ.get("AIC_SERVICE_RUN_STORE")
+    return Path(configured) if configured else _DEFAULT_RUN_STORE
+
+
+def _load_run_records() -> dict[str, Any]:
+    path = _run_store_path()
+    with _RUN_STORE_LOCK:
+        if not path.exists():
+            return {}
+        try:
+            data = orjson.loads(path.read_bytes())
+        except orjson.JSONDecodeError as exc:
+            raise APIError(
+                500,
+                "run_store_corrupt",
+                "Run store JSON could not be parsed.",
+                {"path": str(path), "error": str(exc)},
+            ) from exc
+        if not isinstance(data, dict):
+            raise APIError(500, "run_store_corrupt", "Run store JSON must be an object.", {"path": str(path)})
+        return data
+
+
+def _load_run_record(jid: str) -> dict[str, Any] | None:
+    return _load_run_records().get(jid) or _TRANSIENT_RUNS.get(jid)
+
+
+def _cache_transient_run(jid: str, request: ArtifactRequest, payload: dict[str, Any]) -> None:
+    _TRANSIENT_RUNS[jid] = {
+        "jid": jid,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "request": _normalize_obj(request.model_dump(exclude_none=True)),
+        "payload": _normalize_obj(payload),
+    }
+
+
+def _save_run_record(jid: str, request: ArtifactRequest, payload: dict[str, Any]) -> None:
+    record = {
+        "jid": jid,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "request": _normalize_obj(request.model_dump(exclude_none=True)),
+        "payload": _normalize_obj(payload),
+    }
+    _save_record(jid, record)
+
+
+def _save_record(jid: str, record: dict[str, Any]) -> None:
+    path = _run_store_path()
+    with _RUN_STORE_LOCK:
+        records: dict[str, Any] = {}
+        if path.exists():
+            try:
+                loaded = orjson.loads(path.read_bytes())
+            except orjson.JSONDecodeError as exc:
+                raise APIError(
+                    500,
+                    "run_store_corrupt",
+                    "Run store JSON could not be parsed.",
+                    {"path": str(path), "error": str(exc)},
+                ) from exc
+            if isinstance(loaded, dict):
+                records = loaded
+        records[jid] = record
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(orjson.dumps(records, option=orjson.OPT_INDENT_2, default=str))
+
+
+def _preview_dgd_from_run(jid: str, preview: DGDPreviewRequest) -> dict[str, Any]:
+    record = _load_run_record(jid)
+    if record is None:
+        raise APIError(404, "run_not_found", "No run record found for the requested jid.", {"jid": jid})
+
+    dgd_id = _dgd_id(jid, preview.mode, preview.row_index)
+    cached = ((record.get("payload") or {}).get("dgds") or {}).get(dgd_id)
+    if cached is not None:
+        return cached
+
+    artifact_request = ArtifactRequest(**record["request"])
+    if artifact_request.estimate_request is None:
+        if preview.row_index != 0:
+            raise APIError(
+                422,
+                "invalid_row_index",
+                "Direct generator runs only have row_index=0.",
+                {"jid": jid, "mode": preview.mode, "row_index": preview.row_index},
+            )
+        payload = record.get("payload") or {}
+        if "content" not in payload:
+            raise APIError(409, "missing_artifact", "The stored run has no deployment artifact.", {"jid": jid})
+        return {
+            "jid": jid,
+            "dgd_id": dgd_id,
+            "mode": preview.mode,
+            "row_index": 0,
+            "artifact_name": payload.get("artifact_name", "k8s_deploy.yaml"),
+            "content": payload["content"],
+            "extras": payload.get("extras", {}),
+            "generator_params": payload.get("generator_params", {}),
+        }
+
+    selected_request = artifact_request.model_copy(
+        update={"selected_mode": preview.mode, "row_index": preview.row_index}
+    )
+    params, _ = _resolve_generator_params(selected_request)
+    artifacts = _render_artifacts(selected_request, params)
+    output = {
+        "jid": jid,
+        "dgd_id": dgd_id,
+        "mode": preview.mode,
+        "row_index": preview.row_index,
+        "artifact_name": "k8s_deploy.yaml",
+        "content": _require_artifact(artifacts, "k8s_deploy.yaml"),
+        "extras": _pick_artifacts(artifacts, {"run.sh"}),
+        "generator_params": params,
+    }
+    _cache_dgd(jid, dgd_id, output)
+    return output
+
+
+def _cache_dgd(jid: str, dgd_id: str, artifact: dict[str, Any]) -> None:
+    path = _run_store_path()
+    with _RUN_STORE_LOCK:
+        records: dict[str, Any] = {}
+        if path.exists():
+            loaded = orjson.loads(path.read_bytes())
+            if isinstance(loaded, dict):
+                records = loaded
+        record = records.get(jid)
+        if record is None:
+            record = _TRANSIENT_RUNS.get(jid)
+            if record is not None:
+                payload = record.setdefault("payload", {})
+                payload.setdefault("dgds", {})[dgd_id] = _normalize_obj(artifact)
+            return
+        payload = record.setdefault("payload", {})
+        payload.setdefault("dgds", {})[dgd_id] = _normalize_obj(artifact)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(orjson.dumps(records, option=orjson.OPT_INDENT_2, default=str))
+
+
+def _mark_deployed_dgd(request: ApplyDeploymentRequest, apply_payload: dict[str, Any]) -> None:
+    if not request.jid or not request.dgd_id:
+        return
+    record = _load_run_record(request.jid)
+    if record is None:
+        return
+
+    payload = record.setdefault("payload", {})
+    deployed_at = datetime.now(timezone.utc).isoformat()
+    deployed_dgd = {
+        "dgd_id": request.dgd_id,
+        "mode": request.mode,
+        "row_index": request.row_index,
+        "deployed_at": deployed_at,
+        "apply_result": _normalize_obj(apply_payload),
+    }
+    payload["deployed_dgd"] = deployed_dgd
+    deployed_artifact = _deployed_artifact_from_record(record, request)
+    payload["dgds"] = {request.dgd_id: deployed_artifact}
+    if request.mode:
+        payload["artifacts_by_mode"] = {request.mode: deployed_artifact}
+    payload["artifact_name"] = deployed_artifact.get("artifact_name", "k8s_deploy.yaml")
+    payload["content"] = request.content
+    payload["mode"] = request.mode
+    payload["row_index"] = request.row_index
+    payload["dgd_id"] = request.dgd_id
+
+    record["deployed_at"] = deployed_at
+    _save_record(request.jid, _normalize_obj(record))
+    _TRANSIENT_RUNS.pop(request.jid, None)
+
+
+def _mark_deleted_dgd(request: DeleteDeploymentRequest, delete_payload: dict[str, Any]) -> None:
+    if not request.jid:
+        return
+    record = _load_run_record(request.jid)
+    if record is None:
+        return
+
+    payload = record.setdefault("payload", {})
+    deleted_at = datetime.now(timezone.utc).isoformat()
+    payload["deleted_dgd"] = {
+        "dgd_id": request.dgd_id,
+        "mode": request.mode,
+        "row_index": request.row_index,
+        "deleted_at": deleted_at,
+        "delete_result": _normalize_obj(delete_payload),
+    }
+    payload.pop("deployed_dgd", None)
+    record["deleted_at"] = deleted_at
+    record.pop("deployed_at", None)
+    _save_record(request.jid, _normalize_obj(record))
+
+
+def _deployed_artifact_from_record(record: dict[str, Any], request: ApplyDeploymentRequest) -> dict[str, Any]:
+    payload = record.get("payload") or {}
+    cached = ((payload.get("dgds") or {}).get(request.dgd_id)) if request.dgd_id else None
+    if cached is not None:
+        artifact = copy.deepcopy(cached)
+    else:
+        artifact = copy.deepcopy(((payload.get("artifacts_by_mode") or {}).get(request.mode or "")) or {})
+    artifact.update(
+        {
+            "jid": request.jid,
+            "dgd_id": request.dgd_id,
+            "mode": request.mode,
+            "row_index": request.row_index,
+            "artifact_name": artifact.get("artifact_name", "k8s_deploy.yaml"),
+            "content": request.content,
+        }
+    )
+    return _normalize_obj(artifact)
+
+
+def _resolve_generator_params(request: ArtifactRequest) -> tuple[dict[str, Any], CLIResult | None]:
+    overrides = _build_generator_overrides(request)
+    if request.estimate_request is not None:
+        estimate_result = _run_estimate(request.estimate_request)
+        params = _generator_params_from_estimate_result(
+            estimate_result, request, request.selected_mode, request.row_index, overrides
+        )
+        return params, estimate_result
+
+    if request.direct_generator_params is None:
+        raise APIError(
+            400,
+            "missing_generator_input",
+            "Provide either estimate_request or direct_generator_params.",
+        )
+    try:
+        params = prepare_generator_params(
+            None,
+            overrides=_deep_merge_dicts(request.direct_generator_params, overrides),
+            backend=request.backend,
+        )
+    except (FileNotFoundError, ValueError) as exc:
+        raise APIError(400, "invalid_generator_input", str(exc)) from exc
+    return params, None
+
+
+def _render_artifacts(request: ArtifactRequest, params: dict[str, Any]) -> dict[str, str]:
+    try:
+        return generate_backend_artifacts(
+            params=params,
+            backend=request.backend,
+            backend_version=request.backend_version,
+            deployment_target=request.deployment_target,
+        )
+    except ValueError as exc:
+        raise APIError(400, "invalid_generator_input", str(exc)) from exc
+    except RuntimeError as exc:
+        raise APIError(500, "artifact_generation_failed", str(exc)) from exc
+
+
+def _apply_k8s_deployment(request: ApplyDeploymentRequest) -> dict[str, Any]:
+    if shutil.which("kubectl") is None:
+        raise APIError(
+            503,
+            "kubectl_not_available",
+            "kubectl is not available in the service runtime.",
+            {"hint": "Install kubectl in the AIC service image and grant its ServiceAccount apply/get permissions."},
+        )
+
+    resources = _parse_k8s_resources(request.content, request.namespace)
+    apply_result = _run_kubectl(
+        ["kubectl", "apply", "-f", "-"],
+        stdin=request.content,
+        timeout=request.timeout_seconds,
+    )
+    health = _check_k8s_health(resources, request.timeout_seconds)
+    payload = {
+        "applied": apply_result.returncode == 0,
+        "stdout": apply_result.stdout,
+        "stderr": apply_result.stderr,
+        "resources": resources,
+        "health": health,
+        "healthy": all(item.get("exists") for item in health),
+    }
+    _mark_deployed_dgd(request, payload)
+    return payload
+
+
+def _delete_k8s_deployment(request: DeleteDeploymentRequest) -> dict[str, Any]:
+    if shutil.which("kubectl") is None:
+        raise APIError(
+            503,
+            "kubectl_not_available",
+            "kubectl is not available in the service runtime.",
+            {"hint": "Install kubectl in the AIC service image and grant its ServiceAccount delete/get permissions."},
+        )
+
+    resources = _parse_k8s_resources(request.content, request.namespace)
+    delete_result = _run_kubectl(
+        ["kubectl", "delete", "-f", "-", "--ignore-not-found=true"],
+        stdin=request.content,
+        timeout=request.timeout_seconds,
+    )
+    payload = {
+        "deleted": delete_result.returncode == 0,
+        "stdout": delete_result.stdout,
+        "stderr": delete_result.stderr,
+        "resources": resources,
+    }
+    _mark_deleted_dgd(request, payload)
+    return payload
+
+
+def _parse_k8s_resources(content: str, namespace_override: str | None = None) -> list[dict[str, str]]:
+    try:
+        docs = [doc for doc in yaml.safe_load_all(content) if doc]
+    except yaml.YAMLError as exc:
+        raise APIError(400, "invalid_yaml", f"Deployment YAML could not be parsed: {exc}") from exc
+
+    resources: list[dict[str, str]] = []
+    for doc in docs:
+        if not isinstance(doc, dict):
+            continue
+        metadata = doc.get("metadata") or {}
+        kind = str(doc.get("kind") or "").strip()
+        name = str(metadata.get("name") or "").strip()
+        namespace = namespace_override or metadata.get("namespace") or "default"
+        if kind and name:
+            resources.append({"kind": kind, "name": name, "namespace": str(namespace)})
+    if not resources:
+        raise APIError(400, "invalid_yaml", "Deployment YAML does not contain any named Kubernetes resources.")
+    return resources
+
+
+def _run_kubectl(args: list[str], stdin: str | None = None, timeout: int = 180) -> subprocess.CompletedProcess[str]:
+    try:
+        result = subprocess.run(
+            args,
+            input=stdin,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise APIError(504, "kubectl_timeout", f"kubectl timed out after {timeout} seconds.") from exc
+    if result.returncode != 0:
+        raise APIError(
+            502,
+            "kubectl_failed",
+            "kubectl command failed.",
+            {"command": args, "stdout": result.stdout, "stderr": result.stderr},
+        )
+    return result
+
+
+def _check_k8s_health(resources: list[dict[str, str]], timeout_seconds: int) -> list[dict[str, Any]]:
+    deadline = time.monotonic() + timeout_seconds
+    health: list[dict[str, Any]] = []
+    for resource in resources:
+        remaining = max(1, int(deadline - time.monotonic()))
+        health.append(_check_one_k8s_resource(resource, remaining))
+    return health
+
+
+def _check_one_k8s_resource(resource: dict[str, str], timeout_seconds: int) -> dict[str, Any]:
+    kind = resource["kind"]
+    name = resource["name"]
+    namespace = resource["namespace"]
+    base = {"kind": kind, "name": name, "namespace": namespace}
+
+    if kind.lower() in {"deployment", "statefulset", "daemonset"}:
+        rollout = _run_kubectl(
+            [
+                "kubectl",
+                "rollout",
+                "status",
+                f"{kind}/{name}",
+                "-n",
+                namespace,
+                f"--timeout={timeout_seconds}s",
+            ],
+            timeout=timeout_seconds + 5,
+        )
+        return {**base, "exists": True, "ready": True, "message": rollout.stdout.strip()}
+
+    get_result = _run_kubectl(
+        ["kubectl", "get", kind, name, "-n", namespace, "-o", "json"],
+        timeout=min(timeout_seconds, 30),
+    )
+    payload = orjson.loads(get_result.stdout)
+    conditions = payload.get("status", {}).get("conditions", [])
+    ready_conditions = [
+        condition
+        for condition in conditions
+        if condition.get("type") in {"Ready", "Available", "Reconciled", "Succeeded"}
+    ]
+    if ready_conditions:
+        ready = any(str(condition.get("status")).lower() == "true" for condition in ready_conditions)
+        message = "; ".join(
+            str(condition.get("message") or condition.get("reason") or condition.get("type"))
+            for condition in ready_conditions
+        )
+    else:
+        ready = None
+        message = "Resource exists; no standard Ready/Available condition found."
+    return {**base, "exists": True, "ready": ready, "message": message, "conditions": ready_conditions}
+
+
+def _select_result_row(result: CLIResult, selected_mode: str | None, row_index: int):
+    task_name = selected_mode or result.chosen_exp or next(iter(result.best_configs.keys()), None)
+    if task_name is None or task_name not in result.best_configs:
+        raise APIError(
+            422,
+            "invalid_selection",
+            "The requested estimate result selection is not available.",
+            {"selected_mode": selected_mode, "available_modes": sorted(result.best_configs.keys())},
+        )
+    df = result.best_configs[task_name]
+    if df.empty:
+        raise APIError(
+            409,
+            "empty_result_set",
+            "The selected estimate result has no candidate configurations.",
+            {"selected_mode": task_name},
+        )
+    if row_index >= len(df):
+        raise APIError(
+            422,
+            "invalid_row_index",
+            "The selected row index is out of range.",
+            {"selected_mode": task_name, "row_index": row_index, "num_rows": len(df)},
+        )
+    return task_name, df.iloc[row_index]
+
+
+def _generator_params_from_estimate_result(
+    estimate_result: CLIResult,
+    request: ArtifactRequest,
+    selected_mode: str | None,
+    row_index: int,
+    overrides: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    task_name, row = _select_result_row(estimate_result, selected_mode, row_index)
+    task_config = estimate_result.task_configs.get(task_name)
+    if task_config is None:
+        raise APIError(
+            500,
+            "missing_task_config",
+            "The selected estimate result has no matching task configuration.",
+            {"selected_mode": task_name},
+        )
+    merged_overrides = overrides or _build_generator_overrides(request)
+    return task_config_to_generator_config(task_config, row, generator_overrides=merged_overrides)
+
+
+def _iter_available_modes(result: CLIResult) -> list[str]:
+    ordered_modes = ["agg", "disagg"]
+    available: list[str] = []
+    for mode in ordered_modes:
+        df = result.best_configs.get(mode)
+        if df is not None and not df.empty:
+            available.append(mode)
+    for mode, df in result.best_configs.items():
+        if mode not in available and df is not None and not df.empty:
+            available.append(mode)
+    if not available:
+        raise APIError(409, "empty_result_set", "The estimate produced no candidate configurations.")
+    return available
+
+
+def _build_mode_comparison(result: CLIResult) -> dict[str, Any]:
+    modes: dict[str, Any] = {}
+    recommended_mode = None
+    best_score = float("-inf")
+    for mode in _iter_available_modes(result):
+        df = result.best_configs.get(mode)
+        assert df is not None and not df.empty
+        top1 = _normalize_obj(df.iloc[0].to_dict())
+        throughput = result.best_throughputs.get(mode)
+        latencies = _normalize_obj(result.best_latencies.get(mode, {}))
+        score = float(throughput) if throughput is not None else float("-inf")
+        if score > best_score:
+            best_score = score
+            recommended_mode = mode
+        modes[mode] = {
+            "available": True,
+            "candidate_count": len(df),
+            "top1": top1,
+            "best_throughput": throughput,
+            "best_latency": latencies,
+        }
+    return {"recommended_mode": recommended_mode or result.chosen_exp, "modes": modes}
+
+
+def _build_generator_overrides(request: ArtifactRequest) -> dict[str, Any]:
+    overrides: dict[str, Any] = {}
+    raw = request.generator_overrides.model_dump(exclude_none=True) if request.generator_overrides is not None else {}
+    mapping = {
+        "service_config": "ServiceConfig",
+        "k8s_config": "K8sConfig",
+        "worker_config": "WorkerConfig",
+        "sla_config": "SlaConfig",
+        "bench_config": "BenchConfig",
+        "dyn_config": "DynConfig",
+        "model_cfg": "ModelConfig",
+        "params": "Params",
+        "workers": "Workers",
+        "generator_dynamo_version": "generator_dynamo_version",
+        "rule": "rule",
+    }
+    for src_key, dest_key in mapping.items():
+        if src_key in raw:
+            overrides[dest_key] = raw[src_key]
+    return overrides
+
+
+def _deep_merge_dicts(base: dict[str, Any], extra: dict[str, Any]) -> dict[str, Any]:
+    result = copy.deepcopy(base)
+    for key, value in extra.items():
+        if isinstance(value, dict) and isinstance(result.get(key), dict):
+            result[key] = _deep_merge_dicts(result[key], value)
+        else:
+            result[key] = copy.deepcopy(value)
+    return result
+
+
+def _require_artifact(artifacts: dict[str, str], name: str) -> str:
+    if name not in artifacts:
+        raise APIError(
+            500,
+            "missing_artifact",
+            "The requested artifact was not generated.",
+            {"artifact_name": name, "available_artifacts": sorted(artifacts.keys())},
+        )
+    return artifacts[name]
+
+
+def _pick_artifacts(artifacts: dict[str, str], names: set[str]) -> dict[str, str]:
+    return {name: content for name, content in artifacts.items() if name in names}
+
+
+def _df_to_records(df) -> list[dict[str, Any]]:
+    if df is None:
+        return []
+    records = []
+    for row in df.to_dict(orient="records"):
+        records.append(_normalize_obj(row))
+    return records
+
+
+def _normalize_obj(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {str(key): _normalize_obj(val) for key, val in value.items()}
+    if isinstance(value, list):
+        return [_normalize_obj(item) for item in value]
+    if is_dataclass(value):
+        return _normalize_obj(asdict(value))
+    if isinstance(value, TaskConfig):
+        return repr(value)
+    return value
+
+
+def _map_runtime_error(exc: RuntimeError) -> APIError:
+    message = str(exc)
+    lowered = message.lower()
+    if "does not fit in gpu memory" in lowered or "oom" in lowered:
+        return APIError(409, "oom", message)
+    if "no configuration satisfied" in lowered or "no results found" in lowered:
+        return APIError(409, "no_feasible_config", message)
+    if "support" in lowered and "not" in lowered:
+        return APIError(422, "unsupported_combo", message)
+    return APIError(500, "estimate_failed", message)
+
+
+def _map_system_exit(exc: SystemExit, request: EstimateRequest) -> APIError:
+    exit_code = exc.code if isinstance(exc.code, int) else 1
+    if exit_code in (0, None):
+        return APIError(500, "estimate_failed", "Estimate terminated unexpectedly.")
+
+    return APIError(
+        422,
+        "estimate_failed",
+        "Estimate could not be completed for the requested configuration.",
+        {
+            "system": request.system,
+            "decode_system": request.decode_system,
+            "backend": request.backend,
+            "backend_version": request.backend_version,
+            "database_mode": request.database_mode,
+            "exit_code": exit_code,
+        },
+    )

--- a/src/aiconfigurator/service/main.py
+++ b/src/aiconfigurator/service/main.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+
+import uvicorn
+
+from aiconfigurator.logging_utils import setup_logging
+from aiconfigurator.sdk import perf_database
+
+from .app import create_app
+
+
+def parse_args(argv: list[str] | None = None):
+    parser = argparse.ArgumentParser(description="AIConfigurator service")
+    parser.add_argument("--host", default="0.0.0.0", help="Host to bind the service to.")
+    parser.add_argument("--port", type=int, default=8000, help="Port to bind the service to.")
+    parser.add_argument("--log-level", default="info", help="Uvicorn log level.")
+    parser.add_argument(
+        "--systems-paths",
+        default=None,
+        help="Comma-separated systems database roots. Use 'default' to include built-in data.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+    setup_logging()
+    if args.systems_paths is not None:
+        perf_database.set_systems_paths(args.systems_paths)
+    uvicorn.run(create_app(), host=args.host, port=args.port, log_level=args.log_level)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aiconfigurator/service/models.py
+++ b/src/aiconfigurator/service/models.py
@@ -1,0 +1,172 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class EstimateRequest(BaseModel):
+    model_path: str
+    systems_paths: str | None = None
+    total_gpus: int = Field(..., ge=1)
+    system: str
+    decode_system: str | None = None
+    backend: str = "trtllm"
+    backend_version: str | None = None
+    database_mode: str = "SILICON"
+    isl: int = Field(4000, ge=1)
+    osl: int = Field(1000, ge=1)
+    ttft: float = Field(2000.0, gt=0)
+    tpot: float = Field(30.0, gt=0)
+    request_latency: float | None = Field(None, gt=0)
+    prefix: int = Field(0, ge=0)
+    strict_sla: bool = False
+    free_gpu_memory_fraction: float | None = Field(None, gt=0, le=1)
+    max_seq_len: int | None = Field(None, gt=0)
+    top_n: int = Field(5, ge=1, le=50)
+
+
+class ServiceConfigInput(BaseModel):
+    model_path: str | None = None
+    hf_token: str | None = None
+    served_model_name: str | None = None
+    model_name: str | None = None
+    served_model_path: str | None = None
+    head_node_ip: str | None = None
+    port: int | None = Field(None, ge=1, le=65535)
+    include_frontend: bool | None = None
+    dyn_vllm_kv_event_port: int | None = None
+    vllm_nixl_side_channel_port: int | None = None
+    prefix: int | None = Field(None, ge=0)
+
+
+class K8sConfigInput(BaseModel):
+    name: str | None = None
+    name_prefix: str | None = None
+    k8s_namespace: str | None = None
+    k8s_image: str | None = None
+    k8s_image_pull_secret: str | None = None
+    frontend_image_pull_policy: str | None = None
+    worker_image_pull_policy: str | None = None
+    k8s_engine_mode: str | None = None
+    k8s_pvc_name: str | None = None
+    k8s_model_path_in_pvc: str | None = None
+    k8s_pvc_mount_path: str | None = None
+    k8s_model_cache: str | None = None
+    k8s_etcd_endpoints: str | None = None
+    k8s_hf_home: str | None = None
+    working_dir: str | None = None
+    frontend_working_dir: str | None = None
+    worker_working_dir: str | None = None
+    frontend_node_selector: dict[str, str] | None = None
+    worker_node_selector: dict[str, str] | None = None
+    frontend_extra_volumes: list[dict[str, Any]] | None = None
+    worker_extra_volumes: list[dict[str, Any]] | None = None
+    frontend_extra_volume_mounts: list[dict[str, Any]] | None = None
+    worker_extra_volume_mounts: list[dict[str, Any]] | None = None
+    frontend_extra_envs: list[dict[str, Any]] | None = None
+    worker_extra_envs: list[dict[str, Any]] | None = None
+    oss_enabled: bool | None = None
+    oss_endpoint_url: str | None = None
+    oss_region: str | None = None
+    oss_secret_name: str | None = None
+    oss_model_express_url: str | None = None
+    oss_streamer_concurrency: int | None = Field(None, ge=1)
+
+
+class WorkerConfigInput(BaseModel):
+    prefill_workers: int | None = Field(None, ge=0)
+    decode_workers: int | None = Field(None, ge=0)
+    agg_workers: int | None = Field(None, ge=0)
+
+
+class SlaConfigInput(BaseModel):
+    isl: int | None = Field(None, ge=1)
+    osl: int | None = Field(None, ge=1)
+    ttft: float | None = Field(None, gt=0)
+    tpot: float | None = Field(None, gt=0)
+
+
+class BenchConfigInput(BaseModel):
+    name: str | None = None
+    image: str | None = None
+    profile_start_timeout: int | None = Field(None, ge=0)
+    endpoint_type: str | None = None
+    endpoint_url: str | None = None
+    model: str | None = None
+    tokenizer: str | None = None
+    isl: int | None = Field(None, ge=1)
+    osl: int | None = Field(None, ge=1)
+    isl_stddev: int | None = Field(None, ge=0)
+    osl_stddev: int | None = Field(None, ge=0)
+    concurrency: list[int] | None = None
+    estimated_concurrency: int | None = Field(None, ge=1)
+    num_requests: list[int] | None = None
+    ui: str | None = None
+
+
+class DynConfigInput(BaseModel):
+    mode: str | None = None
+    enable_router: bool | None = None
+
+
+class ModelConfigInput(BaseModel):
+    is_moe: bool | None = None
+    nextn: int | None = Field(None, ge=0)
+    nextn_accept_rates: list[float] | None = None
+    prefix: int | None = Field(None, ge=0)
+
+
+class GenerationOverrides(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    service_config: ServiceConfigInput | None = None
+    k8s_config: K8sConfigInput | None = None
+    worker_config: WorkerConfigInput | None = None
+    sla_config: SlaConfigInput | None = None
+    bench_config: BenchConfigInput | None = None
+    dyn_config: DynConfigInput | None = None
+    model_cfg: ModelConfigInput | None = Field(default=None, alias="model_config")
+    params: dict[str, Any] | None = None
+    workers: dict[str, Any] | None = None
+    generator_dynamo_version: str | None = None
+    rule: str | None = None
+
+
+class ArtifactRequest(BaseModel):
+    backend: str
+    backend_version: str | None = None
+    deployment_target: Literal["dynamo-j2", "dynamo-python", "llm-d"] = "dynamo-j2"
+    estimate_request: EstimateRequest | None = None
+    selected_mode: str | None = None
+    row_index: int = Field(0, ge=0)
+    generator_overrides: GenerationOverrides | None = None
+    direct_generator_params: dict[str, Any] | None = None
+
+
+class AggregateArtifactRequest(ArtifactRequest):
+    artifact_types: list[Literal["deployment", "benchmark"]] = Field(
+        default_factory=lambda: ["deployment", "benchmark"]
+    )
+
+
+class ApplyDeploymentRequest(BaseModel):
+    content: str = Field(..., min_length=1)
+    namespace: str | None = None
+    timeout_seconds: int = Field(180, ge=1, le=1800)
+    jid: str | None = None
+    dgd_id: str | None = None
+    mode: str | None = None
+    row_index: int | None = Field(None, ge=0)
+
+
+class DeleteDeploymentRequest(ApplyDeploymentRequest):
+    pass
+
+
+class DGDPreviewRequest(BaseModel):
+    mode: str
+    row_index: int = Field(0, ge=0)

--- a/src/aiconfigurator/service/static/index.html
+++ b/src/aiconfigurator/service/static/index.html
@@ -549,7 +549,7 @@
           <summary>Kubernetes 高级设置</summary>
           <div class="grid" style="padding: 14px;">
             <div class="field">
-              <label for="deployment-name">部署名称</label>
+              <label for="deployment-name">Kubernetes 部署名称</label>
               <input id="deployment-name" value="dynamo-qwen3-8b">
             </div>
             <div class="field">
@@ -561,7 +561,7 @@
               <input id="image" value="parties-hub.haiercash.com/nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1">
             </div>
             <div class="field">
-              <label for="served-model-name">服务模型名称</label>
+              <label for="served-model-name">API 调用模型名称</label>
               <input id="served-model-name" value="qwen3-8b">
             </div>
             <div class="field">

--- a/src/aiconfigurator/service/static/index.html
+++ b/src/aiconfigurator/service/static/index.html
@@ -533,7 +533,7 @@
           </div>
           <div class="field">
             <label for="tpot">Token 间延迟（TPOT，ms）</label>
-            <input id="tpot" type="number" value="30" min="1" required>
+            <input id="tpot" type="number" value="30" min="1">
           </div>
           <div class="field">
             <label for="request-latency">请求延迟上限（可选）</label>
@@ -794,7 +794,8 @@
 
     function buildEstimateRequest() {
       const requestLatency = ids("request-latency").value.trim();
-      return {
+      const tpot = ids("tpot").value.trim();
+      const request = {
         model_path: ids("model-config-path").value.trim(),
         systems_paths: ids("systems-paths").value.trim() || null,
         total_gpus: Number(ids("total-gpus").value),
@@ -805,10 +806,13 @@
         isl: Number(ids("isl").value),
         osl: Number(ids("osl").value),
         ttft: Number(ids("ttft").value),
-        tpot: Number(ids("tpot").value),
         request_latency: requestLatency ? Number(requestLatency) : null,
         prefix: Number(ids("prefix").value || 0)
       };
+      if (tpot) {
+        request.tpot = Number(tpot);
+      }
+      return request;
     }
 
     function validateEstimateInputs() {
@@ -816,8 +820,7 @@
         ["total-gpus", "GPU 总数"],
         ["isl", "输入序列长度（ISL）"],
         ["osl", "输出序列长度（OSL）"],
-        ["ttft", "首 Token 延迟（TTFT）"],
-        ["tpot", "Token 间延迟（TPOT）"]
+        ["ttft", "首 Token 延迟（TTFT）"]
       ];
       for (const [id, label] of requiredFields) {
         const input = ids(id);
@@ -826,6 +829,11 @@
           input.focus();
           throw new Error(`请填写有效的${label}，数值必须大于 0。`);
         }
+      }
+      const tpot = ids("tpot").value.trim();
+      if (tpot && (!Number.isFinite(Number(tpot)) || Number(tpot) <= 0)) {
+        ids("tpot").focus();
+        throw new Error("Token 间延迟（TPOT）留空时使用默认值；填写时必须大于 0。");
       }
     }
 

--- a/src/aiconfigurator/service/static/index.html
+++ b/src/aiconfigurator/service/static/index.html
@@ -481,7 +481,7 @@
           <div class="field-full">
             <label for="model-path">模型路径</label>
             <input id="model-path" value="/data/models/qwen3-8b">
-            <input id="systems-paths" type="hidden" value="/data/aiconfigurator-data/aic-systems/systems">
+            <input id="systems-paths" type="hidden" value="">
           </div>
           <div class="field">
             <label for="system">GPU 类型</label>
@@ -594,7 +594,7 @@
 
         <div class="note">
           “模型”决定性能估算使用的配置；“模型路径”会写入最终部署 YAML。
-          系统数据目录固定为 <code>/data/aiconfigurator-data/aic-systems/systems</code>。
+          默认使用镜像内置的系统性能数据库。
           当两种模式均可用时，系统会同时生成 agg 与 disagg 的 Top 1 方案。
         </div>
       </div>
@@ -889,7 +889,13 @@
         payload = { raw: text };
       }
       if (!response.ok) {
-        throw new Error(payload.message || payload.detail || `HTTP ${response.status}`);
+        const validationErrors = payload.details && Array.isArray(payload.details.errors)
+          ? payload.details.errors.map((item) => {
+              const field = Array.isArray(item.loc) ? item.loc.filter((part) => part !== "body").join(".") : "";
+              return `${field || "请求参数"}：${item.msg || "格式不正确"}`;
+            }).join("；")
+          : "";
+        throw new Error(validationErrors || payload.message || payload.detail || `HTTP ${response.status}`);
       }
       return payload;
     }

--- a/src/aiconfigurator/service/static/index.html
+++ b/src/aiconfigurator/service/static/index.html
@@ -455,7 +455,6 @@
   <div class="page">
     <section class="hero">
       <div class="card">
-        <div class="pill">AIC SYSTEM</div>
         <h1>推理服务部署</h1>
         <p class="subtitle">
           配置模型与性能目标，自动比较聚合式（agg）和分离式（disagg）部署方案，

--- a/src/aiconfigurator/service/static/index.html
+++ b/src/aiconfigurator/service/static/index.html
@@ -484,7 +484,7 @@
             <input id="systems-paths" type="hidden" value="/data/aiconfigurator-data/aic-systems/systems">
           </div>
           <div class="field">
-            <label for="system">GPU 系统</label>
+            <label for="system">GPU 类型</label>
             <select id="system">
               <option value="h200_sxm" selected>h200_sxm</option>
               <option value="h100_sxm">h100_sxm</option>
@@ -495,7 +495,7 @@
             </select>
           </div>
           <div class="field">
-            <label for="backend">推理后端</label>
+            <label for="backend">推理框架</label>
             <select id="backend">
               <option value="vllm" selected>vllm</option>
               <option value="sglang">sglang</option>
@@ -503,7 +503,7 @@
             </select>
           </div>
           <div class="field">
-            <label for="backend-version">后端版本</label>
+            <label for="backend-version">框架版本</label>
             <input id="backend-version" value="0.19.0" placeholder="0.19.0">
           </div>
           <div class="field">
@@ -557,7 +557,7 @@
               <input id="namespace" value="aic-system">
             </div>
             <div class="field-wide">
-              <label for="image">运行时镜像</label>
+              <label for="image">Dynamo 镜像</label>
               <input id="image" value="parties-hub.haiercash.com/nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1">
             </div>
             <div class="field">

--- a/src/aiconfigurator/service/static/index.html
+++ b/src/aiconfigurator/service/static/index.html
@@ -576,26 +576,14 @@
               <label for="worker-node">Worker 节点</label>
               <input id="worker-node" value="kubeflow-master">
             </div>
-            <div class="field">
-              <label for="worker-working-dir">Worker 工作目录</label>
-              <input id="worker-working-dir" value="/workspace/examples/backends/vllm">
-            </div>
-            <div class="field">
-              <label for="frontend-image-pull-policy">Frontend 镜像拉取策略</label>
-              <input id="frontend-image-pull-policy" value="IfNotPresent">
-            </div>
-            <div class="field">
-              <label for="worker-image-pull-policy">Worker 镜像拉取策略</label>
-              <input id="worker-image-pull-policy" value="IfNotPresent">
-            </div>
-            <div class="field-full">
-              <label for="worker-extra-envs">Worker 额外环境变量（JSON 数组）</label>
-              <textarea id="worker-extra-envs">[
+            <input id="worker-working-dir" type="hidden" value="/workspace/examples/backends/vllm">
+            <input id="frontend-image-pull-policy" type="hidden" value="IfNotPresent">
+            <input id="worker-image-pull-policy" type="hidden" value="IfNotPresent">
+            <textarea id="worker-extra-envs" hidden>[
   {"name":"TRITON_CACHE_DIR","value":"/tmp/triton"},
   {"name":"XDG_CACHE_HOME","value":"/tmp/.cache"},
   {"name":"HOME","value":"/tmp"}
 ]</textarea>
-            </div>
           </div>
         </details>
 

--- a/src/aiconfigurator/service/static/index.html
+++ b/src/aiconfigurator/service/static/index.html
@@ -6,17 +6,17 @@
   <title>AIC 系统部署</title>
   <style>
     :root {
-      --bg: #f7f9fc;
+      --bg: #f5f7fa;
       --panel: #ffffff;
-      --ink: #1f2937;
-      --muted: #607080;
-      --line: #d7dee8;
-      --brand: #326ce5;
-      --brand-dark: #1f4fbf;
-      --brand-soft: #eaf1ff;
+      --ink: #172b4d;
+      --muted: #60738a;
+      --line: #dce3eb;
+      --brand: #064b87;
+      --brand-dark: #033b6c;
+      --brand-soft: #e8eef5;
       --accent: #0097a7;
       --good: #00a67e;
-      --shadow: 0 1px 2px rgba(15, 23, 42, 0.08), 0 8px 24px rgba(15, 23, 42, 0.05);
+      --shadow: none;
     }
     * { box-sizing: border-box; }
     body {
@@ -24,11 +24,47 @@
       font-family: "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
       color: var(--ink);
       background: var(--bg);
+      border-left: 8px solid #073f73;
+      min-height: 100vh;
+    }
+    .app-bar {
+      height: 64px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0 36px 0 44px;
+      background: #fff;
+      border-bottom: 1px solid #e5e9ef;
+      box-shadow: 0 2px 8px rgba(23, 43, 77, 0.08);
+    }
+    .app-brand {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      color: #40536a;
+      font-size: 18px;
+      font-weight: 600;
+    }
+    .app-brand-mark {
+      color: #5d6b7a;
+      font-size: 21px;
+    }
+    .app-brand-caret {
+      width: 0;
+      height: 0;
+      border-left: 5px solid transparent;
+      border-right: 5px solid transparent;
+      border-top: 6px solid #5d6b7a;
+    }
+    .app-exit {
+      color: #111;
+      font-size: 25px;
+      line-height: 1;
     }
     .page {
-      max-width: 1520px;
-      margin: 0 auto;
-      padding: 28px;
+      max-width: none;
+      margin: 0;
+      padding: 0 0 32px;
     }
     .hero, .layout {
       display: grid;
@@ -36,20 +72,24 @@
     }
     .hero {
       grid-template-columns: 1fr;
-      margin-bottom: 20px;
+      margin-bottom: 0;
+      padding: 28px 34px 24px;
+      background: #fff;
+      border-bottom: 1px solid var(--line);
     }
     .layout {
       grid-template-columns: minmax(620px, 0.9fr) minmax(460px, 1.1fr);
       align-items: start;
+      margin: 0 34px;
     }
     .tabs {
       display: flex;
       gap: 10px;
-      margin-bottom: 20px;
+      margin: 24px 34px;
     }
     .tab-button {
       color: var(--muted);
-      background: #e9eef6;
+      background: #e6ebf1;
     }
     .tab-button.active {
       color: #fff;
@@ -64,17 +104,22 @@
     .card {
       background: var(--panel);
       border: 1px solid var(--line);
-      border-radius: 8px;
+      border-radius: 10px;
       box-shadow: var(--shadow);
       padding: 22px;
+    }
+    .hero .card {
+      padding: 0;
+      border: 0;
+      border-radius: 0;
+      background: transparent;
     }
     h1, h2, h3 {
       margin: 0;
     }
     h1 {
-      font-size: 34px;
-      line-height: 1.1;
-      margin-top: 10px;
+      font-size: 29px;
+      line-height: 1.25;
     }
     h2 {
       font-size: 20px;
@@ -88,7 +133,7 @@
       color: var(--muted);
     }
     .subtitle {
-      margin-top: 12px;
+      margin: 6px 0 0;
       line-height: 1.6;
     }
     .pill {
@@ -132,7 +177,7 @@
       width: 100%;
       padding: 11px 13px;
       border: 1px solid var(--line);
-      border-radius: 6px;
+      border-radius: 7px;
       background: #fff;
       color: var(--ink);
       font: inherit;
@@ -143,7 +188,7 @@
     }
     button {
       border: 0;
-      border-radius: 6px;
+      border-radius: 7px;
       padding: 11px 18px;
       font: inherit;
       font-weight: 700;
@@ -438,6 +483,18 @@
       }
     }
     @media (max-width: 760px) {
+      .app-bar {
+        padding: 0 18px;
+      }
+      .hero {
+        padding: 22px 18px;
+      }
+      .tabs {
+        margin: 18px;
+      }
+      .layout {
+        margin: 0 18px;
+      }
       .grid {
         grid-template-columns: 1fr;
       }
@@ -445,6 +502,14 @@
   </style>
 </head>
 <body>
+  <header class="app-bar">
+    <div class="app-brand">
+      <span class="app-brand-mark">◇</span>
+      <span>ai-plat</span>
+      <span class="app-brand-caret" aria-hidden="true"></span>
+    </div>
+    <span class="app-exit" aria-label="退出">↪</span>
+  </header>
   <div class="page">
     <section class="hero">
       <div class="card">

--- a/src/aiconfigurator/service/static/index.html
+++ b/src/aiconfigurator/service/static/index.html
@@ -1,0 +1,1808 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>AIC 系统部署</title>
+  <style>
+    :root {
+      --bg: #f7f9fc;
+      --panel: #ffffff;
+      --ink: #1f2937;
+      --muted: #607080;
+      --line: #d7dee8;
+      --brand: #326ce5;
+      --brand-dark: #1f4fbf;
+      --brand-soft: #eaf1ff;
+      --accent: #0097a7;
+      --good: #00a67e;
+      --shadow: 0 1px 2px rgba(15, 23, 42, 0.08), 0 8px 24px rgba(15, 23, 42, 0.05);
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
+      color: var(--ink);
+      background: var(--bg);
+    }
+    .page {
+      max-width: 1520px;
+      margin: 0 auto;
+      padding: 28px;
+    }
+    .hero, .layout {
+      display: grid;
+      gap: 20px;
+    }
+    .hero {
+      grid-template-columns: 1fr;
+      margin-bottom: 20px;
+    }
+    .layout {
+      grid-template-columns: minmax(620px, 0.9fr) minmax(460px, 1.1fr);
+      align-items: start;
+    }
+    .tabs {
+      display: flex;
+      gap: 10px;
+      margin-bottom: 20px;
+    }
+    .tab-button {
+      color: var(--muted);
+      background: #e9eef6;
+    }
+    .tab-button.active {
+      color: #fff;
+      background: var(--brand);
+    }
+    .tab-panel {
+      display: none;
+    }
+    .tab-panel.active {
+      display: block;
+    }
+    .card {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      box-shadow: var(--shadow);
+      padding: 22px;
+    }
+    h1, h2, h3 {
+      margin: 0;
+    }
+    h1 {
+      font-size: 34px;
+      line-height: 1.1;
+      margin-top: 10px;
+    }
+    h2 {
+      font-size: 20px;
+      margin-bottom: 14px;
+    }
+    h3 {
+      font-size: 16px;
+      margin-bottom: 10px;
+    }
+    .subtitle, .note, .muted {
+      color: var(--muted);
+    }
+    .subtitle {
+      margin-top: 12px;
+      line-height: 1.6;
+    }
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      padding: 8px 12px;
+      border-radius: 16px;
+      background: var(--brand-soft);
+      color: var(--brand);
+      font-size: 12px;
+      font-weight: 700;
+    }
+    .artifact-grid {
+      display: grid;
+      gap: 12px;
+    }
+    .artifact-grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 14px 12px;
+    }
+    .field, .field-full {
+      display: flex;
+      flex-direction: column;
+      gap: 7px;
+    }
+    .field-full {
+      grid-column: 1 / -1;
+    }
+    .field-wide {
+      grid-column: span 2;
+    }
+    label {
+      font-size: 13px;
+      font-weight: 600;
+    }
+    input, select, textarea {
+      width: 100%;
+      padding: 11px 13px;
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      background: #fff;
+      color: var(--ink);
+      font: inherit;
+    }
+    textarea {
+      min-height: 110px;
+      resize: vertical;
+    }
+    button {
+      border: 0;
+      border-radius: 6px;
+      padding: 11px 18px;
+      font: inherit;
+      font-weight: 700;
+      cursor: pointer;
+      transition: transform 120ms ease, opacity 120ms ease;
+    }
+    button:hover { transform: translateY(-1px); }
+    button:disabled { opacity: 0.55; cursor: not-allowed; transform: none; }
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin-top: 18px;
+    }
+    .primary {
+      color: #fff;
+      background: var(--brand);
+    }
+    .primary:hover {
+      background: var(--brand-dark);
+    }
+    .secondary {
+      color: var(--brand);
+      background: var(--brand-soft);
+    }
+    .copy-button {
+      padding: 7px 11px;
+      font-size: 12px;
+      color: #dbeafe;
+      background: rgba(50, 108, 229, 0.8);
+      box-shadow: 0 2px 8px rgba(15, 23, 42, 0.22);
+    }
+    .copy-button:hover {
+      background: var(--brand);
+    }
+    .yaml-deploy-button {
+      padding: 7px 11px;
+      font-size: 12px;
+      color: #fff;
+      background: var(--good);
+      box-shadow: 0 2px 8px rgba(15, 23, 42, 0.22);
+    }
+    .yaml-delete-button {
+      padding: 7px 11px;
+      font-size: 12px;
+      color: #fff;
+      background: #dc2626;
+      box-shadow: 0 2px 8px rgba(15, 23, 42, 0.22);
+    }
+    .note {
+      margin-top: 14px;
+      padding: 12px 14px;
+      border-radius: 8px;
+      background: #f8fbff;
+      border: 1px dashed var(--line);
+      line-height: 1.55;
+      font-size: 13px;
+    }
+    .section {
+      margin-top: 22px;
+    }
+    .result-block {
+      margin-top: 16px;
+    }
+    .collapsible {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: #fbfcff;
+      overflow: hidden;
+    }
+    .collapsible summary {
+      cursor: pointer;
+      padding: 12px 14px;
+      color: var(--muted);
+      font-weight: 600;
+      list-style-position: inside;
+      user-select: none;
+    }
+    .collapsible .codebox {
+      border-radius: 0;
+      margin: 0;
+      max-height: 420px;
+    }
+    .codebox {
+      background: #111827;
+      color: #dbeafe;
+      border-radius: 8px;
+      padding: 14px;
+      min-height: 120px;
+      overflow: auto;
+      white-space: pre-wrap;
+      font-family: "Cascadia Code", "Consolas", monospace;
+      font-size: 12px;
+      line-height: 1.5;
+    }
+    .yaml-box {
+      min-height: 320px;
+    }
+    .artifact-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      margin-bottom: 10px;
+    }
+    .artifact-header h3 {
+      margin-bottom: 0;
+    }
+    .section-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      margin-bottom: 12px;
+    }
+    .code-wrap {
+      position: relative;
+    }
+    .yaml-actions {
+      position: absolute;
+      top: 10px;
+      right: 18px;
+      z-index: 2;
+      display: flex;
+      gap: 8px;
+      align-items: center;
+    }
+    .code-wrap .codebox {
+      padding-top: 56px;
+      padding-right: 112px;
+    }
+    .yaml-editor {
+      display: block;
+      width: 100%;
+      max-width: 100%;
+      border: 0;
+      resize: vertical;
+    }
+    .kpi-row {
+      display: flex;
+      gap: 14px;
+      margin-top: 12px;
+      color: var(--muted);
+      font-size: 13px;
+      flex-wrap: wrap;
+    }
+    .recommendation-tables {
+      display: grid;
+      gap: 14px;
+      margin-top: 16px;
+    }
+    .config-table-card {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: #fff;
+      overflow: hidden;
+    }
+    .config-table-title {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 12px 14px;
+      border-bottom: 1px solid var(--line);
+      color: var(--ink);
+      font-weight: 700;
+    }
+    .title-actions {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      flex-shrink: 0;
+    }
+    .recommended-badge {
+      display: none;
+      padding: 3px 8px;
+      border-radius: 999px;
+      color: var(--brand);
+      background: var(--brand-soft);
+      font-size: 11px;
+      font-weight: 700;
+    }
+    .config-table-card.recommended .recommended-badge {
+      display: inline-flex;
+    }
+    .config-table-scroll {
+      overflow-x: auto;
+    }
+    .table-empty {
+      min-height: 48px;
+      background: #fbfcff;
+    }
+    .config-table {
+      width: 100%;
+      border-collapse: collapse;
+      white-space: nowrap;
+      font-size: 12px;
+    }
+    .config-table th,
+    .config-table td {
+      padding: 10px 12px;
+      border-bottom: 1px solid var(--line);
+      text-align: right;
+    }
+    .config-table th {
+      color: var(--muted);
+      background: #f8fbff;
+      font-weight: 700;
+    }
+    .config-table th:first-child,
+    .config-table td:first-child,
+    .config-table th:nth-child(2),
+    .config-table td:nth-child(2) {
+      text-align: left;
+    }
+    .config-table tbody tr:last-child td {
+      border-bottom: 0;
+    }
+    .config-table tbody tr.selected-row td {
+      background: #eaf1ff;
+      color: #1f4fbf;
+      font-weight: 700;
+    }
+    .select-row-button {
+      padding: 6px 10px;
+      font-size: 12px;
+      color: #fff;
+      background: var(--accent);
+    }
+    .run-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px 16px;
+      margin-bottom: 16px;
+      padding: 12px 14px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: #f8fbff;
+      font-size: 13px;
+    }
+    .run-meta code {
+      color: var(--brand);
+      font-weight: 700;
+    }
+    .run-lookup {
+      display: grid;
+      grid-template-columns: minmax(220px, 1fr) auto;
+      gap: 10px;
+      margin-bottom: 16px;
+    }
+    .records-actions {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 10px;
+      margin: 10px 0;
+      flex-wrap: wrap;
+    }
+    .status-error {
+      display: none;
+      margin-top: -8px;
+      margin-bottom: 14px;
+      padding: 10px 12px;
+      border: 1px solid #fecaca;
+      border-radius: 8px;
+      color: #991b1b;
+      background: #fff5f5;
+      font-size: 13px;
+      line-height: 1.45;
+    }
+    .status-error.active {
+      display: block;
+    }
+    .dgd-note {
+      margin-bottom: 10px;
+      color: var(--muted);
+      font-size: 13px;
+    }
+    .record-actions {
+      display: flex;
+      gap: 8px;
+    }
+    .record-actions button {
+      padding: 6px 10px;
+      font-size: 12px;
+    }
+    .records-yaml {
+      margin-top: 18px;
+    }
+    @media (max-width: 1220px) {
+      .hero, .layout, .artifact-grid {
+        grid-template-columns: 1fr;
+      }
+      .grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+      .field-wide {
+        grid-column: 1 / -1;
+      }
+    }
+    @media (max-width: 760px) {
+      .grid {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <section class="hero">
+      <div class="card">
+        <div class="pill">AIC SYSTEM</div>
+        <h1>推理服务部署</h1>
+        <p class="subtitle">
+          配置模型与性能目标，自动比较聚合式（agg）和分离式（disagg）部署方案，
+          推荐更优配置并生成可直接使用的 Kubernetes YAML。
+        </p>
+      </div>
+    </section>
+
+    <nav class="tabs" aria-label="部署工作区">
+      <button class="tab-button active" data-tab="generate-panel" type="button">创建部署</button>
+      <button class="tab-button" data-tab="records-panel" type="button">部署记录</button>
+    </nav>
+
+    <section class="layout tab-panel active" id="generate-panel">
+      <div class="card">
+        <h2>基础配置</h2>
+        <div class="grid">
+          <div class="field-full">
+            <label for="model-config-path">模型</label>
+            <select id="model-config-path">
+              <option value="Qwen/Qwen3-8B" selected>Qwen/Qwen3-8B</option>
+            </select>
+          </div>
+          <div class="field-full">
+            <label for="model-path">模型路径</label>
+            <input id="model-path" value="/data/models/qwen3-8b">
+            <input id="systems-paths" type="hidden" value="/data/aiconfigurator-data/aic-systems/systems">
+          </div>
+          <div class="field">
+            <label for="system">GPU 系统</label>
+            <select id="system">
+              <option value="h200_sxm" selected>h200_sxm</option>
+              <option value="h100_sxm">h100_sxm</option>
+              <option value="b200_sxm">b200_sxm</option>
+              <option value="gb200">gb200</option>
+              <option value="l20">l20</option>
+              <option value="h20">h20</option>
+            </select>
+          </div>
+          <div class="field">
+            <label for="backend">推理后端</label>
+            <select id="backend">
+              <option value="vllm" selected>vllm</option>
+              <option value="sglang">sglang</option>
+              <option value="trtllm">trtllm</option>
+            </select>
+          </div>
+          <div class="field">
+            <label for="backend-version">后端版本</label>
+            <input id="backend-version" value="0.19.0" placeholder="0.19.0">
+          </div>
+          <div class="field">
+            <label for="database-mode">性能数据库模式</label>
+            <select id="database-mode">
+              <option>SILICON</option>
+              <option selected>HYBRID</option>
+              <option>EMPIRICAL</option>
+              <option>SOL</option>
+            </select>
+          </div>
+          <div class="field">
+            <label for="total-gpus">GPU 总数</label>
+            <input id="total-gpus" type="number" value="8" min="1">
+          </div>
+          <div class="field">
+            <label for="isl">输入序列长度（ISL）</label>
+            <input id="isl" type="number" value="2048" min="1">
+          </div>
+          <div class="field">
+            <label for="osl">输出序列长度（OSL）</label>
+            <input id="osl" type="number" value="128" min="1">
+          </div>
+          <div class="field">
+            <label for="ttft">首 Token 延迟（TTFT，ms）</label>
+            <input id="ttft" type="number" value="1000" min="1">
+          </div>
+          <div class="field">
+            <label for="tpot">Token 间延迟（TPOT，ms）</label>
+            <input id="tpot" type="number" value="30" min="1">
+          </div>
+          <div class="field">
+            <label for="request-latency">请求延迟上限（可选）</label>
+            <input id="request-latency" type="number" value="">
+          </div>
+          <div class="field">
+            <label for="prefix">前缀缓存长度</label>
+            <input id="prefix" type="number" value="0" min="0">
+          </div>
+        </div>
+
+        <details class="section collapsible" open>
+          <summary>Kubernetes 高级设置</summary>
+          <div class="grid" style="padding: 14px;">
+            <div class="field">
+              <label for="deployment-name">部署名称</label>
+              <input id="deployment-name" value="dynamo-qwen3-8b">
+            </div>
+            <div class="field">
+              <label for="namespace">命名空间（Namespace）</label>
+              <input id="namespace" value="aic-system">
+            </div>
+            <div class="field-wide">
+              <label for="image">运行时镜像</label>
+              <input id="image" value="parties-hub.haiercash.com/nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1">
+            </div>
+            <div class="field">
+              <label for="served-model-name">服务模型名称</label>
+              <input id="served-model-name" value="qwen3-8b">
+            </div>
+            <div class="field">
+              <label for="service-port">服务端口</label>
+              <input id="service-port" type="number" value="8000" min="1">
+            </div>
+            <div class="field">
+              <label for="frontend-node">Frontend 节点</label>
+              <input id="frontend-node" value="kubeflow-master">
+            </div>
+            <div class="field">
+              <label for="worker-node">Worker 节点</label>
+              <input id="worker-node" value="kubeflow-master">
+            </div>
+            <div class="field">
+              <label for="worker-working-dir">Worker 工作目录</label>
+              <input id="worker-working-dir" value="/workspace/examples/backends/vllm">
+            </div>
+            <div class="field">
+              <label for="frontend-image-pull-policy">Frontend 镜像拉取策略</label>
+              <input id="frontend-image-pull-policy" value="IfNotPresent">
+            </div>
+            <div class="field">
+              <label for="worker-image-pull-policy">Worker 镜像拉取策略</label>
+              <input id="worker-image-pull-policy" value="IfNotPresent">
+            </div>
+            <div class="field-full">
+              <label for="worker-extra-envs">Worker 额外环境变量（JSON 数组）</label>
+              <textarea id="worker-extra-envs">[
+  {"name":"TRITON_CACHE_DIR","value":"/tmp/triton"},
+  {"name":"XDG_CACHE_HOME","value":"/tmp/.cache"},
+  {"name":"HOME","value":"/tmp"}
+]</textarea>
+            </div>
+          </div>
+        </details>
+
+        <div class="actions">
+          <button class="secondary" id="load-options-btn">刷新选项</button>
+          <button class="primary" id="deployment-btn">生成部署方案</button>
+        </div>
+
+        <div class="note">
+          “模型”决定性能估算使用的配置；“模型路径”会写入最终部署 YAML。
+          系统数据目录固定为 <code>/data/aiconfigurator-data/aic-systems/systems</code>。
+          当两种模式均可用时，系统会同时生成 agg 与 disagg 的 Top 1 方案。
+        </div>
+      </div>
+
+      <div class="card">
+        <h2>运行状态</h2>
+        <div class="run-meta">
+          <span>运行 ID：<code id="current-jid">尚未生成</code></span>
+          <span>已选 DGD：<code id="current-dgd-id">无</code></span>
+          <span>状态：<code id="run-status">空闲</code></span>
+        </div>
+        <div class="status-error" id="status-error"></div>
+
+        <div class="section" id="recommended-result">
+          <h2>推荐方案</h2>
+        </div>
+        <div class="recommendation-tables">
+          <div class="config-table-card" id="agg-config-card">
+            <div class="config-table-title">
+              <span>agg top1</span>
+              <span class="title-actions">
+                <span class="recommended-badge">推荐</span>
+                <button class="select-row-button" data-view-mode="agg" type="button">查看 YAML</button>
+              </span>
+            </div>
+            <div class="config-table-scroll table-empty" id="agg-config-table"></div>
+          </div>
+          <div class="config-table-card" id="disagg-config-card">
+            <div class="config-table-title">
+              <span>disagg top1</span>
+              <span class="title-actions">
+                <span class="recommended-badge">推荐</span>
+                <button class="select-row-button" data-view-mode="disagg" type="button">查看 YAML</button>
+              </span>
+            </div>
+            <div class="config-table-scroll table-empty" id="disagg-config-table"></div>
+          </div>
+        </div>
+
+        <div class="result-block" id="deployment-yamls">
+          <details class="collapsible">
+            <summary>估算响应</summary>
+            <pre class="codebox" id="estimate-output">尚未发起请求。</pre>
+          </details>
+        </div>
+
+        <div class="result-block" id="dgd-yaml-section">
+          <details class="collapsible" id="dgd-yaml-details">
+            <summary>部署 YAML</summary>
+            <div style="padding: 14px;">
+              <div class="dgd-note" id="dgd-yaml-note">尚未生成。</div>
+              <div class="code-wrap">
+                <div class="yaml-actions">
+                  <button class="yaml-deploy-button" id="deploy-selected-btn" type="button">部署所选方案</button>
+                  <button class="yaml-delete-button" id="delete-selected-btn" type="button">删除部署</button>
+                  <button class="copy-button" data-copy-target="deployment-selected-output" type="button">复制</button>
+                </div>
+                <textarea class="codebox yaml-box yaml-editor" id="deployment-selected-output" spellcheck="false" autocomplete="off" autocorrect="off" autocapitalize="off">尚未生成。</textarea>
+              </div>
+            </div>
+          </details>
+        </div>
+
+        <div class="result-block">
+          <details class="collapsible" open>
+            <summary>部署执行状态</summary>
+            <pre class="codebox" id="apply-output">尚未执行部署。</pre>
+          </details>
+        </div>
+
+      </div>
+    </section>
+
+    <section class="tab-panel" id="records-panel">
+      <div class="card">
+        <h2>部署记录</h2>
+        <div class="run-lookup">
+          <input id="lookup-jid" placeholder="输入已部署的运行 ID，例如 aic-20260528-051619-ba115224">
+          <button class="secondary" id="load-run-btn" type="button">加载记录</button>
+        </div>
+        <div class="records-actions">
+          <span class="muted">按运行 ID 查询，或从下方选择历史部署记录。</span>
+          <button class="secondary" id="refresh-records-btn" type="button">刷新记录</button>
+        </div>
+        <div class="config-table-scroll table-empty" id="deployment-records-table"></div>
+        <div class="records-yaml" id="records-yaml-section">
+          <div class="section-header">
+            <h2>记录中的 DGD YAML</h2>
+          </div>
+          <div class="dgd-note" id="records-yaml-note">请选择记录或输入运行 ID。</div>
+          <div class="code-wrap">
+            <div class="yaml-actions">
+              <button class="copy-button" data-copy-target="records-yaml-output" type="button">复制</button>
+            </div>
+            <textarea class="codebox yaml-box yaml-editor" id="records-yaml-output" spellcheck="false" autocomplete="off" autocorrect="off" autocapitalize="off">尚未生成。</textarea>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+
+  <script>
+    const ids = (name) => document.getElementById(name);
+    const fallbackOptions = {
+      models: ["Qwen/Qwen3-8B"],
+      systems: ["h200_sxm", "h100_sxm", "b200_sxm", "gb200", "l20", "h20"],
+      backends: ["vllm", "sglang", "trtllm"],
+      supported_databases: {}
+    };
+    const state = {
+      options: null,
+      lastEstimate: null,
+      lastDeployments: null,
+      jid: null,
+      selected: null,
+      selectedArtifact: null,
+      candidatesByMode: null,
+      modeComparison: null,
+      recommendedMode: null
+    };
+
+    function safeJsonParse(raw, fallback = []) {
+      if (!raw.trim()) {
+        return fallback;
+      }
+      try {
+        return JSON.parse(raw);
+      } catch (error) {
+        throw new Error(`JSON 解析失败：${error.message}`);
+      }
+    }
+
+    function setText(id, value) {
+      ids(id).textContent = value ?? "-";
+    }
+
+    function setCode(id, value) {
+      const element = ids(id);
+      if ("value" in element) {
+        element.value = value || "";
+      } else {
+        element.textContent = value || "";
+      }
+    }
+
+    function setStatus(value) {
+      setText("run-status", value);
+    }
+
+    function setError(value = "") {
+      const target = ids("status-error");
+      target.textContent = value;
+      target.classList.toggle("active", Boolean(value));
+    }
+
+    function switchTab(panelId) {
+      document.querySelectorAll(".tab-panel").forEach((panel) => {
+        panel.classList.toggle("active", panel.id === panelId);
+      });
+      document.querySelectorAll(".tab-button").forEach((button) => {
+        button.classList.toggle("active", button.dataset.tab === panelId);
+      });
+    }
+
+    function getCode(id) {
+      const element = ids(id);
+      return ("value" in element ? element.value : element.textContent).trim();
+    }
+
+    function jsonPretty(value) {
+      return JSON.stringify(value, null, 2);
+    }
+
+    function deriveServedModelName(modelPath) {
+      const cleaned = modelPath.trim().replace(/[\\/]+$/, "");
+      if (!cleaned) {
+        return "";
+      }
+      const lastSegment = cleaned.split(/[\\/]/).pop() || cleaned;
+      return lastSegment.replace(/[^A-Za-z0-9._-]+/g, "-").toLowerCase();
+    }
+
+    function deriveDeploymentName(servedModelName) {
+      const cleaned = servedModelName.trim().replace(/[^A-Za-z0-9._-]+/g, "-").toLowerCase();
+      return cleaned ? `dynamo-${cleaned}` : "dynamo";
+    }
+
+    function syncDeploymentName(force = false) {
+      const deploymentInput = ids("deployment-name");
+      const current = deploymentInput.value.trim();
+      if (!force && current && deploymentInput.dataset.auto !== "true") {
+        return;
+      }
+      deploymentInput.value = deriveDeploymentName(ids("served-model-name").value);
+      deploymentInput.dataset.auto = "true";
+    }
+
+    function buildEstimateRequest() {
+      const requestLatency = ids("request-latency").value.trim();
+      return {
+        model_path: ids("model-config-path").value.trim(),
+        systems_paths: ids("systems-paths").value.trim() || null,
+        total_gpus: Number(ids("total-gpus").value),
+        system: ids("system").value,
+        backend: ids("backend").value,
+        backend_version: ids("backend-version").value || null,
+        database_mode: ids("database-mode").value,
+        isl: Number(ids("isl").value),
+        osl: Number(ids("osl").value),
+        ttft: Number(ids("ttft").value),
+        tpot: Number(ids("tpot").value),
+        request_latency: requestLatency ? Number(requestLatency) : null,
+        prefix: Number(ids("prefix").value || 0)
+      };
+    }
+
+    function buildGeneratorOverrides() {
+      const modelPath = ids("model-path").value.trim();
+      const servedModelName = (ids("served-model-name").value.trim() || deriveServedModelName(modelPath)).toLowerCase();
+      const deploymentName = (ids("deployment-name").value.trim() || deriveDeploymentName(servedModelName)).toLowerCase();
+      return {
+        service_config: {
+          model_path: modelPath,
+          served_model_path: modelPath,
+          served_model_name: servedModelName,
+          port: Number(ids("service-port").value || 8000)
+        },
+        k8s_config: {
+          name: deploymentName,
+          k8s_namespace: ids("namespace").value.trim(),
+          k8s_image: ids("image").value.trim(),
+          frontend_image_pull_policy: ids("frontend-image-pull-policy").value.trim(),
+          worker_image_pull_policy: ids("worker-image-pull-policy").value.trim(),
+          worker_working_dir: ids("worker-working-dir").value.trim(),
+          frontend_node_selector: {
+            "kubernetes.io/hostname": ids("frontend-node").value.trim()
+          },
+          worker_node_selector: {
+            "kubernetes.io/hostname": ids("worker-node").value.trim()
+          },
+          frontend_extra_volumes: [
+            {
+              name: "model-dir",
+              hostPath: { path: modelPath, type: "Directory" }
+            }
+          ],
+          worker_extra_volumes: [
+            {
+              name: "model-dir",
+              hostPath: { path: modelPath, type: "Directory" }
+            },
+            { name: "triton-cache", emptyDir: {} },
+            { name: "xdg-cache", emptyDir: {} }
+          ],
+          frontend_extra_volume_mounts: [
+            {
+              name: "model-dir",
+              mountPath: modelPath,
+              readOnly: true
+            }
+          ],
+          worker_extra_volume_mounts: [
+            {
+              name: "model-dir",
+              mountPath: modelPath,
+              readOnly: true
+            },
+            {
+              name: "triton-cache",
+              mountPath: "/tmp/triton"
+            },
+            {
+              name: "xdg-cache",
+              mountPath: "/tmp/.cache"
+            }
+          ],
+          worker_extra_envs: safeJsonParse(ids("worker-extra-envs").value)
+        }
+      };
+    }
+
+    async function fetchJson(url, options = {}) {
+      const response = await fetch(url, {
+        headers: { "Content-Type": "application/json" },
+        ...options
+      });
+      const text = await response.text();
+      let payload = {};
+      try {
+        payload = text ? JSON.parse(text) : {};
+      } catch {
+        payload = { raw: text };
+      }
+      if (!response.ok) {
+        throw new Error(payload.message || payload.detail || `HTTP ${response.status}`);
+      }
+      return payload;
+    }
+
+    function fillSelect(select, values, preferred) {
+      select.innerHTML = "";
+      const items = values || [];
+      items.forEach((value) => {
+        const option = document.createElement("option");
+        option.value = value;
+        option.textContent = value;
+        if (value === preferred) {
+          option.selected = true;
+        }
+        select.appendChild(option);
+      });
+      if (!select.value && items.length > 0) {
+        select.value = items[0];
+      }
+    }
+
+    function fillModelSelect(models = [], localModelConfigs = [], preferred = "") {
+      const select = ids("model-config-path");
+      select.innerHTML = "";
+
+      const addGroup = (label, items) => {
+        if (!items.length) {
+          return;
+        }
+        const group = document.createElement("optgroup");
+        group.label = label;
+        items.forEach((item) => {
+          const option = document.createElement("option");
+          option.value = item.value;
+          option.textContent = item.label;
+          if (item.value === preferred) {
+            option.selected = true;
+          }
+          group.appendChild(option);
+        });
+        select.appendChild(group);
+      };
+
+      const builtInItems = (models || []).map((model) => ({ label: model, value: model }));
+      const localItems = (localModelConfigs || []).map((item) => ({
+        label: `Local: ${item.label}`,
+        value: item.value
+      }));
+
+      addGroup("Built-in Models", builtInItems);
+      addGroup("/data/model-configs", localItems);
+
+      if (!select.value) {
+        select.value = preferred || "Qwen/Qwen3-8B";
+      }
+      if (!select.value && select.options.length > 0) {
+        select.selectedIndex = 0;
+      }
+    }
+
+    function loadFallbackOptions() {
+      state.options = fallbackOptions;
+      fillModelSelect(fallbackOptions.models || ["Qwen/Qwen3-8B"], [], ids("model-config-path").value || "Qwen/Qwen3-8B");
+      fillSelect(ids("system"), fallbackOptions.systems, ids("system").value || "h200_sxm");
+      fillSelect(ids("backend"), fallbackOptions.backends, ids("backend").value || "vllm");
+      refreshVersions();
+    }
+
+    function refreshVersions() {
+      if (!state.options) {
+        return;
+      }
+      const system = ids("system").value;
+      const backend = ids("backend").value;
+      const versionChoices = (((state.options.supported_databases || {})[system] || {})[backend]) || [];
+      const versionInput = ids("backend-version");
+      versionInput.placeholder = versionChoices.at(-1) || "Enter backend version";
+      if (!versionInput.value && versionChoices.length > 0) {
+        versionInput.value = versionChoices.at(-1);
+      }
+    }
+
+    async function loadOptions() {
+      const payload = await fetchJson("/api/v1/options");
+      state.options = payload;
+      fillModelSelect(payload.models || fallbackOptions.models || [], payload.local_model_configs || [], ids("model-config-path").value || "Qwen/Qwen3-8B");
+      const systems = Array.from(new Set([...(payload.systems || []), "l20", "h20"])).sort();
+      fillSelect(ids("system"), systems.length ? systems : fallbackOptions.systems, ids("system").value || "h200_sxm");
+      fillSelect(ids("backend"), (payload.backends || []).length ? payload.backends : fallbackOptions.backends, ids("backend").value || "vllm");
+      refreshVersions();
+    }
+
+    function renderComparison(payload) {
+      const comparison = payload.mode_comparison || {};
+      const recommended = payload.recommended_mode || payload.chosen_exp || "-";
+      ids("agg-config-card").classList.toggle("recommended", recommended === "agg");
+      ids("disagg-config-card").classList.toggle("recommended", recommended === "disagg");
+      renderTopConfigTable("agg-config-table", "agg", comparison.agg && comparison.agg.top1);
+      renderTopConfigTable("disagg-config-table", "disagg", comparison.disagg && comparison.disagg.top1);
+    }
+
+    function displayValue(value) {
+      if (value === null || value === undefined || value === "") {
+        return "-";
+      }
+      if (typeof value === "number") {
+        return Number.isInteger(value) ? String(value) : value.toFixed(2);
+      }
+      return String(value);
+    }
+
+    function renderTopConfigTable(targetId, mode, top1 = null) {
+      const target = ids(targetId);
+      if (!top1) {
+        target.innerHTML = "";
+        target.classList.add("table-empty");
+        return;
+      }
+      const table = buildTopConfigTable(mode, top1);
+      target.innerHTML = "";
+      target.classList.remove("table-empty");
+      target.appendChild(table);
+    }
+
+    function renderCandidateTable(targetId, mode, candidates = null, fallbackTop1 = null) {
+      if (!candidates || candidates.length === 0) {
+        renderTopConfigTable(targetId, mode, fallbackTop1);
+        return;
+      }
+      const target = ids(targetId);
+      target.innerHTML = "";
+      target.classList.remove("table-empty");
+      const table = document.createElement("table");
+      table.className = "config-table";
+      const headers = ["选择", "序号", "后端", "tokens/s/gpu", "req/s", "TTFT", "TPOT", "并行配置"];
+      const thead = document.createElement("thead");
+      const headRow = document.createElement("tr");
+      headers.forEach((header) => {
+        const th = document.createElement("th");
+        th.textContent = header;
+        headRow.appendChild(th);
+      });
+      thead.appendChild(headRow);
+      const tbody = document.createElement("tbody");
+      candidates.forEach((candidate) => {
+        const row = candidate.summary || {};
+        const tr = document.createElement("tr");
+        tr.dataset.mode = mode;
+        tr.dataset.rowIndex = candidate.row_index;
+        if (state.selected && state.selected.mode === mode && state.selected.rowIndex === candidate.row_index) {
+          tr.classList.add("selected-row");
+        }
+        const buttonCell = document.createElement("td");
+        const button = document.createElement("button");
+        button.className = "select-row-button";
+        button.type = "button";
+        button.textContent = "查看 DGD";
+        button.addEventListener("click", async () => {
+          try {
+            button.disabled = true;
+            button.textContent = "加载中";
+            await viewDgd(mode, candidate.row_index);
+          } catch (error) {
+            setStatus("失败");
+            setError(error.message);
+          } finally {
+            button.disabled = false;
+            button.textContent = "查看 DGD";
+          }
+        });
+        buttonCell.appendChild(button);
+        tr.appendChild(buttonCell);
+        [
+          candidate.row_index,
+          row["(d)backend"] || row["(p)backend"] || row.backend,
+          row["tokens/s/gpu"],
+          row.request_rate ?? row["seq/s"],
+          row.ttft,
+          row.tpot,
+          row.parallel || row["(p)parallel"] || row["(d)parallel"] || parallelLabel(row)
+        ].forEach((value) => {
+          const td = document.createElement("td");
+          td.textContent = displayValue(value);
+          tr.appendChild(td);
+        });
+        tr.addEventListener("dblclick", () => viewDgd(mode, candidate.row_index));
+        tbody.appendChild(tr);
+      });
+      table.appendChild(thead);
+      table.appendChild(tbody);
+      target.appendChild(table);
+    }
+
+    function buildTable(headers, values) {
+      const table = document.createElement("table");
+      table.className = "config-table";
+      const thead = document.createElement("thead");
+      const headRow = document.createElement("tr");
+      headers.forEach((header) => {
+        const th = document.createElement("th");
+        th.textContent = header;
+        headRow.appendChild(th);
+      });
+      thead.appendChild(headRow);
+      const tbody = document.createElement("tbody");
+      const bodyRow = document.createElement("tr");
+      values.forEach((value) => {
+        const td = document.createElement("td");
+        td.textContent = displayValue(value);
+        bodyRow.appendChild(td);
+      });
+      tbody.appendChild(bodyRow);
+      table.appendChild(thead);
+      table.appendChild(tbody);
+      return table;
+    }
+
+    function shortText(value, max = 44) {
+      const text = displayValue(value);
+      return text.length > max ? `${text.slice(0, max - 3)}...` : text;
+    }
+
+    async function refreshDeploymentRecords() {
+      const payload = await fetchJson("/api/v1/deployment-records");
+      renderDeploymentRecords(payload.records || []);
+      return payload;
+    }
+
+    function renderDeploymentRecords(records) {
+      const target = ids("deployment-records-table");
+      target.innerHTML = "";
+      if (!records.length) {
+        target.classList.add("table-empty");
+        target.textContent = "暂无部署记录。";
+        return;
+      }
+      target.classList.remove("table-empty");
+      const table = document.createElement("table");
+      table.className = "config-table";
+      const headers = [
+        "Action",
+        "Model",
+        "Run ID",
+        "推荐模式",
+        "Final Deployed DGD",
+        "Namespace",
+        "部署名称",
+        "部署时间",
+        "Status"
+      ];
+      const thead = document.createElement("thead");
+      const headRow = document.createElement("tr");
+      headers.forEach((header) => {
+        const th = document.createElement("th");
+        th.textContent = header;
+        headRow.appendChild(th);
+      });
+      thead.appendChild(headRow);
+      const tbody = document.createElement("tbody");
+      records.forEach((record) => {
+        const tr = document.createElement("tr");
+        const actionCell = document.createElement("td");
+        const actions = document.createElement("div");
+        actions.className = "record-actions";
+        const yamlButton = document.createElement("button");
+        yamlButton.className = "select-row-button";
+        yamlButton.type = "button";
+        yamlButton.textContent = "查看 YAML";
+        yamlButton.addEventListener("click", async () => {
+          try {
+            yamlButton.disabled = true;
+            yamlButton.textContent = "加载中";
+            await openRecord(record);
+          } catch (error) {
+            setStatus("失败");
+            setError(error.message);
+            setRecordsDgd(null, error.message);
+          } finally {
+            yamlButton.disabled = false;
+            yamlButton.textContent = "查看 YAML";
+          }
+        });
+        const copyButton = document.createElement("button");
+        copyButton.className = "secondary";
+        copyButton.type = "button";
+        copyButton.textContent = "复制运行 ID";
+        copyButton.addEventListener("click", async () => {
+          await copyTextToClipboard(record.jid);
+          copyButton.textContent = "已复制";
+          window.setTimeout(() => {
+            copyButton.textContent = "复制运行 ID";
+          }, 1200);
+        });
+        actions.appendChild(yamlButton);
+        actions.appendChild(copyButton);
+        actionCell.appendChild(actions);
+        tr.appendChild(actionCell);
+        [
+          record.served_model_name || record.model_path,
+          record.jid,
+          record.recommended_mode,
+          record.deployed_dgd_id,
+          record.namespace,
+          record.deployment_name,
+          record.deployed_at || record.created_at,
+          "已部署"
+        ].forEach((value, index) => {
+          const td = document.createElement("td");
+          td.textContent = index === 0 || index === 1 || index === 2 ? shortText(value) : displayValue(value);
+          td.title = displayValue(value);
+          tr.appendChild(td);
+        });
+        tbody.appendChild(tr);
+      });
+      table.appendChild(thead);
+      table.appendChild(tbody);
+      target.appendChild(table);
+    }
+
+    function numeric(value, fallback = 0) {
+      const parsed = Number(value);
+      return Number.isFinite(parsed) ? parsed : fallback;
+    }
+
+    function totalGpuBudget() {
+      return Math.max(1, numeric(ids("total-gpus").value, 1));
+    }
+
+    function replicaCount(gpusPerReplica) {
+      const gpus = numeric(gpusPerReplica, 0);
+      return gpus > 0 ? Math.max(1, Math.floor(totalGpuBudget() / gpus)) : 1;
+    }
+
+    function clusterThroughput(top1, gpusPerReplica, replicas) {
+      if (top1["tokens/s/gpu_cluster"] !== undefined) {
+        return top1["tokens/s/gpu_cluster"];
+      }
+      const budget = totalGpuBudget();
+      return budget > 0 ? numeric(top1["tokens/s/gpu"]) * replicas * numeric(gpusPerReplica) / budget : top1["tokens/s/gpu"];
+    }
+
+    function clusterRequestRate(top1, replicas) {
+      const requestRate = top1.request_rate ?? top1["seq/s"];
+      return numeric(requestRate) * replicas;
+    }
+
+    function clusterConcurrency(top1, replicas) {
+      const concurrency = numeric(top1.concurrency);
+      return `${displayValue(concurrency * replicas)} (=${displayValue(concurrency)}x${replicas})`;
+    }
+
+    function totalGpusUsedLabel(gpusPerReplica, replicas) {
+      const used = numeric(gpusPerReplica) * replicas;
+      return `${totalGpuBudget()} (${displayValue(used)}=${replicas}x${displayValue(gpusPerReplica)})`;
+    }
+
+    function parallelLabel(row, prefix = "") {
+      const get = (name, fallback = 1) => row[`${prefix}${name}`] ?? fallback;
+      const base = `tp${get("tp")}pp${get("pp")}`;
+      const dp = row[`${prefix}dp`] !== undefined ? `dp${get("dp")}` : "";
+      const moe = row[`${prefix}moe_tp`] !== undefined || row[`${prefix}moe_ep`] !== undefined
+        ? `etp${get("moe_tp")}ep${get("moe_ep")}`
+        : "";
+      return `${base}${dp}${moe}`;
+    }
+
+    function gpusWorkerLabel(row, prefix = "") {
+      const tp = numeric(row[`${prefix}tp`], 1);
+      const pp = numeric(row[`${prefix}pp`], 1);
+      const dp = numeric(row[`${prefix}dp`], 1);
+      const hasDp = row[`${prefix}dp`] !== undefined;
+      const total = tp * pp * (hasDp ? dp : 1);
+      return hasDp ? `${total} (=${tp}x${pp}x${dp})` : `${total} (=${tp}x${pp})`;
+    }
+
+    function buildTopConfigTable(mode, top1) {
+      if (mode === "disagg") {
+        const prefillWorkers = top1["(p)workers"];
+        const decodeWorkers = top1["(d)workers"];
+        const prefillGpus = numeric(top1["(p)tp"], 1) * numeric(top1["(p)pp"], 1) * numeric(top1["(p)dp"], 1);
+        const decodeGpus = numeric(top1["(d)tp"], 1) * numeric(top1["(d)pp"], 1) * numeric(top1["(d)dp"], 1);
+        const gpusPerReplica = numeric(top1.num_total_gpus) || numeric(prefillWorkers) * prefillGpus + numeric(decodeWorkers) * decodeGpus;
+        const replicas = replicaCount(gpusPerReplica);
+        return buildTable(
+          [
+            "Rank",
+            "backend",
+            "tokens/s/gpu",
+            "tokens/s/user",
+            "req/s",
+            "TTFT",
+            "TPOT",
+            "request_latency",
+            "concurrency",
+            "total_gpus (used)",
+            "replicas",
+            "gpus/replica",
+            "(p)workers",
+            "(p)gpus/worker",
+            "(p)parallel",
+            "(p)bs",
+            "(d)workers",
+            "(d)gpus/worker",
+            "(d)parallel",
+            "(d)bs"
+          ],
+          [
+            1,
+            top1["(d)backend"] || top1["(p)backend"] || top1.backend,
+            clusterThroughput(top1, gpusPerReplica, replicas),
+            top1["tokens/s/user"],
+            clusterRequestRate(top1, replicas),
+            top1.ttft,
+            top1.tpot,
+            top1.request_latency,
+            clusterConcurrency(top1, replicas),
+            totalGpusUsedLabel(gpusPerReplica, replicas),
+            replicas,
+            `${displayValue(gpusPerReplica)} (=${displayValue(prefillWorkers)}x${displayValue(prefillGpus)}+${displayValue(decodeWorkers)}x${displayValue(decodeGpus)})`,
+            prefillWorkers,
+            gpusWorkerLabel(top1, "(p)"),
+            top1["(p)parallel"] || parallelLabel(top1, "(p)"),
+            top1["(p)bs"],
+            decodeWorkers,
+            gpusWorkerLabel(top1, "(d)"),
+            top1["(d)parallel"] || parallelLabel(top1, "(d)"),
+            top1["(d)bs"]
+          ]
+        );
+      }
+      const gpusPerReplica = numeric(top1.num_total_gpus) || numeric(top1.tp, 1) * numeric(top1.pp, 1) * numeric(top1.dp, 1);
+      const replicas = replicaCount(gpusPerReplica);
+      return buildTable(
+        [
+          "Rank",
+          "backend",
+          "tokens/s/gpu",
+          "tokens/s/user",
+          "req/s",
+          "TTFT",
+          "TPOT",
+          "request_latency",
+          "concurrency",
+          "total_gpus (used)",
+          "replicas",
+          "gpus/replica",
+          "gpus/worker",
+          "parallel",
+          "bs"
+        ],
+        [
+          1,
+          top1.backend,
+          clusterThroughput(top1, gpusPerReplica, replicas),
+          top1["tokens/s/user"],
+          clusterRequestRate(top1, replicas),
+          top1.ttft,
+          top1.tpot,
+          top1.request_latency,
+          clusterConcurrency(top1, replicas),
+          totalGpusUsedLabel(gpusPerReplica, replicas),
+          replicas,
+          gpusPerReplica,
+          gpusWorkerLabel(top1),
+          top1.parallel || parallelLabel(top1),
+          top1.bs
+        ]
+      );
+    }
+
+    function setSelectedDgd(artifact, note = "") {
+      state.selectedArtifact = artifact || null;
+      const content = artifact && artifact.content ? artifact.content : "尚未生成。";
+      setCode("deployment-selected-output", content);
+      setText("current-dgd-id", artifact && artifact.dgd_id ? artifact.dgd_id : "无");
+      ids("dgd-yaml-note").textContent = note || (artifact
+        ? `${artifact.mode} row ${artifact.row_index ?? 0}`
+        : "尚未生成。");
+    }
+
+    function setRecordsDgd(artifact, note = "") {
+      const content = artifact && artifact.content ? artifact.content : "尚未生成。";
+      setCode("records-yaml-output", content);
+      ids("records-yaml-note").textContent = note || (artifact
+        ? `${artifact.dgd_id || `${artifact.mode} row ${artifact.row_index ?? 0}`}`
+        : "请选择记录或输入运行 ID。");
+    }
+
+    function getCachedDgd(mode, rowIndex = 0, payload = null) {
+      const source = payload || {};
+      const dgdId = source.jid ? `${source.jid}:${mode}:${rowIndex}` : null;
+      const cached = dgdId ? (source.dgds || {})[dgdId] : null;
+      if (cached && cached.content) {
+        return cached;
+      }
+      const artifact = ((source.artifacts_by_mode || state.lastDeployments || {})[mode]) || null;
+      if (artifact && artifact.content && Number(artifact.row_index || 0) === Number(rowIndex)) {
+        return artifact;
+      }
+      return null;
+    }
+
+    function renderDeployments(payload) {
+      const artifacts = payload.artifacts_by_mode || {};
+      state.jid = payload.jid || null;
+      state.lastDeployments = artifacts;
+      state.candidatesByMode = payload.candidates_by_mode || null;
+      state.modeComparison = payload.mode_comparison || null;
+      state.recommendedMode = payload.recommended_mode || null;
+      setText("current-jid", state.jid || "尚未生成");
+      ids("lookup-jid").value = state.jid || "";
+      const recommendedArtifact = payload.recommended_mode ? artifacts[payload.recommended_mode] : null;
+      if (recommendedArtifact) {
+        state.selected = {
+          mode: recommendedArtifact.mode || payload.recommended_mode,
+          rowIndex: recommendedArtifact.row_index ?? 0
+        };
+        setSelectedDgd(recommendedArtifact, `推荐方案：${state.selected.mode} Top 1。`);
+      } else {
+        state.selected = null;
+        setSelectedDgd(null);
+      }
+      if (payload.mode_comparison) {
+        renderComparison(payload);
+      }
+    }
+
+    async function loadRunById(jidOverride = null, expandYaml = true) {
+      const jid = (jidOverride || ids("lookup-jid").value).trim();
+      if (!jid) {
+        throw new Error("请先输入运行 ID。");
+      }
+      setStatus("正在加载记录");
+      setError("");
+      const record = await fetchJson(`/api/v1/runs/${encodeURIComponent(jid)}`);
+      const payload = record.payload || {};
+      if (!payload.jid) {
+        payload.jid = jid;
+      }
+      renderDeployments(payload);
+      state.selected = null;
+      setCode("estimate-output", jsonPretty(record));
+      const deployed = payload.deployed_dgd || null;
+      const mode = deployed ? deployed.mode : payload.recommended_mode || Object.keys(payload.candidates_by_mode || {})[0];
+      const rowIndex = deployed && deployed.row_index !== null && deployed.row_index !== undefined ? deployed.row_index : 0;
+      if (mode) {
+        await viewDgd(mode, rowIndex, deployed ? "Final deployed DGD." : "Generated only. Showing recommended top1 DGD.");
+      }
+      if (expandYaml) {
+        ids("dgd-yaml-details").open = true;
+        ids("dgd-yaml-section").scrollIntoView({ behavior: "smooth", block: "start" });
+      } else {
+        ids("recommended-result").scrollIntoView({ behavior: "smooth", block: "start" });
+      }
+      setStatus(deployed ? "已部署" : "已生成");
+      return record;
+    }
+
+    async function viewRecommendedDgd(mode) {
+      await viewDgd(mode, 0, `${mode} top1.`);
+      ids("dgd-yaml-details").open = true;
+      ids("dgd-yaml-section").scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+
+    async function loadRecordYamlById(jidOverride = null) {
+      const jid = (jidOverride || ids("lookup-jid").value).trim();
+      if (!jid) {
+        throw new Error("请先输入运行 ID。");
+      }
+      setStatus("正在加载记录");
+      setError("");
+      setRecordsDgd(null, "正在加载记录...");
+      const record = await fetchJson(`/api/v1/runs/${encodeURIComponent(jid)}`);
+      const payload = record.payload || {};
+      const deployed = payload.deployed_dgd || null;
+      const mode = deployed ? deployed.mode : payload.recommended_mode || Object.keys(payload.candidates_by_mode || {})[0];
+      const rowIndex = deployed && deployed.row_index !== null && deployed.row_index !== undefined ? deployed.row_index : 0;
+      if (!mode) {
+        throw new Error("该运行记录没有可显示的 DGD 模式。");
+      }
+      const cached = getCachedDgd(mode, rowIndex, payload);
+      const artifact = cached || await fetchJson(`/api/v1/runs/${encodeURIComponent(jid)}/dgd`, {
+        method: "POST",
+        body: JSON.stringify({ mode, row_index: rowIndex })
+      });
+      setRecordsDgd(artifact, deployed ? `Final deployed DGD: ${artifact.dgd_id}` : `Generated only. Showing recommended top1 DGD: ${artifact.dgd_id}`);
+      ids("records-yaml-section").scrollIntoView({ behavior: "smooth", block: "start" });
+      setStatus(deployed ? "已部署" : "已生成");
+      return record;
+    }
+
+    async function openRecord(record) {
+      ids("lookup-jid").value = record.jid;
+      return loadRecordYamlById(record.jid);
+    }
+
+    async function viewDgd(mode, rowIndex, note = "") {
+      if (!state.jid) {
+        throw new Error("请先生成部署方案，再查看 DGD。");
+      }
+      setStatus("正在查看 DGD");
+      setError("");
+      const cached = getCachedDgd(mode, rowIndex);
+      const payload = cached || await fetchJson(`/api/v1/runs/${encodeURIComponent(state.jid)}/dgd`, {
+        method: "POST",
+        body: JSON.stringify({ mode, row_index: rowIndex })
+      });
+      state.selected = { mode, rowIndex };
+      state.lastDeployments = state.lastDeployments || {};
+      state.lastDeployments[mode] = payload;
+      setSelectedDgd(payload, note || `${mode} row ${rowIndex}.`);
+      if (state.modeComparison) {
+        renderComparison({
+          mode_comparison: state.modeComparison,
+          candidates_by_mode: state.candidatesByMode,
+          recommended_mode: state.recommendedMode
+        });
+      }
+      setStatus("已生成");
+      return payload;
+    }
+
+    async function copyTextToClipboard(text) {
+      if (navigator.clipboard) {
+        await navigator.clipboard.writeText(text);
+        return;
+      }
+      const textArea = document.createElement("textarea");
+      textArea.value = text;
+      textArea.style.position = "fixed";
+      textArea.style.left = "-9999px";
+      document.body.appendChild(textArea);
+      textArea.focus();
+      textArea.select();
+      const copied = document.execCommand("copy");
+      textArea.remove();
+      if (!copied) {
+        throw new Error("复制失败");
+      }
+    }
+
+    function selectOutput(target) {
+      if ("select" in target) {
+        target.focus();
+        target.select();
+        return;
+      }
+      const range = document.createRange();
+      range.selectNodeContents(target);
+      const selection = window.getSelection();
+      selection.removeAllRanges();
+      selection.addRange(range);
+    }
+
+    async function copyOutput(button) {
+      const text = getCode(button.dataset.copyTarget);
+      if (!text || text === "尚未生成。") {
+        button.textContent = "无内容";
+      } else {
+        await copyTextToClipboard(text);
+        button.textContent = "已复制";
+      }
+      window.setTimeout(() => {
+        button.textContent = "复制";
+      }, 1200);
+    }
+
+    async function generateDeployments() {
+      setStatus("正在估算");
+      setError("");
+      setText("current-jid", "生成中...");
+      setText("current-dgd-id", "无");
+      setSelectedDgd(null, "正在估算，请稍候。");
+      const request = {
+        backend: ids("backend").value,
+        backend_version: ids("backend-version").value || null,
+        generator_overrides: buildGeneratorOverrides(),
+        estimate_request: buildEstimateRequest()
+      };
+      const payload = await fetchJson("/api/v1/generate-k8s-deployment", {
+        method: "POST",
+        body: JSON.stringify(request)
+      });
+      renderDeployments(payload);
+      await refreshDeploymentRecords();
+      setStatus("已生成");
+      if (payload.estimate) {
+        state.lastEstimate = payload.estimate;
+        setCode("estimate-output", jsonPretty(payload.estimate));
+      }
+    }
+
+    async function deploySelectedDgd() {
+      const content = getCode("deployment-selected-output");
+      if (!content || content === "尚未生成。" || content.startsWith("No ")) {
+        throw new Error("请先生成部署 YAML，再应用到集群。");
+      }
+      const selectedArtifact = state.selectedArtifact;
+      if (!selectedArtifact) {
+        throw new Error("请先选择一个 DGD 方案，再部署到集群。");
+      }
+      setStatus("正在部署");
+      setError("");
+      setCode("apply-output", `正在部署 ${selectedArtifact.dgd_id || selectedArtifact.mode}...`);
+      const payload = await fetchJson("/api/v1/apply-k8s-deployment", {
+        method: "POST",
+        body: JSON.stringify({
+          content,
+          namespace: ids("namespace").value.trim() || null,
+          timeout_seconds: 180,
+          jid: state.jid,
+          dgd_id: selectedArtifact.dgd_id,
+          mode: selectedArtifact.mode,
+          row_index: selectedArtifact.row_index ?? 0
+        })
+      });
+      setStatus("已部署");
+      setCode("apply-output", jsonPretty(payload));
+      await refreshDeploymentRecords();
+      return payload;
+    }
+
+    async function deleteSelectedDgd() {
+      const content = getCode("deployment-selected-output");
+      if (!content || content === "尚未生成。" || content.startsWith("No ")) {
+        throw new Error("请先加载已部署的 YAML，再从集群删除。");
+      }
+      const selectedArtifact = state.selectedArtifact;
+      if (!selectedArtifact) {
+        throw new Error("请先选择或加载一个已部署的 DGD，再从集群删除。");
+      }
+      const label = selectedArtifact.dgd_id || selectedArtifact.mode || "selected";
+      if (!window.confirm(`确定要从 Kubernetes 集群删除 ${label} 吗？`)) {
+        return null;
+      }
+      setStatus("正在删除");
+      setError("");
+      setCode("apply-output", `正在删除部署 ${label}...`);
+      const payload = await fetchJson("/api/v1/delete-k8s-deployment", {
+        method: "POST",
+        body: JSON.stringify({
+          content,
+          namespace: ids("namespace").value.trim() || null,
+          timeout_seconds: 180,
+          jid: state.jid,
+          dgd_id: selectedArtifact.dgd_id,
+          mode: selectedArtifact.mode,
+          row_index: selectedArtifact.row_index ?? 0
+        })
+      });
+      setStatus("已删除");
+      setCode("apply-output", jsonPretty(payload));
+      await refreshDeploymentRecords();
+      return payload;
+    }
+
+    function wireEvents() {
+      document.querySelectorAll(".tab-button").forEach((button) => {
+        button.addEventListener("click", () => {
+          switchTab(button.dataset.tab);
+        });
+      });
+      ids("load-options-btn").addEventListener("click", async () => {
+        try {
+          await loadOptions();
+        } catch (error) {
+          setStatus("失败");
+          setError(error.message);
+          setCode("estimate-output", error.message);
+        }
+      });
+      ids("load-run-btn").addEventListener("click", async () => {
+        const button = ids("load-run-btn");
+        try {
+          button.disabled = true;
+          button.textContent = "加载中...";
+          await loadRecordYamlById();
+        } catch (error) {
+          setStatus("失败");
+          setError(error.message);
+          setRecordsDgd(null, error.message);
+        } finally {
+          button.disabled = false;
+          button.textContent = "加载记录";
+        }
+      });
+      ids("refresh-records-btn").addEventListener("click", async () => {
+        const button = ids("refresh-records-btn");
+        try {
+          button.disabled = true;
+          button.textContent = "刷新中...";
+          await refreshDeploymentRecords();
+        } catch (error) {
+          setStatus("失败");
+          setError(error.message);
+        } finally {
+          button.disabled = false;
+          button.textContent = "刷新记录";
+        }
+      });
+
+      ids("system").addEventListener("change", refreshVersions);
+      ids("backend").addEventListener("change", refreshVersions);
+      ids("deployment-name").addEventListener("input", () => {
+        ids("deployment-name").dataset.auto = "false";
+      });
+      ids("model-path").addEventListener("input", () => {
+        if (!ids("served-model-name").value.trim()) {
+          ids("served-model-name").value = deriveServedModelName(ids("model-path").value);
+          syncDeploymentName(true);
+        }
+      });
+      ids("served-model-name").addEventListener("input", () => {
+        const input = ids("served-model-name");
+        const lower = input.value.toLowerCase();
+        if (input.value !== lower) {
+          input.value = lower;
+        }
+        syncDeploymentName();
+      });
+      document.querySelectorAll("[data-view-mode]").forEach((button) => {
+        button.addEventListener("click", async () => {
+          try {
+            button.disabled = true;
+            button.textContent = "加载中";
+            await viewRecommendedDgd(button.dataset.viewMode);
+          } catch (error) {
+            setStatus("失败");
+            setError(error.message);
+          } finally {
+            button.disabled = false;
+            button.textContent = "查看 YAML";
+          }
+        });
+      });
+      document.querySelectorAll("[data-copy-target]").forEach((button) => {
+        button.addEventListener("click", async () => {
+          try {
+            await copyOutput(button);
+          } catch (error) {
+            selectOutput(ids(button.dataset.copyTarget));
+            button.textContent = "已选择";
+            window.setTimeout(() => {
+              button.textContent = "复制";
+            }, 1200);
+          }
+        });
+      });
+      ids("deploy-selected-btn").addEventListener("click", async () => {
+        try {
+          await deploySelectedDgd();
+        } catch (error) {
+          setStatus("失败");
+          setError(error.message);
+          setCode("apply-output", error.message);
+        }
+      });
+      ids("delete-selected-btn").addEventListener("click", async () => {
+        try {
+          await deleteSelectedDgd();
+        } catch (error) {
+          setStatus("失败");
+          setError(error.message);
+          setCode("apply-output", error.message);
+        }
+      });
+
+      ids("deployment-btn").addEventListener("click", async () => {
+        const button = ids("deployment-btn");
+        try {
+          button.disabled = true;
+          button.textContent = "生成中...";
+          await generateDeployments();
+        } catch (error) {
+          setStatus("失败");
+          setError(error.message);
+          setSelectedDgd(null, "尚未生成。");
+        } finally {
+          button.disabled = false;
+          button.textContent = "生成部署方案";
+        }
+      });
+
+    }
+
+    async function init() {
+      wireEvents();
+      loadFallbackOptions();
+      ids("served-model-name").value = deriveServedModelName(ids("model-path").value);
+      syncDeploymentName(true);
+      try {
+        await loadOptions();
+        await refreshDeploymentRecords();
+      } catch (error) {
+        loadFallbackOptions();
+        setCode("estimate-output", `加载选项失败：${error.message}`);
+      }
+    }
+
+    init();
+  </script>
+</body>
+</html>

--- a/src/aiconfigurator/service/static/index.html
+++ b/src/aiconfigurator/service/static/index.html
@@ -455,7 +455,7 @@
   <div class="page">
     <section class="hero">
       <div class="card">
-        <h1>推理参数评估</h1>
+        <h1>部署参数评估</h1>
         <p class="subtitle">
           配置模型与性能目标，自动比较聚合式（agg）和分离式（disagg）部署方案，
           推荐更优配置并生成可直接使用的 Kubernetes YAML。

--- a/src/aiconfigurator/service/static/index.html
+++ b/src/aiconfigurator/service/static/index.html
@@ -186,13 +186,6 @@
       background: var(--good);
       box-shadow: 0 2px 8px rgba(15, 23, 42, 0.22);
     }
-    .yaml-delete-button {
-      padding: 7px 11px;
-      font-size: 12px;
-      color: #fff;
-      background: #dc2626;
-      box-shadow: 0 2px 8px rgba(15, 23, 42, 0.22);
-    }
     .note {
       margin-top: 14px;
       padding: 12px 14px;
@@ -649,7 +642,6 @@
               <div class="code-wrap">
                 <div class="yaml-actions">
                   <button class="yaml-deploy-button" id="deploy-selected-btn" type="button">部署所选方案</button>
-                  <button class="yaml-delete-button" id="delete-selected-btn" type="button">删除部署</button>
                   <button class="copy-button" data-copy-target="deployment-selected-output" type="button">复制</button>
                 </div>
                 <textarea class="codebox yaml-box yaml-editor" id="deployment-selected-output" spellcheck="false" autocomplete="off" autocorrect="off" autocapitalize="off">尚未生成。</textarea>
@@ -1645,40 +1637,6 @@
       return payload;
     }
 
-    async function deleteSelectedDgd() {
-      const content = getCode("deployment-selected-output");
-      if (!content || content === "尚未生成。" || content.startsWith("No ")) {
-        throw new Error("请先加载已部署的 YAML，再从集群删除。");
-      }
-      const selectedArtifact = state.selectedArtifact;
-      if (!selectedArtifact) {
-        throw new Error("请先选择或加载一个已部署的 DGD，再从集群删除。");
-      }
-      const label = selectedArtifact.dgd_id || selectedArtifact.mode || "selected";
-      if (!window.confirm(`确定要从 Kubernetes 集群删除 ${label} 吗？`)) {
-        return null;
-      }
-      setStatus("正在删除");
-      setError("");
-      setCode("apply-output", `正在删除部署 ${label}...`);
-      const payload = await fetchJson("/api/v1/delete-k8s-deployment", {
-        method: "POST",
-        body: JSON.stringify({
-          content,
-          namespace: ids("namespace").value.trim() || null,
-          timeout_seconds: 180,
-          jid: state.jid,
-          dgd_id: selectedArtifact.dgd_id,
-          mode: selectedArtifact.mode,
-          row_index: selectedArtifact.row_index ?? 0
-        })
-      });
-      setStatus("已删除");
-      setCode("apply-output", jsonPretty(payload));
-      await refreshDeploymentRecords();
-      return payload;
-    }
-
     function wireEvents() {
       document.querySelectorAll(".tab-button").forEach((button) => {
         button.addEventListener("click", () => {
@@ -1780,16 +1738,6 @@
           setCode("apply-output", error.message);
         }
       });
-      ids("delete-selected-btn").addEventListener("click", async () => {
-        try {
-          await deleteSelectedDgd();
-        } catch (error) {
-          setStatus("失败");
-          setError(error.message);
-          setCode("apply-output", error.message);
-        }
-      });
-
       ids("deployment-btn").addEventListener("click", async () => {
         const button = ids("deployment-btn");
         try {

--- a/src/aiconfigurator/service/static/index.html
+++ b/src/aiconfigurator/service/static/index.html
@@ -481,7 +481,7 @@
           <div class="field-full">
             <label for="model-path">模型路径</label>
             <input id="model-path" value="/data/models/qwen3-8b">
-            <input id="systems-paths" type="hidden" value="">
+            <input id="systems-paths" type="hidden" value="/data/aiconfigurator-data/aic-systems/systems">
           </div>
           <div class="field">
             <label for="system">GPU 类型</label>
@@ -517,23 +517,23 @@
           </div>
           <div class="field">
             <label for="total-gpus">GPU 总数</label>
-            <input id="total-gpus" type="number" value="8" min="1">
+            <input id="total-gpus" type="number" value="8" min="1" required>
           </div>
           <div class="field">
             <label for="isl">输入序列长度（ISL）</label>
-            <input id="isl" type="number" value="2048" min="1">
+            <input id="isl" type="number" value="2048" min="1" required>
           </div>
           <div class="field">
             <label for="osl">输出序列长度（OSL）</label>
-            <input id="osl" type="number" value="128" min="1">
+            <input id="osl" type="number" value="128" min="1" required>
           </div>
           <div class="field">
             <label for="ttft">首 Token 延迟（TTFT，ms）</label>
-            <input id="ttft" type="number" value="1000" min="1">
+            <input id="ttft" type="number" value="1000" min="1" required>
           </div>
           <div class="field">
             <label for="tpot">Token 间延迟（TPOT，ms）</label>
-            <input id="tpot" type="number" value="30" min="1">
+            <input id="tpot" type="number" value="30" min="1" required>
           </div>
           <div class="field">
             <label for="request-latency">请求延迟上限（可选）</label>
@@ -594,7 +594,7 @@
 
         <div class="note">
           “模型”决定性能估算使用的配置；“模型路径”会写入最终部署 YAML。
-          默认使用镜像内置的系统性能数据库。
+          系统数据目录固定为 <code>/data/aiconfigurator-data/aic-systems/systems</code>。
           当两种模式均可用时，系统会同时生成 agg 与 disagg 的 Top 1 方案。
         </div>
       </div>
@@ -809,6 +809,24 @@
         request_latency: requestLatency ? Number(requestLatency) : null,
         prefix: Number(ids("prefix").value || 0)
       };
+    }
+
+    function validateEstimateInputs() {
+      const requiredFields = [
+        ["total-gpus", "GPU 总数"],
+        ["isl", "输入序列长度（ISL）"],
+        ["osl", "输出序列长度（OSL）"],
+        ["ttft", "首 Token 延迟（TTFT）"],
+        ["tpot", "Token 间延迟（TPOT）"]
+      ];
+      for (const [id, label] of requiredFields) {
+        const input = ids(id);
+        const value = input.value.trim();
+        if (!value || !Number.isFinite(Number(value)) || Number(value) <= 0) {
+          input.focus();
+          throw new Error(`请填写有效的${label}，数值必须大于 0。`);
+        }
+      }
     }
 
     function buildGeneratorOverrides() {
@@ -1564,6 +1582,7 @@
     }
 
     async function generateDeployments() {
+      validateEstimateInputs();
       setStatus("正在估算");
       setError("");
       setText("current-jid", "生成中...");

--- a/src/aiconfigurator/service/static/index.html
+++ b/src/aiconfigurator/service/static/index.html
@@ -455,7 +455,7 @@
   <div class="page">
     <section class="hero">
       <div class="card">
-        <h1>推理服务部署</h1>
+        <h1>推理参数评估</h1>
         <p class="subtitle">
           配置模型与性能目标，自动比较聚合式（agg）和分离式（disagg）部署方案，
           推荐更优配置并生成可直接使用的 Kubernetes YAML。

--- a/src/aiconfigurator/service/static/index.html
+++ b/src/aiconfigurator/service/static/index.html
@@ -531,16 +531,12 @@
         <h2>基础配置</h2>
         <div class="grid">
           <div class="field-full">
-            <label for="model-config-path">模型</label>
+            <label for="model-config-path">OSS 模型（命名空间 / 模型 / 版本）</label>
             <select id="model-config-path">
-              <option value="Qwen/Qwen3-8B" selected>Qwen/Qwen3-8B</option>
+              <option value="" selected>正在从 OSS 加载模型...</option>
             </select>
           </div>
-          <div class="field-full">
-            <label for="model-path">模型路径</label>
-            <input id="model-path" value="/data/models/qwen3-8b">
-            <input id="systems-paths" type="hidden" value="/data/aiconfigurator-data/aic-systems/systems">
-          </div>
+          <input id="systems-paths" type="hidden" value="/data/aiconfigurator-data/aic-systems/systems">
           <div class="field">
             <label for="system">GPU 类型</label>
             <select id="system">
@@ -556,8 +552,6 @@
             <label for="backend">推理框架</label>
             <select id="backend">
               <option value="vllm" selected>vllm</option>
-              <option value="sglang">sglang</option>
-              <option value="trtllm">trtllm</option>
             </select>
           </div>
           <div class="field">
@@ -616,7 +610,7 @@
             </div>
             <div class="field-wide">
               <label for="image">Dynamo 镜像</label>
-              <input id="image" value="parties-hub.haiercash.com/nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1">
+              <input id="image" value="parties-hub.haiercash.com/nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1-mx-pip-0.4.1-s3fix6">
             </div>
             <div class="field">
               <label for="served-model-name">API 调用模型名称</label>
@@ -628,15 +622,20 @@
             </div>
             <div class="field">
               <label for="frontend-node">Frontend 节点</label>
-              <input id="frontend-node" value="kubeflow-master">
+              <input id="frontend-node" value="kubeflow-master2">
             </div>
             <div class="field">
               <label for="worker-node">Worker 节点</label>
-              <input id="worker-node" value="kubeflow-master">
+              <input id="worker-node" value="kubeflow-master2">
             </div>
             <input id="worker-working-dir" type="hidden" value="/workspace/examples/backends/vllm">
             <input id="frontend-image-pull-policy" type="hidden" value="IfNotPresent">
             <input id="worker-image-pull-policy" type="hidden" value="IfNotPresent">
+            <input id="oss-endpoint" type="hidden" value="https://oss-s3.haiercash.com">
+            <input id="oss-region" type="hidden" value="cn-east-1">
+            <input id="oss-secret-name" type="hidden" value="oss-s3-secret">
+            <input id="model-express-url" type="hidden" value="http://model-express-modelexpress.model-express.svc.cluster.local:8001">
+            <input id="oss-streamer-concurrency" type="hidden" value="4">
             <textarea id="worker-extra-envs" hidden>[
   {"name":"TRITON_CACHE_DIR","value":"/tmp/triton"},
   {"name":"XDG_CACHE_HOME","value":"/tmp/.cache"},
@@ -651,7 +650,7 @@
         </div>
 
         <div class="note">
-          “模型”决定性能估算使用的配置；“模型路径”会写入最终部署 YAML。
+          模型列表来自 OSS；所选版本同时用于性能估算和最终部署，不需要单独填写模型路径。
           系统数据目录固定为 <code>/data/aiconfigurator-data/aic-systems/systems</code>。
           当两种模式均可用时，系统会同时生成 agg 与 disagg 的 Top 1 方案。
         </div>
@@ -756,9 +755,9 @@
   <script>
     const ids = (name) => document.getElementById(name);
     const fallbackOptions = {
-      models: ["Qwen/Qwen3-8B"],
+      models: [],
       systems: ["h200_sxm", "h100_sxm", "b200_sxm", "gb200", "l20", "h20"],
-      backends: ["vllm", "sglang", "trtllm"],
+      backends: ["vllm"],
       supported_databases: {}
     };
     const state = {
@@ -830,8 +829,11 @@
       if (!cleaned) {
         return "";
       }
-      const lastSegment = cleaned.split(/[\\/]/).pop() || cleaned;
-      return lastSegment.replace(/[^A-Za-z0-9._-]+/g, "-").toLowerCase();
+      const segments = cleaned.split(/[\\/]/).filter(Boolean);
+      const modelSegment = cleaned.startsWith("s3://") && segments.length >= 2
+        ? segments.at(-2)
+        : segments.at(-1) || cleaned;
+      return modelSegment.replace(/[^A-Za-z0-9._-]+/g, "-").toLowerCase();
     }
 
     function deriveDeploymentName(servedModelName) {
@@ -873,6 +875,10 @@
     }
 
     function validateEstimateInputs() {
+      if (!ids("model-config-path").value.trim()) {
+        ids("model-config-path").focus();
+        throw new Error("OSS 中没有可用模型，请检查 Bucket、凭据和 config.json。");
+      }
       const requiredFields = [
         ["total-gpus", "GPU 总数"],
         ["isl", "输入序列长度（ISL）"],
@@ -895,7 +901,7 @@
     }
 
     function buildGeneratorOverrides() {
-      const modelPath = ids("model-path").value.trim();
+      const modelPath = ids("model-config-path").value.trim();
       const servedModelName = (ids("served-model-name").value.trim() || deriveServedModelName(modelPath)).toLowerCase();
       const deploymentName = (ids("deployment-name").value.trim() || deriveDeploymentName(servedModelName)).toLowerCase();
       return {
@@ -912,39 +918,23 @@
           frontend_image_pull_policy: ids("frontend-image-pull-policy").value.trim(),
           worker_image_pull_policy: ids("worker-image-pull-policy").value.trim(),
           worker_working_dir: ids("worker-working-dir").value.trim(),
+          oss_enabled: true,
+          oss_endpoint_url: ids("oss-endpoint").value.trim(),
+          oss_region: ids("oss-region").value.trim(),
+          oss_secret_name: ids("oss-secret-name").value.trim(),
+          oss_model_express_url: ids("model-express-url").value.trim(),
+          oss_streamer_concurrency: Number(ids("oss-streamer-concurrency").value || 4),
           frontend_node_selector: {
             "kubernetes.io/hostname": ids("frontend-node").value.trim()
           },
           worker_node_selector: {
             "kubernetes.io/hostname": ids("worker-node").value.trim()
           },
-          frontend_extra_volumes: [
-            {
-              name: "model-dir",
-              hostPath: { path: modelPath, type: "Directory" }
-            }
-          ],
           worker_extra_volumes: [
-            {
-              name: "model-dir",
-              hostPath: { path: modelPath, type: "Directory" }
-            },
             { name: "triton-cache", emptyDir: {} },
             { name: "xdg-cache", emptyDir: {} }
           ],
-          frontend_extra_volume_mounts: [
-            {
-              name: "model-dir",
-              mountPath: modelPath,
-              readOnly: true
-            }
-          ],
           worker_extra_volume_mounts: [
-            {
-              name: "model-dir",
-              mountPath: modelPath,
-              readOnly: true
-            },
             {
               name: "triton-cache",
               mountPath: "/tmp/triton"
@@ -1000,7 +990,7 @@
       }
     }
 
-    function fillModelSelect(models = [], localModelConfigs = [], preferred = "") {
+    function fillModelSelect(models = [], preferred = "") {
       const select = ids("model-config-path");
       select.innerHTML = "";
 
@@ -1022,17 +1012,20 @@
         select.appendChild(group);
       };
 
-      const builtInItems = (models || []).map((model) => ({ label: model, value: model }));
-      const localItems = (localModelConfigs || []).map((item) => ({
-        label: `Local: ${item.label}`,
-        value: item.value
-      }));
-
-      addGroup("Built-in Models", builtInItems);
-      addGroup("/data/model-configs", localItems);
+      const builtInItems = (models || []).map((model) => ({
+        label: model.replace(/^s3:\/\/[^/]+\//, ""),
+        value: model
+      })).sort((left, right) => {
+        const leftParts = left.label.split("/");
+        const rightParts = right.label.split("/");
+        const leftModel = leftParts.slice(0, -1).join("/");
+        const rightModel = rightParts.slice(0, -1).join("/");
+        return leftModel.localeCompare(rightModel) || rightParts.at(-1).localeCompare(leftParts.at(-1));
+      });
+      addGroup("OSS Models", builtInItems);
 
       if (!select.value) {
-        select.value = preferred || "Qwen/Qwen3-8B";
+        select.value = preferred;
       }
       if (!select.value && select.options.length > 0) {
         select.selectedIndex = 0;
@@ -1041,7 +1034,7 @@
 
     function loadFallbackOptions() {
       state.options = fallbackOptions;
-      fillModelSelect(fallbackOptions.models || ["Qwen/Qwen3-8B"], [], ids("model-config-path").value || "Qwen/Qwen3-8B");
+      fillModelSelect(fallbackOptions.models || [], ids("model-config-path").value);
       fillSelect(ids("system"), fallbackOptions.systems, ids("system").value || "h200_sxm");
       fillSelect(ids("backend"), fallbackOptions.backends, ids("backend").value || "vllm");
       refreshVersions();
@@ -1064,10 +1057,12 @@
     async function loadOptions() {
       const payload = await fetchJson("/api/v1/options");
       state.options = payload;
-      fillModelSelect(payload.models || fallbackOptions.models || [], payload.local_model_configs || [], ids("model-config-path").value || "Qwen/Qwen3-8B");
+      fillModelSelect(payload.models || [], ids("model-config-path").value);
+      ids("served-model-name").value = deriveServedModelName(ids("model-config-path").value);
+      syncDeploymentName(true);
       const systems = Array.from(new Set([...(payload.systems || []), "l20", "h20"])).sort();
       fillSelect(ids("system"), systems.length ? systems : fallbackOptions.systems, ids("system").value || "h200_sxm");
-      fillSelect(ids("backend"), (payload.backends || []).length ? payload.backends : fallbackOptions.backends, ids("backend").value || "vllm");
+      fillSelect(ids("backend"), ["vllm"], "vllm");
       refreshVersions();
     }
 
@@ -1752,11 +1747,9 @@
       ids("deployment-name").addEventListener("input", () => {
         ids("deployment-name").dataset.auto = "false";
       });
-      ids("model-path").addEventListener("input", () => {
-        if (!ids("served-model-name").value.trim()) {
-          ids("served-model-name").value = deriveServedModelName(ids("model-path").value);
-          syncDeploymentName(true);
-        }
+      ids("model-config-path").addEventListener("change", () => {
+        ids("served-model-name").value = deriveServedModelName(ids("model-config-path").value);
+        syncDeploymentName(true);
       });
       ids("served-model-name").addEventListener("input", () => {
         const input = ids("served-model-name");
@@ -1824,7 +1817,7 @@
     async function init() {
       wireEvents();
       loadFallbackOptions();
-      ids("served-model-name").value = deriveServedModelName(ids("model-path").value);
+      ids("served-model-name").value = deriveServedModelName(ids("model-config-path").value);
       syncDeploymentName(true);
       try {
         await loadOptions();

--- a/tests/unit/generator/test_aggregators.py
+++ b/tests/unit/generator/test_aggregators.py
@@ -9,6 +9,40 @@ from aiconfigurator.generator.aggregators import collect_generator_params
 
 
 @pytest.mark.unit
+class TestDeploymentName:
+    """Test DGD deployment name selection."""
+
+    @pytest.mark.parametrize("mode", ["agg", "disagg"])
+    def test_ui_deployment_name_takes_priority(self, mode):
+        result = collect_generator_params(
+            service={"model_path": "test/model", "served_model_name": "test-model"},
+            k8s={
+                "name": "ui-deployment-name",
+                "name_prefix": "ignored-prefix",
+                "k8s_namespace": "dynamo",
+            },
+            dyn_config={"mode": mode},
+            backend="vllm",
+        )
+
+        assert result["K8sConfig"]["name"] == "ui-deployment-name"
+
+    @pytest.mark.parametrize(
+        "mode,expected_name",
+        [("agg", "custom-agg"), ("disagg", "custom-disagg")],
+    )
+    def test_generated_name_remains_the_fallback(self, mode, expected_name):
+        result = collect_generator_params(
+            service={"model_path": "test/model", "served_model_name": "test-model"},
+            k8s={"name_prefix": "custom", "k8s_namespace": "dynamo"},
+            dyn_config={"mode": mode},
+            backend="vllm",
+        )
+
+        assert result["K8sConfig"]["name"] == expected_name
+
+
+@pytest.mark.unit
 class TestK8sHfHomeDefaulting:
     """Test k8s_hf_home auto-defaulting behavior."""
 

--- a/tests/unit/generator/test_vllm_minimal_k8s_args.py
+++ b/tests/unit/generator/test_vllm_minimal_k8s_args.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from aiconfigurator.generator.rendering.engine import _filter_vllm_k8s_cli_args
+
+
+@pytest.mark.unit
+def test_filter_vllm_k8s_cli_args_keeps_safe_minimum():
+    cli_args = [
+        "--tensor-parallel-size",
+        "2",
+        "--pipeline-parallel-size",
+        "1",
+        "--data-parallel-size",
+        "4",
+        "--enable-expert-parallel",
+        "--kv-cache-dtype",
+        "auto",
+        "--max-model-len",
+        "32768",
+        "--max-num-batched-tokens",
+        "8192",
+        "--skip-tokenizer-init",
+        "--trust-remote-code",
+        "--no-enable-prefix-caching",
+        "--speculative-config",
+        '{"method":"mtp","num_speculative_tokens":1}',
+    ]
+
+    assert _filter_vllm_k8s_cli_args(cli_args) == cli_args
+
+
+@pytest.mark.unit
+def test_filter_vllm_k8s_cli_args_removes_performance_recommendations():
+    cli_args = [
+        "--tensor-parallel-size",
+        "2",
+        "--block-size",
+        "16",
+        "--max-num-seqs",
+        "64",
+        "--enforce-eager",
+        "--cudagraph-capture-sizes",
+        "1",
+        "2",
+        "4",
+        "--max-model-len",
+        "32768",
+    ]
+
+    assert _filter_vllm_k8s_cli_args(cli_args) == [
+        "--tensor-parallel-size",
+        "2",
+        "--max-model-len",
+        "32768",
+    ]

--- a/tests/unit/generator/test_vllm_oss_deployment.py
+++ b/tests/unit/generator/test_vllm_oss_deployment.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import pytest
+import yaml
+from jinja2 import Environment, FileSystemLoader
+
+from aiconfigurator.generator.rendering import apply_defaults
+
+
+@pytest.mark.unit
+def test_s3_model_path_enables_oss_defaults():
+    service = apply_defaults(
+        "ServiceConfig",
+        {"model_path": "s3://aiplat/ai-lab/qwen3-0.6b/2026-07-01"},
+        backend="vllm",
+    )
+    k8s = apply_defaults(
+        "K8sConfig",
+        {},
+        backend="vllm",
+        extra_context={"ServiceConfig": service, "generator_dynamo_version": "1.1.1"},
+    )
+
+    assert service["served_model_name"] == "qwen3-0.6b"
+    assert k8s["oss_enabled"] is True
+    assert k8s["oss_endpoint_url"] == "https://oss-s3.haiercash.com"
+    assert k8s["k8s_image"].endswith("1.1.1-mx-pip-0.4.1-s3fix6")
+
+
+@pytest.mark.unit
+def test_vllm_oss_deployment_uses_model_express_and_secret_refs():
+    template_dir = Path("src/aiconfigurator/generator/config/backend_templates/vllm")
+    template = Environment(loader=FileSystemLoader(template_dir)).get_template("k8s_deploy.yaml.j2")
+    rendered = template.render(
+        working_dir="/workspace/examples/backends/vllm",
+        K8sConfig={
+            "oss_enabled": True,
+            "oss_endpoint_url": "https://oss-s3.haiercash.com",
+            "oss_region": "cn-east-1",
+            "oss_secret_name": "oss-s3-secret",
+            "oss_model_express_url": "http://model-express:8001",
+            "oss_streamer_concurrency": 4,
+            "k8s_namespace": "aic-system",
+            "k8s_image": "example/vllm:modelexpress",
+            "frontend_node_selector": {"kubernetes.io/hostname": "master2"},
+            "worker_node_selector": {"kubernetes.io/hostname": "master2"},
+        },
+        ServiceConfig={
+            "model_path": "s3://aiplat/ai-lab/qwen3-0.6b/2026-07-01",
+            "served_model_name": "qwen3-0.6b",
+        },
+        DynConfig={"mode": "agg", "enable_router": False},
+        name="dynamo-qwen3-oss",
+        frontend_replicas=1,
+        agg_workers=1,
+        agg_gpu=1,
+        agg_cli_args_list=["--tensor-parallel-size", "1", "--max-model-len", "4096"],
+    )
+
+    deployment = yaml.safe_load(rendered)
+    worker = deployment["spec"]["services"]["VllmWorker"]["extraPodSpec"]["mainContainer"]
+    script = worker["args"][0]
+    env = {item["name"]: item for item in worker["env"]}
+
+    assert env["MX_MODEL_URI"]["value"] == "s3://aiplat/ai-lab/qwen3-0.6b/2026-07-01"
+    assert env["AWS_ENDPOINT_URL"]["value"] == "https://oss-s3.haiercash.com"
+    assert env["AWS_ACCESS_KEY_ID"]["valueFrom"]["secretKeyRef"]["name"] == "oss-s3-secret"
+    assert "--load-format modelexpress" in script
+    assert 'worker_cmd+=( "--tensor-parallel-size" )' in script
+    assert "config.json" in script

--- a/tests/unit/sdk/test_s3_models.py
+++ b/tests/unit/sdk/test_s3_models.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import io
+
+import pytest
+
+from aiconfigurator.sdk import s3_models
+
+
+class _FakeS3:
+    def __init__(self):
+        self.pages = [
+            {
+                "Contents": [
+                    {"Key": "ai-lab/qwen3-0.6b/2026-06-01/config.json"},
+                    {"Key": "ai-lab/qwen3-0.6b/2026-07-01/config.json"},
+                    {"Key": "ai-lab/qwen3-0.6b/README.md"},
+                    {"Key": "invalid/config.json"},
+                ],
+                "NextContinuationToken": "next",
+            },
+            {"Contents": [{"Key": "other/model/2026-05-01/config.json"}]},
+        ]
+
+    def list_objects_v2(self, **kwargs):
+        return self.pages[1] if kwargs.get("ContinuationToken") else self.pages[0]
+
+    def get_object(self, **kwargs):
+        assert kwargs["Bucket"] == "aiplat"
+        assert kwargs["Key"] == "ai-lab/qwen3-0.6b/2026-07-01/config.json"
+        return {"Body": io.BytesIO(b'{"architectures":["Qwen3ForCausalLM"]}')}
+
+
+@pytest.fixture(autouse=True)
+def _clear_s3_caches():
+    s3_models.get_s3_client.cache_clear()
+    s3_models.load_s3_json.cache_clear()
+
+
+def test_parse_s3_model_uri_requires_versioned_layout():
+    location = s3_models.parse_s3_model_uri("s3://aiplat/ai-lab/qwen3-0.6b/2026-07-01")
+    assert location.namespace == "ai-lab"
+    assert location.model_name == "qwen3-0.6b"
+    assert location.model_version == "2026-07-01"
+
+    with pytest.raises(s3_models.S3ModelError, match="expected s3://bucket"):
+        s3_models.parse_s3_model_uri("s3://aiplat/ai-lab/qwen3-0.6b")
+
+
+def test_list_s3_models_discovers_config_json_and_sorts_latest_first(monkeypatch):
+    monkeypatch.setattr(s3_models, "get_s3_client", lambda: _FakeS3())
+
+    models = s3_models.list_s3_models("aiplat")
+
+    assert [item.uri for item in models] == [
+        "s3://aiplat/ai-lab/qwen3-0.6b/2026-07-01",
+        "s3://aiplat/ai-lab/qwen3-0.6b/2026-06-01",
+        "s3://aiplat/other/model/2026-05-01",
+    ]
+
+
+def test_load_s3_json_reads_model_metadata(monkeypatch):
+    monkeypatch.setattr(s3_models, "get_s3_client", lambda: _FakeS3())
+    assert s3_models.load_s3_json("s3://aiplat/ai-lab/qwen3-0.6b/2026-07-01", "config.json") == {
+        "architectures": ["Qwen3ForCausalLM"]
+    }

--- a/tests/unit/service/test_api.py
+++ b/tests/unit/service/test_api.py
@@ -1,0 +1,350 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+pandas = pytest.importorskip("pandas")
+
+from fastapi.testclient import TestClient
+
+from aiconfigurator.cli.api import CLIResult
+from aiconfigurator.service.app import create_app
+
+
+def _client():
+    return TestClient(create_app())
+
+
+@pytest.fixture(autouse=True)
+def _run_store(monkeypatch, tmp_path):
+    monkeypatch.setenv("AIC_SERVICE_RUN_STORE", str(tmp_path / "runs.json"))
+
+
+def test_options_returns_quant_modes(monkeypatch):
+    class FakeDatabase:
+        supported_quant_mode: ClassVar = {"gemm": ["bfloat16", "fp8"], "moe": ["bfloat16"]}
+
+    monkeypatch.setattr(
+        "aiconfigurator.service.app.get_default_models",
+        lambda: {"Qwen/Qwen3-8B", "Qwen/Qwen3-32B"},
+    )
+    monkeypatch.setattr(
+        "aiconfigurator.service.app.get_supported_databases",
+        lambda: {"h200_sxm": {"vllm": ["0.19.0"]}},
+    )
+    monkeypatch.setattr("aiconfigurator.service.app.get_database", lambda system, backend, version: FakeDatabase())
+
+    response = _client().get("/api/v1/options?system=h200_sxm&backend=vllm&version=0.19.0")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["systems"] == ["h200_sxm"]
+    assert payload["quant_modes"]["gemm"] == ["bfloat16", "fp8"]
+
+
+def test_estimate_returns_serialized_cli_result(monkeypatch):
+    monkeypatch.setattr("aiconfigurator.service.app.get_database", lambda **kwargs: object())
+    best_df = pandas.DataFrame([{"parallel": "tp4pp1", "tokens/s/gpu": 123.4, "ttft": 250.0, "tpot": 8.0}])
+    disagg_df = pandas.DataFrame([{"parallel": "tp2pp1", "tokens/s/gpu": 111.1, "ttft": 280.0, "tpot": 10.0}])
+    pareto_df = pandas.DataFrame([{"parallel": "tp4pp1", "tokens/s/gpu": 123.4}])
+    result = CLIResult(
+        chosen_exp="agg",
+        best_configs={"agg": best_df, "disagg": disagg_df},
+        pareto_fronts={"agg": pareto_df, "disagg": disagg_df},
+        best_throughputs={"agg": 123.4, "disagg": 111.1},
+        best_latencies={"agg": {"ttft": 250.0, "tpot": 8.0}, "disagg": {"ttft": 280.0, "tpot": 10.0}},
+        task_configs={},
+    )
+    monkeypatch.setattr("aiconfigurator.service.app.cli_default", lambda **kwargs: result)
+
+    response = _client().post(
+        "/api/v1/estimate",
+        json={
+            "model_path": "Qwen/Qwen3-8B",
+            "total_gpus": 8,
+            "system": "h200_sxm",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["chosen_exp"] == "agg"
+    assert payload["recommended_mode"] == "agg"
+    assert payload["mode_comparison"]["agg"]["top1"]["parallel"] == "tp4pp1"
+    assert payload["mode_comparison"]["disagg"]["top1"]["parallel"] == "tp2pp1"
+    assert payload["best_configs"]["agg"][0]["parallel"] == "tp4pp1"
+    assert payload["normalized_input"]["model_path"] == "Qwen/Qwen3-8B"
+
+
+def test_generate_k8s_deployment_direct_params(monkeypatch):
+    monkeypatch.setattr(
+        "aiconfigurator.service.app.prepare_generator_params",
+        lambda config_path, overrides, backend: {
+            "ServiceConfig": {"model_path": "Qwen/Qwen3-8B"},
+            "K8sConfig": {"k8s_namespace": "ai-platform"},
+        },
+    )
+    monkeypatch.setattr(
+        "aiconfigurator.service.app.generate_backend_artifacts",
+        lambda **kwargs: {
+            "k8s_deploy.yaml": "kind: Deployment\nmetadata:\n  name: demo\n",
+            "run.sh": "#!/bin/bash\necho hello\n",
+        },
+    )
+
+    response = _client().post(
+        "/api/v1/generate-k8s-deployment",
+        json={
+            "backend": "vllm",
+            "direct_generator_params": {
+                "ServiceConfig": {"model_path": "Qwen/Qwen3-8B"},
+                "K8sConfig": {"k8s_namespace": "ai-platform"},
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["artifact_name"] == "k8s_deploy.yaml"
+    assert "kind: Deployment" in payload["content"]
+    assert "run.sh" in payload["extras"]
+    assert payload["jid"].startswith("aic-")
+    assert payload["dgd_id"] == f"{payload['jid']}:direct:0"
+
+    run_response = _client().get(f"/api/v1/runs/{payload['jid']}")
+    assert run_response.status_code == 200
+    assert run_response.json()["payload"]["content"] == payload["content"]
+
+
+def test_delete_k8s_deployment_removes_deployed_record(monkeypatch):
+    monkeypatch.setattr(
+        "aiconfigurator.service.app.prepare_generator_params",
+        lambda config_path, overrides, backend: {
+            "ServiceConfig": {"model_path": "Qwen/Qwen3-8B"},
+            "K8sConfig": {"k8s_namespace": "ai-platform", "name": "demo"},
+        },
+    )
+    monkeypatch.setattr(
+        "aiconfigurator.service.app.generate_backend_artifacts",
+        lambda **kwargs: {
+            "k8s_deploy.yaml": "kind: Deployment\nmetadata:\n  name: demo\n  namespace: ai-platform\n",
+        },
+    )
+    monkeypatch.setattr("aiconfigurator.service.app.shutil.which", lambda command: "/usr/bin/kubectl")
+
+    calls = []
+
+    class Result:
+        returncode = 0
+        stdout = "ok"
+        stderr = ""
+
+    def fake_run_kubectl(args, stdin=None, timeout=180):
+        calls.append((args, stdin, timeout))
+        return Result()
+
+    monkeypatch.setattr("aiconfigurator.service.app._run_kubectl", fake_run_kubectl)
+
+    client = _client()
+    generated = client.post(
+        "/api/v1/generate-k8s-deployment",
+        json={
+            "backend": "vllm",
+            "direct_generator_params": {
+                "ServiceConfig": {"model_path": "Qwen/Qwen3-8B"},
+                "K8sConfig": {"k8s_namespace": "ai-platform", "name": "demo"},
+            },
+        },
+    ).json()
+
+    apply_response = client.post(
+        "/api/v1/apply-k8s-deployment",
+        json={
+            "content": generated["content"],
+            "namespace": "ai-platform",
+            "jid": generated["jid"],
+            "dgd_id": generated["dgd_id"],
+            "mode": "direct",
+            "row_index": 0,
+        },
+    )
+    assert apply_response.status_code == 200
+    assert client.get("/api/v1/deployment-records").json()["records"][0]["jid"] == generated["jid"]
+
+    delete_response = client.post(
+        "/api/v1/delete-k8s-deployment",
+        json={
+            "content": generated["content"],
+            "namespace": "ai-platform",
+            "jid": generated["jid"],
+            "dgd_id": generated["dgd_id"],
+            "mode": "direct",
+            "row_index": 0,
+        },
+    )
+
+    assert delete_response.status_code == 200
+    assert delete_response.json()["deleted"] is True
+    assert calls[-1][0] == ["kubectl", "delete", "-f", "-", "--ignore-not-found=true"]
+    assert client.get("/api/v1/deployment-records").json()["records"] == []
+
+    run_payload = client.get(f"/api/v1/runs/{generated['jid']}").json()["payload"]
+    assert "deployed_dgd" not in run_payload
+    assert run_payload["deleted_dgd"]["dgd_id"] == generated["dgd_id"]
+
+
+def test_generate_k8s_deployment_accepts_structured_k8s_overrides(monkeypatch):
+    captured = {}
+
+    def _prepare(config_path, overrides, backend):
+        captured["overrides"] = overrides
+        return {"K8sConfig": overrides.get("K8sConfig", {})}
+
+    monkeypatch.setattr("aiconfigurator.service.app.prepare_generator_params", _prepare)
+    monkeypatch.setattr(
+        "aiconfigurator.service.app.generate_backend_artifacts",
+        lambda **kwargs: {"k8s_deploy.yaml": "kind: Deployment\n"},
+    )
+
+    response = _client().post(
+        "/api/v1/generate-k8s-deployment",
+        json={
+            "backend": "vllm",
+            "direct_generator_params": {"ServiceConfig": {"model_path": "Qwen/Qwen3-8B"}},
+            "generator_overrides": {
+                "k8s_config": {
+                    "name": "dynamo-agg-test",
+                    "frontend_node_selector": {"kubernetes.io/hostname": "kubeflow-master"},
+                    "worker_extra_envs": [{"name": "HOME", "value": "/tmp"}],
+                }
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    assert captured["overrides"]["K8sConfig"]["name"] == "dynamo-agg-test"
+    assert captured["overrides"]["K8sConfig"]["frontend_node_selector"]["kubernetes.io/hostname"] == "kubeflow-master"
+    assert captured["overrides"]["K8sConfig"]["worker_extra_envs"][0]["name"] == "HOME"
+
+
+def test_generate_k8s_benchmark_from_estimate(monkeypatch):
+    monkeypatch.setattr("aiconfigurator.service.app.get_database", lambda **kwargs: object())
+    best_df = pandas.DataFrame([{"parallel": "tp8pp1", "tokens/s/gpu": 321.0, "ttft": 210.0, "tpot": 9.0}])
+    result = CLIResult(
+        chosen_exp="agg",
+        best_configs={"agg": best_df},
+        pareto_fronts={"agg": best_df},
+        best_throughputs={"agg": 321.0},
+        best_latencies={"agg": {"ttft": 210.0, "tpot": 9.0}},
+        task_configs={"agg": object()},
+    )
+    monkeypatch.setattr("aiconfigurator.service.app.cli_default", lambda **kwargs: result)
+    monkeypatch.setattr(
+        "aiconfigurator.service.app.task_config_to_generator_config",
+        lambda task_config, row, generator_overrides=None: {"BenchConfig": {"model": "Qwen/Qwen3-8B"}},
+    )
+    monkeypatch.setattr(
+        "aiconfigurator.service.app.generate_backend_artifacts",
+        lambda **kwargs: {
+            "k8s_bench.yaml": "kind: Job\nmetadata:\n  name: bench\n",
+            "bench_run.sh": "#!/bin/bash\necho bench\n",
+        },
+    )
+
+    response = _client().post(
+        "/api/v1/generate-k8s-benchmark",
+        json={
+            "backend": "trtllm",
+            "estimate_request": {
+                "model_path": "Qwen/Qwen3-8B",
+                "total_gpus": 8,
+                "system": "h200_sxm",
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["artifact_name"] == "k8s_bench.yaml"
+    assert "kind: Job" in payload["content"]
+    assert "bench_run.sh" in payload["extras"]
+
+
+def test_generate_k8s_deployment_from_estimate_returns_top1_for_agg_and_disagg(monkeypatch):
+    monkeypatch.setattr("aiconfigurator.service.app.get_database", lambda **kwargs: object())
+    agg_df = pandas.DataFrame(
+        [
+            {"parallel": "tp8pp1", "tokens/s/gpu": 321.0, "ttft": 210.0, "tpot": 9.0},
+            {"parallel": "tp4pp1", "tokens/s/gpu": 300.0, "ttft": 215.0, "tpot": 10.0},
+        ]
+    )
+    disagg_df = pandas.DataFrame([{"parallel": "tp4pp1", "tokens/s/gpu": 280.0, "ttft": 190.0, "tpot": 12.0}])
+    result = CLIResult(
+        chosen_exp="agg",
+        best_configs={"agg": agg_df, "disagg": disagg_df},
+        pareto_fronts={"agg": agg_df, "disagg": disagg_df},
+        best_throughputs={"agg": 321.0, "disagg": 280.0},
+        best_latencies={"agg": {"ttft": 210.0, "tpot": 9.0}, "disagg": {"ttft": 190.0, "tpot": 12.0}},
+        task_configs={"agg": object(), "disagg": object()},
+    )
+    monkeypatch.setattr("aiconfigurator.service.app.cli_default", lambda **kwargs: result)
+    monkeypatch.setattr(
+        "aiconfigurator.service.app.task_config_to_generator_config",
+        lambda task_config, row, generator_overrides=None: {
+            "DynConfig": {"mode": "agg" if task_config is result.task_configs["agg"] else "disagg"},
+            "row_parallel": row["parallel"],
+        },
+    )
+    monkeypatch.setattr(
+        "aiconfigurator.service.app.generate_backend_artifacts",
+        lambda **kwargs: {
+            "k8s_deploy.yaml": (
+                f"kind: Deployment\n"
+                f"mode: {kwargs['params']['DynConfig']['mode']}\n"
+                f"row: {kwargs['params']['row_parallel']}\n"
+            ),
+            "run.sh": "#!/bin/bash\n",
+        },
+    )
+
+    response = _client().post(
+        "/api/v1/generate-k8s-deployment",
+        json={
+            "backend": "vllm",
+            "estimate_request": {
+                "model_path": "Qwen/Qwen3-8B",
+                "total_gpus": 8,
+                "system": "h200_sxm",
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["recommended_mode"] == "agg"
+    assert payload["jid"].startswith("aic-")
+    assert payload["candidates_by_mode"]["agg"][1]["row_index"] == 1
+    assert payload["candidates_by_mode"]["agg"][1]["dgd_id"] == f"{payload['jid']}:agg:1"
+    assert "agg" in payload["artifacts_by_mode"]
+    assert "disagg" in payload["artifacts_by_mode"]
+    assert "mode: agg" in payload["artifacts_by_mode"]["agg"]["content"]
+    assert "mode: disagg" in payload["artifacts_by_mode"]["disagg"]["content"]
+
+    preview_response = _client().post(
+        f"/api/v1/runs/{payload['jid']}/dgd",
+        json={"mode": "agg", "row_index": 1},
+    )
+    assert preview_response.status_code == 200
+    preview_payload = preview_response.json()
+    assert preview_payload["dgd_id"] == f"{payload['jid']}:agg:1"
+    assert "row: tp4pp1" in preview_payload["content"]
+
+    run_response = _client().get(f"/api/v1/runs/{payload['jid']}")
+    assert run_response.status_code == 200
+    run_payload = run_response.json()
+    assert run_payload["payload"]["dgds"][preview_payload["dgd_id"]]["content"] == preview_payload["content"]

--- a/uv.lock
+++ b/uv.lock
@@ -23,6 +23,7 @@ version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "bokeh" },
+    { name = "boto3" },
     { name = "jinja2" },
     { name = "matplotlib" },
     { name = "munch" },
@@ -42,6 +43,7 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "httpx" },
     { name = "import-ipynb" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -67,8 +69,10 @@ webapp = [
 [package.metadata]
 requires-dist = [
     { name = "bokeh" },
+    { name = "boto3", specifier = ">=1.35.0" },
     { name = "fastapi", marker = "extra == 'service'", specifier = ">=0.115.12" },
     { name = "gradio", marker = "extra == 'webapp'", specifier = "==6.8.0" },
+    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28.0" },
     { name = "import-ipynb", marker = "extra == 'dev'", specifier = "==0.2" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "matplotlib", specifier = ">=3.9.4" },
@@ -242,6 +246,34 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/bf/0d/fabb70707646217e4b0e3943e05730eab8c1f7b7e7485145f8594b52e606/bokeh-3.9.0.tar.gz", hash = "sha256:775219714a8496973ddbae16b1861606ba19fe670a421e4d43267b41148e07a3", size = 5740345, upload-time = "2026-03-11T17:58:34.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/0b/bdf449df87be3f07b23091ceafee8c3ef569cf6d2fb7edec6e3b12b3faa4/bokeh-3.9.0-py3-none-any.whl", hash = "sha256:b252bfb16a505f0e0c57d532d0df308ae1667235bafc622aa9441fe9e7c5ce4a", size = 6396068, upload-time = "2026-03-11T17:58:31.645Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.43.39"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/35/d936d1f77098a84365ab57798cbf41cf935c07a6c397a4892dc95046a277/boto3-1.43.39.tar.gz", hash = "sha256:ca5701ddf1215ba25b9d973d18505bb4def3a75d3daa9b263c6d8c713b601cb3", size = 112679, upload-time = "2026-07-01T19:37:26.165Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/b4/2a105025fa85e27022d55b0dae02b490c74acd20e904e81003d3b622fbbe/boto3-1.43.39-py3-none-any.whl", hash = "sha256:f4eef8bf98559342466a9a1a063b7efcf3e337e98a819479bc2f7a603b8b8ba7", size = 140030, upload-time = "2026-07-01T19:37:24.756Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.39"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/03/8800770b04e6b306172af15c7e0e049cb06ae6fb6eff6744a09563c1b80c/botocore-1.43.39.tar.gz", hash = "sha256:a95b90ea13aca409d79cc90d87c75df7db1a104a4c8e93707b62a3593bfdd17d", size = 15640021, upload-time = "2026-07-01T19:37:16.076Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/de/1155cade4db5fb1121b66d9936b5e958b663db446752d47acc56ad5d380a/botocore-1.43.39-py3-none-any.whl", hash = "sha256:7cd5fab9d33f487777e2c508573bca6ae230779230263d47a617f4af960d3003", size = 15321601, upload-time = "2026-07-01T19:37:12.952Z" },
 ]
 
 [[package]]
@@ -1128,6 +1160,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -2606,6 +2647,18 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.19.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/94/dcdaeb1713cab9c84def276cfac7388b17c7d9855bbcfe88d77e4dbafd44/s3transfer-0.19.0.tar.gz", hash = "sha256:ce436931687addc4c1712d52d40b32f53e88315723f107ffa20ba82b05a0f685", size = 165171, upload-time = "2026-06-16T19:44:51.599Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/5f/4c174edad94f82de888ac00a5ddd8d07b35609b6c94f0bdf4d74af57703e/s3transfer-0.19.0-py3-none-any.whl", hash = "sha256:777cc2415536f1debadb5c2ef7779275d0fc0fe0e042411cdd6caebeb2685262", size = 90101, upload-time = "2026-06-16T19:44:50.439Z" },
+]
+
+[[package]]
 name = "safehttpx"
 version = "0.1.7"
 source = { registry = "https://pypi.org/simple" }
@@ -3009,6 +3062,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

- add an AIConfigurator service entry point and Docker image
- discover versioned models from S3-compatible OSS storage
- generate vLLM DynamoGraphDeployment manifests that load models through ModelExpress
- expose OSS model selection and deployment controls in the service UI
- add unit coverage and deployment documentation

## Why

The service previously assumed local or Hugging Face model paths. This adds an OSS-backed workflow for environments where model artifacts are stored in an S3-compatible object store and streamed into vLLM through ModelExpress.

## Impact

Users can browse models from OSS, estimate configurations, and generate/deploy vLLM manifests without embedding credentials or mounting a local model directory. Existing non-OSS generator behavior remains the fallback.

## Validation

- `TMPDIR=/tmp .venv/bin/pytest -s -q tests/unit/generator/test_aggregators.py tests/unit/generator/test_vllm_oss_deployment.py tests/unit/sdk/test_s3_models.py tests/unit/service` (24 passed)
- targeted `ruff check` for changed Python modules and tests
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a web-based AIConfigurator service for estimates, Kubernetes artifact generation, deployment management, run history, and health checks.
  * Added containerized service deployment with non-root execution and readiness monitoring.
  * Added support for discovering and loading model configurations from S3-compatible storage.
  * Added Kubernetes deployment support for S3-hosted vLLM models and ModelExpress workflows.
  * Added configurable deployment names, node selectors, storage endpoints, regions, and secrets.

* **Bug Fixes**
  * Improved model name resolution for local and S3 model paths.
  * Filtered unsupported vLLM deployment options to produce safer Kubernetes configurations.

* **Documentation**
  * Added Kubernetes and S3-compatible storage deployment guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->