### PR TITLE
fix: make nextn model inference explicit

### DIFF
--- a/docs/cli_user_guide.md
+++ b/docs/cli_user_guide.md
@@ -131,7 +131,7 @@ aiconfigurator cli estimate --model-path Qwen/Qwen3-32B --system h200_sxm --tp-s
 - `--moe-quant-mode`: MoE quantization mode (auto-inferred if omitted)
 - `--comm-quant-mode`: Communication quantization mode (auto-inferred; default `half`)
 - `--prefix`: Prefix cache length (subset of ISL already cached per request). Default: `0`
-- `--nextn`: Number of MTP/speculative draft tokens. Default: `0`. Unlike `cli default`, `estimate` does **not** auto-enable MTP for DeepSeek/Qwen3.5 — pass `--nextn 1` explicitly
+- `--nextn`: Number of MTP/speculative draft tokens. Default: `0`; pass `--nextn 1` explicitly to enable MTP
 - `--nextn-accept-rates`: Comma-separated acceptance rates for the MTP draft tokens (only the first `--nextn` are used). Default: `0.85,0.3,0,0,0`
 - `--stride`: (static modes only) OSL-sweep stride used by `run_static`; ignored for `agg`/`disagg`. Default: `32`
 - `--free-gpu-memory-fraction`: Fraction of free GPU memory for KV cache. Default: `0.9`. Used to estimate max concurrent sequences and warn when batch size exceeds KV cache capacity
@@ -852,9 +852,11 @@ Hybrid mode is a quick solution to support new models without modeling the opera
 These flags enable MTP (Multi-Token Prediction) speculative decoding in the
 configuration search:
 
