### PR TITLE
ci: route macOS wheels to native runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,3 +2,4 @@ self-hosted-runner:
   labels:
     - prod-aiconfigurator-default-amd64-v1
     - prod-aiconfigurator-default-arm64-v1
+    - prod-aiconfigurator-default-macos-arm64-v1

--- a/.github/actions/build-platform-wheel/action.yml
+++ b/.github/actions/build-platform-wheel/action.yml
@@ -49,11 +49,16 @@ runs:
       uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       with:
         version: "0.11.18"
+        enable-cache: false
 
     - name: Create isolated macOS Python environment
       if: inputs.build_method == 'native-macos'
       shell: bash
       run: |
+        uv_cache_dir="${RUNNER_TEMP}/aiconfigurator-uv-cache-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+        export UV_CACHE_DIR="${uv_cache_dir}"
+        echo "UV_CACHE_DIR=${uv_cache_dir}" >> "${GITHUB_ENV}"
+
         uv venv --python 3.12 "${RUNNER_TEMP}/aiconfigurator-wheel-venv"
         echo "${RUNNER_TEMP}/aiconfigurator-wheel-venv/bin" >> "${GITHUB_PATH}"
         echo "VIRTUAL_ENV=${RUNNER_TEMP}/aiconfigurator-wheel-venv" >> "${GITHUB_ENV}"

