### PR TITLE
feat(sdk): declared-reuse ordering, strict provenance mode, evidence policy (AIC-1503, AIC-1219)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -95,7 +95,9 @@ jobs:
           echo "Running pytest paths: ${test_paths[*]}"
 
           docker build -f docker/Dockerfile -t aiconfigurator:test --target test .
-          docker run --name aic aiconfigurator:test \
+          # Fail-closed loader provenance checks (Collector V3 design §7.4); the
+          # committed data tree is fully sidecar-covered post-PR3, so this must stay green.
+          docker run --name aic -e AIC_STRICT_PROVENANCE=1 aiconfigurator:test \
             pytest \
             "${test_paths[@]}" \
             -m "unit or build" \

--- a/aic-core/src/aiconfigurator_core/sdk/perf_database.py
+++ b/aic-core/src/aiconfigurator_core/sdk/perf_database.py
@@ -650,6 +650,196 @@ def _shared_layer_enabled(database_mode: str | None) -> bool:
     return database_mode is None or database_mode.upper() in ("SILICON", "HYBRID")
 
 
+# ─────────────────────────────────────────────────────────────────────────
+# Strict provenance mode (Collector V3 design §5/§7.4, AIC-1503 PR4 task 2).
+#
+# Fail-closed load-time validation, scoped to the dirs a ``get_database()``
+# request actually touches: the REQUESTED (system, backend, version)'s own
+# family dirs (primary), plus any donor dir their own ``reuse.yaml`` declares
+# (channel 2, design §6.3). Nearest-earlier/cross-backend fallback siblings
+# are NOT walked here -- their count is unbounded per request, and auditing
+# them is the CI audit's job (design §8), not this per-request hook's.
+#
+# Off by default; CI turns it on (env var, see build-test.yml). When on, a
+# violation raises instead of the warn-and-continue this module otherwise
+# uses for questionable-but-recoverable data.
+# ─────────────────────────────────────────────────────────────────────────
+
+_STRICT_PROVENANCE_WARNED: set[tuple[str, str]] = set()
+
+
+def _strict_provenance_enabled(strict_provenance: bool | None) -> bool:
+    """Resolve the effective strict-provenance flag. An explicit bool wins;
+    ``None`` falls back to the ``AIC_STRICT_PROVENANCE`` env var (truthy:
+    ``"1"`` or ``"true"``, case-insensitive)."""
+    if strict_provenance is not None:
+        return bool(strict_provenance)
+    return os.environ.get("AIC_STRICT_PROVENANCE", "").strip().lower() in ("1", "true")
+
+
+def _warn_strict_provenance_once(kind: str, key: str, message: str) -> None:
+    """One-time-per-(kind, key) warning, mirroring this module's other
+    warn-once helpers (e.g. ``_warn_legacy_marker_once``)."""
+    dedupe_key = (kind, key)
+    if dedupe_key in _STRICT_PROVENANCE_WARNED:
+        return
+    _STRICT_PROVENANCE_WARNED.add(dedupe_key)
+    logger.warning(message)
+
+
+def _version_dir_data_filenames(version_path: str) -> list[str]:
+    """Real perf-data filenames physically present in a version dir (excludes
+    dotfiles and the structured/legacy provenance marker files themselves)."""
+    try:
+        entries = os.listdir(version_path)
+    except Exception:
+        return []
+    names = []
+    for entry in entries:
+        if entry.startswith(".") or entry in _DATABASE_VERSION_METADATA_FILES:
+            continue
+        if os.path.isfile(os.path.join(version_path, entry)):
+            names.append(entry)
+    return names
+
+
+def _check_strict_provenance_coverage(version_path: str, *, strict: bool, only_table: str | None = None) -> None:
+    """Design §5/§7.4 sidecar-coverage check for one version dir.
+
+    ``only_table`` narrows the check to a single declared-reuse table
+    (channel 2 admits one table at a time, design §6.3); ``None`` checks
+    every real data file physically present (used for primary version
+    dirs). A missing ``collection_meta.yaml`` sidecar, or one that does not
+    list the table(s) in question, raises ``ValueError`` naming the dir and
+    table(s) when ``strict`` is True; otherwise it logs a warning once per
+    (dir, condition) and returns. A malformed sidecar surfaces the existing
+    ``ValueError`` from ``_load_collection_meta_yaml`` in strict mode;
+    non-strict warns instead. A ``provenance: legacy`` sidecar is graced --
+    warns once per dir, never raises -- in BOTH modes (one-release grace,
+    design §5): the AIC-1502 backfill covers the whole tree, but the tier is
+    honest about not having per-table hashes, so a coverage gap there is
+    treated as a data-quality note, not a hard failure.
+    """
+    if only_table is not None:
+        stems = {only_table}
+    else:
+        data_filenames = _version_dir_data_filenames(version_path)
+        if not data_filenames:
+            return
+        stems = {os.path.splitext(name)[0] for name in data_filenames}
+
+    meta_path = os.path.join(version_path, COLLECTION_META_MARKER)
+    if not os.path.isfile(meta_path):
+        message = (
+            f"{version_path}: holds table(s) {sorted(stems)} with no collection_meta.yaml "
+            "sidecar (Collector V3 design §5/§7.4)"
+        )
+        if strict:
+            raise ValueError(message)
+        _warn_strict_provenance_once("missing-sidecar", version_path, message)
+        return
+
+    try:
+        meta = _load_collection_meta_yaml(meta_path)
+    except ValueError as e:
+        if strict:
+            raise
+        _warn_strict_provenance_once("malformed-sidecar", meta_path, str(e))
+        return
+
+    tables = meta.get("tables") if isinstance(meta, dict) else None
+    covered = tables if isinstance(tables, dict) else {}
+    uncovered = sorted(stems - set(covered))
+    if not uncovered:
+        return
+
+    if isinstance(meta, dict) and meta.get("provenance") == "legacy":
+        _warn_strict_provenance_once(
+            "legacy-uncovered",
+            meta_path,
+            f"{meta_path}: provenance: legacy sidecar does not list table(s) {uncovered}; "
+            "graced for one release (Collector V3 design §5)",
+        )
+        return
+
+    message = (
+        f"{meta_path}: table(s) {uncovered} not covered by collection_meta.yaml 'tables' entries "
+        "(Collector V3 design §5/§7.4)"
+    )
+    if strict:
+        raise ValueError(message)
+    _warn_strict_provenance_once("uncovered-table", meta_path, message)
+
+
+def _is_family_layout_version_dir(version_path: str, data_dir: str) -> bool:
+    """True when ``version_path`` is ``<data_dir>/<family>/<backend>/<version>``
+    (3 path components under ``data_dir``), false for the legacy
+    ``<data_dir>/<backend>/<version>`` layout (2 components) or an
+    otherwise-unresolved path. ``collection_meta.yaml``/``reuse.yaml`` are a
+    family-layout-paired concept (design §7 item 1: "family tree first,
+    legacy layout as deprecated fallback for one transition window") -- a
+    legacy-shaped dir predates the V3 metadata regime entirely, so strict
+    provenance does not apply to it, mirroring how ``_op_file_family_from_path``
+    already treats legacy-shaped paths as structurally outside the comm-family
+    exclusion (Task 1's FIX-2).
+    """
+    try:
+        rel = os.path.relpath(version_path, data_dir)
+    except ValueError:
+        return False
+    parts = rel.split(os.sep)
+    return len(parts) == 3 and parts[0] not in KNOWN_BACKEND_DIRS
+
+
+def _check_strict_provenance_for_request(paths: list[str], backend: str, data_dir_abs: str, *, strict: bool) -> None:
+    """Run ``_check_strict_provenance_coverage`` over every dir one
+    ``get_database()`` request touches: each primary ``path`` (a family dir
+    holding the requested (backend, version)), plus every donor dir that
+    path's own ``reuse.yaml`` declares (design §6.3). A malformed
+    ``reuse.yaml`` surfaces its existing ``ValueError`` in strict mode;
+    non-strict warns instead (same contract as the sidecar-coverage check).
+    Legacy-layout primary dirs (see ``_is_family_layout_version_dir``) are
+    skipped entirely -- out of the V3 metadata regime's scope.
+    """
+    for version_path in paths:
+        if not _is_family_layout_version_dir(version_path, data_dir_abs):
+            continue
+        _check_strict_provenance_coverage(version_path, strict=strict)
+        reuse_path = os.path.join(version_path, REUSE_YAML_MARKER)
+        if not os.path.isfile(reuse_path):
+            continue
+        try:
+            declared_entries = _parse_reuse_yaml(reuse_path)["entries"]
+        except ValueError as e:
+            if strict:
+                raise
+            _warn_strict_provenance_once("malformed-reuse", reuse_path, str(e))
+            continue
+        for entry in declared_entries:
+            donor_path = resolve_op_data_path(data_dir_abs, backend, entry["from_version"], f"{entry['table']}.parquet")
+            if not os.path.isfile(donor_path):
+                continue  # not admitted -- mirrors _build_op_sources' own existence check
+            _check_strict_provenance_coverage(os.path.dirname(donor_path), strict=strict, only_table=entry["table"])
+
+
+def _version_dir_partial_for_request(version_path: str, data_dir: str, *, strict: bool) -> bool:
+    """``get_database()``'s request-scoped wrapper around
+    ``_version_dir_state``'s ``partial`` flag: a malformed sidecar under it
+    raises in strict mode (same ``ValueError``), and in non-strict mode is
+    logged and treated as "not partial" rather than aborting the whole
+    lookup. ``_version_dir_state``'s OTHER call sites (discovery/listing,
+    e.g. ``_declared_versions``) are out of this per-request hook's scope and
+    keep their pre-existing unconditional raise.
+    """
+    try:
+        return bool(_version_dir_state(version_path, data_dir=data_dir)["partial"])
+    except ValueError as e:
+        if strict:
+            raise
+        _warn_strict_provenance_once("malformed-sidecar", version_path, str(e))
+        return False
+
+
 def get_database(
     system: str,
     backend: str,
@@ -658,6 +848,7 @@ def get_database(
     allow_missing_data: bool = False,
     database_mode: str | None = None,
     shared_layer: bool | None = None,
+    strict_provenance: bool | None = None,
 ) -> PerfDatabase | None:
     """
     Get the database for a given system, backend and version.
@@ -682,6 +873,13 @@ def get_database(
             active backend/version's own rows even under SILICON; ``True``
             forces sibling inheritance on. Overridden templates are cached
             separately from derived ones.
+        strict_provenance: fail-closed provenance mode (Collector V3 design
+            §5/§7.4). ``None`` (default) resolves from the ``AIC_STRICT_PROVENANCE``
+            env var. When on, a missing/malformed/uncovering ``collection_meta.yaml``
+            or ``reuse.yaml`` sidecar under the requested (system, backend, version)
+            or its declared donors raises instead of the module's usual
+            warn-and-continue; `provenance: legacy` sidecars are always graced
+            (warn, never raise).
 
     Returns:
         PerfDatabase for the given system, backend, version.
@@ -698,8 +896,12 @@ def get_database(
     shared_flag = _shared_layer_enabled(database_mode) if shared_layer is None else bool(shared_layer)
     # Only pass the override kwarg when explicitly set: PerfDatabase derives the
     # same flag from database_mode otherwise, and tests monkeypatch PerfDatabase
-    # with fakes that predate the kwarg.
+    # with fakes that predate the kwarg. Same rule for strict_provenance below --
+    # when unset, PerfDatabase resolves the identical env-derived default itself.
     extra_database_kwargs = {} if shared_layer is None else {"shared_layer": shared_flag}
+    if strict_provenance is not None:
+        extra_database_kwargs["strict_provenance"] = strict_provenance
+    effective_strict = _strict_provenance_enabled(strict_provenance)
     missing_data_candidate = None
     for systems_root in systems_paths:
         system_yaml_path = os.path.join(systems_root, f"{system}.yaml")
@@ -716,7 +918,9 @@ def get_database(
 
         data_dir_abs = os.path.join(systems_root, data_dir)
         paths = [p for v, p in _iter_backend_version_dirs(data_dir_abs, backend) if v == version]
-        is_incomplete = bool(paths) and all(_version_dir_state(p, data_dir=data_dir_abs)["partial"] for p in paths)
+        is_incomplete = bool(paths) and all(
+            _version_dir_partial_for_request(p, data_dir_abs, strict=effective_strict) for p in paths
+        )
         if paths and not is_incomplete:
             try:
                 database = databases_cache[cache_key][backend][version]
@@ -724,6 +928,7 @@ def get_database(
             except KeyError:
                 logger.info(f"Loading database for {system=}, {backend=}, {version=}")
                 try:
+                    _check_strict_provenance_for_request(paths, backend, data_dir_abs, strict=effective_strict)
                     database = PerfDatabase(
                         system,
                         backend,
@@ -735,6 +940,8 @@ def get_database(
                     databases_cache[cache_key][backend][version] = database
                     return database
                 except Exception:
+                    if effective_strict:
+                        raise
                     logger.warning(
                         f"failed to load {system=}, {backend=}, {version=}, continuing searching",
                         exc_info=True,
@@ -767,6 +974,8 @@ def get_database(
                 databases_cache[cache_key][backend][version] = database
                 return database
             except Exception:
+                if effective_strict:
+                    raise
                 logger.warning(
                     f"failed to load estimate-only {system=}, {backend=}, {version=}",
                     exc_info=True,
@@ -842,6 +1051,7 @@ def get_database_view(
     database_mode: str | common.DatabaseMode | None = None,
     transfer_policy=None,
     shared_layer: bool | None = None,
+    strict_provenance: bool | None = None,
 ) -> PerfDatabase | None:
     """Return an isolated, lightweight query view over a cached database.
 
@@ -854,6 +1064,8 @@ def get_database_view(
     shared SILICON data layer. ``shared_layer`` explicitly overrides the
     mode-derived shared-layer flag (see :func:`get_database`); regression
     harnesses pass ``False`` to pin SILICON queries to per-version data.
+    ``strict_provenance`` is forwarded to :func:`get_database` unchanged (see
+    its docstring); ``None`` resolves from the ``AIC_STRICT_PROVENANCE`` env var.
     """
     mode = _normalize_database_mode(database_mode)
     database_kwargs = {
@@ -863,6 +1075,7 @@ def get_database_view(
         "allow_missing_data": allow_missing_data,
         "database_mode": mode.name,
         "shared_layer": shared_layer,
+        "strict_provenance": strict_provenance,
     }
     if systems_paths is not None:
         database_kwargs["systems_paths"] = systems_paths
@@ -1735,6 +1948,7 @@ class PerfDatabase:
         systems_root: str = "./systems",
         database_mode: str | None = None,
         shared_layer: bool | None = None,
+        strict_provenance: bool | None = None,
     ) -> None:
         """
         Initialize the perf database.
@@ -1751,11 +1965,20 @@ class PerfDatabase:
                 ``False`` loads only the active backend/version's own rows even
                 under SILICON (used by regression harnesses to pin per-version
                 behavior); ``True`` forces sibling inheritance on.
+            strict_provenance: fail-closed provenance mode (Collector V3 design
+                §5/§7.4). ``None`` (default) resolves from the
+                ``AIC_STRICT_PROVENANCE`` env var (truthy: ``"1"``/``"true"``).
+                Stored as ``self.strict_provenance``; the load-time validation
+                itself runs in :func:`get_database` (the loader entry point),
+                not here -- constructing a ``PerfDatabase`` directly (as tests
+                commonly do against synthetic trees) performs no provenance
+                validation of its own.
         """
         self.system = system
         self.backend = backend
         self.version = version
         self.systems_root = systems_root
+        self.strict_provenance: bool = _strict_provenance_enabled(strict_provenance)
         self._shared_layer_mode = _shared_layer_enabled(database_mode) if shared_layer is None else bool(shared_layer)
         # Which empirical transfer kinds are permitted (HYBRID/EMPIRICAL only). All on by
         # default = current behaviour; set_transfer_policy() narrows it for fine-grained

--- a/aic-core/src/aiconfigurator_core/sdk/perf_database.py
+++ b/aic-core/src/aiconfigurator_core/sdk/perf_database.py
@@ -1852,7 +1852,7 @@ def _op_file_family_from_path(primary_path: str, system_data_root: str) -> str |
 
 
 def _requested_version_reuse_entries(
-    system_data_root: str, backend: str, version: str, op_file_basename: str
+    system_data_root: str, backend: str, version: str, op_file_basename: str, *, strict: bool
 ) -> list[dict[str, str]]:
     """Declared-reuse entries (design §6.3) for one op file, scoped to the
     REQUESTED version dir(s) only.
@@ -1861,6 +1861,15 @@ def _requested_version_reuse_entries(
     ``_iter_backend_version_dirs``'s own contract); every ``reuse.yaml`` found
     at that pair is parsed and only entries whose ``table`` names this op file
     are kept, in file order.
+
+    A malformed ``reuse.yaml`` raises ``ValueError`` in strict mode (mirrors
+    ``_check_strict_provenance_for_request``'s load-time check). Non-strict
+    mode warns once per path -- the SAME dedupe key as that load-time check,
+    so a tree that already warned at load doesn't warn again here -- and
+    treats that path as declaring zero donors, instead of crashing. Without
+    this, a non-strict ``get_database()`` call would warn-and-continue at
+    load time only to crash on the very same malformed file the first time an
+    op is actually queried (AIC-1503 PR4 task 5, FIX 1).
     """
     matched: list[dict[str, str]] = []
     for candidate_version, version_path in _iter_backend_version_dirs(system_data_root, backend):
@@ -1869,7 +1878,14 @@ def _requested_version_reuse_entries(
         reuse_path = os.path.join(version_path, REUSE_YAML_MARKER)
         if not os.path.isfile(reuse_path):
             continue
-        for reuse_entry in _parse_reuse_yaml(reuse_path)["entries"]:
+        try:
+            entries = _parse_reuse_yaml(reuse_path)["entries"]
+        except ValueError as e:
+            if strict:
+                raise
+            _warn_strict_provenance_once("malformed-reuse", reuse_path, str(e))
+            continue
+        for reuse_entry in entries:
             if f"{reuse_entry['table']}.parquet" == op_file_basename:
                 matched.append(reuse_entry)
     return matched
@@ -2227,25 +2243,37 @@ class PerfDatabase:
         backend_lower = self.backend.lower()
 
         # Channel 2 (design §6.3): declared donors from the REQUESTED version
-        # dir's reuse.yaml, in file order.
+        # dir's reuse.yaml, in file order. Duplicate (table, from_version)
+        # entries in one reuse.yaml would otherwise admit the same source
+        # twice -- table is fixed to op_file_basename for this call, so
+        # `declared_donor_versions` membership alone is the (table,
+        # from_version) dedupe key; first occurrence wins (AIC-1503 PR4
+        # task 5, FIX 2).
         declared_donor_versions: set[str] = set()
         for reuse_entry in _requested_version_reuse_entries(
-            system_data_root, backend_lower, self.version, op_file_basename
+            system_data_root, backend_lower, self.version, op_file_basename, strict=self.strict_provenance
         ):
-            donor_path = resolve_op_data_path(
-                system_data_root, backend_lower, reuse_entry["from_version"], op_file_basename
-            )
+            from_version = reuse_entry["from_version"]
+            if from_version in declared_donor_versions:
+                logger.debug(
+                    "Duplicate declared-reuse entry for table %s from_version %s under %s; first occurrence wins.",
+                    reuse_entry["table"],
+                    from_version,
+                    system_data_root,
+                )
+                continue
+            donor_path = resolve_op_data_path(system_data_root, backend_lower, from_version, op_file_basename)
             if not os.path.isfile(donor_path):
                 continue
             records.append(
                 {
-                    "version": reuse_entry["from_version"],
+                    "version": from_version,
                     "path": donor_path,
                     "channel": "declared_reuse",
                     "ks_filter": None,
                 }
             )
-            declared_donor_versions.add(reuse_entry["from_version"])
+            declared_donor_versions.add(from_version)
 
         # Channel 1 aka §6.2 (nearest-earlier same-backend fallback). Unparseable
         # sibling versions can't be ordered against the requested version, so

--- a/aic-core/src/aiconfigurator_core/sdk/perf_database.py
+++ b/aic-core/src/aiconfigurator_core/sdk/perf_database.py
@@ -667,6 +667,15 @@ def _shared_layer_enabled(database_mode: str | None) -> bool:
 
 _STRICT_PROVENANCE_WARNED: set[tuple[str, str]] = set()
 
+# (sorted primary paths, backend) pairs that already passed
+# ``_check_strict_provenance_for_request`` with ``strict=True`` this process.
+# ``get_database()`` consults it on strict cache HITS: ``databases_cache`` can
+# hold worker-imported instances that were never request-validated (see
+# ``_store_loaded_database``), so a strict hit must validate before returning —
+# this memo keeps repeated strict hits cheap. Cleared wherever
+# ``databases_cache`` entries are invalidated (``unload_database``).
+_STRICT_VALIDATED_REQUESTS: set[tuple[tuple[str, ...], str]] = set()
+
 
 def _strict_provenance_enabled(strict_provenance: bool | None) -> bool:
     """Resolve the effective strict-provenance flag. An explicit bool wins;
@@ -689,10 +698,14 @@ def _warn_strict_provenance_once(kind: str, key: str, message: str) -> None:
 
 def _version_dir_data_filenames(version_path: str) -> list[str]:
     """Real perf-data filenames physically present in a version dir (excludes
-    dotfiles and the structured/legacy provenance marker files themselves)."""
+    dotfiles and the structured/legacy provenance marker files themselves).
+
+    A nonexistent dir is a legitimate "no files" answer; any other ``OSError``
+    (e.g. permission denied) propagates so ``_check_strict_provenance_coverage``
+    can fail closed instead of silently treating an unreadable dir as empty."""
     try:
         entries = os.listdir(version_path)
-    except Exception:
+    except (FileNotFoundError, NotADirectoryError):
         return []
     names = []
     for entry in entries:
@@ -723,7 +736,17 @@ def _check_strict_provenance_coverage(version_path: str, *, strict: bool, only_t
     if only_table is not None:
         stems = {only_table}
     else:
-        data_filenames = _version_dir_data_filenames(version_path)
+        try:
+            data_filenames = _version_dir_data_filenames(version_path)
+        except OSError as e:
+            message = (
+                f"{version_path}: cannot inspect perf-data files ({e}); strict provenance "
+                "cannot verify sidecar coverage (Collector V3 design §5/§7.4)"
+            )
+            if strict:
+                raise ValueError(message) from e
+            _warn_strict_provenance_once("unreadable-version-dir", version_path, message)
+            return
         if not data_filenames:
             return
         stems = {os.path.splitext(name)[0] for name in data_filenames}
@@ -922,13 +945,15 @@ def get_database(
             _version_dir_partial_for_request(p, data_dir_abs, strict=effective_strict) for p in paths
         )
         if paths and not is_incomplete:
+            request_key = (tuple(sorted(paths)), backend)
             try:
                 database = databases_cache[cache_key][backend][version]
-                return database
             except KeyError:
                 logger.info(f"Loading database for {system=}, {backend=}, {version=}")
                 try:
                     _check_strict_provenance_for_request(paths, backend, data_dir_abs, strict=effective_strict)
+                    if effective_strict:
+                        _STRICT_VALIDATED_REQUESTS.add(request_key)
                     database = PerfDatabase(
                         system,
                         backend,
@@ -946,6 +971,15 @@ def get_database(
                         f"failed to load {system=}, {backend=}, {version=}, continuing searching",
                         exc_info=True,
                     )
+            else:
+                # Cache HIT: the entry may be a worker-imported instance that
+                # was never request-validated (``_store_loaded_database``
+                # inserts under a strict key without validating). Strict mode
+                # must fail closed here too, not just on the miss path above.
+                if effective_strict and request_key not in _STRICT_VALIDATED_REQUESTS:
+                    _check_strict_provenance_for_request(paths, backend, data_dir_abs, strict=True)
+                    _STRICT_VALIDATED_REQUESTS.add(request_key)
+                return database
         elif allow_missing_data:
             if missing_data_candidate is None:
                 missing_data_candidate = (systems_root, cache_key)
@@ -1294,6 +1328,9 @@ def unload_database(system: str, backend: str, version: str) -> None:
 
     clear_all_op_caches()
     _cached_configured_database_view.cache_clear()
+    # A future get_database() for this triple must re-validate under strict
+    # mode; the memo is coarse (keyed by primary paths), so drop it wholesale.
+    _STRICT_VALIDATED_REQUESTS.clear()
 
 
 def _load_database_ref_in_parent(ref: DatabaseRef) -> PerfDatabase | None:
@@ -2205,6 +2242,11 @@ class PerfDatabase:
         `self.data_provenance[op_file_basename]` — see that attribute's
         docstring for the granularity contract.
 
+        An existing primary whose containing version dir is marked partial
+        (legacy-layout fallback only — the resolver already skips partial
+        family dirs) is refused entirely: no record, no source tuple, only a
+        warning; channels 2-4 still fill.
+
         Returns just the primary tuple (still recorded) when the shared layer
         is disabled, when the op file is framework-agnostic (nccl / oneccl),
         or when the op's primary path resolves under the `comm` family dir
@@ -2217,9 +2259,28 @@ class PerfDatabase:
         filter, same as reading the active backend's own file.
         """
         op_file_basename = op_filename_enum.value
-        records: list[dict[str, object]] = [
-            {"version": self.version, "path": primary_path, "channel": "primary", "ks_filter": None}
-        ]
+        records: list[dict[str, object]] = []
+        primary_version_dir = os.path.dirname(primary_path)
+        if os.path.isfile(primary_path) and _version_dir_partial_for_request(
+            primary_version_dir, system_data_root, strict=self.strict_provenance
+        ):
+            # Only the LEGACY-layout fallback can get here: resolve_op_data_path
+            # already skips partial FAMILY dirs, so a family-layout primary is
+            # never partial (pinned by test_reuse_ordering.py's
+            # test_partial_family_dir_is_skipped_by_resolver_not_the_admission_guard).
+            # Partial dirs are excluded from discovery and every reuse channel
+            # (design §5/§6) — refuse the primary too; channels 2-4 below still
+            # fill, and data_provenance keeps listing admitted sources only.
+            logger.warning(
+                "Not admitting primary source %s for %s: version dir %s is marked partial "
+                "(collection_meta.yaml status: partial, or legacy INCOMPLETE.txt); partial "
+                "dirs are excluded from data loading (Collector V3 design §5/§6).",
+                primary_path,
+                op_file_basename,
+                primary_version_dir,
+            )
+        else:
+            records.append({"version": self.version, "path": primary_path, "channel": "primary", "ks_filter": None})
 
         def _finish() -> list[tuple[str, Optional[set[str]]]]:
             self.data_provenance[op_file_basename] = [

--- a/aic-core/src/aiconfigurator_core/sdk/perf_database.py
+++ b/aic-core/src/aiconfigurator_core/sdk/perf_database.py
@@ -1606,6 +1606,23 @@ def _op_file_family_from_path(primary_path: str, system_data_root: str) -> str |
     paths (``<data_dir>/<backend>/<version>/<file>``, 3 components) or
     otherwise-unresolved paths — comm exclusion then simply does not trigger;
     detection is deliberately primary-path-only (see ``_build_op_sources``).
+
+    Deliberate exception, not a bug (AIC-1503 PR4 task 1, FIX 2): design
+    §6.5 rule 5's "comm" family is a structural concept that only exists in
+    the family-first layout. A comm op file (custom_allreduce_perf.parquet,
+    trtllm_alltoall_perf.parquet, wideep_deepep_*_perf.parquet, ...) resolved
+    under a legacy-shaped 3-component path has no family component to
+    detect, so this function returns ``None`` for it and `_build_op_sources`
+    does NOT apply the comm hard exclusion — that op keeps the pre-V3
+    sibling-reuse behavior for as long as its tree stays legacy-shaped. This
+    was adjudicated deliberately over the alternative of recognizing these
+    op files by table-name identity: that would smuggle catalog knowledge
+    ("which tables are comm") into a loader that must stay catalog-free. The
+    real committed tree is fully family-first today (zero live exposure);
+    this only matters for the transition window if a legacy-shaped tree is
+    ever loaded again. Pinned by
+    ``test_reuse_ordering.py::test_legacy_layout_comm_op_keeps_pre_v3_siblings``
+    — any future change to this behavior must update that test deliberately.
     """
     try:
         rel = os.path.relpath(primary_path, system_data_root)
@@ -1614,6 +1631,10 @@ def _op_file_family_from_path(primary_path: str, system_data_root: str) -> str |
     parts = rel.split(os.sep)
     if len(parts) == 4 and parts[0] not in KNOWN_BACKEND_DIRS:
         return parts[0]
+    # Legacy-layout (3-component) or otherwise-unresolved path: no family
+    # component exists structurally, so we can't detect "comm" here. This is
+    # the transition-window exception described above, not a bug — legacy
+    # comm op files simply keep pre-V3 sibling-reuse behavior.
     return None
 
 
@@ -1984,6 +2005,7 @@ class PerfDatabase:
 
         # Channel 2 (design §6.3): declared donors from the REQUESTED version
         # dir's reuse.yaml, in file order.
+        declared_donor_versions: set[str] = set()
         for reuse_entry in _requested_version_reuse_entries(
             system_data_root, backend_lower, self.version, op_file_basename
         ):
@@ -2000,15 +2022,21 @@ class PerfDatabase:
                     "ks_filter": None,
                 }
             )
+            declared_donor_versions.add(reuse_entry["from_version"])
 
         # Channel 1 aka §6.2 (nearest-earlier same-backend fallback). Unparseable
         # sibling versions can't be ordered against the requested version, so
         # they're excluded here (logged once) — an explicit declaration still
-        # works for them.
+        # works for them. Versions already admitted as declared donors above
+        # are excluded too — the dominant real reuse.yaml pattern points
+        # BACKWARD at an earlier sibling, and without this exclusion that same
+        # physical source would be listed twice (channels declared_reuse AND
+        # fallback), doubling I/O and duplicating data_provenance rows.
         requested_parsed = parse_support_matrix_version(self.version)
         if requested_parsed is not None:
             sibling_versions = {v for v, _ in _iter_backend_version_dirs(system_data_root, backend_lower)}
             sibling_versions.discard(self.version)
+            sibling_versions -= declared_donor_versions
             earlier_versions = []
             for sibling_version in sibling_versions:
                 parsed = parse_support_matrix_version(sibling_version)

--- a/aic-core/src/aiconfigurator_core/sdk/perf_database.py
+++ b/aic-core/src/aiconfigurator_core/sdk/perf_database.py
@@ -1590,6 +1590,78 @@ def _gemm_key_names(database) -> list[str]:
     return sorted(names)
 
 
+# ``comm`` is the one family design §6.5 rule 5 hard-excludes from every reuse
+# channel (NCCL curves are topology-bound; shape-filling across versions is
+# wrong there). Detected structurally off the op's resolved primary path.
+_COMM_FAMILY_DIR = "comm"
+
+
+def _op_file_family_from_path(primary_path: str, system_data_root: str) -> str | None:
+    """Best-effort family-dir name for an op's resolved primary path.
+
+    Structural: the family-first layout is
+    ``<data_dir>/<family>/<backend>/<version>/<file>``, so the family is the
+    path's first component relative to ``system_data_root`` when that
+    component isn't a known backend dir. Returns ``None`` for legacy-layout
+    paths (``<data_dir>/<backend>/<version>/<file>``, 3 components) or
+    otherwise-unresolved paths — comm exclusion then simply does not trigger;
+    detection is deliberately primary-path-only (see ``_build_op_sources``).
+    """
+    try:
+        rel = os.path.relpath(primary_path, system_data_root)
+    except ValueError:
+        return None
+    parts = rel.split(os.sep)
+    if len(parts) == 4 and parts[0] not in KNOWN_BACKEND_DIRS:
+        return parts[0]
+    return None
+
+
+def _requested_version_reuse_entries(
+    system_data_root: str, backend: str, version: str, op_file_basename: str
+) -> list[dict[str, str]]:
+    """Declared-reuse entries (design §6.3) for one op file, scoped to the
+    REQUESTED version dir(s) only.
+
+    A (backend, version) pair may resolve to several family dirs (mirrors
+    ``_iter_backend_version_dirs``'s own contract); every ``reuse.yaml`` found
+    at that pair is parsed and only entries whose ``table`` names this op file
+    are kept, in file order.
+    """
+    matched: list[dict[str, str]] = []
+    for candidate_version, version_path in _iter_backend_version_dirs(system_data_root, backend):
+        if candidate_version != version:
+            continue
+        reuse_path = os.path.join(version_path, REUSE_YAML_MARKER)
+        if not os.path.isfile(reuse_path):
+            continue
+        for reuse_entry in _parse_reuse_yaml(reuse_path)["entries"]:
+            if f"{reuse_entry['table']}.parquet" == op_file_basename:
+                matched.append(reuse_entry)
+    return matched
+
+
+_UNPARSEABLE_SIBLING_VERSION_WARNED: set[tuple[str, str, str]] = set()
+
+
+def _warn_unparseable_sibling_version_once(system_data_root: str, backend: str, version: str) -> None:
+    """One-time-per-(tree, backend, version) warning for a sibling version string
+    that fails PEP 440 parsing — it cannot be ordered against the requested
+    version, so it's excluded from implicit nearest-earlier fallback entirely
+    (design §6.2). An explicit ``reuse.yaml`` declaration still works for it."""
+    key = (system_data_root, backend, version)
+    if key in _UNPARSEABLE_SIBLING_VERSION_WARNED:
+        return
+    _UNPARSEABLE_SIBLING_VERSION_WARNED.add(key)
+    logger.warning(
+        "Sibling version %r of backend %s is not PEP 440-parseable; excluded from "
+        "implicit nearest-earlier fallback (Collector V3 design §6.2). Declare an "
+        "explicit reuse.yaml entry if this version's data should be reused.",
+        version,
+        backend,
+    )
+
+
 class PerfDatabase:
     """
     The perf database for a given system, backend and version
@@ -1677,6 +1749,14 @@ class PerfDatabase:
         # (lazy-load path inside each op class) to discover which sibling
         # backend/version dirs hold rows the active backend can inherit.
         self._op_kernel_source_manifest_entries = _load_op_kernel_source_manifest_entries(systems_root)
+
+        # Per-op-file source diagnostics (design §6.5 guardrail), lazily populated
+        # by ``_build_op_sources`` as each op loads: op_file basename -> list of
+        # {version, path, channel, exists} for every ADMITTED source, in priority
+        # order. Granularity is admitted sources, not per-row/per-shape
+        # attribution — two different tables in the same source file share one
+        # entry even if only one of them actually contributed rows.
+        self.data_provenance: dict[str, list[dict[str, object]]] = {}
 
         # lazy per-op data ownership: every op class owns its CSV data and loads it on first query
         # via ``OpClass.load_data(database)``. No eager warm-up here — each op
@@ -1841,7 +1921,7 @@ class PerfDatabase:
         primary_path: str,
         system_data_root: str,
     ) -> list[tuple[str, Optional[set[str]]]]:
-        """Build the priority-ordered list of source files for one op.
+        """Build the priority-ordered list of source files for one op (design §6).
 
         Returns a list of `(file_path, kernel_source_filter)` tuples to be
         loaded in order. The first source whose file actually contains rows
@@ -1849,32 +1929,107 @@ class PerfDatabase:
         only fill in shapes the earlier ones lacked. Ordering, in priority:
 
           1. Active backend/version (primary). Filter is `None` — load every row.
-          2. Other versions of the *same* framework, newest first. A different
-             version of the same backend is closer to the active measurement
-             than any other framework, so it wins on shape conflicts.
-          3. Other frameworks alphabetically; within each, newest version first.
+          2. Declared donors from the REQUESTED version dir's `reuse.yaml`
+             (design §6.3), in file order. Same backend, any direction — this
+             is the only channel that may borrow a version NEWER than
+             requested. Filter is `None`.
+          3. Same-backend siblings STRICTLY EARLIER than requested (design
+             §6.2), nearest first. Free and always on; no manifest dependency.
+             A version newer than requested is never admitted here — only an
+             explicit declaration (channel 2) can do that. Filter is `None`.
+          4. Cross-backend fill (design §6.4), kernel-identity gated by
+             `op_kernel_source_manifest.yaml`, newest-first per framework.
 
-        Returns just the primary tuple when the shared layer is disabled, when
-        the op file is framework-agnostic (nccl / oneccl), or when no manifest
-        entry whitelists the active backend for this op. The kernel-source
-        filter on sibling sources is essential — `load_*` functions strip
-        `kernel_source` from dict keys, so unfiltered sibling rows would
-        silently clobber active-backend rows on key conflict.
+        Every admitted source is recorded, tagged with its channel
+        (`primary | declared_reuse | fallback | cross_backend`), into
+        `self.data_provenance[op_file_basename]` — see that attribute's
+        docstring for the granularity contract.
+
+        Returns just the primary tuple (still recorded) when the shared layer
+        is disabled, when the op file is framework-agnostic (nccl / oneccl),
+        or when the op's primary path resolves under the `comm` family dir
+        (design §6.5 rule 5 — comm is hard-excluded from every reuse channel,
+        declarations included; NCCL curves are topology-bound). The
+        kernel-source filter on cross-backend sources is essential — `load_*`
+        functions strip `kernel_source` from dict keys, so an unfiltered
+        cross-backend row would silently clobber an active-backend row on key
+        conflict. Same-backend sources (primary/declared/fallback) use no
+        filter, same as reading the active backend's own file.
         """
-        sources: list[tuple[str, Optional[set[str]]]] = [(primary_path, None)]
-        if not self.enable_shared_layer:
-            return sources
-        if op_filename_enum in (PerfDataFilename.nccl, PerfDataFilename.oneccl):
-            return sources
-
         op_file_basename = op_filename_enum.value
+        records: list[dict[str, object]] = [
+            {"version": self.version, "path": primary_path, "channel": "primary", "ks_filter": None}
+        ]
+
+        def _finish() -> list[tuple[str, Optional[set[str]]]]:
+            self.data_provenance[op_file_basename] = [
+                {
+                    "version": record["version"],
+                    "path": record["path"],
+                    "channel": record["channel"],
+                    "exists": os.path.isfile(record["path"]),
+                }
+                for record in records
+            ]
+            return [(record["path"], record["ks_filter"]) for record in records]
+
+        if not self.enable_shared_layer:
+            return _finish()
+        if op_filename_enum in (PerfDataFilename.nccl, PerfDataFilename.oneccl):
+            return _finish()
+        if _op_file_family_from_path(primary_path, system_data_root) == _COMM_FAMILY_DIR:
+            return _finish()
+
         backend_lower = self.backend.lower()
 
-        # `framework -> set of kernel_sources` that the active backend may inherit
-        # from sibling dirs of that framework. Both `shared` and `shared_fallback`
-        # rows are admitted whenever the shared layer is enabled (SILICON/HYBRID);
-        # the fallback set is tracked separately only so we can emit a single
-        # warning per fallback source.
+        # Channel 2 (design §6.3): declared donors from the REQUESTED version
+        # dir's reuse.yaml, in file order.
+        for reuse_entry in _requested_version_reuse_entries(
+            system_data_root, backend_lower, self.version, op_file_basename
+        ):
+            donor_path = resolve_op_data_path(
+                system_data_root, backend_lower, reuse_entry["from_version"], op_file_basename
+            )
+            if not os.path.isfile(donor_path):
+                continue
+            records.append(
+                {
+                    "version": reuse_entry["from_version"],
+                    "path": donor_path,
+                    "channel": "declared_reuse",
+                    "ks_filter": None,
+                }
+            )
+
+        # Channel 1 aka §6.2 (nearest-earlier same-backend fallback). Unparseable
+        # sibling versions can't be ordered against the requested version, so
+        # they're excluded here (logged once) — an explicit declaration still
+        # works for them.
+        requested_parsed = parse_support_matrix_version(self.version)
+        if requested_parsed is not None:
+            sibling_versions = {v for v, _ in _iter_backend_version_dirs(system_data_root, backend_lower)}
+            sibling_versions.discard(self.version)
+            earlier_versions = []
+            for sibling_version in sibling_versions:
+                parsed = parse_support_matrix_version(sibling_version)
+                if parsed is None:
+                    _warn_unparseable_sibling_version_once(system_data_root, backend_lower, sibling_version)
+                    continue
+                if parsed >= requested_parsed:
+                    continue  # Never admit newer-than-requested implicitly.
+                earlier_versions.append((parsed, sibling_version))
+            earlier_versions.sort(key=lambda item: item[0], reverse=True)  # nearest-earlier first
+            for _, sibling_version in earlier_versions:
+                sibling_path = resolve_op_data_path(system_data_root, backend_lower, sibling_version, op_file_basename)
+                if not os.path.isfile(sibling_path):
+                    continue
+                records.append(
+                    {"version": sibling_version, "path": sibling_path, "channel": "fallback", "ks_filter": None}
+                )
+
+        # Channel 4 aka §6.4 (cross-backend fill, kernel-identity gated). Same
+        # mechanism as before; the active backend is excluded from
+        # `ordered_frameworks` because channels 2-3 above already cover it.
         per_framework_filter: dict[str, set[str]] = defaultdict(set)
         per_framework_fallback: dict[str, set[str]] = defaultdict(set)
         for entry in self._op_kernel_source_manifest_entries.get(op_file_basename, ()):
@@ -1892,16 +2047,7 @@ class PerfDatabase:
                     for fw in frameworks_lower:
                         per_framework_fallback[fw].add(ks)
 
-        if not per_framework_filter:
-            return sources
-
-        # Iterate the active framework first (newest sibling versions first), then
-        # other frameworks alphabetically. Putting the active framework first means
-        # cross-version siblings outrank cross-framework on shape conflicts.
-        ordered_frameworks: list[str] = []
-        if backend_lower in per_framework_filter:
-            ordered_frameworks.append(backend_lower)
-        ordered_frameworks.extend(sorted(set(per_framework_filter) - {backend_lower}))
+        ordered_frameworks = sorted(set(per_framework_filter) - {backend_lower})
 
         # Sort key for newest-first ordering. Parseable PEP 440 versions form one
         # group and always rank above unparseable strings — guarantees `1.10.0`
@@ -1919,12 +2065,17 @@ class PerfDatabase:
                 reverse=True,
             )
             for sibling_version in fw_versions:
-                if framework == backend_lower and sibling_version == self.version:
-                    continue  # Active source already added as the primary.
                 sibling_path = resolve_op_data_path(system_data_root, framework, sibling_version, op_file_basename)
                 if not os.path.isfile(sibling_path):
                     continue
-                sources.append((sibling_path, ks_filter))
+                records.append(
+                    {
+                        "version": sibling_version,
+                        "path": sibling_path,
+                        "channel": "cross_backend",
+                        "ks_filter": ks_filter,
+                    }
+                )
                 if fallback_only & ks_filter:
                     logger.warning(
                         "Loading low-fidelity fallback rows for %s from %s. Queries "
@@ -1933,7 +2084,7 @@ class PerfDatabase:
                         op_file_basename,
                         sibling_path,
                     )
-        return sources
+        return _finish()
 
     def is_inter_node(self, num_gpus: int) -> bool:
         """

--- a/aic-core/src/aiconfigurator_core/sdk/perf_database.py
+++ b/aic-core/src/aiconfigurator_core/sdk/perf_database.py
@@ -907,7 +907,7 @@ def get_database(
         system_yaml_path = os.path.join(systems_root, f"{system}.yaml")
         if not os.path.isfile(system_yaml_path):
             continue
-        cache_key = (systems_root, system, shared_flag)
+        cache_key = (systems_root, system, shared_flag, effective_strict)
         try:
             with open(system_yaml_path) as f:
                 system_spec = yaml.load(f, Loader=yaml.SafeLoader)
@@ -1226,7 +1226,7 @@ def _store_loaded_database(
     # that identity when importing a database from a worker; putting it in the
     # formula-only slot would make a later EMPIRICAL lookup reuse shared rows.
     shared_flag = database.enable_shared_layer
-    databases_cache[(systems_root, system, shared_flag)][backend][version] = database
+    databases_cache[(systems_root, system, shared_flag, database.strict_provenance)][backend][version] = database
 
 
 def clear_database_runtime_caches(system: str, backend: str, version: str) -> None:
@@ -1239,7 +1239,7 @@ def clear_database_runtime_caches(system: str, backend: str, version: str) -> No
     """
     seen_database_ids: set[int] = set()
     for cache_key, systems_cache in databases_cache.items():
-        _, cached_system, _ = cache_key
+        _, cached_system, _, _ = cache_key
         if cached_system != system:
             continue
 
@@ -1272,7 +1272,7 @@ def unload_database(system: str, backend: str, version: str) -> None:
     pop.
     """
     for cache_key in list(databases_cache.keys()):
-        _, cached_system, _ = cache_key
+        _, cached_system, _, _ = cache_key
         if cached_system != system:
             continue
 

--- a/aic-core/src/aiconfigurator_core/systems/data/l40s/attention/sglang/0.5.12/reuse.yaml
+++ b/aic-core/src/aiconfigurator_core/systems/data/l40s/attention/sglang/0.5.12/reuse.yaml
@@ -5,9 +5,9 @@ schema_version: 1
 reuse:
 - table: context_attention_perf
   from_version: 0.5.14
-  reason: migrated from SHARED_LAYER_REUSE.txt (legacy newest-first effective donor)
+  reason: 'self-overlap: dir holds native data for this table; declaration covers missing-shape forward-fill only; mechanically derived from legacy SHARED_LAYER_REUSE.txt (newest-first effective donor); NOT kernel-identity-reviewed'
   approved_by: yimingl
 - table: generation_attention_perf
   from_version: 0.5.14
-  reason: migrated from SHARED_LAYER_REUSE.txt (legacy newest-first effective donor)
+  reason: 'self-overlap: dir holds native data for this table; declaration covers missing-shape forward-fill only; mechanically derived from legacy SHARED_LAYER_REUSE.txt (newest-first effective donor); NOT kernel-identity-reviewed'
   approved_by: yimingl

--- a/aic-core/src/aiconfigurator_core/systems/data/l40s/attention/trtllm/1.3.0rc15/reuse.yaml
+++ b/aic-core/src/aiconfigurator_core/systems/data/l40s/attention/trtllm/1.3.0rc15/reuse.yaml
@@ -5,9 +5,9 @@ schema_version: 1
 reuse:
 - table: context_attention_perf
   from_version: 1.0.0
-  reason: migrated from SHARED_LAYER_REUSE.txt (legacy newest-first effective donor)
+  reason: 'self-overlap: dir holds native data for this table; declaration covers missing-shape forward-fill only; mechanically derived from legacy SHARED_LAYER_REUSE.txt (newest-first effective donor); NOT kernel-identity-reviewed'
   approved_by: yimingl
 - table: generation_attention_perf
   from_version: 1.0.0
-  reason: migrated from SHARED_LAYER_REUSE.txt (legacy newest-first effective donor)
+  reason: 'self-overlap: dir holds native data for this table; declaration covers missing-shape forward-fill only; mechanically derived from legacy SHARED_LAYER_REUSE.txt (newest-first effective donor); NOT kernel-identity-reviewed'
   approved_by: yimingl

--- a/aic-core/src/aiconfigurator_core/systems/data/l40s/attention/vllm/0.22.0/reuse.yaml
+++ b/aic-core/src/aiconfigurator_core/systems/data/l40s/attention/vllm/0.22.0/reuse.yaml
@@ -5,9 +5,9 @@ schema_version: 1
 reuse:
 - table: context_attention_perf
   from_version: 0.24.0
-  reason: migrated from SHARED_LAYER_REUSE.txt (legacy newest-first effective donor)
+  reason: 'self-overlap: dir holds native data for this table; declaration covers missing-shape forward-fill only; mechanically derived from legacy SHARED_LAYER_REUSE.txt (newest-first effective donor); NOT kernel-identity-reviewed'
   approved_by: yimingl
 - table: generation_attention_perf
   from_version: 0.24.0
-  reason: migrated from SHARED_LAYER_REUSE.txt (legacy newest-first effective donor)
+  reason: 'self-overlap: dir holds native data for this table; declaration covers missing-shape forward-fill only; mechanically derived from legacy SHARED_LAYER_REUSE.txt (newest-first effective donor); NOT kernel-identity-reviewed'
   approved_by: yimingl

--- a/aic-core/src/aiconfigurator_core/systems/data/l40s/gemm/sglang/0.5.12/reuse.yaml
+++ b/aic-core/src/aiconfigurator_core/systems/data/l40s/gemm/sglang/0.5.12/reuse.yaml
@@ -5,5 +5,5 @@ schema_version: 1
 reuse:
 - table: gemm_perf
   from_version: 0.5.14
-  reason: migrated from SHARED_LAYER_REUSE.txt (legacy newest-first effective donor)
+  reason: 'self-overlap: dir holds native data for this table; declaration covers missing-shape forward-fill only; mechanically derived from legacy SHARED_LAYER_REUSE.txt (newest-first effective donor); NOT kernel-identity-reviewed'
   approved_by: yimingl

--- a/aic-core/src/aiconfigurator_core/systems/data/l40s/gemm/trtllm/1.3.0rc15/reuse.yaml
+++ b/aic-core/src/aiconfigurator_core/systems/data/l40s/gemm/trtllm/1.3.0rc15/reuse.yaml
@@ -5,5 +5,5 @@ schema_version: 1
 reuse:
 - table: gemm_perf
   from_version: 1.0.0
-  reason: migrated from SHARED_LAYER_REUSE.txt (legacy newest-first effective donor)
+  reason: 'self-overlap: dir holds native data for this table; declaration covers missing-shape forward-fill only; mechanically derived from legacy SHARED_LAYER_REUSE.txt (newest-first effective donor); NOT kernel-identity-reviewed'
   approved_by: yimingl

--- a/aic-core/src/aiconfigurator_core/systems/data/l40s/gemm/vllm/0.22.0/reuse.yaml
+++ b/aic-core/src/aiconfigurator_core/systems/data/l40s/gemm/vllm/0.22.0/reuse.yaml
@@ -5,5 +5,5 @@ schema_version: 1
 reuse:
 - table: gemm_perf
   from_version: 0.24.0
-  reason: migrated from SHARED_LAYER_REUSE.txt (legacy newest-first effective donor)
+  reason: 'self-overlap: dir holds native data for this table; declaration covers missing-shape forward-fill only; mechanically derived from legacy SHARED_LAYER_REUSE.txt (newest-first effective donor); NOT kernel-identity-reviewed'
   approved_by: yimingl

--- a/aic-core/src/aiconfigurator_core/systems/data/l40s/mla/sglang/0.5.12/reuse.yaml
+++ b/aic-core/src/aiconfigurator_core/systems/data/l40s/mla/sglang/0.5.12/reuse.yaml
@@ -5,9 +5,9 @@ schema_version: 1
 reuse:
 - table: context_mla_perf
   from_version: 0.5.14
-  reason: migrated from SHARED_LAYER_REUSE.txt (legacy newest-first effective donor)
+  reason: 'self-overlap: dir holds native data for this table; declaration covers missing-shape forward-fill only; mechanically derived from legacy SHARED_LAYER_REUSE.txt (newest-first effective donor); NOT kernel-identity-reviewed'
   approved_by: yimingl
 - table: generation_mla_perf
   from_version: 0.5.14
-  reason: migrated from SHARED_LAYER_REUSE.txt (legacy newest-first effective donor)
+  reason: 'self-overlap: dir holds native data for this table; declaration covers missing-shape forward-fill only; mechanically derived from legacy SHARED_LAYER_REUSE.txt (newest-first effective donor); NOT kernel-identity-reviewed'
   approved_by: yimingl

--- a/aic-core/src/aiconfigurator_core/systems/data/l40s/mla_bmm/sglang/0.5.12/reuse.yaml
+++ b/aic-core/src/aiconfigurator_core/systems/data/l40s/mla_bmm/sglang/0.5.12/reuse.yaml
@@ -5,5 +5,5 @@ schema_version: 1
 reuse:
 - table: mla_bmm_perf
   from_version: 0.5.14
-  reason: migrated from SHARED_LAYER_REUSE.txt (legacy newest-first effective donor)
+  reason: 'self-overlap: dir holds native data for this table; declaration covers missing-shape forward-fill only; mechanically derived from legacy SHARED_LAYER_REUSE.txt (newest-first effective donor); NOT kernel-identity-reviewed'
   approved_by: yimingl

--- a/aic-core/src/aiconfigurator_core/systems/data/l40s/moe/sglang/0.5.12/reuse.yaml
+++ b/aic-core/src/aiconfigurator_core/systems/data/l40s/moe/sglang/0.5.12/reuse.yaml
@@ -5,5 +5,5 @@ schema_version: 1
 reuse:
 - table: moe_perf
   from_version: 0.5.14
-  reason: migrated from SHARED_LAYER_REUSE.txt (legacy newest-first effective donor)
+  reason: 'self-overlap: dir holds native data for this table; declaration covers missing-shape forward-fill only; mechanically derived from legacy SHARED_LAYER_REUSE.txt (newest-first effective donor); NOT kernel-identity-reviewed'
   approved_by: yimingl

--- a/aic-core/src/aiconfigurator_core/systems/data/l40s/moe/trtllm/1.3.0rc15/reuse.yaml
+++ b/aic-core/src/aiconfigurator_core/systems/data/l40s/moe/trtllm/1.3.0rc15/reuse.yaml
@@ -5,5 +5,5 @@ schema_version: 1
 reuse:
 - table: moe_perf
   from_version: 1.0.0
-  reason: migrated from SHARED_LAYER_REUSE.txt (legacy newest-first effective donor)
+  reason: 'self-overlap: dir holds native data for this table; declaration covers missing-shape forward-fill only; mechanically derived from legacy SHARED_LAYER_REUSE.txt (newest-first effective donor); NOT kernel-identity-reviewed'
   approved_by: yimingl

--- a/aic-core/src/aiconfigurator_core/systems/data/l40s/moe/vllm/0.22.0/reuse.yaml
+++ b/aic-core/src/aiconfigurator_core/systems/data/l40s/moe/vllm/0.22.0/reuse.yaml
@@ -5,5 +5,5 @@ schema_version: 1
 reuse:
 - table: moe_perf
   from_version: 0.24.0
-  reason: migrated from SHARED_LAYER_REUSE.txt (legacy newest-first effective donor)
+  reason: 'self-overlap: dir holds native data for this table; declaration covers missing-shape forward-fill only; mechanically derived from legacy SHARED_LAYER_REUSE.txt (newest-first effective donor); NOT kernel-identity-reviewed'
   approved_by: yimingl

--- a/aic-core/src/aiconfigurator_core/systems/data/l40s/quantize/trtllm/1.3.0rc15/reuse.yaml
+++ b/aic-core/src/aiconfigurator_core/systems/data/l40s/quantize/trtllm/1.3.0rc15/reuse.yaml
@@ -5,9 +5,9 @@ schema_version: 1
 reuse:
 - table: computescale_perf
   from_version: 1.0.0
-  reason: migrated from SHARED_LAYER_REUSE.txt (legacy newest-first effective donor)
+  reason: 'self-overlap: dir holds native data for this table; declaration covers missing-shape forward-fill only; mechanically derived from legacy SHARED_LAYER_REUSE.txt (newest-first effective donor); NOT kernel-identity-reviewed'
   approved_by: yimingl
 - table: scale_matrix_perf
   from_version: 1.0.0
-  reason: migrated from SHARED_LAYER_REUSE.txt (legacy newest-first effective donor)
+  reason: 'self-overlap: dir holds native data for this table; declaration covers missing-shape forward-fill only; mechanically derived from legacy SHARED_LAYER_REUSE.txt (newest-first effective donor); NOT kernel-identity-reviewed'
   approved_by: yimingl

--- a/collector/evidence_policy.yaml
+++ b/collector/evidence_policy.yaml
@@ -19,13 +19,38 @@ thresholds:
   # recollection (design §9 row 2).
   parquet_diff_median_pct: 5
 
+# SM-generation membership for the fleet (design AIC-1219 review fix): which
+# systems (aic-core/src/aiconfigurator_core/systems/*.yaml) belong to which
+# generation. Used to scope pin_version/collector_code evidence requirements
+# to the SM generations a changed entry's `systems` actually touch, instead
+# of demanding evidence from every generation regardless of relevance (e.g.
+# Hopper spot benchmarks for a Blackwell-only nvfp4 family, which
+# capabilities.yaml makes impossible to satisfy).
+#
+# Generation membership and the `evidence_systems` representatives below are
+# authored policy decisions, not derived facts: SM103 Ultra (gb300/b300_sxm)
+# is folded into `blackwell` alongside SM100 rather than split out — revisit
+# if Ultra-specific kernels diverge enough to need their own spot evidence.
+system_generations:
+  ampere: [a100_pcie, a100_sxm, a30]
+  ada: [l4, l40s]
+  hopper: [h100_pcie, h100_sxm, h200_sxm]
+  blackwell: [b200_sxm, b300_sxm, gb200, gb300]
+  blackwell_workstation: [rtx_pro_6000_server]
+  xpu: [b60]
+
 evidence_systems:
-  # One designated system per SM generation: used for declared-reuse spot
-  # benchmarks (pin_version's reuse alternative) and before/after
-  # parquet_diff (collector_code). Authored, adjustable as the fleet's
-  # representative systems change.
+  # One designated representative system per SM generation: used for
+  # declared-reuse spot benchmarks (pin_version's reuse alternative) and
+  # before/after parquet_diff (collector_code). Authored, adjustable as the
+  # fleet's representative systems change; each value must be a member of its
+  # generation in `system_generations` above.
+  ampere: a100_sxm
+  ada: l40s
   hopper: h200_sxm
   blackwell: b200_sxm
+  blackwell_workstation: rtx_pro_6000_server
+  xpu: b60
 
 rules:
   # Pin version change (design §9 row 1): fresh silicon for the family's

--- a/collector/evidence_policy.yaml
+++ b/collector/evidence_policy.yaml
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Evidence policy (AIC-1219): policy-as-code for Collector V3's evidence
+# requirements (design §9: docs/perf_database/collector-v3-op-centric-design.md).
+# Consumed by tools/perf_database/evidence_check.py, the AIC-1214 CI gate, and
+# the out-of-repo support-matrix healer — all three resolve identical
+# requirements from identical (changed_ops manifest, this policy) inputs.
+#
+# Changes to this file are POLICY changes — what silicon evidence a pin,
+# collector-code, or case-plan change requires before it may land — and
+# require human review, not just code review.
+
+schema_version: 1
+
+thresholds:
+  # parquet_diff median latency delta (%) beyond which a collector-code
+  # change (same pin) escalates from before/after diff evidence to full
+  # recollection (design §9 row 2).
+  parquet_diff_median_pct: 5
+
+evidence_systems:
+  # One designated system per SM generation: used for declared-reuse spot
+  # benchmarks (pin_version's reuse alternative) and before/after
+  # parquet_diff (collector_code). Authored, adjustable as the fleet's
+  # representative systems change.
+  hopper: h200_sxm
+  blackwell: b200_sxm
+
+rules:
+  # Pin version change (design §9 row 1): fresh silicon for the family's
+  # tables on every system the manifest lists, OR a reuse.yaml declaration
+  # backed by kernel-identity evidence (#1345 facts showing unchanged
+  # kernels) plus a before/after spot benchmark on one evidence system per
+  # SM generation.
+  pin_version:
+    requirement: recollect_or_declared_reuse
+
+  # Collector code change, same pin (design §9 row 2): before/after
+  # parquet_diff on affected tables from each evidence system; a median
+  # latency delta beyond thresholds.parquet_diff_median_pct escalates to
+  # full recollection.
+  collector_code:
+    requirement: before_after_diff
+
+  # Case plan change (design §9 row 3): additive — collect the new cases
+  # only. Removals prune with the diff visible; no fresh silicon required.
+  case_plan:
+    requirement: collect_new_cases_only
+
+# A pin/collector/case-plan change without the evidence above may proceed
+# only via an entry in this file (approver + expiry, design §9
+# "Exceptions"). The file's absence means no exceptions are in effect.
+exceptions_file: evidence_exceptions.yaml

--- a/docs/perf_database/collector-v3-op-centric-design.md
+++ b/docs/perf_database/collector-v3-op-centric-design.md
@@ -347,9 +347,10 @@ In increasing order of semantic weight:
 
 1. **Dual-layout discovery** — family tree first, legacy layout as deprecated
    fallback for one transition window.
-2. **Effective-source provenance** — per table, expose which versions supplied
-   rows and via which path (`primary | declared_reuse | fallback`), consumed by
-   support-matrix health and diagnostics.
+2. **Effective-source provenance** — `PerfDatabase.data_provenance`: per table,
+   the admitted sources with channel tags (`primary | declared_reuse | fallback |
+   cross_backend`), consumed by support-matrix health. Granularity is
+   admitted sources, not per-row attribution. *(Shipped in PR 4.)*
 3. **Reuse rules** — implement §6 ordering. `get_database(system, backend,
    version)` keeps `version` as the *requested* framework version; per-op
    resolution happens inside.
@@ -417,10 +418,16 @@ The CI audit is the primary gate; loader strict mode is the backstop.
 
 ## 9. Evidence policy
 
-Policy-as-code: `collector/evidence_policy.yaml` plus a pure-function resolver
-`tools/perf_database/evidence_check.py --manifest changed_ops.yaml` → required
-evidence list. Deterministic: CI and the healer get identical answers from
-identical manifests.
+Policy-as-code: `collector/evidence_policy.yaml` (thresholds; an authored
+`system_generations` map covering the whole fleet — SM103 Ultra folded into
+blackwell as a policy decision — and one evidence representative per
+generation) plus the pure-function resolver `tools/perf_database/evidence_check.py
+--manifest changed_ops.yaml` → required evidence, filtered to the SM
+generations the change actually touches (an unmapped system fails closed).
+Deterministic: CI and the healer get identical answers from identical
+manifests. Exception WAIVERS (`evidence_exceptions.yaml`, approver + expiry)
+are applied by the AIC-1214 gate, not the resolver — expiry needs a clock,
+which would break the resolver's purity. *(Shipped in PR 4.)*
 
 | Change | Required evidence |
 |---|---|

--- a/docs/perf_database/collector-v3-op-centric-design.md
+++ b/docs/perf_database/collector-v3-op-centric-design.md
@@ -427,7 +427,12 @@ generations the change actually touches (an unmapped system fails closed).
 Deterministic: CI and the healer get identical answers from identical
 manifests. Exception WAIVERS (`evidence_exceptions.yaml`, approver + expiry)
 are applied by the evidence-gate CI check, not the resolver — expiry needs a clock,
-which would break the resolver's purity. *(Shipped in PR 4.)*
+which would break the resolver's purity. *(Policy and resolver shipped in PR 4;
+the enforcing CI gate — the required check that validates submitted evidence
+and waivers against these requirements and blocks under-evidenced data PRs —
+is a separate tracked deliverable. Until it lands, the audit workflow uploads
+the changed-op manifest as an informational artifact and enforcement is by
+human review against the resolver's output.)*
 
 | Change | Required evidence |
 |---|---|

--- a/docs/perf_database/collector-v3-op-centric-design.md
+++ b/docs/perf_database/collector-v3-op-centric-design.md
@@ -331,10 +331,10 @@ The loader's source ordering (§7) in one list:
 
 Guardrails:
 
-- **Provenance surfacing:** the loader reports, per table, which versions
-  supplied rows and via which channel (`primary | declared_reuse | fallback`),
-  so the support-matrix health classifier can tell "natively collected" from "riding
-  on a declaration" without re-deriving anything.
+- **Provenance surfacing:** the loader reports, per table, the admitted
+  sources with channel tags (`primary | declared_reuse | fallback |
+  cross_backend`), so the support-matrix health classifier can tell "natively
+  collected" from "riding on a declaration" without re-deriving anything.
 - **CI audit:** a `reuse.yaml` pointing at data that does not exist, or any
   fill pattern outside these three channels, fails the PR — that is the
   operational definition of **unsupported silent fallback**.

--- a/docs/perf_database/collector-v3-op-centric-design.md
+++ b/docs/perf_database/collector-v3-op-centric-design.md
@@ -426,7 +426,7 @@ generation) plus the pure-function resolver `tools/perf_database/evidence_check.
 generations the change actually touches (an unmapped system fails closed).
 Deterministic: CI and the healer get identical answers from identical
 manifests. Exception WAIVERS (`evidence_exceptions.yaml`, approver + expiry)
-are applied by the AIC-1214 gate, not the resolver — expiry needs a clock,
+are applied by the evidence-gate CI check, not the resolver — expiry needs a clock,
 which would break the resolver's purity. *(Shipped in PR 4.)*
 
 | Change | Required evidence |

--- a/docs/perf_database/collector-v3-op-centric-design.md
+++ b/docs/perf_database/collector-v3-op-centric-design.md
@@ -336,7 +336,7 @@ Guardrails:
   cross_backend`), so the support-matrix health classifier can tell "natively
   collected" from "riding on a declaration" without re-deriving anything.
 - **CI audit:** a `reuse.yaml` pointing at data that does not exist, or any
-  fill pattern outside these three channels, fails the PR — that is the
+  fill pattern outside these channels, fails the PR — that is the
   operational definition of **unsupported silent fallback**.
 - **Scope limits:** all reuse runs only in SILICON/HYBRID modes; formula-only
   modes (EMPIRICAL, SOL) are untouched.

--- a/tests/unit/sdk/database/test_data_loaders.py
+++ b/tests/unit/sdk/database/test_data_loaders.py
@@ -55,6 +55,7 @@ class DummyPerfDatabase:
         self.systems_root = systems_root_arg
         self.database_mode = database_mode
         self.enable_shared_layer = database_mode is None or database_mode.upper() in ("SILICON", "HYBRID")
+        self.strict_provenance = False
 
 
 def test_read_perf_rows_normalizes_missing_csv_fields(tmp_path):

--- a/tests/unit/sdk/database/test_database_helpers.py
+++ b/tests/unit/sdk/database/test_database_helpers.py
@@ -592,10 +592,10 @@ def test_clear_database_runtime_caches_clears_matching_cached_database_once(perf
     cache_snapshot = dict(perf_database.databases_cache)
     try:
         perf_database.databases_cache.clear()
-        perf_database.databases_cache[("root", "system", False)]["backend"]["1.0.0"] = clear_db
-        perf_database.databases_cache[("root", "system", True)]["backend"]["1.0.0"] = clear_db
-        perf_database.databases_cache[("root", "system", False)]["backend"]["2.0.0"] = keep_db
-        perf_database.databases_cache[("root", "other-system", False)]["backend"]["1.0.0"] = keep_db
+        perf_database.databases_cache[("root", "system", False, False)]["backend"]["1.0.0"] = clear_db
+        perf_database.databases_cache[("root", "system", True, False)]["backend"]["1.0.0"] = clear_db
+        perf_database.databases_cache[("root", "system", False, False)]["backend"]["2.0.0"] = keep_db
+        perf_database.databases_cache[("root", "other-system", False, False)]["backend"]["1.0.0"] = keep_db
 
         perf_database.clear_database_runtime_caches("system", "backend", "1.0.0")
 
@@ -619,15 +619,15 @@ def test_unload_database_removes_matching_database_and_clears_runtime_cache(perf
     cache_snapshot = dict(perf_database.databases_cache)
     try:
         perf_database.databases_cache.clear()
-        perf_database.databases_cache[("root", "system", False)]["backend"]["1.0.0"] = unload_db
-        perf_database.databases_cache[("root", "system", False)]["backend"]["2.0.0"] = keep_db
-        perf_database.databases_cache[("root", "other-system", False)]["backend"]["1.0.0"] = keep_db
+        perf_database.databases_cache[("root", "system", False, False)]["backend"]["1.0.0"] = unload_db
+        perf_database.databases_cache[("root", "system", False, False)]["backend"]["2.0.0"] = keep_db
+        perf_database.databases_cache[("root", "other-system", False, False)]["backend"]["1.0.0"] = keep_db
 
         perf_database.unload_database("system", "backend", "1.0.0")
 
         assert unload_db.clear_count == 1
-        assert perf_database.databases_cache[("root", "system", False)]["backend"] == {"2.0.0": keep_db}
-        assert perf_database.databases_cache[("root", "other-system", False)]["backend"]["1.0.0"] is keep_db
+        assert perf_database.databases_cache[("root", "system", False, False)]["backend"] == {"2.0.0": keep_db}
+        assert perf_database.databases_cache[("root", "other-system", False, False)]["backend"]["1.0.0"] is keep_db
     finally:
         perf_database.databases_cache.clear()
         perf_database.databases_cache.update(cache_snapshot)

--- a/tests/unit/sdk/database/test_reuse_ordering.py
+++ b/tests/unit/sdk/database/test_reuse_ordering.py
@@ -257,6 +257,37 @@ def test_declared_donor_not_duplicated_in_fallback(systems_root: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Duplicate declared-reuse entries within one reuse.yaml (AIC-1503 PR4 task
+# 5, FIX 2)
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_declared_reuse_entry_admitted_once(systems_root: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """Two identical (table, from_version) entries in one reuse.yaml (author
+    copy-paste) must not admit the same donor twice -- first occurrence wins,
+    logged at debug level."""
+    backend, requested, donor = "trtllm", "1.0.0", "0.9.0"
+    _write(systems_root, f"data/h100_sxm/gemm/{backend}/{requested}/gemm_perf.parquet")
+    _write(systems_root, f"data/h100_sxm/gemm/{backend}/{donor}/gemm_perf.parquet")
+    _write_yaml(
+        systems_root,
+        f"data/h100_sxm/gemm/{backend}/{requested}/reuse.yaml",
+        {"reuse": [_reuse_entry("gemm_perf", donor), _reuse_entry("gemm_perf", donor)]},
+    )
+
+    db = _build_db(systems_root, backend=backend, version=requested)
+    with caplog.at_level(logging.DEBUG):
+        sources = _sources_for(db, systems_root, common.PerfDataFilename.gemm)
+
+    provenance = db.data_provenance["gemm_perf.parquet"]
+    donor_entries = [e for e in provenance if e["version"] == donor]
+    assert len(donor_entries) == 1
+    assert donor_entries[0]["channel"] == "declared_reuse"
+    assert [path for path, _ in sources] == [e["path"] for e in provenance]
+    assert any("Duplicate declared-reuse entry" in r.getMessage() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
 # Newer-only-via-declaration + full channel order
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/sdk/database/test_reuse_ordering.py
+++ b/tests/unit/sdk/database/test_reuse_ordering.py
@@ -1,0 +1,402 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the design-§6 reuse-ordering contract in ``_build_op_sources``
+(Collector V3 PR 4, AIC-1503).
+
+New source order per op file: (1) primary, (2) declared donors from the
+REQUESTED version dir's ``reuse.yaml`` (any direction, channel
+``declared_reuse``), (3) same-backend siblings STRICTLY EARLIER than
+requested, nearest first (channel ``fallback`` — never admits a version newer
+than requested implicitly), (4) cross-backend kernel-source-gated fill
+(channel ``cross_backend``, mechanism unchanged from before this PR). The
+``comm`` family is hard-excluded from every non-primary channel. Every
+admitted source is recorded into ``PerfDatabase.data_provenance``.
+
+These tests call ``PerfDatabase._build_op_sources`` directly against
+synthetic on-disk trees — no CSV/parquet content is ever read by that
+function, only path existence, so stub file contents are fine (mirrors
+``tests/unit/sdk/database/test_dual_layout_discovery.py``).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+
+from aiconfigurator.sdk import common
+from aiconfigurator.sdk.operations.base import resolve_op_data_path
+from aiconfigurator.sdk.perf_database import PerfDatabase, _load_op_kernel_source_manifest_entries
+
+pytestmark = pytest.mark.unit
+
+PARQUET_STUB = b"PAR1stub"  # _build_op_sources only checks existence, never parses
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write(root: Path, rel: str, data: bytes = PARQUET_STUB) -> None:
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(data)
+
+
+def _write_yaml(root: Path, rel: str, doc: dict) -> None:
+    _write(root, rel, yaml.safe_dump(doc).encode("utf-8"))
+
+
+def _reuse_entry(table: str, from_version: str, reason: str = "test donor") -> dict:
+    return {"table": table, "from_version": from_version, "reason": reason, "approved_by": "yimingl"}
+
+
+def _write_manifest(systems_root: Path, entries: list[tuple[str, str, str, list[str]]]) -> None:
+    """Write op_kernel_source_manifest.yaml. Each entry is (op_file, kernel_source, tier, frameworks)."""
+    lines = ["groups:"]
+    for op_file, ks, tier, frameworks in entries:
+        lines.extend(
+            [
+                f"  - op_file: {op_file}",
+                f"    kernel_source: '{ks}'",
+                f"    tier: {tier}",
+                f"    frameworks: [{', '.join(frameworks)}]",
+            ]
+        )
+    (systems_root / "op_kernel_source_manifest.yaml").write_text("\n".join(lines) + "\n")
+
+
+@pytest.fixture
+def systems_root(tmp_path: Path) -> Path:
+    """A ``h100_sxm`` systems tree with just a system YAML. Each test adds
+    whatever data/reuse.yaml/manifest it needs under ``data/h100_sxm/``."""
+    root = tmp_path / "systems"
+    root.mkdir()
+    (root / "h100_sxm.yaml").write_text("data_dir: data/h100_sxm\n", encoding="utf-8")
+    _load_op_kernel_source_manifest_entries.cache_clear()
+    return root
+
+
+def _build_db(systems_root: Path, *, backend: str, version: str, database_mode: str | None = "HYBRID") -> PerfDatabase:
+    return PerfDatabase(
+        system="h100_sxm",
+        backend=backend,
+        version=version,
+        systems_root=str(systems_root),
+        database_mode=database_mode,
+    )
+
+
+def _sources_for(db: PerfDatabase, systems_root: Path, op: common.PerfDataFilename):
+    system_data_root = str(systems_root / "data" / "h100_sxm")
+    primary_path = resolve_op_data_path(system_data_root, db.backend, db.version, op.value)
+    return db._build_op_sources(op, primary_path, system_data_root)
+
+
+def _channels(db: PerfDatabase, op_file_basename: str) -> list[str]:
+    return [entry["channel"] for entry in db.data_provenance[op_file_basename]]
+
+
+def _versions(db: PerfDatabase, op_file_basename: str) -> list[str]:
+    return [entry["version"] for entry in db.data_provenance[op_file_basename]]
+
+
+# ---------------------------------------------------------------------------
+# Channel 1 (primary) sanity
+# ---------------------------------------------------------------------------
+
+
+def test_primary_only_when_no_siblings(systems_root: Path) -> None:
+    _write(systems_root, "data/h100_sxm/gemm/trtllm/1.0.0/gemm_perf.parquet")
+
+    db = _build_db(systems_root, backend="trtllm", version="1.0.0")
+    sources = _sources_for(db, systems_root, common.PerfDataFilename.gemm)
+
+    assert len(sources) == 1
+    assert sources[0][1] is None
+    assert _channels(db, "gemm_perf.parquet") == ["primary"]
+    assert db.data_provenance["gemm_perf.parquet"][0]["exists"] is True
+
+
+# ---------------------------------------------------------------------------
+# Channel 2 — declared reuse (reuse.yaml, same backend, any direction)
+# ---------------------------------------------------------------------------
+
+
+def test_declared_reuse_channel_admits_newer_donor_in_isolation(systems_root: Path) -> None:
+    """Declared reuse is the only channel that may borrow FORWARD (a version
+    newer than requested) — proven here with no older siblings at all."""
+    backend, requested, donor = "sglang", "0.5.12", "0.5.14"
+    _write(systems_root, f"data/h100_sxm/moe/{backend}/{requested}/moe_perf.parquet")
+    _write(systems_root, f"data/h100_sxm/moe/{backend}/{donor}/moe_perf.parquet")
+    _write_yaml(
+        systems_root,
+        f"data/h100_sxm/moe/{backend}/{requested}/reuse.yaml",
+        {"reuse": [_reuse_entry("moe_perf", donor)]},
+    )
+
+    db = _build_db(systems_root, backend=backend, version=requested)
+    sources = _sources_for(db, systems_root, common.PerfDataFilename.moe)
+
+    assert len(sources) == 2
+    assert sources[1][0].endswith(f"moe/{backend}/{donor}/moe_perf.parquet")
+    assert sources[1][1] is None  # declared donors are unfiltered, same as primary
+    assert _channels(db, "moe_perf.parquet") == ["primary", "declared_reuse"]
+
+
+def test_declared_reuse_works_with_no_primary_data_at_all(systems_root: Path) -> None:
+    """Mirrors the real l40s/quantize/vllm/0.22.0 case: the requested version
+    dir holds ONLY a reuse.yaml, no parquet of its own."""
+    backend, requested, donor = "vllm", "0.22.0", "0.24.0"
+    _write(systems_root, f"data/h100_sxm/quantize/{backend}/{donor}/computescale_perf.parquet")
+    _write_yaml(
+        systems_root,
+        f"data/h100_sxm/quantize/{backend}/{requested}/reuse.yaml",
+        {"reuse": [_reuse_entry("computescale_perf", donor)]},
+    )
+
+    db = _build_db(systems_root, backend=backend, version=requested)
+    sources = _sources_for(db, systems_root, common.PerfDataFilename.compute_scale)
+
+    assert len(sources) == 2
+    assert sources[1][0].endswith(f"quantize/{backend}/{donor}/computescale_perf.parquet")
+    provenance = db.data_provenance["computescale_perf.parquet"]
+    assert provenance[0]["channel"] == "primary"
+    assert provenance[0]["exists"] is False  # no parquet at the requested dir
+    assert provenance[1]["channel"] == "declared_reuse"
+    assert provenance[1]["exists"] is True
+
+
+# ---------------------------------------------------------------------------
+# Channel 3 — nearest-earlier same-backend fallback
+# ---------------------------------------------------------------------------
+
+
+def test_fallback_nearest_earlier_descending_no_manifest_needed(systems_root: Path) -> None:
+    """Free/always-on channel: no op_kernel_source_manifest.yaml entry needed
+    at all, unlike today's behavior."""
+    backend = "trtllm"
+    _write(systems_root, f"data/h100_sxm/gemm/{backend}/1.0.0/gemm_perf.parquet")
+    _write(systems_root, f"data/h100_sxm/gemm/{backend}/0.9.0/gemm_perf.parquet")
+    _write(systems_root, f"data/h100_sxm/gemm/{backend}/0.8.0/gemm_perf.parquet")
+
+    db = _build_db(systems_root, backend=backend, version="1.0.0")
+    _sources_for(db, systems_root, common.PerfDataFilename.gemm)
+
+    assert _versions(db, "gemm_perf.parquet") == ["1.0.0", "0.9.0", "0.8.0"]
+    assert _channels(db, "gemm_perf.parquet") == ["primary", "fallback", "fallback"]
+
+
+def test_fallback_excludes_newer_than_requested(systems_root: Path) -> None:
+    backend = "trtllm"
+    _write(systems_root, f"data/h100_sxm/gemm/{backend}/1.0.0/gemm_perf.parquet")
+    _write(systems_root, f"data/h100_sxm/gemm/{backend}/1.1.0/gemm_perf.parquet")  # newer, must be excluded
+    _write(systems_root, f"data/h100_sxm/gemm/{backend}/0.9.0/gemm_perf.parquet")  # older, admitted
+
+    db = _build_db(systems_root, backend=backend, version="1.0.0")
+    _sources_for(db, systems_root, common.PerfDataFilename.gemm)
+
+    versions = _versions(db, "gemm_perf.parquet")
+    assert versions == ["1.0.0", "0.9.0"]
+    assert "1.1.0" not in versions
+
+
+def test_unparseable_sibling_version_excluded_and_warns_once(
+    systems_root: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    backend = "trtllm"
+    _write(systems_root, f"data/h100_sxm/gemm/{backend}/1.0.0/gemm_perf.parquet")
+    _write(systems_root, f"data/h100_sxm/gemm/{backend}/nightly-build/gemm_perf.parquet")  # not PEP 440
+
+    db = _build_db(systems_root, backend=backend, version="1.0.0")
+    with caplog.at_level(logging.WARNING):
+        _sources_for(db, systems_root, common.PerfDataFilename.gemm)
+        _sources_for(db, systems_root, common.PerfDataFilename.gemm)  # second call: still only 1 warning
+
+    assert _versions(db, "gemm_perf.parquet") == ["1.0.0"]
+    warnings = [r for r in caplog.records if "not PEP 440-parseable" in r.getMessage()]
+    assert len(warnings) == 1
+
+
+# ---------------------------------------------------------------------------
+# Newer-only-via-declaration + full channel order
+# ---------------------------------------------------------------------------
+
+
+def test_newer_sibling_only_admitted_when_declared(systems_root: Path) -> None:
+    backend, requested = "sglang", "0.5.12"
+    declared_newer, undeclared_newer = "0.5.14", "0.5.15"
+    _write(systems_root, f"data/h100_sxm/gemm/{backend}/{requested}/gemm_perf.parquet")
+    _write(systems_root, f"data/h100_sxm/gemm/{backend}/{declared_newer}/gemm_perf.parquet")
+    _write(systems_root, f"data/h100_sxm/gemm/{backend}/{undeclared_newer}/gemm_perf.parquet")
+    _write_yaml(
+        systems_root,
+        f"data/h100_sxm/gemm/{backend}/{requested}/reuse.yaml",
+        {"reuse": [_reuse_entry("gemm_perf", declared_newer)]},
+    )
+
+    db = _build_db(systems_root, backend=backend, version=requested)
+    _sources_for(db, systems_root, common.PerfDataFilename.gemm)
+
+    versions = _versions(db, "gemm_perf.parquet")
+    assert versions == [requested, declared_newer]
+    assert undeclared_newer not in versions
+
+
+def test_full_channel_order_declared_then_fallback_nearest_then_cross_backend(systems_root: Path) -> None:
+    backend = "trtllm"
+    requested = "1.0.0"
+    declared_donor = "1.2.0"  # newer, only admitted because declared
+    nearest_earlier = "0.9.0"
+    further_earlier = "0.5.0"
+    newer_undeclared = "1.1.0"  # must never appear
+    cross_backend_version = "0.5.0"  # sibling framework (sglang)
+
+    for v in (requested, declared_donor, nearest_earlier, further_earlier, newer_undeclared):
+        _write(systems_root, f"data/h100_sxm/gemm/{backend}/{v}/gemm_perf.parquet")
+    _write(systems_root, f"data/h100_sxm/gemm/sglang/{cross_backend_version}/gemm_perf.parquet")
+
+    _write_yaml(
+        systems_root,
+        f"data/h100_sxm/gemm/{backend}/{requested}/reuse.yaml",
+        {"reuse": [_reuse_entry("gemm_perf", declared_donor)]},
+    )
+    _write_manifest(systems_root, [("gemm_perf.parquet", "shared_kernel", "shared", [backend, "sglang"])])
+
+    db = _build_db(systems_root, backend=backend, version=requested)
+    _sources_for(db, systems_root, common.PerfDataFilename.gemm)
+
+    provenance = db.data_provenance["gemm_perf.parquet"]
+    assert [(e["version"], e["channel"]) for e in provenance] == [
+        (requested, "primary"),
+        (declared_donor, "declared_reuse"),
+        (nearest_earlier, "fallback"),
+        (further_earlier, "fallback"),
+        (cross_backend_version, "cross_backend"),
+    ]
+    assert newer_undeclared not in [e["version"] for e in provenance]
+    # cross_backend rows keep the kernel_source filter; same-backend channels don't.
+    sources = _sources_for(db, systems_root, common.PerfDataFilename.gemm)
+    assert sources[-1][1] == {"shared_kernel"}
+    assert all(ks is None for _, ks in sources[:-1])
+
+
+# ---------------------------------------------------------------------------
+# Self-overlap (the l40s case): primary already owns the table
+# ---------------------------------------------------------------------------
+
+
+def test_self_overlap_declared_donor_admitted_after_primary(systems_root: Path) -> None:
+    """Requested dir owns SOME shapes of gemm_perf AND declares a donor for
+    the SAME table (matches data/l40s/gemm/sglang/0.5.12/reuse.yaml in the
+    real tree). Declared donor must land right after primary — first-wins
+    merge then keeps the requested dir's own shapes authoritative."""
+    backend, requested, donor = "sglang", "0.5.12", "0.5.14"
+    _write(systems_root, f"data/h100_sxm/gemm/{backend}/{requested}/gemm_perf.parquet")
+    _write(systems_root, f"data/h100_sxm/gemm/{backend}/{donor}/gemm_perf.parquet")
+    _write_yaml(
+        systems_root,
+        f"data/h100_sxm/gemm/{backend}/{requested}/reuse.yaml",
+        {"reuse": [_reuse_entry("gemm_perf", donor, reason="self-overlap; mechanically derived")]},
+    )
+
+    db = _build_db(systems_root, backend=backend, version=requested)
+    sources = _sources_for(db, systems_root, common.PerfDataFilename.gemm)
+
+    assert len(sources) == 2
+    assert sources[0][0].endswith(f"gemm/{backend}/{requested}/gemm_perf.parquet")
+    assert sources[1][0].endswith(f"gemm/{backend}/{donor}/gemm_perf.parquet")
+    assert _channels(db, "gemm_perf.parquet") == ["primary", "declared_reuse"]
+
+
+# ---------------------------------------------------------------------------
+# comm family hard exclusion (design §6.5 rule 5)
+# ---------------------------------------------------------------------------
+
+
+def test_comm_family_custom_allreduce_gets_primary_only(systems_root: Path) -> None:
+    """custom_allreduce lives under the comm family. Today it inherits
+    newest-first sibling rows via the kernel-source manifest (same mechanism
+    as any other op); this PR tightens that to primary-only, regardless of a
+    stray declaration or a matching cross-backend manifest entry."""
+    backend, requested, older = "trtllm", "1.3.0", "1.2.0"
+    _write(systems_root, f"data/h100_sxm/comm/{backend}/{requested}/custom_allreduce_perf.parquet")
+    _write(systems_root, f"data/h100_sxm/comm/{backend}/{older}/custom_allreduce_perf.parquet")
+    _write_yaml(
+        systems_root,
+        f"data/h100_sxm/comm/{backend}/{requested}/reuse.yaml",
+        {"reuse": [_reuse_entry("custom_allreduce_perf", older)]},
+    )
+    _write_manifest(systems_root, [("custom_allreduce_perf.parquet", "TRTLLM", "shared", [backend])])
+
+    db = _build_db(systems_root, backend=backend, version=requested)
+    sources = _sources_for(db, systems_root, common.PerfDataFilename.custom_allreduce)
+
+    assert len(sources) == 1
+    assert sources[0][0].endswith(f"comm/{backend}/{requested}/custom_allreduce_perf.parquet")
+    assert _channels(db, "custom_allreduce_perf.parquet") == ["primary"]
+
+
+def test_nccl_op_name_early_exit_still_applies(systems_root: Path) -> None:
+    """NCCL is comm-family too, but this proves the pre-existing op-name
+    early-exit (kept per the PR3 carry-in) independently still short-circuits,
+    not just the new family-based check."""
+    _write(systems_root, "data/h100_sxm/comm/nccl/2.26.2/nccl_perf.parquet")
+    _write(systems_root, "data/h100_sxm/comm/nccl/2.20.0/nccl_perf.parquet")  # older sibling, must be ignored
+
+    db = _build_db(systems_root, backend="trtllm", version="2.26.2")
+    system_data_root = str(systems_root / "data" / "h100_sxm")
+    primary_path = resolve_op_data_path(system_data_root, "nccl", "2.26.2", common.PerfDataFilename.nccl.value)
+    sources = db._build_op_sources(common.PerfDataFilename.nccl, primary_path, system_data_root)
+
+    assert len(sources) == 1
+    assert _channels(db, "nccl_perf.parquet") == ["primary"]
+
+
+# ---------------------------------------------------------------------------
+# data_provenance shape + content
+# ---------------------------------------------------------------------------
+
+
+def test_data_provenance_shape_and_content(systems_root: Path) -> None:
+    backend = "trtllm"
+    requested, older = "1.0.0", "0.9.0"
+    _write(systems_root, f"data/h100_sxm/gemm/{backend}/{older}/gemm_perf.parquet")
+
+    db = _build_db(systems_root, backend=backend, version=requested)
+    sources = _sources_for(db, systems_root, common.PerfDataFilename.gemm)
+
+    provenance = db.data_provenance["gemm_perf.parquet"]
+    assert isinstance(provenance, list)
+    for entry in provenance:
+        assert set(entry.keys()) == {"version", "path", "channel", "exists"}
+        assert isinstance(entry["exists"], bool)
+
+    assert provenance[0]["channel"] == "primary"
+    assert provenance[0]["version"] == requested
+    assert provenance[0]["exists"] is False  # requested dir never populated
+
+    assert provenance[1]["channel"] == "fallback"
+    assert provenance[1]["version"] == older
+    assert provenance[1]["exists"] is True
+    assert provenance[1]["path"].endswith(f"gemm/{backend}/{older}/gemm_perf.parquet")
+
+    # data_provenance mirrors the returned sources list exactly (paths + order).
+    assert [path for path, _ in sources] == [entry["path"] for entry in provenance]
+
+
+def test_data_provenance_populated_per_op_file(systems_root: Path) -> None:
+    """Two different op files get independent data_provenance entries."""
+    backend = "trtllm"
+    _write(systems_root, f"data/h100_sxm/gemm/{backend}/1.0.0/gemm_perf.parquet")
+    _write(systems_root, f"data/h100_sxm/moe/{backend}/1.0.0/moe_perf.parquet")
+
+    db = _build_db(systems_root, backend=backend, version="1.0.0")
+    _sources_for(db, systems_root, common.PerfDataFilename.gemm)
+    _sources_for(db, systems_root, common.PerfDataFilename.moe)
+
+    assert set(db.data_provenance.keys()) == {"gemm_perf.parquet", "moe_perf.parquet"}

--- a/tests/unit/sdk/database/test_reuse_ordering.py
+++ b/tests/unit/sdk/database/test_reuse_ordering.py
@@ -223,6 +223,40 @@ def test_unparseable_sibling_version_excluded_and_warns_once(
 
 
 # ---------------------------------------------------------------------------
+# Declared donor dedup against fallback (AIC-1503 PR4 task 1, FIX 1)
+# ---------------------------------------------------------------------------
+
+
+def test_declared_donor_not_duplicated_in_fallback(systems_root: Path) -> None:
+    """The dominant real pattern (180 of 479 committed reuse.yaml entries):
+    reuse.yaml declares a donor that points BACKWARD at an earlier sibling
+    version which also physically exists on disk. That donor must be
+    admitted exactly once, via ``declared_reuse`` — not a second time via
+    the fallback nearest-earlier scan, which would list the same physical
+    source under two channels (doubling I/O and corrupting
+    data_provenance)."""
+    backend, requested, donor = "trtllm", "1.0.0", "0.9.0"
+    _write(systems_root, f"data/h100_sxm/gemm/{backend}/{requested}/gemm_perf.parquet")
+    _write(systems_root, f"data/h100_sxm/gemm/{backend}/{donor}/gemm_perf.parquet")
+    _write_yaml(
+        systems_root,
+        f"data/h100_sxm/gemm/{backend}/{requested}/reuse.yaml",
+        {"reuse": [_reuse_entry("gemm_perf", donor)]},
+    )
+
+    db = _build_db(systems_root, backend=backend, version=requested)
+    sources = _sources_for(db, systems_root, common.PerfDataFilename.gemm)
+
+    provenance = db.data_provenance["gemm_perf.parquet"]
+    paths = [e["path"] for e in provenance]
+    assert len(paths) == len(set(paths)), f"donor path listed more than once: {paths}"
+    donor_entries = [e for e in provenance if e["version"] == donor]
+    assert len(donor_entries) == 1
+    assert donor_entries[0]["channel"] == "declared_reuse"
+    assert [path for path, _ in sources] == paths
+
+
+# ---------------------------------------------------------------------------
 # Newer-only-via-declaration + full channel order
 # ---------------------------------------------------------------------------
 
@@ -339,6 +373,28 @@ def test_comm_family_custom_allreduce_gets_primary_only(systems_root: Path) -> N
     assert len(sources) == 1
     assert sources[0][0].endswith(f"comm/{backend}/{requested}/custom_allreduce_perf.parquet")
     assert _channels(db, "custom_allreduce_perf.parquet") == ["primary"]
+
+
+def test_legacy_layout_comm_op_keeps_pre_v3_siblings(systems_root: Path) -> None:
+    """Pins the documented AIC-1503 PR4 task-1 FIX-2 exception
+    (``_op_file_family_from_path`` docstring): design §6.5 rule 5's comm
+    hard-exclusion is detected structurally off the primary path's family
+    component, which only exists in the family-first layout. A LEGACY-shaped
+    comm op (3-component path, no ``comm/`` family dir) therefore does NOT
+    get the exclusion applied — it keeps pre-V3 sibling-reuse behavior for
+    as long as its tree stays legacy-shaped. Contrast with
+    ``test_comm_family_custom_allreduce_gets_primary_only`` above, which
+    pins the family-shaped case (exclusion DOES apply, primary-only)."""
+    backend, requested, older = "trtllm", "1.3.0", "1.2.0"
+    _write(systems_root, f"data/h100_sxm/{backend}/{requested}/custom_allreduce_perf.parquet")
+    _write(systems_root, f"data/h100_sxm/{backend}/{older}/custom_allreduce_perf.parquet")
+
+    db = _build_db(systems_root, backend=backend, version=requested)
+    sources = _sources_for(db, systems_root, common.PerfDataFilename.custom_allreduce)
+
+    assert len(sources) == 2
+    assert _channels(db, "custom_allreduce_perf.parquet") == ["primary", "fallback"]
+    assert _versions(db, "custom_allreduce_perf.parquet") == [requested, older]
 
 
 def test_nccl_op_name_early_exit_still_applies(systems_root: Path) -> None:

--- a/tests/unit/sdk/database/test_reuse_ordering.py
+++ b/tests/unit/sdk/database/test_reuse_ordering.py
@@ -445,6 +445,76 @@ def test_nccl_op_name_early_exit_still_applies(systems_root: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Partial version dirs are never admitted as the primary source.
+# resolve_op_data_path skips partial FAMILY dirs, but its final legacy-layout
+# fallback returns an existing file with no partial check — the admission
+# chokepoint (_build_op_sources) must refuse that primary itself.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("marker", ["incomplete_txt", "meta_yaml_partial"])
+def test_partial_legacy_primary_not_admitted_donors_still_fill(
+    systems_root: Path, caplog: pytest.LogCaptureFixture, marker: str
+) -> None:
+    """A legacy-layout dir holding the requested version's table but marked
+    partial (INCOMPLETE.txt legacy marker, or collection_meta.yaml with any
+    ``status: partial`` table) must NOT be admitted as the primary source.
+    Channels 2-4 still fill, and data_provenance lists admitted sources
+    only — no primary record for the refused file."""
+    backend, requested, earlier = "trtllm", "1.0.0", "0.9.0"
+    _write(systems_root, f"data/h100_sxm/{backend}/{requested}/gemm_perf.parquet")
+    if marker == "incomplete_txt":
+        _write(systems_root, f"data/h100_sxm/{backend}/{requested}/INCOMPLETE.txt", b"partial collection\n")
+    else:
+        _write_yaml(
+            systems_root,
+            f"data/h100_sxm/{backend}/{requested}/collection_meta.yaml",
+            {
+                "schema_version": 1,
+                "runtime": {"framework": backend, "version": requested},
+                "tables": {"gemm_perf": {"status": "partial"}},
+            },
+        )
+    # A complete family-layout earlier sibling fills via channel 3 (fallback).
+    _write(systems_root, f"data/h100_sxm/gemm/{backend}/{earlier}/gemm_perf.parquet")
+
+    db = _build_db(systems_root, backend=backend, version=requested)
+    with caplog.at_level(logging.WARNING):
+        sources = _sources_for(db, systems_root, common.PerfDataFilename.gemm)
+
+    provenance = db.data_provenance["gemm_perf.parquet"]
+    assert [e["channel"] for e in provenance] == ["fallback"]
+    assert provenance[0]["version"] == earlier
+    assert [path for path, _ in sources] == [e["path"] for e in provenance]
+    assert not any(f"{backend}/{requested}/gemm_perf.parquet" in path for path, _ in sources)
+    assert any("partial" in r.getMessage() and requested in r.getMessage() for r in caplog.records)
+
+
+def test_partial_family_dir_is_skipped_by_resolver_not_the_admission_guard(systems_root: Path) -> None:
+    """Scope guard: a family-layout primary can never be partial, because
+    resolve_op_data_path already skips partial family dirs — the admission
+    guard in _build_op_sources only ever fires for the legacy-layout
+    fallback path. Here the partial family dir is skipped upstream, so the
+    primary resolves to the (nonexistent) legacy-shaped path and keeps its
+    provenance record with exists=False, per the usual missing-primary
+    semantics."""
+    backend, requested, earlier = "trtllm", "1.0.0", "0.9.0"
+    _write(systems_root, f"data/h100_sxm/gemm/{backend}/{requested}/gemm_perf.parquet")
+    _write(systems_root, f"data/h100_sxm/gemm/{backend}/{requested}/INCOMPLETE.txt", b"partial collection\n")
+    _write(systems_root, f"data/h100_sxm/gemm/{backend}/{earlier}/gemm_perf.parquet")
+
+    db = _build_db(systems_root, backend=backend, version=requested)
+    sources = _sources_for(db, systems_root, common.PerfDataFilename.gemm)
+
+    provenance = db.data_provenance["gemm_perf.parquet"]
+    assert [e["channel"] for e in provenance] == ["primary", "fallback"]
+    assert provenance[0]["exists"] is False  # legacy-shaped path, not the partial family file
+    assert f"gemm/{backend}/{requested}" not in provenance[0]["path"]
+    assert provenance[1]["version"] == earlier
+    assert [path for path, _ in sources] == [e["path"] for e in provenance]
+
+
+# ---------------------------------------------------------------------------
 # data_provenance shape + content
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/sdk/database/test_strict_mode.py
+++ b/tests/unit/sdk/database/test_strict_mode.py
@@ -1,0 +1,479 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for strict provenance mode (Collector V3 PR 4 task 2, AIC-1503,
+design §5/§7.4).
+
+``PerfDatabase(strict_provenance=...)`` resolves ``None`` from the
+``AIC_STRICT_PROVENANCE`` env var. The actual load-time validation runs
+inside ``get_database()`` (the loader entry point), scoped to dirs the
+REQUESTED (system, backend, version) actually touches: its own family-layout
+version dir(s) (primary) plus any donor dir their ``reuse.yaml`` declares
+(channel 2, design §6.3). Constructing a bare ``PerfDatabase`` directly (as
+the rest of this test package does against synthetic trees) performs no
+validation of its own -- see ``test_bare_construction_never_validates``.
+
+Strict mode raises ``ValueError`` (naming the offending dir/table) on: a
+parquet-holding version dir with no ``collection_meta.yaml``; a table not
+listed in its dir's sidecar; a malformed ``reuse.yaml``/``collection_meta.yaml``.
+Non-strict warns instead of raising for all of the above. A
+``provenance: legacy`` sidecar is graced -- warns, never raises -- in BOTH
+modes. Legacy-layout (``<backend>/<version>``, no family segment) version
+dirs predate the V3 metadata regime and are exempt from strict checking
+entirely (mirrors ``_op_file_family_from_path``'s legacy-layout carve-out
+from Task 1).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+
+from aiconfigurator.sdk.perf_database import (
+    PerfDatabase,
+    _strict_provenance_enabled,
+    databases_cache,
+    get_database,
+    get_database_view,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors tests/unit/sdk/database/test_reuse_ordering.py)
+# ---------------------------------------------------------------------------
+
+PARQUET_STUB = b"PAR1stub"
+
+
+def _write(root: Path, rel: str, data: bytes = PARQUET_STUB) -> None:
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(data)
+
+
+def _write_yaml(root: Path, rel: str, doc: dict) -> None:
+    _write(root, rel, yaml.safe_dump(doc).encode("utf-8"))
+
+
+def _write_text(root: Path, rel: str, text: str) -> None:
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+
+
+def _reuse_entry(table: str, from_version: str, reason: str = "test donor") -> dict:
+    return {"table": table, "from_version": from_version, "reason": reason, "approved_by": "yimingl"}
+
+
+@pytest.fixture
+def systems_root(tmp_path: Path) -> Path:
+    """An ``h100_sxm`` systems tree with just a system YAML. Each test adds
+    whatever data/sidecar files it needs under ``data/h100_sxm/``."""
+    root = tmp_path / "systems"
+    root.mkdir()
+    (root / "h100_sxm.yaml").write_text("data_dir: data/h100_sxm\n", encoding="utf-8")
+    return root
+
+
+@pytest.fixture(autouse=True)
+def _clear_databases_cache():
+    databases_cache.clear()
+    yield
+    databases_cache.clear()
+
+
+def _get_db(systems_root: Path, *, backend: str = "trtllm", version: str = "1.0.0", **kwargs):
+    return get_database("h100_sxm", backend, version, systems_paths=str(systems_root), **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Env-var resolution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["1", "true", "True", "TRUE"])
+def test_env_var_truthy_values_enable_strict(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    monkeypatch.setenv("AIC_STRICT_PROVENANCE", value)
+    assert _strict_provenance_enabled(None) is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "False", "", "no"])
+def test_env_var_falsy_values_disable_strict(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    monkeypatch.setenv("AIC_STRICT_PROVENANCE", value)
+    assert _strict_provenance_enabled(None) is False
+
+
+def test_env_var_unset_defaults_non_strict(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AIC_STRICT_PROVENANCE", raising=False)
+    assert _strict_provenance_enabled(None) is False
+
+
+def test_explicit_bool_overrides_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AIC_STRICT_PROVENANCE", "1")
+    assert _strict_provenance_enabled(False) is False
+    monkeypatch.setenv("AIC_STRICT_PROVENANCE", "0")
+    assert _strict_provenance_enabled(True) is True
+
+
+def test_perf_database_stores_resolved_flag(systems_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AIC_STRICT_PROVENANCE", raising=False)
+    db_default = PerfDatabase("h100_sxm", "trtllm", "1.0.0", str(systems_root))
+    assert db_default.strict_provenance is False
+
+    db_true = PerfDatabase("h100_sxm", "trtllm", "1.0.0", str(systems_root), strict_provenance=True)
+    assert db_true.strict_provenance is True
+
+    monkeypatch.setenv("AIC_STRICT_PROVENANCE", "1")
+    db_env = PerfDatabase("h100_sxm", "trtllm", "1.0.0", str(systems_root))
+    assert db_env.strict_provenance is True
+
+
+# ---------------------------------------------------------------------------
+# Bare PerfDatabase() construction never validates (scope decision)
+# ---------------------------------------------------------------------------
+
+
+def test_bare_construction_never_validates(systems_root: Path) -> None:
+    """Constructing a ``PerfDatabase`` directly against a tree with a
+    parquet-holding dir and no ``collection_meta.yaml`` must NOT raise, even
+    with ``strict_provenance=True`` -- the fail-closed validation is a
+    ``get_database()`` (loader entry point) concern, not a constructor
+    concern. This is deliberate: the rest of this test package (and the
+    wider unit suite) constructs ``PerfDatabase`` directly against synthetic
+    trees that predate ``collection_meta.yaml`` sidecars, and must keep
+    working unchanged under CI's ``AIC_STRICT_PROVENANCE=1``.
+    """
+    _write(systems_root, "data/h100_sxm/gemm/trtllm/1.0.0/gemm_perf.parquet")
+
+    db = PerfDatabase("h100_sxm", "trtllm", "1.0.0", str(systems_root), strict_provenance=True)
+    assert db.strict_provenance is True  # flag is stored...
+    # ...but construction itself did not validate anything (no raise above).
+
+
+# ---------------------------------------------------------------------------
+# Missing collection_meta.yaml sidecar
+# ---------------------------------------------------------------------------
+
+
+def test_strict_raises_on_missing_sidecar(systems_root: Path) -> None:
+    _write(systems_root, "data/h100_sxm/gemm/trtllm/1.0.0/gemm_perf.parquet")
+
+    with pytest.raises(ValueError, match=r"no collection_meta\.yaml"):
+        _get_db(systems_root, strict_provenance=True)
+
+
+def test_non_strict_warns_on_missing_sidecar(systems_root: Path, caplog: pytest.LogCaptureFixture) -> None:
+    _write(systems_root, "data/h100_sxm/gemm/trtllm/1.0.0/gemm_perf.parquet")
+
+    with caplog.at_level(logging.WARNING):
+        db = _get_db(systems_root, strict_provenance=False)
+
+    assert db is not None
+    assert any("no collection_meta.yaml" in r.getMessage() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Table present but uncovered by the dir's sidecar
+# ---------------------------------------------------------------------------
+
+
+def test_strict_raises_on_uncovered_table(systems_root: Path) -> None:
+    _write(systems_root, "data/h100_sxm/attention/trtllm/1.0.0/context_attention_perf.parquet")
+    _write(systems_root, "data/h100_sxm/attention/trtllm/1.0.0/generation_attention_perf.parquet")
+    _write_yaml(
+        systems_root,
+        "data/h100_sxm/attention/trtllm/1.0.0/collection_meta.yaml",
+        {
+            "schema_version": 1,
+            "runtime": {"framework": "trtllm", "version": "1.0.0"},
+            "tables": {"context_attention_perf": {"status": "complete"}},
+        },
+    )
+
+    with pytest.raises(ValueError, match="generation_attention_perf"):
+        _get_db(systems_root, strict_provenance=True)
+
+
+def test_non_strict_warns_on_uncovered_table(systems_root: Path, caplog: pytest.LogCaptureFixture) -> None:
+    _write(systems_root, "data/h100_sxm/attention/trtllm/1.0.0/context_attention_perf.parquet")
+    _write(systems_root, "data/h100_sxm/attention/trtllm/1.0.0/generation_attention_perf.parquet")
+    _write_yaml(
+        systems_root,
+        "data/h100_sxm/attention/trtllm/1.0.0/collection_meta.yaml",
+        {
+            "schema_version": 1,
+            "runtime": {"framework": "trtllm", "version": "1.0.0"},
+            "tables": {"context_attention_perf": {"status": "complete"}},
+        },
+    )
+
+    with caplog.at_level(logging.WARNING):
+        db = _get_db(systems_root, strict_provenance=False)
+
+    assert db is not None
+    assert any(
+        "generation_attention_perf" in r.getMessage() and "not covered" in r.getMessage() for r in caplog.records
+    )
+
+
+def test_fully_covered_sidecar_raises_nothing_in_strict(systems_root: Path) -> None:
+    _write(systems_root, "data/h100_sxm/gemm/trtllm/1.0.0/gemm_perf.parquet")
+    _write_yaml(
+        systems_root,
+        "data/h100_sxm/gemm/trtllm/1.0.0/collection_meta.yaml",
+        {
+            "schema_version": 1,
+            "runtime": {"framework": "trtllm", "version": "1.0.0"},
+            "tables": {"gemm_perf": {"status": "complete"}},
+        },
+    )
+
+    db = _get_db(systems_root, strict_provenance=True)
+    assert db is not None
+
+
+# ---------------------------------------------------------------------------
+# Malformed sidecars: strict surfaces the existing ValueError, non-strict warns
+# ---------------------------------------------------------------------------
+
+
+def test_strict_raises_on_malformed_collection_meta(systems_root: Path) -> None:
+    _write(systems_root, "data/h100_sxm/gemm/trtllm/1.0.0/gemm_perf.parquet")
+    _write_text(systems_root, "data/h100_sxm/gemm/trtllm/1.0.0/collection_meta.yaml", "not a mapping\n- oops\n")
+
+    with pytest.raises(ValueError, match=r"collection_meta\.yaml"):
+        _get_db(systems_root, strict_provenance=True)
+
+
+def test_non_strict_warns_on_malformed_collection_meta(systems_root: Path, caplog: pytest.LogCaptureFixture) -> None:
+    _write(systems_root, "data/h100_sxm/gemm/trtllm/1.0.0/gemm_perf.parquet")
+    _write_text(systems_root, "data/h100_sxm/gemm/trtllm/1.0.0/collection_meta.yaml", "not a mapping\n- oops\n")
+
+    with caplog.at_level(logging.WARNING):
+        db = _get_db(systems_root, strict_provenance=False)
+
+    assert db is not None
+    assert any("collection_meta.yaml" in r.getMessage() for r in caplog.records)
+
+
+def test_strict_raises_on_malformed_reuse_yaml(systems_root: Path) -> None:
+    _write(systems_root, "data/h100_sxm/gemm/trtllm/1.0.0/gemm_perf.parquet")
+    _write_yaml(
+        systems_root,
+        "data/h100_sxm/gemm/trtllm/1.0.0/collection_meta.yaml",
+        {
+            "schema_version": 1,
+            "runtime": {"framework": "trtllm", "version": "1.0.0"},
+            "tables": {"gemm_perf": {"status": "complete"}},
+        },
+    )
+    _write_yaml(
+        systems_root,
+        "data/h100_sxm/gemm/trtllm/1.0.0/reuse.yaml",
+        {"reuse": [{"table": "gemm_perf"}]},  # missing from_version/reason/approved_by
+    )
+
+    with pytest.raises(ValueError, match="missing required key"):
+        _get_db(systems_root, strict_provenance=True)
+
+
+def test_non_strict_warns_on_malformed_reuse_yaml(systems_root: Path, caplog: pytest.LogCaptureFixture) -> None:
+    _write(systems_root, "data/h100_sxm/gemm/trtllm/1.0.0/gemm_perf.parquet")
+    _write_yaml(
+        systems_root,
+        "data/h100_sxm/gemm/trtllm/1.0.0/collection_meta.yaml",
+        {
+            "schema_version": 1,
+            "runtime": {"framework": "trtllm", "version": "1.0.0"},
+            "tables": {"gemm_perf": {"status": "complete"}},
+        },
+    )
+    _write_yaml(
+        systems_root,
+        "data/h100_sxm/gemm/trtllm/1.0.0/reuse.yaml",
+        {"reuse": [{"table": "gemm_perf"}]},
+    )
+
+    with caplog.at_level(logging.WARNING):
+        db = _get_db(systems_root, strict_provenance=False)
+
+    assert db is not None
+    assert any("missing required key" in r.getMessage() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Declared-reuse donor dirs (channel 2, design §6.3) are admitted sources too
+# ---------------------------------------------------------------------------
+
+
+def test_strict_raises_on_declared_donor_uncovered_table(systems_root: Path) -> None:
+    requested, donor = "1.0.0", "0.9.0"
+    _write(systems_root, f"data/h100_sxm/moe/trtllm/{requested}/moe_perf.parquet")
+    _write_yaml(
+        systems_root,
+        f"data/h100_sxm/moe/trtllm/{requested}/collection_meta.yaml",
+        {
+            "schema_version": 1,
+            "runtime": {"framework": "trtllm", "version": requested},
+            "tables": {"moe_perf": {"status": "complete"}},
+        },
+    )
+    _write_yaml(
+        systems_root,
+        f"data/h100_sxm/moe/trtllm/{requested}/reuse.yaml",
+        {"reuse": [_reuse_entry("wideep_moe_perf", donor)]},
+    )
+    # Donor exists physically but its own sidecar does not cover wideep_moe_perf.
+    _write(systems_root, f"data/h100_sxm/moe/trtllm/{donor}/wideep_moe_perf.parquet")
+    _write_yaml(
+        systems_root,
+        f"data/h100_sxm/moe/trtllm/{donor}/collection_meta.yaml",
+        {
+            "schema_version": 1,
+            "runtime": {"framework": "trtllm", "version": donor},
+            "tables": {},
+        },
+    )
+
+    with pytest.raises(ValueError, match="wideep_moe_perf"):
+        _get_db(systems_root, version=requested, strict_provenance=True)
+
+
+def test_non_strict_warns_on_declared_donor_missing_sidecar(
+    systems_root: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    requested, donor = "1.0.0", "0.9.0"
+    _write(systems_root, f"data/h100_sxm/moe/trtllm/{requested}/moe_perf.parquet")
+    _write_yaml(
+        systems_root,
+        f"data/h100_sxm/moe/trtllm/{requested}/collection_meta.yaml",
+        {
+            "schema_version": 1,
+            "runtime": {"framework": "trtllm", "version": requested},
+            "tables": {"moe_perf": {"status": "complete"}},
+        },
+    )
+    _write_yaml(
+        systems_root,
+        f"data/h100_sxm/moe/trtllm/{requested}/reuse.yaml",
+        {"reuse": [_reuse_entry("wideep_moe_perf", donor)]},
+    )
+    # Donor exists physically with no collection_meta.yaml at all.
+    _write(systems_root, f"data/h100_sxm/moe/trtllm/{donor}/wideep_moe_perf.parquet")
+
+    with caplog.at_level(logging.WARNING):
+        db = _get_db(systems_root, version=requested, strict_provenance=False)
+
+    assert db is not None
+    assert any(
+        "wideep_moe_perf" in r.getMessage() and "no collection_meta.yaml" in r.getMessage() for r in caplog.records
+    )
+
+
+# ---------------------------------------------------------------------------
+# provenance: legacy grace (design §5) -- warns, never raises, in BOTH modes
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_provenance_uncovered_table_warns_not_raises_in_strict(
+    systems_root: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    _write(systems_root, "data/h100_sxm/gemm/trtllm/1.0.0/gemm_perf.parquet")
+    _write_yaml(
+        systems_root,
+        "data/h100_sxm/gemm/trtllm/1.0.0/collection_meta.yaml",
+        {
+            "schema_version": 1,
+            "provenance": "legacy",
+            "runtime": {"framework": "trtllm", "version": "1.0.0"},
+            "tables": {},  # does not list gemm_perf
+        },
+    )
+
+    with caplog.at_level(logging.WARNING):
+        db = _get_db(systems_root, strict_provenance=True)  # must NOT raise
+
+    assert db is not None
+    assert any("graced" in r.getMessage() for r in caplog.records)
+
+
+def test_legacy_provenance_uncovered_table_warns_in_non_strict_too(
+    systems_root: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    _write(systems_root, "data/h100_sxm/gemm/trtllm/1.0.0/gemm_perf.parquet")
+    _write_yaml(
+        systems_root,
+        "data/h100_sxm/gemm/trtllm/1.0.0/collection_meta.yaml",
+        {
+            "schema_version": 1,
+            "provenance": "legacy",
+            "runtime": {"framework": "trtllm", "version": "1.0.0"},
+            "tables": {},
+        },
+    )
+
+    with caplog.at_level(logging.WARNING):
+        db = _get_db(systems_root, strict_provenance=False)
+
+    assert db is not None
+    assert any("graced" in r.getMessage() for r in caplog.records)
+
+
+def test_legacy_provenance_grace_does_not_extend_to_missing_sidecar(systems_root: Path) -> None:
+    """Grace applies to a sidecar that EXISTS and says legacy; a MISSING
+    sidecar is not a "legacy sidecar" and still raises in strict mode."""
+    _write(systems_root, "data/h100_sxm/gemm/trtllm/1.0.0/gemm_perf.parquet")
+
+    with pytest.raises(ValueError, match=r"no collection_meta\.yaml"):
+        _get_db(systems_root, strict_provenance=True)
+
+
+# ---------------------------------------------------------------------------
+# Legacy tree LAYOUT (no family segment) is exempt from strict checking
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_layout_primary_dir_exempt_from_strict(systems_root: Path) -> None:
+    """<data_dir>/<backend>/<version> (no family dir) predates the V3
+    metadata regime entirely; strict mode must not require a
+    collection_meta.yaml there (mirrors test_perf_database_shared_layer.py's
+    synthetic trees, which use this exact layout)."""
+    _write(systems_root, "data/h100_sxm/trtllm/1.0.0/gemm_perf.parquet")
+
+    db = _get_db(systems_root, strict_provenance=True)
+    assert db is not None
+
+
+# ---------------------------------------------------------------------------
+# get_database_view threads strict_provenance through to get_database
+# ---------------------------------------------------------------------------
+
+
+def test_get_database_view_threads_strict_provenance(systems_root: Path) -> None:
+    _write(systems_root, "data/h100_sxm/gemm/trtllm/1.0.0/gemm_perf.parquet")
+
+    with pytest.raises(ValueError, match=r"no collection_meta\.yaml"):
+        get_database_view("h100_sxm", "trtllm", "1.0.0", systems_paths=str(systems_root), strict_provenance=True)
+
+    view = get_database_view("h100_sxm", "trtllm", "1.0.0", systems_paths=str(systems_root), strict_provenance=False)
+    assert view is not None
+
+
+# ---------------------------------------------------------------------------
+# Real-tree smoke: post-PR3 tree is fully covered, strict ON loads clean
+# ---------------------------------------------------------------------------
+
+
+def test_real_tree_smoke_strict_on() -> None:
+    databases_cache.clear()
+    try:
+        db = get_database("h200_sxm", "trtllm", "1.3.0rc10", strict_provenance=True)
+        assert db is not None
+        assert db.strict_provenance is True
+    finally:
+        databases_cache.clear()

--- a/tests/unit/sdk/database/test_strict_mode.py
+++ b/tests/unit/sdk/database/test_strict_mode.py
@@ -465,6 +465,62 @@ def test_get_database_view_threads_strict_provenance(systems_root: Path) -> None
 
 
 # ---------------------------------------------------------------------------
+# Cache keying: strict_provenance must not collide with non-strict entries
+# (AIC-1503 review defect: databases_cache was keyed by
+# (systems_root, system, shared_flag) only -- not by strict_provenance -- so
+# a strict call for the same (system, backend, version) could silently
+# return an earlier, unvalidated non-strict instance instead of
+# re-validating and raising.)
+# ---------------------------------------------------------------------------
+
+
+def test_non_strict_load_then_strict_call_does_not_reuse_stale_cache_and_raises(
+    systems_root: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    _write(systems_root, "data/h100_sxm/gemm/trtllm/1.0.0/gemm_perf.parquet")
+
+    with caplog.at_level(logging.WARNING):
+        non_strict_db = _get_db(systems_root, strict_provenance=False)
+    assert non_strict_db is not None
+    assert non_strict_db.strict_provenance is False
+
+    # Same (system, backend, version) triple, strict this time: must
+    # re-validate against the coverage-gap tree and raise -- not return the
+    # cached non-strict instance.
+    with pytest.raises(ValueError, match=r"no collection_meta\.yaml"):
+        _get_db(systems_root, strict_provenance=True)
+
+
+def test_strict_load_then_non_strict_load_are_distinct_cache_entries(systems_root: Path) -> None:
+    """Control: a fully-covered tree loads cleanly under both modes; each
+    resolves to its own cache entry and both remain independently usable."""
+    _write(systems_root, "data/h100_sxm/gemm/trtllm/1.0.0/gemm_perf.parquet")
+    _write_yaml(
+        systems_root,
+        "data/h100_sxm/gemm/trtllm/1.0.0/collection_meta.yaml",
+        {
+            "schema_version": 1,
+            "runtime": {"framework": "trtllm", "version": "1.0.0"},
+            "tables": {"gemm_perf": {"status": "complete"}},
+        },
+    )
+
+    strict_db = _get_db(systems_root, strict_provenance=True)
+    non_strict_db = _get_db(systems_root, strict_provenance=False)
+
+    assert strict_db is not None
+    assert non_strict_db is not None
+    assert strict_db is not non_strict_db
+    assert strict_db.strict_provenance is True
+    assert non_strict_db.strict_provenance is False
+
+    # Re-requesting each mode returns its own cached instance, not the
+    # other mode's -- no eviction/overwrite across the strict boundary.
+    assert _get_db(systems_root, strict_provenance=True) is strict_db
+    assert _get_db(systems_root, strict_provenance=False) is non_strict_db
+
+
+# ---------------------------------------------------------------------------
 # Real-tree smoke: post-PR3 tree is fully covered, strict ON loads clean
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/sdk/database/test_strict_mode.py
+++ b/tests/unit/sdk/database/test_strict_mode.py
@@ -27,6 +27,7 @@ from Task 1).
 from __future__ import annotations
 
 import logging
+import os
 from pathlib import Path
 
 import pytest
@@ -35,7 +36,10 @@ import yaml
 from aiconfigurator.sdk import common
 from aiconfigurator.sdk.operations.base import resolve_op_data_path
 from aiconfigurator.sdk.perf_database import (
+    _STRICT_VALIDATED_REQUESTS,
     PerfDatabase,
+    _new_database_dict,
+    _store_loaded_database,
     _strict_provenance_enabled,
     databases_cache,
     get_database,
@@ -85,8 +89,10 @@ def systems_root(tmp_path: Path) -> Path:
 @pytest.fixture(autouse=True)
 def _clear_databases_cache():
     databases_cache.clear()
+    _STRICT_VALIDATED_REQUESTS.clear()
     yield
     databases_cache.clear()
+    _STRICT_VALIDATED_REQUESTS.clear()
 
 
 def _get_db(systems_root: Path, *, backend: str = "trtllm", version: str = "1.0.0", **kwargs):
@@ -583,6 +589,66 @@ def test_strict_load_then_non_strict_load_are_distinct_cache_entries(systems_roo
     # other mode's -- no eviction/overwrite across the strict boundary.
     assert _get_db(systems_root, strict_provenance=True) is strict_db
     assert _get_db(systems_root, strict_provenance=False) is non_strict_db
+
+
+# ---------------------------------------------------------------------------
+# Cache-hit path still validates under strict mode (worker-imported entries)
+# ---------------------------------------------------------------------------
+
+
+def test_strict_cache_hit_validates_worker_imported_unvalidated_entry(systems_root: Path) -> None:
+    """``get_all_databases()`` imports worker-created databases via
+    ``_store_loaded_database`` under a strict cache key WITHOUT any request
+    validation (direct construction validates nothing, see
+    ``test_bare_construction_never_validates``). A later strict
+    ``get_database()`` call that hits that cache entry must still run
+    ``_check_strict_provenance_for_request`` and raise on the coverage gap,
+    not hand back the unvalidated instance."""
+    _write(systems_root, "data/h100_sxm/gemm/trtllm/1.0.0/gemm_perf.parquet")  # no sidecar
+
+    db = PerfDatabase("h100_sxm", "trtllm", "1.0.0", str(systems_root), strict_provenance=True)
+    _store_loaded_database(_new_database_dict(), ("h100_sxm", "trtllm", "1.0.0", str(systems_root)), db)
+
+    with pytest.raises(ValueError, match=r"no collection_meta\.yaml"):
+        _get_db(systems_root, strict_provenance=True)
+
+
+# ---------------------------------------------------------------------------
+# Unreadable version dir: strict fails closed instead of silently accepting
+# an empty file list (the pre-fix _version_dir_data_filenames swallowed
+# os.listdir failures entirely)
+# ---------------------------------------------------------------------------
+
+
+def _chmod_000_or_skip(path: Path) -> None:
+    if os.geteuid() == 0:
+        pytest.skip("chmod 000 does not restrict root")
+    path.chmod(0o000)
+
+
+def test_strict_raises_on_unreadable_version_dir(systems_root: Path) -> None:
+    _write(systems_root, "data/h100_sxm/gemm/trtllm/1.0.0/gemm_perf.parquet")
+    version_dir = systems_root / "data/h100_sxm/gemm/trtllm/1.0.0"
+    _chmod_000_or_skip(version_dir)
+    try:
+        with pytest.raises(ValueError, match="cannot inspect perf-data files"):
+            _get_db(systems_root, strict_provenance=True)
+    finally:
+        version_dir.chmod(0o755)
+
+
+def test_non_strict_warns_on_unreadable_version_dir(systems_root: Path, caplog: pytest.LogCaptureFixture) -> None:
+    _write(systems_root, "data/h100_sxm/gemm/trtllm/1.0.0/gemm_perf.parquet")
+    version_dir = systems_root / "data/h100_sxm/gemm/trtllm/1.0.0"
+    _chmod_000_or_skip(version_dir)
+    try:
+        with caplog.at_level(logging.WARNING):
+            db = _get_db(systems_root, strict_provenance=False)
+    finally:
+        version_dir.chmod(0o755)
+
+    assert db is not None
+    assert any("cannot inspect perf-data files" in r.getMessage() for r in caplog.records)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/sdk/database/test_strict_mode.py
+++ b/tests/unit/sdk/database/test_strict_mode.py
@@ -32,6 +32,8 @@ from pathlib import Path
 import pytest
 import yaml
 
+from aiconfigurator.sdk import common
+from aiconfigurator.sdk.operations.base import resolve_op_data_path
 from aiconfigurator.sdk.perf_database import (
     PerfDatabase,
     _strict_provenance_enabled,
@@ -304,6 +306,69 @@ def test_non_strict_warns_on_malformed_reuse_yaml(systems_root: Path, caplog: py
 
     assert db is not None
     assert any("missing required key" in r.getMessage() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Malformed reuse.yaml: load-time warn must not leave a query-time crash
+# behind (AIC-1503 PR4 task 5, FIX 1). Before this fix, ``get_database()``'s
+# own load-time walk (above) warned and returned a usable non-strict
+# database, but ``_build_op_sources`` -> ``_requested_version_reuse_entries``
+# parsed the SAME malformed reuse.yaml with no strict/non-strict distinction
+# and always raised -- so the first real op query against that database
+# crashed anyway.
+# ---------------------------------------------------------------------------
+
+
+def test_non_strict_query_after_load_does_not_crash_on_malformed_reuse_yaml(
+    systems_root: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    requested, earlier = "1.0.0", "0.9.0"
+    _write(systems_root, f"data/h100_sxm/gemm/trtllm/{requested}/gemm_perf.parquet")
+    _write(systems_root, f"data/h100_sxm/gemm/trtllm/{earlier}/gemm_perf.parquet")
+    _write_yaml(
+        systems_root,
+        f"data/h100_sxm/gemm/trtllm/{requested}/reuse.yaml",
+        {"reuse": [{"table": "gemm_perf"}]},  # missing from_version/reason/approved_by
+    )
+
+    system_data_root = str(systems_root / "data" / "h100_sxm")
+    primary_path = resolve_op_data_path(system_data_root, "trtllm", requested, "gemm_perf.parquet")
+
+    with caplog.at_level(logging.WARNING):
+        db = _get_db(systems_root, version=requested, strict_provenance=False)
+        assert db is not None
+        # Simulates the first real op query against the now-loaded database --
+        # must not raise, and the nearest-earlier fallback channel (design
+        # §6.2) must still admit rows despite the declared-reuse channel
+        # being unusable.
+        sources = db._build_op_sources(common.PerfDataFilename.gemm, primary_path, system_data_root)
+
+    assert [entry["channel"] for entry in db.data_provenance["gemm_perf.parquet"]] == ["primary", "fallback"]
+    assert sources[-1][0].endswith(f"gemm/trtllm/{earlier}/gemm_perf.parquet")
+    assert any("missing required key" in r.getMessage() for r in caplog.records)
+
+
+def test_strict_query_raises_on_malformed_reuse_yaml_even_with_bare_construction(systems_root: Path) -> None:
+    """The strict check inside ``_requested_version_reuse_entries`` itself
+    raises too, not just ``get_database()``'s separate load-time walk --
+    proven by constructing ``PerfDatabase`` directly (bare construction never
+    validates, see ``test_bare_construction_never_validates``) so
+    ``get_database()``'s own pre-check is bypassed entirely."""
+    requested, earlier = "1.0.0", "0.9.0"
+    _write(systems_root, f"data/h100_sxm/gemm/trtllm/{requested}/gemm_perf.parquet")
+    _write(systems_root, f"data/h100_sxm/gemm/trtllm/{earlier}/gemm_perf.parquet")
+    _write_yaml(
+        systems_root,
+        f"data/h100_sxm/gemm/trtllm/{requested}/reuse.yaml",
+        {"reuse": [{"table": "gemm_perf"}]},
+    )
+
+    db = PerfDatabase("h100_sxm", "trtllm", requested, str(systems_root), strict_provenance=True)
+    system_data_root = str(systems_root / "data" / "h100_sxm")
+    primary_path = resolve_op_data_path(system_data_root, "trtllm", requested, "gemm_perf.parquet")
+
+    with pytest.raises(ValueError, match="missing required key"):
+        db._build_op_sources(common.PerfDataFilename.gemm, primary_path, system_data_root)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/sdk/test_perf_database_shared_layer.py
+++ b/tests/unit/sdk/test_perf_database_shared_layer.py
@@ -369,16 +369,25 @@ def test_cross_backend_inheritance(env: Path) -> None:
 
 
 def test_fallback_emits_warning(env: Path, caplog: pytest.LogCaptureFixture) -> None:
-    """Loading `tier=shared_fallback` rows in HYBRID mode emits a single WARNING per
-    sibling source so the user knows latency predictions for those shapes are
-    framework-implicit (kernel_source=default).
+    """Loading `tier=shared_fallback` rows via CROSS-BACKEND fill (design §6.4)
+    in HYBRID mode emits a single WARNING per sibling source so the user knows
+    latency predictions for those shapes are framework-implicit
+    (kernel_source=default).
+
+    Post-AIC-1503 the warning is specific to the `cross_backend` channel: a
+    same-backend older version (design §6.2 `fallback` / §6.3 `declared_reuse`)
+    is still the active backend's OWN measurement, not a framework-implicit
+    substitute, so it never emits this warning (see
+    ``test_reuse_ordering.py`` for that channel's coverage). This test's
+    sibling is therefore a *different* backend (vllm), not an older version of
+    the active one.
     """
     active_csv = _backend_csv(env)
     active_csv.parent.mkdir(parents=True, exist_ok=True)
     active_csv.write_text(_GEMM_HEADER)
 
-    _write_gemm_csv(_backend_csv(env, version="0.9"), [("trtllm", "default", 1024, 4096, 4096, 0.7)])
-    _make_manifest(env, [("gemm_perf.txt", "default", "shared_fallback", ["trtllm"])])
+    _write_gemm_csv(_backend_csv(env, backend="vllm", version="0.5"), [("vllm", "default", 1024, 4096, 4096, 0.7)])
+    _make_manifest(env, [("gemm_perf.txt", "default", "shared_fallback", ["trtllm", "vllm"])])
 
     with caplog.at_level(logging.WARNING, logger="aiconfigurator.sdk.perf_database"):
         db = _build_db(env)  # HYBRID mode

--- a/tests/unit/sdk/test_perf_database_shared_layer.py
+++ b/tests/unit/sdk/test_perf_database_shared_layer.py
@@ -391,9 +391,11 @@ def test_fallback_emits_warning(env: Path, caplog: pytest.LogCaptureFixture) -> 
 
     with caplog.at_level(logging.WARNING, logger="aiconfigurator.sdk.perf_database"):
         db = _build_db(env)  # HYBRID mode
-    assert _gemm_lookup(db, 1024, 4096, 4096) == 0.7
-    fallback_warnings = [r for r in caplog.records if "low-fidelity fallback" in r.getMessage()]
-    assert len(fallback_warnings) == 1
+        # The lazy GEMM.load_data (triggered by _gemm_lookup) emits the
+        # warning, so it must run while capture is active.
+        assert _gemm_lookup(db, 1024, 4096, 4096) == 0.7
+        fallback_warnings = [r for r in caplog.records if "low-fidelity fallback" in r.getMessage()]
+        assert len(fallback_warnings) == 1
 
 
 def test_same_framework_outranks_other_framework(env: Path) -> None:

--- a/tests/unit/tools/test_evidence_check.py
+++ b/tests/unit/tools/test_evidence_check.py
@@ -238,6 +238,26 @@ class TestUnmappedSystem:
 
 
 # --------------------------------------------------------------------------
+# fail-closed: a touched generation with no evidence_systems representative.
+# Distinct from TestInvalidGenerationPolicy below: here the policy loads
+# fine (a generation is simply absent from `evidence_systems`, which
+# `load_policy` does not require to be exhaustive) and the error only
+# surfaces at resolve time, when an entry actually touches that generation.
+# --------------------------------------------------------------------------
+
+
+class TestTouchedGenerationMissingRepresentative:
+    def test_resolve_requirements_raises_naming_generation(self, mod, tmp_path):
+        policy_path = tmp_path / "evidence_policy.yaml"
+        policy_path.write_text(POLICY_YAML.replace("  hopper: h200_sxm\n", ""))
+        policy = mod.load_policy(policy_path)
+        entries = [_entry(reasons=("pin_version",), systems=["h200_sxm"])]
+        changed = mod.load_manifest(_write_manifest(tmp_path, entries))
+        with pytest.raises(mod.EvidencePolicyError, match=r"hopper.*no representative"):
+            mod.resolve_requirements(policy, changed)
+
+
+# --------------------------------------------------------------------------
 # empty changed list
 # --------------------------------------------------------------------------
 

--- a/tests/unit/tools/test_evidence_check.py
+++ b/tests/unit/tools/test_evidence_check.py
@@ -23,6 +23,8 @@ required" contract end to end.
 from __future__ import annotations
 
 import importlib.util
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -472,7 +474,24 @@ class TestDeterminism:
 # --------------------------------------------------------------------------
 
 
+def _repo_root_is_git_checkout() -> bool:
+    if shutil.which("git") is None:
+        return False
+    probe = subprocess.run(
+        ["git", "rev-parse", "--is-inside-work-tree"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return probe.returncode == 0 and probe.stdout.strip() == "true"
+
+
 @pytest.mark.unit
+@pytest.mark.skipif(
+    not _repo_root_is_git_checkout(),
+    reason="needs the real repo checkout (the CI test image COPYs sources without .git)",
+)
 def test_real_repo_no_change_means_no_evidence_required(mod, changed_ops_mod, tmp_path, capsys):
     changed, _unchanged = changed_ops_mod.compute_changed_ops(REPO_ROOT, "HEAD", "HEAD")
     assert changed == []

--- a/tests/unit/tools/test_evidence_check.py
+++ b/tests/unit/tools/test_evidence_check.py
@@ -230,8 +230,12 @@ class TestGenerationScoping:
 
 
 class TestUnmappedSystem:
-    def test_resolve_requirements_raises(self, mod, tmp_path, policy_path):
-        entries = [_entry(reasons=("pin_version",), systems=["mystery_gpu"])]
+    # Every reason must fail closed on an unmapped system — including
+    # case_plan, which skips representative selection but must NOT skip the
+    # system-to-generation mapping validation.
+    @pytest.mark.parametrize("reason", ["pin_version", "collector_code", "case_plan"])
+    def test_resolve_requirements_raises(self, mod, tmp_path, policy_path, reason):
+        entries = [_entry(reasons=(reason,), systems=["mystery_gpu"])]
         manifest_path = _write_manifest(tmp_path, entries)
         policy = mod.load_policy(policy_path)
         changed = mod.load_manifest(manifest_path)
@@ -345,6 +349,20 @@ class TestMalformedPolicy:
 
 
 # --------------------------------------------------------------------------
+# fail-closed: negative / non-finite thresholds
+# --------------------------------------------------------------------------
+
+
+class TestInvalidThreshold:
+    @pytest.mark.parametrize("threshold", ["-1", ".nan", ".inf"], ids=["negative", "nan", "inf"])
+    def test_load_policy_raises(self, mod, tmp_path, threshold):
+        path = tmp_path / "evidence_policy.yaml"
+        path.write_text(POLICY_YAML.replace("parquet_diff_median_pct: 5", f"parquet_diff_median_pct: {threshold}"))
+        with pytest.raises(mod.EvidencePolicyError, match="finite non-negative"):
+            mod.load_policy(path)
+
+
+# --------------------------------------------------------------------------
 # fail-closed: unresolved evidence_system
 # --------------------------------------------------------------------------
 
@@ -404,6 +422,21 @@ class TestInvalidGenerationPolicy:
         with pytest.raises(mod.EvidencePolicyError, match="no entry in 'system_generations'"):
             mod.load_policy(path)
 
+    def test_system_listed_under_two_generations_raises(self, mod, tmp_path):
+        # h200_sxm under both hopper and blackwell would silently match BOTH
+        # owning generations in _touched_generations — ambiguous evidence scope.
+        policy_yaml = (
+            "schema_version: 1\nthresholds: {parquet_diff_median_pct: 5}\n"
+            "system_generations: {hopper: [h200_sxm], blackwell: [h200_sxm, b200_sxm]}\n"
+            "evidence_systems: {hopper: h200_sxm, blackwell: b200_sxm}\n"
+            "rules: {pin_version: {requirement: r}, collector_code: {requirement: r}, case_plan: {requirement: r}}\n"
+            "exceptions_file: e.yaml\n"
+        )
+        path = tmp_path / "evidence_policy.yaml"
+        path.write_text(policy_yaml)
+        with pytest.raises(mod.EvidencePolicyError, match=r"'h200_sxm'.*'hopper'.*'blackwell'"):
+            mod.load_policy(path)
+
 
 # --------------------------------------------------------------------------
 # fail-closed: malformed manifest
@@ -413,8 +446,30 @@ class TestInvalidGenerationPolicy:
 class TestMalformedManifest:
     @pytest.mark.parametrize(
         "raw_manifest",
-        ["not: a manifest\n", "changed: not-a-list\n", "changed:\n  - framework: sglang\n"],  # entry missing fields
-        ids=["missing-changed-key", "changed-not-a-list", "entry-missing-fields"],
+        [
+            "not: a manifest\n",
+            "changed: not-a-list\n",
+            "changed:\n  - framework: sglang\n",  # entry missing fields
+            "changed:\n"
+            "  - framework: sglang\n"
+            "    family: attention\n"
+            "    reasons: [pin_version]\n"
+            "    tables: [{}]\n"
+            "    systems: [h200_sxm]\n",  # non-string tables item
+            "changed:\n"
+            "  - framework: sglang\n"
+            "    family: attention\n"
+            "    reasons: [pin_version]\n"
+            "    tables: [context_attention_perf]\n"
+            "    systems: [[]]\n",  # non-string systems item
+        ],
+        ids=[
+            "missing-changed-key",
+            "changed-not-a-list",
+            "entry-missing-fields",
+            "tables-non-string-item",
+            "systems-non-string-item",
+        ],
     )
     def test_load_manifest_raises(self, mod, tmp_path, raw_manifest):
         path = tmp_path / "changed_ops.yaml"

--- a/tests/unit/tools/test_evidence_check.py
+++ b/tests/unit/tools/test_evidence_check.py
@@ -7,8 +7,12 @@ Exercises the pure resolver (`resolve_requirements`) against fixture
 `changed_ops.py`-shaped manifests and a fixture `evidence_policy.yaml`: one
 test per rule in isolation, combined reasons (asserting the UNION of
 requirements, never a single "strictest" pick), the empty-changed shortcut,
-fail-closed behavior (unknown reason, malformed policy, unresolved evidence
-system, malformed manifest), and determinism (byte-identical reruns).
+generation-scoped evidence systems (AIC-1219 review fix: pin_version/
+collector_code only demand evidence from the SM generations a changed
+entry's `systems` actually touch), fail-closed behavior (unknown reason,
+malformed policy, unresolved evidence system, a `systems` entry unmapped to
+any generation, invalid `system_generations`/`evidence_systems` policy
+authoring, malformed manifest), and determinism (byte-identical reruns).
 
 One integration test runs the real `changed_ops.py` against the real repo
 (base=HEAD head=HEAD, which reports nothing changed) and feeds that manifest
@@ -58,7 +62,12 @@ def changed_ops_mod():
 POLICY_YAML = """schema_version: 1
 thresholds:
   parquet_diff_median_pct: 5
+system_generations:
+  ada: [l40s]
+  hopper: [h100_sxm, h200_sxm]
+  blackwell: [b200_sxm, gb200]
 evidence_systems:
+  ada: l40s
   hopper: h200_sxm
   blackwell: b200_sxm
 rules:
@@ -114,6 +123,9 @@ def _resolve(mod, tmp_path, policy_path, entries: list[dict]) -> list[dict]:
 
 class TestRuleAlone:
     def test_pin_version(self, mod, tmp_path, policy_path):
+        # default entry systems (h200_sxm, b200_sxm, gb200) span BOTH the
+        # hopper and blackwell generations, so both representatives are
+        # required — not the full evidence_systems set regardless of scope.
         [item] = _resolve(mod, tmp_path, policy_path, [_entry(reasons=("pin_version",))])
         assert item["framework"] == "sglang"
         assert item["family"] == "attention"
@@ -126,13 +138,17 @@ class TestRuleAlone:
         assert "threshold" not in req
 
     def test_collector_code(self, mod, tmp_path, policy_path):
+        # systems=[h200_sxm] touches ONLY the hopper generation, so only the
+        # hopper representative is required — asserting the AIC-1219 review
+        # fix: the full evidence_systems set is no longer emitted regardless
+        # of which generations the entry's systems actually span.
         entries = [_entry(family="moe", reasons=("collector_code",), tables=["moe_perf"], systems=["h200_sxm"])]
         [item] = _resolve(mod, tmp_path, policy_path, entries)
         [req] = item["requirements"]
         assert req["type"] == "before_after_diff"
         assert req["tables"] == ["moe_perf"]
         assert req["systems"] == ["h200_sxm"]
-        assert req["evidence_systems"] == ["b200_sxm", "h200_sxm"]
+        assert req["evidence_systems"] == ["h200_sxm"]
         assert req["threshold"] == 5
 
     def test_case_plan(self, mod, tmp_path, policy_path):
@@ -169,6 +185,56 @@ class TestCombinedReasons:
         assert types == ["recollect_or_declared_reuse", "before_after_diff", "collect_new_cases_only"]
         # every reason's requirement is fully present — none dropped or merged
         assert len(item["requirements"]) == 3
+
+
+# --------------------------------------------------------------------------
+# generation-scoped evidence systems (AIC-1219 review fix): pin_version and
+# collector_code must demand evidence only from the SM generations the
+# entry's `systems` actually touch, never the full evidence_systems set.
+# --------------------------------------------------------------------------
+
+
+class TestGenerationScoping:
+    def test_hopper_only_entry_uses_only_hopper_representative(self, mod, tmp_path, policy_path):
+        entries = [_entry(reasons=("pin_version",), systems=["h100_sxm", "h200_sxm"])]
+        [item] = _resolve(mod, tmp_path, policy_path, entries)
+        [req] = item["requirements"]
+        assert req["evidence_systems"] == ["h200_sxm"]
+
+    def test_blackwell_only_entry_uses_only_blackwell_representative(self, mod, tmp_path, policy_path):
+        entries = [_entry(reasons=("pin_version",), systems=["b200_sxm", "gb200"])]
+        [item] = _resolve(mod, tmp_path, policy_path, entries)
+        [req] = item["requirements"]
+        assert req["evidence_systems"] == ["b200_sxm"]
+
+    def test_mixed_generation_entry_uses_both_representatives(self, mod, tmp_path, policy_path):
+        entries = [_entry(reasons=("pin_version",), systems=["h200_sxm", "b200_sxm"])]
+        [item] = _resolve(mod, tmp_path, policy_path, entries)
+        [req] = item["requirements"]
+        assert req["evidence_systems"] == ["b200_sxm", "h200_sxm"]
+
+    def test_ada_only_entry_uses_only_ada_representative(self, mod, tmp_path, policy_path):
+        # l40s (ada) has no hopper/blackwell kin in this entry, so the
+        # requirement must not drag in h200_sxm/b200_sxm.
+        entries = [_entry(reasons=("pin_version",), systems=["l40s"])]
+        [item] = _resolve(mod, tmp_path, policy_path, entries)
+        [req] = item["requirements"]
+        assert req["evidence_systems"] == ["l40s"]
+
+
+# --------------------------------------------------------------------------
+# fail-closed: a changed entry's system not mapped to any SM generation
+# --------------------------------------------------------------------------
+
+
+class TestUnmappedSystem:
+    def test_resolve_requirements_raises(self, mod, tmp_path, policy_path):
+        entries = [_entry(reasons=("pin_version",), systems=["mystery_gpu"])]
+        manifest_path = _write_manifest(tmp_path, entries)
+        policy = mod.load_policy(policy_path)
+        changed = mod.load_manifest(manifest_path)
+        with pytest.raises(mod.EvidencePolicyError, match=r"mystery_gpu.*not mapped to any SM generation"):
+            mod.resolve_requirements(policy, changed)
 
 
 # --------------------------------------------------------------------------
@@ -270,6 +336,7 @@ class TestUnresolvedEvidenceSystem:
     def test_load_policy_raises(self, mod, tmp_path, evidence_systems_block):
         policy_yaml = (
             "schema_version: 1\nthresholds: {parquet_diff_median_pct: 5}\n"
+            "system_generations: {hopper: [h200_sxm]}\n"
             + evidence_systems_block
             + "rules: {pin_version: {requirement: r}, collector_code: {requirement: r}, case_plan: {requirement: r}}\n"
             "exceptions_file: e.yaml\n"
@@ -277,6 +344,42 @@ class TestUnresolvedEvidenceSystem:
         path = tmp_path / "evidence_policy.yaml"
         path.write_text(policy_yaml)
         with pytest.raises(mod.EvidencePolicyError, match="unresolved evidence_system"):
+            mod.load_policy(path)
+
+
+# --------------------------------------------------------------------------
+# fail-closed: policy authoring errors between system_generations and
+# evidence_systems (AIC-1219 review fix's validate-at-load invariants)
+# --------------------------------------------------------------------------
+
+
+class TestInvalidGenerationPolicy:
+    def test_representative_not_in_its_own_generation_raises(self, mod, tmp_path):
+        # b200_sxm is a blackwell system, not hopper's — an authoring bug.
+        policy_yaml = (
+            "schema_version: 1\nthresholds: {parquet_diff_median_pct: 5}\n"
+            "system_generations: {hopper: [h200_sxm], blackwell: [b200_sxm]}\n"
+            "evidence_systems: {hopper: b200_sxm, blackwell: b200_sxm}\n"
+            "rules: {pin_version: {requirement: r}, collector_code: {requirement: r}, case_plan: {requirement: r}}\n"
+            "exceptions_file: e.yaml\n"
+        )
+        path = tmp_path / "evidence_policy.yaml"
+        path.write_text(policy_yaml)
+        with pytest.raises(mod.EvidencePolicyError, match="not a member of system_generations"):
+            mod.load_policy(path)
+
+    def test_evidence_systems_key_without_generation_raises(self, mod, tmp_path):
+        # 'ampere' has no entry in system_generations at all.
+        policy_yaml = (
+            "schema_version: 1\nthresholds: {parquet_diff_median_pct: 5}\n"
+            "system_generations: {hopper: [h200_sxm]}\n"
+            "evidence_systems: {hopper: h200_sxm, ampere: a100_sxm}\n"
+            "rules: {pin_version: {requirement: r}, collector_code: {requirement: r}, case_plan: {requirement: r}}\n"
+            "exceptions_file: e.yaml\n"
+        )
+        path = tmp_path / "evidence_policy.yaml"
+        path.write_text(policy_yaml)
+        with pytest.raises(mod.EvidencePolicyError, match="no entry in 'system_generations'"):
             mod.load_policy(path)
 
 

--- a/tests/unit/tools/test_evidence_check.py
+++ b/tests/unit/tools/test_evidence_check.py
@@ -1,0 +1,362 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for tools/perf_database/evidence_check.py.
+
+Exercises the pure resolver (`resolve_requirements`) against fixture
+`changed_ops.py`-shaped manifests and a fixture `evidence_policy.yaml`: one
+test per rule in isolation, combined reasons (asserting the UNION of
+requirements, never a single "strictest" pick), the empty-changed shortcut,
+fail-closed behavior (unknown reason, malformed policy, unresolved evidence
+system, malformed manifest), and determinism (byte-identical reruns).
+
+One integration test runs the real `changed_ops.py` against the real repo
+(base=HEAD head=HEAD, which reports nothing changed) and feeds that manifest
+through the real `collector/evidence_policy.yaml`, asserting the "no evidence
+required" contract end to end.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = REPO_ROOT / "tools" / "perf_database" / "evidence_check.py"
+CHANGED_OPS_MODULE_PATH = REPO_ROOT / "tools" / "perf_database" / "changed_ops.py"
+REAL_POLICY_PATH = REPO_ROOT / "collector" / "evidence_policy.yaml"
+
+
+def _load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def mod():
+    return _load_module(MODULE_PATH, "evidence_check")
+
+
+@pytest.fixture
+def changed_ops_mod():
+    return _load_module(CHANGED_OPS_MODULE_PATH, "changed_ops")
+
+
+# --------------------------------------------------------------------------
+# fixture policy + manifest builders
+# --------------------------------------------------------------------------
+
+POLICY_YAML = """schema_version: 1
+thresholds:
+  parquet_diff_median_pct: 5
+evidence_systems:
+  hopper: h200_sxm
+  blackwell: b200_sxm
+rules:
+  pin_version:
+    requirement: recollect_or_declared_reuse
+  collector_code:
+    requirement: before_after_diff
+  case_plan:
+    requirement: collect_new_cases_only
+exceptions_file: evidence_exceptions.yaml
+"""
+
+
+def _manifest_yaml(entries: list[dict]) -> str:
+    return yaml.safe_dump({"changed": entries, "unchanged": []}, sort_keys=False)
+
+
+def _entry(framework="sglang", family="attention", reasons=("pin_version",), tables=None, systems=None) -> dict:
+    return {
+        "framework": framework,
+        "family": family,
+        "reasons": list(reasons),
+        "tables": tables or ["context_attention_perf", "generation_attention_perf"],
+        "systems": systems or ["h200_sxm", "b200_sxm", "gb200"],
+        "action": "recollect",
+    }
+
+
+@pytest.fixture
+def policy_path(tmp_path):
+    path = tmp_path / "evidence_policy.yaml"
+    path.write_text(POLICY_YAML)
+    return path
+
+
+def _write_manifest(tmp_path, entries: list[dict]) -> Path:
+    path = tmp_path / "changed_ops.yaml"
+    path.write_text(_manifest_yaml(entries))
+    return path
+
+
+def _resolve(mod, tmp_path, policy_path, entries: list[dict]) -> list[dict]:
+    manifest_path = _write_manifest(tmp_path, entries)
+    policy = mod.load_policy(policy_path)
+    changed = mod.load_manifest(manifest_path)
+    return mod.resolve_requirements(policy, changed)
+
+
+# --------------------------------------------------------------------------
+# each rule alone
+# --------------------------------------------------------------------------
+
+
+class TestRuleAlone:
+    def test_pin_version(self, mod, tmp_path, policy_path):
+        [item] = _resolve(mod, tmp_path, policy_path, [_entry(reasons=("pin_version",))])
+        assert item["framework"] == "sglang"
+        assert item["family"] == "attention"
+        assert item["reasons"] == ["pin_version"]
+        [req] = item["requirements"]
+        assert req["type"] == "recollect_or_declared_reuse"
+        assert req["tables"] == ["context_attention_perf", "generation_attention_perf"]
+        assert req["systems"] == ["b200_sxm", "gb200", "h200_sxm"]
+        assert req["evidence_systems"] == ["b200_sxm", "h200_sxm"]
+        assert "threshold" not in req
+
+    def test_collector_code(self, mod, tmp_path, policy_path):
+        entries = [_entry(family="moe", reasons=("collector_code",), tables=["moe_perf"], systems=["h200_sxm"])]
+        [item] = _resolve(mod, tmp_path, policy_path, entries)
+        [req] = item["requirements"]
+        assert req["type"] == "before_after_diff"
+        assert req["tables"] == ["moe_perf"]
+        assert req["systems"] == ["h200_sxm"]
+        assert req["evidence_systems"] == ["b200_sxm", "h200_sxm"]
+        assert req["threshold"] == 5
+
+    def test_case_plan(self, mod, tmp_path, policy_path):
+        entries = [
+            _entry(
+                framework="trtllm",
+                family="gemm",
+                reasons=("case_plan",),
+                tables=["gemm_perf"],
+                systems=["h200_sxm", "b200_sxm"],
+            )
+        ]
+        [item] = _resolve(mod, tmp_path, policy_path, entries)
+        [req] = item["requirements"]
+        assert req["type"] == "collect_new_cases_only"
+        assert req["tables"] == ["gemm_perf"]
+        assert req["systems"] == ["b200_sxm", "h200_sxm"]
+        assert req["evidence_systems"] == []
+        assert "threshold" not in req
+
+
+# --------------------------------------------------------------------------
+# combined reasons: union, not the "strictest" single pick
+# --------------------------------------------------------------------------
+
+
+class TestCombinedReasons:
+    def test_union_of_requirements_is_emitted(self, mod, tmp_path, policy_path):
+        entries = [_entry(reasons=("case_plan", "pin_version", "collector_code"))]  # deliberately out of order
+        [item] = _resolve(mod, tmp_path, policy_path, entries)
+        # canonical order regardless of input order
+        assert item["reasons"] == ["pin_version", "collector_code", "case_plan"]
+        types = [req["type"] for req in item["requirements"]]
+        assert types == ["recollect_or_declared_reuse", "before_after_diff", "collect_new_cases_only"]
+        # every reason's requirement is fully present — none dropped or merged
+        assert len(item["requirements"]) == 3
+
+
+# --------------------------------------------------------------------------
+# empty changed list
+# --------------------------------------------------------------------------
+
+
+class TestEmptyChanged:
+    def test_resolve_returns_empty_list(self, mod, tmp_path, policy_path):
+        assert _resolve(mod, tmp_path, policy_path, []) == []
+
+    def test_main_prints_no_evidence_required_and_exits_zero(self, mod, tmp_path, policy_path, capsys):
+        manifest_path = _write_manifest(tmp_path, [])
+        rc = mod.main(["--manifest", str(manifest_path), "--policy", str(policy_path)])
+        assert rc == mod.EXIT_OK == 0
+        captured = capsys.readouterr()
+        assert "no evidence required" in captured.err
+        doc = yaml.safe_load(captured.out)
+        assert doc == {"requirements": []}
+
+
+# --------------------------------------------------------------------------
+# fail-closed: unknown reason
+# --------------------------------------------------------------------------
+
+
+class TestUnknownReason:
+    def test_load_manifest_raises(self, mod, tmp_path):
+        entries = [_entry(reasons=("not_a_real_reason",))]
+        manifest_path = _write_manifest(tmp_path, entries)
+        with pytest.raises(mod.EvidenceManifestError, match="unknown reason"):
+            mod.load_manifest(manifest_path)
+
+    def test_main_exits_one_with_loud_message(self, mod, tmp_path, policy_path, capsys):
+        entries = [_entry(reasons=("not_a_real_reason",))]
+        manifest_path = _write_manifest(tmp_path, entries)
+        rc = mod.main(["--manifest", str(manifest_path), "--policy", str(policy_path)])
+        assert rc == mod.EXIT_ERROR == 1
+        assert "unknown reason" in capsys.readouterr().err
+
+
+# --------------------------------------------------------------------------
+# fail-closed: malformed policy
+# --------------------------------------------------------------------------
+
+
+class TestMalformedPolicy:
+    @pytest.mark.parametrize(
+        "broken_yaml",
+        [
+            "schema_version: 2\nthresholds: {parquet_diff_median_pct: 5}\nevidence_systems: {hopper: h200_sxm}\n"
+            "rules: {pin_version: {requirement: r}, collector_code: {requirement: r}, case_plan: {requirement: r}}\n"
+            "exceptions_file: e.yaml\n",  # wrong schema_version
+            "schema_version: 1\nevidence_systems: {hopper: h200_sxm}\n"
+            "rules: {pin_version: {requirement: r}, collector_code: {requirement: r}, case_plan: {requirement: r}}\n"
+            "exceptions_file: e.yaml\n",  # missing thresholds
+            "schema_version: 1\nthresholds: {parquet_diff_median_pct: 5}\nevidence_systems: {hopper: h200_sxm}\n"
+            "rules: {pin_version: {requirement: r}, collector_code: {requirement: r}}\n"  # missing case_plan rule
+            "exceptions_file: e.yaml\n",
+            "schema_version: 1\nthresholds: {parquet_diff_median_pct: 5}\nevidence_systems: {hopper: h200_sxm}\n"
+            "rules: {pin_version: {requirement: r}, collector_code: {requirement: r}, case_plan: {requirement: r}}\n",
+            # missing exceptions_file
+            "not: a policy at all\n",
+        ],
+        ids=[
+            "wrong-schema-version",
+            "missing-thresholds",
+            "missing-case-plan-rule",
+            "missing-exceptions-file",
+            "not-a-policy",
+        ],
+    )
+    def test_load_policy_raises(self, mod, tmp_path, broken_yaml):
+        path = tmp_path / "evidence_policy.yaml"
+        path.write_text(broken_yaml)
+        with pytest.raises(mod.EvidencePolicyError):
+            mod.load_policy(path)
+
+    def test_main_exits_one_with_loud_message(self, mod, tmp_path, capsys):
+        policy_path = tmp_path / "evidence_policy.yaml"
+        policy_path.write_text("not: a policy at all\n")
+        manifest_path = _write_manifest(tmp_path, [])
+        rc = mod.main(["--manifest", str(manifest_path), "--policy", str(policy_path)])
+        assert rc == mod.EXIT_ERROR == 1
+        assert "evidence policy" in capsys.readouterr().err
+
+
+# --------------------------------------------------------------------------
+# fail-closed: unresolved evidence_system
+# --------------------------------------------------------------------------
+
+
+class TestUnresolvedEvidenceSystem:
+    @pytest.mark.parametrize(
+        "evidence_systems_block",
+        ["evidence_systems: {}\n", "evidence_systems: {hopper: ''}\n", "evidence_systems: {hopper: null}\n"],
+        ids=["empty-mapping", "blank-value", "null-value"],
+    )
+    def test_load_policy_raises(self, mod, tmp_path, evidence_systems_block):
+        policy_yaml = (
+            "schema_version: 1\nthresholds: {parquet_diff_median_pct: 5}\n"
+            + evidence_systems_block
+            + "rules: {pin_version: {requirement: r}, collector_code: {requirement: r}, case_plan: {requirement: r}}\n"
+            "exceptions_file: e.yaml\n"
+        )
+        path = tmp_path / "evidence_policy.yaml"
+        path.write_text(policy_yaml)
+        with pytest.raises(mod.EvidencePolicyError, match="unresolved evidence_system"):
+            mod.load_policy(path)
+
+
+# --------------------------------------------------------------------------
+# fail-closed: malformed manifest
+# --------------------------------------------------------------------------
+
+
+class TestMalformedManifest:
+    @pytest.mark.parametrize(
+        "raw_manifest",
+        ["not: a manifest\n", "changed: not-a-list\n", "changed:\n  - framework: sglang\n"],  # entry missing fields
+        ids=["missing-changed-key", "changed-not-a-list", "entry-missing-fields"],
+    )
+    def test_load_manifest_raises(self, mod, tmp_path, raw_manifest):
+        path = tmp_path / "changed_ops.yaml"
+        path.write_text(raw_manifest)
+        with pytest.raises(mod.EvidenceManifestError):
+            mod.load_manifest(path)
+
+    def test_missing_manifest_file_raises(self, mod, tmp_path):
+        with pytest.raises(mod.EvidenceManifestError, match="not found"):
+            mod.load_manifest(tmp_path / "does-not-exist.yaml")
+
+
+# --------------------------------------------------------------------------
+# determinism
+# --------------------------------------------------------------------------
+
+
+class TestDeterminism:
+    def test_resolve_and_render_are_byte_identical_across_runs(self, mod, tmp_path, policy_path):
+        entries = [
+            _entry(framework="vllm", family="gemm", reasons=("case_plan",), tables=["gemm_perf"], systems=["h200_sxm"]),
+            _entry(framework="sglang", family="attention", reasons=("pin_version", "collector_code")),
+            _entry(
+                framework="sglang", family="moe", reasons=("collector_code",), tables=["moe_perf"], systems=["b200_sxm"]
+            ),
+        ]
+        manifest_path = _write_manifest(tmp_path, entries)
+        policy = mod.load_policy(policy_path)
+
+        first_items = mod.resolve_requirements(policy, mod.load_manifest(manifest_path))
+        second_items = mod.resolve_requirements(policy, mod.load_manifest(manifest_path))
+        assert first_items == second_items
+
+        first_report = mod.render_report(first_items)
+        second_report = mod.render_report(second_items)
+        assert first_report == second_report
+
+        # sorted by (framework, family) regardless of input order
+        assert [(item["framework"], item["family"]) for item in first_items] == [
+            ("sglang", "attention"),
+            ("sglang", "moe"),
+            ("vllm", "gemm"),
+        ]
+
+    def test_main_out_file_is_byte_identical_across_runs(self, mod, tmp_path, policy_path):
+        manifest_path = _write_manifest(tmp_path, [_entry()])
+        out1 = tmp_path / "out1.yaml"
+        out2 = tmp_path / "out2.yaml"
+        rc1 = mod.main(["--manifest", str(manifest_path), "--policy", str(policy_path), "--out", str(out1)])
+        rc2 = mod.main(["--manifest", str(manifest_path), "--policy", str(policy_path), "--out", str(out2)])
+        assert rc1 == rc2 == 0
+        assert out1.read_bytes() == out2.read_bytes()
+
+
+# --------------------------------------------------------------------------
+# integration: real changed_ops against the real repo (base=HEAD head=HEAD)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_real_repo_no_change_means_no_evidence_required(mod, changed_ops_mod, tmp_path, capsys):
+    changed, _unchanged = changed_ops_mod.compute_changed_ops(REPO_ROOT, "HEAD", "HEAD")
+    assert changed == []
+
+    manifest_path = tmp_path / "changed_ops.yaml"
+    manifest_path.write_text(changed_ops_mod.render_report(changed, _unchanged))
+
+    rc = mod.main(["--manifest", str(manifest_path), "--policy", str(REAL_POLICY_PATH)])
+    assert rc == 0
+    assert "no evidence required" in capsys.readouterr().err

--- a/tools/perf_database/evidence_check.py
+++ b/tools/perf_database/evidence_check.py
@@ -20,9 +20,10 @@ it dodge any single reason's evidence (design §9: "combined reasons emit the
 union of requirements").
 
 Fail-closed: an unknown `reasons` value in the manifest, a malformed manifest
-or policy file, or a policy that cannot resolve an evidence system for a rule
-that needs one, all abort with a loud error and exit 1 — never a silent
-partial answer.
+or policy file, a changed entry's `systems` naming a system the policy's
+`system_generations` doesn't map to any SM generation, or a policy that
+cannot resolve an evidence system for a rule that needs one, all abort with a
+loud error and exit 1 — never a silent partial answer.
 
 Usage:
     evidence_check.py --manifest changed_ops.yaml [--policy PATH] [--out FILE]
@@ -70,7 +71,8 @@ class EvidenceManifestError(ValueError):
 @dataclass(frozen=True)
 class Policy:
     threshold_pct: float
-    evidence_systems: tuple[str, ...]  # resolved from evidence_systems{generation: system}, sorted+deduped
+    system_generations: dict[str, frozenset[str]]  # SM generation -> member systems (authored fleet map)
+    evidence_systems: dict[str, str]  # SM generation -> representative system, validated against system_generations
     rule_types: dict[str, str]  # reason -> requirement type name (authored in the policy file)
     exceptions_file: str
 
@@ -97,7 +99,8 @@ def load_policy(path: Path) -> Policy:
     if not isinstance(threshold_value, (int, float)) or isinstance(threshold_value, bool):
         raise EvidencePolicyError(f"evidence policy 'thresholds.parquet_diff_median_pct' must be a number: {path}")
 
-    evidence_systems = _resolve_evidence_systems(raw.get("evidence_systems"), path)
+    system_generations = _resolve_system_generations(raw.get("system_generations"), path)
+    evidence_systems = _resolve_evidence_systems(raw.get("evidence_systems"), system_generations, path)
 
     rules = raw.get("rules")
     if not isinstance(rules, dict):
@@ -116,32 +119,71 @@ def load_policy(path: Path) -> Policy:
 
     return Policy(
         threshold_pct=float(threshold_value),
+        system_generations=system_generations,
         evidence_systems=evidence_systems,
         rule_types=rule_types,
         exceptions_file=exceptions_file,
     )
 
 
-def _resolve_evidence_systems(raw_evidence_systems: Any, path: Path) -> tuple[str, ...]:
-    """{SM generation: system name} -> sorted, deduped system names.
+def _resolve_system_generations(raw_system_generations: Any, path: Path) -> dict[str, frozenset[str]]:
+    """{SM generation: [system, ...]} -> {SM generation: frozenset(system, ...)}.
 
-    Fails closed (distinctly from generic malformed-policy errors) when a
-    generation cannot be resolved to a concrete system: an empty mapping, or
-    a blank/non-string value for some generation.
+    Fails closed when the mapping is empty/malformed, or a generation's
+    system list is missing, empty, or contains a non-string/blank entry.
+    """
+    if not isinstance(raw_system_generations, dict) or not raw_system_generations:
+        raise EvidencePolicyError(
+            f"evidence policy 'system_generations' must be a non-empty mapping of "
+            f"SM generation -> [system, ...]: {path}"
+        )
+    resolved: dict[str, frozenset[str]] = {}
+    for generation, systems in raw_system_generations.items():
+        if (
+            not isinstance(systems, list)
+            or not systems
+            or not all(isinstance(system, str) and system.strip() for system in systems)
+        ):
+            raise EvidencePolicyError(
+                f"evidence policy 'system_generations.{generation}' must be a non-empty list of system names: {path}"
+            )
+        resolved[generation] = frozenset(systems)
+    return resolved
+
+
+def _resolve_evidence_systems(
+    raw_evidence_systems: Any, system_generations: dict[str, frozenset[str]], path: Path
+) -> dict[str, str]:
+    """{SM generation: representative system} -> validated mapping.
+
+    Fails closed (distinctly from generic malformed-policy errors) when: the
+    mapping is empty/malformed; a value is blank/non-string; a generation key
+    has no entry in `system_generations` (unresolved evidence_system); or the
+    representative is not itself a member of its own generation.
     """
     if not isinstance(raw_evidence_systems, dict) or not raw_evidence_systems:
         raise EvidencePolicyError(
             f"unresolved evidence_system: evidence policy 'evidence_systems' must be a non-empty "
             f"mapping of SM generation -> system: {path}"
         )
-    resolved: set[str] = set()
+    resolved: dict[str, str] = {}
     for generation, system in raw_evidence_systems.items():
         if not isinstance(system, str) or not system.strip():
             raise EvidencePolicyError(
                 f"unresolved evidence_system for generation {generation!r}: value must be a non-empty string: {path}"
             )
-        resolved.add(system)
-    return tuple(sorted(resolved))
+        if generation not in system_generations:
+            raise EvidencePolicyError(
+                f"unresolved evidence_system: evidence policy 'evidence_systems' generation {generation!r} "
+                f"has no entry in 'system_generations': {path}"
+            )
+        if system not in system_generations[generation]:
+            raise EvidencePolicyError(
+                f"unresolved evidence_system: evidence policy 'evidence_systems.{generation}' representative "
+                f"{system!r} is not a member of system_generations.{generation!r}: {path}"
+            )
+        resolved[generation] = system
+    return resolved
 
 
 # --------------------------------------------------------------------------
@@ -224,11 +266,43 @@ def _parse_changed_entry(item: Any, index: int, path: Path) -> ChangedEntry:
 # --------------------------------------------------------------------------
 
 
+def _touched_generations(entry: ChangedEntry, policy: Policy) -> set[str]:
+    """The SM generations `entry.systems` belong to, per policy `system_generations`.
+
+    Fail-closed: a system not mapped to any generation aborts loudly (design
+    review AIC-1219) instead of silently omitting it from the evidence scope.
+    """
+    generations: set[str] = set()
+    for system in entry.systems:
+        matches = [generation for generation, members in policy.system_generations.items() if system in members]
+        if not matches:
+            raise EvidencePolicyError(
+                f"changed_ops entry ({entry.framework}/{entry.family}): system {system!r} is not mapped to "
+                f"any SM generation in evidence policy 'system_generations'"
+            )
+        generations.update(matches)
+    return generations
+
+
 def _requirement_for(reason: str, entry: ChangedEntry, policy: Policy) -> dict[str, Any]:
     # case_plan is additive/GPU-cheap by design (§9 row 3): it never needs a
     # designated evidence system, unlike pin_version's declared-reuse spot
-    # bench or collector_code's before/after diff.
-    evidence_systems = () if reason == "case_plan" else policy.evidence_systems
+    # bench or collector_code's before/after diff. For those two, scope the
+    # evidence systems to the SM generations the entry's `systems` actually
+    # touch — demanding e.g. Hopper evidence for a Blackwell-only (nvfp4)
+    # family is both wasted and, per capabilities.yaml, sometimes impossible
+    # to satisfy.
+    if reason == "case_plan":
+        evidence_systems: tuple[str, ...] = ()
+    else:
+        touched = _touched_generations(entry, policy)
+        missing = touched - policy.evidence_systems.keys()
+        if missing:
+            raise EvidencePolicyError(
+                f"changed_ops entry ({entry.framework}/{entry.family}) touches SM generation(s) "
+                f"{sorted(missing)} with no representative in evidence policy 'evidence_systems'"
+            )
+        evidence_systems = tuple(sorted(policy.evidence_systems[generation] for generation in touched))
 
     requirement: dict[str, Any] = {
         "type": policy.rule_types[reason],

--- a/tools/perf_database/evidence_check.py
+++ b/tools/perf_database/evidence_check.py
@@ -1,0 +1,319 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Evidence resolver (AIC-1219): changed-operation manifest -> required evidence.
+
+Collector V3 design §9 (docs/perf_database/collector-v3-op-centric-design.md):
+a pure-function resolver over `collector/evidence_policy.yaml` and the
+`tools/perf_database/changed_ops.py` manifest (design §8, a LOCKED schema).
+Consumed by the AIC-1214 CI gate and the support-matrix healer — both must
+get identical requirements from identical (manifest, policy) inputs, which is
+why the core function (`resolve_requirements`) does no I/O and is
+deterministic: sorted entries, sorted tables/systems/evidence_systems, and a
+canonical reason order (`pin_version`, `collector_code`, `case_plan`) so byte-
+identical inputs always produce byte-identical output.
+
+Per changed (framework, family) entry, every reason present emits its own
+requirement item — reasons are never merged or deduplicated into "the
+strictest one", because bundling a change under multiple reasons must not let
+it dodge any single reason's evidence (design §9: "combined reasons emit the
+union of requirements").
+
+Fail-closed: an unknown `reasons` value in the manifest, a malformed manifest
+or policy file, or a policy that cannot resolve an evidence system for a rule
+that needs one, all abort with a loud error and exit 1 — never a silent
+partial answer.
+
+Usage:
+    evidence_check.py --manifest changed_ops.yaml [--policy PATH] [--out FILE]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_POLICY_PATH = REPO_ROOT / "collector" / "evidence_policy.yaml"
+
+# The changed_ops.py manifest schema (design §8) admits exactly these three
+# reasons. Also the canonical, deterministic emission order for a combined
+# entry's requirements.
+KNOWN_REASONS = ("pin_version", "collector_code", "case_plan")
+
+EXIT_OK = 0
+EXIT_ERROR = 1
+
+
+class EvidencePolicyError(ValueError):
+    """`collector/evidence_policy.yaml` is missing, malformed, or cannot
+    resolve an evidence system a rule needs (fail-closed).
+    """
+
+
+class EvidenceManifestError(ValueError):
+    """The changed_ops manifest is missing, malformed, or names a reason the
+    policy does not recognize (fail-closed).
+    """
+
+
+# --------------------------------------------------------------------------
+# policy loading
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Policy:
+    threshold_pct: float
+    evidence_systems: tuple[str, ...]  # resolved from evidence_systems{generation: system}, sorted+deduped
+    rule_types: dict[str, str]  # reason -> requirement type name (authored in the policy file)
+    exceptions_file: str
+
+
+def load_policy(path: Path) -> Policy:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise EvidencePolicyError(f"evidence policy not found: {path}") from exc
+    try:
+        raw = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise EvidencePolicyError(f"evidence policy is not valid YAML: {path}: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise EvidencePolicyError(f"evidence policy must be a YAML mapping: {path}")
+
+    if raw.get("schema_version") != 1:
+        raise EvidencePolicyError(
+            f"evidence policy schema_version must be 1, got {raw.get('schema_version')!r}: {path}"
+        )
+
+    thresholds = raw.get("thresholds")
+    threshold_value = thresholds.get("parquet_diff_median_pct") if isinstance(thresholds, dict) else None
+    if not isinstance(threshold_value, (int, float)) or isinstance(threshold_value, bool):
+        raise EvidencePolicyError(f"evidence policy 'thresholds.parquet_diff_median_pct' must be a number: {path}")
+
+    evidence_systems = _resolve_evidence_systems(raw.get("evidence_systems"), path)
+
+    rules = raw.get("rules")
+    if not isinstance(rules, dict):
+        raise EvidencePolicyError(f"evidence policy 'rules' must be a mapping: {path}")
+    rule_types: dict[str, str] = {}
+    for reason in KNOWN_REASONS:
+        rule = rules.get(reason)
+        requirement = rule.get("requirement") if isinstance(rule, dict) else None
+        if not isinstance(requirement, str) or not requirement.strip():
+            raise EvidencePolicyError(f"evidence policy missing/invalid 'rules.{reason}.requirement': {path}")
+        rule_types[reason] = requirement
+
+    exceptions_file = raw.get("exceptions_file")
+    if not isinstance(exceptions_file, str) or not exceptions_file.strip():
+        raise EvidencePolicyError(f"evidence policy 'exceptions_file' must be a non-empty string: {path}")
+
+    return Policy(
+        threshold_pct=float(threshold_value),
+        evidence_systems=evidence_systems,
+        rule_types=rule_types,
+        exceptions_file=exceptions_file,
+    )
+
+
+def _resolve_evidence_systems(raw_evidence_systems: Any, path: Path) -> tuple[str, ...]:
+    """{SM generation: system name} -> sorted, deduped system names.
+
+    Fails closed (distinctly from generic malformed-policy errors) when a
+    generation cannot be resolved to a concrete system: an empty mapping, or
+    a blank/non-string value for some generation.
+    """
+    if not isinstance(raw_evidence_systems, dict) or not raw_evidence_systems:
+        raise EvidencePolicyError(
+            f"unresolved evidence_system: evidence policy 'evidence_systems' must be a non-empty "
+            f"mapping of SM generation -> system: {path}"
+        )
+    resolved: set[str] = set()
+    for generation, system in raw_evidence_systems.items():
+        if not isinstance(system, str) or not system.strip():
+            raise EvidencePolicyError(
+                f"unresolved evidence_system for generation {generation!r}: value must be a non-empty string: {path}"
+            )
+        resolved.add(system)
+    return tuple(sorted(resolved))
+
+
+# --------------------------------------------------------------------------
+# manifest loading (design §8's locked `changed_ops.py` schema)
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ChangedEntry:
+    framework: str
+    family: str
+    reasons: tuple[str, ...]
+    tables: tuple[str, ...]
+    systems: tuple[str, ...]
+
+
+def load_manifest(path: Path) -> list[ChangedEntry]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise EvidenceManifestError(f"changed_ops manifest not found: {path}") from exc
+    try:
+        raw = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise EvidenceManifestError(f"changed_ops manifest is not valid YAML: {path}: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise EvidenceManifestError(f"changed_ops manifest must be a YAML mapping: {path}")
+
+    changed_raw = raw.get("changed")
+    if not isinstance(changed_raw, list):
+        raise EvidenceManifestError(f"changed_ops manifest 'changed' must be a list: {path}")
+
+    entries: list[ChangedEntry] = []
+    for index, item in enumerate(changed_raw):
+        entries.append(_parse_changed_entry(item, index, path))
+    return entries
+
+
+def _parse_changed_entry(item: Any, index: int, path: Path) -> ChangedEntry:
+    if not isinstance(item, dict):
+        raise EvidenceManifestError(f"changed_ops manifest 'changed[{index}]' must be a mapping: {path}")
+
+    framework = item.get("framework")
+    family = item.get("family")
+    reasons = item.get("reasons")
+    tables = item.get("tables")
+    systems = item.get("systems")
+
+    if not isinstance(framework, str) or not isinstance(family, str):
+        raise EvidenceManifestError(
+            f"changed_ops manifest 'changed[{index}]': 'framework'/'family' must be strings: {path}"
+        )
+    if not isinstance(reasons, list) or not reasons:
+        raise EvidenceManifestError(
+            f"changed_ops manifest 'changed[{index}]': 'reasons' must be a non-empty list: {path}"
+        )
+    if not isinstance(tables, list) or not isinstance(systems, list):
+        raise EvidenceManifestError(
+            f"changed_ops manifest 'changed[{index}]': 'tables'/'systems' must be lists: {path}"
+        )
+
+    for reason in reasons:
+        if reason not in KNOWN_REASONS:
+            raise EvidenceManifestError(
+                f"changed_ops manifest 'changed[{index}]' ({framework}/{family}): unknown reason {reason!r}; "
+                f"known reasons: {KNOWN_REASONS}: {path}"
+            )
+
+    return ChangedEntry(
+        framework=framework,
+        family=family,
+        reasons=tuple(reasons),
+        tables=tuple(tables),
+        systems=tuple(systems),
+    )
+
+
+# --------------------------------------------------------------------------
+# resolution: pure function, no I/O
+# --------------------------------------------------------------------------
+
+
+def _requirement_for(reason: str, entry: ChangedEntry, policy: Policy) -> dict[str, Any]:
+    # case_plan is additive/GPU-cheap by design (§9 row 3): it never needs a
+    # designated evidence system, unlike pin_version's declared-reuse spot
+    # bench or collector_code's before/after diff.
+    evidence_systems = () if reason == "case_plan" else policy.evidence_systems
+
+    requirement: dict[str, Any] = {
+        "type": policy.rule_types[reason],
+        "tables": sorted(set(entry.tables)),
+        "systems": sorted(set(entry.systems)),
+        "evidence_systems": list(evidence_systems),
+    }
+    if reason == "collector_code":
+        requirement["threshold"] = policy.threshold_pct
+    return requirement
+
+
+def resolve_requirements(policy: Policy, entries: list[ChangedEntry]) -> list[dict[str, Any]]:
+    """Pure function: (policy, changed entries) -> deterministic requirements.
+
+    Every reason on an entry contributes its own requirement item — the
+    union, never a single "strictest" pick — so a change cannot dodge one
+    reason's evidence by being bundled with another (design §9).
+    """
+    items: list[dict[str, Any]] = []
+    for entry in entries:
+        ordered_reasons = [reason for reason in KNOWN_REASONS if reason in entry.reasons]
+        items.append(
+            {
+                "framework": entry.framework,
+                "family": entry.family,
+                "reasons": ordered_reasons,
+                "requirements": [_requirement_for(reason, entry, policy) for reason in ordered_reasons],
+            }
+        )
+    items.sort(key=lambda item: (item["framework"], item["family"]))
+    return items
+
+
+# --------------------------------------------------------------------------
+# rendering
+# --------------------------------------------------------------------------
+
+
+def render_report(items: list[dict[str, Any]]) -> str:
+    return yaml.safe_dump({"requirements": items}, sort_keys=False, default_flow_style=False)
+
+
+def render_summary(items: list[dict[str, Any]]) -> str:
+    if not items:
+        return "no evidence required\n"
+    lines = [f"evidence required for {len(items)} changed (framework, family) pair(s):"]
+    for item in items:
+        reasons = ", ".join(item["reasons"])
+        types = ", ".join(requirement["type"] for requirement in item["requirements"])
+        lines.append(f"  - {item['framework']}/{item['family']}: reasons=[{reasons}] requirements=[{types}]")
+    return "\n".join(lines) + "\n"
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--manifest", required=True, type=Path, help="changed_ops.py output (design §8 schema)")
+    parser.add_argument("--policy", type=Path, default=DEFAULT_POLICY_PATH, help="evidence_policy.yaml path")
+    parser.add_argument("--out", type=Path, default=None, help="write machine-readable yaml here instead of stdout")
+    args = parser.parse_args(argv)
+
+    try:
+        policy = load_policy(args.policy)
+        entries = load_manifest(args.manifest)
+        items = resolve_requirements(policy, entries)
+    except (EvidencePolicyError, EvidenceManifestError) as exc:
+        print(f"evidence_check: {exc}", file=sys.stderr)
+        return EXIT_ERROR
+
+    sys.stderr.write(render_summary(items))
+
+    report = render_report(items)
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(report)
+    else:
+        sys.stdout.write(report)
+
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/perf_database/evidence_check.py
+++ b/tools/perf_database/evidence_check.py
@@ -32,6 +32,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import math
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -96,8 +97,15 @@ def load_policy(path: Path) -> Policy:
 
     thresholds = raw.get("thresholds")
     threshold_value = thresholds.get("parquet_diff_median_pct") if isinstance(thresholds, dict) else None
-    if not isinstance(threshold_value, (int, float)) or isinstance(threshold_value, bool):
-        raise EvidencePolicyError(f"evidence policy 'thresholds.parquet_diff_median_pct' must be a number: {path}")
+    if (
+        not isinstance(threshold_value, (int, float))
+        or isinstance(threshold_value, bool)
+        or not math.isfinite(threshold_value)
+        or threshold_value < 0
+    ):
+        raise EvidencePolicyError(
+            f"evidence policy 'thresholds.parquet_diff_median_pct' must be a finite non-negative number: {path}"
+        )
 
     system_generations = _resolve_system_generations(raw.get("system_generations"), path)
     evidence_systems = _resolve_evidence_systems(raw.get("evidence_systems"), system_generations, path)
@@ -129,8 +137,10 @@ def load_policy(path: Path) -> Policy:
 def _resolve_system_generations(raw_system_generations: Any, path: Path) -> dict[str, frozenset[str]]:
     """{SM generation: [system, ...]} -> {SM generation: frozenset(system, ...)}.
 
-    Fails closed when the mapping is empty/malformed, or a generation's
-    system list is missing, empty, or contains a non-string/blank entry.
+    Fails closed when the mapping is empty/malformed, a generation's
+    system list is missing, empty, or contains a non-string/blank entry, or
+    a system is listed under more than one generation (ambiguous ownership
+    would silently match every owning generation in ``_touched_generations``).
     """
     if not isinstance(raw_system_generations, dict) or not raw_system_generations:
         raise EvidencePolicyError(
@@ -138,6 +148,7 @@ def _resolve_system_generations(raw_system_generations: Any, path: Path) -> dict
             f"SM generation -> [system, ...]: {path}"
         )
     resolved: dict[str, frozenset[str]] = {}
+    owners: dict[str, str] = {}
     for generation, systems in raw_system_generations.items():
         if (
             not isinstance(systems, list)
@@ -147,6 +158,14 @@ def _resolve_system_generations(raw_system_generations: Any, path: Path) -> dict
             raise EvidencePolicyError(
                 f"evidence policy 'system_generations.{generation}' must be a non-empty list of system names: {path}"
             )
+        for system in systems:
+            if system in owners:
+                raise EvidencePolicyError(
+                    f"evidence policy 'system_generations' lists system {system!r} under both "
+                    f"{owners[system]!r} and {generation!r}; each system must belong to exactly "
+                    f"one SM generation: {path}"
+                )
+            owners[system] = generation
         resolved[generation] = frozenset(systems)
     return resolved
 
@@ -244,6 +263,10 @@ def _parse_changed_entry(item: Any, index: int, path: Path) -> ChangedEntry:
         raise EvidenceManifestError(
             f"changed_ops manifest 'changed[{index}]': 'tables'/'systems' must be lists: {path}"
         )
+    if not all(isinstance(table, str) for table in tables) or not all(isinstance(system, str) for system in systems):
+        raise EvidenceManifestError(
+            f"changed_ops manifest 'changed[{index}]': 'tables'/'systems' items must be strings: {path}"
+        )
 
     for reason in reasons:
         if reason not in KNOWN_REASONS:
@@ -291,11 +314,12 @@ def _requirement_for(reason: str, entry: ChangedEntry, policy: Policy) -> dict[s
     # evidence systems to the SM generations the entry's `systems` actually
     # touch — demanding e.g. Hopper evidence for a Blackwell-only (nvfp4)
     # family is both wasted and, per capabilities.yaml, sometimes impossible
-    # to satisfy.
+    # to satisfy. The unmapped-system fail-closed check runs for EVERY
+    # reason, case_plan included — only representative selection is skipped.
+    touched = _touched_generations(entry, policy)
     if reason == "case_plan":
         evidence_systems: tuple[str, ...] = ()
     else:
-        touched = _touched_generations(entry, policy)
         missing = touched - policy.evidence_systems.keys()
         if missing:
             raise EvidencePolicyError(


### PR DESCRIPTION
PR 4 of 4 — the final PR of the **Collector V3: op-centric collector management** project (Linear: [AIC-1503](https://linear.app/nvidia/issue/AIC-1503/collector-v3-d-loader-reuse-rules-backward-only-default-strict-mode) + [AIC-1219](https://linear.app/nvidia/issue/AIC-1219/define-and-enforce-silicon-evidence-requirements-for-collector-v3)), implementing design §6 ordering, §7 strict mode + diagnostics, and §9 evidence policy. **Stacked on #1372**; merge order #1370 → #1371 → #1372 → this.

## What this does

- **The §6 reuse-ordering flip** (`_build_op_sources`): sources per op are now primary → `reuse.yaml`-declared donors (any direction, file order, deduped) → same-backend **nearest-earlier** siblings (newer-than-requested is never admitted implicitly) → cross-backend kernel-gated fill (unchanged mechanism). The `comm` family is hard-excluded from all reuse regardless of declarations (rule 5 — a deliberate tightening for `custom_allreduce`/`trtllm_alltoall`/`wideep_deepep_*`). Each admitted source is channel-tagged and exposed as **`PerfDatabase.data_provenance`**.
- **Strict provenance mode**: `strict_provenance` param / `AIC_STRICT_PROVENANCE` env (ON in CI, off for users this release). At load time, fail-closed on missing/uncovered/malformed sidecars for the requested version's dirs and declared donors; `provenance: legacy` warns (one-release grace); non-strict warns and degrades gracefully (including query-time resilience to malformed declarations). The database cache is keyed by the strict bool, so strict calls are deterministic.
- **Evidence policy (AIC-1219)**: `collector/evidence_policy.yaml` (thresholds; a full-fleet authored `system_generations` map — SM103 Ultra folded into blackwell as a policy decision — with one evidence representative per generation) + `tools/perf_database/evidence_check.py`, the pure deterministic resolver from the changed-ops manifest to required evidence, **filtered to the SM generations the change actually touches** (unmapped systems fail closed; combined reasons emit the union — evidence can't be dodged by bundling). Exception *waivers* (`evidence_exceptions.yaml`, approver + expiry) are applied by the enforcement gate, not the resolver — expiry needs a clock, which would break resolver purity. **Scope note (per review):** this PR ships the deterministic *policy + resolver foundation* — computation of requirements, not merge enforcement. `collector-audit.yml` uploads the changed-ops manifest as an informational artifact; the **required CI gate** that consumes it, validates submitted evidence/waivers, and blocks under-evidenced data PRs is the separately tracked deliverable [AIC-1214](https://linear.app/nvidia/issue/AIC-1214/require-performance-evidence-for-op-collector-changes) (In Progress). Until it lands, the §8 evidence requirement is enforced by human review against `evidence_check.py`'s output.

## Disclosures for reviewers

1. **Strict-mode scope, two deliberate narrowings vs a literal §7.4 reading**: (a) validation covers the requested version's primary dirs + declared donors — not fallback/cross-backend sibling dirs; (b) legacy-*layout* dirs (transition-window only; none exist in-tree) are exempt rather than raising as "table without family". Rationale for both: design §8 names the **CI audit as the primary gate** (it sweeps the whole tree on every data PR — all six rules green on this branch); strict mode is the per-request backstop for exactly the sources a load admits.
2. **Prediction-gate evidence, stated precisely**: the ordering flip was adjudicated on tier-2 (16 curated configs) + silicon anchors (35 points): **2 divergences, both intended §6.2 behavior** (undeclared forward-fill removed for historical versions), zero comm or kernel-filter surprises. Full-grid tier-1 enumeration did not run locally — tier-1 was broken by a pre-existing family-layout gap (fixed on this stack, see #1371/#1372 comments) — so **this PR's own required "AIC Prediction Regression Gate" CI run is the authoritative full-grid old-vs-new comparison; merge is contingent on it passing.**
3. **For AIC-1087 consumers of `data_provenance`**: entries mean *admitted sources*, not *rows actually used* (first-wins merge decides usage); keys are op-file basenames (`gemm_perf.parquet`) — two tables sharing one file share one entry; entries exist for every op the engine touches, including ops a given model never queries.
4. **l40s reuse declarations**: the 12 files / 17 self-overlap entries flagged in #1372 now carry rewritten `reason` fields disclosing they are mechanical migrations (missing-shape forward-fill only, not kernel-identity-reviewed). Under the new ordering they are consumed as declared donors *after* primary — behavior-preserving vs the legacy newest-first semantics.

## Test plan

`uv run pytest tests/unit -m unit -n 2` green, and again with `AIC_STRICT_PROVENANCE=1` (identical results) · ordering suite (15), strict suite (32+), evidence resolver (30+) all new · real-tree audit 6/6 OK · discovery parity 10 systems / 89 pairs unchanged · gate tier-2 + silicon adjudicated with root-cause traces via `data_provenance` · every fix wave re-reviewed.

Completes the Collector V3 *data-plane* implementation: with this merged, a quarterly pin bump computes its own work list (`changed_ops`), the evidence resolver prices it, the audit + strict mode keep every byte provenanced, and `collector-snapshot-2026-08` tags the first reproducible quarter. The one deliberately-out-of-scope piece is the evidence *enforcement* gate ([AIC-1214](https://linear.app/nvidia/issue/AIC-1214/require-performance-evidence-for-op-collector-changes)): this stack makes evidence requirements computable and auditable; making them merge-blocking is that follow-up's job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added strict provenance validation for performance data, with fail-closed errors when metadata, coverage, or reuse declarations are missing or invalid.
  * Added source provenance reporting and clearer reuse-channel tracking.
  * Added a deterministic evidence-policy checker for validating required collection evidence.

* **Documentation**
  * Clarified reuse coverage, provenance channels, and evidence-policy behavior.

* **Bug Fixes**
  * Improved cache isolation between strict and non-strict data loads.
  * Prevented unsupported or undeclared data reuse from being silently accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
