### PR TITLE
fix(generator): use vLLM disaggregation mode flags

### DIFF
--- a/src/aiconfigurator/generator/aggregators.py
+++ b/src/aiconfigurator/generator/aggregators.py
@@ -157,7 +157,7 @@ def collect_generator_params(
         workers_dict["encode_workers"] = int(encode_workers if encode_workers is not None else 1)
         workers_dict["encode_gpus_per_worker"] = coerce_int(encode_params.get("gpus_per_worker"))
 
-    return {
+    result = {
         "ServiceConfig": service_payload,
         "K8sConfig": k8s_payload,
         "DynConfig": dict(dyn_cfg),
@@ -168,6 +168,9 @@ def collect_generator_params(
         "NodeConfig": {"num_gpus_per_node": int(num_gpus_per_node)},
         "params": role_params,
     }
+    if generator_dynamo_version:
+        result["generator_dynamo_version"] = generator_dynamo_version
+    return result
 
 
 def generate_config_from_yaml(

--- a/src/aiconfigurator/generator/builders/k8s_builder.py
+++ b/src/aiconfigurator/generator/builders/k8s_builder.py
@@ -332,10 +332,15 @@ def _populate_vllm(context: dict[str, Any], resolved_facts: Any = None) -> list[
                 )
             else:
                 transfer_config = '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
-            args.extend(["--is-prefill-worker", "--kv-transfer-config", transfer_config])
+            args.extend(["--disaggregation-mode", "prefill", "--kv-transfer-config", transfer_config])
         elif role == "decode":
             args.extend(
-                ["--is-decode-worker", "--kv-transfer-config", '{"kv_connector":"NixlConnector","kv_role":"kv_both"}']
+                [
+                    "--disaggregation-mode",
+                    "decode",
+                    "--kv-transfer-config",
+                    '{"kv_connector":"NixlConnector","kv_role":"kv_both"}',
+                ]
             )
         elif role is None and kvbm_enabled:
             args.extend(

--- a/src/aiconfigurator/generator/builders/k8s_builder.py
+++ b/src/aiconfigurator/generator/builders/k8s_builder.py
@@ -332,16 +332,11 @@ def _populate_vllm(context: dict[str, Any], resolved_facts: Any = None) -> list[
                 )
             else:
                 transfer_config = '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
-            args.extend(["--disaggregation-mode", "prefill", "--kv-transfer-config", transfer_config])
+            args.extend(context["vllm_prefill_worker_role_args"])
+            args.extend(["--kv-transfer-config", transfer_config])
         elif role == "decode":
-            args.extend(
-                [
-                    "--disaggregation-mode",
-                    "decode",
-                    "--kv-transfer-config",
-                    '{"kv_connector":"NixlConnector","kv_role":"kv_both"}',
-                ]
-            )
+            args.extend(context["vllm_decode_worker_role_args"])
+            args.extend(["--kv-transfer-config", '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'])
         elif role is None and kvbm_enabled:
             args.extend(
                 [

--- a/src/aiconfigurator/generator/config/backend_templates/vllm/run.sh.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/vllm/run.sh.j2
@@ -74,7 +74,7 @@ for ((w=0; w<PREFILL_WORKERS; w++)); do
       --model "$MODEL_PATH" \
       {% if ServiceConfig.served_model_name %}--served-model-name "$SERVED_MODEL_NAME" {% endif %}\
       {% if enable_router %}--kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${EVENT_PORT}\",\"enable_kv_cache_events\":true}" {% endif %}\
-      {{ prefill_cli_args }} --is-prefill-worker --kv-transfer-config '{% if kvbm_enabled %}{"kv_connector":"PdConnector","kv_role":"kv_both","kv_connector_extra_config":{"connectors":[{"kv_connector":"DynamoConnector","kv_connector_module_path":"kvbm.vllm_integration.connector","kv_role":"kv_both"},{"kv_connector":"NixlConnector","kv_role":"kv_both"}]},"kv_connector_module_path":"kvbm.vllm_integration.connector"}{% else %}{"kv_connector":"NixlConnector","kv_role":"kv_both"}{% endif %}' 2>&1 | sed "s/^/[Prefill $w] /" ) &
+      {{ prefill_cli_args }} --disaggregation-mode prefill --kv-transfer-config '{% if kvbm_enabled %}{"kv_connector":"PdConnector","kv_role":"kv_both","kv_connector_extra_config":{"connectors":[{"kv_connector":"DynamoConnector","kv_connector_module_path":"kvbm.vllm_integration.connector","kv_role":"kv_both"},{"kv_connector":"NixlConnector","kv_role":"kv_both"}]},"kv_connector_module_path":"kvbm.vllm_integration.connector"}{% else %}{"kv_connector":"NixlConnector","kv_role":"kv_both"}{% endif %}' 2>&1 | sed "s/^/[Prefill $w] /" ) &
 done
 {% endif %}
 
@@ -95,7 +95,7 @@ for ((w=0; w<DECODE_WORKERS; w++)); do
       --model "$MODEL_PATH" \
       {% if ServiceConfig.served_model_name %}--served-model-name "$SERVED_MODEL_NAME" {% endif %}\
       {% if enable_router %}--kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${EVENT_PORT}\",\"enable_kv_cache_events\":true}" {% endif %}\
-      {{ decode_cli_args }} --is-decode-worker --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' 2>&1 | sed "s/^/[Decode $w] /" ) &
+      {{ decode_cli_args }} --disaggregation-mode decode --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' 2>&1 | sed "s/^/[Decode $w] /" ) &
 done
 {% endif %}
 wait

--- a/src/aiconfigurator/generator/config/backend_templates/vllm/run.sh.j2
+++ b/src/aiconfigurator/generator/config/backend_templates/vllm/run.sh.j2
@@ -74,7 +74,7 @@ for ((w=0; w<PREFILL_WORKERS; w++)); do
       --model "$MODEL_PATH" \
       {% if ServiceConfig.served_model_name %}--served-model-name "$SERVED_MODEL_NAME" {% endif %}\
       {% if enable_router %}--kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${EVENT_PORT}\",\"enable_kv_cache_events\":true}" {% endif %}\
-      {{ prefill_cli_args }} --disaggregation-mode prefill --kv-transfer-config '{% if kvbm_enabled %}{"kv_connector":"PdConnector","kv_role":"kv_both","kv_connector_extra_config":{"connectors":[{"kv_connector":"DynamoConnector","kv_connector_module_path":"kvbm.vllm_integration.connector","kv_role":"kv_both"},{"kv_connector":"NixlConnector","kv_role":"kv_both"}]},"kv_connector_module_path":"kvbm.vllm_integration.connector"}{% else %}{"kv_connector":"NixlConnector","kv_role":"kv_both"}{% endif %}' 2>&1 | sed "s/^/[Prefill $w] /" ) &
+      {{ prefill_cli_args }} {{ vllm_prefill_worker_role_args | join(' ') }} --kv-transfer-config '{% if kvbm_enabled %}{"kv_connector":"PdConnector","kv_role":"kv_both","kv_connector_extra_config":{"connectors":[{"kv_connector":"DynamoConnector","kv_connector_module_path":"kvbm.vllm_integration.connector","kv_role":"kv_both"},{"kv_connector":"NixlConnector","kv_role":"kv_both"}]},"kv_connector_module_path":"kvbm.vllm_integration.connector"}{% else %}{"kv_connector":"NixlConnector","kv_role":"kv_both"}{% endif %}' 2>&1 | sed "s/^/[Prefill $w] /" ) &
 done
 {% endif %}
 
@@ -95,7 +95,7 @@ for ((w=0; w<DECODE_WORKERS; w++)); do
       --model "$MODEL_PATH" \
       {% if ServiceConfig.served_model_name %}--served-model-name "$SERVED_MODEL_NAME" {% endif %}\
       {% if enable_router %}--kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${EVENT_PORT}\",\"enable_kv_cache_events\":true}" {% endif %}\
-      {{ decode_cli_args }} --disaggregation-mode decode --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' 2>&1 | sed "s/^/[Decode $w] /" ) &
+      {{ decode_cli_args }} {{ vllm_decode_worker_role_args | join(' ') }} --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' 2>&1 | sed "s/^/[Decode $w] /" ) &
 done
 {% endif %}
 wait

--- a/src/aiconfigurator/generator/dynamo_features.py
+++ b/src/aiconfigurator/generator/dynamo_features.py
@@ -10,7 +10,10 @@ import json
 import shlex
 from typing import Any
 
+from packaging.version import InvalidVersion, Version
+
 KVBM_SUPPORTED_BACKENDS = frozenset({"trtllm", "vllm"})
+_VLLM_DISAGGREGATION_MODE_MIN_DYNAMO_VERSION = Version("1.0.0")
 
 
 def _present(value: Any) -> bool:
@@ -24,6 +27,32 @@ def normalize_router_mode(value: Any) -> str:
     if text in {"round-robin", "round robin"}:
         return "round-robin"
     return text
+
+
+def vllm_worker_role_args(role: str, dynamo_version: str | None) -> list[str]:
+    """Return the vLLM worker-role arguments supported by a Dynamo release.
+
+    Dynamo releases before 1.0 use the legacy boolean worker flags. Dynamo 1.0
+    introduced ``--disaggregation-mode`` and Dynamo 1.4 removed the legacy
+    flags. Missing or non-standard versions use the current interface so
+    callers that select only a backend template version retain modern output.
+    """
+
+    legacy_flags = {
+        "prefill": "--is-prefill-worker",
+        "decode": "--is-decode-worker",
+    }
+    legacy_flag = legacy_flags.get(role)
+    if legacy_flag is None:
+        raise ValueError(f"Unsupported vLLM worker role: {role}")
+
+    try:
+        version = Version(str(dynamo_version).strip()) if dynamo_version else None
+    except InvalidVersion:
+        version = None
+    if version is not None and version < _VLLM_DISAGGREGATION_MODE_MIN_DYNAMO_VERSION:
+        return [legacy_flag]
+    return ["--disaggregation-mode", role]
 
 
 def frontend_cli_args_from_dyn_config(

--- a/src/aiconfigurator/generator/rendering/engine.py
+++ b/src/aiconfigurator/generator/rendering/engine.py
@@ -22,6 +22,7 @@ from packaging.version import InvalidVersion, Version
 from aiconfigurator.generator.dynamo_features import (
     frontend_cli_args_string,
     kvbm_shell_exports_from_dyn_config,
+    vllm_worker_role_args,
 )
 
 from .rule_engine import apply_rule_plugins
@@ -293,6 +294,10 @@ def render_backend_templates(
     _raw_param_values = param_values
     param_values = apply_rule_plugins(dict(param_values), backend)
     context = prepare_template_context(param_values, backend)
+    if backend == "vllm":
+        dynamo_version = param_values.get("generator_dynamo_version")
+        context["vllm_prefill_worker_role_args"] = vllm_worker_role_args("prefill", dynamo_version)
+        context["vllm_decode_worker_role_args"] = vllm_worker_role_args("decode", dynamo_version)
     # Assign backend-specific working_dir (removes need for input-driven path)
     backend_dirs = {
         "trtllm": "/workspace/components/backends/trtllm",

--- a/src/aiconfigurator/generator/sflow.py
+++ b/src/aiconfigurator/generator/sflow.py
@@ -351,7 +351,7 @@ def _vllm_server_script(
         cmd_parts.append(f"  {cli_args} \\")
 
     if disagg_mode == "prefill":
-        cmd_parts.append("  --is-prefill-worker \\")
+        cmd_parts.append("  --disaggregation-mode prefill \\")
         if context.get("sflow_kvbm_env_exports"):
             cmd_parts.append(
                 '  --kv-transfer-config \'{"kv_connector":"PdConnector","kv_role":"kv_both",'
@@ -363,7 +363,7 @@ def _vllm_server_script(
         else:
             cmd_parts.append('  --kv-transfer-config \'{"kv_connector":"NixlConnector","kv_role":"kv_both"}\' \\')
     elif disagg_mode == "decode":
-        cmd_parts.append("  --is-decode-worker \\")
+        cmd_parts.append("  --disaggregation-mode decode \\")
         cmd_parts.append('  --kv-transfer-config \'{"kv_connector":"NixlConnector","kv_role":"kv_both"}\' \\')
     elif context.get("sflow_kvbm_env_exports"):
         cmd_parts.append(

--- a/src/aiconfigurator/generator/sflow.py
+++ b/src/aiconfigurator/generator/sflow.py
@@ -351,7 +351,8 @@ def _vllm_server_script(
         cmd_parts.append(f"  {cli_args} \\")
 
     if disagg_mode == "prefill":
-        cmd_parts.append("  --disaggregation-mode prefill \\")
+        role_args = " ".join(context["vllm_prefill_worker_role_args"])
+        cmd_parts.append(f"  {role_args} \\")
         if context.get("sflow_kvbm_env_exports"):
             cmd_parts.append(
                 '  --kv-transfer-config \'{"kv_connector":"PdConnector","kv_role":"kv_both",'
@@ -363,7 +364,8 @@ def _vllm_server_script(
         else:
             cmd_parts.append('  --kv-transfer-config \'{"kv_connector":"NixlConnector","kv_role":"kv_both"}\' \\')
     elif disagg_mode == "decode":
-        cmd_parts.append("  --disaggregation-mode decode \\")
+        role_args = " ".join(context["vllm_decode_worker_role_args"])
+        cmd_parts.append(f"  {role_args} \\")
         cmd_parts.append('  --kv-transfer-config \'{"kv_connector":"NixlConnector","kv_role":"kv_both"}\' \\')
     elif context.get("sflow_kvbm_env_exports"):
         cmd_parts.append(

--- a/tests/unit/generator/test_aggregators.py
+++ b/tests/unit/generator/test_aggregators.py
@@ -61,3 +61,13 @@ def test_collect_generator_params_preserves_explicit_dynamo_version():
     )
 
     assert result["generator_dynamo_version"] == "0.9.0"
+
+
+def test_collect_generator_params_omits_unspecified_dynamo_version():
+    result = collect_generator_params(
+        service={"model_path": "test/model"},
+        k8s={},
+        backend="vllm",
+    )
+
+    assert "generator_dynamo_version" not in result

--- a/tests/unit/generator/test_aggregators.py
+++ b/tests/unit/generator/test_aggregators.py
@@ -50,3 +50,14 @@ class TestK8sHfHomeDefaulting:
         result = collect_generator_params(service=service, k8s=k8s, backend=backend)
 
         assert result["K8sConfig"]["k8s_hf_home"] == "/workspace/model_cache"
+
+
+def test_collect_generator_params_preserves_explicit_dynamo_version():
+    result = collect_generator_params(
+        service={"model_path": "test/model"},
+        k8s={},
+        backend="vllm",
+        generator_dynamo_version="0.9.0",
+    )
+
+    assert result["generator_dynamo_version"] == "0.9.0"

--- a/tests/unit/generator/test_vllm_worker_role_args.py
+++ b/tests/unit/generator/test_vllm_worker_role_args.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression coverage for vLLM disaggregated worker role arguments."""
+
+from __future__ import annotations
+
+import copy
+
+import yaml
+
+from aiconfigurator.generator.api import generate_backend_artifacts
+
+_BACKEND_VERSION = "0.26.0"
+_REMOVED_ROLE_FLAGS = {"--is-prefill-worker", "--is-decode-worker"}
+
+_PARAMS = {
+    "ServiceConfig": {
+        "model_path": "Qwen/Qwen3-32B-FP8",
+        "served_model_path": "Qwen/Qwen3-32B-FP8",
+        "served_model_name": "Qwen3-32B-FP8",
+        "include_frontend": True,
+    },
+    "K8sConfig": {"name_prefix": "test", "k8s_namespace": "default"},
+    "DynConfig": {"mode": "disagg"},
+    "WorkerConfig": {
+        "agg_workers": 0,
+        "agg_gpus_per_worker": 0,
+        "prefill_workers": 1,
+        "prefill_gpus_per_worker": 1,
+        "decode_workers": 1,
+        "decode_gpus_per_worker": 1,
+    },
+    "NodeConfig": {"num_gpus_per_node": 8},
+    "SlaConfig": {"isl": 1024, "osl": 256},
+    "ModelConfig": {"is_moe": False, "prefix": 0, "nextn": 0},
+    "BenchConfig": {},
+    "params": {
+        "prefill": {
+            "tensor_parallel_size": 1,
+            "pipeline_parallel_size": 1,
+            "data_parallel_size": 1,
+            "max_batch_size": 1,
+            "max_num_tokens": 2524,
+            "max_seq_len": 4096,
+        },
+        "decode": {
+            "tensor_parallel_size": 1,
+            "pipeline_parallel_size": 1,
+            "data_parallel_size": 1,
+            "max_batch_size": 512,
+            "max_num_tokens": 512,
+            "max_seq_len": 4096,
+        },
+    },
+}
+
+
+def _render() -> dict[str, str]:
+    return generate_backend_artifacts(
+        copy.deepcopy(_PARAMS),
+        "vllm",
+        backend_version=_BACKEND_VERSION,
+        deployment_target="dynamo-j2",
+    )
+
+
+def _value_after(args: list[str], flag: str) -> str:
+    assert args.count(flag) == 1
+    return args[args.index(flag) + 1]
+
+
+def test_vllm_disaggregated_k8s_workers_use_disaggregation_mode():
+    artifacts = _render()
+    manifest = yaml.safe_load(artifacts["k8s_deploy.yaml"])
+    services = manifest["spec"]["services"]
+
+    prefill_args = services["VllmPrefillWorker"]["extraPodSpec"]["mainContainer"]["args"]
+    decode_args = services["VllmDecodeWorker"]["extraPodSpec"]["mainContainer"]["args"]
+
+    assert _REMOVED_ROLE_FLAGS.isdisjoint(prefill_args)
+    assert _REMOVED_ROLE_FLAGS.isdisjoint(decode_args)
+    assert _value_after(prefill_args, "--disaggregation-mode") == "prefill"
+    assert _value_after(decode_args, "--disaggregation-mode") == "decode"
+    assert "--kv-transfer-config" in prefill_args
+    assert "--kv-transfer-config" in decode_args
+
+
+def test_vllm_disaggregated_launch_artifacts_use_disaggregation_mode():
+    artifacts = _render()
+    run_scripts = "\n".join(content for name, content in artifacts.items() if name.startswith("run_"))
+    sflow = artifacts["sflow.yaml"]
+
+    for content in (run_scripts, sflow):
+        assert "--is-prefill-worker" not in content
+        assert "--is-decode-worker" not in content
+        assert content.count("--disaggregation-mode prefill") == 1
+        assert content.count("--disaggregation-mode decode") == 1
+        assert content.count("--kv-transfer-config") >= 2

--- a/tests/unit/generator/test_vllm_worker_role_args.py
+++ b/tests/unit/generator/test_vllm_worker_role_args.py
@@ -7,12 +7,16 @@ from __future__ import annotations
 
 import copy
 
+import pytest
 import yaml
 
 from aiconfigurator.generator.api import generate_backend_artifacts
 
-_BACKEND_VERSION = "0.26.0"
-_REMOVED_ROLE_FLAGS = {"--is-prefill-worker", "--is-decode-worker"}
+_VERSION_CASES = [
+    pytest.param("0.9.0", "0.14.1", "legacy", id="dynamo-0.9"),
+    pytest.param("1.0.0", "0.16.0", "disaggregation-mode", id="dynamo-1.0"),
+    pytest.param("1.4.0", "0.26.0", "disaggregation-mode", id="dynamo-1.4"),
+]
 
 _PARAMS = {
     "ServiceConfig": {
@@ -56,11 +60,13 @@ _PARAMS = {
 }
 
 
-def _render() -> dict[str, str]:
+def _render(dynamo_version: str, backend_version: str) -> dict[str, str]:
+    params = copy.deepcopy(_PARAMS)
+    params["generator_dynamo_version"] = dynamo_version
     return generate_backend_artifacts(
-        copy.deepcopy(_PARAMS),
+        params,
         "vllm",
-        backend_version=_BACKEND_VERSION,
+        backend_version=backend_version,
         deployment_target="dynamo-j2",
     )
 
@@ -70,30 +76,51 @@ def _value_after(args: list[str], flag: str) -> str:
     return args[args.index(flag) + 1]
 
 
-def test_vllm_disaggregated_k8s_workers_use_disaggregation_mode():
-    artifacts = _render()
+@pytest.mark.parametrize("dynamo_version,backend_version,interface", _VERSION_CASES)
+def test_vllm_disaggregated_k8s_workers_use_versioned_role_interface(
+    dynamo_version,
+    backend_version,
+    interface,
+):
+    artifacts = _render(dynamo_version, backend_version)
     manifest = yaml.safe_load(artifacts["k8s_deploy.yaml"])
     services = manifest["spec"]["services"]
 
     prefill_args = services["VllmPrefillWorker"]["extraPodSpec"]["mainContainer"]["args"]
     decode_args = services["VllmDecodeWorker"]["extraPodSpec"]["mainContainer"]["args"]
 
-    assert _REMOVED_ROLE_FLAGS.isdisjoint(prefill_args)
-    assert _REMOVED_ROLE_FLAGS.isdisjoint(decode_args)
-    assert _value_after(prefill_args, "--disaggregation-mode") == "prefill"
-    assert _value_after(decode_args, "--disaggregation-mode") == "decode"
+    if interface == "legacy":
+        assert "--is-prefill-worker" in prefill_args
+        assert "--is-decode-worker" in decode_args
+        assert "--disaggregation-mode" not in prefill_args
+        assert "--disaggregation-mode" not in decode_args
+    else:
+        assert "--is-prefill-worker" not in prefill_args
+        assert "--is-decode-worker" not in decode_args
+        assert _value_after(prefill_args, "--disaggregation-mode") == "prefill"
+        assert _value_after(decode_args, "--disaggregation-mode") == "decode"
     assert "--kv-transfer-config" in prefill_args
     assert "--kv-transfer-config" in decode_args
 
 
-def test_vllm_disaggregated_launch_artifacts_use_disaggregation_mode():
-    artifacts = _render()
+@pytest.mark.parametrize("dynamo_version,backend_version,interface", _VERSION_CASES)
+def test_vllm_disaggregated_launch_artifacts_use_versioned_role_interface(
+    dynamo_version,
+    backend_version,
+    interface,
+):
+    artifacts = _render(dynamo_version, backend_version)
     run_scripts = "\n".join(content for name, content in artifacts.items() if name.startswith("run_"))
     sflow = artifacts["sflow.yaml"]
 
     for content in (run_scripts, sflow):
-        assert "--is-prefill-worker" not in content
-        assert "--is-decode-worker" not in content
-        assert content.count("--disaggregation-mode prefill") == 1
-        assert content.count("--disaggregation-mode decode") == 1
+        if interface == "legacy":
+            assert content.count("--is-prefill-worker") == 1
+            assert content.count("--is-decode-worker") == 1
+            assert "--disaggregation-mode" not in content
+        else:
+            assert "--is-prefill-worker" not in content
+            assert "--is-decode-worker" not in content
+            assert content.count("--disaggregation-mode prefill") == 1
+            assert content.count("--disaggregation-mode decode") == 1
         assert content.count("--kv-transfer-config") >= 2

--- a/tests/unit/generator_validator/test_vllm_validator.py
+++ b/tests/unit/generator_validator/test_vllm_validator.py
@@ -84,8 +84,8 @@ def _write_vllm_result_tree(root: Path) -> None:
     _write_k8s_manifest(
         root / "disagg" / "top1" / "k8s_deploy.yaml",
         {
-            "VllmPrefillWorker": [*_base_vllm_args(), "--is-prefill-worker"],
-            "VllmDecodeWorker": [*_base_vllm_args(), "--is-decode-worker"],
+            "VllmPrefillWorker": [*_base_vllm_args(), "--disaggregation-mode", "prefill"],
+            "VllmDecodeWorker": [*_base_vllm_args(), "--disaggregation-mode", "decode"],
         },
     )
 
@@ -165,3 +165,24 @@ def test_vllm_engine_args_yaml_still_uses_dict_fallback(tmp_path, monkeypatch):
 
     assert config == {"model": "Qwen/Qwen3-0.6B"}
     assert resolved_model is None
+
+
+@pytest.mark.parametrize("flag", ["--is-prefill-worker", "--is-decode-worker"])
+def test_vllm_validator_rejects_removed_worker_role_flags(flag, monkeypatch):
+    monkeypatch.setattr(vllm_backend, "_import_vllm_engine_args", _fake_vllm_import)
+
+    with pytest.raises(ValueError, match=flag):
+        vllm_backend.validate_vllm_engine_args_from_cli([*_base_vllm_args(), flag])
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["--disaggregation-mode"],
+        ["--disaggregation-mode", "invalid"],
+        ["--disaggregation-mode=invalid"],
+    ],
+)
+def test_vllm_validator_rejects_invalid_disaggregation_mode(args):
+    with pytest.raises(ValueError, match="disaggregation-mode"):
+        vllm_backend._normalize_cli_args(args)

--- a/tests/unit/generator_validator/test_vllm_validator.py
+++ b/tests/unit/generator_validator/test_vllm_validator.py
@@ -167,12 +167,28 @@ def test_vllm_engine_args_yaml_still_uses_dict_fallback(tmp_path, monkeypatch):
     assert resolved_model is None
 
 
-@pytest.mark.parametrize("flag", ["--is-prefill-worker", "--is-decode-worker"])
-def test_vllm_validator_rejects_removed_worker_role_flags(flag, monkeypatch):
+@pytest.mark.parametrize(
+    "role_args",
+    [
+        ["--is-prefill-worker"],
+        ["--is-decode-worker"],
+        ["--disaggregation-mode", "prefill"],
+        ["--disaggregation-mode", "decode"],
+    ],
+)
+def test_vllm_validator_accepts_supported_dynamo_worker_role_interfaces(role_args, monkeypatch):
     monkeypatch.setattr(vllm_backend, "_import_vllm_engine_args", _fake_vllm_import)
 
-    with pytest.raises(ValueError, match=flag):
-        vllm_backend.validate_vllm_engine_args_from_cli([*_base_vllm_args(), flag])
+    config = vllm_backend.validate_vllm_engine_args_from_cli([*_base_vllm_args(), *role_args])
+
+    assert config == {"model": "Qwen/Qwen3-0.6B"}
+
+
+def test_vllm_validator_rejects_mixed_worker_role_interfaces():
+    with pytest.raises(ValueError, match="Cannot mix legacy"):
+        vllm_backend._normalize_cli_args(
+            [*_base_vllm_args(), "--is-prefill-worker", "--disaggregation-mode", "prefill"]
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/generator_validator/test_vllm_validator.py
+++ b/tests/unit/generator_validator/test_vllm_validator.py
@@ -174,6 +174,8 @@ def test_vllm_engine_args_yaml_still_uses_dict_fallback(tmp_path, monkeypatch):
         ["--is-decode-worker"],
         ["--disaggregation-mode", "prefill"],
         ["--disaggregation-mode", "decode"],
+        ["--disaggregation-mode=prefill"],
+        ["--disaggregation-mode=decode"],
     ],
 )
 def test_vllm_validator_accepts_supported_dynamo_worker_role_interfaces(role_args, monkeypatch):

--- a/tools/generator_validator/backend/vllm.py
+++ b/tools/generator_validator/backend/vllm.py
@@ -40,10 +40,21 @@ def _dict_to_cli_args(payload: dict[str, Any]) -> list[str]:
 
 
 def _normalize_cli_args(args: list[str]) -> list[str]:
+    legacy_role_flags = {"--is-prefill-worker", "--is-decode-worker"}
+    has_legacy_role = any(str(item) in legacy_role_flags for item in args)
+    has_disaggregation_mode = any(
+        str(item) == "--disaggregation-mode" or str(item).startswith("--disaggregation-mode=") for item in args
+    )
+    if has_legacy_role and has_disaggregation_mode:
+        raise ValueError("Cannot mix legacy vLLM worker-role flags with --disaggregation-mode.")
+
     normalized: list[str] = []
     index = 0
     while index < len(args):
         item = str(args[index])
+        if item in legacy_role_flags:
+            index += 1
+            continue
         if item == "--disaggregation-mode":
             if index + 1 >= len(args):
                 raise ValueError("--disaggregation-mode requires a value.")

--- a/tools/generator_validator/backend/vllm.py
+++ b/tools/generator_validator/backend/vllm.py
@@ -40,8 +40,27 @@ def _dict_to_cli_args(payload: dict[str, Any]) -> list[str]:
 
 
 def _normalize_cli_args(args: list[str]) -> list[str]:
-    ignored_flags = {"--is-prefill-worker", "--is-decode-worker"}
-    return [str(item) for item in args if str(item) not in ignored_flags]
+    normalized: list[str] = []
+    index = 0
+    while index < len(args):
+        item = str(args[index])
+        if item == "--disaggregation-mode":
+            if index + 1 >= len(args):
+                raise ValueError("--disaggregation-mode requires a value.")
+            mode = str(args[index + 1])
+            if mode not in {"agg", "pd", "prefill", "decode", "encode"}:
+                raise ValueError(f"Unsupported --disaggregation-mode value: {mode}")
+            index += 2
+            continue
+        if item.startswith("--disaggregation-mode="):
+            mode = item.partition("=")[2]
+            if mode not in {"agg", "pd", "prefill", "decode", "encode"}:
+                raise ValueError(f"Unsupported --disaggregation-mode value: {mode}")
+            index += 1
+            continue
+        normalized.append(item)
+        index += 1
+    return normalized
 
 
 def _parse_args_with_errors(parser, args: list[str], context: str):


### PR DESCRIPTION
## Summary

- select the vLLM worker-role interface from `generator_dynamo_version`
  - Dynamo 0.9 and earlier: `--is-prefill-worker` / `--is-decode-worker`
  - Dynamo 1.0 and later: `--disaggregation-mode prefill|decode`
- apply the same capability decision to Kubernetes DGD, local `run.sh`, and SFlow generation while preserving KV-transfer configuration
- preserve an explicitly requested Dynamo version through generator parameter aggregation
- validate both supported Dynamo role interfaces while rejecting malformed or mixed role arguments
- add regression coverage at the Dynamo 0.9, 1.0, and 1.4 boundaries

## Root cause

AIConfigurator appended Dynamo's vLLM worker-role flags in builder and launcher code outside the versioned vLLM CLI templates. Dynamo 1.0 introduced `--disaggregation-mode`, and Dynamo 1.4 removed the legacy role flags. Replacing the flags unconditionally fixes Dynamo 1.4 but breaks supported Dynamo 0.6 through 0.9 runtimes.

## Impact

Generated disaggregated vLLM deployments now use the worker-role contract accepted by their target Dynamo runtime:

- supported pre-1.0 releases retain their legacy worker flags
- Dynamo 1.0 and newer releases use `--disaggregation-mode`
- all versions retain their existing `--kv-transfer-config` values

## Validation

- `.venv/bin/python -m pytest -p no:timeout -q tests/unit/generator tests/unit/generator_validator` — 254 passed, 4 skipped
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- generated Dynamo 0.9 and 1.4 vLLM disaggregated `run.sh` artifacts validated with `bash -n`
- `git diff --check`

## Tracking

- NVBug 6537437
- DYN-917


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Disaggregated vLLM worker launch commands now select role interface by Dynamo version, using `--disaggregation-mode prefill|decode`.
  * Worker CLI args are generated for legacy vs modern interfaces.
* **Bug Fixes**
  * CLI validation now errors when legacy role flags and `--disaggregation-mode` are mixed.
  * `--kv-transfer-config` behavior for prefill/decode remains consistent.
* **Tests**
  * Expanded unit and validator coverage with version/interface matrices and additional regression cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->