### PR TITLE
feat(cli): GPU recommender mode with auto-recommend and sweep optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,12 @@ docker create --name aic aiconfigurator:latest && docker cp aic:/workspace/dist 
 
 ```bash
 aiconfigurator cli default --model Qwen/Qwen3-32B-FP8 --total-gpus 32 --system h200_sxm
+aiconfigurator cli recommend --model Qwen/Qwen3-32B-FP8 --system h200_sxm --target-request-rate 50 --ttft 2000 --tpot 30
 aiconfigurator cli exp --yaml-path exp.yaml
 aiconfigurator cli generate --model-path Qwen/Qwen3-32B-FP8 --total-gpus 8 --system h200_sxm
 aiconfigurator cli support --model-path Qwen/Qwen3-32B-FP8 --system h200_sxm
 ```
-- We have four modes: `default`, `exp`, `generate`, and `support`.
+- We have six modes: `default`, `estimate`, `recommend`, `exp`, `generate`, and `support`.
 - Use `default` to find the estimated best deployment by searching the configuration space.
 - The experimental Spica smart sweeper now lives in Dynamo's standalone
   [AI Simulate distribution](https://github.com/ai-dynamo/dynamo/blob/95587b1a3fe28a3916362ba5f54aa65c8bfb9d3b/docs/components/aisimulate/spica/README.md).
@@ -120,6 +121,7 @@ aiconfigurator cli support --model-path Qwen/Qwen3-32B-FP8 --system h200_sxm
   `examples/aisimulate/spica`.
 - Use `exp` to run customized experiments defined in a YAML file.
 - Use `generate` to quickly create a naive configuration without a parameter sweep.
+- Use `recommend` to find the minimum GPU count and optimal deployment configuration needed to meet a performance target. This mode is designed as a procurement sizing tool -- specify a throughput target (`--target-request-rate` or `--target-concurrency`) along with SLA constraints, and the system calculates the minimum GPUs required. You can also omit `--total-gpus` in default mode with a load target for the same behavior.
 - Use `support` to verify if AIC supports a model/hardware combination for agg and disagg modes.
 - `--model` is an alias for `--model-path` in the CLI.
 - Use `--backend` to specify the inference backend: `trtllm` (default), `vllm`, or `sglang`.
@@ -148,7 +150,7 @@ Refer to [CLI User Guide](docs/cli_user_guide.md)
 You can also use `aiconfigurator` programmatically in Python:
 
 ```python
-from aiconfigurator.cli import cli_default, cli_exp, cli_generate, cli_support
+from aiconfigurator.cli import cli_default, cli_exp, cli_generate, cli_recommend, cli_support
 
 # 1. Run default agg vs disagg comparison
 result = cli_default(model_path="Qwen/Qwen3-32B-FP8", total_gpus=32, system="h200_sxm")
@@ -168,11 +170,16 @@ result = cli_exp(config={
     }
 })
 
-# 3. Generate a naive configuration
+# 3. Find minimum GPUs for a performance target (procurement sizing)
+result = cli_recommend(model_path="Qwen/Qwen3-32B-FP8", system="h200_sxm", target_request_rate=50.0, ttft=2000, tpot=30)
+for mode, df in result.best_configs.items():
+    print(f"{mode}: {df[['total_gpus_needed', 'replicas_needed', 'tp', 'tpot']].head()}")
+
+# 4. Generate a naive configuration
 result = cli_generate(model_path="Qwen/Qwen3-32B-FP8", total_gpus=8, system="h200_sxm")
 print(result["parallelism"]) # {'tp': 1, 'pp': 1, 'replicas': 8, 'gpus_used': 8}
 
-# 4. Check support for a model/system combination
+# 5. Check support for a model/system combination
 agg, disagg = cli_support(model_path="Qwen/Qwen3-32B-FP8", system="h200_sxm")
 print(f"Agg supported: {agg}, Disagg supported: {disagg}")
 ```

--- a/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
+++ b/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import copy
+import dataclasses
 import inspect
 import logging
 from collections import defaultdict
@@ -181,9 +182,7 @@ class BaseBackend:
 
     @staticmethod
     def _runtime_config_for_agg_candidate(runtime_config: RuntimeConfig, batch_size: int) -> RuntimeConfig:
-        candidate = copy.deepcopy(runtime_config)
-        candidate.batch_size = batch_size
-        return candidate
+        return dataclasses.replace(runtime_config, batch_size=batch_size)
 
     def _memory_usage_kwargs_for_agg(self, num_tokens: int, agg_extra: dict) -> dict:
         """Kwargs for the ``_get_memory_usage`` call from ``run_agg``.

--- a/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
+++ b/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
@@ -1419,7 +1419,6 @@ class BaseBackend:
             "system": database.system,
             "power_w": agg_power_avg_w,
         }
-        result = pd.DataFrame([result_dict], columns=common.ColumnsAgg).round(3)
         summary = InferenceSummary(RuntimeConfig(isl=isl, osl=osl))
         summary.set_memory_and_check_oom(
             memory,
@@ -1430,7 +1429,6 @@ class BaseBackend:
         summary.set_encoder_energy_wms_dict(encoder_energy_wms_dict)
         summary.set_encoder_power_avg(encoder_energy_wms / encoder_latency_ms if encoder_latency_ms > 0 else 0.0)
         summary.set_encoder_source_dict(encoder_source_dict)
-        summary.set_summary_df(result)
         summary.set_result_dict(result_dict)
         if encoder_memory:
             summary.set_encoder_memory(encoder_memory)

--- a/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
+++ b/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
@@ -763,7 +763,7 @@ class BaseBackend:
             ]
         ]
 
-        summary_df = pd.DataFrame(data, columns=common.ColumnsStatic).round(3)
+        summary.set_deferred_row(data, common.ColumnsStatic)
 
         summary.set_encoder_latency_dict(encoder_latency_dict)
         summary.set_context_latency_dict(context_latency_dict)
@@ -791,8 +791,6 @@ class BaseBackend:
 
         if encoder_memory:
             summary.set_encoder_memory(encoder_memory)
-
-        summary.set_summary_df(summary_df)
 
         return summary
 

--- a/aic-core/src/aiconfigurator_core/sdk/errors.py
+++ b/aic-core/src/aiconfigurator_core/sdk/errors.py
@@ -1,7 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Shared SDK exception types."""
+"""Shared SDK exception types and per-experiment outcome classification."""
+
+from __future__ import annotations
+
+import dataclasses
 
 
 class NoResultsError(RuntimeError):
@@ -130,3 +134,30 @@ def is_expected_cli_error(error: BaseException) -> bool:
         error,
         (NoResultsError, PerfDataNotAvailableError, EmpiricalNotImplementedError, ValueError),
     )
+
+
+def is_gpu_retriable(error: BaseException) -> bool:
+    """Return True when ``error`` might be resolved by adding more GPUs.
+
+    ``InsufficientMemoryError`` and ``KVCacheCapacityError`` are retriable:
+    more GPUs means more aggregate memory and KV-cache capacity.  All other
+    expected errors (SLA-infeasible, missing perf data, unsupported config)
+    are structural and will not be helped by more hardware.
+
+    Walks the exception chain via :func:`_chain_has`.
+    """
+    return _chain_has(error, (InsufficientMemoryError, KVCacheCapacityError))
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ExperimentOutcome:
+    """Per-experiment verdict from :func:`_execute_tasks`.
+
+    ``error is None`` means the experiment succeeded (results are in the
+    parallel ``best_configs`` / ``pareto_fronts`` dicts).  A non-None
+    ``error`` carries the original exception for caller classification
+    (e.g. :func:`is_gpu_retriable`).
+    """
+
+    experiment: str
+    error: BaseException | None = None

--- a/aic-core/src/aiconfigurator_core/sdk/inference_summary.py
+++ b/aic-core/src/aiconfigurator_core/sdk/inference_summary.py
@@ -5,6 +5,7 @@ import logging
 
 import pandas as pd
 
+from aiconfigurator_core.sdk.common import ColumnsAgg
 from aiconfigurator_core.sdk.config import RuntimeConfig
 
 logger = logging.getLogger(__name__)
@@ -441,9 +442,15 @@ class InferenceSummary:
         self._summary_df = summary_df
 
     def get_summary_df(self) -> pd.DataFrame:
+        """Get summary dataframe, building it lazily from the result dict.
+
+        run_agg sets result_dict but defers DataFrame construction so the
+        sweep hot path (which only reads result_dict) avoids the overhead.
+        Callers that need the DataFrame (disagg concat, CLI display, save)
+        trigger construction here on first access.
         """
-        Get summary dataframe.
-        """
+        if self._summary_df is None and self._result_dict is not None:
+            self._summary_df = pd.DataFrame([self._result_dict], columns=ColumnsAgg).round(3)
         if self._summary_df is None:
             logger.warning("WARNING: summary df is not set")
         return self._summary_df

--- a/aic-core/src/aiconfigurator_core/sdk/inference_summary.py
+++ b/aic-core/src/aiconfigurator_core/sdk/inference_summary.py
@@ -80,8 +80,9 @@ class InferenceSummary:
         self._generation_power_avg = 0.0
         self._e2e_power_avg = 0.0
 
-        # summary dataframe
+        # summary dataframe (built lazily from _deferred_row when available)
         self._summary_df = None
+        self._deferred_row: tuple[list, list] | None = None  # (data, columns)
 
         # cached result dict for efficient batch operations
         self._result_dict = None
@@ -441,16 +442,23 @@ class InferenceSummary:
         """
         self._summary_df = summary_df
 
-    def get_summary_df(self) -> pd.DataFrame:
-        """Get summary dataframe, building it lazily from the result dict.
+    def set_deferred_row(self, data: list, columns: list) -> None:
+        """Store raw row data for lazy DataFrame construction."""
+        self._deferred_row = (data, columns)
 
-        run_agg sets result_dict but defers DataFrame construction so the
-        sweep hot path (which only reads result_dict) avoids the overhead.
-        Callers that need the DataFrame (disagg concat, CLI display, save)
-        trigger construction here on first access.
+    def get_summary_df(self) -> pd.DataFrame:
+        """Get summary dataframe, building it lazily on first access.
+
+        run_agg and run_static defer DataFrame construction so the sweep
+        hot path avoids the overhead. Callers that need the DataFrame
+        (disagg concat, CLI display, save) trigger construction here.
         """
-        if self._summary_df is None and self._result_dict is not None:
-            self._summary_df = pd.DataFrame([self._result_dict], columns=ColumnsAgg).round(3)
+        if self._summary_df is None:
+            if self._deferred_row is not None:
+                data, columns = self._deferred_row
+                self._summary_df = pd.DataFrame(data, columns=columns).round(3)
+            elif self._result_dict is not None:
+                self._summary_df = pd.DataFrame([self._result_dict], columns=ColumnsAgg).round(3)
         if self._summary_df is None:
             logger.warning("WARNING: summary df is not set")
         return self._summary_df
@@ -526,10 +534,17 @@ class InferenceSummary:
     def get_result_dict(self) -> dict | None:
         """
         Get the result as a dict. Returns cached dict if available,
