### PR TITLE
test(generator): cover TRT-LLM cache transceiver config

### DIFF
--- a/tests/unit/generator/test_trtllm_extra_engine_args.py
+++ b/tests/unit/generator/test_trtllm_extra_engine_args.py
@@ -145,8 +145,10 @@ class TestExtraEngineArgsMode:
         assert "cache_transceiver_config" not in engine_yaml["kv_cache_config"]
 
     @pytest.mark.parametrize("version", [None, "1.3.0rc1"])
-    def test_disagg_cache_transceiver_config_is_top_level(self, version):
+    @pytest.mark.parametrize("backend", [None, "UCX", "NIXL", "MPI"], ids=["DEFAULT", "UCX", "NIXL", "MPI"])
+    def test_disagg_cache_transceiver_config_is_top_level(self, version, backend):
         """Keep valid disagg cache transceiver settings outside kv_cache_config."""
+        cache_transceiver_config = {"backend": backend} if backend is not None else {}
         params = _build_params(
             DynConfig={"mode": "disagg"},
             WorkerConfig={
@@ -164,6 +166,7 @@ class TestExtraEngineArgsMode:
                     "max_num_tokens": 8192,
                     "kv_cache_free_gpu_memory_fraction": 0.85,
                     "cache_transceiver_max_tokens_in_buffer": 4096,
+                    "cache_transceiver_config": cache_transceiver_config,
                     "gpus_per_worker": 1,
                 },
                 "decode": {
@@ -173,6 +176,7 @@ class TestExtraEngineArgsMode:
                     "max_num_tokens": 16384,
                     "kv_cache_free_gpu_memory_fraction": 0.80,
                     "cache_transceiver_max_tokens_in_buffer": 4096,
+                    "cache_transceiver_config": cache_transceiver_config,
                     "gpus_per_worker": 1,
                 },
             },
@@ -189,7 +193,7 @@ class TestExtraEngineArgsMode:
             engine_yaml = yaml.safe_load(artifacts[f"extra_engine_args_{role}.yaml"])
             assert "cache_transceiver_config" not in engine_yaml["kv_cache_config"]
             assert engine_yaml["cache_transceiver_config"] == {
-                "backend": "DEFAULT",
+                "backend": backend or "DEFAULT",
                 "max_tokens_in_buffer": 4096,
             }
 

--- a/tests/unit/generator/test_trtllm_extra_engine_args.py
+++ b/tests/unit/generator/test_trtllm_extra_engine_args.py
@@ -130,6 +130,69 @@ class TestExtraEngineArgsMode:
         assert engine_yaml["tensor_parallel_size"] == 1
         assert "kv_cache_config" in engine_yaml
 
+    @pytest.mark.parametrize("version", [None, "1.3.0rc1"])
+    def test_agg_omits_unused_cache_transceiver_config(self, version):
+        """OPS-7083: naive agg output must not emit an empty cache transceiver config."""
+        artifacts = render_backend_templates(
+            _build_params(),
+            "trtllm",
+            version=version,
+            deployment_target="dynamo-j2",
+        )
+        engine_yaml = yaml.safe_load(artifacts["extra_engine_args_agg.yaml"])
+
+        assert "cache_transceiver_config" not in engine_yaml
+        assert "cache_transceiver_config" not in engine_yaml["kv_cache_config"]
+
+    @pytest.mark.parametrize("version", [None, "1.3.0rc1"])
+    def test_disagg_cache_transceiver_config_is_top_level(self, version):
+        """Keep valid disagg cache transceiver settings outside kv_cache_config."""
+        params = _build_params(
+            DynConfig={"mode": "disagg"},
+            WorkerConfig={
+                "prefill_workers": 1,
+                "prefill_gpus_per_worker": 1,
+                "decode_workers": 1,
+                "decode_gpus_per_worker": 1,
+                "agg_workers": 0,
+            },
+            params={
+                "prefill": {
+                    "tensor_parallel_size": 1,
+                    "pipeline_parallel_size": 1,
+                    "max_batch_size": 64,
+                    "max_num_tokens": 8192,
+                    "kv_cache_free_gpu_memory_fraction": 0.85,
+                    "cache_transceiver_max_tokens_in_buffer": 4096,
+                    "gpus_per_worker": 1,
+                },
+                "decode": {
+                    "tensor_parallel_size": 1,
+                    "pipeline_parallel_size": 1,
+                    "max_batch_size": 256,
+                    "max_num_tokens": 16384,
+                    "kv_cache_free_gpu_memory_fraction": 0.80,
+                    "cache_transceiver_max_tokens_in_buffer": 4096,
+                    "gpus_per_worker": 1,
+                },
+            },
+        )
+
+        artifacts = render_backend_templates(
+            params,
+            "trtllm",
+            version=version,
+            deployment_target="dynamo-j2",
+        )
+
+        for role in ("prefill", "decode"):
+            engine_yaml = yaml.safe_load(artifacts[f"extra_engine_args_{role}.yaml"])
+            assert "cache_transceiver_config" not in engine_yaml["kv_cache_config"]
+            assert engine_yaml["cache_transceiver_config"] == {
+                "backend": "DEFAULT",
+                "max_tokens_in_buffer": 4096,
+            }
+
     def test_disagg_mode(self):
         params = _build_params(
             DynConfig={"mode": "disagg"},


### PR DESCRIPTION
#### Overview:

Add focused unit regression coverage for OPS-7083 so TRT-LLM engine YAML cannot place `cache_transceiver_config` inside `kv_cache_config`.

#### Details:

- Render both the current TRT-LLM engine-args template and the `1.3.0rc1` compatibility template.
- Verify aggregation output omits the unused `cache_transceiver_config` entirely.
- Verify valid disaggregated prefill/decode output keeps `cache_transceiver_config` at the YAML top level with the expected token buffer.
- Cover the `DEFAULT` fallback and each documented explicit backend: `UCX`, `NIXL`, and `MPI`.
- Keep the change test-only; the underlying generator fix is already present on `main`.

These methods are collected as pre-merge tests because they are under `tests/unit` and inherit `@pytest.mark.unit` from `TestExtraEngineArgsMode`. The existing pull-request lane runs `tests/unit -m "unit or build" -n 2`.

#### Where should the reviewer start?

- `tests/unit/generator/test_trtllm_extra_engine_args.py`

#### Validation:

- `pytest tests/unit -m "unit or build" -n 2 --timeout=600`: 2,803 passed, 47 skipped.
- Target module: 20 passed, 4 skipped.
- Targeted cache-transceiver cases: 10 passed.
- `pre-commit run --all-files`: passed.
- `ruff check .` and `ruff format --check .`: passed.
- CODEOWNERS policy tests: 117 passed; changed-path ownership coverage is 100%.
- Every commit includes a DCO sign-off.
- The changed Python file retains the required 2026 SPDX header.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to [OPS-7083](https://linear.app/nvidia/issue/OPS-7083)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded TRT-LLM engine argument coverage across aggregation and disaggregated modes.
  * Verified cache transceiver settings for default, UCX, NIXL, and MPI backends.
  * Confirmed settings are omitted or emitted correctly with expected backend and token-buffer values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->