### PR TITLE
perf(core): cache successful GEMM queries

### DIFF
--- a/aic-core/rust/aiconfigurator-core/Cargo.toml
+++ b/aic-core/rust/aiconfigurator-core/Cargo.toml
@@ -20,6 +20,7 @@ crate-type = ["rlib", "cdylib"]
 bincode = "1.3"
 parquet = { version = "55", default-features = false, features = ["zstd", "snap"] }
 pyo3 = { version = "0.23", features = ["abi3-py310"] }
+quick_cache = "0.7.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/gemm.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/gemm.rs
@@ -45,10 +45,14 @@ struct GemmQueryKey {
     k: u32,
 }
 
-fn gemm_query_cache(capacity: usize) -> Cache<GemmQueryKey, f64> {
+// Quick Cache is the intended pattern for hot, high-cardinality scalar-query
+// memoization in the perf database. DSA's `sparse` map is deliberately
+// different: it holds a small, unbounded set of lazily loaded table objects,
+// rather than memoizing high-volume scalar results.
+fn gemm_query_cache() -> Cache<GemmQueryKey, f64> {
     let options = OptionsBuilder::new()
-        .estimated_items_capacity(capacity)
-        .weight_capacity(capacity as u64)
+        .estimated_items_capacity(GEMM_QUERY_CACHE_CAPACITY)
+        .weight_capacity(GEMM_QUERY_CACHE_CAPACITY as u64)
         .shards(GEMM_QUERY_CACHE_SHARDS)
         .build()
         .expect("valid static GEMM query cache options");
@@ -92,7 +96,12 @@ pub struct GemmTable {
     gemm: OnceLock<Result<GemmEngineGrids, AicError>>,
     compute_scale: OnceLock<Result<TwoDGrids, AicError>>,
     scale_matrix: OnceLock<Result<TwoDGrids, AicError>>,
+    /// Successful finite scalar GEMM queries, keyed by normalized quant and
+    /// shape and bounded independently for each shard.
     query_cache: OnceLock<Cache<GemmQueryKey, f64>>,
+    // These test-only counters intentionally measure probes at this call site.
+    // Quick Cache's optional internal statistics cannot distinguish a missed
+    // probe from `GemmTable::query` never reaching the cache at all.
     #[cfg(test)]
     query_cache_hits: AtomicUsize,
     #[cfg(test)]
@@ -177,15 +186,15 @@ impl GemmTable {
         // data miss when the quant's table also happens to be uncollected.
         let spec = &self.system_spec;
         let tc_flops = quant_tc_flops(spec, lookup_quant.mapping())?;
+        // Keep the cache probe below FLOPS resolution, even on hits. Hoisting
+        // it would change MissingSystemFlops-over-PerfDatabase error precedence.
         let key = GemmQueryKey {
             quant: lookup_quant,
             m,
             n,
             k,
         };
-        let cache = self
-            .query_cache
-            .get_or_init(|| gemm_query_cache(GEMM_QUERY_CACHE_CAPACITY));
+        let cache = self.query_cache.get_or_init(gemm_query_cache);
         if let Some(value) = cache.get(&key) {
             #[cfg(test)]
             self.query_cache_hits.fetch_add(1, Ordering::Relaxed);
@@ -208,6 +217,8 @@ impl GemmTable {
         };
         let cfg = gemm_engine_config(&sol);
         let value = index.resolve(&cfg, &[m as f64, n as f64, k as f64])?;
+        // Preserve resolver behavior by returning non-finite results, but do
+        // not make them sticky cache hits for later queries.
         if value.is_finite() {
             cache.insert(key, value);
         }
@@ -885,20 +896,35 @@ mod tests {
     }
 
     #[test]
-    fn gemm_query_cache_is_bounded() {
-        let cache = gemm_query_cache(2);
+    fn gemm_query_cache_enforces_production_per_shard_bound() {
+        let cache = gemm_query_cache();
         let key = |m| GemmQueryKey {
             quant: GemmQuantMode::Bfloat16,
             m,
             n: 32,
             k: 32,
         };
+        let per_shard_capacity = GEMM_QUERY_CACHE_CAPACITY / GEMM_QUERY_CACHE_SHARDS;
 
-        cache.insert(key(1), 1.0);
-        cache.insert(key(2), 2.0);
-        cache.insert(key(3), 3.0);
+        assert_eq!(per_shard_capacity, 2_048);
+        assert_eq!(cache.num_shards(), GEMM_QUERY_CACHE_SHARDS);
+        assert_eq!(cache.shard_capacity(), per_shard_capacity as u64);
+        assert_eq!(cache.capacity(), GEMM_QUERY_CACHE_CAPACITY as u64);
 
-        assert_eq!(cache.len(), 2);
+        let target_shard = cache.shard_index(&key(0));
+        let keys: Vec<_> = (0..)
+            .map(key)
+            .filter(|key| cache.shard_index(key) == target_shard)
+            .take(per_shard_capacity + 1)
+            .collect();
+        assert_eq!(keys.len(), 2_049);
+
+        for (value, key) in keys.into_iter().enumerate() {
+            cache.insert(key, value as f64);
+        }
+
+        assert_eq!(cache.len(), per_shard_capacity);
+        assert!(cache.len() < GEMM_QUERY_CACHE_CAPACITY);
     }
 
     #[test]

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/gemm.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/gemm.rs
@@ -18,9 +18,6 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
-#[cfg(test)]
-use std::sync::atomic::{AtomicUsize, Ordering};
-
 use quick_cache::sync::{Cache, DefaultLifecycle};
 use quick_cache::{DefaultHashBuilder, OptionsBuilder, UnitWeighter};
 
@@ -64,12 +61,26 @@ fn gemm_query_cache() -> Cache<GemmQueryKey, f64> {
     )
 }
 
-#[cfg(test)]
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-struct GemmQueryCacheStats {
-    hits: usize,
-    misses: usize,
-    entries: usize,
+#[inline(always)]
+fn resolve_gemm_query_cached<F>(
+    cache: &Cache<GemmQueryKey, f64>,
+    key: GemmQueryKey,
+    resolve: F,
+) -> Result<f64, AicError>
+where
+    F: FnOnce() -> Result<f64, AicError>,
+{
+    if let Some(value) = cache.get(&key) {
+        return Ok(value);
+    }
+
+    let value = resolve()?;
+    // Preserve resolver behavior by returning non-finite results, but do
+    // not make them sticky cache hits for later queries.
+    if value.is_finite() {
+        cache.insert(key, value);
+    }
+    Ok(value)
 }
 
 /// GEMM-family perf-data owner for one logical
@@ -99,13 +110,6 @@ pub struct GemmTable {
     /// Successful finite scalar GEMM queries, keyed by normalized quant and
     /// shape and bounded independently for each shard.
     query_cache: OnceLock<Cache<GemmQueryKey, f64>>,
-    // These test-only counters intentionally measure probes at this call site.
-    // Quick Cache's optional internal statistics cannot distinguish a missed
-    // probe from `GemmTable::query` never reaching the cache at all.
-    #[cfg(test)]
-    query_cache_hits: AtomicUsize,
-    #[cfg(test)]
-    query_cache_misses: AtomicUsize,
 }
 
 /// 3-D GEMM tables keyed by quant name -> m -> n -> k -> latency_ms.
@@ -160,10 +164,6 @@ impl GemmTable {
             compute_scale: OnceLock::new(),
             scale_matrix: OnceLock::new(),
             query_cache: OnceLock::new(),
-            #[cfg(test)]
-            query_cache_hits: AtomicUsize::new(0),
-            #[cfg(test)]
-            query_cache_misses: AtomicUsize::new(0),
         }
     }
 
@@ -195,34 +195,22 @@ impl GemmTable {
             k,
         };
         let cache = self.query_cache.get_or_init(gemm_query_cache);
-        if let Some(value) = cache.get(&key) {
-            #[cfg(test)]
-            self.query_cache_hits.fetch_add(1, Ordering::Relaxed);
-            return Ok(value);
-        }
-        #[cfg(test)]
-        self.query_cache_misses.fetch_add(1, Ordering::Relaxed);
-
-        let grids = self.load_gemm()?;
-        let quant_name = lookup_quant.name();
-        let (_, index) = grids.by_quant.get(quant_name).ok_or_else(|| {
-            AicError::PerfDatabase(format!(
-                "GEMM perf data missing for quant '{quant_name}' at {}; available: {:?}",
-                self.data_root.display(),
-                grids.by_quant.keys().collect::<Vec<_>>(),
-            ))
-        })?;
-        let sol = move |c: &[f64]| {
-            gemm_sol_latency_ms_with_flops(spec, lookup_quant, tc_flops, c[0], c[1], c[2])
-        };
-        let cfg = gemm_engine_config(&sol);
-        let value = index.resolve(&cfg, &[m as f64, n as f64, k as f64])?;
-        // Preserve resolver behavior by returning non-finite results, but do
-        // not make them sticky cache hits for later queries.
-        if value.is_finite() {
-            cache.insert(key, value);
-        }
-        Ok(value)
+        resolve_gemm_query_cached(cache, key, || {
+            let grids = self.load_gemm()?;
+            let quant_name = lookup_quant.name();
+            let (_, index) = grids.by_quant.get(quant_name).ok_or_else(|| {
+                AicError::PerfDatabase(format!(
+                    "GEMM perf data missing for quant '{quant_name}' at {}; available: {:?}",
+                    self.data_root.display(),
+                    grids.by_quant.keys().collect::<Vec<_>>(),
+                ))
+            })?;
+            let sol = move |c: &[f64]| {
+                gemm_sol_latency_ms_with_flops(spec, lookup_quant, tc_flops, c[0], c[1], c[2])
+            };
+            let cfg = gemm_engine_config(&sol);
+            index.resolve(&cfg, &[m as f64, n as f64, k as f64])
+        })
     }
 
     /// Query compute-scale latency (ms) — used by `fp8_static` GEMM only.
@@ -380,16 +368,6 @@ impl GemmTable {
             .scale_matrix
             .get_or_init(|| load_two_d_parquet(&self.scale_matrix_sources));
         cell.as_ref().map_err(|err| clone_err(err))
-    }
-
-    #[cfg(test)]
-    fn query_cache_stats(&self) -> GemmQueryCacheStats {
-        let entries = self.query_cache.get().map_or(0, Cache::len);
-        GemmQueryCacheStats {
-            hits: self.query_cache_hits.load(Ordering::Relaxed),
-            misses: self.query_cache_misses.load(Ordering::Relaxed),
-            entries,
-        }
     }
 }
 
@@ -695,6 +673,10 @@ fn clone_err(err: &AicError) -> AicError {
 mod tests {
     use super::*;
 
+    fn query_cache_len(table: &GemmTable) -> usize {
+        table.query_cache.get().map_or(0, Cache::len)
+    }
+
     const REPO_ROOT_HINT: &str = env!("CARGO_MANIFEST_DIR");
 
     fn b200_vllm_data_root() -> PathBuf {
@@ -840,14 +822,7 @@ mod tests {
             );
         }
 
-        assert_eq!(
-            table.query_cache_stats(),
-            GemmQueryCacheStats {
-                hits: cases.len(),
-                misses: cases.len(),
-                entries: cases.len(),
-            }
-        );
+        assert_eq!(query_cache_len(&table), cases.len());
     }
 
     #[test]
@@ -857,8 +832,7 @@ mod tests {
         let fp8 = table.query(GemmQuantMode::Fp8, 256, 32, 32).unwrap();
         let fp8_static = table.query(GemmQuantMode::Fp8Static, 256, 32, 32).unwrap();
         assert_eq!(fp8.to_bits(), fp8_static.to_bits());
-        assert_eq!(table.query_cache_stats().entries, 1);
-        assert_eq!(table.query_cache_stats().hits, 1);
+        assert_eq!(query_cache_len(&table), 1);
 
         for (quant, m, n, k) in [
             (GemmQuantMode::Bfloat16, 256, 32, 32),
@@ -868,7 +842,7 @@ mod tests {
         ] {
             table.query(quant, m, n, k).unwrap();
         }
-        assert_eq!(table.query_cache_stats().entries, 5);
+        assert_eq!(query_cache_len(&table), 5);
     }
 
     #[test]
@@ -879,20 +853,13 @@ mod tests {
                 .query(GemmQuantMode::Int4Wo, 1024, 4096, 4096)
                 .is_err());
         }
-        assert_eq!(
-            table.query_cache_stats(),
-            GemmQueryCacheStats {
-                hits: 0,
-                misses: 2,
-                entries: 0,
-            }
-        );
+        assert_eq!(query_cache_len(&table), 0);
 
         let missing = GemmTable::new(PathBuf::from("/nonexistent/aic/data/root"), b200_sxm_spec());
         for _ in 0..2 {
             assert!(missing.query(GemmQuantMode::Bfloat16, 1, 1, 1).is_err());
         }
-        assert_eq!(missing.query_cache_stats().entries, 0);
+        assert_eq!(query_cache_len(&missing), 0);
     }
 
     #[test]
@@ -929,18 +896,33 @@ mod tests {
 
     #[test]
     fn gemm_query_cache_allows_concurrent_duplicate_misses() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
         use std::sync::{Arc, Barrier};
 
         const THREADS: usize = 4;
-        let table = Arc::new(GemmTable::new(b200_vllm_data_root(), b200_sxm_spec()));
+        const EXPECTED: f64 = 1.25;
+
+        let cache = Arc::new(gemm_query_cache());
         let barrier = Arc::new(Barrier::new(THREADS));
+        let resolutions = Arc::new(AtomicUsize::new(0));
+        let key = GemmQueryKey {
+            quant: GemmQuantMode::Bfloat16,
+            m: 259,
+            n: 32,
+            k: 32,
+        };
         let handles: Vec<_> = (0..THREADS)
             .map(|_| {
-                let table = Arc::clone(&table);
+                let cache = Arc::clone(&cache);
                 let barrier = Arc::clone(&barrier);
+                let resolutions = Arc::clone(&resolutions);
                 std::thread::spawn(move || {
-                    barrier.wait();
-                    table.query(GemmQuantMode::Bfloat16, 259, 32, 32).unwrap()
+                    resolve_gemm_query_cached(&cache, key, || {
+                        resolutions.fetch_add(1, Ordering::Relaxed);
+                        barrier.wait();
+                        Ok(EXPECTED)
+                    })
+                    .unwrap()
                 })
             })
             .collect();
@@ -952,7 +934,14 @@ mod tests {
         assert!(values
             .windows(2)
             .all(|pair| pair[0].to_bits() == pair[1].to_bits()));
-        assert_eq!(table.query_cache_stats().entries, 1);
+        assert_eq!(resolutions.load(Ordering::Relaxed), THREADS);
+        assert_eq!(cache.len(), 1);
+
+        let cached = resolve_gemm_query_cached(&cache, key, || -> Result<f64, AicError> {
+            panic!("cache hit unexpectedly invoked the resolver")
+        })
+        .unwrap();
+        assert_eq!(cached.to_bits(), EXPECTED.to_bits());
     }
 
     /// Values generated from the Python v2 engine on the same table

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/gemm.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/gemm.rs
@@ -18,6 +18,12 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use quick_cache::sync::{Cache, DefaultLifecycle};
+use quick_cache::{DefaultHashBuilder, OptionsBuilder, UnitWeighter};
+
 use super::interpolation::Grid3;
 use super::perf_interp::{self, Node, OpInterpConfig, Resolver, SiteIndex, ValueTransform};
 use super::{kernel_source_ok, resolve_op_sources};
@@ -26,6 +32,41 @@ use crate::common::error::AicError;
 use crate::common::system_spec::SystemSpec;
 use crate::config::{PerfDbSources, PerfSource};
 use crate::perf_database::parquet_loader::PerfReader;
+
+const GEMM_QUERY_CACHE_CAPACITY: usize = 32_768;
+// Keep construction and per-table memory independent of large host CPU counts.
+const GEMM_QUERY_CACHE_SHARDS: usize = 16;
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+struct GemmQueryKey {
+    quant: GemmQuantMode,
+    m: u32,
+    n: u32,
+    k: u32,
+}
+
+fn gemm_query_cache(capacity: usize) -> Cache<GemmQueryKey, f64> {
+    let options = OptionsBuilder::new()
+        .estimated_items_capacity(capacity)
+        .weight_capacity(capacity as u64)
+        .shards(GEMM_QUERY_CACHE_SHARDS)
+        .build()
+        .expect("valid static GEMM query cache options");
+    Cache::with_options(
+        options,
+        UnitWeighter,
+        DefaultHashBuilder::default(),
+        DefaultLifecycle::default(),
+    )
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct GemmQueryCacheStats {
+    hits: usize,
+    misses: usize,
+    entries: usize,
+}
 
 /// GEMM-family perf-data owner for one logical
 /// `<system>/<backend>/<version>` selection.
@@ -51,6 +92,11 @@ pub struct GemmTable {
     gemm: OnceLock<Result<GemmEngineGrids, AicError>>,
     compute_scale: OnceLock<Result<TwoDGrids, AicError>>,
     scale_matrix: OnceLock<Result<TwoDGrids, AicError>>,
+    query_cache: OnceLock<Cache<GemmQueryKey, f64>>,
+    #[cfg(test)]
+    query_cache_hits: AtomicUsize,
+    #[cfg(test)]
+    query_cache_misses: AtomicUsize,
 }
 
 /// 3-D GEMM tables keyed by quant name -> m -> n -> k -> latency_ms.
@@ -104,6 +150,11 @@ impl GemmTable {
             gemm: OnceLock::new(),
             compute_scale: OnceLock::new(),
             scale_matrix: OnceLock::new(),
+            query_cache: OnceLock::new(),
+            #[cfg(test)]
+            query_cache_hits: AtomicUsize::new(0),
+            #[cfg(test)]
+            query_cache_misses: AtomicUsize::new(0),
         }
     }
 
@@ -126,6 +177,23 @@ impl GemmTable {
         // data miss when the quant's table also happens to be uncollected.
         let spec = &self.system_spec;
         let tc_flops = quant_tc_flops(spec, lookup_quant.mapping())?;
+        let key = GemmQueryKey {
+            quant: lookup_quant,
+            m,
+            n,
+            k,
+        };
+        let cache = self
+            .query_cache
+            .get_or_init(|| gemm_query_cache(GEMM_QUERY_CACHE_CAPACITY));
+        if let Some(value) = cache.get(&key) {
+            #[cfg(test)]
+            self.query_cache_hits.fetch_add(1, Ordering::Relaxed);
+            return Ok(value);
+        }
+        #[cfg(test)]
+        self.query_cache_misses.fetch_add(1, Ordering::Relaxed);
+
         let grids = self.load_gemm()?;
         let quant_name = lookup_quant.name();
         let (_, index) = grids.by_quant.get(quant_name).ok_or_else(|| {
@@ -139,7 +207,11 @@ impl GemmTable {
             gemm_sol_latency_ms_with_flops(spec, lookup_quant, tc_flops, c[0], c[1], c[2])
         };
         let cfg = gemm_engine_config(&sol);
-        index.resolve(&cfg, &[m as f64, n as f64, k as f64])
+        let value = index.resolve(&cfg, &[m as f64, n as f64, k as f64])?;
+        if value.is_finite() {
+            cache.insert(key, value);
+        }
+        Ok(value)
     }
 
     /// Query compute-scale latency (ms) — used by `fp8_static` GEMM only.
@@ -297,6 +369,16 @@ impl GemmTable {
             .scale_matrix
             .get_or_init(|| load_two_d_parquet(&self.scale_matrix_sources));
         cell.as_ref().map_err(|err| clone_err(err))
+    }
+
+    #[cfg(test)]
+    fn query_cache_stats(&self) -> GemmQueryCacheStats {
+        let entries = self.query_cache.get().map_or(0, Cache::len);
+        GemmQueryCacheStats {
+            hits: self.query_cache_hits.load(Ordering::Relaxed),
+            misses: self.query_cache_misses.load(Ordering::Relaxed),
+            entries,
+        }
     }
 }
 
@@ -725,6 +807,126 @@ mod tests {
         let first = table.query(GemmQuantMode::Bfloat16, 32768, 65536, 16384).unwrap();
         let second = table.query(GemmQuantMode::Bfloat16, 32768, 65536, 16384).unwrap();
         assert_eq!(first, second);
+    }
+
+    #[test]
+    fn gemm_query_cache_is_bit_identical_for_all_resolution_classes() {
+        let table = GemmTable::new(b200_vllm_data_root(), b200_sxm_spec());
+        let cases = [
+            (256, 32, 32),
+            (259, 32, 32),
+            (10_000_000, 32, 32),
+            (256, 128, 96),
+        ];
+
+        for (m, n, k) in cases {
+            let uncached = table.query(GemmQuantMode::Bfloat16, m, n, k).unwrap();
+            let cached = table.query(GemmQuantMode::Bfloat16, m, n, k).unwrap();
+            assert_eq!(
+                cached.to_bits(),
+                uncached.to_bits(),
+                "cache changed ({m},{n},{k})"
+            );
+        }
+
+        assert_eq!(
+            table.query_cache_stats(),
+            GemmQueryCacheStats {
+                hits: cases.len(),
+                misses: cases.len(),
+                entries: cases.len(),
+            }
+        );
+    }
+
+    #[test]
+    fn gemm_query_cache_normalizes_quant_and_separates_shape_fields() {
+        let table = GemmTable::new(b200_vllm_data_root(), b200_sxm_spec());
+
+        let fp8 = table.query(GemmQuantMode::Fp8, 256, 32, 32).unwrap();
+        let fp8_static = table.query(GemmQuantMode::Fp8Static, 256, 32, 32).unwrap();
+        assert_eq!(fp8.to_bits(), fp8_static.to_bits());
+        assert_eq!(table.query_cache_stats().entries, 1);
+        assert_eq!(table.query_cache_stats().hits, 1);
+
+        for (quant, m, n, k) in [
+            (GemmQuantMode::Bfloat16, 256, 32, 32),
+            (GemmQuantMode::Bfloat16, 257, 32, 32),
+            (GemmQuantMode::Bfloat16, 256, 64, 32),
+            (GemmQuantMode::Bfloat16, 256, 32, 64),
+        ] {
+            table.query(quant, m, n, k).unwrap();
+        }
+        assert_eq!(table.query_cache_stats().entries, 5);
+    }
+
+    #[test]
+    fn gemm_query_errors_never_enter_the_cache() {
+        let table = GemmTable::new(b200_vllm_data_root(), b200_sxm_spec());
+        for _ in 0..2 {
+            assert!(table
+                .query(GemmQuantMode::Int4Wo, 1024, 4096, 4096)
+                .is_err());
+        }
+        assert_eq!(
+            table.query_cache_stats(),
+            GemmQueryCacheStats {
+                hits: 0,
+                misses: 2,
+                entries: 0,
+            }
+        );
+
+        let missing = GemmTable::new(PathBuf::from("/nonexistent/aic/data/root"), b200_sxm_spec());
+        for _ in 0..2 {
+            assert!(missing.query(GemmQuantMode::Bfloat16, 1, 1, 1).is_err());
+        }
+        assert_eq!(missing.query_cache_stats().entries, 0);
+    }
+
+    #[test]
+    fn gemm_query_cache_is_bounded() {
+        let cache = gemm_query_cache(2);
+        let key = |m| GemmQueryKey {
+            quant: GemmQuantMode::Bfloat16,
+            m,
+            n: 32,
+            k: 32,
+        };
+
+        cache.insert(key(1), 1.0);
+        cache.insert(key(2), 2.0);
+        cache.insert(key(3), 3.0);
+
+        assert_eq!(cache.len(), 2);
+    }
+
+    #[test]
+    fn gemm_query_cache_allows_concurrent_duplicate_misses() {
+        use std::sync::{Arc, Barrier};
+
+        const THREADS: usize = 4;
+        let table = Arc::new(GemmTable::new(b200_vllm_data_root(), b200_sxm_spec()));
+        let barrier = Arc::new(Barrier::new(THREADS));
+        let handles: Vec<_> = (0..THREADS)
+            .map(|_| {
+                let table = Arc::clone(&table);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    table.query(GemmQuantMode::Bfloat16, 259, 32, 32).unwrap()
+                })
+            })
+            .collect();
+        let values: Vec<_> = handles
+            .into_iter()
+            .map(|handle| handle.join().unwrap())
+            .collect();
+
+        assert!(values
+            .windows(2)
+            .all(|pair| pair[0].to_bits() == pair[1].to_bits()));
+        assert_eq!(table.query_cache_stats().entries, 1);
     }
 
     /// Values generated from the Python v2 engine on the same table


### PR DESCRIPTION
## Summary

- add a private, per-`GemmTable` `quick_cache::sync::Cache` using its modified CLOCK-Pro/S3-FIFO policy, with 32,768 total unit-weight capacity split evenly across 16 shards (2,048 entries per shard); skew can therefore evict before global occupancy reaches 32,768
- use 16 internal shards rather than the host-core-derived default, keeping construction cost and per-table memory predictable on large CPU hosts
- use Quick Cache as the pattern for hot, high-cardinality scalar-query memoization; DSA's small, unbounded map instead caches a handful of lazily loaded table objects
- key successful GEMM table results by normalized quant and `(m, n, k)`, so `fp8_static` and `fp8` share the raw lookup
- preserve error precedence and cache only finite successful table results; errors, fallbacks, provenance, compute-scale, and scale-matrix results are unchanged
- keep miss resolution outside cache synchronization and allow benign duplicate concurrent misses

No public API, prediction, fallback, or provenance behavior changes.

## Validation

Correctness:

- `cargo check -p aiconfigurator-core`
- `cargo test -p aiconfigurator-core gemm_query_cache` — 4 passed, including the exact production 16-shard/2,048-entry-per-shard skew case and a forced four-way duplicate-miss case (4 resolutions, 1 cached entry, then a resolver-free hit)
- `cargo test -p aiconfigurator-core` — 314 passed
- `cargo test -p aiconfigurator-core --features embed-python` — 321 unit tests and 3 integration tests passed
- deterministic 12-worker DynoSim reports were byte-identical after removing only `wall_time_ms`, `processed_tokens_per_s`, and `processed_output_tokens_per_s`; normalized SHA-256: `9a9fc6f636917b1bd84c5c97450299e08e5ca28167875cb1729a87a2f55a51e3`
- `git diff --check`
- exact `6169ef4` versus `ead965e` release safety check: no out-of-line `resolve_gemm_query_cached` symbol, identical corpus digests, repeated-hit latency 12.95% lower, and unique-cold latency unchanged within 0.002%

`cargo clippy -p aiconfigurator-core --all-targets -- -D warnings` remains blocked by the current `main` baseline (64 library and 70 test-target diagnostics). `cargo fmt --all -- --check` likewise reproduces the repository's existing formatting drift.

Performance, exact `main` baseline `3f05337`, ordinary release with `RUSTFLAGS="-C target-cpu=x86-64-v3"`:

| Benchmark | Baseline | Candidate | Result |
| --- | ---: | ---: | ---: |
| repeated GEMM queries | 376.793 ns/query | 26.820 ns/query | 14.05x faster |
| unique cold GEMM queries | 1,596.714 ns/query | 1,682.506 ns/query | 5.37% slower |
| SILICON engine-step corpus | 61.593 us | 25.328 us | 58.88% faster |
| EMPIRICAL engine-step corpus | 32,327.515 us | 32,041.709 us | 0.88% faster |
| Astra HYBRID-miss engine-step corpus | 46.899 us | 26.024 us | 44.51% faster |

Quick Cache is 3.51x faster than the prior Moka candidate on repeated hits and reduces its cold-query overhead by 17.26%. It exceeds the repeated-query and engine-step targets, misses the synthetic <=3% cold-regression target by 2.37 percentage points, and produces bit-identical prediction vectors.

Matched DynoSim point using Dynamo `e322c8d5ce0649c86c9235dac5e3243007fd6a85`, 12-worker aggregated Astra SGLang/B200, CPU 0, candidate then baseline, no warm-ups:

| Revision | Wall time | Processed tokens/s | Requests | Processed tokens |
| --- | ---: | ---: | ---: | ---: |
| baseline | 48.495 s | 26,609,074 | 93,953 | 1,290,416,132 |
| candidate | 42.418 s | 30,421,081 | 93,953 | 1,290,416,132 |

That is 14.33% higher processed-token throughput and 12.53% lower wall time in this point comparison. Against the deterministic Moka candidate, Quick Cache improved throughput by another 0.62%. The host has no isolated CPU; preflight showed background host load but no competing process on CPU 0.

The deterministic baseline, Moka, and Quick Cache reports all completed 93,953 requests with identical token totals and were byte-identical after normalization.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved repeated matrix multiplication configuration queries through bounded caching.
  * Reduced redundant computation for frequently requested matrix shapes and quantization settings.
  * Cache behavior avoids retaining failed or invalid results and remains responsive under concurrent access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
