### PR TITLE
refactor(sdk): move MTP acceptance above aic-core

### DIFF
--- a/aic-core/rust/aiconfigurator-core/README.md
+++ b/aic-core/rust/aiconfigurator-core/README.md
@@ -71,7 +71,7 @@ let decode = engine.decode_latency_ms(/* bs */ 1, /* isl */ 1024, /* osl */ 2)?;
 The `EngineConfig` identity carried by the spec groups its fields into cohesive
 sub-structs — `ParallelMapping` (`tp_size`, `pp_size`, `attention_dp_size`,
 `moe_tp_size`, `moe_ep_size`, `cp_size`), `QuantizationConfig`, and an optional
-`SpeculativeConfig` (`nextn`, `nextn_accepted`) — all `#[serde(flatten)]`-ed
+`SpeculativeConfig` (`nextn`) — all `#[serde(flatten)]`-ed
 so the wire JSON stays the flat object Python emits.
 
 ## Supported vs. not supported

--- a/aic-core/rust/aiconfigurator-core/parity_tests/test_compile_engine_parity.py
+++ b/aic-core/rust/aiconfigurator-core/parity_tests/test_compile_engine_parity.py
@@ -174,7 +174,6 @@ class TestOpTransferRoundTrip:
             kv_block_size=None,
             systems_path=None,
             nextn=0,
-            nextn_accepted=None,
             database=database,
         )
         spec = json.loads(spec_json)

--- a/aic-core/rust/aiconfigurator-core/src/config.rs
+++ b/aic-core/rust/aiconfigurator-core/src/config.rs
@@ -21,7 +21,7 @@ pub const ENGINE_CONFIG_SCHEMA_VERSION: u32 = 1;
 // only distinguishable by this version — `EngineSpec::from_bincode` reads and
 // checks it before decoding the op lists. Bump whenever an `OpSpec` field
 // changes; keep in lockstep with `sdk/engine.py::ENGINE_SPEC_SCHEMA_VERSION`.
-pub const ENGINE_SPEC_SCHEMA_VERSION: u32 = 2;
+pub const ENGINE_SPEC_SCHEMA_VERSION: u32 = 3;
 
 /// Static engine identity and setup information carried by an
 /// [`crate::engine::spec::EngineSpec`].
