### PR TITLE
fix(tools): use fork context for support matrix parallelism on macOS

### DIFF
--- a/tools/support_matrix/support_matrix.py
+++ b/tools/support_matrix/support_matrix.py
@@ -12,6 +12,7 @@ the model/system/backend/version support matrix for AIConfigurator.
 import csv
 import json
 import logging
+import multiprocessing
 import os
 import shlex
 import traceback
@@ -606,9 +607,13 @@ def _compare_pareto_dfs(
 
 
 # Per-process SupportMatrix instance for ProcessPoolExecutor workers.
-# Set in the parent before forking; children inherit it via copy-on-write.
+# Set in the parent before forking; children inherit via copy-on-write.
+# We explicitly use a "fork" mp context (see _run_parallel_combinations) so
+# this works on macOS too, where the default start method is "spawn".
 _worker_matrix: "SupportMatrix | None" = None
 _worker_modes_to_test: tuple[str, ...] | None = None
+
+_fork_ctx = multiprocessing.get_context("fork")
 
 
 def _process_combination_worker(
@@ -618,7 +623,7 @@ def _process_combination_worker(
     Run a single combination in a worker process. Uses the process-local SupportMatrix.
     Must be a module-level function for pickling by ProcessPoolExecutor.
     """
-    assert _worker_matrix is not None  # this only works in linux, not in windows/macos
+    assert _worker_matrix is not None
     model, system, backend, version = combo
     status_dict, error_dict, command_dict, provenance_dict = _worker_matrix.run_single_test(
         model=model,
@@ -1019,7 +1024,10 @@ class SupportMatrix:
         retry_combos: set[tuple[str, str, str, str]] = set()
         processed_futures = set()
 
-        with ProcessPoolExecutor(max_workers=min(max_workers, len(combinations))) as executor:
+        with ProcessPoolExecutor(
+            max_workers=min(max_workers, len(combinations)),
+            mp_context=_fork_ctx,
+        ) as executor:
             futures = {executor.submit(_process_combination_worker, combo): combo for combo in combinations}
             for future in as_completed(futures):
                 combo = futures[future]


### PR DESCRIPTION
## Overview

Fix `generate_support_matrix.py` so Phase 1 parallel workers actually succeed on macOS, eliminating the ~60-100x slower sequential Phase 2 fallback.

## Details

macOS defaults to `spawn` for `multiprocessing` (since Python 3.8), which requires pickling all data passed to child processes. The `SupportMatrix` object contains `defaultdict(lambda)` entries from the perf database loader, which cannot be pickled. This caused every Phase 1 worker to crash with `BrokenExecutor`, silently falling through to sequential Phase 2 retry for all combinations.

The fix uses `multiprocessing.get_context("fork")` to create a fork-based process pool, so child processes inherit the parent globals via copy-on-write — matching the Linux behavior the code was originally written for.

**Before (macOS):** Phase 1 completes in ~44s but all 89 combinations fail → Phase 2 retries all 89 sequentially at ~40-100s each → ~1 hour per model.

**After (macOS):** Phase 1 succeeds, no Phase 2 needed. Full matrix generation with many models benefits from parallel workers across the pool.

Linux behavior is unchanged (already uses fork by default).

## Test plan

- [x] `ruff check tools/support_matrix/support_matrix.py` passes
- [x] `pytest tests/unit/support_matrix/ tests/unit/cli/test_support_matrix_version.py` — 94 tests pass
- [x] Manual: `generate_support_matrix.py --model zai-org/GLM-5 --no-save` completes with zero Phase 2 retries on macOS (previously 89/89 retried)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved support-matrix generation reliability by explicitly using fork-based multiprocessing for worker creation.
  * Added an explicit runtime check to ensure worker processing starts only after the necessary initialization is in place.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->