### PR TITLE
feat(collector): Collector V3 design + manifest v2 per-op runtime pins (AIC-1217, AIC-1500)

### DIFF
--- a/collector/README.md
+++ b/collector/README.md
@@ -139,8 +139,9 @@ ops cannot generate the needed data points.
 Each backend (trtllm, vllm, sglang) has a **registry** (`registry.py`) that maps ops to collector modules, and a **version resolver** (`version_resolver.py`) that picks the right module at runtime. Individual collector files declare their compatibility via `__compat__`. The current collector framework versions and runtime images are declared in `framework_manifest.yaml`.
 
 ```text
-framework_manifest.yaml — current collector framework versions and images
-framework_manifest.py   — manifest loader/validator
+framework_manifest.yaml — current collector framework versions and images (schema v2)
+framework_manifest.py   — manifest loader/validator/resolver
+op_catalog.py         — table→family identity map (op_backend_catalog.yaml)
 model_cases.py       — collector v2 model/SM case-plan resolver
 registry.py          — declares which module handles which version range
 version_resolver.py  — routes runtime version → module (packaging.version)
@@ -152,8 +153,36 @@ wideep/*/registry.py — WideEP-only ops appended when the v2 plan requests them
 network/             — collective communication collectors and Slurm network jobs
 ```
 
-WideEP entries in `framework_manifest.yaml` describe independent runtimes.
-`collect.py` requires the exact public version and rejects mixed-pin runs.
+`framework_manifest.yaml` is `schema_version: 2`: each framework entry has a
+`default` runtime (`version` + `images`) plus an optional `families:` map of
+per-family overrides. Resolution for a given `(framework, op)` walks
+`table → catalog family → families[family] or default` — exactly one runtime
+per op, always. `families:` overrides require the op catalog
+(`op_backend_catalog.yaml`); without it, family-scoped pins fail closed rather
+than silently falling back to `default`.
+
+WideEP runtimes (`wideep_sglang`, `wideep_trtllm`) are flattened into peer
+framework entries rather than nested under a `wideep:` key, so the same
+per-op resolution logic applies uniformly. Each WideEP entry adds
+`base_framework` (the stock framework it forks from), `data_backend` (which
+table namespace its output is written under), and `collector_dir`.
+`collect.py` requires the exact public version for a run and rejects
+mixed-pin selections across ops.
+
+Image digests are policy, not decoration: any image reference that names a
+public registry path (contains `/`) must be pinned with `@sha256:<64 hex>`;
+bare internal image names (no `/`, e.g. `deepseek-v4-blackwell`) are exempt.
+When bumping a version pin, re-fetch and update the digest for every image
+variant touched — a stale digest silently keeps pulling the old image.
+
+Use `collector.framework_manifest.resolve_op_runtime(framework, op)` to
+resolve a single op's runtime, and
+`collector.framework_manifest.validate_resolution()` to check the whole
+manifest against every backend registry at once — it returns a list of error
+strings (empty = valid) and is the fail-closed CI gate asserting every
+registered op resolves to exactly one pinned runtime. See
+`docs/perf_database/collector-v3-op-centric-design.md` §4 for the full
+design.
 
 ## File Naming Convention
 

--- a/collector/README.md
+++ b/collector/README.md
@@ -169,9 +169,10 @@ table namespace its output is written under), and `collector_dir`.
 `collect.py` requires the exact public version for a run and rejects
 mixed-pin selections across ops.
 
-Image digests are policy, not decoration: any image reference that names a
-public registry path (contains `/`) must be pinned with `@sha256:<64 hex>`;
-bare internal image names (no `/`, e.g. `deepseek-v4-blackwell`) are exempt.
+Image digests are policy, not decoration: the rule is syntactic — any image
+reference containing `/` must be pinned with `@sha256:<64 hex>`; only bare
+internal image names (no `/`, e.g. `deepseek-v4-blackwell`) are exempt. In
+practice that means every public-registry reference is digest-pinned.
 When bumping a version pin, re-fetch and update the digest for every image
 variant touched — a stale digest silently keeps pulling the old image. Always
 pin the manifest-list (index) digest, never a platform-child digest —

--- a/collector/README.md
+++ b/collector/README.md
@@ -59,13 +59,17 @@ Today we only collect intra-node comm. This script will collect custom allreduce
 It will also collect nccl allreduce, all_gather, all2all, reduce_scatter using nccl.
 The generated files are nccl_perf.txt, oneccl_perf.txt, and custom_allreduce_perf.txt.
 
-# Collector v2: model-centric cases
+# Model-centric cases and healing runs
 
