### PR TITLE
fix(fpm): constrain regression slopes to be non-negative

### DIFF
--- a/aic-core/rust/aiconfigurator-core/src/fpm/correction.rs
+++ b/aic-core/rust/aiconfigurator-core/src/fpm/correction.rs
@@ -23,11 +23,7 @@ struct CorrectionObservation {
 }
 
 impl WithOptions for CorrectionBuckets {
-    fn with_options(
-        options: &ForwardPassPerfOptions,
-        axis_ranges: &[AxisRange],
-        _relaxable: &[usize],
-    ) -> Self {
+    fn with_options(options: &ForwardPassPerfOptions, axis_ranges: &[AxisRange]) -> Self {
         Self {
             samples: BucketedSamples::new_fixed(options, axis_ranges),
             min_observations: options.min_observations,

--- a/aic-core/rust/aiconfigurator-core/src/fpm/model.rs
+++ b/aic-core/rust/aiconfigurator-core/src/fpm/model.rs
@@ -584,18 +584,13 @@ pub(crate) struct WorkloadStores<T> {
 impl<T: WithOptions> WorkloadStores<T> {
     fn with_options(options: &ForwardPassPerfOptions) -> Self {
         Self {
-            prefill: T::with_options(
-                options,
-                &[AxisRange::from_zero_to(options.max_num_tokens)],
-                &[],
-            ),
+            prefill: T::with_options(options, &[AxisRange::from_zero_to(options.max_num_tokens)]),
             decode: T::with_options(
                 options,
                 &[
                     AxisRange::from_zero_to(options.max_batch_size),
                     AxisRange::from_zero_to(options.max_kv_tokens),
                 ],
-                &[0],
             ),
             mixed: T::with_options(
                 options,
@@ -603,7 +598,6 @@ impl<T: WithOptions> WorkloadStores<T> {
                     AxisRange::from_zero_to(options.max_num_tokens),
                     AxisRange::from_zero_to(options.max_kv_tokens),
                 ],
-                &[],
             ),
         }
     }

--- a/aic-core/rust/aiconfigurator-core/src/fpm/regression.rs
+++ b/aic-core/rust/aiconfigurator-core/src/fpm/regression.rs
@@ -173,10 +173,15 @@ fn fit_linear(
         }
     }
 
-    // An intercept-only boundary remains a valid constrained solution. This
-    // preserves readiness for deliberately small min-observation settings,
-    // while every workload slope still stays monotonic non-negative.
-    best.map(|(_, fit)| fit)
+    let fit = best.map(|(_, fit)| fit)?;
+    let is_underdetermined = observations.len() <= ndim;
+    let has_load_signal = fit.coefficients.iter().any(|coef| *coef > 0.0);
+
+    // Preserve explicitly configured low-observation behavior while the
+    // system is underdetermined. Once there are enough observations to
+    // identify the slopes, an intercept-only boundary has no usable load
+    // signal and must not make the model ready.
+    (is_underdetermined || has_load_signal).then_some(fit)
 }
 
 fn fit_linear_active_set(

--- a/aic-core/rust/aiconfigurator-core/src/fpm/regression.rs
+++ b/aic-core/rust/aiconfigurator-core/src/fpm/regression.rs
@@ -109,8 +109,7 @@ impl WeightedHingeFit {
 
     fn normalize_monotonic_nonnegative(mut self) -> Option<Self> {
         let right_slope = self.left_slope + self.right_slope_delta;
-        if self.intercept < -HINGE_NEG_TOLERANCE
-            || self.left_slope < -HINGE_NEG_TOLERANCE
+        if self.left_slope < -HINGE_NEG_TOLERANCE
             || right_slope < -HINGE_NEG_TOLERANCE
             || ![self.intercept, self.left_slope, right_slope]
                 .iter()
@@ -119,7 +118,6 @@ impl WeightedHingeFit {
             return None;
         }
 
-        self.intercept = self.intercept.max(0.0);
         self.left_slope = self.left_slope.max(0.0);
         self.right_slope_delta = right_slope.max(0.0) - self.left_slope;
         Some(self)
@@ -393,7 +391,7 @@ mod tests {
     #[test]
     fn weighted_hinge_normalizes_tolerated_negative_slopes() {
         let fit = WeightedHingeFit {
-            intercept: 10.0,
+            intercept: -10.0,
             left_slope: -HINGE_NEG_TOLERANCE / 2.0,
             right_slope_delta: HINGE_NEG_TOLERANCE / 4.0,
             knot: 2.0,
@@ -403,6 +401,7 @@ mod tests {
 
         assert_eq!(fit.left_slope, 0.0);
         assert_eq!(fit.left_slope + fit.right_slope_delta, 0.0);
+        assert_eq!(fit.intercept, -10.0);
 
         let invalid = WeightedHingeFit {
             left_slope: -2.0 * HINGE_NEG_TOLERANCE,

--- a/aic-core/rust/aiconfigurator-core/src/fpm/regression.rs
+++ b/aic-core/rust/aiconfigurator-core/src/fpm/regression.rs
@@ -107,10 +107,22 @@ impl WeightedHingeFit {
             + self.right_slope_delta * (value - self.knot).max(0.0)
     }
 
-    fn is_monotonic_nonnegative(&self) -> bool {
-        self.intercept >= -HINGE_NEG_TOLERANCE
-            && self.left_slope >= -HINGE_NEG_TOLERANCE
-            && self.left_slope + self.right_slope_delta >= -HINGE_NEG_TOLERANCE
+    fn normalize_monotonic_nonnegative(mut self) -> Option<Self> {
+        let right_slope = self.left_slope + self.right_slope_delta;
+        if self.intercept < -HINGE_NEG_TOLERANCE
+            || self.left_slope < -HINGE_NEG_TOLERANCE
+            || right_slope < -HINGE_NEG_TOLERANCE
+            || ![self.intercept, self.left_slope, right_slope]
+                .iter()
+                .all(|value| value.is_finite())
+        {
+            return None;
+        }
+
+        self.intercept = self.intercept.max(0.0);
+        self.left_slope = self.left_slope.max(0.0);
+        self.right_slope_delta = right_slope.max(0.0) - self.left_slope;
+        Some(self)
     }
 }
 
@@ -266,7 +278,7 @@ fn fit_weighted_hinge_at(observations: &[(Vec<f64>, f64)], knot: f64) -> Option<
         right_slope_delta: solution[2],
         knot,
     };
-    fit.is_monotonic_nonnegative().then_some(fit)
+    fit.normalize_monotonic_nonnegative()
 }
 
 fn weighted_hinge_rmse(observations: &[(Vec<f64>, f64)], fit: &WeightedHingeFit) -> f64 {
@@ -372,4 +384,30 @@ fn solve_linear_system(mut lhs: Vec<Vec<f64>>, mut rhs: Vec<f64>) -> Option<Vec<
         }
     }
     Some(rhs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{WeightedHingeFit, HINGE_NEG_TOLERANCE};
+
+    #[test]
+    fn weighted_hinge_normalizes_tolerated_negative_slopes() {
+        let fit = WeightedHingeFit {
+            intercept: 10.0,
+            left_slope: -HINGE_NEG_TOLERANCE / 2.0,
+            right_slope_delta: HINGE_NEG_TOLERANCE / 4.0,
+            knot: 2.0,
+        }
+        .normalize_monotonic_nonnegative()
+        .unwrap();
+
+        assert_eq!(fit.left_slope, 0.0);
+        assert_eq!(fit.left_slope + fit.right_slope_delta, 0.0);
+
+        let invalid = WeightedHingeFit {
+            left_slope: -2.0 * HINGE_NEG_TOLERANCE,
+            ..fit
+        };
+        assert!(invalid.normalize_monotonic_nonnegative().is_none());
+    }
 }

--- a/aic-core/rust/aiconfigurator-core/src/fpm/regression.rs
+++ b/aic-core/rust/aiconfigurator-core/src/fpm/regression.rs
@@ -10,7 +10,7 @@
 use super::options::ForwardPassPerfOptions;
 use super::samples::{AxisRange, BucketedSamples, StoreStats, WithOptions};
 
-const RELAXABLE_NEG_TOLERANCE: f64 = 1e-6;
+const HINGE_NEG_TOLERANCE: f64 = 1e-6;
 const PREFILL_HINGE_MIN_OBSERVATIONS: usize = 6;
 const RELATIVE_WEIGHT_FLOOR_MS: f64 = 25.0;
 const HINGE_LOGSPACE_CANDIDATES: usize = 8;
@@ -20,22 +20,16 @@ pub(crate) struct BucketedRegression {
     samples: BucketedSamples<f64>,
     ndim: usize,
     min_observations: usize,
-    relaxable: Vec<usize>,
     fit: Option<RegressionFit>,
 }
 
 impl WithOptions for BucketedRegression {
-    fn with_options(
-        options: &ForwardPassPerfOptions,
-        axis_ranges: &[AxisRange],
-        relaxable: &[usize],
-    ) -> Self {
+    fn with_options(options: &ForwardPassPerfOptions, axis_ranges: &[AxisRange]) -> Self {
         let ndim = axis_ranges.len();
         Self {
             samples: BucketedSamples::new_dynamic(options, ndim),
             ndim,
             min_observations: options.min_observations,
-            relaxable: relaxable.to_vec(),
             fit: None,
         }
     }
@@ -55,12 +49,7 @@ impl BucketedRegression {
     pub(crate) fn add_observation(&mut self, x: Vec<f64>, y: f64) {
         if self.samples.add(x, y) {
             let observations = self.samples.observations();
-            self.fit = fit_regression(
-                &observations,
-                self.ndim,
-                self.min_observations,
-                &self.relaxable,
-            );
+            self.fit = fit_regression(&observations, self.ndim, self.min_observations);
         }
     }
 
@@ -119,9 +108,9 @@ impl WeightedHingeFit {
     }
 
     fn is_monotonic_nonnegative(&self) -> bool {
-        self.intercept >= -RELAXABLE_NEG_TOLERANCE
-            && self.left_slope >= -RELAXABLE_NEG_TOLERANCE
-            && self.left_slope + self.right_slope_delta >= -RELAXABLE_NEG_TOLERANCE
+        self.intercept >= -HINGE_NEG_TOLERANCE
+            && self.left_slope >= -HINGE_NEG_TOLERANCE
+            && self.left_slope + self.right_slope_delta >= -HINGE_NEG_TOLERANCE
     }
 }
 
@@ -129,40 +118,82 @@ fn fit_regression(
     observations: &[(Vec<f64>, f64)],
     ndim: usize,
     min_observations: usize,
-    relaxable: &[usize],
 ) -> Option<RegressionFit> {
     // Prefill is the only one-dimensional workload kind today. Its latency is
     // overhead-heavy at low token counts and slope-heavy at high token counts,
     // so a weighted hinge avoids the negative intercepts a global line can fit.
-    if ndim == 1
-        && relaxable.is_empty()
-        && observations.len() >= min_observations.max(PREFILL_HINGE_MIN_OBSERVATIONS)
-    {
+    if ndim == 1 && observations.len() >= min_observations.max(PREFILL_HINGE_MIN_OBSERVATIONS) {
         if let Some(fit) = fit_weighted_hinge(observations) {
             return Some(RegressionFit::WeightedHinge(fit));
         }
     }
 
-    fit_linear(observations, ndim, min_observations, relaxable).map(RegressionFit::Linear)
+    fit_linear(observations, ndim, min_observations).map(RegressionFit::Linear)
 }
 
 fn fit_linear(
     observations: &[(Vec<f64>, f64)],
     ndim: usize,
     min_observations: usize,
-    relaxable: &[usize],
 ) -> Option<LinearFit> {
     if observations.len() < min_observations {
         return None;
     }
-    let size = ndim + 1;
+
+    // The forward-pass regressions have at most two workload dimensions. Find
+    // the non-negative least-squares solution by enumerating every active set:
+    // each bit selects a slope that is free, while unselected slopes are fixed
+    // at zero. The intercept remains unconstrained. Comparing the residuals of
+    // all feasible faces gives the constrained optimum without relying on an
+    // absolute coefficient tolerance across differently-scaled features.
+    let active_set_count = 1usize.checked_shl(ndim.try_into().ok()?)?;
+    let mut best: Option<(f64, LinearFit)> = None;
+    for active_mask in 0..active_set_count {
+        let active = (0..ndim)
+            .filter(|idx| active_mask & (1usize << idx) != 0)
+            .collect::<Vec<_>>();
+        let Some(fit) = fit_linear_active_set(observations, ndim, &active) else {
+            continue;
+        };
+        let squared_error = observations
+            .iter()
+            .map(|(x, y)| {
+                let residual = fit.predict(x) - *y;
+                residual * residual
+            })
+            .sum::<f64>();
+        if !squared_error.is_finite() {
+            continue;
+        }
+        if best
+            .as_ref()
+            .is_none_or(|(best_error, _)| squared_error < *best_error)
+        {
+            best = Some((squared_error, fit));
+        }
+    }
+
+    // An intercept-only boundary remains a valid constrained solution. This
+    // preserves readiness for deliberately small min-observation settings,
+    // while every workload slope still stays monotonic non-negative.
+    best.map(|(_, fit)| fit)
+}
+
+fn fit_linear_active_set(
+    observations: &[(Vec<f64>, f64)],
+    ndim: usize,
+    active: &[usize],
+) -> Option<LinearFit> {
+    let size = active.len() + 1;
     let mut lhs = vec![vec![0.0_f64; size]; size];
     let mut rhs = vec![0.0_f64; size];
 
     for (x, y) in observations {
         let mut row = Vec::with_capacity(size);
         row.push(1.0);
-        row.extend(x.iter().copied().take(ndim));
+        for idx in active {
+            row.push(*x.get(*idx)?);
+        }
         for i in 0..size {
             rhs[i] += row[i] * *y;
             for j in 0..size {
@@ -173,21 +204,14 @@ fn fit_linear(
 
     let solution = solve_linear_system(lhs.clone(), rhs.clone())
         .or_else(|| solve_regularized_linear_system(lhs, rhs))?;
-    let mut coefficients = solution[1..].to_vec();
-    let mut has_non_relaxable_negative = false;
-    for (idx, coef) in coefficients.iter_mut().enumerate() {
-        if *coef < 0.0 {
-            if relaxable.contains(&idx) {
-                if *coef < -RELAXABLE_NEG_TOLERANCE {
-                    *coef = 0.0;
-                }
-            } else {
-                has_non_relaxable_negative = true;
-            }
-        }
-    }
-    if has_non_relaxable_negative {
+    if !solution.iter().all(|value| value.is_finite())
+        || solution[1..].iter().any(|coef| *coef < 0.0)
+    {
         return None;
+    }
+    let mut coefficients = vec![0.0; ndim];
+    for (solution_idx, feature_idx) in active.iter().enumerate() {
+        coefficients[*feature_idx] = solution[solution_idx + 1];
     }
     Some(LinearFit {
         intercept: solution[0],

--- a/aic-core/rust/aiconfigurator-core/src/fpm/samples.rs
+++ b/aic-core/rust/aiconfigurator-core/src/fpm/samples.rs
@@ -15,11 +15,7 @@ use std::collections::HashMap;
 use super::options::ForwardPassPerfOptions;
 
 pub(crate) trait WithOptions {
-    fn with_options(
-        options: &ForwardPassPerfOptions,
-        axis_ranges: &[AxisRange],
-        relaxable: &[usize],
-    ) -> Self;
+    fn with_options(options: &ForwardPassPerfOptions, axis_ranges: &[AxisRange]) -> Self;
 }
 
 pub(crate) trait StoreStats {

--- a/aic-core/rust/aiconfigurator-core/src/fpm/tests.rs
+++ b/aic-core/rust/aiconfigurator-core/src/fpm/tests.rs
@@ -443,6 +443,48 @@ fn fallback_regression_keeps_decode_fit_ready_when_ols_kv_slope_is_negative() {
         higher_kv >= lower_kv,
         "decode estimate must not decrease with KV load: lower={lower_kv}, higher={higher_kv}"
     );
+
+    let fewer_requests = model
+        .estimate_forward_pass_time_ms(&[decode_fpm(24, 70_000, 0.0)])
+        .unwrap()
+        .unwrap();
+    let more_requests = model
+        .estimate_forward_pass_time_ms(&[decode_fpm(40, 70_000, 0.0)])
+        .unwrap()
+        .unwrap();
+    assert!(
+        more_requests > fewer_requests,
+        "constrained fit must retain a positive decode load signal: fewer={fewer_requests}, more={more_requests}"
+    );
+}
+
+#[test]
+fn fallback_regression_rejects_intercept_only_fit_when_slopes_are_identifiable() {
+    let mut model = ForwardPassPerfModel::from_regression(ForwardPassPerfOptions {
+        min_observations: 4,
+        ..Default::default()
+    })
+    .unwrap();
+
+    model
+        .tune_with_fpms(&[
+            vec![decode_fpm(8, 10_000, 0.020)],
+            vec![decode_fpm(16, 10_000, 0.018)],
+            vec![decode_fpm(8, 20_000, 0.017)],
+            vec![decode_fpm(16, 20_000, 0.015)],
+        ])
+        .unwrap();
+
+    assert_eq!(
+        model.diagnostics().readiness,
+        ForwardPassPerfReadiness::InsufficientData
+    );
+    assert_eq!(
+        model
+            .estimate_forward_pass_time_ms(&[decode_fpm(12, 15_000, 0.0)])
+            .unwrap(),
+        None
+    );
 }
 
 #[test]

--- a/aic-core/rust/aiconfigurator-core/src/fpm/tests.rs
+++ b/aic-core/rust/aiconfigurator-core/src/fpm/tests.rs
@@ -395,6 +395,57 @@ fn fallback_regression_predicts_prefill_decode_and_mixed_workload_kinds() {
 }
 
 #[test]
+fn fallback_regression_keeps_decode_fit_ready_when_ols_kv_slope_is_negative() {
+    let mut model = ForwardPassPerfModel::from_regression(ForwardPassPerfOptions {
+        min_observations: 6,
+        ..Default::default()
+    })
+    .unwrap();
+
+    // Highly correlated decode batch and KV-token features can make
+    // unconstrained OLS assign a negative slope to KV tokens even while the
+    // combined observed latency trend is positive. A monotonic constrained fit
+    // should put that slope on the zero boundary instead of staying unready.
+    let observations = [
+        (8, 16_000),
+        (16, 33_000),
+        (24, 47_000),
+        (32, 66_000),
+        (40, 79_000),
+        (48, 98_000),
+    ];
+    model
+        .tune_with_fpms(
+            &observations
+                .into_iter()
+                .map(|(requests, kv_tokens)| {
+                    let wall_time_ms =
+                        5.0 + 0.07 * f64::from(requests) - 0.00003 * f64::from(kv_tokens);
+                    vec![decode_fpm(requests, kv_tokens, wall_time_ms / 1_000.0)]
+                })
+                .collect::<Vec<_>>(),
+        )
+        .unwrap();
+
+    assert_eq!(
+        model.diagnostics().readiness,
+        ForwardPassPerfReadiness::Ready
+    );
+    let lower_kv = model
+        .estimate_forward_pass_time_ms(&[decode_fpm(32, 60_000, 0.0)])
+        .unwrap()
+        .unwrap();
+    let higher_kv = model
+        .estimate_forward_pass_time_ms(&[decode_fpm(32, 80_000, 0.0)])
+        .unwrap()
+        .unwrap();
+    assert!(
+        higher_kv >= lower_kv,
+        "decode estimate must not decrease with KV load: lower={lower_kv}, higher={higher_kv}"
+    );
+}
+
+#[test]
 fn fallback_regression_prefill_weighted_hinge_avoids_small_token_collapse() {
     let mut model = ForwardPassPerfModel::from_regression(ForwardPassPerfOptions {
         min_observations: 6,


### PR DESCRIPTION
## Summary

- replace post-fit rejection/clamping of negative linear-regression slopes with a constrained active-set fit
- keep the intercept unconstrained while enforcing non-negative workload slopes
- reject identifiable intercept-only fits so a model without a usable load signal remains `insufficient_data`
- preserve explicitly configured low-observation behavior while the regression is still underdetermined
- normalize tolerated weighted-hinge numerical noise so both returned effective slopes are strictly non-negative
- add coverage for the DYN-3111 decode regression, the all-negative/intercept-only boundary, and weighted-hinge slope normalization

## Validation

- `cargo test -p aiconfigurator-core 'fpm::' -- --nocapture` (21 passed)
- `cargo test -p aiconfigurator-core --lib` (293 passed)
- `cargo clippy -p aiconfigurator-core --lib --tests`

Related: DYN-3111 / NVBug 6216503


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance modeling to prevent predictions from decreasing unexpectedly as workload increases.
  * Increased reliability of tuning for decode workloads with challenging or limited data.
  * Improved regression fitting to produce more consistent, physically sensible latency estimates.
  * Improved handling of limited data and monotonic workload relationships.

* **Tests**
  * Added coverage confirming tuning readiness and non-decreasing decode latency as KV-token load grows.
  * Added validation for fallback behavior when available data cannot support reliable estimates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->