### PR TITLE
fix(generator): size unsupported architectures in naive mode (cherry-pick #1490)

### DIFF
--- a/aic-core/src/aiconfigurator_core/sdk/memory.py
+++ b/aic-core/src/aiconfigurator_core/sdk/memory.py
@@ -518,6 +518,29 @@ class NaiveKVCacheEstimator:
                 f"insufficient model metadata: no HF config for {model_path!r} (not a local "
                 "directory / not pre-cached, and HF download is disabled)"
             )
+        return cls.from_hf_config(
+            hf_config,
+            tp_size=tp_size,
+            pp_size=pp_size,
+            moe_ep_size=moe_ep_size,
+            moe_tp_size=moe_tp_size,
+        )
+
+    @classmethod
+    def from_hf_config(
+        cls,
+        hf_config: dict,
+        *,
+        tp_size: int,
+        pp_size: int,
+        moe_ep_size: int = 1,
+        moe_tp_size: int = 1,
+    ) -> NaiveKVCacheEstimator:
+        """Build directly from an already-loaded HF ``config.json`` dictionary.
+
+        This is the no-I/O counterpart to :meth:`from_model_path`. Callers that
+        already loaded a config can reuse it without issuing a second HF request.
+        """
         try:
             parsed = _parse_hf_config_json(hf_config)  # supported arch -> normalized parse
         except Exception:

--- a/src/aiconfigurator/generator/naive.py
+++ b/src/aiconfigurator/generator/naive.py
@@ -24,7 +24,11 @@ from typing import Any
 import yaml
 
 from aiconfigurator.sdk import perf_database
-from aiconfigurator.sdk.utils import get_model_config_from_model_path
+from aiconfigurator.sdk.utils import (
+    _load_model_config_from_model_path,
+    _parse_hf_config_json,
+    get_model_config_from_model_path,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -164,7 +168,7 @@ def _get_system_config(system_name: str) -> dict[str, Any]:
     return result
 
 
-def _estimate_model_weight_bytes(model_path: str) -> int:
+def _estimate_model_weight_bytes(model_path: str, *, model_metadata: dict[str, Any] | None = None) -> int:
     """
     Estimate model weight size in bytes based on model config.
 
@@ -178,6 +182,9 @@ def _estimate_model_weight_bytes(model_path: str) -> int:
 
     Args:
         model_path: HuggingFace model path or local path.
+        model_metadata: Optional dictionary populated with the detected
+            ``architecture`` and ``is_moe`` values from the same config used
+            for sizing.
 
     Returns:
         Estimated model weight size in bytes.
@@ -186,10 +193,14 @@ def _estimate_model_weight_bytes(model_path: str) -> int:
         RuntimeError: If the model config cannot be fetched (e.g. model not found
             on HuggingFace). Callers must not proceed with guessed parameters.
     """
-    from aiconfigurator.sdk.utils import get_model_config_from_model_path
+    try:
+        raw_config = _load_model_config_from_model_path(model_path)
+    except Exception as e:
+        logger.exception("Could not estimate model size for %s.", model_path)
+        raise RuntimeError(f"Model {model_path!r} not found or config unavailable") from e
 
     try:
-        config = get_model_config_from_model_path(model_path)
+        config = _parse_hf_config_json(raw_config)
         num_layers = config["layers"]
         hidden_size = config["hidden_size"]
         inter_size = config["inter_size"]
@@ -232,7 +243,60 @@ def _estimate_model_weight_bytes(model_path: str) -> int:
             f"{weight_bytes / (1024**3):.2f} GiB ({total_params / 1e9:.2f}B params)"
         )
 
+        if model_metadata is not None:
+            model_metadata.update(
+                architecture=config.get("architecture", ""),
+                is_moe=bool(num_experts and num_experts > 1),
+            )
+
         return weight_bytes
