### PR TITLE
feat(fpm): add the shared Generator/collector FPM contract table

### DIFF
--- a/src/aiconfigurator/fpm_contract.py
+++ b/src/aiconfigurator/fpm_contract.py
@@ -164,6 +164,8 @@ def fpm_validate_benchmark_output_path(output_path: str) -> None:
             f"benchmark output basename must match {FPM_BENCHMARK_RESULT_GLOB!r} "
             f"so collector discovery can find it: {output_path!r}"
         )
+    if path.stem.endswith("_merged"):
+        raise ValueError(f"benchmark output basename is reserved for merged artifacts: {output_path!r}")
 
 
 def fpm_benchmark_result_name(output_path: str, dp_rank: int) -> str:

--- a/src/aiconfigurator/fpm_contract.py
+++ b/src/aiconfigurator/fpm_contract.py
@@ -138,6 +138,26 @@ def fpm_resolved_config_name(node_rank: int) -> str:
     return FPM_RESOLVED_CONFIG_TEMPLATE.format(node_rank=node_rank)
 
 
+def fpm_validate_resolved_config_path(output_path: str) -> None:
+    """Reject resolved-config paths the collector's marker sweep cannot find.
+
+    A Generator override may retain the ``{node_rank}`` placeholder that
+    ``run.sh`` substitutes at runtime. The surrounding path and basename must
+    still remain inside the collector's recursive discovery surface.
+    """
+
+    path = PurePosixPath(output_path)
+    if not path.is_absolute() or any(part in (".", "..") for part in path.parts):
+        raise ValueError(f"resolved-config path must be absolute without '.' or '..' segments: {output_path!r}")
+    if PurePosixPath(FPM_RESULTS_DIR) not in path.parents:
+        raise ValueError(f"resolved-config path must live under {FPM_RESULTS_DIR}: {output_path!r}")
+    if not fnmatch.fnmatch(path.name, FPM_RESOLVED_CONFIG_GLOB):
+        raise ValueError(
+            f"resolved-config basename must match {FPM_RESOLVED_CONFIG_GLOB!r} "
+            f"so collector marker discovery can find it: {output_path!r}"
+        )
+
+
 def fpm_validate_benchmark_output_path(output_path: str) -> None:
     """Reject benchmark output paths the collector could never discover.
 

--- a/src/aiconfigurator/fpm_contract.py
+++ b/src/aiconfigurator/fpm_contract.py
@@ -121,6 +121,22 @@ FPM_RESULTS_DIR = "/results"
 # artifacts such as ``benchmark_merged.json`` alongside the per-rank files).
 FPM_BENCHMARK_RESULT_GLOB = "benchmark*.json"
 
+# Resolved engine-config snapshots the rendered run script writes under
+# /results, one per node. The Generator renders the template (its ``run.sh``
+# substitutes ``{node_rank}`` at runtime); the collector's expected-marker
+# validation sweeps the glob over the collected results tree. Both sides
+# import the convention from here so it is spelled exactly once.
+FPM_RESOLVED_CONFIG_TEMPLATE = "resolved-config-node{node_rank}.json"
+FPM_RESOLVED_CONFIG_GLOB = "resolved-config*.json"
+
+
+def fpm_resolved_config_name(node_rank: int) -> str:
+    """Return the resolved-config snapshot filename for one node."""
+
+    if not isinstance(node_rank, int) or isinstance(node_rank, bool) or node_rank < 0:
+        raise ValueError("node_rank must be a non-negative integer")
+    return FPM_RESOLVED_CONFIG_TEMPLATE.format(node_rank=node_rank)
+
 
 def fpm_validate_benchmark_output_path(output_path: str) -> None:
     """Reject benchmark output paths the collector could never discover.
@@ -131,6 +147,11 @@ def fpm_validate_benchmark_output_path(output_path: str) -> None:
     :data:`FPM_RESULTS_DIR`. A path outside that surface renders and passes
     the gate, then burns the whole measurement before failing at collection
     -- so the render must fail closed instead.
