### PR TITLE
fix(cli): address post-merge review follow-ups from GPU recommender

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ aiconfigurator cli support --model-path Qwen/Qwen3-32B-FP8 --system h200_sxm
   `examples/aisimulate/spica`.
 - Use `exp` to run customized experiments defined in a YAML file.
 - Use `generate` to quickly create a naive configuration without a parameter sweep.
-- Use `recommend` to find the minimum GPU count and optimal deployment configuration needed to meet a performance target. This mode is designed as a procurement sizing tool -- specify exactly one load target (`--target-request-rate` or `--target-concurrency` — mutually exclusive) along with SLA constraints, and the system calculates the minimum GPUs required. You can also omit `--total-gpus` in default mode with a load target for the same behavior.
+- Use `recommend` to find the minimum GPU count and optimal deployment configuration needed to meet a performance target. This mode is designed as a procurement sizing tool -- specify a load target (`--target-request-rate` or `--target-concurrency`, mutually exclusive) along with SLA constraints, and the system calculates the minimum GPUs required. You can also omit `--total-gpus` in default mode with a load target for the same behavior.
 - Use `support` to verify if AIC supports a model/hardware combination for agg and disagg modes.
 - `--model` is an alias for `--model-path` in the CLI.
 - Use `--backend` to specify the inference backend: `trtllm` (default), `vllm`, or `sglang`.

--- a/docs/cli_user_guide.md
+++ b/docs/cli_user_guide.md
@@ -347,7 +347,7 @@ print(f"Agg: {agg_supported}, Disagg: {disagg_supported}")
 ### Recommend mode (deployment sizing)
 This mode finds the minimum number of GPUs needed to meet a performance target. It is designed as a procurement sizing tool — the output is unconstrained, suitable for driving purchasing decisions.
 
-Instead of specifying a GPU count (like `default` mode), you specify exactly one load target (request rate or concurrency) along with SLA constraints, and the system calculates the minimum GPUs required.
+Instead of specifying a GPU count (like `default` mode), you specify a load target (request rate or concurrency, mutually exclusive) along with SLA constraints, and the system calculates the minimum GPUs required.
 
 The recommender searches both tensor-parallel and pipeline-parallel configurations to find the most efficient layout. For models too large to fit on a single node, it automatically escalates to multi-node configurations.
 
@@ -366,7 +366,7 @@ aiconfigurator cli recommend --model-path Qwen/Qwen3-32B --system h200_sxm --bac
 **Required arguments:**
 - `--model-path` (alias `--model`): HuggingFace model path or local path containing `config.json`
 - `--system`: System name (GPU type)
-- Exactly one of the following (mutually exclusive):
+- One of the following (mutually exclusive):
   - `--target-request-rate`: Target system request rate in req/s
   - `--target-concurrency`: Target number of concurrent users
 

