### PR TITLE
docs: clarify platform wheel installation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,19 @@ Let's get started.
 
 ### Install from PyPI
 
-> **Published-wheel support: Linux x86-64 only.** The required
-> `aiconfigurator-core` wheel bundles a native Rust/PyO3 extension and is built
-> as a `manylinux_2_28_x86_64` wheel (Linux x86-64, glibc >= 2.28). Linux
-> aarch64 has no published core wheel and must build `./aic-core` and the root
-> project from source; that path is not covered by published-wheel support.
-> macOS and Windows have no supported installation path.
+> **Public PyPI support: Linux x86-64 only.** The required
+> `aiconfigurator-core` wheel bundles a native Rust/PyO3 extension and is
+> published to PyPI as a `manylinux_2_28_x86_64` wheel (Linux x86-64,
+> glibc >= 2.28).
+>
+> **Release wheel coverage:** The
+> [platform-wheel workflow](.github/workflows/build-platform-wheels.yml) also
+> builds, installs, and verifies `manylinux_2_28_aarch64` and
+> `macosx_11_0_arm64` core wheels. Release-branch runs stage the complete wheel
+> set to Artifactory when platform-wheel staging is enabled. These Artifactory
+> artifacts are separate from public PyPI: Linux aarch64 and macOS arm64 users
+> with access to the release artifacts can install the matching wheel set.
+> Windows has no supported installation path.
 
 ```bash
 pip3 install aiconfigurator


### PR DESCRIPTION
## Summary

- distinguish public PyPI support from the release Artifactory wheel matrix
- document the validated Linux aarch64 and macOS arm64 core-wheel tags
- retain the unsupported Windows limitation

## Root cause

The README treated the public PyPI wheel set as if it were the entire release platform matrix. The release workflow also builds, installs, verifies, and stages Linux aarch64 and macOS arm64 core wheels to Artifactory, so the old wording incorrectly told those users that no supported release artifact existed.

## Validation

- `git diff --check`
- verified every platform tag in the README against `.github/workflows/build-platform-wheels.yml`
- confirmed the latest `release/0.11.0` platform-wheel run built and staged all three platform wheel sets and finalized successfully: https://github.com/ai-dynamo/aiconfigurator/actions/runs/30956839894
- documentation-only change; no unit tests run

## Tracking

- NVBugs 6562784
- DYN-957

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified PyPI installation support for Linux x86-64.
  * Documented Linux aarch64 and macOS arm64 wheel availability through platform-specific builds.
  * Added installation guidance for Artifactory-hosted wheels.
  * Confirmed that Windows is not supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->