+
+    Subdirectories under :data:`FPM_RESULTS_DIR` are permitted: the pod-side
+    manifest enumerates ``/results`` recursively, the transfer recreates the
+    relative directory layout, and every discovery sweep matches the glob
+    recursively (``**/``) -- so a nested path stays discoverable end to end.
     """
 
     path = PurePosixPath(output_path)
@@ -203,7 +224,10 @@ def fpm_workload_node_count(workload: dict[str, Any]) -> int:
     if kind == "Pod":
         return 1
     if kind == "LeaderWorkerSet":
-        return int(workload["spec"]["leaderWorkerTemplate"]["size"])
+        size = workload["spec"]["leaderWorkerTemplate"]["size"]
+        if not isinstance(size, int) or isinstance(size, bool) or size < 1:
+            raise ValueError(f"FPM LeaderWorkerSet leaderWorkerTemplate.size must be a positive integer: {size!r}")
+        return size
     if kind == "PodCliqueSet":
         spec = workload.get("spec") or {}
         if not isinstance(spec, dict):

--- a/src/aiconfigurator/fpm_contract.py
+++ b/src/aiconfigurator/fpm_contract.py
@@ -216,9 +216,10 @@ def fpm_workload_node_count(workload: dict[str, Any]) -> int:
     """Return the pod count a generated FPM workload document schedules.
 
     This enumerates the only manifest-internal fields the collector may read:
+    ``spec.replicas`` (pinned to 1) and
     ``spec.leaderWorkerTemplate.size`` for a LeaderWorkerSet, and