-Collector v2 is model-centric. A healing run collects cases for a specific
-model/GPU pair instead of running every op bucket and hoping the support
-matrix improves. Use `--model-cases-full` when you want collector v2 YAML to
-define a full model-centric run. Omitting all model-case flags runs the
-backend registry directly without a collector v2 case plan.
+The model-centric case layer (introduced as "collector v2") is how collection
+coverage is declared, and it is unchanged under Collector V3 — V3 adds
+op-centric *management* on top (per-family runtime pins, provenance sidecars,
+declared reuse; see `docs/perf_database/collector-v3-op-centric-design.md`),
+it does not replace how cases are declared or healed. A healing run collects
+cases for a specific model/GPU pair instead of running every op bucket and
+hoping the support matrix improves. Use `--model-cases-full` when you want
+the case YAML to define a full model-centric run. Omitting all model-case
+flags runs the backend registry directly without a model-centric case plan.
 
 ```bash
 # Heal one model on one GPU type.
@@ -85,10 +89,10 @@ python3 collect.py --backend trtllm \
   --gpu b200_sxm \
   --plan-only
 
-# Collector v2 full run: aggregate base ops plus every model case YAML file.
+# Full model-centric run: aggregate base ops plus every model case YAML file.
 python3 collect.py --backend trtllm --model-cases-full
 
-# Raw backend registry run: no collector v2 case plan.
+# Raw backend registry run: no model-centric case plan.
 python3 collect.py --backend trtllm
 
 # Ephemeral subset filter (healing): substring match, repeatable.
@@ -142,7 +146,7 @@ Each backend (trtllm, vllm, sglang) has a **registry** (`registry.py`) that maps
 framework_manifest.yaml — current collector framework versions and images (schema v2)
 framework_manifest.py   — manifest loader/validator/resolver
 op_catalog.py         — table→family identity map (op_backend_catalog.yaml)
-model_cases.py       — collector v2 model/SM case-plan resolver
+model_cases.py       — model-centric model/SM case-plan resolver
 registry.py          — declares which module handles which version range
 version_resolver.py  — routes runtime version → module (packaging.version)
 collect.py/collect_ops — validates __compat__ and fails incompatible ops

--- a/collector/README.md
+++ b/collector/README.md
@@ -173,7 +173,10 @@ Image digests are policy, not decoration: any image reference that names a
 public registry path (contains `/`) must be pinned with `@sha256:<64 hex>`;
 bare internal image names (no `/`, e.g. `deepseek-v4-blackwell`) are exempt.
 When bumping a version pin, re-fetch and update the digest for every image
-variant touched — a stale digest silently keeps pulling the old image.
+variant touched — a stale digest silently keeps pulling the old image. Always
+pin the manifest-list (index) digest, never a platform-child digest —
+`docker buildx imagetools inspect <image>` prints the index digest; a child
+digest pins one architecture and breaks the other platforms.
 
 Use `collector.framework_manifest.resolve_op_runtime(framework, op)` to
 resolve a single op's runtime, and

--- a/collector/framework_manifest.py
+++ b/collector/framework_manifest.py
@@ -194,6 +194,8 @@ def require_collector_runtime(
                 f"{framework} ops resolve to multiple runtime versions ({split}); "
                 "run each version group in its own container"
             )
+        if not by_version:
+            raise KeyError(f"{key} registry has none of the requested ops: {sorted(ops)}")
         resolved[key] = next(iter(by_version.values()))
 
     wideep_key = f"wideep_{normalized}"
@@ -228,11 +230,11 @@ def validate_resolution(
     """Return one error per registry op that does not resolve to a pinned runtime."""
     try:
         manifest = load_manifest(manifest_path)
-    except (TypeError, ValueError) as error:
+    except (TypeError, ValueError, yaml.YAMLError) as error:
         return [f"manifest: {error}"]
     try:
         family_map = load_family_map(catalog_path)
-    except ValueError as error:
+    except (ValueError, yaml.YAMLError) as error:
         return [f"op catalog: {error}"]
 
     errors: list[str] = []

--- a/collector/framework_manifest.py
+++ b/collector/framework_manifest.py
@@ -220,6 +220,34 @@ def require_collector_runtime(
     return runtime
 
 
+def validate_resolution(
+    *,
+    manifest_path: str | Path = MANIFEST_PATH,
+    catalog_path: str | Path = CATALOG_PATH,
+) -> list[str]:
+    """Return one error per registry op that does not resolve to a pinned runtime."""
+    try:
+        manifest = load_manifest(manifest_path)
+    except (TypeError, ValueError) as error:
+        return [f"manifest: {error}"]
+    try:
+        family_map = load_family_map(catalog_path)
+    except ValueError as error:
+        return [f"op catalog: {error}"]
+
+    errors: list[str] = []
+    for framework_key in _REGISTRY_MODULES:
+        if framework_key not in manifest["frameworks"]:
+            errors.append(f"{framework_key}: registry exists but the manifest has no entry")
+            continue
+        for entry in _registry_entries(framework_key):
+            try:
+                _resolve_from(manifest, family_map, framework_key, entry)
+            except (KeyError, LookupError, ValueError) as error:
+                errors.append(f"{framework_key}:{entry.op}: {error}")
+    return errors
+
+
 def validate_manifest(manifest: dict[str, Any]) -> None:
     if manifest.get("schema_version") != 2:
         raise ValueError("collector framework manifest schema_version must be 2")

--- a/collector/framework_manifest.py
+++ b/collector/framework_manifest.py
@@ -152,6 +152,19 @@ def resolve_op_runtime(
     raise KeyError(f"{framework_key} registry has no op {op!r}")
 
 
+def _runtime_identity(runtime: CollectorRuntime) -> tuple[str, tuple[tuple[str, str], ...]]:
+    """Executor identity: version plus the pinned images. Two runtimes with the
+    same package version but different images are different containers. `family`
+    stays out — it is routing metadata, not an executor property."""
+    return runtime.version, tuple(sorted(runtime.images.items()))
+
+
+def _describe_runtime(runtime: CollectorRuntime) -> str:
+    """Version plus images, for errors where the version alone cannot distinguish."""
+    images = ", ".join(f"{variant}={image}" for variant, image in sorted(runtime.images.items()))
+    return f"{runtime.version} [{images}]"
+
+
 def require_collector_runtime(
     framework: str,
     installed_version: str,
@@ -186,27 +199,40 @@ def require_collector_runtime(
             missing = ops - {e.op for e in entries}
             if missing:
                 raise KeyError(f"{key} registry has no op(s): {sorted(missing)}")
-        by_version: dict[str, CollectorRuntime] = {}
-        op_versions: dict[str, str] = {}
+        by_identity: dict[tuple[str, tuple[tuple[str, str], ...]], CollectorRuntime] = {}
+        op_runtimes: dict[str, CollectorRuntime] = {}
         for entry in entries:
             runtime = _resolve_from(manifest, family_map, key, entry)
-            by_version.setdefault(runtime.version, runtime)
-            op_versions[entry.op] = runtime.version
-        if len(by_version) > 1:
-            split = ", ".join(f"{op}→{ver}" for op, ver in sorted(op_versions.items()))
+            by_identity.setdefault(_runtime_identity(runtime), runtime)
+            op_runtimes[entry.op] = runtime
+        if len(by_identity) > 1:
+            if len({version for version, _ in by_identity}) > 1:
+                split = ", ".join(f"{op}→{rt.version}" for op, rt in sorted(op_runtimes.items()))
+                raise RuntimeError(
+                    f"{framework} ops resolve to multiple runtime versions ({split}); "
+                    "run each version group in its own container"
+                )
+            split = ", ".join(f"{op}→{_describe_runtime(rt)}" for op, rt in sorted(op_runtimes.items()))
             raise RuntimeError(
-                f"{framework} ops resolve to multiple runtime versions ({split}); "
-                "run each version group in its own container"
+                f"{framework} ops resolve to the same runtime version but different images ({split}); "
+                "run each image group in its own container"
             )
-        if not by_version:
+        if not by_identity:
             raise KeyError(f"{key} registry has no ops to resolve")
-        resolved[key] = next(iter(by_version.values()))
+        resolved[key] = next(iter(by_identity.values()))
 
     wideep_key = f"wideep_{normalized}"
-    if len({r.version for r in resolved.values()}) > 1:
+    if len({_runtime_identity(r) for r in resolved.values()}) > 1:
+        stock, wideep = resolved[normalized], resolved[wideep_key]
+        if stock.version != wideep.version:
+            raise RuntimeError(
+                f"Stock {framework} and WideEP ops require different runtime versions "
+                f"({stock.version} != {wideep.version}); "
+                "run them in separate containers"
+            )
         raise RuntimeError(
-            f"Stock {framework} and WideEP ops require different runtime versions "
-            f"({resolved[normalized].version} != {resolved[wideep_key].version}); "
+            f"Stock {framework} and WideEP ops require different images for the same runtime version "
+            f"({_describe_runtime(stock)} != {_describe_runtime(wideep)}); "
             "run them in separate containers"
         )
     runtime = resolved.get(wideep_key) or resolved[normalized]

--- a/collector/framework_manifest.py
+++ b/collector/framework_manifest.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -14,14 +15,18 @@ from packaging.version import InvalidVersion, Version
 
 MANIFEST_PATH = Path(__file__).with_name("framework_manifest.yaml")
 
+_DIGEST_RE = re.compile(r"@sha256:[0-9a-f]{64}$")
+
 
 @dataclass(frozen=True)
 class CollectorRuntime:
-    framework: str
+    framework: str  # manifest key: sglang | trtllm | vllm | wideep_sglang | wideep_trtllm
     version: str
     images: dict[str, str]
     source_repo: str | None = None
     collector_dir: str | None = None
+    data_backend: str | None = None
+    family: str | None = None  # set when resolved per-op with the catalog present
     workload: str = "default"
 
     def image(self, variant: str = "default") -> str:
@@ -45,24 +50,41 @@ def get_collector_runtime(
     path: str | Path = MANIFEST_PATH,
 ) -> CollectorRuntime:
     manifest = load_manifest(path)
-    normalized = framework.lower()
-    if workload == "wideep":
-        section = manifest.get("wideep", {})
-    elif workload == "default":
-        section = manifest.get("frameworks", {})
-    else:
-        raise KeyError(f"Unsupported collector workload {workload!r}")
-
-    spec = section.get(normalized)
+    key = _framework_key(framework, workload)
+    spec = manifest["frameworks"].get(key)
     if spec is None:
-        raise KeyError(f"No {workload} collector runtime is configured for {framework!r}")
+        raise KeyError(f"No collector runtime is configured for {framework!r} (workload={workload!r})")
+    return _runtime_from_spec(key, spec, spec["default"], manifest, family=None)
+
+
+def _framework_key(framework: str, workload: str) -> str:
+    normalized = framework.lower()
+    if workload == "wideep" and not normalized.startswith("wideep_"):
+        return f"wideep_{normalized}"
+    if workload not in ("default", "wideep"):
+        raise KeyError(f"Unsupported collector workload {workload!r}")
+    return normalized
+
+
+def _runtime_from_spec(
+    framework_key: str,
+    spec: dict[str, Any],
+    runtime_spec: dict[str, Any],
+    manifest: dict[str, Any],
+    *,
+    family: str | None,
+) -> CollectorRuntime:
+    base = spec.get("base_framework")
+    source_repo = spec.get("source_repo") or (manifest["frameworks"].get(base, {}).get("source_repo") if base else None)
     return CollectorRuntime(
-        framework=normalized,
-        version=spec["version"],
-        images=dict(spec["images"]),
-        source_repo=spec.get("source_repo") or manifest["frameworks"].get(normalized, {}).get("source_repo"),
+        framework=framework_key,
+        version=runtime_spec["version"],
+        images=dict(runtime_spec["images"]),
+        source_repo=source_repo,
         collector_dir=spec.get("collector_dir"),
-        workload=workload,
+        data_backend=spec.get("data_backend"),
+        family=family,
+        workload="wideep" if framework_key.startswith("wideep_") else "default",
     )
 
 
@@ -105,24 +127,35 @@ def require_collector_runtime(
 
 
 def validate_manifest(manifest: dict[str, Any]) -> None:
-    if manifest.get("schema_version") != 1:
-        raise ValueError("collector framework manifest schema_version must be 1")
+    if manifest.get("schema_version") != 2:
+        raise ValueError("collector framework manifest schema_version must be 2")
 
     frameworks = manifest.get("frameworks")
     if not isinstance(frameworks, dict) or not frameworks:
         raise ValueError("collector framework manifest must define frameworks")
     for framework, spec in frameworks.items():
-        _validate_runtime_spec(f"frameworks.{framework}", spec)
+        _validate_framework_spec(framework, spec, frameworks)
 
-    wideep = manifest.get("wideep", {})
-    if not isinstance(wideep, dict):
-        raise TypeError("collector framework manifest wideep section must be a mapping")
-    for framework, spec in wideep.items():
-        if framework not in frameworks:
-            raise ValueError(f"wideep.{framework} does not have a matching framework entry")
-        _validate_runtime_spec(f"wideep.{framework}", spec)
+
+def _validate_framework_spec(name: str, spec: object, frameworks: dict[str, Any]) -> None:
+    if not isinstance(spec, dict):
+        raise TypeError(f"frameworks.{name} must be a mapping")
+    if name.startswith("wideep_"):
+        base = name.removeprefix("wideep_")
+        if spec.get("base_framework") != base:
+            raise ValueError(f"frameworks.{name}.base_framework must be {base!r}")
+        if base not in frameworks:
+            raise ValueError(f"frameworks.{name}.base_framework {base!r} has no manifest entry")
         if not spec.get("collector_dir"):
-            raise ValueError(f"wideep.{framework}.collector_dir is required")
+            raise ValueError(f"frameworks.{name}.collector_dir is required")
+        if not spec.get("data_backend"):
+            raise ValueError(f"frameworks.{name}.data_backend is required")
+    _validate_runtime_spec(f"frameworks.{name}.default", spec.get("default"))
+    families = spec.get("families") or {}
+    if not isinstance(families, dict):
+        raise TypeError(f"frameworks.{name}.families must be a mapping")
+    for family, override in families.items():
+        _validate_runtime_spec(f"frameworks.{name}.families.{family}", override)
 
 
 def _validate_runtime_spec(name: str, spec: object) -> None:
@@ -135,3 +168,9 @@ def _validate_runtime_spec(name: str, spec: object) -> None:
         raise ValueError(f"{name}.images.default is required")
     if not all(isinstance(key, str) and isinstance(value, str) and value for key, value in images.items()):
         raise ValueError(f"{name}.images must map image variants to non-empty strings")
+    for variant, image in images.items():
+        if "/" in image and not _DIGEST_RE.search(image):
+            raise ValueError(
+                f"{name}.images.{variant} must be digest-pinned (...@sha256:<64 hex>); "
+                "bare internal image names without '/' are exempt"
+            )

--- a/collector/framework_manifest.py
+++ b/collector/framework_manifest.py
@@ -159,21 +159,51 @@ def require_collector_runtime(
     requested_ops: set[str],
     wideep_ops: set[str] | None = None,
     path: str | Path = MANIFEST_PATH,
+    catalog_path: str | Path = CATALOG_PATH,
 ) -> CollectorRuntime:
-    """Select the requested workload runtime and enforce its exact public version."""
-    wideep_ops = wideep_ops or set()
-    requested_wideep = requested_ops & wideep_ops
-    requested_stock = not requested_ops or bool(requested_ops - wideep_ops)
-    runtime = get_collector_runtime(framework, path=path)
+    """Resolve the single runtime the requested ops pin, and enforce it exactly.
 
-    if requested_wideep:
-        wideep_runtime = get_collector_runtime(framework, workload="wideep", path=path)
-        if requested_stock and runtime.version != wideep_runtime.version:
+    Collector V3 semantics: every op resolves independently (family override or
+    framework default); one executor container serves exactly one runtime, so
+    any spread across versions is an error telling the caller to split the run.
+    """
+    wideep_ops = wideep_ops or set()
+    manifest = load_manifest(path)
+    family_map = load_family_map(catalog_path)
+    normalized = framework.lower()
+
+    ops_by_key: dict[str, set[str]] = {}
+    for op in requested_ops:
+        key = f"wideep_{normalized}" if op in wideep_ops else normalized
+        ops_by_key.setdefault(key, set()).add(op)
+    if not requested_ops:
+        ops_by_key[normalized] = set()  # empty selection = the whole stock registry
+
+    resolved: dict[str, CollectorRuntime] = {}
+    for key, ops in ops_by_key.items():
+        entries = [e for e in _registry_entries(key) if not ops or e.op in ops]
+        by_version: dict[str, CollectorRuntime] = {}
+        op_versions: dict[str, str] = {}
+        for entry in entries:
+            runtime = _resolve_from(manifest, family_map, key, entry)
+            by_version.setdefault(runtime.version, runtime)
+            op_versions[entry.op] = runtime.version
+        if len(by_version) > 1:
+            split = ", ".join(f"{op}→{ver}" for op, ver in sorted(op_versions.items()))
             raise RuntimeError(
-                f"Stock {framework} and WideEP ops require different runtime versions "
-                f"({runtime.version} != {wideep_runtime.version}); run them in separate containers"
+                f"{framework} ops resolve to multiple runtime versions ({split}); "
+                "run each version group in its own container"
             )
-        runtime = wideep_runtime
+        resolved[key] = next(iter(by_version.values()))
+
+    wideep_key = f"wideep_{normalized}"
+    if len({r.version for r in resolved.values()}) > 1:
+        raise RuntimeError(
+            f"Stock {framework} and WideEP ops require different runtime versions "
+            f"({resolved[normalized].version} != {resolved[wideep_key].version}); "
+            "run them in separate containers"
+        )
+    runtime = resolved.get(wideep_key) or resolved[normalized]
 
     try:
         installed_public = Version(installed_version).public

--- a/collector/framework_manifest.py
+++ b/collector/framework_manifest.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import importlib
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -12,6 +13,9 @@ from typing import Any
 
 import yaml
 from packaging.version import InvalidVersion, Version
+
+from collector.op_catalog import CATALOG_PATH, family_for_perf_file, load_family_map
+from collector.registry_types import OpEntry
 
 MANIFEST_PATH = Path(__file__).with_name("framework_manifest.yaml")
 
@@ -86,6 +90,66 @@ def _runtime_from_spec(
         family=family,
         workload="wideep" if framework_key.startswith("wideep_") else "default",
     )
+
+
+_REGISTRY_MODULES = {
+    "sglang": "collector.sglang.registry",
+    "trtllm": "collector.trtllm.registry",
+    "vllm": "collector.vllm.registry",
+    "wideep_sglang": "collector.wideep.sglang.registry",
+    "wideep_trtllm": "collector.wideep.trtllm.registry",
+}
+
+
+def _registry_entries(framework_key: str) -> list[OpEntry]:
+    module_path = _REGISTRY_MODULES.get(framework_key)
+    if module_path is None:
+        raise KeyError(f"No collector registry is known for framework {framework_key!r}")
+    return list(importlib.import_module(module_path).REGISTRY)
+
+
+def _resolve_from(
+    manifest: dict[str, Any],
+    family_map: dict[str, str] | None,
+    framework_key: str,
+    entry: OpEntry,
+) -> CollectorRuntime:
+    spec = manifest["frameworks"].get(framework_key)
+    if spec is None:
+        raise KeyError(f"No collector runtime is configured for {framework_key!r}")
+    families = spec.get("families") or {}
+    family: str | None = None
+    if family_map is not None:
+        family = family_for_perf_file(str(entry.perf_filename), family_map)
+        if family is None:
+            raise LookupError(
+                f"{framework_key}:{entry.op} table {entry.perf_filename} has no family in the "
+                "op catalog; add it before collecting (fail-closed identity gate, spec §2)"
+            )
+    elif families:
+        raise LookupError(
+            f"frameworks.{framework_key}.families overrides require the op catalog "
+            f"({CATALOG_PATH.name}), but the op catalog is missing"
+        )
+    runtime_spec = families.get(family) or spec["default"]
+    return _runtime_from_spec(framework_key, spec, runtime_spec, manifest, family=family)
+
+
+def resolve_op_runtime(
+    framework: str,
+    op: str,
+    *,
+    manifest_path: str | Path = MANIFEST_PATH,
+    catalog_path: str | Path = CATALOG_PATH,
+) -> CollectorRuntime:
+    """Resolve the exactly-one pinned runtime for (framework, op) — spec §4."""
+    manifest = load_manifest(manifest_path)
+    family_map = load_family_map(catalog_path)
+    framework_key = framework.lower()
+    for entry in _registry_entries(framework_key):
+        if entry.op == op:
+            return _resolve_from(manifest, family_map, framework_key, entry)
+    raise KeyError(f"{framework_key} registry has no op {op!r}")
 
 
 def require_collector_runtime(

--- a/collector/framework_manifest.py
+++ b/collector/framework_manifest.py
@@ -182,6 +182,10 @@ def require_collector_runtime(
     resolved: dict[str, CollectorRuntime] = {}
     for key, ops in ops_by_key.items():
         entries = [e for e in _registry_entries(key) if not ops or e.op in ops]
+        if ops:
+            missing = ops - {e.op for e in entries}
+            if missing:
+                raise KeyError(f"{key} registry has no op(s): {sorted(missing)}")
         by_version: dict[str, CollectorRuntime] = {}
         op_versions: dict[str, str] = {}
         for entry in entries:
@@ -195,7 +199,7 @@ def require_collector_runtime(
                 "run each version group in its own container"
             )
         if not by_version:
-            raise KeyError(f"{key} registry has none of the requested ops: {sorted(ops)}")
+            raise KeyError(f"{key} registry has no ops to resolve")
         resolved[key] = next(iter(by_version.values()))
 
     wideep_key = f"wideep_{normalized}"
@@ -242,7 +246,12 @@ def validate_resolution(
         if framework_key not in manifest["frameworks"]:
             errors.append(f"{framework_key}: registry exists but the manifest has no entry")
             continue
-        for entry in _registry_entries(framework_key):
+        try:
+            entries = _registry_entries(framework_key)
+        except ImportError as error:
+            errors.append(f"{framework_key}: registry import failed: {error}")
+            continue
+        for entry in entries:
             try:
                 _resolve_from(manifest, family_map, framework_key, entry)
             except (KeyError, LookupError, ValueError) as error:

--- a/collector/framework_manifest.yaml
+++ b/collector/framework_manifest.yaml
@@ -1,39 +1,53 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Collector V3 manifest (schema v2): one `default` runtime per framework plus
+# explicit per-family overrides (design: docs/perf_database/
+# collector-v3-op-centric-design.md §4). Public images are digest-pinned;
+# bare internal image names are exempt. WideEP runtimes are peer framework
+# entries (wideep_<base>) so per-op resolution is uniform.
 
-schema_version: 1
+schema_version: 2
 
 frameworks:
   sglang:
-    version: "0.5.14"
-    images:
-      default: "lmsysorg/sglang:v0.5.14"
-      cu130: "lmsysorg/sglang:v0.5.14-cu130"
     source_repo: "https://github.com/sgl-project/sglang.git"
+    default:
+      version: "0.5.14"
+      images:
+        default: "lmsysorg/sglang:v0.5.14@sha256:9611bd4c5624b0e9e17829506188a12f17205f2083de0dd44d6c521733553a50"
+        cu130: "lmsysorg/sglang:v0.5.14-cu130@sha256:9611bd4c5624b0e9e17829506188a12f17205f2083de0dd44d6c521733553a50"
+    # families: {}   # explicit per-family overrides go here (spec §4)
   trtllm:
-    version: "1.3.0rc10"
-    images:
-      default: "nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10"
     source_repo: "https://github.com/NVIDIA/TensorRT-LLM.git"
+    default:
+      version: "1.3.0rc10"
+      images:
+        default: "nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10@sha256:4f42ccc3d292e489c349f9d1d18cf6f19064b2287f7b69de322d3549c9386532"
   vllm:
-    version: "0.24.0"
-    images:
-      default: "vllm/vllm-openai:v0.24.0"
-      cu129: "vllm/vllm-openai:v0.24.0-cu129"
     source_repo: "https://github.com/vllm-project/vllm.git"
-
-wideep:
-  sglang:
-    version: "0.5.10"
-    images:
-      default: "deepseek-v4-blackwell"
-      grace_blackwell: "deepseek-v4-grace-blackwell"
+    default:
+      version: "0.24.0"
+      images:
+        default: "vllm/vllm-openai:v0.24.0@sha256:32445b36556244d8a721cd21a2b47a7915bc6408432d05aaeab205bb223ced8b"
+        cu129: "vllm/vllm-openai:v0.24.0-cu129@sha256:b1147613bbeeccf2e74f2857b13b4d0ed9a59d64ab66ec35cc12dd410c1a7123"
+  wideep_sglang:
+    base_framework: sglang
     collector_dir: "collector/wideep/sglang"
+    data_backend: sglang
+    default:
+      version: "0.5.10"
+      images:
+        default: "deepseek-v4-blackwell"
+        grace_blackwell: "deepseek-v4-grace-blackwell"
     notes: >
       Requires an SGLang image with DeepSeek-V4/DeepEP modules; stock
       lmsysorg/sglang images may not include them.
-  trtllm:
-    version: "1.3.0rc10"
-    images:
-      default: "nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10"
+  wideep_trtllm:
+    base_framework: trtllm
     collector_dir: "collector/wideep/trtllm"
+    data_backend: trtllm
+    default:
+      version: "1.3.0rc10"
+      images:
+        default: "nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10@sha256:4f42ccc3d292e489c349f9d1d18cf6f19064b2287f7b69de322d3549c9386532"

--- a/collector/framework_manifest.yaml
+++ b/collector/framework_manifest.yaml
@@ -15,22 +15,22 @@ frameworks:
     default:
       version: "0.5.14"
       images:
-        default: "lmsysorg/sglang:v0.5.14@sha256:9611bd4c5624b0e9e17829506188a12f17205f2083de0dd44d6c521733553a50"
-        cu130: "lmsysorg/sglang:v0.5.14-cu130@sha256:9611bd4c5624b0e9e17829506188a12f17205f2083de0dd44d6c521733553a50"
+        default: "lmsysorg/sglang:v0.5.14@sha256:5027e95bf6ec536856b1b52a91d1f35ff5c564ab83e8a94758a169ff09bb8df3"
+        cu130: "lmsysorg/sglang:v0.5.14-cu130@sha256:5027e95bf6ec536856b1b52a91d1f35ff5c564ab83e8a94758a169ff09bb8df3"
     # families: {}   # explicit per-family overrides go here (spec §4)
   trtllm:
     source_repo: "https://github.com/NVIDIA/TensorRT-LLM.git"
     default:
       version: "1.3.0rc10"
       images:
-        default: "nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10@sha256:4f42ccc3d292e489c349f9d1d18cf6f19064b2287f7b69de322d3549c9386532"
+        default: "nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10@sha256:fd68e7500952100df58bb3682c4ea69b6e6723dc4d13dfc911a1bdee80ac389a"
   vllm:
     source_repo: "https://github.com/vllm-project/vllm.git"
     default:
       version: "0.24.0"
       images:
-        default: "vllm/vllm-openai:v0.24.0@sha256:32445b36556244d8a721cd21a2b47a7915bc6408432d05aaeab205bb223ced8b"
-        cu129: "vllm/vllm-openai:v0.24.0-cu129@sha256:b1147613bbeeccf2e74f2857b13b4d0ed9a59d64ab66ec35cc12dd410c1a7123"
+        default: "vllm/vllm-openai:v0.24.0@sha256:251eba5cc7c12fed0b75da22a9240e582b1c9e39f6fbc064f86781b963bd814f"
+        cu129: "vllm/vllm-openai:v0.24.0-cu129@sha256:6b005c78cd17a1f0215f31e95d183833f4dfd6167c4473241b80d1c8843b91e8"
   wideep_sglang:
     base_framework: sglang
     collector_dir: "collector/wideep/sglang"
@@ -50,4 +50,4 @@ frameworks:
     default:
       version: "1.3.0rc10"
       images:
-        default: "nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10@sha256:4f42ccc3d292e489c349f9d1d18cf6f19064b2287f7b69de322d3549c9386532"
+        default: "nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10@sha256:fd68e7500952100df58bb3682c4ea69b6e6723dc4d13dfc911a1bdee80ac389a"

--- a/collector/op_catalog.py
+++ b/collector/op_catalog.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Table→family identity map from the op-backend catalog (Collector V3 §2).
+
+The catalog file is introduced by the op-backend-facts registry (PR #1345).
+Until it lands on main, ``load_family_map`` returns ``None`` and callers must
+reject configurations that need family identity (fail-closed, spec §4).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+CATALOG_PATH = Path(__file__).with_name("op_backend_catalog.yaml")
+
+
+def load_family_map(path: str | Path = CATALOG_PATH) -> dict[str, str] | None:
+    """Return {perf-table stem -> family}, or None when the catalog is absent."""
+    catalog_path = Path(path)
+    if not catalog_path.exists():
+        return None
+    with catalog_path.open(encoding="utf-8") as catalog_file:
+        catalog = yaml.safe_load(catalog_file) or {}
+    families = catalog.get("families")
+    if not isinstance(families, list) or not families:
+        raise ValueError("op catalog must define a non-empty families list")
+    family_map: dict[str, str] = {}
+    for entry in families:
+        family = entry.get("family") if isinstance(entry, dict) else None
+        op_files = entry.get("op_files") if isinstance(entry, dict) else None
+        if not isinstance(family, str) or not isinstance(op_files, list) or not op_files:
+            raise ValueError(f"invalid catalog family entry: {entry!r}")
+        for op_file in op_files:
+            if op_file in family_map:
+                raise ValueError(f"table {op_file} is mapped to two families: {family_map[op_file]}, {family}")
+            family_map[op_file] = family
+    return family_map
+
+
+def family_for_perf_file(perf_filename: str, family_map: dict[str, str]) -> str | None:
+    """Map a perf filename ('gemm_perf.txt'/'.parquet' or a PerfFile) to its family."""
+    return family_map.get(Path(str(perf_filename)).stem)

--- a/collector/op_catalog.py
+++ b/collector/op_catalog.py
@@ -3,9 +3,10 @@
 
 """Table→family identity map from the op-backend catalog (Collector V3 §2).
 
-The catalog file is introduced by the op-backend-facts registry (PR #1345).
-Until it lands on main, ``load_family_map`` returns ``None`` and callers must
-reject configurations that need family identity (fail-closed, spec §4).
+The catalog file comes from the op-backend-facts registry (PR #1345, on main).
+``load_family_map`` returns ``None`` when the catalog is absent (e.g. a
+stripped or partial checkout); callers must then reject configurations that
+need family identity (fail-closed, spec §4).
 """
 
 from __future__ import annotations

--- a/collector/op_catalog.py
+++ b/collector/op_catalog.py
@@ -24,6 +24,8 @@ def load_family_map(path: str | Path = CATALOG_PATH) -> dict[str, str] | None:
         return None
     with catalog_path.open(encoding="utf-8") as catalog_file:
         catalog = yaml.safe_load(catalog_file) or {}
+    if not isinstance(catalog, dict):
+        raise ValueError("op catalog must be a mapping at the top level")  # noqa: TRY004 (caught alongside ValueError by validate_resolution)
     families = catalog.get("families")
     if not isinstance(families, list) or not families:
         raise ValueError("op catalog must define a non-empty families list")

--- a/docs/perf_database/collector-v3-op-centric-design.md
+++ b/docs/perf_database/collector-v3-op-centric-design.md
@@ -462,17 +462,24 @@ data. V3 makes that cycle computed and mostly declarative:
    `data/<system>/<family>/<backend>/<new_version>/` dirs with provenance), or
    declare reuse (`reuse.yaml` ← previous quarter's version) backed by
    kernel-identity evidence from the #1345 facts plus a spot benchmark per SM
-   generation. Precedence is decided at plan time, not runtime: the DEFAULT
-   move is recollect, and there is no runtime fallback between the two — the
-   quarter's data PR ships one or the other per family, and the evidence gate
-   checks whichever was chosen. Declaring reuse is the exception, permitted
-   only when the kernel-identity facts show the family's kernels did not
-   change across the pin bump and the per-generation spot benchmark confirms
-   it. (On pure data quality, fresh collection is never worse — declared
-   reuse exists because unchanged kernels mean statistically identical rows,
-   so recollecting them buys nothing at fleet-wide GPU cost. The quarter's
-   GPU bill stays proportional to what the framework actually changed, not
-   to the size of the support matrix.)
+   generation. How to choose, per changed family:
+
+   1. **Default: recollect.** Fresh collection is always valid and needs no
+      extra justification.
+   2. **Reuse is allowed only if BOTH hold:** the kernel-identity facts
+      (#1345) show the family's kernels are the same before and after the
+      pin bump, AND a spot benchmark on one system per SM generation
+      confirms it (median latency delta within the policy threshold).
+   3. **If either check fails, recollect.** This is a plan-time decision:
+      the data PR ships one move or the other, the evidence gate verifies
+      whichever was shipped, and the loader never switches between them at
+      query time.
+
+   Why reuse exists at all: when kernels are unchanged, recollection
+   produces statistically identical rows — reuse buys the same answer
+   without the fleet-wide GPU cost, so the quarter's bill stays
+   proportional to what the framework actually changed, not to the size
+   of the support matrix.
 3. **Per-family progress; partial upgrades are first-class.** Each
    *(framework, family)* is an independently ownable task. A family that
    breaks on the new baseline keeps an explicit `families:` override on the

--- a/docs/perf_database/collector-v3-op-centric-design.md
+++ b/docs/perf_database/collector-v3-op-centric-design.md
@@ -1,9 +1,8 @@
 # Collector V3: Op-Centric Collector Management — Design
 
-- **Status:** Draft for review (AIC-1217)
+- **Status:** In review
 - **Last updated:** 2026-07-15
 - **Source proposal:** *Per-Op Collector Version Management* (Google Doc, 2026-06-28)
-- **Linear:** [Feature: Collector V3](https://linear.app/nvidia/project/feature-collector-v3-op-centric-collector-management-4392c878361a) — AIC-1217 (this design), AIC-1218 (implementation), AIC-1219 (evidence policy)
 - **Release:** v0.11.0 (code freeze 2026-07-28)
 
 ## 1. Goal
@@ -18,7 +17,7 @@ backward-safe rules. CI and the support-matrix healer decide from manifest +
 provenance alone whether required silicon evidence exists — anything unknown
 fails closed.
 
-### Success criteria (from the Linear project)
+### Success criteria
 
 1. A collector change identifies exactly which operations and data slices require
    recollection.
@@ -60,8 +59,8 @@ V3 splits.
 
 **Fail-closed identity gate:** a registry op whose `perf_filename` table appears
 in no catalog family is a hard validation error — no family means no pin, no
-home directory, and no evidence rule. This is the "unknown identity" gate of
-AIC-1217.
+home directory, and no evidence rule. This is the design's "unknown identity"
+gate.
 
 **Relationship to #1345:** op-backend facts are observational (which backend an
 op actually ran on / can run on) and never gate collection. V3 is normative
@@ -207,7 +206,7 @@ tables:
 - Scope of `status`: it asserts execution-completeness of the attempted plan
   on that one system dir. Whether the *right* systems and cases were collected
   for a given change is enforced one layer up — the §8 changed-op manifest
-  names the required systems and the §9 evidence gate (AIC-1214) demands the
+  names the required systems and the §9 evidence gate demands the
   corresponding evidence. CI deliberately never re-expands a case plan to
   check per-dir coverage: case generation consults live device memory (§8),
   so the attempted-set attestation is collection-time only.
@@ -259,8 +258,9 @@ reproducibility; forward fill silently answers "how fast is 0.5.14" with
 
 When we *know* data is valid for a version we never collected — typically a
 framework upgrade where a family's kernels did not change — we say so
-explicitly. Replaces the presence-only `SHARED_LAYER_REUSE.txt`. A
-declared-reuse version dir contains no parquet of its own, only:
+explicitly. Replaces the presence-only `SHARED_LAYER_REUSE.txt`. In the
+typical case a declared-reuse version dir carries no parquet of its own, only
+a `reuse.yaml`:
 
 ```yaml
 # data/h200_sxm/moe/sglang/0.5.12/reuse.yaml
