### PR TITLE
fix(cli): resolve SGLang DeepEP gate through the perf database

### DIFF
--- a/aic-core/src/aiconfigurator_core/sdk/perf_database.py
+++ b/aic-core/src/aiconfigurator_core/sdk/perf_database.py
@@ -1888,6 +1888,231 @@ def _op_file_family_from_path(primary_path: str, system_data_root: str) -> str |
     return None
 
 
+def _reuse_op_source_records(
+    op_filename_enum: PerfDataFilename,
+    primary_path: str,
+    system_data_root: str,
+    *,
+    backend: str,
+    version: str,
+    enable_shared_layer: bool,
+    strict_provenance: bool,
+    kernel_source_manifest_entries: dict[str, tuple[dict, ...]],
+) -> list[dict[str, object]]:
+    """Reuse-channel sources (design §6.2-§6.4) for one op file, in priority order.
+
+    This is everything ``PerfDatabase._build_op_sources`` admits AFTER the
+    active backend/version's own primary file: declared donors, nearest-earlier
+    same-backend siblings, then kernel-identity-gated cross-backend fill. Only
+    sources whose file exists are returned; each record carries ``version``,
+    ``path``, ``channel`` and ``ks_filter``, plus ``low_fidelity`` on
+    cross-backend records so the caller can warn about them.
+
+    Module-level (rather than a method) so the CLI can ask "would the database
+    find rows for this op at this version?" via ``resolve_op_data_sources``
+    without instantiating -- and therefore fully loading -- a ``PerfDatabase``.
+    Both callers share this one implementation so the ordering and the
+    exclusions below cannot drift apart.
+    """
+    if not enable_shared_layer:
+        return []
+    if op_filename_enum in (PerfDataFilename.nccl, PerfDataFilename.oneccl):
+        return []
+    if _op_file_family_from_path(primary_path, system_data_root) == _COMM_FAMILY_DIR:
+        return []
+
+    op_file_basename = op_filename_enum.value
+    backend_lower = backend.lower()
+    records: list[dict[str, object]] = []
+
+    # Channel 2 (design §6.3): declared donors from the REQUESTED version
+    # dir's reuse.yaml, in file order. Duplicate (table, from_version)
+    # entries in one reuse.yaml would otherwise admit the same source
+    # twice -- table is fixed to op_file_basename for this call, so
+    # `declared_donor_versions` membership alone is the (table,
+    # from_version) dedupe key; first occurrence wins (AIC-1503 PR4
+    # task 5, FIX 2).
+    declared_donor_versions: set[str] = set()
+    for reuse_entry in _requested_version_reuse_entries(
+        system_data_root, backend_lower, version, op_file_basename, strict=strict_provenance
+    ):
+        from_version = reuse_entry["from_version"]
+        if from_version in declared_donor_versions:
+            logger.debug(
+                "Duplicate declared-reuse entry for table %s from_version %s under %s; first occurrence wins.",
+                reuse_entry["table"],
+                from_version,
+                system_data_root,
+            )
+            continue
+        donor_path = resolve_op_data_path(system_data_root, backend_lower, from_version, op_file_basename)
+        if not os.path.isfile(donor_path):
+            continue
+        records.append(
+            {
+                "version": from_version,
+                "path": donor_path,
+                "channel": "declared_reuse",
+                "ks_filter": None,
+            }
+        )
+        declared_donor_versions.add(from_version)
+
+    # Channel 1 aka §6.2 (nearest-earlier same-backend fallback). Unparseable
+    # sibling versions can't be ordered against the requested version, so
+    # they're excluded here (logged once) — an explicit declaration still
+    # works for them. Versions already admitted as declared donors above
+    # are excluded too — the dominant real reuse.yaml pattern points
+    # BACKWARD at an earlier sibling, and without this exclusion that same
+    # physical source would be listed twice (channels declared_reuse AND
+    # fallback), doubling I/O and duplicating data_provenance rows.
+    requested_parsed = parse_support_matrix_version(version)
+    if requested_parsed is not None:
+        sibling_versions = {v for v, _ in _iter_backend_version_dirs(system_data_root, backend_lower)}
+        sibling_versions.discard(version)
+        sibling_versions -= declared_donor_versions
+        earlier_versions = []
+        for sibling_version in sibling_versions:
+            parsed = parse_support_matrix_version(sibling_version)
+            if parsed is None:
+                _warn_unparseable_sibling_version_once(system_data_root, backend_lower, sibling_version)
+                continue
+            if parsed >= requested_parsed:
+                continue  # Never admit newer-than-requested implicitly.
+            earlier_versions.append((parsed, sibling_version))
+        earlier_versions.sort(key=lambda item: item[0], reverse=True)  # nearest-earlier first
+        for _, sibling_version in earlier_versions:
+            sibling_path = resolve_op_data_path(system_data_root, backend_lower, sibling_version, op_file_basename)
+            if not os.path.isfile(sibling_path):
+                continue
+            records.append({"version": sibling_version, "path": sibling_path, "channel": "fallback", "ks_filter": None})
+
+    # Channel 4 aka §6.4 (cross-backend fill, kernel-identity gated). Same
+    # mechanism as before; the active backend is excluded from
+    # `ordered_frameworks` because channels 2-3 above already cover it.
+    per_framework_filter: dict[str, set[str]] = defaultdict(set)
+    per_framework_fallback: dict[str, set[str]] = defaultdict(set)
+    for entry in kernel_source_manifest_entries.get(op_file_basename, ()):
+        frameworks_lower = {fw.lower() for fw in entry.get("frameworks") or []}
+        if backend_lower not in frameworks_lower:
+            continue  # Active backend isn't listed as a consumer of this kernel_source.
+        ks = entry.get("kernel_source")
+        if not ks:
+            continue
+        tier = entry.get("tier")
+        if tier in ("shared", "shared_fallback"):
+            for fw in frameworks_lower:
+                per_framework_filter[fw].add(ks)
+            if tier == "shared_fallback":
+                for fw in frameworks_lower:
+                    per_framework_fallback[fw].add(ks)
+
+    ordered_frameworks = sorted(set(per_framework_filter) - {backend_lower})
+
+    # Sort key for newest-first ordering. Parseable PEP 440 versions form one
+    # group and always rank above unparseable strings — guarantees `1.10.0`
+    # beats `1.2.0` regardless of the lexicographic accident.
+    def _newest_first(candidate_version: str) -> tuple:
+        parsed = parse_support_matrix_version(candidate_version)
+        return (1, parsed) if parsed is not None else (0, candidate_version)
+
+    for framework in ordered_frameworks:
+        ks_filter = per_framework_filter[framework]
+        fallback_only = per_framework_fallback.get(framework, set())
+        fw_versions = sorted(
+            {v for v, _ in _iter_backend_version_dirs(system_data_root, framework)},
+            key=_newest_first,
+            reverse=True,
+        )
+        for sibling_version in fw_versions:
+            sibling_path = resolve_op_data_path(system_data_root, framework, sibling_version, op_file_basename)
+            if not os.path.isfile(sibling_path):
+                continue
+            records.append(
+                {
+                    "version": sibling_version,
+                    "path": sibling_path,
+                    "channel": "cross_backend",
+                    "ks_filter": ks_filter,
+                    "low_fidelity": bool(fallback_only & ks_filter),
+                }
+            )
+    return records
+
+
+def resolve_op_data_sources(
+    system: str,
+    backend: str,
+    version: str,
+    op_filename: str | PerfDataFilename,
+    systems_paths: str | list[str] | None = None,
+    *,
+    shared_layer: bool = True,
+    strict_provenance: bool | None = None,
+) -> list[str]:
+    """Existing perf files a ``get_database`` would read for one op table.
+
+    Answers "if I ask the perf database for this table at this version, will
+    it find rows?" — the returned list is empty exactly when every source
+    ``PerfDatabase._build_op_sources`` would admit is absent from disk. Paths
+    come back in load priority order (primary first, then the reuse channels),
+    resolved across both the family-first and legacy tree layouts.
+
+    Use this instead of ``os.path.isfile(resolve_op_data_path(...))`` whenever
+    the question is availability rather than the identity of one specific
+    file: a version bucket that inherits a table from an earlier bucket has no
+    raw file of its own, yet the database loads it fine.
+
+    Searches ``systems_paths`` in order and answers from the first root that
+    holds anything for this op, mirroring how ``get_database`` keeps looking
+    past a root that declares the system but not the data. Returns an empty
+    list when no root has it. Raises ``ValueError`` for an op filename that is
+    not a known ``PerfDataFilename``.
+    """
+    op_filename_enum = op_filename if isinstance(op_filename, PerfDataFilename) else PerfDataFilename(str(op_filename))
+    if systems_paths is None:
+        systems_paths = get_systems_paths()
+    elif isinstance(systems_paths, str):
+        systems_paths = [systems_paths]
+
+    effective_strict = _strict_provenance_enabled(strict_provenance)
+    for systems_root in systems_paths:
+        system_yaml_path = os.path.join(systems_root, f"{system}.yaml")
+        if not os.path.isfile(system_yaml_path):
+            continue
+        try:
+            with open(system_yaml_path, encoding="utf-8") as f:
+                system_spec = yaml.load(f, Loader=yaml.SafeLoader) or {}
+            data_dir = system_spec["data_dir"]
+        except Exception:
+            logger.warning(f"failed to read system spec at {system_yaml_path}, continuing searching")
+            continue
+
+        system_data_root = os.path.join(systems_root, data_dir)
+        primary_path = resolve_op_data_path(system_data_root, backend.lower(), version, op_filename_enum.value)
+        paths = []
+        if os.path.isfile(primary_path) and not _version_dir_partial_for_request(
+            os.path.dirname(primary_path), system_data_root, strict=effective_strict
+        ):
+            paths.append(primary_path)
+        paths.extend(
+            str(record["path"])
+            for record in _reuse_op_source_records(
+                op_filename_enum,
+                primary_path,
+                system_data_root,
+                backend=backend,
+                version=version,
+                enable_shared_layer=shared_layer,
+                strict_provenance=effective_strict,
+                kernel_source_manifest_entries=_load_op_kernel_source_manifest_entries(systems_root),
+            )
+        )
+        if paths:
+            return paths
+    return []
+
+
 def _requested_version_reuse_entries(
     system_data_root: str, backend: str, version: str, op_file_basename: str, *, strict: bool
 ) -> list[dict[str, str]]:
