### PR TITLE
feat(sdk): GEMM quant-transfer ladder via shared primitive + validate-gate mirror

### DIFF
--- a/aic-core/rust/aiconfigurator-core/parity_tests/test_engine_step_parity.py
+++ b/aic-core/rust/aiconfigurator-core/parity_tests/test_engine_step_parity.py
@@ -1185,17 +1185,33 @@ HYBRID_CASES = [
         ),
         id="kimi-k25-b200-vllm-019-hybrid-invariant",
     ),
-    # Ladder miss: NVFP4 MoE on Hopper has no own-shape, cross-shape, or
-    # sibling reference anywhere in the h200/vllm/0.19.0 tables — Python
-    # raises EmpiricalNotImplementedError; the Rust port must fail the same
-    # query point (error-symmetry), never fabricate a SOL/constant value.
+    # Full-model xprofile resolution: NVFP4 on Hopper has no collected GEMM
+    # or MoE tables, but under the default (aggressive) policy the GEMM
+    # quant-transfer ladder borrows across profiles (as does MoE's), so the
+    # whole HYBRID breakdown computes on both sides — value parity. (Before
+    # the GEMM ladder existed this case pinned the error-symmetric miss; the
+    # miss contract moved to the "balanced" case below.)
     pytest.param(
         EngineStepParityCase(
             model_path="nvidia/MiniMax-M2.5-NVFP4",
             system_name="h200_sxm",
             database_mode="HYBRID",
         ),
-        id="minimax-m25-nvfp4-h200-vllm-019-hybrid-miss",
+        id="minimax-m25-nvfp4-h200-vllm-019-hybrid-xprofile",
+    ),
+    # Ladder miss (error-symmetry): with XPROFILE policy-disabled
+    # ("balanced" = xshape+xquant), NVFP4 GEMM (profile (0.5625, 4)) has no
+    # same-profile sibling anywhere in the h200/vllm/0.19.0 tables — Python
+    # raises EmpiricalNotImplementedError; the Rust port must fail the same
+    # query point, never fabricate a SOL/constant value.
+    pytest.param(
+        EngineStepParityCase(
+            model_path="nvidia/MiniMax-M2.5-NVFP4",
+            system_name="h200_sxm",
+            database_mode="HYBRID",
+            transfer_policy="balanced",
+        ),
+        id="minimax-m25-nvfp4-h200-vllm-019-hybrid-balanced-miss",
     ),
     # EMPIRICAL mode: every data-backed op answers SOL(query)/util from its
     # own collected slice — the broadest guard of the ported util math (grid
@@ -1362,16 +1378,19 @@ class TestRustTypedErrorsAcrossFfi:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        # NVFP4 MoE on Hopper: no own-shape/cross-shape/sibling reference
-        # anywhere (the HYBRID_CASES ladder-miss config). Rust raises
-        # `AicError::EmpiricalNotImplemented`, which must surface as the sdk's
-        # EmpiricalNotImplementedError — the typed hybrid-miss — and NOT be
-        # classified as a plain perf-data miss.
+        # NVFP4 GEMM on Hopper with XPROFILE policy-disabled ("balanced"):
+        # no same-profile sibling exists for (0.5625, 4), so the transfer
+        # ladder finds nothing (under the default policy the xprofile borrow
+        # would resolve this — see the HYBRID_CASES xprofile entry). Rust
+        # raises `AicError::EmpiricalNotImplemented`, which must surface as
+        # the sdk's EmpiricalNotImplementedError — the typed hybrid-miss —
+        # and NOT be classified as a plain perf-data miss.
         _prepare_rust_core(monkeypatch)
         case = EngineStepParityCase(
             model_path="nvidia/MiniMax-M2.5-NVFP4",
             system_name="h200_sxm",
             database_mode="HYBRID",
+            transfer_policy="balanced",
         )
         with pytest.raises(errors.EmpiricalNotImplementedError) as excinfo:
             _rust_static_breakdown(case)

--- a/aic-core/rust/aiconfigurator-core/src/operators/gemm.rs
+++ b/aic-core/rust/aiconfigurator-core/src/operators/gemm.rs
@@ -15,11 +15,12 @@
 //! `latency_floor = query_gemm(..., DatabaseMode.SOL)` — not at 0.
 
 use serde::{Deserialize, Serialize};
-use crate::common::enums::{DatabaseMode, GemmQuantMode};
+use crate::common::enums::{DatabaseMode, GemmQuantMode, TransferKind};
 use crate::common::error::AicError;
 use crate::operators::base::{PerformanceResult, Source};
+use crate::operators::moe::policy_fingerprint;
 use crate::operators::util_empirical::{self, UtilGrid, ZeroAwareDeltaLookup};
-use crate::perf_database::gemm::{gemm_sol_latency_ms, normalize_fp8_static_quant};
+use crate::perf_database::gemm::{gemm_quant_by_name, gemm_sol_latency_ms, normalize_fp8_static_quant};
 use crate::perf_database::PerfDatabase;
 
 /// GEMM operation: a dense matrix multiply of shape `M=x, N=n, K=k`.
@@ -151,10 +152,119 @@ fn query_gemm_table(
     }
 }
 
