### PR TITLE
docs: clarify forward-pass API selection

### DIFF
--- a/aic-core/API.md
+++ b/aic-core/API.md
@@ -72,8 +72,13 @@ replacement for `best_available(...)`.
 ```python
 from aiconfigurator_core.sdk import RustForwardPassPerfModel
 
+# Engine-config and per-rank FPM dictionary setup is omitted here.
 model = RustForwardPassPerfModel.best_available(config)
 diagnostics = model.diagnostics()
+print(diagnostics["source"])
+if diagnostics["last_warning"] is not None:
+    print(diagnostics["last_warning"])
+
 estimate_ms = model.estimate_forward_pass_time_ms(metrics_by_rank)
 ```
 

--- a/aic-core/API.md
+++ b/aic-core/API.md
@@ -55,19 +55,22 @@ Python modules carry their own annotations.
 For adaptive forward-pass modeling, use
 `RustForwardPassPerfModel.best_available(...)` from Python or
 `ForwardPassPerfModel::best_available(...)` from Rust. This path uses the
-native AIC estimate when the engine configuration is supported, learns online
-correction factors from FPM observations, and falls back to regression for an
-eligible native-unsupported configuration. Check `diagnostics()` to determine
-whether the active source is `aic`, `aic_with_correction`, or
-`fallback_regression`, and to inspect any fallback warning.
+native AIC estimate when the native estimator can be built, learns online
+correction factors from FPM observations, and falls back to regression for
+eligible native build or data-availability failures. These include unsupported
+models and missing or unreadable model, system, or performance data. Check
+`diagnostics()` to determine whether the active source is `aic`,
+`aic_with_correction`, or `fallback_regression`, and to inspect any fallback
+warning.
 
 Use `from_native(...)` instead when native AIC support is required and an
-unsupported configuration should fail rather than fall back.
+unsupported configuration or native data failure should surface rather than
+fall back.
 
 `AicEngineBuilder` serves a different purpose: it constructs the strict native
-Rust engine for direct prefill, decode, and mixed-step latency calls. It does
-not provide regression fallback or online correction, so it is not a
-replacement for `best_available(...)`.
+Rust engine for direct public prefill and decode latency calls. It does not
+provide regression fallback or online correction, so it is not a replacement
+for `best_available(...)`.
 
 ```python
 from aiconfigurator_core.sdk import RustForwardPassPerfModel
@@ -80,6 +83,12 @@ if diagnostics["last_warning"] is not None:
     print(diagnostics["last_warning"])
 
 estimate_ms = model.estimate_forward_pass_time_ms(metrics_by_rank)
+if estimate_ms is None:
+    # Regression fallback starts without observations for each workload kind.
+    # Supply observed FPM iterations with positive wall_time until the configured
+    # min_observations threshold is reached, then retry the estimate.
+    model.tune_with_fpms(observed_iterations)  # Observed-iteration setup omitted.
+    estimate_ms = model.estimate_forward_pass_time_ms(metrics_by_rank)
 ```
 
 ## Stable Rust facade

--- a/aic-core/API.md
+++ b/aic-core/API.md
@@ -50,6 +50,33 @@ extension contract:
 The wheel includes `py.typed` and a stub for that native extension. The SDK
 Python modules carry their own annotations.
 
+## Choosing a forward-pass API
+
+For adaptive forward-pass modeling, use
+`RustForwardPassPerfModel.best_available(...)` from Python or
+`ForwardPassPerfModel::best_available(...)` from Rust. This path uses the
+native AIC estimate when the engine configuration is supported, learns online
+correction factors from FPM observations, and falls back to regression for an
+eligible native-unsupported configuration. Check `diagnostics()` to determine
+whether the active source is `aic`, `aic_with_correction`, or
+`fallback_regression`, and to inspect any fallback warning.
+
+Use `from_native(...)` instead when native AIC support is required and an
+unsupported configuration should fail rather than fall back.
+
+`AicEngineBuilder` serves a different purpose: it constructs the strict native
+Rust engine for direct prefill, decode, and mixed-step latency calls. It does
+not provide regression fallback or online correction, so it is not a
+replacement for `best_available(...)`.
+
+```python
+from aiconfigurator_core.sdk import RustForwardPassPerfModel
+
+model = RustForwardPassPerfModel.best_available(config)
+diagnostics = model.diagnostics()
+estimate_ms = model.estimate_forward_pass_time_ms(metrics_by_rank)
+```
+
 ## Stable Rust facade
 
 New embedded consumers should construct engines with `AicEngineBuilder`. The

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/communication.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/communication.rs
@@ -367,10 +367,10 @@ mod tests {
         systems_root().join("data/b200_sxm/sglang/0.5.10")
     }
 
