### PR TITLE
chore(licenses): remove LGPL from cargo-deny allowlist

### DIFF
--- a/.agents/skills/aic-codeowners/SKILL.md
+++ b/.agents/skills/aic-codeowners/SKILL.md
@@ -63,8 +63,10 @@ The coverage report lists globs that no longer match any file.
 Edit `.github/codeowners/areas.yaml` - move a glob between areas, add a
 `shared:` entry (multi-team; any one team's approval satisfies the gate), or
 adjust `classify` rules - then regenerate as in Flow 2. Changes to the
-policy itself route to aiconfigurator-infra + maintainers (the `CODEOWNERS`
-and `.github/` shared lines).
+taxonomy and tooling under `.github/` route to aiconfigurator-infra +
+maintainers. Two explicit exceptions route only to DevOps: the generated root
+`CODEOWNERS` artifact and every `deny.toml`, enforced by the final-tier
+file-type rule.
 
 ## Flow 4: Grant an External Contributor Area-Scoped Ownership
 

--- a/.github/codeowners/areas.yaml
+++ b/.github/codeowners/areas.yaml
@@ -67,6 +67,9 @@ shared:
     owners: [generators, docs]
   - glob: aic-core/
     owners: [runtime, docs]
+  # Cargo license policy changes require DevOps review.
+  - glob: "**/deny.toml"
+    owners: ["@ai-dynamo/devops"]
   - glob: collector/
     owners: [runtime, docs]
   - glob: tools/
@@ -117,10 +120,9 @@ shared:
   # Preserve the existing cross-area documentation exception.
   - glob: docs/dynamo_deployment_guide.md
     owners: [runtime, infra, docs]
-  # Ownership policy changes require infra and maintainer review (docs area
-  # is the maintainers team), mirroring the previous hand-written policy.
+  # Ownership policy changes require DevOps review.
   - glob: CODEOWNERS
-    owners: [infra, docs]
+    owners: ["@ai-dynamo/devops"]
 
 classify:
   keyword_rules:

--- a/.github/codeowners/areas.yaml
+++ b/.github/codeowners/areas.yaml
@@ -54,6 +54,9 @@ areas:
       - CODE_OF_CONDUCT.md
       - CONTRIBUTING.md
       - LICENSE
+  - label: devops
+    github_team: "@ai-dynamo/devops"
+    path_globs: []
 
 shared:
   # Preserve the existing policy: maintainers co-own every runtime,
@@ -67,9 +70,6 @@ shared:
     owners: [generators, docs]
   - glob: aic-core/
     owners: [runtime, docs]
-  # Cargo license policy changes require DevOps review.
-  - glob: "**/deny.toml"
-    owners: ["@ai-dynamo/devops"]
   - glob: collector/
     owners: [runtime, docs]
   - glob: tools/
@@ -122,10 +122,13 @@ shared:
     owners: [runtime, infra, docs]
   # Ownership policy changes require DevOps review.
   - glob: CODEOWNERS
-    owners: ["@ai-dynamo/devops"]
+    owners: [devops]
 
 classify:
   keyword_rules:
     - match: generator
       area: generators
-  filetype_rules: []
+  # Cargo license policy changes require DevOps review at any depth.
+  filetype_rules:
+    - pattern: deny.toml
+      coowner: devops

--- a/.github/codeowners/test_aic_policy.py
+++ b/.github/codeowners/test_aic_policy.py
@@ -11,6 +11,7 @@ from codeowners_match import parse_codeowners, resolve_owners
 
 ROOT = Path(__file__).resolve().parents[2]
 MAINTAINERS = "@ai-dynamo/maintainers-aiconfigurator"
+DEVOPS = "@ai-dynamo/devops"
 AREA_TEAMS = {
     "@ai-dynamo/aiconfigurator-runtime",
     "@ai-dynamo/aiconfigurator-generators",
@@ -66,3 +67,7 @@ def test_representative_routing_contract() -> None:
         "@ai-dynamo/aiconfigurator-infra",
         MAINTAINERS,
     }
+    assert _owners("CODEOWNERS") == {DEVOPS}
+    assert _owners("aic-core/rust/aiconfigurator-core/deny.toml") == {DEVOPS}
+    assert _owners("src/aiconfigurator/generator/deny.toml") == {DEVOPS}
+    assert _owners("tools/support_matrix/deny.toml") == {DEVOPS}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,6 +6,7 @@
 #   python .github/codeowners/who_owns.py --codeowners CODEOWNERS <path> ...  # owners of specific paths
 #
 # Area index (base owner per subsystem; the catch-all owns everything else):
+#   devops      @ai-dynamo/devops
 #   docs        @ai-dynamo/maintainers-aiconfigurator
 #   generators  @ai-dynamo/aiconfigurator-generators
 #   infra       @ai-dynamo/aiconfigurator-infra
@@ -17,6 +18,7 @@
 #   @ai-dynamo/aiconfigurator-infra
 #   @ai-dynamo/aiconfigurator-runtime
 #   @ai-dynamo/contributors-aiconfigurator
+#   @ai-dynamo/devops
 #   @ai-dynamo/maintainers-aiconfigurator
 
 *                                 @ai-dynamo/contributors-aiconfigurator
@@ -82,7 +84,6 @@
 /collector/                       @ai-dynamo/aiconfigurator-runtime @ai-dynamo/maintainers-aiconfigurator
 /pytest.ini                       @ai-dynamo/aiconfigurator-infra @ai-dynamo/maintainers-aiconfigurator
 /SECURITY.md                      @ai-dynamo/aiconfigurator-infra @ai-dynamo/maintainers-aiconfigurator
-/**/deny.toml                     @ai-dynamo/devops
 /.dockerignore                    @ai-dynamo/aiconfigurator-infra @ai-dynamo/maintainers-aiconfigurator
 /.gitattributes                   @ai-dynamo/aiconfigurator-infra @ai-dynamo/maintainers-aiconfigurator
 /DEVELOPMENT.md                   @ai-dynamo/aiconfigurator-infra @ai-dynamo/maintainers-aiconfigurator
@@ -96,3 +97,6 @@
 /src/aiconfigurator/cli/          @ai-dynamo/aiconfigurator-generators @ai-dynamo/maintainers-aiconfigurator
 /src/aiconfigurator/generator/    @ai-dynamo/aiconfigurator-generators @ai-dynamo/maintainers-aiconfigurator
 /docs/dynamo_deployment_guide.md  @ai-dynamo/aiconfigurator-runtime @ai-dynamo/aiconfigurator-infra @ai-dynamo/maintainers-aiconfigurator
+
+# --- File-type ownership: unanchored patterns (wins via last-match at any depth) ---
+deny.toml                         @ai-dynamo/devops

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -77,11 +77,12 @@
 /AGENTS.md                        @ai-dynamo/aiconfigurator-infra @ai-dynamo/maintainers-aiconfigurator
 /aic-core/                        @ai-dynamo/aiconfigurator-runtime @ai-dynamo/maintainers-aiconfigurator
 /.gitignore                       @ai-dynamo/aiconfigurator-infra @ai-dynamo/maintainers-aiconfigurator
-/CODEOWNERS                       @ai-dynamo/aiconfigurator-infra @ai-dynamo/maintainers-aiconfigurator
+/CODEOWNERS                       @ai-dynamo/devops
 /Cargo.toml                       @ai-dynamo/aiconfigurator-infra @ai-dynamo/maintainers-aiconfigurator
 /collector/                       @ai-dynamo/aiconfigurator-runtime @ai-dynamo/maintainers-aiconfigurator
 /pytest.ini                       @ai-dynamo/aiconfigurator-infra @ai-dynamo/maintainers-aiconfigurator
 /SECURITY.md                      @ai-dynamo/aiconfigurator-infra @ai-dynamo/maintainers-aiconfigurator
+/**/deny.toml                     @ai-dynamo/devops
 /.dockerignore                    @ai-dynamo/aiconfigurator-infra @ai-dynamo/maintainers-aiconfigurator
 /.gitattributes                   @ai-dynamo/aiconfigurator-infra @ai-dynamo/maintainers-aiconfigurator
 /DEVELOPMENT.md                   @ai-dynamo/aiconfigurator-infra @ai-dynamo/maintainers-aiconfigurator

--- a/aic-core/rust/aiconfigurator-core/deny.toml
+++ b/aic-core/rust/aiconfigurator-core/deny.toml
@@ -22,8 +22,6 @@ allow = [
     "CDLA-Permissive-2.0",
     "Zlib",
     "NCSA",
-    "LGPL-3.0",
-    "LGPL-3.0-only",
     "CC0-1.0",
     "Unicode-DFS-2016",
     "WTFPL"


### PR DESCRIPTION
#### Overview:

Remove `LGPL-3.0` and `LGPL-3.0-only` from the `aiconfigurator-core` cargo-deny license allowlist. The resolved dependency graph does not require either license allowance.

#### Details:

This keeps the license policy limited to licenses needed by the current dependency graph. A full cargo-deny inventory reports `r-efi` 5.3.0 and 6.0.0 as `MIT OR Apache-2.0 OR LGPL-2.1-or-later`; cargo-deny accepts those crates through their MIT or Apache alternatives, so no LGPL-only dependency remains.

#### Where should the reviewer start?

`aic-core/rust/aiconfigurator-core/deny.toml`

#### Validation:

- `cargo-deny 0.19.0 --all-features check --show-stats licenses bans`
  - `licenses ok`: 0 errors
  - `bans ok`: 0 errors
- `cargo-deny list --format json --layout crate` reviewed for LGPL-only dependencies
- `git diff --check`

#### Related Issues:

None.

#### Ownership:

- Generated `CODEOWNERS` now assigns `@ai-dynamo/devops` to all `deny.toml` files and to `CODEOWNERS` itself.
- Updated `.github/codeowners/areas.yaml`, regenerated `CODEOWNERS`, and confirmed 100% ownership coverage.
- Resolver validation confirms both `aic-core/rust/aiconfigurator-core/deny.toml` and `CODEOWNERS` route to `@ai-dynamo/devops`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the set of permitted open-source licenses.
  * Added support for CDLA-Permissive-2.0, Zlib, and NCSA licenses.
  * Removed LGPL-3.0 and LGPL-3.0-only from the permitted license list.
* **Chores**
  * Updated code ownership rules to include a dedicated DevOps area and assign relevant policy files.
* **Tests**
  * Extended automated checks to validate the updated ownership routing for policy-related files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->