-/// `SOL(query)/util` over the quant's own collected `(m, n, k)` grid.
-/// Mirrors Python `_query_gemm_table::get_empirical` (grid depth 3; the SOL
-/// uses the ORIGINAL quant, numerically identical to the fp8_static->fp8
-/// table quant since the profiles match).
+/// Per-quant achieved-util LEVEL `e(q)` for GEMM, keyed by the
+/// `(memory, compute)` profile. Mirrors `_GEMM_QUANT_UTIL_LEVEL`
+/// (`operations/gemm.py`); consumed ONLY by the cross-profile relation of
+/// the quant-transfer ladder, and only as the ratio `e(query)/e(ref)`.
+/// Derivation method + LOO evidence documented on the Python table.
+const GEMM_QUANT_UTIL_LEVEL: &[(f64, f64, f64)] = &[
+    (2.0, 1.0, 0.70),    // w16a16 / bfloat16              [data 0.55-0.79]
+    (1.0, 1.0, 0.55),    // w8a16 / int8_wo                [inferred]
+    (0.5, 1.0, 0.45),    // w4a16 / int4_wo                [inferred]
+    (1.0, 2.0, 0.45),    // w8a8 / fp8(_block/_ootb), sq   [data 0.28-0.55]
+    (0.5, 2.0, 0.35),    // w4a8                           [inferred]
+    (1.0, 4.0, 0.30),    // w8a4                           [inferred]
+    (0.5, 4.0, 0.30),    // w4a4                           [inferred ≈ nvfp4]
+    (0.5625, 4.0, 0.30), // w4a4 / nvfp4                   [data 0.21-0.36]
+];
+/// Unlisted profile: mid-range relative level (Python `_GEMM_QUANT_UTIL_DEFAULT`).
+const GEMM_QUANT_UTIL_DEFAULT: f64 = 0.45;
+
+/// Achieved-util level `e(q)` for a GEMM quant, by `(memory, compute)`
+/// profile (mirrors `_gemm_quant_util_level`, `operations/gemm.py`).
+fn gemm_quant_util_level(quant: GemmQuantMode) -> f64 {
+    let mapping = quant.mapping();
+    GEMM_QUANT_UTIL_LEVEL
+        .iter()
+        .find(|(memory, compute, _)| *memory == mapping.memory && *compute == mapping.compute)
+        .map(|(_, _, level)| *level)
+        .unwrap_or(GEMM_QUANT_UTIL_DEFAULT)
+}
+
+/// Collected quants with a DIFFERENT `(memory, compute)` profile than the
+/// query, ordered lexicographically by `(|Δcompute|, |Δmemory|)` — GEMM uses
+/// the compute-first metric (Python `xprofile_quant_order(...,
+/// prefer_same_compute=True)`): the COMPUTE factor (activation precision)
+/// determines the dense kernel's compute family (a weight-only quant runs
+/// bf16 MMA after fused dequant), so a same-compute reference must always
+/// beat a cross-compute one — under plain L1 a weight-only quant such as
+/// (0.5625, 1) TIES between bfloat16 and fp8 and the reference would be a
+/// file-order lottery. Stable sort keeps file order on full ties.
+fn xprofile_gemm_quants(query: GemmQuantMode, table_quants: &[GemmQuantMode]) -> Vec<GemmQuantMode> {
+    let qp = query.mapping();
+    let mut refs: Vec<GemmQuantMode> = table_quants
+        .iter()
+        .copied()
+        .filter(|q| {
+            let mapping = q.mapping();
+            *q != query && !(mapping.memory == qp.memory && mapping.compute == qp.compute)
+        })
+        .collect();
+    let dist = |q: GemmQuantMode| {
+        let mapping = q.mapping();
+        (
+            (mapping.compute - qp.compute).abs(),
+            (mapping.memory - qp.memory).abs(),
+        )
+    };
+    refs.sort_by(|a, b| dist(*a).partial_cmp(&dist(*b)).expect("finite profile distances"));
+    refs
+}
+
+/// Distinct quant names of the loaded GEMM table in first-seen (file row)
+/// order, parsed to the enum. A typed table miss yields an empty list —
+/// mirroring Python, where the ladder's table accesses happen inside
+/// `grid_from_reference`'s typed-miss catch.
+fn gemm_table_quants(db: &PerfDatabase) -> Result<Vec<GemmQuantMode>, AicError> {
+    match db.gemm.available_quants() {
+        Ok(names) => Ok(names.iter().filter_map(|n| gemm_quant_by_name(n)).collect()),
+        Err(err) if err.is_missing_perf_data() => Ok(Vec::new()),
+        Err(err) => Err(err),
+    }
+}
+
+/// A borrowed util grid over `source_quant`'s whole `(m, n, k)` table, built
+/// with `sol_quant`'s SOL (ReferenceCandidate contract: QUERY quant for the
+/// same-profile relation — numerically identical SOL — REFERENCE quant for
+/// cross-profile). `None` on a typed data miss or an empty sample set check
+/// left to the caller.
+fn gemm_reference_grid(
+    db: &PerfDatabase,
+    source_quant: GemmQuantMode,
+    sol_quant: GemmQuantMode,
+    provenance: &'static str,
+    key: &str,
+) -> Result<Option<std::sync::Arc<UtilGrid>>, AicError> {
+    let spec = &db.system_spec;
+    db.util_grids.get_or_try_build(key, || {
+        let sol = |c: &[f64]| gemm_sol_latency_ms(spec, sol_quant, c[0], c[1], c[2]);
+        match db.gemm.gemm_points(source_quant) {
+            Ok(points) => {
+                let mut grid = UtilGrid::new(util_empirical::build_samples(points, sol));
+                grid.reference_provenance = Some(provenance);
+                Ok(Some(grid))
+            }
+            Err(err) if err.is_missing_perf_data() => Ok(None),
+            Err(err) => Err(err),
+        }
+    })
+}
+
+/// `SOL(query)/util` over the quant's own collected `(m, n, k)` grid, with
+/// the quant-transfer ladder behind an own-data miss. Mirrors Python
+/// `_query_gemm_table::get_empirical` + `util_empirical.quant_transfer_grid`
+/// (grid depth 3; the own-grid SOL uses the ORIGINAL quant, numerically
+/// identical to the fp8_static->fp8 table quant since the profiles match):
+///
+/// 1. own-quant grid — inherently cross-shape (depth-3 over every collected
+///    `(m, n, k)`), so GEMM's **xshape relation class is structurally
+///    empty** and no xshape step exists;
+/// 2. **xquant** — FIRST same-profile sibling in file order (Python pools
+///    one whole-table candidate per sibling with constant features; the
+///    stable nearest-candidate argmin selects the first). Not retried on an
+///    empty grid — parity with the single pooled selection;
+/// 3. **xprofile** — compute-first nearest-profile walk, first quant with a
+///    non-empty grid wins, util rescaled by `e(query)/e(ref)`.
 fn gemm_empirical(
     db: &PerfDatabase,
     quant: GemmQuantMode,
@@ -164,20 +274,72 @@ fn gemm_empirical(
 ) -> Result<f64, AicError> {
     let spec = &db.system_spec;
     let sol = |c: &[f64]| gemm_sol_latency_ms(spec, quant, c[0], c[1], c[2]);
-    let key = format!("gemm:{}", normalize_fp8_static_quant(quant).name());
-    let grid = db.util_grids.get_or_try_build(&key, || {
+    let tqm = normalize_fp8_static_quant(quant);
+    let key = format!("gemm:{}", tqm.name());
+    let mut grid = db.util_grids.get_or_try_build(&key, || {
         match db.gemm.gemm_points(quant) {
             Ok(points) => Ok(Some(UtilGrid::new(util_empirical::build_samples(points, sol)))),
-            // Typed coverage miss -> no grid (estimate() raises the
-            // empirical miss); schema/load errors propagate.
+            // Typed coverage miss -> no grid (the ladder below, then
+            // estimate(), takes over); schema/load errors propagate.
             Err(err) if err.is_missing_perf_data() => Ok(None),
             Err(err) => Err(err),
         }
     })?;
+
+    let mut util_scale = 1.0;
+    if grid.as_deref().is_none_or(UtilGrid::is_empty) {
+        let policy = db.transfer_policy;
+        let table_quants = gemm_table_quants(db)?;
+        let fingerprint = policy_fingerprint(policy);
+
+        if policy.contains(TransferKind::XQuant) {
+            let qp = tqm.mapping();
+            if let Some(ref_q) = table_quants.iter().copied().find(|q| {
+                let mapping = q.mapping();
+                *q != tqm && mapping.memory == qp.memory && mapping.compute == qp.compute
+            }) {
+                let key = format!(
+                    "gemm_xquant:{}:policy={}:ref={}",
+                    tqm.name(),
+                    fingerprint,
+                    ref_q.name()
+                );
+                if let Some(reference) = gemm_reference_grid(db, ref_q, tqm, "xquant", &key)? {
+                    grid = Some(reference);
+                }
+            }
+        }
+
+        if grid.as_deref().is_none_or(UtilGrid::is_empty) && policy.contains(TransferKind::XProfile)
+        {
+            for ref_q in xprofile_gemm_quants(tqm, &table_quants) {
+                let key = format!(
+                    "gemm_xprofile:{}:policy={}:ref={}",
+                    tqm.name(),
+                    fingerprint,
+                    ref_q.name()
+                );
+                if let Some(reference) = gemm_reference_grid(db, ref_q, ref_q, "xprofile", &key)? {
+                    if !reference.is_empty() {
+                        grid = Some(reference);
+                        util_scale = gemm_quant_util_level(tqm) / gemm_quant_util_level(ref_q);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
     let query = [m as f64, n as f64, k as f64];
-    let (latency, _) = util_empirical::estimate(sol(&query), &query, grid.as_deref(), 1.0)?;
-    // Own-shape util fired (Python estimate()'s default provenance).
-    db.note_provenance(util_empirical::ProvenanceTier::Empirical);
+    let (latency, _) = util_empirical::estimate(sol(&query), &query, grid.as_deref(), util_scale)?;
+    // Relation fired = the reference grid's transfer kind (xquant/xprofile),
+    // or own-quant "empirical" when no borrow happened.
+    db.note_provenance(
+        grid.as_deref()
+            .and_then(|g| g.reference_provenance)
+            .and_then(util_empirical::ProvenanceTier::from_tag)
+            .unwrap_or(util_empirical::ProvenanceTier::Empirical),
+    );
     Ok(latency)
 }
 
@@ -392,15 +554,100 @@ mod tests {
         }
     }
 
-    /// HYBRID on a quant with NO collected table (int4_wo on b200/vllm) must
-    /// surface the terminal EmpiricalNotImplemented miss, never a fabricated
-    /// value (mirrors the Python contract).
+    /// HYBRID on a quant with NO collected table under a policy WITHOUT
+    /// XProfile must surface the terminal EmpiricalNotImplemented miss, never
+    /// a fabricated value (mirrors the Python contract: cross-profile
+    /// borrowing is policy-gated, never implicit). int4_wo (0.5, 1) has no
+    /// same-profile sibling anywhere, so "balanced" finds nothing.
     #[test]
-    fn gemm_hybrid_missing_quant_raises_empirical_not_implemented() {
-        let mut db = b200_vllm_db();
-        db.database_mode = crate::common::enums::DatabaseMode::Hybrid;
+    fn gemm_hybrid_missing_quant_raises_when_policy_forbids_transfer() {
+        let balanced = crate::common::enums::TransferPolicy {
+            xshape: true,
+            xquant: true,
+            xprofile: false,
+            xop: false,
+        };
+        let db = b200_vllm_db().with_mode(crate::common::enums::DatabaseMode::Hybrid, balanced);
         let result = query_gemm_table(&db, GemmQuantMode::Int4Wo, 64, 64, 64);
         assert!(matches!(result, Err(AicError::EmpiricalNotImplemented(_))), "got {result:?}");
+    }
+
+    /// Under the default (all-on) policy the same query resolves via the
+    /// xprofile borrow. Python oracle (shared layer OFF, HYBRID):
+    ///
+    /// ```text
+    /// db = perf_database.get_database_view("b200_sxm", "vllm", "0.19.0",
+    ///     allow_missing_data=True, database_mode=DatabaseMode.HYBRID,
+    ///     shared_layer=False)
+    /// float(GEMM._query_gemm_table(db, 64, 64, 64, GEMMQuantMode.int4_wo))
+    /// # -> 0.0007006913814463733, provenance {"xprofile"}
+    /// ```
+    ///
+    /// The b200/vllm file order is [nvfp4, bfloat16, fp8, fp8_block]; the
+    /// compute-first ordering must borrow bfloat16 (Δcompute=0), not the
+    /// file-order-first nvfp4.
+    #[test]
+    fn gemm_hybrid_missing_quant_borrows_xprofile_under_default_policy() {
+        let mut db = b200_vllm_db();
+        db.database_mode = crate::common::enums::DatabaseMode::Hybrid;
+        let (latency, source) =
+            query_gemm_table(&db, GemmQuantMode::Int4Wo, 64, 64, 64).expect("xprofile borrow");
+        assert!(
+            (latency - 0.0007006913814463733).abs() < 1e-9,
+            "expected python oracle, got {latency}"
+        );
+        assert_eq!(source, Source::Empirical);
+        assert_eq!(db.worst_provenance(), util_empirical::ProvenanceTier::XProfile);
+    }
+
+    fn h200_vllm_db() -> PerfDatabase {
+        let systems_root = PathBuf::from(REPO_ROOT_HINT)
+            .join("../..")
+            .join("src/aiconfigurator_core/systems");
+        PerfDatabase::load(&systems_root, "h200_sxm", "vllm", "0.19.0").expect("db must load")
+    }
+
+    /// Quant-transfer ladder oracles on h200/vllm/0.19.0 (collected quants in
+    /// file order: [fp8, bfloat16, fp8_block]). Python oracle generation:
+    ///
+    /// ```text
+    /// db = perf_database.get_database_view("h200_sxm", "vllm", "0.19.0",
+    ///     allow_missing_data=True, database_mode=DatabaseMode.HYBRID,
+    ///     shared_layer=False)
+    /// float(GEMM._query_gemm_table(db, m, 4096, 4096, quant))
+    /// ```
+    ///
+    /// - sq (1, 2): xquant borrow from fp8 (first same-profile in file
+    ///   order; identical SOL, no rescale).
+    /// - nvfp4 (0.5625, 4): xprofile borrow, compute-first walk lands on fp8
+    ///   (Δcompute=2 beats bfloat16's 3), rescaled by e(nvfp4)/e(fp8).
+    /// - int4_wo (0.5, 1): xprofile borrow from bfloat16 (Δcompute=0), NOT
+    ///   the file-order-first fp8 — under plain L1 the two TIE at 1.5 and a
+    ///   regression to L1/file-order selection changes this value.
+    /// Regenerate if the shipped GEMM tables or the util math change.
+    #[test]
+    fn gemm_quant_transfer_ladder_matches_python_oracles() {
+        let mut db = h200_vllm_db();
+        db.database_mode = crate::common::enums::DatabaseMode::Hybrid;
+        let cases = [
+            (GemmQuantMode::Sq, 512u32, 0.01826755536927117, util_empirical::ProvenanceTier::XQuant),
+            (GemmQuantMode::Sq, 8192, 0.21285422643025717, util_empirical::ProvenanceTier::XQuant),
+            (GemmQuantMode::Nvfp4, 512, 0.013700666526953379, util_empirical::ProvenanceTier::XProfile),
+            (GemmQuantMode::Nvfp4, 8192, 0.1596406698226929, util_empirical::ProvenanceTier::XProfile),
+            (GemmQuantMode::Int4Wo, 512, 0.036529976276703825, util_empirical::ProvenanceTier::XProfile),
+            (GemmQuantMode::Int4Wo, 8192, 0.5714972813924153, util_empirical::ProvenanceTier::XProfile),
+        ];
+        for (quant, m, expected, tier) in cases {
+            db.reset_provenance();
+            let (latency, source) =
+                query_gemm_table(&db, quant, m, 4096, 4096).expect("ladder query");
+            assert!(
+                (latency - expected).abs() < 1e-9,
+                "({quant:?}, m={m}): expected {expected}, got {latency}"
+            );
+            assert_eq!(source, Source::Empirical, "({quant:?}, m={m}): wrong source");
+            assert_eq!(db.worst_provenance(), tier, "({quant:?}, m={m}): wrong tier");
+        }
     }
 
     #[test]

--- a/aic-core/rust/aiconfigurator-core/src/operators/gemm.rs
+++ b/aic-core/rust/aiconfigurator-core/src/operators/gemm.rs
@@ -226,8 +226,8 @@ fn gemm_table_quants(db: &PerfDatabase) -> Result<Vec<GemmQuantMode>, AicError> 
 /// A borrowed util grid over `source_quant`'s whole `(m, n, k)` table, built
 /// with `sol_quant`'s SOL (ReferenceCandidate contract: QUERY quant for the
 /// same-profile relation — numerically identical SOL — REFERENCE quant for
-/// cross-profile). `None` on a typed data miss or an empty sample set check
-/// left to the caller.
+/// cross-profile). `None` on a typed data miss; emptiness is the caller's
+/// check.
 fn gemm_reference_grid(
     db: &PerfDatabase,
     source_quant: GemmQuantMode,

--- a/aic-core/rust/aiconfigurator-core/src/operators/moe.rs
+++ b/aic-core/rust/aiconfigurator-core/src/operators/moe.rs
@@ -118,8 +118,9 @@ fn xprofile_moe_quants(query: MoeQuantMode, table_quants: &[MoeQuantMode]) -> Ve
 
 /// Enabled-tier fingerprint folded into reference-grid cache keys so grids
 /// selected under different policies cannot alias (Python's
-/// `selection_key`/`identity_key` include the policy frozenset).
-fn policy_fingerprint(policy: TransferPolicy) -> String {
+/// `selection_key`/`identity_key` include the policy frozenset). Shared with
+/// the GEMM ladder (operators/gemm.rs).
+pub(crate) fn policy_fingerprint(policy: TransferPolicy) -> String {
     format!(
         "xshape={},xquant={},xprofile={},xop={}",
         policy.xshape as u8, policy.xquant as u8, policy.xprofile as u8, policy.xop as u8

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/gemm.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/gemm.rs
@@ -243,8 +243,8 @@ impl GemmTable {
     /// Python's dict-insertion iteration over the gemm data. The
     /// quant-transfer ladder's tie-breaks depend on this order; the
     /// alphabetical `BTreeMap` iteration must NOT be used for it.
-    pub fn available_quants(&self) -> Result<Vec<String>, AicError> {
-        Ok(self.load_gemm()?.quant_order.clone())
+    pub fn available_quants(&self) -> Result<&[String], AicError> {
+        Ok(&self.load_gemm()?.quant_order)
     }
 
     fn load_gemm(&self) -> Result<&GemmEngineGrids, AicError> {

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/gemm.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/gemm.rs
@@ -54,14 +54,19 @@ pub struct GemmTable {
 }
 
 /// 3-D GEMM tables keyed by quant name -> m -> n -> k -> latency_ms.
+/// `quant_order` records first-seen (file row) order: the `BTreeMap` iterates
+/// alphabetically, but the quant-transfer ladder's tie-breaks are pinned to
+/// Python's dict-insertion (= file row) order.
 struct GemmGrids {
     by_quant: BTreeMap<String, Grid3<f64>>,
+    quant_order: Vec<String>,
 }
 
 /// Engine-ready GEMM tables: per quant, the nested table plus the scattered
 /// (n, k)-site index, both built once at load (tables are immutable).
 struct GemmEngineGrids {
     by_quant: BTreeMap<String, (Node, SiteIndex)>,
+    quant_order: Vec<String>,
 }
 
 /// 2-D scale tables keyed by quant name -> m -> k -> latency_ms.
@@ -233,6 +238,15 @@ impl GemmTable {
         Ok(points)
     }
 
+    /// Distinct quant names of the loaded GEMM table, in first-seen (file
+    /// row) order — the exact analogue of `MoeTable::available_quants` and of
+    /// Python's dict-insertion iteration over the gemm data. The
+    /// quant-transfer ladder's tie-breaks depend on this order; the
+    /// alphabetical `BTreeMap` iteration must NOT be used for it.
+    pub fn available_quants(&self) -> Result<Vec<String>, AicError> {
+        Ok(self.load_gemm()?.quant_order.clone())
+    }
+
     fn load_gemm(&self) -> Result<&GemmEngineGrids, AicError> {
         let cell = self.gemm.get_or_init(|| {
             let mut grids = load_gemm_parquet(&self.gemm_sources)?;
@@ -249,6 +263,7 @@ impl GemmTable {
             // sees the same monotone-bounded inputs as Python.
             clamp_gemm_grids_to_sol(&self.system_spec, &mut grids);
             // Build the engine table + (n, k)-site index once per quant.
+            let quant_order = grids.quant_order;
             let by_quant = grids
                 .by_quant
                 .into_iter()
@@ -258,7 +273,7 @@ impl GemmTable {
                     (quant_name, (node, index))
                 })
                 .collect();
-            Ok(GemmEngineGrids { by_quant })
+            Ok(GemmEngineGrids { by_quant, quant_order })
         });
         cell.as_ref().map_err(|err| clone_err(err))
     }
@@ -344,7 +359,7 @@ fn clamp_gemm_grids_to_sol(spec: &SystemSpec, grids: &mut GemmGrids) {
     }
 }
 
-fn gemm_quant_by_name(name: &str) -> Option<GemmQuantMode> {
+pub(crate) fn gemm_quant_by_name(name: &str) -> Option<GemmQuantMode> {
     use GemmQuantMode::*;
     Some(match name {
         "bfloat16" => Bfloat16,
@@ -473,6 +488,7 @@ fn query_scale_table(
 /// source yields rows.
 fn load_gemm_parquet(sources: &[PerfSource]) -> Result<GemmGrids, AicError> {
     let mut by_quant: BTreeMap<String, Grid3<f64>> = BTreeMap::new();
+    let mut quant_order: Vec<String> = Vec::new();
     let mut any_source = false;
     for source in sources {
         let path = source.path();
@@ -499,6 +515,9 @@ fn load_gemm_parquet(sources: &[PerfSource]) -> Result<GemmGrids, AicError> {
                 continue;
             }
             let dtype = dtype.to_string();
+            if !by_quant.contains_key(&dtype) {
+                quant_order.push(dtype.clone());
+            }
             // First-wins parity with Python's `load_gemm_data` try/except
             // KeyError, extended across shared-layer sources (earlier source wins).
             by_quant
@@ -519,7 +538,7 @@ fn load_gemm_parquet(sources: &[PerfSource]) -> Result<GemmGrids, AicError> {
             sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
         )));
     }
-    Ok(GemmGrids { by_quant })
+    Ok(GemmGrids { by_quant, quant_order })
 }
 
 /// Load a 2-D (compute_scale / scale_matrix) table from an ordered source list.

--- a/aic-core/src/aiconfigurator_core/sdk/operations/gemm.py
+++ b/aic-core/src/aiconfigurator_core/sdk/operations/gemm.py
@@ -552,9 +552,8 @@ class GEMM(Operation):
                     _gemm_quant_util_level,
                     depth=3,
                     selection_key=(id(wrapper), policy),
-                    # Dense kernel compute family ≡ activation precision: a
-                    # weight-only quant (compute=1) must borrow bfloat16's
-                    # curve, never tie-break into fp8 (see xprofile_quant_order).
+                    # weight-only must borrow bf16, never tie-break into fp8
+                    # (rationale on xprofile_quant_order)
                     prefer_same_compute=True,
                 )
                 if ref_prov:

--- a/aic-core/src/aiconfigurator_core/sdk/operations/gemm.py
+++ b/aic-core/src/aiconfigurator_core/sdk/operations/gemm.py
@@ -40,6 +40,54 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+# Per-quant achieved-util LEVEL e(q) for GEMM, keyed by the (memory, compute)
+# profile — the GEMM counterpart of moe.py's _MOE_QUANT_UTIL_LEVEL, consumed
+# ONLY by the cross-PROFILE relation of the quant-transfer primitive as the
+# ratio e(query)/e(ref) (see util_empirical.quant_transfer_grid). A SINGLE
+# scalar per profile by design (the per-component split was validated as
+# untrustworthy on MoE; the same SOL-attribution argument holds here).
+#
+# [data] rows: median of util = SOL/measured over the clearly compute-bound
+# region (m >= 1024, n >= 2048, k >= 2048) of every collected gemm table on
+# b200/h200/h100 x trtllm/vllm/sglang (2026-08 snapshot); the range across
+# those six stacks is quoted per row. The bf16/fp8 level RATIO spans
+# 1.38-2.00 (~±20% around 1.6) — looser than MoE's ~10% but acceptable for
+# the last-resort relation. LOO on the mechanism (predict a collected quant
+# from its nearest-profile sibling at shared shapes, m >= 64): nvfp4 <- fp8
+# = 22-33% MAPE, comparable to MoE's ~24% xprofile LOO. [inferred] rows
+# follow the structure (efficiency drops with weight precision, mildly
+# recovers as activation precision drops); levels are relative and tunable —
+# only ratios are consumed.
+_GEMM_QUANT_UTIL_LEVEL: dict[tuple[float, float], float] = {
+    (2, 1): 0.70,  # w16a16 / bfloat16               [data 0.55-0.79]
+    (1, 1): 0.55,  # w8a16 / int8_wo                 [inferred]
+    (0.5, 1): 0.45,  # w4a16 / int4_wo (fused-dequant weight-only runs below
+    #                  the bf16 compute roofline it shares; Marlin-class) [inferred]
+    (1, 2): 0.45,  # w8a8 / fp8(_block/_ootb), sq    [data 0.28-0.55]
+    (0.5, 2): 0.35,  # w4a8                          [inferred]
+    (1, 4): 0.30,  # w8a4                            [inferred]
+    (0.5, 4): 0.30,  # w4a4                          [inferred ≈ nvfp4]
+    (0.5625, 4): 0.30,  # w4a4 / nvfp4               [data 0.21-0.36]
+}
+_GEMM_QUANT_UTIL_DEFAULT = 0.45  # unlisted profile: mid-range relative level
+
+
+def _gemm_quant_util_level(quant_mode) -> float:
+    """Achieved-util level e(q) for a GEMM quant, by (memory, compute) profile."""
+    return _GEMM_QUANT_UTIL_LEVEL.get(util_empirical.quant_profile(quant_mode), _GEMM_QUANT_UTIL_DEFAULT)
+
+
+def xprofile_util_level_known(quant_mode) -> bool:
+    """Whether the GEMM util-LEVEL table lists this quant's profile.
+
+    The runtime ladder falls back to ``_GEMM_QUANT_UTIL_DEFAULT`` for
+    unlisted profiles; the validate gate deliberately does NOT (admitting a
+    quant nobody calibrated would hide the missing level line the
+    add-a-quant recipe requires), so it asks this instead of reaching into
+    the table."""
+    return util_empirical.quant_profile(quant_mode) in _GEMM_QUANT_UTIL_LEVEL
+
+
 class _ZeroAwareDeltaLookup:
     """Preprocessed nearest-neighbour lookup for one immutable delta table.
 
@@ -445,7 +493,10 @@ class GEMM(Operation):
 
         def get_empirical(m_v: int, n_v: int, k_v: int, qm: common.GEMMQuantMode) -> float:
             # SOL / util, where util is read best-effort from this op's own
-            # collected data; raises EmpiricalNotImplementedError when no data.
+            # collected data; when the quant has none, the shared
+            # quant-transfer primitive borrows a sibling quant's util grid
+            # (xquant same-profile / xprofile cross-profile). Raises
+            # EmpiricalNotImplementedError only when no relation finds data.
             sol_time = get_sol(m_v, n_v, k_v, qm)[0]
             tqm = cls._normalize_gemm_quant_mode_for_table(qm)
 
@@ -461,7 +512,57 @@ class GEMM(Operation):
                 lambda c: get_sol(c[0], c[1], c[2], qm)[0],
                 depth=3,
             )
-            latency, _ = util_empirical.estimate(sol_time, (m_v, n_v, k_v), grid)
+
+            util_scale = 1.0
+            prov = "empirical"  # own-quant util grid; relations below override
+            if grid is None or not grid.samples:
+                cls.load_data(database)
+                wrapper = database._gemm_data
+                policy = database.transfer_policy
+
+                def _collect(q, sol_q, provenance):
+                    # GEMM's xshape relation class is structurally EMPTY: the
+                    # own-quant grid above is already depth-3 over every
+                    # collected (m, n, k) — there is no "other slice of the
+                    # same quant" left to borrow, so a same-quant candidate
+                    # could only rebuild the identical (empty) sample set.
+                    if provenance == "xshape":
+                        return []
+                    # One candidate per sibling quant: its whole m->n->k
+                    # table. GEMM has no categorical slice features, so
+                    # features are constant and the pooled xquant selection
+                    # degrades to first-in-table (file row) order.
+                    return [
+                        util_empirical.ReferenceCandidate(
+                            features=(1.0,),
+                            node=wrapper[q],
+                            sol_fn=(lambda c, _sq=sol_q: get_sol(c[0], c[1], c[2], _sq)[0]),
+                            provenance=provenance,
+                        )
+                    ]
+
+                grid, util_scale, ref_prov = util_empirical.quant_transfer_grid(
+                    "gemm",
+                    (database.system, database.backend, database.version, tqm.name),
+                    (1.0,),
+                    policy,
+                    tqm,
+                    wrapper,
+                    _collect,
+                    _gemm_quant_util_level,
+                    depth=3,
+                    selection_key=(id(wrapper), policy),
+                    # Dense kernel compute family ≡ activation precision: a
+                    # weight-only quant (compute=1) must borrow bfloat16's
+                    # curve, never tie-break into fp8 (see xprofile_quant_order).
+                    prefer_same_compute=True,
+                )
+                if ref_prov:
+                    prov = ref_prov
+
+            latency, _ = util_empirical.estimate(
+                sol_time, (m_v, n_v, k_v), grid, util_scale=util_scale, provenance=prov
+            )
             return latency
 
         if database_mode is None:

--- a/aic-core/src/aiconfigurator_core/sdk/operations/moe.py
+++ b/aic-core/src/aiconfigurator_core/sdk/operations/moe.py
@@ -104,17 +104,19 @@ def _moe_quant_util_level(quant_mode) -> float:
 
 def _xprofile_moe_quants(query_quant, table) -> list:
     """Collected quants with a DIFFERENT (memory, compute) profile than the query,
-    nearest-profile first. Same-profile quants are handled by the same-profile tier;
-    these are the cross-profile transfer references, rescaled by the util-level ratio."""
-    qp = (query_quant.value.memory, query_quant.value.compute)
+    nearest-profile first. Kept as a named MoE entry point for existing callers;
+    the ordering itself lives in the shared quant-transfer primitive."""
+    return util_empirical.xprofile_quant_order(query_quant, table)
 
-    def dist(q):
-        return abs(q.value.memory - qp[0]) + abs(q.value.compute - qp[1])
 
-    return sorted(
-        (q for q in table if q is not query_quant and (q.value.memory, q.value.compute) != qp),
-        key=dist,
-    )
+def xprofile_util_level_known(quant_mode) -> bool:
+    """Whether the MoE util-LEVEL table lists this quant's profile.
+
+    The runtime ladder falls back to ``_MOE_QUANT_UTIL_DEFAULT`` for unlisted
+    profiles; the validate gate deliberately does NOT (admitting a quant
+    nobody calibrated would hide the missing level line the add-a-quant
+    recipe requires), so it asks this instead of reaching into the table."""
+    return util_empirical.quant_profile(quant_mode) in _MOE_QUANT_UTIL_LEVEL
 
 
 # ───────────────────────────────────────────────────────────────────────
@@ -493,32 +495,15 @@ class MoE(Operation):
                                     )
                     return out
 
+                # Relation ladder (xshape -> xquant -> xprofile) via the shared
+                # quant-transfer primitive; MoE contributes candidate
+                # enumeration (_collect), its SOL, and its util-LEVEL table.
+                # Same-profile transfer measured ~13% MAPE (fp8_block <- fp8);
+                # cross-profile raw ~58% -> ~24% MAPE LOO with the level ratio.
                 policy = database.transfer_policy
-
-                def _moe_candidates():
-                    # Tier 1 (XSHAPE): cross-shape within the query quant (closest measurement).
-                    cands = (
-                        _collect(quant_mode, quant_mode, "xshape")
-                        if (common.TransferKind.XSHAPE in policy and quant_mode in moe_table)
-                        else []
-                    )
-                    if cands:
-                        return cands
-                    # Tier 2 (XQUANT): cross-quant within the same (memory, compute) profile.
-                    # Same profile => same SOL coefficients and binding regime, so util
-                    # transfers (measured ~13% MAPE for fp8_block <- fp8; the query quant's
-                    # SOL is used unchanged). Only when the query quant has no data of any shape.
-                    if common.TransferKind.XQUANT in policy:
-                        qp = (quant_mode.value.memory, quant_mode.value.compute)
-                        for q in moe_table:
-                            if q is quant_mode or (q.value.memory, q.value.compute) != qp:
-                                continue
-                            cands.extend(_collect(q, quant_mode, "xquant"))
-                    return cands
-
-                grid = util_empirical.grid_from_reference(
+                grid, util_scale, ref_prov = util_empirical.quant_transfer_grid(
+                    "moe",
                     (
-                        "moe_xshape",
                         database.system,
                         database.backend,
                         database.version,
@@ -534,48 +519,16 @@ class MoE(Operation):
                         num_gemms,
                     ),
                     (topk, num_experts, hidden_size, inter_size),
-                    _moe_candidates,
+                    policy,
+                    quant_mode,
+                    moe_table,
+                    _collect,
+                    _moe_quant_util_level,
                     depth=1,
                     selection_key=(id(moe_table), policy, workload_distribution, num_gemms),
                 )
-                if grid is not None and grid.samples and grid.reference_provenance:
-                    prov = grid.reference_provenance
-
-                # Tier 3: cross-PROFILE. No own- or same-profile data at all -> borrow the
-                # nearest collected quant's util curve, built with the REFERENCE quant's own
-                # SOL, and rescale by the per-quant util-LEVEL ratio e(query)/e(ref). The
-                # cross-profile error is ~pure systematic kernel-efficiency bias, which this
-                # ratio removes (raw ~58% -> ~24% MAPE LOO). Last resort, lowest confidence.
-                if (grid is None or not grid.samples) and common.TransferKind.XPROFILE in policy:
-                    for ref_q in _xprofile_moe_quants(quant_mode, moe_table):
-                        g = util_empirical.grid_from_reference(
-                            (
-                                "moe_xprofile",
-                                database.system,
-                                database.backend,
-                                database.version,
-                                quant_mode.name,
-                                ref_q.name,
-                                kernel_tag,
-                                topk,
-                                num_experts,
-                                hidden_size,
-                                inter_size,
-                                moe_tp_size,
-                                moe_ep_size,
-                                workload_distribution,
-                                num_gemms,
-                            ),
-                            (topk, num_experts, hidden_size, inter_size),
-                            (lambda _rq=ref_q: _collect(_rq, _rq, "xprofile")),
-                            depth=1,
-                            selection_key=(id(moe_table), policy, workload_distribution, num_gemms),
-                        )
-                        if g is not None and g.samples:
-                            grid = g
-                            util_scale = _moe_quant_util_level(quant_mode) / _moe_quant_util_level(ref_q)
-                            prov = "xprofile"
-                            break
+                if ref_prov:
+                    prov = ref_prov
             latency, _ = util_empirical.estimate(sol_time, (num_tokens,), grid, util_scale=util_scale, provenance=prov)
             return latency
 

--- a/aic-core/src/aiconfigurator_core/sdk/operations/util_empirical.py
+++ b/aic-core/src/aiconfigurator_core/sdk/operations/util_empirical.py
@@ -354,3 +354,173 @@ def grid_from_reference(
         return get_grid(identity_key, build_reference_grid)
     except (PerfDataNotAvailableError, InterpolationDataNotAvailableError):
         return None
+
+
+# ---------------------------------------------------------------------------
+# Quant-transfer primitive: ONE borrow mechanism, labels derived from the
+# selected reference's relation to the query quant.
+#
+#     latency(query) = SOL_query / (util_borrowed * e(profile_query)/e(profile_ref))
+#
+# where the correction ratio is IDENTICALLY 1 within a profile (both lookups
+# hit the same level-table row), so "xshape" (same quant, another slice) and
+# "xquant" (same (memory, compute) profile, another quant) are the ratio-1
+# degenerations of the cross-profile borrow — three confidence labels over one
+# mechanism, not three mechanisms:
+#
+# - xshape:   same quant  -> trust follows from the kernel identity.
+# - xquant:   same profile -> trust follows from SOL-coefficient identity
+#             (no calibrated constant involved; the level table is not read).
+# - xprofile: cross profile -> trust rests on the calibrated per-profile
+#             util LEVEL ratio. Last resort, lowest confidence.
+#
+# Reference preference is lexicographic (relation rank, profile distance,
+# slice-feature distance), realised as the historical tier flow below so MoE's
+# established selection semantics (and its Rust parity oracles) are preserved
+# bit-for-bit: xshape/xquant candidates are POOLED and resolved by nearest
+# slice features; xprofile walks quants nearest-profile-first (stable ties =
+# table/file order) and takes the first with data.
+# ---------------------------------------------------------------------------
+
+
+def quant_profile(quant) -> tuple[float, float]:
+    """The (memory, compute) profile of a quant enum member — the key of the
+    per-op util-LEVEL tables and the equality that separates xquant from
+    xprofile."""
+    return (quant.value.memory, quant.value.compute)
+
+
+def xprofile_quant_order(query_quant, table_quants, *, prefer_same_compute: bool = False) -> list:
+    """Collected quants with a DIFFERENT (memory, compute) profile than the
+    query, nearest-profile first (the stable sort keeps table/file insertion
+    order on distance ties). Same-profile quants belong to the xquant
+    relation and are excluded here.
+
+    Two distance metrics, chosen per op:
+
+    - default (``prefer_same_compute=False``): ``|Δmemory| + |Δcompute|`` —
+      MoE's historical L1 metric, kept as-is (its level ratios were validated
+      under this ordering; changing it would silently reshuffle existing
+      MoE selections).
+    - ``prefer_same_compute=True``: lexicographic ``(|Δcompute|, |Δmemory|)``
+      — for ops where the COMPUTE factor (activation precision) determines
+      the kernel's compute family and the memory factor only scales the
+      weight fetch. Dense GEMM is the motivating case: a weight-only quant
+      (w4a16/w8a16, compute=1) runs bf16 MMA after fused dequant, so its
+      util curve family follows bfloat16's — under plain L1 such a quant
+      TIES between bfloat16 and fp8 (e.g. (0.5625, 1): both at 1.4375) and
+      the reference would be a file-order lottery.
+    """
+    qp = quant_profile(query_quant)
+
+    def l1(q):
+        p = quant_profile(q)
+        return abs(p[0] - qp[0]) + abs(p[1] - qp[1])
+
+    def compute_first(q):
+        p = quant_profile(q)
+        return (abs(p[1] - qp[1]), abs(p[0] - qp[0]))
+
+    return sorted(
+        (q for q in table_quants if q is not query_quant and quant_profile(q) != qp),
+        key=compute_first if prefer_same_compute else l1,
+    )
+
+
+def quant_transfer_grid(
+    op_tag: str,
+    slice_key: tuple,
+    query_features: Coords,
+    policy,
+    query_quant,
+    table,
+    collect: Callable,
+    util_level: Callable[[object], float],
+    depth: int,
+    selection_key,
+    *,
+    prefer_same_compute: bool = False,
+):
+    """Resolve a borrowed util grid for a quant with no own-slice data.
+
+    Parameters:
+    - ``op_tag``: cache-key prefix (``"moe"``, ``"gemm"``, ...).
+    - ``slice_key``: tuple identifying the query slice (system/backend/
+      version/quant/shape/...), folded into every grid cache key.
+    - ``query_features``: coords for nearest-candidate matching within the
+      pooled xshape/xquant tier (ops without categorical slice axes pass a
+      constant, making the pooled selection degrade to first-in-table-order).
+    - ``policy``: the resolved frozenset of ``common.TransferKind``.
+    - ``table``: the op's quant-keyed data mapping (usually a
+      ``LoadedOpData``). Membership/getitem may raise the typed
+      ``PerfDataNotAvailableError`` — accessed only inside guarded regions,
+      preserving each op's existing miss semantics. Plain iteration yields
+      quants in file first-seen order (empty when not loaded).
+    - ``collect(ref_quant, sol_quant, provenance) -> list[ReferenceCandidate]``:
+      op-specific candidate enumeration. Called only for quants present in
+      ``table``. ``sol_quant`` follows the ReferenceCandidate contract: the
+      QUERY quant for same-profile relations (coefficients identical), the
+      REFERENCE quant for cross-profile (util = that kernel's true
+      efficiency, rescaled by the level ratio). An op whose relation class is
+      structurally empty returns ``[]`` (e.g. GEMM for ``"xshape"``).
+    - ``util_level(quant) -> float``: the op's per-profile achieved-util
+      LEVEL e(q); consumed ONLY as the xprofile ratio e(query)/e(ref).
+
+    Returns ``(grid, util_scale, provenance)`` — ``grid`` may be ``None`` or
+    empty (the caller's :func:`estimate` then raises the typed empirical
+    miss), ``util_scale`` is 1.0 except for a cross-profile borrow, and
+    ``provenance`` is the relation label of the reference that produced the
+    samples (``None`` when nothing usable was found).
+    """
+    from aiconfigurator_core.sdk import common
+
+    util_scale = 1.0
+    prov = None
+
+    def _pooled_candidates():
+        # Relation ranks 1+2 in ONE selection: xshape candidates win outright
+        # when any exist; only an empty xshape set falls through to pooled
+        # same-profile xquant siblings resolved by nearest slice features.
+        cands = (
+            collect(query_quant, query_quant, "xshape")
+            if (common.TransferKind.XSHAPE in policy and query_quant in table)
+            else []
+        )
+        if cands:
+            return cands
+        if common.TransferKind.XQUANT in policy:
+            qp = quant_profile(query_quant)
+            for q in table:
+                if q is query_quant or quant_profile(q) != qp:
+                    continue
+                cands.extend(collect(q, query_quant, "xquant"))
+        return cands
+
+    grid = grid_from_reference(
+        (f"{op_tag}_xshape", *slice_key),
+        query_features,
+        _pooled_candidates,
+        depth=depth,
+        selection_key=selection_key,
+    )
+    if grid is not None and grid.samples and grid.reference_provenance:
+        prov = grid.reference_provenance
+
+    # Relation rank 3: cross-profile, nearest-profile-first, first quant with
+    # data wins (slice features only break ties WITHIN the chosen quant).
+    if (grid is None or not grid.samples) and common.TransferKind.XPROFILE in policy:
+        for ref_q in xprofile_quant_order(query_quant, table, prefer_same_compute=prefer_same_compute):
+            g = grid_from_reference(
+                (f"{op_tag}_xprofile", *slice_key, ref_q.name),
+                query_features,
+                (lambda _rq=ref_q: collect(_rq, _rq, "xprofile")),
+                depth=depth,
+                selection_key=selection_key,
+            )
+            if g is not None and g.samples:
+                grid = g
+                util_scale = util_level(query_quant) / util_level(ref_q)
+                prov = "xprofile"
+                break
+
+    return grid, util_scale, prov

--- a/aic-core/src/aiconfigurator_core/sdk/operations/util_empirical.py
+++ b/aic-core/src/aiconfigurator_core/sdk/operations/util_empirical.py
@@ -362,20 +362,18 @@ def grid_from_reference(
 #
 #     latency(query) = SOL_query / (util_borrowed * e(profile_query)/e(profile_ref))
 #
-# where the correction ratio is IDENTICALLY 1 within a profile (both lookups
-# hit the same level-table row), so "xshape" (same quant, another slice) and
-# "xquant" (same (memory, compute) profile, another quant) are the ratio-1
-# degenerations of the cross-profile borrow — three confidence labels over one
-# mechanism, not three mechanisms:
+# The correction ratio is IDENTICALLY 1 within a (memory, compute) profile
+# (both lookups hit the same level-table row), so the labels are confidence
+# bands over one mechanism, not three mechanisms:
 #
-# - xshape:   same quant  -> trust follows from the kernel identity.
+# - xshape:   same quant, another slice -> trust follows from kernel identity.
 # - xquant:   same profile -> trust follows from SOL-coefficient identity
 #             (no calibrated constant involved; the level table is not read).
 # - xprofile: cross profile -> trust rests on the calibrated per-profile
-#             util LEVEL ratio. Last resort, lowest confidence.
+#             util-LEVEL ratio. Last resort, lowest confidence.
 #
 # Reference preference is lexicographic (relation rank, profile distance,
-# slice-feature distance), realised as the historical tier flow below so MoE's
+# slice-feature distance), realised as the historical tier flow so MoE's
 # established selection semantics (and its Rust parity oracles) are preserved
 # bit-for-bit: xshape/xquant candidates are POOLED and resolved by nearest
 # slice features; xprofile walks quants nearest-profile-first (stable ties =
@@ -441,36 +439,29 @@ def quant_transfer_grid(
     *,
     prefer_same_compute: bool = False,
 ):
-    """Resolve a borrowed util grid for a quant with no own-slice data.
+    """Resolve a borrowed util grid for a quant with no own-slice data
+    (semantics in the block comment above).
 
-    Parameters:
-    - ``op_tag``: cache-key prefix (``"moe"``, ``"gemm"``, ...).
-    - ``slice_key``: tuple identifying the query slice (system/backend/
-      version/quant/shape/...), folded into every grid cache key.
-    - ``query_features``: coords for nearest-candidate matching within the
-      pooled xshape/xquant tier (ops without categorical slice axes pass a
-      constant, making the pooled selection degrade to first-in-table-order).
-    - ``policy``: the resolved frozenset of ``common.TransferKind``.
-    - ``table``: the op's quant-keyed data mapping (usually a
-      ``LoadedOpData``). Membership/getitem may raise the typed
-      ``PerfDataNotAvailableError`` — accessed only inside guarded regions,
-      preserving each op's existing miss semantics. Plain iteration yields
-      quants in file first-seen order (empty when not loaded).
-    - ``collect(ref_quant, sol_quant, provenance) -> list[ReferenceCandidate]``:
-      op-specific candidate enumeration. Called only for quants present in
-      ``table``. ``sol_quant`` follows the ReferenceCandidate contract: the
-      QUERY quant for same-profile relations (coefficients identical), the
-      REFERENCE quant for cross-profile (util = that kernel's true
-      efficiency, rescaled by the level ratio). An op whose relation class is
-      structurally empty returns ``[]`` (e.g. GEMM for ``"xshape"``).
-    - ``util_level(quant) -> float``: the op's per-profile achieved-util
-      LEVEL e(q); consumed ONLY as the xprofile ratio e(query)/e(ref).
+    ``slice_key`` identifies the query slice inside every grid cache key
+    (prefixed by ``op_tag``). ``query_features`` are the coords for
+    nearest-candidate matching in the pooled xshape/xquant selection — ops
+    without categorical slice axes pass a constant, degrading it to
+    first-in-table-order. ``table`` is the op's quant-keyed data mapping
+    (usually a ``LoadedOpData``): membership/getitem may raise the typed
+    ``PerfDataNotAvailableError`` and is accessed only inside guarded
+    regions; plain iteration yields quants in file first-seen order.
+    ``collect(ref_quant, sol_quant, provenance)`` enumerates a quant's
+    :class:`ReferenceCandidate` list — ``sol_quant`` is the QUERY quant for
+    same-profile relations and the REFERENCE quant for cross-profile; a
+    structurally empty relation class returns ``[]`` (e.g. GEMM for
+    ``"xshape"``). ``util_level(quant)`` is the op's per-profile level
+    e(q), consumed only as the xprofile ratio.
 
-    Returns ``(grid, util_scale, provenance)`` — ``grid`` may be ``None`` or
+    Returns ``(grid, util_scale, provenance)``: ``grid`` may be ``None`` or
     empty (the caller's :func:`estimate` then raises the typed empirical
     miss), ``util_scale`` is 1.0 except for a cross-profile borrow, and
-    ``provenance`` is the relation label of the reference that produced the
-    samples (``None`` when nothing usable was found).
+    ``provenance`` is the relation label that produced the samples (``None``
+    when nothing usable was found).
     """
     from aiconfigurator_core.sdk import common
 

--- a/aic-core/src/aiconfigurator_core/sdk/operations/util_empirical.py
+++ b/aic-core/src/aiconfigurator_core/sdk/operations/util_empirical.py
@@ -488,7 +488,7 @@ def quant_transfer_grid(
         return cands
 
     grid = grid_from_reference(
-        (f"{op_tag}_xshape", *slice_key),
+        (f"{op_tag}_pooled", *slice_key),  # pooled xshape+xquant selection
         query_features,
         _pooled_candidates,
         depth=depth,

--- a/docs/design/gemm_quant_transfer_design.md
+++ b/docs/design/gemm_quant_transfer_design.md
@@ -72,6 +72,12 @@ at the zero-calibration relations.
   way the gate is stricter than the ladder (which has a default level): it
   enforces the enum-line + level-line recipe instead of silently admitting a
   quant nobody calibrated.
+- **`fp8_static` is excluded from transfer admission**: it is a composite
+  mode (fp8 base minus `compute_scale`/`scale_matrix`), and the overhead
+  tables have no ladder — profile-reachability could admit it wherever plain
+  fp8 data exists while `query_compute_scale` still dies at run time. Its
+  admission stays purely data-driven (in `supported_quant_mode` iff all
+  three tables exist).
 - Dead `"nvfp4_wo": "bfloat16"` validation alias removed (no such enum
   member; normalize-to-bf16 was reviewed out of #1392 — it substitutes the
   reference's SOL for the query's, losing the w4 memory-side benefit). The

--- a/docs/design/gemm_quant_transfer_design.md
+++ b/docs/design/gemm_quant_transfer_design.md
@@ -1,0 +1,279 @@
+# GEMM quant-transfer tiers + validate-gate cleanup — design
+
+Status: IMPLEMENTED (see §11 for as-built resolutions of the open items and
+confirmed-in-review semantic decisions; §3/§5/§6 below are the original
+proposal and remain accurate except where §11 notes a delta)
+Branch: `worktree-gemm-xprofile-borrow`
+Relation: prerequisite mechanism for PR #1392 (nvfp4_wo); adds **no new quant**.
+Companion recipe: `docs/design/how_to_add_a_gemm_quant_mode.md`.
+
+## 1. Goal
+
+Give GEMM the same empirical transfer ladder MoE already has, so a quant with
+no collected GEMM data can be estimated in HYBRID/EMPIRICAL via util borrowing
+instead of raising, and clean the `task_v2` validate gate so it mirrors —
+never exceeds — the query ladder's admission policy.
+
+Acceptance: adding a future data-less quant requires only (a) one
+`GEMMQuantMode` enum line and (b) one `_GEMM_QUANT_UTIL_LEVEL` line, and
+HYBRID estimate works end-to-end while SILICON still rejects early.
+
+Out of scope (unchanged): `nvfp4_wo` or any new enum member, `cli/api.py`
+resolve_* call sites, `tools/support_matrix/` FP4 gate, `collector/`,
+`generator/`, WideEP alltoall dispatch path.
+
+## 2. Current state and gap
+
+`operations/moe.py::get_empirical` walks: own-shape grid → XSHAPE → XQUANT →
+XPROFILE (util-level-ratio rescale), each gated by
+`database.transfer_policy`.
+
+`operations/gemm.py::_query_gemm_table::get_empirical` (gemm.py:446-465) only
+builds the query quant's own depth-3 `(m, n, k)` util grid via
+`util_empirical.grid_for`. A quant with zero rows in `gemm_perf.parquet`
+yields `grid=None` → `EmpiricalNotImplementedError`, regardless of policy.
+Rust `operators/gemm.rs::gemm_empirical` mirrors that exactly.
+
+The validate gate (`task_v2.py:1268-1406`) checks GEMM with **no**
+`profile_transfer`, and its `_profile_reachable` only models XQUANT
+(same-profile). It also carries a dead string alias
+`"nvfp4_wo": "bfloat16"` (task_v2.py:1372) pre-planted by #1395 — no such
+enum member exists, and normalize-to-bf16 was the review-rejected approach.
+
+## 3. GEMM ladder design — tier by tier
+
+Ladder inserted in `get_empirical` after the own-grid miss
+(`grid is None or not grid.samples`), mirroring moe.py's structure and
+respecting `database.transfer_policy`:
+
+| Tier | Decision | Reason |
+|---|---|---|
+| own-grid | keep as-is | unchanged fast path; provenance `empirical` |
+| XSHAPE | **omitted** | GEMM's own grid is already depth-3 over *all* collected `(m, n, k)` of the query quant with per-axis clamping + 2-NN in normalized log space — any own-quant sample anywhere already feeds it. A separate "nearest collected shape within the query quant" tier would select from exactly the same sample set and can never fire when the own grid is empty. (MoE needs XSHAPE because its own grid is sliced per categorical shape `(topk, experts, hidden, inter, tp, ep)`; GEMM has no categorical shape axes.) |
+| XQUANT | **added** | same `(memory, compute)` profile ⇒ GEMM SOL is *numerically identical* (profile fully determines `sol_math`/`sol_mem` for a given shape), so a sibling's util grid transfers with no rescale. Real coverage wins today: `sq`/`fp8_ootb`/`fp8_block` ↔ `fp8` (all `(1,2)`) on systems where only one was collected. Provenance `xquant`, `util_scale=1`. |
+| XPROFILE | **added** (the core deliverable) | no same-profile data at all → borrow the nearest-profile collected quant's full `(m, n, k)` util grid, built with the **reference** quant's own SOL, rescaled by `e(query)/e(ref)` from `_GEMM_QUANT_UTIL_LEVEL`. Provenance `xprofile`. Last resort, lowest confidence. |
+| XOP | **omitted** | no meaningful donor op for a dense GEMM; MoE's per-expert grouped GEMM has different launch/kernel structure. Nothing enables it; the policy token stays inert for GEMM. |
+
+Mechanics shared with MoE (reuse, don't fork):
+
+- Python: candidates built as `util_empirical.ReferenceCandidate`; grids via
+  `util_empirical.grid_from_reference` (cache keys `("gemm_xquant", ...)` /
+  `("gemm_xprofile", ...)` including quant, ref-quant and policy in
+  `selection_key`). One candidate per sibling quant; its `node` is that
+  quant's whole `m→n→k` table, `features` are the profile pair
+  `(memory, compute)`, `sol_fn` bound per the ReferenceCandidate contract
+  (query quant's SOL for XQUANT — numerically equal anyway; ref quant's SOL
+  for XPROFILE).
+- Candidate ordering: XQUANT candidates all tie on features →
+  `_nearest_candidate`'s stable argmin picks the **first-seen table quant**
+  (dict insertion = file row order), identical to MoE's tie-break convention.
+  XPROFILE loops nearest-profile-first via a `_xprofile_gemm_quants` helper
+  with the same `|Δmemory| + |Δcompute|` distance as `_xprofile_moe_quants`.
+- The ladder operates on the **table quant** after
+  `_normalize_gemm_quant_mode_for_table` (fp8_static→fp8), exactly like the
+  own-grid path does today; `fp8_static` therefore inherits fp8's ladder
+  for the base GEMM term.
+- `compute_scale` / `scale_matrix` tables get **no** transfer ladder: they
+  are only consumed by `fp8_static` (which has data wherever it's admitted;
+  the SILICON early-reject for missing overhead tables at task_v2.py:1315
+  stays). A future data-less quant never touches them.
+
+## 4. `_GEMM_QUANT_UTIL_LEVEL` — seed method and values
+
+Same contract as `_MOE_QUANT_UTIL_LEVEL` (moe.py:87): keyed by
+`(memory, compute)` profile, single scalar per profile (the per-component
+split was already validated as untrustworthy for MoE — same reasoning holds:
+only the *ratio* is consumed), levels relative and tunable, `[data]` /
+`[inferred]` annotations per row.
+
+Derivation (offline, script committed under the PR as the method-of-record in
+the table's comment): for every `(system, backend, version)` gemm table,
+`util = SOL/measured` per row, level = median util over the clearly
+compute-bound region (`m ≥ 1024, n ≥ 2048, k ≥ 2048`) — the region where the
+systematic kernel-efficiency offset dominates and launch-overhead noise is
+excluded. Cross-stack check on b200/h200/h100 × trtllm/vllm/sglang:
+
+| profile | measured medians (min–max across 6 stacks) | seed |
+|---|---|---|
+| (2, 1) bf16 | 0.55 – 0.79 | 0.70 `[data]` |
+| (1, 2) fp8-family | 0.28 – 0.55 | 0.45 `[data]` |
+| (0.5625, 4) nvfp4 | 0.21 – 0.36 | 0.30 `[data]` |
+| (0.5, 4) w4a4 | — | 0.30 `[inferred ≈ nvfp4]` |
+| (1, 1) w8a16 | — | 0.55 `[inferred]` |
+| (0.5, 1) w4a16 | — | 0.45 `[inferred: fused-dequant weight-only runs below the bf16 compute roofline it shares; Marlin-class]` |
+| (0.5, 2) w4a8 | — | 0.35 `[inferred]` |
+| default | — | 0.45 |
+
+The bf16/fp8 ratio is 1.38–2.00 across the six stacks (±20% around ~1.6) —
+looser than MoE's ~10% but stable enough for a last-resort tier. LOO on the
+mechanism (predict a collected quant from its nearest-profile sibling at
+shared shapes, `m ≥ 64`): the practically relevant direction
+`nvfp4 ← fp8` gives 22–33% MAPE (vs 24–33% unscaled — levels near-tie there);
+`fp8 ← bf16` gives ~50–60% scaled vs ~60–80% raw. Final seeds re-derived at
+implementation time with this script and recorded in the comment, MoE-style.
+
+## 5. Rust mirror
+
+Same-PR, point-for-point parity:
+
+- `operators/gemm.rs`: `gemm_empirical` gains the ladder
+  (own grid → xquant → xprofile), reusing `util_empirical.rs`'s
+  `UtilGrid.reference_provenance`, `nearest_candidate_index`, and
+  `ProvenanceTier::XProfile` (already present). `GEMM_QUANT_UTIL_LEVEL`
+  const + `gemm_quant_util_level()` mirroring the Python table verbatim.
+- **Ordering gotcha**: `GemmGrids.by_quant` is a `BTreeMap` (alphabetical),
+  but Python iterates the gemm dict in file-row (first-seen) order and the
+  XQUANT tie-break depends on it. The loader must additionally record
+  first-seen quant order (`quant_order: Vec<String>`), and a new
+  `GemmTable::available_quants()` returns that order — the exact analogue of
+  `MoeTable::available_quants` ("first-seen (file row) order").
+- Grid cache keys: `gemm_xquant:{...}` / `gemm_xprofile:{...}` carrying
+  quant, ref-quant, and `policy_fingerprint` (moe.rs:122 pattern) so
+  differently-policied lookups cannot alias.
+- Pre-push: `cargo test --workspace --all-features` (default args miss the
+  public-api pins and pyo3-gated tests).
+
+## 6. Validate-gate cleanup (`task_v2._check_role_against_db`)
+
+Target invariant: **the gate mirrors the ladder — admits exactly what the
+resolved policy + DB contents make reachable at query time, and never more.**
+
+1. `_check("gemm", gemm_quant_mode)` → `profile_transfer=True` (GEMM now has
+   the transfer machinery, so the relaxation MoE already gets applies).
+2. Reachability extends beyond XQUANT:
+   - `xquant_enabled` (existing, task_v2.py:1342): non-SILICON mode AND
+     `TransferKind.XQUANT ∈ resolve_transfer_policy(...)` AND
+     `_profile_reachable` (a same-profile supported quant exists).
+   - **new** `xprofile_enabled`: non-SILICON mode AND
+     `TransferKind.XPROFILE ∈ resolve_transfer_policy(...)` AND the query
+     quant's `(memory, compute)` profile is listed in the op's util-level
+     table AND the DB has ≥1 supported quant of a *different* profile
+     (any collected quant is a viable nearest-profile reference).
+   - The profile-listed condition is exposed as a small public helper per op
+     (e.g. `gemm.xprofile_util_level_known(mode)` /
+     `moe.xprofile_util_level_known(mode)`) so the gate doesn't reach into
+     private tables. Note the one deliberate delta vs. runtime: the ladder
+     falls back to a default level for unlisted profiles, but the gate
+     requires a listed profile — this enforces the "enum line + level line"
+     recipe instead of silently admitting a quant nobody calibrated.
+     (Flagged here because the stated goal is "not stricter than the
+     ladder"; this is the single, intentional exception.)
+   - Applies to `gemm`, `moe`, and `wideep_*_moe` `_check` calls (the MoE
+     runtime ladder already has XPROFILE; today's gate is stricter than the
+     MoE ladder — that asymmetry is part of what this cleans).
+3. `validation_aliases` (task_v2.py:1372): drop `"nvfp4_wo": "bfloat16"`
+   (dead — no such enum member, and the normalize-to-bf16 design was
+   rejected in #1392 review; profile-reachability is its replacement).
+   **Keep** `"w4a16_mxfp4_cutlass": "w4a16_mxfp4"` — verified real: moe.py's
+   query path normalizes `w4a16_mxfp4_cutlass` for table lookup
+   (moe.py:2491), so the alias mirrors an actual normalize.
+4. SILICON behavior unchanged: both flags require non-SILICON mode, so
+   data-less quants still fail fast in SILICON.
+
+## 7. Behavior changes (intentional, to be stated in the PR)
+
+- HYBRID/EMPIRICAL estimates for *existing* quants on systems where they have
+  no data change from "raise `EmpiricalNotImplementedError`" to "xprofile
+  estimate" under the default (`aggressive`) policy — e.g. nvfp4 GEMM on
+  Hopper. This is the mechanism working as intended; previously-computable
+  values (silicon, own-grid empirical, covered hybrid) are bit-unchanged —
+  the ladder only extends behind the existing miss.
+- Parity ladder-miss case
+  `minimax-m25-nvfp4-h200-vllm-019-hybrid-miss` +
+  `test_hybrid_ladder_miss_raises_typed_empirical_miss`: after the GEMM
+  ladder lands, the raise moves from the first NVFP4 GEMM op to the NVFP4
+  MoE op (whose h200/vllm tables have no reference slice at that tp/ep, per
+  the case's own comment) — error symmetry must be re-verified and the case
+  comments updated, **not deleted** (main is the error-symmetric version).
+  The SILICON typed-miss case (`test_silicon_data_gap_raises_typed_perf_data_miss`)
+  is untouched by construction.
+- Support-matrix HYBRID tier labels may improve for previously-failing
+  configs (provenance `xprofile` now reachable for dense models). No
+  support-matrix code changes.
+
+## 8. Tests
+
+1. **Mechanism acceptance (Python)**: fixture DB whose gemm table carries
+   only `bfloat16`; query an existing dataless quant (`int4_wo`, profile
+   `(0.5, 1)` — present in the enum, absent from every fixture) →
+   HYBRID returns a finite latency with provenance `xprofile` and
+   `util_scale = e(0.5,1)/e(2,1)`; SILICON raises
+   `PerfDataNotAvailableError`; policy `balanced` (no XPROFILE) still raises
+   `EmpiricalNotImplementedError`. This is the "synthetic new quant"
+   equivalent — the mechanism keys only off profile + level line, so an
+   existing enum member with no data exercises exactly the add-a-quant path.
+2. **XQUANT tier (Python)**: fixture with `fp8` data only; query `sq` →
+   provenance `xquant`, latency equals the fp8-grid reconstruction with the
+   query's own SOL (no rescale).
+3. **Gate tests**: gemm quant admitted under HYBRID+aggressive when only a
+   different-profile quant is in `supported_quant_mode`; rejected under
+   SILICON; rejected under `transfer_policy="balanced"`; rejected when the
+   profile is not in the level table. Alias-removal regression: a fake
+   `"nvfp4_wo"` string no longer validates.
+4. **Rust parity**: unit oracles in `gemm.rs` tests pinning Python-probed
+   values for one xquant and one xprofile query (same fixture pattern as
+   `moe_xprofile_transfer_matches_python_oracle`, moe.rs:937), incl. the
+   first-seen-order tie-break; engine-step parity gains a
+   dense-model xprofile case; existing ladder-miss/error-symmetry cases kept
+   (§7).
+5. **Zero-change regression**: full unit suite + golden comparison; goldens
+   must not move (all golden configs resolve at silicon/own-grid tiers).
+
+## 9. Docs deliverable
+
+`docs/design/how_to_add_a_gemm_quant_mode.md` (one page, the #1392 handoff):
+enum line → level-table line (both languages) → what the gate now admits →
+how to verify (the §8.1 test as template) → when to graduate from XPROFILE
+borrow to collected data.
+
+## 10. Open items to confirm before coding
+
+1. Gate/ladder delta in §6.2 (gate requires a *listed* profile; ladder has a
+   default): keep as specified (recommended — enforces the recipe), or relax
+   the gate to mirror the default too?
+2. Seed statistic: median over the compute-bound region (`m≥1024, n,k≥2048`)
+   as above; alternative is per-stack tables (rejected: MoE precedent is one
+   global table, and only ratios are consumed).
+3. XQUANT first-seen-order tie-break (MoE convention, needs the Rust
+   `quant_order` addition) vs. a fixed enum-order tie-break (no loader
+   change, but diverges from MoE's established semantics). Design assumes
+   the former.
+
+## 11. As-built resolutions (post-review, implemented)
+
+1. **§10.1–3 resolved as recommended**: gate requires a listed profile
+   (recipe enforcement, the one intentional gate-stricter delta); global
+   level table seeded from compute-bound medians; first-seen-order
+   tie-break with the Rust `GemmGrids.quant_order` addition.
+2. **Semantics unified — one primitive, derived labels (review decision).**
+   `xshape`/`xquant`/`xprofile` are not three mechanisms but confidence
+   labels over ONE borrow primitive
+   (`util_empirical.quant_transfer_grid`): correction is
+   `e(profile_q)/e(profile_ref)`, identically 1 within a profile. MoE was
+   refactored onto the primitive with zero behavior change (pinned by the
+   existing unit suite and Rust parity oracles); GEMM is the second
+   consumer. GEMM's xshape relation class is structurally EMPTY (the
+   own-quant depth-3 grid subsumes cross-shape), encoded as an empty
+   candidate list, not an omitted code path.
+3. **Compute-first XPROFILE ordering for GEMM** (review requirement: a
+   weight-only quant must borrow float16/bfloat16 data, without any
+   quant-specific code). GEMM orders cross-profile references
+   lexicographically by `(|Δcompute|, |Δmemory|)`
+   (`xprofile_quant_order(prefer_same_compute=True)`): the compute factor
+   (activation precision) determines the dense kernel's compute family, so
+   e.g. `(0.5625, 1)` deterministically borrows bfloat16 instead of
+   tie-breaking into fp8 under plain L1 (both at distance 1.4375). MoE
+   keeps its historical L1 metric — its level ratios were validated under
+   that ordering and existing selections must not reshuffle.
+4. **§7 parity-case outcome, stronger than predicted**: on
+   h200/vllm/0.19.0 the MiniMax-M2.5-NVFP4 HYBRID case now COMPUTES on both
+   sides under the default policy (the MoE ladder always had a reachable
+   reference there; the old raise came from the GEMM op, and the old test
+   comment misattributed it to MoE). The case was re-labelled
+   `...-hybrid-xprofile` (value parity) and the error-symmetry contract
+   moved to a new `...-hybrid-balanced-miss` case + the FFI typed-miss test,
+   both pinned with `transfer_policy="balanced"` (no same-profile sibling
+   for (0.5625, 4) ⇒ the miss is stable by construction).
+5. **Level seeds shipped as proposed** (bf16 0.70, fp8-family 0.45, nvfp4
+   0.30, inferred rows per §4), with method + LOO documented on the Python
+   table and mirrored in the Rust const.

--- a/docs/design/gemm_quant_transfer_design.md
+++ b/docs/design/gemm_quant_transfer_design.md
@@ -1,279 +1,114 @@
-# GEMM quant-transfer tiers + validate-gate cleanup — design
+# GEMM quant transfer + validate-gate mirror (as built)
 
-Status: IMPLEMENTED (see §11 for as-built resolutions of the open items and
-confirmed-in-review semantic decisions; §3/§5/§6 below are the original
-proposal and remain accurate except where §11 notes a delta)
-Branch: `worktree-gemm-xprofile-borrow`
-Relation: prerequisite mechanism for PR #1392 (nvfp4_wo); adds **no new quant**.
-Companion recipe: `docs/design/how_to_add_a_gemm_quant_mode.md`.
+PR #1455 — prerequisite mechanism for #1392 (nvfp4_wo); adds **no new quant**.
+Recipe for adding one: `how_to_add_a_gemm_quant_mode.md`.
 
-## 1. Goal
+## Goal
 
-Give GEMM the same empirical transfer ladder MoE already has, so a quant with
-no collected GEMM data can be estimated in HYBRID/EMPIRICAL via util borrowing
-instead of raising, and clean the `task_v2` validate gate so it mirrors —
-never exceeds — the query ladder's admission policy.
+A quant with no collected GEMM data becomes estimable in HYBRID/EMPIRICAL by
+borrowing a collected quant's util curve (as MoE already could), and the
+`task_v2` validate gate admits exactly what the resolved transfer policy + DB
+contents make reachable at query time — never more. Acceptance: one enum line
++ one util-level line per new quant.
 
-Acceptance: adding a future data-less quant requires only (a) one
-`GEMMQuantMode` enum line and (b) one `_GEMM_QUANT_UTIL_LEVEL` line, and
-HYBRID estimate works end-to-end while SILICON still rejects early.
+## Semantics: one primitive, derived labels
 
-Out of scope (unchanged): `nvfp4_wo` or any new enum member, `cli/api.py`
-resolve_* call sites, `tools/support_matrix/` FP4 gate, `collector/`,
-`generator/`, WideEP alltoall dispatch path.
+`util_empirical.quant_transfer_grid` is the single borrow mechanism:
 
-## 2. Current state and gap
+    latency(query) = SOL_query / (util_ref × e(profile_query)/e(profile_ref))
 
-`operations/moe.py::get_empirical` walks: own-shape grid → XSHAPE → XQUANT →
-XPROFILE (util-level-ratio rescale), each gated by
-`database.transfer_policy`.
+The correction ratio is identically 1 within a `(memory, compute)` profile,
+so `xshape` / `xquant` / `xprofile` are **confidence labels derived from the
+selected reference's relation to the query**, not three mechanisms:
 
-`operations/gemm.py::_query_gemm_table::get_empirical` (gemm.py:446-465) only
-builds the query quant's own depth-3 `(m, n, k)` util grid via
-`util_empirical.grid_for`. A quant with zero rows in `gemm_perf.parquet`
-yields `grid=None` → `EmpiricalNotImplementedError`, regardless of policy.
-Rust `operators/gemm.rs::gemm_empirical` mirrors that exactly.
+| label | relation | correction | trust source |
+|---|---|---|---|
+| `xshape` | same quant, other slice | 1 | kernel identity |
+| `xquant` | same profile | 1 (structural) | SOL-coefficient identity — no calibrated constant |
+| `xprofile` | cross profile | level ratio | calibrated per-profile util LEVEL; last resort |
 
-The validate gate (`task_v2.py:1268-1406`) checks GEMM with **no**
-`profile_transfer`, and its `_profile_reachable` only models XQUANT
-(same-profile). It also carries a dead string alias
-`"nvfp4_wo": "bfloat16"` (task_v2.py:1372) pre-planted by #1395 — no such
-enum member exists, and normalize-to-bf16 was the review-rejected approach.
+Reference preference is lexicographic (relation rank, profile distance,
+slice-feature distance), implemented as the historical tier flow so MoE's
+established selection semantics stay bit-identical (MoE was refactored onto
+the primitive; pinned by its unit suite and Rust parity oracles). Policy
+tokens (`TransferKind`) act as relation admission filters — `balanced` stops
+at the zero-calibration relations.
 
-## 3. GEMM ladder design — tier by tier
+## GEMM specifics
 
-Ladder inserted in `get_empirical` after the own-grid miss
-(`grid is None or not grid.samples`), mirroring moe.py's structure and
-respecting `database.transfer_policy`:
+- **`xshape` is structurally empty**: the own-quant grid is already depth-3
+  over every collected `(m, n, k)` (GEMM has no categorical slice axes), so
+  there is no "other slice of the same quant" to borrow. Encoded as an empty
+  candidate list, not an omitted code path.
+- **`xquant`**: first same-profile sibling in file (first-seen) order — one
+  whole-table candidate per sibling with constant features, so the pooled
+  nearest-feature selection degrades to file order. Same SOL, no rescale.
+- **`xprofile` ordering is compute-first**: `(|Δcompute|, |Δmemory|)`
+  lexicographic (`xprofile_quant_order(prefer_same_compute=True)`). The
+  compute factor (activation precision) determines the dense kernel's
+  compute family — a weight-only quant runs bf16 MMA after fused dequant —
+  so e.g. `(0.5625, 1)` deterministically borrows **bfloat16**; under plain
+  L1 it ties bf16/fp8 at 1.4375 and the reference would be a file-order
+  lottery. **MoE keeps its historical L1 metric**: its level ratios were
+  validated under that ordering and existing selections must not reshuffle.
+- `fp8_static` enters the ladder as its table quant `fp8` (existing
+  normalize); the `compute_scale`/`scale_matrix` overhead tables get no
+  ladder (only `fp8_static` consumes them, and it requires data anyway).
+- Level table `_GEMM_QUANT_UTIL_LEVEL` (`operations/gemm.py`, Rust mirror in
+  `operators/gemm.rs`): values, derivation method (compute-bound-region
+  medians across b200/h200/h100 × trtllm/vllm/sglang) and LOO evidence
+  (nvfp4←fp8 22–33% MAPE; bf16/fp8 ratio stable to ~±20%) are documented on
+  the table itself — the code comment is the method-of-record.
 
-| Tier | Decision | Reason |
-|---|---|---|
-| own-grid | keep as-is | unchanged fast path; provenance `empirical` |
-| XSHAPE | **omitted** | GEMM's own grid is already depth-3 over *all* collected `(m, n, k)` of the query quant with per-axis clamping + 2-NN in normalized log space — any own-quant sample anywhere already feeds it. A separate "nearest collected shape within the query quant" tier would select from exactly the same sample set and can never fire when the own grid is empty. (MoE needs XSHAPE because its own grid is sliced per categorical shape `(topk, experts, hidden, inter, tp, ep)`; GEMM has no categorical shape axes.) |
-| XQUANT | **added** | same `(memory, compute)` profile ⇒ GEMM SOL is *numerically identical* (profile fully determines `sol_math`/`sol_mem` for a given shape), so a sibling's util grid transfers with no rescale. Real coverage wins today: `sq`/`fp8_ootb`/`fp8_block` ↔ `fp8` (all `(1,2)`) on systems where only one was collected. Provenance `xquant`, `util_scale=1`. |
-| XPROFILE | **added** (the core deliverable) | no same-profile data at all → borrow the nearest-profile collected quant's full `(m, n, k)` util grid, built with the **reference** quant's own SOL, rescaled by `e(query)/e(ref)` from `_GEMM_QUANT_UTIL_LEVEL`. Provenance `xprofile`. Last resort, lowest confidence. |
-| XOP | **omitted** | no meaningful donor op for a dense GEMM; MoE's per-expert grouped GEMM has different launch/kernel structure. Nothing enables it; the policy token stays inert for GEMM. |
+## Validate gate (`task_v2._check_role_against_db`)
 
-Mechanics shared with MoE (reuse, don't fork):
+`gemm` (and `moe`/`wideep_*_moe`) `_check` with `profile_transfer=True`:
 
-- Python: candidates built as `util_empirical.ReferenceCandidate`; grids via
-  `util_empirical.grid_from_reference` (cache keys `("gemm_xquant", ...)` /
-  `("gemm_xprofile", ...)` including quant, ref-quant and policy in
-  `selection_key`). One candidate per sibling quant; its `node` is that
-  quant's whole `m→n→k` table, `features` are the profile pair
-  `(memory, compute)`, `sol_fn` bound per the ReferenceCandidate contract
-  (query quant's SOL for XQUANT — numerically equal anyway; ref quant's SOL
-  for XPROFILE).
-- Candidate ordering: XQUANT candidates all tie on features →
-  `_nearest_candidate`'s stable argmin picks the **first-seen table quant**
-  (dict insertion = file row order), identical to MoE's tie-break convention.
-  XPROFILE loops nearest-profile-first via a `_xprofile_gemm_quants` helper
-  with the same `|Δmemory| + |Δcompute|` distance as `_xprofile_moe_quants`.
-- The ladder operates on the **table quant** after
-  `_normalize_gemm_quant_mode_for_table` (fp8_static→fp8), exactly like the
-  own-grid path does today; `fp8_static` therefore inherits fp8's ladder
-  for the base GEMM term.
-- `compute_scale` / `scale_matrix` tables get **no** transfer ladder: they
-  are only consumed by `fp8_static` (which has data wherever it's admitted;
-  the SILICON early-reject for missing overhead tables at task_v2.py:1315
-  stays). A future data-less quant never touches them.
+- `xquant_enabled` = non-SILICON mode ∧ `XQUANT` ∈ resolved policy ∧ a
+  same-profile supported quant exists.
+- `xprofile_enabled` = non-SILICON mode ∧ `XPROFILE` ∈ resolved policy ∧ the
+  query profile is **listed** in the op's level table ∧ ≥1 supported quant
+  of a different profile. The listed-profile condition is the one deliberate
+  way the gate is stricter than the ladder (which has a default level): it
+  enforces the enum-line + level-line recipe instead of silently admitting a
+  quant nobody calibrated.
+- Dead `"nvfp4_wo": "bfloat16"` validation alias removed (no such enum
+  member; normalize-to-bf16 was reviewed out of #1392 — it substitutes the
+  reference's SOL for the query's, losing the w4 memory-side benefit). The
+  real `w4a16_mxfp4_cutlass → w4a16_mxfp4` alias (a query-time normalize,
+  moe.py) is kept. SILICON behavior unchanged.
 
-## 4. `_GEMM_QUANT_UTIL_LEVEL` — seed method and values
+## Rust parity notes
 
-Same contract as `_MOE_QUANT_UTIL_LEVEL` (moe.py:87): keyed by
-`(memory, compute)` profile, single scalar per profile (the per-component
-split was already validated as untrustworthy for MoE — same reasoning holds:
-only the *ratio* is consumed), levels relative and tunable, `[data]` /
-`[inferred]` annotations per row.
+- `GemmGrids.by_quant` is a `BTreeMap` (alphabetical); ladder tie-breaks are
+  pinned to Python's dict-insertion (file row) order, so the loader records
+  `quant_order` and `GemmTable::available_quants()` exposes it — the
+  analogue of `MoeTable::available_quants`.
+- xquant takes the FIRST same-profile sibling and does not retry on an empty
+  grid (parity with Python's single pooled selection); xprofile loops until
+  a non-empty grid.
+- Oracle tests in `operators/gemm.rs` pin Python values at 1e-9, including a
+  case where compute-first and L1/file-order orderings disagree.
 
-Derivation (offline, script committed under the PR as the method-of-record in
-the table's comment): for every `(system, backend, version)` gemm table,
-`util = SOL/measured` per row, level = median util over the clearly
-compute-bound region (`m ≥ 1024, n ≥ 2048, k ≥ 2048`) — the region where the
-systematic kernel-efficiency offset dominates and launch-overhead noise is
-excluded. Cross-stack check on b200/h200/h100 × trtllm/vllm/sglang:
+## Behavior change (intentional)
 
-| profile | measured medians (min–max across 6 stacks) | seed |
-|---|---|---|
-| (2, 1) bf16 | 0.55 – 0.79 | 0.70 `[data]` |
-| (1, 2) fp8-family | 0.28 – 0.55 | 0.45 `[data]` |
-| (0.5625, 4) nvfp4 | 0.21 – 0.36 | 0.30 `[data]` |
-| (0.5, 4) w4a4 | — | 0.30 `[inferred ≈ nvfp4]` |
-| (1, 1) w8a16 | — | 0.55 `[inferred]` |
-| (0.5, 1) w4a16 | — | 0.45 `[inferred: fused-dequant weight-only runs below the bf16 compute roofline it shares; Marlin-class]` |
-| (0.5, 2) w4a8 | — | 0.35 `[inferred]` |
-| default | — | 0.45 |
+HYBRID/EMPIRICAL queries for existing quants with no data on a system change
+from raising `EmpiricalNotImplementedError` to a policy-gated estimate under
+the default policy (e.g. nvfp4 GEMM on Hopper). Previously-computable paths
+are bit-unchanged; restrictive policies still reject. Parity-case fallout:
+`minimax-m25-nvfp4-h200` HYBRID now computes on both sides — the old raise
+came from the GEMM op (the old comment misattributed it to MoE) — so that
+case became a value-parity `…-hybrid-xprofile` case and the error-symmetry
+contract moved to `…-hybrid-balanced-miss` + the FFI typed-miss test, pinned
+with `transfer_policy="balanced"` (no same-profile sibling for `(0.5625, 4)`
+⇒ the miss is stable by construction).
 
-The bf16/fp8 ratio is 1.38–2.00 across the six stacks (±20% around ~1.6) —
-looser than MoE's ~10% but stable enough for a last-resort tier. LOO on the
-mechanism (predict a collected quant from its nearest-profile sibling at
-shared shapes, `m ≥ 64`): the practically relevant direction
-`nvfp4 ← fp8` gives 22–33% MAPE (vs 24–33% unscaled — levels near-tie there);
-`fp8 ← bf16` gives ~50–60% scaled vs ~60–80% raw. Final seeds re-derived at
-implementation time with this script and recorded in the comment, MoE-style.
+## Out of scope
 
-## 5. Rust mirror
-
-Same-PR, point-for-point parity:
-
-- `operators/gemm.rs`: `gemm_empirical` gains the ladder
-  (own grid → xquant → xprofile), reusing `util_empirical.rs`'s
-  `UtilGrid.reference_provenance`, `nearest_candidate_index`, and
-  `ProvenanceTier::XProfile` (already present). `GEMM_QUANT_UTIL_LEVEL`
-  const + `gemm_quant_util_level()` mirroring the Python table verbatim.
-- **Ordering gotcha**: `GemmGrids.by_quant` is a `BTreeMap` (alphabetical),
-  but Python iterates the gemm dict in file-row (first-seen) order and the
-  XQUANT tie-break depends on it. The loader must additionally record
-  first-seen quant order (`quant_order: Vec<String>`), and a new
-  `GemmTable::available_quants()` returns that order — the exact analogue of
-  `MoeTable::available_quants` ("first-seen (file row) order").
-- Grid cache keys: `gemm_xquant:{...}` / `gemm_xprofile:{...}` carrying
-  quant, ref-quant, and `policy_fingerprint` (moe.rs:122 pattern) so
-  differently-policied lookups cannot alias.
-- Pre-push: `cargo test --workspace --all-features` (default args miss the
-  public-api pins and pyo3-gated tests).
-
-## 6. Validate-gate cleanup (`task_v2._check_role_against_db`)
-
-Target invariant: **the gate mirrors the ladder — admits exactly what the
-resolved policy + DB contents make reachable at query time, and never more.**
-
-1. `_check("gemm", gemm_quant_mode)` → `profile_transfer=True` (GEMM now has
-   the transfer machinery, so the relaxation MoE already gets applies).
-2. Reachability extends beyond XQUANT:
-   - `xquant_enabled` (existing, task_v2.py:1342): non-SILICON mode AND
-     `TransferKind.XQUANT ∈ resolve_transfer_policy(...)` AND
-     `_profile_reachable` (a same-profile supported quant exists).
-   - **new** `xprofile_enabled`: non-SILICON mode AND
-     `TransferKind.XPROFILE ∈ resolve_transfer_policy(...)` AND the query
-     quant's `(memory, compute)` profile is listed in the op's util-level
-     table AND the DB has ≥1 supported quant of a *different* profile
-     (any collected quant is a viable nearest-profile reference).
-   - The profile-listed condition is exposed as a small public helper per op
-     (e.g. `gemm.xprofile_util_level_known(mode)` /
-     `moe.xprofile_util_level_known(mode)`) so the gate doesn't reach into
-     private tables. Note the one deliberate delta vs. runtime: the ladder
-     falls back to a default level for unlisted profiles, but the gate
-     requires a listed profile — this enforces the "enum line + level line"
-     recipe instead of silently admitting a quant nobody calibrated.
-     (Flagged here because the stated goal is "not stricter than the
-     ladder"; this is the single, intentional exception.)
-   - Applies to `gemm`, `moe`, and `wideep_*_moe` `_check` calls (the MoE
-     runtime ladder already has XPROFILE; today's gate is stricter than the
-     MoE ladder — that asymmetry is part of what this cleans).
-3. `validation_aliases` (task_v2.py:1372): drop `"nvfp4_wo": "bfloat16"`
-   (dead — no such enum member, and the normalize-to-bf16 design was
-   rejected in #1392 review; profile-reachability is its replacement).
-   **Keep** `"w4a16_mxfp4_cutlass": "w4a16_mxfp4"` — verified real: moe.py's
-   query path normalizes `w4a16_mxfp4_cutlass` for table lookup
-   (moe.py:2491), so the alias mirrors an actual normalize.
-4. SILICON behavior unchanged: both flags require non-SILICON mode, so
-   data-less quants still fail fast in SILICON.
-
-## 7. Behavior changes (intentional, to be stated in the PR)
-
-- HYBRID/EMPIRICAL estimates for *existing* quants on systems where they have
-  no data change from "raise `EmpiricalNotImplementedError`" to "xprofile
-  estimate" under the default (`aggressive`) policy — e.g. nvfp4 GEMM on
-  Hopper. This is the mechanism working as intended; previously-computable
-  values (silicon, own-grid empirical, covered hybrid) are bit-unchanged —
-  the ladder only extends behind the existing miss.
-- Parity ladder-miss case
-  `minimax-m25-nvfp4-h200-vllm-019-hybrid-miss` +
-  `test_hybrid_ladder_miss_raises_typed_empirical_miss`: after the GEMM
-  ladder lands, the raise moves from the first NVFP4 GEMM op to the NVFP4
-  MoE op (whose h200/vllm tables have no reference slice at that tp/ep, per
-  the case's own comment) — error symmetry must be re-verified and the case
-  comments updated, **not deleted** (main is the error-symmetric version).
-  The SILICON typed-miss case (`test_silicon_data_gap_raises_typed_perf_data_miss`)
-  is untouched by construction.
-- Support-matrix HYBRID tier labels may improve for previously-failing
-  configs (provenance `xprofile` now reachable for dense models). No
-  support-matrix code changes.
-
-## 8. Tests
-
-1. **Mechanism acceptance (Python)**: fixture DB whose gemm table carries
-   only `bfloat16`; query an existing dataless quant (`int4_wo`, profile
-   `(0.5, 1)` — present in the enum, absent from every fixture) →
-   HYBRID returns a finite latency with provenance `xprofile` and
-   `util_scale = e(0.5,1)/e(2,1)`; SILICON raises
-   `PerfDataNotAvailableError`; policy `balanced` (no XPROFILE) still raises
-   `EmpiricalNotImplementedError`. This is the "synthetic new quant"
-   equivalent — the mechanism keys only off profile + level line, so an
-   existing enum member with no data exercises exactly the add-a-quant path.
-2. **XQUANT tier (Python)**: fixture with `fp8` data only; query `sq` →
-   provenance `xquant`, latency equals the fp8-grid reconstruction with the
-   query's own SOL (no rescale).
-3. **Gate tests**: gemm quant admitted under HYBRID+aggressive when only a
-   different-profile quant is in `supported_quant_mode`; rejected under
-   SILICON; rejected under `transfer_policy="balanced"`; rejected when the
-   profile is not in the level table. Alias-removal regression: a fake
-   `"nvfp4_wo"` string no longer validates.
-4. **Rust parity**: unit oracles in `gemm.rs` tests pinning Python-probed
-   values for one xquant and one xprofile query (same fixture pattern as
-   `moe_xprofile_transfer_matches_python_oracle`, moe.rs:937), incl. the
-   first-seen-order tie-break; engine-step parity gains a
-   dense-model xprofile case; existing ladder-miss/error-symmetry cases kept
-   (§7).
-5. **Zero-change regression**: full unit suite + golden comparison; goldens
-   must not move (all golden configs resolve at silicon/own-grid tiers).
-
-## 9. Docs deliverable
-
-`docs/design/how_to_add_a_gemm_quant_mode.md` (one page, the #1392 handoff):
-enum line → level-table line (both languages) → what the gate now admits →
-how to verify (the §8.1 test as template) → when to graduate from XPROFILE
-borrow to collected data.
-
-## 10. Open items to confirm before coding
-
-1. Gate/ladder delta in §6.2 (gate requires a *listed* profile; ladder has a
-   default): keep as specified (recommended — enforces the recipe), or relax
-   the gate to mirror the default too?
-2. Seed statistic: median over the compute-bound region (`m≥1024, n,k≥2048`)
-   as above; alternative is per-stack tables (rejected: MoE precedent is one
-   global table, and only ratios are consumed).
-3. XQUANT first-seen-order tie-break (MoE convention, needs the Rust
-   `quant_order` addition) vs. a fixed enum-order tie-break (no loader
-   change, but diverges from MoE's established semantics). Design assumes
-   the former.
-
-## 11. As-built resolutions (post-review, implemented)
-
-1. **§10.1–3 resolved as recommended**: gate requires a listed profile
-   (recipe enforcement, the one intentional gate-stricter delta); global
-   level table seeded from compute-bound medians; first-seen-order
-   tie-break with the Rust `GemmGrids.quant_order` addition.
-2. **Semantics unified — one primitive, derived labels (review decision).**
-   `xshape`/`xquant`/`xprofile` are not three mechanisms but confidence
-   labels over ONE borrow primitive
-   (`util_empirical.quant_transfer_grid`): correction is
-   `e(profile_q)/e(profile_ref)`, identically 1 within a profile. MoE was
-   refactored onto the primitive with zero behavior change (pinned by the
-   existing unit suite and Rust parity oracles); GEMM is the second
-   consumer. GEMM's xshape relation class is structurally EMPTY (the
-   own-quant depth-3 grid subsumes cross-shape), encoded as an empty
-   candidate list, not an omitted code path.
-3. **Compute-first XPROFILE ordering for GEMM** (review requirement: a
-   weight-only quant must borrow float16/bfloat16 data, without any
-   quant-specific code). GEMM orders cross-profile references
-   lexicographically by `(|Δcompute|, |Δmemory|)`
-   (`xprofile_quant_order(prefer_same_compute=True)`): the compute factor
-   (activation precision) determines the dense kernel's compute family, so
-   e.g. `(0.5625, 1)` deterministically borrows bfloat16 instead of
-   tie-breaking into fp8 under plain L1 (both at distance 1.4375). MoE
-   keeps its historical L1 metric — its level ratios were validated under
-   that ordering and existing selections must not reshuffle.
-4. **§7 parity-case outcome, stronger than predicted**: on
-   h200/vllm/0.19.0 the MiniMax-M2.5-NVFP4 HYBRID case now COMPUTES on both
-   sides under the default policy (the MoE ladder always had a reachable
-   reference there; the old raise came from the GEMM op, and the old test
-   comment misattributed it to MoE). The case was re-labelled
-   `...-hybrid-xprofile` (value parity) and the error-symmetry contract
-   moved to a new `...-hybrid-balanced-miss` case + the FFI typed-miss test,
-   both pinned with `transfer_policy="balanced"` (no same-profile sibling
-   for (0.5625, 4) ⇒ the miss is stable by construction).
-5. **Level seeds shipped as proposed** (bf16 0.70, fp8-family 0.45, nvfp4
-   0.30, inferred rows per §4), with method + LOO documented on the Python
-   table and mirrored in the Rust const.
+No new quant enum members; no `cli/api.py` resolve_* changes; no
+`tools/support_matrix/` FP4-gate changes; no `collector/` or `generator/`
+changes; WideEP alltoall dispatch unchanged. A possible follow-up (not this
+PR): route the borrowed slice through the perf_interp v2 engine instead of
+the deliberately simple `UtilGrid` 2-NN, unifying within-slice resolution —
+changes every empirical estimate's numerics, so it needs its own LOO
+evidence and golden re-pinning.

--- a/docs/design/how_to_add_a_gemm_quant_mode.md
+++ b/docs/design/how_to_add_a_gemm_quant_mode.md
@@ -1,0 +1,82 @@
+# How to add a GEMM quant mode (without collected data)
+
+Audience: anyone adding a quant mode the perf DB has no data for — the
+handoff recipe for PR #1392's `nvfp4_wo` and any successor. The transfer
+mechanism (this repo's "quant-transfer primitive") makes a data-less quant
+estimable in HYBRID/EMPIRICAL by borrowing a collected quant's util curve;
+you only declare *what the quant is*, never *whose table it should read*.
+
+## The two lines
+
+1. **Enum line** — `GEMMQuantMode` in
+   `aic-core/src/aiconfigurator_core/sdk/common.py`, with the correct
+   `QuantMapping(memory, compute, name)`:
+   - `memory` = weight bytes per element **including scales** (nvfp4-style
+     4-bit + 1 fp8 scale per 16 = `9/16`).
+   - `compute` = the precision the MMA actually runs in: 1 = bf16, 2 = fp8,
+     4 = fp4. **A weight-only quant computes in bf16 ⇒ `compute=1`**, no
+     matter how the weights are stored. This field decides which data the
+     mechanism borrows (see below) — get it right.
+
+   Rust mirror (same PR): the `GemmQuantMode` variant + mapping in
+   `aic-core/rust/aiconfigurator-core/src/common/enums.rs`, and the
+   name-parse arm in `gemm_quant_by_name`
+   (`src/perf_database/gemm.rs`).
+
+2. **Util-level line** — only if the `(memory, compute)` profile is not yet
+   listed: one row in `_GEMM_QUANT_UTIL_LEVEL`
+   (`aic-core/src/aiconfigurator_core/sdk/operations/gemm.py`) and its Rust
+   mirror `GEMM_QUANT_UTIL_LEVEL` (`src/operators/gemm.rs`). The value is
+   the profile's typical achieved util (SOL/measured) in the compute-bound
+   region; derivation method and LOO evidence are documented on the Python
+   table. If unsure, match the structurally nearest `[inferred]` row — only
+   ratios are consumed. **The validate gate requires the profile to be
+   listed** (it deliberately refuses the runtime default fallback), so this
+   line is not optional for a new profile.
+
+That's it. No table normalization, no `validation_aliases`, no query-layer
+changes.
+
+## What you get, and from where
+
+- **HYBRID / EMPIRICAL**: `latency = SOL(your quant) / (util_ref ×
+  e(your profile)/e(ref profile))`, provenance `xprofile` (or `xquant`
+  unscaled, if a same-profile quant is collected). SOL uses YOUR profile —
+  a weight-only quant keeps its w4 HBM benefit on the memory-bound end.
+  This is why normalizing to another quant's table (the approach reviewed
+  out of #1392) is wrong: it substitutes the reference's SOL for yours.
+- **Reference selection is compute-first**: nearest profile by
+  `(|Δcompute|, |Δmemory|)`. A weight-only quant (`compute=1`) therefore
+  borrows **bfloat16** data — never tie-breaks into fp8 — because it runs
+  the bf16 MMA kernel family. `nvfp4_wo (0.5625, 1)` on Hopper borrows
+  bf16's util curve rescaled by `e(0.5-ish,1)/e(2,1)`.
+- **SILICON**: still rejects early (`_validate_database_quant_modes`) — no
+  data is no data; the gate admits the quant only in non-SILICON modes with
+  `TransferKind.XPROFILE` in the resolved transfer policy.
+
+## Verify
+
+- Template test:
+  `tests/unit/sdk/database/test_gemm_quant_transfer.py::test_xprofile_weight_only_borrows_bf16_not_fp8`
+  (uses `int4_wo` as the data-less stand-in; clone it for your quant, or
+  just extend `test_level_table_covers_every_gemm_quant_profile`).
+- Rust parity: extend
+  `gemm_quant_transfer_ladder_matches_python_oracles`
+  (`src/operators/gemm.rs`) with a Python-probed oracle for your quant
+  (generation snippet in the test doc comment).
+- Before pushing: `cargo test --workspace --all-features` (default args
+  miss the public-api pins and pyo3-gated tests) + the parity suite
+  `parity_tests/test_engine_step_parity.py`.
+
+## Graduating to collected data
+
+The ladder only fires behind an own-data miss: the day
+`gemm_perf.parquet` carries rows for your quant, they win automatically —
+no code change, delete nothing. Collect on the systems that matter and the
+provenance moves `xprofile → silicon` by itself.
+
+## Out of the mechanism's scope
+
+Checkpoint-name → quant resolution (`cli/api.py` `resolve_*`) and the
+support-matrix FP4 gate are separate decisions with their own owners; this
+recipe only makes the quant *estimable*.

--- a/docs/design/how_to_add_a_gemm_quant_mode.md
+++ b/docs/design/how_to_add_a_gemm_quant_mode.md
@@ -1,79 +1,56 @@
 # How to add a GEMM quant mode (without collected data)
 
-Audience: anyone adding a quant mode the perf DB has no data for — the
-handoff recipe for PR #1392's `nvfp4_wo` and any successor. The transfer
-mechanism (this repo's "quant-transfer primitive") makes a data-less quant
-estimable in HYBRID/EMPIRICAL by borrowing a collected quant's util curve;
-you only declare *what the quant is*, never *whose table it should read*.
+The handoff recipe for PR #1392's `nvfp4_wo` and any successor. Mechanism
+rationale lives in `gemm_quant_transfer_design.md`; this page is only the
+steps.
 
 ## The two lines
 
 1. **Enum line** — `GEMMQuantMode` in
-   `aic-core/src/aiconfigurator_core/sdk/common.py`, with the correct
+   `aic-core/src/aiconfigurator_core/sdk/common.py`, with
    `QuantMapping(memory, compute, name)`:
-   - `memory` = weight bytes per element **including scales** (nvfp4-style
-     4-bit + 1 fp8 scale per 16 = `9/16`).
-   - `compute` = the precision the MMA actually runs in: 1 = bf16, 2 = fp8,
-     4 = fp4. **A weight-only quant computes in bf16 ⇒ `compute=1`**, no
-     matter how the weights are stored. This field decides which data the
-     mechanism borrows (see below) — get it right.
+   - `memory` = weight bytes per element **including scales**
+     (nvfp4-style 4-bit + 1 fp8 scale per 16 = `9/16`).
+   - `compute` = the precision the MMA actually runs in (1 = bf16, 2 = fp8,
+     4 = fp4). **A weight-only quant computes in bf16 ⇒ `compute=1`** —
+     this field decides which data is borrowed (compute-first ordering ⇒
+     weight-only borrows bfloat16), so get it right.
 
-   Rust mirror (same PR): the `GemmQuantMode` variant + mapping in
-   `aic-core/rust/aiconfigurator-core/src/common/enums.rs`, and the
-   name-parse arm in `gemm_quant_by_name`
-   (`src/perf_database/gemm.rs`).
+   Rust mirror, same PR: the `GemmQuantMode` variant in
+   `rust/aiconfigurator-core/src/common/enums.rs` and the name-parse arm in
+   `gemm_quant_by_name` (`src/perf_database/gemm.rs`).
 
 2. **Util-level line** — only if the `(memory, compute)` profile is not yet
    listed: one row in `_GEMM_QUANT_UTIL_LEVEL`
-   (`aic-core/src/aiconfigurator_core/sdk/operations/gemm.py`) and its Rust
-   mirror `GEMM_QUANT_UTIL_LEVEL` (`src/operators/gemm.rs`). The value is
-   the profile's typical achieved util (SOL/measured) in the compute-bound
-   region; derivation method and LOO evidence are documented on the Python
-   table. If unsure, match the structurally nearest `[inferred]` row — only
-   ratios are consumed. **The validate gate requires the profile to be
-   listed** (it deliberately refuses the runtime default fallback), so this
-   line is not optional for a new profile.
+   (`operations/gemm.py`; derivation method on the table) and its Rust
+   mirror `GEMM_QUANT_UTIL_LEVEL` (`operators/gemm.rs`). If unsure, match
+   the structurally nearest `[inferred]` row — only ratios are consumed.
+   **The validate gate requires the profile to be listed**, so this line is
+   not optional for a new profile.
 
-That's it. No table normalization, no `validation_aliases`, no query-layer
-changes.
-
-## What you get, and from where
-
-- **HYBRID / EMPIRICAL**: `latency = SOL(your quant) / (util_ref ×
-  e(your profile)/e(ref profile))`, provenance `xprofile` (or `xquant`
-  unscaled, if a same-profile quant is collected). SOL uses YOUR profile —
-  a weight-only quant keeps its w4 HBM benefit on the memory-bound end.
-  This is why normalizing to another quant's table (the approach reviewed
-  out of #1392) is wrong: it substitutes the reference's SOL for yours.
-- **Reference selection is compute-first**: nearest profile by
-  `(|Δcompute|, |Δmemory|)`. A weight-only quant (`compute=1`) therefore
-  borrows **bfloat16** data — never tie-breaks into fp8 — because it runs
-  the bf16 MMA kernel family. `nvfp4_wo (0.5625, 1)` on Hopper borrows
-  bf16's util curve rescaled by `e(0.5-ish,1)/e(2,1)`.
-- **SILICON**: still rejects early (`_validate_database_quant_modes`) — no
-  data is no data; the gate admits the quant only in non-SILICON modes with
-  `TransferKind.XPROFILE` in the resolved transfer policy.
+No table normalization, no `validation_aliases`, no query-layer changes.
+HYBRID/EMPIRICAL then estimates via the transfer ladder (SOL stays your
+quant's own — the w4 memory-side benefit is preserved); SILICON still
+rejects until real data exists.
 
 ## Verify
 
 - Template test:
   `tests/unit/sdk/database/test_gemm_quant_transfer.py::test_xprofile_weight_only_borrows_bf16_not_fp8`
-  (uses `int4_wo` as the data-less stand-in; clone it for your quant, or
-  just extend `test_level_table_covers_every_gemm_quant_profile`).
-- Rust parity: extend
-  `gemm_quant_transfer_ladder_matches_python_oracles`
-  (`src/operators/gemm.rs`) with a Python-probed oracle for your quant
-  (generation snippet in the test doc comment).
-- Before pushing: `cargo test --workspace --all-features` (default args
-  miss the public-api pins and pyo3-gated tests) + the parity suite
+  (`int4_wo` is the data-less stand-in; clone for your quant).
+  `test_level_table_covers_every_gemm_quant_profile` will fail loudly if
+  the level line is missing.
+- Rust parity: extend `gemm_quant_transfer_ladder_matches_python_oracles`
+  (`operators/gemm.rs`) with a Python-probed oracle (generation snippet in
+  its doc comment).
+- Before pushing: `cargo test --workspace --all-features` +
   `parity_tests/test_engine_step_parity.py`.
 
 ## Graduating to collected data
 
-The ladder only fires behind an own-data miss: the day
-`gemm_perf.parquet` carries rows for your quant, they win automatically —
-no code change, delete nothing. Collect on the systems that matter and the
-provenance moves `xprofile → silicon` by itself.
+The ladder only fires behind an own-data miss: once `gemm_perf.parquet`
+carries rows for your quant they win automatically — no code change, delete
+nothing. Provenance moves `xprofile → silicon` by itself.
 
 ## Out of the mechanism's scope
 

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -1408,9 +1408,15 @@ class Task:
             alias = validation_aliases.get(name)
             if alias and alias in modes:
                 return
-            if profile_transfer and xquant_enabled and _profile_reachable(mode, modes):
+            # fp8_static is a COMPOSITE mode: its base GEMM is transferable, but
+            # it also requires compute_scale/scale_matrix overhead tables that
+            # have no transfer ladder (by design). Its admission stays purely
+            # data-driven (fp8_static in modes iff all three tables exist, see
+            # _gemm_key_names).
+            transfer_ok = profile_transfer and mode is not common.GEMMQuantMode.fp8_static
+            if transfer_ok and xquant_enabled and _profile_reachable(mode, modes):
                 return  # XQUANT-reachable in HYBRID/EMPIRICAL (same-profile data)
-            if profile_transfer and xprofile_enabled and _xprofile_reachable(op, mode, modes):
+            if transfer_ok and xprofile_enabled and _xprofile_reachable(op, mode, modes):
                 return  # XPROFILE-reachable (calibrated level + any other-profile data)
             exc_type = UnsupportedWideepConfigError if op.startswith("wideep_") else ValueError
             raise exc_type(

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -1349,18 +1349,32 @@ class Task:
         xquant_enabled = _non_silicon and common.TransferKind.XQUANT in _policy
         xprofile_enabled = _non_silicon and common.TransferKind.XPROFILE in _policy
 
-        def _profile_reachable(mode: Any, supported_names: list) -> bool:
-            enum_cls = type(mode)
+        from aiconfigurator.sdk.operations import gemm as gemm_ops
+        from aiconfigurator.sdk.operations import moe as moe_ops
+
+        _xprofile_level_known = {
+            "gemm": gemm_ops.xprofile_util_level_known,
+            "moe": moe_ops.xprofile_util_level_known,
+            "wideep_context_moe": moe_ops.xprofile_util_level_known,
+            "wideep_generation_moe": moe_ops.xprofile_util_level_known,
+        }
+
+        def _mode_profile(mode: Any) -> tuple:
             val = getattr(mode, "value", None)
-            qp = (getattr(val, "memory", None), getattr(val, "compute", None))
+            return (getattr(val, "memory", None), getattr(val, "compute", None))
+
+        def _supported_profiles(mode: Any, supported_names: list) -> list[tuple]:
+            enum_cls = type(mode)
+            out = []
             for nm in supported_names:
                 try:
-                    other = enum_cls[nm].value
+                    out.append(_mode_profile(enum_cls[nm]))
                 except (KeyError, AttributeError):
                     continue
-                if (getattr(other, "memory", None), getattr(other, "compute", None)) == qp:
-                    return True
-            return False
+            return out
+
+        def _profile_reachable(mode: Any, supported_names: list) -> bool:
+            return _mode_profile(mode) in _supported_profiles(mode, supported_names)
 
         def _xprofile_reachable(op: str, mode: Any, supported_names: list) -> bool:
             """XPROFILE admission: the op's util-LEVEL table must list the query
@@ -1369,28 +1383,11 @@ class Task:
             enforces the enum-line + level-line add-a-quant recipe), and the DB
             must carry at least one quant of a DIFFERENT profile to borrow from
             (any collected quant is a viable nearest-profile reference)."""
-            from aiconfigurator.sdk.operations import gemm as gemm_ops
-            from aiconfigurator.sdk.operations import moe as moe_ops
-
-            level_known = {
-                "gemm": gemm_ops.xprofile_util_level_known,
-                "moe": moe_ops.xprofile_util_level_known,
-                "wideep_context_moe": moe_ops.xprofile_util_level_known,
-                "wideep_generation_moe": moe_ops.xprofile_util_level_known,
-            }.get(op)
+            level_known = _xprofile_level_known.get(op)
             if level_known is None or not level_known(mode):
                 return False
-            enum_cls = type(mode)
-            val = getattr(mode, "value", None)
-            qp = (getattr(val, "memory", None), getattr(val, "compute", None))
-            for nm in supported_names:
-                try:
-                    other = enum_cls[nm].value
-                except (KeyError, AttributeError):
-                    continue
-                if (getattr(other, "memory", None), getattr(other, "compute", None)) != qp:
-                    return True
-            return False
+            qp = _mode_profile(mode)
+            return any(p != qp for p in _supported_profiles(mode, supported_names))
 
         def _check(op: str, mode: Any, *, profile_transfer: bool = False) -> None:
             if mode is None:

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -1330,19 +1330,24 @@ class Task:
 
         # supported_quant_mode is a DATA-PRESENCE list (which quants the DB carries
         # tables for), not a backend-capability list. In SILICON that equals what we
-        # can model. In HYBRID/EMPIRICAL the MoE util-empirical path can synthesize a
-        # quant from a collected quant that shares its (memory, compute) profile
-        # (XQUANT cross-quant transfer, see operations/moe.py) -- only MoE implements
-        # this, so only MoE relaxes. Truly-unreachable quants (no same-profile data)
-        # still fail early here rather than crashing late in the sweep.
-        # Admission via the XQUANT cross-quant transfer only holds if (a) we're in a
-        # non-SILICON mode AND (b) the resolved transfer policy actually enables XQUANT.
-        # Otherwise operations/moe.py rejects the quant at query time by policy, so
-        # validate must not pre-admit it (e.g. transfer_policy="off"/"conservative").
-        xquant_enabled = self.database_mode not in (
+        # can model. In HYBRID/EMPIRICAL the util-empirical path (GEMM and MoE; the
+        # shared quant-transfer primitive in operations/util_empirical.py) can
+        # synthesize a quant from a collected sibling: XQUANT borrows within the
+        # same (memory, compute) profile, XPROFILE borrows across profiles rescaled
+        # by the op's util-LEVEL ratio. This gate mirrors exactly what the resolved
+        # policy + DB contents make reachable at query time — truly-unreachable
+        # quants still fail early here rather than crashing late in the sweep.
+        # Admission only holds if (a) we're in a non-SILICON mode AND (b) the
+        # resolved transfer policy actually enables that relation. Otherwise the
+        # query path rejects the quant at run time by policy, so validate must not
+        # pre-admit it (e.g. transfer_policy="off"/"conservative").
+        _non_silicon = self.database_mode not in (
             None,
             common.DatabaseMode.SILICON.name,
-        ) and common.TransferKind.XQUANT in common.resolve_transfer_policy(self.transfer_policy)
+        )
+        _policy = common.resolve_transfer_policy(self.transfer_policy)
+        xquant_enabled = _non_silicon and common.TransferKind.XQUANT in _policy
+        xprofile_enabled = _non_silicon and common.TransferKind.XPROFILE in _policy
 
         def _profile_reachable(mode: Any, supported_names: list) -> bool:
             enum_cls = type(mode)
@@ -1357,6 +1362,36 @@ class Task:
                     return True
             return False
 
+        def _xprofile_reachable(op: str, mode: Any, supported_names: list) -> bool:
+            """XPROFILE admission: the op's util-LEVEL table must list the query
+            profile (the runtime default fallback is deliberately NOT admitted —
+            the one intentional way this gate is stricter than the ladder: it
+            enforces the enum-line + level-line add-a-quant recipe), and the DB
+            must carry at least one quant of a DIFFERENT profile to borrow from
+            (any collected quant is a viable nearest-profile reference)."""
+            from aiconfigurator.sdk.operations import gemm as gemm_ops
+            from aiconfigurator.sdk.operations import moe as moe_ops
+
+            level_known = {
+                "gemm": gemm_ops.xprofile_util_level_known,
+                "moe": moe_ops.xprofile_util_level_known,
+                "wideep_context_moe": moe_ops.xprofile_util_level_known,
+                "wideep_generation_moe": moe_ops.xprofile_util_level_known,
+            }.get(op)
+            if level_known is None or not level_known(mode):
+                return False
+            enum_cls = type(mode)
+            val = getattr(mode, "value", None)
+            qp = (getattr(val, "memory", None), getattr(val, "compute", None))
+            for nm in supported_names:
+                try:
+                    other = enum_cls[nm].value
+                except (KeyError, AttributeError):
+                    continue
+                if (getattr(other, "memory", None), getattr(other, "compute", None)) != qp:
+                    return True
+            return False
+
         def _check(op: str, mode: Any, *, profile_transfer: bool = False) -> None:
             if mode is None:
                 return
@@ -1367,14 +1402,19 @@ class Task:
             if name in modes:
                 return
             # Modes that normalize to a different table name for perf queries
-            # (nvfp4_wo -> bfloat16, w4a16_mxfp4_cutlass -> w4a16_mxfp4) are
-            # accepted when the target table mode is supported.
-            validation_aliases = {"nvfp4_wo": "bfloat16", "w4a16_mxfp4_cutlass": "w4a16_mxfp4"}
+            # (w4a16_mxfp4_cutlass -> w4a16_mxfp4, see operations/moe.py) are
+            # accepted when the target table mode is supported. Data-less quants
+            # are NOT aliased to a collected table — they are admitted (or not)
+            # through the transfer reachability checks below, mirroring the
+            # query-time ladder.
+            validation_aliases = {"w4a16_mxfp4_cutlass": "w4a16_mxfp4"}
             alias = validation_aliases.get(name)
             if alias and alias in modes:
                 return
             if profile_transfer and xquant_enabled and _profile_reachable(mode, modes):
-                return  # transfer-reachable in HYBRID/EMPIRICAL with XQUANT enabled
+                return  # XQUANT-reachable in HYBRID/EMPIRICAL (same-profile data)
+            if profile_transfer and xprofile_enabled and _xprofile_reachable(op, mode, modes):
+                return  # XPROFILE-reachable (calibrated level + any other-profile data)
             exc_type = UnsupportedWideepConfigError if op.startswith("wideep_") else ValueError
             raise exc_type(
                 f"Unsupported {op} quant mode {name!r} for system={system!r}, "
@@ -1382,8 +1422,10 @@ class Task:
                 f"Supported {op} modes: {sorted(modes)}"
             )
 
-        # GEMM is always validated (applies to all worker shapes).
-        _check("gemm", self._role_attr(role, "gemm_quant_mode"))
+        # GEMM is always validated (applies to all worker shapes). It has the
+        # same transfer ladder as MoE (shared primitive), so the same
+        # HYBRID/EMPIRICAL relaxation applies.
+        _check("gemm", self._role_attr(role, "gemm_quant_mode"), profile_transfer=True)
 
         # MoE — only when model is MoE.
         if is_moe:

--- a/tests/unit/sdk/database/test_base_queries.py
+++ b/tests/unit/sdk/database/test_base_queries.py
@@ -43,18 +43,40 @@ def test_query_gemm_empirical_data_calibrated(stub_perf_db):
     assert math.isclose(float(empirical_value), float(silicon_value), rel_tol=1e-6)
 
 
-def test_query_gemm_empirical_raises_without_data(stub_perf_db):
-    """When the op has no data for the requested slice (fp8 absent in the stub),
-    EMPIRICAL raises EmpiricalNotImplementedError instead of fabricating a
-    SOL / constant -- the legacy placeholder fallback was removed.
+def test_query_gemm_empirical_borrows_cross_profile_under_default_policy(stub_perf_db):
+    """When the op has no data for the requested quant (fp8 absent in the stub)
+    the GEMM quant-transfer ladder borrows the collected bfloat16 grid across
+    profiles under the default (aggressive) policy — a data-calibrated
+    estimate tagged "xprofile", not a fabricated SOL / constant.
+    """
+    from aiconfigurator.sdk.operations import util_empirical
+
+    quant_mode = common.GEMMQuantMode.fp8  # no fp8 GEMM data in the stub; bf16 present
+    m, n, k = 64, 128, 256
+
+    with util_empirical.capture_provenance() as tags:
+        borrowed = stub_perf_db.query_gemm(m, n, k, quant_mode, database_mode=common.DatabaseMode.EMPIRICAL)
+    assert float(borrowed) > 0
+    assert "xprofile" in tags
+
+
+def test_query_gemm_empirical_raises_without_data_when_policy_forbids_transfer(stub_perf_db):
+    """Without a same-profile sibling, a policy that stops at XQUANT
+    ("balanced") must keep raising EmpiricalNotImplementedError instead of
+    fabricating a SOL / constant -- the legacy placeholder fallback stays
+    removed; cross-profile borrowing is policy-gated, never implicit.
     """
     from aiconfigurator.sdk.errors import EmpiricalNotImplementedError
 
     quant_mode = common.GEMMQuantMode.fp8  # no fp8 GEMM data in the stub
     m, n, k = 64, 128, 256
 
-    with pytest.raises(EmpiricalNotImplementedError):
-        stub_perf_db.query_gemm(m, n, k, quant_mode, database_mode=common.DatabaseMode.EMPIRICAL)
+    stub_perf_db.set_transfer_policy("balanced")
+    try:
+        with pytest.raises(EmpiricalNotImplementedError):
+            stub_perf_db.query_gemm(m, n, k, quant_mode, database_mode=common.DatabaseMode.EMPIRICAL)
+    finally:
+        stub_perf_db.set_transfer_policy(None)
 
 
 def test_query_gemm_exact_match_skips_3d_interpolation(comprehensive_perf_db, monkeypatch):

--- a/tests/unit/sdk/database/test_gemm_quant_transfer.py
+++ b/tests/unit/sdk/database/test_gemm_quant_transfer.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""GEMM quant-transfer ladder (shared quant-transfer primitive).
+
+The mechanism acceptance contract for adding a data-less quant: with only an
+enum member and a util-LEVEL line, HYBRID/EMPIRICAL must resolve end-to-end
+through the borrow relations while SILICON keeps rejecting. ``int4_wo``
+(profile (0.5, 1), no fixture data) plays the synthetic new quant — the
+ladder keys only off the profile and the level table, so an existing member
+without data exercises exactly the add-a-quant path (e.g. #1392's nvfp4_wo).
+"""
+
+import math
+
+import pytest
+
+from aiconfigurator.sdk import common
+from aiconfigurator.sdk.errors import EmpiricalNotImplementedError, PerfDataNotAvailableError
+from aiconfigurator.sdk.operations import util_empirical
+from aiconfigurator.sdk.operations.gemm import _GEMM_QUANT_UTIL_LEVEL
+
+pytestmark = pytest.mark.unit
+
+
+def _sol(db, m, n, k, quant):
+    return float(db.query_gemm(m, n, k, quant, database_mode=common.DatabaseMode.SOL))
+
+
+def test_xquant_borrows_same_profile_sibling(comprehensive_perf_db):
+    """sq (1,2) has no data; fp8 (1,2) does. Same profile => identical SOL
+    coefficients => the borrowed estimate at a collected point equals fp8's
+    measured value exactly, tagged xquant (no level-table involvement)."""
+    db = comprehensive_perf_db
+    m, n, k = 16, 256, 512  # collected point in the fixture grid
+
+    fp8_silicon = float(db.query_gemm(m, n, k, common.GEMMQuantMode.fp8, database_mode=common.DatabaseMode.SILICON))
+    with util_empirical.capture_provenance() as tags:
+        borrowed = float(db.query_gemm(m, n, k, common.GEMMQuantMode.sq, database_mode=common.DatabaseMode.HYBRID))
+
+    assert "xquant" in tags
+    assert math.isclose(borrowed, fp8_silicon, rel_tol=1e-9)
+
+
+def test_xprofile_weight_only_borrows_bf16_not_fp8(comprehensive_perf_db):
+    """The nvfp4_wo guarantee, exercised via int4_wo (0.5, 1): a weight-only
+    quant runs the bf16 compute family, so with BOTH bfloat16 and fp8
+    collected the reference must be bfloat16 (prefer_same_compute ordering,
+    never a file-order tie-break into fp8), rescaled by e(0.5,1)/e(2,1)."""
+    db = comprehensive_perf_db
+    m, n, k = 16, 256, 512
+    quant = common.GEMMQuantMode.int4_wo
+
+    with util_empirical.capture_provenance() as tags:
+        borrowed = float(db.query_gemm(m, n, k, quant, database_mode=common.DatabaseMode.HYBRID))
+    assert "xprofile" in tags
+
+    bf16_silicon = float(
+        db.query_gemm(m, n, k, common.GEMMQuantMode.bfloat16, database_mode=common.DatabaseMode.SILICON)
+    )
+    util_bf16 = _sol(db, m, n, k, common.GEMMQuantMode.bfloat16) / bf16_silicon
+    ratio = _GEMM_QUANT_UTIL_LEVEL[(0.5, 1)] / _GEMM_QUANT_UTIL_LEVEL[(2, 1)]
+    expected_from_bf16 = _sol(db, m, n, k, quant) / (util_bf16 * ratio)
+    assert math.isclose(borrowed, expected_from_bf16, rel_tol=1e-9)
+
+    # And it must NOT be the fp8-derived value (guards against the ordering
+    # silently regressing to profile-L1 / file-order selection).
+    fp8_silicon = float(db.query_gemm(m, n, k, common.GEMMQuantMode.fp8, database_mode=common.DatabaseMode.SILICON))
+    util_fp8 = _sol(db, m, n, k, common.GEMMQuantMode.fp8) / fp8_silicon
+    ratio_fp8 = _GEMM_QUANT_UTIL_LEVEL[(0.5, 1)] / _GEMM_QUANT_UTIL_LEVEL[(1, 2)]
+    expected_from_fp8 = _sol(db, m, n, k, quant) / (util_fp8 * ratio_fp8)
+    assert not math.isclose(borrowed, expected_from_fp8, rel_tol=1e-6)
+
+
+def test_xprofile_is_policy_gated(comprehensive_perf_db):
+    """balanced (XSHAPE+XQUANT) finds nothing for (0.5, 1) — no same-profile
+    sibling — and must raise the typed empirical miss, not silently borrow."""
+    db = comprehensive_perf_db
+    db.set_transfer_policy("balanced")
+    try:
+        with pytest.raises(EmpiricalNotImplementedError):
+            db.query_gemm(16, 256, 512, common.GEMMQuantMode.int4_wo, database_mode=common.DatabaseMode.HYBRID)
+    finally:
+        db.set_transfer_policy(None)
+
+
+def test_silicon_still_rejects_dataless_quant(comprehensive_perf_db):
+    """SILICON never borrows: a data-less quant stays a typed perf-data miss."""
+    with pytest.raises(PerfDataNotAvailableError):
+        comprehensive_perf_db.query_gemm(
+            16, 256, 512, common.GEMMQuantMode.int4_wo, database_mode=common.DatabaseMode.SILICON
+        )
+
+
+def test_hybrid_is_invariant_for_covered_quants(comprehensive_perf_db):
+    """The ladder only extends behind the existing miss: covered queries are
+    bit-unchanged under HYBRID."""
+    db = comprehensive_perf_db
+    for quant in (common.GEMMQuantMode.bfloat16, common.GEMMQuantMode.fp8):
+        silicon = float(db.query_gemm(16, 256, 512, quant, database_mode=common.DatabaseMode.SILICON))
+        hybrid = float(db.query_gemm(16, 256, 512, quant, database_mode=common.DatabaseMode.HYBRID))
+        assert hybrid == silicon
+
+
+def test_level_table_covers_every_gemm_quant_profile():
+    """Every GEMMQuantMode profile must have a calibrated level line — the
+    gate refuses XPROFILE admission for unlisted profiles by design, so a
+    profile silently missing here would strand its quants in HYBRID."""
+    for quant in common.GEMMQuantMode:
+        assert util_empirical.quant_profile(quant) in _GEMM_QUANT_UTIL_LEVEL, quant

--- a/tests/unit/sdk/database/test_gemm_quant_transfer.py
+++ b/tests/unit/sdk/database/test_gemm_quant_transfer.py
@@ -27,6 +27,14 @@ def _sol(db, m, n, k, quant):
     return float(db.query_gemm(m, n, k, quant, database_mode=common.DatabaseMode.SOL))
 
 
+def _assert_dataless(db, quant):
+    """Guard the fixture premise: ``quant`` must have no collected GEMM table
+    (otherwise the ladder tests below stop exercising the borrow and pass for
+    the wrong reason)."""
+    with pytest.raises(PerfDataNotAvailableError):
+        db.query_gemm(16, 256, 512, quant, database_mode=common.DatabaseMode.SILICON)
+
+
 def test_xquant_borrows_same_profile_sibling(comprehensive_perf_db):
     """sq (1,2) has no data; fp8 (1,2) does. Same profile => identical SOL
     coefficients => the borrowed estimate at a collected point equals fp8's
@@ -50,6 +58,7 @@ def test_xprofile_weight_only_borrows_bf16_not_fp8(comprehensive_perf_db):
     db = comprehensive_perf_db
     m, n, k = 16, 256, 512
     quant = common.GEMMQuantMode.int4_wo
+    _assert_dataless(db, quant)
 
     with util_empirical.capture_provenance() as tags:
         borrowed = float(db.query_gemm(m, n, k, quant, database_mode=common.DatabaseMode.HYBRID))
@@ -76,6 +85,7 @@ def test_xprofile_is_policy_gated(comprehensive_perf_db):
     """balanced (XSHAPE+XQUANT) finds nothing for (0.5, 1) — no same-profile
     sibling — and must raise the typed empirical miss, not silently borrow."""
     db = comprehensive_perf_db
+    _assert_dataless(db, common.GEMMQuantMode.int4_wo)
     db.set_transfer_policy("balanced")
     try:
         with pytest.raises(EmpiricalNotImplementedError):

--- a/tests/unit/sdk/task_v2/test_task_config.py
+++ b/tests/unit/sdk/task_v2/test_task_config.py
@@ -1724,6 +1724,62 @@ def test_validate_moe_quant_transfer_reachable_in_hybrid():
             make("HYBRID", disabled).validate()
 
 
+def test_validate_gemm_quant_transfer_reachable_in_hybrid():
+    """GEMM now has the same transfer ladder as MoE (shared quant-transfer
+    primitive), so the gate mirrors it: nvfp4 GEMM (profile (0.5625, 4)) has
+    no Hopper data and no same-profile sibling, but is XPROFILE-reachable in
+    HYBRID from the collected bf16/fp8 tables. SILICON and non-XPROFILE
+    policies keep rejecting — the gate admits exactly what the resolved
+    policy + DB contents make reachable at query time."""
+
+    def make(mode, policy=None):
+        t = Task(
+            serving_mode="agg",
+            model_path="Qwen/Qwen3-32B",
+            system_name="h200_sxm",
+            backend_name="trtllm",
+            backend_version="1.3.0rc10",
+            database_mode=mode,
+            transfer_policy=policy,
+        )
+        t.gemm_quant_mode = common.GEMMQuantMode.nvfp4  # not collected on Hopper
+        return t
+
+    with pytest.raises(ValueError, match="Unsupported gemm quant mode 'nvfp4'"):
+        make("SILICON").validate()
+    make("HYBRID").validate()  # default policy (all on) -> XPROFILE reachable -> no raise
+    make("HYBRID", "xprofile").validate()  # XPROFILE explicitly enabled -> no raise
+
+    # No same-profile sibling for (0.5625, 4): XQUANT alone must not admit it,
+    # and neither may weaker policies — the query ladder would reject at run time.
+    for disabled in ("off", "conservative", "balanced", "xquant"):
+        with pytest.raises(ValueError, match="Unsupported gemm quant mode 'nvfp4'"):
+            make("HYBRID", disabled).validate()
+
+
+def test_validate_gemm_xprofile_requires_listed_level_profile(monkeypatch):
+    """The gate deliberately refuses XPROFILE admission for a profile missing
+    from the GEMM util-LEVEL table (the runtime ladder would fall back to a
+    default level, but the gate enforces the enum-line + level-line
+    add-a-quant recipe — the one intentional way it is stricter)."""
+    from aiconfigurator.sdk.operations import gemm as gemm_ops
+
+    trimmed = {p: lv for p, lv in gemm_ops._GEMM_QUANT_UTIL_LEVEL.items() if p != (9 / 16, 4)}
+    monkeypatch.setattr(gemm_ops, "_GEMM_QUANT_UTIL_LEVEL", trimmed)
+
+    t = Task(
+        serving_mode="agg",
+        model_path="Qwen/Qwen3-32B",
+        system_name="h200_sxm",
+        backend_name="trtllm",
+        backend_version="1.3.0rc10",
+        database_mode="HYBRID",
+    )
+    t.gemm_quant_mode = common.GEMMQuantMode.nvfp4
+    with pytest.raises(ValueError, match="Unsupported gemm quant mode 'nvfp4'"):
+        t.validate()
+
+
 def test_validate_skips_db_check_when_database_unavailable():
     """If DB can't be loaded, DB validation silently skips (caller sees other errors)."""
     t = Task(

--- a/tests/unit/sdk/task_v2/test_task_config.py
+++ b/tests/unit/sdk/task_v2/test_task_config.py
@@ -1757,6 +1757,24 @@ def test_validate_gemm_quant_transfer_reachable_in_hybrid():
             make("HYBRID", disabled).validate()
 
 
+def test_validate_fp8_static_not_transfer_admitted_in_hybrid():
+    """fp8_static is a composite mode (fp8 base minus compute_scale/scale_matrix);
+    the overhead tables have no transfer ladder, so HYBRID must NOT admit it via
+    profile transfer on combos without quantize data — validate keeps failing
+    fast instead of the sweep dying late in query_compute_scale."""
+    t = Task(
+        serving_mode="agg",
+        model_path="Qwen/Qwen3-32B",
+        system_name="b200_sxm",
+        backend_name="vllm",
+        backend_version="0.19.0",
+        database_mode="HYBRID",
+    )
+    t.gemm_quant_mode = common.GEMMQuantMode.fp8_static
+    with pytest.raises(ValueError, match="Unsupported gemm quant mode 'fp8_static'"):
+        t.validate()
+
+
 def test_validate_gemm_xprofile_requires_listed_level_profile(monkeypatch):
     """The gate deliberately refuses XPROFILE admission for a profile missing
     from the GEMM util-LEVEL table (the runtime ladder would fall back to a


### PR DESCRIPTION
## What

Prerequisite mechanism for #1392 (`nvfp4_wo`) — adds **no new quant**. Gives GEMM the empirical quant-transfer ladder MoE already has, unified behind one shared primitive, and cleans the `task_v2` validate gate so it mirrors (never exceeds) the query ladder's admission policy.

After this lands, adding a data-less quant is **one enum line + one util-level line** (both languages): HYBRID/EMPIRICAL estimates end-to-end via util borrowing, SILICON still rejects early. Full recipe for the #1392 author: `docs/design/how_to_add_a_gemm_quant_mode.md`. Design + as-built decisions: `docs/design/gemm_quant_transfer_design.md`.

## How

**One borrow primitive, labels derived from the reference's relation** (`util_empirical.quant_transfer_grid`): correction is `e(profile_query)/e(profile_ref)` from a per-op util-LEVEL table — identically 1 within a profile, so `xshape` (same quant) and `xquant` (same profile) are the ratio-1 degenerations of the cross-profile borrow; three confidence labels over one mechanism, not three mechanisms.

- **MoE**: refactored onto the primitive with zero behavior change (pinned by the existing unit suite and the Rust parity oracles).
- **GEMM** (new): own depth-3 `(m,n,k)` grid (its `xshape` relation class is structurally empty — the own grid already spans every collected shape) → `xquant` → `xprofile`. `_GEMM_QUANT_UTIL_LEVEL` seeded from compute-bound medians (`m≥1024, n,k≥2048`) across b200/h200/h100 × trtllm/vllm/sglang; method + LOO evidence on the table (LOO `nvfp4 ← fp8`: 22–33% MAPE, comparable to MoE's ~24% xprofile tier).
- **Compute-first XPROFILE ordering for GEMM** (`(|Δcompute|, |Δmemory|)` lexicographic): the compute factor (activation precision) determines the dense kernel's compute family, so a weight-only quant deterministically borrows **bfloat16** data — under plain L1 it would tie between bf16 and fp8 (e.g. `(0.5625, 1)`: both 1.4375) and fall to a file-order lottery. MoE keeps its validated L1 metric unchanged.
- **Validate gate** (`task_v2._check_role_against_db`): `gemm` now gets `profile_transfer`; new XPROFILE reachability = non-SILICON + `XPROFILE` in the resolved policy + query profile **listed** in the op's level table (deliberately stricter than the runtime default fallback — enforces the recipe) + ≥1 other-profile collected quant. Dead `"nvfp4_wo": "bfloat16"` alias removed (no such enum member; the normalize-to-bf16 design was reviewed out of #1392); the real `w4a16_mxfp4_cutlass → w4a16_mxfp4` alias kept.
- **Rust point-for-point**: `GemmGrids.quant_order` records first-seen (file row) quant order (the `BTreeMap` iterates alphabetically, but tie-breaks are pinned to Python's dict-insertion order) + `GemmTable::available_quants()`; ladder in `gemm_empirical`; `GEMM_QUANT_UTIL_LEVEL` const; oracle tests pinned to Python at 1e-9.

## Behavior change (intentional — the mechanism working)

HYBRID/EMPIRICAL queries for existing quants with no data on a system change from raising `EmpiricalNotImplementedError` to a policy-gated, provenance-tagged estimate under the default (aggressive) policy — e.g. nvfp4 GEMM on Hopper. All previously-computable paths (silicon, own-grid empirical, covered hybrid) are bit-unchanged; the ladder only extends behind the existing miss, and `transfer_policy="balanced"`/`"conservative"`/`"off"` still reject.

Parity-case archaeology: the `minimax-m25-nvfp4-h200` HYBRID case now computes on both sides — the old raise came from the **GEMM** op (the old test comment misattributed it to MoE, whose ladder always had a reachable reference there). The error-symmetry contract is preserved in a new `...-hybrid-balanced-miss` case and the FFI typed-miss test, both pinned with `transfer_policy="balanced"` (no same-profile sibling exists for `(0.5625, 4)`, so the miss is stable by construction).

## Verification

- Python unit: 2943 passed (3 pre-existing collector/GLM failures verified present at base via stash).
- `cargo test --workspace --all-features`: green.
- Engine-step parity: 307 passed; compile-engine parity + goldens: 68 passed.
- New mechanism tests: `tests/unit/sdk/database/test_gemm_quant_transfer.py` (xquant exactness, weight-only-borrows-bf16 guarantee, policy gating, SILICON rejection, covered-quant invariance, level-table completeness) + gate admission tests in `test_task_config.py` + Rust ladder oracles in `operators/gemm.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added GEMM quantization transfer for empirical estimates, including same-profile and cross-profile fallback.
  - Added utilization-based scaling and provenance tracking.
  - Extended hybrid-mode validation for reachable quantization profiles under configured policies.
  - Aligned MoE and GEMM transfer behavior.

- **Bug Fixes**
  - Improved policy-aware handling of missing quantization data.
  - Removed the obsolete `nvfp4_wo` alias.

- **Documentation**
  - Added guidance for quantization transfer and new GEMM quantization modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->