-    ``spec.replicas`` (pinned to 1) times the clique ``spec.replicas`` sum for
-    a PodCliqueSet. Everything else inside the manifest is opaque to the
+    ``spec.replicas`` (also pinned to 1) plus the clique ``spec.replicas`` sum
+    for a PodCliqueSet. Everything else inside the manifest is opaque to the
     collector.
     """
 
@@ -226,7 +227,16 @@ def fpm_workload_node_count(workload: dict[str, Any]) -> int:
     if kind == "Pod":
         return 1
     if kind == "LeaderWorkerSet":
-        size = workload["spec"]["leaderWorkerTemplate"]["size"]
+        spec = workload.get("spec") or {}
+        if not isinstance(spec, dict):
+            raise ValueError("FPM LeaderWorkerSet spec must be a mapping")
+        replicas = spec.get("replicas")
+        if not isinstance(replicas, int) or isinstance(replicas, bool) or replicas != 1:
+            raise ValueError("FPM LeaderWorkerSet spec.replicas must be 1")
+        template = spec.get("leaderWorkerTemplate") or {}
+        if not isinstance(template, dict):
+            raise ValueError("FPM LeaderWorkerSet spec.leaderWorkerTemplate must be a mapping")
+        size = template.get("size")
         if not isinstance(size, int) or isinstance(size, bool) or size < 1:
             raise ValueError(f"FPM LeaderWorkerSet leaderWorkerTemplate.size must be a positive integer: {size!r}")
         return size

--- a/src/aiconfigurator/generator/builders/fpm_builder.py
+++ b/src/aiconfigurator/generator/builders/fpm_builder.py
@@ -23,9 +23,11 @@ from aiconfigurator.fpm_contract import (
     FPM_ENV_FILENAME,
     FPM_MANIFEST_FILENAME,
     FPM_NATIVE_BENCHMARK_RESULT_SCHEMA_VERSION,
+    FPM_RESOLVED_CONFIG_TEMPLATE,
     FPM_RESULTS_DIR,
     FPM_RUN_SCRIPT_FILENAME,
     fpm_validate_benchmark_output_path,
+    fpm_validate_resolved_config_path,
 )
 
 from .dgd_model import DGD, ComputeDomainDoc, DGDService, MainContainer, _dump_k8s_yaml
@@ -186,9 +188,9 @@ def _ensure_dump_config_path(args: list[str], node_count: int) -> None:
         raise ValueError(f"FPM accepts at most one {flag} option")
 
     default = (
-        f"{FPM_RESULTS_DIR}/resolved-config-node{{node_rank}}.json"
+        f"{FPM_RESULTS_DIR}/{FPM_RESOLVED_CONFIG_TEMPLATE}"
         if node_count > 1
-        else f"{FPM_RESULTS_DIR}/resolved-config-node0.json"
+        else f"{FPM_RESULTS_DIR}/{FPM_RESOLVED_CONFIG_TEMPLATE.format(node_rank=0)}"
     )
     if not occurrences:
         value = default
@@ -199,6 +201,7 @@ def _ensure_dump_config_path(args: list[str], node_count: int) -> None:
     value = args[index].split("=", 1)[1] if joined else args[index]
     if node_count > 1 and "{node_rank}" not in value:
         raise ValueError(f"Multinode FPM {flag} must contain the {{node_rank}} placeholder")
+    fpm_validate_resolved_config_path(value)
     if node_count == 1:
         value = value.replace("{node_rank}", "0")
     else:

--- a/tests/unit/generator/test_fpm_artifacts.py
+++ b/tests/unit/generator/test_fpm_artifacts.py
@@ -1132,6 +1132,31 @@ def test_fpm_multinode_dump_config_override_requires_rank_placeholder():
         _render(params)
 
 
+@pytest.mark.parametrize(
+    "output_path",
+    [
+        pytest.param("/results/custom-config.json", id="glob-mismatch"),
+        pytest.param("/tmp/resolved-config-node0.json", id="outside-results"),
+    ],
+)
+def test_fpm_single_node_dump_config_override_must_be_discoverable(output_path):
+    params = _params()
+    params["params"]["agg"]["extra_cli_args"].extend(["--dump-config-to", output_path])
+
+    with pytest.raises(ValueError, match="resolved-config"):
+        _render(params)
+
+
+def test_fpm_multinode_dump_config_override_must_match_discovery_glob():
+    params = _multinode_params()
+    params["params"]["agg"]["extra_cli_args"].extend(
+        ["--dump-config-to", "/results/custom-config-node{node_rank}.json"]
+    )
+
+    with pytest.raises(ValueError, match="basename must match"):
+        _render(params)
+
+
 def test_fpm_multinode_rejects_name_too_long_for_lws_revision_labels():
     params = _params()
     params["K8sConfig"]["name_prefix"] = "f" * 51

--- a/tests/unit/test_fpm_contract.py
+++ b/tests/unit/test_fpm_contract.py
@@ -72,6 +72,8 @@ def test_fpm_validate_benchmark_output_path_accepts_discoverable_paths(output_pa
         pytest.param("relative/benchmark.json", "must be absolute", id="relative"),
         pytest.param("/results/benchmark", "basename must match", id="extensionless"),
         pytest.param("/results", "must live under /results", id="results-dir-itself"),
+        pytest.param("/results/benchmark_merged.json", "reserved for merged", id="merged-default"),
+        pytest.param("/results/benchmark.smoke_merged.json", "reserved for merged", id="merged-multi-dot"),
     ],
 )
 def test_fpm_validate_benchmark_output_path_rejects_undiscoverable_paths(output_path, match):

--- a/tests/unit/test_fpm_contract.py
+++ b/tests/unit/test_fpm_contract.py
@@ -13,8 +13,11 @@ from __future__ import annotations
 import pytest
 
 from aiconfigurator.fpm_contract import (
+    FPM_RESOLVED_CONFIG_GLOB,
+    FPM_RESOLVED_CONFIG_TEMPLATE,
     fpm_benchmark_result_name,
     fpm_expected_result_paths,
+    fpm_resolved_config_name,
     fpm_validate_benchmark_output_path,
     fpm_workload_node_count,
 )
@@ -51,6 +54,9 @@ def test_fpm_benchmark_result_name_rejects_invalid_ranks(dp_rank):
         pytest.param("/results/benchmark.json", id="default"),
         pytest.param("/results/benchmark_smoke.json", id="custom-conforming"),
         pytest.param("/results/benchmark.smoke.json", id="multi-dot-conforming"),
+        # Subdirectories stay discoverable: the pod-side manifest, the
+        # transfer, and every discovery sweep are all recursive.
+        pytest.param("/results/run1/benchmark.json", id="subdirectory"),
     ],
 )
 def test_fpm_validate_benchmark_output_path_accepts_discoverable_paths(output_path):
@@ -82,13 +88,36 @@ def test_every_gate_accepted_path_is_discoverable_by_every_glob_consumer():
 
     from aiconfigurator.fpm_contract import FPM_BENCHMARK_RESULT_GLOB, FPM_RESULTS_DIR
 
-    accepted = ["/results/benchmark.json", "/results/benchmark_smoke.json", "/results/benchmark.v2.json"]
+    accepted = [
+        "/results/benchmark.json",
+        "/results/benchmark_smoke.json",
+        "/results/benchmark.v2.json",
+        "/results/run1/benchmark.json",
+    ]
     for base in accepted:
         fpm_validate_benchmark_output_path(base)
         for dp_rank in range(0, 5):
             name = PurePosixPath(fpm_benchmark_result_name(base, dp_rank))
             assert fnmatch.fnmatch(name.name, FPM_BENCHMARK_RESULT_GLOB), name
             assert PurePosixPath(FPM_RESULTS_DIR) in name.parents, name
+
+
+def test_fpm_resolved_config_name_matches_the_shared_glob():
+    # Both sides import the convention; the name must stay discoverable by
+    # the glob the collector sweeps for expected-marker validation.
+    import fnmatch
+
+    for node_rank in range(0, 4):
+        name = fpm_resolved_config_name(node_rank)
+        assert name == f"resolved-config-node{node_rank}.json"
+        assert name == FPM_RESOLVED_CONFIG_TEMPLATE.format(node_rank=node_rank)
+        assert fnmatch.fnmatch(name, FPM_RESOLVED_CONFIG_GLOB), name
+
+
+@pytest.mark.parametrize("node_rank", [-1, True, 1.5, "0"], ids=["negative", "bool", "float", "string"])
+def test_fpm_resolved_config_name_rejects_invalid_ranks(node_rank):
+    with pytest.raises(ValueError, match="node_rank must be a non-negative integer"):
+        fpm_resolved_config_name(node_rank)
 
 
 def test_fpm_expected_result_paths_window_covers_the_node_local_rank_range():
@@ -192,6 +221,23 @@ def test_fpm_workload_node_count_rejects_non_mapping_clique_spec(clique):
     workload = _podcliqueset({"replicas": 1, "template": {"cliques": [clique]}})
 
     with pytest.raises(TypeError, match="cliques must be mappings with spec"):
+        fpm_workload_node_count(workload)
+
+
+@pytest.mark.parametrize(
+    "size",
+    [
+        pytest.param(True, id="bool"),
+        pytest.param(0, id="zero"),
+        pytest.param(-2, id="negative"),
+        pytest.param("4", id="string"),
+        pytest.param(4.0, id="float"),
+    ],
+)
+def test_fpm_workload_node_count_rejects_non_strict_lws_size(size):
+    workload = {"kind": "LeaderWorkerSet", "spec": {"leaderWorkerTemplate": {"size": size}}}
+
+    with pytest.raises(ValueError, match=r"leaderWorkerTemplate\.size must be a positive integer"):
         fpm_workload_node_count(workload)
 
 

--- a/tests/unit/test_fpm_contract.py
+++ b/tests/unit/test_fpm_contract.py
@@ -19,6 +19,7 @@ from aiconfigurator.fpm_contract import (
     fpm_expected_result_paths,
     fpm_resolved_config_name,
     fpm_validate_benchmark_output_path,
+    fpm_validate_resolved_config_path,
     fpm_workload_node_count,
 )
 
@@ -120,6 +121,34 @@ def test_fpm_resolved_config_name_matches_the_shared_glob():
 def test_fpm_resolved_config_name_rejects_invalid_ranks(node_rank):
     with pytest.raises(ValueError, match="node_rank must be a non-negative integer"):
         fpm_resolved_config_name(node_rank)
+
+
+@pytest.mark.parametrize(
+    "output_path",
+    [
+        pytest.param("/results/resolved-config-node0.json", id="default-single-node"),
+        pytest.param("/results/resolved-config.json", id="custom-conforming"),
+        pytest.param("/results/run1/resolved-config-node{node_rank}.json", id="nested-placeholder"),
+    ],
+)
+def test_fpm_validate_resolved_config_path_accepts_discoverable_paths(output_path):
+    fpm_validate_resolved_config_path(output_path)
+
+
+@pytest.mark.parametrize(
+    ("output_path", "match"),
+    [
+        pytest.param("/results/custom-config.json", "basename must match", id="glob-mismatch"),
+        pytest.param("/tmp/resolved-config-node0.json", "must live under /results", id="outside-results"),
+        pytest.param("/results/../tmp/resolved-config.json", "without '.' or '..'", id="traversal"),
+        pytest.param("relative/resolved-config.json", "must be absolute", id="relative"),
+        pytest.param("/results/resolved-config", "basename must match", id="extensionless"),
+        pytest.param("/results", "must live under /results", id="results-dir-itself"),
+    ],
+)
+def test_fpm_validate_resolved_config_path_rejects_undiscoverable_paths(output_path, match):
+    with pytest.raises(ValueError, match=match):
+        fpm_validate_resolved_config_path(output_path)
 
 
 def test_fpm_expected_result_paths_window_covers_the_node_local_rank_range():

--- a/tests/unit/test_fpm_contract.py
+++ b/tests/unit/test_fpm_contract.py
@@ -160,7 +160,7 @@ def _podcliqueset(spec: object) -> dict:
     [
         pytest.param({"kind": "Pod"}, 1, id="pod-is-one-node"),
         pytest.param(
-            {"kind": "LeaderWorkerSet", "spec": {"leaderWorkerTemplate": {"size": 4}}},
+            {"kind": "LeaderWorkerSet", "spec": {"replicas": 1, "leaderWorkerTemplate": {"size": 4}}},
             4,
             id="lws-size",
         ),
@@ -227,6 +227,43 @@ def test_fpm_workload_node_count_rejects_non_mapping_clique_spec(clique):
 
 
 @pytest.mark.parametrize(
+    "replicas",
+    [
+        pytest.param(2, id="multiple"),
+        pytest.param(True, id="bool"),
+        pytest.param(0, id="zero"),
+        pytest.param(-1, id="negative"),
+        pytest.param("1", id="string"),
+        pytest.param(None, id="missing"),
+    ],
+)
+def test_fpm_workload_node_count_rejects_lws_replicas_other_than_one(replicas):
+    workload = {
+        "kind": "LeaderWorkerSet",
+        "spec": {"replicas": replicas, "leaderWorkerTemplate": {"size": 4}},
+    }
+
+    with pytest.raises(ValueError, match=r"LeaderWorkerSet spec\.replicas must be 1"):
+        fpm_workload_node_count(workload)
+
+
+@pytest.mark.parametrize(
+    ("spec", "match"),
+    [
+        pytest.param("invalid", "spec must be a mapping", id="non-mapping-spec"),
+        pytest.param(
+            {"replicas": 1, "leaderWorkerTemplate": "invalid"},
+            "leaderWorkerTemplate must be a mapping",
+            id="non-mapping-template",
+        ),
+    ],
+)
+def test_fpm_workload_node_count_rejects_malformed_lws_structure(spec, match):
+    with pytest.raises(ValueError, match=match):
+        fpm_workload_node_count({"kind": "LeaderWorkerSet", "spec": spec})
+
+
+@pytest.mark.parametrize(
     "size",
     [
         pytest.param(True, id="bool"),
@@ -237,7 +274,7 @@ def test_fpm_workload_node_count_rejects_non_mapping_clique_spec(clique):
     ],
 )
 def test_fpm_workload_node_count_rejects_non_strict_lws_size(size):
-    workload = {"kind": "LeaderWorkerSet", "spec": {"leaderWorkerTemplate": {"size": size}}}
+    workload = {"kind": "LeaderWorkerSet", "spec": {"replicas": 1, "leaderWorkerTemplate": {"size": size}}}
 
     with pytest.raises(ValueError, match=r"leaderWorkerTemplate\.size must be a positive integer"):
         fpm_workload_node_count(workload)


### PR DESCRIPTION
> [!IMPORTANT]
> **Review remediation at `86bbb4f5c`:**
> - reject benchmark output basenames reserved for merged artifacts;
> - require the generated LeaderWorkerSet contract to keep `spec.replicas: 1`;
> - constrain `--dump-config-to` overrides to the collector's resolved-config discovery surface.
>
> Local validation: 176 focused contract/Generator tests passed on both the branch and a synthetic merge with current `main`; Ruff and diff checks passed. A synthetic stack with collector PR #1475 passed 384/385 focused tests, with the sole failure being #1475's hand-written LeaderWorkerSet fixture that must add the now-required `spec.replicas: 1` when rebased.

> [!NOTE]
> Rebased to a **delta PR**: the original contract table landed in `main`
> when #1474 was squash-merged (1eedd536, which carried this stack's base
> commits). What remains here is the review-driven contract hardening on
> top of `main`:
>
> - the resolved-config snapshot naming convention
>   (`FPM_RESOLVED_CONFIG_TEMPLATE` / `FPM_RESOLVED_CONFIG_GLOB` /
>   `fpm_resolved_config_name()`) moves into the contract so the Generator
>   render and the collector's marker-validation sweep import one spelling;
> - the benchmark-output path validator documents the end-to-end recursive
>   discovery contract (subdirectories under `/results` are valid) with
>   tests;
> - `fpm_workload_node_count` rejects non-strict LeaderWorkerSet sizes
>   (bool/zero/negative/str/float) instead of coercing via `int()`.
>
> The collector consumer remains #1475; the Generator's fail-closed override
> validation now lands here because it produces paths that collector discovery consumes.
> The original stack description below is kept for history.

## Overview

Add `src/aiconfigurator/fpm_contract.py`: the single home for every fact the
Generator's FPM deployment target and the FPM collector must agree on.

- native benchmark result schema version (the one fact the two sides already
  shared) plus the previously implicit ones:
- rendered artifact names (`k8s_deploy.yaml`, `fpm_env.sh`, `run.sh`),
- workload/auxiliary kind whitelists,
- the collector-owned pod identity label,
- the `fpm_env.sh` export set (rank/leader discovery semantics documented),
- cross-boundary env names (`FPM_RUN_ID`, `DYN_FPM_BENCHMARK_OUTPUT_PATH`,
  the barrier-timeout tunable),
- the engine's per-DP-rank result naming convention (pure function), and
- the enumerated manifest fields behind workload node counting (pure function).

The shared module remains pure. The Generator adds render-time fail-closed
validation for benchmark and resolved-config output paths.

## Why

The audit behind the decoupling proposal found 15 cross-boundary facts spelled
independently by the two modules (schema validation ×3, rank discovery ×2,
result naming ×2, …). Each is a place where one side can change and the other
cannot notice. This table makes every such fact a reviewable, importable constant. To give
both owning teams visibility, suggest registering this file as a shared area
in `.github/codeowners/areas.yaml` so changes request review from both the
generator and collector owners (the generated CODEOWNERS uses any-one-approves
semantics; a strict two-team gate would additionally need a workflow check).

## Validation

- module self-check (naming/window/node-count functions) and doctest-free import;
- `ruff check` / `ruff format --check` clean under the CI-pinned ruff 0.14.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized benchmark artifact names, result locations, labels, and runtime settings.
  * Added consistent benchmark result naming and per-node result path generation.
  * Added support for calculating node counts across supported workload configurations.
  * Added validation for benchmark output paths and workload structures, with clear errors for invalid configurations.

* **Tests**
  * Expanded coverage for result naming, path validation, workload calculations, and malformed configuration handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
