### PR TITLE
fix(image): Ensure Hugging Face SSL trusted by image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,6 +12,8 @@ RUN mkdir /opt/aiconfigurator && \
     uv venv --python 3.12 ${VIRTUAL_ENV} && \
     chmod a+rx /root && \
     chmod -R a+rX /root/.local
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 ENV MPLCONFIGDIR=/tmp/matplotlib
 


### PR DESCRIPTION
#### Overview:

Add ca-certificates to image

#### Details:

ca-certificates is necessary to trust the SSL certificates used by Hugging Face

#### Where should the reviewer start?

docker/Dockerfile

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #1361


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secure network connectivity in the container environment by adding trusted certificate support.
  * Kept the container image lean by cleaning up package metadata after installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->