### PR TITLE
docs: add Web App section to README and webapp user guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,19 @@ agg, disagg = cli_support(model_path="Qwen/Qwen3-32B-FP8", system="h200_sxm")
 print(f"Agg supported: {agg}, Disagg supported: {disagg}")
 ```
 
+### Web App
+
+AIConfigurator includes an interactive Gradio web interface for exploring
+configurations visually:
+
+```bash
+pip install 'aiconfigurator[webapp]'   # or pip install -e '.[webapp]' for dev
+python -m aiconfigurator.webapp.main
+```
+
+The app binds to `0.0.0.0:7860` by default (all interfaces). Use `--server-name 127.0.0.1` for local-only access.
+Refer to the [Web App User Guide](docs/webapp_user_guide.md) for flags and tab descriptions.
+
 An example here,
 ```bash
 aiconfigurator cli default --model-path Qwen/Qwen3-32B-FP8 --total-gpus 32 --system h200_sxm --isl 4000 --osl 500 --prefix 500 --ttft 300 --tpot 10

--- a/docs/webapp_user_guide.md
+++ b/docs/webapp_user_guide.md
@@ -46,14 +46,14 @@ flag to activate.
 **Always visible:**
 
 - **Readme** -- Embedded documentation and version info.
-- **Static** -- Single-point static latency exploration (select model, system, parallelism, and batch size to see estimated TTFT/TPOT).
-- **Agg Pareto** -- Aggregated serving Pareto frontier search (analogous to `cli default` in agg mode).
-- **Disagg Pareto** -- Disaggregated serving Pareto frontier search.
+- **Static Estimation** -- Single-point static latency exploration (select model, system, parallelism, and batch size to see estimated TTFT/TPOT).
+- **Agg(IFB) Pareto Estimation** -- Aggregated serving Pareto frontier search (analogous to `cli default` in agg mode).
+- **Disaggregation Pareto Estimation** -- Disaggregated serving Pareto frontier search.
 - **Pareto Comparison** -- Save and compare results from the Agg/Disagg Pareto tabs side by side.
 - **Support Matrix** -- Interactive support matrix for model/system/backend combinations.
 
 **Optional (flag-gated):**
 
-- **Agg** (`--enable-agg`) -- Aggregated serving configuration explorer.
-- **Disagg PD Ratio** (`--enable-disagg-pd-ratio`) -- Disaggregated prefill/decode ratio analysis.
+- **Agg Estimation** (`--enable-agg`) -- Aggregated serving configuration explorer.
+- **Disaggregation PD Ratio Analysis** (`--enable-disagg-pd-ratio`) -- Disaggregated prefill/decode ratio analysis.
 - **Profiling** (`--enable-profiling`) -- Per-operation latency breakdown visualization (GEMM, attention, communication, MoE, etc.) for understanding where inference time is spent.

--- a/docs/webapp_user_guide.md
+++ b/docs/webapp_user_guide.md
@@ -1,0 +1,59 @@
+# Web App User Guide
+
+AIConfigurator ships with an interactive Gradio web interface that provides the
+same configuration exploration as the CLI, but with visual controls and plots.
+The webapp is not a CLI subcommand -- launch it directly as a Python module:
+
+```bash
+# Install the webapp extra (Gradio and dependencies)
+pip install 'aiconfigurator[webapp]'        # from PyPI
+pip install -e '.[webapp]'               # editable / dev install
+
+# Launch
+python -m aiconfigurator.webapp.main
+```
+
+The app binds to `0.0.0.0:7860` by default (all network interfaces).
+Access it locally at `http://localhost:7860`. For local-only access, use
+`--server-name 127.0.0.1`.
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--server-name` | `0.0.0.0` | Bind address |
+| `--server-port` | `7860` | Bind port |
+| `--enable-agg` | off | Show the Agg tab (aggregated serving explorer) |
+| `--enable-disagg-pd-ratio` | off | Show the Disagg PD Ratio tab |
+| `--enable-profiling` | off | Show the Profiling tab |
+| `--debug` | off | Enable debug-level logging |
+| `--experimental` | off | Enable experimental features |
+| `--systems-paths` | built-in | Override system data search paths (comma-separated; use `default` for the built-in path) |
+
+Example with all optional tabs enabled:
+
+```bash
+python -m aiconfigurator.webapp.main \
+  --enable-agg --enable-profiling --enable-disagg-pd-ratio \
+  --server-port 8080
+```
+
+## Tabs
+
+The webapp is organized into tabs. Some are always visible; others require a
+flag to activate.
+
+**Always visible:**
+
+- **Readme** -- Embedded documentation and version info.
+- **Static** -- Single-point static latency exploration (select model, system, parallelism, and batch size to see estimated TTFT/TPOT).
+- **Agg Pareto** -- Aggregated serving Pareto frontier search (analogous to `cli default` in agg mode).
+- **Disagg Pareto** -- Disaggregated serving Pareto frontier search.
+- **Pareto Comparison** -- Save and compare results from the Agg/Disagg Pareto tabs side by side.
+- **Support Matrix** -- Interactive support matrix for model/system/backend combinations.
+
+**Optional (flag-gated):**
+
+- **Agg** (`--enable-agg`) -- Aggregated serving configuration explorer.
+- **Disagg PD Ratio** (`--enable-disagg-pd-ratio`) -- Disaggregated prefill/decode ratio analysis.
+- **Profiling** (`--enable-profiling`) -- Per-operation latency breakdown visualization (GEMM, attention, communication, MoE, etc.) for understanding where inference time is spent.


### PR DESCRIPTION
#### Overview:

Documents the Gradio webapp launch command, available flags, and tab
descriptions. The webapp was previously undocumented — this adds a
standalone `docs/webapp_user_guide.md` and a short pointer in the README.

#### Details:

- New `docs/webapp_user_guide.md` covering installation (`pip install
  'aiconfigurator[webapp]'`), launch command (`python -m
  aiconfigurator.webapp.main`), server flags, and descriptions of all
  always-visible and flag-gated tabs.
- New "Web App" section in `README.md` with install/launch quickstart
  and a link to the full guide.
- Clarified that the default bind address is `0.0.0.0` (all interfaces)
  and recommended `--server-name 127.0.0.1` for local-only access.

#### Where should the reviewer start?

- `docs/webapp_user_guide.md` — the new standalone guide (single file)
- `README.md` — the short "Web App" section (~10 lines)

#### Related Issues:

- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Web App section to the README with installation and launch instructions.
  * Documented default and local-only server access settings.
  * Added a comprehensive Web App User Guide covering available options, tabs, and functionality.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->