### PR TITLE
feat(collector): enable native DeepSeek-V4 w4a8_mxfp4_mxfp8 MoE collection on vLLM 0.24.0

### DIFF
--- a/collector/cases/base_ops/moe.yaml
+++ b/collector/cases/base_ops/moe.yaml
@@ -226,6 +226,24 @@ common_case_values:
     - name: w4a16_mxfp4
       requires_runtime_feature: mxfp4
       requires_model_quantization_config: true
+    - name: w4a8_mxfp4_mxfp8
+      min_sm: 100
+      # vLLM 0.24.0 serves the native (expert_dtype=fp4) DeepSeek-V4
+      # checkpoints through DeepseekV4FP8Config -> Mxfp4MoEMethod
+      # (models/deepseek_v4/quant_config.py:142-152 @0.24.0). Auto backend
+      # selection prefers FLASHINFER_TRTLLM_MXFP4_MXFP8
+      # (fused_moe/oracle/mxfp4.py:336-344), and that trtllm-gen kernel
+      # accepts only the SM100 capability family
+      # (fused_moe/experts/trtllm_mxfp4_moe.py:87). Below SM100 the oracle
+      # falls through to Marlin — weight-only BF16 activation, the distinct
+      # w4a16_mxfp4 identity — and on SM120 to DeepGemmFP4 (fp8-block
+      # activation, fused_moe/experts/deep_gemm_moe.py:423-428) or Marlin,
+      # so the MXFP8-activation label exists only on SM100/103.
+      max_sm_exclusive: 120
+      requires_runtime_feature: mxfp4
+      allowed_model_paths:
+      - deepseek-ai/DeepSeek-V4-Flash
+      - deepseek-ai/DeepSeek-V4-Pro
   moe_vllm_xpu:
     token_counts:
     - 1

--- a/collector/cases/models/DeepseekV4ForCausalLM_cases.yaml
+++ b/collector/cases/models/DeepseekV4ForCausalLM_cases.yaml
@@ -41,11 +41,15 @@ model_case_values:
           allowed_modes:
             - w4a8_mxfp4_mxfp8
         vllm:
-          # vLLM 0.24.0 selects W4A16 on SM90 but W4A8 on Blackwell for this
-          # artifact. The SDK currently requests only W4A8 and its MoE key has
-          # no system/backend dimension, so neither label is consumable across
-          # platforms yet.
-          allowed_modes: []
+          # Native-FP4 serving path: DeepseekV4FP8Config -> Mxfp4MoEMethod ->
+          # trtllm-gen MXFP4xMXFP8 on the SM100 family (see the base moe_vllm
+          # w4a8_mxfp4_mxfp8 entry for the dispatch citations). The label is
+          # SM-gated there (min_sm 100 / max_sm_exclusive 120), so SM90 —
+          # where vLLM 0.24.0 serves this artifact as Marlin W4A16 — never
+          # collects under it; Hopper stays an observed gap in the failure
+          # log rather than a mislabeled row.
+          allowed_modes:
+            - w4a8_mxfp4_mxfp8
     - model_path: sgl-project/DeepSeek-V4-Flash-FP8
       hidden_size: 4096
       inter_size: 2048
@@ -104,8 +108,9 @@ model_case_values:
           allowed_modes:
             - w4a8_mxfp4_mxfp8
         vllm:
-          # See the native Flash consumer-contract note above.
-          allowed_modes: []
+          # See the native Flash note above (same SM100-gated trtllm-gen path).
+          allowed_modes:
+            - w4a8_mxfp4_mxfp8
     - model_path: sgl-project/DeepSeek-V4-Pro-FP8
       hidden_size: 7168
       inter_size: 3072

--- a/collector/vllm/collect_moe.py
+++ b/collector/vllm/collect_moe.py
@@ -70,12 +70,14 @@ def _resolve_moe_runtime_config(model_name: str, module_config: dict) -> dict:
         or model_config.get("topk_group") is not None
         or model_config.get("topk_method") == "noaux_tc"
     )