@@ -277,6 +277,12 @@ after the primary), because it is a vetted claim rather than a heuristic. This
 is the only way to borrow *forward* (from a newer version) — which is exactly
 what today's blank marker dirs do implicitly; V3 keeps the capability but
 makes it per-table, reviewable, and reasoned.
+
+A dir may also hold BOTH its own parquet and a declaration for the same
+table (self-overlap): per §6.1 the dir's own rows always win the shapes they
+cover, so such a declaration only forward-fills shapes the dir's own data is
+missing. The migrated tree carries a small set of these (l40s), each with a
+`reason` field disclosing exactly that mechanical derivation.
 
 This channel is also what makes per-op pinning cheap: on a scheduled upgrade
 to 0.5.15, families whose kernels did not move are not recollected — each gets
@@ -320,7 +326,7 @@ Guardrails:
 
 - **Provenance surfacing:** the loader reports, per table, which versions
   supplied rows and via which channel (`primary | declared_reuse | fallback`),
-  so AIC-1087's health classifier can tell "natively collected" from "riding
+  so the support-matrix health classifier can tell "natively collected" from "riding
   on a declaration" without re-deriving anything.
 - **CI audit:** a `reuse.yaml` pointing at data that does not exist, or any
   fill pattern outside these three channels, fails the PR — that is the