-    /// `<systems_root>/data/b200_sxm/nccl/2.27.3/` — the system-spec-aware
-    /// NCCL root for b200_sxm, mirroring Python's path layout.
+    /// `<systems_root>/data/b200_sxm/comm/nccl/2.27.3/` — the family-first
+    /// system-spec-aware NCCL root for b200_sxm.
     fn b200_nccl_root() -> Option<PathBuf> {
-        Some(systems_root().join("data/b200_sxm/nccl/2.27.3"))
+        Some(systems_root().join("data/b200_sxm/comm/nccl/2.27.3"))
     }
 
     #[test]
@@ -418,7 +418,7 @@ mod tests {
     fn nccl_loads_from_system_wide_path() {
         // With the system-spec-aware path (b200_sxm declares
         // `nccl_version: '2.27.3'`), NCCL data resolves to
-        // `<systems_root>/data/b200_sxm/nccl/2.27.3/nccl_perf.parquet`
+        // `<systems_root>/data/b200_sxm/comm/nccl/2.27.3/nccl_perf.parquet`
         // and the table loads successfully — NOT
         // `<vllm/0.19.0>/nccl_perf.parquet` which never existed.
         let table = CommunicationTable::new(b200_vllm_data_root(), b200_nccl_root(), None);

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/gemm.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/gemm.rs
@@ -544,7 +544,7 @@ mod tests {
         PathBuf::from(REPO_ROOT_HINT)
             .join("../..")
             .join(format!(
-                "src/aiconfigurator_core/systems/data/b200_sxm/{backend}/{version}/gemm_perf.parquet"
+                "src/aiconfigurator_core/systems/data/b200_sxm/gemm/{backend}/{version}/gemm_perf.parquet"
             ))
     }
 

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/mod.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/mod.rs
@@ -321,8 +321,15 @@ mod tests {
         assert_eq!(db.system, "b200_sxm");
         assert_eq!(db.backend, "vllm");
         assert_eq!(db.version, "0.19.0");
-        assert!(db.data_root.is_dir(), "data_root must exist");
-        assert!(db.data_root.join("gemm_perf.parquet").is_file());
+        let gemm_sources = resolve_op_sources(
+            &PerfDbSources::default(),
+            "gemm_perf.parquet",
+            &db.data_root,
+        );
+        assert!(
+            gemm_sources[0].0.is_file(),
+            "resolved GEMM source must exist"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- add a short decision guide to `aic-core/API.md`
- recommend `RustForwardPassPerfModel.best_available(...)` / `ForwardPassPerfModel::best_available(...)` for adaptive forward-pass modeling
- distinguish strict-native `from_native(...)` from `AicEngineBuilder`
- show how to inspect the selected source and fallback warning through `diagnostics()`
- align Rust perf-database tests with the current family-first data layout

## Why

The public API contract listed the adaptive forward-pass model and compiled engine surfaces, but did not explain which one users should choose. The newly enforced core API-contract job also exposed test fixtures that still referenced the legacy perf-data layout even though the loader already supports the family-first layout.

## User impact

Users can now select the adaptive model for native AIC estimates, online correction, and eligible regression fallback, while reserving `AicEngineBuilder` for strict native prefill/decode/mixed-step engine calls. The public API-contract test now validates the current perf-data layout.

## Validation

- `git diff --check`
- `cargo test --workspace --no-default-features` — 198 core tests and 3 external public-API consumer tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance on selecting a forward-pass API, including how diagnostics report the active source and when regression fallback is used.
  - Clarified the role of native-only forward-pass loading versus adaptive “best available” selection.
  - Included a Python example demonstrating diagnostics and estimating forward-pass time with fallback.

- **Tests**
  - Updated performance database tests to verify resolved op-source file paths instead of only legacy data-root layout checks.

- **Chores**
  - Corrected test documentation/comments and adjusted GEMM test dataset path construction for the expected NCCL/GEMM directory layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->