-    # DeepSeek V4 (model_type "deepseek_ref") declares topk_method=noaux_tc
-    # but routes UNGROUPED in vLLM 0.24: its FusedMoE gets no expert grouping
-    # — only the noaux_tc e_score_correction_bias with sqrtsoftplus scoring
-    # and float32 router logits (models/deepseek_v4/nvidia/model.py:652-669,
-    # 557-561 @0.24.0). The bias/scoring fields below already carry that.
-    ungrouped_noaux_tc = model_type == "deepseek_ref"
+    # DeepSeek V4 declares topk_method=noaux_tc but routes UNGROUPED in vLLM
+    # 0.24: its FusedMoE gets no expert grouping — only the noaux_tc
+    # e_score_correction_bias with sqrtsoftplus scoring and float32 router
+    # logits (models/deepseek_v4/nvidia/model.py:652-669, 557-561 @0.24.0).
+    # The bias/scoring fields below already carry that. Both V4 model_types
+    # share that model code: "deepseek_ref" (the sgl-project FP8 requants)
+    # and "deepseek_v4" (the native expert_dtype=fp4 checkpoints).
+    ungrouped_noaux_tc = model_type in ("deepseek_ref", "deepseek_v4")
     if declares_grouped_routing and not use_grouped_topk and not ungrouped_noaux_tc:
         raise ValueError(
             f"vLLM MoE model {model_name!r} (model_type={model_type!r}) declares grouped/noaux_tc "
@@ -372,6 +374,28 @@ def run_moe_torch(
         )
     elif moe_type == "w4a16_mxfp4":
         quant_config = Mxfp4Config()
+    elif moe_type == "w4a8_mxfp4_mxfp8":
+        # Native DeepSeek-V4 (expert_dtype=fp4) serving path: vLLM overrides
+        # the checkpoint's fp8 quant_method to DeepseekV4FP8Config
+        # (models/deepseek_v4/quant_config.py:120-132 @0.24.0), which returns
+        # Mxfp4MoEMethod for the routed experts (quant_config.py:142-152);
+        # backend selection then runs select_deepseek_v4_mxfp4_moe_backend
+        # exactly as in serving. Constructor args mirror the checkpoints'
+        # quantization_config (fp8-serialized, dynamic, 128x128 blocks).
+        from vllm.models.deepseek_v4.quant_config import DeepseekV4FP8Config
+
+        expert_dtype = _load_model_moe_config(model_name).get("expert_dtype")
+        if expert_dtype != "fp4":
+            raise ValueError(
+                f"vLLM MoE case {model_name!r} requests w4a8_mxfp4_mxfp8 but its packaged "
+                f"config declares expert_dtype={expert_dtype!r}; only the native fp4-expert "
+                "DeepSeek-V4 checkpoints run this path"
+            )
+        quant_config = DeepseekV4FP8Config(
+            is_checkpoint_fp8_serialized=True,
+            activation_scheme="dynamic",
+            weight_block_size=[128, 128],
+        )
     elif moe_type == "nvfp4":
         nvfp4_args = {
             "num_bits": 4,
@@ -430,6 +454,15 @@ def run_moe_torch(
         model="collector_dummy",
         quantization_config=None,
     )
+    if moe_type == "w4a8_mxfp4_mxfp8":
+        # DeepseekV4FP8Config resolves expert_dtype lazily from the current
+        # vllm_config's hf_config (models/deepseek_v4/quant_config.py:57-78
+        # @0.24.0); mirror the native checkpoint field so the RoutedExperts
+        # dispatch resolves to the MXFP4 expert path deterministically.
+        vllm_config.model_config.hf_config = SimpleNamespace(
+            model_type="deepseek_v4",
+            expert_dtype="fp4",
+        )
     vllm_config.scheduler_config.max_num_batched_tokens = max(num_tokens_lists)
     vllm_config.parallel_config.enable_expert_parallel = moe_ep_size > 1
 

--- a/tests/unit/collector/test_getter_deduplication.py
+++ b/tests/unit/collector/test_getter_deduplication.py
@@ -381,13 +381,31 @@ def test_vllm_sm90_repository_moe_getter_excludes_unconsumable_dsv4_cases(monkey
 
     assert len(cases) == 1887
     assert sum(len(case[1]) for case in cases) == 50949
-    # Native artifacts stay excluded (their w4a8_mxfp4_mxfp8 label has no
-    # consumable vLLM path); the converted FP8 artifacts are collected as
-    # fp8_block only — the layout vLLM serves with the documented
-    # expert_dtype override.
+    # Native artifacts stay excluded on SM90 (vLLM 0.24.0 serves them there
+    # as Marlin W4A16, so the SM100-gated w4a8_mxfp4_mxfp8 label must not
+    # expand); the converted FP8 artifacts are collected as fp8_block only —
+    # the layout vLLM serves with the documented expert_dtype override.
     assert not any(case[8] in native_dsv4_models for case in cases)
     converted_modes = {case[0] for case in cases if case[8] in converted_dsv4_models}
     assert converted_modes == {"fp8_block"}
+
+
+def test_vllm_sm100_repository_moe_getter_expands_native_dsv4_w4a8_cases(monkeypatch):
+    monkeypatch.delenv("COLLECTOR_MODEL_PATH", raising=False)
+    _install_vllm_stubs(monkeypatch)
+    module = _load_collector(monkeypatch, "collector.vllm.collect_moe", "collector/vllm/collect_moe.py")
+    monkeypatch.setattr(module, "get_sm_version", lambda: 100)
+
+    cases = module.get_moe_test_cases()
+    native_dsv4_models = {
+        "deepseek-ai/DeepSeek-V4-Flash",
+        "deepseek-ai/DeepSeek-V4-Pro",
+    }
+
+    # On the SM100 family the native artifacts run the trtllm-gen
+    # MXFP4xMXFP8 serving path, and only under that label.
+    native_modes = {case[0] for case in cases if case[8] in native_dsv4_models}
+    assert native_modes == {"w4a8_mxfp4_mxfp8"}
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/collector/test_model_cases.py
+++ b/tests/unit/collector/test_model_cases.py
@@ -345,8 +345,8 @@ def test_dsv4_moe_quantization_policy_prunes_unrelated_modes():
             "sgl-project/DeepSeek-V4-Pro-FP8": {"fp8_block"},
         },
         "vllm": {
-            "deepseek-ai/DeepSeek-V4-Flash": set(),
-            "deepseek-ai/DeepSeek-V4-Pro": set(),
+            "deepseek-ai/DeepSeek-V4-Flash": {"w4a8_mxfp4_mxfp8"},
+            "deepseek-ai/DeepSeek-V4-Pro": {"w4a8_mxfp4_mxfp8"},
             "sgl-project/DeepSeek-V4-Flash-FP8": {"fp8_block"},
             "sgl-project/DeepSeek-V4-Pro-FP8": {"fp8_block"},
         },
@@ -519,6 +519,29 @@ def test_gptoss_mxfp4_modes_are_additive_on_blackwell():
     assert selected_modes("sglang", 90) == {"w4a16_mxfp4"}
     assert selected_modes("trtllm", 90) == {"w4a16_mxfp4"}
     assert selected_modes("trtllm", 100) == {"w4a16_mxfp4", "w4a8_mxfp4_mxfp8"}
+
+
+def test_vllm_dsv4_native_w4a8_mode_is_sm100_interval_gated():
+    from collector.case_generator import get_moe_quantization_modes
+
+    def selected_modes(sm_version):
+        return {
+            mode
+            for mode in get_moe_quantization_modes(
+                "vllm",
+                sm_version=sm_version,
+                runtime_features={"per_block_fp8": True, "nvfp4": True, "mxfp4": True},
+            )
+            if moe_model_allows_quantization("vllm", "deepseek-ai/DeepSeek-V4-Flash", mode)
+        }
+
+    # The trtllm-gen MXFP4xMXFP8 kernel exists only on the SM100 capability
+    # family; SM90 serves this artifact as Marlin W4A16 and SM120 routes to
+    # DeepGemmFP4/Marlin, so the label must not be collected there.
+    assert selected_modes(90) == set()
+    assert selected_modes(100) == {"w4a8_mxfp4_mxfp8"}
+    assert selected_modes(103) == {"w4a8_mxfp4_mxfp8"}
+    assert selected_modes(120) == set()
 
 
 def test_sglang_mxfp4_quant_labels_select_explicit_activation_precision():
@@ -731,7 +754,7 @@ def test_vllm_moe_quantization_metadata_is_yaml_backed():
         "vllm",
         sm_version=100,
         runtime_features={"per_block_fp8": True, "nvfp4": True, "mxfp4": True},
-    ) == ["bfloat16", "int4_wo", "fp8", "fp8_block", "nvfp4", "w4a16_mxfp4"]
+    ) == ["bfloat16", "int4_wo", "fp8", "fp8_block", "nvfp4", "w4a16_mxfp4", "w4a8_mxfp4_mxfp8"]
     assert get_moe_quantization_modes(
         "vllm",
         sm_version=120,

--- a/tests/unit/collector/test_model_cases.py
+++ b/tests/unit/collector/test_model_cases.py
@@ -524,13 +524,13 @@ def test_gptoss_mxfp4_modes_are_additive_on_blackwell():
 def test_vllm_dsv4_native_w4a8_mode_is_sm100_interval_gated():
     from collector.case_generator import get_moe_quantization_modes
 
-    def selected_modes(sm_version):
+    def selected_modes(sm_version, *, mxfp4=True):
         return {
             mode
             for mode in get_moe_quantization_modes(
                 "vllm",
                 sm_version=sm_version,
-                runtime_features={"per_block_fp8": True, "nvfp4": True, "mxfp4": True},
+                runtime_features={"per_block_fp8": True, "nvfp4": True, "mxfp4": mxfp4},
             )
             if moe_model_allows_quantization("vllm", "deepseek-ai/DeepSeek-V4-Flash", mode)
         }
@@ -542,6 +542,8 @@ def test_vllm_dsv4_native_w4a8_mode_is_sm100_interval_gated():
     assert selected_modes(100) == {"w4a8_mxfp4_mxfp8"}
     assert selected_modes(103) == {"w4a8_mxfp4_mxfp8"}
     assert selected_modes(120) == set()
+    # The mxfp4 runtime-feature gate must hold even inside the SM interval.
+    assert selected_modes(100, mxfp4=False) == set()
 
 
 def test_sglang_mxfp4_quant_labels_select_explicit_activation_precision():


### PR DESCRIPTION
## Problem

Native (`expert_dtype=fp4`) DeepSeek-V4 checkpoints have no consumable MoE path on the vLLM backend: the SDK infers `w4a8_mxfp4_mxfp8` for them (HF auto-inference on `DeepseekV4ForCausalLM` + `expert_dtype=fp4`), but no vLLM database carries that label, so DSV4-native × vLLM fails `task_v2` quant validation everywhere and shows as a gap in the support matrix.

The label was deliberately disabled in #1344 (`allowed_modes: []`, no `moe_vllm` quant-axis entry) because vLLM 0.24.0 serves the same artifact as **Marlin W4A16 on SM90** but as **trtllm-gen MXFP4×MXFP8 W4A8 on Blackwell**, and one un-gated label cannot carry two kernel identities.

## Fix

Resolve the cross-platform concern the way the quant-mode axis already sanctions (owner decision 2026-07-13, `case_authoring.md`): gate the label to the SM interval where the W4A8 identity actually exists, instead of disabling it everywhere.

- **`collector/cases/base_ops/moe.yaml`** — add `moe_vllm` `w4a8_mxfp4_mxfp8` with `min_sm: 100` / `max_sm_exclusive: 120` and serving-dispatch citations at 0.24.0: `DeepseekV4FP8Config → Mxfp4MoEMethod` (`models/deepseek_v4/quant_config.py:142-152`), auto priority `FLASHINFER_TRTLLM_MXFP4_MXFP8` first (`fused_moe/oracle/mxfp4.py:336-344`), kernel accepts only the SM100 capability family (`fused_moe/experts/trtllm_mxfp4_moe.py:87`). SM90 falls through to Marlin (the distinct `w4a16_mxfp4` identity) and SM120 to DeepGemmFP4/Marlin, so the label never expands there.
- **`collector/cases/models/DeepseekV4ForCausalLM_cases.yaml`** — flip the two native artifacts' vllm `allowed_modes` from `[]` to `[w4a8_mxfp4_mxfp8]`.
- **`collector/vllm/collect_moe.py`** — construct `DeepseekV4FP8Config` (the serving quant config, args mirroring the checkpoints' `quantization_config`) so `FusedMoE` runs vLLM's own `select_deepseek_v4_mxfp4_moe_backend` exactly as in serving; fail loudly if the packaged config is not `expert_dtype=fp4`. Also accept `model_type "deepseek_v4"` in the ungrouped-noaux_tc routing guard — the native configs report it (only the sgl-project FP8 requants report `deepseek_ref`), and vLLM routes both ungrouped (`models/deepseek_v4/nvidia/model.py:652-669`).

SM90/Hopper collection is unchanged: the label is SM-gated, so Hopper stays an observed, classified gap (the version-agnostic support-matrix classifier entry keeps covering it) rather than a mislabeled row. The loader needs no change: vLLM rows keep `kernel_source=vllm_*`, so they file under plain `w4a8_mxfp4_mxfp8` — exactly the mode the SDK requests for vLLM.

## Validation

- **B200 (SM100) hardware smoke test**: `FusedMoE` auto-selects `FLASHINFER_TRTLLM_MXFP4_MXFP8` / `TrtLlmMxfp4ExpertsModular` for both native geometries — Flash (4096×2048, 256e, topk 6) and Pro (7168×3072, 384e, TP=4, power-law) — recording `kernel_source=vllm_mxfp4moe_flashinfer_trtllm_mxfp4_mxfp8_trtllmmxfp4expertsmodular`.
- **Cross-check against sglang**: the same trtllm-gen kernel already collected on sglang 0.5.14 b200 (`sglang_mxfp4_flashinfer_trtllm_moe`); at 512 tokens the vLLM row measures 0.7226 ms vs sglang 0.7201 ms (0.3%), at 1 token 0.0344 vs 0.0308 ms.
- **Unit tests**: full `tests/unit/collector` suite passes (435 passed). New tests pin the SM interval (90/120 → no cases, 100/103 → `w4a8_mxfp4_mxfp8` only) and the SM100 population expansion; the SM90 population counts are unchanged.

## Notes / follow-ups

- b200/gb200-class `w4a8_mxfp4_mxfp8` data for vLLM 0.24.0 still needs a collection campaign before the support matrix flips to PASS; this PR is the collector enablement only (module-boundary rules keep packaged data and `tools/support_matrix` out of scope here).
- The support-matrix known-gap comment ("no consumable path on any collected version") becomes Hopper-/pre-campaign-specific once data lands; happy to refresh it in a follow-up if maintainers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new vLLM quantization option (W4A8 MXFP4/MXFP8) for DeepSeek-V4 Flash and Pro models.
  - Improved expert routing behavior for compatible MoE configurations to better match DeepSeek-V4 expectations.
- **Bug Fixes**
  - Fixed model collection/labeling so the new native W4A8 MXFP4/MXFP8 mode is correctly enabled only for supported SM ranges and when the required runtime feature is available.
- **Tests**
  - Expanded unit coverage to verify native-mode inclusion/exclusion across SM100/SM103 vs SM90/SM120.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->