-        otherwise extracts from the first row of the summary DataFrame.
+        otherwise extracts from the deferred row or summary DataFrame.
         """
         if self._result_dict is not None:
             return self._result_dict
+
+        # Fallback: build from deferred row (run_static lazy path)
+        if self._deferred_row is not None:
+            data, columns = self._deferred_row
+            if data and columns:
+                self._result_dict = dict(zip(columns, data[0], strict=False))
+                return self._result_dict
 
         # Fallback: create from DataFrame if not cached
         if self._summary_df is not None and len(self._summary_df) > 0:

--- a/docs/cli_user_guide.md
+++ b/docs/cli_user_guide.md
@@ -1,6 +1,6 @@
 # CLI User Guide
 ## Basic Command
-As mentioned in root Readme, CLI supports five modes: `default`, `exp`, `generate`, `estimate`, and `support`. We'll go through these modes one by one.
+As mentioned in root Readme, CLI supports six modes: `default`, `recommend`, `exp`, `generate`, `estimate`, and `support`. We'll go through these modes one by one.
 
 Quantization defaults are inferred from the Hugging Face model config (`config.json` plus optional `hf_quant_config.json`).  
 For low-precision models, use a quantized HF ID (for example, `Qwen/Qwen3-32B-FP8`) or a local model directory containing those files.
@@ -342,6 +342,56 @@ agg_supported, disagg_supported = cli_support(
     backend="trtllm"
 )
 print(f"Agg: {agg_supported}, Disagg: {disagg_supported}")
+```
+
+### Recommend mode (deployment sizing)
+This mode finds the minimum number of GPUs needed to meet a performance target. It is designed as a procurement sizing tool — the output is unconstrained, suitable for driving purchasing decisions.
+
+Instead of specifying a GPU count (like `default` mode), you specify a throughput target (request rate or concurrency) along with SLA constraints, and the system calculates the minimum GPUs required.
+
+The recommender searches both tensor-parallel and pipeline-parallel configurations to find the most efficient layout. For models too large to fit on a single node, it automatically escalates to multi-node configurations.
+
+```bash
+aiconfigurator cli recommend --model-path Qwen/Qwen3-32B --system h200_sxm --backend trtllm \
+    --target-request-rate 50 --ttft 2000 --tpot 30 --isl 4000 --osl 1000
+```
+
+or with a concurrency target:
+
+```bash
+aiconfigurator cli recommend --model-path Qwen/Qwen3-32B --system h200_sxm --backend sglang \
+    --target-concurrency 200 --ttft 2000 --tpot 30
+```
+
+**Required arguments:**
+- `--model-path` (alias `--model`): HuggingFace model path or local path containing `config.json`
+- `--system`: System name (GPU type)
+- One of:
+  - `--target-request-rate`: Target system throughput in req/s
+  - `--target-concurrency`: Target number of concurrent users
+
+**Optional arguments:**
+- `--backend`: Backend name (`trtllm`, `vllm`, `sglang`, `auto`). Default: `trtllm`
+- `--ttft`, `--tpot`: SLA targets in ms (default: 2000ms, 30ms)
+- `--request-latency`: End-to-end request latency target in ms
+- `--isl`, `--osl`: Input/output sequence lengths (default: 4000, 1000)
+- All other arguments match `default` mode (quantization, prefix caching, nextn, etc.)
+
+The output includes `total_gpus_needed` and `replicas_needed` columns, showing both agg and disagg configurations ranked by fewest GPUs first.
+
+**Python API equivalent:**
+```python
+from aiconfigurator.cli import cli_recommend
+
+result = cli_recommend(
+    model_path="Qwen/Qwen3-32B",
+    system="h200_sxm",
+    target_request_rate=50.0,
+    ttft=2000,
+    tpot=30,
+)
+for mode, df in result.best_configs.items():
+    print(f"{mode}: {df[['total_gpus_needed', 'replicas_needed', 'tp', 'tpot']].head()}")
 ```
 
 ### Default mode

--- a/src/aiconfigurator/cli/__init__.py
+++ b/src/aiconfigurator/cli/__init__.py
@@ -7,13 +7,22 @@ CLI module for aiconfigurator.
 Provides both command-line interface and programmatic Python API.
 
 Python API usage:
-    from aiconfigurator.cli import cli_default, cli_exp, cli_generate, cli_support
+    from aiconfigurator.cli import cli_default, cli_exp, cli_generate, cli_recommend, cli_support
 
     # cli_default: Run agg vs disagg comparison
     result = cli_default(
         model_path="Qwen/Qwen3-32B",
         total_gpus=8,
         system="h200_sxm",
+    )
+
+    # cli_recommend: Find minimum GPUs for a performance target
+    result = cli_recommend(
+        model_path="Qwen/Qwen3-32B",
+        system="h200_sxm",
+        target_request_rate=50.0,
+        ttft=2000,
+        tpot=30,
     )
 
     # cli_exp: Run experiments from YAML or dict config
@@ -42,6 +51,7 @@ from aiconfigurator.cli.api import (
     cli_default,
     cli_exp,
     cli_generate,
+    cli_recommend,
     cli_support,
 )
 
@@ -50,5 +60,6 @@ __all__ = [
     "cli_default",
     "cli_exp",
     "cli_generate",
+    "cli_recommend",
     "cli_support",
 ]

--- a/src/aiconfigurator/cli/__init__.py
+++ b/src/aiconfigurator/cli/__init__.py
@@ -16,7 +16,7 @@ Python API usage:
         system="h200_sxm",
     )
 
-    # cli_recommend: Find minimum GPUs for a performance target
+    # recommend: Find minimum GPUs for a performance target
     result = cli_recommend(
         model_path="Qwen/Qwen3-32B",
         system="h200_sxm",

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -126,6 +126,7 @@ def _execute_and_wrap_result(
     strict_sla: bool = False,
     target_request_rate: float | None = None,
     target_concurrency: float | None = None,
+    parallel_experiments: bool = False,
 ) -> CLIResult:
     """Execute task configs using main.py's function and wrap result in CLIResult."""
     chosen_exp, best_configs, pareto_fronts, best_throughputs, best_latencies, outcomes = _execute_tasks_internal(
@@ -135,6 +136,7 @@ def _execute_and_wrap_result(
         strict_sla=strict_sla,
         target_request_rate=target_request_rate,
         target_concurrency=target_concurrency,
+        parallel_experiments=parallel_experiments,
     )
 
     return CLIResult(
@@ -519,6 +521,7 @@ def cli_recommend(
             strict_sla=strict_sla,
             target_request_rate=target_request_rate,
             target_concurrency=target_concurrency,
+            parallel_experiments=True,
         )
         retriable = [
             name

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -27,7 +27,7 @@ from aiconfigurator.sdk.config import ModelConfig
 from aiconfigurator.sdk.config_builders import apply_nextn as _apply_nextn
 from aiconfigurator.sdk.config_builders import build_model_config as _build_model_config
 from aiconfigurator.sdk.config_builders import resolve_nextn_auto as _resolve_nextn_auto
-from aiconfigurator.sdk.errors import ExperimentOutcome, is_gpu_retriable
+from aiconfigurator.sdk.errors import ExperimentOutcome, NoFeasibleConfigError, is_gpu_retriable
 from aiconfigurator.sdk.models import check_is_moe, resolve_context_fmha_by_data, resolve_dsv4_moe_arch
 from aiconfigurator.sdk.speculative import (
     SpeculativeDecodingProfile,
@@ -304,7 +304,7 @@ def cli_default(
 
     result = _execute_and_wrap_result(tasks, mode="default", top_n=top_n, strict_sla=strict_sla)
     if not result.best_configs:
-        raise SystemExit(1)
+        raise NoFeasibleConfigError("No feasible configurations found for the given parameters.")
 
     if save_dir:
         # Create a mock args object for save_results compatibility
@@ -537,7 +537,7 @@ def cli_recommend(
         )
 
     if not result.best_configs:
-        raise SystemExit(1)
+        raise NoFeasibleConfigError("No feasible GPU configuration found for the given load target.")
 
     if save_dir:
 
@@ -664,7 +664,7 @@ def cli_exp(
 
     result = _execute_and_wrap_result(tasks, mode="exp", top_n=top_n)
     if not result.best_configs:
-        raise SystemExit(1)
+        raise NoFeasibleConfigError("No feasible configurations found for the given experiments.")
 
     if save_dir:
         # Create a mock args object for save_results compatibility

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -120,10 +120,17 @@ def _execute_and_wrap_result(
     mode: str,
     top_n: int = 5,
     strict_sla: bool = False,
+    target_request_rate: float | None = None,
+    target_concurrency: float | None = None,
 ) -> CLIResult:
     """Execute task configs using main.py's function and wrap result in CLIResult."""
     chosen_exp, best_configs, pareto_fronts, best_throughputs, best_latencies = _execute_tasks_internal(
-        tasks, mode, top_n=top_n, strict_sla=strict_sla
+        tasks,
+        mode,
+        top_n=top_n,
+        strict_sla=strict_sla,
+        target_request_rate=target_request_rate,
+        target_concurrency=target_concurrency,
     )
 
     return CLIResult(
@@ -315,6 +322,237 @@ def cli_default(
         mock_args.generator_set = generator_set
         mock_args.generator_config = generator_config
         mock_args.generator_dynamo_version = generator_dynamo_version
+
+        save_results(
+            args=mock_args,
+            best_configs=result.best_configs,
+            pareto_fronts=result.pareto_fronts,
+            tasks=result.tasks,
+            save_dir=save_dir,
+            generated_backend_version=None,
+        )
+
+    return result
+
+
+_MAX_GPUS_PER_WORKER = 64
+
+
+def _build_recommend_tasks(base_tasks: dict, total_gpus: int) -> dict:
+    """Widen the search space for recommend mode: enable PP and scale GPU candidates."""
+    import dataclasses
+
+    num_gpu_candidates = [1 << i for i in range(total_gpus.bit_length()) if (1 << i) <= total_gpus]
+
+    rebuilt = {}
+    for name, task in base_tasks.items():
+        overrides = {
+            "total_gpus": total_gpus,
+            "agg_pp_candidates": [1, 2, 4],
+            "agg_num_gpu_candidates": num_gpu_candidates,
+        }
+        if task.serving_mode == "disagg":
+            overrides.update(
+                prefill_pp_candidates=[1, 2, 4],
+                prefill_num_gpu_candidates=num_gpu_candidates,
+                decode_pp_candidates=[1, 2, 4],
+                decode_num_gpu_candidates=num_gpu_candidates,
+            )
+        rebuilt[name] = dataclasses.replace(task, **overrides)
+    return rebuilt
+
+
+def cli_recommend(
+    model_path: str,
+    system: str,
+    *,
+    target_request_rate: float | None = None,
+    target_concurrency: float | None = None,
+    decode_system: str | None = None,
+    backend: str = "trtllm",
+    backend_version: str | None = None,
+    database_mode: str = "SILICON",
+    transfer_policy: str | list | None = None,
+    isl: int = 4000,
+    osl: int = 1000,
+    image_height: int = 0,
+    image_width: int = 0,
+    num_images: int = 1,
+    ttft: float = 2000.0,
+    tpot: float = 30.0,
+    request_latency: float | None = None,
+    prefix: int = 0,
+    nextn: int = 0,
+    nextn_accept_rates: list[float] | None = None,
+    strict_sla: bool = False,
+    enable_chunked_prefill: bool = False,
+    free_gpu_memory_fraction: float | None = None,
+    max_seq_len: int | None = None,
+    enable_wideep: bool = False,
+    moe_backend: str | None = None,
+    top_n: int = 5,
+    save_dir: str | None = None,
+    engine_step_backend: str | None = None,
+) -> CLIResult:
+    """Find the minimum number of GPUs to meet a performance target.
+
+    This is the programmatic equivalent of:
+        aiconfigurator cli recommend --model-path ... --system ... --target-request-rate ...
+
+    Inverts the default mode: instead of 'given GPUs, find best config',
+    this answers 'given performance targets, find minimum GPUs'.  Designed
+    as a procurement sizing tool — the output is unconstrained.
+
+    The function sweeps all valid per-worker parallelism configurations and
+    uses :func:`pick_load_match` to compute the replica count needed to
+    serve the target load under the given SLA constraints.
+
+    Exactly one of ``target_request_rate`` or ``target_concurrency`` must
+    be provided.
+
+    Args:
+        model_path: HuggingFace model path (e.g., 'Qwen/Qwen3-32B') or local path.
+        system: System name (GPU type), e.g., 'h200_sxm', 'b200_sxm'.
+        target_request_rate: Target system request rate in req/s.
+        target_concurrency: Target number of concurrent requests.
+        decode_system: System name for disagg decode workers. Defaults to ``system``.
+        backend: Backend name ('trtllm', 'sglang', 'vllm', 'auto').
+        backend_version: Backend database version. Default is latest.
+        database_mode: Database mode ('SILICON', 'HYBRID', 'EMPIRICAL', 'SOL').
+        transfer_policy: Fine-grained HYBRID/EMPIRICAL transfer control.
+        isl: Input sequence length. Default is 4000.
+        osl: Output sequence length. Default is 1000.
+        image_height: Image height for vision-language models.
+        image_width: Image width for vision-language models.
+        num_images: Number of images per request.
+        ttft: Time to first token SLA target in ms. Default is 2000.
+        tpot: Time per output token SLA target in ms. Default is 30.
+        request_latency: Optional end-to-end request latency target (ms).
+        prefix: Prefix cache length.
+        nextn: Number of draft tokens for MTP speculative decoding.
+        nextn_accept_rates: Acceptance rates for MTP draft tokens.
+        strict_sla: When True, filter to SLA-compliant configs only.
+        enable_chunked_prefill: Enable chunked prefill for finer context sweep.
+        free_gpu_memory_fraction: Fraction of free GPU memory for KV cache.
+        max_seq_len: TRT-LLM max_seq_len setting.
+        enable_wideep: Enable Wide Expert Parallelism for MoE models.
+        moe_backend: Explicit SGLang MoE backend override.
+        top_n: Number of top configurations to return per mode. Default is 5.
+        save_dir: Directory to save results. If None, results are not saved.
+        engine_step_backend: Experimental static latency backend.
+
+    Returns:
+        CLIResult with best configs containing ``total_gpus_needed`` and
+        ``replicas_needed`` columns, ranked by fewest GPUs first.
+
+    Example:
+        >>> result = cli_recommend(
+        ...     model_path="Qwen/Qwen3-32B",
+        ...     system="h200_sxm",
+        ...     target_request_rate=50.0,
+        ...     ttft=2000,
+        ...     tpot=30,
+        ... )
+        >>> print(result.best_configs)
+    """
+    from aiconfigurator.sdk.perf_database import load_system_spec
+
+    has_rate = target_request_rate is not None
+    has_conc = target_concurrency is not None
+    if has_rate == has_conc:
+        raise ValueError("Exactly one of target_request_rate or target_concurrency must be provided.")
+
+    spec = load_system_spec(system)
+    gpus_per_node = spec["node"]["num_gpus_per_node"]
+
+    base_tasks = build_default_tasks(
+        model_path=model_path,
+        total_gpus=gpus_per_node,
+        system=system,
+        decode_system=decode_system,
+        backend=backend,
+        backend_version=backend_version,
+        database_mode=database_mode,
+        transfer_policy=transfer_policy,
+        isl=isl,
+        osl=osl,
+        image_height=image_height,
+        image_width=image_width,
+        num_images=num_images,
+        ttft=ttft,
+        tpot=tpot,
+        request_latency=request_latency,
+        prefix=prefix,
+        nextn=nextn,
+        nextn_accept_rates=nextn_accept_rates,
+        enable_chunked_prefill=enable_chunked_prefill,
+        free_gpu_memory_fraction=free_gpu_memory_fraction,
+        max_seq_len=max_seq_len,
+        engine_step_backend=engine_step_backend,
+        enable_wideep=enable_wideep,
+        moe_backend=moe_backend,
+    )
+
+    # Build escalation sequence: gpus_per_node, *2, *4, *8, capped at _MAX_GPUS_PER_WORKER.
+    budgets = [gpus_per_node]
+    budget = gpus_per_node * 2
+    while budget <= _MAX_GPUS_PER_WORKER:
+        budgets.append(budget)
+        budget *= 2
+
+    result = None
+    for attempt, gpu_budget in enumerate(budgets):
+        tasks = _build_recommend_tasks(base_tasks, gpu_budget)
+        try:
+            result = _execute_and_wrap_result(
+                tasks,
+                mode="default",
+                top_n=top_n,
+                strict_sla=strict_sla,
+                target_request_rate=target_request_rate,
+                target_concurrency=target_concurrency,
+            )
+            break
+        except SystemExit as exc:
+            if exc.code != 1 or attempt == len(budgets) - 1:
+                raise
+            logger.info(
+                "Recommend: no valid config at %d GPUs/worker; escalating to %d.",
+                gpu_budget,
+                budgets[attempt + 1],
+            )
+
+    if result is None:
+        raise ValueError(
+            f"System {system} has {gpus_per_node} GPUs/node which exceeds "
+            f"the maximum per-worker search limit ({_MAX_GPUS_PER_WORKER})."
+        )
+
+    if save_dir:
+
+        class _MockArgs:
+            pass
+
+        mock_args = _MockArgs()
+        mock_args.save_dir = save_dir
+        mock_args.mode = "recommend"
+        mock_args.model_path = model_path
+        mock_args.total_gpus = 0
+        mock_args.system = system
+        mock_args.backend = backend
+        mock_args.isl = isl
+        mock_args.osl = osl
+        mock_args.image_height = image_height
+        mock_args.image_width = image_width
+        mock_args.num_images = num_images
+        mock_args.ttft = ttft
+        mock_args.tpot = tpot
+        mock_args.request_latency = request_latency
+        mock_args.top_n = top_n
+        mock_args.generated_config_version = None
+        mock_args.generator_set = None
+        mock_args.generator_config = None
+        mock_args.generator_dynamo_version = None
 
         save_results(
             args=mock_args,
@@ -1877,5 +2115,6 @@ __all__ = [
     "cli_estimate",
     "cli_exp",
     "cli_generate",
+    "cli_recommend",
     "cli_support",
 ]

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -27,6 +27,7 @@ from aiconfigurator.sdk.config import ModelConfig
 from aiconfigurator.sdk.config_builders import apply_nextn as _apply_nextn
 from aiconfigurator.sdk.config_builders import build_model_config as _build_model_config
 from aiconfigurator.sdk.config_builders import resolve_nextn_auto as _resolve_nextn_auto
+from aiconfigurator.sdk.errors import ExperimentOutcome, is_gpu_retriable
 from aiconfigurator.sdk.models import check_is_moe, resolve_context_fmha_by_data, resolve_dsv4_moe_arch
 from aiconfigurator.sdk.speculative import (
     SpeculativeDecodingProfile,
@@ -107,6 +108,9 @@ class CLIResult:
     raw_results: dict[str, dict[str, pd.DataFrame | None]] = field(default_factory=dict)
     """Raw pareto_df results from TaskRunner, keyed by experiment name."""
 
+    outcomes: dict[str, ExperimentOutcome] = field(default_factory=dict)
+    """Per-experiment success/failure verdicts from _execute_tasks."""
+
     def __repr__(self) -> str:
         return (
             f"CLIResult(chosen_exp={self.chosen_exp!r}, "
@@ -124,7 +128,7 @@ def _execute_and_wrap_result(
     target_concurrency: float | None = None,
 ) -> CLIResult:
     """Execute task configs using main.py's function and wrap result in CLIResult."""
-    chosen_exp, best_configs, pareto_fronts, best_throughputs, best_latencies = _execute_tasks_internal(
+    chosen_exp, best_configs, pareto_fronts, best_throughputs, best_latencies, outcomes = _execute_tasks_internal(
         tasks,
         mode,
         top_n=top_n,
@@ -141,6 +145,7 @@ def _execute_and_wrap_result(
         best_latencies=best_latencies,
         tasks=tasks,
         raw_results={},
+        outcomes=outcomes,
     )
 
 
@@ -296,6 +301,8 @@ def cli_default(
     )
 
     result = _execute_and_wrap_result(tasks, mode="default", top_n=top_n, strict_sla=strict_sla)
+    if not result.best_configs:
+        raise SystemExit(1)
 
     if save_dir:
         # Create a mock args object for save_results compatibility
@@ -339,7 +346,7 @@ _MAX_GPUS_PER_WORKER = 64
 
 
 def _build_recommend_tasks(base_tasks: dict, total_gpus: int) -> dict:
-    """Widen the search space for recommend mode: enable PP and scale GPU candidates."""
+    """Scale GPU candidates for recommend mode."""
     import dataclasses
 
     num_gpu_candidates = [1 << i for i in range(total_gpus.bit_length()) if (1 << i) <= total_gpus]
@@ -348,14 +355,11 @@ def _build_recommend_tasks(base_tasks: dict, total_gpus: int) -> dict:
     for name, task in base_tasks.items():
         overrides = {
             "total_gpus": total_gpus,
-            "agg_pp_candidates": [1, 2, 4],
             "agg_num_gpu_candidates": num_gpu_candidates,
         }
         if task.serving_mode == "disagg":
             overrides.update(
-                prefill_pp_candidates=[1, 2, 4],
                 prefill_num_gpu_candidates=num_gpu_candidates,
-                decode_pp_candidates=[1, 2, 4],
                 decode_num_gpu_candidates=num_gpu_candidates,
             )
         rebuilt[name] = dataclasses.replace(task, **overrides)
@@ -371,7 +375,7 @@ def cli_recommend(
     decode_system: str | None = None,
     backend: str = "trtllm",
     backend_version: str | None = None,
-    database_mode: str = "SILICON",
+    database_mode: str = "HYBRID",
     transfer_policy: str | list | None = None,
     isl: int = 4000,
     osl: int = 1000,
@@ -455,12 +459,17 @@ def cli_recommend(
         ... )
         >>> print(result.best_configs)
     """
+    import math
+
     from aiconfigurator.sdk.perf_database import load_system_spec
 
     has_rate = target_request_rate is not None
     has_conc = target_concurrency is not None
     if has_rate == has_conc:
         raise ValueError("Exactly one of target_request_rate or target_concurrency must be provided.")
+    load_target = target_request_rate if has_rate else target_concurrency
+    if not (math.isfinite(load_target) and load_target > 0):
+        raise ValueError(f"Load target must be a positive finite number, got {load_target}.")
 
     spec = load_system_spec(system)
     gpus_per_node = spec["node"]["num_gpus_per_node"]
@@ -503,30 +512,29 @@ def cli_recommend(
     result = None
     for attempt, gpu_budget in enumerate(budgets):
         tasks = _build_recommend_tasks(base_tasks, gpu_budget)
-        try:
-            result = _execute_and_wrap_result(
-                tasks,
-                mode="default",
-                top_n=top_n,
-                strict_sla=strict_sla,
-                target_request_rate=target_request_rate,
-                target_concurrency=target_concurrency,
-            )
-            break
-        except SystemExit as exc:
-            if exc.code != 1 or attempt == len(budgets) - 1:
-                raise
-            logger.info(
-                "Recommend: no valid config at %d GPUs/worker; escalating to %d.",
-                gpu_budget,
-                budgets[attempt + 1],
-            )
-
-    if result is None:
-        raise ValueError(
-            f"System {system} has {gpus_per_node} GPUs/node which exceeds "
-            f"the maximum per-worker search limit ({_MAX_GPUS_PER_WORKER})."
+        result = _execute_and_wrap_result(
+            tasks,
+            mode="default",
+            top_n=top_n,
+            strict_sla=strict_sla,
+            target_request_rate=target_request_rate,
+            target_concurrency=target_concurrency,
         )
+        retriable = [
+            name
+            for name, outcome in result.outcomes.items()
+            if outcome.error is not None and is_gpu_retriable(outcome.error)
+        ]
+        if not retriable or attempt == len(budgets) - 1:
+            break
+        logger.info(
+            "Recommend: %s may fit at larger budget; escalating to %d.",
+            ", ".join(retriable),
+            budgets[attempt + 1],
+        )
+
+    if not result.best_configs:
+        raise SystemExit(1)
 
     if save_dir:
 
@@ -652,6 +660,8 @@ def cli_exp(
         raise ValueError("No valid experiments found in configuration.")
 
     result = _execute_and_wrap_result(tasks, mode="exp", top_n=top_n)
+    if not result.best_configs:
+        raise SystemExit(1)
 
     if save_dir:
         # Create a mock args object for save_results compatibility

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -6,6 +6,7 @@ import logging
 import os
 import sys
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
 
 import pandas as pd
@@ -1811,6 +1812,7 @@ def _execute_tasks(
     max_total_gpus: int | None = None,
     strict_sla: bool = False,
     inclusive_tpot: bool = False,
+    parallel_experiments: bool = False,
 ) -> tuple[
     str,
     dict[str, pd.DataFrame],
@@ -1850,50 +1852,61 @@ def _execute_tasks(
     results: dict[str, dict[str, pd.DataFrame]] = {}
     outcomes: dict[str, ExperimentOutcome] = {}
     start_time = time.time()
-    # TODO: outcomes are per-experiment and immutable — this loop can be
-    # parallelised with ThreadPoolExecutor once the perf-database cache
-    # (databases_cache / functools.cache in perf_database.py) is thread-safe.
-    for exp_name, task in tasks.items():
+
+    def _run_one(exp_name: str, task) -> tuple[str, dict | None, ExperimentOutcome]:
+        """Run a single experiment and return (name, result_or_None, outcome)."""
         try:
             logger.info("Starting experiment: %s", exp_name)
             logger.debug("Task config: \n%s", task.to_yaml())
             pareto_df = task.run()
-            task_result = {"pareto_df": pareto_df}
             if pareto_df is not None and not pareto_df.empty:
-                results[exp_name] = task_result
-                outcomes[exp_name] = ExperimentOutcome(exp_name)
                 logger.info("Experiment %s completed with %d results.", exp_name, len(pareto_df))
-            else:
-                db_mode = getattr(task, "database_mode", None)
-                hybrid_hint = (
-                    " For frontier/new models without silicon data, try --database-mode HYBRID."
-                    if db_mode == common.DatabaseMode.SILICON.name
-                    else ""
-                )
-                gpu_hint = (
-                    "(2) the model does not fit — try a quantized model; "
-                    if mode == "recommend"
-                    else "(2) the model does not fit — try a larger --total-gpus value or a quantized model; "
-                )
-                msg = (
-                    f"Experiment {exp_name} returned no results. Possible causes: "
-                    "(1) TTFT/TPOT constraints are too tight — try relaxing --ttft or --tpot; "
-                    f"{gpu_hint}"
-                    f"(3) no perf data in the database for this configuration.{hybrid_hint}"
-                )
-                logger.warning(msg)
-                outcomes[exp_name] = ExperimentOutcome(exp_name)
+                return exp_name, {"pareto_df": pareto_df}, ExperimentOutcome(exp_name)
+            db_mode = getattr(task, "database_mode", None)
+            hybrid_hint = (
+                " For frontier/new models without silicon data, try --database-mode HYBRID."
+                if db_mode == common.DatabaseMode.SILICON.name
+                else ""
+            )
+            gpu_hint = (
+                "(2) the model does not fit — try a quantized model; "
+                if mode == "recommend"
+                else "(2) the model does not fit — try a larger --total-gpus value or a quantized model; "
+            )
+            msg = (
+                f"Experiment {exp_name} returned no results. Possible causes: "
+                "(1) TTFT/TPOT constraints are too tight — try relaxing --ttft or --tpot; "
+                f"{gpu_hint}"
+                f"(3) no perf data in the database for this configuration.{hybrid_hint}"
+            )
+            logger.warning(msg)
+            return exp_name, None, ExperimentOutcome(exp_name)
         except NoFeasibleConfigError as exc:
             msg = f"Experiment {exp_name} found no SLA-feasible configuration: {exc}"
             logger.warning(msg)
-            outcomes[exp_name] = ExperimentOutcome(exp_name, error=exc)
+            return exp_name, None, ExperimentOutcome(exp_name, error=exc)
         except Exception as exc:
             if is_expected_cli_error(exc):
                 logger.log(logging.ERROR, "Error running experiment %s: %s", exp_name, exc)
                 logger.debug("Traceback for experiment %s", exp_name, exc_info=True)
             else:
                 logger.exception("Error running experiment %s", exp_name)
-            outcomes[exp_name] = ExperimentOutcome(exp_name, error=exc)
+            return exp_name, None, ExperimentOutcome(exp_name, error=exc)
+
+    if parallel_experiments and len(tasks) >= 2:
+        with ThreadPoolExecutor(max_workers=len(tasks)) as pool:
+            futures = {pool.submit(_run_one, n, t): n for n, t in tasks.items()}
+            for future in as_completed(futures):
+                exp_name, task_result, outcome = future.result()
+                outcomes[exp_name] = outcome
+                if task_result is not None:
+                    results[exp_name] = task_result
+    else:
+        for exp_name, task in tasks.items():
+            exp_name, task_result, outcome = _run_one(exp_name, task)
+            outcomes[exp_name] = outcome
+            if task_result is not None:
+                results[exp_name] = task_result
 
     if len(results) < 1:
         first_config = next(iter(tasks.values()), None)

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -2589,6 +2589,7 @@ def _validate_fpm_sweep_tasks(args, tasks: dict[str, Task]) -> None:
 def _run_recommend(args) -> None:
     """Run recommend mode: find minimum GPUs for a load target."""
     from aiconfigurator.cli.api import cli_recommend
+    from aiconfigurator.sdk.errors import NoResultsError
 
     logger.info(
         "Finding minimum GPUs for %s on %s (backend=%s)",
@@ -2596,37 +2597,41 @@ def _run_recommend(args) -> None:
         args.system,
         args.backend,
     )
-    cli_recommend(
-        model_path=args.model_path,
-        system=args.system,
-        target_request_rate=getattr(args, "target_request_rate", None),
-        target_concurrency=getattr(args, "target_concurrency", None),
-        decode_system=args.decode_system,
-        backend=args.backend,
-        backend_version=args.backend_version,
-        database_mode=args.database_mode,
-        transfer_policy=args.transfer_policy,
-        isl=args.isl,
-        osl=args.osl,
-        image_height=args.image_height,
-        image_width=args.image_width,
-        num_images=args.num_images,
-        ttft=args.ttft,
-        tpot=args.tpot,
-        request_latency=args.request_latency,
-        prefix=args.prefix,
-        nextn=args.nextn,
-        nextn_accept_rates=[float(x) for x in args.nextn_accept_rates.split(",")],
-        strict_sla=getattr(args, "strict_sla", False),
-        enable_chunked_prefill=args.enable_chunked_prefill,
-        free_gpu_memory_fraction=args.free_gpu_memory_fraction,
-        max_seq_len=args.max_seq_len,
-        enable_wideep=getattr(args, "enable_wideep", False),
-        moe_backend=getattr(args, "moe_backend", None),
-        top_n=args.top_n,
-        save_dir=args.save_dir,
-        engine_step_backend=args.engine_step_backend,
-    )
+    try:
+        cli_recommend(
+            model_path=args.model_path,
+            system=args.system,
+            target_request_rate=getattr(args, "target_request_rate", None),
+            target_concurrency=getattr(args, "target_concurrency", None),
+            decode_system=args.decode_system,
+            backend=args.backend,
+            backend_version=args.backend_version,
+            database_mode=args.database_mode,
+            transfer_policy=args.transfer_policy,
+            isl=args.isl,
+            osl=args.osl,
+            image_height=args.image_height,
+            image_width=args.image_width,
+            num_images=args.num_images,
+            ttft=args.ttft,
+            tpot=args.tpot,
+            request_latency=args.request_latency,
+            prefix=args.prefix,
+            nextn=args.nextn,
+            nextn_accept_rates=[float(x) for x in args.nextn_accept_rates.split(",")],
+            strict_sla=getattr(args, "strict_sla", False),
+            enable_chunked_prefill=args.enable_chunked_prefill,
+            free_gpu_memory_fraction=args.free_gpu_memory_fraction,
+            max_seq_len=args.max_seq_len,
+            enable_wideep=getattr(args, "enable_wideep", False),
+            moe_backend=getattr(args, "moe_backend", None),
+            top_n=args.top_n,
+            save_dir=args.save_dir,
+            engine_step_backend=args.engine_step_backend,
+        )
+    except NoResultsError as exc:
+        logger.debug("Recommend mode traceback", exc_info=True)
+        raise SystemExit(1) from exc
 
 
 def _validate_default_mode_inputs(args) -> None:

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -424,6 +424,167 @@ def _add_default_mode_arguments(parser):
     )
 
 
+def _add_recommend_mode_arguments(parser):
+    parser.add_argument(
+        "--model-path",
+        "--model",
+        dest="model_path",
+        type=_validate_model_path,
+        default=None,
+        help="Model path: HuggingFace model path (e.g., 'Qwen/Qwen3-32B') or "
+        "local path to directory containing config.json.",
+    )
+    load_group = parser.add_mutually_exclusive_group(required=True)
+    load_group.add_argument(
+        "--target-request-rate",
+        type=float,
+        default=None,
+        help="Target system request rate in req/s. Find minimum GPUs to serve this rate.",
+    )
+    load_group.add_argument(
+        "--target-concurrency",
+        type=float,
+        default=None,
+        help="Target number of concurrent users. Find minimum GPUs to serve this concurrency.",
+    )
+    parser.add_argument(
+        "--system",
+        type=str,
+        default=None,
+        help=(
+            "System name (GPU type). Example: "
+            "h200_sxm,h100_sxm,h100_pcie,b200_sxm,b300_sxm,gb200,a100_sxm,a100_pcie,l40s,l4,a30,gb300."
+        ),
+    )
+    parser.add_argument(
+        "--decode-system",
+        type=str,
+        default=None,
+        help="System name for disagg decode workers. Defaults to --system if omitted.",
+    )
+    parser.add_argument(
+        "--backend",
+        choices=[backend.value for backend in common.BackendName] + ["auto"],
+        type=str,
+        default=common.BackendName.trtllm.value,
+        help="Backend name. Use a specific backend (trtllm, vllm, sglang) or 'auto' to sweep "
+        "across all supported backends for the given system and compare results side by side. "
+        "Default: trtllm.",
+    )
+    parser.add_argument(
+        "--perf-db-version",
+        "--backend-version",
+        dest="backend_version",
+        type=str,
+        default=None,
+        help="[expert] Performance-database version used for the simulation/search "
+        "(search fidelity). Default: latest measured version. Alias: --backend-version.",
+    )
+    parser.add_argument(
+        "--database-mode",
+        choices=[mode.name for mode in common.DatabaseMode if mode != common.DatabaseMode.SOL_FULL],
+        type=str,
+        default=common.DatabaseMode.SILICON.name,
+        help="Database mode for performance estimation. "
+        "SILICON (default): uses silicon-collected data. "
+        "HYBRID (recommended for frontier/new models): extends SILICON with SOL+empirical estimates. "
+        "EMPIRICAL: SOL+empirical factor only. SOL: theoretical Speed-of-Light only.",
+    )
+    parser.add_argument(
+        "--transfer-policy",
+        type=str,
+        default=None,
+        help="Fine-grained HYBRID/EMPIRICAL transfer control. "
+        "A preset (off|conservative|balanced|aggressive) or comma-separated kinds. "
+        "Default: all kinds enabled. Ignored in SILICON mode.",
+    )
+    parser.add_argument("--isl", type=int, default=4000, help="Input sequence length. Default: 4000.")
+    parser.add_argument("--osl", type=int, default=1000, help="Output sequence length. Default: 1000.")
+    parser.add_argument(
+        "--image-height",
+        type=int,
+        default=0,
+        help="Image height in pixels for vision-language models. Default: 0 (disabled).",
+    )
+    parser.add_argument(
+        "--image-width",
+        type=int,
+        default=0,
+        help="Image width in pixels for vision-language models. Default: 0 (disabled).",
+    )
+    parser.add_argument(
+        "--num-images", type=int, default=1, help="Number of images per request for vision-language models. Default: 1."
+    )
+    parser.add_argument(
+        "--ttft",
+        type=float,
+        default=2000.0,
+        help="Time to first token SLA target in ms. (Default: 2000)",
+    )
+    parser.add_argument(
+        "--tpot",
+        type=float,
+        default=30.0,
+        help="Time per output token SLA target in ms. (Default: 30)",
+    )
+    parser.add_argument(
+        "--strict-sla",
+        action="store_true",
+        default=False,
+        help="Filter the Pareto frontier and best configs to only SLA-compliant data points.",
+    )
+    parser.add_argument(
+        "--request-latency",
+        type=float,
+        default=None,
+        help="Optional end-to-end request latency target (ms). Enables request-latency optimization mode.",
+    )
+    parser.add_argument("--prefix", type=int, default=0, help="Prefix cache length. Default to 0.")
+    parser.add_argument(
+        "--nextn",
+        type=int,
+        default=0,
+        help="Number of draft tokens for MTP speculative decoding. Default: 0 (disabled).",
+    )
+    parser.add_argument(
+        "--nextn-accept-rates",
+        type=str,
+        default="0.85,0.3,0,0,0",
+        help="Comma-separated acceptance rates for MTP draft tokens (5 values). Default: '0.85,0.3,0,0,0'.",
+    )
+    parser.add_argument(
+        "--enable-chunked-prefill",
+        action="store_true",
+        default=False,
+        help="Enable chunked prefill for finer-grained context token sweep during optimization.",
+    )
+    parser.add_argument(
+        "--free-gpu-memory-fraction",
+        type=float,
+        default=1.0,
+        help="Fraction of free GPU memory allocated for KV cache (default: 1.0).",
+    )
+    parser.add_argument(
+        "--max-seq-len",
+        type=int,
+        default=None,
+        help="TRT-LLM --max_seq_len setting (default: isl + osl).",
+    )
+    parser.add_argument(
+        "--enable-wideep",
+        action="store_true",
+        default=False,
+        help="Enable Wide Expert Parallelism (WideEP) for MoE models.",
+    )
+    parser.add_argument(
+        "--moe-backend",
+        type=str,
+        choices=["deepep_moe", "megamoe"],
+        default=None,
+        help="Explicit SGLang MoE backend. Use 'megamoe' to model DeepSeek-V4 MegaMoE on Blackwell.",
+    )
+
+
 def _add_experiments_mode_arguments(parser):
     parser.add_argument(
         "--yaml-path",
@@ -1048,6 +1209,19 @@ def configure_parser(parser):
     )
     _add_support_mode_arguments(support_parser)
 
+    recommend_parser = subparsers.add_parser(
+        "recommend",
+        parents=[common_cli_parser, common_cli_experiments_parser],
+        help="Find minimum GPUs to meet a performance target.",
+        description=(
+            "Given a model, system, workload (ISL/OSL), SLA targets (TTFT/TPOT), "
+            "and a load target (request rate or concurrency), find the minimum "
+            "number of GPUs needed. Designed as a procurement sizing tool — "
+            "the output is unconstrained."
+        ),
+    )
+    _add_recommend_mode_arguments(recommend_parser)
+
 
 def _get_system_data_root(system_name: str) -> str | None:
     """Resolve a system's perf-data root (the dir holding either
@@ -1656,7 +1830,7 @@ def _execute_tasks(
                 msg = (
                     f"Experiment {exp_name} returned no results. Possible causes: "
                     "(1) TTFT/TPOT constraints are too tight — try relaxing --ttft or --tpot; "
-                    "(2) the model does not fit on the available GPUs — try increasing --total-gpus; "
+                    "(2) the model does not fit — try a larger --total-gpus value or a quantized model; "
                     f"(3) no perf data in the database for this configuration.{hybrid_hint}"
                 )
                 logger.warning(msg)
@@ -2393,6 +2567,53 @@ def main(args):
                 logger.debug("Traceback for estimate mode", exc_info=True)
                 raise SystemExit("Error: " + str(exc)) from exc
             raise
+        return
+
+    if args.mode == "recommend":
+        if not getattr(args, "model_path", None):
+            raise SystemExit("recommend mode requires --model-path")
+        if not getattr(args, "system", None):
+            raise SystemExit("recommend mode requires --system")
+
+        from aiconfigurator.cli.api import cli_recommend
+
+        logger.info(
+            "Recommend mode: finding minimum GPUs for %s on %s (backend=%s)",
+            args.model_path,
+            args.system,
+            args.backend,
+        )
+        cli_recommend(
+            model_path=args.model_path,
+            system=args.system,
+            target_request_rate=args.target_request_rate,
+            target_concurrency=args.target_concurrency,
+            decode_system=args.decode_system,
+            backend=args.backend,
+            backend_version=args.backend_version,
+            database_mode=args.database_mode,
+            transfer_policy=args.transfer_policy,
+            isl=args.isl,
+            osl=args.osl,
+            image_height=args.image_height,
+            image_width=args.image_width,
+            num_images=args.num_images,
+            ttft=args.ttft,
+            tpot=args.tpot,
+            request_latency=args.request_latency,
+            prefix=args.prefix,
+            nextn=args.nextn,
+            nextn_accept_rates=[float(x) for x in args.nextn_accept_rates.split(",")],
+            strict_sla=getattr(args, "strict_sla", False),
+            enable_chunked_prefill=args.enable_chunked_prefill,
+            free_gpu_memory_fraction=args.free_gpu_memory_fraction,
+            max_seq_len=args.max_seq_len,
+            enable_wideep=getattr(args, "enable_wideep", False),
+            moe_backend=getattr(args, "moe_backend", None),
+            top_n=args.top_n,
+            save_dir=args.save_dir,
+            engine_step_backend=args.engine_step_backend,
+        )
         return
 
     if args.mode == "default":

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -25,6 +25,7 @@ from aiconfigurator.logging_utils import setup_logging
 from aiconfigurator.sdk import common, perf_database
 from aiconfigurator.sdk.config_builders import resolve_nextn_auto
 from aiconfigurator.sdk.errors import (
+    ExperimentOutcome,
     NoFeasibleConfigError,
     UnsupportedWideepConfigError,
     is_expected_cli_error,
@@ -204,6 +205,16 @@ def _resolve_and_validate_nextn(args) -> None:
         raise SystemExit(str(exc)) from exc
 
 
+def _positive_float(value: str) -> float:
+    """Argparse type for positive finite floats (load targets, SLA thresholds)."""
+    import math
+
+    f = float(value)
+    if not (math.isfinite(f) and f > 0):
+        raise argparse.ArgumentTypeError(f"must be a positive finite number, got {value!r}")
+    return f
+
+
 def _validate_model_path(model_path: str) -> str:
     """
     Validate model_path which can be:
@@ -247,7 +258,28 @@ def _add_default_mode_arguments(parser):
         help="Model path: HuggingFace model path (e.g., 'Qwen/Qwen3-32B') or "
         "local path to directory containing config.json.",
     )
-    parser.add_argument("--total-gpus", type=int, required=True, help="Total GPUs for deployment.")
+    parser.add_argument(
+        "--total-gpus",
+        type=int,
+        default=None,
+        help="Total GPUs for deployment. "
+        "Omit and provide --target-request-rate or --target-concurrency to find minimum GPUs.",
+    )
+    load_group = parser.add_mutually_exclusive_group()
+    load_group.add_argument(
+        "--target-request-rate",
+        type=_positive_float,
+        default=None,
+        help="Target system request rate in req/s. When provided without --total-gpus, "
+        "finds the minimum GPU count (recommend mode).",
+    )
+    load_group.add_argument(
+        "--target-concurrency",
+        type=_positive_float,
+        default=None,
+        help="Target number of concurrent users. When provided without --total-gpus, "
+        "finds the minimum GPU count (recommend mode).",
+    )
     parser.add_argument(
         "--system",
         type=str,
@@ -437,13 +469,13 @@ def _add_recommend_mode_arguments(parser):
     load_group = parser.add_mutually_exclusive_group(required=True)
     load_group.add_argument(
         "--target-request-rate",
-        type=float,
+        type=_positive_float,
         default=None,
         help="Target system request rate in req/s. Find minimum GPUs to serve this rate.",
     )
     load_group.add_argument(
         "--target-concurrency",
-        type=float,
+        type=_positive_float,
         default=None,
         help="Target number of concurrent users. Find minimum GPUs to serve this concurrency.",
     )
@@ -484,10 +516,11 @@ def _add_recommend_mode_arguments(parser):
         "--database-mode",
         choices=[mode.name for mode in common.DatabaseMode if mode != common.DatabaseMode.SOL_FULL],
         type=str,
-        default=common.DatabaseMode.SILICON.name,
+        default=common.DatabaseMode.HYBRID.name,
         help="Database mode for performance estimation. "
-        "SILICON (default): uses silicon-collected data. "
-        "HYBRID (recommended for frontier/new models): extends SILICON with SOL+empirical estimates. "
+        "HYBRID (default for recommend): extends SILICON with SOL+empirical estimates — "
+        "produces results even for frontier/new models without full silicon data. "
+        "SILICON: silicon-collected data only; results are fully reproducible. "
         "EMPIRICAL: SOL+empirical factor only. SOL: theoretical Speed-of-Light only.",
     )
     parser.add_argument(
@@ -1778,7 +1811,14 @@ def _execute_tasks(
     max_total_gpus: int | None = None,
     strict_sla: bool = False,
     inclusive_tpot: bool = False,
-) -> tuple[str, dict[str, pd.DataFrame], dict[str, pd.DataFrame], dict[str, float], dict[str, dict[str, float]]]:
+) -> tuple[
+    str,
+    dict[str, pd.DataFrame],
+    dict[str, pd.DataFrame],
+    dict[str, float],
+    dict[str, dict[str, float]],
+    dict[str, ExperimentOutcome],
+]:
     """
     Execute task configs and return the chosen experiment, best configs, results, best
     throughputs, and estimated latencies.
@@ -1808,9 +1848,11 @@ def _execute_tasks(
               extracted from the rank-1 config.
     """
     results: dict[str, dict[str, pd.DataFrame]] = {}
-    failure_messages: list[str] = []
+    outcomes: dict[str, ExperimentOutcome] = {}
     start_time = time.time()
-    # TODO, can run in parallel
+    # TODO: outcomes are per-experiment and immutable — this loop can be
+    # parallelised with ThreadPoolExecutor once the perf-database cache
+    # (databases_cache / functools.cache in perf_database.py) is thread-safe.
     for exp_name, task in tasks.items():
         try:
             logger.info("Starting experiment: %s", exp_name)
@@ -1819,6 +1861,7 @@ def _execute_tasks(
             task_result = {"pareto_df": pareto_df}
             if pareto_df is not None and not pareto_df.empty:
                 results[exp_name] = task_result
+                outcomes[exp_name] = ExperimentOutcome(exp_name)
                 logger.info("Experiment %s completed with %d results.", exp_name, len(pareto_df))
             else:
                 db_mode = getattr(task, "database_mode", None)
@@ -1827,29 +1870,30 @@ def _execute_tasks(
                     if db_mode == common.DatabaseMode.SILICON.name
                     else ""
                 )
+                gpu_hint = (
+                    "(2) the model does not fit — try a quantized model; "
+                    if mode == "recommend"
+                    else "(2) the model does not fit — try a larger --total-gpus value or a quantized model; "
+                )
                 msg = (
                     f"Experiment {exp_name} returned no results. Possible causes: "
                     "(1) TTFT/TPOT constraints are too tight — try relaxing --ttft or --tpot; "
-                    "(2) the model does not fit — try a larger --total-gpus value or a quantized model; "
+                    f"{gpu_hint}"
                     f"(3) no perf data in the database for this configuration.{hybrid_hint}"
                 )
                 logger.warning(msg)
-                failure_messages.append(msg)
+                outcomes[exp_name] = ExperimentOutcome(exp_name)
         except NoFeasibleConfigError as exc:
             msg = f"Experiment {exp_name} found no SLA-feasible configuration: {exc}"
             logger.warning(msg)
-            failure_messages.append(msg)
+            outcomes[exp_name] = ExperimentOutcome(exp_name, error=exc)
         except Exception as exc:
             if is_expected_cli_error(exc):
-                # Expected failure (no feasible config / OOM / KV-cache capacity,
-                # a per-op perf-data miss, or an unsupported quant/compatibility
-                # config): report cleanly. Keep the traceback at DEBUG for
-                # diagnosis via --log-level DEBUG.
                 logger.log(logging.ERROR, "Error running experiment %s: %s", exp_name, exc)
                 logger.debug("Traceback for experiment %s", exp_name, exc_info=True)
             else:
                 logger.exception("Error running experiment %s", exp_name)
-            failure_messages.append(f"Experiment {exp_name} failed: {exc}")
+            outcomes[exp_name] = ExperimentOutcome(exp_name, error=exc)
 
     if len(results) < 1:
         first_config = next(iter(tasks.values()), None)
@@ -1862,9 +1906,10 @@ def _execute_tasks(
             )
         else:
             logger.error("No successful experiment runs to compare.")
-        for msg in failure_messages:
-            logger.error("  -> %s", msg)
-        raise SystemExit(1)
+        for outcome in outcomes.values():
+            if outcome.error is not None:
+                logger.error("  -> Experiment %s failed: %s", outcome.experiment, outcome.error)
+        return "none", {}, {}, {}, {}, outcomes
 
     best_configs: dict[str, pd.DataFrame] = {}
     best_throughputs: dict[str, float] = {}
@@ -1912,7 +1957,7 @@ def _execute_tasks(
     end_time = time.time()
     logger.info("All experiments completed in %.2f seconds", end_time - start_time)
 
-    return chosen_exp, best_configs, pareto_fronts, best_throughputs, best_latencies
+    return chosen_exp, best_configs, pareto_fronts, best_throughputs, best_latencies, outcomes
 
 
 def _run_generate_mode(args):
@@ -2528,6 +2573,77 @@ def _validate_fpm_sweep_tasks(args, tasks: dict[str, Task]) -> None:
         )
 
 
+def _run_recommend(args) -> None:
+    """Run recommend mode: find minimum GPUs for a load target."""
+    from aiconfigurator.cli.api import cli_recommend
+
+    logger.info(
+        "Finding minimum GPUs for %s on %s (backend=%s)",
+        args.model_path,
+        args.system,
+        args.backend,
+    )
+    cli_recommend(
+        model_path=args.model_path,
+        system=args.system,
+        target_request_rate=getattr(args, "target_request_rate", None),
+        target_concurrency=getattr(args, "target_concurrency", None),
+        decode_system=args.decode_system,
+        backend=args.backend,
+        backend_version=args.backend_version,
+        database_mode=args.database_mode,
+        transfer_policy=args.transfer_policy,
+        isl=args.isl,
+        osl=args.osl,
+        image_height=args.image_height,
+        image_width=args.image_width,
+        num_images=args.num_images,
+        ttft=args.ttft,
+        tpot=args.tpot,
+        request_latency=args.request_latency,
+        prefix=args.prefix,
+        nextn=args.nextn,
+        nextn_accept_rates=[float(x) for x in args.nextn_accept_rates.split(",")],
+        strict_sla=getattr(args, "strict_sla", False),
+        enable_chunked_prefill=args.enable_chunked_prefill,
+        free_gpu_memory_fraction=args.free_gpu_memory_fraction,
+        max_seq_len=args.max_seq_len,
+        enable_wideep=getattr(args, "enable_wideep", False),
+        moe_backend=getattr(args, "moe_backend", None),
+        top_n=args.top_n,
+        save_dir=args.save_dir,
+        engine_step_backend=args.engine_step_backend,
+    )
+
+
+def _validate_default_mode_inputs(args) -> None:
+    """Validate default-mode args that are conditional on the selected sweeper."""
+    if args.mode != "default":
+        return
+    if getattr(args, "thorough_config", None):
+        return
+
+    required = {
+        "model_path": "--model-path/--model",
+        "system": "--system",
+    }
+    missing = [flag for attr, flag in required.items() if getattr(args, attr, None) is None]
+    if missing:
+        raise SystemExit(
+            "default mode requires "
+            + ", ".join(missing)
+            + " unless --thorough-config provides a native Spica SmartSearchConfig."
+        )
+    has_gpus = getattr(args, "total_gpus", None) is not None
+    has_load_target = (
+        getattr(args, "target_request_rate", None) is not None or getattr(args, "target_concurrency", None) is not None
+    )
+    if not has_gpus and not has_load_target:
+        raise SystemExit(
+            "default mode requires either --total-gpus or a load target (--target-request-rate / --target-concurrency)."
+        )
+
+
 def main(args):
     setup_logging(
         level=_resolve_cli_log_level(args),
@@ -2574,50 +2690,21 @@ def main(args):
             raise SystemExit("recommend mode requires --model-path")
         if not getattr(args, "system", None):
             raise SystemExit("recommend mode requires --system")
-
-        from aiconfigurator.cli.api import cli_recommend
-
-        logger.info(
-            "Recommend mode: finding minimum GPUs for %s on %s (backend=%s)",
-            args.model_path,
-            args.system,
-            args.backend,
-        )
-        cli_recommend(
-            model_path=args.model_path,
-            system=args.system,
-            target_request_rate=args.target_request_rate,
-            target_concurrency=args.target_concurrency,
-            decode_system=args.decode_system,
-            backend=args.backend,
-            backend_version=args.backend_version,
-            database_mode=args.database_mode,
-            transfer_policy=args.transfer_policy,
-            isl=args.isl,
-            osl=args.osl,
-            image_height=args.image_height,
-            image_width=args.image_width,
-            num_images=args.num_images,
-            ttft=args.ttft,
-            tpot=args.tpot,
-            request_latency=args.request_latency,
-            prefix=args.prefix,
-            nextn=args.nextn,
-            nextn_accept_rates=[float(x) for x in args.nextn_accept_rates.split(",")],
-            strict_sla=getattr(args, "strict_sla", False),
-            enable_chunked_prefill=args.enable_chunked_prefill,
-            free_gpu_memory_fraction=args.free_gpu_memory_fraction,
-            max_seq_len=args.max_seq_len,
-            enable_wideep=getattr(args, "enable_wideep", False),
-            moe_backend=getattr(args, "moe_backend", None),
-            top_n=args.top_n,
-            save_dir=args.save_dir,
-            engine_step_backend=args.engine_step_backend,
-        )
+        _run_recommend(args)
         return
 
     if args.mode == "default":
         _resolve_and_validate_nextn(args)
+        _validate_default_mode_inputs(args)
+
+        # No --total-gpus but a load target means recommend mode
+        has_load_target = (
+            getattr(args, "target_request_rate", None) is not None
+            or getattr(args, "target_concurrency", None) is not None
+        )
+        if getattr(args, "total_gpus", None) is None and has_load_target:
+            _run_recommend(args)
+            return
 
         # Warn when SLA/workload parameters are implicitly defaulted
         _default_params = {"isl": 4000, "osl": 1000, "ttft": 2000.0, "tpot": 30.0}
@@ -2691,12 +2778,14 @@ def main(args):
         execute_kwargs["strict_sla"] = True
     if getattr(args, "inclusive_tpot", False):
         execute_kwargs["inclusive_tpot"] = True
-    _, best_configs, pareto_fronts, _, _ = _execute_tasks(
+    _, best_configs, pareto_fronts, _, _, _ = _execute_tasks(
         tasks,
         args.mode,
         top_n=args.top_n,
         **execute_kwargs,
     )
+    if not best_configs:
+        raise SystemExit(1)
 
     if args.save_dir:
         save_results(

--- a/src/aiconfigurator/cli/report_and_save.py
+++ b/src/aiconfigurator/cli/report_and_save.py
@@ -88,14 +88,17 @@ def _plot_worker_setup_table(
         return ""
 
     config_df = config_df.copy()
-    config_df["tokens/s/gpu_cluster"] = (
-        config_df["tokens/s/gpu"]
-        * (total_gpus // config_df["num_total_gpus"])
-        * config_df["num_total_gpus"]
-        / total_gpus
-        if total_gpus > 0
-        else 0
-    )
+    if "replicas_needed" in config_df.columns:
+        config_df["tokens/s/gpu_cluster"] = config_df["tokens/s/gpu"]
+    else:
+        config_df["tokens/s/gpu_cluster"] = (
+            config_df["tokens/s/gpu"]
+            * (total_gpus // config_df["num_total_gpus"])
+            * config_df["num_total_gpus"]
+            / total_gpus
+            if total_gpus > 0
+            else 0
+        )
     constraint_col = "tpot"
     constraint_target = tpot_target
     constraint_label = "TPOT"
@@ -107,16 +110,24 @@ def _plot_worker_setup_table(
         top_configs = config_df[config_df[constraint_col] <= constraint_target].copy()
     else:
         top_configs = config_df.copy()
-    top_configs = top_configs.sort_values(by="tokens/s/gpu_cluster", ascending=False)
+    if "replicas_needed" in top_configs.columns:
+        top_configs = top_configs.sort_values(by="total_gpus_needed", ascending=True)
+    else:
+        top_configs = top_configs.sort_values(by="tokens/s/gpu_cluster", ascending=False)
     top_configs = top_configs.head(top).copy()
 
     if top_configs.empty:
         return f"\nNo configurations for {exp_name} met the {constraint_label} constraint."
 
-    top_configs["replicas"] = total_gpus // top_configs["num_total_gpus"]
-    top_configs["total_gpus_used"] = top_configs["num_total_gpus"] * top_configs["replicas"]
+    if "replicas_needed" in top_configs.columns:
+        top_configs["replicas"] = top_configs["replicas_needed"].astype(int)
+        top_configs["total_gpus_used"] = top_configs["total_gpus_needed"].astype(int)
+    else:
+        top_configs["replicas"] = total_gpus // top_configs["num_total_gpus"]
+        top_configs["total_gpus_used"] = top_configs["num_total_gpus"] * top_configs["replicas"]
 
-    buf.append(f"\n{exp_name} Top Configurations: (Ranked by tokens/s/gpu)")
+    ranking_label = "total_gpus_needed" if "replicas_needed" in top_configs.columns else "tokens/s/gpu"
+    buf.append(f"\n{exp_name} Top Configurations: (Ranked by {ranking_label})")
     table = PrettyTable()
 
     # Check if it is disagg config by checking for prefill/decode specific columns
@@ -150,7 +161,7 @@ def _plot_worker_setup_table(
             field_names.append("power_w")
         table.field_names = field_names
         for i, row in enumerate(top_configs.to_dict("records")):
-            display_total_gpus = total_gpus
+            display_total_gpus = row["total_gpus_used"] if "replicas_needed" in row else total_gpus
             display_concurrency = row["concurrency"] * row["replicas"]
             if is_moe:
                 p_parallel = (
@@ -244,7 +255,7 @@ def _plot_worker_setup_table(
             field_names.append("power_w")
         table.field_names = field_names
         for i, row in enumerate(top_configs.to_dict("records")):
-            display_total_gpus = total_gpus
+            display_total_gpus = row["total_gpus_used"] if "replicas_needed" in row else total_gpus
             display_concurrency = row["concurrency"] * row["replicas"]
             if is_moe:
                 parallel = (
@@ -342,7 +353,8 @@ def log_final_summary(
         chosen_task = tasks[chosen_exp]
 
     summary_box.append(f"    Model: {chosen_task.primary_model_path} (is_moe: {chosen_task.is_moe})")
-    summary_box.append(f"    Total GPUs: {chosen_task.total_gpus}")
+    if not load_match:
+        summary_box.append(f"    Total GPUs: {chosen_task.total_gpus}")
 
     if load_match:
         # Load-match mode summary
@@ -391,11 +403,18 @@ def log_final_summary(
 
     if not best_config_df.empty:
         best_conf_details = best_config_df.iloc[0]
-        summary_box.append(f"    - Best Throughput: {best_throughput * chosen_task.total_gpus:,.2f} tokens/s")
+        if load_match and "replicas_needed" in best_conf_details.index:
+            display_total_gpus = int(best_conf_details["total_gpus_needed"])
+        else:
+            display_total_gpus = chosen_task.total_gpus
+        summary_box.append(f"    - Best Throughput: {best_throughput * display_total_gpus:,.2f} tokens/s")
         summary_box.append(f"    - Per-GPU Throughput: {best_throughput:.2f} tokens/s/gpu")
         summary_box.append(f"    - Per-User Throughput: {best_conf_details['tokens/s/user']:.2f} tokens/s/user")
-        replicas = chosen_task.total_gpus // int(best_conf_details["num_total_gpus"])
-        cluster_rr = float(best_conf_details["request_rate"]) * replicas
+        if load_match and "replicas_needed" in best_conf_details.index:
+            cluster_rr = float(best_conf_details["request_rate"]) * int(best_conf_details["replicas_needed"])
+        else:
+            replicas = chosen_task.total_gpus // int(best_conf_details["num_total_gpus"])
+            cluster_rr = float(best_conf_details["request_rate"]) * replicas
         summary_box.append(f"    - Request Rate: {cluster_rr:.2f} req/s")
         summary_box.append(f"    - TTFT: {best_conf_details['ttft']:.2f}ms")
         summary_box.append(f"    - TPOT: {best_conf_details['tpot']:.2f}ms")

--- a/src/aiconfigurator/cli/report_and_save.py
+++ b/src/aiconfigurator/cli/report_and_save.py
@@ -404,11 +404,15 @@ def log_final_summary(
     if not best_config_df.empty:
         best_conf_details = best_config_df.iloc[0]
         if load_match and "replicas_needed" in best_conf_details.index:
+            per_gpu = float(best_conf_details["tokens/s/gpu"])
             display_total_gpus = int(best_conf_details["total_gpus_needed"])
+            total_throughput = per_gpu * display_total_gpus
         else:
+            per_gpu = best_throughput
             display_total_gpus = chosen_task.total_gpus
-        summary_box.append(f"    - Best Throughput: {best_throughput * display_total_gpus:,.2f} tokens/s")
-        summary_box.append(f"    - Per-GPU Throughput: {best_throughput:.2f} tokens/s/gpu")
+            total_throughput = best_throughput * display_total_gpus
+        summary_box.append(f"    - Best Throughput: {total_throughput:,.2f} tokens/s")
+        summary_box.append(f"    - Per-GPU Throughput: {per_gpu:.2f} tokens/s/gpu")
         summary_box.append(f"    - Per-User Throughput: {best_conf_details['tokens/s/user']:.2f} tokens/s/user")
         if load_match and "replicas_needed" in best_conf_details.index:
             cluster_rr = float(best_conf_details["request_rate"]) * int(best_conf_details["replicas_needed"])

--- a/src/aiconfigurator/generator/module_bridge.py
+++ b/src/aiconfigurator/generator/module_bridge.py
@@ -202,14 +202,18 @@ def task_config_to_generator_config(
     worker_overrides = overrides.get("Workers", {})
     worker_count_overrides = overrides.get("WorkerCounts") or overrides.get("WorkerConfig") or {}
 
+    # Recommend mode sets total_gpus to the escalation budget, not the actual
+    # recommendation.  Prefer the per-row total_gpus_needed when present.
+    effective_total_gpus = _safe_int(_series_val(result_df, "total_gpus_needed", None), None) or task_config.total_gpus
+
     if task_config.serving_mode == "agg":
         agg_params, agg_workers = _build_worker_params("", worker_overrides.get("agg"))
-        if task_config.total_gpus:
+        if effective_total_gpus:
             tp = agg_params.get("tensor_parallel_size", 1)
             pp = agg_params.get("pipeline_parallel_size", 1)
             dp = agg_params.get("data_parallel_size", 1)
             gpus_per_replica = tp * pp * dp
-            agg_workers = task_config.total_gpus // gpus_per_replica
+            agg_workers = effective_total_gpus // gpus_per_replica
         prefill_params, prefill_workers = None, 0
         decode_params, decode_workers = None, 0
     else:
@@ -217,8 +221,8 @@ def task_config_to_generator_config(
         prefill_params, prefill_workers = _build_worker_params("(p)", worker_overrides.get("prefill"))
         decode_params, decode_workers = _build_worker_params("(d)", worker_overrides.get("decode"))
 
-        # Scale disagg workers based on total_gpus (similar to agg mode)
-        if task_config.total_gpus and prefill_params and decode_params:
+        # Scale disagg workers based on total GPU count (similar to agg mode)
+        if effective_total_gpus and prefill_params and decode_params:
             p_tp = prefill_params.get("tensor_parallel_size", 1)
             p_pp = prefill_params.get("pipeline_parallel_size", 1)
             p_dp = prefill_params.get("data_parallel_size", 1)
@@ -233,7 +237,7 @@ def task_config_to_generator_config(
             # For simplicity, assume 1:1 prefill:decode ratio per replica
             gpus_per_replica = (prefill_workers * prefill_gpus_per_worker) + (decode_workers * decode_gpus_per_worker)
             if gpus_per_replica > 0:
-                replicas = task_config.total_gpus // gpus_per_replica
+                replicas = effective_total_gpus // gpus_per_replica
                 prefill_workers = replicas * prefill_workers
                 decode_workers = replicas * decode_workers
 

--- a/src/aiconfigurator/sdk/sweep.py
+++ b/src/aiconfigurator/sdk/sweep.py
@@ -559,7 +559,7 @@ def _get_disagg_worker_candidates(
     ``DisaggInferenceSession.get_worker_candidates``.
     """
     backend = get_backend(backend_name)
-    summary_df = pd.DataFrame(columns=common.ColumnsStatic)
+    result_rows: list[pd.DataFrame] = []
     exceptions: list[Exception] = []
     all_configs_oom = True
 
@@ -602,11 +602,7 @@ def _get_disagg_worker_candidates(
                 )
                 if not summary.check_oom():
                     all_configs_oom = False
-                    summary_df = pd.concat(
-                        [summary_df, summary.get_summary_df()],
-                        axis=0,
-                        ignore_index=True,
-                    )
+                    result_rows.append(summary.get_summary_df())
                 else:
                     break
         except Exception as e:
@@ -623,7 +619,7 @@ def _get_disagg_worker_candidates(
             exceptions.append(e)
             continue
 
-    if summary_df.empty:
+    if not result_rows:
         if exceptions:
             raise RuntimeError(
                 f"sweep_disagg/{role}: no results for any parallel config. Last exception: {exceptions[-1]}"
@@ -636,7 +632,7 @@ def _get_disagg_worker_candidates(
         raise NoFeasibleConfigError(
             f"sweep_disagg/{role}: no parallel configuration met TTFT/TPOT or request-latency constraints."
         )
-    return summary_df
+    return pd.concat(result_rows, axis=0, ignore_index=True)
 
 
 def _find_best_disagg_under_constraint(

--- a/src/aiconfigurator/sdk/sweep.py
+++ b/src/aiconfigurator/sdk/sweep.py
@@ -30,7 +30,7 @@ Output DataFrame schema is ``common.ColumnsAgg`` for agg and
 
 from __future__ import annotations
 
-import copy
+import dataclasses
 import functools
 import logging
 from typing import Any
@@ -311,13 +311,11 @@ def _sweep_one_parallel_agg(
                     continue
                 capped_b.append(gen_tokens)
 
-            # Deep-copy the full runtime_config (mirrors the disagg path below) so
-            # every field is preserved per batch point. Explicit field-by-field
-            # construction silently dropped multimodal fields (image_height/width,
-            # num_images_per_request, num_image_tokens), zeroing the image encoder
-            # workload in agg while disagg stayed correct (NVBug 6401839).
-            point_rt = copy.deepcopy(runtime_config)
-            point_rt.batch_size = b
+            # dataclasses.replace shallow-copies all fields (including multimodal
+            # fields like image_height/width that field-by-field construction
+            # silently dropped -- NVBug 6401839) and overrides only the named
+            # ones. Safe because the sweep never mutates list-valued fields.
+            point_rt = dataclasses.replace(runtime_config, batch_size=b)
 
             backend_kwargs: dict[str, Any] = {}
             if max_seq_len is not None:
@@ -432,13 +430,15 @@ def sweep_agg(
             cp_size,
         )
         try:
-            point_model_config = copy.deepcopy(model_config)
-            point_model_config.tp_size = tp_size
-            point_model_config.pp_size = pp_size
-            point_model_config.moe_tp_size = moe_tp_size
-            point_model_config.moe_ep_size = moe_ep_size
-            point_model_config.attention_dp_size = dp_size
-            point_model_config.cp_size = cp_size
+            point_model_config = dataclasses.replace(
+                model_config,
+                tp_size=tp_size,
+                pp_size=pp_size,
+                moe_tp_size=moe_tp_size,
+                moe_ep_size=moe_ep_size,
+                attention_dp_size=dp_size,
+                cp_size=cp_size,
+            )
 
             # Build backend + model ONCE per parallel choice so the backend's
             # internal _agg_cache survives across the tpot sweep below.
@@ -463,16 +463,11 @@ def sweep_agg(
                     )
                     continue
                 for ttft_c, tpot_c in pairs:
-                    rt = copy.deepcopy(runtime_config)
-                    rt.ttft = ttft_c
-                    rt.tpot = tpot_c
-                    runtime_configs_to_evaluate.append(rt)
+                    runtime_configs_to_evaluate.append(dataclasses.replace(runtime_config, ttft=ttft_c, tpot=tpot_c))
             else:
                 tpot_list = runtime_config.tpot if isinstance(runtime_config.tpot, list) else [runtime_config.tpot]
                 for tpot_v in tpot_list:
-                    rt = copy.deepcopy(runtime_config)
-                    rt.tpot = tpot_v
-                    runtime_configs_to_evaluate.append(rt)
+                    runtime_configs_to_evaluate.append(dataclasses.replace(runtime_config, tpot=tpot_v))
 
             if not runtime_configs_to_evaluate:
                 continue
@@ -581,19 +576,20 @@ def _get_disagg_worker_candidates(
             cp_size,
         )
         try:
-            point_mc = copy.deepcopy(model_config)
-            point_mc.tp_size = tp_size
-            point_mc.pp_size = pp_size
-            point_mc.moe_tp_size = moe_tp_size
-            point_mc.moe_ep_size = moe_ep_size
-            point_mc.attention_dp_size = dp_size
-            point_mc.cp_size = cp_size
+            point_mc = dataclasses.replace(
+                model_config,
+                tp_size=tp_size,
+                pp_size=pp_size,
+                moe_tp_size=moe_tp_size,
+                moe_ep_size=moe_ep_size,
+                attention_dp_size=dp_size,
+                cp_size=cp_size,
+            )
 
             model = get_model(model_path=model_path, model_config=point_mc, backend_name=backend_name)
 
             for b in b_list:
-                point_rt = copy.deepcopy(runtime_config)
-                point_rt.batch_size = b
+                point_rt = dataclasses.replace(runtime_config, batch_size=b)
                 summary = predict_disagg_worker(
                     model=model,
                     backend=backend,

--- a/tests/integration/test_picking.py
+++ b/tests/integration/test_picking.py
@@ -176,6 +176,64 @@ class TestLoadMatchPicking:
         assert (tmp_path / chosen / "generator_config.yaml").exists()
 
 
+class TestRecommendPicking:
+    """Recommend mode: find minimum GPUs for a target load via cli_recommend."""
+
+    def test_recommend_by_request_rate(self):
+        """cli_recommend should return results with total_gpus_needed."""
+        from aiconfigurator.cli.api import cli_recommend
+
+        result = cli_recommend(
+            model_path=MODEL,
+            system=SYSTEM,
+            backend=BACKEND,
+            target_request_rate=5.0,
+            isl=4000,
+            osl=1000,
+            ttft=2000,
+            tpot=50,
+        )
+
+        assert result.chosen_exp in result.best_configs
+        has_results = False
+        for mode, df in result.best_configs.items():
+            if df is not None and not df.empty:
+                has_results = True
+                assert "replicas_needed" in df.columns, f"{mode} missing replicas_needed"
+                assert "total_gpus_needed" in df.columns, f"{mode} missing total_gpus_needed"
+                assert (df["total_gpus_needed"] > 0).all(), f"{mode} has zero GPU recommendations"
+                assert (df["replicas_needed"] >= 1).all(), f"{mode} has replicas < 1"
+        assert has_results, "cli_recommend returned no results"
+
+    def test_recommend_higher_rate_needs_more_gpus(self):
+        """Doubling the target rate should need at least as many GPUs."""
+        from aiconfigurator.cli.api import cli_recommend
+
+        common = dict(
+            model_path=MODEL,
+            system=SYSTEM,
+            backend=BACKEND,
+            isl=4000,
+            osl=1000,
+            ttft=2000,
+            tpot=50,
+        )
+        result_low = cli_recommend(target_request_rate=2.0, **common)
+        result_high = cli_recommend(target_request_rate=20.0, **common)
+
+        def min_gpus(cli_result):
+            for df in cli_result.best_configs.values():
+                if df is not None and not df.empty and "total_gpus_needed" in df.columns:
+                    return int(df["total_gpus_needed"].min())
+            return 0
+
+        low_gpus = min_gpus(result_low)
+        high_gpus = min_gpus(result_high)
+        assert high_gpus >= low_gpus, (
+            f"Higher rate (20 req/s) recommended fewer GPUs ({high_gpus}) than lower rate (2 req/s, {low_gpus})"
+        )
+
+
 class TestAutoscalePicking:
     """Autoscale mode: independent P/D picking, 1 replica each."""
 

--- a/tests/integration/test_picking.py
+++ b/tests/integration/test_picking.py
@@ -177,10 +177,10 @@ class TestLoadMatchPicking:
 
 
 class TestRecommendPicking:
-    """Recommend mode: find minimum GPUs for a target load via cli_recommend."""
+    """Recommend mode: find minimum GPUs for a target load via recommend."""
 
     def test_recommend_by_request_rate(self):
-        """cli_recommend should return results with total_gpus_needed."""
+        """recommend should return results with total_gpus_needed."""
         from aiconfigurator.cli.api import cli_recommend
 
         result = cli_recommend(
@@ -203,7 +203,7 @@ class TestRecommendPicking:
                 assert "total_gpus_needed" in df.columns, f"{mode} missing total_gpus_needed"
                 assert (df["total_gpus_needed"] > 0).all(), f"{mode} has zero GPU recommendations"
                 assert (df["replicas_needed"] >= 1).all(), f"{mode} has replicas < 1"
-        assert has_results, "cli_recommend returned no results"
+        assert has_results, "recommend returned no results"
 
     def test_recommend_higher_rate_needs_more_gpus(self):
         """Doubling the target rate should need at least as many GPUs."""

--- a/tests/unit/cli/test_argument_parsing.py
+++ b/tests/unit/cli/test_argument_parsing.py
@@ -18,7 +18,7 @@ class TestCLIArgumentParsing:
     """Test CLI argument parsing and validation."""
 
     def test_default_mode_core_args_are_required(self, cli_parser):
-        """Default mode requires the model, GPU budget, and system."""
+        """Default mode requires model and system; total_gpus is optional when a load target is provided."""
         subparsers = [action for action in cli_parser._actions if action.dest == "mode"]
         assert len(subparsers) == 1
 
@@ -29,8 +29,9 @@ class TestCLIArgumentParsing:
         required_args = [action.dest for action in required_actions]
 
         assert "model_path" in required_args
-        assert "total_gpus" in required_args
         assert "system" in required_args
+        # total_gpus is optional -- omitting it with a load target triggers recommend
+        assert "total_gpus" not in required_args
 
     def test_exp_mode_required_args(self, cli_parser):
         """Test that exp mode requires the yaml_path argument."""

--- a/tests/unit/cli/test_argument_parsing.py
+++ b/tests/unit/cli/test_argument_parsing.py
@@ -48,7 +48,7 @@ class TestCLIArgumentParsing:
     def test_mode_choices(self, cli_parser):
         """Ensure supported CLI modes are exposed."""
         action = next(action for action in cli_parser._actions if action.dest == "mode")
-        assert set(action.choices.keys()) == {"default", "exp", "generate", "support", "estimate"}
+        assert set(action.choices.keys()) == {"default", "exp", "generate", "support", "estimate", "recommend"}
 
     def test_generate_mode_required_args(self, cli_parser):
         """Test that generate mode requires the correct arguments."""
@@ -435,3 +435,77 @@ class TestCLIArgumentParsing:
         assert args.disable_encoder_dp is False
         args = cli_parser.parse_args(["estimate", *common_args, "--disable-encoder-dp"])
         assert args.disable_encoder_dp is True
+
+    def test_recommend_mode_parses_request_rate(self, cli_parser):
+        args = cli_parser.parse_args(
+            [
+                "recommend",
+                "--model-path",
+                "Qwen/Qwen3-32B",
+                "--system",
+                "h200_sxm",
+                "--target-request-rate",
+                "50.0",
+            ]
+        )
+        assert args.mode == "recommend"
+        assert args.target_request_rate == 50.0
+        assert args.target_concurrency is None
+
+    def test_recommend_mode_parses_concurrency(self, cli_parser):
+        args = cli_parser.parse_args(
+            [
+                "recommend",
+                "--model-path",
+                "Qwen/Qwen3-32B",
+                "--system",
+                "h200_sxm",
+                "--target-concurrency",
+                "200",
+            ]
+        )
+        assert args.mode == "recommend"
+        assert args.target_request_rate is None
+        assert args.target_concurrency == 200.0
+
+    def test_recommend_mode_rejects_both_targets(self, cli_parser):
+        with pytest.raises(SystemExit):
+            cli_parser.parse_args(
+                [
+                    "recommend",
+                    "--model-path",
+                    "Qwen/Qwen3-32B",
+                    "--system",
+                    "h200_sxm",
+                    "--target-request-rate",
+                    "50.0",
+                    "--target-concurrency",
+                    "200",
+                ]
+            )
+
+    def test_recommend_mode_requires_a_target(self, cli_parser):
+        with pytest.raises(SystemExit):
+            cli_parser.parse_args(
+                [
+                    "recommend",
+                    "--model-path",
+                    "Qwen/Qwen3-32B",
+                    "--system",
+                    "h200_sxm",
+                ]
+            )
+
+    def test_recommend_mode_has_no_total_gpus(self, cli_parser):
+        args = cli_parser.parse_args(
+            [
+                "recommend",
+                "--model-path",
+                "Qwen/Qwen3-32B",
+                "--system",
+                "h200_sxm",
+                "--target-request-rate",
+                "10",
+            ]
+        )
+        assert not hasattr(args, "total_gpus")

--- a/tests/unit/cli/test_cli_api.py
+++ b/tests/unit/cli/test_cli_api.py
@@ -377,3 +377,243 @@ class TestCLISupportEquivalence:
         assert api_result.disagg_supported == cli_disagg_supported, (
             f"Disaggregated support mismatch: API={api_result.disagg_supported}, CLI={cli_disagg_supported}"
         )
+
+
+class TestCLIRecommendUnit:
+    """Unit tests for cli_recommend API."""
+
+    def test_requires_exactly_one_load_target(self):
+        from aiconfigurator.cli.api import cli_recommend
+
+        with pytest.raises(ValueError, match="Exactly one of"):
+            cli_recommend(
+                model_path="Qwen/Qwen3-32B",
+                system="h200_sxm",
+            )
+
+        with pytest.raises(ValueError, match="Exactly one of"):
+            cli_recommend(
+                model_path="Qwen/Qwen3-32B",
+                system="h200_sxm",
+                target_request_rate=10.0,
+                target_concurrency=50.0,
+            )
+
+    def test_calls_build_default_tasks_with_gpus_per_node(self, monkeypatch):
+        import aiconfigurator.cli.api as api
+
+        captured_kwargs = {}
+
+        def fake_build_default_tasks(**kwargs):
+            captured_kwargs.update(kwargs)
+            return {}
+
+        def fake_execute(tasks, mode, **kwargs):
+            return ("agg", {}, {}, {}, {})
+
+        monkeypatch.setattr(api, "build_default_tasks", fake_build_default_tasks)
+        monkeypatch.setattr(api, "_execute_tasks_internal", fake_execute)
+
+        api.cli_recommend(
+            model_path="Qwen/Qwen3-32B",
+            system="h200_sxm",
+            target_request_rate=10.0,
+        )
+
+        assert captured_kwargs["total_gpus"] == 8
+        assert captured_kwargs["model_path"] == "Qwen/Qwen3-32B"
+
+    def test_forwards_load_match_params(self, monkeypatch):
+        import aiconfigurator.cli.api as api
+
+        execute_kwargs = {}
+
+        def fake_build_default_tasks(**kwargs):
+            return {}
+
+        def fake_execute(tasks, mode, **kwargs):
+            execute_kwargs.update(kwargs)
+            return ("agg", {}, {}, {}, {})
+
+        monkeypatch.setattr(api, "build_default_tasks", fake_build_default_tasks)
+        monkeypatch.setattr(api, "_execute_tasks_internal", fake_execute)
+
+        api.cli_recommend(
+            model_path="Qwen/Qwen3-32B",
+            system="h200_sxm",
+            target_request_rate=42.0,
+        )
+
+        assert execute_kwargs["target_request_rate"] == 42.0
+        assert execute_kwargs.get("target_concurrency") is None
+
+    def test_concurrency_mode(self, monkeypatch):
+        import aiconfigurator.cli.api as api
+
+        execute_kwargs = {}
+
+        def fake_build_default_tasks(**kwargs):
+            return {}
+
+        def fake_execute(tasks, mode, **kwargs):
+            execute_kwargs.update(kwargs)
+            return ("agg", {}, {}, {}, {})
+
+        monkeypatch.setattr(api, "build_default_tasks", fake_build_default_tasks)
+        monkeypatch.setattr(api, "_execute_tasks_internal", fake_execute)
+
+        api.cli_recommend(
+            model_path="Qwen/Qwen3-32B",
+            system="h200_sxm",
+            target_concurrency=200.0,
+        )
+
+        assert execute_kwargs.get("target_request_rate") is None
+        assert execute_kwargs["target_concurrency"] == 200.0
+
+    def test_strict_sla_forwarded(self, monkeypatch):
+        import aiconfigurator.cli.api as api
+
+        execute_kwargs = {}
+
+        def fake_build_default_tasks(**kwargs):
+            return {}
+
+        def fake_execute(tasks, mode, **kwargs):
+            execute_kwargs.update(kwargs)
+            return ("agg", {}, {}, {}, {})
+
+        monkeypatch.setattr(api, "build_default_tasks", fake_build_default_tasks)
+        monkeypatch.setattr(api, "_execute_tasks_internal", fake_execute)
+
+        api.cli_recommend(
+            model_path="Qwen/Qwen3-32B",
+            system="h200_sxm",
+            target_request_rate=10.0,
+            strict_sla=True,
+        )
+
+        assert execute_kwargs["strict_sla"] is True
+
+    def test_wideep_and_moe_backend_forwarded(self, monkeypatch):
+        import aiconfigurator.cli.api as api
+
+        captured_kwargs = {}
+
+        def fake_build_default_tasks(**kwargs):
+            captured_kwargs.update(kwargs)
+            return {}
+
+        def fake_execute(tasks, mode, **kwargs):
+            return ("agg", {}, {}, {}, {})
+
+        monkeypatch.setattr(api, "build_default_tasks", fake_build_default_tasks)
+        monkeypatch.setattr(api, "_execute_tasks_internal", fake_execute)
+
+        api.cli_recommend(
+            model_path="Qwen/Qwen3-32B",
+            system="h200_sxm",
+            target_request_rate=10.0,
+            enable_wideep=True,
+            moe_backend="deepep_moe",
+        )
+
+        assert captured_kwargs["enable_wideep"] is True
+        assert captured_kwargs["moe_backend"] == "deepep_moe"
+
+    def test_recommend_includes_pp_candidates(self, monkeypatch):
+        import aiconfigurator.cli.api as api
+
+        execute_tasks = {}
+
+        def fake_build_default_tasks(**kwargs):
+            from dataclasses import dataclass, field
+
+            @dataclass
+            class FakeTask:
+                total_gpus: int = 8
+                serving_mode: str = "agg"
+                agg_pp_candidates: list = field(default_factory=lambda: [1])
+                agg_num_gpu_candidates: list = field(default_factory=lambda: [1, 2, 4, 8])
+
+            return {"agg": FakeTask()}
+
+        def fake_execute(tasks, mode, **kwargs):
+            execute_tasks.update(tasks)
+            return ("agg", {}, {}, {}, {})
+
+        monkeypatch.setattr(api, "build_default_tasks", fake_build_default_tasks)
+        monkeypatch.setattr(api, "_execute_tasks_internal", fake_execute)
+
+        api.cli_recommend(
+            model_path="Qwen/Qwen3-32B",
+            system="h200_sxm",
+            target_request_rate=10.0,
+        )
+
+        task = execute_tasks["agg"]
+        assert 2 in task.agg_pp_candidates
+        assert 4 in task.agg_pp_candidates
+
+    def test_escalates_on_oom(self, monkeypatch):
+        import aiconfigurator.cli.api as api
+
+        call_count = 0
+
+        def fake_build_default_tasks(**kwargs):
+            from dataclasses import dataclass, field
+
+            @dataclass
+            class FakeTask:
+                total_gpus: int = 8
+                serving_mode: str = "agg"
+                agg_pp_candidates: list = field(default_factory=lambda: [1])
+                agg_num_gpu_candidates: list = field(default_factory=lambda: [1, 2, 4, 8])
+
+            return {"agg": FakeTask()}
+
+        def fake_execute(tasks, mode, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise SystemExit(1)
+            return ("agg", {}, {}, {}, {})
+
+        monkeypatch.setattr(api, "build_default_tasks", fake_build_default_tasks)
+        monkeypatch.setattr(api, "_execute_tasks_internal", fake_execute)
+
+        api.cli_recommend(
+            model_path="Qwen/Qwen3-32B",
+            system="h200_sxm",
+            target_request_rate=10.0,
+        )
+
+        assert call_count == 2
+
+    def test_escalation_ceiling(self, monkeypatch):
+        import aiconfigurator.cli.api as api
+
+        def fake_build_default_tasks(**kwargs):
+            from dataclasses import dataclass, field
+
+            @dataclass
+            class FakeTask:
+                total_gpus: int = 8
+                serving_mode: str = "agg"
+                agg_pp_candidates: list = field(default_factory=lambda: [1])
+                agg_num_gpu_candidates: list = field(default_factory=lambda: [1, 2, 4, 8])
+
+            return {"agg": FakeTask()}
+
+        def fake_execute(tasks, mode, **kwargs):
+            raise SystemExit(1)
+
+        monkeypatch.setattr(api, "build_default_tasks", fake_build_default_tasks)
+        monkeypatch.setattr(api, "_execute_tasks_internal", fake_execute)
+
+        with pytest.raises(SystemExit):
+            api.cli_recommend(
+                model_path="Qwen/Qwen3-32B",
+                system="h200_sxm",
+                target_request_rate=10.0,
+            )

--- a/tests/unit/cli/test_cli_api.py
+++ b/tests/unit/cli/test_cli_api.py
@@ -226,6 +226,7 @@ class TestCLIExpUnit:
             {"exp_agg_simplified": pd.DataFrame()},
             {"exp_agg_simplified": 100.0},
             {"exp_agg_simplified": {"ttft": 0.0, "tpot": 0.0, "request_latency": 0.0}},
+            {},
         )
 
         # Simplified version based on example.yaml exp_agg_simplified
@@ -380,7 +381,7 @@ class TestCLISupportEquivalence:
 
 
 class TestCLIRecommendUnit:
-    """Unit tests for cli_recommend API."""
+    """Unit tests for recommend API."""
 
     def test_requires_exactly_one_load_target(self):
         from aiconfigurator.cli.api import cli_recommend
@@ -409,7 +410,7 @@ class TestCLIRecommendUnit:
             return {}
 
         def fake_execute(tasks, mode, **kwargs):
-            return ("agg", {}, {}, {}, {})
+            return ("agg", {"agg": pd.DataFrame({"x": [1]})}, {}, {}, {}, {})
 
         monkeypatch.setattr(api, "build_default_tasks", fake_build_default_tasks)
         monkeypatch.setattr(api, "_execute_tasks_internal", fake_execute)
@@ -433,7 +434,7 @@ class TestCLIRecommendUnit:
 
         def fake_execute(tasks, mode, **kwargs):
             execute_kwargs.update(kwargs)
-            return ("agg", {}, {}, {}, {})
+            return ("agg", {"agg": pd.DataFrame({"x": [1]})}, {}, {}, {}, {})
 
         monkeypatch.setattr(api, "build_default_tasks", fake_build_default_tasks)
         monkeypatch.setattr(api, "_execute_tasks_internal", fake_execute)
@@ -457,7 +458,7 @@ class TestCLIRecommendUnit:
 
         def fake_execute(tasks, mode, **kwargs):
             execute_kwargs.update(kwargs)
-            return ("agg", {}, {}, {}, {})
+            return ("agg", {"agg": pd.DataFrame({"x": [1]})}, {}, {}, {}, {})
 
         monkeypatch.setattr(api, "build_default_tasks", fake_build_default_tasks)
         monkeypatch.setattr(api, "_execute_tasks_internal", fake_execute)
@@ -481,7 +482,7 @@ class TestCLIRecommendUnit:
 
         def fake_execute(tasks, mode, **kwargs):
             execute_kwargs.update(kwargs)
-            return ("agg", {}, {}, {}, {})
+            return ("agg", {"agg": pd.DataFrame({"x": [1]})}, {}, {}, {}, {})
 
         monkeypatch.setattr(api, "build_default_tasks", fake_build_default_tasks)
         monkeypatch.setattr(api, "_execute_tasks_internal", fake_execute)
@@ -505,7 +506,7 @@ class TestCLIRecommendUnit:
             return {}
 
         def fake_execute(tasks, mode, **kwargs):
-            return ("agg", {}, {}, {}, {})
+            return ("agg", {"agg": pd.DataFrame({"x": [1]})}, {}, {}, {}, {})
 
         monkeypatch.setattr(api, "build_default_tasks", fake_build_default_tasks)
         monkeypatch.setattr(api, "_execute_tasks_internal", fake_execute)
@@ -521,42 +522,9 @@ class TestCLIRecommendUnit:
         assert captured_kwargs["enable_wideep"] is True
         assert captured_kwargs["moe_backend"] == "deepep_moe"
 
-    def test_recommend_includes_pp_candidates(self, monkeypatch):
-        import aiconfigurator.cli.api as api
-
-        execute_tasks = {}
-
-        def fake_build_default_tasks(**kwargs):
-            from dataclasses import dataclass, field
-
-            @dataclass
-            class FakeTask:
-                total_gpus: int = 8
-                serving_mode: str = "agg"
-                agg_pp_candidates: list = field(default_factory=lambda: [1])
-                agg_num_gpu_candidates: list = field(default_factory=lambda: [1, 2, 4, 8])
-
-            return {"agg": FakeTask()}
-
-        def fake_execute(tasks, mode, **kwargs):
-            execute_tasks.update(tasks)
-            return ("agg", {}, {}, {}, {})
-
-        monkeypatch.setattr(api, "build_default_tasks", fake_build_default_tasks)
-        monkeypatch.setattr(api, "_execute_tasks_internal", fake_execute)
-
-        api.cli_recommend(
-            model_path="Qwen/Qwen3-32B",
-            system="h200_sxm",
-            target_request_rate=10.0,
-        )
-
-        task = execute_tasks["agg"]
-        assert 2 in task.agg_pp_candidates
-        assert 4 in task.agg_pp_candidates
-
     def test_escalates_on_oom(self, monkeypatch):
         import aiconfigurator.cli.api as api
+        from aiconfigurator.sdk.errors import ExperimentOutcome, InsufficientMemoryError
 
         call_count = 0
 
@@ -567,6 +535,8 @@ class TestCLIRecommendUnit:
             class FakeTask:
                 total_gpus: int = 8
                 serving_mode: str = "agg"
+                enable_wideep: bool = False
+                moe_backend: str | None = None
                 agg_pp_candidates: list = field(default_factory=lambda: [1])
                 agg_num_gpu_candidates: list = field(default_factory=lambda: [1, 2, 4, 8])
 
@@ -576,8 +546,9 @@ class TestCLIRecommendUnit:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                raise SystemExit(1)
-            return ("agg", {}, {}, {}, {})
+                oom = InsufficientMemoryError("model does not fit")
+                return ("none", {}, {}, {}, {}, {"agg": ExperimentOutcome("agg", error=oom)})
+            return ("agg", {"agg": pd.DataFrame({"x": [1]})}, {}, {}, {}, {"agg": ExperimentOutcome("agg")})
 
         monkeypatch.setattr(api, "build_default_tasks", fake_build_default_tasks)
         monkeypatch.setattr(api, "_execute_tasks_internal", fake_execute)
@@ -592,6 +563,158 @@ class TestCLIRecommendUnit:
 
     def test_escalation_ceiling(self, monkeypatch):
         import aiconfigurator.cli.api as api
+        from aiconfigurator.sdk.errors import ExperimentOutcome, InsufficientMemoryError
+
+        def fake_build_default_tasks(**kwargs):
+            from dataclasses import dataclass, field
+
+            @dataclass
+            class FakeTask:
+                total_gpus: int = 8
+                serving_mode: str = "agg"
+                enable_wideep: bool = False
+                moe_backend: str | None = None
+                agg_pp_candidates: list = field(default_factory=lambda: [1])
+                agg_num_gpu_candidates: list = field(default_factory=lambda: [1, 2, 4, 8])
+
+            return {"agg": FakeTask()}
+
+        def fake_execute(tasks, mode, **kwargs):
+            oom = InsufficientMemoryError("model does not fit")
+            return ("none", {}, {}, {}, {}, {"agg": ExperimentOutcome("agg", error=oom)})
+
+        monkeypatch.setattr(api, "build_default_tasks", fake_build_default_tasks)
+        monkeypatch.setattr(api, "_execute_tasks_internal", fake_execute)
+
+        with pytest.raises(SystemExit):
+            api.cli_recommend(
+                model_path="Qwen/Qwen3-32B",
+                system="h200_sxm",
+                target_request_rate=10.0,
+            )
+
+    def test_no_escalation_on_non_retriable_failure(self, monkeypatch):
+        import aiconfigurator.cli.api as api
+        from aiconfigurator.sdk.errors import ExperimentOutcome, NoFeasibleConfigError
+
+        call_count = 0
+
+        def fake_build_default_tasks(**kwargs):
+            from dataclasses import dataclass, field
+
+            @dataclass
+            class FakeTask:
+                total_gpus: int = 8
+                serving_mode: str = "agg"
+                enable_wideep: bool = False
+                moe_backend: str | None = None
+                agg_pp_candidates: list = field(default_factory=lambda: [1])
+                agg_num_gpu_candidates: list = field(default_factory=lambda: [1, 2, 4, 8])
+
+            return {"agg": FakeTask()}
+
+        def fake_execute(tasks, mode, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            sla_fail = NoFeasibleConfigError("SLA impossible")
+            return ("none", {}, {}, {}, {}, {"agg": ExperimentOutcome("agg", error=sla_fail)})
+
+        monkeypatch.setattr(api, "build_default_tasks", fake_build_default_tasks)
+        monkeypatch.setattr(api, "_execute_tasks_internal", fake_execute)
+
+        with pytest.raises(SystemExit):
+            api.cli_recommend(
+                model_path="Qwen/Qwen3-32B",
+                system="h200_sxm",
+                target_request_rate=10.0,
+            )
+
+        assert call_count == 1, "Should not escalate for non-retriable failures"
+
+    def test_partial_failure_triggers_escalation(self, monkeypatch):
+        """agg succeeds at first budget, disagg OOMs → retry at larger budget."""
+        import aiconfigurator.cli.api as api
+        from aiconfigurator.sdk.errors import ExperimentOutcome, InsufficientMemoryError
+
+        call_count = 0
+
+        def fake_build_default_tasks(**kwargs):
+            from dataclasses import dataclass, field
+
+            @dataclass
+            class FakeTask:
+                total_gpus: int = 8
+                serving_mode: str = "agg"
+                enable_wideep: bool = False
+                moe_backend: str | None = None
+                agg_pp_candidates: list = field(default_factory=lambda: [1])
+                agg_num_gpu_candidates: list = field(default_factory=lambda: [1, 2, 4, 8])
+                prefill_pp_candidates: list = field(default_factory=lambda: [1])
+                prefill_num_gpu_candidates: list = field(default_factory=lambda: [1, 2, 4, 8])
+                decode_pp_candidates: list = field(default_factory=lambda: [1])
+                decode_num_gpu_candidates: list = field(default_factory=lambda: [1, 2, 4, 8])
+
+            return {"agg": FakeTask(), "disagg": FakeTask(serving_mode="disagg")}
+
+        def fake_execute(tasks, mode, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                oom = InsufficientMemoryError("disagg does not fit")
+                return (
+                    "agg",
+                    {"agg": pd.DataFrame({"x": [1]})},
+                    {},
+                    {},
+                    {},
+                    {
+                        "agg": ExperimentOutcome("agg"),
+                        "disagg": ExperimentOutcome("disagg", error=oom),
+                    },
+                )
+            return (
+                "agg",
+                {"agg": pd.DataFrame({"x": [1]}), "disagg": pd.DataFrame({"x": [1]})},
+                {},
+                {},
+                {},
+                {
+                    "agg": ExperimentOutcome("agg"),
+                    "disagg": ExperimentOutcome("disagg"),
+                },
+            )
+
+        monkeypatch.setattr(api, "build_default_tasks", fake_build_default_tasks)
+        monkeypatch.setattr(api, "_execute_tasks_internal", fake_execute)
+
+        api.cli_recommend(
+            model_path="Qwen/Qwen3-32B",
+            system="h200_sxm",
+            target_request_rate=10.0,
+        )
+
+        assert call_count == 2, "Should escalate when disagg OOMs but agg succeeds"
+
+    def test_save_dir_passes_total_gpus_needed_to_save_results(self, monkeypatch, tmp_path):
+        """save_results receives best_configs with total_gpus_needed so
+        task_config_to_generator_config can use it for artifact sizing."""
+        import aiconfigurator.cli.api as api
+
+        best_df = pd.DataFrame(
+            {
+                "tp": [8],
+                "pp": [1],
+                "dp": [1],
+                "moe_tp": [1],
+                "moe_ep": [1],
+                "bs": [64],
+                "workers": [1],
+                "num_total_gpus": [8],
+                "total_gpus_needed": [24],
+                "replicas_needed": [3],
+                "tokens/s/gpu": [100.0],
+            }
+        )
 
         def fake_build_default_tasks(**kwargs):
             from dataclasses import dataclass, field
@@ -606,14 +729,25 @@ class TestCLIRecommendUnit:
             return {"agg": FakeTask()}
 
         def fake_execute(tasks, mode, **kwargs):
-            raise SystemExit(1)
+            return ("agg", {"agg": best_df}, {"agg": best_df}, {"agg": 100.0}, {}, {})
+
+        captured = {}
+
+        def capture_save(**kwargs):
+            captured.update(kwargs)
 
         monkeypatch.setattr(api, "build_default_tasks", fake_build_default_tasks)
         monkeypatch.setattr(api, "_execute_tasks_internal", fake_execute)
+        monkeypatch.setattr(api, "save_results", capture_save)
 
-        with pytest.raises(SystemExit):
-            api.cli_recommend(
-                model_path="Qwen/Qwen3-32B",
-                system="h200_sxm",
-                target_request_rate=10.0,
-            )
+        api.cli_recommend(
+            model_path="Qwen/Qwen3-32B",
+            system="h200_sxm",
+            target_request_rate=10.0,
+            save_dir=str(tmp_path),
+        )
+
+        assert "best_configs" in captured
+        saved_df = captured["best_configs"]["agg"]
+        assert "total_gpus_needed" in saved_df.columns
+        assert int(saved_df.iloc[0]["total_gpus_needed"]) == 24

--- a/tests/unit/cli/test_cli_api.py
+++ b/tests/unit/cli/test_cli_api.py
@@ -12,6 +12,7 @@ import pytest
 
 from aiconfigurator.cli import CLIResult, cli_exp, cli_generate
 from aiconfigurator.sdk import common
+from aiconfigurator.sdk.errors import NoFeasibleConfigError
 
 pytestmark = pytest.mark.unit
 
@@ -586,7 +587,7 @@ class TestCLIRecommendUnit:
         monkeypatch.setattr(api, "build_default_tasks", fake_build_default_tasks)
         monkeypatch.setattr(api, "_execute_tasks_internal", fake_execute)
 
-        with pytest.raises(SystemExit):
+        with pytest.raises(NoFeasibleConfigError):
             api.cli_recommend(
                 model_path="Qwen/Qwen3-32B",
                 system="h200_sxm",
@@ -622,7 +623,7 @@ class TestCLIRecommendUnit:
         monkeypatch.setattr(api, "build_default_tasks", fake_build_default_tasks)
         monkeypatch.setattr(api, "_execute_tasks_internal", fake_execute)
 
-        with pytest.raises(SystemExit):
+        with pytest.raises(NoFeasibleConfigError):
             api.cli_recommend(
                 model_path="Qwen/Qwen3-32B",
                 system="h200_sxm",

--- a/tests/unit/cli/test_cli_workflow.py
+++ b/tests/unit/cli/test_cli_workflow.py
@@ -87,6 +87,7 @@ class TestCLIIntegration:
             {"agg": mock_results_df},
             mock_best_throughputs,
             {"agg": {"ttft": 100.0, "tpot": 10.0, "request_latency": 1000.0}},
+            {},
         )
 
         with patch("aiconfigurator.cli.main.save_results") as mock_save:
@@ -129,6 +130,7 @@ class TestCLIIntegration:
             {"my_exp": mock_results_df},
             mock_best_throughputs,
             {"my_exp": {"ttft": 100.0, "tpot": 10.0, "request_latency": 1000.0}},
+            {},
         )
 
         args = cli_args_factory(
@@ -163,7 +165,7 @@ class TestCLIIntegration:
     @patch("aiconfigurator.cli.main._execute_tasks")
     def test_cli_main_build_dispatch(self, mock_execute, mode, build_patch, cli_args_factory, mock_exp_yaml_path):
         """Main should dispatch to the correct builder based on CLI mode."""
-        mock_execute.return_value = ("agg", {}, {}, {}, {})
+        mock_execute.return_value = ("agg", {"agg": True}, {}, {}, {}, {})
         mock_task_config = MagicMock(name="TaskConfig")
 
         with patch(build_patch) as mock_builder:
@@ -300,10 +302,15 @@ class TestCLIIntegration:
             "No configuration satisfied the TTFT/TPOT constraints."
         )
 
-        with caplog.at_level(logging.WARNING), pytest.raises(SystemExit) as exc_info:
-            _execute_tasks({"agg": mock_task_config}, mode="default", strict_sla=True)
+        with caplog.at_level(logging.WARNING):
+            chosen_exp, best_configs, _, _, _, outcomes = _execute_tasks(
+                {"agg": mock_task_config}, mode="default", strict_sla=True
+            )
 
-        assert exc_info.value.code == 1
+        assert chosen_exp == "none"
+        assert not best_configs
+        assert "agg" in outcomes
+        assert isinstance(outcomes["agg"].error, NoFeasibleConfigError)
         assert "Experiment agg found no SLA-feasible configuration" in caplog.text
         assert "No successful experiment runs to compare." in caplog.text
         assert "Traceback" not in caplog.text
@@ -326,7 +333,7 @@ exp_with_db_mode:
 
         mock_task_config = MagicMock(name="TaskConfig")
         mock_build_exp.return_value = {"exp_with_db_mode": mock_task_config}
-        mock_execute.return_value = ("exp_with_db_mode", {}, {}, {}, {})
+        mock_execute.return_value = ("exp_with_db_mode", {"exp_with_db_mode": True}, {}, {}, {}, {})
 
         parser = argparse.ArgumentParser()
         configure_parser(parser)
@@ -348,7 +355,7 @@ exp_with_db_mode:
     ):
         """The shared --engine-step-backend flag should apply to exp mode."""
         mock_build_exp.return_value = {"my_exp": MagicMock(name="TaskConfig")}
-        mock_execute.return_value = ("my_exp", {}, {}, {}, {})
+        mock_execute.return_value = ("my_exp", {"my_exp": True}, {}, {}, {}, {})
 
         args = cli_args_factory(
             mode="exp",

--- a/tests/unit/generator/test_module_bridge_recommend_gpus.py
+++ b/tests/unit/generator/test_module_bridge_recommend_gpus.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The bridge must use total_gpus_needed (not the escalation budget) for recommend mode.
+
+When recommend mode escalates the GPU budget to fit a model, task.total_gpus
+holds the search ceiling (8/16/32/64), not the actual recommendation.  The
+per-row ``total_gpus_needed`` from load-match picking is the true result.
+``task_config_to_generator_config`` must prefer ``total_gpus_needed`` from the
+result row so generated deployment artifacts have the correct replica count.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from aiconfigurator.generator.module_bridge import task_config_to_generator_config
+
+
+def _task(*, total_gpus: int, serving_mode: str = "agg") -> SimpleNamespace:
+    return SimpleNamespace(
+        primary_backend_name="vllm",
+        primary_system_name="h200_sxm",
+        primary_backend_version="0.20.1",
+        primary_model_path="Qwen/Qwen3-32B-FP8",
+        prefix=0,
+        is_moe=False,
+        nextn=0,
+        nextn_accept_rates=[],
+        serving_mode=serving_mode,
+        total_gpus=total_gpus,
+        system_name="h200_sxm",
+        prefill_system_name="h200_sxm",
+        decode_system_name="h200_sxm",
+        isl=1024,
+        osl=256,
+        ttft=2000.0,
+        tpot=50.0,
+    )
+
+
+def _result_row(**kwargs) -> pd.Series:
+    base = {"tp": 1, "pp": 1, "dp": 1, "moe_tp": 1, "moe_ep": 1, "bs": 64, "workers": 1}
+    base.update(kwargs)
+    return pd.Series(base)
+
+
+@pytest.mark.unit
+class TestRecommendGPUCount:
+    def test_uses_total_gpus_needed_over_task_budget(self):
+        task = _task(total_gpus=64)
+        row = _result_row(total_gpus_needed=16, tp=8, pp=1, dp=1)
+        cfg = task_config_to_generator_config(task, row)
+        assert cfg["WorkerConfig"]["agg_workers"] == 2  # 16 // 8 = 2
+
+    def test_falls_back_to_task_total_gpus_without_column(self):
+        task = _task(total_gpus=16)
+        row = _result_row(tp=8, pp=1, dp=1)
+        cfg = task_config_to_generator_config(task, row)
+        assert cfg["WorkerConfig"]["agg_workers"] == 2  # 16 // 8 = 2
+
+    def test_zero_total_gpus_needed_falls_back(self):
+        task = _task(total_gpus=8)
+        row = _result_row(total_gpus_needed=0, tp=8, pp=1, dp=1)
+        cfg = task_config_to_generator_config(task, row)
+        assert cfg["WorkerConfig"]["agg_workers"] == 1  # 8 // 8 = 1

--- a/tests/unit/sdk/test_errors.py
+++ b/tests/unit/sdk/test_errors.py
@@ -25,6 +25,7 @@ from aiconfigurator.sdk.errors import (
     NoResultsError,
     is_expected_cli_error,
     is_expected_no_result_cause,
+    is_gpu_retriable,
 )
 from aiconfigurator.sdk.perf_database import PerfDataNotAvailableError
 
@@ -168,3 +169,37 @@ def test_cli_classifier_rejects_wrapper_around_real_bug() -> None:
         raise RuntimeError("task failed") from KeyError("unexpected")
     except RuntimeError as exc:
         assert not is_expected_cli_error(exc)
+
+
+# is_gpu_retriable — classify whether more GPUs could fix a failure
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        InsufficientMemoryError("model does not fit"),
+        KVCacheCapacityError("KV-cache too small"),
+    ],
+)
+def test_gpu_retriable_accepts_memory_errors(exc) -> None:
+    assert is_gpu_retriable(exc)
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        NoFeasibleConfigError("SLA impossible"),
+        PerfDataNotAvailableError("no data"),
+        EmpiricalNotImplementedError("no basis"),
+        ValueError("unsupported quant mode"),
+    ],
+)
+def test_gpu_retriable_rejects_non_memory_errors(exc) -> None:
+    assert not is_gpu_retriable(exc)
+
+
+def test_gpu_retriable_walks_exception_chain() -> None:
+    try:
+        raise RuntimeError("wrapper") from InsufficientMemoryError("OOM")
+    except RuntimeError as exc:
+        assert is_gpu_retriable(exc)

--- a/tools/simple_sdk_demo/sla_service/sla_service.py
+++ b/tools/simple_sdk_demo/sla_service/sla_service.py
@@ -12,6 +12,7 @@ import pandas as pd
 import uvicorn
 from fastapi import Body, FastAPI, Response
 
+from aiconfigurator.cli.api import cli_recommend
 from aiconfigurator.sdk import common
 from aiconfigurator.sdk.backends.factory import get_backend
 from aiconfigurator.sdk.common import get_default_models
@@ -44,6 +45,66 @@ def list_supported_models():
         content=orjson.dumps({"model list:": sorted(get_default_models())}),
         media_type="application/json",
     )
+
+
+@app.post("/recommend")
+def post_recommend(
+    model_path: str = Body("Qwen/Qwen3-32B-FP8", description="HuggingFace model path"),
+    system: str = Body(
+        "h200_sxm",
+        description="GPU system: h200_sxm, h100_sxm, b200_sxm, b300_sxm, gb200, gb300, a100_sxm, l40s",
+    ),
+    backend: str = Body("trtllm", description="backend: trtllm, sglang, vllm"),
+    backend_version: str | None = Body(None, description="backend version (default: latest)"),
+    target_request_rate: float | None = Body(
+        None, description="Target request rate in req/s. Set exactly one of rate or concurrency."
+    ),
+    target_concurrency: float | None = Body(
+        None, description="Target number of concurrent users. Set exactly one of rate or concurrency."
+    ),
+    isl: int = Body(4000, description="input sequence length"),
+    osl: int = Body(1000, description="output sequence length"),
+    ttft: float = Body(2000.0, description="TTFT target in ms"),
+    tpot: float = Body(30.0, description="TPOT target in ms"),
+    request_latency: float | None = Body(None, description="end-to-end request latency target in ms (optional)"),
+    prefix: int = Body(0, description="prefix cache length"),
+    database_mode: str = Body("HYBRID", description="HYBRID (default), SILICON, EMPIRICAL, or SOL"),
+    top_n: int = Body(5, description="number of top configurations to return"),
+):
+    """Find the minimum number of GPUs and optimal deployment configuration.
+
+    Given a model, system, backend, workload, and a load target (request rate
+    or concurrency), searches across parallelism configs (TP/PP/DP/EP) and
+    serving modes (agg and disagg) to find the deployment with the fewest GPUs
+    that meets the SLA constraints.
+    """
+    try:
+        result = cli_recommend(
+            model_path=model_path,
+            system=system,
+            target_request_rate=target_request_rate,
+            target_concurrency=target_concurrency,
+            backend=backend,
+            backend_version=backend_version,
+            database_mode=database_mode,
+            isl=isl,
+            osl=osl,
+            ttft=ttft,
+            tpot=tpot,
+            request_latency=request_latency,
+            prefix=prefix,
+            top_n=top_n,
+        )
+        best = result.best_configs.get(result.chosen_exp)
+        if best is not None and not best.empty:
+            row = best.iloc[0].to_dict()
+            return {k: v for k, v in row.items() if pd.notna(v)}
+        return {"error": "No configuration meets the specified requirements."}
+    except ValueError as e:
+        return {"error": str(e)}
+    except Exception as e:
+        logger.exception("recommend failed")
+        return {"error": str(e)}
 
 
 @app.post("/sla")


### PR DESCRIPTION
## Summary

Adds a recommend capability for procurement sizing: given a performance<br>target, find the minimum GPUs and optimal deployment configuration.<br>Inverts the default mode flow -- instead of "given N GPUs, estimate<br>performance" it answers "given a performance target, find minimum GPUs."

Two ways to access it:

```bash
# Explicit recommend subcommand:
aiconfigurator cli recommend --model-path Qwen/Qwen3-32B \
  --system h200_sxm --target-request-rate 10

# Or omit --total-gpus in default mode (auto-recommend):
aiconfigurator cli default --model-path Qwen/Qwen3-32B \
  --system h200_sxm --target-request-rate 10
```

The auto-recommend path was inspired by @jasonqinzhou's suggestion<br>to consolidate modes.

## Details

**SDK API** (`cli/api.py`):

* New `recommend()` function with the same inputs as `cli_default`<br>minus `total_gpus`, plus `target_request_rate` / `target_concurrency`<br>(mutually exclusive).
* Sweeps all valid per-worker TP/DP/EP configurations using<br>`build_default_tasks`, then applies `pick_load_match` to compute<br>`replicas_needed = ceil(target_rate / per_replica_rate)` and<br>`total_gpus_needed = replicas * gpus_per_replica`.
* Auto-escalates GPU budget (8->16->32->64) when the model does not fit<br>on a single node. Escalation uses structured `ExperimentOutcome` to<br>retry only on OOM/KV-cache errors, not SLA or data-gap failures.

**CLI** (`cli/main.py`):

* `recommend` subparser with `--target-request-rate` /<br>`--target-concurrency` mutually exclusive group.
* `default` mode gains the same load target args; omitting<br>`--total-gpus` with a load target auto-dispatches to recommend.

**Generator bridge** (`module_bridge.py`):

* `task_config_to_generator_config` prefers `total_gpus_needed` from<br>the result row over the escalation budget, so saved deployment<br>artifacts have correct replica/worker counts.

**Webapp**:

* Sizing Recommender tab (quant/eplb params removed -- auto-inferred).
* `/recommend` endpoint added to sla_service.py demo FastAPI service.

## Review feedback addressed

* \[tianhaox HIGH\] Generator artifacts sized from recommendation, not budget
* \[tianhaox HIGH\] PP search uses default PP=1 (no PP>1 data; see ai-dynamo/aiconfigurator#1385)
* \[tianhaox MED\] Structured ExperimentOutcome replaces SystemExit(1)
* \[tianhaox MED\] Dead quant/eplb webapp params removed
* \[tianhaox LOW\] Unreachable ValueError removed
* \[CodeRabbit\] README mode count, input validation, load target wording

## Sweep performance optimizations (commits 3-7)

\~31% faster for MoE, \~18% faster for dense (measured on same PP=1 base):

* `copy.deepcopy` -> `dataclasses.replace` in sweep hot paths
* Lazy DataFrame construction in `run_agg` and `run_static`
* Batch disagg results instead of incremental `pd.concat`
* Opt-in `parallel_experiments` via ThreadPoolExecutor

## Test plan

- [X] 254 unit tests pass
- [X] Profiled: MoE 5.63s -> 3.89s, dense 1.78s -> 1.46s
- [X] Integration tests for recommend monotonicity
- [X] New tests: ExperimentOutcome, is_gpu_retriable, module_bridge<br>total_gpus_needed, non-retriable escalation stop, partial failure

Generated with [Claude Code](<https://claude.com/claude-code>)

## Summary by CodeRabbit

* **New Features**
  * Added a `recommend` mode to size the minimum GPUs needed to meet request-rate or concurrency targets and SLA constraints.
  * Added a Sizing Recommender tab with ranked recommendations, debugging info, and CSV download.
  * Added a `/recommend` endpoint for programmatic retrieval of sizing results.
* **Documentation**
  * Updated README, CLI user guide, and Python API examples with `recommend` usage and walkthroughs.
* **Bug Fixes**
  * Improved recommendation reporting and “top config” selection when replica-based sizing is available.
* **Tests**
  * Added integration and unit coverage for `recommend` behavior and escalating sizing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `recommend` CLI mode to size GPUs from throughput targets with SLA inputs, returning ranked GPU and replica requirements.
  * Exposed Python support via `cli_recommend` and added a `/recommend` service endpoint for retrieving the top recommendation.
* **Documentation**
  * Updated README and CLI user guide with the new mode, parameters, and examples.
* **Bug Fixes**
  * Improved recommendation handling when no valid configs are found, including clearer retry/escalation behavior for retriable GPU-capacity failures.
  * Refined reporting/ranking when GPU sizing is driven by `*_needed` fields.
* **Tests**
  * Added integration and unit coverage for parsing, escalation logic, and recommendation correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->