### PR TITLE
perf(core): optimize MoE perf-table queries

### DIFF
--- a/aic-core/rust/aiconfigurator-core/src/perf_database/dsv4_megamoe.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/dsv4_megamoe.rs
@@ -43,9 +43,9 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
+use super::token_curve::TokenCurve;
 use crate::common::enums::MoeQuantMode;
 use crate::common::error::AicError;
-use super::token_curve::TokenCurve;
 use crate::perf_database::parquet_loader::PerfReader;
 
 pub struct Dsv4MegaMoeTable {
@@ -215,7 +215,11 @@ fn load_module_parquet(path: &PathBuf) -> Result<Dsv4MegaMoeGrids, AicError> {
     for row in reader.rows()? {
         let row = row?;
         for (col, expected, error) in [
-            (used_cuda_graph_col, true, "DSv4 MegaMoE perf row was not collected with CUDA Graph"),
+            (
+                used_cuda_graph_col,
+                true,
+                "DSv4 MegaMoE perf row was not collected with CUDA Graph",
+            ),
             (
                 includes_gate_topk_col,
                 false,
@@ -228,7 +232,10 @@ fn load_module_parquet(path: &PathBuf) -> Result<Dsv4MegaMoeGrids, AicError> {
             ),
         ] {
             if row.bool(col)? != expected {
-                return Err(AicError::PerfDatabase(format!("{error}: {}", path.display())));
+                return Err(AicError::PerfDatabase(format!(
+                    "{error}: {}",
+                    path.display()
+                )));
             }
         }
         let phase = row.str_owned(phase_col)?;
@@ -305,7 +312,10 @@ mod tests {
             moe_dtype_from_name("w4a8_mxfp4_mxfp8"),
             Some(MoeQuantMode::W4a8Mxfp4Mxfp8)
         );
-        assert_eq!(moe_dtype_from_name("fp8_block"), Some(MoeQuantMode::Fp8Block));
+        assert_eq!(
+            moe_dtype_from_name("fp8_block"),
+            Some(MoeQuantMode::Fp8Block)
+        );
         assert_eq!(moe_dtype_from_name("not_a_dtype"), None);
     }
 
@@ -334,6 +344,8 @@ mod tests {
             )
             .unwrap_err();
         assert!(err.is_missing_perf_data(), "got {err:?}");
-        assert!(err.to_string().contains("DSv4 MegaMoE module data not loaded"));
+        assert!(err
+            .to_string()
+            .contains("DSv4 MegaMoE module data not loaded"));
     }
 }

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/dsv4_megamoe.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/dsv4_megamoe.rs
@@ -45,7 +45,7 @@ use std::sync::OnceLock;
 
 use crate::common::enums::MoeQuantMode;
 use crate::common::error::AicError;
-use super::moe::query_token_curve;
+use super::token_curve::TokenCurve;
 use crate::perf_database::parquet_loader::PerfReader;
 
 pub struct Dsv4MegaMoeTable {
@@ -56,7 +56,7 @@ pub struct Dsv4MegaMoeTable {
 }
 
 struct Dsv4MegaMoeGrids {
-    by_keys: BTreeMap<Dsv4MegaMoeKey, BTreeMap<u32, f64>>,
+    by_keys: BTreeMap<Dsv4MegaMoeKey, TokenCurve>,
 }
 
 /// Full table key (every level of the Python nested dict except the trailing
@@ -153,7 +153,7 @@ impl Dsv4MegaMoeTable {
         // Python: OpInterpConfig(axes=("num_tokens",), resolver=Grid(),
         // sol_fn=lambda t: float(t)) — in-range RAW lerp, boundary util-hold
         // beyond the collected range with the linear token proxy.
-        query_token_curve(curve, f64::from(num_tokens), &|t| t)
+        curve.query(f64::from(num_tokens), &|t| t)
     }
 
     fn load_module(&self) -> Result<&Dsv4MegaMoeGrids, AicError> {
@@ -283,7 +283,12 @@ fn load_module_parquet(path: &PathBuf) -> Result<Dsv4MegaMoeGrids, AicError> {
             )));
         }
     }