--- a/docs/cli_user_guide.md
+++ b/docs/cli_user_guide.md
@@ -403,8 +403,8 @@ aiconfigurator cli default --model-path Qwen/Qwen3-32B-FP8 --total-gpus 32 --sys
 or
 aiconfigurator cli default --model-path Qwen/Qwen3-32B-FP8 --total-gpus 32 --system h200_sxm --ttft 1000 --tpot 10 --isl 3000 --osl 512 --prefix 0
 ```
-`model_path`, `total_gpus`, `system` are three required arguments to define the problem.
-If you want to specify your problem with more details, we allow to define `ttft`, `tpot`, `isl`, `osl` and `prefix`.
+`model_path` and `system` are always required. You must provide either `--total-gpus` (fixed GPU budget) or a load target (`--target-request-rate` / `--target-concurrency`, mutually exclusive). When a load target is given without `--total-gpus`, default mode automatically routes to the recommend engine to find the minimum GPU count.
+If you want to specify your problem with more details, you can define `ttft`, `tpot`, `isl`, `osl` and `prefix`.
 
 #### Additional arguments
 

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -2738,9 +2738,9 @@ def main(args):
             _run_recommend(args)
             return
         if has_load_target:
-            logger.warning(
-                "--target-request-rate/--target-concurrency are ignored in default mode when "
-                "--total-gpus is set. Omit --total-gpus to find the minimum GPUs for the load target."
+            raise SystemExit(
+                "--target-request-rate/--target-concurrency cannot be combined with --total-gpus. "
+                "Omit --total-gpus to find the minimum GPUs for the load target."
             )
 
         # Warn when SLA/workload parameters are implicitly defaulted

--- a/tests/integration/test_picking.py
+++ b/tests/integration/test_picking.py
@@ -222,12 +222,10 @@ class TestRecommendPicking:
         result_high = cli_recommend(target_request_rate=20.0, **common)
 
         def min_gpus(cli_result):
-            totals = [
-                int(df["total_gpus_needed"].min())
-                for df in cli_result.best_configs.values()
-                if df is not None and not df.empty and "total_gpus_needed" in df.columns
-            ]
-            return min(totals) if totals else 0
+            df = cli_result.best_configs.get(cli_result.chosen_exp)
+            if df is None or df.empty or "total_gpus_needed" not in df.columns:
+                return 0
+            return int(df["total_gpus_needed"].min())
 
         low_gpus = min_gpus(result_low)
         high_gpus = min_gpus(result_high)

--- a/tests/integration/test_picking.py
+++ b/tests/integration/test_picking.py
@@ -223,9 +223,12 @@ class TestRecommendPicking:
 
         def min_gpus(cli_result):
             df = cli_result.best_configs.get(cli_result.chosen_exp)
-            if df is None or df.empty or "total_gpus_needed" not in df.columns:
-                return 0
-            return int(df["total_gpus_needed"].min())
+            assert df is not None and not df.empty and "total_gpus_needed" in df.columns, (
+                f"{cli_result.chosen_exp} has no total_gpus_needed results"
+            )
+            result = int(df["total_gpus_needed"].min())
+            assert result > 0
+            return result
 
         low_gpus = min_gpus(result_low)
         high_gpus = min_gpus(result_high)

--- a/tests/unit/cli/test_argument_parsing.py
+++ b/tests/unit/cli/test_argument_parsing.py
@@ -604,3 +604,32 @@ class TestCLIArgumentParsing:
                     value,
                 ]
             )
+
+    @pytest.mark.parametrize(
+        ("flag", "value"),
+        [
+            ("--target-request-rate", "0"),
+            ("--target-request-rate", "-1"),
+            ("--target-request-rate", "nan"),
+            ("--target-request-rate", "inf"),
+            ("--target-concurrency", "0"),
+            ("--target-concurrency", "-1"),
+            ("--target-concurrency", "nan"),
+            ("--target-concurrency", "inf"),
+        ],
+    )
+    def test_default_mode_rejects_non_positive_target(self, cli_parser, flag, value):
+        with pytest.raises(SystemExit):
+            cli_parser.parse_args(
+                [
+                    "default",
+                    "--model-path",
+                    "Qwen/Qwen3-32B",
+                    "--system",
+                    "h200_sxm",
+                    "--total-gpus",
+                    "8",
+                    flag,
+                    value,
+                ]
+            )

--- a/tests/unit/generator/test_module_bridge_recommend_gpus.py
+++ b/tests/unit/generator/test_module_bridge_recommend_gpus.py
@@ -104,3 +104,10 @@ class TestRecommendGPUCountDisagg:
         cfg = task_config_to_generator_config(task, row)
         assert cfg["WorkerConfig"]["prefill_workers"] == 2  # 16 // 8 replicas * 1
         assert cfg["WorkerConfig"]["decode_workers"] == 4  # 16 // 8 replicas * 2
+
+    def test_zero_total_gpus_needed_falls_back(self):
+        task = _task(total_gpus=16, serving_mode="disagg")
+        row = _disagg_result_row(total_gpus_needed=0)
+        cfg = task_config_to_generator_config(task, row)
+        assert cfg["WorkerConfig"]["prefill_workers"] == 2  # 16 // 8 replicas * 1
+        assert cfg["WorkerConfig"]["decode_workers"] == 4  # 16 // 8 replicas * 2


### PR DESCRIPTION
## Overview

Address the 5 non-blocking CodeRabbit minors flagged by @Yiming992 during the GPU recommender PR (#1369) review.

## Details

- **min_gpus cross-mode minimum**: The integration test helper compared GPU counts across all modes (agg + disagg), which could produce spurious results. Now compares only the `chosen_exp` mode.
- **Doc wording**: Removed redundant "exactly one ... mutually exclusive" phrasing in README and user guide -- argparse enforces mutual exclusivity, so the docs now say just "mutually exclusive".
- **Silent load target drop**: When both `--total-gpus` and a load target were provided, the load target was silently dropped with a warning. Now raises a hard error so the user must choose one or the other.
- **Non-positive target parse tests**: Added default-mode test coverage mirroring the existing recommend-mode tests for `_positive_float` validation (0, -1, nan, inf).
- **Disagg bridge test**: Added the missing `test_zero_total_gpus_needed_falls_back` case to `TestRecommendGPUCountDisagg`.

Relates to: #1369

## Test plan

- [x] `pytest tests/unit/cli/test_argument_parsing.py` -- 79 passed (8 new)
- [x] `pytest tests/unit/generator/test_module_bridge_recommend_gpus.py` -- 7 passed (1 new)
- [x] `ruff check` -- all clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The CLI now rejects combining `--total-gpus` with load-target options instead of silently ignoring the targets.
  - Improved GPU recommendation handling for disaggregated deployments, including zero-GPU fallback scenarios.
  - Recommendation calculations now use results from the selected experiment only.

- **Documentation**
  - Clarified that request-rate and concurrency targets are mutually exclusive in `recommend` mode.
  - Updated guidance for using load targets in `default` mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->