### PR TITLE
chore: bump version to 0.11.0

### DIFF
--- a/aic-core/pyproject.toml
+++ b/aic-core/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "aiconfigurator-core"
-version = "0.10.0"
+version = "0.11.0"
 authors = [
     { name = "NVIDIA Inc.", email = "sw-dl-dynamo@nvidia.com" },
 ]

--- a/aic-core/rust/aiconfigurator-core/Cargo.lock
+++ b/aic-core/rust/aiconfigurator-core/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "aiconfigurator-core"
-version = "0.9.0"
+version = "0.11.0"
 dependencies = [
  "csv",
  "serde",

--- a/aic-core/rust/aiconfigurator-core/Cargo.toml
+++ b/aic-core/rust/aiconfigurator-core/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "aiconfigurator-core"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "Rust-native core latency estimator for AIConfigurator"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "aiconfigurator"
-version = "0.10.0"
+version = "0.11.0"
 authors = [
     { name = "NVIDIA Inc.", email = "sw-dl-dynamo@nvidia.com" },
 ]
@@ -40,7 +40,7 @@ license-files = ["LICENSE"]
 requires-python = ">=3.10"
 
 dependencies = [
-    "aiconfigurator-core==0.10.0",
+    "aiconfigurator-core==0.11.0",
     "jinja2>=3.1.0",
     "packaging>=20.0",
     "matplotlib>=3.9.4",

--- a/uv.lock
+++ b/uv.lock
@@ -19,7 +19,7 @@ resolution-markers = [
 
 [[package]]
 name = "aiconfigurator"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiconfigurator-core" },
@@ -106,7 +106,7 @@ provides-extras = ["dev", "webapp", "service"]
 
 [[package]]
 name = "aiconfigurator-core"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "aic-core" }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary

- bump `aiconfigurator` and `aiconfigurator-core` Python package metadata to `0.11.0`
- bump the `aiconfigurator-core` Rust crate to `0.11.0`
- pin the upper wheel to `aiconfigurator-core==0.11.0`
- refresh the Python and Rust lockfile package entries

## Why

`main` still declared the previous `0.10.0` release even though the active release line is 0.11. This makes the two Python wheels and the Rust crate produce consistently versioned 0.11.0 artifacts.

## Impact

Packaging metadata only; there are no runtime behavior changes.

## Validation

- `uv lock --check`
- `cargo metadata --locked --no-deps --format-version 1`
- built both release wheels and confirmed both report `Version: 0.11.0`
- confirmed the upper wheel requires `aiconfigurator-core==0.11.0`
- `uv run python tools/verify_release_wheels.py <dist-dir>`
- `uv run --extra dev pytest -q tests/unit/tools/test_verify_release_wheels.py` (2 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.11.0 of the application and its core components.
  * Updated internal package references to align with the new release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->