### PR TITLE
fix(sdk): support third-party DSV4 FP4-expert checkpoints (e.g. RedHatAI)

### DIFF
--- a/aic-core/src/aiconfigurator_core/sdk/models/helpers.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/helpers.py
@@ -275,6 +275,10 @@ def _infer_quant_modes_from_raw_config(raw_config: dict, architecture: str | Non
     elif kv_cache_algo is not None:
         raise ValueError(f"Unsupported kv cache algorithm: {kv_cache_algo}")
 
+    # DSV4 sparse attention requires FP8 KV cache across all backends.
+    if architecture == "DeepseekV4ForCausalLM":
+        overrides["kvcache_quant_mode"] = common.KVCacheQuantMode.fp8
+
     # FMHA quant mode
     if quant_algo is not None and (quant_algo in ("fp8", "fp8_block", "nvfp4") or kv_cache_algo in ("fp8",)):
         overrides["fmha_quant_mode"] = common.FMHAQuantMode.fp8
@@ -354,9 +358,18 @@ def _apply_model_quant_defaults(
         )
 
 
-# Native (FP4 routed-expert) DeepSeek-V4 checkpoints. The sgl-project *-FP8
-# requant artifacts are deliberately absent: their MoE runs fp8_block.
-_DSV4_NATIVE_MODEL_PATHS = ("deepseek-ai/DeepSeek-V4-Pro", "deepseek-ai/DeepSeek-V4-Flash")
+def _is_dsv4_fp4_expert_model(model_path: str) -> bool:
+    """True for DeepSeek-V4 checkpoints with native FP4 routed experts.
+
+    Checks ``expert_dtype == "fp4"`` in the HF config rather than hardcoded
+    paths, so third-party requant artifacts (e.g. RedHatAI NVFP4-FP8) are
+    recognized. FP8-only requants (sgl-project) have no ``expert_dtype`` and
+    return False.
+    """
+    info = _get_model_info(model_path)
+    if info.get("architecture") != "DeepseekV4ForCausalLM":
+        return False
+    return str(info.get("raw_config", {}).get("expert_dtype") or "").lower() == "fp4"
 
 
 def resolve_dsv4_moe_arch_mode(
@@ -365,21 +378,21 @@ def resolve_dsv4_moe_arch_mode(
     backend_name: str | None,
     moe_backend: str | None = None,
 ) -> common.MoEQuantMode | None:
-    """Arch-specific MoE quant mode for native DeepSeek-V4 checkpoints on sglang.
+    """Arch-specific MoE quant mode for FP4-expert DeepSeek-V4 checkpoints on sglang.
 
-    SGLang serves the native V4 checkpoints through arch-specific MoE kernels,
+    SGLang serves FP4-expert V4 checkpoints through arch-specific MoE kernels,
     and the perf DB files those rows under dedicated quant modes (loader
     routing in ``operations/moe.py``): Blackwell -> ``w4a8_mxfp4_mxfp8_trtllm``
     (kernel_source ``sglang_mxfp4_flashinfer_trtllm_moe``), Hopper ->
     ``w4a16_mxfp4_cutlass`` (``sglang_flashinfer_cutlass_moe``). Returns the
     remapped mode, or None when the rule does not apply (non-sglang backends,
-    megamoe, requant artifacts, other systems). Mirrors ``task_v2``'s HF-base
-    resolution (legacy V1 dsv4pro-moe-arch); an explicit user mode must win,
-    so callers only apply this when moe_quant_mode was not explicitly set.
+    megamoe, FP8-only requant artifacts, other systems). An explicit user mode
+    must win, so callers only apply this when moe_quant_mode was not explicitly
+    set.
     """
     if backend_name != "sglang" or moe_backend == "megamoe":
         return None
-    if model_path not in _DSV4_NATIVE_MODEL_PATHS:
+    if not _is_dsv4_fp4_expert_model(model_path):
         return None
     from aiconfigurator_core.sdk.perf_database import is_blackwell_system, is_hopper_system
 

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -1305,6 +1305,13 @@ class Task:
             name = mode.name if hasattr(mode, "name") else str(mode)
             if name in modes:
                 return
+            # Modes that normalize to a different table name for perf queries
+            # (nvfp4_wo -> bfloat16, w4a16_mxfp4_cutlass -> w4a16_mxfp4) are
+            # accepted when the target table mode is supported.
+            validation_aliases = {"nvfp4_wo": "bfloat16", "w4a16_mxfp4_cutlass": "w4a16_mxfp4"}
+            alias = validation_aliases.get(name)
+            if alias and alias in modes:
+                return
             if profile_transfer and xquant_enabled and _profile_reachable(mode, modes):
                 return  # transfer-reachable in HYBRID/EMPIRICAL with XQUANT enabled
             exc_type = UnsupportedWideepConfigError if op.startswith("wideep_") else ValueError

--- a/tests/unit/sdk/task_v2/test_task_config.py
+++ b/tests/unit/sdk/task_v2/test_task_config.py
@@ -669,6 +669,56 @@ def test_dsv4_native_sglang_moe_remap():
     assert moe("sglang", mp="sgl-project/DeepSeek-V4-Flash-FP8") != common.MoEQuantMode.w4a8_mxfp4_mxfp8_trtllm
 
 
+def test_dsv4_third_party_fp4_sglang_moe_remap_on_hopper():
+    """Third-party FP4-expert DSV4 checkpoints (e.g. RedHatAI) get the sglang
+    MoE remap based on expert_dtype rather than hardcoded model paths.
+    Hopper -> w4a16_mxfp4_cutlass; Blackwell -> w4a8_mxfp4_mxfp8_trtllm."""
+    hopper = Task(
+        serving_mode="agg",
+        model_path="RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
+        system_name="h200_sxm",
+        backend_name="sglang",
+    )
+    assert hopper.moe_quant_mode == common.MoEQuantMode.w4a16_mxfp4_cutlass
+    blackwell = Task(
+        serving_mode="agg",
+        model_path="RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
+        system_name="b200_sxm",
+        backend_name="sglang",
+    )
+    assert blackwell.moe_quant_mode == common.MoEQuantMode.w4a8_mxfp4_mxfp8_trtllm
+    # FP8-only requants (no expert_dtype=fp4) are NOT remapped.
+    fp8_requant = Task(
+        serving_mode="agg",
+        model_path="sgl-project/DeepSeek-V4-Flash-FP8",
+        system_name="h200_sxm",
+        backend_name="sglang",
+    )
+    assert fp8_requant.moe_quant_mode not in (
+        common.MoEQuantMode.w4a16_mxfp4_cutlass,
+        common.MoEQuantMode.w4a8_mxfp4_mxfp8_trtllm,
+    )
+
+
+@pytest.mark.parametrize(
+    "model_path",
+    [
+        "RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
+        "sgl-project/DeepSeek-V4-Flash-FP8",
+        "deepseek-ai/DeepSeek-V4-Flash",
+    ],
+)
+def test_dsv4_fp8_kvcache_enforced(model_path):
+    """All DSV4 models use FP8 KV cache, regardless of HF config."""
+    t = Task(
+        serving_mode="agg",
+        model_path=model_path,
+        system_name="b200_sxm",
+        backend_name="trtllm",
+    )
+    assert t.kvcache_quant_mode == common.KVCacheQuantMode.fp8
+
+
 def test_pareto_sweep_controls_tpot_grid():
     """pareto_sweep=True (default) sweeps the legacy TPOT grid (matches v1); False
     evaluates only the single tpot target (Planner path)."""


### PR DESCRIPTION
#### Overview:

Fix AIC support for third-party DeepSeek-V4 FP4-expert checkpoints like `RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8`. Previously failed with `Unsupported moe quant mode 'w4a8_mxfp4_mxfp8'` on Hopper and `Unsupported deepseek_v4_generation_module quant mode 'bfloat16'` on all systems.

#### Details:

- **Replace hardcoded DSV4 path allowlist with config-based detection**: New `_is_dsv4_fp4_expert_model()` checks `architecture == DeepseekV4ForCausalLM` + `expert_dtype == "fp4"` from HF config instead of matching against a fixed list of model paths. Third-party requant artifacts are now recognized; FP8-only requants (sgl-project) correctly return False.
- **Infer FP8 KV cache for all DSV4 models**: DSV4 sparse attention requires FP8 KV cache across all backends (vLLM hard-asserts this; verified on 8xH100 cluster). Added `setdefault` in `_infer_quant_modes_from_raw_config` so FP8 KV is inferred for all DSV4 models regardless of `kv_cache_quant_algo` in the HF config.
- **Add `w4a16_mxfp4_cutlass` validation alias**: The Hopper MoE quant mode passes DB validation when `w4a16_mxfp4` data is present. Also includes forward-looking `nvfp4_wo` alias (depends on PR #1392).

#### Where should the reviewer start?

- `aic-core/src/aiconfigurator_core/sdk/models/helpers.py` — `_is_dsv4_fp4_expert_model()` and the DSV4 KV cache inference in `_infer_quant_modes_from_raw_config`
- `tests/unit/sdk/task_v2/test_task_config.py` — new tests covering Hopper/Blackwell MoE remap, FP8-requant exclusion, and KV cache enforcement across 3 DSV4 variants

#### Related Issues:

- Depends on: #1392 (for `nvfp4_wo` validation alias)
- Relates to: RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8 HF config missing `kv_cache_scheme` declaration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved DeepSeek-V4 quant-mode handling by enforcing FP8 KV-cache for DSV4 checkpoints and preventing overrides of an explicitly selected KV-cache mode.
  * Enhanced detection of DeepSeek-V4 FP4-expert models using checkpoint configuration rather than model-path allowlists.
  * Added quantization-mode name alias support during performance validation.
* **Bug Fixes**
  * Fixed DeepSeek-V4 MoE quant remapping to apply only when FP4-expert weights are detected, avoiding incorrect remapping for FP8-only variants.
* **Tests**
  * Added unit coverage for DSV4 FP4/FP8 expert remapping and KV-cache enforcement behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->