### PR TITLE
fix(sdk): detect block FP8 compressed-tensors weights (cherry-pick #1444)

### DIFF
--- a/aic-core/src/aiconfigurator_core/sdk/utils.py
+++ b/aic-core/src/aiconfigurator_core/sdk/utils.py
@@ -946,7 +946,8 @@ def parse_compressed_tensors_quant(
     Returns ``(base_algo, ignored_categories)`` where:
 
     - ``base_algo``: weight quantization algorithm (``"int4_wo"``, ``"int8_wo"``,
-      ``"fp8"``), or ``None`` when the config carries no quantization information.
+      ``"fp8"``, ``"fp8_block"``), or ``None`` when the config carries no
+      quantization information.
     - ``ignored_categories``: frozenset of layer-category names excluded from
       quantization (i.e. remaining in float16/bfloat16).  Empty when nothing is
       ignored or when ``base_algo`` is ``None``.
@@ -970,7 +971,9 @@ def parse_compressed_tensors_quant(
             elif num_bits == 8 and "int" in w_type:
                 base_algo = "int8_wo"
             elif num_bits == 8 and "float" in w_type:
-                base_algo = "fp8"
+                strategy = str(weights.get("strategy", "")).lower()
+                block_structure = weights.get("block_structure")
+                base_algo = "fp8_block" if strategy == "block" or block_structure else "fp8"
         if base_algo:
             break
 

--- a/tests/unit/sdk/test_utils.py
+++ b/tests/unit/sdk/test_utils.py
@@ -1139,6 +1139,27 @@ class TestParseCompressedTensorsQuant:
         algo, _ = parse_compressed_tensors_quant(self._make_quant_config(8, "float"))
         assert algo == "fp8"
 
+    @pytest.mark.parametrize(
+        ("strategy", "block_structure"),
+        [
+            pytest.param("block", None, id="block-strategy"),
+            pytest.param("group", [128, 128], id="block-structure"),
+        ],
+    )
+    def test_block_fp8_base_algo(self, strategy, block_structure):
+        """Either compressed-tensors block signal selects block-scaled FP8."""
+        from aiconfigurator.sdk.utils import parse_compressed_tensors_quant
+
+        cfg = self._make_quant_config(8, "float")
+        cfg["config_groups"]["group_0"]["weights"].update(
+            {
+                "strategy": strategy,
+                "block_structure": block_structure,
+            }
+        )
+        algo, _ = parse_compressed_tensors_quant(cfg)
+        assert algo == "fp8_block"
+
     # --- ignored_categories detection ---
 
     def test_no_ignore_empty_set(self):
@@ -1241,6 +1262,45 @@ class TestParseCompressedTensorsQuant:
         overrides = _infer_quant_modes_from_raw_config(raw_config)
         assert overrides.get("gemm_quant_mode") == common.GEMMQuantMode.int4_wo
         assert overrides.get("moe_quant_mode") == common.MoEQuantMode.int4_wo
+
+    def test_redhat_dsv4_maps_block_fp8_attention_and_fp4_experts(self):
+        """The real RedHatAI DSV4 quant layout maps attention and experts independently."""
+        from aiconfigurator.sdk import common
+        from aiconfigurator.sdk.models import _infer_quant_modes_from_raw_config
+
+        fp8_weights = {
+            "num_bits": 8,
+            "type": "float",
+            "strategy": "block",
+            "block_structure": [128, 128],
+        }
+        raw_config = {
+            "architecture": "DeepseekV4ForCausalLM",
+            "expert_dtype": "fp4",
+            "quant_algo": "compressed-tensors",
+            "quantization_config": {
+                "config_groups": {
+                    "group_0": {
+                        "targets": ["re:.*attn.*(fused_wqa_wkv|wq_b|wo_a|wo_b)$"],
+                        "weights": fp8_weights,
+                    },
+                    "group_1": {
+                        "targets": ["re:.*ffn.*(gate|up|down)_proj$"],
+                        "weights": {
+                            "num_bits": 4,
+                            "type": "float",
+                            "strategy": "tensor_group",
+                        },
+                    },
+                },
+                "ignore": [],
+            },
+        }
+
+        overrides = _infer_quant_modes_from_raw_config(raw_config)
+        assert overrides["gemm_quant_mode"] == common.GEMMQuantMode.fp8_block
+        assert overrides["moe_quant_mode"] == common.MoEQuantMode.w4a8_mxfp4_mxfp8
+        assert overrides["kvcache_quant_mode"] == common.KVCacheQuantMode.fp8
 
     def test_modelopt_mixed_precision_config_groups_map_sdk_modes(self):
         """ModelOpt MIXED_PRECISION config groups map FP8 dense layers and NVFP4 routed experts."""


### PR DESCRIPTION
## Overview

Backports [#1444](https://github.com/ai-dynamo/aiconfigurator/pull/1444) to `release/0.11.0`.

## Details

- cherry-picks the merged `main` squash commit `7acb43a64d2740450b24c362830761de0fc43c89`
- contains one signed, DCO-compliant commit based directly on release tip `faa9350523495bb394d8ff1687f40e81e70345ac`
- classifies compressed-tensors FP8 block weights correctly and preserves the RedHatAI DeepSeek-V4 variant boundary
- applies cleanly with no release-specific conflict resolution and no dependency on the other requested backports

## Validation

- stable patch ID matches the merged source commit exactly
- focused model/parser regression suite: 187 passed
- Ruff check and format check on changed Python files
- `git diff --check`

## Tracking

- [NVBug 6531573](https://nvbugspro.nvidia.com/bug/6531573)

## Where should the reviewer start?

See the original PR: https://github.com/ai-dynamo/aiconfigurator/pull/1444
