### PR TITLE
fix(test): shield helper MoE distribution tests from leaked torch mock

### DIFF
--- a/tests/unit/collector/test_helper_moe_distribution.py
+++ b/tests/unit/collector/test_helper_moe_distribution.py
@@ -13,9 +13,32 @@ requires either extracting the dispatch to a helper or mocking the full TRT-LLM
 KV-cache stack. That is left for a follow-up if the function is ever refactored.
 """
 
+import sys
+from unittest.mock import MagicMock
+
 import pytest
 
-torch = pytest.importorskip("torch")
+# test_collect_provenance_writer deliberately leaves a MagicMock cached as
+# sys.modules["torch"] (collect.py's fork-worker tests depend on it), so a
+# plain importorskip("torch") can "succeed" with the mock and every tensor
+# assertion below dies with `TypeError: '<' not supported between instances
+# of 'MagicMock' and 'int'` — whether that happens depends only on which
+# module pytest-xdist imports first on the worker (same pattern as
+# test_dsv4_megamoe_workload). Evict the mock, import the real torch (or
+# skip when it isn't installed), then put the mock back for the siblings
+# that rely on it.
+_saved_mock = sys.modules.get("torch")
+_restore_mock = isinstance(_saved_mock, MagicMock)
+if _restore_mock:
+    sys.modules.pop("torch")
+try:
+    import torch
+except ImportError:
+    if _restore_mock:
+        sys.modules["torch"] = _saved_mock
+    pytest.skip("real torch required for tensor operations", allow_module_level=True)
+if _restore_mock:
+    sys.modules["torch"] = _saved_mock
 
 from collector.helper import (
     _generate_power_law_distribution,
@@ -23,6 +46,18 @@ from collector.helper import (
 )
 
 pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _real_torch_in_sys_modules(monkeypatch):
+    """Pin the real torch for the duration of each test.
+
+    ``collector/helper.py`` imports torch lazily inside the functions under
+    test, so binding the real module at collection time is not enough — the
+    call-time ``import torch`` resolves whatever sits in ``sys.modules`` at
+    that moment.
+    """
+    monkeypatch.setitem(sys.modules, "torch", torch)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/collector/test_helper_moe_distribution.py
+++ b/tests/unit/collector/test_helper_moe_distribution.py
@@ -26,7 +26,10 @@ import pytest
 # module pytest-xdist imports first on the worker (same pattern as
 # test_dsv4_megamoe_workload). Evict the mock, import the real torch (or
 # skip when it isn't installed), then put the mock back for the siblings
-# that rely on it.
+# that rely on it. The restore lives in a `finally` so even an unexpected
+# import failure (e.g. an OSError loading torch's native libraries) cannot
+# leave the eviction in place; do NOT let collect.py see the real torch —
+# its fork-worker tests deadlock on macOS with a real torch cached.
 _saved_mock = sys.modules.get("torch")
 _restore_mock = isinstance(_saved_mock, MagicMock)
 if _restore_mock:
@@ -34,11 +37,11 @@ if _restore_mock:
 try:
     import torch
 except ImportError:
+    # pytest.skip raises; the mock is restored by the finally during unwind.
+    pytest.skip("real torch required for tensor operations", allow_module_level=True)
+finally:
     if _restore_mock:
         sys.modules["torch"] = _saved_mock
-    pytest.skip("real torch required for tensor operations", allow_module_level=True)
-if _restore_mock:
-    sys.modules["torch"] = _saved_mock
 
 from collector.helper import (
     _generate_power_law_distribution,


### PR DESCRIPTION
#### Overview:

Main CI (`Build and Test (unit)`) has been red since #1358: `tests/unit/collector/test_helper_moe_distribution.py` fails with `TypeError: '<' not supported between instances of 'MagicMock' and 'int'` depending only on pytest-xdist module import order.

#### Details:

**Root cause**

- `test_collect_provenance_writer.py` **deliberately** leaves a `MagicMock` cached as `sys.modules["torch"]` — the `collect.py` fork-worker tests depend on the mock **at run time** (forked workers must see it; with a real torch cached they deadlock on macOS, experimentally confirmed), so it must not be "fixed" at the polluter.
- `test_helper_moe_distribution.py` (added in #1358) uses a plain `pytest.importorskip("torch")`, which "succeeds" with the leaked mock when the polluter is imported first on the same xdist worker.

**Fix** (victim-side, same guard pattern as `test_dsv4_megamoe_workload.py`): evict the mock, import the real torch (or module-level skip when absent), restore the mock in a `finally` for the siblings that rely on it, and pin the real torch in `sys.modules` via an autouse fixture during each test (`collector/helper.py` imports torch lazily inside the functions under test).

**Design notes from controlled experiments** (all locally verified):

- A conftest that pre-imports the real torch was tried and **retracted**: it lets `collect.py` cache the real torch and `test_parallel_run`'s fork-worker tests then genuinely deadlock on macOS. Returning the mock after the borrow is load-bearing, not defensive.
- On torch-equipped machines the evict→fresh-import→restore pattern can only succeed once per process (`TORCH_LIBRARY` re-registration aborts collection on the second). This PR adds the third such module — but main **already** aborts collection in that environment via the pre-existing `test_sglang_moe_ep_routing.py`, so the practical increment is zero. A follow-up (#see linked issue) will move the one-shot fresh-import into a shared per-process helper for all three modules.

**Verification**

- CI scenario (no torch): pollution-order run goes from 13 failed to a clean skip.
- Fork red-line: `test_parallel_run` green alone and combined with the polluter and victim.
- Dev scenario (real torch): pollution-order run actually executes the tests (21 passed).

#### Where should the reviewer start?

`tests/unit/collector/test_helper_moe_distribution.py` (only file changed)

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #1358

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability in environments where the machine learning library is mocked.
  * Tests now use the real library when available and skip gracefully when it cannot be imported.
  * Ensured runtime imports consistently resolve to the correct library during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->