### PR TITLE
fix(webapp): move CSS to launch() for Gradio 6 and disable analytics

### DIFF
--- a/src/aiconfigurator/webapp/main.py
+++ b/src/aiconfigurator/webapp/main.py
@@ -51,6 +51,10 @@ def main(args):
     """
     Main function for the WebApp.
     """
+    import os
+
+    os.environ.setdefault("GRADIO_ANALYTICS_ENABLED", "False")
+
     try:
         import gradio as gr
     except ModuleNotFoundError as e:
@@ -97,9 +101,7 @@ def main(args):
     if not perf_database.get_supported_databases():
         raise SystemExit(perf_database.build_no_databases_message())
 
-    with gr.Blocks(
-        title="AIConfigurator for Disaggregated Serving Deployment",
-        css="""
+    _css = """
         .config-column {
             border-right: 5px solid #e0e0e0;
             padding-right: 20px;
@@ -122,7 +124,10 @@ def main(args):
             scrollbar-width: none !important;
             -ms-overflow-style: none !important;
         }
-    """,
+    """
+
+    with gr.Blocks(
+        title="AIConfigurator for Disaggregated Serving Deployment",
     ) as demo:
         pareto_results_state = gr.State(defaultdict())
 
@@ -188,7 +193,7 @@ def main(args):
         if app_config["enable_profiling"]:
             EventHandler.setup_profiling_events(profiling_components)
 
-        demo.launch(server_name=args.server_name, server_port=args.server_port)
+        demo.launch(server_name=args.server_name, server_port=args.server_port, css=_css)
 
 
 if __name__ == "__main__":

--- a/src/aiconfigurator/webapp/main.py
+++ b/src/aiconfigurator/webapp/main.py
@@ -3,6 +3,7 @@
 
 import argparse
 import logging
+import os
 from collections import defaultdict
 
 import aiconfigurator
@@ -51,8 +52,6 @@ def main(args):
     """
     Main function for the WebApp.
     """
-    import os
-
     os.environ.setdefault("GRADIO_ANALYTICS_ENABLED", "False")
 
     try:


### PR DESCRIPTION
#### Overview:

Fixes Gradio 6.0 deprecation warning and suppresses noisy telemetry requests on webapp startup.

#### Details:

- Moved the `css` parameter from `gr.Blocks()` constructor to `demo.launch()`, as required by Gradio 6.0. Eliminates the `UserWarning: The parameters have been moved from the Blocks constructor to the launch() method` warning on every startup.
- Disabled Gradio telemetry by default via `os.environ.setdefault("GRADIO_ANALYTICS_ENABLED", "False")`. AIC is a self-hosted tool and the HuggingFace/Gradio analytics HTTP requests add startup noise without user benefit. Uses `setdefault` so users can re-enable with `GRADIO_ANALYTICS_ENABLED=True` if desired.

#### Where should the reviewer start?

- `src/aiconfigurator/webapp/main.py` — single file, ~10 lines changed

#### Related Issues:

- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Disabled Gradio analytics during application startup.
  * Improved consistency of the web app’s custom styling by ensuring the stylesheet is correctly applied when the server launches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->