+
+    except ValueError as e:
+        # The normalized AIC parser rejects architectures that AIC cannot model,
+        # but those are exactly the models that use naive config generation.
+        # Reuse the architecture-agnostic raw-config estimator so sizing remains
+        # available without weakening the native AIC support boundary.
+        from aiconfigurator.sdk.memory import NaiveKVCacheEstimator
+
+        logger.info(
+            "Normalized model parsing failed for %s; using raw config for naive sizing.",
+            model_path,
+        )
+        logger.debug("Normalized parser error for %s: %s", model_path, e)
+        try:
+            estimator = NaiveKVCacheEstimator.from_hf_config(
+                raw_config,
+                tp_size=1,
+                pp_size=1,
+            )
+            weight_bytes = estimator.weight_bytes()
+            if weight_bytes is None:
+                raise ValueError(
+                    "insufficient raw model metadata; expected hidden_size, "
+                    "num_hidden_layers, vocab_size, and intermediate_size"
+                )
+            logger.info(
+                "Estimated model weight size from raw config for %s: %.2f GiB",
+                model_path,
+                weight_bytes / (1024**3),
+            )
+            if model_metadata is not None:
+                architectures = raw_config.get("architectures")
+                architecture = architectures[0] if isinstance(architectures, list) and architectures else ""
+                num_experts = estimator.geometry.get("num_experts") or 0
+                model_metadata.update(
+                    architecture=architecture,
+                    is_moe=bool(num_experts and num_experts > 1),
+                )
+            return weight_bytes
+        except Exception as fallback_error:
+            logger.exception(
+                "Could not estimate model size for %s from raw config.",
+                model_path,
+            )
+            raise RuntimeError(
+                f"Could not estimate model size for {model_path!r}: {fallback_error}"
+            ) from fallback_error
 
     except Exception as e:
         logger.exception("Could not estimate model size for %s.", model_path)
