### PR TITLE
fix(collector): align model dtype for vLLM FlashInfer fp8 KV attention

### DIFF
--- a/collector/vllm/collect_attn.py
+++ b/collector/vllm/collect_attn.py
@@ -207,6 +207,10 @@ def run_attention_torch(
 
     # Mock flashinfer's get_per_layer_parameters if needed
     if backend_name_str == "FLASHINFER":
+        if use_fp8_kv_cache:
+            # FlashInferMetadataBuilder asserts kv_cache_spec.dtype ==
+            # model_config.dtype; KV spec uses fp8 while model_config stays bf16.
+            vllm_config.model_config.dtype = kv_cache_spec.dtype
         import unittest.mock
 
         from vllm.v1.attention.backends.utils import PerLayerParameters


### PR DESCRIPTION
## Summary

- **`collector/vllm/collect_attn.py`**: When fp8 KV cache is enabled and vLLM routes attention to `FLASHINFER`, align `vllm_config.model_config.dtype` with `kv_cache_spec.dtype` before `FlashInferMetadataBuilder` init. vLLM 0.22 asserts these dtypes match; the collector's KV spec uses fp8 while `model_config` stayed bfloat16, causing `AssertionError` on every fp8+head_dim=128 case on SM100.

## Context

Discovered during B200 vLLM `0.22.0` power re-collection (R2). fp8+head_dim=192 used a different backend and did not hit this path. Targeted re-collect with this WAR produced 11,288 context + 11,333 generation rows (job `3137493`, `umb-b200-236`).

Independent of #1358 (helper + TRT-LLM MLA API) and #1359 (TRT-LLM kernel-limit FIXME comments).

## Test plan

- [ ] `pytest tests/unit/collector/test_vllm_collect_attn.py -m unit`
- [ ] Smoke: `collector/collect.py --backend vllm --ops attention_generation --case-filter "128, True" --smoke` on vLLM 0.22.x + SM100 — confirm fp8+head_dim=128 cases run without FlashInfer dtype assert


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed FlashInfer attention processing with FP8 KV caches by ensuring consistent data types during metadata setup.
  * Prevented dtype mismatch errors when the model configuration uses a different default type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->