@@ -2257,6 +2482,10 @@ class PerfDatabase:
         cross-backend row would silently clobber an active-backend row on key
         conflict. Same-backend sources (primary/declared/fallback) use no
         filter, same as reading the active backend's own file.
+
+        Channels 2-4 live in the module-level ``_reuse_op_source_records`` so
+        that ``resolve_op_data_sources`` can answer availability questions
+        under the exact same rules without loading a database.
         """
         op_file_basename = op_filename_enum.value
         records: list[dict[str, object]] = []
@@ -2294,136 +2523,26 @@ class PerfDatabase:
             ]
             return [(record["path"], record["ks_filter"]) for record in records]
 
-        if not self.enable_shared_layer:
-            return _finish()
-        if op_filename_enum in (PerfDataFilename.nccl, PerfDataFilename.oneccl):
-            return _finish()
-        if _op_file_family_from_path(primary_path, system_data_root) == _COMM_FAMILY_DIR:
-            return _finish()
-
-        backend_lower = self.backend.lower()
-
-        # Channel 2 (design §6.3): declared donors from the REQUESTED version
-        # dir's reuse.yaml, in file order. Duplicate (table, from_version)
-        # entries in one reuse.yaml would otherwise admit the same source
-        # twice -- table is fixed to op_file_basename for this call, so
-        # `declared_donor_versions` membership alone is the (table,
-        # from_version) dedupe key; first occurrence wins (AIC-1503 PR4
-        # task 5, FIX 2).
-        declared_donor_versions: set[str] = set()
-        for reuse_entry in _requested_version_reuse_entries(
-            system_data_root, backend_lower, self.version, op_file_basename, strict=self.strict_provenance
-        ):
-            from_version = reuse_entry["from_version"]
-            if from_version in declared_donor_versions:
-                logger.debug(
-                    "Duplicate declared-reuse entry for table %s from_version %s under %s; first occurrence wins.",
-                    reuse_entry["table"],
-                    from_version,
-                    system_data_root,
+        reuse_records = _reuse_op_source_records(
+            op_filename_enum,
+            primary_path,
+            system_data_root,
+            backend=self.backend,
+            version=self.version,
+            enable_shared_layer=self.enable_shared_layer,
+            strict_provenance=self.strict_provenance,
+            kernel_source_manifest_entries=self._op_kernel_source_manifest_entries,
+        )
+        for record in reuse_records:
+            if record.pop("low_fidelity", False):
+                logger.warning(
+                    "Loading low-fidelity fallback rows for %s from %s. Queries "
+                    "returning these rows are framework-implicit and may differ "
+                    "from real backend behavior.",
+                    op_file_basename,
+                    record["path"],
                 )
-                continue
-            donor_path = resolve_op_data_path(system_data_root, backend_lower, from_version, op_file_basename)
-            if not os.path.isfile(donor_path):
-                continue
-            records.append(
-                {
-                    "version": from_version,
-                    "path": donor_path,
-                    "channel": "declared_reuse",
-                    "ks_filter": None,
-                }
-            )
-            declared_donor_versions.add(from_version)
-
-        # Channel 1 aka §6.2 (nearest-earlier same-backend fallback). Unparseable
-        # sibling versions can't be ordered against the requested version, so
-        # they're excluded here (logged once) — an explicit declaration still
-        # works for them. Versions already admitted as declared donors above
-        # are excluded too — the dominant real reuse.yaml pattern points
-        # BACKWARD at an earlier sibling, and without this exclusion that same
-        # physical source would be listed twice (channels declared_reuse AND
-        # fallback), doubling I/O and duplicating data_provenance rows.
-        requested_parsed = parse_support_matrix_version(self.version)
-        if requested_parsed is not None:
-            sibling_versions = {v for v, _ in _iter_backend_version_dirs(system_data_root, backend_lower)}
-            sibling_versions.discard(self.version)
-            sibling_versions -= declared_donor_versions
-            earlier_versions = []
-            for sibling_version in sibling_versions:
-                parsed = parse_support_matrix_version(sibling_version)
-                if parsed is None:
-                    _warn_unparseable_sibling_version_once(system_data_root, backend_lower, sibling_version)
-                    continue
-                if parsed >= requested_parsed:
-                    continue  # Never admit newer-than-requested implicitly.
-                earlier_versions.append((parsed, sibling_version))
-            earlier_versions.sort(key=lambda item: item[0], reverse=True)  # nearest-earlier first
-            for _, sibling_version in earlier_versions:
-                sibling_path = resolve_op_data_path(system_data_root, backend_lower, sibling_version, op_file_basename)
-                if not os.path.isfile(sibling_path):
-                    continue
-                records.append(
-                    {"version": sibling_version, "path": sibling_path, "channel": "fallback", "ks_filter": None}
-                )
-
-        # Channel 4 aka §6.4 (cross-backend fill, kernel-identity gated). Same
-        # mechanism as before; the active backend is excluded from
-        # `ordered_frameworks` because channels 2-3 above already cover it.
-        per_framework_filter: dict[str, set[str]] = defaultdict(set)
-        per_framework_fallback: dict[str, set[str]] = defaultdict(set)
-        for entry in self._op_kernel_source_manifest_entries.get(op_file_basename, ()):
-            frameworks_lower = {fw.lower() for fw in entry.get("frameworks") or []}
-            if backend_lower not in frameworks_lower:
-                continue  # Active backend isn't listed as a consumer of this kernel_source.
-            ks = entry.get("kernel_source")
-            if not ks:
-                continue
-            tier = entry.get("tier")
-            if tier in ("shared", "shared_fallback"):
-                for fw in frameworks_lower:
-                    per_framework_filter[fw].add(ks)
-                if tier == "shared_fallback":
-                    for fw in frameworks_lower:
-                        per_framework_fallback[fw].add(ks)
-
-        ordered_frameworks = sorted(set(per_framework_filter) - {backend_lower})
-
-        # Sort key for newest-first ordering. Parseable PEP 440 versions form one
-        # group and always rank above unparseable strings — guarantees `1.10.0`
-        # beats `1.2.0` regardless of the lexicographic accident.
-        def _newest_first(version: str) -> tuple:
-            parsed = parse_support_matrix_version(version)
-            return (1, parsed) if parsed is not None else (0, version)
-
-        for framework in ordered_frameworks:
-            ks_filter = per_framework_filter[framework]
-            fallback_only = per_framework_fallback.get(framework, set())
-            fw_versions = sorted(
-                {v for v, _ in _iter_backend_version_dirs(system_data_root, framework)},
-                key=_newest_first,
-                reverse=True,
-            )
-            for sibling_version in fw_versions:
-                sibling_path = resolve_op_data_path(system_data_root, framework, sibling_version, op_file_basename)
-                if not os.path.isfile(sibling_path):
-                    continue
-                records.append(
-                    {
-                        "version": sibling_version,
-                        "path": sibling_path,
-                        "channel": "cross_backend",
-                        "ks_filter": ks_filter,
-                    }
-                )
-                if fallback_only & ks_filter:
-                    logger.warning(
-                        "Loading low-fidelity fallback rows for %s from %s. Queries "
-                        "returning these rows are framework-implicit and may differ "
-                        "from real backend behavior.",
-                        op_file_basename,
-                        sibling_path,
-                    )
+        records.extend(reuse_records)
         return _finish()
 
     def is_inter_node(self, num_gpus: int) -> bool:

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -32,7 +32,6 @@ from aiconfigurator.sdk.errors import (
     is_expected_cli_error,
 )
 from aiconfigurator.sdk.models import check_is_moe
-from aiconfigurator.sdk.operations.base import resolve_op_data_path
 from aiconfigurator.sdk.speculative import normalize_speculative_decoding
 from aiconfigurator.sdk.task_v2 import Task
 from aiconfigurator.sdk.utils import ListFlowDumper, get_model_config_from_model_path
@@ -1279,15 +1278,6 @@ def _get_system_data_root(system_name: str) -> str | None:
     return None
 
 
-def _get_backend_data_path(system_name: str, backend_name: str, backend_version: str, op_filename: str) -> str | None:
-    """Resolve one perf-data file's on-disk path for (system, backend, version),
-    across both the family-first and legacy tree layouts (see resolve_op_data_path)."""
-    system_data_root = _get_system_data_root(system_name)
-    if system_data_root is None:
-        return None
-    return resolve_op_data_path(system_data_root, backend_name, backend_version, op_filename)
-
-
 _SGLANG_DEEPEP_REQUIRED_FILES = (
     common.PerfDataFilename.wideep_deepep_normal.value,
     common.PerfDataFilename.wideep_deepep_ll.value,
@@ -1306,8 +1296,15 @@ def _sglang_deepep_perf_data_skip_reason(
     decode_system_name: str | None,
     backend_version: str | None,
 ) -> str | None:
-    """Return a concise skip reason when optional SGLang DeepEP data is absent."""
-    missing_paths: list[str] = []
+    """Return a concise skip reason when optional SGLang DeepEP data is absent.
+
+    Availability is decided the same way the perf database decides it
+    (``resolve_op_data_sources``), not by probing for a raw file at the
+    resolved version: a version bucket that inherits the DeepEP tables from an
+    earlier bucket carries no file of its own yet queries fine, and gating on
+    the raw file would skip the sweeps for data the run would have found.
+    """
+    missing_tables: list[str] = []
     missing_versions: list[str] = []
 
     systems_to_check = [system_name]
@@ -1324,19 +1321,18 @@ def _sglang_deepep_perf_data_skip_reason(
             continue
 
         for filename in _SGLANG_DEEPEP_REQUIRED_FILES:
-            resolved_path = _get_backend_data_path(
+            sources = perf_database.resolve_op_data_sources(
                 system_to_check, common.BackendName.sglang.value, resolved_version, filename
             )
-            if resolved_path is None or not os.path.isfile(resolved_path):
-                missing_paths.append(
-                    resolved_path
-                    or f"{system_to_check}/{common.BackendName.sglang.value}/{resolved_version}/{filename}"
+            if not sources:
+                missing_tables.append(
+                    f"{system_to_check}/{common.BackendName.sglang.value}/{resolved_version}/{filename}"
                 )
 
     if missing_versions:
         return "no database version available for " + ", ".join(missing_versions)
-    if missing_paths:
-        return "missing required DeepEP perf data: " + ", ".join(missing_paths)
+    if missing_tables:
+        return "missing required DeepEP perf data: " + ", ".join(missing_tables)
     return None
 
 

--- a/tests/unit/cli/test_cli_workflow.py
+++ b/tests/unit/cli/test_cli_workflow.py
@@ -26,6 +26,7 @@ from aiconfigurator.cli.main import (
 )
 from aiconfigurator.cli.main import main as cli_main
 from aiconfigurator.cli.report_and_save import _apply_inclusive_tpot
+from aiconfigurator.sdk import perf_database
 from aiconfigurator.sdk.errors import NoFeasibleConfigError
 
 pytestmark = pytest.mark.unit
@@ -586,8 +587,8 @@ class TestBuildDefaultTaskConfigs:
         caplog.set_level(logging.INFO, logger="aiconfigurator.cli.main")
 
         with patch(
-            "aiconfigurator.cli.main._get_backend_data_path",
-            side_effect=lambda system, backend, version, filename: str(tmp_path / filename),
+            "aiconfigurator.cli.main.perf_database.resolve_op_data_sources",
+            side_effect=lambda system, backend, version, filename: [],
         ):
             result = build_default_tasks(
                 model_path="deepseek-ai/DeepSeek-R1",
@@ -618,8 +619,8 @@ class TestBuildDefaultTaskConfigs:
             (tmp_path / filename).write_text("header\n", encoding="utf-8")
 
         with patch(
-            "aiconfigurator.cli.main._get_backend_data_path",
-            side_effect=lambda system, backend, version, filename: str(tmp_path / filename),
+            "aiconfigurator.cli.main.perf_database.resolve_op_data_sources",
+            side_effect=lambda system, backend, version, filename: [str(tmp_path / filename)],
         ):
             result = build_default_tasks(
                 model_path="deepseek-ai/DeepSeek-R1",
@@ -634,23 +635,32 @@ class TestBuildDefaultTaskConfigs:
 
 
 class TestSglangDeepepPerfDataSkipReason:
-    """`_sglang_deepep_perf_data_skip_reason` must find DeepEP perf files under the
-    family-first layout (e.g. comm/sglang/<version>/), not just the legacy
-    sglang/<version>/ shape."""
+    """`_sglang_deepep_perf_data_skip_reason` must decide DeepEP availability the
+    way the perf database does: across the family-first layout (e.g.
+    comm/sglang/<version>/) as well as the legacy sglang/<version>/ shape, and
+    including tables the requested version inherits from an earlier one."""
 
     def _write_system_yaml(self, systems_root, system_name, data_dir):
         (systems_root / f"{system_name}.yaml").write_text(f"data_dir: {data_dir}\n", encoding="utf-8")
+
+    def _write_version_dir(self, systems_root, version, *filenames):
+        version_dir = systems_root / "data" / "fake_sys" / "comm" / "sglang" / version
+        version_dir.mkdir(parents=True)
+        for filename in filenames:
+            (version_dir / filename).write_bytes(b"stub")
+        return version_dir
 
     @patch("aiconfigurator.cli.main.perf_database.get_systems_paths")
     def test_none_when_both_files_exist_under_family_dir(self, mock_systems_paths, tmp_path):
         systems_root = tmp_path
         mock_systems_paths.return_value = [str(systems_root)]
         self._write_system_yaml(systems_root, "fake_sys", "data/fake_sys")
-
-        version_dir = systems_root / "data" / "fake_sys" / "comm" / "sglang" / "0.5.6.post2"
-        version_dir.mkdir(parents=True)
-        (version_dir / "wideep_deepep_normal_perf.parquet").write_bytes(b"stub")
-        (version_dir / "wideep_deepep_ll_perf.parquet").write_bytes(b"stub")
+        self._write_version_dir(
+            systems_root,
+            "0.5.6.post2",
+            "wideep_deepep_normal_perf.parquet",
+            "wideep_deepep_ll_perf.parquet",
+        )
 
         reason = _sglang_deepep_perf_data_skip_reason("fake_sys", None, "0.5.6.post2")
 
@@ -666,6 +676,44 @@ class TestSglangDeepepPerfDataSkipReason:
         reason = _sglang_deepep_perf_data_skip_reason("fake_sys", None, "0.5.6.post2")
 
         assert reason is not None
+        assert "wideep_deepep_normal_perf.parquet" in reason
+        assert "wideep_deepep_ll_perf.parquet" in reason
+
+    @patch("aiconfigurator.cli.main.perf_database.get_systems_paths")
+    def test_none_when_default_version_inherits_deepep_from_earlier_version(self, mock_systems_paths, tmp_path):
+        """The latest version bucket routinely ships without its own DeepEP
+        tables and inherits them from an earlier bucket. Gating on a raw file
+        at the resolved version skipped every DeepEP sweep by default even
+        though the perf database loads those rows fine."""
+        systems_root = tmp_path
+        mock_systems_paths.return_value = [str(systems_root)]
+        self._write_system_yaml(systems_root, "fake_sys", "data/fake_sys")
+        self._write_version_dir(
+            systems_root,
+            "0.5.10",
+            "custom_allreduce_perf.parquet",
+            "wideep_deepep_normal_perf.parquet",
+            "wideep_deepep_ll_perf.parquet",
+        )
+        self._write_version_dir(systems_root, "0.5.14", "custom_allreduce_perf.parquet")
+
+        assert perf_database.get_latest_database_version(system="fake_sys", backend="sglang") == "0.5.14"
+        assert _sglang_deepep_perf_data_skip_reason("fake_sys", None, None) is None
+
+    @patch("aiconfigurator.cli.main.perf_database.get_systems_paths")
+    def test_names_missing_files_when_no_version_has_deepep(self, mock_systems_paths, tmp_path):
+        """The inherit-aware lookup must still refuse a tree where no version
+        carries the DeepEP tables at all."""
+        systems_root = tmp_path
+        mock_systems_paths.return_value = [str(systems_root)]
+        self._write_system_yaml(systems_root, "fake_sys", "data/fake_sys")
+        self._write_version_dir(systems_root, "0.5.10", "custom_allreduce_perf.parquet")
+        self._write_version_dir(systems_root, "0.5.14", "custom_allreduce_perf.parquet")
+
+        reason = _sglang_deepep_perf_data_skip_reason("fake_sys", None, None)
+
+        assert reason is not None
+        assert "0.5.14" in reason
         assert "wideep_deepep_normal_perf.parquet" in reason
         assert "wideep_deepep_ll_perf.parquet" in reason
 

--- a/tests/unit/sdk/database/test_reuse_ordering.py
+++ b/tests/unit/sdk/database/test_reuse_ordering.py
@@ -29,7 +29,11 @@ import yaml
 
 from aiconfigurator.sdk import common
 from aiconfigurator.sdk.operations.base import resolve_op_data_path
-from aiconfigurator.sdk.perf_database import PerfDatabase, _load_op_kernel_source_manifest_entries
+from aiconfigurator.sdk.perf_database import (
+    PerfDatabase,
+    _load_op_kernel_source_manifest_entries,
+    resolve_op_data_sources,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -557,3 +561,93 @@ def test_data_provenance_populated_per_op_file(systems_root: Path) -> None:
     _sources_for(db, systems_root, common.PerfDataFilename.moe)
 
     assert set(db.data_provenance.keys()) == {"gemm_perf.parquet", "moe_perf.parquet"}
+
+
+# ---------------------------------------------------------------------------
+# resolve_op_data_sources — the same ordering, answered without loading a
+# database. Callers that only need "will a query find rows?" must get exactly
+# the sources _build_op_sources would admit and find on disk.
+# ---------------------------------------------------------------------------
+
+
+def _existing_sources(db: PerfDatabase, systems_root: Path, op: common.PerfDataFilename) -> list[str]:
+    return [entry["path"] for entry in db.data_provenance[op.value] if entry["exists"]]
+
+
+def test_resolve_op_data_sources_matches_build_op_sources_across_channels(systems_root: Path) -> None:
+    backend, requested, declared, earlier = "trtllm", "1.3.0", "1.4.0", "1.2.0"
+    _write(systems_root, f"data/h100_sxm/gemm/{backend}/{declared}/gemm_perf.parquet")
+    _write(systems_root, f"data/h100_sxm/gemm/{backend}/{earlier}/gemm_perf.parquet")
+    _write(systems_root, "data/h100_sxm/gemm/sglang/0.5.0/gemm_perf.parquet")
+    _write_yaml(
+        systems_root,
+        f"data/h100_sxm/gemm/{backend}/{requested}/reuse.yaml",
+        {"reuse": [_reuse_entry("gemm_perf", declared)]},
+    )
+    _write_manifest(systems_root, [("gemm_perf.parquet", "cutlass", "shared", [backend, "sglang"])])
+
+    db = _build_db(systems_root, backend=backend, version=requested)
+    _sources_for(db, systems_root, common.PerfDataFilename.gemm)
+
+    assert _channels(db, "gemm_perf.parquet") == ["primary", "declared_reuse", "fallback", "cross_backend"]
+    assert resolve_op_data_sources(
+        "h100_sxm", backend, requested, common.PerfDataFilename.gemm, str(systems_root)
+    ) == _existing_sources(db, systems_root, common.PerfDataFilename.gemm)
+
+
+def test_resolve_op_data_sources_finds_comm_table_inherited_by_a_later_version(systems_root: Path) -> None:
+    """The shape that made the CLI's DeepEP gate skip every sweep: the
+    requested (latest) version dir exists under ``comm/`` but carries no
+    DeepEP table, so the primary resolves to the legacy-shaped path, the comm
+    exclusion does not fire (see ``_op_file_family_from_path``), and the
+    earlier sibling fills. A raw-file probe at the requested version sees
+    nothing; the database sees the sibling."""
+    backend, requested, earlier = "sglang", "0.5.14", "0.5.10"
+    _write(systems_root, f"data/h100_sxm/comm/{backend}/{requested}/custom_allreduce_perf.parquet")
+    _write(systems_root, f"data/h100_sxm/comm/{backend}/{earlier}/wideep_deepep_normal_perf.parquet")
+
+    db = _build_db(systems_root, backend=backend, version=requested)
+    _sources_for(db, systems_root, common.PerfDataFilename.wideep_deepep_normal)
+
+    sources = resolve_op_data_sources(
+        "h100_sxm", backend, requested, common.PerfDataFilename.wideep_deepep_normal, str(systems_root)
+    )
+    assert len(sources) == 1
+    assert sources[0].endswith(f"comm/{backend}/{earlier}/wideep_deepep_normal_perf.parquet")
+    assert sources == _existing_sources(db, systems_root, common.PerfDataFilename.wideep_deepep_normal)
+
+
+def test_resolve_op_data_sources_honors_family_layout_comm_exclusion(systems_root: Path) -> None:
+    """When the requested version DOES carry the comm table, the exclusion
+    fires off the family-shaped primary and the earlier sibling stays out —
+    the helper must not report more than the database would load."""
+    backend, requested, earlier = "trtllm", "1.3.0", "1.2.0"
+    _write(systems_root, f"data/h100_sxm/comm/{backend}/{requested}/custom_allreduce_perf.parquet")
+    _write(systems_root, f"data/h100_sxm/comm/{backend}/{earlier}/custom_allreduce_perf.parquet")
+
+    sources = resolve_op_data_sources(
+        "h100_sxm", backend, requested, common.PerfDataFilename.custom_allreduce, str(systems_root)
+    )
+
+    assert len(sources) == 1
+    assert sources[0].endswith(f"comm/{backend}/{requested}/custom_allreduce_perf.parquet")
+
+
+def test_resolve_op_data_sources_empty_when_nothing_on_disk(systems_root: Path) -> None:
+    _write(systems_root, "data/h100_sxm/gemm/trtllm/1.0.0/gemm_perf.parquet")
+
+    root = str(systems_root)
+    assert resolve_op_data_sources("h100_sxm", "trtllm", "1.0.0", common.PerfDataFilename.moe, root) == []
+    assert resolve_op_data_sources("no_such_sys", "trtllm", "1.0.0", common.PerfDataFilename.gemm, root) == []
+
+
+def test_resolve_op_data_sources_shared_layer_off_sees_primary_only(systems_root: Path) -> None:
+    backend, requested, earlier = "trtllm", "1.3.0", "1.2.0"
+    _write(systems_root, f"data/h100_sxm/gemm/{backend}/{earlier}/gemm_perf.parquet")
+
+    assert (
+        resolve_op_data_sources(
+            "h100_sxm", backend, requested, common.PerfDataFilename.gemm, str(systems_root), shared_layer=False
+        )
+        == []
+    )


### PR DESCRIPTION
## Symptom

DeepEP sweeps were silently skipped at the default backend version on every system that actually ships DeepEP data. On `main`, `h100_sxm` and `h200_sxm` — the only two systems carrying `wideep_deepep_normal_perf.parquet` / `wideep_deepep_ll_perf.parquet` — both report:

```
missing required DeepEP perf data:
  .../systems/data/h200_sxm/sglang/0.5.14/wideep_deepep_normal_perf.parquet,
  .../systems/data/h200_sxm/sglang/0.5.14/wideep_deepep_ll_perf.parquet
```

The sweeps were reachable only by passing `--backend-version 0.5.6.post2` explicitly. The path named in that message is itself the tell: it exists in neither tree layout.

## Mechanism

`_sglang_deepep_perf_data_skip_reason` decided availability with `os.path.isfile(resolve_op_data_path(...))` — is there a raw file for this table at the resolved version? The latest declared sglang bucket is `0.5.14`, while the DeepEP tables live at `0.5.6.post2` and are reached through the perf database's nearest-earlier same-backend fallback (design §6.2). The loader finds those rows; a raw-file probe at `0.5.14` cannot see them. The gate and the loader were answering the same question through two different implementations, and they disagreed.

## Fix

Decide availability with the perf database's own source resolution instead of a second, weaker rule.

- The reuse channels of `PerfDatabase._build_op_sources` (declared donors, nearest-earlier same-backend siblings, kernel-identity-gated cross-backend fill) move verbatim to a module-level `_reuse_op_source_records`. `_build_op_sources` now calls it and keeps its existing behaviour, including the low-fidelity warning and the `data_provenance` record shape.
- New `resolve_op_data_sources` answers "which files would a query for this table at this version actually read?" without instantiating — and therefore fully loading — a `PerfDatabase`. It returns existing paths in load-priority order.
- The CLI gate calls that. Gate and loader now share one implementation and cannot drift apart.

The comm-family exclusion asymmetry documented on `_op_file_family_from_path` is untouched: it is still decided from the primary path only, and `test_legacy_layout_comm_op_keeps_pre_v3_siblings` is unmodified. That asymmetry is load-bearing here — when the requested version carries no DeepEP table the primary resolves to a legacy-shaped path, family reads as `None`, and sibling fallback proceeds. The new `test_resolve_op_data_sources_honors_family_layout_comm_exclusion` pins the other side, so a version that *does* carry the table still gets primary-only.

## Effect

Measured on the committed tree, `_sglang_deepep_perf_data_skip_reason(system, None, None)`:

| system | latest sglang | before | after |
| --- | --- | --- | --- |
| `h100_sxm` | 0.5.14 | skipped | **runs** (inherits from 0.5.6.post2) |
| `h200_sxm` | 0.5.14 | skipped | **runs** (inherits from 0.5.6.post2) |
| `gb200`, `gb300`, `b200_sxm`, `b300_sxm`, `l40s`, `rtx_pro_6000_server`, `a100_sxm` | — | skipped | skipped (no DeepEP table at any version) |

Systems with no DeepEP data anywhere still skip, and the reason now names the missing table logically (`<system>/sglang/<version>/<table>`) rather than printing an absolute path that does not exist. When only one of the two tables is missing, only that one is named.

## Why now

We are landing new DeepEP LL data at a new `0.5.12` bucket whose `normal` table stays at `0.5.10` and is inherited rather than duplicated. Under the old raw-file gate, `--backend-version 0.5.12` would have skipped the DeepEP sweep entirely even with a perfect LL table, so this is on the critical path for that data rather than a cleanup. Verified against a synthetic tree of exactly that shape: LL at `comm/sglang/0.5.12/`, `normal` only at `0.5.10` — skipped before, runs after.

## Verification

- **Behaviour preservation of the extraction:** 9,000 randomized synthetic-tree cases comparing `_build_op_sources` on this branch against `origin/main`'s, asserting identical `(path, kernel_source_filter)` lists *and* identical `data_provenance` records. Zero divergence, with coverage across all four channels (8,684 primary / 137 declared_reuse / 1,932 fallback / 6,631 cross_backend) and all 17,384 provenance rows keeping exactly the original key set.
- **Gate/loader agreement:** 12,000 cases asserting `resolve_op_data_sources` returns exactly the sources `_build_op_sources` admits and finds on disk, in the same order, across both tree layouts, partial markers, unparseable versions and `shared_layer` on/off.
- `ruff check .` and `ruff format --check .` clean; `pytest -m unit` 2786 passed, 10 skipped, 0 failures.
- `CODEOWNERS` needs no regeneration: strict coverage 2722/2722 with 0 catch-all-only, and regeneration is byte-identical to the committed artifact.

One scoping note for reviewers: with multiple `--systems-paths`, `resolve_op_data_sources` answers from the first root holding any source for the op, whereas `get_database` selects the first root holding the requested version dir. These coincide for the single-root default; the behaviour is documented on the function.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public SDK utility for discovering all performance-data sources available to an operation, including shared, inherited, fallback, and cross-backend data.
  * Added an option to limit discovery to the primary data source.

* **Improvements**
  * Performance data can now be reused across compatible versions and backends more consistently.
  * DeepEP availability checks now recognize inherited performance data and provide clearer messages when required tables are unavailable.
  * Improved handling of communication performance data and provenance information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->