@@ -339,8 +403,10 @@ def build_naive_generator_params(
     gpus_per_node = system_config["gpus_per_node"]
     vram_per_gpu = system_config["vram_per_gpu"]
 
-    # Estimate model weight size
-    model_weight_bytes = _estimate_model_weight_bytes(model_name)
+    # Estimate model weight size and retain architecture metadata from the same
+    # raw config so unsupported models do not require another parse/download.
+    model_metadata: dict[str, Any] = {}
+    model_weight_bytes = _estimate_model_weight_bytes(model_name, model_metadata=model_metadata)
 
     # Calculate minimum GPU count that fits the model
     min_gpus, fits, required_tp = _calculate_min_tp(
@@ -351,18 +417,21 @@ def build_naive_generator_params(
     )
 
     # Detect model architecture for MoE-aware parallelization
-    architecture = ""
-    is_moe = False
-    try:
-        model_config = get_model_config_from_model_path(model_name)
-        architecture = model_config.get("architecture", "")
-        num_experts = model_config.get("num_experts", 0)
-        is_moe = bool(num_experts and num_experts > 1)
-    except Exception:
-        logger.warning(
-            "Could not detect model architecture for %s; assuming dense (TP-only).",
-            model_name,
-        )
+    architecture = str(model_metadata.get("architecture", ""))
+    is_moe = bool(model_metadata.get("is_moe", False))
+    if not model_metadata:
+        # Preserve the test/mocking seam and compatibility for callers that
+        # replace the weight estimator with a plain integer-returning stub.
+        try:
+            model_config = get_model_config_from_model_path(model_name)
+            architecture = model_config.get("architecture", "")
+            num_experts = model_config.get("num_experts", 0)
+            is_moe = bool(num_experts and num_experts > 1)
+        except Exception:
+            logger.warning(
+                "Could not detect model architecture for %s; assuming dense (TP-only).",
+                model_name,
+            )
 
     # Resolve parallelization strategy
     parallel = _resolve_parallelization(

--- a/tests/unit/generator/test_naive.py
+++ b/tests/unit/generator/test_naive.py
@@ -3,6 +3,7 @@
 
 """Unit tests for generator naive module — nvbug 5941223."""
 
+import json
 import re
 from unittest.mock import patch
 
@@ -16,6 +17,20 @@ from aiconfigurator.generator.naive import (
 )
 
 _RFC1123_LABEL_RE = re.compile(r"^[a-z0-9]([a-z0-9\-.]*[a-z0-9])?$")
+_UNSUPPORTED_GPT_NEOX_CONFIG = {
+    "architectures": ["GPTNeoXForCausalLM"],
+    "hidden_size": 512,
+    "intermediate_size": 2048,
+    "num_attention_heads": 8,
+    "num_hidden_layers": 6,
+    "torch_dtype": "float16",
+    "vocab_size": 50304,
+}
+_UNSUPPORTED_MOE_CONFIG = {
+    **_UNSUPPORTED_GPT_NEOX_CONFIG,
+    "architectures": ["UnsupportedMoeForCausalLM"],
+    "num_local_experts": 8,
+}
 
 
 @pytest.mark.unit
@@ -212,8 +227,57 @@ class TestBuildNaiveGeneratorParams:
 
 
 @pytest.mark.unit
-class TestEstimateModelWeightBytesFailsOnMissingModel:
-    @patch("aiconfigurator.sdk.utils.get_model_config_from_model_path")
+class TestEstimateModelWeightBytes:
+    def test_estimates_unsupported_architecture_from_raw_config(self, tmp_path):
+        (tmp_path / "config.json").write_text(json.dumps(_UNSUPPORTED_GPT_NEOX_CONFIG))
+
+        assert _estimate_model_weight_bytes(str(tmp_path)) == 153354240
+
+    @patch(
+        "aiconfigurator.generator.naive._load_model_config_from_model_path",
+        return_value=_UNSUPPORTED_GPT_NEOX_CONFIG,
+    )
+    def test_remote_unsupported_architecture_loads_config_once(self, mock_load_config):
+        assert _estimate_model_weight_bytes("EleutherAI/pythia-70m") == 153354240
+        mock_load_config.assert_called_once_with("EleutherAI/pythia-70m")
+
+    @patch(
+        "aiconfigurator.generator.naive._get_system_config",
+        return_value={"gpus_per_node": 8, "vram_per_gpu": 80 * 1024**3},
+    )
+    def test_builds_params_for_unsupported_architecture(self, _mock_system, tmp_path):
+        (tmp_path / "config.json").write_text(json.dumps(_UNSUPPORTED_GPT_NEOX_CONFIG))
+
+        result = build_naive_generator_params(
+            model_name=str(tmp_path),
+            total_gpus=8,
+            system_name="h100_sxm",
+            backend_name="vllm",
+        )
+
+        assert result["params"]["agg"]["tensor_parallel_size"] == 1
+        assert result["ModelConfig"]["fits_in_memory"] is True
+
+    @patch(
+        "aiconfigurator.generator.naive._get_system_config",
+        return_value={"gpus_per_node": 8, "vram_per_gpu": 512 * 1024**2},
+    )
+    def test_builds_tep_params_for_unsupported_moe_architecture(self, _mock_system, tmp_path):
+        (tmp_path / "config.json").write_text(json.dumps(_UNSUPPORTED_MOE_CONFIG))
+
+        result = build_naive_generator_params(
+            model_name=str(tmp_path),
+            total_gpus=8,
+            system_name="h100_sxm",
+            backend_name="vllm",
+        )
+
+        assert result["ModelConfig"]["is_moe"] is True
+        assert result["params"]["agg"]["tensor_parallel_size"] == 1
+        assert result["params"]["agg"]["moe_tensor_parallel_size"] == 2
+        assert result["params"]["agg"]["moe_expert_parallel_size"] == 1
+
+    @patch("aiconfigurator.generator.naive._load_model_config_from_model_path")
     def test_raises_when_config_download_fails(self, mock_get_config):
         mock_get_config.side_effect = Exception(
             "Failed to download nonexistent-org/fake-model-12345's config.json from HuggingFace: "


### PR DESCRIPTION
## Summary

- cherry-pick #1490 to `release/0.11.0`
- size AIC-unsupported architectures from their raw Hugging Face config
- reuse one config load and preserve raw architecture/MoE metadata for naive parallelization
- add dense, remote-ID, and unsupported-MoE regression coverage

Source: #1490
Source merge commit: `e1e36e653c9cacc520203e4abef17e6a6994c3de`
Refs [DYN-3751](https://linear.app/nvidia/issue/DYN-3751/dynamorelease140dgdr-naive-fallback-always-fails-for-aic-unsupported).

## Validation

- `.venv/bin/pytest tests/unit/generator/ -q` — 243 passed, 4 skipped
- `.venv/bin/pytest tests/unit/generator/test_naive.py tests/unit/sdk/test_memory_estimation.py tests/cross_package/test_core_public_api.py -q` — 80 passed
- `.venv/bin/ruff check src/aiconfigurator/generator/naive.py aic-core/src/aiconfigurator_core/sdk/memory.py tests/unit/generator/test_naive.py`
- `.venv/bin/ruff format --check src/aiconfigurator/generator/naive.py aic-core/src/aiconfigurator_core/sdk/memory.py tests/unit/generator/test_naive.py`
- release import smoke: `aiconfigurator==0.11.0` and `aiconfigurator-core==0.11.0` loaded from the release worktree