-- `--nextn N` — Number of draft tokens. When > 0, the sweep includes
-  speculative decoding configurations. Requires the model to support MTP.
-  Default: 0 (disabled).
+- `--nextn N|auto` — Number of draft tokens. MTP is disabled when this flag is
+  omitted or set to `0`. Pass a positive value to enable MTP with that many
+  draft tokens, or pass `auto` to use `num_nextn_predict_layers` from the model
+  config and then the model-family fallback if the field is absent. Requires
+  the model to support MTP.
 - `--nextn-accept-rates RATES` — Comma-separated list of 5 floats representing
   the acceptance probability of each draft token position. Only the first
   `--nextn` values are used. Default: `0.85,0.3,0,0,0`.

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -149,6 +149,8 @@ def cli_default(
     tpot: float = 30.0,
     request_latency: float | None = None,
     prefix: int = 0,
+    nextn: int | None = 0,
+    nextn_accept_rates: list[float] | None = None,
     strict_sla: bool = False,
     free_gpu_memory_fraction: float | None = None,
     max_seq_len: int | None = None,
@@ -182,6 +184,9 @@ def cli_default(
         request_latency: Optional end-to-end request latency target (ms).
             Enables request-latency optimization mode.
         prefix: Prefix cache length. Default is 0.
+        nextn: Number of MTP draft tokens. ``0`` disables MTP (the default);
+            explicitly pass ``None`` to use the model-config/family default.
+        nextn_accept_rates: Acceptance rates for MTP draft tokens.
         strict_sla: When True, ``pareto_df`` is filtered to only
             SLA-compliant data points (TPOT or request-latency) *before*
             the Pareto frontier is computed.  TTFT is already enforced at
@@ -255,6 +260,8 @@ def cli_default(
         tpot=tpot,
         request_latency=request_latency,
         prefix=prefix,
+        nextn=nextn,
+        nextn_accept_rates=nextn_accept_rates,
         free_gpu_memory_fraction=free_gpu_memory_fraction,
         max_seq_len=max_seq_len,
         engine_step_backend=engine_step_backend,
@@ -730,10 +737,8 @@ def cli_estimate(
             Applied to agg, disagg, and all static modes. Default 0.
         nextn: (common) Number of MTP/speculative draft tokens. Applied to
             agg, disagg, and all static modes. Default 0 (disabled).
-            **Note:** unlike :func:`cli_default`, this entrypoint does **not**
-            auto-set ``nextn=1`` for DeepSeek/Qwen3.5 models — pass
-            ``nextn=1`` explicitly when you want MTP to mirror the default-mode
-            behavior.
+            This entrypoint does not infer MTP from the model config; pass
+            ``nextn=1`` explicitly when you want MTP.
         nextn_accept_rates: (common) Acceptance rates for the MTP draft tokens
             (only the first ``nextn`` entries are used).
             Default ``[0.85, 0.3, 0, 0, 0]``.

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -186,6 +186,29 @@ def _validate_model_path(model_path: str) -> str:
         ) from e
 
 
+def _validate_nextn(nextn: int | None) -> None:
+    """Validate the public default-mode MTP draft depth."""
+    if nextn is None:
+        return
+    if isinstance(nextn, bool) or not isinstance(nextn, int) or nextn < 0:
+        raise ValueError(f"nextn must be 'auto' or a non-negative integer, got {nextn}")
+
+
+def _parse_nextn(value: str) -> int | None:
+    """Parse ``--nextn`` while keeping model inference explicit."""
+    if value.strip().lower() == "auto":
+        return None
+    try:
+        nextn = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"nextn must be 'auto' or a non-negative integer, got {value!r}") from exc
+    try:
+        _validate_nextn(nextn)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+    return nextn
+
+
 def _add_default_mode_arguments(parser):
     parser.add_argument(
         "--model-path",
@@ -312,11 +335,12 @@ def _add_default_mode_arguments(parser):
     parser.add_argument("--prefix", type=int, default=0, help="Prefix cache length. Default to 0.")
     parser.add_argument(
         "--nextn",
-        type=int,
+        type=_parse_nextn,
         default=0,
         help="Number of draft tokens for MTP (Multi-Token Prediction) speculative decoding. "
-        "When set > 0, enables speculative decoding in the configuration search. "
-        "Requires the model to support MTP. Default: 0 (disabled).",
+        "Omit the flag or set it to 0 to disable MTP; values > 0 enable it with that many draft tokens. "
+        "Set it to 'auto' to infer the value from the model config or AIC's model-family default. "
+        "Requires the model to support MTP.",
     )
     parser.add_argument(
         "--nextn-accept-rates",
@@ -820,8 +844,7 @@ def _add_estimate_mode_arguments(parser):
         default=0,
         help="(common) Number of MTP/speculative draft tokens. Default: 0 (disabled). "
         "Applied to agg, disagg, and all static modes. "
-        "Note: unlike `cli default`, `cli estimate` does NOT auto-set nextn=1 for "
-        "DeepSeek/Qwen3.5 — pass --nextn 1 explicitly when you want MTP.",
+        "This mode does not infer MTP from the model config; pass --nextn 1 explicitly when you want MTP.",
     )
     parser.add_argument(
         "--nextn-accept-rates",
@@ -1136,7 +1159,7 @@ def build_default_tasks(
     tpot: float = 30.0,
     request_latency: float | None = None,
     prefix: int = 0,
-    nextn: int = 0,
+    nextn: int | None = 0,
     nextn_accept_rates: list[float] | None = None,
     enable_chunked_prefill: bool = False,
     free_gpu_memory_fraction: float | None = None,
@@ -1162,7 +1185,8 @@ def build_default_tasks(
         tpot: Time per output token target in ms.
         request_latency: Optional end-to-end request latency target (ms).
         prefix: Prefix cache length.
-        nextn: Number of draft tokens for MTP speculative decoding.
+        nextn: Number of draft tokens for MTP speculative decoding. ``0`` disables
+            MTP (the default); ``None`` uses the model-config/family default.
         nextn_accept_rates: Acceptance rates for MTP draft tokens.
         enable_chunked_prefill: Whether to enable chunked prefill for finer context token sweep.
         enable_wideep: Whether to enable Wide Expert Parallelism (WideEP) for MoE models.
@@ -1174,7 +1198,9 @@ def build_default_tasks(
         (agg_trtllm, agg_vllm, agg_sglang, disagg_trtllm, disagg_vllm, disagg_sglang).
         Otherwise returns 2 configs ('agg' and 'disagg').
     """
-    nextn_accept_rates = nextn_accept_rates or [0.85, 0.3, 0.0, 0.0, 0.0]
+    _validate_nextn(nextn)
+    if nextn_accept_rates is None:
+        nextn_accept_rates = [0.85, 0.3, 0.0, 0.0, 0.0]
     decode_system = decode_system or system
     # Expand "auto" backend to all available backends
     backends_to_sweep = [b.value for b in common.BackendName] if backend == "auto" else [backend]
@@ -1288,8 +1314,9 @@ def build_default_tasks(
         "max_seq_len": max_seq_len,
         "engine_step_backend": engine_step_backend,
     }
-    if nextn and nextn > 0:
+    if nextn is not None:
         global_kwargs["nextn"] = nextn
+    if nextn_accept_rates is not None:
         global_kwargs["nextn_accept_rates"] = nextn_accept_rates
 
     if image_height or image_width or (num_images and num_images != 1):

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -661,12 +661,11 @@ class Task:
         # ``None`` distinguishes "field absent" from an explicit 0 (e.g. Kimi-K2.5).
         hf_nextn = cfg.get("num_nextn_predict_layers")
         if self.nextn is not None:
-            # User-supplied value wins. Warn when it diverges from the checkpoint --
-            # nextn can stack extra MTP layers beyond what the checkpoint ships, so
-            # an override is a deliberate choice worth surfacing.
+            # User-supplied value wins. Warn when it diverges from the checkpoint;
+            # this can explicitly disable MTP or select a different draft depth.
             if hf_nextn is not None and self.nextn != hf_nextn:
                 logger.warning(
-                    "nextn=%d overrides the checkpoint's num_nextn_predict_layers=%d (stacking additional MTP layers).",
+                    "nextn=%d overrides the checkpoint's num_nextn_predict_layers=%d.",
                     self.nextn,
                     hf_nextn,
                 )

--- a/tests/unit/cli/test_argument_parsing.py
+++ b/tests/unit/cli/test_argument_parsing.py
@@ -346,11 +346,59 @@ class TestCLIArgumentParsing:
         assert sorted(action.choices) == sorted(expected_choices)
 
     def test_nextn_default_value(self, cli_parser):
-        """Test that --nextn defaults to 0."""
+        """Omitting --nextn keeps the backward-compatible disabled default."""
         args = cli_parser.parse_args(
             ["default", "--model-path", "Qwen/Qwen3-32B", "--total-gpus", "8", "--system", "h200_sxm"]
         )
         assert args.nextn == 0
+
+    def test_nextn_can_explicitly_disable_mtp(self, cli_parser):
+        args = cli_parser.parse_args(
+            [
+                "default",
+                "--model-path",
+                "Qwen/Qwen3-32B",
+                "--total-gpus",
+                "8",
+                "--system",
+                "h200_sxm",
+                "--nextn",
+                "0",
+            ]
+        )
+        assert args.nextn == 0
+
+    def test_nextn_auto_uses_model_default(self, cli_parser):
+        args = cli_parser.parse_args(
+            [
+                "default",
+                "--model-path",
+                "Qwen/Qwen3-32B",
+                "--total-gpus",
+                "8",
+                "--system",
+                "h200_sxm",
+                "--nextn",
+                "auto",
+            ]
+        )
+        assert args.nextn is None
+
+    def test_nextn_rejects_negative_values(self, cli_parser):
+        with pytest.raises(SystemExit):
+            cli_parser.parse_args(
+                [
+                    "default",
+                    "--model-path",
+                    "Qwen/Qwen3-32B",
+                    "--total-gpus",
+                    "8",
+                    "--system",
+                    "h200_sxm",
+                    "--nextn",
+                    "-1",
+                ]
+            )
 
     def test_nextn_accept_rates_default_value(self, cli_parser):
         """Test that --nextn-accept-rates defaults to '0.85,0.3,0,0,0'."""

--- a/tests/unit/cli/test_backend_any.py
+++ b/tests/unit/cli/test_backend_any.py
@@ -110,19 +110,46 @@ class TestBackendAny:
             assert task_config.nextn == 3
             assert task_config.nextn_accept_rates == [0.9, 0.5, 0.2, 0.1, 0.0]
 
-    def test_build_default_tasks_nextn_default_zero(self):
-        """Test that nextn defaults to 0 (MTP disabled) when not specified."""
+    def test_build_default_tasks_omitted_nextn_disables_mtp(self):
+        """Omitted nextn should preserve the public default of disabled MTP."""
         tasks = build_default_tasks(
-            model_path="Qwen/Qwen3-32B",
+            model_path="nvidia/GLM-5.2-NVFP4",
             total_gpus=8,
-            system="h200_sxm",
-            backend="trtllm",
+            system="gb200",
+            backend="vllm",
+            backend_version="0.11.0",
+            database_mode="SOL",
         )
 
         assert len(tasks) == 2
 
-        # Verify nextn defaults to 0
         for task_config in tasks.values():
             assert task_config.nextn == 0
-            # Default accept rates should still be present
-            assert task_config.nextn_accept_rates is not None
+
+    def test_build_default_tasks_none_uses_model_default_and_preserves_accept_rates(self):
+        """Explicit None opts into model inference without dropping custom rates."""
+        accept_rates = [0.9, 0.4, 0.1, 0.0, 0.0]
+        tasks = build_default_tasks(
+            model_path="nvidia/GLM-5.2-NVFP4",
+            total_gpus=8,
+            system="gb200",
+            backend="vllm",
+            backend_version="0.11.0",
+            database_mode="SOL",
+            nextn=None,
+            nextn_accept_rates=accept_rates,
+        )
+
+        for task_config in tasks.values():
+            assert task_config.nextn == 1
+            assert task_config.nextn_accept_rates == accept_rates
+
+    def test_build_default_tasks_rejects_negative_nextn(self):
+        with pytest.raises(ValueError, match="non-negative integer"):
+            build_default_tasks(
+                model_path="Qwen/Qwen3-32B",
+                total_gpus=8,
+                system="h200_sxm",
+                backend="trtllm",
+                nextn=-1,
+            )

--- a/tests/unit/cli/test_cli_api.py
+++ b/tests/unit/cli/test_cli_api.py
@@ -10,10 +10,49 @@ from unittest.mock import MagicMock, patch
 import pandas as pd
 import pytest
 
-from aiconfigurator.cli import CLIResult, cli_exp, cli_generate
+from aiconfigurator.cli import CLIResult, cli_default, cli_exp, cli_generate
 from aiconfigurator.sdk import common
 
 pytestmark = pytest.mark.unit
+
+
+class TestCLIDefaultUnit:
+    """Unit tests for the public default-mode API boundary."""
+
+    @pytest.mark.parametrize(
+        ("api_kwargs", "expected_nextn", "expected_accept_rates"),
+        [
+            ({}, 0, None),
+            ({"nextn": 0, "nextn_accept_rates": [0.9, 0.4]}, 0, [0.9, 0.4]),
+            ({"nextn": None, "nextn_accept_rates": [0.8, 0.2]}, None, [0.8, 0.2]),
+        ],
+    )
+    @patch("aiconfigurator.cli.api._execute_and_wrap_result")
+    @patch("aiconfigurator.cli.api.build_default_tasks")
+    def test_nextn_contract_is_forwarded(
+        self,
+        mock_build_default_tasks,
+        mock_execute_and_wrap,
+        api_kwargs,
+        expected_nextn,
+        expected_accept_rates,
+    ):
+        tasks = {"agg": MagicMock()}
+        expected_result = MagicMock()
+        mock_build_default_tasks.return_value = tasks
+        mock_execute_and_wrap.return_value = expected_result
+
+        result = cli_default(
+            model_path="Qwen/Qwen3-32B",
+            total_gpus=8,
+            system="h200_sxm",
+            **api_kwargs,
+        )
+
+        assert result is expected_result
+        build_kwargs = mock_build_default_tasks.call_args.kwargs
+        assert build_kwargs["nextn"] == expected_nextn
+        assert build_kwargs["nextn_accept_rates"] == expected_accept_rates
 
 
 class TestCLIEstimateUnit:

--- a/tests/unit/cli/test_nextn_tristate.py
+++ b/tests/unit/cli/test_nextn_tristate.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from aiconfigurator.cli.main import build_default_tasks
+from aiconfigurator.cli.report_and_save import save_results
+
+pytestmark = pytest.mark.unit
+
+
+def test_glm52_explicit_nextn_zero_is_preserved_in_dumped_exp_config(tmp_path):
+    """Regression: an explicit zero must not fall back to GLM-5.2's MTP default."""
+    tasks = build_default_tasks(
+        model_path="nvidia/GLM-5.2-NVFP4",
+        total_gpus=1,
+        system="gb200",
+        backend="vllm",
+        backend_version="0.11.0",
+        database_mode="SOL",
+        nextn=0,
+    )
+    task = tasks["agg"]
+    assert task.nextn == 0
+
+    args = argparse.Namespace(inclusive_tpot=False, deployment_target="dynamo-j2")
+    with patch(
+        "aiconfigurator.cli.report_and_save.get_default_dynamo_version_mapping",
+        return_value=("1.0.0", {"vllm": "0.11.0"}),
+    ):
+        save_results(
+            args=args,
+            best_configs={},
+            pareto_fronts={"agg": None},
+            tasks=tasks,
+            save_dir=str(tmp_path),
+            backend="vllm",
+        )
+
+    exp_config_path = next(tmp_path.glob("**/agg/exp_config.yaml"))
+    dumped = yaml.safe_load(exp_config_path.read_text(encoding="utf-8"))
+    assert dumped["nextn"] == 0
+
+
+def test_glm52_explicit_auto_uses_model_default(tmp_path):
+    """Explicit auto/None should retain GLM-5.2's checkpoint MTP depth."""
+    tasks = build_default_tasks(
+        model_path="nvidia/GLM-5.2-NVFP4",
+        total_gpus=1,
+        system="gb200",
+        backend="vllm",
+        backend_version="0.11.0",
+        database_mode="SOL",
+        nextn=None,
+    )
+    task = tasks["agg"]
+    assert task.nextn == 1
+
+    args = argparse.Namespace(inclusive_tpot=False, deployment_target="dynamo-j2")
+    with patch(
+        "aiconfigurator.cli.report_and_save.get_default_dynamo_version_mapping",
+        return_value=("1.0.0", {"vllm": "0.11.0"}),
+    ):
+        save_results(
+            args=args,
+            best_configs={},
+            pareto_fronts={"agg": None},
+            tasks=tasks,
+            save_dir=str(tmp_path),
+            backend="vllm",
+        )
+
+    exp_config_path = next(tmp_path.glob("**/agg/exp_config.yaml"))
+    dumped = yaml.safe_load(exp_config_path.read_text(encoding="utf-8"))
+    assert dumped["nextn"] == 1


### PR DESCRIPTION
## Summary

- keep the default CLI and Python behavior backward-compatible: omitted `--nextn` / omitted `nextn` disables MTP
- add `--nextn auto` (and Python `nextn=None`) to opt into the model checkpoint/family default
- preserve explicit zero and positive draft depths through task construction and saved experiment configs
- reject negative draft depths and preserve custom acceptance rates during model inference
- rebase onto current `main` after Spica moved out of AIConfigurator in #1389

## Behavior

| Input | Behavior |
|---|---|
| omit `--nextn` | MTP disabled (`nextn: 0`) |
| `--nextn 0` | explicitly disable MTP |
| `--nextn auto` | use `num_nextn_predict_layers`, then the model-family fallback |
| `--nextn N` where `N > 0` | use the explicit draft depth |

The Python API mirrors this contract: `cli_default()` defaults to `nextn=0`; explicitly pass `nextn=None` for model inference.

## Root cause

`TaskV2` uses `None` as its internal model-inference sentinel. The old default CLI path only forwarded truthy positive `nextn` values, so explicit `--nextn 0` was dropped and GLM-5.2 fell back to checkpoint metadata (`num_nextn_predict_layers: 1`). The first PR revision made omission map to that sentinel, but that changed the public default. This revision keeps the public default disabled and makes model inference explicit.

## Validation

- `.venv/bin/python -m pytest -qq -m unit --tb=short --color=no` — 2,220 passed, 39 skipped
- focused CLI/API/serialization tests — 62 passed
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- installed CLI E2E with `nvidia/GLM-5.2-NVFP4`, `gb200`, `vllm 0.11.0`, and `database-mode SOL`:
  - omitted `--nextn`: agg/disagg `exp_config.yaml` contain `nextn: 0`
  - `--nextn 0`: agg/disagg contain `nextn: 0`
  - `--nextn auto`: agg/disagg contain `nextn: 1`
