### PR TITLE
fix(sdk): count cp in disagg rate-match GPU accounting

### DIFF
--- a/src/aiconfigurator/cli/report_and_save.py
+++ b/src/aiconfigurator/cli/report_and_save.py
@@ -24,7 +24,7 @@ from aiconfigurator.generator.request import from_legacy_params
 from aiconfigurator.logging_utils import _cli_bold, _cli_underline
 from aiconfigurator.sdk import pareto_analysis
 from aiconfigurator.sdk.pareto_analysis import draw_pareto_to_string
-from aiconfigurator.sdk.picking import WORKER_GPU_DIMS
+from aiconfigurator.sdk.picking import WORKER_GPU_DIMS, parallel_dim
 from aiconfigurator.sdk.task_v2 import Task
 from aiconfigurator.sdk.utils import safe_mkdir
 
@@ -87,7 +87,7 @@ def _composed_worker_gpus(row: dict, role: str) -> int:
     """
     gpus = 1
     for dim in WORKER_GPU_DIMS:
-        gpus *= int(row.get(f"({role}){dim}") or 1)
+        gpus *= parallel_dim(row.get(f"({role}){dim}"))
     return gpus
 
 
@@ -251,7 +251,7 @@ def _plot_worker_setup_table(
             # the cp display factor stays hidden when cp=1 for readability.
             p_gpus = _composed_worker_gpus(row, "p")
             d_gpus = _composed_worker_gpus(row, "d")
-            p_cp = int(row.get("(p)cp") or 1)
+            p_cp = parallel_dim(row.get("(p)cp"))
             p_cp_label = f"cp{_cli_underline(str(p_cp))}" if p_cp > 1 else ""
             p_cp_factor = f"x{_cli_underline(str(p_cp))}" if p_cp > 1 else ""
             if is_moe:

--- a/src/aiconfigurator/cli/report_and_save.py
+++ b/src/aiconfigurator/cli/report_and_save.py
@@ -24,6 +24,7 @@ from aiconfigurator.generator.request import from_legacy_params
 from aiconfigurator.logging_utils import _cli_bold, _cli_underline
 from aiconfigurator.sdk import pareto_analysis
 from aiconfigurator.sdk.pareto_analysis import draw_pareto_to_string
+from aiconfigurator.sdk.picking import WORKER_GPU_DIMS
 from aiconfigurator.sdk.task_v2 import Task
 from aiconfigurator.sdk.utils import safe_mkdir
 
@@ -75,6 +76,19 @@ def _check_power_data_available(best_configs: dict[str, pd.DataFrame], threshold
 
 def _format_power(power_w: object) -> str:
     return "" if pd.isna(power_w) else f"{float(power_w):.1f}W"
+
+
+def _composed_worker_gpus(row: dict, role: str) -> int:
+    """Per-worker GPU count from a composed disagg row's ``(p)``/``(d)`` columns.
+
+    Iterates :data:`aiconfigurator.sdk.picking.WORKER_GPU_DIMS` so every
+    parallelism dimension lands here automatically; columns a row predates
+    (e.g. ``(d)cp``) default to 1.
+    """
+    gpus = 1
+    for dim in WORKER_GPU_DIMS:
+        gpus *= int(row.get(f"({role}){dim}") or 1)
+    return gpus
 
 
 def _plot_worker_setup_table(
@@ -232,11 +246,20 @@ def _plot_worker_setup_table(
         for i, row in enumerate(top_configs.to_dict("records")):
             display_total_gpus = row["total_gpus_used"] if "replicas_needed" in row else total_gpus
             display_concurrency = row["concurrency"] * row["replicas"]
+            # Worker GPU totals come from the shared dims list so a new
+            # parallelism dimension cannot be silently dropped again (#1476);
+            # the cp display factor stays hidden when cp=1 for readability.
+            p_gpus = _composed_worker_gpus(row, "p")
+            d_gpus = _composed_worker_gpus(row, "d")
+            p_cp = int(row.get("(p)cp") or 1)
+            p_cp_label = f"cp{_cli_underline(str(p_cp))}" if p_cp > 1 else ""
+            p_cp_factor = f"x{_cli_underline(str(p_cp))}" if p_cp > 1 else ""
             if is_moe:
                 p_parallel = (
                     f"tp{_cli_underline(str(row['(p)tp']))}"
                     f"pp{_cli_underline(str(row['(p)pp']))}"
                     f"dp{_cli_underline(str(row['(p)dp']))}"
+                    f"{p_cp_label}"
                     f"etp{row['(p)moe_tp']}ep{row['(p)moe_ep']}"
                 )
                 d_parallel = (
@@ -246,35 +269,25 @@ def _plot_worker_setup_table(
                     f"etp{row['(d)moe_tp']}ep{row['(d)moe_ep']}"
                 )
                 p_gpus_worker = (
-                    f"{row['(p)pp'] * row['(p)tp'] * row['(p)dp']} "
+                    f"{p_gpus} "
                     f"(={_cli_underline(str(row['(p)tp']))}x"
                     f"{_cli_underline(str(row['(p)pp']))}x"
-                    f"{_cli_underline(str(row['(p)dp']))})"
+                    f"{_cli_underline(str(row['(p)dp']))}{p_cp_factor})"
                 )
                 d_gpus_worker = (
-                    f"{row['(d)pp'] * row['(d)tp'] * row['(d)dp']} "
+                    f"{d_gpus} "
                     f"(={_cli_underline(str(row['(d)tp']))}x"
                     f"{_cli_underline(str(row['(d)pp']))}x"
                     f"{_cli_underline(str(row['(d)dp']))})"
                 )
             else:
-                p_parallel = f"tp{_cli_underline(str(row['(p)tp']))}pp{_cli_underline(str(row['(p)pp']))}"
+                p_parallel = f"tp{_cli_underline(str(row['(p)tp']))}pp{_cli_underline(str(row['(p)pp']))}{p_cp_label}"
                 d_parallel = f"tp{_cli_underline(str(row['(d)tp']))}pp{_cli_underline(str(row['(d)pp']))}"
                 p_gpus_worker = (
-                    f"{row['(p)pp'] * row['(p)tp']} "
-                    f"(={_cli_underline(str(row['(p)tp']))}x"
-                    f"{_cli_underline(str(row['(p)pp']))})"
+                    f"{p_gpus} (={_cli_underline(str(row['(p)tp']))}x{_cli_underline(str(row['(p)pp']))}{p_cp_factor})"
                 )
-                d_gpus_worker = (
-                    f"{row['(d)pp'] * row['(d)tp']} "
-                    f"(={_cli_underline(str(row['(d)tp']))}x"
-                    f"{_cli_underline(str(row['(d)pp']))})"
-                )
-            gpus_replica_str = (
-                f"{row['num_total_gpus']} "
-                f"(={row['(p)workers']}x{row['(p)pp'] * row['(p)tp'] * row['(p)dp']}"
-                f"+{row['(d)workers']}x{row['(d)pp'] * row['(d)tp'] * row['(d)dp']})"
-            )
+                d_gpus_worker = f"{d_gpus} (={_cli_underline(str(row['(d)tp']))}x{_cli_underline(str(row['(d)pp']))})"
+            gpus_replica_str = f"{row['num_total_gpus']} (={row['(p)workers']}x{p_gpus}+{row['(d)workers']}x{d_gpus})"
             row_data = [
                 i + 1,
                 row["backend"],

--- a/src/aiconfigurator/sdk/picking.py
+++ b/src/aiconfigurator/sdk/picking.py
@@ -44,6 +44,19 @@ _AUTOSCALE_TTFT_CORRECTION_FACTOR = 1.8
 WORKER_GPU_DIMS = ("tp", "pp", "dp", "cp")
 
 
+def parallel_dim(value: object, default: int = 1) -> int:
+    """Normalize a parallelism-dimension cell to a positive int.
+
+    Rows materialized through the schema column lists NaN-fill dimensions
+    they predate (e.g. ``cp`` / ``(p)cp``), and ``NaN or default`` does not
+    catch that because NaN is truthy — so missing / None / NaN / non-positive
+    all normalize to ``default`` here.
+    """
+    if isinstance(value, (int, float)) and value == value and value > 0:  # value == value filters NaN
+        return int(value)
+    return default
+
+
 def worker_gpus(summary_dict: dict) -> int:
     """GPUs occupied by one worker, from a ``ColumnsStatic``-style row dict.
 