-    Ok(Dsv4MegaMoeGrids { by_keys })
+    Ok(Dsv4MegaMoeGrids {
+        by_keys: by_keys
+            .into_iter()
+            .map(|(key, curve)| (key, TokenCurve::from_map(curve)))
+            .collect(),
+    })
 }
 
 fn clone_err(err: &AicError) -> AicError {

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/mhc.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/mhc.rs
@@ -26,10 +26,10 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
+use super::token_curve::TokenCurve;
+use super::{kernel_source_ok, resolve_op_sources};
 use crate::common::error::AicError;
 use crate::config::{PerfDbSources, PerfSource};
-use super::{kernel_source_ok, resolve_op_sources};
-use super::token_curve::TokenCurve;
 use crate::perf_database::parquet_loader::PerfReader;
 
 pub struct MhcTable {
@@ -97,8 +97,10 @@ impl MhcTable {
         let grids = self.load()?;
         // "both" aggregates the two silicon look-ups (Python sums pre+post).
         if op == "both" {
-            return Ok(self.query_single("pre", num_tokens, hc_mult, hidden_size, sol, grids)?
-                + self.query_single("post", num_tokens, hc_mult, hidden_size, sol, grids)?);
+            return Ok(
+                self.query_single("pre", num_tokens, hc_mult, hidden_size, sol, grids)?
+                    + self.query_single("post", num_tokens, hc_mult, hidden_size, sol, grids)?,
+            );
         }
         self.query_single(op, num_tokens, hc_mult, hidden_size, sol, grids)
     }
@@ -303,7 +305,10 @@ mod tests {
 
     #[test]
     fn mhc_absent_on_vllm_b200_errors_clearly() {
-        let table = MhcTable::new(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../src/aiconfigurator_core/systems/data/b200_sxm/vllm/0.19.0"));
+        let table = MhcTable::new(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("../../src/aiconfigurator_core/systems/data/b200_sxm/vllm/0.19.0"),
+        );
         let err = table
             .query_module("pre", 1024, 2, 4096, &linear_sol)
             .unwrap_err();
@@ -341,7 +346,9 @@ mod tests {
                 .map(|r| ByteArray::from(if str_field == 0 { r.0 } else { r.1 }))
                 .collect();
             let mut col = rg.next_column().expect("next col").expect("str col");
-            col.typed::<ByteArrayType>().write_batch(&values, None, None).expect("write str");
+            col.typed::<ByteArrayType>()
+                .write_batch(&values, None, None)
+                .expect("write str");
             col.close().expect("close col");
         }
         let int_cols: [Vec<i64>; 3] = [
@@ -351,12 +358,16 @@ mod tests {
         ];
         for values in &int_cols {
             let mut col = rg.next_column().expect("next col").expect("int col");
-            col.typed::<Int64Type>().write_batch(values, None, None).expect("write ints");
+            col.typed::<Int64Type>()
+                .write_batch(values, None, None)
+                .expect("write ints");
             col.close().expect("close col");
         }
         let latencies: Vec<f64> = rows.iter().map(|r| r.5).collect();
         let mut col = rg.next_column().expect("next col").expect("latency col");
-        col.typed::<DoubleType>().write_batch(&latencies, None, None).expect("write latency");
+        col.typed::<DoubleType>()
+            .write_batch(&latencies, None, None)
+            .expect("write latency");
         col.close().expect("close col");
         rg.close().expect("close row group");
         writer.close().expect("close writer");

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/mhc.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/mhc.rs
@@ -29,7 +29,7 @@ use std::sync::OnceLock;
 use crate::common::error::AicError;
 use crate::config::{PerfDbSources, PerfSource};
 use super::{kernel_source_ok, resolve_op_sources};
-use super::moe::query_token_curve;
+use super::token_curve::TokenCurve;
 use crate::perf_database::parquet_loader::PerfReader;
 
 pub struct MhcTable {
@@ -42,7 +42,7 @@ pub struct MhcTable {
 }
 
 struct MhcGrids {
-    by_keys: BTreeMap<MhcKey, BTreeMap<u32, f64>>,
+    by_keys: BTreeMap<MhcKey, TokenCurve>,
 }
 
 /// Python `load_mhc_module_data` keys `data[op][hc_mult][hidden_size]` — NO
@@ -126,7 +126,7 @@ impl MhcTable {
         // Engine 1-axis token curve; the caller-threaded per-op roofline
         // anchors beyond-range holds (Python `sol_fn=lambda t: get_sol(t,
         // op_name)[0]`).
-        query_token_curve(by_tokens, num_tokens as f64, &|t| sol(op, t))
+        by_tokens.query(num_tokens as f64, &|t| sol(op, t))
     }
 
     /// Collected `(num_tokens,) -> latency` points for one RESOLVED op half
@@ -162,7 +162,7 @@ impl MhcTable {
         }
         Ok(by_tokens
             .iter()
-            .map(|(&tokens, &latency)| (vec![f64::from(tokens)], latency))
+            .map(|(tokens, latency)| (vec![f64::from(tokens)], latency))
             .collect())
     }
 
@@ -231,7 +231,12 @@ fn load_mhc_parquet(sources: &[PerfSource]) -> Result<MhcGrids, AicError> {
                 .unwrap_or_default()
         )));
     }
-    Ok(MhcGrids { by_keys })
+    Ok(MhcGrids {
+        by_keys: by_keys
+            .into_iter()
+            .map(|(key, curve)| (key, TokenCurve::from_map(curve)))
+            .collect(),
+    })
 }
 
 fn clone_err(err: &AicError) -> AicError {

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/mod.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/mod.rs
@@ -121,7 +121,10 @@ fn has_family_backend_version(system_data_root: &Path, backend: &str, version: &
 /// NCCL/OneCCL only ever land under that name in practice — a plain path
 /// check is simpler than a directory scan and behaves identically here.
 fn comm_root(system_data_root: &Path, backend_dir: &str, version: &str) -> PathBuf {
-    let family_root = system_data_root.join("comm").join(backend_dir).join(version);
+    let family_root = system_data_root
+        .join("comm")
+        .join(backend_dir)
+        .join(version);
     if family_root.is_dir() {
         family_root
     } else {
@@ -155,13 +158,14 @@ pub mod dsv4;
 pub mod dsv4_megamoe;
 pub mod gemm;
 mod interpolation;
-mod token_curve;
 pub mod mhc;
 pub mod mla;
 pub mod moe;
+mod moe_index;
 pub mod parquet_loader;
 pub mod perf_interp;
 pub mod state_space;
+mod token_curve;
 pub mod wideep;
 pub mod wideep_mla;
 pub mod wideep_moe;
@@ -267,7 +271,13 @@ impl PerfDatabase {
         backend: &str,
         version: &str,
     ) -> Result<Self, AicError> {
-        Self::load_with_sources(systems_root, system, backend, version, &PerfDbSources::default())
+        Self::load_with_sources(
+            systems_root,
+            system,
+            backend,
+            version,
+            &PerfDbSources::default(),
+        )
     }
 
     /// Like [`PerfDatabase::load`], but honours the shared-layer
@@ -330,7 +340,11 @@ impl PerfDatabase {
             // NCCL/OneCCL are framework-agnostic and never inherit siblings, so
             // their roots stay as the direct system-wide dirs.
             gemm: GemmTable::with_sources(data_root.clone(), spec.clone(), perf_db_sources),
-            attention: AttentionTable::with_sources(data_root.clone(), spec.clone(), perf_db_sources),
+            attention: AttentionTable::with_sources(
+                data_root.clone(),
+                spec.clone(),
+                perf_db_sources,
+            ),
             mla: MlaTable::with_sources(data_root.clone(), spec.clone(), perf_db_sources),
             moe: MoeTable::with_sources(data_root.clone(), perf_db_sources),
             communication: CommunicationTable::with_sources(
@@ -347,7 +361,11 @@ impl PerfDatabase {
             dsv4_megamoe: Dsv4MegaMoeTable::new(data_root.clone()),
             mhc: MhcTable::with_sources(data_root.clone(), perf_db_sources),
             wideep: WideEpTable::with_sources(data_root.clone(), perf_db_sources),
-            wideep_mla: WideEpMlaTable::with_sources(data_root.clone(), spec.clone(), perf_db_sources),
+            wideep_mla: WideEpMlaTable::with_sources(
+                data_root.clone(),
+                spec.clone(),
+                perf_db_sources,
+            ),
             wideep_moe: WideEpMoeTable::with_sources(data_root.clone(), perf_db_sources),
             state_space: StateSpaceTable::with_sources(
                 data_root.clone(),
@@ -396,7 +414,11 @@ impl PerfDatabase {
     /// Configure the query mode + transfer policy (both immutable per
     /// database instance afterwards, mirroring Python's configured query
     /// views). Called by `Engine::from_spec_bytes` with the spec's values.
-    pub fn with_mode(mut self, database_mode: DatabaseMode, transfer_policy: TransferPolicy) -> Self {
+    pub fn with_mode(
+        mut self,
+        database_mode: DatabaseMode,
+        transfer_policy: TransferPolicy,
+    ) -> Self {
         self.database_mode = database_mode;
         self.transfer_policy = transfer_policy;
         self
@@ -449,8 +471,11 @@ mod tests {
         assert_eq!(db.system, "b200_sxm");
         assert_eq!(db.backend, "vllm");
         assert_eq!(db.version, "0.19.0");
-        let gemm_sources =
-            resolve_op_sources(&PerfDbSources::default(), "gemm_perf.parquet", &db.data_root);
+        let gemm_sources = resolve_op_sources(
+            &PerfDbSources::default(),
+            "gemm_perf.parquet",
+            &db.data_root,
+        );
         assert_eq!(gemm_sources.len(), 1);
         assert!(
             gemm_sources[0].0.is_file(),
@@ -505,7 +530,11 @@ mod tests {
         std::fs::create_dir_all(&family_data_root).unwrap();
         std::fs::write(family_data_root.join("gemm_perf.parquet"), b"stub").unwrap();
 
-        let sources = resolve_op_sources(&PerfDbSources::default(), "gemm_perf.parquet", &legacy_data_root);
+        let sources = resolve_op_sources(
+            &PerfDbSources::default(),
+            "gemm_perf.parquet",
+            &legacy_data_root,
+        );
         assert_eq!(sources.len(), 1);
         assert_eq!(sources[0].0, family_data_root.join("gemm_perf.parquet"));
         assert!(sources[0].1.is_none());
@@ -525,7 +554,11 @@ mod tests {
         std::fs::create_dir_all(&decoy).unwrap();
         std::fs::write(decoy.join("nccl_perf.parquet"), b"stub").unwrap();
 
-        let sources = resolve_op_sources(&PerfDbSources::default(), "nccl_perf.parquet", &legacy_data_root);
+        let sources = resolve_op_sources(
+            &PerfDbSources::default(),
+            "nccl_perf.parquet",
+            &legacy_data_root,
+        );
         // Falls back to the legacy (nonexistent) path since "vllm" is a known
         // backend dir, not a family dir, and must be skipped during the scan.
         assert_eq!(sources.len(), 1);
@@ -558,12 +591,19 @@ node:
 
         // Family-first layout only: <data>/gemm/<backend>/<version>/gemm_perf.parquet.
         // No legacy <data>/<backend>/<version> dir exists at all.
-        let family_dir = systems_root.join("data").join("gemm").join(backend).join(version);
+        let family_dir = systems_root
+            .join("data")
+            .join("gemm")
+            .join(backend)
+            .join(version);
         std::fs::create_dir_all(&family_dir).unwrap();
         std::fs::write(family_dir.join("gemm_perf.parquet"), b"stub").unwrap();
 
         let legacy_data_root = systems_root.join("data").join(backend).join(version);
-        assert!(!legacy_data_root.is_dir(), "fixture must not have a legacy dir");
+        assert!(
+            !legacy_data_root.is_dir(),
+            "fixture must not have a legacy dir"
+        );
 
         let db = PerfDatabase::load(systems_root, system, backend, version)
             .expect("family-only layout must load");
@@ -599,8 +639,14 @@ node:
 
         match PerfDatabase::load(systems_root, system, backend, version) {
             Err(AicError::PerfDatabase(msg)) => {
-                assert!(msg.contains("legacy"), "error should mention legacy layout: {msg}");
-                assert!(msg.contains("family"), "error should mention family layout: {msg}");
+                assert!(
+                    msg.contains("legacy"),
+                    "error should mention legacy layout: {msg}"
+                );
+                assert!(
+                    msg.contains("family"),
+                    "error should mention family layout: {msg}"
+                );
             }
             Ok(_) => panic!("expected load to fail for a totally missing tuple"),
             Err(other) => panic!("expected PerfDatabase error, got {other:?}"),

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/mod.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/mod.rs
@@ -155,6 +155,7 @@ pub mod dsv4;
 pub mod dsv4_megamoe;
 pub mod gemm;
 mod interpolation;
+mod token_curve;
 pub mod mhc;
 pub mod mla;
 pub mod moe;

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/moe.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/moe.rs
@@ -35,40 +35,8 @@ use crate::common::enums::MoeQuantMode;
 use crate::common::error::AicError;
 use crate::config::{PerfDbSources, PerfSource};
 use super::{kernel_source_ok, resolve_op_sources};
-use super::perf_interp::{self, Node, OpInterpConfig};
+use super::token_curve::TokenCurve;
 use crate::perf_database::parquet_loader::PerfReader;
-
-/// Resolve a 1-axis `num_tokens -> latency_ms` curve on the perf_interp v2
-/// engine: exact hit / RAW lerp in range; beyond the collected range the
-/// engine holds the boundary util (`k_tail=1`) and lets `sol` carry the
-/// growth. Shared by the MoE / WideEP / mHC token-curve families.
-pub(crate) fn query_token_curve(
-    curve: &BTreeMap<u32, f64>,
-    num_tokens: f64,
-    sol: &dyn Fn(f64) -> f64,
-) -> Result<f64, AicError> {
-    let mut node = Node::branch();
-    for (&t, &lat) in curve {
-        node.insert(&[t], lat);
-    }
-    let sol_slice = |c: &[f64]| sol(c[0]);
-    let cfg = OpInterpConfig::grid(&["num_tokens"], &sol_slice);
-    perf_interp::query(&cfg, &node, &[num_tokens])
-}
-
-/// Python `_require_moe_token_points`: a singleton curve queried below its
-/// only measured point is a structured miss (it cannot define the low-token
-/// launch-overhead regime). Multi-point underflow and singleton overflow go
-/// to the engine's util-hold unchanged.
-pub(crate) fn singleton_underflow(curve: &BTreeMap<u32, f64>, num_tokens: u32) -> Option<u32> {
-    if curve.len() == 1 {
-        let &only = curve.keys().next().expect("len checked");
-        if num_tokens < only {
-            return Some(only);
-        }
-    }
-    None
-}
 
 pub struct MoeTable {
     data_root: PathBuf,
@@ -114,7 +82,7 @@ struct LoadedMoeGrids {
 }
 
 struct MoeGrids {
-    by_keys: BTreeMap<MoeKey, BTreeMap<u32, f64>>,
+    by_keys: BTreeMap<MoeKey, TokenCurve>,
     index: MoeIndex,
     /// Distinct quant names in first-seen (file row) order. Python's
     /// transfer ladder iterates the table dict in INSERTION order
@@ -234,7 +202,7 @@ impl MoeTable {
                 self.data_root.display()
             )));
         }
-        if let Some(only) = singleton_underflow(by_tokens, num_tokens) {
+        if let Some(only) = by_tokens.singleton_underflow(num_tokens) {
             let key = MoeKey::from_shape(quant_name, dist, shape);
             return Err(AicError::PerfDatabase(format!(
                 "MoE silicon token underflow has only one measured point; cannot infer \
@@ -242,7 +210,7 @@ impl MoeTable {
                  measured_token={only}, key={key:?}"
             )));
         }
-        query_token_curve(by_tokens, num_tokens as f64, sol)
+        by_tokens.query(num_tokens as f64, sol)
     }
 
     /// Probe the TRT-LLM low-latency NVFP4 MoE kernel table.
@@ -294,7 +262,7 @@ impl MoeTable {
         if by_tokens.is_empty() {
             return Ok(None);
         }
-        if let Some(only) = singleton_underflow(by_tokens, num_tokens) {
+        if let Some(only) = by_tokens.singleton_underflow(num_tokens) {
             let key = MoeKey::from_shape(quant_name, dist, shape);
             return Err(AicError::PerfDatabase(format!(
                 "MoE low-latency token underflow has only one measured point; cannot infer \
@@ -302,7 +270,7 @@ impl MoeTable {
                  measured_token={only}, key={key:?}"
             )));
         }
-        query_token_curve(by_tokens, num_tokens as f64, sol).map(Some)
+        by_tokens.query(num_tokens as f64, sol).map(Some)
     }
 
     /// `true` iff the loaded low-latency grid has any rows.
@@ -354,7 +322,7 @@ impl MoeTable {
                     self.data_root.display()
                 ))
             })?;
-        Ok(by_tokens.iter().map(|(&t, &lat)| (t, lat)).collect())
+        Ok(by_tokens.iter().collect())
     }
 
     /// All collected sibling slices for `(quant, distribution-after-uniform-
@@ -393,7 +361,7 @@ impl MoeTable {
                 num_experts: key.num_experts,
                 hidden_size: key.hidden_size,
                 inter_size: key.inter_size,
-                points: curve.iter().map(|(&t, &lat)| (t, lat)).collect(),
+                points: curve.iter().collect(),
             });
         }
         Ok(slices)
@@ -550,6 +518,8 @@ fn load_moe_parquet(sources: &[PerfSource]) -> Result<LoadedMoeGrids, AicError> 
             sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
         )));
     }
+    let default_keys = finalize_curves(default_keys);
+    let low_latency_keys = finalize_curves(low_latency_keys);
     Ok(LoadedMoeGrids {
         default: MoeGrids {
             index: build_moe_index(&default_keys),
@@ -564,7 +534,16 @@ fn load_moe_parquet(sources: &[PerfSource]) -> Result<LoadedMoeGrids, AicError> 
     })
 }
 
-fn build_moe_index(by_keys: &BTreeMap<MoeKey, BTreeMap<u32, f64>>) -> MoeIndex {
+fn finalize_curves(
+    by_keys: BTreeMap<MoeKey, BTreeMap<u32, f64>>,
+) -> BTreeMap<MoeKey, TokenCurve> {
+    by_keys
+        .into_iter()
+        .map(|(key, curve)| (key, TokenCurve::from_map(curve)))
+        .collect()
+}
+
+fn build_moe_index(by_keys: &BTreeMap<MoeKey, TokenCurve>) -> MoeIndex {
     let mut index = MoeIndex::new();
     for key in by_keys.keys() {
         let shape = MoeShapeKey {
@@ -626,8 +605,8 @@ mod tests {
         let requested = MoeKey::from_shape("fp8", "power_law", shape);
         let uniform = MoeKey::from_shape("fp8", "uniform", shape);
         let by_keys = BTreeMap::from([
-            (requested, BTreeMap::from([(1, 1.0)])),
-            (uniform, BTreeMap::from([(1, 2.0)])),
+            (requested, TokenCurve::from_map(BTreeMap::from([(1, 1.0)]))),
+            (uniform, TokenCurve::from_map(BTreeMap::from([(1, 2.0)]))),
         ]);
         let grids = MoeGrids {
             index: build_moe_index(&by_keys),
@@ -638,11 +617,11 @@ mod tests {
 
         let (dist, key) = table.resolve_key(&grids, "fp8", "power_law", shape);
         assert_eq!(dist, "power_law");
-        assert_eq!(grids.by_keys[key.unwrap()][&1], 1.0);
+        assert_eq!(grids.by_keys[key.unwrap()].get(1), Some(1.0));
 
         let (dist, key) = table.resolve_key(&grids, "fp8", "missing", shape);
         assert_eq!(dist, "uniform");
-        assert_eq!(grids.by_keys[key.unwrap()][&1], 2.0);
+        assert_eq!(grids.by_keys[key.unwrap()].get(1), Some(2.0));
     }
 
     #[test]

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/moe.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/moe.rs
@@ -31,11 +31,12 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
+use super::moe_index::{MoeIndex, MoeShapeKey};
+use super::token_curve::TokenCurve;
+use super::{kernel_source_ok, resolve_op_sources};
 use crate::common::enums::MoeQuantMode;
 use crate::common::error::AicError;
 use crate::config::{PerfDbSources, PerfSource};
-use super::{kernel_source_ok, resolve_op_sources};
-use super::token_curve::TokenCurve;
 use crate::perf_database::parquet_loader::PerfReader;
 
 pub struct MoeTable {
@@ -82,26 +83,13 @@ struct LoadedMoeGrids {
 }
 
 struct MoeGrids {
-    by_keys: BTreeMap<MoeKey, TokenCurve>,
-    index: MoeIndex,
+    index: MoeIndex<MoeShapeKey, TokenCurve>,
     /// Distinct quant names in first-seen (file row) order. Python's
     /// transfer ladder iterates the table dict in INSERTION order
     /// (`for q in moe_table`), which breaks profile-distance ties by file
     /// order — live on shards whose file order differs from sorted order
     /// (e.g. b200/vllm/0.24.0 lists `fp8_block` before `fp8`).
     quants_in_load_order: Vec<String>,
-}
-
-type MoeIndex = BTreeMap<String, BTreeMap<String, BTreeMap<MoeShapeKey, MoeKey>>>;
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
-struct MoeShapeKey {
-    topk: u32,
-    num_experts: u32,
-    hidden_size: u32,
-    inter_size: u32,
-    moe_tp_size: u32,
-    moe_ep_size: u32,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -187,8 +175,11 @@ impl MoeTable {
             moe_tp_size,
             moe_ep_size,
         };
-        let (dist, key) = self.resolve_key(grids, quant_name, workload_distribution, shape);
-        let by_tokens = key.and_then(|key| grids.by_keys.get(key)).ok_or_else(|| {
+        let (dist, by_tokens) =
+            grids
+                .index
+                .resolve_uniform(quant_name, workload_distribution, &shape);
+        let by_tokens = by_tokens.ok_or_else(|| {
             let key = MoeKey::from_shape(quant_name, dist, shape);
             AicError::PerfDatabase(format!(
                 "MoE data missing for {key:?} at {}",
@@ -243,7 +234,7 @@ impl MoeTable {
     ) -> Result<Option<f64>, AicError> {
         let loaded = self.load()?;
         let grids = &loaded.low_latency;
-        if grids.by_keys.is_empty() {
+        if grids.index.is_empty() {
             return Ok(None);
         }
         let quant_name = quant.name();
@@ -255,8 +246,11 @@ impl MoeTable {
             moe_tp_size,
             moe_ep_size,
         };
-        let (dist, key) = self.resolve_key(grids, quant_name, workload_distribution, shape);
-        let Some(by_tokens) = key.and_then(|key| grids.by_keys.get(key)) else {
+        let (dist, by_tokens) =
+            grids
+                .index
+                .resolve_uniform(quant_name, workload_distribution, &shape);
+        let Some(by_tokens) = by_tokens else {
             return Ok(None);
         };
         if by_tokens.is_empty() {
@@ -280,7 +274,7 @@ impl MoeTable {
     /// is short-circuited at the operator layer.
     pub fn low_latency_available(&self) -> Result<bool, AicError> {
         let loaded = self.load()?;
-        Ok(!loaded.low_latency.by_keys.is_empty())
+        Ok(!loaded.low_latency.index.is_empty())
     }
 
     /// Own-slice `num_tokens -> latency_ms` curve for a full MoE key, after
@@ -311,17 +305,17 @@ impl MoeTable {
             moe_tp_size,
             moe_ep_size,
         };
-        let (dist, key) = self.resolve_key(grids, quant_name, workload_distribution, shape);
-        let by_tokens = key
-            .and_then(|key| grids.by_keys.get(key))
-            .filter(|curve| !curve.is_empty())
-            .ok_or_else(|| {
-                let key = MoeKey::from_shape(quant_name, dist, shape);
-                AicError::PerfDatabase(format!(
-                    "MoE data missing for {key:?} ({kernel:?}) at {}",
-                    self.data_root.display()
-                ))
-            })?;
+        let (dist, by_tokens) =
+            grids
+                .index
+                .resolve_uniform(quant_name, workload_distribution, &shape);
+        let by_tokens = by_tokens.filter(|curve| !curve.is_empty()).ok_or_else(|| {
+            let key = MoeKey::from_shape(quant_name, dist, shape);
+            AicError::PerfDatabase(format!(
+                "MoE data missing for {key:?} ({kernel:?}) at {}",
+                self.data_root.display()
+            ))
+        })?;
         Ok(by_tokens.iter().collect())
     }
 
@@ -342,25 +336,25 @@ impl MoeTable {
         moe_ep_size: u32,
     ) -> Result<Vec<MoeSiblingSlice>, AicError> {
         let grids = self.grids_for(kernel)?;
-        let by_distribution = grids.index.get(quant_name);
-        let dist = self.resolve_distribution(by_distribution, workload_distribution);
+        let (_, by_shape) = grids
+            .index
+            .resolve_uniform_shapes(quant_name, workload_distribution);
         let mut slices = Vec::new();
-        let Some(by_shape) = by_distribution.and_then(|index| index.get(dist)) else {
+        let Some(by_shape) = by_shape else {
             return Ok(slices);
         };
-        for key in by_shape.values() {
-            let curve = &grids.by_keys[key];
-            if key.moe_tp_size != moe_tp_size
-                || key.moe_ep_size != moe_ep_size
+        for (shape, curve) in by_shape {
+            if shape.moe_tp_size != moe_tp_size
+                || shape.moe_ep_size != moe_ep_size
                 || curve.is_empty()
             {
                 continue;
             }
             slices.push(MoeSiblingSlice {
-                topk: key.topk,
-                num_experts: key.num_experts,
-                hidden_size: key.hidden_size,
-                inter_size: key.inter_size,
+                topk: shape.topk,
+                num_experts: shape.num_experts,
+                hidden_size: shape.hidden_size,
+                inter_size: shape.inter_size,
                 points: curve.iter().collect(),
             });
         }
@@ -383,39 +377,8 @@ impl MoeTable {
         })
     }
 
-    /// Mirrors Python's:
-    /// `dist = workload if workload in moe_data[quant] else "uniform"`
-    fn resolve_distribution<'q>(
-        &self,
-        by_distribution: Option<&BTreeMap<String, BTreeMap<MoeShapeKey, MoeKey>>>,
-        workload_distribution: &'q str,
-    ) -> &'q str {
-        if by_distribution.is_some_and(|index| index.contains_key(workload_distribution)) {
-            workload_distribution
-        } else {
-            "uniform"
-        }
-    }
-
-    fn resolve_key<'g, 'q>(
-        &self,
-        grids: &'g MoeGrids,
-        quant: &str,
-        workload_distribution: &'q str,
-        shape: MoeShapeKey,
-    ) -> (&'q str, Option<&'g MoeKey>) {
-        let by_distribution = grids.index.get(quant);
-        let distribution = self.resolve_distribution(by_distribution, workload_distribution);
-        let key = by_distribution
-            .and_then(|index| index.get(distribution))
-            .and_then(|index| index.get(&shape));
-        (distribution, key)
-    }
-
     fn load(&self) -> Result<&LoadedMoeGrids, AicError> {
-        let cell = self
-            .moe
-            .get_or_init(|| load_moe_parquet(&self.moe_sources));
+        let cell = self.moe.get_or_init(|| load_moe_parquet(&self.moe_sources));
         cell.as_ref().map_err(clone_err)
     }
 }
@@ -427,8 +390,8 @@ impl MoeTable {
 /// declared in the manifest need not exist for every system); an error is
 /// returned only when no source yields rows.
 fn load_moe_parquet(sources: &[PerfSource]) -> Result<LoadedMoeGrids, AicError> {
-    let mut default_keys: BTreeMap<MoeKey, BTreeMap<u32, f64>> = BTreeMap::new();
-    let mut low_latency_keys: BTreeMap<MoeKey, BTreeMap<u32, f64>> = BTreeMap::new();
+    let mut default_index: MoeIndex<MoeShapeKey, BTreeMap<u32, f64>> = MoeIndex::default();
+    let mut low_latency_index: MoeIndex<MoeShapeKey, BTreeMap<u32, f64>> = MoeIndex::default();
     let mut default_quants: Vec<String> = Vec::new();
     let mut low_latency_quants: Vec<String> = Vec::new();
     let mut any_source = false;
@@ -458,7 +421,10 @@ fn load_moe_parquet(sources: &[PerfSource]) -> Result<LoadedMoeGrids, AicError> 
             if !kernel_source_ok(source.kernel_sources(), kernel_source_col, &row)? {
                 continue;
             }
-            let kernel_source = row.str_optional(kernel_source_col)?.unwrap_or("").to_string();
+            let kernel_source = row
+                .str_optional(kernel_source_col)?
+                .unwrap_or("")
+                .to_string();
             // Kernel-specific mxfp4 remaps (mirror Python `load_moe_data`):
             // the collector logs two distinct kernels under one `moe_dtype`;
             // route them to dedicated quant modes so DeepSeek-V4 modeling can
@@ -479,9 +445,8 @@ fn load_moe_parquet(sources: &[PerfSource]) -> Result<LoadedMoeGrids, AicError> 
                 }
                 _ => raw_quant,
             };
-            let key = MoeKey {
-                quant,
-                distribution: row.str_owned(distribution_col)?,
+            let distribution = row.str_owned(distribution_col)?;
+            let shape = MoeShapeKey {
                 topk: row.u32(topk_col)?,
                 num_experts: row.u32(num_experts_col)?,
                 hidden_size: row.u32(hidden_size_col)?,
@@ -490,14 +455,14 @@ fn load_moe_parquet(sources: &[PerfSource]) -> Result<LoadedMoeGrids, AicError> 
                 moe_ep_size: row.u32(moe_ep_size_col)?,
             };
             let (target, target_quants) = if kernel_source == "moe_torch_flow_min_latency" {
-                (&mut low_latency_keys, &mut low_latency_quants)
+                (&mut low_latency_index, &mut low_latency_quants)
             } else {
-                (&mut default_keys, &mut default_quants)
+                (&mut default_index, &mut default_quants)
             };
             // First-seen (file row) quant order — Python's dict insertion
             // order, consumed by `available_quants`.
-            if !target_quants.iter().any(|q| q == &key.quant) {
-                target_quants.push(key.quant.clone());
+            if !target_quants.iter().any(|q| q == &quant) {
+                target_quants.push(quant.clone());
             }
             // Python's `load_moe_data` wraps the leaf insert in a try/except KeyError
             // and skips on conflict, i.e. it keeps the FIRST occurrence of each
@@ -505,63 +470,31 @@ fn load_moe_parquet(sources: &[PerfSource]) -> Result<LoadedMoeGrids, AicError> 
             // (same kernel_source, same shape) — preserving first-wins parity here,
             // extended across shared-layer sources (earlier source wins).
             target
-                .entry(key)
-                .or_default()
+                .entry(quant, distribution, shape)
                 .entry(row.u32(num_tokens_col)?)
                 .or_insert(row.f64(latency_col)?);
         }
     }
-    if !any_source || (default_keys.is_empty() && low_latency_keys.is_empty()) {
+    if !any_source || (default_index.is_empty() && low_latency_index.is_empty()) {
         return Err(AicError::PerfDatabase(format!(
             "no rows loaded from {} source(s) (first: {})",
             sources.len(),
-            sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
+            sources
+                .first()
+                .map(|s| s.path().display().to_string())
+                .unwrap_or_default()
         )));
     }
-    let default_keys = finalize_curves(default_keys);
-    let low_latency_keys = finalize_curves(low_latency_keys);
     Ok(LoadedMoeGrids {
         default: MoeGrids {
-            index: build_moe_index(&default_keys),
-            by_keys: default_keys,
+            index: default_index.map_values(TokenCurve::from_map),
             quants_in_load_order: default_quants,
         },
         low_latency: MoeGrids {
-            index: build_moe_index(&low_latency_keys),
-            by_keys: low_latency_keys,
+            index: low_latency_index.map_values(TokenCurve::from_map),
             quants_in_load_order: low_latency_quants,
         },
     })
-}
-
-fn finalize_curves(
-    by_keys: BTreeMap<MoeKey, BTreeMap<u32, f64>>,
-) -> BTreeMap<MoeKey, TokenCurve> {
-    by_keys
-        .into_iter()
-        .map(|(key, curve)| (key, TokenCurve::from_map(curve)))
-        .collect()
-}
-
-fn build_moe_index(by_keys: &BTreeMap<MoeKey, TokenCurve>) -> MoeIndex {
-    let mut index = MoeIndex::new();
-    for key in by_keys.keys() {
-        let shape = MoeShapeKey {
-            topk: key.topk,
-            num_experts: key.num_experts,
-            hidden_size: key.hidden_size,
-            inter_size: key.inter_size,
-            moe_tp_size: key.moe_tp_size,
-            moe_ep_size: key.moe_ep_size,
-        };
-        index
-            .entry(key.quant.clone())
-            .or_default()
-            .entry(key.distribution.clone())
-            .or_default()
-            .insert(shape, key.clone());
-    }
-    index
 }
 
 fn clone_err(err: &AicError) -> AicError {
@@ -602,26 +535,23 @@ mod tests {
             moe_tp_size: 1,
             moe_ep_size: 4,
         };
-        let requested = MoeKey::from_shape("fp8", "power_law", shape);
-        let uniform = MoeKey::from_shape("fp8", "uniform", shape);
-        let by_keys = BTreeMap::from([
-            (requested, TokenCurve::from_map(BTreeMap::from([(1, 1.0)]))),
-            (uniform, TokenCurve::from_map(BTreeMap::from([(1, 2.0)]))),
-        ]);
+        let mut index = MoeIndex::default();
+        *index.entry("fp8".into(), "power_law".into(), shape) =
+            TokenCurve::from_map(BTreeMap::from([(1, 1.0)]));
+        *index.entry("fp8".into(), "uniform".into(), shape) =
+            TokenCurve::from_map(BTreeMap::from([(1, 2.0)]));
         let grids = MoeGrids {
-            index: build_moe_index(&by_keys),
-            by_keys,
+            index,
             quants_in_load_order: vec!["fp8".to_string()],
         };
-        let table = MoeTable::new(PathBuf::new());
 
-        let (dist, key) = table.resolve_key(&grids, "fp8", "power_law", shape);
+        let (dist, curve) = grids.index.resolve_uniform("fp8", "power_law", &shape);
         assert_eq!(dist, "power_law");
-        assert_eq!(grids.by_keys[key.unwrap()].get(1), Some(1.0));
+        assert_eq!(curve.unwrap().get(1), Some(1.0));
 
-        let (dist, key) = table.resolve_key(&grids, "fp8", "missing", shape);
+        let (dist, curve) = grids.index.resolve_uniform("fp8", "missing", &shape);
         assert_eq!(dist, "uniform");
-        assert_eq!(grids.by_keys[key.unwrap()].get(1), Some(2.0));
+        assert_eq!(curve.unwrap().get(1), Some(2.0));
     }
 
     #[test]

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/moe.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/moe.rs
@@ -115,12 +115,25 @@ struct LoadedMoeGrids {
 
 struct MoeGrids {
     by_keys: BTreeMap<MoeKey, BTreeMap<u32, f64>>,
+    index: MoeIndex,
     /// Distinct quant names in first-seen (file row) order. Python's
     /// transfer ladder iterates the table dict in INSERTION order
     /// (`for q in moe_table`), which breaks profile-distance ties by file
     /// order — live on shards whose file order differs from sorted order
     /// (e.g. b200/vllm/0.24.0 lists `fp8_block` before `fp8`).
     quants_in_load_order: Vec<String>,
+}
+
+type MoeIndex = BTreeMap<String, BTreeMap<String, BTreeMap<MoeShapeKey, MoeKey>>>;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct MoeShapeKey {
+    topk: u32,
+    num_experts: u32,
+    hidden_size: u32,
+    inter_size: u32,
+    moe_tp_size: u32,
+    moe_ep_size: u32,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -133,6 +146,21 @@ struct MoeKey {
     inter_size: u32,
     moe_tp_size: u32,
     moe_ep_size: u32,
+}
+
+impl MoeKey {
+    fn from_shape(quant: &str, distribution: &str, shape: MoeShapeKey) -> Self {
+        Self {
+            quant: quant.to_string(),
+            distribution: distribution.to_string(),
+            topk: shape.topk,
+            num_experts: shape.num_experts,
+            hidden_size: shape.hidden_size,
+            inter_size: shape.inter_size,
+            moe_tp_size: shape.moe_tp_size,
+            moe_ep_size: shape.moe_ep_size,
+        }
+    }
 }
 
 impl MoeTable {
@@ -183,10 +211,7 @@ impl MoeTable {
         let grids = &loaded.default;
         let quant_name = quant.name();
 
-        let dist = self.resolve_distribution(grids, quant_name, workload_distribution);
-        let key = MoeKey {
-            quant: quant_name.to_string(),
-            distribution: dist,
+        let shape = MoeShapeKey {
             topk,
             num_experts,
             hidden_size,
@@ -194,19 +219,23 @@ impl MoeTable {
             moe_tp_size,
             moe_ep_size,
         };
-        let by_tokens = grids.by_keys.get(&key).ok_or_else(|| {
+        let (dist, key) = self.resolve_key(grids, quant_name, workload_distribution, shape);
+        let by_tokens = key.and_then(|key| grids.by_keys.get(key)).ok_or_else(|| {
+            let key = MoeKey::from_shape(quant_name, dist, shape);
             AicError::PerfDatabase(format!(
                 "MoE data missing for {key:?} at {}",
                 self.data_root.display()
             ))
         })?;
         if by_tokens.is_empty() {
+            let key = MoeKey::from_shape(quant_name, dist, shape);
             return Err(AicError::PerfDatabase(format!(
                 "MoE data has no token points for {key:?} at {}",
                 self.data_root.display()
             )));
         }
         if let Some(only) = singleton_underflow(by_tokens, num_tokens) {
+            let key = MoeKey::from_shape(quant_name, dist, shape);
             return Err(AicError::PerfDatabase(format!(
                 "MoE silicon token underflow has only one measured point; cannot infer \
                  low-token latency from a singleton. num_tokens={num_tokens}, \
@@ -250,10 +279,7 @@ impl MoeTable {
             return Ok(None);
         }
         let quant_name = quant.name();
-        let dist = self.resolve_distribution(grids, quant_name, workload_distribution);
-        let key = MoeKey {
-            quant: quant_name.to_string(),
-            distribution: dist,
+        let shape = MoeShapeKey {
             topk,
             num_experts,
             hidden_size,
@@ -261,13 +287,15 @@ impl MoeTable {
             moe_tp_size,
             moe_ep_size,
         };
-        let Some(by_tokens) = grids.by_keys.get(&key) else {
+        let (dist, key) = self.resolve_key(grids, quant_name, workload_distribution, shape);
+        let Some(by_tokens) = key.and_then(|key| grids.by_keys.get(key)) else {
             return Ok(None);
         };
         if by_tokens.is_empty() {
             return Ok(None);
         }
         if let Some(only) = singleton_underflow(by_tokens, num_tokens) {
+            let key = MoeKey::from_shape(quant_name, dist, shape);
             return Err(AicError::PerfDatabase(format!(
                 "MoE low-latency token underflow has only one measured point; cannot infer \
                  low-token latency from a singleton. num_tokens={num_tokens}, \
@@ -307,10 +335,7 @@ impl MoeTable {
         moe_ep_size: u32,
     ) -> Result<Vec<(u32, f64)>, AicError> {
         let grids = self.grids_for(kernel)?;
-        let dist = self.resolve_distribution(grids, quant_name, workload_distribution);
-        let key = MoeKey {
-            quant: quant_name.to_string(),
-            distribution: dist,
+        let shape = MoeShapeKey {
             topk,
             num_experts,
             hidden_size,
@@ -318,12 +343,17 @@ impl MoeTable {
             moe_tp_size,
             moe_ep_size,
         };
-        let by_tokens = grids.by_keys.get(&key).filter(|curve| !curve.is_empty()).ok_or_else(|| {
-            AicError::PerfDatabase(format!(
-                "MoE data missing for {key:?} ({kernel:?}) at {}",
-                self.data_root.display()
-            ))
-        })?;
+        let (dist, key) = self.resolve_key(grids, quant_name, workload_distribution, shape);
+        let by_tokens = key
+            .and_then(|key| grids.by_keys.get(key))
+            .filter(|curve| !curve.is_empty())
+            .ok_or_else(|| {
+                let key = MoeKey::from_shape(quant_name, dist, shape);
+                AicError::PerfDatabase(format!(
+                    "MoE data missing for {key:?} ({kernel:?}) at {}",
+                    self.data_root.display()
+                ))
+            })?;
         Ok(by_tokens.iter().map(|(&t, &lat)| (t, lat)).collect())
     }
 
@@ -344,12 +374,15 @@ impl MoeTable {
         moe_ep_size: u32,
     ) -> Result<Vec<MoeSiblingSlice>, AicError> {
         let grids = self.grids_for(kernel)?;
-        let dist = self.resolve_distribution(grids, quant_name, workload_distribution);
+        let by_distribution = grids.index.get(quant_name);
+        let dist = self.resolve_distribution(by_distribution, workload_distribution);
         let mut slices = Vec::new();
-        for (key, curve) in &grids.by_keys {
-            if key.quant != quant_name
-                || key.distribution != dist
-                || key.moe_tp_size != moe_tp_size
+        let Some(by_shape) = by_distribution.and_then(|index| index.get(dist)) else {
+            return Ok(slices);
+        };
+        for key in by_shape.values() {
+            let curve = &grids.by_keys[key];
+            if key.moe_tp_size != moe_tp_size
                 || key.moe_ep_size != moe_ep_size
                 || curve.is_empty()
             {
@@ -384,22 +417,31 @@ impl MoeTable {
 
     /// Mirrors Python's:
     /// `dist = workload if workload in moe_data[quant] else "uniform"`
-    fn resolve_distribution(
+    fn resolve_distribution<'q>(
         &self,
-        grids: &MoeGrids,
-        quant: &str,
-        workload_distribution: &str,
-    ) -> String {
-        // Check whether any key with this (quant, distribution) exists.
-        let requested_exists = grids
-            .by_keys
-            .keys()
-            .any(|k| k.quant == quant && k.distribution == workload_distribution);
-        if requested_exists {
-            workload_distribution.to_string()
+        by_distribution: Option<&BTreeMap<String, BTreeMap<MoeShapeKey, MoeKey>>>,
+        workload_distribution: &'q str,
+    ) -> &'q str {
+        if by_distribution.is_some_and(|index| index.contains_key(workload_distribution)) {
+            workload_distribution
         } else {
-            "uniform".to_string()
+            "uniform"
         }
+    }
+
+    fn resolve_key<'g, 'q>(
+        &self,
+        grids: &'g MoeGrids,
+        quant: &str,
+        workload_distribution: &'q str,
+        shape: MoeShapeKey,
+    ) -> (&'q str, Option<&'g MoeKey>) {
+        let by_distribution = grids.index.get(quant);
+        let distribution = self.resolve_distribution(by_distribution, workload_distribution);
+        let key = by_distribution
+            .and_then(|index| index.get(distribution))
+            .and_then(|index| index.get(&shape));
+        (distribution, key)
     }
 
     fn load(&self) -> Result<&LoadedMoeGrids, AicError> {
@@ -510,14 +552,37 @@ fn load_moe_parquet(sources: &[PerfSource]) -> Result<LoadedMoeGrids, AicError> 
     }
     Ok(LoadedMoeGrids {
         default: MoeGrids {
+            index: build_moe_index(&default_keys),
             by_keys: default_keys,
             quants_in_load_order: default_quants,
         },
         low_latency: MoeGrids {
+            index: build_moe_index(&low_latency_keys),
             by_keys: low_latency_keys,
             quants_in_load_order: low_latency_quants,
         },
     })
+}
+
+fn build_moe_index(by_keys: &BTreeMap<MoeKey, BTreeMap<u32, f64>>) -> MoeIndex {
+    let mut index = MoeIndex::new();
+    for key in by_keys.keys() {
+        let shape = MoeShapeKey {
+            topk: key.topk,
+            num_experts: key.num_experts,
+            hidden_size: key.hidden_size,
+            inter_size: key.inter_size,
+            moe_tp_size: key.moe_tp_size,
+            moe_ep_size: key.moe_ep_size,
+        };
+        index
+            .entry(key.quant.clone())
+            .or_default()
+            .entry(key.distribution.clone())
+            .or_default()
+            .insert(shape, key.clone());
+    }
+    index
 }
 
 fn clone_err(err: &AicError) -> AicError {
@@ -546,6 +611,38 @@ mod tests {
     /// resolution path (not the extrapolated value) matters.
     fn proxy_sol(t: f64) -> f64 {
         t
+    }
+
+    #[test]
+    fn moe_index_resolves_requested_and_uniform_distributions() {
+        let shape = MoeShapeKey {
+            topk: 2,
+            num_experts: 8,
+            hidden_size: 4096,
+            inter_size: 2048,
+            moe_tp_size: 1,
+            moe_ep_size: 4,
+        };
+        let requested = MoeKey::from_shape("fp8", "power_law", shape);
+        let uniform = MoeKey::from_shape("fp8", "uniform", shape);
+        let by_keys = BTreeMap::from([
+            (requested, BTreeMap::from([(1, 1.0)])),
+            (uniform, BTreeMap::from([(1, 2.0)])),
+        ]);
+        let grids = MoeGrids {
+            index: build_moe_index(&by_keys),
+            by_keys,
+            quants_in_load_order: vec!["fp8".to_string()],
+        };
+        let table = MoeTable::new(PathBuf::new());
+
+        let (dist, key) = table.resolve_key(&grids, "fp8", "power_law", shape);
+        assert_eq!(dist, "power_law");
+        assert_eq!(grids.by_keys[key.unwrap()][&1], 1.0);
+
+        let (dist, key) = table.resolve_key(&grids, "fp8", "missing", shape);
+        assert_eq!(dist, "uniform");
+        assert_eq!(grids.by_keys[key.unwrap()][&1], 2.0);
     }
 
     #[test]

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/moe_index.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/moe_index.rs
@@ -1,0 +1,176 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared categorical index for MoE-family token curves.
+
+use std::collections::BTreeMap;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(super) struct MoeShapeKey {
+    pub(super) topk: u32,
+    pub(super) num_experts: u32,
+    pub(super) hidden_size: u32,
+    pub(super) inter_size: u32,
+    pub(super) moe_tp_size: u32,
+    pub(super) moe_ep_size: u32,
+}
+
+pub(super) struct MoeIndex<S, V> {
+    by_quant: BTreeMap<String, MoeQuantIndex<S, V>>,
+}
+
+pub(super) struct MoeQuantIndex<S, V> {
+    first_distribution: String,
+    by_distribution: BTreeMap<String, BTreeMap<S, V>>,
+}
+
+impl<S, V> Default for MoeIndex<S, V> {
+    fn default() -> Self {
+        Self {
+            by_quant: BTreeMap::new(),
+        }
+    }
+}
+
+impl<S: Ord, V> MoeIndex<S, V> {
+    pub(super) fn is_empty(&self) -> bool {
+        self.by_quant.is_empty()
+    }
+
+    pub(super) fn quant(&self, quant: &str) -> Option<&MoeQuantIndex<S, V>> {
+        self.by_quant.get(quant)
+    }
+
+    pub(super) fn entry(&mut self, quant: String, distribution: String, shape: S) -> &mut V
+    where
+        V: Default,
+    {
+        let quant_index = self.by_quant.entry(quant).or_insert_with(|| MoeQuantIndex {
+            first_distribution: distribution.clone(),
+            by_distribution: BTreeMap::new(),
+        });
+        quant_index
+            .by_distribution
+            .entry(distribution)
+            .or_default()
+            .entry(shape)
+            .or_default()
+    }
+
+    pub(super) fn map_values<U>(self, mut map: impl FnMut(V) -> U) -> MoeIndex<S, U> {
+        let mut by_quant = BTreeMap::new();
+        for (quant, index) in self.by_quant {
+            let mut by_distribution = BTreeMap::new();
+            for (distribution, by_shape) in index.by_distribution {
+                by_distribution.insert(
+                    distribution,
+                    by_shape
+                        .into_iter()
+                        .map(|(shape, value)| (shape, map(value)))
+                        .collect(),
+                );
+            }
+            by_quant.insert(
+                quant,
+                MoeQuantIndex {
+                    first_distribution: index.first_distribution,
+                    by_distribution,
+                },
+            );
+        }
+        MoeIndex { by_quant }
+    }
+
+    pub(super) fn resolve_uniform(
+        &self,
+        quant: &str,
+        requested_distribution: &str,
+        shape: &S,
+    ) -> (&str, Option<&V>) {
+        let Some(index) = self.quant(quant) else {
+            return ("uniform", None);
+        };
+        let (distribution, by_shape) = index.resolve_named_or(requested_distribution, "uniform");
+        (
+            distribution,
+            by_shape.and_then(|by_shape| by_shape.get(shape)),
+        )
+    }
+
+    pub(super) fn resolve_uniform_shapes(
+        &self,
+        quant: &str,
+        requested_distribution: &str,
+    ) -> (&str, Option<&BTreeMap<S, V>>) {
+        let Some(index) = self.quant(quant) else {
+            return ("uniform", None);
+        };
+        index.resolve_named_or(requested_distribution, "uniform")
+    }
+}
+
+impl<S: Ord, V> MoeQuantIndex<S, V> {
+    fn resolve_named_or(
+        &self,
+        requested_distribution: &str,
+        fallback: &'static str,
+    ) -> (&str, Option<&BTreeMap<S, V>>) {
+        if let Some((distribution, by_shape)) =
+            self.by_distribution.get_key_value(requested_distribution)
+        {
+            (distribution.as_str(), Some(by_shape))
+        } else {
+            (fallback, self.by_distribution.get(fallback))
+        }
+    }
+
+    pub(super) fn resolve_first(
+        &self,
+        requested_distribution: &str,
+        shape: &S,
+    ) -> (&str, Option<&V>) {
+        let distribution = self
+            .by_distribution
+            .get_key_value(requested_distribution)
+            .map(|(distribution, _)| distribution.as_str())
+            .unwrap_or(self.first_distribution.as_str());
+        let value = self
+            .by_distribution
+            .get(distribution)
+            .and_then(|by_shape| by_shape.get(shape));
+        (distribution, value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_named_uniform_and_first_distributions() {
+        let shape = MoeShapeKey {
+            topk: 2,
+            num_experts: 8,
+            hidden_size: 4096,
+            inter_size: 2048,
+            moe_tp_size: 1,
+            moe_ep_size: 4,
+        };
+        let mut index = MoeIndex::<_, u32>::default();
+        *index.entry("fp8".into(), "power_law".into(), shape) = 1;
+        *index.entry("fp8".into(), "uniform".into(), shape) = 2;
+
+        assert_eq!(
+            index.resolve_uniform("fp8", "power_law", &shape),
+            ("power_law", Some(&1))
+        );
+        assert_eq!(
+            index.resolve_uniform("fp8", "missing", &shape),
+            ("uniform", Some(&2))
+        );
+        assert_eq!(
+            index.quant("fp8").unwrap().resolve_first("missing", &shape),
+            ("power_law", Some(&1))
+        );
+    }
+}

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/token_curve.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/token_curve.rs
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Immutable one-axis token curves used by MoE-family perf tables.
+
+use std::collections::BTreeMap;
+
+use crate::common::error::AicError;
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct TokenCurve {
+    points: Box<[(u32, f64)]>,
+}
+
+impl TokenCurve {
+    pub(crate) fn from_map(points: BTreeMap<u32, f64>) -> Self {
+        Self {
+            points: points.into_iter().collect(),
+        }
+    }
+
+    pub(crate) fn from_iter(points: impl IntoIterator<Item = (u32, f64)>) -> Self {
+        let points: Vec<_> = points.into_iter().collect();
+        debug_assert!(points.windows(2).all(|pair| pair[0].0 < pair[1].0));
+        Self {
+            points: points.into_boxed_slice(),
+        }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.points.is_empty()
+    }
+
+    pub(crate) fn get(&self, token: u32) -> Option<f64> {
+        self.points
+            .binary_search_by_key(&token, |&(token, _)| token)
+            .ok()
+            .map(|index| self.points[index].1)
+    }
+
+    pub(crate) fn iter(&self) -> impl DoubleEndedIterator<Item = (u32, f64)> + '_ {
+        self.points.iter().copied()
+    }
+
+    pub(crate) fn singleton_underflow(&self, num_tokens: u32) -> Option<u32> {
+        if self.points.len() == 1 && num_tokens < self.points[0].0 {
+            Some(self.points[0].0)
+        } else {
+            None
+        }
+    }
+
+    /// Resolve with the one-axis `perf_interp` Grid contract: exact hits,
+    /// raw interpolation within the measured range, and a boundary-util hold
+    /// outside it with `k_tail=1`.
+    pub(crate) fn query(
+        &self,
+        num_tokens: f64,
+        sol: &dyn Fn(f64) -> f64,
+    ) -> Result<f64, AicError> {
+        if self.points.is_empty() {
+            return Err(miss(num_tokens, "empty table"));
+        }
+
+        if let Some(token) = exact_token(num_tokens) {
+            if let Some(latency) = self.get(token) {
+                return Ok(latency);
+            }
+        }
+
+        let upper = self
+            .points
+            .partition_point(|&(token, _)| f64::from(token) < num_tokens);
+        if upper == 0 || upper == self.points.len() {
+            let anchor = if upper == 0 {
+                self.points[0]
+            } else {
+                self.points[self.points.len() - 1]
+            };
+            let anchor_sol = sol(f64::from(anchor.0));
+            if !(anchor.1 > 0.0 && anchor_sol > 0.0) {
+                return Err(miss(num_tokens, "no positive-util boundary anchor"));
+            }
+            let query_sol = sol(num_tokens);
+            if !(query_sol > 0.0) {
+                return Err(miss(num_tokens, "non-positive SOL at query"));
+            }
+            return Ok(query_sol / (anchor_sol / anchor.1));
+        }
+
+        let lower = self.points[upper - 1];
+        let upper = self.points[upper];
+        let weight =
+            (num_tokens - f64::from(lower.0)) / f64::from(upper.0 - lower.0);
+        Ok(lower.1 + (upper.1 - lower.1) * weight)
+    }
+}
+
+fn exact_token(value: f64) -> Option<u32> {
+    if value >= 0.0 && value <= f64::from(u32::MAX) && value.fract() == 0.0 {
+        Some(value as u32)
+    } else {
+        None
+    }
+}
+
+fn miss(num_tokens: f64, reason: &str) -> AicError {
+    AicError::PerfDatabase(format!(
+        "perf_interp: no data to anchor query {{num_tokens={num_tokens}}} ({reason})"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::perf_database::perf_interp::{self, Node, OpInterpConfig};
+
+    #[test]
+    fn token_curve_resolves_exact_interpolated_and_held_values() {
+        let curve = TokenCurve::from_map(BTreeMap::from([(10, 1.0), (20, 3.0)]));
+        assert_eq!(curve.query(10.0, &|tokens| tokens).unwrap(), 1.0);
+        assert_eq!(curve.query(15.0, &|tokens| tokens).unwrap(), 2.0);
+        assert_eq!(curve.query(40.0, &|tokens| tokens).unwrap(), 6.0);
+        assert_eq!(curve.query(5.0, &|tokens| tokens).unwrap(), 0.5);
+    }
+
+    #[test]
+    fn token_curve_preserves_singleton_and_invalid_hold_semantics() {
+        let singleton = TokenCurve::from_map(BTreeMap::from([(10, 0.0)]));
+        assert_eq!(singleton.singleton_underflow(9), Some(10));
+        assert!(singleton.query(20.0, &|tokens| tokens).is_err());
+    }
+
+    #[test]
+    fn token_curve_is_bit_exact_with_the_generic_grid() {
+        let points = BTreeMap::from([(10, 1.25), (20, 2.75), (40, 5.5)]);
+        let curve = TokenCurve::from_map(points.clone());
+        let mut node = Node::branch();
+        for (&token, &latency) in &points {
+            node.insert(&[token], latency);
+        }
+        let sol = |tokens: f64| tokens * tokens + 1.0;
+        let generic_sol = |coords: &[f64]| sol(coords[0]);
+        let config = OpInterpConfig::grid(&["num_tokens"], &generic_sol);
+
+        for tokens in [5.0, 10.0, 15.5, 20.0, 31.0, 40.0, 80.0] {
+            let expected = perf_interp::query(&config, &node, &[tokens]).unwrap();
+            let actual = curve.query(tokens, &sol).unwrap();
+            assert_eq!(actual.to_bits(), expected.to_bits(), "tokens={tokens}");
+        }
+    }
+}

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/token_curve.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/token_curve.rs
@@ -19,9 +19,12 @@ impl TokenCurve {
         }
     }
 
-    pub(crate) fn from_iter(points: impl IntoIterator<Item = (u32, f64)>) -> Self {
+    pub(crate) fn from_sorted_iter(points: impl IntoIterator<Item = (u32, f64)>) -> Self {
         let points: Vec<_> = points.into_iter().collect();
-        debug_assert!(points.windows(2).all(|pair| pair[0].0 < pair[1].0));
+        assert!(
+            points.windows(2).all(|pair| pair[0].0 < pair[1].0),
+            "TokenCurve points must be strictly ascending and unique"
+        );
         Self {
             points: points.into_boxed_slice(),
         }
@@ -53,11 +56,7 @@ impl TokenCurve {
     /// Resolve with the one-axis `perf_interp` Grid contract: exact hits,
     /// raw interpolation within the measured range, and a boundary-util hold
     /// outside it with `k_tail=1`.
-    pub(crate) fn query(
-        &self,
-        num_tokens: f64,
-        sol: &dyn Fn(f64) -> f64,
-    ) -> Result<f64, AicError> {
+    pub(crate) fn query(&self, num_tokens: f64, sol: &dyn Fn(f64) -> f64) -> Result<f64, AicError> {
         if self.points.is_empty() {
             return Err(miss(num_tokens, "empty table"));
         }
@@ -78,11 +77,11 @@ impl TokenCurve {
                 self.points[self.points.len() - 1]
             };
             let anchor_sol = sol(f64::from(anchor.0));
-            if !(anchor.1 > 0.0 && anchor_sol > 0.0) {
+            if anchor.1.is_nan() || anchor.1 <= 0.0 || anchor_sol.is_nan() || anchor_sol <= 0.0 {
                 return Err(miss(num_tokens, "no positive-util boundary anchor"));
             }
             let query_sol = sol(num_tokens);
-            if !(query_sol > 0.0) {
+            if query_sol.is_nan() || query_sol <= 0.0 {
                 return Err(miss(num_tokens, "non-positive SOL at query"));
             }
             return Ok(query_sol / (anchor_sol / anchor.1));
@@ -90,8 +89,7 @@ impl TokenCurve {
 
         let lower = self.points[upper - 1];
         let upper = self.points[upper];
-        let weight =
-            (num_tokens - f64::from(lower.0)) / f64::from(upper.0 - lower.0);
+        let weight = (num_tokens - f64::from(lower.0)) / f64::from(upper.0 - lower.0);
         Ok(lower.1 + (upper.1 - lower.1) * weight)
     }
 }
@@ -148,5 +146,54 @@ mod tests {
             let actual = curve.query(tokens, &sol).unwrap();
             assert_eq!(actual.to_bits(), expected.to_bits(), "tokens={tokens}");
         }
+    }
+
+    fn assert_query_parity(points: BTreeMap<u32, f64>, num_tokens: f64, sol: &dyn Fn(f64) -> f64) {
+        let curve = TokenCurve::from_map(points.clone());
+        let mut node = Node::branch();
+        for (&token, &latency) in &points {
+            node.insert(&[token], latency);
+        }
+        let generic_sol = |coords: &[f64]| sol(coords[0]);
+        let config = OpInterpConfig::grid(&["num_tokens"], &generic_sol);
+        let expected = perf_interp::query(&config, &node, &[num_tokens]);
+        let actual = curve.query(num_tokens, sol);
+        match (actual, expected) {
+            (Ok(actual), Ok(expected)) => assert_eq!(actual.to_bits(), expected.to_bits()),
+            (Err(actual), Err(expected)) => assert_eq!(actual.to_string(), expected.to_string()),
+            (actual, expected) => panic!("specialized={actual:?}, generic={expected:?}"),
+        }
+    }
+
+    #[test]
+    fn token_curve_errors_match_the_generic_grid() {
+        assert_query_parity(BTreeMap::new(), 10.0, &|tokens| tokens);
+        assert_query_parity(BTreeMap::from([(10, 0.0)]), 20.0, &|tokens| tokens);
+        assert_query_parity(BTreeMap::from([(10, 1.0)]), 20.0, &|tokens| {
+            if tokens == 20.0 {
+                0.0
+            } else {
+                tokens
+            }
+        });
+        assert_query_parity(BTreeMap::from([(10, 1.0)]), 20.0, &|tokens| {
+            if tokens == 20.0 {
+                f64::NAN
+            } else {
+                tokens
+            }
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "TokenCurve points must be strictly ascending and unique")]
+    fn token_curve_rejects_unsorted_points() {
+        TokenCurve::from_sorted_iter([(2, 2.0), (1, 1.0)]);
+    }
+
+    #[test]
+    #[should_panic(expected = "TokenCurve points must be strictly ascending and unique")]
+    fn token_curve_rejects_duplicate_points() {
+        TokenCurve::from_sorted_iter([(1, 1.0), (1, 2.0)]);
     }
 }

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/wideep.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/wideep.rs
@@ -78,11 +78,14 @@ pub struct WideEpTable {
 
 struct MoeGrids {
     by_keys: BTreeMap<MoeKey, BTreeMap<u32, f64>>,
+    index: MoeIndex,
     /// Distinct quant names in first-seen (file row) order — Python's dict
     /// insertion order, consumed by the operator-layer transfer ladder
     /// (same contract as `moe.rs::MoeTable::available_quants`).
     quants_in_load_order: Vec<String>,
 }
+
+type MoeIndex = BTreeMap<String, BTreeMap<String, BTreeMap<MoeShapeKey, MoeKey>>>;
 
 /// TRT-LLM alltoall grids. Keying mirrors Python `load_trtllm_alltoall_data`
 /// exactly: `[kernel_source][op_name][quant][num_nodes][hidden_size][topk]
@@ -126,6 +129,31 @@ struct MoeKey {
     inter_size: u32,
     moe_tp_size: u32,
     moe_ep_size: u32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct MoeShapeKey {
+    topk: u32,
+    num_experts: u32,
+    hidden_size: u32,
+    inter_size: u32,
+    moe_tp_size: u32,
+    moe_ep_size: u32,
+}
+
+impl MoeKey {
+    fn from_shape(quant: &str, distribution: &str, shape: MoeShapeKey) -> Self {
+        Self {
+            quant: quant.to_string(),
+            distribution: distribution.to_string(),
+            topk: shape.topk,
+            num_experts: shape.num_experts,
+            hidden_size: shape.hidden_size,
+            inter_size: shape.inter_size,
+            moe_tp_size: shape.moe_tp_size,
+            moe_ep_size: shape.moe_ep_size,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -287,9 +315,7 @@ impl WideEpTable {
         moe_ep_size: u32,
     ) -> Result<Vec<(u32, f64)>, AicError> {
         let grids = self.load_ctx_or_gen_moe(is_context)?;
-        let key = MoeKey {
-            quant: quant_name.to_string(),
-            distribution: resolve_moe_distribution(grids, quant_name, workload_distribution),
+        let shape = MoeShapeKey {
             topk,
             num_experts,
             hidden_size,
@@ -297,12 +323,18 @@ impl WideEpTable {
             moe_tp_size,
             moe_ep_size,
         };
-        let by_tokens = grids.by_keys.get(&key).filter(|curve| !curve.is_empty()).ok_or_else(|| {
-            AicError::PerfDatabase(format!(
-                "WideEP MoE data missing for {key:?} at {}",
-                self.data_root.display()
-            ))
-        })?;
+        let (distribution, key) =
+            resolve_moe_key(grids, quant_name, workload_distribution, shape);
+        let by_tokens = key
+            .and_then(|key| grids.by_keys.get(key))
+            .filter(|curve| !curve.is_empty())
+            .ok_or_else(|| {
+                let key = MoeKey::from_shape(quant_name, distribution, shape);
+                AicError::PerfDatabase(format!(
+                    "WideEP MoE data missing for {key:?} at {}",
+                    self.data_root.display()
+                ))
+            })?;
         Ok(by_tokens.iter().map(|(&t, &lat)| (t, lat)).collect())
     }
 
@@ -321,12 +353,15 @@ impl WideEpTable {
         moe_ep_size: u32,
     ) -> Result<Vec<MoeSiblingSlice>, AicError> {
         let grids = self.load_ctx_or_gen_moe(is_context)?;
-        let dist = resolve_moe_distribution(grids, quant_name, workload_distribution);
+        let by_distribution = grids.index.get(quant_name);
+        let dist = resolve_moe_distribution(by_distribution, workload_distribution);
         let mut slices = Vec::new();
-        for (key, curve) in &grids.by_keys {
-            if key.quant != quant_name
-                || key.distribution != dist
-                || key.moe_tp_size != moe_tp_size
+        let Some(by_shape) = by_distribution.and_then(|index| index.get(dist)) else {
+            return Ok(slices);
+        };
+        for key in by_shape.values() {
+            let curve = &grids.by_keys[key];
+            if key.moe_tp_size != moe_tp_size
                 || key.moe_ep_size != moe_ep_size
                 || curve.is_empty()
             {
@@ -624,20 +659,29 @@ impl WideEpTable {
 
 /// Mirrors Python's `wl = workload if workload in moe_data[quant] else
 /// "uniform"` on a wideep MoE grid.
-fn resolve_moe_distribution(
-    grids: &MoeGrids,
-    quant_name: &str,
-    workload_distribution: &str,
-) -> String {
-    let requested_exists = grids
-        .by_keys
-        .keys()
-        .any(|k| k.quant == quant_name && k.distribution == workload_distribution);
-    if requested_exists {
-        workload_distribution.to_string()
+fn resolve_moe_distribution<'q>(
+    by_distribution: Option<&BTreeMap<String, BTreeMap<MoeShapeKey, MoeKey>>>,
+    workload_distribution: &'q str,
+) -> &'q str {
+    if by_distribution.is_some_and(|index| index.contains_key(workload_distribution)) {
+        workload_distribution
     } else {
-        "uniform".to_string()
+        "uniform"
     }
+}
+
+fn resolve_moe_key<'g, 'q>(
+    grids: &'g MoeGrids,
+    quant_name: &str,
+    workload_distribution: &'q str,
+    shape: MoeShapeKey,
+) -> (&'q str, Option<&'g MoeKey>) {
+    let by_distribution = grids.index.get(quant_name);
+    let distribution = resolve_moe_distribution(by_distribution, workload_distribution);
+    let key = by_distribution
+        .and_then(|index| index.get(distribution))
+        .and_then(|index| index.get(&shape));
+    (distribution, key)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -657,10 +701,7 @@ fn query_moe(
     sol: &dyn Fn(f64) -> f64,
 ) -> Result<f64, AicError> {
     let quant_name = quant.name();
-    let distribution = resolve_moe_distribution(grids, quant_name, workload_distribution);
-    let key = MoeKey {
-        quant: quant_name.to_string(),
-        distribution,
+    let shape = MoeShapeKey {
         topk,
         num_experts,
         hidden_size,
@@ -668,10 +709,17 @@ fn query_moe(
         moe_tp_size,
         moe_ep_size,
     };
-    let by_tokens = grids
-        .by_keys
-        .get(&key)
-        .ok_or_else(|| AicError::PerfDatabase(format!("MoE data missing for {key:?} at {}", data_root.display())))?;
+    let (distribution, key) =
+        resolve_moe_key(grids, quant_name, workload_distribution, shape);
+    let by_tokens = key
+        .and_then(|key| grids.by_keys.get(key))
+        .ok_or_else(|| {
+            let key = MoeKey::from_shape(quant_name, distribution, shape);
+            AicError::PerfDatabase(format!(
+                "MoE data missing for {key:?} at {}",
+                data_root.display()
+            ))
+        })?;
     if by_tokens.is_empty() {
         return Err(AicError::PerfDatabase("MoE table has no token points".to_string()));
     }
@@ -681,6 +729,7 @@ fn query_moe(
     // engine directly and let a singleton curve util-hold instead.
     if guard_singleton_underflow {
         if let Some(only) = singleton_underflow(by_tokens, num_tokens) {
+            let key = MoeKey::from_shape(quant_name, distribution, shape);
             return Err(AicError::PerfDatabase(format!(
                 "MoE silicon token underflow has only one measured point; cannot infer \
                  low-token latency from a singleton. num_tokens={num_tokens}, \
@@ -916,7 +965,32 @@ fn load_moe_parquet(sources: &[PerfSource]) -> Result<MoeGrids, AicError> {
             sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
         )));
     }
-    Ok(MoeGrids { by_keys, quants_in_load_order })
+    Ok(MoeGrids {
+        index: build_moe_index(&by_keys),
+        by_keys,
+        quants_in_load_order,
+    })
+}
+
+fn build_moe_index(by_keys: &BTreeMap<MoeKey, BTreeMap<u32, f64>>) -> MoeIndex {
+    let mut index = MoeIndex::new();
+    for key in by_keys.keys() {
+        let shape = MoeShapeKey {
+            topk: key.topk,
+            num_experts: key.num_experts,
+            hidden_size: key.hidden_size,
+            inter_size: key.inter_size,
+            moe_tp_size: key.moe_tp_size,
+            moe_ep_size: key.moe_ep_size,
+        };
+        index
+            .entry(key.quant.clone())
+            .or_default()
+            .entry(key.distribution.clone())
+            .or_default()
+            .insert(shape, key.clone());
+    }
+    index
 }
 
 /// Auto-select the TRT-LLM All2All kernel. Verbatim port of Python

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/wideep.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/wideep.rs
@@ -54,7 +54,8 @@ use crate::common::system_spec::SystemSpec;
 use crate::config::{PerfDbSources, PerfSource};
 use super::perf_interp::{self, Node, OpInterpConfig};
 use super::{kernel_source_ok, resolve_op_sources};
-use super::moe::{query_token_curve, singleton_underflow, MoeSiblingSlice};
+use super::moe::MoeSiblingSlice;
+use super::token_curve::TokenCurve;
 use crate::perf_database::parquet_loader::PerfReader;
 
 pub struct WideEpTable {
@@ -77,7 +78,7 @@ pub struct WideEpTable {
 }
 
 struct MoeGrids {
-    by_keys: BTreeMap<MoeKey, BTreeMap<u32, f64>>,
+    by_keys: BTreeMap<MoeKey, TokenCurve>,
     index: MoeIndex,
     /// Distinct quant names in first-seen (file row) order — Python's dict
     /// insertion order, consumed by the operator-layer transfer ladder
@@ -93,7 +94,7 @@ type MoeIndex = BTreeMap<String, BTreeMap<String, BTreeMap<MoeShapeKey, MoeKey>>
 /// `distribution` axis (the parquet column is ignored, as in Python) and NO
 /// `inter_size`/`moe_tp_size`.
 struct AlltoallGrids {
-    by_keys: BTreeMap<AlltoallKey, BTreeMap<u32, f64>>,
+    by_keys: BTreeMap<AlltoallKey, TokenCurve>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -109,14 +110,119 @@ struct AlltoallKey {
 }
 
 struct DispatchGrids {
-    by_keys: BTreeMap<DispatchKey, BTreeMap<u32, DispatchPoint>>,
+    by_keys: BTreeMap<DispatchKey, DispatchCurve>,
 }
 
 /// DeepEP-normal grids carry the `dispatch_sms` level Python keys by
 /// (`moe.py::load_wideep_deepep_normal_data`:
 /// `[node_num][hidden_size][topk][num_experts][dispatch_sms][num_token]`).
 struct NormalDispatchGrids {
-    by_keys: BTreeMap<DispatchKey, BTreeMap<u32, BTreeMap<u32, DispatchPoint>>>,
+    by_keys: BTreeMap<DispatchKey, NormalDispatchSlice>,
+}
+
+struct NormalDispatchSlice {
+    by_sms: BTreeMap<u32, DispatchCurve>,
+    fields: [Node; DispatchField::COUNT],
+}
+
+struct DispatchCurve {
+    points: Box<[(u32, DispatchPoint)]>,
+    fields: [TokenCurve; DispatchField::COUNT],
+}
+
+#[derive(Clone, Copy)]
+enum DispatchField {
+    DispatchTransmit,
+    DispatchNotify,
+    CombineTransmit,
+    CombineNotify,
+    CombineAverage,
+    DispatchAverage,
+}
+
+impl DispatchField {
+    const COUNT: usize = 6;
+    const ALL: [Self; Self::COUNT] = [
+        Self::DispatchTransmit,
+        Self::DispatchNotify,
+        Self::CombineTransmit,
+        Self::CombineNotify,
+        Self::CombineAverage,
+        Self::DispatchAverage,
+    ];
+
+    fn index(self) -> usize {
+        self as usize
+    }
+
+    fn value(self, point: DispatchPoint) -> f64 {
+        match self {
+            Self::DispatchTransmit => point.dispatch_transmit_us,
+            Self::DispatchNotify => point.dispatch_notify_us,
+            Self::CombineTransmit => point.combine_transmit_us,
+            Self::CombineNotify => point.combine_notify_us,
+            Self::CombineAverage => point.combine_avg_t_us,
+            Self::DispatchAverage => point.dispatch_avg_t_us,
+        }
+    }
+}
+
+impl DispatchCurve {
+    fn new(points: BTreeMap<u32, DispatchPoint>) -> Self {
+        let fields = std::array::from_fn(|index| {
+            let field = DispatchField::ALL[index];
+            TokenCurve::from_iter(points.iter().map(|(&token, &point)| {
+                (token, field.value(point))
+            }))
+        });
+        Self {
+            points: points.into_iter().collect(),
+            fields,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.points.is_empty()
+    }
+
+    fn get(&self, token: u32) -> Option<DispatchPoint> {
+        self.points
+            .binary_search_by_key(&token, |&(token, _)| token)
+            .ok()
+            .map(|index| self.points[index].1)
+    }
+
+    fn first(&self) -> (u32, DispatchPoint) {
+        self.points[0]
+    }
+
+    fn last(&self) -> (u32, DispatchPoint) {
+        self.points[self.points.len() - 1]
+    }
+
+    fn token_keys(&self) -> impl Iterator<Item = u32> + '_ {
+        self.points.iter().map(|&(token, _)| token)
+    }
+}
+
+impl NormalDispatchSlice {
+    fn new(by_sms: BTreeMap<u32, BTreeMap<u32, DispatchPoint>>) -> Self {
+        let mut fields = std::array::from_fn(|_| Node::branch());
+        for (&sms, by_tokens) in &by_sms {
+            for (&token, &point) in by_tokens {
+                for field in DispatchField::ALL {
+                    fields[field.index()].insert(&[sms, token], field.value(point));
+                }
+            }
+        }
+        Self {
+            by_sms: by_sms
+                .into_iter()
+                .map(|(sms, curve)| (sms, DispatchCurve::new(curve)))
+                .collect(),
+            fields,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -335,7 +441,7 @@ impl WideEpTable {
                     self.data_root.display()
                 ))
             })?;
-        Ok(by_tokens.iter().map(|(&t, &lat)| (t, lat)).collect())
+        Ok(by_tokens.iter().collect())
     }
 
     /// All collected sibling slices of the context/generation WideEP MoE
@@ -372,7 +478,7 @@ impl WideEpTable {
                 num_experts: key.num_experts,
                 hidden_size: key.hidden_size,
                 inter_size: key.inter_size,
-                points: curve.iter().map(|(&t, &lat)| (t, lat)).collect(),
+                points: curve.iter().collect(),
             });
         }
         Ok(slices)
@@ -494,7 +600,7 @@ impl WideEpTable {
                 self.data_root.display()
             ))
         })?;
-        query_token_curve(by_tokens, num_tokens as f64, &|t| t)
+        by_tokens.query(num_tokens as f64, &|t| t)
     }
 
     /// Collected `(num_tokens, latency)` points of one resolved alltoall
@@ -538,7 +644,7 @@ impl WideEpTable {
                 self.data_root.display()
             )));
         }
-        Ok(by_tokens.iter().map(|(&t, &lat)| (t, lat)).collect())
+        Ok(by_tokens.iter().collect())
     }
 
     /// DeepEP normal-mode dispatch point.
@@ -565,7 +671,7 @@ impl WideEpTable {
             num_topk,
             num_experts,
         };
-        let by_sms = grids.by_keys.get(&key).ok_or_else(|| {
+        let slice = grids.by_keys.get(&key).ok_or_else(|| {
             AicError::PerfDatabase(format!(
                 "dispatch data missing for {key:?} at {}",
                 self.data_root.display()
@@ -575,34 +681,34 @@ impl WideEpTable {
             // Python: only sm=20 is collected for node_num==1 today; the
             // sms bucket is indexed directly and the token curve rides the
             // 1-axis engine.
-            let by_tokens = by_sms.get(&20).ok_or_else(|| {
+            let by_tokens = slice.by_sms.get(&20).ok_or_else(|| {
                 AicError::PerfDatabase(format!(
                     "dispatch data missing for {key:?} (sms=20) at {}",
                     self.data_root.display()
                 ))
             })?;
-            if let Some(point) = by_tokens.get(&num_tokens) {
-                return Ok(*point);
+            if let Some(point) = by_tokens.get(num_tokens) {
+                return Ok(point);
             }
             return Ok(DispatchPoint {
-                dispatch_transmit_us: dispatch_field(by_tokens, |p| p.dispatch_transmit_us, num_tokens)?,
-                dispatch_notify_us: dispatch_field(by_tokens, |p| p.dispatch_notify_us, num_tokens)?,
-                combine_transmit_us: dispatch_field(by_tokens, |p| p.combine_transmit_us, num_tokens)?,
-                combine_notify_us: dispatch_field(by_tokens, |p| p.combine_notify_us, num_tokens)?,
-                combine_avg_t_us: dispatch_field(by_tokens, |p| p.combine_avg_t_us, num_tokens)?,
-                dispatch_avg_t_us: dispatch_field(by_tokens, |p| p.dispatch_avg_t_us, num_tokens)?,
+                dispatch_transmit_us: dispatch_field(by_tokens, DispatchField::DispatchTransmit, num_tokens)?,
+                dispatch_notify_us: dispatch_field(by_tokens, DispatchField::DispatchNotify, num_tokens)?,
+                combine_transmit_us: dispatch_field(by_tokens, DispatchField::CombineTransmit, num_tokens)?,
+                combine_notify_us: dispatch_field(by_tokens, DispatchField::CombineNotify, num_tokens)?,
+                combine_avg_t_us: dispatch_field(by_tokens, DispatchField::CombineAverage, num_tokens)?,
+                dispatch_avg_t_us: dispatch_field(by_tokens, DispatchField::DispatchAverage, num_tokens)?,
             });
         }
-        if let Some(point) = by_sms.get(&sms).and_then(|slice| slice.get(&num_tokens)) {
-            return Ok(*point);
+        if let Some(point) = slice.by_sms.get(&sms).and_then(|curve| curve.get(num_tokens)) {
+            return Ok(point);
         }
         Ok(DispatchPoint {
-            dispatch_transmit_us: dispatch_field_2d(by_sms, |p| p.dispatch_transmit_us, sms, num_tokens)?,
-            dispatch_notify_us: dispatch_field_2d(by_sms, |p| p.dispatch_notify_us, sms, num_tokens)?,
-            combine_transmit_us: dispatch_field_2d(by_sms, |p| p.combine_transmit_us, sms, num_tokens)?,
-            combine_notify_us: dispatch_field_2d(by_sms, |p| p.combine_notify_us, sms, num_tokens)?,
-            combine_avg_t_us: dispatch_field_2d(by_sms, |p| p.combine_avg_t_us, sms, num_tokens)?,
-            dispatch_avg_t_us: dispatch_field_2d(by_sms, |p| p.dispatch_avg_t_us, sms, num_tokens)?,
+            dispatch_transmit_us: dispatch_field_2d(slice, DispatchField::DispatchTransmit, sms, num_tokens)?,
+            dispatch_notify_us: dispatch_field_2d(slice, DispatchField::DispatchNotify, sms, num_tokens)?,
+            combine_transmit_us: dispatch_field_2d(slice, DispatchField::CombineTransmit, sms, num_tokens)?,
+            combine_notify_us: dispatch_field_2d(slice, DispatchField::CombineNotify, sms, num_tokens)?,
+            combine_avg_t_us: dispatch_field_2d(slice, DispatchField::CombineAverage, sms, num_tokens)?,
+            dispatch_avg_t_us: dispatch_field_2d(slice, DispatchField::DispatchAverage, sms, num_tokens)?,
         })
     }
 
@@ -728,7 +834,7 @@ fn query_moe(
     // compute); `_query_alltoall_table` / `_query_compute_table` query the
     // engine directly and let a singleton curve util-hold instead.
     if guard_singleton_underflow {
-        if let Some(only) = singleton_underflow(by_tokens, num_tokens) {
+        if let Some(only) = by_tokens.singleton_underflow(num_tokens) {
             let key = MoeKey::from_shape(quant_name, distribution, shape);
             return Err(AicError::PerfDatabase(format!(
                 "MoE silicon token underflow has only one measured point; cannot infer \
@@ -737,7 +843,7 @@ fn query_moe(
             )));
         }
     }
-    query_token_curve(by_tokens, num_tokens as f64, sol)
+    by_tokens.query(num_tokens as f64, sol)
 }
 
 /// Resolve one `DispatchPoint` field's token curve on the engine, with the
@@ -747,20 +853,19 @@ fn query_moe(
 /// anchor" miss. Under the linear proxy this is numerically identical to
 /// Python's util-hold on the SUMMED curve (`q/b * 0 = 0`).
 fn dispatch_field(
-    by_tokens: &BTreeMap<u32, DispatchPoint>,
-    field: fn(&DispatchPoint) -> f64,
+    by_tokens: &DispatchCurve,
+    field: DispatchField,
     num_tokens: u32,
 ) -> Result<f64, AicError> {
-    let (&first, _) = by_tokens.iter().next().expect("caller checked non-empty");
-    let (&last, _) = by_tokens.iter().next_back().expect("caller checked non-empty");
+    let (first, first_point) = by_tokens.first();
+    let (last, last_point) = by_tokens.last();
     if num_tokens < first || num_tokens > last {
-        let anchor = if num_tokens < first { &by_tokens[&first] } else { &by_tokens[&last] };
-        if field(anchor) == 0.0 {
+        let anchor = if num_tokens < first { first_point } else { last_point };
+        if field.value(anchor) == 0.0 {
             return Ok(0.0);
         }
     }
-    let curve: BTreeMap<u32, f64> = by_tokens.iter().map(|(&t, p)| (t, field(p))).collect();
-    query_token_curve(&curve, num_tokens as f64, &|t| t)
+    by_tokens.fields[field.index()].query(num_tokens as f64, &|t| t)
 }
 
 /// Resolve one `DispatchPoint` field on the DeepEP-normal 2-axis
@@ -774,25 +879,23 @@ fn dispatch_field(
 /// instead of a spurious "no positive-util anchor" miss — numerically
 /// identical to Python's util-hold on the SUMMED curve.
 fn dispatch_field_2d(
-    by_sms: &BTreeMap<u32, BTreeMap<u32, DispatchPoint>>,
-    field: fn(&DispatchPoint) -> f64,
+    slice: &NormalDispatchSlice,
+    field: DispatchField,
     sms: u32,
     num_tokens: u32,
 ) -> Result<f64, AicError> {
-    if let Some(anchor) = normal_hold_anchor(by_sms, sms, num_tokens) {
-        if field(anchor) == 0.0 {
+    if let Some(anchor) = normal_hold_anchor(slice, sms, num_tokens) {
+        if field.value(anchor) == 0.0 {
             return Ok(0.0);
-        }
-    }
-    let mut node = Node::branch();
-    for (&sm, by_tokens) in by_sms {
-        for (&t, point) in by_tokens {
-            node.insert(&[sm, t], field(point));
         }
     }
     let sol = |c: &[f64]| c[1];
     let cfg = OpInterpConfig::grid(&["sms", "num_tokens"], &sol);
-    perf_interp::query(&cfg, &node, &[sms as f64, num_tokens as f64])
+    perf_interp::query(
+        &cfg,
+        &slice.fields[field.index()],
+        &[sms as f64, num_tokens as f64],
+    )
 }
 
 /// Predict the engine's `grid_hold` anchor for a `(sms, num_tokens)` query on
@@ -801,17 +904,18 @@ fn dispatch_field_2d(
 /// snap-then-tail walk with `k_tail = 1`: sms snaps to the nearest collected
 /// key (tie -> smaller), tokens anchor at the boundary key when beyond the
 /// slice's range and at the nearest key otherwise.
-fn normal_hold_anchor<'a>(
-    by_sms: &'a BTreeMap<u32, BTreeMap<u32, DispatchPoint>>,
+fn normal_hold_anchor(
+    slice: &NormalDispatchSlice,
     sms: u32,
     num_tokens: u32,
-) -> Option<&'a DispatchPoint> {
+) -> Option<DispatchPoint> {
+    let by_sms = &slice.by_sms;
     if by_sms.is_empty() {
         return None;
     }
-    let covered = |slice: &BTreeMap<u32, DispatchPoint>| -> bool {
-        let (&first, _) = slice.iter().next().expect("loader never stores empty slices");
-        let (&last, _) = slice.iter().next_back().expect("loader never stores empty slices");
+    let covered = |slice: &DispatchCurve| -> bool {
+        let (first, _) = slice.first();
+        let (last, _) = slice.last();
         first <= num_tokens && num_tokens <= last
     };
     let nearest = |keys: &mut dyn Iterator<Item = u32>, c: u32| -> u32 {
@@ -822,18 +926,18 @@ fn normal_hold_anchor<'a>(
         })
         .expect("non-empty")
     };
-    let anchor_in = |slice: &'a BTreeMap<u32, DispatchPoint>| -> &'a DispatchPoint {
-        let (&first, _) = slice.iter().next().expect("non-empty");
-        let (&last, _) = slice.iter().next_back().expect("non-empty");
+    let anchor_in = |slice: &DispatchCurve| -> DispatchPoint {
+        let (first, first_point) = slice.first();
+        let (last, last_point) = slice.last();
         if num_tokens > last {
-            &slice[&last]
+            last_point
         } else if num_tokens < first {
-            &slice[&first]
+            first_point
         } else {
             // tokens in range but an OUTER (sms) axis was snapped -> the
             // engine holds at the NEAREST token key, not a lerp.
-            let key = nearest(&mut slice.keys().copied(), num_tokens);
-            &slice[&key]
+            let key = nearest(&mut slice.token_keys(), num_tokens);
+            slice.get(key).expect("nearest token key must exist")
         }
     };
     if let Some(slice) = by_sms.get(&sms) {
@@ -877,8 +981,8 @@ fn dispatch_lookup(
     let by_tokens = grids.by_keys.get(&key).ok_or_else(|| {
         AicError::PerfDatabase(format!("dispatch data missing for {key:?} at {}", data_root.display()))
     })?;
-    if let Some(point) = by_tokens.get(&num_tokens) {
-        return Ok(*point);
+    if let Some(point) = by_tokens.get(num_tokens) {
+        return Ok(point);
     }
     if by_tokens.is_empty() {
         return Err(AicError::PerfDatabase(format!(
@@ -887,12 +991,12 @@ fn dispatch_lookup(
         )));
     }
     Ok(DispatchPoint {
-        dispatch_transmit_us: dispatch_field(by_tokens, |p| p.dispatch_transmit_us, num_tokens)?,
-        dispatch_notify_us: dispatch_field(by_tokens, |p| p.dispatch_notify_us, num_tokens)?,
-        combine_transmit_us: dispatch_field(by_tokens, |p| p.combine_transmit_us, num_tokens)?,
-        combine_notify_us: dispatch_field(by_tokens, |p| p.combine_notify_us, num_tokens)?,
-        combine_avg_t_us: dispatch_field(by_tokens, |p| p.combine_avg_t_us, num_tokens)?,
-        dispatch_avg_t_us: dispatch_field(by_tokens, |p| p.dispatch_avg_t_us, num_tokens)?,
+        dispatch_transmit_us: dispatch_field(by_tokens, DispatchField::DispatchTransmit, num_tokens)?,
+        dispatch_notify_us: dispatch_field(by_tokens, DispatchField::DispatchNotify, num_tokens)?,
+        combine_transmit_us: dispatch_field(by_tokens, DispatchField::CombineTransmit, num_tokens)?,
+        combine_notify_us: dispatch_field(by_tokens, DispatchField::CombineNotify, num_tokens)?,
+        combine_avg_t_us: dispatch_field(by_tokens, DispatchField::CombineAverage, num_tokens)?,
+        dispatch_avg_t_us: dispatch_field(by_tokens, DispatchField::DispatchAverage, num_tokens)?,
     })
 }
 
@@ -965,6 +1069,10 @@ fn load_moe_parquet(sources: &[PerfSource]) -> Result<MoeGrids, AicError> {
             sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
         )));
     }
+    let by_keys: BTreeMap<_, _> = by_keys
+        .into_iter()
+        .map(|(key, curve)| (key, TokenCurve::from_map(curve)))
+        .collect();
     Ok(MoeGrids {
         index: build_moe_index(&by_keys),
         by_keys,
@@ -972,7 +1080,7 @@ fn load_moe_parquet(sources: &[PerfSource]) -> Result<MoeGrids, AicError> {
     })
 }
 
-fn build_moe_index(by_keys: &BTreeMap<MoeKey, BTreeMap<u32, f64>>) -> MoeIndex {
+fn build_moe_index(by_keys: &BTreeMap<MoeKey, TokenCurve>) -> MoeIndex {
     let mut index = MoeIndex::new();
     for key in by_keys.keys() {
         let shape = MoeShapeKey {
@@ -1107,7 +1215,12 @@ fn load_alltoall_parquet(sources: &[PerfSource]) -> Result<AlltoallGrids, AicErr
             sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
         )));
     }
-    Ok(AlltoallGrids { by_keys })
+    Ok(AlltoallGrids {
+        by_keys: by_keys
+            .into_iter()
+            .map(|(key, curve)| (key, TokenCurve::from_map(curve)))
+            .collect(),
+    })
 }
 
 /// Load the DeepEP-normal dispatch table from an ordered source list. Missing
@@ -1178,7 +1291,12 @@ fn load_deepep_normal_parquet(sources: &[PerfSource]) -> Result<NormalDispatchGr
             sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
         )));
     }
-    Ok(NormalDispatchGrids { by_keys })
+    Ok(NormalDispatchGrids {
+        by_keys: by_keys
+            .into_iter()
+            .map(|(key, by_sms)| (key, NormalDispatchSlice::new(by_sms)))
+            .collect(),
+    })
 }
 
 /// Load the DeepEP low-latency dispatch table from an ordered source list.
@@ -1235,7 +1353,12 @@ fn load_deepep_ll_parquet(sources: &[PerfSource]) -> Result<DispatchGrids, AicEr
             sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
         )));
     }
-    Ok(DispatchGrids { by_keys })
+    Ok(DispatchGrids {
+        by_keys: by_keys
+            .into_iter()
+            .map(|(key, curve)| (key, DispatchCurve::new(curve)))
+            .collect(),
+    })
 }
 
 fn clone_err(err: &AicError) -> AicError {

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/wideep.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/wideep.rs
@@ -48,14 +48,15 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
+use super::moe::MoeSiblingSlice;
+use super::moe_index::{MoeIndex, MoeShapeKey};
+use super::perf_interp::{self, Node, OpInterpConfig};
+use super::token_curve::TokenCurve;
+use super::{kernel_source_ok, resolve_op_sources};
 use crate::common::enums::MoeQuantMode;
 use crate::common::error::AicError;
 use crate::common::system_spec::SystemSpec;
 use crate::config::{PerfDbSources, PerfSource};
-use super::perf_interp::{self, Node, OpInterpConfig};
-use super::{kernel_source_ok, resolve_op_sources};
-use super::moe::MoeSiblingSlice;
-use super::token_curve::TokenCurve;
 use crate::perf_database::parquet_loader::PerfReader;
 
 pub struct WideEpTable {
@@ -78,15 +79,12 @@ pub struct WideEpTable {
 }
 
 struct MoeGrids {
-    by_keys: BTreeMap<MoeKey, TokenCurve>,
-    index: MoeIndex,
+    index: MoeIndex<MoeShapeKey, TokenCurve>,
     /// Distinct quant names in first-seen (file row) order — Python's dict
     /// insertion order, consumed by the operator-layer transfer ladder
     /// (same contract as `moe.rs::MoeTable::available_quants`).
     quants_in_load_order: Vec<String>,
 }
-
-type MoeIndex = BTreeMap<String, BTreeMap<String, BTreeMap<MoeShapeKey, MoeKey>>>;
 
 /// TRT-LLM alltoall grids. Keying mirrors Python `load_trtllm_alltoall_data`
 /// exactly: `[kernel_source][op_name][quant][num_nodes][hidden_size][topk]
@@ -121,13 +119,18 @@ struct NormalDispatchGrids {
 }
 
 struct NormalDispatchSlice {
-    by_sms: BTreeMap<u32, DispatchCurve>,
+    by_sms: BTreeMap<u32, DispatchPoints>,
+    direct_fields: Option<[TokenCurve; DispatchField::COUNT]>,
     fields: [Node; DispatchField::COUNT],
 }
 
 struct DispatchCurve {
-    points: Box<[(u32, DispatchPoint)]>,
+    points: DispatchPoints,
     fields: [TokenCurve; DispatchField::COUNT],
+}
+
+struct DispatchPoints {
+    points: Box<[(u32, DispatchPoint)]>,
 }
 
 #[derive(Clone, Copy)]
@@ -169,20 +172,23 @@ impl DispatchField {
 
 impl DispatchCurve {
     fn new(points: BTreeMap<u32, DispatchPoint>) -> Self {
-        let fields = std::array::from_fn(|index| {
-            let field = DispatchField::ALL[index];
-            TokenCurve::from_iter(points.iter().map(|(&token, &point)| {
-                (token, field.value(point))
-            }))
-        });
+        let fields = dispatch_fields(&points);
         Self {
-            points: points.into_iter().collect(),
+            points: DispatchPoints::new(points),
             fields,
         }
     }
+}
 
-    fn is_empty(&self) -> bool {
-        self.points.is_empty()
+impl DispatchPoints {
+    fn new(points: BTreeMap<u32, DispatchPoint>) -> Self {
+        assert!(
+            !points.is_empty(),
+            "dispatch curves must carry at least one token point"
+        );
+        Self {
+            points: points.into_iter().collect(),
+        }
     }
 
     fn get(&self, token: u32) -> Option<DispatchPoint> {
@@ -193,11 +199,17 @@ impl DispatchCurve {
     }
 
     fn first(&self) -> (u32, DispatchPoint) {
-        self.points[0]
+        *self
+            .points
+            .first()
+            .expect("DispatchPoints is non-empty by construction")
     }
 
     fn last(&self) -> (u32, DispatchPoint) {
-        self.points[self.points.len() - 1]
+        *self
+            .points
+            .last()
+            .expect("DispatchPoints is non-empty by construction")
     }
 
     fn token_keys(&self) -> impl Iterator<Item = u32> + '_ {
@@ -205,8 +217,24 @@ impl DispatchCurve {
     }
 }
 
+fn dispatch_fields(points: &BTreeMap<u32, DispatchPoint>) -> [TokenCurve; DispatchField::COUNT] {
+    std::array::from_fn(|index| {
+        let field = DispatchField::ALL[index];
+        TokenCurve::from_sorted_iter(
+            points
+                .iter()
+                .map(|(&token, &point)| (token, field.value(point))),
+        )
+    })
+}
+
 impl NormalDispatchSlice {
-    fn new(by_sms: BTreeMap<u32, BTreeMap<u32, DispatchPoint>>) -> Self {
+    fn new(node_num: u32, by_sms: BTreeMap<u32, BTreeMap<u32, DispatchPoint>>) -> Self {
+        let direct_fields = if node_num == 1 {
+            by_sms.get(&20).map(dispatch_fields)
+        } else {
+            None
+        };
         let mut fields = std::array::from_fn(|_| Node::branch());
         for (&sms, by_tokens) in &by_sms {
             for (&token, &point) in by_tokens {
@@ -218,8 +246,9 @@ impl NormalDispatchSlice {
         Self {
             by_sms: by_sms
                 .into_iter()
-                .map(|(sms, curve)| (sms, DispatchCurve::new(curve)))
+                .map(|(sms, points)| (sms, DispatchPoints::new(points)))
                 .collect(),
+            direct_fields,
             fields,
         }
     }
@@ -229,16 +258,6 @@ impl NormalDispatchSlice {
 struct MoeKey {
     quant: String,
     distribution: String,
-    topk: u32,
-    num_experts: u32,
-    hidden_size: u32,
-    inter_size: u32,
-    moe_tp_size: u32,
-    moe_ep_size: u32,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
-struct MoeShapeKey {
     topk: u32,
     num_experts: u32,
     hidden_size: u32,
@@ -297,14 +316,18 @@ impl WideEpTable {
     /// `perf_db_sources` (Python-supplied). Each perf file falls back to its
     /// primary `data_root/<basename>` when absent from the map. No I/O.
     pub fn with_sources(data_root: PathBuf, perf_db_sources: &PerfDbSources) -> Self {
-        let context_moe_sources =
-            resolve_op_sources(perf_db_sources, "wideep_context_moe_perf.parquet", &data_root);
+        let context_moe_sources = resolve_op_sources(
+            perf_db_sources,
+            "wideep_context_moe_perf.parquet",
+            &data_root,
+        );
         let generation_moe_sources = resolve_op_sources(
             perf_db_sources,
             "wideep_generation_moe_perf.parquet",
             &data_root,
         );
-        let moe_sources = resolve_op_sources(perf_db_sources, "wideep_moe_perf.parquet", &data_root);
+        let moe_sources =
+            resolve_op_sources(perf_db_sources, "wideep_moe_perf.parquet", &data_root);
         let alltoall_sources =
             resolve_op_sources(perf_db_sources, "trtllm_alltoall_perf.parquet", &data_root);
         let deepep_normal_sources = resolve_op_sources(
@@ -429,18 +452,17 @@ impl WideEpTable {
             moe_tp_size,
             moe_ep_size,
         };
-        let (distribution, key) =
-            resolve_moe_key(grids, quant_name, workload_distribution, shape);
-        let by_tokens = key
-            .and_then(|key| grids.by_keys.get(key))
-            .filter(|curve| !curve.is_empty())
-            .ok_or_else(|| {
-                let key = MoeKey::from_shape(quant_name, distribution, shape);
-                AicError::PerfDatabase(format!(
-                    "WideEP MoE data missing for {key:?} at {}",
-                    self.data_root.display()
-                ))
-            })?;
+        let (distribution, by_tokens) =
+            grids
+                .index
+                .resolve_uniform(quant_name, workload_distribution, &shape);
+        let by_tokens = by_tokens.filter(|curve| !curve.is_empty()).ok_or_else(|| {
+            let key = MoeKey::from_shape(quant_name, distribution, shape);
+            AicError::PerfDatabase(format!(
+                "WideEP MoE data missing for {key:?} at {}",
+                self.data_root.display()
+            ))
+        })?;
         Ok(by_tokens.iter().collect())
     }
 
@@ -459,25 +481,25 @@ impl WideEpTable {
         moe_ep_size: u32,
     ) -> Result<Vec<MoeSiblingSlice>, AicError> {
         let grids = self.load_ctx_or_gen_moe(is_context)?;
-        let by_distribution = grids.index.get(quant_name);
-        let dist = resolve_moe_distribution(by_distribution, workload_distribution);
+        let (_, by_shape) = grids
+            .index
+            .resolve_uniform_shapes(quant_name, workload_distribution);
         let mut slices = Vec::new();
-        let Some(by_shape) = by_distribution.and_then(|index| index.get(dist)) else {
+        let Some(by_shape) = by_shape else {
             return Ok(slices);
         };
-        for key in by_shape.values() {
-            let curve = &grids.by_keys[key];
-            if key.moe_tp_size != moe_tp_size
-                || key.moe_ep_size != moe_ep_size
+        for (shape, curve) in by_shape {
+            if shape.moe_tp_size != moe_tp_size
+                || shape.moe_ep_size != moe_ep_size
                 || curve.is_empty()
             {
                 continue;
             }
             slices.push(MoeSiblingSlice {
-                topk: key.topk,
-                num_experts: key.num_experts,
-                hidden_size: key.hidden_size,
-                inter_size: key.inter_size,
+                topk: shape.topk,
+                num_experts: shape.num_experts,
+                hidden_size: shape.hidden_size,
+                inter_size: shape.inter_size,
                 points: curve.iter().collect(),
             });
         }
@@ -488,7 +510,10 @@ impl WideEpTable {
     /// first-seen (file row) order (Python dict insertion order — same
     /// contract as `moe.rs::MoeTable::available_quants`).
     pub fn moe_available_quants(&self, is_context: bool) -> Result<Vec<String>, AicError> {
-        Ok(self.load_ctx_or_gen_moe(is_context)?.quants_in_load_order.clone())
+        Ok(self
+            .load_ctx_or_gen_moe(is_context)?
+            .quants_in_load_order
+            .clone())
     }
 
     fn load_ctx_or_gen_moe(&self, is_context: bool) -> Result<&MoeGrids, AicError> {
@@ -690,25 +715,93 @@ impl WideEpTable {
             if let Some(point) = by_tokens.get(num_tokens) {
                 return Ok(point);
             }
+            let fields = slice
+                .direct_fields
+                .as_ref()
+                .expect("node_num=1 sms=20 fields are built with the slice");
             return Ok(DispatchPoint {
-                dispatch_transmit_us: dispatch_field(by_tokens, DispatchField::DispatchTransmit, num_tokens)?,
-                dispatch_notify_us: dispatch_field(by_tokens, DispatchField::DispatchNotify, num_tokens)?,
-                combine_transmit_us: dispatch_field(by_tokens, DispatchField::CombineTransmit, num_tokens)?,
-                combine_notify_us: dispatch_field(by_tokens, DispatchField::CombineNotify, num_tokens)?,
-                combine_avg_t_us: dispatch_field(by_tokens, DispatchField::CombineAverage, num_tokens)?,
-                dispatch_avg_t_us: dispatch_field(by_tokens, DispatchField::DispatchAverage, num_tokens)?,
+                dispatch_transmit_us: dispatch_field(
+                    by_tokens,
+                    fields,
+                    DispatchField::DispatchTransmit,
+                    num_tokens,
+                )?,
+                dispatch_notify_us: dispatch_field(
+                    by_tokens,
+                    fields,
+                    DispatchField::DispatchNotify,
+                    num_tokens,
+                )?,
+                combine_transmit_us: dispatch_field(
+                    by_tokens,
+                    fields,
+                    DispatchField::CombineTransmit,
+                    num_tokens,
+                )?,
+                combine_notify_us: dispatch_field(
+                    by_tokens,
+                    fields,
+                    DispatchField::CombineNotify,
+                    num_tokens,
+                )?,
+                combine_avg_t_us: dispatch_field(
+                    by_tokens,
+                    fields,
+                    DispatchField::CombineAverage,
+                    num_tokens,
+                )?,
+                dispatch_avg_t_us: dispatch_field(
+                    by_tokens,
+                    fields,
+                    DispatchField::DispatchAverage,
+                    num_tokens,
+                )?,
             });
         }
-        if let Some(point) = slice.by_sms.get(&sms).and_then(|curve| curve.get(num_tokens)) {
+        if let Some(point) = slice
+            .by_sms
+            .get(&sms)
+            .and_then(|curve| curve.get(num_tokens))
+        {
             return Ok(point);
         }
         Ok(DispatchPoint {
-            dispatch_transmit_us: dispatch_field_2d(slice, DispatchField::DispatchTransmit, sms, num_tokens)?,
-            dispatch_notify_us: dispatch_field_2d(slice, DispatchField::DispatchNotify, sms, num_tokens)?,
-            combine_transmit_us: dispatch_field_2d(slice, DispatchField::CombineTransmit, sms, num_tokens)?,
-            combine_notify_us: dispatch_field_2d(slice, DispatchField::CombineNotify, sms, num_tokens)?,
-            combine_avg_t_us: dispatch_field_2d(slice, DispatchField::CombineAverage, sms, num_tokens)?,
-            dispatch_avg_t_us: dispatch_field_2d(slice, DispatchField::DispatchAverage, sms, num_tokens)?,
+            dispatch_transmit_us: dispatch_field_2d(
+                slice,
+                DispatchField::DispatchTransmit,
+                sms,
+                num_tokens,
+            )?,
+            dispatch_notify_us: dispatch_field_2d(
+                slice,
+                DispatchField::DispatchNotify,
+                sms,
+                num_tokens,
+            )?,
+            combine_transmit_us: dispatch_field_2d(
+                slice,
+                DispatchField::CombineTransmit,
+                sms,
+                num_tokens,
+            )?,
+            combine_notify_us: dispatch_field_2d(
+                slice,
+                DispatchField::CombineNotify,
+                sms,
+                num_tokens,
+            )?,
+            combine_avg_t_us: dispatch_field_2d(
+                slice,
+                DispatchField::CombineAverage,
+                sms,
+                num_tokens,
+            )?,
+            dispatch_avg_t_us: dispatch_field_2d(
+                slice,
+                DispatchField::DispatchAverage,
+                sms,
+                num_tokens,
+            )?,
         })
     }
 
@@ -722,7 +815,15 @@ impl WideEpTable {
         num_experts: u32,
     ) -> Result<DispatchPoint, AicError> {
         let grids = self.load_deepep_ll()?;
-        dispatch_lookup(grids, node_num, hidden_size, num_tokens, num_topk, num_experts, &self.data_root)
+        dispatch_lookup(
+            grids,
+            node_num,
+            hidden_size,
+            num_tokens,
+            num_topk,
+            num_experts,
+            &self.data_root,
+        )
     }
 
     fn load_context_moe(&self) -> Result<&MoeGrids, AicError> {
@@ -763,33 +864,6 @@ impl WideEpTable {
     }
 }
 
-/// Mirrors Python's `wl = workload if workload in moe_data[quant] else
-/// "uniform"` on a wideep MoE grid.
-fn resolve_moe_distribution<'q>(
-    by_distribution: Option<&BTreeMap<String, BTreeMap<MoeShapeKey, MoeKey>>>,
-    workload_distribution: &'q str,
-) -> &'q str {
-    if by_distribution.is_some_and(|index| index.contains_key(workload_distribution)) {
-        workload_distribution
-    } else {
-        "uniform"
-    }
-}
-
-fn resolve_moe_key<'g, 'q>(
-    grids: &'g MoeGrids,
-    quant_name: &str,
-    workload_distribution: &'q str,
-    shape: MoeShapeKey,
-) -> (&'q str, Option<&'g MoeKey>) {
-    let by_distribution = grids.index.get(quant_name);
-    let distribution = resolve_moe_distribution(by_distribution, workload_distribution);
-    let key = by_distribution
-        .and_then(|index| index.get(distribution))
-        .and_then(|index| index.get(&shape));
-    (distribution, key)
-}
-
 #[allow(clippy::too_many_arguments)]
 fn query_moe(
     grids: &MoeGrids,
@@ -815,19 +889,21 @@ fn query_moe(
         moe_tp_size,
         moe_ep_size,
     };
-    let (distribution, key) =
-        resolve_moe_key(grids, quant_name, workload_distribution, shape);
-    let by_tokens = key
-        .and_then(|key| grids.by_keys.get(key))
-        .ok_or_else(|| {
-            let key = MoeKey::from_shape(quant_name, distribution, shape);
-            AicError::PerfDatabase(format!(
-                "MoE data missing for {key:?} at {}",
-                data_root.display()
-            ))
-        })?;
+    let (distribution, by_tokens) =
+        grids
+            .index
+            .resolve_uniform(quant_name, workload_distribution, &shape);
+    let by_tokens = by_tokens.ok_or_else(|| {
+        let key = MoeKey::from_shape(quant_name, distribution, shape);
+        AicError::PerfDatabase(format!(
+            "MoE data missing for {key:?} at {}",
+            data_root.display()
+        ))
+    })?;
     if by_tokens.is_empty() {
-        return Err(AicError::PerfDatabase("MoE table has no token points".to_string()));
+        return Err(AicError::PerfDatabase(
+            "MoE table has no token points".to_string(),
+        ));
     }
     // Python's `_resolve_tokens` singleton-underflow guard applies only to
     // the paths that route through it (sglang deepep context/generation MoE
@@ -853,19 +929,24 @@ fn query_moe(
 /// anchor" miss. Under the linear proxy this is numerically identical to
 /// Python's util-hold on the SUMMED curve (`q/b * 0 = 0`).
 fn dispatch_field(
-    by_tokens: &DispatchCurve,
+    by_tokens: &DispatchPoints,
+    fields: &[TokenCurve; DispatchField::COUNT],
     field: DispatchField,
     num_tokens: u32,
 ) -> Result<f64, AicError> {
     let (first, first_point) = by_tokens.first();
     let (last, last_point) = by_tokens.last();
     if num_tokens < first || num_tokens > last {
-        let anchor = if num_tokens < first { first_point } else { last_point };
+        let anchor = if num_tokens < first {
+            first_point
+        } else {
+            last_point
+        };
         if field.value(anchor) == 0.0 {
             return Ok(0.0);
         }
     }
-    by_tokens.fields[field.index()].query(num_tokens as f64, &|t| t)
+    fields[field.index()].query(num_tokens as f64, &|t| t)
 }
 
 /// Resolve one `DispatchPoint` field on the DeepEP-normal 2-axis
@@ -913,7 +994,7 @@ fn normal_hold_anchor(
     if by_sms.is_empty() {
         return None;
     }
-    let covered = |slice: &DispatchCurve| -> bool {
+    let covered = |slice: &DispatchPoints| -> bool {
         let (first, _) = slice.first();
         let (last, _) = slice.last();
         first <= num_tokens && num_tokens <= last
@@ -926,7 +1007,7 @@ fn normal_hold_anchor(
         })
         .expect("non-empty")
     };
-    let anchor_in = |slice: &DispatchCurve| -> DispatchPoint {
+    let anchor_in = |slice: &DispatchPoints| -> DispatchPoint {
         let (first, first_point) = slice.first();
         let (last, last_point) = slice.last();
         if num_tokens > last {
@@ -979,24 +1060,51 @@ fn dispatch_lookup(
         num_experts,
     };
     let by_tokens = grids.by_keys.get(&key).ok_or_else(|| {
-        AicError::PerfDatabase(format!("dispatch data missing for {key:?} at {}", data_root.display()))
+        AicError::PerfDatabase(format!(
+            "dispatch data missing for {key:?} at {}",
+            data_root.display()
+        ))
     })?;
-    if let Some(point) = by_tokens.get(num_tokens) {
+    if let Some(point) = by_tokens.points.get(num_tokens) {
         return Ok(point);
     }
-    if by_tokens.is_empty() {
-        return Err(AicError::PerfDatabase(format!(
-            "dispatch data has no token points for {key:?} at {}",
-            data_root.display()
-        )));
-    }
     Ok(DispatchPoint {
-        dispatch_transmit_us: dispatch_field(by_tokens, DispatchField::DispatchTransmit, num_tokens)?,
-        dispatch_notify_us: dispatch_field(by_tokens, DispatchField::DispatchNotify, num_tokens)?,
-        combine_transmit_us: dispatch_field(by_tokens, DispatchField::CombineTransmit, num_tokens)?,
-        combine_notify_us: dispatch_field(by_tokens, DispatchField::CombineNotify, num_tokens)?,
-        combine_avg_t_us: dispatch_field(by_tokens, DispatchField::CombineAverage, num_tokens)?,
-        dispatch_avg_t_us: dispatch_field(by_tokens, DispatchField::DispatchAverage, num_tokens)?,
+        dispatch_transmit_us: dispatch_field(
+            &by_tokens.points,
+            &by_tokens.fields,
+            DispatchField::DispatchTransmit,
+            num_tokens,
+        )?,
+        dispatch_notify_us: dispatch_field(
+            &by_tokens.points,
+            &by_tokens.fields,
+            DispatchField::DispatchNotify,
+            num_tokens,
+        )?,
+        combine_transmit_us: dispatch_field(
+            &by_tokens.points,
+            &by_tokens.fields,
+            DispatchField::CombineTransmit,
+            num_tokens,
+        )?,
+        combine_notify_us: dispatch_field(
+            &by_tokens.points,
+            &by_tokens.fields,
+            DispatchField::CombineNotify,
+            num_tokens,
+        )?,
+        combine_avg_t_us: dispatch_field(
+            &by_tokens.points,
+            &by_tokens.fields,
+            DispatchField::CombineAverage,
+            num_tokens,
+        )?,
+        dispatch_avg_t_us: dispatch_field(
+            &by_tokens.points,
+            &by_tokens.fields,
+            DispatchField::DispatchAverage,
+            num_tokens,
+        )?,
     })
 }
 
@@ -1009,7 +1117,7 @@ fn dispatch_lookup(
 /// returned only when no source yields rows. Reused for the
 /// context/generation/wideep-moe parquets (alltoall has its own loader).
 fn load_moe_parquet(sources: &[PerfSource]) -> Result<MoeGrids, AicError> {
-    let mut by_keys: BTreeMap<MoeKey, BTreeMap<u32, f64>> = BTreeMap::new();
+    let mut index: MoeIndex<MoeShapeKey, BTreeMap<u32, f64>> = MoeIndex::default();
     let mut quants_in_load_order: Vec<String> = Vec::new();
     let mut any_source = false;
     for source in sources {
@@ -1038,9 +1146,9 @@ fn load_moe_parquet(sources: &[PerfSource]) -> Result<MoeGrids, AicError> {
             if !kernel_source_ok(source.kernel_sources(), ks_col, &row)? {
                 continue;
             }
-            let key = MoeKey {
-                quant: row.str_owned(moe_dtype_col)?,
-                distribution: row.str_owned(distribution_col)?,
+            let quant = row.str_owned(moe_dtype_col)?;
+            let distribution = row.str_owned(distribution_col)?;
+            let shape = MoeShapeKey {
                 topk: row.u32(topk_col)?,
                 num_experts: row.u32(num_experts_col)?,
                 hidden_size: row.u32(hidden_size_col)?,
@@ -1049,56 +1157,32 @@ fn load_moe_parquet(sources: &[PerfSource]) -> Result<MoeGrids, AicError> {
                 moe_ep_size: row.u32(moe_ep_size_col)?,
             };
             // First-seen (file row) quant order (Python dict insertion order).
-            if !quants_in_load_order.iter().any(|q| q == &key.quant) {
-                quants_in_load_order.push(key.quant.clone());
+            if !quants_in_load_order.iter().any(|q| q == &quant) {
+                quants_in_load_order.push(quant.clone());
             }
             // First-wins parity with Python `load_wideep_*_moe_data`, which now
             // guards with the standard skip-on-key-conflict idiom
             // (shared-layer contract, design §6.1).
-            by_keys
-                .entry(key)
-                .or_default()
+            index
+                .entry(quant, distribution, shape)
                 .entry(row.u32(num_tokens_col)?)
                 .or_insert(row.f64(latency_col)?);
         }
     }
-    if !any_source || by_keys.is_empty() {
+    if !any_source || index.is_empty() {
         return Err(AicError::PerfDatabase(format!(
             "no MoE-shape rows loaded from {} source(s) (first: {})",
             sources.len(),
-            sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
+            sources
+                .first()
+                .map(|s| s.path().display().to_string())
+                .unwrap_or_default()
         )));
     }
-    let by_keys: BTreeMap<_, _> = by_keys
-        .into_iter()
-        .map(|(key, curve)| (key, TokenCurve::from_map(curve)))
-        .collect();
     Ok(MoeGrids {
-        index: build_moe_index(&by_keys),
-        by_keys,
+        index: index.map_values(TokenCurve::from_map),
         quants_in_load_order,
     })
-}
-
-fn build_moe_index(by_keys: &BTreeMap<MoeKey, TokenCurve>) -> MoeIndex {
-    let mut index = MoeIndex::new();
-    for key in by_keys.keys() {
-        let shape = MoeShapeKey {
-            topk: key.topk,
-            num_experts: key.num_experts,
-            hidden_size: key.hidden_size,
-            inter_size: key.inter_size,
-            moe_tp_size: key.moe_tp_size,
-            moe_ep_size: key.moe_ep_size,
-        };
-        index
-            .entry(key.quant.clone())
-            .or_default()
-            .entry(key.distribution.clone())
-            .or_default()
-            .insert(shape, key.clone());
-    }
-    index
 }
 
 /// Auto-select the TRT-LLM All2All kernel. Verbatim port of Python
@@ -1127,7 +1211,9 @@ pub(crate) fn select_alltoall_kernel(
         }
     }
     let supports_mnnvl = spec.gpu.sm_version.unwrap_or(0) >= 100;
-    let is_wideep = moe_backend.map(|b| b.to_uppercase() == "WIDEEP").unwrap_or(false);
+    let is_wideep = moe_backend
+        .map(|b| b.to_uppercase() == "WIDEEP")
+        .unwrap_or(false);
     if is_wideep {
         if supports_mnnvl {
             return "NVLinkTwoSided";
@@ -1212,7 +1298,10 @@ fn load_alltoall_parquet(sources: &[PerfSource]) -> Result<AlltoallGrids, AicErr
         return Err(AicError::PerfDatabase(format!(
             "no TRT-LLM alltoall rows loaded from {} source(s) (first: {})",
             sources.len(),
-            sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
+            sources
+                .first()
+                .map(|s| s.path().display().to_string())
+                .unwrap_or_default()
         )));
     }
     Ok(AlltoallGrids {
@@ -1275,7 +1364,9 @@ fn load_deepep_normal_parquet(sources: &[PerfSource]) -> Result<NormalDispatchGr
                 .or_default()
                 .entry(row.u32(num_token_col)?)
                 .or_insert(DispatchPoint {
-                    dispatch_transmit_us: row.f64_optional(dispatch_transmit_us_col)?.unwrap_or(0.0),
+                    dispatch_transmit_us: row
+                        .f64_optional(dispatch_transmit_us_col)?
+                        .unwrap_or(0.0),
                     dispatch_notify_us: row.f64_optional(dispatch_notify_us_col)?.unwrap_or(0.0),
                     combine_transmit_us: row.f64_optional(combine_transmit_us_col)?.unwrap_or(0.0),
                     combine_notify_us: row.f64_optional(combine_notify_us_col)?.unwrap_or(0.0),
@@ -1288,13 +1379,19 @@ fn load_deepep_normal_parquet(sources: &[PerfSource]) -> Result<NormalDispatchGr
         return Err(AicError::PerfDatabase(format!(
             "no DeepEP-normal rows loaded from {} source(s) (first: {})",
             sources.len(),
-            sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
+            sources
+                .first()
+                .map(|s| s.path().display().to_string())
+                .unwrap_or_default()
         )));
     }
     Ok(NormalDispatchGrids {
         by_keys: by_keys
             .into_iter()
-            .map(|(key, by_sms)| (key, NormalDispatchSlice::new(by_sms)))
+            .map(|(key, by_sms)| {
+                let slice = NormalDispatchSlice::new(key.node_num, by_sms);
+                (key, slice)
+            })
             .collect(),
     })
 }
@@ -1334,23 +1431,28 @@ fn load_deepep_ll_parquet(sources: &[PerfSource]) -> Result<DispatchGrids, AicEr
                 num_experts: row.u32(num_experts_col)?,
             };
             // First-wins on the full coordinate (Python skip-on-conflict).
-            by_keys.entry(key).or_default().entry(row.u32(num_token_col)?).or_insert(
-                DispatchPoint {
+            by_keys
+                .entry(key)
+                .or_default()
+                .entry(row.u32(num_token_col)?)
+                .or_insert(DispatchPoint {
                     dispatch_transmit_us: 0.0,
                     dispatch_notify_us: 0.0,
                     combine_transmit_us: 0.0,
                     combine_notify_us: 0.0,
                     combine_avg_t_us: row.f64_optional(combine_avg_t_us_col)?.unwrap_or(0.0),
                     dispatch_avg_t_us: row.f64_optional(dispatch_avg_t_us_col)?.unwrap_or(0.0),
-                },
-            );
+                });
         }
     }
     if !any_source || by_keys.is_empty() {
         return Err(AicError::PerfDatabase(format!(
             "no DeepEP-LL rows loaded from {} source(s) (first: {})",
             sources.len(),
-            sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
+            sources
+                .first()
+                .map(|s| s.path().display().to_string())
+                .unwrap_or_default()
         )));
     }
     Ok(DispatchGrids {
@@ -1447,27 +1549,31 @@ mod tests {
                 .expect("writer");
         let mut rg = writer.next_row_group().expect("row group");
         let int_cols: [Vec<i64>; 6] = [
-            rows.iter().map(|r| r.0).collect(),                // node_num
-            rows.iter().map(|_| 7168).collect(),               // hidden_size
-            rows.iter().map(|r| r.2).collect(),                // num_token
-            rows.iter().map(|_| 8).collect(),                  // num_topk
-            rows.iter().map(|_| 256).collect(),                // num_experts
-            rows.iter().map(|r| r.1).collect(),                // dispatch_sms
+            rows.iter().map(|r| r.0).collect(),  // node_num
+            rows.iter().map(|_| 7168).collect(), // hidden_size
+            rows.iter().map(|r| r.2).collect(),  // num_token
+            rows.iter().map(|_| 8).collect(),    // num_topk
+            rows.iter().map(|_| 256).collect(),  // num_experts
+            rows.iter().map(|r| r.1).collect(),  // dispatch_sms
         ];
         for values in &int_cols {
             let mut col = rg.next_column().expect("next col").expect("int col");
-            col.typed::<Int64Type>().write_batch(values, None, None).expect("write ints");
+            col.typed::<Int64Type>()
+                .write_batch(values, None, None)
+                .expect("write ints");
             col.close().expect("close col");
         }
         let f64_cols: [Vec<f64>; 4] = [
-            rows.iter().map(|r| r.3).collect(),                // dispatch_transmit_us
-            rows.iter().map(|_| 1.0).collect(),                // dispatch_notify_us
-            rows.iter().map(|_| 2.0).collect(),                // combine_transmit_us
-            rows.iter().map(|_| 0.0).collect(),                // combine_notify_us (zero-boundary)
+            rows.iter().map(|r| r.3).collect(), // dispatch_transmit_us
+            rows.iter().map(|_| 1.0).collect(), // dispatch_notify_us
+            rows.iter().map(|_| 2.0).collect(), // combine_transmit_us
+            rows.iter().map(|_| 0.0).collect(), // combine_notify_us (zero-boundary)
         ];
         for values in &f64_cols {
             let mut col = rg.next_column().expect("next col").expect("f64 col");
-            col.typed::<DoubleType>().write_batch(values, None, None).expect("write f64");
+            col.typed::<DoubleType>()
+                .write_batch(values, None, None)
+                .expect("write f64");
             col.close().expect("close col");
         }
         rg.close().expect("close row group");
@@ -1512,6 +1618,15 @@ mod tests {
         // combine_notify_us is measured-zero in this fixture: snap/hold paths
         // must yield 0, not a "no positive-util anchor" miss.
         assert_eq!(q(12).combine_notify_us, 0.0);
+        let key = DispatchKey {
+            node_num: 2,
+            hidden_size: 7168,
+            num_topk: 8,
+            num_experts: 256,
+        };
+        assert!(table.load_deepep_normal().unwrap().by_keys[&key]
+            .direct_fields
+            .is_none());
     }
 
     /// Item 3 (token axis under the sms grid): beyond-range tokens util-hold
@@ -1559,6 +1674,21 @@ mod tests {
             .query_deepep_normal(1, 7168, 96, 8, 256, 20)
             .expect("query must succeed");
         assert!((lerp.dispatch_transmit_us - 150.0).abs() < 1e-9);
+        let key = DispatchKey {
+            node_num: 1,
+            hidden_size: 7168,
+            num_topk: 8,
+            num_experts: 256,
+        };
+        assert!(table.load_deepep_normal().unwrap().by_keys[&key]
+            .direct_fields
+            .is_some());
+    }
+
+    #[test]
+    #[should_panic(expected = "dispatch curves must carry at least one token point")]
+    fn dispatch_points_reject_empty_curves() {
+        DispatchPoints::new(BTreeMap::new());
     }
 
     /// Duplicate coordinates (same sms + token) resolve FIRST-wins, mirroring
@@ -1596,12 +1726,31 @@ mod tests {
     fn alltoall_kernel_selection_matches_python() {
         let spec = gb200_spec();
         assert_eq!(select_alltoall_kernel(&spec, 4, 8, None), "NVLinkOneSided");
-        assert_eq!(select_alltoall_kernel(&spec, 4, 8, Some("WIDEEP")), "NVLinkTwoSided");
-        assert_eq!(select_alltoall_kernel(&spec, 4, 8, Some("DeepGemm")), "NotEnabled");
-        assert_eq!(select_alltoall_kernel(&spec, 4, 8, Some("cute_dsl")), "NotEnabled");
+        assert_eq!(
+            select_alltoall_kernel(&spec, 4, 8, Some("WIDEEP")),
+            "NVLinkTwoSided"
+        );
+        assert_eq!(
+            select_alltoall_kernel(&spec, 4, 8, Some("DeepGemm")),
+            "NotEnabled"
+        );
+        assert_eq!(
+            select_alltoall_kernel(&spec, 4, 8, Some("cute_dsl")),
+            "NotEnabled"
+        );
         let table = gb200_trtllm_table();
         let zero = table
-            .query_trtllm_alltoall(&spec, "alltoall_dispatch", 1, 7168, 8, 256, 4, MoeQuantMode::Fp8, Some("DEEPGEMM"))
+            .query_trtllm_alltoall(
+                &spec,
+                "alltoall_dispatch",
+                1,
+                7168,
+                8,
+                256,
+                4,
+                MoeQuantMode::Fp8,
+                Some("DEEPGEMM"),
+            )
             .expect("NotEnabled short-circuits");
         assert_eq!(zero, 0.0);
     }
@@ -1616,24 +1765,73 @@ mod tests {
         let table = gb200_trtllm_table();
         // WideEP -> NVLinkTwoSided; fp8 dispatch row (ep=4 -> node_num=1).
         let dispatch = table
-            .query_trtllm_alltoall(&spec, "alltoall_dispatch", 1, 7168, 8, 256, 4, MoeQuantMode::Fp8, Some("WIDEEP"))
+            .query_trtllm_alltoall(
+                &spec,
+                "alltoall_dispatch",
+                1,
+                7168,
+                8,
+                256,
+                4,
+                MoeQuantMode::Fp8,
+                Some("WIDEEP"),
+            )
             .expect("dispatch row");
-        assert!((dispatch - 0.011_372_800_171_375_274).abs() < 1e-12, "got {dispatch}");
+        assert!(
+            (dispatch - 0.011_372_800_171_375_274).abs() < 1e-12,
+            "got {dispatch}"
+        );
         // Same slice, combine phase: distinct value proves op_name keys the table.
         let combine = table
-            .query_trtllm_alltoall(&spec, "alltoall_combine", 1, 7168, 8, 256, 4, MoeQuantMode::Fp8, Some("WIDEEP"))
+            .query_trtllm_alltoall(
+                &spec,
+                "alltoall_combine",
+                1,
+                7168,
+                8,
+                256,
+                4,
+                MoeQuantMode::Fp8,
+                Some("WIDEEP"),
+            )
             .expect("combine row");
-        assert!((combine - 0.012_921_600_043_773_651).abs() < 1e-12, "got {combine}");
+        assert!(
+            (combine - 0.012_921_600_043_773_651).abs() < 1e-12,
+            "got {combine}"
+        );
         // fp8_block reuses the fp8 tables (Python `_normalize_quant_mode_for_table`).
         let block = table
-            .query_trtllm_alltoall(&spec, "alltoall_dispatch", 1, 7168, 8, 256, 4, MoeQuantMode::Fp8Block, Some("WIDEEP"))
+            .query_trtllm_alltoall(
+                &spec,
+                "alltoall_dispatch",
+                1,
+                7168,
+                8,
+                256,
+                4,
+                MoeQuantMode::Fp8Block,
+                Some("WIDEEP"),
+            )
             .expect("fp8_block reroutes to fp8");
         assert_eq!(block, dispatch);
         // Non-WideEP -> NVLinkOneSided (nvfp4-only slice, ep=2 -> node_num=1).
         let one_sided = table
-            .query_trtllm_alltoall(&spec, "alltoall_dispatch", 1, 7168, 8, 256, 2, MoeQuantMode::Nvfp4, None)
+            .query_trtllm_alltoall(
+                &spec,
+                "alltoall_dispatch",
+                1,
+                7168,
+                8,
+                256,
+                2,
+                MoeQuantMode::Nvfp4,
+                None,
+            )
             .expect("one-sided row");
-        assert!((one_sided - 0.012_895_999_848_842_621).abs() < 1e-12, "got {one_sided}");
+        assert!(
+            (one_sided - 0.012_895_999_848_842_621).abs() < 1e-12,
+            "got {one_sided}"
+        );
     }
 
     #[test]

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/wideep_moe.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/wideep_moe.rs
@@ -34,7 +34,7 @@ use crate::common::enums::MoeQuantMode;
 use crate::common::error::AicError;
 use crate::config::{PerfDbSources, PerfSource};
 use super::{kernel_source_ok, resolve_op_sources};
-use super::moe::query_token_curve;
+use super::token_curve::TokenCurve;
 use crate::perf_database::parquet_loader::PerfReader;
 
 pub struct WideEpMoeTable {
@@ -49,13 +49,13 @@ pub struct WideEpMoeTable {
 /// `(kernel_source, quant, distribution, topk, num_experts, hidden, inter,
 ///   num_slots, moe_tp, moe_ep)` -> `num_tokens -> latency`.
 pub struct WideEpMoeGrids {
-    pub by_keys: BTreeMap<WideEpMoeKey, BTreeMap<u32, f64>>,
+    by_keys: BTreeMap<WideEpMoeKey, TokenCurve>,
     /// First-seen (file row order) distribution per `(kernel_source, quant)`.
     /// Python's fallback takes `list(quant_data.keys())[0]` — dict INSERTION
     /// order, i.e. the distribution of the first row loaded for that
     /// `(kernel, quant)` — which differs from sorted order on real shards
     /// (e.g. gb200/h100 wideep files start with `power_law_1.01_eplb`).
-    pub first_distribution: BTreeMap<(String, String), String>,
+    first_distribution: BTreeMap<(String, String), String>,
     index: WideEpMoeIndex,
 }
 
@@ -160,7 +160,7 @@ impl WideEpMoeTable {
             moe_tp_size,
             moe_ep_size,
         )?;
-        query_token_curve(by_tokens, num_tokens as f64, sol)
+        by_tokens.query(num_tokens as f64, sol)
     }
 
     /// Own-slice `num_tokens -> latency_ms` points, after the level-wise
@@ -194,7 +194,7 @@ impl WideEpMoeTable {
             moe_tp_size,
             moe_ep_size,
         )?;
-        Ok(by_tokens.iter().map(|(&t, &lat)| (t, lat)).collect())
+        Ok(by_tokens.iter().collect())
     }
 
     /// Distinct kernel names present in the loaded table, in sorted
@@ -238,7 +238,7 @@ impl WideEpMoeTable {
         num_slots: u32,
         moe_tp_size: u32,
         moe_ep_size: u32,
-    ) -> Result<&BTreeMap<u32, f64>, AicError> {
+    ) -> Result<&TokenCurve, AicError> {
         let grids = self.load_compute()?;
         let Some(by_quant) = grids.index.get(kernel_source) else {
             return Err(AicError::PerfDatabase(format!(
@@ -390,6 +390,10 @@ fn load_compute_parquet(sources: &[PerfSource]) -> Result<WideEpMoeGrids, AicErr
             sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
         )));
     }
+    let by_keys: BTreeMap<_, _> = by_keys
+        .into_iter()
+        .map(|(key, curve)| (key, TokenCurve::from_map(curve)))
+        .collect();
     let index = build_wideep_moe_index(&by_keys, &first_distribution);
     Ok(WideEpMoeGrids {
         by_keys,
@@ -399,7 +403,7 @@ fn load_compute_parquet(sources: &[PerfSource]) -> Result<WideEpMoeGrids, AicErr
 }
 
 fn build_wideep_moe_index(
-    by_keys: &BTreeMap<WideEpMoeKey, BTreeMap<u32, f64>>,
+    by_keys: &BTreeMap<WideEpMoeKey, TokenCurve>,
     first_distribution: &BTreeMap<(String, String), String>,
 ) -> WideEpMoeIndex {
     let mut index = WideEpMoeIndex::new();

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/wideep_moe.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/wideep_moe.rs
@@ -30,11 +30,12 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
+use super::moe_index::MoeIndex;
+use super::token_curve::TokenCurve;
+use super::{kernel_source_ok, resolve_op_sources};
 use crate::common::enums::MoeQuantMode;
 use crate::common::error::AicError;
 use crate::config::{PerfDbSources, PerfSource};
-use super::{kernel_source_ok, resolve_op_sources};
-use super::token_curve::TokenCurve;
 use crate::perf_database::parquet_loader::PerfReader;
 
 pub struct WideEpMoeTable {
@@ -46,39 +47,22 @@ pub struct WideEpMoeTable {
     compute: OnceLock<Result<WideEpMoeGrids, AicError>>,
 }
 
-/// `(kernel_source, quant, distribution, topk, num_experts, hidden, inter,
-///   num_slots, moe_tp, moe_ep)` -> `num_tokens -> latency`.
-pub struct WideEpMoeGrids {
-    by_keys: BTreeMap<WideEpMoeKey, TokenCurve>,
-    /// First-seen (file row order) distribution per `(kernel_source, quant)`.
-    /// Python's fallback takes `list(quant_data.keys())[0]` — dict INSERTION
-    /// order, i.e. the distribution of the first row loaded for that
-    /// `(kernel, quant)` — which differs from sorted order on real shards
-    /// (e.g. gb200/h100 wideep files start with `power_law_1.01_eplb`).
-    first_distribution: BTreeMap<(String, String), String>,
-    index: WideEpMoeIndex,
-}
-
-type WideEpMoeIndex = BTreeMap<String, BTreeMap<String, WideEpMoeQuantIndex>>;
-
-#[derive(Default)]
-struct WideEpMoeQuantIndex {
-    first_distribution: String,
-    by_distribution: BTreeMap<String, BTreeMap<WideEpMoeShapeKey, WideEpMoeKey>>,
+struct WideEpMoeGrids {
+    index: BTreeMap<String, MoeIndex<WideEpMoeShapeKey, TokenCurve>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub struct WideEpMoeKey {
-    pub kernel_source: String,
-    pub quant: String,
-    pub distribution: String,
-    pub topk: u32,
-    pub num_experts: u32,
-    pub hidden_size: u32,
-    pub inter_size: u32,
-    pub num_slots: u32,
-    pub moe_tp_size: u32,
-    pub moe_ep_size: u32,
+struct WideEpMoeKey {
+    kernel_source: String,
+    quant: String,
+    distribution: String,
+    topk: u32,
+    num_experts: u32,
+    hidden_size: u32,
+    inter_size: u32,
+    num_slots: u32,
+    moe_tp_size: u32,
+    moe_ep_size: u32,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -222,7 +206,7 @@ impl WideEpMoeTable {
     /// under (kernel, quant)`) -> exact remaining coordinate. Each level
     /// misses with a typed `AicError::PerfDatabase`. The Python fallback
     /// takes the FIRST distribution in dict-insertion (file row) order —
-    /// served here from the load-time `first_distribution` map — and then
+    /// served here from the load-time quant index — and then
     /// requires the full shape under it (a shape present only under a later
     /// distribution still misses).
     #[allow(clippy::too_many_arguments)]
@@ -246,25 +230,12 @@ impl WideEpMoeTable {
                 self.data_root.display()
             )));
         };
-        let Some(index) = by_quant.get(quant_name) else {
+        let Some(index) = by_quant.quant(quant_name) else {
             return Err(AicError::PerfDatabase(format!(
                 "WideEP MoE compute data missing for kernel_source={kernel_source:?} \
                  quant={quant_name:?} at {}",
-                 self.data_root.display()
+                self.data_root.display()
             )));
-        };
-        debug_assert_eq!(
-            grids
-                .first_distribution
-                .iter()
-                .find(|((kernel, quant), _)| kernel == kernel_source && quant == quant_name)
-                .map(|(_, distribution)| distribution.as_str()),
-            Some(index.first_distribution.as_str())
-        );
-        let dist = if index.by_distribution.contains_key(distribution) {
-            distribution
-        } else {
-            index.first_distribution.as_str()
         };
         let shape = WideEpMoeShapeKey {
             topk,
@@ -275,30 +246,25 @@ impl WideEpMoeTable {
             moe_tp_size,
             moe_ep_size,
         };
-        let key = index
-            .by_distribution
-            .get(dist)
-            .and_then(|by_shape| by_shape.get(&shape));
-        key.and_then(|key| grids.by_keys.get(key))
-            .filter(|curve| !curve.is_empty())
-            .ok_or_else(|| {
-                let key = WideEpMoeKey {
-                    kernel_source: kernel_source.to_string(),
-                    quant: quant_name.to_string(),
-                    distribution: dist.to_string(),
-                    topk,
-                    num_experts,
-                    hidden_size,
-                    inter_size,
-                    num_slots,
-                    moe_tp_size,
-                    moe_ep_size,
-                };
-                AicError::PerfDatabase(format!(
-                    "WideEP MoE compute data missing for {key:?} at {}",
-                    self.data_root.display()
-                ))
-            })
+        let (dist, curve) = index.resolve_first(distribution, &shape);
+        curve.filter(|curve| !curve.is_empty()).ok_or_else(|| {
+            let key = WideEpMoeKey {
+                kernel_source: kernel_source.to_string(),
+                quant: quant_name.to_string(),
+                distribution: dist.to_string(),
+                topk,
+                num_experts,
+                hidden_size,
+                inter_size,
+                num_slots,
+                moe_tp_size,
+                moe_ep_size,
+            };
+            AicError::PerfDatabase(format!(
+                "WideEP MoE compute data missing for {key:?} at {}",
+                self.data_root.display()
+            ))
+        })
     }
 
     fn load_compute(&self) -> Result<&WideEpMoeGrids, AicError> {
@@ -315,8 +281,8 @@ impl WideEpMoeTable {
 /// need not exist for every system); an error is returned only when no source
 /// yields rows.
 fn load_compute_parquet(sources: &[PerfSource]) -> Result<WideEpMoeGrids, AicError> {
-    let mut by_keys: BTreeMap<WideEpMoeKey, BTreeMap<u32, f64>> = BTreeMap::new();
-    let mut first_distribution: BTreeMap<(String, String), String> = BTreeMap::new();
+    let mut index: BTreeMap<String, MoeIndex<WideEpMoeShapeKey, BTreeMap<u32, f64>>> =
+        BTreeMap::new();
     let mut any_source = false;
     for source in sources {
         let path = source.path();
@@ -349,10 +315,9 @@ fn load_compute_parquet(sources: &[PerfSource]) -> Result<WideEpMoeGrids, AicErr
                 .str_optional(kernel_source_col)?
                 .map(|s| s.to_string())
                 .unwrap_or_else(|| DEFAULT_KERNEL_SOURCE.to_string());
-            let key = WideEpMoeKey {
-                kernel_source,
-                quant: row.str_owned(moe_dtype_col)?,
-                distribution: row.str_owned(distribution_col)?,
+            let quant = row.str_owned(moe_dtype_col)?;
+            let distribution = row.str_owned(distribution_col)?;
+            let shape = WideEpMoeShapeKey {
                 topk: row.u32(topk_col)?,
                 num_experts: row.u32(num_experts_col)?,
                 hidden_size: row.u32(hidden_size_col)?,
@@ -361,80 +326,33 @@ fn load_compute_parquet(sources: &[PerfSource]) -> Result<WideEpMoeGrids, AicErr
                 moe_tp_size: row.u32(moe_tp_size_col)?,
                 moe_ep_size: row.u32(moe_ep_size_col)?,
             };
-            // First-seen (file order) distribution per (kernel, quant) — the
-            // distribution-fallback anchor (Python dict insertion order).
-            first_distribution
-                .entry((key.kernel_source.clone(), key.quant.clone()))
-                .or_insert_with(|| key.distribution.clone());
-            // Last-wins parity with Python `load_wideep_moe_compute_data`
-            // (moe.py): it direct-assigns per coordinate with no
-            // `try/except KeyError` guard, so a later row overwrites an
-            // earlier one — both within a file and across the concatenated
-            // shared-layer sources (`_read_filtered_rows` appends in source
-            // order and the loader assigns in row order). Real shards carry
-            // duplicate keys with differing latencies (e.g. 270 keys in
-            // rtx_pro_6000_server/trtllm/1.3.0rc10), so first-wins here was a
-            // live numeric divergence, same class as the MLA-module fix in
-            // `mla.rs::load_module_parquet`.
-            by_keys
-                .entry(key)
+            // The quant index captures the first-seen distribution as its
+            // fallback anchor. Leaf insertion remains first-wins, matching
+            // Python's skip-on-key-conflict shared-layer contract.
+            index
+                .entry(kernel_source)
                 .or_default()
+                .entry(quant, distribution, shape)
                 .entry(row.u32(num_tokens_col)?)
                 .or_insert(row.f64(latency_col)?);
         }
     }
-    if !any_source || by_keys.is_empty() {
+    if !any_source || index.is_empty() {
         return Err(AicError::PerfDatabase(format!(
             "no WideEP MoE compute rows loaded from {} source(s) (first: {})",
             sources.len(),
-            sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
+            sources
+                .first()
+                .map(|s| s.path().display().to_string())
+                .unwrap_or_default()
         )));
     }
-    let by_keys: BTreeMap<_, _> = by_keys
-        .into_iter()
-        .map(|(key, curve)| (key, TokenCurve::from_map(curve)))
-        .collect();
-    let index = build_wideep_moe_index(&by_keys, &first_distribution);
     Ok(WideEpMoeGrids {
-        by_keys,
-        first_distribution,
-        index,
+        index: index
+            .into_iter()
+            .map(|(kernel, index)| (kernel, index.map_values(TokenCurve::from_map)))
+            .collect(),
     })
-}
-
-fn build_wideep_moe_index(
-    by_keys: &BTreeMap<WideEpMoeKey, TokenCurve>,
-    first_distribution: &BTreeMap<(String, String), String>,
-) -> WideEpMoeIndex {
-    let mut index = WideEpMoeIndex::new();
-    for key in by_keys.keys() {
-        let quant_index = index
-            .entry(key.kernel_source.clone())
-            .or_default()
-            .entry(key.quant.clone())
-            .or_default();
-        if quant_index.first_distribution.is_empty() {
-            quant_index.first_distribution = first_distribution
-                .get(&(key.kernel_source.clone(), key.quant.clone()))
-                .expect("loaded key must have a first distribution")
-                .clone();
-        }
-        let shape = WideEpMoeShapeKey {
-            topk: key.topk,
-            num_experts: key.num_experts,
-            hidden_size: key.hidden_size,
-            inter_size: key.inter_size,
-            num_slots: key.num_slots,
-            moe_tp_size: key.moe_tp_size,
-            moe_ep_size: key.moe_ep_size,
-        };
-        quant_index
-            .by_distribution
-            .entry(key.distribution.clone())
-            .or_default()
-            .insert(shape, key.clone());
-    }
-    index
 }
 
 fn clone_err(err: &AicError) -> AicError {

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/wideep_moe.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/wideep_moe.rs
@@ -56,6 +56,15 @@ pub struct WideEpMoeGrids {
     /// `(kernel, quant)` — which differs from sorted order on real shards
     /// (e.g. gb200/h100 wideep files start with `power_law_1.01_eplb`).
     pub first_distribution: BTreeMap<(String, String), String>,
+    index: WideEpMoeIndex,
+}
+
+type WideEpMoeIndex = BTreeMap<String, BTreeMap<String, WideEpMoeQuantIndex>>;
+
+#[derive(Default)]
+struct WideEpMoeQuantIndex {
+    first_distribution: String,
+    by_distribution: BTreeMap<String, BTreeMap<WideEpMoeShapeKey, WideEpMoeKey>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -70,6 +79,17 @@ pub struct WideEpMoeKey {
     pub num_slots: u32,
     pub moe_tp_size: u32,
     pub moe_ep_size: u32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct WideEpMoeShapeKey {
+    topk: u32,
+    num_experts: u32,
+    hidden_size: u32,
+    inter_size: u32,
+    num_slots: u32,
+    moe_tp_size: u32,
+    moe_ep_size: u32,
 }
 
 /// `kernel_source` defaults to `"moe_torch_flow"` when null, matching Python's
@@ -192,13 +212,7 @@ impl WideEpMoeTable {
             Err(err) => return Err(err),
         };
         let mut names: Vec<String> = Vec::new();
-        for key in grids.by_keys.keys() {
-            // `WideEpMoeKey` sorts by kernel_source first, so consecutive
-            // dedup suffices.
-            if names.last().map(String::as_str) != Some(key.kernel_source.as_str()) {
-                names.push(key.kernel_source.clone());
-            }
-        }
+        names.extend(grids.index.keys().cloned());
         Ok(names)
     }
 
@@ -226,48 +240,33 @@ impl WideEpMoeTable {
         moe_ep_size: u32,
     ) -> Result<&BTreeMap<u32, f64>, AicError> {
         let grids = self.load_compute()?;
-        let mut kernel_seen = false;
-        let mut quant_seen = false;
-        let mut requested_distribution_seen = false;
-        for key in grids.by_keys.keys() {
-            if key.kernel_source != kernel_source {
-                continue;
-            }
-            kernel_seen = true;
-            if key.quant != quant_name {
-                continue;
-            }
-            quant_seen = true;
-            if key.distribution == distribution {
-                requested_distribution_seen = true;
-                break;
-            }
-        }
-        if !kernel_seen {
+        let Some(by_quant) = grids.index.get(kernel_source) else {
             return Err(AicError::PerfDatabase(format!(
                 "WideEP MoE compute data missing for kernel_source={kernel_source:?} at {}",
                 self.data_root.display()
             )));
-        }
-        if !quant_seen {
+        };
+        let Some(index) = by_quant.get(quant_name) else {
             return Err(AicError::PerfDatabase(format!(
                 "WideEP MoE compute data missing for kernel_source={kernel_source:?} \
                  quant={quant_name:?} at {}",
-                self.data_root.display()
+                 self.data_root.display()
             )));
-        }
-        let dist = if requested_distribution_seen {
-            distribution
-        } else {
+        };
+        debug_assert_eq!(
             grids
                 .first_distribution
-                .get(&(kernel_source.to_string(), quant_name.to_string()))
-                .expect("quant_seen implies a recorded first distribution")
+                .iter()
+                .find(|((kernel, quant), _)| kernel == kernel_source && quant == quant_name)
+                .map(|(_, distribution)| distribution.as_str()),
+            Some(index.first_distribution.as_str())
+        );
+        let dist = if index.by_distribution.contains_key(distribution) {
+            distribution
+        } else {
+            index.first_distribution.as_str()
         };
-        let key = WideEpMoeKey {
-            kernel_source: kernel_source.to_string(),
-            quant: quant_name.to_string(),
-            distribution: dist.to_string(),
+        let shape = WideEpMoeShapeKey {
             topk,
             num_experts,
             hidden_size,
@@ -276,11 +275,25 @@ impl WideEpMoeTable {
             moe_tp_size,
             moe_ep_size,
         };
-        grids
-            .by_keys
-            .get(&key)
+        let key = index
+            .by_distribution
+            .get(dist)
+            .and_then(|by_shape| by_shape.get(&shape));
+        key.and_then(|key| grids.by_keys.get(key))
             .filter(|curve| !curve.is_empty())
             .ok_or_else(|| {
+                let key = WideEpMoeKey {
+                    kernel_source: kernel_source.to_string(),
+                    quant: quant_name.to_string(),
+                    distribution: dist.to_string(),
+                    topk,
+                    num_experts,
+                    hidden_size,
+                    inter_size,
+                    num_slots,
+                    moe_tp_size,
+                    moe_ep_size,
+                };
                 AicError::PerfDatabase(format!(
                     "WideEP MoE compute data missing for {key:?} at {}",
                     self.data_root.display()
@@ -377,7 +390,47 @@ fn load_compute_parquet(sources: &[PerfSource]) -> Result<WideEpMoeGrids, AicErr
             sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
         )));
     }
-    Ok(WideEpMoeGrids { by_keys, first_distribution })
+    let index = build_wideep_moe_index(&by_keys, &first_distribution);
+    Ok(WideEpMoeGrids {
+        by_keys,
+        first_distribution,
+        index,
+    })
+}
+
+fn build_wideep_moe_index(
+    by_keys: &BTreeMap<WideEpMoeKey, BTreeMap<u32, f64>>,
+    first_distribution: &BTreeMap<(String, String), String>,
+) -> WideEpMoeIndex {
+    let mut index = WideEpMoeIndex::new();
+    for key in by_keys.keys() {
+        let quant_index = index
+            .entry(key.kernel_source.clone())
+            .or_default()
+            .entry(key.quant.clone())
+            .or_default();
+        if quant_index.first_distribution.is_empty() {
+            quant_index.first_distribution = first_distribution
+                .get(&(key.kernel_source.clone(), key.quant.clone()))
+                .expect("loaded key must have a first distribution")
+                .clone();
+        }
+        let shape = WideEpMoeShapeKey {
+            topk: key.topk,
+            num_experts: key.num_experts,
+            hidden_size: key.hidden_size,
+            inter_size: key.inter_size,
+            num_slots: key.num_slots,
+            moe_tp_size: key.moe_tp_size,
+            moe_ep_size: key.moe_ep_size,
+        };
+        quant_index
+            .by_distribution
+            .entry(key.distribution.clone())
+            .or_default()
+            .insert(shape, key.clone());
+    }
+    index
 }
 
 fn clone_err(err: &AicError) -> AicError {
@@ -424,6 +477,23 @@ mod tests {
             (latency - 0.086_009_597_778_320_32).abs() < 1e-6,
             "expected recorded latency, got {latency}"
         );
+        let fallback = table
+            .query_compute(
+                1,
+                6144,
+                2048,
+                8,
+                256,
+                256,
+                1,
+                2,
+                MoeQuantMode::Nvfp4,
+                "not_collected",
+                "wideep_compute_cutlass",
+                &|t| t,
+            )
+            .expect("unknown distribution must use the first collected distribution");
+        assert_eq!(fallback, latency);
         assert_eq!(
             table.available_kernels().expect("kernels list"),
             vec!["wideep_compute_cutlass".to_string()]


### PR DESCRIPTION
## Summary

- build hierarchical categorical/numeric indices when MoE perf tables load, replacing per-query full-table scans and query-string construction
- store MoE token-latency data as immutable sorted curves, replacing per-query generic interpolation-tree construction
- convert ordinary and low-latency MoE, SGLang DeepEP/WideEP, TRT-LLM WideEP, MegaMoE, projected dispatch, and mHC callers without adding a compatibility path or changing public APIs
- share one direct curve-owning MoE index across ordinary, SGLang WideEP, and TRT-LLM WideEP paths, and retain raw DeepEP-normal dispatch points instead of multiplying them into six curves per SMS bucket

## Details

The lookup index preserves existing distribution precedence and fallback rules, duplicate handling, quantization selection, and error behavior. Successful queries borrow their loaded key directly; detailed key construction is retained only on error paths.

`TokenCurve` performs exact lookup, adjacent-point interpolation, and boundary util-hold directly over one load-time sorted boxed slice. Generic multidimensional interpolation remains available for unrelated operators.

## Validation

Correctness:

- `cargo test -p aiconfigurator-core --lib`: 309 passed
- `cargo test -p aiconfigurator-core --all-features --lib`: 316 passed
- `cargo check -p aiconfigurator-core-public-api`
- relevant non-Torch Python MoE, WideEP, shared-layer, compile-engine, and engine-step tests: 108 passed
- rebuilt-extension compile-engine and engine-step parity corpus: 376 passed
- `test_moe_dispatch.py` could not be collected because the local development environment does not include its optional Torch dependency; the corresponding Rust dispatch tests passed
- `git diff --check`
- final-tree Clippy has 64 existing warnings versus 65 at the pre-fix head; the `token_curve.rs` warning is gone and the review fix adds no new warning
- targeted `rustfmt --check` over the Rust files changed by this PR

Focused tests cover indexed selection/fallback/duplicates plus exact, interpolated, singleton, and held-boundary curves across ordinary and low-latency MoE, SGLang DeepEP/WideEP, TRT-LLM WideEP, MegaMoE, dispatch projections, and mHC.

Performance (uncommitted harness, internal sampling only):

| Group | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| 4,096-shape distribution lookup | 16,719 ns | 14 ns | 1,194.21x |
| Combined 12-curve MoE corpus | 1,160 ns | 54 ns | 21.48x / 95.34% lower |

| Engine-step case | Before | After | Result |
| --- | ---: | ---: | ---: |
| SILICON, Kimi K2.5 vLLM | 88.920 us | 60.903 us | 31.51% faster |
| EMPIRICAL, Kimi K2.5 vLLM | 32,496.620 us | 31,924.127 us | 1.76% faster |
| HYBRID miss, Astra DeepSeek V4 Flash SGLang | 122.885 us | 46.002 us | 62.56% faster |

All 12 prediction values in every engine-step case were exactly equal between revisions.

The review-fix lookup point is 14 ns versus 196 ns at the pre-fix head, and the combined curve point is 54 ns versus 73 ns, so the follow-up introduces no material lookup regression.

A final 59.998-second, 12-worker steady-state Astra profile captured 5,870 samples with no loss. The former `MoeTable::resolve_distribution` hotspot (23.87% self) and old `query_token_curve` helper have no samples; the new `TokenCurve::query` is 0.41% self. Remaining generic `perf_interp::Node` construction is under unrelated collective-message interpolation, not any converted MoE token-curve path.

The optimized one-hour Astra input completes before a 60-second attachment can finish, so this structural confirmation used an uncommitted deterministic 2x extension of the same trace with shifted timestamps and hash remapping that preserves within-copy prefix relationships without cross-copy reuse. The older profile and candidate use different coherent AIC wire-schema revisions and are therefore used for structural hotspot confirmation, not as a direct end-to-end throughput comparison.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved performance-data lookup and interpolation across MoE, mHC, WideEP, and DeepEP configurations.
  * Added more consistent token-based performance estimates between measured points and beyond measured ranges.
  * Improved resolution when requested distribution data is unavailable through appropriate fallback behavior.
* **Reliability**
  * Preserved existing validation, error handling, kernel selection, and boundary behavior.
  * Added coverage for interpolation, fallback resolution, duplicate data, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->