@@ -130,8 +130,8 @@ pub struct QuantizationConfig {
 
 /// Multi-Token Prediction speculative-decoding parameters. Wrapped in
 /// `Option<>` on [`EngineConfig`] so models without MTP don't carry the
-/// noise, and `#[serde(flatten)]`-ed so the flat wire keys (`nextn`,
-/// `nextn_accepted`) parse unchanged.
+/// noise, and `#[serde(flatten)]`-ed so the flat wire key (`nextn`) parses
+/// unchanged. Accepted-token progress is modeled above `aic-core`.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct SpeculativeConfig {
     /// Multi-Token Prediction speculative decoding depth / draft length
@@ -139,12 +139,6 @@ pub struct SpeculativeConfig {
     /// never auto-enabled; the user opts in explicitly.
     #[serde(default)]
     pub nextn: Option<u32>,
-
-    /// Average accepted draft tokens per decode step used by MTP scaling
-    /// (Python's `task_config.nextn_accepted`, `0 <= nextn_accepted <= nextn`). Ignored
-    /// when `nextn` is `None` or 0.
-    #[serde(default)]
-    pub nextn_accepted: Option<f64>,
 }
 
 /// Backend performance database family.
@@ -223,7 +217,6 @@ mod engine_config_wire_tests {
             "kv_cache_dtype": "bfloat16",
             "kv_block_size": null,
             "nextn": null,
-            "nextn_accepted": null,
             "extra": {}
         }"#;
 

--- a/aic-core/rust/aiconfigurator-core/src/engine/runtime.rs
+++ b/aic-core/rust/aiconfigurator-core/src/engine/runtime.rs
@@ -603,9 +603,6 @@ mod tests {
             },
             speculative: nextn.map(|n| crate::SpeculativeConfig {
                 nextn: Some(n),
-                // Batch-scaling-only fixture; 0.0 keeps the enabled-MTP
-                // contract (nextn > 0 requires an acceptance value) satisfied.
-                nextn_accepted: Some(0.0),
             }),
             perf_db_sources: Default::default(),
             extra: BTreeMap::new(),

--- a/aic-core/rust/aiconfigurator-core/src/engine/spec.rs
+++ b/aic-core/rust/aiconfigurator-core/src/engine/spec.rs
@@ -615,7 +615,6 @@ mod tests {
             },
             speculative: Some(SpeculativeConfig {
                 nextn: Some(1),
-                nextn_accepted: Some(0.85),
             }),
             perf_db_sources: Default::default(),
             extra: BTreeMap::new(),

--- a/aic-core/rust/aiconfigurator-core/src/memory.rs
+++ b/aic-core/rust/aiconfigurator-core/src/memory.rs
@@ -250,10 +250,6 @@ fn fetch_python_estimate(
         .as_ref()
         .and_then(|s| s.nextn)
         .unwrap_or(0);
-    let nextn_accepted = engine
-        .speculative
-        .as_ref()
-        .and_then(|s| s.nextn_accepted);
     let (fraction_kind, fraction_value) = req.kv_cache_memory_fraction.to_wire();
 
     Python::with_gil(|py| -> PyResult<KvCacheEstimate> {
@@ -286,7 +282,6 @@ fn fetch_python_estimate(
         // overhead comes from `system_spec` (`nccl_mem` / `other_mem`), not the
         // comm quant mode, so it does not affect the non-KV breakdown.
         kwargs.set_item("nextn", nextn)?;
-        kwargs.set_item("nextn_accepted", nextn_accepted)?;
         kwargs.set_item(
             "systems_path",
             engine.systems_path.as_deref().and_then(|p| p.to_str()),

--- a/aic-core/rust/aiconfigurator-core/src/py.rs
+++ b/aic-core/rust/aiconfigurator-core/src/py.rs
@@ -311,7 +311,6 @@ struct EngineBuildRequest {
     fmha_quant_mode: Option<String>,
     comm_quant_mode: Option<String>,
     nextn: u32,
-    nextn_accepted: Option<f64>,
     kv_block_size: Option<u32>,
     systems_path: Option<String>,
 }
@@ -352,7 +351,6 @@ impl AicEngineBuilder {
                 fmha_quant_mode: None,
                 comm_quant_mode: None,
                 nextn: 0,
-                nextn_accepted: None,
                 kv_block_size: None,
                 systems_path: None,
             },
@@ -421,9 +419,8 @@ impl AicEngineBuilder {
     }
 
     /// Configure speculative decoding.
-    pub fn speculative_decoding(mut self, nextn: u32, nextn_accepted: Option<f64>) -> Self {
+    pub fn speculative_decoding(mut self, nextn: u32) -> Self {
         self.request.nextn = nextn;
-        self.request.nextn_accepted = nextn_accepted;
         self
     }
 
@@ -470,7 +467,7 @@ mod builder_tests {
             .pp_size(2)
             .attention_dp_size(4)
             .moe_parallelism(Some(1), Some(8))
-            .speculative_decoding(2, Some(0.8))
+            .speculative_decoding(2)
             .kv_block_size(16)
             .systems_path("/tmp/systems");
         assert_eq!(builder.request.backend, "sglang");
@@ -481,7 +478,7 @@ mod builder_tests {
             (builder.request.moe_tp_size, builder.request.moe_ep_size),
             (Some(1), Some(8))
         );
-        assert_eq!(builder.request.nextn_accepted, Some(0.8));
+        assert_eq!(builder.request.nextn, 2);
         assert_eq!(builder.request.kv_block_size, Some(16));
         assert_eq!(
             builder.request.systems_path.as_deref(),
@@ -533,7 +530,6 @@ pub fn build_aic_engine(
     fmha_quant_mode: Option<&str>,
     comm_quant_mode: Option<&str>,
     nextn: u32,
-    nextn_accepted: Option<f64>,
     kv_block_size: Option<u32>,
     systems_path: Option<&str>,
 ) -> Result<AicEngine, AicError> {
@@ -553,7 +549,6 @@ pub fn build_aic_engine(
         fmha_quant_mode: fmha_quant_mode.map(str::to_owned),
         comm_quant_mode: comm_quant_mode.map(str::to_owned),
         nextn,
-        nextn_accepted,
         kv_block_size,
         systems_path: systems_path.map(str::to_owned),
     })
@@ -595,7 +590,6 @@ fn compile_engine_from_request(request: EngineBuildRequest) -> Result<Engine, Ai
         kwargs.set_item("fmha_quant_mode", request.fmha_quant_mode.as_deref())?;
         kwargs.set_item("comm_quant_mode", request.comm_quant_mode.as_deref())?;
         kwargs.set_item("nextn", request.nextn)?;
-        kwargs.set_item("nextn_accepted", request.nextn_accepted)?;
         kwargs.set_item("kv_block_size", request.kv_block_size)?;
         kwargs.set_item("systems_path", systems_root_str)?;
         engine_mod
@@ -640,8 +634,6 @@ pub(crate) fn compile_engine_to_engine(
         .as_ref()
         .and_then(|s| s.nextn)
         .unwrap_or(0);
-    let nextn_accepted = config.speculative.as_ref().and_then(|s| s.nextn_accepted);
-
     compile_engine_from_request(EngineBuildRequest {
         model_path: config.model_name.clone(),
         system: config.system_name.clone(),
@@ -662,7 +654,6 @@ pub(crate) fn compile_engine_to_engine(
         // Comm quant is not carried on EngineConfig; let Python default it.
         comm_quant_mode: None,
         nextn,
-        nextn_accepted,
         kv_block_size: config.kv_block_size,
         systems_path: systems_path.map(str::to_owned),
     })

--- a/aic-core/rust/aiconfigurator-core/tests/embedded_round_trip.rs
+++ b/aic-core/rust/aiconfigurator-core/tests/embedded_round_trip.rs
@@ -122,7 +122,6 @@ fn embedded_builder_and_compatibility_adapter_match() {
         None,    // fmha_quant_mode
         None,    // comm_quant_mode
         0,       // nextn
-        None,    // nextn_accepted
         None,    // kv_block_size
         None,    // resolve the installed core wheel's bundled systems data
     )

--- a/aic-core/rust/tests/public-api/src/lib.rs
+++ b/aic-core/rust/tests/public-api/src/lib.rs
@@ -21,7 +21,7 @@ pub fn configured_builder() -> AicEngineBuilder {
         .kvcache_quant_mode("bfloat16")
         .fmha_quant_mode("bfloat16")
         .comm_quant_mode("bfloat16")
-        .speculative_decoding(0, None)
+        .speculative_decoding(0)
         .kv_block_size(16)
         .systems_path("/tmp/systems")
 }
@@ -53,7 +53,6 @@ pub fn build_engine_compatibility_adapter() -> Result<AicEngine, AicError> {
         Some("bfloat16"),
         Some("bfloat16"),
         0,
-        None,
         Some(16),
         Some("/tmp/systems"),
     )
@@ -80,7 +79,7 @@ mod tests {
     #[test]
     fn schema_constants_and_metric_defaults_are_public() {
         assert_eq!(ENGINE_CONFIG_SCHEMA_VERSION, 1);
-        assert_eq!(ENGINE_SPEC_SCHEMA_VERSION, 2);
+        assert_eq!(ENGINE_SPEC_SCHEMA_VERSION, 3);
         assert_eq!(FPM_VERSION, 1);
         assert_eq!(ForwardPassMetrics::default().version, FPM_VERSION);
     }

--- a/aic-core/src/aiconfigurator_core/sdk/config.py
+++ b/aic-core/src/aiconfigurator_core/sdk/config.py
@@ -30,11 +30,9 @@ class ModelConfig:
     cp_style: str = "none"
     workload_distribution: str = "power_law"
     # quantization options
-    # MTP speculative decoding: nextn = draft length (compute cost side),
-    # nextn_accepted = average accepted draft tokens per step (generation benefit
-    # side, 0 <= nextn_accepted <= nextn). nextn_accepted is required when nextn > 0.
+    # MTP speculative decoding: draft length (compute/verification cost only).
+    # Accepted-token progress belongs to the upper prediction/simulation layer.
     nextn: int = 0
-    nextn_accepted: float = None
     overwrite_num_layers: int = 0
     # model builder falvors
     sms: int = 20

--- a/aic-core/src/aiconfigurator_core/sdk/config_builders.py
+++ b/aic-core/src/aiconfigurator_core/sdk/config_builders.py
@@ -9,8 +9,6 @@ Keeping them in ``sdk`` prevents lower-level code from importing CLI code.
 
 from __future__ import annotations
 
-import math
-
 from aiconfigurator_core.sdk.common import (
     CommQuantMode,
     FMHAQuantMode,
@@ -48,30 +46,24 @@ def build_model_config(
     )
 
 
-def validate_nextn(nextn: int | None, nextn_accepted: float | None) -> int:
-    """Validate the MTP pair and return the normalized ``nextn``.
+def validate_nextn(nextn: int | None) -> int:
+    """Validate and normalize the MTP draft length.
 
-    ``nextn`` must be a non-negative integer draft length; when it is positive,
-    ``nextn_accepted`` must be a finite scalar within ``[0, nextn]`` -- there is
-    no built-in acceptance assumption. Single source for the Task / ModelConfig /
-    memory-estimation entry points so user-input errors surface identically
-    everywhere (and are never swallowed by fallback paths).
+    The ``aic-core`` layer owns only the compute-side draft depth. Accepted-token progress is
+    modeled by the upper prediction layer and therefore is intentionally not
+    part of this helper or :class:`ModelConfig`.
     """
     if nextn is not None and int(nextn) != nextn:
         raise ValueError(f"nextn ({nextn}) must be an integer draft length.")
     normalized = int(nextn or 0)
     if normalized < 0:
         raise ValueError(f"nextn ({nextn}) must be >= 0.")
-    if normalized > 0:
-        if nextn_accepted is None:
-            raise ValueError(
-                f"nextn={normalized} requires 'nextn_accepted' (average accepted draft tokens "
-                f"per step, 0 <= nextn_accepted <= nextn); there is no built-in acceptance assumption."
-            )
-        accepted = float(nextn_accepted)
-        if not math.isfinite(accepted) or not 0 <= accepted <= normalized:
-            raise ValueError(f"nextn_accepted ({nextn_accepted}) must be within [0, nextn={normalized}].")
     return normalized
+
+
+def normalize_nextn(nextn: int | None) -> int:
+    """Return the MTP draft length normalized for ``aic-core``."""
+    return validate_nextn(nextn)
 
 
 def resolve_nextn_auto(model_path: str) -> int:
@@ -80,8 +72,7 @@ def resolve_nextn_auto(model_path: str) -> int:
     Reads ``num_nextn_predict_layers`` from the model config (the multimodal
     text sub-config when applicable); absent or 0 means the checkpoint ships no
     MTP layers and MTP stays disabled. The checkpoint is the single source of
-    truth -- there is no model-family fallback, and ``nextn_accepted`` is never
-    inferred (acceptance is a workload measurement, not a checkpoint fact).
+    truth -- there is no model-family fallback.
     """
     # Local import: utils pulls in the perf-database layer, which config
     # builders must not depend on at import time.
@@ -100,14 +91,6 @@ def resolve_nextn_auto(model_path: str) -> int:
 def apply_nextn(
     model_config: ModelConfig,
     nextn: int | None,
-    nextn_accepted: float | None,
 ) -> None:
-    """Apply MTP speculative-decoding overrides onto a ModelConfig.
-
-    ``nextn`` is the draft length, ``nextn_accepted`` the average accepted draft
-    tokens per step. ``nextn_accepted`` is required when ``nextn > 0`` -- there is
-    no built-in acceptance assumption.
-    """
-    model_config.nextn = validate_nextn(nextn, nextn_accepted)
-    if model_config.nextn > 0:
-        model_config.nextn_accepted = float(nextn_accepted)
+    """Apply the MTP compute-side draft depth onto a ModelConfig."""
+    model_config.nextn = normalize_nextn(nextn)

--- a/aic-core/src/aiconfigurator_core/sdk/engine.py
+++ b/aic-core/src/aiconfigurator_core/sdk/engine.py
@@ -89,7 +89,7 @@ from aiconfigurator_core.sdk.rust_engine_step import (
 # refactor added serialized `OpSpec` fields); the Rust consumer gates on this
 # version before decoding the positional op lists. Keep in lockstep with the
 # Rust `ENGINE_SPEC_SCHEMA_VERSION`.
-ENGINE_SPEC_SCHEMA_VERSION = 2
+ENGINE_SPEC_SCHEMA_VERSION = 3
 ENGINE_CONFIG_SCHEMA_VERSION = 1
 
 
@@ -648,7 +648,6 @@ def _engine_config_dict(
     kv_block_size: int | None,
     systems_path: str | None,
     nextn: int,
-    nextn_accepted: float | None,
     database: Any = None,
 ) -> dict:
     """Build the ``EngineConfig`` JSON (matches the Rust modularised struct).
@@ -664,10 +663,7 @@ def _engine_config_dict(
     effective_nextn = int(model_nextn) if model_nextn is not None else int(nextn)
     speculative = None
     if effective_nextn:
-        speculative = {
-            "nextn": effective_nextn,
-            "nextn_accepted": (float(nextn_accepted) if nextn_accepted is not None else None),
-        }
+        speculative = {"nextn": effective_nextn}
     # The Rust ``EngineConfig`` flattens ``parallel`` / ``quantization`` /
     # ``speculative`` via ``#[serde(flatten)]``, so their fields live at the
     # TOP LEVEL of this dict (NOT nested under sub-keys).
@@ -697,12 +693,11 @@ def _engine_config_dict(
         "perf_db_sources": _compute_perf_db_sources(database),
         "extra": {},
     }
-    # SpeculativeConfig (flattened, Option<>): emit nextn/nextn_accepted at
-    # the top level when MTP is active. When inactive, omit both keys so the
+    # SpeculativeConfig (flattened, Option<>): emit nextn at the top level
+    # when MTP is active. When inactive, omit it so the
     # flattened Option deserializes to None.
     if speculative is not None:
         engine["nextn"] = speculative["nextn"]
-        engine["nextn_accepted"] = speculative["nextn_accepted"]
     return engine
 
 
@@ -732,7 +727,6 @@ def compile_engine(
     fmha_quant_mode: str | None = None,
     comm_quant_mode: str | None = None,
     nextn: int = 0,
-    nextn_accepted: float | None = None,
     kv_block_size: int | None = None,
     systems_path: str | None = None,
 ) -> bytes:
@@ -761,9 +755,8 @@ def compile_engine(
         comm_quant_mode=comm_quant_mode,
     )
     # Apply MTP BEFORE get_model so the walked op lists carry the
-    # 1/(1+nextn_accepted)*(L+nextn)/L generation scale; the spec's top-level
-    # nextn only drives the Rust (nextn+1) decode-batch multiplier.
-    apply_nextn(model_config, nextn, nextn_accepted)
+    # (L+nextn)/L compute scale; accepted-token progress is applied above core.
+    apply_nextn(model_config, nextn)
     model = get_model(model_path, model_config, backend)
 
     # The database is only needed to pre-bake the WideEP MoE kernel selection
@@ -779,8 +772,7 @@ def compile_engine(
         backend_version=backend_version,
         kv_block_size=kv_block_size,
         systems_path=systems_path,
-        nextn=nextn,
-        nextn_accepted=nextn_accepted,
+        nextn=model_config.nextn,
         database=database,
     )
 
@@ -797,7 +789,6 @@ def build_engine_spec_json(
     kv_block_size: int | None,
     systems_path: str | None,
     nextn: int,
-    nextn_accepted: float | None,
     database: Any = None,
 ) -> str:
     """Walk a built model's op lists into an ``EngineSpec`` JSON string.
@@ -836,7 +827,6 @@ def build_engine_spec_json(
             kv_block_size=kv_block_size,
             systems_path=systems_path,
             nextn=nextn,
-            nextn_accepted=nextn_accepted,
             database=database,
         ),
         "context_ops": context_ops,

--- a/aic-core/src/aiconfigurator_core/sdk/memory.py
+++ b/aic-core/src/aiconfigurator_core/sdk/memory.py
@@ -262,7 +262,6 @@ class KVCacheEstimator:
         fmha_quant_mode: str | None = None,
         comm_quant_mode: str | None = None,
         nextn: int = 0,
-        nextn_accepted: float | None = None,
         systems_path: str | None = None,
     ) -> KVCacheEstimator:
         """Build the model/backend/perf-DB and the non-KV memory breakdown.
@@ -302,10 +301,9 @@ class KVCacheEstimator:
         # spec-decode aware (e.g. for any draft-module weights). This does NOT scale
         # the capacity activation by (nextn+1); that multiplier is suppressed below
         # (see mtp_activation_scaling). Mirrors the agg/disagg/static estimate paths.
-        # Memory is cost-side only: nextn_accepted (the acceptance benefit) never
-        # enters capacity math, so feed apply_nextn a neutral 0.0 when the caller
-        # did not supply one instead of forcing a benefit-side parameter here.
-        apply_nextn(model_config, nextn, nextn_accepted if nextn_accepted is not None else 0.0)
+        # Memory is cost-side only; accepted-token progress never enters
+        # capacity math.
+        apply_nextn(model_config, nextn)
         model = get_model(model_path, model_config, backend)
         backend_obj = get_backend(backend)
         database = perf_database.get_database(system, backend, backend_version, systems_paths=systems_path)
@@ -858,7 +856,6 @@ def estimate_kv_cache(
     fmha_quant_mode: str | None = None,
     comm_quant_mode: str | None = None,
     nextn: int = 0,
-    nextn_accepted: float | None = None,
     systems_path: str | None = None,
     gpu_memory_capacity_bytes_override: int | None = None,
     tolerance_fraction: float | None = None,
@@ -916,11 +913,8 @@ def estimate_kv_cache(
     fraction = float(memory_fraction_value)
     is_of_free = memory_fraction_kind == "of_free"
 
-    # Validate MTP inputs up front: an out-of-range value must surface as-is, not
-    # be swallowed by the naive fallback below (which ignores MTP entirely).
-    # Unlike the latency paths, nextn_accepted is OPTIONAL here: capacity math
-    # never consumes the acceptance benefit, so only range-check it when given.
-    validate_nextn(nextn, nextn_accepted if nextn_accepted is not None else 0.0)
+    # Validate the compute-side MTP depth before any fallback path.
+    validate_nextn(nextn)
 
     try:
         native = KVCacheEstimator.from_request(
@@ -941,7 +935,6 @@ def estimate_kv_cache(
             fmha_quant_mode=fmha_quant_mode,
             comm_quant_mode=comm_quant_mode,
             nextn=int(nextn),
-            nextn_accepted=nextn_accepted,
             systems_path=systems_path,
         )
     except Exception as exc:  # native model build unsupported (model/backend/perf DB)
@@ -999,7 +992,6 @@ def estimate_num_gpu_blocks(
     fmha_quant_mode: str | None = None,
     comm_quant_mode: str | None = None,
     nextn: int = 0,
-    nextn_accepted: float | None = None,
     systems_path: str | None = None,
     gpu_memory_capacity_bytes_override: int | None = None,
     tolerance_fraction: float | None = None,
@@ -1054,7 +1046,6 @@ def estimate_num_gpu_blocks(
         fmha_quant_mode=fmha_quant_mode,
         comm_quant_mode=comm_quant_mode,
         nextn=int(nextn),
-        nextn_accepted=nextn_accepted,
         systems_path=systems_path,
         gpu_memory_capacity_bytes_override=gpu_memory_capacity_bytes_override,
         tolerance_fraction=tolerance_fraction,

--- a/aic-core/src/aiconfigurator_core/sdk/models/base.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/base.py
@@ -33,6 +33,7 @@ import logging
 from typing import ClassVar
 
 from aiconfigurator_core.sdk import config
+from aiconfigurator_core.sdk.config_builders import normalize_nextn
 
 logger = logging.getLogger(__name__)
 
@@ -123,8 +124,8 @@ class BaseModel:
             f"num_heads {self._num_heads} should be divisible by tp_size {model_config.tp_size} "
         )
 
-        self._nextn = model_config.nextn
-        self._nextn_accepted = model_config.nextn_accepted
+        self._nextn = normalize_nextn(model_config.nextn)
+        model_config.nextn = self._nextn
 
     @property
     def activation_hidden_size(self) -> int:

--- a/aic-core/src/aiconfigurator_core/sdk/models/deepseek.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/deepseek.py
@@ -112,7 +112,7 @@ class DeepSeekModel(BaseModel):
         #    non-attn part
         # meanwhile, needs to scale the actual bs of generation by nextn,
         # this is covered in inferencesession
-        self._mtp_scale_factor = mtp_scale_factor(self._nextn, self._nextn_accepted, self._num_layers)
+        self._mtp_scale_factor = mtp_scale_factor(self._nextn, self._num_layers)
         self._power_law_alpha = 1.01
 
         gemm_quant_mode = self.config.gemm_quant_mode
@@ -600,7 +600,7 @@ class TrtllmWideEPDeepSeekModel(BaseModel):
         self._moe_inter_size = moe_inter_size
 
         # MTP scale factor for generation phase
-        self._mtp_scale_factor = mtp_scale_factor(self._nextn, self._nextn_accepted, self._num_layers)
+        self._mtp_scale_factor = mtp_scale_factor(self._nextn, self._num_layers)
         self._pdl_factor = 0.9
         self._power_law_alpha = 1.01
 
@@ -1067,7 +1067,7 @@ class WideEPDeepSeekModel(BaseModel):
         self._topk = topk
         self._num_experts = num_experts
         self._moe_inter_size = moe_inter_size
-        self._mtp_scale_factor = mtp_scale_factor(self._nextn, self._nextn_accepted, self._num_layers)
+        self._mtp_scale_factor = mtp_scale_factor(self._nextn, self._num_layers)
 
         h = self._hidden_size
         tp_size = self.config.tp_size

--- a/aic-core/src/aiconfigurator_core/sdk/models/deepseek_v32.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/deepseek_v32.py
@@ -184,7 +184,7 @@ class DeepSeekV32Model(BaseModel):
         self._topk = topk
         self._num_experts = num_experts
         self._moe_inter_size = moe_inter_size
-        self._mtp_scale_factor = mtp_scale_factor(self._nextn, self._nextn_accepted, self._num_layers)
+        self._mtp_scale_factor = mtp_scale_factor(self._nextn, self._num_layers)
         self._power_law_alpha = 1.01
 
         h = self._hidden_size
@@ -459,7 +459,7 @@ class TrtllmWideEPDeepSeekV32Model(BaseModel):
         self._topk = topk
         self._num_experts = num_experts
         self._moe_inter_size = moe_inter_size
-        self._mtp_scale_factor = mtp_scale_factor(self._nextn, self._nextn_accepted, self._num_layers)
+        self._mtp_scale_factor = mtp_scale_factor(self._nextn, self._num_layers)
         self._pdl_factor = 0.9
         self._power_law_alpha = 1.01
 
@@ -721,7 +721,7 @@ class WideEPDeepSeekV32Model(BaseModel):
         self._topk = topk
         self._num_experts = num_experts
         self._moe_inter_size = moe_inter_size
-        self._mtp_scale_factor = mtp_scale_factor(self._nextn, self._nextn_accepted, self._num_layers)
+        self._mtp_scale_factor = mtp_scale_factor(self._nextn, self._num_layers)
 
         h = self._hidden_size
         tp_size = self.config.tp_size

--- a/aic-core/src/aiconfigurator_core/sdk/models/deepseek_v4.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/deepseek_v4.py
@@ -77,7 +77,7 @@ class DeepSeekV4Model(BaseModel):
         self._topk = topk
         self._num_experts = num_experts
         self._moe_inter_size = moe_inter_size
-        self._mtp_scale_factor = mtp_scale_factor(self._nextn, self._nextn_accepted, self._num_layers)
+        self._mtp_scale_factor = mtp_scale_factor(self._nextn, self._num_layers)
         self._power_law_alpha = 1.01
 
         h = self._hidden_size

--- a/aic-core/src/aiconfigurator_core/sdk/models/gemma4.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/gemma4.py
@@ -89,7 +89,7 @@ class Gemma4MixModel(BaseModel):
         self._topk = topk
         self._num_experts = num_experts
         self._moe_inter_size = moe_inter_size
-        self._mtp_scale_factor = mtp_scale_factor(self._nextn, self._nextn_accepted, self._num_layers)
+        self._mtp_scale_factor = mtp_scale_factor(self._nextn, self._num_layers)
         self._gemma4_config: common.Gemma4MixConfig | None = None
         self._power_law_alpha = 1.01
 

--- a/aic-core/src/aiconfigurator_core/sdk/models/helpers.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/helpers.py
@@ -528,18 +528,13 @@ def check_is_moe(model_path: str, model_info: dict | None = None) -> bool:
     return False
 
 
-def mtp_scale_factor(nextn: int, nextn_accepted: float | None, num_layers: int) -> float:
-    """Per-output-token generation scale for MTP speculative decoding.
+def mtp_scale_factor(nextn: int, num_layers: int) -> float:
+    """Per-iteration compute scale for MTP speculative decoding.
 
-    ``nextn`` is the draft length (cost side: the model runs ``num_layers + nextn``
-    layers' worth of compute per decode step). ``nextn_accepted`` is the average number
-    of draft tokens actually accepted per step (benefit side: each step yields
-    ``1 + nextn_accepted`` output tokens). Returns 1.0 when MTP is disabled.
+    A decode iteration evaluates ``num_layers + nextn`` layers' worth of work.
+    Accepted-token progress is deliberately excluded: it is a workload-level
+    assumption applied by the upper prediction layer.
     """
     if nextn <= 0:
         return 1.0
-    if nextn_accepted is None:
-        raise ValueError("nextn_accepted (average accepted draft tokens per step) is required when nextn > 0")
-    if not 0 <= nextn_accepted <= nextn:
-        raise ValueError(f"nextn_accepted ({nextn_accepted}) must be within [0, nextn={nextn}]")
-    return (nextn + num_layers) / num_layers / (1 + nextn_accepted)
+    return (nextn + num_layers) / num_layers

--- a/aic-core/src/aiconfigurator_core/sdk/models/hybrid_moe.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/hybrid_moe.py
@@ -66,7 +66,7 @@ class HybridMoEModel(BaseModel):
         self._topk = topk
         self._num_experts = num_experts
         self._moe_inter_size = moe_inter_size
-        self._mtp_scale_factor = mtp_scale_factor(self._nextn, self._nextn_accepted, self._num_layers)
+        self._mtp_scale_factor = mtp_scale_factor(self._nextn, self._num_layers)
         self._validate_fp8_block_quantized_moe_config()
         self._hybrid_config: common.HybridMoEConfig | None = None
         self._power_law_alpha = 1.01

--- a/aic-core/src/aiconfigurator_core/sdk/models/llama.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/llama.py
@@ -48,7 +48,7 @@ class LLAMAModel(BaseModel):
         super().__init__(*args)
 
         # MTP scale factor: throughput boost / compute overhead
-        self._mtp_scale_factor = mtp_scale_factor(self._nextn, self._nextn_accepted, self._num_layers)
+        self._mtp_scale_factor = mtp_scale_factor(self._nextn, self._num_layers)
 
         h = self._hidden_size
         tp_size = self.config.tp_size

--- a/aic-core/src/aiconfigurator_core/sdk/models/minimax_m3.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/minimax_m3.py
@@ -71,7 +71,7 @@ class MiniMaxM3Model(BaseModel):
         self._topk = topk
         self._num_experts = num_experts
         self._moe_inter_size = moe_inter_size
-        self._mtp_scale_factor = mtp_scale_factor(self._nextn, self._nextn_accepted, self._num_layers)
+        self._mtp_scale_factor = mtp_scale_factor(self._nextn, self._num_layers)
         self._power_law_alpha = 1.01
 
         h = self._hidden_size

--- a/aic-core/src/aiconfigurator_core/sdk/models/moe.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/moe.py
@@ -62,7 +62,7 @@ class MOEModel(BaseModel):
         super().__init__(*args)
 
         # MTP scale factor: throughput boost / compute overhead
-        self._mtp_scale_factor = mtp_scale_factor(self._nextn, self._nextn_accepted, self._num_layers)
+        self._mtp_scale_factor = mtp_scale_factor(self._nextn, self._num_layers)
 
         # make sure the paralel width is same (cp is an independent attention
         # dimension that also contributes to the width the MoE must match)
@@ -395,7 +395,7 @@ class SGLangEPMOEModel(BaseModel):
         super().__init__(*args)
 
         # MTP scale factor: throughput boost / compute overhead
-        self._mtp_scale_factor = mtp_scale_factor(self._nextn, self._nextn_accepted, self._num_layers)
+        self._mtp_scale_factor = mtp_scale_factor(self._nextn, self._num_layers)
 
         # make sure the parallel width is same (cp is an independent attention
         # dimension that also contributes to the width the MoE must match)

--- a/aic-core/src/aiconfigurator_core/sdk/models/nemotron_h.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/nemotron_h.py
@@ -53,10 +53,9 @@ class NemotronHModel(BaseModel):
         self._moe_inter_size = moe_inter_size
         self._hybrid_config: common.NemotronHConfig | None = None
         self._power_law_alpha = 1.01  # follow DeepSeek MoE
-        # MTP (num_nextn_predict_layers > 0): scale generation by the accepted-token
-        # speedup 1/(1+E[accept]) and the small extra-layer factor (nextn+L)/L, the
-        # same first-order model as DeepSeek. nextn == 0 -> factor 1.0 (exact no-op, so
-        # non-MTP NemotronH is unchanged).
+        # MTP (num_nextn_predict_layers > 0): scale generation iteration cost by
+        # the small extra-layer factor (nextn+L)/L. Accepted-token progress is
+        # applied by the upper prediction layer. nextn == 0 -> factor 1.0.
         #
         # APPROXIMATION (intentional, hybrid architecture). NemotronH is a mixed
         # Mamba / attention / MoE stack (e.g. Ultra-550B = 48 mamba + 48 moe + 12
@@ -66,9 +65,9 @@ class NemotronHModel(BaseModel):
         # uniformly over all layer-type groups, so the extra MTP-block cost is slightly
         # mis-attributed: we add a little fake Mamba and under-count the real attn+moe
         # MTP block. This is bounded by ~1/L of one layer's cost (<1% of TPOT for these
-        # deep models), and the dominant, exactly-correct term is the 1/(1+E[accept])
-        # speedup. Not worth modeling an explicit attn+moe MTP block for sub-1% gain.
-        self._mtp_scale_factor = mtp_scale_factor(self._nextn, self._nextn_accepted, self._num_layers)
+        # deep models). Not worth modeling an explicit attn+moe MTP block for
+        # sub-1% gain.
+        self._mtp_scale_factor = mtp_scale_factor(self._nextn, self._num_layers)
 
     def set_hybrid_config(self, hybrid_config: common.NemotronHConfig) -> None:
         """

--- a/aic-core/src/aiconfigurator_core/sdk/models/qwen35.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/qwen35.py
@@ -46,7 +46,7 @@ class Qwen35Model(BaseModel):
         cfg: common.Qwen35Config = self.extra_params
         assert isinstance(cfg, common.Qwen35Config), "Qwen35Model requires Qwen35Config extra_params"
 
-        self._mtp_scale_factor = mtp_scale_factor(self._nextn, self._nextn_accepted, self._num_layers)
+        self._mtp_scale_factor = mtp_scale_factor(self._nextn, self._num_layers)
 
         if cfg.num_experts > 0:
             assert (

--- a/aic-core/src/aiconfigurator_core/sdk/rust_engine_step.py
+++ b/aic-core/src/aiconfigurator_core/sdk/rust_engine_step.py
@@ -387,7 +387,6 @@ def _cached_engine_handle(model: Any, database: Any) -> Any:
         kv_block_size=None,
         systems_path=systems_path,
         nextn=int(nextn) if nextn is not None else 0,
-        nextn_accepted=getattr(model, "_nextn_accepted", None),
         database=database,
     )
     spec_bytes = bytes(aiconfigurator_core.engine_spec_bincode_from_json(spec_json))
@@ -398,14 +397,9 @@ def _cached_engine_handle(model: Any, database: Any) -> Any:
 
 def _engine_config_json(model: Any, database: Any) -> str:
     model_config = model.config
-    # Forward MTP speculative-decoding params (`nextn` draft length, `nextn_accepted`
-    # average accepted draft tokens per step) so the Rust model builders can
-    # compute the same `_mtp_scale_factor` Python applies. MTP is never
-    # auto-enabled; both values come from the user's explicit config and are
-    # stored on the model object via `BaseModel._nextn` / `_nextn_accepted`. Rust
-    # treats `nextn=None` or `nextn=0` as MTP-disabled (scale=1.0).
+    # Forward only the MTP draft length. The aic-core layer models iteration compute cost;
+    # accepted-token progress belongs to the upper prediction layer.
     nextn = getattr(model, "_nextn", None)
-    nextn_accepted = getattr(model, "_nextn_accepted", None)
     config = {
         "schema_version": 1,
         "model_name": getattr(model, "model_path", getattr(model, "model_name", "")),
@@ -426,7 +420,6 @@ def _engine_config_json(model: Any, database: Any) -> str:
         "kv_cache_dtype": _quant_to_dtype(getattr(model_config, "kvcache_quant_mode", None)),
         "kv_block_size": None,
         "nextn": int(nextn) if nextn is not None else None,
-        "nextn_accepted": (float(nextn_accepted) if nextn_accepted is not None else None),
         "extra": {},
     }
     return json.dumps(config, sort_keys=True, separators=(",", ":"))

--- a/docs/cli_user_guide.md
+++ b/docs/cli_user_guide.md
@@ -132,7 +132,7 @@ aiconfigurator cli estimate --model-path Qwen/Qwen3-32B --system h200_sxm --tp-s
 - `--comm-quant-mode`: Communication quantization mode (auto-inferred; default `half`)
 - `--prefix`: Prefix cache length (subset of ISL already cached per request). Default: `0`
 - `--nextn`: MTP draft length, or `auto` to use the checkpoint's `num_nextn_predict_layers` (absent/0 keeps MTP disabled). Default: `0`; MTP is never enabled implicitly — pass `--nextn` explicitly to model it
-- `--nextn-accepted`: Average accepted draft tokens per decode step (`0 <= nextn_accepted <= nextn`). Required when the resolved draft depth is > 0 (including via `--nextn auto`); use a measured value from your deployment
+- `--nextn-accepted`: Average accepted draft tokens per decode step (`0 <= nextn_accepted <= nextn`). Required when the draft depth is > 0 (including via `--nextn auto`); use a measured value from your deployment
 - `--stride`: (static modes only) OSL-sweep stride used by `run_static`; ignored for `agg`/`disagg`. Default: `32`
 - `--free-gpu-memory-fraction`: Fraction of free GPU memory for KV cache. Default: `0.9`. Used to estimate max concurrent sequences and warn when batch size exceeds KV cache capacity
 - `--max-seq-len`: TRT-LLM `--max_seq_len` (default: `isl + osl`). Controls KV blocks pre-allocated per sequence; set to match your deployment for an accurate KV-capacity warning
@@ -866,9 +866,9 @@ the checkpoint declares them):
   because it is a property of your workload, not of the model.
 - `--nextn-accepted A` — Average accepted draft tokens per decode step
   (`0 <= nextn_accepted <= nextn`); each step yields `1 + nextn_accepted` output tokens.
-  Required whenever the resolved draft depth is > 0 (explicit or via `auto`) —
-  there is no built-in acceptance assumption. Use a measured value from your
-  deployment (e.g. the engine's reported average acceptance length minus 1).
+  Required whenever the draft depth is > 0 (explicit or via `auto`) — there is
+  no built-in acceptance assumption. Use a measured value from your deployment
+  (e.g. the engine's reported average acceptance length minus 1).
 
 `nextn` is part of the `aic-core` operation and iteration-cost model.
 `nextn_accepted` is a workload assumption applied by the SDK predictor/sweep
@@ -970,7 +970,7 @@ disagg_full:
   tpot: 40.0                      # target TPOT in ms (default 40.0)
 
   # Speculative decoding: never enabled implicitly; nextn_accepted is required
-  # when the resolved draft depth is > 0. nextn: auto takes the depth from the
+  # when the draft depth is > 0. nextn: auto takes the depth from the
   # checkpoint's num_nextn_predict_layers (the acceptance value is still yours).
   nextn: 1
   nextn_accepted: 0.85

--- a/docs/cli_user_guide.md
+++ b/docs/cli_user_guide.md
@@ -132,7 +132,7 @@ aiconfigurator cli estimate --model-path Qwen/Qwen3-32B --system h200_sxm --tp-s
 - `--comm-quant-mode`: Communication quantization mode (auto-inferred; default `half`)
 - `--prefix`: Prefix cache length (subset of ISL already cached per request). Default: `0`
 - `--nextn`: MTP draft length, or `auto` to use the checkpoint's `num_nextn_predict_layers` (absent/0 keeps MTP disabled). Default: `0`; MTP is never enabled implicitly — pass `--nextn` explicitly to model it
-- `--nextn-accepted`: Average accepted draft tokens per decode step (`0 <= nextn_accepted <= nextn`). Required when the draft depth is > 0 (including via `--nextn auto`); use a measured value from your deployment
+- `--nextn-accepted`: Average accepted draft tokens per decode step (`0 <= nextn_accepted <= nextn`). Required when the resolved draft depth is > 0 (including via `--nextn auto`); use a measured value from your deployment
 - `--stride`: (static modes only) OSL-sweep stride used by `run_static`; ignored for `agg`/`disagg`. Default: `32`
 - `--free-gpu-memory-fraction`: Fraction of free GPU memory for KV cache. Default: `0.9`. Used to estimate max concurrent sequences and warn when batch size exceeds KV cache capacity
 - `--max-seq-len`: TRT-LLM `--max_seq_len` (default: `isl + osl`). Controls KV blocks pre-allocated per sequence; set to match your deployment for an accurate KV-capacity warning
@@ -866,9 +866,14 @@ the checkpoint declares them):
   because it is a property of your workload, not of the model.
 - `--nextn-accepted A` — Average accepted draft tokens per decode step
   (`0 <= nextn_accepted <= nextn`); each step yields `1 + nextn_accepted` output tokens.
-  Required whenever the draft depth is > 0 (explicit or via `auto`) — there is
-  no built-in acceptance assumption. Use a measured value from your deployment
-  (e.g. the engine's reported average acceptance length minus 1).
+  Required whenever the resolved draft depth is > 0 (explicit or via `auto`) —
+  there is no built-in acceptance assumption. Use a measured value from your
+  deployment (e.g. the engine's reported average acceptance length minus 1).
+
+`nextn` is part of the `aic-core` operation and iteration-cost model.
+`nextn_accepted` is a workload assumption applied by the SDK predictor/sweep
+after core timing, so acceptance values can be swept without recompiling or
+rerunning the `aic-core` engine.
 
 Example:
 ```bash
@@ -965,7 +970,7 @@ disagg_full:
   tpot: 40.0                      # target TPOT in ms (default 40.0)
 
   # Speculative decoding: never enabled implicitly; nextn_accepted is required
-  # when the draft depth is > 0. nextn: auto takes the depth from the
+  # when the resolved draft depth is > 0. nextn: auto takes the depth from the
   # checkpoint's num_nextn_predict_layers (the acceptance value is still yours).
   nextn: 1
   nextn_accepted: 0.85
@@ -1024,7 +1029,7 @@ This is long; the basics:
     - `backend_name`: `trtllm` (default), `vllm`, or `sglang`.  
     - `backend_version`, `isl`, `osl`, `ttft`, `tpot`: same meaning as in `default` mode (shared, top-level).  
     - `*_enable_wideep`: enables wide-EP for fine-grained MoE models.  
-    - `nextn` / `nextn_accepted`: MTP speculative decoding (never auto-enabled; `nextn_accepted` is required when `nextn > 0`).  
+    - `nextn` / `nextn_accepted`: MTP speculative decoding (never auto-enabled; `nextn_accepted` is required when the resolved `nextn > 0`).
     - The replica/correction knobs (`num_gpu_per_replica`, `max_*_workers`, `*_latency_correction`, ...) are covered in [Advanced Tuning](advanced_tuning.md). Typically the only thing you need to touch is the quantization.
 
 Quantization override order: explicit `*_quant_mode` fields take precedence; any mode left unset is filled from the model's HF quantization metadata.

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -27,8 +27,13 @@ from aiconfigurator.sdk.config import ModelConfig
 from aiconfigurator.sdk.config_builders import apply_nextn as _apply_nextn
 from aiconfigurator.sdk.config_builders import build_model_config as _build_model_config
 from aiconfigurator.sdk.config_builders import resolve_nextn_auto as _resolve_nextn_auto
-from aiconfigurator.sdk.config_builders import validate_nextn as _validate_nextn
 from aiconfigurator.sdk.models import check_is_moe, resolve_context_fmha_by_data, resolve_dsv4_moe_arch
+from aiconfigurator.sdk.speculative import (
+    SpeculativeDecodingProfile,
+)
+from aiconfigurator.sdk.speculative import (
+    normalize_speculative_decoding as _normalize_nextn,
+)
 from aiconfigurator.sdk.task_v2 import Task
 
 # Default per-phase latency-correction scales for single-point disagg estimates.
@@ -190,8 +195,8 @@ def cli_default(
             ``num_nextn_predict_layers`` (absent/0 keeps MTP disabled).
             Default 0 (disabled); never enabled implicitly.
         nextn_accepted: Average accepted draft tokens per decode step
-            (0 <= nextn_accepted <= nextn). Required when the draft depth
-            resolves to > 0; never inferred.
+            (0 <= nextn_accepted <= nextn). Required when the resolved draft
+            depth is > 0; never inferred.
         strict_sla: When True, ``pareto_df`` is filtered to only
             SLA-compliant data points (TPOT or request-latency) *before*
             the Pareto frontier is computed.  TTFT is already enforced at
@@ -250,7 +255,7 @@ def cli_default(
     # nextn="auto" resolves the draft depth from the checkpoint first.
     if nextn == "auto":
         nextn = _resolve_nextn_auto(model_path)
-    _validate_nextn(nextn, nextn_accepted)
+    nextn, nextn_accepted = _normalize_nextn(nextn, nextn_accepted)
 
     # Reuse build_default_tasks from main.py
     tasks = build_default_tasks(
@@ -750,8 +755,8 @@ def cli_estimate(
             ``num_nextn_predict_layers``. Applied to agg, disagg, and all
             static modes. Default 0 (disabled); MTP is never enabled implicitly.
         nextn_accepted: (common) Average accepted draft tokens per decode step
-            (0 <= nextn_accepted <= nextn). Required when the draft depth
-            resolves to > 0; never inferred.
+            (0 <= nextn_accepted <= nextn). Required when the resolved draft
+            depth is > 0; never inferred.
         stride: (static-only) Stride used by ``run_static`` to accelerate the
             OSL sweep. Ignored by agg / disagg. Default 32.
         n_a_nodes: (afd-only) Number of A-Worker (attention) nodes. Required
@@ -811,7 +816,7 @@ def cli_estimate(
     # estimate path (agg/disagg/static/afd) sees a plain int.
     if nextn == "auto":
         nextn = _resolve_nextn_auto(model_path)
-    _validate_nextn(nextn, nextn_accepted)
+    nextn, nextn_accepted = _normalize_nextn(nextn, nextn_accepted)
 
     active_systems_paths = None
     if systems_paths is not None:
@@ -1166,7 +1171,7 @@ def _run_agg_estimate(
         moe_quant_mode,
         comm_quant_mode,
     )
-    _apply_nextn(model_config, nextn, nextn_accepted)
+    _apply_nextn(model_config, nextn)
     # Agg workers run context attention → resolve fmha against the perf data
     # before building the model (mirrors the sweep/task_v2 path).
     resolve_context_fmha_by_data(
@@ -1194,6 +1199,7 @@ def _run_agg_estimate(
         max_seq_len=max_seq_len,
         free_gpu_memory_fraction=free_gpu_memory_fraction,
     )
+    summary = SpeculativeDecodingProfile.from_inputs(nextn, nextn_accepted).project_summary(summary, role="agg")
 
     if summary.check_oom():
         raise RuntimeError(
@@ -1300,7 +1306,7 @@ def _run_static_estimate(
         moe_quant_mode,
         comm_quant_mode,
     )
-    _apply_nextn(model_config, nextn, nextn_accepted)
+    _apply_nextn(model_config, nextn)
     # static / static_ctx run context attention; static_gen is generation-only
     # and legitimately keeps fp8 FMHA. Resolve fmha against the perf data accordingly.
     resolve_context_fmha_by_data(
@@ -1331,6 +1337,12 @@ def _run_static_estimate(
         runtime_config=runtime_config,
         mode=static_mode,
         stride=stride,
+    )
+    projection_role = (
+        "prefill" if static_mode == "static_ctx" else ("decode" if static_mode == "static_gen" else "static")
+    )
+    summary = SpeculativeDecodingProfile.from_inputs(nextn, nextn_accepted).project_summary(
+        summary, role=projection_role
     )
 
     static_warning = None
@@ -1455,8 +1467,8 @@ def _run_disagg_estimate(
     )
     # Apply common nextn/MTP overrides to *both* prefill and decode worker
     # configs so a single ``--nextn N`` reaches each side of the disagg pair.
-    _apply_nextn(prefill_model_config, nextn, nextn_accepted)
-    _apply_nextn(decode_model_config, nextn, nextn_accepted)
+    _apply_nextn(prefill_model_config, nextn)
+    _apply_nextn(decode_model_config, nextn)
     # Prefill runs context attention → resolve fmha against the perf data. Decode
     # is generation-only and keeps fp8, so it needs no adjustment.
     resolve_context_fmha_by_data(
@@ -1505,6 +1517,7 @@ def _run_disagg_estimate(
         decode_model_config=decode_model_config,
         decode_batch_size=decode_batch_size,
         decode_num_worker=decode_num_workers,
+        speculative_profile=SpeculativeDecodingProfile.from_inputs(nextn, nextn_accepted),
     )
 
     if summary.check_oom():
@@ -1745,8 +1758,8 @@ def _run_afd_estimate(
     # Pass speculative decode knobs through to A/F model configs. TODO:
     # AFDTransfer still models committed decode-token volume only; recalibrate
     # MTP transfer amplification once the serving semantics are finalized.
-    _apply_nextn(a_model_config, nextn, nextn_accepted)
-    _apply_nextn(f_model_config, nextn, nextn_accepted)
+    _apply_nextn(a_model_config, nextn)
+    _apply_nextn(f_model_config, nextn)
     # The A-worker runs context attention whenever the phase covers prefill
     # ("prefill" or "both"); resolve fmha against the perf data then. The
     # F-worker is FFN/MoE only and never touches FMHA. The decode-phase static
@@ -1792,6 +1805,7 @@ def _run_afd_estimate(
         phase=afd_phase,
         free_gpu_memory_fraction=free_gpu_memory_fraction,
         max_seq_len=max_seq_len,
+        speculative_profile=SpeculativeDecodingProfile.from_inputs(nextn, nextn_accepted),
     )
 
     if summary.check_oom():

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -195,8 +195,8 @@ def cli_default(
             ``num_nextn_predict_layers`` (absent/0 keeps MTP disabled).
             Default 0 (disabled); never enabled implicitly.
         nextn_accepted: Average accepted draft tokens per decode step
-            (0 <= nextn_accepted <= nextn). Required when the resolved draft
-            depth is > 0; never inferred.
+            (0 <= nextn_accepted <= nextn). Required when the draft depth
+            resolves to > 0; never inferred.
         strict_sla: When True, ``pareto_df`` is filtered to only
             SLA-compliant data points (TPOT or request-latency) *before*
             the Pareto frontier is computed.  TTFT is already enforced at
@@ -755,8 +755,8 @@ def cli_estimate(
             ``num_nextn_predict_layers``. Applied to agg, disagg, and all
             static modes. Default 0 (disabled); MTP is never enabled implicitly.
         nextn_accepted: (common) Average accepted draft tokens per decode step
-            (0 <= nextn_accepted <= nextn). Required when the resolved draft
-            depth is > 0; never inferred.
+            (0 <= nextn_accepted <= nextn). Required when the draft depth
+            resolves to > 0; never inferred.
         stride: (static-only) Stride used by ``run_static`` to accelerate the
             OSL sweep. Ignored by agg / disagg. Default 32.
         n_a_nodes: (afd-only) Number of A-Worker (attention) nodes. Required

--- a/src/aiconfigurator/cli/example.yaml
+++ b/src/aiconfigurator/cli/example.yaml
@@ -61,8 +61,8 @@ agg_full:
   enable_eplb: false
   moe_backend: null
 
-  # Speculative decoding: never auto-enabled. nextn = draft length,
-  # nextn_accepted = average accepted draft tokens per step (required when nextn > 0).
+  # Speculative decoding: never auto-enabled. nextn = draft length;
+  # nextn_accepted = average accepted draft tokens per step and is required when nextn > 0.
   nextn: 1
   nextn_accepted: 0.85
 
@@ -113,8 +113,8 @@ disagg_full:
   tpot: 40.0
   total_gpus: 32
 
-  # Speculative decoding (shared): never auto-enabled. nextn = draft length,
-  # nextn_accepted = average accepted draft tokens per step (required when nextn > 0).
+  # Speculative decoding (shared): never auto-enabled. nextn = draft length;
+  # nextn_accepted = average accepted draft tokens per step and is required when nextn > 0.
   nextn: 1
   nextn_accepted: 0.85
 

--- a/src/aiconfigurator/cli/example.yaml
+++ b/src/aiconfigurator/cli/example.yaml
@@ -61,8 +61,8 @@ agg_full:
   enable_eplb: false
   moe_backend: null
 
-  # Speculative decoding: never auto-enabled. nextn = draft length;
-  # nextn_accepted = average accepted draft tokens per step and is required when nextn > 0.
+  # Speculative decoding: never auto-enabled. nextn = draft length,
+  # nextn_accepted = average accepted draft tokens per step (required when nextn > 0).
   nextn: 1
   nextn_accepted: 0.85
 
@@ -113,8 +113,8 @@ disagg_full:
   tpot: 40.0
   total_gpus: 32
 
-  # Speculative decoding (shared): never auto-enabled. nextn = draft length;
-  # nextn_accepted = average accepted draft tokens per step and is required when nextn > 0.
+  # Speculative decoding (shared): never auto-enabled. nextn = draft length,
+  # nextn_accepted = average accepted draft tokens per step (required when nextn > 0).
   nextn: 1
   nextn_accepted: 0.85
 

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -1235,8 +1235,8 @@ def build_default_tasks(
             ``num_nextn_predict_layers`` (absent/0 keeps MTP disabled).
             Default 0 (disabled); never enabled implicitly.
         nextn_accepted: Average accepted draft tokens per decode step
-            (0 <= nextn_accepted <= nextn). Required when the resolved draft
-            depth is > 0; never inferred.
+            (0 <= nextn_accepted <= nextn). Required when the draft depth
+            resolves to > 0; never inferred.
         enable_chunked_prefill: Whether to enable chunked prefill for finer context token sweep.
         enable_wideep: Whether to enable Wide Expert Parallelism (WideEP) for MoE models.
         moe_backend: Explicit SGLang MoE backend override.

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -23,7 +23,7 @@ from aiconfigurator.generator.api import (
 )
 from aiconfigurator.logging_utils import setup_logging
 from aiconfigurator.sdk import common, perf_database
-from aiconfigurator.sdk.config_builders import resolve_nextn_auto, validate_nextn
+from aiconfigurator.sdk.config_builders import resolve_nextn_auto
 from aiconfigurator.sdk.errors import (
     NoFeasibleConfigError,
     UnsupportedWideepConfigError,
@@ -31,6 +31,7 @@ from aiconfigurator.sdk.errors import (
 )
 from aiconfigurator.sdk.models import check_is_moe
 from aiconfigurator.sdk.operations.base import resolve_op_data_path
+from aiconfigurator.sdk.speculative import normalize_speculative_decoding
 from aiconfigurator.sdk.task_v2 import Task
 from aiconfigurator.sdk.utils import ListFlowDumper, get_model_config_from_model_path
 
@@ -190,7 +191,7 @@ def _resolve_and_validate_nextn(args) -> None:
                 "MTP stays disabled."
             )
         try:
-            validate_nextn(resolved, args.nextn_accepted)
+            resolved, args.nextn_accepted = normalize_speculative_decoding(resolved, args.nextn_accepted)
         except ValueError as exc:
             raise SystemExit(
                 f"--nextn auto resolved to nextn={resolved} from the checkpoint's num_nextn_predict_layers: {exc}"
@@ -198,7 +199,7 @@ def _resolve_and_validate_nextn(args) -> None:
         args.nextn = resolved
         return
     try:
-        validate_nextn(args.nextn, args.nextn_accepted)
+        args.nextn, args.nextn_accepted = normalize_speculative_decoding(args.nextn, args.nextn_accepted)
     except ValueError as exc:
         raise SystemExit(str(exc)) from exc
 
@@ -374,9 +375,9 @@ def _add_default_mode_arguments(parser):
         type=float,
         default=None,
         help="Average accepted draft tokens per decode step (0 <= nextn_accepted <= nextn). "
-        "Required when --nextn > 0; there is no built-in acceptance assumption — "
-        "use a measured value from your deployment (e.g. the engine's reported "
-        "average acceptance length minus 1).",
+        "Required when --nextn resolves to > 0; there is no built-in acceptance "
+        "assumption — use a measured value from your deployment (e.g. the engine's "
+        "reported average acceptance length minus 1).",
     )
     parser.add_argument(
         "--enable-chunked-prefill",
@@ -872,15 +873,16 @@ def _add_estimate_mode_arguments(parser):
         help="(common) MTP draft length (compute cost side), or 'auto' to use the checkpoint's "
         "num_nextn_predict_layers. Default: 0 (disabled); MTP is never enabled implicitly. "
         "Applied to agg, disagg, and all static modes. Requires --nextn-accepted when the "
-        "depth is > 0.",
+        "resolved depth is > 0.",
     )
     parser.add_argument(
         "--nextn-accepted",
         type=float,
         default=None,
         help="(common) Average accepted draft tokens per decode step "
-        "(0 <= nextn_accepted <= nextn). Required when --nextn > 0; there is no "
-        "built-in acceptance assumption — use a measured value from your deployment.",
+        "(0 <= nextn_accepted <= nextn). Required when --nextn resolves to > 0; "
+        "there is no built-in acceptance assumption — use a measured value from "
+        "your deployment.",
     )
     parser.add_argument(
         "--stride",
@@ -1233,8 +1235,8 @@ def build_default_tasks(
             ``num_nextn_predict_layers`` (absent/0 keeps MTP disabled).
             Default 0 (disabled); never enabled implicitly.
         nextn_accepted: Average accepted draft tokens per decode step
-            (0 <= nextn_accepted <= nextn). Required when the draft depth
-            resolves to > 0; never inferred.
+            (0 <= nextn_accepted <= nextn). Required when the resolved draft
+            depth is > 0; never inferred.
         enable_chunked_prefill: Whether to enable chunked prefill for finer context token sweep.
         enable_wideep: Whether to enable Wide Expert Parallelism (WideEP) for MoE models.
         moe_backend: Explicit SGLang MoE backend override.

--- a/src/aiconfigurator/sdk/inference_session.py
+++ b/src/aiconfigurator/sdk/inference_session.py
@@ -19,6 +19,7 @@ from aiconfigurator.sdk.picking import (
     _RATE_MATCHING_PREFILL_DEGRADATION_FACTOR,
     _build_disagg_summary_dict,
 )
+from aiconfigurator.sdk.speculative import SpeculativeDecodingProfile
 from aiconfigurator.sdk.utils import enumerate_ttft_tpot_constraints, get_model_config_from_model_path
 
 logger = logging.getLogger(__name__)
@@ -274,6 +275,7 @@ class DisaggInferenceSession:
         decode_model_config: config.ModelConfig,
         decode_batch_size: int,
         decode_num_worker: int,
+        speculative_profile: SpeculativeDecodingProfile | None = None,
     ) -> InferenceSummary:
         """
         Run disagg with given prefill/decode worker info
@@ -287,6 +289,8 @@ class DisaggInferenceSession:
             decode_model_config (ModelConfig): the decode model config
             decode_batch_size (int): the decode batch size
             decode_num_worker (int): the number of decode workers
+            speculative_profile: Optional accepted-token progress assumption.
+                Projects decode metrics before prefill/decode rate matching.
 
         Returns:
             InferenceSummary: the summary of the inference result
@@ -313,6 +317,8 @@ class DisaggInferenceSession:
             runtime_config=decode_runtime_config,
             latency_correction_scale=self._decode_latency_correction_scale,
         )
+        if speculative_profile is not None:
+            decode_summary = speculative_profile.project_summary(decode_summary, role="decode")
         disagg_summary_df = self._get_disagg_summary_df(
             prefill_summary.get_summary_df(),
             prefill_num_worker,
@@ -1559,6 +1565,7 @@ class AFDInferenceSession:
         phase: str | None = None,
         free_gpu_memory_fraction: float | None = None,
         max_seq_len: int | None = None,
+        speculative_profile: SpeculativeDecodingProfile | None = None,
     ) -> InferenceSummary:
         """Run AFD performance simulation, possibly for prefill, decode, or both.
 
@@ -1574,6 +1581,8 @@ class AFDInferenceSession:
             free_gpu_memory_fraction: Fraction of free GPU memory allocated
                              for KV cache. Defaults to backend behavior.
             max_seq_len:    Optional runtime max sequence length for KV cache.
+            speculative_profile: Optional accepted-token progress assumption.
+                             The projection role is derived from ``phase``.
 
         Returns:
             InferenceSummary.  ``check_oom()`` reflects the per-pool HBM check.
@@ -1608,12 +1617,16 @@ class AFDInferenceSession:
                 max_seq_len=max_seq_len,
             )
 
-        return self._build_summary(
+        summary = self._build_summary(
             runtime_config=runtime_config,
             phase=phase,
             prefill_metrics=prefill_metrics,
             decode_metrics=decode_metrics,
         )
+        if speculative_profile is None:
+            return summary
+        projection_role = "prefill" if phase == "prefill" else ("decode" if phase == "decode" else "static")
+        return speculative_profile.project_summary(summary, role=projection_role)
 
     def run_afd_decode(
         self,

--- a/src/aiconfigurator/sdk/predict.py
+++ b/src/aiconfigurator/sdk/predict.py
@@ -38,6 +38,7 @@ from aiconfigurator.sdk.inference_summary import InferenceSummary
 from aiconfigurator.sdk.models import BaseModel
 from aiconfigurator.sdk.perf_database import PerfDatabase
 from aiconfigurator.sdk.predictor import DEFAULT_PREDICTOR, Predictor
+from aiconfigurator.sdk.speculative import SpeculativeDecodingProfile
 
 DisaggRole = Literal["prefill", "decode"]
 
@@ -52,6 +53,7 @@ def predict_disagg_worker(
     latency_correction: float = 1.0,
     stride: int = 32,
     predictor: Predictor | None = None,
+    speculative_profile: SpeculativeDecodingProfile | None = None,
 ) -> InferenceSummary:
     """Predict perf for one phase of a disaggregated worker.
 
@@ -80,7 +82,7 @@ def predict_disagg_worker(
         workers, the predictor interface (and the call site) can be
         extended without touching every caller.
     """
-    return (predictor or DEFAULT_PREDICTOR).predict_disagg_worker(
+    summary = (predictor or DEFAULT_PREDICTOR).predict_disagg_worker(
         model=model,
         backend=backend,
         database=database,
@@ -89,6 +91,9 @@ def predict_disagg_worker(
         latency_correction=latency_correction,
         stride=stride,
     )
+    if speculative_profile is None:
+        return summary
+    return speculative_profile.project_summary(summary, role=role)
 
 
 def predict_agg_worker(
@@ -99,6 +104,7 @@ def predict_agg_worker(
     runtime_config: config.RuntimeConfig,
     ctx_tokens: int,
     predictor: Predictor | None = None,
+    speculative_profile: SpeculativeDecodingProfile | None = None,
     **backend_kwargs: Any,
 ) -> InferenceSummary:
     """Predict perf for an aggregated IFB worker.
@@ -124,7 +130,7 @@ def predict_agg_worker(
     Returns:
         InferenceSummary for the aggregated worker.
     """
-    return (predictor or DEFAULT_PREDICTOR).predict_agg_worker(
+    summary = (predictor or DEFAULT_PREDICTOR).predict_agg_worker(
         model=model,
         backend=backend,
         database=database,
@@ -132,3 +138,6 @@ def predict_agg_worker(
         ctx_tokens=ctx_tokens,
         **backend_kwargs,
     )
+    if speculative_profile is None:
+        return summary
+    return speculative_profile.project_summary(summary, role="agg")

--- a/src/aiconfigurator/sdk/speculative.py
+++ b/src/aiconfigurator/sdk/speculative.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Workload-level speculative-decoding progress assumptions.
+
+``aic-core`` predicts the cost of one decode/verification iteration from ``nextn``.
+This module converts that iteration cost into expected service metrics using
+the average number of accepted draft tokens. Keeping the projection here means
+the same ``aic-core`` engine can be reused across acceptance-rate sweeps.
+"""
+
+from __future__ import annotations
+
+import copy
+import math
+from dataclasses import dataclass
+from typing import Literal
+
+from aiconfigurator.sdk.config_builders import normalize_nextn
+from aiconfigurator.sdk.inference_summary import InferenceSummary
+
+ProjectionRole = Literal["agg", "prefill", "decode", "static"]
+
+
+def normalize_speculative_decoding(
+    nextn: int | None,
+    nextn_accepted: float | None,
+) -> tuple[int, float | None]:
+    """Normalize public MTP inputs.
+
+    Active MTP requires an explicit acceptance assumption. When MTP is
+    disabled, the value is retained for compatibility but ignored by
+    prediction.
+    """
+    normalized_nextn = normalize_nextn(nextn)
+    if normalized_nextn <= 0:
+        return normalized_nextn, nextn_accepted
+
+    if nextn_accepted is None:
+        raise ValueError(
+            f"nextn={normalized_nextn} requires 'nextn_accepted' (average accepted draft tokens "
+            f"per step, 0 <= nextn_accepted <= nextn); there is no built-in acceptance assumption."
+        )
+    accepted = float(nextn_accepted)
+    if not math.isfinite(accepted) or not 0 <= accepted <= normalized_nextn:
+        raise ValueError(f"nextn_accepted ({nextn_accepted}) must be within [0, nextn={normalized_nextn}].")
+    return normalized_nextn, accepted
+
+
+@dataclass(frozen=True)
+class SpeculativeDecodingProfile:
+    """Expected accepted-token progress applied above ``aic-core``."""
+
+    expected_accepted_tokens: float = 0.0
+
+    def __post_init__(self) -> None:
+        if not math.isfinite(self.expected_accepted_tokens) or self.expected_accepted_tokens < 0:
+            raise ValueError("expected_accepted_tokens must be finite and non-negative.")
+
+    @classmethod
+    def from_inputs(
+        cls,
+        nextn: int | None,
+        nextn_accepted: float | None,
+    ) -> SpeculativeDecodingProfile:
+        """Construct the effective upper-layer profile from public inputs."""
+        normalized_nextn, normalized_accepted = normalize_speculative_decoding(nextn, nextn_accepted)
+        effective_accepted = float(normalized_accepted or 0.0) if normalized_nextn > 0 else 0.0
+        return cls(effective_accepted)
+
+    @property
+    def tokens_per_iteration(self) -> float:
+        """Expected output-token progress made by one decode iteration."""
+        return 1.0 + self.expected_accepted_tokens
+
+    def project_summary(
+        self,
+        summary: InferenceSummary,
+        *,
+        role: ProjectionRole,
+    ) -> InferenceSummary:
+        """Project raw ``aic-core`` iteration metrics into expected service metrics.
+
+        The returned summary is a deep copy. Raw operation/iteration breakdowns
+        remain untouched, so callers can still inspect the simulated cost from
+        ``aic-core``.
+        """
+        if role == "prefill" or self.expected_accepted_tokens <= 0:
+            return summary
+
+        projected = copy.deepcopy(summary)
+        frame = projected.get_summary_df()
+        if frame is None or frame.empty:
+            return projected
+
+        frame = frame.copy(deep=True)
+        progress = self.tokens_per_iteration
+        original_request_latency = frame.get("request_latency")
+
+        if "tpot" in frame:
+            frame["tpot"] = frame["tpot"] / progress
+        if "generation_latency" in frame:
+            frame["generation_latency"] = frame["generation_latency"] / progress
+
+        if {"ttft", "tpot", "osl"}.issubset(frame.columns):
+            frame["request_latency"] = frame["ttft"] + frame["tpot"] * (frame["osl"] - 1).clip(lower=0)
+
+        if role == "static" and original_request_latency is not None and "request_latency" in frame:
+            # Combined static inference includes an unscaled prefill segment, so
+            # request throughput follows the old/new end-to-end latency ratio.
+            ratio = original_request_latency / frame["request_latency"].replace(0, float("nan"))
+            ratio = ratio.fillna(1.0)
+        else:
+            ratio = progress
+
+        for column in ("request_rate", "seq/s", "seq/s/gpu", "tokens/s", "tokens/s/gpu"):
+            if column in frame:
+                frame[column] = frame[column] * ratio
+        if "tokens/s/user" in frame:
+            frame["tokens/s/user"] = frame["tokens/s/user"] * progress
+
+        frame = frame.round(3)
+        projected.set_summary_df(frame)
+        projected.set_result_dict(frame.iloc[0].to_dict())
+        return projected
+
+
+__all__ = [
+    "ProjectionRole",
+    "SpeculativeDecodingProfile",
+    "normalize_speculative_decoding",
+]

--- a/src/aiconfigurator/sdk/speculative.py
+++ b/src/aiconfigurator/sdk/speculative.py
@@ -113,6 +113,18 @@ class SpeculativeDecodingProfile:
         else:
             ratio = progress
 
+        if role == "agg" and {"backend", "concurrency", "request_latency", "seq/s"}.issubset(frame.columns):
+            # vLLM caps aggregate output throughput with Little's Law in
+            # aic-core. Reapply the equivalent request-rate cap after TPOT is
+            # projected because TTFT remains fixed and therefore prevents the
+            # end-to-end rate from scaling by ``progress`` in every case.
+            vllm_rows = frame["backend"].astype(str).str.lower() == "vllm"
+            projected_seq_cap = frame["concurrency"] * 1000.0 / frame["request_latency"].replace(0, float("nan"))
+            capped_ratio = projected_seq_cap / frame["seq/s"].replace(0, float("nan"))
+            capped_ratio = capped_ratio.clip(lower=0.0, upper=progress).fillna(progress)
+            ratio = frame["seq/s"] * 0.0 + progress
+            ratio.loc[vllm_rows] = capped_ratio.loc[vllm_rows]
+
         for column in ("request_rate", "seq/s", "seq/s/gpu", "tokens/s", "tokens/s/gpu"):
             if column in frame:
                 frame[column] = frame[column] * ratio

--- a/src/aiconfigurator/sdk/sweep.py
+++ b/src/aiconfigurator/sdk/sweep.py
@@ -49,6 +49,7 @@ from aiconfigurator.sdk.errors import (
 from aiconfigurator.sdk.models import get_model
 from aiconfigurator.sdk.perf_database import PerfDatabase
 from aiconfigurator.sdk.predict import predict_agg_worker, predict_disagg_worker
+from aiconfigurator.sdk.speculative import SpeculativeDecodingProfile
 from aiconfigurator.sdk.utils import enumerate_ttft_tpot_constraints
 
 logger = logging.getLogger(__name__)
@@ -265,6 +266,7 @@ def _sweep_one_parallel_agg(
     free_gpu_memory_fraction: float | None,
     max_seq_len: int | None,
     predictor: Any = None,
+    speculative_profile: SpeculativeDecodingProfile | None = None,
 ) -> tuple[pd.DataFrame, bool, bool]:
     """Sweep batch_size x ctx_tokens for one fixed parallel choice.
 
@@ -330,6 +332,7 @@ def _sweep_one_parallel_agg(
                 runtime_config=point_rt,
                 ctx_tokens=ctx_tokens,
                 predictor=predictor,
+                speculative_profile=speculative_profile,
                 **backend_kwargs,
             )
 
@@ -370,6 +373,7 @@ def sweep_agg(
     free_gpu_memory_fraction: float | None = None,
     max_seq_len: int | None = None,
     predictor: Any = None,
+    speculative_profile: SpeculativeDecodingProfile | None = None,
 ) -> pd.DataFrame:
     """Sweep parallel x batch x ctx_tokens for agg; return feasible-candidate DataFrame.
 
@@ -486,6 +490,7 @@ def sweep_agg(
                     free_gpu_memory_fraction=free_gpu_memory_fraction,
                     max_seq_len=max_seq_len,
                     predictor=predictor,
+                    speculative_profile=speculative_profile,
                 )
                 saw_model_fit |= point_saw_model_fit
                 saw_memory_fit |= point_saw_memory_fit
@@ -550,6 +555,7 @@ def _get_disagg_worker_candidates(
     backend_name: str,
     latency_correction: float,
     predictor: Any = None,
+    speculative_profile: SpeculativeDecodingProfile | None = None,
 ) -> pd.DataFrame:
     """Enumerate (parallel, batch_size) worker candidates for a disagg role.
 
@@ -596,6 +602,7 @@ def _get_disagg_worker_candidates(
                     role=role,  # type: ignore[arg-type]
                     latency_correction=latency_correction,
                     predictor=predictor,
+                    speculative_profile=speculative_profile,
                 )
                 if not summary.check_oom():
                     all_configs_oom = False
@@ -765,6 +772,7 @@ def sweep_disagg(
     rate_matching_decode_degradation: float | None = None,
     autoscale_ttft_correction_factor: float | None = None,
     predictor: Any = None,
+    speculative_profile: SpeculativeDecodingProfile | None = None,
 ) -> pd.DataFrame:
     """Sweep prefill_parallel x decode_parallel x batches x workers with rate matching.
 
@@ -839,6 +847,7 @@ def sweep_disagg(
         backend_name=prefill_backend_name,
         latency_correction=prefill_latency_correction,
         predictor=predictor,
+        speculative_profile=speculative_profile,
     )
     decode_summary_df = _get_disagg_worker_candidates(
         model_path=model_path,
@@ -851,6 +860,7 @@ def sweep_disagg(
         backend_name=decode_backend_name,
         latency_correction=decode_latency_correction,
         predictor=predictor,
+        speculative_profile=speculative_profile,
     )
 
     if len(prefill_summary_df) == 0 or len(decode_summary_df) == 0:

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -36,7 +36,6 @@ from dataclasses import dataclass, field
 from typing import Any, Literal
 
 from aiconfigurator.sdk import common, config
-from aiconfigurator.sdk.config_builders import validate_nextn
 from aiconfigurator.sdk.models import (
     _infer_quant_modes_from_raw_config,
     attention_op_keys,
@@ -49,6 +48,10 @@ from aiconfigurator.sdk.perf_database import (
     is_blackwell_system,
     is_hopper_system,
     load_system_spec,
+)
+from aiconfigurator.sdk.speculative import (
+    SpeculativeDecodingProfile,
+    normalize_speculative_decoding,
 )
 from aiconfigurator.sdk.utils import enumerate_parallel_config, get_model_config_from_model_path
 
@@ -562,7 +565,7 @@ class Task:
         # nextn="auto" is the one exception: its depth comes from the checkpoint,
         # so it is resolved and validated in _resolve_model_identity.
         if self.nextn != "auto":
-            validate_nextn(self.nextn, self.nextn_accepted)
+            self.nextn, self.nextn_accepted = normalize_speculative_decoding(self.nextn, self.nextn_accepted)
         self._validate_deepseek_v4_hardware()
         self._resolve_model_identity()
         if self.nextn == "auto":
@@ -676,7 +679,7 @@ class Task:
             resolved = int(hf_nextn or 0)
             if resolved > 0:
                 try:
-                    validate_nextn(resolved, self.nextn_accepted)
+                    resolved, self.nextn_accepted = normalize_speculative_decoding(resolved, self.nextn_accepted)
                 except ValueError as exc:
                     raise ValueError(
                         f"nextn='auto' resolved to nextn={resolved} from the checkpoint's "
@@ -1117,7 +1120,6 @@ class Task:
             fmha_quant_mode=self._role_attr(role, "fmha_quant_mode"),
             comm_quant_mode=self._role_attr(role, "comm_quant_mode"),
             nextn=self.nextn,
-            nextn_accepted=self.nextn_accepted,
             enable_wideep=self._role_attr(role, "enable_wideep"),
             enable_eplb=self._role_attr(role, "enable_eplb"),
             # moe_backend / attention_backend / wideep_num_slots are shared across roles
@@ -1130,6 +1132,10 @@ class Task:
             attention_backend=self.attention_backend or "flashinfer",
             wideep_num_slots=self.wideep_num_slots,
         )
+
+    def build_speculative_profile(self) -> SpeculativeDecodingProfile:
+        """Build the upper-layer expected-progress assumption for prediction."""
+        return SpeculativeDecodingProfile.from_inputs(self.nextn, self.nextn_accepted)
 
     def iter_parallel(self, role: Literal["agg", "prefill", "decode"]) -> Iterator[ParallelChoice]:
         """Yield (tp, pp, dp, moe_tp, moe_ep, cp) tuples for the role.
@@ -1565,6 +1571,7 @@ class Task:
             return sweep_agg(
                 **self.sweep_agg_kwargs(database=database),
                 predictor=self.predictor,
+                speculative_profile=self.build_speculative_profile(),
             )
         if self.serving_mode == "disagg":
             prefill_database = self._load_database(
@@ -1577,6 +1584,7 @@ class Task:
                 **self.sweep_disagg_kwargs(prefill_database=prefill_database, decode_database=decode_database),
                 autoscale=autoscale,
                 predictor=self.predictor,
+                speculative_profile=self.build_speculative_profile(),
             )
         raise ValueError(f"Invalid serving_mode: {self.serving_mode!r}")
 
@@ -1653,6 +1661,7 @@ class Task:
             runtime_config=runtime_config,
             ctx_tokens=ctx_tokens if ctx_tokens is not None else self.isl,
             predictor=self.predictor,
+            speculative_profile=self.build_speculative_profile(),
             **backend_kwargs,
         )
         if summary.check_oom():
@@ -1729,6 +1738,7 @@ class Task:
             role="prefill",
             latency_correction=self.prefill_latency_correction,
             predictor=self.predictor,
+            speculative_profile=self.build_speculative_profile(),
         )
         if p_summary.check_oom():
             raise RuntimeError(
@@ -1757,6 +1767,7 @@ class Task:
             role="decode",
             latency_correction=self.decode_latency_correction,
             predictor=self.predictor,
+            speculative_profile=self.build_speculative_profile(),
         )
         if d_summary.check_oom():
             raise RuntimeError(

--- a/src/aiconfigurator/webapp/events/event_fn.py
+++ b/src/aiconfigurator/webapp/events/event_fn.py
@@ -18,6 +18,8 @@ from aiconfigurator.sdk.inference_session import InferenceSession
 from aiconfigurator.sdk.models import check_is_moe, get_model, get_model_family
 from aiconfigurator.sdk.models.helpers import _get_model_info, _infer_quant_modes_from_raw_config
 from aiconfigurator.sdk.perf_database import get_database, get_supported_databases
+from aiconfigurator.sdk.speculative import SpeculativeDecodingProfile
+from aiconfigurator.sdk.sweep import sweep_agg, sweep_disagg
 from aiconfigurator.sdk.utils import enumerate_parallel_config
 
 
@@ -196,6 +198,7 @@ class EventFn:
             LogCapture() as (logger, log_buffer),
         ):
             try:
+                speculative_profile = SpeculativeDecodingProfile.from_inputs(nextn, nextn_accepted)
                 database = copy.deepcopy(get_database(system_name, backend_name, version))
                 assert database is not None
                 database.set_default_database_mode(common.DatabaseMode[database_mode])
@@ -211,7 +214,6 @@ class EventFn:
                     moe_quant_mode=common.MoEQuantMode[moe_quant_mode],
                     comm_quant_mode=common.CommQuantMode[comm_quant_mode],
                     nextn=nextn,
-                    nextn_accepted=nextn_accepted,
                     enable_wideep=enable_wideep,
                     enable_eplb=enable_eplb if enable_wideep else False,
                     moe_backend="deepep_moe" if (enable_wideep and backend_name == "sglang") else None,
@@ -232,6 +234,10 @@ class EventFn:
                 backend = get_backend(backend_name)
                 session = InferenceSession(model, database, backend)
                 summary = session.run_static(runtime_config=runtime_config, mode=mode, stride=stride)
+                projection_role = (
+                    "prefill" if mode == "static_ctx" else ("decode" if mode == "static_gen" else "static")
+                )
+                summary = speculative_profile.project_summary(summary, role=projection_role)
             except Exception:
                 traceback_log = traceback.format_exc()
                 is_error = True
@@ -304,6 +310,7 @@ class EventFn:
             LogCapture() as (logger, log_buffer),
         ):
             try:
+                speculative_profile = SpeculativeDecodingProfile.from_inputs(nextn, nextn_accepted)
                 database = get_database(system_name, backend_name, version)
                 assert database is not None
                 database.set_default_database_mode(common.DatabaseMode[database_mode])
@@ -319,7 +326,6 @@ class EventFn:
                     moe_quant_mode=common.MoEQuantMode[moe_quant_mode],
                     comm_quant_mode=common.CommQuantMode[comm_quant_mode],
                     nextn=nextn,
-                    nextn_accepted=nextn_accepted,
                     enable_wideep=enable_wideep,
                     enable_eplb=enable_eplb if enable_wideep else False,
                     moe_backend="deepep_moe" if (enable_wideep and backend_name == "sglang") else None,
@@ -353,13 +359,18 @@ class EventFn:
 
                 results_df = None
 
-                backend = get_backend(backend_name)
-                model = get_model(model_path, model_config, backend_name)
-                session = InferenceSession(model, database, backend)
-                summary = session.find_best_agg_result_under_constraints(
-                    runtime_config=runtime_config, top_k=10, max_batch_size=512, ctx_stride=512
+                results_df = sweep_agg(
+                    model_path=model_path,
+                    runtime_config=runtime_config,
+                    database=database,
+                    backend_name=backend_name,
+                    model_config=model_config,
+                    parallel_config_list=parallel_config_list,
+                    top_k=10,
+                    max_batch_size=512,
+                    ctx_stride=512,
+                    speculative_profile=speculative_profile,
                 )
-                results_df = summary.get_summary_df()
 
                 if results_df is None or results_df.size == 0:
                     logger.error(
@@ -417,6 +428,7 @@ class EventFn:
             LogCapture() as (logger, log_buffer),
         ):
             try:
+                speculative_profile = SpeculativeDecodingProfile.from_inputs(nextn, nextn_accepted)
                 database = copy.deepcopy(get_database(system_name, backend_name, version))
                 assert database is not None
                 database.set_default_database_mode(common.DatabaseMode[database_mode])
@@ -427,7 +439,6 @@ class EventFn:
                     moe_quant_mode=common.MoEQuantMode[moe_quant_mode],
                     comm_quant_mode=common.CommQuantMode[comm_quant_mode],
                     nextn=nextn,
-                    nextn_accepted=nextn_accepted,
                     enable_wideep=enable_wideep,
                     enable_eplb=enable_eplb if enable_wideep else False,
                     moe_backend="deepep_moe" if (enable_wideep and backend_name == "sglang") else None,
@@ -467,13 +478,14 @@ class EventFn:
                         "Please double check your parallel configs."
                     )
 
-                results_df = pareto_analysis.agg_pareto(
+                results_df = sweep_agg(
                     model_path=model_path,
                     runtime_config=runtime_config,
                     database=database,
                     backend_name=backend_name,
                     model_config=model_config,
                     parallel_config_list=parallel_config_list,
+                    speculative_profile=speculative_profile,
                 )
 
                 # Use request_latency as x-axis if request_latency mode is active
@@ -591,6 +603,7 @@ class EventFn:
             LogCapture() as (logger, log_buffer),
         ):
             try:
+                speculative_profile = SpeculativeDecodingProfile.from_inputs(nextn, nextn_accepted)
                 prefill_database = copy.deepcopy(
                     get_database(prefill_system_name, prefill_backend_name, prefill_version)
                 )
@@ -611,7 +624,6 @@ class EventFn:
                     moe_quant_mode=common.MoEQuantMode[prefill_moe_quant_mode],
                     comm_quant_mode=common.CommQuantMode[prefill_comm_quant_mode],
                     nextn=nextn,
-                    nextn_accepted=nextn_accepted,
                     enable_wideep=enable_wideep,
                     enable_eplb=enable_eplb if enable_wideep else False,
                     moe_backend="deepep_moe" if (enable_wideep and prefill_backend_name == "sglang") else None,
@@ -629,7 +641,6 @@ class EventFn:
                     moe_quant_mode=common.MoEQuantMode[decode_moe_quant_mode],
                     comm_quant_mode=common.CommQuantMode[decode_comm_quant_mode],
                     nextn=nextn,
-                    nextn_accepted=nextn_accepted,
                     enable_wideep=enable_wideep,
                     enable_eplb=enable_eplb if enable_wideep else False,
                     moe_backend="deepep_moe" if (enable_wideep and decode_backend_name == "sglang") else None,
@@ -703,6 +714,12 @@ class EventFn:
                     decode_num_worker_list = [decode_num_worker]
 
                 num_gpu_list = [int(x) for x in num_gpu_list.split(",")] if len(num_gpu_list) > 0 else None
+                if max_num_gpu > 0:
+                    num_gpu_list = (
+                        [num_gpu for num_gpu in num_gpu_list if num_gpu <= max_num_gpu]
+                        if num_gpu_list is not None
+                        else list(range(1, max_num_gpu + 1))
+                    )
                 # logger.info(f"target num_gpu_list in the disagg system: {num_gpu_list}")
 
                 # For SGLang non-wideep disaggregated serving
@@ -715,7 +732,7 @@ class EventFn:
                         "sizes will be filtered out. "
                     )
 
-                results_df = pareto_analysis.disagg_pareto(
+                results_df = sweep_disagg(
                     model_path=model_path,
                     runtime_config=runtime_config,
                     prefill_database=prefill_database,
@@ -723,18 +740,18 @@ class EventFn:
                     prefill_model_config=prefill_model_config,
                     prefill_parallel_config_list=prefill_parallel_config_list,
                     prefill_num_worker_list=prefill_num_worker_list,
-                    prefill_latency_correction_scale=prefill_latency_correction_scale,
+                    prefill_latency_correction=prefill_latency_correction_scale,
                     decode_database=decode_database,
                     decode_backend_name=decode_backend_name,
                     decode_model_config=decode_model_config,
                     decode_parallel_config_list=decode_parallel_config_list,
                     decode_num_worker_list=decode_num_worker_list,
-                    decode_latency_correction_scale=decode_latency_correction_scale,
+                    decode_latency_correction=decode_latency_correction_scale,
                     num_gpu_list=num_gpu_list,
-                    max_num_gpu=max_num_gpu if max_num_gpu > 0 else None,
                     prefill_max_num_tokens=prefill_max_batch_size * isl,
                     decode_max_num_tokens=decode_max_batch_size,
                     require_same_tp=require_same_tp,
+                    speculative_profile=speculative_profile,
                 )
 
                 # Use request_latency as x-axis if request_latency mode is active
@@ -895,6 +912,7 @@ class EventFn:
             LogCapture() as (logger, log_buffer),
         ):
             try:
+                speculative_profile = SpeculativeDecodingProfile.from_inputs(nextn, nextn_accepted)
                 prefill_model_config = config.ModelConfig(
                     tp_size=prefill_tp_size,
                     pp_size=prefill_pp_size,
@@ -907,7 +925,6 @@ class EventFn:
                     moe_quant_mode=common.MoEQuantMode[prefill_moe_quant_mode],
                     comm_quant_mode=common.CommQuantMode[prefill_comm_quant_mode],
                     nextn=nextn,
-                    nextn_accepted=nextn_accepted,
                     enable_wideep=enable_wideep,
                     enable_eplb=enable_eplb if enable_wideep else False,
                     moe_backend="deepep_moe" if (enable_wideep and prefill_backend_name == "sglang") else None,
@@ -925,7 +942,6 @@ class EventFn:
                     moe_quant_mode=common.MoEQuantMode[decode_moe_quant_mode],
                     comm_quant_mode=common.CommQuantMode[decode_comm_quant_mode],
                     nextn=nextn,
-                    nextn_accepted=nextn_accepted,
                     enable_wideep=enable_wideep,
                     enable_eplb=enable_eplb if enable_wideep else False,
                     moe_backend="deepep_moe" if (enable_wideep and decode_backend_name == "sglang") else None,
@@ -995,6 +1011,7 @@ class EventFn:
                         runtime_config=config.RuntimeConfig(batch_size=b, isl=isl, osl=osl),
                         stride=decode_stride,
                     )
+                    decode_summary = speculative_profile.project_summary(decode_summary, role="decode")
                     decode_results_df = pd.concat(
                         [decode_results_df, decode_summary.get_summary_df()], ignore_index=True
                     )

--- a/tests/cross_package/test_core_public_api.py
+++ b/tests/cross_package/test_core_public_api.py
@@ -69,7 +69,7 @@ def test_stable_function_signatures() -> None:
         "gemm_quant_mode: 'str | None' = None, moe_quant_mode: 'str | None' = None, "
         "kvcache_quant_mode: 'str | None' = None, fmha_quant_mode: 'str | None' = None, "
         "comm_quant_mode: 'str | None' = None, nextn: 'int' = 0, "
-        "nextn_accepted: 'float | None' = None, kv_block_size: 'int | None' = None, "
+        "kv_block_size: 'int | None' = None, "
         "systems_path: 'str | None' = None) -> 'bytes'"
     )
     assert "scheduler_block_size" in inspect.signature(estimate_num_gpu_blocks).parameters

--- a/tests/integration/test_memory_estimation.py
+++ b/tests/integration/test_memory_estimation.py
@@ -243,7 +243,7 @@ def test_eagle_prefill_kv_budget_nonnegative_kimi_gb200(nextn):
     """
     try:
         baseline = memory.estimate_kv_cache(**_EAGLE_PREFILL_CASE, nextn=0)
-        est = memory.estimate_kv_cache(**_EAGLE_PREFILL_CASE, nextn=nextn, nextn_accepted=0.85)
+        est = memory.estimate_kv_cache(**_EAGLE_PREFILL_CASE, nextn=nextn)
     except ValueError as exc:
         # A genuinely-missing perf DB / model soft-skips; the "no KV budget" regression
         # (any other ValueError) is re-raised by the helper and fails the test.

--- a/tests/unit/cli/test_afd_phase_completion.py
+++ b/tests/unit/cli/test_afd_phase_completion.py
@@ -231,8 +231,9 @@ def test_run_afd_estimate_passes_prefix_and_nextn(monkeypatch):
             captured["a_model_config"] = kwargs["a_model_config"]
             captured["f_model_config"] = kwargs["f_model_config"]
 
-        def run_afd(self, runtime_config, **_kwargs):
+        def run_afd(self, runtime_config, **kwargs):
             captured["runtime_config"] = runtime_config
+            captured["speculative_profile"] = kwargs["speculative_profile"]
             summary = InferenceSummary(runtime_config)
             summary.set_oom(False)
             summary.set_result_dict(
@@ -292,8 +293,9 @@ def test_run_afd_estimate_passes_prefix_and_nextn(monkeypatch):
     assert captured["runtime_config"].prefix == 32
     assert captured["a_model_config"].nextn == 2
     assert captured["f_model_config"].nextn == 2
-    assert captured["a_model_config"].nextn_accepted == 0.85
-    assert captured["f_model_config"].nextn_accepted == 0.85
+    assert not hasattr(captured["a_model_config"], "nextn_accepted")
+    assert not hasattr(captured["f_model_config"], "nextn_accepted")
+    assert captured["speculative_profile"].expected_accepted_tokens == 0.85
 
 
 def test_afd_prefill_uses_uncached_prefix_suffix_for_token_math(monkeypatch):

--- a/tests/unit/cli/test_argument_parsing.py
+++ b/tests/unit/cli/test_argument_parsing.py
@@ -282,6 +282,47 @@ class TestCLIArgumentParsing:
         )
         assert args.nextn == "auto"
 
+    def test_nextn_requires_explicit_acceptance(self, cli_parser):
+        from aiconfigurator.cli.main import _resolve_and_validate_nextn
+
+        args = cli_parser.parse_args(
+            [
+                "default",
+                "--model-path",
+                "Qwen/Qwen3-32B",
+                "--total-gpus",
+                "8",
+                "--system",
+                "h200_sxm",
+                "--nextn",
+                "2",
+            ]
+        )
+
+        with pytest.raises(SystemExit, match="nextn_accepted"):
+            _resolve_and_validate_nextn(args)
+
+    def test_nextn_auto_requires_explicit_acceptance_when_resolved_positive(self, cli_parser, monkeypatch):
+        import aiconfigurator.cli.main as cli_main
+
+        args = cli_parser.parse_args(
+            [
+                "default",
+                "--model-path",
+                "Qwen/Qwen3-32B",
+                "--total-gpus",
+                "8",
+                "--system",
+                "h200_sxm",
+                "--nextn",
+                "auto",
+            ]
+        )
+        monkeypatch.setattr(cli_main, "resolve_nextn_auto", lambda _model_path: 2)
+
+        with pytest.raises(SystemExit, match=r"resolved to nextn=2.*nextn_accepted"):
+            cli_main._resolve_and_validate_nextn(args)
+
     @pytest.mark.parametrize("bad_value", ["-1", "1.5", "always", ""])
     def test_nextn_rejects_non_auto_junk(self, cli_parser, bad_value):
         """--nextn takes a non-negative integer or the literal 'auto'."""

--- a/tests/unit/sdk/database/test_deepseek_v4_module.py
+++ b/tests/unit/sdk/database/test_deepseek_v4_module.py
@@ -636,7 +636,6 @@ def test_deepseek_v4_static_sol_runs_end_to_end(mutable_comprehensive_perf_db):
         moe_tp_size=1,
         moe_ep_size=1,
         nextn=1,
-        nextn_accepted=0.85,
         overwrite_num_layers=2,
     )
     model = get_model("sgl-project/DeepSeek-V4-Flash-FP8", model_config, backend_name="trtllm")

--- a/tests/unit/sdk/models/test_model_config.py
+++ b/tests/unit/sdk/models/test_model_config.py
@@ -146,14 +146,13 @@ class TestMOEParallelismResolution:
                 moe_tp_size=1,
                 moe_ep_size=8,
                 nextn=nextn,
-                nextn_accepted=0.85,
             )
             return get_model("nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16", mc, backend_name="trtllm")
 
         baseline = build(0)
         mtp = build(1)
         assert baseline._mtp_scale_factor == 1.0
-        assert 0.0 < mtp._mtp_scale_factor < 1.0
+        assert mtp._mtp_scale_factor > 1.0
 
         baseline_context = {op._name: op._scale_factor for op in baseline.context_ops}
         mtp_context = {op._name: op._scale_factor for op in mtp.context_ops}
@@ -449,7 +448,6 @@ class TestHFModelSupport:
             moe_tp_size=1,
             moe_ep_size=1,
             nextn=1,
-            nextn_accepted=0.85,
         )
         model = get_model(hf_id, model_config, backend_name="trtllm")
         assert model.model_family == "DEEPSEEKV4"
@@ -473,7 +471,6 @@ class TestHFModelSupport:
             moe_ep_size=8,
             attention_dp_size=1,
             nextn=1,
-            nextn_accepted=0.85,
         )
         model = get_model("sgl-project/DeepSeek-V4-Pro-FP8", model_config, backend_name="trtllm")
         seq_len = 4096
@@ -508,7 +505,6 @@ class TestHFModelSupport:
             moe_ep_size=4,
             attention_dp_size=1,
             nextn=1,
-            nextn_accepted=0.85,
         )
         model = get_model("sgl-project/DeepSeek-V4-Pro-FP8", model_config, backend_name="trtllm")
         local_inter_size = model._moe_inter_size // model_config.tp_size
@@ -539,7 +535,6 @@ class TestHFModelSupport:
             moe_backend="megamoe",
             workload_distribution="uniform",
             nextn=1,
-            nextn_accepted=0.85,
         )
         model = get_model("deepseek-ai/DeepSeek-V4-Pro", model_config, backend_name="sglang")
 
@@ -563,7 +558,6 @@ class TestHFModelSupport:
             attention_dp_size=8,
             moe_backend="deepep_moe",
             nextn=1,
-            nextn_accepted=0.85,
         )
         model = get_model("deepseek-ai/DeepSeek-V4-Pro", model_config, backend_name="sglang")
 
@@ -826,7 +820,6 @@ class TestGetKvcacheMaxTokens:
             moe_ep_size=8,
             attention_dp_size=1,
             nextn=1,
-            nextn_accepted=0.85,
         )
         model = models.get_model("sgl-project/DeepSeek-V4-Pro-FP8", model_config, backend_name="trtllm")
         window = model.extra_params.sliding_window

--- a/tests/unit/sdk/models/test_mtp_scaling.py
+++ b/tests/unit/sdk/models/test_mtp_scaling.py
@@ -5,7 +5,7 @@
 Unit tests for MTP (Multi-Token Prediction) speculative decoding scaling.
 
 Tests that verify:
-1. the mtp_scale_factor helper (formula + nextn/nextn_accepted validation)
+1. the mtp_scale_factor helper models compute-side nextn only
 2. generation ops ARE scaled by mtp_scale_factor while context ops are NOT
    (context_p2p bug-fix regression), incl. the Qwen3.5 hybrid GDN arch
 """
@@ -22,41 +22,44 @@ pytestmark = pytest.mark.unit
 class TestMTPScaling:
     """Tests for MTP speculative decoding scaling behavior."""
 
-    def _create_model_config(self, nextn=0, nextn_accepted=None):
+    def _create_model_config(self, nextn=0):
         """Helper to create a ModelConfig for testing."""
-        if nextn_accepted is None and nextn > 0:
-            nextn_accepted = 0.5 * nextn
         return sdk_config.ModelConfig(
             tp_size=1,
             pp_size=1,
             gemm_quant_mode=common.GEMMQuantMode.bfloat16,
             kvcache_quant_mode=common.KVCacheQuantMode.bfloat16,
             nextn=nextn,
-            nextn_accepted=nextn_accepted,
         )
 
     def test_mtp_scale_factor_calculation(self):
         """
         Test the mtp_scale_factor helper.
 
-        Formula: (nextn + num_layers) / num_layers / (1 + nextn_accepted)
+        Formula: (nextn + num_layers) / num_layers
         """
         from aiconfigurator.sdk.models import mtp_scale_factor
 
-        assert mtp_scale_factor(0, None, 64) == 1.0
-        assert mtp_scale_factor(1, 0.85, 64) == pytest.approx((1 + 64) / 64 / 1.85)
-        assert mtp_scale_factor(3, 2.0, 61) == pytest.approx((3 + 61) / 61 / 3.0)
+        assert mtp_scale_factor(0, 64) == 1.0
+        assert mtp_scale_factor(2, 64) == pytest.approx((2 + 64) / 64)
+        assert mtp_scale_factor(1, 64) == pytest.approx((1 + 64) / 64)
+        assert mtp_scale_factor(3, 61) == pytest.approx((3 + 61) / 61)
 
-    def test_mtp_scale_factor_validation(self):
-        """nextn_accepted is required when nextn > 0, and must lie in [0, nextn]."""
-        from aiconfigurator.sdk.models import mtp_scale_factor
+    def test_model_config_contains_compute_side_nextn_only(self):
+        """Core model configuration does not carry workload acceptance."""
+        model_config = sdk_config.ModelConfig(
+            tp_size=1,
+            pp_size=1,
+            gemm_quant_mode=common.GEMMQuantMode.bfloat16,
+            kvcache_quant_mode=common.KVCacheQuantMode.bfloat16,
+            nextn=2,
+        )
 
-        with pytest.raises(ValueError, match="required"):
-            mtp_scale_factor(2, None, 64)
-        with pytest.raises(ValueError, match="within"):
-            mtp_scale_factor(2, 2.5, 64)
-        with pytest.raises(ValueError, match="within"):
-            mtp_scale_factor(2, -0.1, 64)
+        model = models.get_model("Qwen/Qwen3-32B", model_config, "trtllm")
+
+        assert not hasattr(model_config, "nextn_accepted")
+        assert not hasattr(model, "_nextn_accepted")
+        assert model._mtp_scale_factor == pytest.approx((2 + model._num_layers) / model._num_layers)
 
     def test_generation_ops_scaled_by_mtp(self):
         """
@@ -138,7 +141,6 @@ class TestMTPScaling:
                 gemm_quant_mode=common.GEMMQuantMode.bfloat16,
                 kvcache_quant_mode=common.KVCacheQuantMode.bfloat16,
                 nextn=nextn,
-                nextn_accepted=(0.85 if nextn else None),
             )
             return models.get_model("Qwen/Qwen3-32B", mc, "trtllm")
 

--- a/tests/unit/sdk/task_v2/test_task_config.py
+++ b/tests/unit/sdk/task_v2/test_task_config.py
@@ -325,7 +325,9 @@ def test_build_model_config_agg_uses_resolved_quant():
     mc = t.build_model_config(role="agg")
     assert mc.gemm_quant_mode == common.GEMMQuantMode.bfloat16
     assert mc.nextn == t.nextn == 2
-    assert mc.nextn_accepted == t.nextn_accepted == 1.2
+    assert not hasattr(mc, "nextn_accepted")
+    assert t.nextn_accepted == 1.2
+    assert t.build_speculative_profile().expected_accepted_tokens == 1.2
 
 
 def test_sweep_agg_kwargs_shape():
@@ -618,7 +620,7 @@ def test_nextn_never_auto_enabled(caplog):
 
 
 def test_nextn_auto_resolves_depth_from_checkpoint():
-    """nextn='auto' takes the draft DEPTH from num_nextn_predict_layers; the
+    """nextn='auto' takes the draft depth from num_nextn_predict_layers; the
     acceptance value is still required -- it is never inferred."""
     import pytest as _pytest
 

--- a/tests/unit/sdk/test_compile_engine_mtp.py
+++ b/tests/unit/sdk/test_compile_engine_mtp.py
@@ -1,14 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""compile_engine must apply MTP to the model it builds.
-
-``compile_engine`` (the flat-kwargs entry the Rust ``build_aic_engine`` path
-calls) previously forwarded ``nextn``/``nextn_accepted`` only into the spec
-JSON; the model itself was built with ``nextn=0``, so the walked op lists
-carried no ``1/(1+nextn_accepted)*(L+nextn)/L`` generation scale and compiled
-engines ignored the MTP benefit entirely.
-"""
+"""Compiled aic-core engines carry MTP compute depth, not acceptance."""
 
 from __future__ import annotations
 
@@ -19,13 +12,12 @@ from aiconfigurator.sdk import engine
 pytestmark = pytest.mark.unit
 
 
-def test_compile_engine_applies_mtp_to_model(monkeypatch):
+def test_compile_engine_applies_nextn_compute_cost_only(monkeypatch):
     captured = {}
 
     def _capture_spec(model, **kwargs):
         captured["model"] = model
-        captured["nextn"] = kwargs["nextn"]
-        captured["nextn_accepted"] = kwargs["nextn_accepted"]
+        captured["kwargs"] = kwargs
         return "{}"
 
     monkeypatch.setattr(engine, "build_engine_spec_json", _capture_spec)
@@ -37,11 +29,22 @@ def test_compile_engine_applies_mtp_to_model(monkeypatch):
         "h200_sxm",
         "trtllm",
         nextn=1,
-        nextn_accepted=0.85,
     )
 
     model = captured["model"]
     assert model._nextn == 1
-    assert model._nextn_accepted == 0.85
-    assert model._mtp_scale_factor != 1.0
-    assert captured["nextn"] == 1 and captured["nextn_accepted"] == 0.85
+    assert not hasattr(model, "_nextn_accepted")
+    assert model._mtp_scale_factor == pytest.approx((model._num_layers + 1) / model._num_layers)
+    assert captured["kwargs"]["nextn"] == 1
+    assert "nextn_accepted" not in captured["kwargs"]
+
+
+def test_compile_engine_rejects_removed_nextn_accepted_parameter():
+    with pytest.raises(TypeError, match=r"unexpected keyword argument 'nextn_accepted'"):
+        engine.compile_engine(
+            "Qwen/Qwen3-32B",
+            "h200_sxm",
+            "trtllm",
+            nextn=1,
+            nextn_accepted=0.7,
+        )

--- a/tests/unit/sdk/test_memory_estimation.py
+++ b/tests/unit/sdk/test_memory_estimation.py
@@ -182,7 +182,7 @@ def test_breakdown_applies_nextn_to_model_config(monkeypatch):
 
     def _fake_get_model(model_path, model_config, backend):
         captured["nextn"] = model_config.nextn
-        captured["nextn_accepted"] = model_config.nextn_accepted
+        captured["has_nextn_accepted"] = hasattr(model_config, "nextn_accepted")
 
         class _StubModel:
             def get_kvcache_bytes_per_sequence(self, seq_len):
@@ -217,23 +217,20 @@ def test_breakdown_applies_nextn_to_model_config(monkeypatch):
         max_num_tokens=8192,
         max_batch_size=256,
         nextn=2,
-        nextn_accepted=1.1,
         systems_path="/tmp/aic-core-systems",
     )
     assert captured["nextn"] == 2
-    assert captured["nextn_accepted"] == 1.1
+    assert captured["has_nextn_accepted"] is False
     assert captured["systems_paths"] == "/tmp/aic-core-systems"
 
 
-def test_breakdown_accepts_nextn_without_accepted(monkeypatch):
-    # Capacity math never consumes the acceptance benefit, so external KV
-    # estimation callers with nextn > 0 must not require nextn_accepted -- a
-    # neutral 0.0 is applied to the ModelConfig instead.
+def test_breakdown_accepts_nextn_without_acceptance_field(monkeypatch):
+    # Capacity math consumes only the core-owned draft depth.
     captured = {}
 
     def _fake_get_model(model_path, model_config, backend):
         captured["nextn"] = model_config.nextn
-        captured["nextn_accepted"] = model_config.nextn_accepted
+        captured["has_nextn_accepted"] = hasattr(model_config, "nextn_accepted")
 
         class _StubModel:
             def get_kvcache_bytes_per_sequence(self, seq_len):
@@ -265,7 +262,7 @@ def test_breakdown_accepts_nextn_without_accepted(monkeypatch):
         nextn=2,
     )
     assert captured["nextn"] == 2
-    assert captured["nextn_accepted"] == 0.0
+    assert captured["has_nextn_accepted"] is False
 
 
 def test_native_capacity_override_wins():
@@ -627,13 +624,13 @@ def test_estimate_kv_cache_propagates_when_fallback_disabled(monkeypatch):
         )
 
 
-def test_estimate_kv_cache_nextn_accepted_is_optional_but_range_checked(monkeypatch):
-    # nextn without nextn_accepted must reach the breakdown for external
-    # capacity callers; an out-of-range value still fails fast.
+def test_estimate_kv_cache_nextn_reaches_breakdown(monkeypatch):
+    # Acceptance is not part of the aic-core memory API.
     reached = {"n": 0}
 
     def _spy(*args, **kwargs):
         reached["n"] += 1
+        reached["nextn"] = kwargs.get("nextn")
         raise RuntimeError("stop here")
 
     monkeypatch.setattr(memory.KVCacheEstimator, "from_request", classmethod(_spy))
@@ -651,21 +648,7 @@ def test_estimate_kv_cache_nextn_accepted_is_optional_but_range_checked(monkeypa
             allow_naive_fallback=False,
         )
     assert reached["n"] == 1
-
-    with pytest.raises(ValueError, match="nextn_accepted"):
-        memory.estimate_kv_cache(
-            "Qwen/Qwen3-32B",
-            "h200_sxm",
-            "trtllm",
-            max_num_tokens=8192,
-            max_batch_size=256,
-            memory_fraction_kind="of_free",
-            memory_fraction_value=0.9,
-            nextn=2,
-            nextn_accepted=3.5,
-            allow_naive_fallback=False,
-        )
-    assert reached["n"] == 1
+    assert reached["nextn"] == 2
 
 
 def test_estimate_kv_cache_rejects_bad_fraction_before_breakdown(monkeypatch):

--- a/tests/unit/sdk/test_rust_engine_step.py
+++ b/tests/unit/sdk/test_rust_engine_step.py
@@ -252,7 +252,6 @@ def test_forward_pass_perf_model_native_end_to_end() -> None:
         "kv_cache_dtype": None,
         "kv_block_size": None,
         "nextn": None,
-        "nextn_accepted": None,
         "extra": {},
     }
     model = RustForwardPassPerfModel.from_native(config, {"min_observations": 2})
@@ -316,7 +315,6 @@ def test_forward_pass_perf_model_best_available_falls_back_on_bad_config() -> No
         "kv_cache_dtype": None,
         "kv_block_size": None,
         "nextn": None,
-        "nextn_accepted": None,
         "extra": {},
     }
     model = RustForwardPassPerfModel.best_available(config, {"min_observations": 2})

--- a/tests/unit/sdk/test_speculative.py
+++ b/tests/unit/sdk/test_speculative.py
@@ -81,6 +81,31 @@ def test_expected_progress_projects_service_metrics_not_core_breakdown():
     assert original.get_result_dict()["tpot"] == 10.0
 
 
+def test_aggregate_projection_reapplies_vllm_little_law_cap():
+    original = _summary()
+    frame = original.get_summary_df().copy()
+    frame["backend"] = "vllm"
+    frame["concurrency"] = 1
+    frame["request_rate"] = 10.0
+    frame["seq/s"] = 10.0
+    frame["seq/s/gpu"] = 2.5
+    frame["tokens/s"] = 80.0
+    frame["tokens/s/gpu"] = 20.0
+    original.set_summary_df(frame)
+    original.set_result_dict(frame.iloc[0].to_dict())
+
+    projected = SpeculativeDecodingProfile(1.0).project_summary(original, role="agg")
+    row = projected.get_result_dict()
+
+    # Projected request latency is 60 ms, so one concurrent request caps the
+    # request rate at 1000 / 60 rather than the naive 10 * 2 = 20 seq/s.
+    assert row["request_latency"] == 60.0
+    assert row["seq/s"] == pytest.approx(16.667)
+    assert row["request_rate"] == pytest.approx(16.667)
+    assert row["tokens/s"] == pytest.approx(133.333)
+    assert row["tokens/s/gpu"] == pytest.approx(33.333)
+
+
 def test_prefill_metrics_are_not_projected():
     summary = _summary()
     assert SpeculativeDecodingProfile(1.0).project_summary(summary, role="prefill") is summary

--- a/tests/unit/sdk/test_speculative.py
+++ b/tests/unit/sdk/test_speculative.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from aiconfigurator.sdk.config import RuntimeConfig
+from aiconfigurator.sdk.inference_summary import InferenceSummary
+from aiconfigurator.sdk.speculative import (
+    SpeculativeDecodingProfile,
+    normalize_speculative_decoding,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _summary() -> InferenceSummary:
+    summary = InferenceSummary(RuntimeConfig(isl=128, osl=9))
+    row = {
+        "isl": 128,
+        "osl": 9,
+        "ttft": 20.0,
+        "tpot": 10.0,
+        "request_latency": 100.0,
+        "request_rate": 5.0,
+        "seq/s": 5.0,
+        "seq/s/gpu": 1.25,
+        "tokens/s": 45.0,
+        "tokens/s/gpu": 11.25,
+        "tokens/s/user": 100.0,
+        "generation_latency": 80.0,
+        "memory": 42.0,
+    }
+    summary.set_summary_df(pd.DataFrame([row]))
+    summary.set_result_dict(dict(row))
+    summary.set_generation_latency_dict({"generation_qkv": 80.0})
+    return summary
+
+
+def test_active_mtp_requires_explicit_acceptance_above_core():
+    with pytest.raises(ValueError, match="requires 'nextn_accepted'"):
+        normalize_speculative_decoding(2, None)
+
+
+def test_acceptance_is_ignored_when_mtp_is_disabled():
+    profile = SpeculativeDecodingProfile.from_inputs(0, 0.9)
+    assert profile.expected_accepted_tokens == 0.0
+
+
+@pytest.mark.parametrize("accepted", [-0.1, 2.1, float("inf"), float("nan")])
+def test_acceptance_range_is_validated_by_upper_layer(accepted):
+    with pytest.raises(ValueError, match="nextn_accepted"):
+        normalize_speculative_decoding(2, accepted)
+
+
+@pytest.mark.parametrize("accepted", [-0.1, float("inf"), float("nan")])
+def test_direct_profile_rejects_invalid_acceptance(accepted):
+    with pytest.raises(ValueError, match="finite and non-negative"):
+        SpeculativeDecodingProfile(accepted)
+
+
+def test_expected_progress_projects_service_metrics_not_core_breakdown():
+    original = _summary()
+    projected = SpeculativeDecodingProfile(1.0).project_summary(original, role="agg")
+    row = projected.get_result_dict()
+
+    assert row["ttft"] == 20.0
+    assert row["tpot"] == 5.0
+    assert row["request_latency"] == 60.0
+    assert row["seq/s"] == 10.0
+    assert row["tokens/s"] == 90.0
+    assert row["tokens/s/user"] == 200.0
+    assert row["generation_latency"] == 40.0
+    assert row["memory"] == 42.0
+
+    # The raw per-operation iteration cost from aic-core remains available and the
+    # cached backend summary is not mutated by the projection.
+    assert projected.get_generation_latency_dict() == {"generation_qkv": 80.0}
+    assert original.get_result_dict()["tpot"] == 10.0
+
+
+def test_prefill_metrics_are_not_projected():
+    summary = _summary()
+    assert SpeculativeDecodingProfile(1.0).project_summary(summary, role="prefill") is summary

--- a/tests/unit/webapp/test_event_fn.py
+++ b/tests/unit/webapp/test_event_fn.py
@@ -17,6 +17,9 @@ silently for the model families we explicitly own. Each test owns
 exactly one family.
 """
 
+import ast
+import inspect
+
 import pytest
 
 pytestmark = pytest.mark.unit
@@ -26,7 +29,21 @@ pytestmark = pytest.mark.unit
 # runtime, so this is purely a test-environment shim.
 pytest.importorskip("gradio")
 
+from aiconfigurator.webapp.events import event_fn
 from aiconfigurator.webapp.events.event_fn import EventFn
+
+
+def test_model_config_calls_do_not_receive_acceptance_assumption():
+    """The webapp keeps acceptance above the aic-core ModelConfig boundary."""
+    tree = ast.parse(inspect.getsource(event_fn))
+    model_config_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "ModelConfig"
+    ]
+
+    assert model_config_calls
+    assert all("nextn_accepted" not in {keyword.arg for keyword in call.keywords} for call in model_config_calls)
 
 
 class TestUpdateModelRelatedComponents:


### PR DESCRIPTION
## Summary

- keep the existing user-facing contract: active MTP (`nextn > 0`, including `nextn="auto"` resolving above zero) requires an explicit `nextn_accepted`
- remove acceptance-progress modeling from the Python and Rust `aic-core` layers
- keep `nextn` in `aic-core` so raw simulation still includes MTP draft/verification compute
- add an SDK-level `SpeculativeDecodingProfile` that projects accepted-token progress into service metrics
- apply the projection before disaggregated prefill/decode rate matching
- bump the Rust engine-spec schema to v3 after removing acceptance from the serialized core config

## Architecture

`aic-core` models work performed per engine iteration. Its raw operation breakdown and iteration time depend on `nextn`, but not on how many draft tokens the workload accepts.

The upper AIC SDK predictor/sweeper owns workload interpretation:

- `nextn_accepted` remains an explicit required input whenever resolved `nextn > 0`
- the upper layer validates `nextn_accepted` as finite and within `[0, nextn]`
- accepted-token progress adjusts derived service TPOT, generation/request latency, and throughput
- the same raw `aic-core` result can be reused across different acceptance assumptions

Prefill metrics remain unchanged. For disaggregated inference, decode metrics are projected before rate matching so the matched system rate reflects accepted-token progress.

## User impact

There is no relaxation of the CLI/API contract: `--nextn 2` without `--nextn-accepted` remains an error. `--nextn auto` also requires `--nextn-accepted` when the checkpoint resolves to a positive draft depth. The architectural change is that the accepted-token value no longer crosses into `aic-core`.

## Validation

- Python unit suite: `2624 passed, 10 skipped`
- focused SDK/CLI suite: `153 passed`
- cross-package contracts: `66 passed`
- changed integration/e2e paths: `25 passed`
- Rust workspace without Python embedding: `198` core + `3` public-API tests passed
- Rust workspace with all features: `203` core + embedded/memory/PyO3 round trips + `3` public-API tests passed
- `ruff check .`
- `ruff format --check .`
- `git diff --check`
