### PR TITLE
fix(sdk): scale-up frontier fallback for the perf_interp site distance gate

### DIFF
--- a/aic-core/rust/aiconfigurator-core/src/perf_database/perf_interp.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/perf_interp.rs
@@ -621,29 +621,29 @@ impl SiteIndex {
     }
 
     /// True iff the query site exceeds the collected frontier in the scale-up
-    /// direction ONLY: no collected site weakly dominates it (>= on every site
-    /// axis), and it is not below the collected minimum on any axis. Interior
-    /// holes (dominated) and scale-down / mixed-direction queries keep the
-    /// distance-gate miss — util genuinely doesn't transfer downward, but at
+    /// direction ONLY: strictly above the collected maximum on at least one
+    /// site axis, and not below the collected minimum on any axis. Everything
+    /// else — dominated interior holes, incomparable notches inside the
+    /// bounding box, scale-down / mixed-direction queries — keeps the
+    /// distance-gate miss: util genuinely doesn't transfer downward, but at
     /// the top of the collected range boundary efficiency is the best signal
     /// we have (the same reasoning as the unbounded m-curve / grid hold).
     fn beyond_frontier_scale_up(&self, q_site: &[f64]) -> bool {
-        let dominated = self
-            .site_logs
-            .iter()
-            .any(|(key, _)| key.iter().zip(q_site).all(|(&s, &q)| s as f64 >= q));
-        if dominated {
-            return false;
+        let mut above_some_max = false;
+        for (a, &q) in q_site.iter().enumerate() {
+            let (mut lo, mut hi) = (u32::MAX, 0u32);
+            for (key, _) in &self.site_logs {
+                lo = lo.min(key[a]);
+                hi = hi.max(key[a]);
+            }
+            if q < lo as f64 {
+                return false;
+            }
+            if q > hi as f64 {
+                above_some_max = true;
+            }
         }
-        (0..q_site.len()).all(|a| {
-            let min_a = self
-                .site_logs
-                .iter()
-                .map(|(key, _)| key[a])
-                .min()
-                .expect("beyond_frontier_scale_up on empty index");
-            q_site[a] >= min_a as f64
-        })
+        above_some_max
     }
 
     /// Evaluate one site's curve at coordinate `q`.
@@ -1016,6 +1016,22 @@ mod tests {
         }
         let cfg = gemm_cfg(&gemm_lat);
         assert!(query(&cfg, &t, &[32.0, 8192.0, 8192.0]).is_err());
+    }
+
+    #[test]
+    fn gemm_incomparable_notch_inside_bounding_box_still_misses() {
+        // (4096, 4096) sits in the notch between (256, 65536) and (65536,
+        // 256): no site dominates it, yet it exceeds the collected maximum on
+        // NO axis — an interior hole in the Pareto staircase, not a scale-up
+        // frontier query. The waiver must not fire; the gate stands.
+        let mut t = Node::branch();
+        for m in [16u32, 32, 64] {
+            for &(n, k) in &[(256u32, 65536u32), (65536, 256)] {
+                t.insert(&[m, n, k], gemm_lat(&[m as f64, n as f64, k as f64]));
+            }
+        }
+        let cfg = gemm_cfg(&gemm_lat);
+        assert!(query(&cfg, &t, &[32.0, 4096.0, 4096.0]).is_err());
     }
 
     #[test]

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/perf_interp.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/perf_interp.rs
@@ -14,8 +14,8 @@
 //!                             the dropped axis). ScatteredSites: site curve
 //!                             eval; unknown site -> nearest-site transfer in
 //!                             util space (log2 IDW, curve-coverage filter,
-//!                             distance gate; a site beyond the scale-up
-//!                             frontier falls back to boundary util-hold).
+//!                             distance gate; the gate is waived for a site
+//!                             beyond the scale-up frontier).
 //! 3. beyond the range      -> hold the boundary util (k_tail-median anchor),
 //!                             latency = SOL(query) / util
 //! 4. nothing to anchor on  -> Err (structured miss; never fabricate)