@@ -336,7 +342,7 @@ In increasing order of semantic weight:
    fallback for one transition window.
 2. **Effective-source provenance** — per table, expose which versions supplied
    rows and via which path (`primary | declared_reuse | fallback`), consumed by
-   support-matrix health (AIC-1087) and diagnostics.
+   support-matrix health and diagnostics.
 3. **Reuse rules** — implement §6 ordering. `get_database(system, backend,
    version)` keeps `version` as the *requested* framework version; per-op
    resolution happens inside.
@@ -377,7 +383,7 @@ unchanged:
 ```
 
 This file is the single input consumed by the evidence resolver (§9), the CI
-gate (AIC-1214), and the support-matrix healer — same manifest in, same
+gate, and the support-matrix healer — same manifest in, same
 requirements out.
 
 ### CI audit (fail-closed surface)
@@ -393,7 +399,7 @@ One audit tool (sibling of `audit_kernel_source.py`), run on every PR touching
 
 The CI audit is the primary gate; loader strict mode is the backstop.
 
-## 9. Evidence policy (AIC-1219)
+## 9. Evidence policy
 
 Policy-as-code: `collector/evidence_policy.yaml` plus a pure-function resolver
 `tools/perf_database/evidence_check.py --manifest changed_ops.yaml` → required
@@ -415,16 +421,15 @@ identical manifests.
 
 ## 10. Delivery plan (v0.11.0, freeze 2026-07-28)
 
-AIC-1218 is the umbrella; the implementation is split into four sub-issues
-AIC-1500–AIC-1503, delivered as exactly four PRs (one per sub-issue) to bound
-CI time and review load.
+The implementation is split into four sub-scopes, delivered as exactly four
+PRs (one per sub-scope) to bound CI time and review load.
 
-| PR | Content | Issues closed | Depends on |
-|---|---|---|---|
-| 1 | This design doc + manifest v2 + resolver + validation; wideep flattened | AIC-1217, AIC-1500 | — |
-| 2 | Physical reorg: scripted `git mv` + dual-read loader + tools path sweep | AIC-1501 | #1345 catalog |
-| 3 | Provenance writer + `reuse.yaml` + marker migration + `changed_ops.py` + CI audit | AIC-1502 | PR 2 |
-| 4 | Loader reuse rules + strict mode + source diagnostics + evidence policy/resolver | AIC-1503, AIC-1219 | PR 3, regression gate |
+| PR | Content | Depends on |
+|---|---|---|
+| 1 | This design doc + manifest v2 + resolver + validation; wideep flattened | — |
+| 2 | Physical reorg: scripted `git mv` + dual-read loader + tools path sweep | #1345 catalog |
+| 3 | Provenance writer + `reuse.yaml` + marker migration + `changed_ops.py` + CI audit | PR 2 |
+| 4 | Loader reuse rules + strict mode + source diagnostics + evidence policy/resolver | PR 3, regression gate |
 
 - PR 1 proceeds immediately and carries the reviewed design doc; PRs 2→3→4
   are sequential.
@@ -457,8 +462,17 @@ data. V3 makes that cycle computed and mostly declarative:
    `data/<system>/<family>/<backend>/<new_version>/` dirs with provenance), or
    declare reuse (`reuse.yaml` ← previous quarter's version) backed by
    kernel-identity evidence from the #1345 facts plus a spot benchmark per SM
-   generation. The quarter's GPU bill is proportional to what the framework
-   actually changed, not to the size of the support matrix.
+   generation. Precedence is decided at plan time, not runtime: the DEFAULT
+   move is recollect, and there is no runtime fallback between the two — the
+   quarter's data PR ships one or the other per family, and the evidence gate
+   checks whichever was chosen. Declaring reuse is the exception, permitted
+   only when the kernel-identity facts show the family's kernels did not
+   change across the pin bump and the per-generation spot benchmark confirms
+   it. (On pure data quality, fresh collection is never worse — declared
+   reuse exists because unchanged kernels mean statistically identical rows,
+   so recollecting them buys nothing at fleet-wide GPU cost. The quarter's
+   GPU bill stays proportional to what the framework actually changed, not
+   to the size of the support matrix.)
 3. **Per-family progress; partial upgrades are first-class.** Each
    *(framework, family)* is an independently ownable task. A family that
    breaks on the new baseline keeps an explicit `families:` override on the

--- a/docs/perf_database/collector-v3-op-centric-design.md
+++ b/docs/perf_database/collector-v3-op-centric-design.md
@@ -132,6 +132,7 @@ frameworks:
         version: "0.5.15"
         images: {default: "lmsysorg/sglang:v0.5.15@sha256:..."}
   wideep_sglang:                   # flattened from the v1 `wideep:` section
+    base_framework: sglang
     collector_dir: collector/wideep/sglang
     data_backend: sglang           # writes under <family>/sglang/<its version>/
     default:

--- a/docs/perf_database/collector-v3-op-centric-design.md
+++ b/docs/perf_database/collector-v3-op-centric-design.md
@@ -196,6 +196,21 @@ tables:
 - `collector_hash` covers the registry-declared `collect_*.py` module plus its
   declared shared dependencies (e.g. `helper.py`, the family's
   `cases/base_ops/*.yaml`); it is content-based, so it survives rebases.
+- `status` is derived, never asserted: at finalize the collector marks a table
+  `complete` iff its producing ops' checkpoints hold zero unresolved failed
+  cases and no module-level collection failure was recorded — anything else is
+  `partial`. The run's observed failure records are the only input; the mere
+  presence of provenance fields implies nothing about coverage.
+  `case_plan_hash` attests the case set the run actually attempted, so a
+  filtered subset/healing run stays distinguishable from a full-plan run even
+  when both finish `complete`.
+- Scope of `status`: it asserts execution-completeness of the attempted plan
+  on that one system dir. Whether the *right* systems and cases were collected
+  for a given change is enforced one layer up — the §8 changed-op manifest
+  names the required systems and the §9 evidence gate (AIC-1214) demands the
+  corresponding evidence. CI deliberately never re-expands a case plan to
+  check per-dir coverage: case generation consults live device memory (§8),
+  so the attempted-set attestation is collection-time only.
 - "Missing provenance" = a parquet table present with no matching `tables`
   entry. CI fails closed on it (§8); the loader's strict mode refuses it (§7).
 - Transient run artifacts (`collection_summary_*.json`, `errors_*.json`) remain

--- a/docs/perf_database/collector-v3-op-centric-design.md
+++ b/docs/perf_database/collector-v3-op-centric-design.md
@@ -38,7 +38,7 @@ fails closed.
 
 One identity chain, single-sourced, three levels:
 
-```
+```text
 registry OpEntry.op  →  PerfFile table  →  family
 (collection unit)       (storage unit)     (management unit)
 ```
@@ -71,7 +71,7 @@ backends.
 
 ## 3. Physical data layout
 
-```
+```text
 aic-core/src/aiconfigurator_core/systems/data/<system>/<family>/<backend>/<version>/
     <table>_perf.parquet     # filenames unchanged (PerfFile enum untouched)
     collection_meta.yaml     # provenance sidecar (committed, required)
@@ -149,10 +149,11 @@ same family (sglang and wideep_sglang both feed `moe`); pins are therefore per
 *(framework, family)*, and each registry belongs to one framework.
 
 **Validation (fail-closed):** a validator run in CI and before collection
-asserts every registry op across all frameworks resolves to a version and image,
-and that every image is digest-pinned where the registry supports digests
-(public registries: mandatory; internal image names, e.g.
-`deepseek-v4-blackwell`: tag-only allowed). Unresolvable op or missing image =
+asserts every registry op across all frameworks resolves to a version and
+image, and enforces the digest rule syntactically: any image reference
+containing `/` must carry `@sha256:<64 hex>`; only bare internal image names
+(no `/`, e.g. `deepseek-v4-blackwell`) are exempt — in practice, every
+public-registry reference is digest-pinned. Unresolvable op or missing image =
 hard error.
 
 **Snapshots:** the manifest at a git revision *is* the snapshot. Each
@@ -225,7 +226,7 @@ list assembly in the shared-layer sourcing code); V3 does not change the merge
 The free, always-on channel. Example: requesting `sglang 0.5.14` gemm on
 h200_sxm where a few shapes were only ever collected at 0.5.12:
 
-```
+```text
 source order for (h200_sxm, gemm, sglang, requested=0.5.14):
   1. gemm/sglang/0.5.14/     ← primary
   2. gemm/sglang/0.5.12/     ← nearest EARLIER sibling, fills gaps only
@@ -463,8 +464,10 @@ data. V3 makes that cycle computed and mostly declarative:
 
 1. **Cadence** — quarterly (decided; see §11), with targeted mid-quarter
    upgrades for new models. The mechanism itself hard-codes no cadence.
-2. **Image digests** — mandatory for public registries, tag-only allowed for
-   internal image names; enforced by manifest validation.
+2. **Image digests** — mandatory for any image reference containing `/` (in
+   practice, every public-registry reference; multi-arch index digests, never
+   platform-child digests); bare internal image names are exempt. Enforced
+   syntactically by manifest validation.
 3. **Minimum bar to claim version support** — a *(framework, family, version)*
    is supported iff its data dir has complete provenance (`status: complete`
    for all the family's tables) or a valid `reuse.yaml` chain to one that does;

--- a/docs/perf_database/collector-v3-op-centric-design.md
+++ b/docs/perf_database/collector-v3-op-centric-design.md
@@ -1,0 +1,480 @@
+# Collector V3: Op-Centric Collector Management — Design
+
+- **Status:** Draft for review (AIC-1217)
+- **Last updated:** 2026-07-15
+- **Source proposal:** *Per-Op Collector Version Management* (Google Doc, 2026-06-28)
+- **Linear:** [Feature: Collector V3](https://linear.app/nvidia/project/feature-collector-v3-op-centric-collector-management-4392c878361a) — AIC-1217 (this design), AIC-1218 (implementation), AIC-1219 (evidence policy)
+- **Release:** v0.11.0 (code freeze 2026-07-28)
+
+## 1. Goal
+
+Make the operation, not the framework version, the unit of collector management.
+Every op resolves to exactly one pinned, reproducible runtime (framework default
+plus explicit per-op overrides). Collected data carries enough provenance to know
+which collector, runtime, and case plan produced it. Any change to a pin or
+collector produces an exact changed-operation manifest saying what must be
+recollected; everything else is reused deterministically under authored,
+backward-safe rules. CI and the support-matrix healer decide from manifest +
+provenance alone whether required silicon evidence exists — anything unknown
+fails closed.
+
+### Success criteria (from the Linear project)
+
+1. A collector change identifies exactly which operations and data slices require
+   recollection.
+2. Unchanged compatible operation data remains reusable.
+3. CI rejects missing provenance, missing required silicon data, and unsupported
+   silent fallback.
+
+### Non-goals
+
+- The latest collector code working against all historical framework versions.
+- Revalidating historical framework versions after each upgrade.
+- Forcing all ops to one version during out-of-cycle model onboarding.
+- Unifying op naming across frameworks into one global op (identity is always
+  the pair *(framework, family)*).
+
+## 2. Op identity
+
+One identity chain, single-sourced, three levels:
+
+```
+registry OpEntry.op  →  PerfFile table  →  family
+(collection unit)       (storage unit)     (management unit)
+```
+
+- **Registry op** (`collector/<framework>/registry.py`): what you run
+  (`collect.py --ops attention_context`). Also the granularity of collector-code
+  identity — ops sharing a `collect_*.py` module change together.
+- **Table** (`PerfFile` enum, `collector/registry_types.py`): what is stored and
+  diffed (`context_attention_perf.parquet`). Provenance is tracked per table.
+- **Family**: the unit of pinning, physical layout, reuse, and evidence. The
+  table→family mapping is **`collector/op_backend_catalog.yaml`** (introduced by
+  PR #1345, op-backend facts) — 12 canonical families covering all 36 tables:
+  `attention, encoder_attention, mla, mla_bmm, sparse_attention, moe, gemm,
+  mlp, quantize, linear_attention, mhc, comm`.
+
+V3 adds no new identity source. Where the catalog splits (e.g.
+`encoder_attention` is its own single-table family, separate from `attention`),
+V3 splits.
+
+**Fail-closed identity gate:** a registry op whose `perf_filename` table appears
+in no catalog family is a hard validation error — no family means no pin, no
+home directory, and no evidence rule. This is the "unknown identity" gate of
+AIC-1217.
+
+**Relationship to #1345:** op-backend facts are observational (which backend an
+op actually ran on / can run on) and never gate collection. V3 is normative
+(which runtime an op must use; what evidence a change requires). V3 consumes the
+catalog vocabulary; it never keys management decisions on observed kernel
+backends.
+
+## 3. Physical data layout
+
+```
+aic-core/src/aiconfigurator_core/systems/data/<system>/<family>/<backend>/<version>/
+    <table>_perf.parquet     # filenames unchanged (PerfFile enum untouched)
+    collection_meta.yaml     # provenance sidecar (committed, required)
+    reuse.yaml               # authored reuse declarations (only in declared-reuse dirs)
+```
+
+Example: `data/h200_sxm/attention/trtllm/1.3.0rc10/context_attention_perf.parquet`.
+
+- `<family>` is one of the 12 catalog families.
+- `<backend>` stays the consumer backend (`trtllm | sglang | vllm`). WideEP data
+  lives under its backend at its own version
+  (`moe/sglang/0.5.10/wideep_moe_perf.parquet` next to
+  `moe/sglang/0.5.14/moe_perf.parquet`); the producing runtime is recorded in
+  provenance, not in the path.
+- One op's entire history — all backends, all versions — is one subtree.
+  A framework upgrade for one family adds exactly one directory; the change is
+  visible in `git diff --stat` rather than derived.
+- `SHARED_LAYER_REUSE.txt` and `INCOMPLETE.txt` are retired: the former becomes
+  `reuse.yaml` (§6), the latter becomes `status: partial` in
+  `collection_meta.yaml` (§5).
+
+### Migration
+
+- A generated `git mv` script maps every existing
+  `data/<system>/<backend>/<version>/<table>_perf.parquet` to
+  `data/<system>/<family>/<backend>/<version>/` using the catalog `op_files`
+  mapping. LFS OIDs are unchanged — no re-upload.
+- The loader reads **both layouts during one transition window** (legacy path
+  deprecated, warning logged), so tools and the GitLab auto-collect pipeline do
+  not have to cut over the same day.
+- Path-aware consumers to sweep in the same PR: loader discovery,
+  `tools/perf_database/audit_kernel_source.py`, `tools/perf_database/parquet_diff.py`,
+  `tools/support_matrix/*`, chart tooling, collector finalize output paths.
+  The GitLab auto-collect pipeline is updated in lockstep; in-flight data PRs
+  rebase after the move.
+- Note: `src/aiconfigurator/systems` is a symlink into aic-core since #1322.
+  Anything fetching raw file contents by URL (raw.githubusercontent does not
+  traverse symlinks) must use the real `aic-core/...` path.
+
+## 4. Manifest v2: per-op runtime pins
+
+`collector/framework_manifest.yaml` moves to `schema_version: 2`: per-framework
+`default` runtime plus explicit per-family overrides. WideEP entries flatten to
+peer frameworks so resolution is uniform.
+
+```yaml
+schema_version: 2
+frameworks:
+  sglang:
+    source_repo: https://github.com/sgl-project/sglang.git
+    default:
+      version: "0.5.14"
+      images:
+        default: "lmsysorg/sglang:v0.5.14@sha256:..."
+        cu130:   "lmsysorg/sglang:v0.5.14-cu130@sha256:..."
+    families:                      # explicit overrides only
+      moe:
+        version: "0.5.15"
+        images: {default: "lmsysorg/sglang:v0.5.15@sha256:..."}
+  wideep_sglang:                   # flattened from the v1 `wideep:` section
+    collector_dir: collector/wideep/sglang
+    data_backend: sglang           # writes under <family>/sglang/<its version>/
+    default:
+      version: "0.5.10"
+      images: {default: "deepseek-v4-blackwell"}
+  trtllm: {...}
+  vllm: {...}
+  wideep_trtllm: {...}
+```
+
+**Resolution:** `(framework, op) → table → family → families[family] or default`
+— exactly one runtime per op, always. Two runtimes may contribute tables to the
+same family (sglang and wideep_sglang both feed `moe`); pins are therefore per
+*(framework, family)*, and each registry belongs to one framework.
+
+**Validation (fail-closed):** a validator run in CI and before collection
+asserts every registry op across all frameworks resolves to a version and image,
+and that every image is digest-pinned where the registry supports digests
+(public registries: mandatory; internal image names, e.g.
+`deepseek-v4-blackwell`: tag-only allowed). Unresolvable op or missing image =
+hard error.
+
+**Snapshots:** the manifest at a git revision *is* the snapshot. Each
+coordinated upgrade tags `collector-snapshot-YYYY-MM` (first tag:
+`collector-snapshot-2026-08` when v0.11.0 data settles). Historical support =
+check out the snapshot and run its pinned images. No historical mappings
+accumulate in the latest manifest.
+
+**Upgrade paths** (unchanged from the source proposal):
+
+1. *Scheduled* (quarterly cadence, §11): umbrella issue, one collection task
+   per op, all pins move to the selected baseline where practical, each op
+   validated only against its new pin, merge + snapshot tag.
+2. *Targeted* (new model): upgrade only the families whose old runtime cannot
+   collect the model; unrelated pins unchanged; mixed-version snapshot recorded
+   in the manifest.
+
+## 5. Provenance: `collection_meta.yaml`
+
+Written by the collector finalize step into every version dir it produces;
+committed with the data. Parquet row schema is unchanged.
+
+```yaml
+schema_version: 1
+runtime:
+  framework: sglang                # or wideep_sglang — the producing runtime
+  version: "0.5.14"
+  image: "lmsysorg/sglang:v0.5.14"
+  image_digest: "sha256:..."
+tables:
+  moe_perf:
+    collector_ref: 0b077da5        # repo SHA the collector ran from
+    collector_hash: "sha256:..."   # content hash of the op's module closure
+    case_plan_hash: "sha256:..."   # hash of the resolved case set
+    collected_at: 2026-07-20
+    rows: 12345
+    status: complete               # complete | partial
+```
+
+- `collector_hash` covers the registry-declared `collect_*.py` module plus its
+  declared shared dependencies (e.g. `helper.py`, the family's
+  `cases/base_ops/*.yaml`); it is content-based, so it survives rebases.
+- "Missing provenance" = a parquet table present with no matching `tables`
+  entry. CI fails closed on it (§8); the loader's strict mode refuses it (§7).
+- Transient run artifacts (`collection_summary_*.json`, `errors_*.json`) remain
+  uncommitted but are retained as CI artifacts on data PRs (§9).
+
+## 6. Data reuse: three channels
+
+Reuse is never wholesale. The loader never reuses "a database" or "a version";
+it fills individual missing shapes from approved donors, through exactly three
+channels that carry different risk and therefore different requirements.
+
+### 6.1 The substrate: per-table, per-shape merging
+
+For each table (say `moe_perf`), the loader builds a priority-ordered list of
+donor version dirs, loads rows from all of them, and merges **by shape key**
+(m/n/k, batch, dtype, …): the first source that has a shape wins; later
+sources only fill gaps. This is how `perf_database.py` already works (source
+list assembly in the shared-layer sourcing code); V3 does not change the merge
+— it changes *which sources are admitted and in what order*. Consequences:
+
+- Different shapes of the same table may legitimately come from different
+  versions.
+- A donor can never shadow the primary: newer valid data always wins for
+  shapes it actually has.
+
+### 6.2 Channel 1 — implicit backward fill (same backend, earlier version)
+
+The free, always-on channel. Example: requesting `sglang 0.5.14` gemm on
+h200_sxm where a few shapes were only ever collected at 0.5.12:
+
+```
+source order for (h200_sxm, gemm, sglang, requested=0.5.14):
+  1. gemm/sglang/0.5.14/     ← primary
+  2. gemm/sglang/0.5.12/     ← nearest EARLIER sibling, fills gaps only
+  x. gemm/sglang/0.5.15/     ← skipped: newer than requested, not declared
+```
+
+The V3 change from today's behavior: ordering becomes *nearest-earlier*
+instead of *newest-first*, and newer-than-requested donors are excluded by
+default. Rationale: data collected before the requested version existed cannot
+have been invalidated by it, so backward fill preserves historical
+reproducibility; forward fill silently answers "how fast is 0.5.14" with
+0.5.15's kernels.
+
+### 6.3 Channel 2 — declared reuse (`reuse.yaml`, same backend, any direction)
+
+When we *know* data is valid for a version we never collected — typically a
+framework upgrade where a family's kernels did not change — we say so
+explicitly. Replaces the presence-only `SHARED_LAYER_REUSE.txt`. A
+declared-reuse version dir contains no parquet of its own, only:
+
+```yaml
+# data/h200_sxm/moe/sglang/0.5.12/reuse.yaml
+schema_version: 1
+reuse:
+  - table: moe_perf
+    from_version: "0.5.14"
+    reason: "MoE kernels unchanged 0.5.12→0.5.14; verified <link/commit>"
+    approved_by: yimingl
+```
+
+The loader inserts the declared donor **ahead of** implicit fallback (right
+after the primary), because it is a vetted claim rather than a heuristic. This
+is the only way to borrow *forward* (from a newer version) — which is exactly
+what today's blank marker dirs do implicitly; V3 keeps the capability but
+makes it per-table, reviewable, and reasoned.
+
+This channel is also what makes per-op pinning cheap: on a scheduled upgrade
+to 0.5.15, families whose kernels did not move are not recollected — each gets
+a one-entry `reuse.yaml` backed by the evidence policy (§9: kernel-identity
+evidence from the #1345 facts registry plus a spot benchmark on one system per
+SM generation), and the fleet-wide GPU cost of the upgrade shrinks to the
+families that actually changed.
+
+### 6.4 Channel 3 — cross-framework fill (kernel-identity gated)
+
+Cross-framework reuse is legitimate only when it is not really cross-framework
+at the kernel level — e.g. trtllm and sglang both dispatching the same cuBLAS
+GEMM or the same flashinfer attention kernel. The gate is the existing
+`op_kernel_source_manifest.yaml`: rows are admitted from a sibling backend only
+when their `kernel_source` is in a `shared`/`shared_fallback` tier whitelisting
+the active backend, and only to fill shapes the same-backend chain (channels
+1–2) could not. Example: a `gemm_perf` shape missing from all sglang versions
+may be filled from trtllm rows whose `kernel_source` is a whitelisted shared
+cuBLAS kernel — but never from trtllm rows whose kernel is trtllm-internal.
+
+V3 keeps this mechanism unchanged. What #1345 adds is a stronger verification
+story for the whitelist itself: its `kernel_source_backends.yaml` translation
+table documents what each label actually is, with code citations.
+
+### 6.5 Summary rules and guardrails
+
+The loader's source ordering (§7) in one list:
+
+1. Same backend only, by default.
+2. Requested version first, then declared `reuse.yaml` targets, then the
+   nearest **earlier** version.
+3. Never a version newer than requested — unless an explicit `reuse.yaml`
+   declaration says so.
+4. Cross-backend fill only for kernel sources whitelisted by
+   `op_kernel_source_manifest.yaml`, and only after channels 1–2.
+5. The `comm` family is excluded from sibling-version reuse entirely — NCCL
+   curves are topology-bound, so shape-filling across versions is wrong there
+   (current NCCL/oneCCL behavior, now stated as policy).
+
+Guardrails:
+
+- **Provenance surfacing:** the loader reports, per table, which versions
+  supplied rows and via which channel (`primary | declared_reuse | fallback`),
+  so AIC-1087's health classifier can tell "natively collected" from "riding
+  on a declaration" without re-deriving anything.
+- **CI audit:** a `reuse.yaml` pointing at data that does not exist, or any
+  fill pattern outside these three channels, fails the PR — that is the
+  operational definition of **unsupported silent fallback**.
+- **Scope limits:** all reuse runs only in SILICON/HYBRID modes; formula-only
+  modes (EMPIRICAL, SOL) are untouched.
+
+## 7. Loader changes (`aic-core/src/aiconfigurator_core/sdk/perf_database.py`)
+
+In increasing order of semantic weight:
+
+1. **Dual-layout discovery** — family tree first, legacy layout as deprecated
+   fallback for one transition window.
+2. **Effective-source provenance** — per table, expose which versions supplied
+   rows and via which path (`primary | declared_reuse | fallback`), consumed by
+   support-matrix health (AIC-1087) and diagnostics.
+3. **Reuse rules** — implement §6 ordering. `get_database(system, backend,
+   version)` keeps `version` as the *requested* framework version; per-op
+   resolution happens inside.
+4. **Strict mode** — missing `collection_meta.yaml`, undeclared reuse, or a
+   table without a family raises instead of warning. Default **on in CI, off
+   for end users** in v0.11.0.
+
+Shared-layer reuse remains enabled only for SILICON/HYBRID modes and disabled
+for EMPIRICAL/SOL (unchanged).
+
+**Safety net:** every loader PR must pass the prediction-regression gate
+(old-vs-new snapshot comparison, workflows from #1289/#1336), which catches
+unintended semantic drift in exactly this layer.
+
+## 8. Changed-operation manifest and CI enforcement
+
+### `tools/perf_database/changed_ops.py`
+
+Diffs two git revisions (typically `origin/main` vs PR head). Per
+*(framework, family)* it compares three change signals:
+
+1. **Pin** — manifest v2 version / image digest;
+2. **Collector code** — `collector_hash` over the op's module closure;
+3. **Case plan** — `case_plan_hash` of the resolved case set.
+
+Output (machine-readable, exhaustive):
+
+```yaml
+changed:
+  - framework: sglang
+    family: attention
+    reasons: [pin_version]
+    tables: [context_attention_perf, generation_attention_perf]
+    systems: [h200_sxm, b200_sxm, gb200]   # systems holding data at the old pin
+    action: recollect
+unchanged:
+  - {framework: sglang, family: moe, ...}
+```
+
+This file is the single input consumed by the evidence resolver (§9), the CI
+gate (AIC-1214), and the support-matrix healer — same manifest in, same
+requirements out.
+
+### CI audit (fail-closed surface)
+
+One audit tool (sibling of `audit_kernel_source.py`), run on every PR touching
+`data/`, `collector/`, or the manifest. Hard failures:
+
+- a parquet table without a matching provenance entry;
+- a `reuse.yaml` pointing at nonexistent data or violating §6 rules;
+- any registry op that does not resolve through manifest v2;
+- a table filed under the wrong family;
+- pin/collector/case-plan changes without the evidence the policy demands (§9).
+
+The CI audit is the primary gate; loader strict mode is the backstop.
+
+## 9. Evidence policy (AIC-1219)
+
+Policy-as-code: `collector/evidence_policy.yaml` plus a pure-function resolver
+`tools/perf_database/evidence_check.py --manifest changed_ops.yaml` → required
+evidence list. Deterministic: CI and the healer get identical answers from
+identical manifests.
+
+| Change | Required evidence |
+|---|---|
+| Pin version change | Fresh silicon for the family's tables on every system in the manifest — **or** a `reuse.yaml` declaration backed by kernel-identity evidence (#1345 facts showing unchanged kernels) plus a before/after spot-benchmark on one system per SM generation |
+| Collector code change, same pin | Before/after `parquet_diff` on affected tables from an evidence system (one designated system per SM generation, named in `evidence_policy.yaml`); median latency delta beyond threshold (initial: 5%) escalates to full recollection |
+| Case plan additions | Collect the new cases only (additive); removals prune with the diff visible |
+
+- **Retention:** collection summary + error JSONs attached as CI artifacts on
+  the data PR; provenance committed with the data.
+- **Exceptions:** only via an `evidence_exceptions.yaml` entry with approver and
+  expiry — explicit, reviewed, auditable.
+- The support-matrix healer may *propose* pin or reuse changes, but its PRs pass
+  the same evidence gate and human review as any other.
+
+## 10. Delivery plan (v0.11.0, freeze 2026-07-28)
+
+AIC-1218 is the umbrella; the implementation is split into four sub-issues
+AIC-1500–AIC-1503, delivered as exactly four PRs (one per sub-issue) to bound
+CI time and review load.
+
+| PR | Content | Issues closed | Depends on |
+|---|---|---|---|
+| 1 | This design doc + manifest v2 + resolver + validation; wideep flattened | AIC-1217, AIC-1500 | — |
+| 2 | Physical reorg: scripted `git mv` + dual-read loader + tools path sweep | AIC-1501 | #1345 catalog |
+| 3 | Provenance writer + `reuse.yaml` + marker migration + `changed_ops.py` + CI audit | AIC-1502 | PR 2 |
+| 4 | Loader reuse rules + strict mode + source diagnostics + evidence policy/resolver | AIC-1503, AIC-1219 | PR 3, regression gate |
+
+- PR 1 proceeds immediately and carries the reviewed design doc; PRs 2→3→4
+  are sequential.
+- PR 2 needs `op_backend_catalog.yaml` on main — either #1345 merges first or
+  the catalog file is co-landed with its author's agreement.
+- PRs 3 and 4 span collector/tools/aic-core: each declares the approved
+  cross-module contract change per
+  `.claude/rules/collector/layer_permissions.md` (approval, not PR count, is
+  the requirement).
+- **De-scope line:** if the window tightens, PR 4's runtime strict mode drops to
+  CI-only enforcement; everything else still lands.
+- After release data settles: tag `collector-snapshot-2026-08`.
+
+## 11. Quarterly operation
+
+The operating premise: once per quarter, the collector is pinned to a new
+framework baseline and the database is updated with that pinned version's
+data. V3 makes that cycle computed and mostly declarative:
+
+1. **Kickoff = one manifest commit.** The cycle's umbrella issue bumps each
+   framework's `default` pin (e.g. sglang 0.5.14 → 0.6.2). The goal state of
+   every quarter is `families: {}` — overrides accumulated mid-quarter
+   converge back into the new default. `changed_ops.py` between main and the
+   pin-bump commit emits the quarter's work list mechanically: every
+   *(framework, family)* whose pin moved, with tables and systems. No human
+   enumerates recollection scope.
+2. **The work list splits into "collect" and "declare".** Per changed family,
+   the evidence policy (§9) allows exactly two moves: recollect the family's
+   tables inside the new pinned image (new
+   `data/<system>/<family>/<backend>/<new_version>/` dirs with provenance), or
+   declare reuse (`reuse.yaml` ← previous quarter's version) backed by
+   kernel-identity evidence from the #1345 facts plus a spot benchmark per SM
+   generation. The quarter's GPU bill is proportional to what the framework
+   actually changed, not to the size of the support matrix.
+3. **Per-family progress; partial upgrades are first-class.** Each
+   *(framework, family)* is an independently ownable task. A family that
+   breaks on the new baseline keeps an explicit `families:` override on the
+   old version — visible debt in the manifest and next quarter's backlog —
+   without blocking the rest of the cycle.
+4. **Fail-closed completion.** *(framework, family, new_version)* counts as
+   supported only under the §12.3 bar (complete provenance or a valid reuse
+   chain). An uncollected, undeclared family is missing provenance: CI rejects
+   it and the support matrix never lists the new version for it.
+5. **Quarter close = snapshot tag.** When the work list is empty, tag
+   `collector-snapshot-YYYY-MM`. The tag is the quarter's deliverable and its
+   reproducibility contract (manifest pins + collector code + data at one
+   revision). Prior quarters' data dirs stay in the tree (append-only), which
+   keeps historical version requests and channel-1 backward fill working on
+   latest main.
+
+## 12. Resolved open questions (from the source proposal)
+
+1. **Cadence** — quarterly (decided; see §11), with targeted mid-quarter
+   upgrades for new models. The mechanism itself hard-codes no cadence.
+2. **Image digests** — mandatory for public registries, tag-only allowed for
+   internal image names; enforced by manifest validation.
+3. **Minimum bar to claim version support** — a *(framework, family, version)*
+   is supported iff its data dir has complete provenance (`status: complete`
+   for all the family's tables) or a valid `reuse.yaml` chain to one that does;
+   the support matrix derives from this, so the bar is machine-checkable.
+
+## 13. Open question: data retention across quarters
+
+Quarterly appends grow the LFS tree without bound (~906 parquet files today,
+plus each quarter's changed families). This design does not prune. A sensible
+policy would be "keep the most recent N quarters of version dirs on main;
+older quarters remain reachable only through their `collector-snapshot-*`
+tags" — but N, and whether pruning also drops declared-reuse chains that
+reference pruned donors, must be decided deliberately. Decide before the
+second quarterly cycle, not by accident.

--- a/tests/unit/collector/test_framework_manifest.py
+++ b/tests/unit/collector/test_framework_manifest.py
@@ -258,3 +258,104 @@ families:
         catalog_path=tmp_path / "op_backend_catalog.yaml",
     )
     assert (runtime.family, runtime.version) == ("gemm", "0.5.15")
+
+
+def test_family_override_same_version_different_image_is_rejected(tmp_path):
+    digest_a = "@sha256:" + "a" * 64
+    digest_b = "@sha256:" + "b" * 64
+    (tmp_path / "framework_manifest.yaml").write_text(
+        f"""
+schema_version: 2
+frameworks:
+  sglang:
+    source_repo: "https://github.com/sgl-project/sglang.git"
+    default:
+      version: "0.5.14"
+      images:
+        default: "lmsysorg/sglang:v0.5.14{digest_a}"
+    families:
+      gemm:
+        version: "0.5.14"
+        images:
+          default: "lmsysorg/sglang:v0.5.14-gemm{digest_b}"
+""",
+        encoding="utf-8",
+    )
+    (tmp_path / "op_backend_catalog.yaml").write_text(
+        """
+schema_version: 1
+families:
+  - family: gemm
+    op_files: [gemm_perf]
+  - family: attention
+    op_files: [context_attention_perf, generation_attention_perf]
+""",
+        encoding="utf-8",
+    )
+    # Runtime identity is (version, images), not version alone: the same package
+    # version pinned to two different images is still two containers, so a mixed
+    # request must fail closed with the op->runtime split instead of letting
+    # registry order pick one image silently.
+    with pytest.raises(RuntimeError) as excinfo:
+        require_collector_runtime(
+            "sglang",
+            "0.5.14",
+            requested_ops={"gemm", "attention_context"},
+            wideep_ops=set(),
+            path=tmp_path / "framework_manifest.yaml",
+            catalog_path=tmp_path / "op_backend_catalog.yaml",
+        )
+    message = str(excinfo.value)
+    assert "same runtime version but different images" in message
+    assert f"gemm→0.5.14 [default=lmsysorg/sglang:v0.5.14-gemm{digest_b}]" in message
+    assert f"attention_context→0.5.14 [default=lmsysorg/sglang:v0.5.14{digest_a}]" in message
+    # Each image group alone is still a valid single-container request.
+    runtime = require_collector_runtime(
+        "sglang",
+        "0.5.14",
+        requested_ops={"gemm"},
+        wideep_ops=set(),
+        path=tmp_path / "framework_manifest.yaml",
+        catalog_path=tmp_path / "op_backend_catalog.yaml",
+    )
+    assert (runtime.family, runtime.version) == ("gemm", "0.5.14")
+    assert runtime.image() == f"lmsysorg/sglang:v0.5.14-gemm{digest_b}"
+
+
+def test_stock_and_wideep_same_version_different_image_is_rejected(tmp_path):
+    digest_a = "@sha256:" + "a" * 64
+    digest_b = "@sha256:" + "b" * 64
+    (tmp_path / "framework_manifest.yaml").write_text(
+        f"""
+schema_version: 2
+frameworks:
+  sglang:
+    source_repo: "https://github.com/sgl-project/sglang.git"
+    default:
+      version: "0.5.14"
+      images:
+        default: "lmsysorg/sglang:v0.5.14{digest_a}"
+  wideep_sglang:
+    base_framework: sglang
+    collector_dir: "collector/wideep/sglang"
+    data_backend: "sglang"
+    default:
+      version: "0.5.14"
+      images:
+        default: "lmsysorg/sglang:v0.5.14-wideep{digest_b}"
+""",
+        encoding="utf-8",
+    )
+    with pytest.raises(RuntimeError) as excinfo:
+        require_collector_runtime(
+            "sglang",
+            "0.5.14",
+            requested_ops={"gemm", "wideep_moe"},
+            wideep_ops={"wideep_moe"},
+            path=tmp_path / "framework_manifest.yaml",
+        )
+    message = str(excinfo.value)
+    assert "different images for the same runtime version" in message
+    assert f"lmsysorg/sglang:v0.5.14{digest_a}" in message
+    assert f"lmsysorg/sglang:v0.5.14-wideep{digest_b}" in message
+    assert "separate containers" in message

--- a/tests/unit/collector/test_framework_manifest.py
+++ b/tests/unit/collector/test_framework_manifest.py
@@ -171,8 +171,14 @@ def test_runtime_selection_rejects_mismatched_or_mixed_pins(installed_version, r
 
 
 def test_unknown_requested_op_fails_with_key_error():
-    with pytest.raises(KeyError, match="none of the requested ops"):
+    with pytest.raises(KeyError, match=r"has no op\(s\): \['not_a_real_op'\]"):
         require_collector_runtime("sglang", "0.5.14", requested_ops={"not_a_real_op"}, wideep_ops=set())
+
+
+def test_typo_mixed_with_real_op_fails_closed():
+    # A typo must not be silently dropped just because another requested op is valid.
+    with pytest.raises(KeyError, match=r"has no op\(s\): \['not_a_real_op'\]"):
+        require_collector_runtime("sglang", "0.5.14", requested_ops={"gemm", "not_a_real_op"}, wideep_ops=set())
 
 
 def test_wideep_registry_entries_are_separate_from_stock_backend_registries():

--- a/tests/unit/collector/test_framework_manifest.py
+++ b/tests/unit/collector/test_framework_manifest.py
@@ -140,3 +140,56 @@ def test_deepep_collectors_live_under_wideep_namespace():
     assert not (COLLECTOR_ROOT / "deep_collector").exists()
     assert not (COLLECTOR_ROOT / "sglang" / "collect_wideep_deepep_moe.py").exists()
     assert not (COLLECTOR_ROOT / "trtllm" / "collect_wideep_moe_compute.py").exists()
+
+
+def test_family_overrides_split_ops_across_runtimes(tmp_path):
+    digest = "@sha256:" + "0" * 64
+    (tmp_path / "framework_manifest.yaml").write_text(
+        f"""
+schema_version: 2
+frameworks:
+  sglang:
+    source_repo: "https://github.com/sgl-project/sglang.git"
+    default:
+      version: "0.5.14"
+      images:
+        default: "lmsysorg/sglang:v0.5.14{digest}"
+    families:
+      gemm:
+        version: "0.5.15"
+        images:
+          default: "lmsysorg/sglang:v0.5.15{digest}"
+""",
+        encoding="utf-8",
+    )
+    (tmp_path / "op_backend_catalog.yaml").write_text(
+        """
+schema_version: 1
+families:
+  - family: gemm
+    op_files: [gemm_perf]
+  - family: attention
+    op_files: [context_attention_perf, generation_attention_perf]
+""",
+        encoding="utf-8",
+    )
+    # One container cannot serve two pins: fail closed with the op->version split.
+    with pytest.raises(RuntimeError, match="multiple runtime versions"):
+        require_collector_runtime(
+            "sglang",
+            "0.5.14",
+            requested_ops={"gemm", "attention_context"},
+            wideep_ops=set(),
+            path=tmp_path / "framework_manifest.yaml",
+            catalog_path=tmp_path / "op_backend_catalog.yaml",
+        )
+    # A single-family request against the matching container succeeds.
+    runtime = require_collector_runtime(
+        "sglang",
+        "0.5.15",
+        requested_ops={"gemm"},
+        wideep_ops=set(),
+        path=tmp_path / "framework_manifest.yaml",
+        catalog_path=tmp_path / "op_backend_catalog.yaml",
+    )
+    assert (runtime.family, runtime.version) == ("gemm", "0.5.15")

--- a/tests/unit/collector/test_framework_manifest.py
+++ b/tests/unit/collector/test_framework_manifest.py
@@ -26,16 +26,15 @@ def test_manifest_exposes_current_framework_versions_and_images():
     vllm = get_collector_runtime("vllm")
 
     assert sglang.version == "0.5.14"
-    assert sglang.image() == "lmsysorg/sglang:v0.5.14"
-    assert sglang.image("cu130") == "lmsysorg/sglang:v0.5.14-cu130"
+    assert sglang.image().startswith("lmsysorg/sglang:v0.5.14@sha256:")
+    assert sglang.image("cu130").startswith("lmsysorg/sglang:v0.5.14-cu130@sha256:")
     assert trtllm.version == "1.3.0rc10"
-    assert trtllm.image() == "nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10"
+    assert trtllm.image().startswith("nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10@sha256:")
     assert vllm.version == "0.24.0"
-    assert vllm.image() == "vllm/vllm-openai:v0.24.0"
-    assert vllm.image("cu129") == "vllm/vllm-openai:v0.24.0-cu129"
-    # vLLM 0.24.0 has no separately published cu130 tag. Unknown variants
-    # intentionally fall back to the pinned default image.
-    assert vllm.image("cu130") == "vllm/vllm-openai:v0.24.0"
+    assert vllm.image().startswith("vllm/vllm-openai:v0.24.0@sha256:")
+    assert vllm.image("cu129").startswith("vllm/vllm-openai:v0.24.0-cu129@sha256:")
+    # Unknown variants intentionally fall back to the pinned default image.
+    assert vllm.image("cu130") == vllm.image()
 
 
 def test_active_cuda_vllm_collectors_are_exactly_pinned_to_manifest_version():
@@ -54,6 +53,37 @@ def test_wideep_runtime_stays_independent_from_default_framework_runtime():
     assert wideep_sglang.version != get_collector_runtime("sglang").version
     assert wideep_sglang.collector_dir == "collector/wideep/sglang"
     assert "deepseek-v4" in wideep_sglang.image()
+
+
+def test_wideep_entries_are_flattened_peer_frameworks():
+    # workload="wideep" is the compatibility spelling for manifest key wideep_<fw>
+    via_workload = get_collector_runtime("sglang", workload="wideep")
+    direct = get_collector_runtime("wideep_sglang")
+    assert via_workload == direct
+    assert direct.framework == "wideep_sglang"
+    assert direct.data_backend == "sglang"
+    assert direct.collector_dir == "collector/wideep/sglang"
+    # wideep inherits the base framework's source_repo unless overridden
+    assert direct.source_repo == get_collector_runtime("sglang").source_repo
+
+
+def test_public_images_must_be_digest_pinned(tmp_path):
+    manifest = tmp_path / "framework_manifest.yaml"
+    manifest.write_text(
+        """
+schema_version: 2
+frameworks:
+  sglang:
+    source_repo: "https://github.com/sgl-project/sglang.git"
+    default:
+      version: "0.5.14"
+      images:
+        default: "lmsysorg/sglang:v0.5.14"
+""",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="digest-pinned"):
+        get_collector_runtime("sglang", path=manifest)
 
 
 WIDEEP_OPS = {entry.op for entry in WIDEEP_SGLANG_REGISTRY}

--- a/tests/unit/collector/test_framework_manifest.py
+++ b/tests/unit/collector/test_framework_manifest.py
@@ -86,6 +86,60 @@ frameworks:
         get_collector_runtime("sglang", path=manifest)
 
 
+def test_wideep_entry_missing_base_framework_is_rejected(tmp_path):
+    digest = "@sha256:" + "0" * 64
+    manifest = tmp_path / "framework_manifest.yaml"
+    manifest.write_text(
+        f"""
+schema_version: 2
+frameworks:
+  sglang:
+    source_repo: "https://github.com/sgl-project/sglang.git"
+    default:
+      version: "0.5.14"
+      images:
+        default: "lmsysorg/sglang:v0.5.14{digest}"
+  wideep_sglang:
+    collector_dir: "collector/wideep/sglang"
+    data_backend: "sglang"
+    default:
+      version: "0.5.10"
+      images:
+        default: "deepseek-v4-blackwell"
+""",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="base_framework"):
+        get_collector_runtime("wideep_sglang", path=manifest)
+
+
+def test_wideep_entry_missing_data_backend_is_rejected(tmp_path):
+    digest = "@sha256:" + "0" * 64
+    manifest = tmp_path / "framework_manifest.yaml"
+    manifest.write_text(
+        f"""
+schema_version: 2
+frameworks:
+  sglang:
+    source_repo: "https://github.com/sgl-project/sglang.git"
+    default:
+      version: "0.5.14"
+      images:
+        default: "lmsysorg/sglang:v0.5.14{digest}"
+  wideep_sglang:
+    base_framework: sglang
+    collector_dir: "collector/wideep/sglang"
+    default:
+      version: "0.5.10"
+      images:
+        default: "deepseek-v4-blackwell"
+""",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="data_backend"):
+        get_collector_runtime("wideep_sglang", path=manifest)
+
+
 WIDEEP_OPS = {entry.op for entry in WIDEEP_SGLANG_REGISTRY}
 
 
@@ -114,6 +168,11 @@ def test_runtime_selection_accepts_only_the_matching_pin(installed_version, requ
 def test_runtime_selection_rejects_mismatched_or_mixed_pins(installed_version, requested_ops, match):
     with pytest.raises(RuntimeError, match=match):
         require_collector_runtime("sglang", installed_version, requested_ops=requested_ops, wideep_ops=WIDEEP_OPS)
+
+
+def test_unknown_requested_op_fails_with_key_error():
+    with pytest.raises(KeyError, match="none of the requested ops"):
+        require_collector_runtime("sglang", "0.5.14", requested_ops={"not_a_real_op"}, wideep_ops=set())
 
 
 def test_wideep_registry_entries_are_separate_from_stock_backend_registries():

--- a/tests/unit/collector/test_manifest_resolution.py
+++ b/tests/unit/collector/test_manifest_resolution.py
@@ -137,3 +137,11 @@ def test_validator_reports_malformed_catalog_yaml(paths):
     errors = validate_resolution(manifest_path=manifest, catalog_path=catalog)
     assert len(errors) == 1
     assert errors[0].startswith("op catalog: ")
+
+
+def test_validator_reports_registry_import_failure(monkeypatch):
+    import collector.framework_manifest as fm
+
+    monkeypatch.setitem(fm._REGISTRY_MODULES, "sglang", "collector.nonexistent_registry")
+    errors = fm.validate_resolution()
+    assert any(error.startswith("sglang: registry import failed") for error in errors)

--- a/tests/unit/collector/test_manifest_resolution.py
+++ b/tests/unit/collector/test_manifest_resolution.py
@@ -95,3 +95,34 @@ def test_unknown_op_is_a_hard_error(paths):
     manifest, catalog = paths(MANIFEST_NO_OVERRIDES)
     with pytest.raises(KeyError, match="no op 'not_an_op'"):
         resolve_op_runtime("sglang", "not_an_op", manifest_path=manifest, catalog_path=catalog)
+
+
+from collector.framework_manifest import validate_resolution
+
+
+def test_real_manifest_resolves_every_registry_op():
+    # The fail-closed CI gate (spec §4): every op in every registry resolves to
+    # exactly one pinned runtime with the committed manifest (+ catalog, once
+    # PR #1345 lands). Runs in CI via the unit suite.
+    assert validate_resolution() == []
+
+
+def test_validator_reports_missing_framework_entry(tmp_path):
+    digest = "@sha256:" + "0" * 64
+    manifest = tmp_path / "framework_manifest.yaml"
+    manifest.write_text(
+        f"""
+schema_version: 2
+frameworks:
+  sglang:
+    source_repo: "https://github.com/sgl-project/sglang.git"
+    default:
+      version: "0.5.14"
+      images:
+        default: "lmsysorg/sglang:v0.5.14{digest}"
+""",
+        encoding="utf-8",
+    )
+    errors = validate_resolution(manifest_path=manifest, catalog_path=tmp_path / "op_backend_catalog.yaml")
+    assert any("trtllm" in error for error in errors)
+    assert any("wideep_sglang" in error for error in errors)

--- a/tests/unit/collector/test_manifest_resolution.py
+++ b/tests/unit/collector/test_manifest_resolution.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-op runtime resolution tests (Collector V3 spec §4)."""
+
+import pytest
+
+from collector.framework_manifest import resolve_op_runtime
+
+pytestmark = pytest.mark.unit
+
+DIGEST = "@sha256:" + "0" * 64
+
+MANIFEST_NO_OVERRIDES = f"""
+schema_version: 2
+frameworks:
+  sglang:
+    source_repo: "https://github.com/sgl-project/sglang.git"
+    default:
+      version: "0.5.14"
+      images:
+        default: "lmsysorg/sglang:v0.5.14{DIGEST}"
+"""
+
+MANIFEST_WITH_OVERRIDE = f"""
+schema_version: 2
+frameworks:
+  sglang:
+    source_repo: "https://github.com/sgl-project/sglang.git"
+    default:
+      version: "0.5.14"
+      images:
+        default: "lmsysorg/sglang:v0.5.14{DIGEST}"
+    families:
+      gemm:
+        version: "0.5.15"
+        images:
+          default: "lmsysorg/sglang:v0.5.15{DIGEST}"
+"""
+
+CATALOG = """
+schema_version: 1
+families:
+  - family: gemm
+    op_files: [gemm_perf]
+  - family: attention
+    op_files: [context_attention_perf, generation_attention_perf]
+"""
+
+
+@pytest.fixture
+def paths(tmp_path):
+    def _write(manifest_text, catalog_text=None):
+        manifest = tmp_path / "framework_manifest.yaml"
+        manifest.write_text(manifest_text, encoding="utf-8")
+        catalog = tmp_path / "op_backend_catalog.yaml"
+        if catalog_text is not None:
+            catalog.write_text(catalog_text, encoding="utf-8")
+        return manifest, catalog
+
+    return _write
+
+
+def test_default_resolution_without_catalog(paths):
+    manifest, catalog = paths(MANIFEST_NO_OVERRIDES)
+    runtime = resolve_op_runtime("sglang", "gemm", manifest_path=manifest, catalog_path=catalog)
+    assert runtime.version == "0.5.14"
+    assert runtime.family is None  # no catalog -> no family identity yet
+
+
+def test_family_override_wins_with_catalog(paths):
+    manifest, catalog = paths(MANIFEST_WITH_OVERRIDE, CATALOG)
+    gemm = resolve_op_runtime("sglang", "gemm", manifest_path=manifest, catalog_path=catalog)
+    attn = resolve_op_runtime("sglang", "attention_context", manifest_path=manifest, catalog_path=catalog)
+    assert (gemm.family, gemm.version) == ("gemm", "0.5.15")
+    assert (attn.family, attn.version) == ("attention", "0.5.14")
+
+
+def test_overrides_without_catalog_fail_closed(paths):
+    manifest, catalog = paths(MANIFEST_WITH_OVERRIDE)  # no catalog file
+    with pytest.raises(LookupError, match="op catalog is missing"):
+        resolve_op_runtime("sglang", "gemm", manifest_path=manifest, catalog_path=catalog)
+
+
+def test_table_missing_from_catalog_fails_closed(paths):
+    manifest, catalog = paths(
+        MANIFEST_NO_OVERRIDES,
+        "schema_version: 1\nfamilies:\n  - family: gemm\n    op_files: [gemm_perf]\n",
+    )
+    with pytest.raises(LookupError, match="has no family"):
+        resolve_op_runtime("sglang", "attention_context", manifest_path=manifest, catalog_path=catalog)
+
+
+def test_unknown_op_is_a_hard_error(paths):
+    manifest, catalog = paths(MANIFEST_NO_OVERRIDES)
+    with pytest.raises(KeyError, match="no op 'not_an_op'"):
+        resolve_op_runtime("sglang", "not_an_op", manifest_path=manifest, catalog_path=catalog)

--- a/tests/unit/collector/test_manifest_resolution.py
+++ b/tests/unit/collector/test_manifest_resolution.py
@@ -5,7 +5,7 @@
 
 import pytest
 
-from collector.framework_manifest import resolve_op_runtime
+from collector.framework_manifest import resolve_op_runtime, validate_resolution
 
 pytestmark = pytest.mark.unit
 
@@ -97,9 +97,6 @@ def test_unknown_op_is_a_hard_error(paths):
         resolve_op_runtime("sglang", "not_an_op", manifest_path=manifest, catalog_path=catalog)
 
 
-from collector.framework_manifest import validate_resolution
-
-
 def test_real_manifest_resolves_every_registry_op():
     # The fail-closed CI gate (spec §4): every op in every registry resolves to
     # exactly one pinned runtime with the committed manifest (+ catalog, once
@@ -126,3 +123,17 @@ frameworks:
     errors = validate_resolution(manifest_path=manifest, catalog_path=tmp_path / "op_backend_catalog.yaml")
     assert any("trtllm" in error for error in errors)
     assert any("wideep_sglang" in error for error in errors)
+
+
+def test_validator_reports_non_mapping_catalog(paths):
+    manifest, catalog = paths(MANIFEST_NO_OVERRIDES, "- foo\n- bar\n")
+    errors = validate_resolution(manifest_path=manifest, catalog_path=catalog)
+    assert len(errors) == 1
+    assert errors[0].startswith("op catalog: ")
+
+
+def test_validator_reports_malformed_catalog_yaml(paths):
+    manifest, catalog = paths(MANIFEST_NO_OVERRIDES, "families: [\n")
+    errors = validate_resolution(manifest_path=manifest, catalog_path=catalog)
+    assert len(errors) == 1
+    assert errors[0].startswith("op catalog: ")

--- a/tests/unit/collector/test_op_catalog.py
+++ b/tests/unit/collector/test_op_catalog.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the op_backend_catalog family-map loader (Collector V3 identity)."""
+
+import pytest
+
+from collector.op_catalog import family_for_perf_file, load_family_map
+from collector.registry_types import PerfFile
+
+pytestmark = pytest.mark.unit
+
+CATALOG = """
+schema_version: 1
+families:
+  - family: attention
+    op_files: [context_attention_perf, generation_attention_perf]
+  - family: gemm
+    op_files: [gemm_perf]
+"""
+
+
+def test_absent_catalog_returns_none(tmp_path):
+    assert load_family_map(tmp_path / "op_backend_catalog.yaml") is None
+
+
+def test_family_map_indexes_tables_by_stem(tmp_path):
+    path = tmp_path / "op_backend_catalog.yaml"
+    path.write_text(CATALOG, encoding="utf-8")
+    family_map = load_family_map(path)
+    assert family_map == {
+        "context_attention_perf": "attention",
+        "generation_attention_perf": "attention",
+        "gemm_perf": "gemm",
+    }
+
+
+def test_family_for_perf_file_matches_txt_parquet_and_enum(tmp_path):
+    path = tmp_path / "op_backend_catalog.yaml"
+    path.write_text(CATALOG, encoding="utf-8")
+    family_map = load_family_map(path)
+    assert family_for_perf_file("gemm_perf.txt", family_map) == "gemm"
+    assert family_for_perf_file("gemm_perf.parquet", family_map) == "gemm"
+    assert family_for_perf_file(str(PerfFile.CONTEXT_ATTENTION), family_map) == "attention"
+    assert family_for_perf_file("nonexistent_perf.txt", family_map) is None
+
+
+def test_duplicate_table_across_families_is_rejected(tmp_path):
+    path = tmp_path / "op_backend_catalog.yaml"
+    path.write_text(
+        CATALOG + "  - family: moe\n    op_files: [gemm_perf]\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="two families"):
+        load_family_map(path)


### PR DESCRIPTION
PR 1 of 4 of the **Collector V3: op-centric collector management** project (Linear: [AIC-1217](https://linear.app/nvidia/issue/AIC-1217/finalize-collector-v3-design) design + [AIC-1500](https://linear.app/nvidia/issue/AIC-1500/collector-v3-a-manifest-v2-per-op-runtime-pins-resolver-validation) manifest v2). It carries the reviewed design contract and the first implementation slice: per-op runtime pins. The remaining PRs (family-tree data reorg → provenance/`reuse.yaml`/`changed_ops` + CI audit → loader reuse rules + evidence policy) build on this one; the full delivery plan is §10 of the design doc.

## What's in here

- **`docs/perf_database/collector-v3-op-centric-design.md`** — the Collector V3 design contract (op identity chain, family-first physical layout, manifest v2, provenance, three-channel reuse, changed-op manifest, evidence policy, quarterly operation). Mirrored in Linear on the project; this copy is canonical.
- **`collector/framework_manifest.yaml` → `schema_version: 2`** — per-framework `default` runtime + explicit per-family override slots; wideep flattened to peer frameworks (`wideep_sglang`, `wideep_trtllm`) with `base_framework`/`data_backend`; all public images pinned by **multi-arch index digest** (`name:tag@sha256:...`; bare internal image names exempt). Pins are unchanged: sglang 0.5.14, trtllm 1.3.0rc10, vllm 0.24.0, wideep-sglang 0.5.10.
- **`collector/framework_manifest.py`** — v2 validation (incl. the digest rule), `resolve_op_runtime(framework, op)` implementing `op → PerfFile table → catalog family → families[family] or default`, per-op `require_collector_runtime` (public signature preserved — `collector/collect.py` is deliberately untouched; mixed-pin requests fail with the exact op→version split), and `validate_resolution()` returning one error per unresolvable registry op.
- **`collector/op_catalog.py`** — loader for the table→family map from `collector/op_backend_catalog.yaml`. The catalog does not exist on main yet (it arrives with #1345), so the loader returns `None` when absent: all-default resolution works today, while declaring a `families:` override without the catalog is a hard error.
- **CI gate**: `test_real_manifest_resolves_every_registry_op` asserts `validate_resolution() == []` in the standard unit suite — every op in all five registries must resolve to exactly one pinned runtime, fail-closed.
- README version-management section rewritten for v2, including: pin the **index** digest, never a platform-child digest (a child digest pins one architecture and breaks the rest of the fleet).

## Coordination notes

- **#1345 (op-backend facts):** the moment its `op_backend_catalog.yaml` lands, the CI gate here starts requiring every registry op's table to have a catalog family (including `wideep_moe_perf`, used by both wideep registries). Three currently-missing tables are already flagged on that PR ([comment](https://github.com/ai-dynamo/aiconfigurator/pull/1345#issuecomment-4979252717)); whichever PR rebases second will see the gate fire if the catalog misses a registry table — that is intended fail-closed behavior.
- **GitLab auto-collect pipeline:** if it parses `frameworks.<fw>.version` (v1 schema), it must learn the v2 path `frameworks.<fw>.default.version` before its next run against a checkout containing this change.

## Known limitation (deliberate)

`require_collector_runtime` detects mixed pins by version string only; two family overrides sharing a version but pinning different images would not be split. Unreachable with today's manifest (no overrides yet) — noted here so PR 4's reviewer sees it with fresh eyes.

## Test plan

`uv run pytest tests/unit/collector -m unit` → 428 passed, 5 skipped (includes the real-manifest CI gate, all five v1 `require_collector_runtime` regression cases, fail-closed gates for override-without-catalog / table-without-family / unknown-op, malformed-catalog hardening, and wideep validator branches). All five image digests were verified against the live registries as manifest-list/index digests, twice (implementation + independent review pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Collector V3 per-operation runtime resolution using `(framework, op)` → table → catalog family mappings.
  * Introduced workload-aware runtime selection (including WideEP compatibility) and variant-based runtime image access.
* **Documentation**
  * Updated Version Management for manifest schema v2 and added the op-centric Collector V3 design spec.
* **Bug Fixes**
  * Enforced fail-closed resolution for unknown identities and stricter manifest validation; tightened public container images to require digest pinning.
* **Tests**
  * Added/expanded unit tests for op catalog loading, schema v2 validation, WideEP/override rules, and `validate_resolution` error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->