### PR TITLE
fix(webapp): use monospace font for debugging output textboxes

### DIFF
--- a/src/aiconfigurator/webapp/components/agg_pareto_tab.py
+++ b/src/aiconfigurator/webapp/components/agg_pareto_tab.py
@@ -49,7 +49,7 @@ def create_agg_pareto_tab(app_config):
             interactive=False,
             visible=True,
         )
-        debugging_box = gr.Textbox(label="Debugging", lines=5, required=False)
+        debugging_box = gr.Textbox(label="Debugging", lines=5, required=False, elem_classes=["debug-output"])
 
         download_btn = gr.Button("Download")
         output_file = gr.File(label="When you click the download button, the downloaded form will be displayed here.")

--- a/src/aiconfigurator/webapp/components/agg_tab.py
+++ b/src/aiconfigurator/webapp/components/agg_tab.py
@@ -35,7 +35,7 @@ def create_agg_tab(app_config):
         # agg section, by default, they are invisible
         estimate_btn = gr.Button("Estimate Agg Inference", visible=True)
         result_df = gr.Dataframe(label="Suggested Config List", headers=ColumnsAgg, interactive=False, visible=True)
-        debugging_box = gr.Textbox(label="Debugging", lines=5, required=False)
+        debugging_box = gr.Textbox(label="Debugging", lines=5, required=False, elem_classes=["debug-output"])
         download_btn = gr.Button("Download")
         output_file = gr.File(label="When you click the download button, the downloaded form will be displayed here.")
 

--- a/src/aiconfigurator/webapp/components/disagg_pareto_tab.py
+++ b/src/aiconfigurator/webapp/components/disagg_pareto_tab.py
@@ -97,7 +97,7 @@ def create_disagg_pareto_tab(app_config):
             interactive=False,
             visible=True,
         )
-        debugging_box = gr.Textbox(label="Debugging", lines=5, required=False)
+        debugging_box = gr.Textbox(label="Debugging", lines=5, required=False, elem_classes=["debug-output"])
 
         download_btn = gr.Button("Download")
         output_file = gr.File(label="When you click the download button, the downloaded form will be displayed here.")

--- a/src/aiconfigurator/webapp/components/disagg_pd_ratio_tab.py
+++ b/src/aiconfigurator/webapp/components/disagg_pd_ratio_tab.py
@@ -69,7 +69,7 @@ def create_disagg_pd_ratio_tab(app_config):
                 interactive=False,
                 visible=True,
             )
-        debugging_box = gr.Textbox(label="Debugging", lines=5, required=False)
+        debugging_box = gr.Textbox(label="Debugging", lines=5, required=False, elem_classes=["debug-output"])
 
         download_btn = gr.Button("Download")
         output_file = gr.File(label="When you click the download button, the downloaded form will be displayed here.")

--- a/src/aiconfigurator/webapp/components/static_tab.py
+++ b/src/aiconfigurator/webapp/components/static_tab.py
@@ -59,7 +59,7 @@ def create_static_tab(app_config):
                 label="Generation Breakdown",
             )
         record_df = gr.Dataframe(label="Records:", headers=ColumnsStatic, interactive=False)
-        debugging_box = gr.Textbox(label="Debugging", lines=5, required=False)
+        debugging_box = gr.Textbox(label="Debugging", lines=5, required=False, elem_classes=["debug-output"])
         with gr.Row():
             clear_btn = gr.Button("Clear")
             download_btn = gr.Button("Download")

--- a/src/aiconfigurator/webapp/main.py
+++ b/src/aiconfigurator/webapp/main.py
@@ -123,6 +123,10 @@ def main(args):
             scrollbar-width: none !important;
             -ms-overflow-style: none !important;
         }
+        /* Monospace font for debugging output textboxes */
+        .debug-output textarea {
+            font-family: monospace !important;
+        }
     """
 
     with gr.Blocks(


### PR DESCRIPTION
#### Overview:

The webapp debugging textboxes display CLI output (PrettyTable tables, Pareto frontier charts) that assumes a fixed-width font. Without monospace styling, columns are misaligned and ASCII charts are unreadable.

#### Details:

- Added `.debug-output textarea { font-family: monospace !important; }` CSS rule to `src/aiconfigurator/webapp/main.py`
- Applied `elem_classes=["debug-output"]` to all 5 existing debugging textboxes across the webapp tabs (static, agg, agg_pareto, disagg_pareto, disagg_pd_ratio)

#### Where should the reviewer start?

- `src/aiconfigurator/webapp/main.py` — the CSS rule (4 lines)
- Any of the 5 tab component files — identical one-line change each

#### Related Issues:

- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the presentation of debugging output across estimation and configuration tabs.
  * Debugging text areas now use consistent monospace formatting for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->