@@ -52,12 +65,12 @@ def worker_gpus(summary_dict: dict) -> int:
     back to the ``WORKER_GPU_DIMS`` product for partial dicts that predate
     the column.
     """
-    n = summary_dict.get("num_total_gpus")
-    if isinstance(n, (int, float)) and n == n and n > 0:  # n == n filters NaN
-        return int(n)
+    n = parallel_dim(summary_dict.get("num_total_gpus"), default=0)
+    if n:
+        return n
     gpus = 1
     for dim in WORKER_GPU_DIMS:
-        gpus *= int(summary_dict.get(dim) or 1)
+        gpus *= parallel_dim(summary_dict.get(dim))
     return gpus
 
 
@@ -149,7 +162,7 @@ def _build_disagg_summary_dict(
         "(p)dp": prefill_summary_dict["dp"],
         "(p)moe_tp": prefill_summary_dict["moe_tp"],
         "(p)moe_ep": prefill_summary_dict["moe_ep"],
-        "(p)cp": prefill_summary_dict.get("cp", 1),
+        "(p)cp": parallel_dim(prefill_summary_dict.get("cp")),
         "(p)parallel": prefill_summary_dict["parallel"],
         "(p)gemm": prefill_summary_dict["gemm"],
         "(p)kvcache": prefill_summary_dict["kvcache"],

--- a/src/aiconfigurator/sdk/picking.py
+++ b/src/aiconfigurator/sdk/picking.py
@@ -37,6 +37,29 @@ _RATE_MATCHING_DECODE_DEGRADATION_FACTOR = 0.92
 # local concurrency lc=15-20, formula lc/20+0.95 gives ~1.8
 _AUTOSCALE_TTFT_CORRECTION_FACTOR = 1.8
 
+# Parallelism dimensions that multiply into a worker's GPU footprint,
+# mirroring ModelConfig.total_gpus_per_worker.  Every consumer that sizes a
+# worker from a row dict must go through this list (or worker_gpus below) —
+# a dimension listed nowhere else was exactly how cp got dropped (#1476).
+WORKER_GPU_DIMS = ("tp", "pp", "dp", "cp")
+
+
+def worker_gpus(summary_dict: dict) -> int:
+    """GPUs occupied by one worker, from a ``ColumnsStatic``-style row dict.
+
+    Prefers the row's own ``num_total_gpus`` — the authoritative value the
+    backends stamp from ``ModelConfig.total_gpus_per_worker`` — and falls
+    back to the ``WORKER_GPU_DIMS`` product for partial dicts that predate
+    the column.
+    """
+    n = summary_dict.get("num_total_gpus")
+    if isinstance(n, (int, float)) and n == n and n > 0:  # n == n filters NaN
+        return int(n)
+    gpus = 1
+    for dim in WORKER_GPU_DIMS:
+        gpus *= int(summary_dict.get(dim) or 1)
+    return gpus
+
 
 # ---------------------------------------------------------------------------
 # Helper: build a disagg summary dict from prefill + decode dicts
@@ -74,8 +97,8 @@ def _build_disagg_summary_dict(
         prefill_summary_dict["seq/s"] * prefill_num_worker * prefill_degradation_factor,
         decode_summary_dict["seq/s"] * decode_num_worker * decode_degradation_factor,
     )
-    prefill_gpus = prefill_summary_dict["pp"] * prefill_summary_dict["tp"] * prefill_summary_dict["dp"]
-    decode_gpus = decode_summary_dict["pp"] * decode_summary_dict["tp"] * decode_summary_dict["dp"]
+    prefill_gpus = worker_gpus(prefill_summary_dict)
+    decode_gpus = worker_gpus(decode_summary_dict)
     num_total_gpus = prefill_gpus * prefill_num_worker + decode_gpus * decode_num_worker
     seq_s_gpu = seq_s / num_total_gpus if num_total_gpus > 0 else 0.0
 

--- a/src/aiconfigurator/sdk/sweep.py
+++ b/src/aiconfigurator/sdk/sweep.py
@@ -48,6 +48,7 @@ from aiconfigurator.sdk.errors import (
 )
 from aiconfigurator.sdk.models import get_model
 from aiconfigurator.sdk.perf_database import PerfDatabase
+from aiconfigurator.sdk.picking import worker_gpus
 from aiconfigurator.sdk.predict import predict_agg_worker, predict_disagg_worker
 from aiconfigurator.sdk.speculative import SpeculativeDecodingProfile
 from aiconfigurator.sdk.utils import enumerate_ttft_tpot_constraints
@@ -117,8 +118,8 @@ def _rate_match_dict(
         p["seq/s"] * prefill_num_worker * prefill_degradation,
         d["seq/s"] * decode_num_worker * decode_degradation,
     )
-    prefill_gpus = p["pp"] * p["tp"] * p["dp"]
-    decode_gpus = d["pp"] * d["tp"] * d["dp"]
+    prefill_gpus = worker_gpus(p)
+    decode_gpus = worker_gpus(d)
     num_total_gpus = prefill_gpus * prefill_num_worker + decode_gpus * decode_num_worker
     seq_s_gpu = seq_s / num_total_gpus if num_total_gpus > 0 else 0.0
     tokens_s = seq_s * osl

--- a/src/aiconfigurator/sdk/sweep.py
+++ b/src/aiconfigurator/sdk/sweep.py
@@ -48,7 +48,7 @@ from aiconfigurator.sdk.errors import (
 )
 from aiconfigurator.sdk.models import get_model
 from aiconfigurator.sdk.perf_database import PerfDatabase
-from aiconfigurator.sdk.picking import worker_gpus
+from aiconfigurator.sdk.picking import parallel_dim, worker_gpus
 from aiconfigurator.sdk.predict import predict_agg_worker, predict_disagg_worker
 from aiconfigurator.sdk.speculative import SpeculativeDecodingProfile
 from aiconfigurator.sdk.utils import enumerate_ttft_tpot_constraints
@@ -168,7 +168,7 @@ def _rate_match_dict(
         "(p)dp": p["dp"],
         "(p)moe_tp": p["moe_tp"],
         "(p)moe_ep": p["moe_ep"],
-        "(p)cp": p.get("cp", 1),
+        "(p)cp": parallel_dim(p.get("cp")),
         "(p)parallel": p["parallel"],
         "(p)gemm": p["gemm"],
         "(p)kvcache": p["kvcache"],

--- a/tests/unit/sdk/sweep/test_rate_match_parity.py
+++ b/tests/unit/sdk/sweep/test_rate_match_parity.py
@@ -223,3 +223,56 @@ class TestWorkerGpus:
         from aiconfigurator.sdk.picking import worker_gpus
 
         assert worker_gpus({"tp": 2, "pp": 1, "dp": 1, "num_total_gpus": float("nan")}) == 2
+
+    def test_nan_dim_in_fallback_counts_as_one(self):
+        from aiconfigurator.sdk.picking import worker_gpus
+
+        # Schema-materialized legacy rows NaN-fill dims they predate.
+        assert worker_gpus({"tp": 2, "pp": 1, "dp": 1, "cp": float("nan")}) == 2
+
+
+class TestSchemaMaterializedRows:
+    """Legacy rows round-tripped through the schema column lists NaN-fill the
+    dims they predate; composing and rendering them must not crash (#1477
+    review): ``NaN or 1`` does not normalize because NaN is truthy."""
+
+    @staticmethod
+    def _materialize(d: dict, columns) -> dict:
+        import pandas as pd
+
+        return pd.DataFrame([d], columns=list(columns)).to_dict("records")[0]
+
+    def test_compose_and_render_schema_materialized_legacy_rows(self):
+        import pandas as pd
+
+        from aiconfigurator.cli.report_and_save import _plot_worker_setup_table
+        from aiconfigurator.sdk import common
+
+        # Legacy per-worker rows: no cp key; num_total_gpus authoritative.
+        p = self._materialize(_make_prefill_dict(tp=4, num_total_gpus=4), common.ColumnsStatic)
+        d = self._materialize(_make_decode_dict(tp=2, num_total_gpus=2), common.ColumnsStatic)
+        assert p["cp"] != p["cp"], "expected schema materialization to NaN-fill cp"
+
+        for result in (_rate_match_dict(p, 1, d, 1), _build_disagg_summary_dict(p, 1, d, 1)):
+            assert result["num_total_gpus"] == 4 + 2
+            assert result["(p)cp"] == 1  # normalized, not NaN
+
+        # A fully legacy composed row (e.g. reloaded CSV predating (p)cp)
+        # must still render: (p)cp materializes as NaN.
+        row = _rate_match_dict(p, 1, d, 1)
+        row.pop("(p)cp")
+        row = self._materialize(row, [*common.ColumnsDisagg, "backend", "replicas"])
+        row["backend"] = "trtllm"
+        row["replicas"] = 1
+        assert row["(p)cp"] != row["(p)cp"], "expected NaN-filled (p)cp"
+        out = _plot_worker_setup_table(
+            "disagg",
+            pd.DataFrame([row]),
+            total_gpus=8,
+            tpot_target=30.0,
+            top=5,
+            is_moe=False,
+            request_latency_target=None,
+            show_power=False,
+        )
+        assert "6 (=1x4+1x2)" in out.replace("\x1b[4m", "").replace("\x1b[0m", "")

--- a/tests/unit/sdk/sweep/test_rate_match_parity.py
+++ b/tests/unit/sdk/sweep/test_rate_match_parity.py
@@ -159,3 +159,67 @@ def test_rate_match_missing_power_w_defaults_to_zero():
     old_result = _build_disagg_summary_dict(p, 1, d, 1)
     for key in new_result:
         assert new_result[key] == old_result[key]
+
+
+def test_rate_match_counts_cp_in_gpu_accounting():
+    """#1476: a cp8 prefill worker occupies tp*pp*dp*cp GPUs, not tp*pp*dp.
+
+    Before the fix a cp8 worker was accounted as one GPU, inflating
+    num_total_gpus-normalized metrics ~8x and producing replica math the
+    cluster cannot satisfy.
+    """
+    p = _make_prefill_dict(tp=1, pp=1, dp=1, cp=8, parallel="tp1pp1dp1cp8")
+    d = _make_decode_dict(tp=1, pp=1, dp=1, parallel="tp1pp1dp1")
+
+    for result in (_rate_match_dict(p, 2, d, 4), _build_disagg_summary_dict(p, 2, d, 4)):
+        # 2 prefill workers x 8 GPUs (cp8) + 4 decode workers x 1 GPU
+        assert result["num_total_gpus"] == 2 * 8 + 4 * 1
+        assert result["(p)cp"] == 8
+        seq_s = min(p["seq/s"] * 2 * 0.9, d["seq/s"] * 4 * 0.92)
+        assert result["tokens/s/gpu"] == pytest.approx(seq_s * p["osl"] / 20)
+
+
+def test_rate_match_missing_cp_key_defaults_to_one():
+    """Rows predating the cp column (older CSVs, partial dicts) keep working."""
+    p = _make_prefill_dict()  # no "cp" key
+    d = _make_decode_dict()
+    for result in (_rate_match_dict(p, 1, d, 1), _build_disagg_summary_dict(p, 1, d, 1)):
+        assert result["num_total_gpus"] == 4 + 2  # tp4 prefill + tp2 decode
+        assert result["(p)cp"] == 1
+
+
+def test_rate_match_parity_holds_with_cp():
+    p = _make_prefill_dict(cp=4, parallel="tp4pp1dp1cp4")
+    d = _make_decode_dict()
+    new_result = _rate_match_dict(p, 3, d, 5)
+    old_result = _build_disagg_summary_dict(p, 3, d, 5)
+    for key in new_result:
+        assert new_result[key] == old_result[key], (
+            f"Field {key!r} differs with cp: new={new_result[key]} vs old={old_result[key]}"
+        )
+
+
+class TestWorkerGpus:
+    """worker_gpus: num_total_gpus is authoritative, dims are the fallback."""
+
+    def test_prefers_authoritative_num_total_gpus(self):
+        from aiconfigurator.sdk.picking import worker_gpus
+
+        # Dims say 1 GPU, but the backend stamped 8 (e.g. a dimension this
+        # helper's fallback list does not know about yet) — trust the stamp.
+        assert worker_gpus({"tp": 1, "pp": 1, "dp": 1, "num_total_gpus": 8}) == 8
+
+    def test_falls_back_to_dims_product_including_cp(self):
+        from aiconfigurator.sdk.picking import worker_gpus
+
+        assert worker_gpus({"tp": 2, "pp": 2, "dp": 1, "cp": 4}) == 16
+
+    def test_missing_dims_default_to_one(self):
+        from aiconfigurator.sdk.picking import worker_gpus
+
+        assert worker_gpus({"tp": 4}) == 4
+
+    def test_nan_num_total_gpus_falls_back(self):
+        from aiconfigurator.sdk.picking import worker_gpus
+
+        assert worker_gpus({"tp": 2, "pp": 1, "dp": 1, "num_total_gpus": float("nan")}) == 2

--- a/tests/unit/sdk/sweep/test_rate_match_parity.py
+++ b/tests/unit/sdk/sweep/test_rate_match_parity.py
@@ -230,6 +230,18 @@ class TestWorkerGpus:
         # Schema-materialized legacy rows NaN-fill dims they predate.
         assert worker_gpus({"tp": 2, "pp": 1, "dp": 1, "cp": float("nan")}) == 2
 
+    @pytest.mark.parametrize("cp", [None, 0, -1])
+    def test_invalid_dim_in_fallback_defaults_to_one(self, cp):
+        from aiconfigurator.sdk.picking import worker_gpus
+
+        assert worker_gpus({"tp": 2, "pp": 1, "dp": 1, "cp": cp}) == 2
+
+    @pytest.mark.parametrize("n", [None, 0, -8])
+    def test_invalid_num_total_gpus_falls_back(self, n):
+        from aiconfigurator.sdk.picking import worker_gpus
+
+        assert worker_gpus({"tp": 2, "pp": 1, "dp": 1, "num_total_gpus": n}) == 2
+
 
 class TestSchemaMaterializedRows:
     """Legacy rows round-tripped through the schema column lists NaN-fill the