--- a/.github/actions/build-platform-wheel/action.yml
+++ b/.github/actions/build-platform-wheel/action.yml
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Build and verify a platform wheel
+description: Build and verify one AIConfigurator platform wheel set
+
+inputs:
+  build_method:
+    description: Wheel build method
+    required: true
+  python_architecture:
+    description: Python architecture passed to setup-python
+    required: true
+  platform:
+    description: Docker target platform for Linux builds
+    required: false
+    default: ""
+  wheel_base:
+    description: Manylinux wheel-builder base image
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Docker Buildx
+      if: inputs.build_method == 'docker'
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+    - name: Build Linux wheel
+      if: inputs.build_method == 'docker'
+      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+      with:
+        context: .
+        file: docker/Dockerfile
+        platforms: ${{ inputs.platform }}
+        target: wheel-out
+        build-args: WHEEL_BUILD_BASE=${{ inputs.wheel_base }}
+        outputs: type=local,dest=./wheelhouse
+
+    - name: Set up Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      with:
+        python-version: "3.12"
+        architecture: ${{ inputs.python_architecture }}
+
+    - name: Set up uv
+      if: inputs.build_method == 'native-macos'
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      with:
+        version: "0.12.0"
+
+    - name: Create isolated macOS Python environment
+      if: inputs.build_method == 'native-macos'
+      shell: bash
+      run: |
+        uv venv --python 3.12 "${RUNNER_TEMP}/aiconfigurator-wheel-venv"
+        echo "${RUNNER_TEMP}/aiconfigurator-wheel-venv/bin" >> "${GITHUB_PATH}"
+        echo "VIRTUAL_ENV=${RUNNER_TEMP}/aiconfigurator-wheel-venv" >> "${GITHUB_ENV}"
+
+    - name: Select Rust toolchain for macOS wheel
+      if: inputs.build_method == 'native-macos'
+      shell: bash
+      run: |
+        rustup toolchain install 1.96.0 --profile minimal
+        rustup default 1.96.0
+
+    - name: Build and verify macOS wheel
+      if: inputs.build_method == 'native-macos'
+      shell: bash
+      env:
+        MACOSX_DEPLOYMENT_TARGET: "11.0"
+      run: |
+        uv pip install --quiet 'build>=1,<2' 'maturin>=1.12,<2' 'delocate>=0.13,<1'
+        mkdir -p wheelhouse repaired-wheelhouse
+        (cd aic-core && maturin build --release --out ../wheelhouse)
+        python -m build --wheel --outdir wheelhouse
+        delocate-wheel --wheel-dir repaired-wheelhouse --verbose wheelhouse/aiconfigurator_core-*.whl
+        rm wheelhouse/aiconfigurator_core-*.whl
+        mv repaired-wheelhouse/*.whl wheelhouse/
+        python tools/verify_release_wheels.py wheelhouse
+
+    - name: Smoke-test Linux native extension
+      if: inputs.build_method == 'docker'
+      shell: bash
+      run: |
+        python -m pip install --quiet --no-deps \
+          wheelhouse/aiconfigurator_core-*.whl \
+          wheelhouse/aiconfigurator-*.whl
+        python -c \
+          'import aiconfigurator_core; assert aiconfigurator_core._build_smoke() == 1'
+
+    - name: Verify installed macOS wheel set
+      if: inputs.build_method == 'native-macos'
+      shell: bash
+      run: |
+        uv pip install --quiet \
+          wheelhouse/aiconfigurator_core-*.whl \
+          wheelhouse/aiconfigurator-*.whl
+        python tools/verify_installed_package_layers.py \
+          --expect full \
+          --exercise-engine

--- a/.github/actions/build-platform-wheel/action.yml
+++ b/.github/actions/build-platform-wheel/action.yml
@@ -48,7 +48,7 @@ runs:
       if: inputs.build_method == 'native-macos'
       uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       with:
-        version: "0.12.0"
+        version: "0.11.18"
 
     - name: Create isolated macOS Python environment
       if: inputs.build_method == 'native-macos'

--- a/.github/workflows/build-platform-wheels-copied-pr.yml
+++ b/.github/workflows/build-platform-wheels-copied-pr.yml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Build copied-PR platform wheels
+
+on:
+  push:
+    branches:
+      # copy-pr-bot is the approval boundary for privileged pull-request builds.
+      - "pull-request/*"
+    paths:
+      - ".github/actions/build-platform-wheel/**"
+      - ".github/workflows/build-platform-wheels-copied-pr.yml"
+      - ".github/workflows/build-platform-wheels.yml"
+      - "docker/Dockerfile"
+      - "LICENSE"
+      - "pyproject.toml"
+      - "README.md"
+      - "aic-core/**"
+      - "src/**"
+      - "tools/build_legacy_monolith_fixture.py"
+      - "tools/stage_wheels_in_artifactory.sh"
+      - "tools/verify_installed_package_layers.py"
+      - "tools/verify_release_wheels.py"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build copied-PR platform wheels
+    uses: ./.github/workflows/build-platform-wheels.yml
+    secrets: inherit

--- a/.github/workflows/build-platform-wheels.yml
+++ b/.github/workflows/build-platform-wheels.yml
@@ -65,6 +65,7 @@ jobs:
             runner: prod-aiconfigurator-default-amd64-v1
             fork_runner: ubuntu-24.04
             build_method: docker
+            python_architecture: x64
             platform: linux/amd64
             wheel_base: quay.io/pypa/manylinux_2_28_x86_64
             upload_upper: true
@@ -72,16 +73,30 @@ jobs:
             runner: prod-aiconfigurator-default-arm64-v1
             fork_runner: ubuntu-24.04-arm
             build_method: docker
+            python_architecture: arm64
             platform: linux/arm64
             wheel_base: quay.io/pypa/manylinux_2_28_aarch64
             upload_upper: false
           - platform_name: macosx_arm64
-            runner: macos-14
+            runner: prod-aiconfigurator-default-macos-arm64-v1
             fork_runner: macos-14
             build_method: native-macos
+            python_architecture: arm64
             upload_upper: false
 
     steps:
+      - name: Verify macOS runner prerequisites
+        if: matrix.build_method == 'native-macos'
+        shell: bash
+        run: |
+          test "$(uname -m)" = "arm64"
+          sw_vers
+          xcode-select --print-path
+          git lfs version
+          rustup --version
+          test -d /Users/runner/hostedtoolcache
+          test -w /Users/runner/hostedtoolcache
+
       - name: Checkout repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
@@ -107,6 +122,14 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
+          architecture: ${{ matrix.python_architecture }}
+
+      - name: Create isolated macOS Python environment
+        if: matrix.build_method == 'native-macos'
+        shell: bash
+        run: |
+          python -m venv "${RUNNER_TEMP}/aiconfigurator-wheel-venv"
+          echo "${RUNNER_TEMP}/aiconfigurator-wheel-venv/bin" >> "${GITHUB_PATH}"
 
       - name: Select Rust toolchain for macOS wheel
         if: matrix.build_method == 'native-macos'
@@ -128,7 +151,8 @@ jobs:
           mv repaired-wheelhouse/*.whl wheelhouse/
           python tools/verify_release_wheels.py wheelhouse
 
-      - name: Smoke-test native extension
+      - name: Smoke-test Linux native extension
+        if: matrix.build_method == 'docker'
         shell: bash
         run: |
           python -m pip install --quiet --no-deps \
@@ -136,6 +160,17 @@ jobs:
             wheelhouse/aiconfigurator-*.whl
           python -c \
             'import aiconfigurator_core; assert aiconfigurator_core._build_smoke() == 1'
+
+      - name: Verify installed macOS wheel set
+        if: matrix.build_method == 'native-macos'
+        shell: bash
+        run: |
+          python -m pip install --quiet \
+            wheelhouse/aiconfigurator_core-*.whl \
+            wheelhouse/aiconfigurator-*.whl
+          python tools/verify_installed_package_layers.py \
+            --expect full \
+            --exercise-engine
 
       - name: Report disabled Artifactory staging
         if: >-

--- a/.github/workflows/build-platform-wheels.yml
+++ b/.github/workflows/build-platform-wheels.yml
@@ -124,11 +124,16 @@ jobs:
           python-version: "3.12"
           architecture: ${{ matrix.python_architecture }}
 
+      - name: Set up uv
+        if: matrix.build_method == 'native-macos'
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          version: "0.12.0"
+
       - name: Create isolated macOS Python environment
         if: matrix.build_method == 'native-macos'
         shell: bash
         run: |
-          python -m pip install --quiet uv
           uv venv --python 3.12 "${RUNNER_TEMP}/aiconfigurator-wheel-venv"
           echo "${RUNNER_TEMP}/aiconfigurator-wheel-venv/bin" >> "${GITHUB_PATH}"
           echo "VIRTUAL_ENV=${RUNNER_TEMP}/aiconfigurator-wheel-venv" >> "${GITHUB_ENV}"

--- a/.github/workflows/build-platform-wheels.yml
+++ b/.github/workflows/build-platform-wheels.yml
@@ -4,28 +4,14 @@
 name: Build platform wheels
 
 on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-    paths:
-      - ".github/workflows/build-platform-wheels.yml"
-      - "docker/Dockerfile"
-      - "LICENSE"
-      - "pyproject.toml"
-      - "README.md"
-      - "aic-core/**"
-      - "src/**"
-      - "tools/build_legacy_monolith_fixture.py"
-      - "tools/stage_wheels_in_artifactory.sh"
-      - "tools/verify_installed_package_layers.py"
-      - "tools/verify_release_wheels.py"
   push:
     branches:
       - main
       - "release/*"
+      # copy-pr-bot is the approval boundary for privileged pull-request builds.
+      - "pull-request/*"
     paths:
+      - ".github/actions/build-platform-wheel/**"
       - ".github/workflows/build-platform-wheels.yml"
       - "docker/Dockerfile"
       - "LICENSE"
@@ -37,11 +23,10 @@ on:
       - "tools/stage_wheels_in_artifactory.sh"
       - "tools/verify_installed_package_layers.py"
       - "tools/verify_release_wheels.py"
-  workflow_dispatch:
 
 concurrency:
   group: platform-wheels-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/heads/pull-request/') }}
 
 permissions:
   contents: read
@@ -49,13 +34,7 @@ permissions:
 jobs:
   build:
     name: Build wheels (${{ matrix.platform_name }})
-    runs-on: >-
-      ${{
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.full_name != github.repository &&
-        matrix.fork_runner ||
-        matrix.runner
-      }}
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
     strategy:
       fail-fast: false
@@ -63,7 +42,6 @@ jobs:
         include:
           - platform_name: manylinux_2_28_x86_64
             runner: prod-aiconfigurator-default-amd64-v1
-            fork_runner: ubuntu-24.04
             build_method: docker
             python_architecture: x64
             platform: linux/amd64
@@ -71,7 +49,6 @@ jobs:
             upload_upper: true
           - platform_name: manylinux_2_28_aarch64
             runner: prod-aiconfigurator-default-arm64-v1
-            fork_runner: ubuntu-24.04-arm
             build_method: docker
             python_architecture: arm64
             platform: linux/arm64
@@ -79,9 +56,10 @@ jobs:
             upload_upper: false
           - platform_name: macosx_arm64
             runner: prod-aiconfigurator-default-macos-arm64-v1
-            fork_runner: macos-14
             build_method: native-macos
             python_architecture: arm64
+            platform: ""
+            wheel_base: ""
             upload_upper: false
 
     steps:
@@ -103,116 +81,64 @@ jobs:
           persist-credentials: false
           lfs: true
 
-      - name: Set up Docker Buildx
-        if: matrix.build_method == 'docker'
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-
-      - name: Build Linux wheel
-        if: matrix.build_method == 'docker'
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+      - name: Build and verify wheel set
+        uses: ./.github/actions/build-platform-wheel
         with:
-          context: .
-          file: docker/Dockerfile
-          platforms: ${{ matrix.platform }}
-          target: wheel-out
-          build-args: WHEEL_BUILD_BASE=${{ matrix.wheel_base }}
-          outputs: type=local,dest=./wheelhouse
+          build_method: ${{ matrix.build_method }}
+          python_architecture: ${{ matrix.python_architecture }}
+          platform: ${{ matrix.platform }}
+          wheel_base: ${{ matrix.wheel_base }}
 
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with:
-          python-version: "3.12"
-          architecture: ${{ matrix.python_architecture }}
-
-      - name: Set up uv
-        if: matrix.build_method == 'native-macos'
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-        with:
-          version: "0.12.0"
-
-      - name: Create isolated macOS Python environment
-        if: matrix.build_method == 'native-macos'
-        shell: bash
-        run: |
-          uv venv --python 3.12 "${RUNNER_TEMP}/aiconfigurator-wheel-venv"
-          echo "${RUNNER_TEMP}/aiconfigurator-wheel-venv/bin" >> "${GITHUB_PATH}"
-          echo "VIRTUAL_ENV=${RUNNER_TEMP}/aiconfigurator-wheel-venv" >> "${GITHUB_ENV}"
-
-      - name: Select Rust toolchain for macOS wheel
-        if: matrix.build_method == 'native-macos'
-        run: |
-          rustup toolchain install 1.96.0 --profile minimal
-          rustup default 1.96.0
-
-      - name: Build and verify macOS wheel
-        if: matrix.build_method == 'native-macos'
-        env:
-          MACOSX_DEPLOYMENT_TARGET: "11.0"
-        run: |
-          uv pip install --quiet 'build>=1,<2' 'maturin>=1.12,<2' 'delocate>=0.13,<1'
-          mkdir -p wheelhouse repaired-wheelhouse
-          (cd aic-core && maturin build --release --out ../wheelhouse)
-          python -m build --wheel --outdir wheelhouse
-          delocate-wheel --wheel-dir repaired-wheelhouse --verbose wheelhouse/aiconfigurator_core-*.whl
-          rm wheelhouse/aiconfigurator_core-*.whl
-          mv repaired-wheelhouse/*.whl wheelhouse/
-          python tools/verify_release_wheels.py wheelhouse
-
-      - name: Smoke-test Linux native extension
-        if: matrix.build_method == 'docker'
-        shell: bash
-        run: |
-          python -m pip install --quiet --no-deps \
-            wheelhouse/aiconfigurator_core-*.whl \
-            wheelhouse/aiconfigurator-*.whl
-          python -c \
-            'import aiconfigurator_core; assert aiconfigurator_core._build_smoke() == 1'
-
-      - name: Verify installed macOS wheel set
-        if: matrix.build_method == 'native-macos'
-        shell: bash
-        run: |
-          uv pip install --quiet \
-            wheelhouse/aiconfigurator_core-*.whl \
-            wheelhouse/aiconfigurator-*.whl
-          python tools/verify_installed_package_layers.py \
-            --expect full \
-            --exercise-engine
-
-      - name: Report disabled Artifactory staging
+      - name: Report disabled copied-PR Artifactory staging
         if: >-
           matrix.upload_upper &&
-          vars.PLATFORM_WHEEL_STAGING_ENABLED != 'true' &&
-          (
-            (
-              github.event_name == 'pull_request' &&
-              github.event.pull_request.head.repo.full_name == github.repository
-            ) ||
-            (
-              github.event_name == 'push' &&
-              (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/'))
-            )
-          )
+          startsWith(github.ref, 'refs/heads/pull-request/') &&
+          vars.PLATFORM_WHEEL_STAGING_ENABLED != 'true'
         shell: bash
         run: |
-          echo "::notice title=Artifactory staging disabled::Set PLATFORM_WHEEL_STAGING_ENABLED=true after issues #1432 and #1433 are complete."
+          echo "::notice title=Copied-PR Artifactory staging disabled::Set PLATFORM_WHEEL_STAGING_ENABLED=true when staging is ready."
           {
-            echo "### Artifactory staging"
+            echo "### Copied pull-request Artifactory staging"
             echo
             echo '- Status: skipped because `PLATFORM_WHEEL_STAGING_ENABLED` is not `true`.'
-            echo '- Follow-up: [#1432](https://github.com/ai-dynamo/aiconfigurator/issues/1432) and [#1433](https://github.com/ai-dynamo/aiconfigurator/issues/1433).'
+            echo '- Follow-up: [#1432](https://github.com/ai-dynamo/aiconfigurator/issues/1432).'
           } >> "${GITHUB_STEP_SUMMARY}"
 
-      - name: Stage pull-request wheels in Artifactory
+      - name: Report disabled post-merge Artifactory staging
+        if: >-
+          matrix.upload_upper &&
+          (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) &&
+          vars.PLATFORM_WHEEL_STAGING_ENABLED != 'true'
+        shell: bash
+        run: |
+          echo "::notice title=Post-merge Artifactory staging disabled::Set PLATFORM_WHEEL_STAGING_ENABLED=true when post-merge publication is ready."
+          {
+            echo "### Post-merge Artifactory staging"
+            echo
+            echo '- Status: skipped because `PLATFORM_WHEEL_STAGING_ENABLED` is not `true`.'
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Resolve copied pull-request staging path
+        id: pr-staging
+        if: startsWith(github.ref, 'refs/heads/pull-request/')
+        shell: bash
+        run: |
+          pr_number="${GITHUB_REF_NAME#pull-request/}"
+          if [[ ! "${pr_number}" =~ ^[0-9]+$ ]]; then
+            echo "::error::Expected a copy-pr-bot branch named pull-request/<number>, got ${GITHUB_REF_NAME}"
+            exit 1
+          fi
+          echo "subpath=PR/${pr_number}/${GITHUB_SHA}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}" >> "${GITHUB_OUTPUT}"
+
+      - name: Stage copied pull-request wheels in Artifactory
         if: >-
           vars.PLATFORM_WHEEL_STAGING_ENABLED == 'true' &&
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository
+          startsWith(github.ref, 'refs/heads/pull-request/')
         env:
           ARTIFACTORY_URL: ${{ secrets.ARTIFACTORY_URL }}
           ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
           ARTIFACTORY_PYPI_REPO_NAME: ${{ secrets.ARTIFACTORY_PYPI_REPO_NAME }}
-          ARTIFACTORY_SUBPATH: PR/${{ github.event.pull_request.number }}/${{ github.event.pull_request.head.sha }}/${{ github.run_id }}/${{ github.run_attempt }}
+          ARTIFACTORY_SUBPATH: ${{ steps.pr-staging.outputs.subpath }}
           UPLOAD_UPPER: ${{ matrix.upload_upper }}
         shell: bash
         run: bash tools/stage_wheels_in_artifactory.sh
@@ -220,7 +146,6 @@ jobs:
       - name: Stage post-merge wheels in Artifactory
         if: >-
           vars.PLATFORM_WHEEL_STAGING_ENABLED == 'true' &&
-          github.event_name == 'push' &&
           (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/'))
         env:
           ARTIFACTORY_URL: ${{ secrets.ARTIFACTORY_URL }}
@@ -232,13 +157,12 @@ jobs:
         run: bash tools/stage_wheels_in_artifactory.sh
 
   finalize-pr:
-    name: Finalize pull-request wheel set
+    name: Finalize copied pull-request wheel set
     needs: build
     if: >-
       success() &&
       vars.PLATFORM_WHEEL_STAGING_ENABLED == 'true' &&
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      startsWith(github.ref, 'refs/heads/pull-request/')
     runs-on: prod-aiconfigurator-default-amd64-v1
     permissions:
       contents: read
@@ -248,10 +172,15 @@ jobs:
           ARTIFACTORY_URL: ${{ secrets.ARTIFACTORY_URL }}
           ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
           ARTIFACTORY_PYPI_REPO_NAME: ${{ secrets.ARTIFACTORY_PYPI_REPO_NAME }}
-          ARTIFACTORY_SUBPATH: PR/${{ github.event.pull_request.number }}/${{ github.event.pull_request.head.sha }}/${{ github.run_id }}/${{ github.run_attempt }}
         shell: bash
         run: |
           set -euo pipefail
+          pr_number="${GITHUB_REF_NAME#pull-request/}"
+          if [[ ! "${pr_number}" =~ ^[0-9]+$ ]]; then
+            echo "::error::Expected a copy-pr-bot branch named pull-request/<number>, got ${GITHUB_REF_NAME}"
+            exit 1
+          fi
+          ARTIFACTORY_SUBPATH="PR/${pr_number}/${GITHUB_SHA}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}"
           : "${ARTIFACTORY_URL:?ARTIFACTORY_URL is not configured}"
           : "${ARTIFACTORY_TOKEN:?ARTIFACTORY_TOKEN is not configured}"
           : "${ARTIFACTORY_PYPI_REPO_NAME:?ARTIFACTORY_PYPI_REPO_NAME is not configured}"
@@ -277,7 +206,6 @@ jobs:
     if: >-
       success() &&
       vars.PLATFORM_WHEEL_STAGING_ENABLED == 'true' &&
-      github.event_name == 'push' &&
       (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/'))
     runs-on: prod-aiconfigurator-default-amd64-v1
     permissions:

--- a/.github/workflows/build-platform-wheels.yml
+++ b/.github/workflows/build-platform-wheels.yml
@@ -122,7 +122,7 @@ jobs:
           startsWith(github.ref, 'refs/heads/pull-request/')
         env:
           ARTIFACTORY_URL: ${{ secrets.ARTIFACTORY_URL }}
-          ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
+          ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_PR_TOKEN }}
           ARTIFACTORY_PYPI_REPO_NAME: ${{ secrets.ARTIFACTORY_PYPI_REPO_NAME }}
           ARTIFACTORY_SUBPATH: ${{ steps.pr-staging.outputs.subpath }}
           UPLOAD_UPPER: ${{ matrix.upload_upper }}
@@ -156,7 +156,7 @@ jobs:
       - name: Mark the validated matrix complete
         env:
           ARTIFACTORY_URL: ${{ secrets.ARTIFACTORY_URL }}
-          ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
+          ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_PR_TOKEN }}
           ARTIFACTORY_PYPI_REPO_NAME: ${{ secrets.ARTIFACTORY_PYPI_REPO_NAME }}
         shell: bash
         run: |

--- a/.github/workflows/build-platform-wheels.yml
+++ b/.github/workflows/build-platform-wheels.yml
@@ -8,21 +8,7 @@ on:
     branches:
       - main
       - "release/*"
-      # copy-pr-bot is the approval boundary for privileged pull-request builds.
-      - "pull-request/*"
-    paths:
-      - ".github/actions/build-platform-wheel/**"
-      - ".github/workflows/build-platform-wheels.yml"
-      - "docker/Dockerfile"
-      - "LICENSE"
-      - "pyproject.toml"
-      - "README.md"
-      - "aic-core/**"
-      - "src/**"
-      - "tools/build_legacy_monolith_fixture.py"
-      - "tools/stage_wheels_in_artifactory.sh"
-      - "tools/verify_installed_package_layers.py"
-      - "tools/verify_release_wheels.py"
+  workflow_call:
 
 concurrency:
   group: platform-wheels-${{ github.ref }}

--- a/.github/workflows/build-platform-wheels.yml
+++ b/.github/workflows/build-platform-wheels.yml
@@ -128,8 +128,10 @@ jobs:
         if: matrix.build_method == 'native-macos'
         shell: bash
         run: |
-          python -m venv "${RUNNER_TEMP}/aiconfigurator-wheel-venv"
+          python -m pip install --quiet uv
+          uv venv --python 3.12 "${RUNNER_TEMP}/aiconfigurator-wheel-venv"
           echo "${RUNNER_TEMP}/aiconfigurator-wheel-venv/bin" >> "${GITHUB_PATH}"
+          echo "VIRTUAL_ENV=${RUNNER_TEMP}/aiconfigurator-wheel-venv" >> "${GITHUB_ENV}"
 
       - name: Select Rust toolchain for macOS wheel
         if: matrix.build_method == 'native-macos'
@@ -142,7 +144,7 @@ jobs:
         env:
           MACOSX_DEPLOYMENT_TARGET: "11.0"
         run: |
-          python -m pip install --quiet 'build>=1,<2' 'maturin>=1.12,<2' 'delocate>=0.13,<1'
+          uv pip install --quiet 'build>=1,<2' 'maturin>=1.12,<2' 'delocate>=0.13,<1'
           mkdir -p wheelhouse repaired-wheelhouse
           (cd aic-core && maturin build --release --out ../wheelhouse)
           python -m build --wheel --outdir wheelhouse
@@ -165,7 +167,7 @@ jobs:
         if: matrix.build_method == 'native-macos'
         shell: bash
         run: |
-          python -m pip install --quiet \
+          uv pip install --quiet \
             wheelhouse/aiconfigurator_core-*.whl \
             wheelhouse/aiconfigurator-*.whl
           python tools/verify_installed_package_layers.py \

--- a/.github/workflows/build-platform-wheels.yml
+++ b/.github/workflows/build-platform-wheels.yml
@@ -210,7 +210,7 @@ jobs:
           github.event.pull_request.head.repo.full_name == github.repository
         env:
           ARTIFACTORY_URL: ${{ secrets.ARTIFACTORY_URL }}
-          ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_PR_TOKEN }}
+          ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
           ARTIFACTORY_PYPI_REPO_NAME: ${{ secrets.ARTIFACTORY_PYPI_REPO_NAME }}
           ARTIFACTORY_SUBPATH: PR/${{ github.event.pull_request.number }}/${{ github.event.pull_request.head.sha }}/${{ github.run_id }}/${{ github.run_attempt }}
           UPLOAD_UPPER: ${{ matrix.upload_upper }}
@@ -246,14 +246,14 @@ jobs:
       - name: Mark the validated matrix complete
         env:
           ARTIFACTORY_URL: ${{ secrets.ARTIFACTORY_URL }}
-          ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_PR_TOKEN }}
+          ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
           ARTIFACTORY_PYPI_REPO_NAME: ${{ secrets.ARTIFACTORY_PYPI_REPO_NAME }}
           ARTIFACTORY_SUBPATH: PR/${{ github.event.pull_request.number }}/${{ github.event.pull_request.head.sha }}/${{ github.run_id }}/${{ github.run_attempt }}
         shell: bash
         run: |
           set -euo pipefail
           : "${ARTIFACTORY_URL:?ARTIFACTORY_URL is not configured}"
-          : "${ARTIFACTORY_TOKEN:?ARTIFACTORY_PR_TOKEN is not configured}"
+          : "${ARTIFACTORY_TOKEN:?ARTIFACTORY_TOKEN is not configured}"
           : "${ARTIFACTORY_PYPI_REPO_NAME:?ARTIFACTORY_PYPI_REPO_NAME is not configured}"
           if [[ "${ARTIFACTORY_URL}" != https://* ]]; then
             echo "::error::ARTIFACTORY_URL must use HTTPS"

--- a/.github/workflows/validate-platform-wheels.yml
+++ b/.github/workflows/validate-platform-wheels.yml
@@ -11,6 +11,7 @@ on:
       - synchronize
     paths:
       - ".github/actions/build-platform-wheel/**"
+      - ".github/workflows/build-platform-wheels-copied-pr.yml"
       - ".github/workflows/build-platform-wheels.yml"
       - ".github/workflows/validate-platform-wheels.yml"
       - "docker/Dockerfile"

--- a/.github/workflows/validate-platform-wheels.yml
+++ b/.github/workflows/validate-platform-wheels.yml
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Validate platform wheels
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    paths:
+      - ".github/actions/build-platform-wheel/**"
+      - ".github/workflows/build-platform-wheels.yml"
+      - ".github/workflows/validate-platform-wheels.yml"
+      - "docker/Dockerfile"
+      - "LICENSE"
+      - "pyproject.toml"
+      - "README.md"
+      - "aic-core/**"
+      - "src/**"
+      - "tools/build_legacy_monolith_fixture.py"
+      - "tools/verify_installed_package_layers.py"
+      - "tools/verify_release_wheels.py"
+
+concurrency:
+  group: validate-platform-wheels-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  linux-amd64:
+    name: Build wheels (manylinux_2_28_x86_64)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+          lfs: true
+
+      - name: Build and verify wheel set
+        uses: ./.github/actions/build-platform-wheel
+        with:
+          build_method: docker
+          python_architecture: x64
+          platform: linux/amd64
+          wheel_base: quay.io/pypa/manylinux_2_28_x86_64
+
+  linux-arm64:
+    name: Build wheels (manylinux_2_28_aarch64)
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 90
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+          lfs: true
+
+      - name: Build and verify wheel set
+        uses: ./.github/actions/build-platform-wheel
+        with:
+          build_method: docker
+          python_architecture: arm64
+          platform: linux/arm64
+          wheel_base: quay.io/pypa/manylinux_2_28_aarch64
+
+  macos-arm64:
+    name: Build wheels (macosx_arm64)
+    runs-on: macos-14
+    timeout-minutes: 90
+    steps:
+      - name: Verify GitHub-hosted macOS runner
+        shell: bash
+        run: |
+          test "$(uname -m)" = "arm64"
+          sw_vers
+
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+          lfs: true
+
+      - name: Build and verify wheel set
+        uses: ./.github/actions/build-platform-wheel
+        with:
+          build_method: native-macos
+          python_architecture: arm64


### PR DESCRIPTION
## Summary

- keep ordinary pull-request wheel validation on GitHub-hosted Linux and macOS runners
- run privileged native builds and Artifactory staging only after copy-pr-bot pushes the approved SHA to `pull-request/<number>`
- route trusted Apple Silicon wheel jobs to `prod-aiconfigurator-default-macos-arm64-v1`
- verify the native macOS host is ARM64 and has Xcode Command Line Tools, Git LFS, Rustup, and a writable fixed-path Python tool cache
- select the expected Python architecture explicitly on every platform
- install pinned `uv 0.11.18` through the org-allowlisted, SHA-pinned `astral-sh/setup-uv` action and isolate both the macOS virtual environment and uv cache per run
- use `ARTIFACTORY_PR_TOKEN` for copied-PR staging/finalization while retaining `ARTIFACTORY_TOKEN` for trusted `main` and `release/*` publication

## Why

The macOS wheel build from #1381 succeeded through wheel verification and native-extension smoke testing on GitHub-hosted Apple Silicon, but that runner could not resolve `artifactory.nvidia.com`. The production VPC-connected native runner provides the required Artifactory path and prewarmed Python tool cache.

PR-controlled workflow code must not execute automatically on persistent self-hosted runners or receive release-scoped credentials. This PR therefore separates unprivileged hosted validation from copy-pr-bot-approved privileged execution and uses the dedicated PR-scoped Artifactory credential for the copied-PR namespace.

## Trust and publication model

- `.github/workflows/validate-platform-wheels.yml` handles `pull_request` validation on GitHub-hosted runners without Artifactory secrets.
- `.github/workflows/build-platform-wheels-copied-pr.yml` runs on trusted `push` events to `pull-request/*` after copy-pr-bot approval.
- Copied-PR artifacts are written below immutable `PR/<number>/<sha>/<run>/<attempt>/` paths with `ARTIFACTORY_PR_TOKEN`.
- Post-merge `main` and `release/*` publication continues to use `ARTIFACTORY_TOKEN`.

## Live validation

- exact commit: `1060a3b9dd966ed9b56daa3392b1c252d48e0af6`
- [Build copied-PR platform wheels run 30602089526](https://github.com/ai-dynamo/aiconfigurator/actions/runs/30602089526) passed
- Linux AMD64, Linux ARM64, and macOS ARM64 all built and verified successfully
- copied-PR staging authenticated with `ARTIFACTORY_PR_TOKEN`
- the finalizer created `_COMPLETE.json` under `PR/1436/1060a3b9dd966ed9b56daa3392b1c252d48e0af6/30602089526/1/`

## Validation

- YAML parse for `.github/workflows/build-platform-wheels.yml`
- `git diff --check`
- exact-head hosted validation and copied-PR native build/staging run
- SSH-signed, DCO-compliant commits verified by GitHub

## Infrastructure status

The native runner is provisioned, registered, and online. [Velonix PR #542](https://github.com/ai-dynamo/velonix/pull/542) captures the final M2 Pro placement, Python tool-cache prewarm, and boot-persistent LaunchDaemon configuration. No Terraform apply is part of this PR.