@@ -568,18 +568,19 @@ impl SiteIndex {
         let cmp =
             |a: &(f64, usize), b: &(f64, usize)| a.0.total_cmp(&b.0).then_with(|| a.1.cmp(&b.1));
         if let Some(gate) = max_site_distance {
-            if !ranked.iter().any(|&(d, _)| d <= *gate) {
-                // Direction-aware frontier fallback: a query site beyond the
-                // collected frontier in the scale-up direction holds the
-                // boundary util instead of missing (big-vocab LM heads at low
-                // tp). Interior holes and scale-down queries keep the miss.
+            if ranked.iter().any(|&(d, _)| d <= *gate) {
+                ranked.retain(|&(d, _)| d <= *gate);
+            } else {
+                // The gate is waived for a query site beyond the collected
+                // frontier in the scale-up direction (big-vocab LM heads at
+                // low tp): the ungated nearest (near-frontier) sites anchor
+                // the transfer below and SOL(query) carries the growth.
+                // Interior holes and scale-down queries keep the miss.
                 let q_site: Vec<f64> = site_axes.iter().map(|&p| coords[p]).collect();
-                if self.beyond_frontier_scale_up(&q_site) {
-                    return self.hold_frontier(cfg, ranked, coords, q);
+                if !self.beyond_frontier_scale_up(&q_site) {
+                    return Err(miss(cfg, coords, "no site within max_site_distance"));
                 }
-                return Err(miss(cfg, coords, "no site within max_site_distance"));
             }
-            ranked.retain(|&(d, _)| d <= *gate);
         }
         let k = (*nn_sites).min(ranked.len());
         if k < ranked.len() {
@@ -643,65 +644,6 @@ impl SiteIndex {
                 .expect("beyond_frontier_scale_up on empty index");
             q_site[a] >= min_a as f64
         })
-    }
-
-    /// Boundary util-hold for a query site beyond the scale-up frontier, where
-    /// the distance gate found no neighbour. The log-nearest sites to such a
-    /// query ARE the frontier sites; anchor on the median util of the nn_sites
-    /// nearest (coverage-filtered upstream) and let SOL(query) carry the
-    /// growth — median, not IDW, matching the util-hold convention (robust to
-    /// one bad anchor). `ranked` is the ungated `(distance, site index)`
-    /// buffer from `resolve`.
-    fn hold_frontier(
-        &self,
-        cfg: &OpInterpConfig,
-        mut ranked: Vec<(f64, usize)>,
-        coords: &[f64],
-        q: f64,
-    ) -> Result<f64, AicError> {
-        let Resolver::ScatteredSites {
-            site_axes,
-            curve_axis,
-            nn_sites,
-            ..
-        } = &cfg.resolver
-        else {
-            unreachable!()
-        };
-        let cmp =
-            |a: &(f64, usize), b: &(f64, usize)| a.0.total_cmp(&b.0).then_with(|| a.1.cmp(&b.1));
-        let k = (*nn_sites).min(ranked.len());
-        if k < ranked.len() {
-            ranked.select_nth_unstable_by(k, cmp);
-            ranked.truncate(k);
-        }
-
-        let mut utils: Vec<f64> = Vec::with_capacity(ranked.len());
-        for &(_, i) in &ranked {
-            let neigh = &self.site_logs[i].0;
-            let curve = &self.sites[neigh];
-            // one bad anchor must not poison the query
-            let Ok(lat_i) = self.eval_curve(cfg, curve, neigh, q, coords) else {
-                continue;
-            };
-            let mut n_coords = coords.to_vec();
-            for (&p, &v) in site_axes.iter().zip(neigh) {
-                n_coords[p] = v as f64;
-            }
-            n_coords[*curve_axis] = q;
-            let sol_i = (cfg.sol_fn)(&n_coords);
-            if lat_i.is_finite() && lat_i > 0.0 && sol_i.is_finite() && sol_i > 0.0 {
-                utils.push(sol_i / lat_i);
-            }
-        }
-        if utils.is_empty() {
-            return Err(miss(cfg, coords, "no positive-util frontier anchor"));
-        }
-        let sol_q = (cfg.sol_fn)(coords);
-        if !(sol_q > 0.0) {
-            return Err(miss(cfg, coords, "non-positive SOL at query"));
-        }
-        Ok(sol_q / median(&mut utils))
     }
 
     /// Evaluate one site's curve at coordinate `q`.

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/perf_interp.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/perf_interp.rs
@@ -573,12 +573,14 @@ impl SiteIndex {
             } else {
                 // The gate is waived for a query site beyond the collected
                 // frontier in the scale-up direction (big-vocab LM heads at
-                // low tp): the ungated nearest (near-frontier) sites anchor
-                // the transfer below and SOL(query) carries the growth.
-                // Interior holes and scale-down queries keep the miss.
+                // low tp): anchors are the coverage-eligible sites that still
+                // pass the gate on the non-overflow axes, and SOL(query)
+                // carries the growth. Interior holes, scale-down / mixed
+                // queries, and sparse-stub multi-axis overflow keep the miss.
                 let q_site: Vec<f64> = site_axes.iter().map(|&p| coords[p]).collect();
-                if !self.beyond_frontier_scale_up(&q_site) {
-                    return Err(miss(cfg, coords, "no site within max_site_distance"));
+                match self.frontier_waiver_anchors(&ranked, &q_site, &q_log, *gate) {
+                    Some(admissible) => ranked = admissible,
+                    None => return Err(miss(cfg, coords, "no site within max_site_distance")),
                 }
             }
         }
@@ -620,30 +622,75 @@ impl SiteIndex {
         Ok(sol_q / (u_acc / wsum))
     }
 
-    /// True iff the query site exceeds the collected frontier in the scale-up
-    /// direction ONLY: strictly above the collected maximum on at least one
-    /// site axis, and not below the collected minimum on any axis. Everything
-    /// else — dominated interior holes, incomparable notches inside the
-    /// bounding box, scale-down / mixed-direction queries — keeps the
-    /// distance-gate miss: util genuinely doesn't transfer downward, but at
-    /// the top of the collected range boundary efficiency is the best signal
-    /// we have (the same reasoning as the unbounded m-curve / grid hold).
-    fn beyond_frontier_scale_up(&self, q_site: &[f64]) -> bool {
-        let mut above_some_max = false;
-        for (a, &q) in q_site.iter().enumerate() {
+    /// Anchor set for a scale-up frontier query, or None (gate miss stands).
+    ///
+    /// The distance gate is waived ONLY for the intended frontier overflow,
+    /// and everything is computed over `candidates` (the coverage-eligible
+    /// `(full distance, site index)` buffer from `resolve`) so admissibility
+    /// and the anchors actually used cannot diverge:
+    ///
+    /// - exactly ONE site axis overflows (strictly above the candidates'
+    ///   maximum). Simultaneous multi-axis overflow means the table is a
+    ///   sparse stub for this shape (e.g. an fp8_block table collected at
+    ///   n,k<=128 queried with a real logits GEMM) — holding a launch-bound
+    ///   stub's util across many octaves fabricates arbitrarily wrong
+    ///   latencies, so it stays a miss;
+    /// - no axis sits below the candidates' minimum (scale-down never
+    ///   transfers);
+    /// - the NON-overflow axes still pass the gate (residual log2 distance),
+    ///   so anchors are genuine frontier neighbours of the query and the
+    ///   transfer is scale-up along the overflow axis only.
+    ///
+    /// On the overflow axis every anchor is below the query by construction;
+    /// the caller's inverse-distance weighting then favours the largest
+    /// collected sites, and SOL(query) carries the growth (the same trust as
+    /// the m curve axis and the grid out-of-range hold).
+    fn frontier_waiver_anchors(
+        &self,
+        candidates: &[(f64, usize)],
+        q_site: &[f64],
+        q_log: &[f64],
+        gate: f64,
+    ) -> Option<Vec<(f64, usize)>> {
+        let axes = q_site.len();
+        let mut overflow: Vec<usize> = Vec::new();
+        for a in 0..axes {
             let (mut lo, mut hi) = (u32::MAX, 0u32);
-            for (key, _) in &self.site_logs {
+            for &(_, i) in candidates {
+                let key = &self.site_logs[i].0;
                 lo = lo.min(key[a]);
                 hi = hi.max(key[a]);
             }
-            if q < lo as f64 {
-                return false;
+            if q_site[a] < lo as f64 {
+                return None;
             }
-            if q > hi as f64 {
-                above_some_max = true;
+            if q_site[a] > hi as f64 {
+                overflow.push(a);
             }
         }
-        above_some_max
+        if overflow.len() != 1 {
+            return None;
+        }
+        let resid_dist = |i: usize| -> f64 {
+            (0..axes)
+                .filter(|a| !overflow.contains(a))
+                .map(|a| {
+                    let d = self.site_logs[i].1[a] - q_log[a];
+                    d * d
+                })
+                .sum::<f64>()
+                .sqrt()
+        };
+        let admissible: Vec<(f64, usize)> = candidates
+            .iter()
+            .copied()
+            .filter(|&(_, i)| resid_dist(i) <= gate)
+            .collect();
+        if admissible.is_empty() {
+            None
+        } else {
+            Some(admissible)
+        }
     }
 
     /// Evaluate one site's curve at coordinate `q`.
@@ -1032,6 +1079,42 @@ mod tests {
         }
         let cfg = gemm_cfg(&gemm_lat);
         assert!(query(&cfg, &t, &[32.0, 4096.0, 4096.0]).is_err());
+    }
+
+    #[test]
+    fn gemm_sparse_stub_multi_axis_overflow_still_misses() {
+        // Real-table regression (PR #1419 review): an fp8_block-like stub
+        // collected only at n,k in 32..128 queried with a real logits GEMM
+        // (m=1, n=151936, k=5120) — BOTH site axes past the collected
+        // maximum. Simultaneous multi-axis overflow must stay a miss.
+        let mut t = Node::branch();
+        for m in [1u32, 2, 4] {
+            for n in [32u32, 64, 128] {
+                for k in [32u32, 64, 128] {
+                    t.insert(&[m, n, k], gemm_lat(&[m as f64, n as f64, k as f64]));
+                }
+            }
+        }
+        let cfg = gemm_cfg(&gemm_lat);
+        assert!(query(&cfg, &t, &[1.0, 151936.0, 5120.0]).is_err());
+    }
+
+    #[test]
+    fn gemm_waiver_admissibility_computed_over_coverage_candidates() {
+        // PR #1419 review: site (1, 1) covers only m<=2, site (64, 64) covers
+        // m=16..64. Query (m=32, n=1024, k=1) used to pass a GLOBAL frontier
+        // check while the only coverage-eligible anchor (64, 64) required a
+        // k=64 -> k=1 scale-DOWN transfer. Admissibility over the coverage
+        // candidates puts k=1 below the minimum -> miss.
+        let mut t = Node::branch();
+        for m in [1u32, 2] {
+            t.insert(&[m, 1, 1], gemm_lat(&[m as f64, 1.0, 1.0]));
+        }
+        for m in [16u32, 32, 64] {
+            t.insert(&[m, 64, 64], gemm_lat(&[m as f64, 64.0, 64.0]));
+        }
+        let cfg = gemm_cfg(&gemm_lat);
+        assert!(query(&cfg, &t, &[32.0, 1024.0, 1.0]).is_err());
     }
 
     #[test]

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/perf_interp.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/perf_interp.rs
@@ -14,7 +14,8 @@
 //!                             the dropped axis). ScatteredSites: site curve
 //!                             eval; unknown site -> nearest-site transfer in
 //!                             util space (log2 IDW, curve-coverage filter,
-//!                             distance gate).
+//!                             distance gate; a site beyond the scale-up
+//!                             frontier falls back to boundary util-hold).
 //! 3. beyond the range      -> hold the boundary util (k_tail-median anchor),
 //!                             latency = SOL(query) / util
 //! 4. nothing to anchor on  -> Err (structured miss; never fabricate)
@@ -564,14 +565,22 @@ impl SiteIndex {
         // tie-break reproduces the previous *stable* sort's order on equal
         // distances (sites are pushed in ascending-index order), so the selected
         // set and its ordering are identical.
-        if let Some(gate) = max_site_distance {
-            ranked.retain(|&(d, _)| d <= *gate);
-            if ranked.is_empty() {
-                return Err(miss(cfg, coords, "no site within max_site_distance"));
-            }
-        }
         let cmp =
             |a: &(f64, usize), b: &(f64, usize)| a.0.total_cmp(&b.0).then_with(|| a.1.cmp(&b.1));
+        if let Some(gate) = max_site_distance {
+            if !ranked.iter().any(|&(d, _)| d <= *gate) {
+                // Direction-aware frontier fallback: a query site beyond the
+                // collected frontier in the scale-up direction holds the
+                // boundary util instead of missing (big-vocab LM heads at low
+                // tp). Interior holes and scale-down queries keep the miss.
+                let q_site: Vec<f64> = site_axes.iter().map(|&p| coords[p]).collect();
+                if self.beyond_frontier_scale_up(&q_site) {
+                    return self.hold_frontier(cfg, ranked, coords, q);
+                }
+                return Err(miss(cfg, coords, "no site within max_site_distance"));
+            }
+            ranked.retain(|&(d, _)| d <= *gate);
+        }
         let k = (*nn_sites).min(ranked.len());
         if k < ranked.len() {
             ranked.select_nth_unstable_by(k, cmp);
@@ -608,6 +617,91 @@ impl SiteIndex {
             return Err(miss(cfg, coords, "non-positive SOL at query"));
         }
         Ok(sol_q / (u_acc / wsum))
+    }
+
+    /// True iff the query site exceeds the collected frontier in the scale-up
+    /// direction ONLY: no collected site weakly dominates it (>= on every site
+    /// axis), and it is not below the collected minimum on any axis. Interior
+    /// holes (dominated) and scale-down / mixed-direction queries keep the
+    /// distance-gate miss — util genuinely doesn't transfer downward, but at
+    /// the top of the collected range boundary efficiency is the best signal
+    /// we have (the same reasoning as the unbounded m-curve / grid hold).
+    fn beyond_frontier_scale_up(&self, q_site: &[f64]) -> bool {
+        let dominated = self
+            .site_logs
+            .iter()
+            .any(|(key, _)| key.iter().zip(q_site).all(|(&s, &q)| s as f64 >= q));
+        if dominated {
+            return false;
+        }
+        (0..q_site.len()).all(|a| {
+            let min_a = self
+                .site_logs
+                .iter()
+                .map(|(key, _)| key[a])
+                .min()
+                .expect("beyond_frontier_scale_up on empty index");
+            q_site[a] >= min_a as f64
+        })
+    }
+
+    /// Boundary util-hold for a query site beyond the scale-up frontier, where
+    /// the distance gate found no neighbour. The log-nearest sites to such a
+    /// query ARE the frontier sites; anchor on the median util of the nn_sites
+    /// nearest (coverage-filtered upstream) and let SOL(query) carry the
+    /// growth — median, not IDW, matching the util-hold convention (robust to
+    /// one bad anchor). `ranked` is the ungated `(distance, site index)`
+    /// buffer from `resolve`.
+    fn hold_frontier(
+        &self,
+        cfg: &OpInterpConfig,
+        mut ranked: Vec<(f64, usize)>,
+        coords: &[f64],
+        q: f64,
+    ) -> Result<f64, AicError> {
+        let Resolver::ScatteredSites {
+            site_axes,
+            curve_axis,
+            nn_sites,
+            ..
+        } = &cfg.resolver
+        else {
+            unreachable!()
+        };
+        let cmp =
+            |a: &(f64, usize), b: &(f64, usize)| a.0.total_cmp(&b.0).then_with(|| a.1.cmp(&b.1));
+        let k = (*nn_sites).min(ranked.len());
+        if k < ranked.len() {
+            ranked.select_nth_unstable_by(k, cmp);
+            ranked.truncate(k);
+        }
+
+        let mut utils: Vec<f64> = Vec::with_capacity(ranked.len());
+        for &(_, i) in &ranked {
+            let neigh = &self.site_logs[i].0;
+            let curve = &self.sites[neigh];
+            // one bad anchor must not poison the query
+            let Ok(lat_i) = self.eval_curve(cfg, curve, neigh, q, coords) else {
+                continue;
+            };
+            let mut n_coords = coords.to_vec();
+            for (&p, &v) in site_axes.iter().zip(neigh) {
+                n_coords[p] = v as f64;
+            }
+            n_coords[*curve_axis] = q;
+            let sol_i = (cfg.sol_fn)(&n_coords);
+            if lat_i.is_finite() && lat_i > 0.0 && sol_i.is_finite() && sol_i > 0.0 {
+                utils.push(sol_i / lat_i);
+            }
+        }
+        if utils.is_empty() {
+            return Err(miss(cfg, coords, "no positive-util frontier anchor"));
+        }
+        let sol_q = (cfg.sol_fn)(coords);
+        if !(sol_q > 0.0) {
+            return Err(miss(cfg, coords, "non-positive SOL at query"));
+        }
+        Ok(sol_q / median(&mut utils))
     }
 
     /// Evaluate one site's curve at coordinate `q`.
@@ -945,6 +1039,41 @@ mod tests {
         let cfg = gemm_cfg(&gemm_lat);
         // (64, 64): > 2 octaves from every collected site -> miss, not a guess.
         assert!(query(&cfg, &t, &[64.0, 64.0, 64.0]).is_err());
+    }
+
+    #[test]
+    fn gemm_scale_up_beyond_frontier_holds_util() {
+        // Gemma-4-26B-A4B tp1 LM head (issue #1415): (n=262144, k=2816) is
+        // ~2.005 octaves from the nearest collected site — past the distance
+        // gate — but beyond the frontier in the scale-up direction, so the
+        // engine holds the frontier util instead of missing. util==1 fixture
+        // -> the hold is exact.
+        let mut t = Node::branch();
+        for m in [16u32, 32, 64] {
+            for &(n, k) in &[(65536u32, 2560u32), (65536, 3072), (4096, 2816)] {
+                t.insert(&[m, n, k], gemm_lat(&[m as f64, n as f64, k as f64]));
+            }
+        }
+        let cfg = gemm_cfg(&gemm_lat);
+        approx(
+            query(&cfg, &t, &[32.0, 262144.0, 2816.0]).unwrap(),
+            gemm_lat(&[32.0, 262144.0, 2816.0]),
+        );
+    }
+
+    #[test]
+    fn gemm_interior_hole_beyond_gate_still_misses() {
+        // (8192, 8192) is dominated by the collected (65536, 65536) corner but
+        // >2 octaves from every site — a sparse interior hole, not a frontier
+        // query. The gate must still refuse to guess.
+        let mut t = Node::branch();
+        for m in [16u32, 32, 64] {
+            for &(n, k) in &[(256u32, 256u32), (65536, 65536)] {
+                t.insert(&[m, n, k], gemm_lat(&[m as f64, n as f64, k as f64]));
+            }
+        }
+        let cfg = gemm_cfg(&gemm_lat);
+        assert!(query(&cfg, &t, &[32.0, 8192.0, 8192.0]).is_err());
     }
 
     #[test]

--- a/aic-core/src/aiconfigurator_core/sdk/perf_interp/config.py
+++ b/aic-core/src/aiconfigurator_core/sdk/perf_interp/config.py
@@ -126,13 +126,15 @@ class ScatteredSites:
     #: query site is not collected. 1 = single nearest.
     nn_sites: int = 4
     #: Log-space distance gate: no site within this radius -> genuine miss for
-    #: interior holes and the scale-down direction. The gate is waived for a
-    #: query site beyond the collected frontier in the scale-up direction
-    #: (strictly above the collected maximum on at least one site axis, and
-    #: not below the collected minimum on any axis): the ungated log-nearest
-    #: (near-frontier) sites anchor the ordinary util transfer — the same
+    #: interior holes and the scale-down direction. The gate is waived along
+    #: exactly ONE overflowing site axis for a query beyond the collected
+    #: frontier in the scale-up direction (strictly above the coverage-eligible
+    #: candidates' maximum on that axis, not below their minimum on any axis,
+    #: and still within this gate on the remaining axes): the admissible
+    #: frontier sites anchor the ordinary util transfer — the same
     #: unbounded-extrapolation trust as the m curve axis and Grid out-of-range
     #: (big-vocab LM heads, e.g. vocab/tp past the collected n range).
+    #: Simultaneous multi-axis overflow (a sparse stub table) stays a miss.
     #: None = always accept the nearest site.
     max_site_distance: float | None = None
     #: Only consider sites whose curve range covers the query coordinate (a

--- a/aic-core/src/aiconfigurator_core/sdk/perf_interp/config.py
+++ b/aic-core/src/aiconfigurator_core/sdk/perf_interp/config.py
@@ -40,8 +40,9 @@ Resolution order (the whole engine in four steps)
    answer at any distance, so there is no distance cap.
 4. **nothing to anchor on** -> genuine miss: raise. (Empty table / empty
    branch, or no site within ``max_site_distance`` for an interior-hole or
-   scale-down query — a query beyond the scale-up frontier holds the frontier
-   util instead, step 3.) The engine never fabricates a value from nothing.
+   scale-down query — the gate is waived for a query beyond the scale-up
+   frontier, which resolves via step 2's nearest-site transfer.) The engine
+   never fabricates a value from nothing.
 
 Invariants (deliberately NOT knobs)
 -----------------------------------
@@ -125,13 +126,13 @@ class ScatteredSites:
     #: query site is not collected. 1 = single nearest.
     nn_sites: int = 4
     #: Log-space distance gate: no site within this radius -> genuine miss for
-    #: interior holes and the scale-down direction. A query site beyond the
-    #: collected frontier in the scale-up direction (no site dominates it, and
-    #: it is not below the collected minimum on any axis) instead falls back to
-    #: boundary util-hold on the log-nearest frontier sites — the same
-    #: unbounded-extrapolation trust as the m curve axis and Grid out-of-range
-    #: (big-vocab LM heads, e.g. vocab/tp past the collected n range).
-    #: None = always accept the nearest site.
+    #: interior holes and the scale-down direction. The gate is waived for a
+    #: query site beyond the collected frontier in the scale-up direction (no
+    #: site dominates it, and it is not below the collected minimum on any
+    #: axis): the ungated log-nearest (near-frontier) sites anchor the ordinary
+    #: util transfer — the same unbounded-extrapolation trust as the m curve
+    #: axis and Grid out-of-range (big-vocab LM heads, e.g. vocab/tp past the
+    #: collected n range). None = always accept the nearest site.
     max_site_distance: float | None = None
     #: Only consider sites whose curve range covers the query coordinate (a
     #: decode-only site with m<=64 must not answer an m=8192 query). If no site
@@ -221,11 +222,12 @@ def gemm_config(sol_fn: Callable[[float, float, float], float]) -> OpInterpConfi
     max_site_distance = 2.0 octaves joint (n,k) distance (~4x per dimension):
     util transfers well between comparable shapes (and SOL re-applies the exact
     m*n*k scaling), but a shape with no collected neighbour within ~4x has no
-    efficiency basis -> structured miss. Exception: a shape beyond the
-    collected frontier in the scale-up direction (e.g. a big-vocab LM head at
-    tp1, n = vocab > every collected n) holds the frontier util instead of
-    missing. Tune the gate with the site-holdout LOO; validate the frontier
-    hold with a frontier-holdout LOO (hold out the largest-n sites)."""
+    efficiency basis -> structured miss. Exception: the gate is waived for a
+    shape beyond the collected frontier in the scale-up direction (e.g. a
+    big-vocab LM head at tp1, n = vocab > every collected n) — the ungated
+    nearest sites anchor the transfer. Tune the gate with the site-holdout
+    LOO; validate the waiver with a frontier-holdout LOO (hold out the
+    largest-n sites)."""
     return OpInterpConfig(
         axes=("m", "n", "k"),
         resolver=ScatteredSites(site_axes=("n", "k"), curve_axis="m", max_site_distance=2.0),

--- a/aic-core/src/aiconfigurator_core/sdk/perf_interp/config.py
+++ b/aic-core/src/aiconfigurator_core/sdk/perf_interp/config.py
@@ -127,12 +127,13 @@ class ScatteredSites:
     nn_sites: int = 4
     #: Log-space distance gate: no site within this radius -> genuine miss for
     #: interior holes and the scale-down direction. The gate is waived for a
-    #: query site beyond the collected frontier in the scale-up direction (no
-    #: site dominates it, and it is not below the collected minimum on any
-    #: axis): the ungated log-nearest (near-frontier) sites anchor the ordinary
-    #: util transfer — the same unbounded-extrapolation trust as the m curve
-    #: axis and Grid out-of-range (big-vocab LM heads, e.g. vocab/tp past the
-    #: collected n range). None = always accept the nearest site.
+    #: query site beyond the collected frontier in the scale-up direction
+    #: (strictly above the collected maximum on at least one site axis, and
+    #: not below the collected minimum on any axis): the ungated log-nearest
+    #: (near-frontier) sites anchor the ordinary util transfer — the same
+    #: unbounded-extrapolation trust as the m curve axis and Grid out-of-range
+    #: (big-vocab LM heads, e.g. vocab/tp past the collected n range).
+    #: None = always accept the nearest site.
     max_site_distance: float | None = None
     #: Only consider sites whose curve range covers the query coordinate (a
     #: decode-only site with m<=64 must not answer an m=8192 query). If no site

--- a/aic-core/src/aiconfigurator_core/sdk/perf_interp/config.py
+++ b/aic-core/src/aiconfigurator_core/sdk/perf_interp/config.py
@@ -39,8 +39,9 @@ Resolution order (the whole engine in four steps)
    measured efficiency and letting physics carry the growth is the honest
    answer at any distance, so there is no distance cap.
 4. **nothing to anchor on** -> genuine miss: raise. (Empty table / empty
-   branch, or no site within ``max_site_distance``.) The engine never
-   fabricates a value from nothing.
+   branch, or no site within ``max_site_distance`` for an interior-hole or
+   scale-down query — a query beyond the scale-up frontier holds the frontier
+   util instead, step 3.) The engine never fabricates a value from nothing.
 
 Invariants (deliberately NOT knobs)
 -----------------------------------
@@ -123,7 +124,13 @@ class ScatteredSites:
     #: How many nearest sites to blend (inverse-distance, util space) when the
     #: query site is not collected. 1 = single nearest.
     nn_sites: int = 4
-    #: Log-space distance gate: no site within this radius -> genuine miss.
+    #: Log-space distance gate: no site within this radius -> genuine miss for
+    #: interior holes and the scale-down direction. A query site beyond the
+    #: collected frontier in the scale-up direction (no site dominates it, and
+    #: it is not below the collected minimum on any axis) instead falls back to
+    #: boundary util-hold on the log-nearest frontier sites — the same
+    #: unbounded-extrapolation trust as the m curve axis and Grid out-of-range
+    #: (big-vocab LM heads, e.g. vocab/tp past the collected n range).
     #: None = always accept the nearest site.
     max_site_distance: float | None = None
     #: Only consider sites whose curve range covers the query coordinate (a
@@ -214,7 +221,11 @@ def gemm_config(sol_fn: Callable[[float, float, float], float]) -> OpInterpConfi
     max_site_distance = 2.0 octaves joint (n,k) distance (~4x per dimension):
     util transfers well between comparable shapes (and SOL re-applies the exact
     m*n*k scaling), but a shape with no collected neighbour within ~4x has no
-    efficiency basis -> structured miss. Tune with the site-holdout LOO."""
+    efficiency basis -> structured miss. Exception: a shape beyond the
+    collected frontier in the scale-up direction (e.g. a big-vocab LM head at
+    tp1, n = vocab > every collected n) holds the frontier util instead of
+    missing. Tune the gate with the site-holdout LOO; validate the frontier
+    hold with a frontier-holdout LOO (hold out the largest-n sites)."""
     return OpInterpConfig(
         axes=("m", "n", "k"),
         resolver=ScatteredSites(site_axes=("n", "k"), curve_axis="m", max_site_distance=2.0),

--- a/aic-core/src/aiconfigurator_core/sdk/perf_interp/engine.py
+++ b/aic-core/src/aiconfigurator_core/sdk/perf_interp/engine.py
@@ -7,7 +7,9 @@ Executes the four-step resolution declared in :mod:`config`:
     1. exact hit            -> return the measured leaf verbatim
     2. resolve in the data  -> Grid: nested bracket+blend (value_transform space)
                                ScatteredSites: site curve eval; unknown site ->
-                               nearest-site transfer in util space
+                               nearest-site transfer in util space (a site
+                               beyond the scale-up frontier that fails the
+                               distance gate falls back to boundary util-hold)
     3. beyond the range     -> hold the boundary util (k_tail median anchor),
                                latency = SOL(query) / util
     4. nothing to anchor on -> raise InterpolationDataNotAvailableError
@@ -252,6 +254,52 @@ def _eval_curve(cfg: OpInterpConfig, curve: list, q, n_axes, curve_pos, site_pos
     return lat, power
 
 
+def _beyond_frontier_scale_up(site_keys: list, site_key: tuple) -> bool:
+    """True iff the query site exceeds the collected frontier in the scale-up
+    direction ONLY: no collected site weakly dominates it (>= on every site
+    axis), and it is not below the collected minimum on any axis. Interior
+    holes (dominated) and scale-down / mixed-direction queries keep the
+    distance-gate miss — util genuinely doesn't transfer downward, but at the
+    top of the collected range boundary efficiency is the best signal we have
+    (the same reasoning as the unbounded m-curve / Grid out-of-range hold)."""
+    axes = range(len(site_key))
+    if any(all(s[a] >= site_key[a] for a in axes) for s in site_keys):
+        return False
+    return all(site_key[a] >= min(s[a] for s in site_keys) for a in axes)
+
+
+def _hold_frontier(cfg: OpInterpConfig, sites, site_keys, ranked, dist, q, n_axes, curve_pos, site_pos, coords):
+    """Boundary util-hold for a query site beyond the scale-up frontier, where
+    the distance gate found no neighbour. The log-nearest sites to such a query
+    ARE the frontier sites; anchor on the median util of the nn_sites nearest
+    (coverage-filtered upstream) and let SOL(query) carry the growth — median,
+    not IDW, matching the util-hold convention (robust to one bad anchor)."""
+    utils, powers = [], []
+    for i in ranked[: cfg.resolver.nn_sites]:
+        neigh = site_keys[i]
+        try:
+            lat_i, p_i = _eval_curve(cfg, sites[neigh], q, n_axes, curve_pos, site_pos, neigh, coords)
+        except InterpolationDataNotAvailableError:  # one bad anchor must not poison the query
+            continue
+        sol_i = cfg.sol_fn(*_full_coords(n_axes, curve_pos, site_pos, q, neigh))
+        if math.isfinite(lat_i) and lat_i > 0 and math.isfinite(sol_i) and sol_i > 0:
+            utils.append(sol_i / lat_i)
+            powers.append(p_i)
+    if not utils:
+        raise _miss(cfg, coords, "no positive-util frontier anchor")
+    sol_q = cfg.sol_fn(*coords)
+    if sol_q <= 0:
+        raise _miss(cfg, coords, "non-positive SOL at query")
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug(
+            "perf_interp util-hold (site frontier): coords=%s anchor_util=%.4g nearest_distance=%.3f",
+            dict(zip(cfg.axes, coords, strict=True)),
+            statistics.median(utils),
+            dist(ranked[0]),
+        )
+    return sol_q / statistics.median(utils), statistics.median(powers)
+
+
 def _resolve_scattered(cfg: OpInterpConfig, data: dict, coords):
     sites, site_keys, site_logs, curve_pos, site_pos, n_axes = _site_index(cfg, data)
     res = cfg.resolver
@@ -277,9 +325,12 @@ def _resolve_scattered(cfg: OpInterpConfig, data: dict, coords):
 
     ranked = sorted(candidates, key=dist)
     if res.max_site_distance is not None:
-        ranked = [i for i in ranked if dist(i) <= res.max_site_distance]
-        if not ranked:
+        gated = [i for i in ranked if dist(i) <= res.max_site_distance]
+        if not gated:
+            if _beyond_frontier_scale_up(site_keys, site_key):
+                return _hold_frontier(cfg, sites, site_keys, ranked, dist, q, n_axes, curve_pos, site_pos, coords)
             raise _miss(cfg, coords, "no site within max_site_distance")
+        ranked = gated
 
     wsum = u_acc = p_acc = 0.0
     for i in ranked[: res.nn_sites]:

--- a/aic-core/src/aiconfigurator_core/sdk/perf_interp/engine.py
+++ b/aic-core/src/aiconfigurator_core/sdk/perf_interp/engine.py
@@ -256,16 +256,17 @@ def _eval_curve(cfg: OpInterpConfig, curve: list, q, n_axes, curve_pos, site_pos
 
 def _beyond_frontier_scale_up(site_keys: list, site_key: tuple) -> bool:
     """True iff the query site exceeds the collected frontier in the scale-up
-    direction ONLY: no collected site weakly dominates it (>= on every site
-    axis), and it is not below the collected minimum on any axis. Interior
-    holes (dominated) and scale-down / mixed-direction queries keep the
-    distance-gate miss — util genuinely doesn't transfer downward, but at the
-    top of the collected range boundary efficiency is the best signal we have
-    (the same reasoning as the unbounded m-curve / Grid out-of-range hold)."""
+    direction ONLY: strictly above the collected maximum on at least one site
+    axis, and not below the collected minimum on any axis. Everything else —
+    dominated interior holes, incomparable notches inside the bounding box,
+    scale-down / mixed-direction queries — keeps the distance-gate miss: util
+    genuinely doesn't transfer downward, but at the top of the collected range
+    boundary efficiency is the best signal we have (the same reasoning as the
+    unbounded m-curve / Grid out-of-range hold)."""
     axes = range(len(site_key))
-    if any(all(s[a] >= site_key[a] for a in axes) for s in site_keys):
+    if any(site_key[a] < min(s[a] for s in site_keys) for a in axes):
         return False
-    return all(site_key[a] >= min(s[a] for s in site_keys) for a in axes)
+    return any(site_key[a] > max(s[a] for s in site_keys) for a in axes)
 
 
 def _resolve_scattered(cfg: OpInterpConfig, data: dict, coords):

--- a/aic-core/src/aiconfigurator_core/sdk/perf_interp/engine.py
+++ b/aic-core/src/aiconfigurator_core/sdk/perf_interp/engine.py
@@ -7,9 +7,9 @@ Executes the four-step resolution declared in :mod:`config`:
     1. exact hit            -> return the measured leaf verbatim
     2. resolve in the data  -> Grid: nested bracket+blend (value_transform space)
                                ScatteredSites: site curve eval; unknown site ->
-                               nearest-site transfer in util space (a site
-                               beyond the scale-up frontier that fails the
-                               distance gate falls back to boundary util-hold)
+                               nearest-site transfer in util space (the distance
+                               gate is waived for a site beyond the scale-up
+                               frontier)
     3. beyond the range     -> hold the boundary util (k_tail median anchor),
                                latency = SOL(query) / util
     4. nothing to anchor on -> raise InterpolationDataNotAvailableError
@@ -268,38 +268,6 @@ def _beyond_frontier_scale_up(site_keys: list, site_key: tuple) -> bool:
     return all(site_key[a] >= min(s[a] for s in site_keys) for a in axes)
 
 
-def _hold_frontier(cfg: OpInterpConfig, sites, site_keys, ranked, dist, q, n_axes, curve_pos, site_pos, coords):
-    """Boundary util-hold for a query site beyond the scale-up frontier, where
-    the distance gate found no neighbour. The log-nearest sites to such a query
-    ARE the frontier sites; anchor on the median util of the nn_sites nearest
-    (coverage-filtered upstream) and let SOL(query) carry the growth — median,
-    not IDW, matching the util-hold convention (robust to one bad anchor)."""
-    utils, powers = [], []
-    for i in ranked[: cfg.resolver.nn_sites]:
-        neigh = site_keys[i]
-        try:
-            lat_i, p_i = _eval_curve(cfg, sites[neigh], q, n_axes, curve_pos, site_pos, neigh, coords)
-        except InterpolationDataNotAvailableError:  # one bad anchor must not poison the query
-            continue
-        sol_i = cfg.sol_fn(*_full_coords(n_axes, curve_pos, site_pos, q, neigh))
-        if math.isfinite(lat_i) and lat_i > 0 and math.isfinite(sol_i) and sol_i > 0:
-            utils.append(sol_i / lat_i)
-            powers.append(p_i)
-    if not utils:
-        raise _miss(cfg, coords, "no positive-util frontier anchor")
-    sol_q = cfg.sol_fn(*coords)
-    if sol_q <= 0:
-        raise _miss(cfg, coords, "non-positive SOL at query")
-    if logger.isEnabledFor(logging.DEBUG):
-        logger.debug(
-            "perf_interp util-hold (site frontier): coords=%s anchor_util=%.4g nearest_distance=%.3f",
-            dict(zip(cfg.axes, coords, strict=True)),
-            statistics.median(utils),
-            dist(ranked[0]),
-        )
-    return sol_q / statistics.median(utils), statistics.median(powers)
-
-
 def _resolve_scattered(cfg: OpInterpConfig, data: dict, coords):
     sites, site_keys, site_logs, curve_pos, site_pos, n_axes = _site_index(cfg, data)
     res = cfg.resolver
@@ -326,11 +294,14 @@ def _resolve_scattered(cfg: OpInterpConfig, data: dict, coords):
     ranked = sorted(candidates, key=dist)
     if res.max_site_distance is not None:
         gated = [i for i in ranked if dist(i) <= res.max_site_distance]
-        if not gated:
-            if _beyond_frontier_scale_up(site_keys, site_key):
-                return _hold_frontier(cfg, sites, site_keys, ranked, dist, q, n_axes, curve_pos, site_pos, coords)
+        if gated:
+            ranked = gated
+        elif not _beyond_frontier_scale_up(site_keys, site_key):
             raise _miss(cfg, coords, "no site within max_site_distance")
-        ranked = gated
+        # else: beyond the scale-up frontier the gate is waived — the ungated
+        # nearest (near-frontier) sites anchor the transfer below, and
+        # SOL(query) carries the growth (frontier-holdout LOO: median vs IDW
+        # anchoring measured equivalent, so the ordinary transfer path serves).
 
     wsum = u_acc = p_acc = 0.0
     for i in ranked[: res.nn_sites]:

--- a/aic-core/src/aiconfigurator_core/sdk/perf_interp/engine.py
+++ b/aic-core/src/aiconfigurator_core/sdk/perf_interp/engine.py
@@ -8,8 +8,8 @@ Executes the four-step resolution declared in :mod:`config`:
     2. resolve in the data  -> Grid: nested bracket+blend (value_transform space)
                                ScatteredSites: site curve eval; unknown site ->
                                nearest-site transfer in util space (the distance
-                               gate is waived for a site beyond the scale-up
-                               frontier)
+                               gate is waived along a single overflowing axis
+                               for a site beyond the scale-up frontier)
     3. beyond the range     -> hold the boundary util (k_tail median anchor),
                                latency = SOL(query) / util
     4. nothing to anchor on -> raise InterpolationDataNotAvailableError
@@ -254,19 +254,41 @@ def _eval_curve(cfg: OpInterpConfig, curve: list, q, n_axes, curve_pos, site_pos
     return lat, power
 
 
-def _beyond_frontier_scale_up(site_keys: list, site_key: tuple) -> bool:
-    """True iff the query site exceeds the collected frontier in the scale-up
-    direction ONLY: strictly above the collected maximum on at least one site
-    axis, and not below the collected minimum on any axis. Everything else —
-    dominated interior holes, incomparable notches inside the bounding box,
-    scale-down / mixed-direction queries — keeps the distance-gate miss: util
-    genuinely doesn't transfer downward, but at the top of the collected range
-    boundary efficiency is the best signal we have (the same reasoning as the
-    unbounded m-curve / Grid out-of-range hold)."""
+def _frontier_waiver_anchors(site_keys, candidates, site_key, q_log, site_logs, max_site_distance):
+    """Anchor indices for a scale-up frontier query, or None (gate miss stands).
+
+    The distance gate is waived ONLY for the intended frontier overflow, and
+    everything is computed over ``candidates`` (the coverage-eligible sites) so
+    admissibility and the anchors actually used cannot diverge:
+
+    - exactly ONE site axis overflows (strictly above the candidates' maximum).
+      Simultaneous multi-axis overflow means the table is a sparse stub for
+      this shape (e.g. an fp8_block table collected at n,k<=128 queried with a
+      real logits GEMM) — holding a launch-bound stub's util across many
+      octaves fabricates arbitrarily wrong latencies, so it stays a miss;
+    - no axis sits below the candidates' minimum (scale-down never transfers);
+    - the NON-overflow axes still pass the 2-octave gate (residual log2
+      distance), so anchors are genuine frontier neighbours of the query and
+      the transfer is scale-up along the overflow axis only.
+
+    On the overflow axis every anchor is below the query by construction; the
+    caller's inverse-distance weighting then favours the largest collected
+    sites, and SOL(query) carries the growth (the same trust as the m curve
+    axis and the Grid out-of-range hold)."""
     axes = range(len(site_key))
-    if any(site_key[a] < min(s[a] for s in site_keys) for a in axes):
-        return False
-    return any(site_key[a] > max(s[a] for s in site_keys) for a in axes)
+    cand_keys = [site_keys[i] for i in candidates]
+    overflow = [a for a in axes if site_key[a] > max(k[a] for k in cand_keys)]
+    if len(overflow) != 1:
+        return None
+    if any(site_key[a] < min(k[a] for k in cand_keys) for a in axes):
+        return None
+    resid = [a for a in axes if a not in overflow]
+
+    def resid_dist(i: int) -> float:
+        return math.sqrt(sum((site_logs[i][a] - q_log[a]) ** 2 for a in resid))
+
+    admissible = [i for i in candidates if resid_dist(i) <= max_site_distance]
+    return admissible or None
 
 
 def _resolve_scattered(cfg: OpInterpConfig, data: dict, coords):
@@ -295,14 +317,17 @@ def _resolve_scattered(cfg: OpInterpConfig, data: dict, coords):
     ranked = sorted(candidates, key=dist)
     if res.max_site_distance is not None:
         gated = [i for i in ranked if dist(i) <= res.max_site_distance]
-        if gated:
-            ranked = gated
-        elif not _beyond_frontier_scale_up(site_keys, site_key):
-            raise _miss(cfg, coords, "no site within max_site_distance")
-        # else: beyond the scale-up frontier the gate is waived — the ungated
-        # nearest (near-frontier) sites anchor the transfer below, and
-        # SOL(query) carries the growth (frontier-holdout LOO: median vs IDW
-        # anchoring measured equivalent, so the ordinary transfer path serves).
+        if not gated:
+            # Beyond the scale-up frontier the gate is waived for the overflow
+            # axis only: anchors are the coverage-eligible sites that still
+            # pass the gate on the remaining axes, and SOL(query) carries the
+            # growth (frontier-holdout LOO: median vs IDW anchoring measured
+            # equivalent, so the ordinary transfer below serves).
+            gated = _frontier_waiver_anchors(site_keys, candidates, site_key, q_log, site_logs, res.max_site_distance)
+            if gated is None:
+                raise _miss(cfg, coords, "no site within max_site_distance")
+            gated.sort(key=dist)
+        ranked = gated
 
     wsum = u_acc = p_acc = 0.0
     for i in ranked[: res.nn_sites]:

--- a/docs/design/perf_interp_design.md
+++ b/docs/design/perf_interp_design.md
@@ -53,7 +53,7 @@ adding a config, not a code path.
 
 | Resolver | Table shape | Handling |
 |---|---|---|
-| `ScatteredSites(site_axes, curve_axis)` | GEMM: scattered `(n,k)` sites, each owning an m-curve | exact site answers from its **own** curve; an uncollected shape borrows **util** from the nearest collected shapes (log-space IDW, filtered to sites whose curve covers the query m, 2.0-octave miss gate) |
+| `ScatteredSites(site_axes, curve_axis)` | GEMM: scattered `(n,k)` sites, each owning an m-curve | exact site answers from its **own** curve; an uncollected shape borrows **util** from the nearest collected shapes (log-space IDW, filtered to sites whose curve covers the query m, 2.0-octave miss gate). The gate is **waived along exactly one overflowing axis** for a query beyond the collected frontier in the scale-up direction (issue #1415, big-vocab LM heads: `n = vocab/tp` past every collected `n`): admissibility is computed over the coverage-eligible candidates — the query must exceed their maximum on exactly one axis, sit at/above their minimum on every axis, and still pass the 2.0-octave gate on the remaining axes; the admissible frontier sites anchor the ordinary IDW util transfer and `SOL(query)` carries the growth. Interior holes, scale-down / mixed-direction queries, and simultaneous multi-axis overflow (a sparse stub table, e.g. an `fp8_block` table collected only at `n,k<=128`) keep the miss. |
 | `Grid()` | everything else, 1..N axes | per level: exact key collapses; otherwise bracket + blend; a ragged branch is dropped -- and when only one branch survives, its value is **SOL-ratio-corrected along the dropped axis** (util held), never clamped; past the staircase frontier = ordinary out-of-range util-hold |
 
 The engine is N-axis: context DSA/CSA carries a past-KV axis
@@ -116,6 +116,16 @@ Data: h100_sxm sglang 0.5.10 / vllm 0.19.0, gb200 sglang 0.5.10.
 | context DSA, 4-axis leaf holdout, interior / frontier | 5.4% / 10.8% | 27% / 52% (0 misses; the s-grid is sparse around the top-k knee, and holding out a knee anchor is worst-case -- the signed knee fold below shows no systematic bias) |
 | CSA (gb200) plain crossing vs regime-aware | **1.72% vs 1.92%** | 4.3% / 4.3% |
 | CSA knee-just-above, signed | plain **+0.57%** vs regime −2.94% | — |
+| GEMM **frontier-holdout** (scale-up waiver; drop all sites with `n > 8192`, predict measured `n = 65536` points through the waived path, ≥3 octaves — h200 vllm 0.24.0 / h100 trtllm 1.3.0rc15 / b200 sglang 0.5.10) | 10.1% / 8.9% / 15.1% | 83% / 51% / 112% |
+
+The frontier-holdout tail is dominated by skinny `k <= 256` shapes whose
+anchor util sits on the rising part of the saturation curve (signed error is
+systematically **positive** — the hold overestimates latency, the safe
+direction); at real LM-head dimensions (`k >= 2048`) the signed median is
++7~10%. On B60 against PR #1413's newly measured `n = 65536` rows, the
+Llama-3.1-8B LM-head shape itself lands at 3.6–4.3% (bf16) / 10–11% (fp8).
+Median-vs-IDW anchoring A/B'd equal (within 0.6% median), so the waiver
+reuses the ordinary IDW transfer path.
 
 Notable robustness result: 1705 ragged queries across four op families on the
 raw (un-expanded) tables produced **zero crashes and zero Qhull errors** —

--- a/tests/unit/sdk/database/test_perf_interp_engine.py
+++ b/tests/unit/sdk/database/test_perf_interp_engine.py
@@ -133,6 +133,38 @@ def test_incomparable_notch_inside_bounding_box_still_misses():
         perf_interp.query(_gemm_cfg(), data, 32, 4096, 4096)
 
 
+def test_sparse_stub_multi_axis_overflow_still_misses():
+    # Real-table regression (PR #1419 review): rtx_pro_6000_server's fp8_block
+    # gemm table only collects n,k in 32..128; Qwen3-32B's logits GEMM
+    # (m=1, n=151936, k=5120) sits ~12 octaves away with BOTH site axes past
+    # the collected maximum. Holding a launch-bound stub's util across that
+    # gap fabricated 24,506 ms against a 0.543 ms truth — simultaneous
+    # multi-axis overflow must stay a structured miss.
+    data = {}
+    for m in (1, 2, 4):
+        for n in (32, 64, 128):
+            for k in (32, 64, 128):
+                data.setdefault(m, {}).setdefault(n, {})[k] = {"latency": _gemm_lat(m, n, k), "energy": 0.0}
+    with pytest.raises(InterpolationDataNotAvailableError):
+        perf_interp.query(_gemm_cfg(), data, 1, 151936, 5120)
+
+
+def test_waiver_admissibility_computed_over_coverage_candidates():
+    # PR #1419 review: with site (1, 1) covering only m<=2 and site (64, 64)
+    # covering m=16..64, the query (m=32, n=1024, k=1) used to pass a GLOBAL
+    # frontier check (n above the global max, k at the global min) while the
+    # only coverage-eligible anchor (64, 64) required a k=64 -> k=1 scale-DOWN
+    # transfer. Admissibility must be computed over the coverage-eligible
+    # candidates, where k=1 sits below the minimum -> miss.
+    data = {}
+    for m in (1, 2):
+        data.setdefault(m, {}).setdefault(1, {})[1] = {"latency": _gemm_lat(m, 1, 1), "energy": 0.0}
+    for m in (16, 32, 64):
+        data.setdefault(m, {}).setdefault(64, {})[64] = {"latency": _gemm_lat(m, 64, 64), "energy": 0.0}
+    with pytest.raises(InterpolationDataNotAvailableError):
+        perf_interp.query(_gemm_cfg(), data, 32, 1024, 1)
+
+
 def test_coverage_filter_prefers_sites_that_span_the_query_m():
     # Site A (2048, 2048) only has tiny m (decode-like sweep, m <= 4) with a
     # BAD tail util; site B (2000, 2000) covers large m with util == 1. A naive

--- a/tests/unit/sdk/database/test_perf_interp_engine.py
+++ b/tests/unit/sdk/database/test_perf_interp_engine.py
@@ -120,6 +120,19 @@ def test_interior_hole_beyond_gate_still_misses():
         perf_interp.query(_gemm_cfg(), data, 32, 8192, 8192)
 
 
+def test_incomparable_notch_inside_bounding_box_still_misses():
+    # (4096, 4096) sits in the notch between (256, 65536) and (65536, 256): no
+    # site dominates it, yet it exceeds the collected maximum on NO axis — an
+    # interior hole in the Pareto staircase, not a scale-up frontier query.
+    # The waiver must not fire; the distance gate stands.
+    data = {}
+    for m in (16, 32, 64):
+        for n, k in ((256, 65536), (65536, 256)):
+            data.setdefault(m, {}).setdefault(n, {})[k] = {"latency": _gemm_lat(m, n, k), "energy": 0.0}
+    with pytest.raises(InterpolationDataNotAvailableError):
+        perf_interp.query(_gemm_cfg(), data, 32, 4096, 4096)
+
+
 def test_coverage_filter_prefers_sites_that_span_the_query_m():
     # Site A (2048, 2048) only has tiny m (decode-like sweep, m <= 4) with a
     # BAD tail util; site B (2000, 2000) covers large m with util == 1. A naive

--- a/tests/unit/sdk/database/test_perf_interp_engine.py
+++ b/tests/unit/sdk/database/test_perf_interp_engine.py
@@ -87,9 +87,37 @@ def test_unknown_site_transfers_util_from_neighbours():
 
 
 def test_far_site_is_a_structured_miss():
-    # (16384, 512) is ~2.6 octaves from every collected shape -> miss, not a guess.
+    # (16384, 512) is ~2.6 octaves from every collected shape -> miss, not a
+    # guess. (Also the mixed-direction case: n is scale-up beyond the frontier
+    # but k is BELOW every collected k, so the frontier fallback must not fire.)
     with pytest.raises(InterpolationDataNotAvailableError):
         perf_interp.query(_gemm_cfg(), _gemm_table(), 1000, 16384, 512)
+
+
+def test_scale_up_beyond_frontier_holds_util():
+    # Gemma-4-26B-A4B tp1 LM head (issue #1415): (n=262144, k=2816) is ~2.005
+    # octaves from the nearest collected site (n caps at 65536 in every GPU
+    # database) — past the distance gate — but lies beyond the frontier in the
+    # scale-up direction, so the engine holds the frontier util instead of
+    # missing. util==1 fixture -> the hold is exact.
+    data = {}
+    for m in (16, 32, 64):
+        for n, k in ((65536, 2560), (65536, 3072), (4096, 2816)):
+            data.setdefault(m, {}).setdefault(n, {})[k] = {"latency": _gemm_lat(m, n, k), "energy": 0.0}
+    lat = _lat(perf_interp.query(_gemm_cfg(), data, 32, 262144, 2816))
+    assert lat == pytest.approx(_gemm_lat(32, 262144, 2816), rel=1e-6)
+
+
+def test_interior_hole_beyond_gate_still_misses():
+    # (8192, 8192) is dominated by the collected (65536, 65536) corner but >2
+    # octaves from every site — a sparse interior hole, not a frontier query.
+    # The gate must still refuse to guess.
+    data = {}
+    for m in (16, 32, 64):
+        for n, k in ((256, 256), (65536, 65536)):
+            data.setdefault(m, {}).setdefault(n, {})[k] = {"latency": _gemm_lat(m, n, k), "energy": 0.0}
+    with pytest.raises(InterpolationDataNotAvailableError):
+        perf_interp.query(_gemm_cfg(), data, 32, 8192, 8192)
 
 
 def test_coverage_filter_prefers_sites_that_span_the_query_m():


### PR DESCRIPTION
## Summary

Root fix for ai-dynamo/aiconfigurator#1415: the `ScatteredSites` `max_site_distance` gate (2.0 octaves joint log2 over the site axes) made Gemma-4-26B-A4B's tp1 LM-head GEMM `(n=262144, k=2816)` a structured miss on every GPU database (distance \~2.005; every gemm table caps n at 65536), and the Pareto search silently dropped the tp1 candidates while the support matrix stayed PASS.

This PR makes the gate **direction-aware** in both engines (Python `aic-core/src/aiconfigurator_core/sdk/perf_interp/engine.py` and Rust `aic-core/rust/aiconfigurator-core/src/perf_database/perf_interp.rs`, mirrored implementations):

* **Waiver condition** (both must hold when the gate finds no neighbour): the query sits strictly above the collected maximum on at least one site axis (the query is beyond the scale-up frontier; this implies no site dominates it), and it is not below the collected minimum on any axis. Dominated interior holes, incomparable notches inside the bounding box, and scale-down / mixed-direction queries keep the miss.
* **Waiver action**: the gate is skipped and the query falls through to the *existing* nearest-site IDW util transfer (coverage-filtered, `SOL(query)` re-applies the scaling) — the same unbounded trust the engine already gives along the m curve axis and past the Grid staircase. A median-anchored variant was A/B'd on the frontier-holdout LOO and measured equivalent (within 0.6% median), so the simpler reuse of the transfer path wins.
* **Unchanged**: interior holes and scale-down queries still raise `InterpolationDataNotAvailableError`; the existing mixed-direction `(16384, 512)` test keeps its miss semantics.

## Validation

* **Real tables**: Gemma tp1 now resolves on h200_sxm/vllm/0.24.0, h100_sxm/trtllm/1.3.0rc15, b200_sxm/sglang/0.5.10 with latency \~4.0x the collected n=65536 site — exactly the linear-n physics (tp2/tp4 answers unchanged).
* **Frontier-holdout LOO** (as suggested in the issue): dropping all sites with n > 8192 forces every measured n=65536 point through the waived-gate path (≥3 octaves, harsher than gemma's 2.005) → median error 8.9–15.1% (p90 51–112%) across the three databases above. A milder n > 16384 cut leaves the eval points exactly at the 2.0 gate boundary, where they resolve through the gated path at 5.9–9.3% median — the waived path at gemma's just-past-the-gate distance anchors on those same sites, so its accuracy there is comparable.
* **Tests**: 2 new Python + 2 mirrored Rust unit tests (gemma-shaped scale-up fallback; interior-hole still misses). Full SDK unit suite (1443) passes; `cargo test --workspace --all-features` (287) passes; Rust engine-step parity tests pass.

## Not in this PR (issue suggestions 2 & 3)

* Data patch extending `output_feature_sizes` with vocab-derived n grid points (would bring gemma tp1 back from extrapolation to interpolation accuracy).
* CI guardrail enumerating every supported model's LM-head `(vocab/tp, hidden)` shapes against each database.

Fixes ai-dynamo/aiconfigurator#1415. Related: ai-dynamo/aiconfigurator#1303, ai-dynamo/aiconfigurator#1413.

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)

## Summary by CodeRabbit

* **Enhancements**
  * Improved scattered-sites performance interpolation so that when `ScatteredSites.max_site_distance` would block all candidates for scale-up queries beyond the scale-up frontier, the resolver waives the distance gate and falls back to frontier boundary utilization-hold behavior instead of returning an immediate miss.
  * Interior-hole and comparable “incomparable notch” cases beyond the gate still raise structured misses when no valid site data applies.
* **Documentation**
  * Clarified `max_site_distance` “structured miss” vs “frontier fallback” behavior, including the scale-up-frontier exception.
* **Tests**
  * Added unit coverage for frontier util holding and for continued miss behavior in interior-gap scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved performance interpolation for scale-up queries beyond the collected frontier.
  - Eligible frontier queries can now resolve using nearest-site utilization transfer instead of failing immediately.

- **Bug Fixes**
  - Preserved structured misses for interior holes, scale-down queries, multi-axis overflows, and other unsupported gaps.
  - Improved candidate eligibility checks for frontier resolution.

- **Documentation**
  - Clarified frontier-waiver behavior, miss conditions, and validation results.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->