### PR TITLE
fix(sdk): divide MoE expert weights by EP in naive KV-cache estimator

### DIFF
--- a/aic-core/src/aiconfigurator_core/sdk/memory.py
+++ b/aic-core/src/aiconfigurator_core/sdk/memory.py
@@ -477,15 +477,33 @@ class NaiveKVCacheEstimator:
     and the token-capacity inverse from that geometry.
     """
 
-    def __init__(self, geometry: dict, *, dtype_bytes: int, tp_size: int, pp_size: int):
+    def __init__(
+        self,
+        geometry: dict,
+        *,
+        dtype_bytes: int,
+        tp_size: int,
+        pp_size: int,
+        moe_ep_size: int = 1,
+        moe_tp_size: int = 1,
+    ):
         self.geometry = geometry
         self.dtype_bytes = int(dtype_bytes)
         self.tp_size = int(tp_size)
         self.pp_size = int(pp_size)
+        self.moe_ep_size = max(int(moe_ep_size), 1)
+        self.moe_tp_size = max(int(moe_tp_size), 1)
 
     @classmethod
     def from_model_path(
-        cls, model_path: str, *, tp_size: int, pp_size: int, allow_hf_config_download: bool
+        cls,
+        model_path: str,
+        *,
+        tp_size: int,
+        pp_size: int,
+        allow_hf_config_download: bool,
+        moe_ep_size: int = 1,
+        moe_tp_size: int = 1,
     ) -> NaiveKVCacheEstimator:
         """Build from an HF ``config.json`` (local dir / pre-cached / optional download).
 
@@ -509,6 +527,8 @@ class NaiveKVCacheEstimator:
             dtype_bytes=cls._dtype_bytes(hf_config),
             tp_size=tp_size,
             pp_size=pp_size,
+            moe_ep_size=moe_ep_size,
+            moe_tp_size=moe_tp_size,
         )
 
     # ----------------------------- config -> geometry ----------------------------- #
@@ -699,15 +719,21 @@ class NaiveKVCacheEstimator:
         attn_params_per_layer = 4 * hidden * hidden
 
         n_experts = int(geom.get("num_experts") or 0)
+        pp = max(self.pp_size, 1)
+        tp = max(self.tp_size, 1)
         if n_experts > 0:
             moe_inter = int(geom.get("moe_inter") or inter)
-            ffn_params_per_layer = n_experts * 3 * hidden * moe_inter
+            # Expert FFN is sharded by moe_tp * moe_ep, not by the attention TP.
+            moe_divisor = self.moe_tp_size * self.moe_ep_size
+            expert_params = n_experts * 3 * hidden * moe_inter // moe_divisor
+            non_expert_params = embed_params + layers * attn_params_per_layer
+            non_expert_bytes = non_expert_params * self.dtype_bytes // (tp * pp)
+            expert_bytes = layers * expert_params * self.dtype_bytes // pp
+            return non_expert_bytes + expert_bytes
         else:
             ffn_params_per_layer = 3 * hidden * inter
-
-        total_params = embed_params + layers * (attn_params_per_layer + ffn_params_per_layer)
-        divisor = max(self.tp_size, 1) * max(self.pp_size, 1)
-        return (total_params * self.dtype_bytes) // max(divisor, 1)
+            total_params = embed_params + layers * (attn_params_per_layer + ffn_params_per_layer)
+            return (total_params * self.dtype_bytes) // (tp * pp)
 
     # --------------------------- byte budget -> tokens ---------------------------- #
 