### PR DESCRIPTION
#### Overview:

Fixes #1476: the disagg rate-match composition counted a cp-parallel prefill worker as `pp*tp*dp` GPUs — **cp was missing** — so a cp8 worker was accounted as one GPU. This inflated `num_total_gpus`-normalized metrics (`seq/s/gpu`, `tokens/s/gpu`) up to ~8x, mis-ranked cp rows to the top of the disagg results, and reported replica math the cluster cannot satisfy (e.g. "3 replicas in 32 GPUs" for a shape that needs 72).

The `pp*tp*dp` derivation dates from the original picking implementation (#386 — correct at the time, cp didn't exist). CP arrived in #1247 and updated the parallel enumeration and `ModelConfig.total_gpus_per_worker`, but not these compose sites or the report.

#### Details:

Rather than patching `cp` into each product (which leaves the next parallelism dimension exposed to the same landmine), the worker GPU footprint becomes a single definition:

- **`picking.worker_gpus(row)`** — per-worker GPU count for a `ColumnsStatic`-style row: prefers the row's own `num_total_gpus` (the authoritative value backends stamp from `total_gpus_per_worker`, which already includes cp) and falls back to the dims product for partial dicts predating the column. Both `sweep._rate_match_dict` and `picking._build_disagg_summary_dict` now call it, so their arithmetic cannot drift.
- **`picking.WORKER_GPU_DIMS = ("tp", "pp", "dp", "cp")`** — the one list of dimensions that multiply into a worker's footprint. The CLI report derives `(p)`/`(d)` worker GPU totals from it (a future dimension lands in the table automatically), and now renders cp when > 1: `(p)parallel tp1pp1cp8`, `(p)gpus/worker 8 (=1x1x8)`, `gpus/replica (=2x8+4x1)`. The report previously hid cp entirely — which is what kept the inflation invisible.

Note the *candidate* frames and `sweep_disagg`'s `_match_workers` argmax already used the correct per-worker `num_total_gpus`; only the composed row dict, the cross-category ranking, and the CLI report were wrong.

**Tests**: regression pins for the cp8 accounting (`num_total_gpus == 2*8 + 4*1` + normalized throughput), the missing-`cp`-key default, sweep/picking parity with cp, and `worker_gpus` authoritative-first semantics (incl. NaN fallback). All 309 sweep/picking/cli unit tests pass.

#### Where should the reviewer start?

- `src/aiconfigurator/sdk/picking.py` — `WORKER_GPU_DIMS` + `worker_gpus()`, and `_build_disagg_summary_dict` consuming it; `sweep._rate_match_dict` mirrors.
- `tests/unit/sdk/sweep/test_rate_match_parity.py::test_rate_match_counts_cp_in_gpu_accounting` — the pinned repro.

#### Related Issues:

- Closes #1476
- Context: found while validating EPD sweep output on #1340 (whose language-only prefill makes cp candidates selectable under tight TTFT, surfacing the inflation); the bug itself predates that PR and is reachable on main.
- Out of scope, follow-up candidate: `generator/module_bridge.py` has five sibling `tp*pp*dp` products; whether cp ever reaches the generator's task_config is a separate contract question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected GPU totals and per-GPU performance metrics for configurations using context parallelism.
  - Improved worker and replica summaries to accurately reflect prefill and decode resources.
  - Preserved existing reporting behavior when context parallelism is disabled or set to one.
  - Updated parallelism labels and GPU counts in disaggregated worker reports.

- **Tests**
  - Added coverage for context-parallel GPU accounting, default handling, authoritative totals, and consistency across performance summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->