### PR TITLE
docs: align package examples with 0.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ owner first when crossing this package boundary:
 
 ```bash
 python3 -m pip uninstall -y aiconfigurator aiconfigurator-core
-python3 -m pip install 'aiconfigurator==0.10.0'
+python3 -m pip install 'aiconfigurator==0.11.0'
 ```
 
 If a normal upgrade was already attempted, repair the core payload with:
 
 ```bash
-python3 -m pip install --force-reinstall --no-deps 'aiconfigurator-core==0.10.0'
+python3 -m pip install --force-reinstall --no-deps 'aiconfigurator-core==0.11.0'
 ```
 
 ### Build and Install from Source

--- a/aic-core/rust/aiconfigurator-core/README.md
+++ b/aic-core/rust/aiconfigurator-core/README.md
@@ -41,7 +41,7 @@ crate's `embed-python` feature, which enables PyO3's `auto-initialize` support:
 
 ```toml
 [dependencies]
-aiconfigurator-core = { version = "0.10.0", features = ["embed-python"] }
+aiconfigurator-core = { version = "0.11.0", features = ["embed-python"] }
 ```
 
 Applications that embed Python in an existing host may initialize the


### PR DESCRIPTION
## Summary

- update the documented `aiconfigurator` 0.9 migration install and repair commands from `0.10.0` to the current stable `0.11.0` release
- update the Rust `aiconfigurator-core` consumer dependency example to `0.11.0`
- preserve historical schema/attribution references, backend/test fixture versions, and the non-publishable `aiconfigurator-core-public-api` test crate at `0.0.0`

## Why

The 0.11.0 release bump updated both publishable Python project versions, the exact `aiconfigurator-core` wheel dependency pin, the Rust crate manifest, and tracked lock metadata, but three current installation/dependency examples remained pinned to 0.10.0. This aligns the user-facing examples with the published package metadata.

## Impact

Users following the upgrade and Rust consumer documentation will install or depend on the matching 0.11.0 packages. There is no runtime, backend-data, or package-manifest behavior change.

## Validation

- structural TOML/lock audit of every tracked publishable `aiconfigurator*` project/crate and lock entry
- `uv lock --check --offline`
- `pytest -q tests/cross_package/test_core_version_contract.py -p no:timeout` (2 passed)
- `ruff check .`
- `ruff format --check .`
- `cargo metadata --no-deps --format-version 1 --manifest-path aic-core/rust/aiconfigurator-core/Cargo.toml`
- `PYO3_PYTHON=.venv/bin/python cargo check --locked --workspace`
- built `aiconfigurator-0.11.0-py3-none-any.whl`
- built `aiconfigurator_core-0.11.0-cp310-abi3-macosx_11_0_arm64.whl`
- `python tools/verify_release_wheels.py <wheelhouse>` (181 upper + 1,894 core payload files; disjoint ownership; exact `aiconfigurator-core==0.11.0` wheel requirement)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated upgrade instructions to use `aiconfigurator` version 0.11.0.
  * Updated core package repair instructions to force-install version 0.11.0.
  * Updated the Rust dependency example to reference `aiconfigurator-core` 0.11.0 with Python embedding enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->