@@ -948,6 +974,8 @@ def estimate_kv_cache(
             tp_size=int(tp_size),
             pp_size=int(pp_size),
             allow_hf_config_download=allow_hf_config_download,
+            moe_ep_size=int(moe_ep_size or 1),
+            moe_tp_size=int(moe_tp_size or 1),
         ).estimate(
             capacity=gpu_memory_capacity_bytes_override,
             naive_kv_reservation=float(naive_kv_reservation),

--- a/tests/unit/sdk/test_memory_estimation.py
+++ b/tests/unit/sdk/test_memory_estimation.py
@@ -118,13 +118,20 @@ def _naive_estimate(
     *,
     tp_size=1,
     pp_size=1,
+    moe_ep_size=1,
+    moe_tp_size=1,
     gpu_memory_capacity_bytes_override,
     naive_kv_reservation,
     allow_hf_config_download=False,
 ):
     """Build a NaiveKVCacheEstimator and run its estimate (mirrors the old helper)."""
     return memory.NaiveKVCacheEstimator.from_model_path(
-        model_path, tp_size=tp_size, pp_size=pp_size, allow_hf_config_download=allow_hf_config_download
+        model_path,
+        tp_size=tp_size,
+        pp_size=pp_size,
+        allow_hf_config_download=allow_hf_config_download,
+        moe_ep_size=moe_ep_size,
+        moe_tp_size=moe_tp_size,
     ).estimate(capacity=gpu_memory_capacity_bytes_override, naive_kv_reservation=naive_kv_reservation)
 
 
@@ -285,8 +292,15 @@ def test_native_capacity_override_wins():
 # --------------------------------------------------------------------------- #
 
 
-def _estimator(geometry, *, dtype_bytes=2, tp_size=1, pp_size=1):
-    return memory.NaiveKVCacheEstimator(geometry, dtype_bytes=dtype_bytes, tp_size=tp_size, pp_size=pp_size)
+def _estimator(geometry, *, dtype_bytes=2, tp_size=1, pp_size=1, moe_ep_size=1, moe_tp_size=1):
+    return memory.NaiveKVCacheEstimator(
+        geometry,
+        dtype_bytes=dtype_bytes,
+        tp_size=tp_size,
+        pp_size=pp_size,
+        moe_ep_size=moe_ep_size,
+        moe_tp_size=moe_tp_size,
+    )
 
 
 def test_naive_kv_per_token_mla():
@@ -339,6 +353,35 @@ def test_naive_geometry_from_raw_unsupported_arch():
 def test_naive_kv_per_token_empty_geometry_is_none():
     assert _estimator({}).kv_bytes_per_token() is None
     assert _estimator({}).weight_bytes() is None
+
+
+def test_naive_weight_bytes_moe_divides_by_ep_and_moe_tp():
+    # MoE model: 32 layers, hidden=4096, 64 experts, moe_inter=2048, bf16.
+    geom = {
+        "hidden": 4096,
+        "layers": 32,
+        "vocab": 128_000,
+        "inter": 11_008,
+        "num_experts": 64,
+        "moe_inter": 2048,
+    }
+    # EP=8 should reduce expert weight vs EP=1 (both at tp=8, moe_tp=1).
+    w_ep1 = _estimator(geom, tp_size=8, moe_ep_size=1).weight_bytes()
+    w_ep8 = _estimator(geom, tp_size=8, moe_ep_size=8).weight_bytes()
+    assert w_ep8 < w_ep1
+
+    # moe_tp=2,ep=4 vs moe_tp=1,ep=8: same total MoE sharding (product=8),
+    # so expert weight should be identical; non-expert params unchanged.
+    w_tp2_ep4 = _estimator(geom, tp_size=8, moe_tp_size=2, moe_ep_size=4).weight_bytes()
+    w_tp1_ep8 = _estimator(geom, tp_size=8, moe_tp_size=1, moe_ep_size=8).weight_bytes()
+    assert w_tp2_ep4 == w_tp1_ep8
+
+    # Expert weight should scale with the product moe_tp * moe_ep.
+    expert_params_per_layer = 64 * 3 * 4096 * 2048
+    # EP=1,moe_tp=1 vs EP=8,moe_tp=1: expert diff = (1 - 1/8) of expert params / pp=1.
+    expert_diff = w_ep1 - w_ep8
+    expected = expert_params_per_layer * 32 * (1 - 1 / 8) * 2  # bf16, pp=1
+    assert abs(expert_diff - expected) < 1024
 
 
 def test_dtype_bytes():
@@ -439,11 +482,13 @@ def test_naive_fallback_mla_fixture():
     # `deepseek-ai/DeepSeek-V3` is cached in model_configs (DefaultHFModels), so
     # `NaiveKVCacheEstimator._load_config` loads it without a download; the
     # supported arch goes through `_parse_hf_config_json` -> 70_272 bytes/token.
+    # moe_ep_size=16 shards the 256 experts across 16 GPUs (16 local each).
     capacity = 180 * _GIB
     out = _naive_estimate(
         "deepseek-ai/DeepSeek-V3",
         tp_size=16,
         pp_size=1,
+        moe_ep_size=16,
         gpu_memory_capacity_bytes_override=capacity,
         naive_kv_reservation=memory._DEFAULT_NAIVE_KV_RESERVATION,
         allow_hf_config_download=False,


### PR DESCRIPTION
#### Overview:

Fixes the naive KV-cache fallback estimator to correctly divide MoE
expert weights by `moe_tp_size * moe_ep_size`. Previously, expert
weights were counted for all experts on every GPU, inflating per-GPU
weight memory by up to 8x for EP=8 configurations.

#### Details:

`NaiveKVCacheEstimator.weight_bytes()` counted all MoE experts on
every GPU, ignoring both expert parallelism (EP) and MoE tensor
parallelism (moe_tp). With EP=8 and 384 experts (e.g. Kimi K2.5),
per-GPU weight memory was inflated 8x, underestimating KV-cache
capacity.

The fix threads `moe_ep_size` and `moe_tp_size` through
`__init__`, `from_model_path`, and the `estimate_kv_cache`
fallback path. Expert weight is now divided by `moe_tp * moe_ep`,
while non-expert params (embeddings, attention) remain divided by
`tp * pp`.

The native path (used by sweeps and supported models) was already
correct -- this only affects the naive fallback triggered via
`allow_naive_fallback=True` when the native model build fails.

#### Reviewer start:

- `aic-core/src/aiconfigurator_core/sdk/memory.py` --
  `NaiveKVCacheEstimator` class and `estimate_kv_cache()` function
- `tests/unit/sdk/test_memory_estimation.py` -- new and updated tests

#### Related Issues:

Discovered during GPU recommender work (PR #1369) while investigating
a report that AIC treats all MoE params as needing to be on every GPU.

#### Test plan:

- [x] New test `test_naive_weight_bytes_moe_divides_by_ep_and_moe_tp`
  verifies EP and moe_tp division, and that equal products give equal
  weight
- [x] Updated `test_naive_fallback_mla_fixture` with realistic
  moe_ep_size=16 for DeepSeek-V3
- [x] All 39 memory estimation tests pass
- [x] Verified with live `/kv_cache_calc` endpoint: native path
  returns correct weights for Kimi K2.5 at EP=8

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved memory and KV-cache estimates for Mixture-of-Experts models by incorporating MoE expert-parallel sizing.
  - Weight/parameter estimates now scale correctly with MoE expert-parallel and MoE tensor-parallel settings, improving accuracy when expert-parallelism changes.
  - Defaults remain unchanged when MoE expert-parallel parameters aren’t provided.
- **Tests**
  - Added and updated unit tests to validate MoE expert weight estimation across expert-parallel configurations, including fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->