### PR TITLE
fix: Qwen3.5 modeling and collection gaps (GDN hybrid)

### DIFF
--- a/aic-core/rust/aiconfigurator-core/src/config.rs
+++ b/aic-core/rust/aiconfigurator-core/src/config.rs
@@ -34,7 +34,9 @@ pub const ENGINE_CONFIG_SCHEMA_VERSION: u32 = 1;
 // - 6: `Kda` op variant appended (Kimi-K3). Claimed version 5 on its own
 //   branch concurrently with #1460, so the merge renumbered it (same
 //   precedent as the v3/v4 collision above).
-pub const ENGINE_SPEC_SCHEMA_VERSION: u32 = 6;
+// - 7: `MoEDispatchOp` gained `attn_ar_modeled` — a bincode op-layout
+//   change (same class as v5).
+pub const ENGINE_SPEC_SCHEMA_VERSION: u32 = 7;
 
 /// Static engine identity and setup information carried by an
 /// [`crate::engine::spec::EngineSpec`].

--- a/aic-core/rust/aiconfigurator-core/src/engine/spec.rs
+++ b/aic-core/rust/aiconfigurator-core/src/engine/spec.rs
@@ -327,6 +327,7 @@ mod tests {
             is_context: false,
             sms: 12,
             scale_num_tokens: 1,
+            attn_ar_modeled: false,
         }
     }
 

--- a/aic-core/rust/aiconfigurator-core/src/operators/mamba.rs
+++ b/aic-core/rust/aiconfigurator-core/src/operators/mamba.rs
@@ -165,7 +165,8 @@ impl GdnOp {
         let hk = self.head_k_dim as f64;
         let nv = self.num_v_heads as f64;
         let hv = self.head_v_dim as f64;
-        let conv_channels = nk * hk + nv * hv;
+        // Packed q/k/v convolution width (2K + V), matching the collector's conv_dim.
+        let conv_channels = 2.0 * nk * hk + nv * hv;
         let d_conv = self.d_conv as f64;
         let d_model = self.d_model as f64;
         let state_size = nv * hk * hv;
@@ -184,13 +185,15 @@ impl GdnOp {
                 x * conv_channels * (d_conv + 1.0) * 2.0,
                 x * conv_channels * 2.0,
             ),
+            // q/k/v reads are 2K + V wide; the recurrent state is FP32 (Qwen3.5
+            // pins mamba_ssm_dtype=float32) while h_chunks stay input-dtype BF16.
             "chunk_gated_delta_rule" => (
-                x * (nk * hk + nv * hv) * 2.0 + state_size * 2.0 * bs + h_chunks_bytes,
-                x * nv * hv * 2.0 + state_size * 2.0 * bs + h_chunks_bytes,
+                x * (2.0 * nk * hk + nv * hv) * 2.0 + state_size * 4.0 * bs + h_chunks_bytes,
+                x * nv * hv * 2.0 + state_size * 4.0 * bs + h_chunks_bytes,
             ),
             "fused_sigmoid_gating_delta_rule_update" => (
-                x * (nk * hk + nv * hv) * 2.0 + state_size * 2.0 * bs,
-                x * nv * hv * 2.0 + state_size * 2.0 * bs,
+                x * (2.0 * nk * hk + nv * hv) * 2.0 + state_size * 4.0 * bs,
+                x * nv * hv * 2.0 + state_size * 4.0 * bs,
             ),
             _ => (x * d_model * 2.0, x * d_model * 2.0),
         };

--- a/aic-core/rust/aiconfigurator-core/src/operators/moe_dispatch.rs
+++ b/aic-core/rust/aiconfigurator-core/src/operators/moe_dispatch.rs
@@ -54,6 +54,11 @@ pub struct MoEDispatchOp {
     pub moe_ep_size: u32,
     pub attention_dp_size: u32,
     pub pre_dispatch: bool,
+    /// True when the model composes its attention-output all-reduce
+    /// explicitly; the vLLM pre-dispatch proxy AR is then not charged
+    /// (mirrors Python `MoEDispatch._attn_ar_modeled`).
+    #[serde(default)]
+    pub attn_ar_modeled: bool,
     pub backend: BackendKind,
     pub flavor: DispatchFlavor,
     pub comm_quant: CommQuantMode,
@@ -225,7 +230,8 @@ impl MoEDispatchOp {
                 // Python (`operations/moe.py`):
                 //  * vllm (:1003-1020):
                 //      comm = 0
-                //      if attn_tp > 1: comm += custom_allreduce(num_gpus, volume)
+                //      if attn_tp > 1 and not (pre and attn_ar_modeled):
+                //          comm += custom_allreduce(num_gpus, volume)
                 //      if attn_dp > 1: comm += nccl(num_gpus, "all_gather" if pre
                 //                                  else "reduce_scatter", volume * dp)
                 //      (both terms can add; Python asserts moe_tp==1 or moe_ep==1)
@@ -255,7 +261,9 @@ impl MoEDispatchOp {
                 let comm_latency_ms = match self.backend {
                     BackendKind::Vllm => {
                         let mut total = 0.0;
-                        if attn_tp > 1 {
+                        // Pre-dispatch AR is a proxy for the attention-output
+                        // all-reduce; skipped when the model prices it itself.
+                        if attn_tp > 1 && !(pre && self.attn_ar_modeled) {
                             let ar = CustomAllReduceOp::new(
                                 &self.name,
                                 1.0,

--- a/aic-core/rust/aiconfigurator-core/src/operators/moe_dispatch.rs
+++ b/aic-core/rust/aiconfigurator-core/src/operators/moe_dispatch.rs
@@ -191,6 +191,7 @@ impl MoEDispatchOp {
             is_context: false,
             sms: default_sms(),
             scale_num_tokens: 1,
+            attn_ar_modeled: false,
         }
     }
 

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/state_space.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/state_space.rs
@@ -882,7 +882,9 @@ mod tests {
     }
 
     #[test]
-    fn vllm_024_gdn_preserves_logical_source_nearest_fallback() {
+    fn vllm_024_gdn_does_not_borrow_nearest_shape_within_logical_source() {
+        // Exact geometry only: nearest-num_v_heads rows are never returned as
+        // silicon (mirrors the Python twin test).
         let table = in_memory_gdn_table(
             "vllm",
             "0.24.0",
@@ -892,10 +894,7 @@ mod tests {
                 ("chunk_gated_delta_rule", "context", 64, 5.0),
             ],
         );
-        assert_eq!(
-            query_gdn_test_shape(&table, "chunk_gated_delta_rule", "context", 48).unwrap(),
-            5.0
-        );
+        assert!(query_gdn_test_shape(&table, "chunk_gated_delta_rule", "context", 48).is_err());
     }
 
     /// In-memory KDA table over one fixed model shape (d_model=4096, heads
@@ -1043,8 +1042,9 @@ mod tests {
         let bw = h100_sxm_mem_bw();
 
         // GDN causal_conv1d kernels: read = x*conv_channels*(d_conv+1)*2,
-        // write = x*conv_channels*2; x = b*s (context) or b (generation).
-        let conv_channels = (16 * 128 + 32 * 128) as f64;
+        // write = x*conv_channels*2; x = b*s (context) or b (generation);
+        // conv_channels is the packed q/k/v width (2K + V).
+        let conv_channels = (2 * 16 * 128 + 32 * 128) as f64;
         let gdn_conv_sol = move |x: f64| {
             (x * conv_channels * (4.0 + 1.0) * 2.0 + x * conv_channels * 2.0) / bw * 1000.0
         };

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/state_space.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/state_space.rs
@@ -249,11 +249,9 @@ impl StateSpaceTable {
             num_v_heads,
             head_v_dim,
         };
-        // Mirror Python `_query_gdn_table`: on exact-shape miss, fall back to
-        // any same-d_model entry, breaking ties by minimum `|num_v_heads -
-        // query.num_v_heads|`. (Mamba2 uses "first by d_model"; GDN uses
-        // "nearest by num_v_heads" — keep them distinct.) Surface as
-        // `PerfDatabase` if no d_model match exists.
+        // Mirror Python `_query_gdn_table`: exact geometry (or an exact
+        // physical-alias hit) only; any miss surfaces as `PerfDatabase` so
+        // the operator degrades to SOL.
         let node = match grids.by_keys.get(&key) {
             Some(node) => node,
             None => {
@@ -299,19 +297,7 @@ impl StateSpaceTable {
                     return engine_query(node, phase, batch_size, seq_len, sol);
                 }
 
-                let nearest = grids
-                    .by_keys
-                    .iter()
-                    .filter(|(k, _)| {
-                        k.kernel_source == key.kernel_source
-                            && k.phase == key.phase
-                            && k.d_model == key.d_model
-                    })
-                    .min_by_key(|(k, _)| (k.num_v_heads as i64 - key.num_v_heads as i64).abs());
-                match nearest {
-                    Some((_, node)) => node,
-                    None => return Err(missing("GDN", &self.data_root, format!("{key:?}"))),
-                }
+                return Err(missing("GDN", &self.data_root, format!("{key:?}")));
             }
         };
         engine_query(node, phase, batch_size, seq_len, sol)

--- a/aic-core/src/aiconfigurator_core/sdk/engine.py
+++ b/aic-core/src/aiconfigurator_core/sdk/engine.py
@@ -324,6 +324,7 @@ def _moe_dispatch(op: MoEDispatch, *, backend: str) -> dict:
         "moe_ep_size": op._moe_ep_size,
         "attention_dp_size": op._attention_dp_size,
         "pre_dispatch": op._pre_dispatch,
+        "attn_ar_modeled": op._attn_ar_modeled,
         "backend": backend,
         "flavor": _dispatch_flavor(backend, op),
         # DeepEP branches divide the dispatch token count by this (Python

--- a/aic-core/src/aiconfigurator_core/sdk/engine.py
+++ b/aic-core/src/aiconfigurator_core/sdk/engine.py
@@ -107,7 +107,9 @@ from aiconfigurator_core.sdk.rust_engine_step import (
 #   `native_num_heads` (always serialized — bincode decodes positionally).
 # - 6: `Kda` op variant appended (Kimi-K3 KDA kernels; draft_tokens field).
 #   Claimed version 5 concurrently with #1460; renumbered at the merge.
-ENGINE_SPEC_SCHEMA_VERSION = 6
+# - 7: `MoEDispatchOp` gained `attn_ar_modeled` (always serialized — bincode
+#   decodes positionally).
+ENGINE_SPEC_SCHEMA_VERSION = 7
 ENGINE_CONFIG_SCHEMA_VERSION = 1
 
 logger = logging.getLogger(__name__)

--- a/aic-core/src/aiconfigurator_core/sdk/models/qwen35.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/qwen35.py
@@ -39,10 +39,12 @@ class Qwen35Model(BaseModel):
             model_info["context"],
             model_config,
             model_info["extra_params"],
+            backend_name=backend_name,
         )
 
-    def __init__(self, *args) -> None:
+    def __init__(self, *args, backend_name: str) -> None:
         super().__init__(*args)
+        self._backend_name = backend_name
         cfg: common.Qwen35Config = self.extra_params
         assert isinstance(cfg, common.Qwen35Config), "Qwen35Model requires Qwen35Config extra_params"
 
@@ -208,9 +210,11 @@ class Qwen35Model(BaseModel):
                 ops_list.append(
                     ops.GEMM(f"{prefix}_router_gemm", count, cfg.num_experts, h, common.GEMMQuantMode.bfloat16)
                 )
-            # Layout-specific MoE collectives are priced inside MoEDispatch.
-            ops_list.extend(
-                [
+            # StandardDispatcher performs only local expert-id mapping before
+            # routed experts; unlike vLLM/DeepEP it has no pre-dispatch
+            # collective. The post-expert TP reduction remains physical.
+            if not (self._backend_name == "sglang" and self.config.moe_backend is None):
+                ops_list.append(
                     ops.MoEDispatch(
                         f"{prefix}_moe_pre_dispatch",
                         count,
@@ -222,7 +226,10 @@ class Qwen35Model(BaseModel):
                         attn_dp,
                         True,
                         quant_mode=moe_q,
-                    ),
+                    )
+                )
+            ops_list.extend(
+                [
                     ops.MoE(
                         f"{prefix}_moe",
                         count,
@@ -253,13 +260,11 @@ class Qwen35Model(BaseModel):
             if cfg.shared_expert_inter_size > 0:
                 ops_list.extend(
                     [
-                        # Scalar expert gate (ReplicatedLinear hidden->1). True
-                        # N=1 is below the GEMM table grid; n=8 stands in as a
-                        # launch-floor proxy.
+                        # Scalar expert gate (ReplicatedLinear hidden->1).
                         ops.GEMM(
                             f"{prefix}_shared_expert_gate_gemm",
                             count,
-                            8,
+                            1,
                             h,
                             common.GEMMQuantMode.bfloat16,
                         ),
@@ -430,9 +435,11 @@ class Qwen35Model(BaseModel):
                 ops_list.append(
                     ops.GEMM(f"{prefix}_router_gemm", count, cfg.num_experts, h, common.GEMMQuantMode.bfloat16)
                 )
-            # Layout-specific MoE collectives are priced inside MoEDispatch.
-            ops_list.extend(
-                [
+            # StandardDispatcher performs only local expert-id mapping before
+            # routed experts; unlike vLLM/DeepEP it has no pre-dispatch
+            # collective. The post-expert TP reduction remains physical.
+            if not (self._backend_name == "sglang" and self.config.moe_backend is None):
+                ops_list.append(
                     ops.MoEDispatch(
                         f"{prefix}_moe_pre_dispatch",
                         count,
@@ -444,7 +451,10 @@ class Qwen35Model(BaseModel):
                         attn_dp,
                         True,
                         quant_mode=moe_q,
-                    ),
+                    )
+                )
+            ops_list.extend(
+                [
                     ops.MoE(
                         f"{prefix}_moe",
                         count,
@@ -475,13 +485,11 @@ class Qwen35Model(BaseModel):
             if cfg.shared_expert_inter_size > 0:
                 ops_list.extend(
                     [
-                        # Scalar expert gate (ReplicatedLinear hidden->1). True
-                        # N=1 is below the GEMM table grid; n=8 stands in as a
-                        # launch-floor proxy.
+                        # Scalar expert gate (ReplicatedLinear hidden->1).
                         ops.GEMM(
                             f"{prefix}_shared_expert_gate_gemm",
                             count,
-                            8,
+                            1,
                             h,
                             common.GEMMQuantMode.bfloat16,
                         ),

--- a/aic-core/src/aiconfigurator_core/sdk/models/qwen35.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/qwen35.py
@@ -46,6 +46,14 @@ class Qwen35Model(BaseModel):
         cfg: common.Qwen35Config = self.extra_params
         assert isinstance(cfg, common.Qwen35Config), "Qwen35Model requires Qwen35Config extra_params"
 
+        tp = self.config.tp_size
+        if cfg.linear_num_key_heads % tp != 0 or cfg.linear_num_value_heads % tp != 0:
+            raise ValueError(
+                "Qwen3.5 GDN head counts must both be divisible by tensor parallel size: "
+                f"num_k_heads={cfg.linear_num_key_heads}, "
+                f"num_v_heads={cfg.linear_num_value_heads}, tp_size={tp}"
+            )
+
         self._mtp_scale_factor = mtp_scale_factor(self._nextn, self._num_layers)
 
         if cfg.num_experts > 0:
@@ -88,7 +96,8 @@ class Qwen35Model(BaseModel):
         )
         counts = self._count_layer_types()
 
-        # Unsharded GDN dims (used for kernel lookup)
+        # GDN kernel lookups use TP-local head counts; projection GEMM widths
+        # derive from the global dims.
         nk = cfg.linear_num_key_heads
         hk = cfg.linear_key_head_dim
         nv = cfg.linear_num_value_heads
@@ -98,8 +107,12 @@ class Qwen35Model(BaseModel):
         # Per-TP sizes
         n_q_per_tp = self._num_heads // tp
         n_kv_per_tp = (self._num_kv_heads + tp - 1) // tp
-        # GDN projections: Q+K+V+gate(Z)+beta sharded by tp
-        gdn_in_proj_out = (nk * hk + nk * hk + nv * hv + nv * hv + nk * hk) // tp
+        gdn_nk_per_tp = nk // tp
+        gdn_nv_per_tp = nv // tp
+        # in_proj_qkvz (Q+K+V+gate Z) and in_proj_ba (b+a, 2 scalars per V head)
+        # are separate runtime GEMM kernels.
+        gdn_in_proj_out = (nk * hk + nk * hk + nv * hv + nv * hv) // tp
+        gdn_ba_out = 2 * nv // tp
         gdn_out_proj_in = nv * hv // tp
 
         self.context_ops = [
@@ -114,15 +127,16 @@ class Qwen35Model(BaseModel):
                 [
                     ops.ElementWise("context_gdn_norm", c, 2 * h, 2 * h, 0.8),
                     ops.GEMM("context_gdn_in_proj_gemm", c, gdn_in_proj_out, h, gemm_q),
+                    ops.GEMM("context_gdn_in_proj_ba_gemm", c, gdn_ba_out, h, gemm_q),
                     ops.GDNKernel(
                         "context_gdn_conv1d",
                         c,
                         "causal_conv1d_fn",
                         "context",
                         h,
-                        nk,
+                        gdn_nk_per_tp,
                         hk,
-                        nv,
+                        gdn_nv_per_tp,
                         hv,
                         d_conv,
                     ),
@@ -132,9 +146,9 @@ class Qwen35Model(BaseModel):
                         "chunk_gated_delta_rule",
                         "context",
                         h,
-                        nk,
+                        gdn_nk_per_tp,
                         hk,
-                        nv,
+                        gdn_nv_per_tp,
                         hv,
                         d_conv,
                     ),
@@ -151,7 +165,9 @@ class Qwen35Model(BaseModel):
         # --- full_attention (GQA) layers ---
         if counts["full"] > 0:
             c = counts["full"]
-            qkv_out = n_q_per_tp * self._head_size + n_kv_per_tp * self._head_size * 2
+            # attn_output_gate=True on all Qwen3.5 checkpoints doubles the q slice
+            # (query + output gate).
+            qkv_out = 2 * n_q_per_tp * self._head_size + n_kv_per_tp * self._head_size * 2
             self.context_ops.extend(
                 [
                     ops.ElementWise("context_full_attn_norm", c, 2 * h, 2 * h, 0.8),
@@ -192,6 +208,7 @@ class Qwen35Model(BaseModel):
                 ops_list.append(
                     ops.GEMM(f"{prefix}_router_gemm", count, cfg.num_experts, h, common.GEMMQuantMode.bfloat16)
                 )
+            # Layout-specific MoE collectives are priced inside MoEDispatch.
             ops_list.extend(
                 [
                     ops.MoEDispatch(
@@ -236,11 +253,29 @@ class Qwen35Model(BaseModel):
             if cfg.shared_expert_inter_size > 0:
                 ops_list.extend(
                     [
-                        ops.GEMM(f"{prefix}_shared_up_gemm", count, cfg.shared_expert_inter_size // tp, h, gemm_q),
-                        ops.ElementWise(
-                            f"{prefix}_shared_relu2",
+                        # Scalar expert gate (ReplicatedLinear hidden->1). True
+                        # N=1 is below the GEMM table grid; n=8 stands in as a
+                        # launch-floor proxy.
+                        ops.GEMM(
+                            f"{prefix}_shared_expert_gate_gemm",
                             count,
-                            cfg.shared_expert_inter_size // tp,
+                            8,
+                            h,
+                            common.GEMMQuantMode.bfloat16,
+                        ),
+                        # Shared expert is a gated-SiLU MLP (Qwen2MoeMLP) with a
+                        # fused gate_up projection.
+                        ops.GEMM(
+                            f"{prefix}_shared_gate_up_gemm",
+                            count,
+                            2 * cfg.shared_expert_inter_size // tp,
+                            h,
+                            gemm_q,
+                        ),
+                        ops.ElementWise(
+                            f"{prefix}_shared_act_gate",
+                            count,
+                            2 * cfg.shared_expert_inter_size // tp,
                             cfg.shared_expert_inter_size // tp,
                             0.8,
                         ),
@@ -293,7 +328,10 @@ class Qwen35Model(BaseModel):
 
         n_q_per_tp = self._num_heads // tp
         n_kv_per_tp = (self._num_kv_heads + tp - 1) // tp
-        gdn_in_proj_out = (nk * hk + nk * hk + nv * hv + nv * hv + nk * hk) // tp
+        gdn_nk_per_tp = nk // tp
+        gdn_nv_per_tp = nv // tp
+        gdn_in_proj_out = (nk * hk + nk * hk + nv * hv + nv * hv) // tp
+        gdn_ba_out = 2 * nv // tp
         gdn_out_proj_in = nv * hv // tp
 
         sf = self._mtp_scale_factor
@@ -310,15 +348,16 @@ class Qwen35Model(BaseModel):
                 [
                     ops.ElementWise("generation_gdn_norm", c, 2 * h, 2 * h, 0.8),
                     ops.GEMM("generation_gdn_in_proj_gemm", c, gdn_in_proj_out, h, gemm_q),
+                    ops.GEMM("generation_gdn_in_proj_ba_gemm", c, gdn_ba_out, h, gemm_q),
                     ops.GDNKernel(
                         "generation_gdn_conv1d",
                         c,
                         "causal_conv1d_update",
                         "generation",
                         h,
-                        nk,
+                        gdn_nk_per_tp,
                         hk,
-                        nv,
+                        gdn_nv_per_tp,
                         hv,
                         d_conv,
                     ),
@@ -328,9 +367,9 @@ class Qwen35Model(BaseModel):
                         "fused_sigmoid_gating_delta_rule_update",
                         "generation",
                         h,
-                        nk,
+                        gdn_nk_per_tp,
                         hk,
-                        nv,
+                        gdn_nv_per_tp,
                         hv,
                         d_conv,
                     ),
@@ -347,7 +386,9 @@ class Qwen35Model(BaseModel):
         # --- full_attention (GQA) layers ---
         if counts["full"] > 0:
             c = counts["full"] * sf
-            qkv_out = n_q_per_tp * self._head_size + n_kv_per_tp * self._head_size * 2
+            # attn_output_gate=True on all Qwen3.5 checkpoints doubles the q slice
+            # (query + output gate).
+            qkv_out = 2 * n_q_per_tp * self._head_size + n_kv_per_tp * self._head_size * 2
             self.generation_ops.extend(
                 [
                     ops.ElementWise("generation_full_attn_norm", c, 2 * h, 2 * h, 0.8),
@@ -389,6 +430,7 @@ class Qwen35Model(BaseModel):
                 ops_list.append(
                     ops.GEMM(f"{prefix}_router_gemm", count, cfg.num_experts, h, common.GEMMQuantMode.bfloat16)
                 )
+            # Layout-specific MoE collectives are priced inside MoEDispatch.
             ops_list.extend(
                 [
                     ops.MoEDispatch(
@@ -433,11 +475,29 @@ class Qwen35Model(BaseModel):
             if cfg.shared_expert_inter_size > 0:
                 ops_list.extend(
                     [
-                        ops.GEMM(f"{prefix}_shared_up_gemm", count, cfg.shared_expert_inter_size // tp, h, gemm_q),
-                        ops.ElementWise(
-                            f"{prefix}_shared_relu2",
+                        # Scalar expert gate (ReplicatedLinear hidden->1). True
+                        # N=1 is below the GEMM table grid; n=8 stands in as a
+                        # launch-floor proxy.
+                        ops.GEMM(
+                            f"{prefix}_shared_expert_gate_gemm",
                             count,
-                            cfg.shared_expert_inter_size // tp,
+                            8,
+                            h,
+                            common.GEMMQuantMode.bfloat16,
+                        ),
+                        # Shared expert is a gated-SiLU MLP (Qwen2MoeMLP) with a
+                        # fused gate_up projection.
+                        ops.GEMM(
+                            f"{prefix}_shared_gate_up_gemm",
+                            count,
+                            2 * cfg.shared_expert_inter_size // tp,
+                            h,
+                            gemm_q,
+                        ),
+                        ops.ElementWise(
+                            f"{prefix}_shared_act_gate",
+                            count,
+                            2 * cfg.shared_expert_inter_size // tp,
                             cfg.shared_expert_inter_size // tp,
                             0.8,
                         ),

--- a/aic-core/src/aiconfigurator_core/sdk/models/qwen35.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/qwen35.py
@@ -224,6 +224,7 @@ class Qwen35Model(BaseModel):
                         kvcache_q,
                         fmha_q,
                         head_size=self._head_size,
+                        use_qk_norm=True,
                     ),
                     ops.GEMM("context_proj_gemm", c, h, n_q_per_tp * self._head_size, gemm_q, low_precision_input=True),
                     ops.CustomAllReduce("context_full_ar", c, h, tp),
@@ -241,6 +242,52 @@ class Qwen35Model(BaseModel):
                 ops.P2P("context_p2p", pp - 1, h, pp),
             ]
         )
+
+    def _sglang_deepep(self) -> bool:
+        return self._backend_name == "sglang" and self.config.moe_backend == "deepep_moe"
+
+    def _shared_expert_ops(self, prefix, count, h, tp, gemm_q, cfg: common.Qwen35Config):
+        """Shared-expert block: scalar gate + gated-SiLU MLP (Qwen2MoeMLP) with
+        a fused gate_up projection. DeepEP replicates the shared expert across
+        ranks (tp_size=1) instead of TP-sharding it."""
+        if self._sglang_deepep():
+            tp = 1
+        return [
+            # Scalar expert gate (ReplicatedLinear hidden->1).
+            ops.GEMM(
+                f"{prefix}_shared_expert_gate_gemm",
+                count,
+                1,
+                h,
+                common.GEMMQuantMode.bfloat16,
+            ),
+            ops.GEMM(
+                f"{prefix}_shared_gate_up_gemm",
+                count,
+                2 * cfg.shared_expert_inter_size // tp,
+                h,
+                gemm_q,
+            ),
+            ops.ElementWise(
+                f"{prefix}_shared_act_gate",
+                count,
+                2 * cfg.shared_expert_inter_size // tp,
+                cfg.shared_expert_inter_size // tp,
+                0.8,
+            ),
+            ops.GEMM(
+                f"{prefix}_shared_down_gemm",
+                count,
+                h,
+                cfg.shared_expert_inter_size // tp,
+                gemm_q,
+                low_precision_input=True,
+            ),
+        ]
+
+    def _shared_merge_op(self, prefix, count, h):
+        # sigmoid(expert gate) * shared output + routed output.
+        return ops.ElementWise(f"{prefix}_shared_merge", count, 2 * h, h, 0.8)
 
     def _ffn_context_ops(
         self, prefix, count, h, tp, moe_tp, moe_ep, attn_dp, gemm_q, moe_q, workload_dist, cfg: common.Qwen35Config
@@ -275,25 +322,29 @@ class Qwen35Model(BaseModel):
                         attn_ar_modeled=True,
                     )
                 )
-            ops_list.extend(
-                [
-                    ops.MoE(
-                        f"{prefix}_moe",
-                        count,
-                        h,
-                        cfg.moe_inter_size,
-                        cfg.topk,
-                        cfg.num_experts,
-                        moe_tp,
-                        moe_ep,
-                        moe_q,
-                        workload_dist,
-                        attn_dp,
-                        is_context=True,
-                        moe_backend=self.config.moe_backend,
-                        # EPLB is not modeled for Qwen3.5 (the load curve stays 1.2).
-                        enable_eplb=False,
-                    ),
+            ops_list.append(
+                ops.MoE(
+                    f"{prefix}_moe",
+                    count,
+                    h,
+                    cfg.moe_inter_size,
+                    cfg.topk,
+                    cfg.num_experts,
+                    moe_tp,
+                    moe_ep,
+                    moe_q,
+                    workload_dist,
+                    attn_dp,
+                    is_context=True,
+                    moe_backend=self.config.moe_backend,
+                    # EPLB is not modeled for Qwen3.5 (the load curve stays 1.2).
+                    enable_eplb=False,
+                )
+            )
+            # DeepEP rows hold the full dispatch+combine round trip; the pre
+            # op prices it once (SGLangEPMOEModel precedent), so no post op.
+            if not self._sglang_deepep():
+                ops_list.append(
                     ops.MoEDispatch(
                         f"{prefix}_moe_post_dispatch",
                         count,
@@ -309,46 +360,11 @@ class Qwen35Model(BaseModel):
                         moe_backend=self.config.moe_backend,
                         is_context=True,
                         attn_ar_modeled=True,
-                    ),
-                ]
-            )
-            if cfg.shared_expert_inter_size > 0:
-                ops_list.extend(
-                    [
-                        # Scalar expert gate (ReplicatedLinear hidden->1).
-                        ops.GEMM(
-                            f"{prefix}_shared_expert_gate_gemm",
-                            count,
-                            1,
-                            h,
-                            common.GEMMQuantMode.bfloat16,
-                        ),
-                        # Shared expert is a gated-SiLU MLP (Qwen2MoeMLP) with a
-                        # fused gate_up projection.
-                        ops.GEMM(
-                            f"{prefix}_shared_gate_up_gemm",
-                            count,
-                            2 * cfg.shared_expert_inter_size // tp,
-                            h,
-                            gemm_q,
-                        ),
-                        ops.ElementWise(
-                            f"{prefix}_shared_act_gate",
-                            count,
-                            2 * cfg.shared_expert_inter_size // tp,
-                            cfg.shared_expert_inter_size // tp,
-                            0.8,
-                        ),
-                        ops.GEMM(
-                            f"{prefix}_shared_down_gemm",
-                            count,
-                            h,
-                            cfg.shared_expert_inter_size // tp,
-                            gemm_q,
-                            low_precision_input=True,
-                        ),
-                    ]
+                    )
                 )
+            if cfg.shared_expert_inter_size > 0:
+                ops_list.extend(self._shared_expert_ops(prefix, count, h, tp, gemm_q, cfg))
+                ops_list.append(self._shared_merge_op(prefix, count, h))
         else:
             ops_list.extend(
                 [
@@ -460,6 +476,7 @@ class Qwen35Model(BaseModel):
                         n_kv_per_tp,
                         kvcache_q,
                         head_size=self._head_size,
+                        use_qk_norm=True,
                     ),
                     ops.GEMM(
                         "generation_proj_gemm", c, h, n_q_per_tp * self._head_size, gemm_q, low_precision_input=True
@@ -486,15 +503,16 @@ class Qwen35Model(BaseModel):
         """Return FFN ops for generation phase: dense SwiGLU or MoE."""
         ops_list = [ops.ElementWise(f"{prefix}_ffn_norm", count, 2 * h, 2 * h, 0.8)]
         if cfg.num_experts > 0:
+            routed_ops = []
             if cfg.num_experts >= 128:
-                ops_list.append(
+                routed_ops.append(
                     ops.GEMM(f"{prefix}_router_gemm", count, cfg.num_experts, h, common.GEMMQuantMode.bfloat16)
                 )
             # StandardDispatcher (sglang default MoE path) has no pre-dispatch
             # collective when attention_dp == 1; with DP the LayerCommunicator
             # pre-MLP gather is priced by the dispatch op.
             if not (self._backend_name == "sglang" and self.config.moe_backend is None and attn_dp == 1):
-                ops_list.append(
+                routed_ops.append(
                     ops.MoEDispatch(
                         f"{prefix}_moe_pre_dispatch",
                         count,
@@ -512,24 +530,28 @@ class Qwen35Model(BaseModel):
                         attn_ar_modeled=True,
                     )
                 )
-            ops_list.extend(
-                [
-                    ops.MoE(
-                        f"{prefix}_moe",
-                        count,
-                        h,
-                        cfg.moe_inter_size,
-                        cfg.topk,
-                        cfg.num_experts,
-                        moe_tp,
-                        moe_ep,
-                        moe_q,
-                        workload_dist,
-                        attn_dp,
-                        is_context=False,
-                        moe_backend=self.config.moe_backend,
-                        enable_eplb=False,
-                    ),
+            routed_ops.append(
+                ops.MoE(
+                    f"{prefix}_moe",
+                    count,
+                    h,
+                    cfg.moe_inter_size,
+                    cfg.topk,
+                    cfg.num_experts,
+                    moe_tp,
+                    moe_ep,
+                    moe_q,
+                    workload_dist,
+                    attn_dp,
+                    is_context=False,
+                    moe_backend=self.config.moe_backend,
+                    enable_eplb=False,
+                )
+            )
+            # DeepEP rows hold the full dispatch+combine round trip; the pre
+            # op prices it once (SGLangEPMOEModel precedent), so no post op.
+            if not self._sglang_deepep():
+                routed_ops.append(
                     ops.MoEDispatch(
                         f"{prefix}_moe_post_dispatch",
                         count,
@@ -545,46 +567,20 @@ class Qwen35Model(BaseModel):
                         moe_backend=self.config.moe_backend,
                         is_context=False,
                         attn_ar_modeled=True,
-                    ),
-                ]
-            )
-            if cfg.shared_expert_inter_size > 0:
-                ops_list.extend(
-                    [
-                        # Scalar expert gate (ReplicatedLinear hidden->1).
-                        ops.GEMM(
-                            f"{prefix}_shared_expert_gate_gemm",
-                            count,
-                            1,
-                            h,
-                            common.GEMMQuantMode.bfloat16,
-                        ),
-                        # Shared expert is a gated-SiLU MLP (Qwen2MoeMLP) with a
-                        # fused gate_up projection.
-                        ops.GEMM(
-                            f"{prefix}_shared_gate_up_gemm",
-                            count,
-                            2 * cfg.shared_expert_inter_size // tp,
-                            h,
-                            gemm_q,
-                        ),
-                        ops.ElementWise(
-                            f"{prefix}_shared_act_gate",
-                            count,
-                            2 * cfg.shared_expert_inter_size // tp,
-                            cfg.shared_expert_inter_size // tp,
-                            0.8,
-                        ),
-                        ops.GEMM(
-                            f"{prefix}_shared_down_gemm",
-                            count,
-                            h,
-                            cfg.shared_expert_inter_size // tp,
-                            gemm_q,
-                            low_precision_input=True,
-                        ),
-                    ]
+                    )
                 )
+            shared_ops = (
+                self._shared_expert_ops(prefix, count, h, tp, gemm_q, cfg) if cfg.shared_expert_inter_size > 0 else []
+            )
+            # vLLM decode runs shared and routed experts on parallel CUDA
+            # streams; sglang runs them serially.
+            if shared_ops and self._backend_name == "vllm":
+                ops_list.append(ops.OverlapOp(f"{prefix}_moe_overlap", group_a=routed_ops, group_b=shared_ops))
+            else:
+                ops_list.extend(routed_ops)
+                ops_list.extend(shared_ops)
+            if cfg.shared_expert_inter_size > 0:
+                ops_list.append(self._shared_merge_op(prefix, count, h))
         else:
             ops_list.extend(
                 [

--- a/aic-core/src/aiconfigurator_core/sdk/models/qwen35.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/qwen35.py
@@ -291,7 +291,8 @@ class Qwen35Model(BaseModel):
                         attn_dp,
                         is_context=True,
                         moe_backend=self.config.moe_backend,
-                        enable_eplb=self.config.enable_eplb,
+                        # EPLB is not modeled for Qwen3.5 (the load curve stays 1.2).
+                        enable_eplb=False,
                     ),
                     ops.MoEDispatch(
                         f"{prefix}_moe_post_dispatch",

--- a/aic-core/src/aiconfigurator_core/sdk/models/qwen35.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/qwen35.py
@@ -56,6 +56,9 @@ class Qwen35Model(BaseModel):
                 f"num_v_heads={cfg.linear_num_value_heads}, tp_size={tp}"
             )
 
+        if self.config.cp_size > 1:
+            raise ValueError("Qwen3.5 does not model context parallelism; cp_size must be 1")
+
         self._mtp_scale_factor = mtp_scale_factor(self._nextn, self._num_layers)
 
         if cfg.num_experts > 0:
@@ -78,6 +81,45 @@ class Qwen35Model(BaseModel):
             "linear": cfg.layer_types.count("linear_attention"),
             "full": cfg.layer_types.count("full_attention"),
         }
+
+    # ------------------------------------------------------------------
+    # Memory: paged KV on full-attention layers + constant GDN state
+    # ------------------------------------------------------------------
+
+    def get_kvcache_elements_per_token(self) -> int:
+        """Only full_attention layers hold token-linear KV; GDN layers keep a
+        constant per-request state priced in _gdn_state_bytes_per_request."""
+        cfg: common.Qwen35Config = self.extra_params
+        tp = self.config.tp_size
+        n_kv_per_tp = (self._num_kv_heads + tp - 1) // tp
+        return cfg.layer_types.count("full_attention") * 2 * n_kv_per_tp * self._head_size
+
+    def _gdn_state_bytes_per_request(self) -> float:
+        """Constant GDN state per request on one GPU: fp32 SSM state (Qwen3.5
+        pins mamba_ssm_dtype=float32) + model-dtype conv window, per GDN layer,
+        TP-sharded."""
+        cfg: common.Qwen35Config = self.extra_params
+        tp = self.config.tp_size
+        n_gdn = cfg.layer_types.count("linear_attention")
+        nk, hk = cfg.linear_num_key_heads, cfg.linear_key_head_dim
+        nv, hv = cfg.linear_num_value_heads, cfg.linear_value_head_dim
+        ssm_bytes = (nv // tp) * hk * hv * 4
+        conv_bytes = (2 * nk * hk + nv * hv) // tp * (cfg.linear_conv_kernel_dim - 1) * 2
+        return n_gdn * (ssm_bytes + conv_bytes)
+
+    def get_kvcache_bytes_per_sequence(self, seq_len: int) -> float:
+        seq_len = max(0, seq_len)
+        token_bytes = seq_len * self.config.kvcache_quant_mode.value.memory * self.get_kvcache_elements_per_token()
+        return token_bytes + self._gdn_state_bytes_per_request()
+
+    def get_kvcache_max_tokens(self, kv_budget_bytes: float) -> int:
+        # Single elastic byte pool holding one request's GDN state — same
+        # assumption as kimi_k3.get_kvcache_max_tokens.
+        per_token = self.config.kvcache_quant_mode.value.memory * self.get_kvcache_elements_per_token()
+        budget = kv_budget_bytes - self._gdn_state_bytes_per_request()
+        if budget <= 0 or per_token <= 0:
+            return 0
+        return int(budget // per_token)
 
     def _build_context_ops(self) -> None:
         cfg: common.Qwen35Config = self.extra_params
@@ -210,10 +252,10 @@ class Qwen35Model(BaseModel):
                 ops_list.append(
                     ops.GEMM(f"{prefix}_router_gemm", count, cfg.num_experts, h, common.GEMMQuantMode.bfloat16)
                 )
-            # StandardDispatcher performs only local expert-id mapping before
-            # routed experts; unlike vLLM/DeepEP it has no pre-dispatch
-            # collective. The post-expert TP reduction remains physical.
-            if not (self._backend_name == "sglang" and self.config.moe_backend is None):
+            # StandardDispatcher (sglang default MoE path) has no pre-dispatch
+            # collective when attention_dp == 1; with DP the LayerCommunicator
+            # pre-MLP gather is priced by the dispatch op.
+            if not (self._backend_name == "sglang" and self.config.moe_backend is None and attn_dp == 1):
                 ops_list.append(
                     ops.MoEDispatch(
                         f"{prefix}_moe_pre_dispatch",
@@ -226,6 +268,11 @@ class Qwen35Model(BaseModel):
                         attn_dp,
                         True,
                         quant_mode=moe_q,
+                        sms=self.config.sms,
+                        moe_backend=self.config.moe_backend,
+                        is_context=True,
+                        scale_num_tokens=tp,
+                        attn_ar_modeled=True,
                     )
                 )
             ops_list.extend(
@@ -242,6 +289,9 @@ class Qwen35Model(BaseModel):
                         moe_q,
                         workload_dist,
                         attn_dp,
+                        is_context=True,
+                        moe_backend=self.config.moe_backend,
+                        enable_eplb=self.config.enable_eplb,
                     ),
                     ops.MoEDispatch(
                         f"{prefix}_moe_post_dispatch",
@@ -254,6 +304,10 @@ class Qwen35Model(BaseModel):
                         attn_dp,
                         False,
                         quant_mode=moe_q,
+                        sms=self.config.sms,
+                        moe_backend=self.config.moe_backend,
+                        is_context=True,
+                        attn_ar_modeled=True,
                     ),
                 ]
             )
@@ -435,10 +489,10 @@ class Qwen35Model(BaseModel):
                 ops_list.append(
                     ops.GEMM(f"{prefix}_router_gemm", count, cfg.num_experts, h, common.GEMMQuantMode.bfloat16)
                 )
-            # StandardDispatcher performs only local expert-id mapping before
-            # routed experts; unlike vLLM/DeepEP it has no pre-dispatch
-            # collective. The post-expert TP reduction remains physical.
-            if not (self._backend_name == "sglang" and self.config.moe_backend is None):
+            # StandardDispatcher (sglang default MoE path) has no pre-dispatch
+            # collective when attention_dp == 1; with DP the LayerCommunicator
+            # pre-MLP gather is priced by the dispatch op.
+            if not (self._backend_name == "sglang" and self.config.moe_backend is None and attn_dp == 1):
                 ops_list.append(
                     ops.MoEDispatch(
                         f"{prefix}_moe_pre_dispatch",
@@ -451,6 +505,10 @@ class Qwen35Model(BaseModel):
                         attn_dp,
                         True,
                         quant_mode=moe_q,
+                        sms=self.config.sms,
+                        moe_backend=self.config.moe_backend,
+                        is_context=False,
+                        attn_ar_modeled=True,
                     )
                 )
             ops_list.extend(
@@ -467,6 +525,9 @@ class Qwen35Model(BaseModel):
                         moe_q,
                         workload_dist,
                         attn_dp,
+                        is_context=False,
+                        moe_backend=self.config.moe_backend,
+                        enable_eplb=False,
                     ),
                     ops.MoEDispatch(
                         f"{prefix}_moe_post_dispatch",
@@ -479,6 +540,10 @@ class Qwen35Model(BaseModel):
                         attn_dp,
                         False,
                         quant_mode=moe_q,
+                        sms=self.config.sms,
+                        moe_backend=self.config.moe_backend,
+                        is_context=False,
+                        attn_ar_modeled=True,
                     ),
                 ]
             )

--- a/aic-core/src/aiconfigurator_core/sdk/operations/mamba.py
+++ b/aic-core/src/aiconfigurator_core/sdk/operations/mamba.py
@@ -290,7 +290,8 @@ class GDNKernel(Operation):
         - "causal_conv1d_update": Single-step causal conv state update
         - "fused_sigmoid_gating_delta_rule_update": Single-step GDN recurrence
 
-    Uses full (unsharded) dimensions for database lookup; collector data is per-layer.
+    Uses the runtime kernel dimensions supplied by the model builder for database
+    lookup. Tensor-parallel model builders therefore pass per-rank head counts.
 
     Owns ``_data_cache`` for the packaged gdn_perf Parquet perf table.
     """
@@ -451,11 +452,21 @@ class GDNKernel(Operation):
             elif exact_aliases:
                 return PerformanceResult(get_sol()[0], energy=0.0, source="sol")
             else:
-                # Preserve the legacy fallback only within the logical source;
-                # physical aliases must match the complete model shape.
-                keys_same_d_model = [k for k in by_key if k[0] == d_model]
-                if keys_same_d_model:
-                    model_key = min(keys_same_d_model, key=lambda k: abs(k[3] - num_v_heads))
+                # Nearest-shape fallback is allowed only across num_v_heads;
+                # every other dimension must match exactly so a TP-local query
+                # can never be priced from a different head geometry. A genuine
+                # miss degrades to SOL.
+                candidate_keys = [
+                    k
+                    for k in by_key
+                    if k[0] == d_model
+                    and k[1] == num_k_heads
+                    and k[2] == head_k_dim
+                    and k[4] == head_v_dim
+                    and k[5] == d_conv
+                ]
+                if candidate_keys:
+                    model_key = min(candidate_keys, key=lambda k: abs(k[3] - num_v_heads))
                 else:
                     return PerformanceResult(get_sol()[0], energy=0.0, source="sol")
 

--- a/aic-core/src/aiconfigurator_core/sdk/operations/mamba.py
+++ b/aic-core/src/aiconfigurator_core/sdk/operations/mamba.py
@@ -384,34 +384,36 @@ class GDNKernel(Operation):
         def get_sol(b: int = batch_size, s: int | None = seq_len) -> tuple[float, float, float]:
             x = (b * s) if phase == "context" and s else b
             if kernel_source in ("causal_conv1d_fn", "causal_conv1d_update"):
-                conv_channels = num_k_heads * head_k_dim + num_v_heads * head_v_dim
+                # Packed q/k/v convolution width (2K + V), matching the collector's conv_dim.
+                conv_channels = 2 * num_k_heads * head_k_dim + num_v_heads * head_v_dim
                 read_bytes = x * conv_channels * (d_conv + 1) * 2
                 write_bytes = x * conv_channels * 2
             elif kernel_source == "chunk_gated_delta_rule":
-                # GDN chunked scan (context phase).
-                # State shape: [num_v_heads, head_k_dim, head_v_dim], stored as BF16 in global memory.
-                # Intermediate h_chunks [B, NT, H, K, V] are written by chunk_delta_h and read by
-                # chunk_o via global memory (separate kernel launches). Allocated via k.new_empty()
-                # (no dtype override), so matches input dtype: FP16/BF16 → 2 bytes.
+                # GDN chunked scan (context phase). Reads q/k/v (2K + V wide);
+                # state [num_v_heads, head_k_dim, head_v_dim] is FP32 (Qwen3.5 pins
+                # mamba_ssm_dtype=float32). Intermediate h_chunks [B, NT, H, K, V]
+                # are written by chunk_delta_h and read by chunk_o via global
+                # memory, allocated at input dtype (BF16 -> 2 bytes).
                 chunk_size = 64  # flash-linear-attention default for chunk_gated_delta_rule
                 state_size = num_v_heads * head_k_dim * head_v_dim
                 num_chunks = (s // chunk_size) if s else 0
                 h_chunks_bytes = num_chunks * state_size * 2 * b
                 read_bytes = (
-                    x * (num_k_heads * head_k_dim + num_v_heads * head_v_dim) * 2
-                    + state_size * 2 * b
+                    x * (2 * num_k_heads * head_k_dim + num_v_heads * head_v_dim) * 2
+                    + state_size * 4 * b
                     + h_chunks_bytes  # chunk_o reads h_chunks from global memory
                 )
                 write_bytes = (
                     x * num_v_heads * head_v_dim * 2
-                    + state_size * 2 * b
+                    + state_size * 4 * b
                     + h_chunks_bytes  # chunk_delta_h writes h_chunks to global memory
                 )
             elif kernel_source == "fused_sigmoid_gating_delta_rule_update":
-                # GDN single-step decode. State stored as BF16 in global memory.
+                # GDN single-step decode: reads q/k/v (2K + V wide) plus the FP32
+                # recurrent state.
                 state_size = num_v_heads * head_k_dim * head_v_dim
-                read_bytes = x * (num_k_heads * head_k_dim + num_v_heads * head_v_dim) * 2 + state_size * 2 * b
-                write_bytes = x * num_v_heads * head_v_dim * 2 + state_size * 2 * b
+                read_bytes = x * (2 * num_k_heads * head_k_dim + num_v_heads * head_v_dim) * 2 + state_size * 4 * b
+                write_bytes = x * num_v_heads * head_v_dim * 2 + state_size * 4 * b
             else:
                 read_bytes = x * d_model * 2
                 write_bytes = x * d_model * 2
@@ -449,26 +451,11 @@ class GDNKernel(Operation):
 
             if len(exact_aliases) == 1:
                 by_key = exact_aliases[0]
-            elif exact_aliases:
-                return PerformanceResult(get_sol()[0], energy=0.0, source="sol")
             else:
-                # Nearest-shape fallback is allowed only across num_v_heads;
-                # every other dimension must match exactly so a TP-local query
-                # can never be priced from a different head geometry. A genuine
-                # miss degrades to SOL.
-                candidate_keys = [
-                    k
-                    for k in by_key
-                    if k[0] == d_model
-                    and k[1] == num_k_heads
-                    and k[2] == head_k_dim
-                    and k[4] == head_v_dim
-                    and k[5] == d_conv
-                ]
-                if candidate_keys:
-                    model_key = min(candidate_keys, key=lambda k: abs(k[3] - num_v_heads))
-                else:
-                    return PerformanceResult(get_sol()[0], energy=0.0, source="sol")
+                # Exact geometry only — ambiguous physical aliases or a genuine
+                # miss degrade to SOL; nearest-shape rows are never returned as
+                # silicon.
+                return PerformanceResult(get_sol()[0], energy=0.0, source="sol")
 
         table = by_key[model_key]
 

--- a/aic-core/src/aiconfigurator_core/sdk/operations/moe.py
+++ b/aic-core/src/aiconfigurator_core/sdk/operations/moe.py
@@ -872,6 +872,7 @@ class MoEDispatch(Operation):
         self._quant_mode = kwargs.get("quant_mode")
         self._reduce_results = kwargs.get("reduce_results", True)
         self._attn_cp_size = kwargs.get("attn_cp_size", 1)
+        self._attn_ar_modeled = kwargs.get("attn_ar_modeled", False)
 
     # ------------------------------------------------------------------
     # Data ownership
@@ -1293,11 +1294,11 @@ class MoEDispatch(Operation):
 
             comm_latency = 0
 
-            # With attention_dp == 1 activations are already replicated by the
-            # attention-side all-reduce, so vLLM's FusedMoE has no pre-dispatch
-            # collective; the single final all-reduce covers both the TP
-            # partial-sum and the EP combine.
-            if self._attention_tp_size > 1 and not self._pre_dispatch:
+            # vLLM's FusedMoE has no pre-dispatch collective when attention_dp == 1;
+            # the pre-dispatch AR here doubles as the attention-output all-reduce
+            # for models that do not compose it explicitly. Models that price that
+            # AR themselves pass attn_ar_modeled=True.
+            if self._attention_tp_size > 1 and not (self._pre_dispatch and self._attn_ar_modeled):
                 comm_latency += database.query_custom_allreduce(common.CommQuantMode.half, self.num_gpus, volume)
 
             if self._attention_dp_size > 1:

--- a/aic-core/src/aiconfigurator_core/sdk/operations/moe.py
+++ b/aic-core/src/aiconfigurator_core/sdk/operations/moe.py
@@ -1293,8 +1293,11 @@ class MoEDispatch(Operation):
 
             comm_latency = 0
 
-            # Add allreduce latency when TP > 1
-            if self._attention_tp_size > 1:
+            # With attention_dp == 1 activations are already replicated by the
+            # attention-side all-reduce, so vLLM's FusedMoE has no pre-dispatch
+            # collective; the single final all-reduce covers both the TP
+            # partial-sum and the EP combine.
+            if self._attention_tp_size > 1 and not self._pre_dispatch:
                 comm_latency += database.query_custom_allreduce(common.CommQuantMode.half, self.num_gpus, volume)
 
             if self._attention_dp_size > 1:

--- a/collector/case_generator.py
+++ b/collector/case_generator.py
@@ -1627,8 +1627,10 @@ def _get_base_gemm_shape_sweeps(backend: str | None = None) -> list[dict[str, ob
 
 def get_gemm_case_specs(backend: str | None = None) -> list[GemmCommonTestCase]:
     test_cases = []
+    base_token_counts: set[int] = set()
     for shape_sweep in _get_base_gemm_shape_sweeps(backend):
         token_counts = _as_int_list(shape_sweep.get("token_counts"), field_name="gemm.token_counts")
+        base_token_counts.update(token_counts)
         feature_sizes = shape_sweep.get("feature_sizes")
         input_feature_sizes = _as_int_list(
             shape_sweep.get("input_feature_sizes", feature_sizes),
@@ -1650,6 +1652,30 @@ def get_gemm_case_specs(backend: str | None = None) -> list[GemmCommonTestCase]:
                     if output_features * input_features == 65536 * 65536:
                         continue
                     test_cases.append(GemmCommonTestCase(x=token_count, n=output_features, k=input_features))
+
+    # Model-declared exact widths (model_case_values.gemm), e.g. scalar expert
+    # gates and GDN b/a projections below the base feature grid. Token density
+    # comes from the base sweeps; dedup on the physical (x, n, k) tuple.
+    seen = {(case.x, case.n, case.k) for case in test_cases}
+    for model_row in _model_case_values("gemm"):
+        output_features = _as_int_list(
+            model_row.get("output_feature_sizes"),
+            field_name="model_case_values.gemm.output_feature_sizes",
+        )
+        input_features = _as_int_list(
+            model_row.get("input_feature_sizes"),
+            field_name="model_case_values.gemm.input_feature_sizes",
+        )
+        for value in (*output_features, *input_features):
+            if value <= 0:
+                raise ValueError(f"model_case_values.gemm feature sizes must be positive integers, got {value}")
+        for token_count in sorted(base_token_counts, reverse=True):
+            for n in sorted(output_features, reverse=True):
+                for k in sorted(input_features, reverse=True):
+                    if (token_count, n, k) in seen:
+                        continue
+                    seen.add((token_count, n, k))
+                    test_cases.append(GemmCommonTestCase(x=token_count, n=n, k=k))
 
     return test_cases
 

--- a/collector/case_generator.py
+++ b/collector/case_generator.py
@@ -2023,10 +2023,14 @@ def get_common_gdn_test_cases() -> list[GdnCommonTestCase]:
     """
     Generate common test cases for GDN (Gated DeltaNet) kernel benchmarking.
 
-    Covers all 8 unique dimension sets across the full Qwen3.5 collection
-    for both context (prefill) and generation (decode) phases.
+    Expands each model's global GDN geometry over its declared tensor-parallel
+    sizes. ``d_model`` remains global because it is part of the persisted
+    lookup key; K/V head counts are TP-local because that is the geometry
+    executed by the runtime kernels. Batch/seq density comes from the base
+    sweep grid only, like every other base op.
     """
     test_cases: list[GdnCommonTestCase] = []
+    seen_model_keys: set[tuple[int, int, int, int, int, int]] = set()
     gdn_sweep = _required_base_common_case_values("gdn")
     context_seq_lens = _as_int_list(
         gdn_sweep.get("context_sequence_lengths"),
@@ -2051,38 +2055,68 @@ def get_common_gdn_test_cases() -> list[GdnCommonTestCase]:
         num_v_heads = int(model_config["num_v_heads"])
         head_v_dim = int(model_config["head_v_dim"])
         model_name = str(model_config["model_path"])
-
-        # Context (prefill) test case
-        test_cases.append(
-            GdnCommonTestCase(
-                phase="context",
-                d_model=d_model,
-                d_conv=d_conv,
-                num_k_heads=num_k_heads,
-                head_k_dim=head_k_dim,
-                num_v_heads=num_v_heads,
-                head_v_dim=head_v_dim,
-                batch_size_list=context_batch_sizes,
-                seq_len_list=context_seq_lens,
-                model_name=model_name,
-            )
+        tp_sizes = _as_int_list(
+            model_config.get("tensor_parallel_sizes"),
+            field_name="model_case_values.gdn.tensor_parallel_sizes",
         )
 
-        # Generation (decode) test case
-        test_cases.append(
-            GdnCommonTestCase(
-                phase="generation",
-                d_model=d_model,
-                d_conv=d_conv,
-                num_k_heads=num_k_heads,
-                head_k_dim=head_k_dim,
-                num_v_heads=num_v_heads,
-                head_v_dim=head_v_dim,
-                batch_size_list=generation_batch_sizes,
-                seq_len_list=None,
-                model_name=model_name,
+        for tp_size in tp_sizes:
+            if tp_size <= 0:
+                raise ValueError(
+                    "model_case_values.gdn.tensor_parallel_sizes must contain only positive integers, "
+                    f"got {tp_size} for {model_name}"
+                )
+            if num_k_heads % tp_size != 0 or num_v_heads % tp_size != 0:
+                raise ValueError(
+                    "GDN TP-local heads require both global head counts to be divisible by tensor parallel size: "
+                    f"model={model_name}, num_k_heads={num_k_heads}, num_v_heads={num_v_heads}, tp={tp_size}"
+                )
+
+            local_num_k_heads = num_k_heads // tp_size
+            local_num_v_heads = num_v_heads // tp_size
+            model_key = (
+                d_model,
+                local_num_k_heads,
+                head_k_dim,
+                local_num_v_heads,
+                head_v_dim,
+                d_conv,
             )
-        )
+            if model_key in seen_model_keys:
+                continue
+            seen_model_keys.add(model_key)
+
+            # Context (prefill) test case
+            test_cases.append(
+                GdnCommonTestCase(
+                    phase="context",
+                    d_model=d_model,
+                    d_conv=d_conv,
+                    num_k_heads=local_num_k_heads,
+                    head_k_dim=head_k_dim,
+                    num_v_heads=local_num_v_heads,
+                    head_v_dim=head_v_dim,
+                    batch_size_list=context_batch_sizes,
+                    seq_len_list=context_seq_lens,
+                    model_name=model_name,
+                )
+            )
+
+            # Generation (decode) test case
+            test_cases.append(
+                GdnCommonTestCase(
+                    phase="generation",
+                    d_model=d_model,
+                    d_conv=d_conv,
+                    num_k_heads=local_num_k_heads,
+                    head_k_dim=head_k_dim,
+                    num_v_heads=local_num_v_heads,
+                    head_v_dim=head_v_dim,
+                    batch_size_list=generation_batch_sizes,
+                    seq_len_list=None,
+                    model_name=model_name,
+                )
+            )
 
     return test_cases
 

--- a/collector/cases/models/Qwen3_5ForConditionalGeneration_cases.yaml
+++ b/collector/cases/models/Qwen3_5ForConditionalGeneration_cases.yaml
@@ -56,6 +56,7 @@ model_case_values:
       head_k_dim: 128
       num_v_heads: 16
       head_v_dim: 128
+      tensor_parallel_sizes: [1, 2, 4, 8]
     - model_path: Qwen/Qwen3.5-2B
       d_model: 2048
       d_conv: 4
@@ -63,6 +64,7 @@ model_case_values:
       head_k_dim: 128
       num_v_heads: 16
       head_v_dim: 128
+      tensor_parallel_sizes: [1, 2, 4, 8]
     - model_path: Qwen/Qwen3.5-4B
       d_model: 2560
       d_conv: 4
@@ -70,6 +72,7 @@ model_case_values:
       head_k_dim: 128
       num_v_heads: 32
       head_v_dim: 128
+      tensor_parallel_sizes: [1, 2, 4, 8]
     - model_path: Qwen/Qwen3.5-9B
       d_model: 4096
       d_conv: 4
@@ -77,6 +80,7 @@ model_case_values:
       head_k_dim: 128
       num_v_heads: 32
       head_v_dim: 128
+      tensor_parallel_sizes: [1, 2, 4, 8]
     - model_path: Qwen/Qwen3.5-27B
       d_model: 5120
       d_conv: 4
@@ -84,6 +88,7 @@ model_case_values:
       head_k_dim: 128
       num_v_heads: 48
       head_v_dim: 128
+      tensor_parallel_sizes: [1, 2, 4, 8]
 
 all_frameworks_op_cases:
   gdn:

--- a/collector/cases/models/Qwen3_5ForConditionalGeneration_cases.yaml
+++ b/collector/cases/models/Qwen3_5ForConditionalGeneration_cases.yaml
@@ -48,6 +48,23 @@ model_case_values:
       window_size: 0
       sglang_backends: {90: fa3, 100: triton, 103: triton, 120: flashinfer}
       tensor_parallel_sizes: [1, 2, 4, 8]
+  gemm:
+    # GDN in_proj_ba widths (2 * num_v_heads / tp) below the base feature grid (min 32).
+    - model_path: Qwen/Qwen3.5-0.8B
+      output_feature_sizes: [4, 8, 16]
+      input_feature_sizes: [1024]
+    - model_path: Qwen/Qwen3.5-2B
+      output_feature_sizes: [4, 8, 16]
+      input_feature_sizes: [2048]
+    - model_path: Qwen/Qwen3.5-4B
+      output_feature_sizes: [8, 16]
+      input_feature_sizes: [2560]
+    - model_path: Qwen/Qwen3.5-9B
+      output_feature_sizes: [8, 16]
+      input_feature_sizes: [4096]
+    - model_path: Qwen/Qwen3.5-27B
+      output_feature_sizes: [12, 24]
+      input_feature_sizes: [5120]
   gdn:
     - model_path: Qwen/Qwen3.5-0.8B
       d_model: 1024

--- a/collector/cases/models/Qwen3_5MoeForConditionalGeneration_cases.yaml
+++ b/collector/cases/models/Qwen3_5MoeForConditionalGeneration_cases.yaml
@@ -70,6 +70,18 @@ model_case_values:
       sglang_moe_backends:
         bfloat16: {100: flashinfer_trtllm, 103: flashinfer_trtllm}
         fp8_block: {100: flashinfer_trtllm, 103: flashinfer_trtllm}
+  gemm:
+    # Exact widths below the base feature grid (min 32): scalar shared-expert
+    # gate (hidden -> 1) and GDN in_proj_ba (2 * num_v_heads / tp).
+    - model_path: Qwen/Qwen3.5-35B-A3B
+      output_feature_sizes: [1, 8, 16]
+      input_feature_sizes: [2048]
+    - model_path: Qwen/Qwen3.5-122B-A10B
+      output_feature_sizes: [1, 16]
+      input_feature_sizes: [3072]
+    - model_path: Qwen/Qwen3.5-397B-A17B
+      output_feature_sizes: [1, 16]
+      input_feature_sizes: [4096]
   gdn:
     - model_path: Qwen/Qwen3.5-35B-A3B
       d_model: 2048

--- a/collector/cases/models/Qwen3_5MoeForConditionalGeneration_cases.yaml
+++ b/collector/cases/models/Qwen3_5MoeForConditionalGeneration_cases.yaml
@@ -74,13 +74,13 @@ model_case_values:
     # Exact widths below the base feature grid (min 32): scalar shared-expert
     # gate (hidden -> 1) and GDN in_proj_ba (2 * num_v_heads / tp).
     - model_path: Qwen/Qwen3.5-35B-A3B
-      output_feature_sizes: [1, 8, 16]
+      output_feature_sizes: [1, 4, 8, 16]
       input_feature_sizes: [2048]
     - model_path: Qwen/Qwen3.5-122B-A10B
-      output_feature_sizes: [1, 16]
+      output_feature_sizes: [1, 8, 16]
       input_feature_sizes: [3072]
     - model_path: Qwen/Qwen3.5-397B-A17B
-      output_feature_sizes: [1, 16]
+      output_feature_sizes: [1, 8, 16]
       input_feature_sizes: [4096]
   gdn:
     - model_path: Qwen/Qwen3.5-35B-A3B
@@ -90,7 +90,7 @@ model_case_values:
       head_k_dim: 128
       num_v_heads: 32
       head_v_dim: 128
-      tensor_parallel_sizes: [1, 2, 4, 8]
+      tensor_parallel_sizes: [1, 2, 4, 8, 16]
     - model_path: Qwen/Qwen3.5-122B-A10B
       d_model: 3072
       d_conv: 4
@@ -98,7 +98,7 @@ model_case_values:
       head_k_dim: 128
       num_v_heads: 64
       head_v_dim: 128
-      tensor_parallel_sizes: [1, 2, 4, 8]
+      tensor_parallel_sizes: [1, 2, 4, 8, 16]
     - model_path: Qwen/Qwen3.5-397B-A17B
       d_model: 4096
       d_conv: 4
@@ -106,7 +106,7 @@ model_case_values:
       head_k_dim: 128
       num_v_heads: 64
       head_v_dim: 128
-      tensor_parallel_sizes: [1, 2, 4, 8]
+      tensor_parallel_sizes: [1, 2, 4, 8, 16]
 
 all_frameworks_op_cases:
   moe:

--- a/collector/cases/models/Qwen3_5MoeForConditionalGeneration_cases.yaml
+++ b/collector/cases/models/Qwen3_5MoeForConditionalGeneration_cases.yaml
@@ -78,6 +78,7 @@ model_case_values:
       head_k_dim: 128
       num_v_heads: 32
       head_v_dim: 128
+      tensor_parallel_sizes: [1, 2, 4, 8]
     - model_path: Qwen/Qwen3.5-122B-A10B
       d_model: 3072
       d_conv: 4
@@ -85,6 +86,7 @@ model_case_values:
       head_k_dim: 128
       num_v_heads: 64
       head_v_dim: 128
+      tensor_parallel_sizes: [1, 2, 4, 8]
     - model_path: Qwen/Qwen3.5-397B-A17B
       d_model: 4096
       d_conv: 4
@@ -92,6 +94,7 @@ model_case_values:
       head_k_dim: 128
       num_v_heads: 64
       head_v_dim: 128
+      tensor_parallel_sizes: [1, 2, 4, 8]
 
 all_frameworks_op_cases:
   moe:

--- a/collector/sglang/collect_gdn.py
+++ b/collector/sglang/collect_gdn.py
@@ -396,7 +396,7 @@ def run_gdn_generation_benchmark(
             a = torch.randn(batch_size, num_v_heads, dtype=dtype, device=device)
             b = torch.randn(batch_size, num_v_heads, dtype=dtype, device=device)
             a_log = torch.zeros(num_v_heads, dtype=torch.float32, device=device)
-            dt_bias = torch.ones(num_v_heads, dtype=torch.float32, device=device)
+            dt_bias = torch.ones(num_v_heads, dtype=dtype, device=device)
             output = torch.empty(
                 batch_size,
                 1,

--- a/collector/sglang/collect_gdn.py
+++ b/collector/sglang/collect_gdn.py
@@ -255,7 +255,7 @@ def run_gdn_context_benchmark(
                     kernel_func=run_conv1d,
                     num_warmups=num_warmups,
                     num_runs=num_runs,
-                    repeat_n=1,
+                    repeat_n=10,
                 ) as results:
                     if not log_perf(
                         item_list=[{**common_log_data, "latency": results["latency_ms"]}],
@@ -288,7 +288,7 @@ def run_gdn_context_benchmark(
                     kernel_func=run_gdn_scan,
                     num_warmups=num_warmups,
                     num_runs=num_runs,
-                    repeat_n=1,
+                    repeat_n=10,
                 ) as results:
                     if not log_perf(
                         item_list=[{**common_log_data, "latency": results["latency_ms"]}],
@@ -435,7 +435,7 @@ def run_gdn_generation_benchmark(
                 kernel_func=run_conv1d_update,
                 num_warmups=num_warmups,
                 num_runs=num_runs,
-                repeat_n=1,
+                repeat_n=10,
             ) as results:
                 if not log_perf(
                     item_list=[{**common_log_data, "latency": results["latency_ms"]}],
@@ -468,7 +468,7 @@ def run_gdn_generation_benchmark(
                 kernel_func=run_gdn_update,
                 num_warmups=num_warmups,
                 num_runs=num_runs,
-                repeat_n=1,
+                repeat_n=10,
             ) as results:
                 if not log_perf(
                     item_list=[{**common_log_data, "latency": results["latency_ms"]}],

--- a/collector/vllm/collect_gdn.py
+++ b/collector/vllm/collect_gdn.py
@@ -206,10 +206,13 @@ def run_gdn_context_benchmark(
                 kernel_func=run_conv1d,
                 num_warmups=num_warmups,
                 num_runs=num_runs,
+                # Production launches this op eagerly but back-to-back in a deep
+                # queue, so the row must hold GPU service time: graph replay
+                # (the helper default) matches production timeline activity to
+                # -0.3%, while a sync-bounded eager loop times the launch
+                # envelope instead (~4.9x high; qwen35_397b prefill
+                # qualification, 2026-08).
                 repeat_n=1,
-                # Qwen3.5 production prefill is eager in the alignment
-                # benchmark. Pin the collector to that same execution regime.
-                use_cuda_graph=False,
             ) as results:
                 log_perf(
                     item_list=[{**common_log_data, "latency": results["latency_ms"]}],

--- a/collector/vllm/collect_gdn.py
+++ b/collector/vllm/collect_gdn.py
@@ -212,7 +212,7 @@ def run_gdn_context_benchmark(
                 # -0.3%, while a sync-bounded eager loop times the launch
                 # envelope instead (~4.9x high; qwen35_397b prefill
                 # qualification, 2026-08).
-                repeat_n=1,
+                repeat_n=10,
             ) as results:
                 log_perf(
                     item_list=[{**common_log_data, "latency": results["latency_ms"]}],
@@ -321,7 +321,7 @@ def run_gdn_context_benchmark(
                 kernel_func=run_gdn_scan,
                 num_warmups=num_warmups,
                 num_runs=num_runs,
-                repeat_n=1,
+                repeat_n=10,
             ) as results:
                 log_perf(
                     item_list=[{**common_log_data, "latency": results["latency_ms"]}],
@@ -421,7 +421,7 @@ def run_gdn_generation_benchmark(
             kernel_func=run_conv1d_update,
             num_warmups=num_warmups,
             num_runs=num_runs,
-            repeat_n=1,
+            repeat_n=10,
         ) as results:
             log_perf(
                 item_list=[{**common_log_data, "latency": results["latency_ms"]}],
@@ -507,7 +507,7 @@ def run_gdn_generation_benchmark(
             kernel_func=run_gdn_update,
             num_warmups=num_warmups,
             num_runs=num_runs,
-            repeat_n=1,
+            repeat_n=10,
         ) as results:
             log_perf(
                 item_list=[{**common_log_data, "latency": results["latency_ms"]}],

--- a/collector/vllm/collect_gdn.py
+++ b/collector/vllm/collect_gdn.py
@@ -174,13 +174,17 @@ def run_gdn_context_benchmark(
             # Production prefill applies the depthwise convolution to packed
             # QKV, not only to K. Fresh prompts have no initial conv state.
             conv_input = torch.randn(num_tokens, conv_dim, dtype=dtype, device=device).transpose(0, 1)
+            # Serving stores conv state in the SD layout and hands the
+            # stride-aware conv kernels a transposed (dim, width-1) view
+            # (vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+            # :1311-1314 @0.24.0); match its strides.
             conv_state = torch.zeros(
                 batch_size + 1,
-                conv_dim,
                 d_conv - 1,
+                conv_dim,
                 dtype=dtype,
                 device=device,
-            )
+            ).transpose(-1, -2)
             # State slot zero is vLLM's null block and is intentionally never
             # assigned to a live request.
             cache_indices = torch.arange(1, batch_size + 1, dtype=torch.int32, device=device)
@@ -391,13 +395,15 @@ def run_gdn_generation_benchmark(
         }
 
         conv_input = torch.randn(batch_size, conv_dim, dtype=dtype, device=device)
+        # SD-layout state with a transposed view, matching serving strides
+        # (see the context-phase note).
         conv_state = torch.randn(
             batch_size + 1,
-            conv_dim,
             d_conv - 1,
+            conv_dim,
             dtype=dtype,
             device=device,
-        )
+        ).transpose(-1, -2)
         state_indices = torch.arange(1, batch_size + 1, dtype=torch.int32, device=device)
 
         def run_conv1d_update(_conv_input=conv_input, _conv_state=conv_state):

--- a/collector/vllm/collect_gdn.py
+++ b/collector/vllm/collect_gdn.py
@@ -21,6 +21,8 @@ from vllm.config import VllmConfig, set_current_vllm_config
 from vllm.model_executor.layers.fla.ops import fused_recurrent_gated_delta_rule_packed_decode
 from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import ChunkGatedDeltaRule
 from vllm.model_executor.layers.mamba.ops.causal_conv1d import causal_conv1d_fn, causal_conv1d_update
+from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
+from vllm.v1.attention.backends.utils import compute_causal_conv1d_metadata
 from vllm.version import __version__ as vllm_version
 
 from collector.case_generator import get_common_gdn_test_cases
@@ -137,12 +139,36 @@ def run_gdn_context_benchmark(
                 "head_v_dim": head_v_dim,
                 "model_name": model_name,
             }
-            query_start_loc = torch.arange(
+            query_start_loc_cpu = torch.arange(
                 0,
                 num_tokens + 1,
                 seq_len,
                 dtype=torch.int32,
+                device="cpu",
+            )
+            query_start_loc = query_start_loc_cpu.to(device)
+            # Serving precomputes this metadata once in the attention builder
+            # and passes it into every layer's causal_conv1d_fn call. Omitting
+            # it takes the non-serving branch, which performs D2H/NumPy/list
+            # setup inside every timed invocation. Keep the collector on the
+            # pinned vLLM 0.24.0 serving path:
+            # vllm/v1/attention/backends/gdn_attn.py:394-401 and
+            # vllm/v1/attention/backends/utils.py:810-856 @ ee0da84ab.
+            nums_dict, batch_ptr, token_chunk_offset_ptr = compute_causal_conv1d_metadata(
+                query_start_loc_cpu,
                 device=device,
+            )
+            conv_metadata = GDNAttentionMetadata(
+                num_prefills=batch_size,
+                num_prefill_tokens=num_tokens,
+                num_decodes=0,
+                num_decode_tokens=0,
+                num_spec_decodes=0,
+                num_spec_decode_tokens=0,
+                num_actual_tokens=num_tokens,
+                nums_dict=nums_dict,
+                batch_ptr=batch_ptr,
+                token_chunk_offset_ptr=token_chunk_offset_ptr,
             )
 
             # Production prefill applies the depthwise convolution to packed
@@ -170,6 +196,7 @@ def run_gdn_context_benchmark(
                     cache_indices=cache_indices,
                     has_initial_state=has_initial_state,
                     activation="silu",
+                    metadata=conv_metadata,
                 )
 
             run_conv1d()
@@ -180,10 +207,8 @@ def run_gdn_context_benchmark(
                 num_warmups=num_warmups,
                 num_runs=num_runs,
                 repeat_n=1,
-                # vLLM 0.24's packed prefill convolution performs a metadata
-                # copy that CUDA graph capture rejects. Every SM90 full-run
-                # point therefore used eager execution; make that method
-                # explicit instead of silently falling back at runtime.
+                # Qwen3.5 production prefill is eager in the alignment
+                # benchmark. Pin the collector to that same execution regime.
                 use_cuda_graph=False,
             ) as results:
                 log_perf(
@@ -247,12 +272,15 @@ def run_gdn_context_benchmark(
                     device=device,
                 )
             )
+            # FP32 recurrent state matches serving: Qwen3.5 checkpoints pin
+            # mamba_ssm_dtype=float32 (vllm/model_executor/models/config.py:603-628
+            # @0.24.0). Qwen3.5-only contract; revisit if other GDN models join.
             gdn_state = torch.zeros(
                 batch_size,
                 num_v_heads,
                 head_v_dim,
                 head_k_dim,
-                dtype=dtype,
+                dtype=torch.float32,
                 device=device,
             )
 
@@ -431,12 +459,13 @@ def run_gdn_generation_benchmark(
         # which defaults to True (vllm/envs.py:115).
         a = torch.randn(batch_size, num_v_heads, dtype=dtype, device=device)
         b = torch.randn(batch_size, num_v_heads, dtype=dtype, device=device)
+        # FP32 recurrent state matches serving (see the context-phase note).
         gdn_state = torch.randn(
             batch_size + 1,
             num_v_heads,
             head_v_dim,
             head_k_dim,
-            dtype=dtype,
+            dtype=torch.float32,
             device=device,
         )
         out = torch.empty(

--- a/collector/vllm/collect_gdn.py
+++ b/collector/vllm/collect_gdn.py
@@ -207,11 +207,8 @@ def run_gdn_context_benchmark(
                 num_warmups=num_warmups,
                 num_runs=num_runs,
                 # Production launches this op eagerly but back-to-back in a deep
-                # queue, so the row must hold GPU service time: graph replay
-                # (the helper default) matches production timeline activity to
-                # -0.3%, while a sync-bounded eager loop times the launch
-                # envelope instead (~4.9x high; qwen35_397b prefill
-                # qualification, 2026-08).
+                # queue, so the row must hold GPU service time; a sync-bounded
+                # eager loop would time the launch envelope instead.
                 repeat_n=10,
             ) as results:
                 log_perf(

--- a/tests/unit/collector/test_gdn_dtype_contract.py
+++ b/tests/unit/collector/test_gdn_dtype_contract.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _function(source_path: Path, name: str) -> ast.FunctionDef:
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    return next(node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == name)
+
+
+def _assigned_torch_call(function: ast.FunctionDef, variable: str) -> list[ast.Call]:
+    calls = []
+    for node in ast.walk(function):
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(target, ast.Name) and target.id == variable for target in node.targets):
+            continue
+        if isinstance(node.value, ast.Call):
+            calls.append(node.value)
+    return calls
+
+
+def _dtype_expression(call: ast.Call) -> str | None:
+    for keyword in call.keywords:
+        if keyword.arg == "dtype":
+            return ast.unparse(keyword.value)
+    return None
+
+
+@pytest.mark.parametrize(
+    "function_name",
+    ("run_gdn_context_benchmark", "run_gdn_generation_benchmark"),
+)
+def test_vllm_gdn_temporal_state_matches_qwen35_fp32_cache(function_name):
+    """All Qwen3.5 checkpoints declare mamba_ssm_dtype=float32, and vLLM's
+    Qwen3_5ForConditionalGenerationConfig.verify_and_update_config
+    (vllm/model_executor/models/config.py:603-628 @ v0.24.0) adopts it when
+    --mamba-ssm-cache-dtype is left at 'auto' — serving ssm state is fp32."""
+    source_path = REPO_ROOT / "collector" / "vllm" / "collect_gdn.py"
+    calls = _assigned_torch_call(_function(source_path, function_name), "gdn_state")
+
+    assert len(calls) == 1
+    assert _dtype_expression(calls[0]) == "torch.float32"
+
+
+def test_sglang_gdn_generation_matches_bf16_model_dt_bias():
+    """sglang's Qwen3_5GatedDeltaNet creates dt_bias without an explicit
+    dtype (python/sglang/srt/models/qwen3_5.py:237-239 @ v0.5.14), so the
+    parameter follows the model dtype (bf16), not fp32."""
+    source_path = REPO_ROOT / "collector" / "sglang" / "collect_gdn.py"
+    function = _function(source_path, "run_gdn_generation_benchmark")
+    calls = _assigned_torch_call(function, "dt_bias")
+
+    assert len(calls) == 1
+    assert _dtype_expression(calls[0]) == "dtype"

--- a/tests/unit/collector/test_model_cases.py
+++ b/tests/unit/collector/test_model_cases.py
@@ -40,6 +40,19 @@ def _load_mla_adapter(module_path: str, globals_dict: dict):
     return namespace["_build_mla_test_cases"]
 
 
+def _load_gdn_getter(module_path: str):
+    from collector.case_generator import get_common_gdn_test_cases
+
+    source_path = REPO_ROOT / module_path
+    tree = ast.parse(source_path.read_text(), filename=str(source_path))
+    function = next(
+        node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == "get_gdn_test_cases"
+    )
+    namespace = {"get_common_gdn_test_cases": get_common_gdn_test_cases}
+    exec(compile(ast.Module(body=[function], type_ignores=[]), str(source_path), "exec"), namespace)
+    return namespace["get_gdn_test_cases"]
+
+
 def test_model_case_plan_merges_required_base_and_framework_specific_ops():
     plan = build_collection_case_plan(backend="sglang", model_path="deepseek-ai/DeepSeek-V3")
 
@@ -196,6 +209,71 @@ def test_added_model_moe_profiles_resolve_targeted_aliases(monkeypatch):
         assert {
             (case.model_name, case.hidden_size, case.inter_size, case.topk, case.num_experts) for case in cases
         } == {expected}
+
+
+@pytest.mark.parametrize(
+    ("model_path", "d_model", "global_k_heads", "global_v_heads", "tp_sizes"),
+    [
+        ("Qwen/Qwen3.5-27B", 5120, 16, 48, (1, 2, 4, 8)),
+        ("Qwen/Qwen3.5-35B-A3B", 2048, 16, 32, (1, 2, 4, 8)),
+    ],
+)
+def test_qwen35_gdn_getters_expand_tp_local_physical_keys(
+    monkeypatch, model_path, d_model, global_k_heads, global_v_heads, tp_sizes
+):
+    monkeypatch.setenv("COLLECTOR_MODEL_PATH", model_path)
+    expected = {
+        (phase, d_model, 4, global_k_heads // tp, 128, global_v_heads // tp, 128)
+        for phase in ("context", "generation")
+        for tp in tp_sizes
+    }
+
+    for module_path in ("collector/sglang/collect_gdn.py", "collector/vllm/collect_gdn.py"):
+        cases = _load_gdn_getter(module_path)()
+        assert {(case[0], case[1], case[2], case[3], case[4], case[5], case[6]) for case in cases} == expected
+
+
+def test_gdn_tp_declarations_fail_loud_and_dedupe_on_loader_key(monkeypatch):
+    from collector import case_generator
+
+    invalid = {
+        "model_path": "example/invalid",
+        "d_model": 2048,
+        "d_conv": 4,
+        "num_k_heads": 16,
+        "head_k_dim": 128,
+        "num_v_heads": 32,
+        "head_v_dim": 128,
+        "tensor_parallel_sizes": [3],
+    }
+    monkeypatch.setattr(case_generator, "_model_case_values", lambda op_name: [invalid])
+    with pytest.raises(ValueError, match="both global head counts to be divisible"):
+        case_generator.get_common_gdn_test_cases()
+
+    def profile(model_path, d_model, num_k_heads, num_v_heads, tp):
+        return {
+            "model_path": model_path,
+            "d_model": d_model,
+            "d_conv": 4,
+            "num_k_heads": num_k_heads,
+            "head_k_dim": 128,
+            "num_v_heads": num_v_heads,
+            "head_v_dim": 128,
+            "tensor_parallel_sizes": [tp],
+        }
+
+    profiles = [
+        profile("example/first", 2048, 16, 32, 4),
+        profile("example/duplicate", 2048, 4, 8, 1),
+        profile("example/distinct-d-model", 4096, 4, 8, 1),
+    ]
+    monkeypatch.setattr(case_generator, "_model_case_values", lambda op_name: profiles)
+    cases = case_generator.get_common_gdn_test_cases()
+
+    assert len(cases) == 4
+    assert {(case.phase, case.d_model, case.num_k_heads, case.num_v_heads, case.model_name) for case in cases} == {
+        (phase, 2048, 4, 8, "example/first") for phase in ("context", "generation")
+    } | {(phase, 4096, 4, 8, "example/distinct-d-model") for phase in ("context", "generation")}
 
 
 def test_mimo_attention_profile_matches_aic_full_attention_window(monkeypatch):
@@ -676,7 +754,7 @@ def test_cross_model_common_cases_expand_from_base_op_yaml_sweeps(monkeypatch):
     mamba_cases = get_common_mamba2_test_cases()
     assert len(mamba_cases) == 12
     assert {case.model_name for case in mamba_cases} >= {"MAMBA2_GENERIC_4K", "MAMBA2_GENERIC_1K"}
-    assert len(get_common_gdn_test_cases()) == 16
+    assert len(get_common_gdn_test_cases()) == 64
     mhc_cases = get_common_mhc_test_cases()
     assert len(mhc_cases) == 8
     assert {(case.model_name, case.phase, case.hidden_size, case.hc_mult) for case in mhc_cases} == {

--- a/tests/unit/collector/test_model_cases.py
+++ b/tests/unit/collector/test_model_cases.py
@@ -13,6 +13,7 @@ import pytest
 
 from collector.case_generator import (
     get_attention_head_configs,
+    get_gemm_case_specs,
     get_moe_quantization_specs,
     moe_model_allows_quantization,
 )
@@ -701,14 +702,18 @@ def test_gemm_common_cases_expand_from_base_op_yaml_shape_specs():
     cases = get_gemm_case_specs()
     xpu_cases = get_gemm_case_specs("vllm_xpu")
 
-    assert len(cases) == 35742
+    # Base sweep expansion first (order preserved for checkpoint stability),
+    # then model_case_values.gemm rows.
+    assert len(cases) == 36926
     assert cases[0] == GemmCommonTestCase(x=32768, n=65536, k=51200)
-    assert cases[-1] == GemmCommonTestCase(x=1, n=32, k=32)
+    assert cases[35741] == GemmCommonTestCase(x=1, n=32, k=32)
+    assert cases[-1] == GemmCommonTestCase(x=1, n=1, k=4096)
     assert not any(case.n == 65536 and case.k == 65536 for case in cases)
 
-    assert len(xpu_cases) == 9177
+    assert len(xpu_cases) == 9513
     assert xpu_cases[0] == GemmCommonTestCase(x=8192, n=65536, k=12288)
-    assert xpu_cases[-1] == GemmCommonTestCase(x=1, n=32, k=32)
+    assert xpu_cases[9176] == GemmCommonTestCase(x=1, n=32, k=32)
+    assert xpu_cases[-1] == GemmCommonTestCase(x=1, n=1, k=4096)
     assert get_gemm_type_specs("vllm_xpu") == ["bfloat16", "fp8"]
 
     compute_scale_cases = get_compute_scale_case_specs()
@@ -1554,3 +1559,19 @@ def test_collector_case_yaml_numeric_lists_are_sorted():
                 violations.append(f"{path.relative_to(REPO_ROOT)}:{'.'.join(yaml_path)} = {values}")
 
     assert violations == []
+
+
+def test_qwen35_gemm_model_rows_add_exact_below_grid_widths():
+    """model_case_values.gemm supplies exact widths under the base feature grid
+    (scalar expert gate n=1, GDN b/a projections); token density comes from the
+    base sweeps and cases dedupe on the physical (x, n, k) tuple."""
+    specs = get_gemm_case_specs()
+    shapes = {(case.n, case.k) for case in specs}
+    assert {(1, 2048), (8, 2048), (16, 4096), (12, 5120)} <= shapes
+
+    base_tokens = set()
+    for sweep in load_yaml_file(BASE_OP_CASES_DIR / "gemm.yaml")["all_frameworks_op_cases"]["gemm"]["cases"]:
+        base_tokens.update(int(token) for token in sweep["token_counts"])
+    assert {case.x for case in specs if (case.n, case.k) == (1, 2048)} == base_tokens
+
+    assert len(specs) == len({(case.x, case.n, case.k) for case in specs})

--- a/tests/unit/collector/test_model_cases.py
+++ b/tests/unit/collector/test_model_cases.py
@@ -216,7 +216,7 @@ def test_added_model_moe_profiles_resolve_targeted_aliases(monkeypatch):
     ("model_path", "d_model", "global_k_heads", "global_v_heads", "tp_sizes"),
     [
         ("Qwen/Qwen3.5-27B", 5120, 16, 48, (1, 2, 4, 8)),
-        ("Qwen/Qwen3.5-35B-A3B", 2048, 16, 32, (1, 2, 4, 8)),
+        ("Qwen/Qwen3.5-35B-A3B", 2048, 16, 32, (1, 2, 4, 8, 16)),
     ],
 )
 def test_qwen35_gdn_getters_expand_tp_local_physical_keys(
@@ -704,13 +704,13 @@ def test_gemm_common_cases_expand_from_base_op_yaml_shape_specs():
 
     # Base sweep expansion first (order preserved for checkpoint stability),
     # then model_case_values.gemm rows.
-    assert len(cases) == 36926
+    assert len(cases) == 37000
     assert cases[0] == GemmCommonTestCase(x=32768, n=65536, k=51200)
     assert cases[35741] == GemmCommonTestCase(x=1, n=32, k=32)
     assert cases[-1] == GemmCommonTestCase(x=1, n=1, k=4096)
     assert not any(case.n == 65536 and case.k == 65536 for case in cases)
 
-    assert len(xpu_cases) == 9513
+    assert len(xpu_cases) == 9534
     assert xpu_cases[0] == GemmCommonTestCase(x=8192, n=65536, k=12288)
     assert xpu_cases[9176] == GemmCommonTestCase(x=1, n=32, k=32)
     assert xpu_cases[-1] == GemmCommonTestCase(x=1, n=1, k=4096)
@@ -759,7 +759,7 @@ def test_cross_model_common_cases_expand_from_base_op_yaml_sweeps(monkeypatch):
     mamba_cases = get_common_mamba2_test_cases()
     assert len(mamba_cases) == 12
     assert {case.model_name for case in mamba_cases} >= {"MAMBA2_GENERIC_4K", "MAMBA2_GENERIC_1K"}
-    assert len(get_common_gdn_test_cases()) == 64
+    assert len(get_common_gdn_test_cases()) == 70
     mhc_cases = get_common_mhc_test_cases()
     assert len(mhc_cases) == 8
     assert {(case.model_name, case.phase, case.hidden_size, case.hc_mult) for case in mhc_cases} == {

--- a/tests/unit/sdk/database/test_gdn_kernel_alias.py
+++ b/tests/unit/sdk/database/test_gdn_kernel_alias.py
@@ -143,7 +143,8 @@ def test_query_gdn_does_not_use_nearest_shape_from_physical_alias(vllm_gdn_db):
     assert result.source == "sol"
 
 
-def test_query_gdn_preserves_nearest_shape_fallback_within_logical_source(vllm_gdn_db):
+def test_query_gdn_does_not_borrow_nearest_shape_within_logical_source(vllm_gdn_db):
+    """Exact geometry only: nearest-num_v_heads rows are never returned as silicon."""
     farther_logical_shape = (2048, 16, 128, 8, 128, 4)
     nearer_logical_shape = (2048, 16, 128, 24, 128, 4)
     nearest_alias_shape = (2048, 16, 128, 31, 128, 4)
@@ -169,8 +170,7 @@ def test_query_gdn_preserves_nearest_shape_fallback_within_logical_source(vllm_g
         **MODEL_SHAPE,
     )
 
-    assert float(result) == pytest.approx(4.0)
-    assert result.source == "silicon"
+    assert result.source == "sol"
 
 
 @pytest.mark.parametrize(("backend", "version"), (("vllm", "0.23.0"), ("sglang", "0.24.0")))

--- a/tests/unit/sdk/database/test_moe_dispatch.py
+++ b/tests/unit/sdk/database/test_moe_dispatch.py
@@ -609,5 +609,25 @@ class TestWideEpDeepEpLlNodeNumFallback:
         assert exact.source == "silicon"
 
 
+@pytest.mark.skipif(torch.xpu.is_available(), reason="skip for xpu")
+class TestVllmCommPath:
+    """With attention_dp == 1 vLLM's MoE block has no pre-dispatch collective
+    and exactly one final all-reduce, for pure TP and EP alike."""
+
+    def test_pre_dispatch_is_free_when_attention_dp_is_1(self):
+        db = _make_mock_db(sm_version=90, backend="vllm")
+        pre = _make_dispatch(moe_tp_size=1, moe_ep_size=8, attention_dp_size=1, pre_dispatch=True)
+
+        assert float(pre.query(db, x=8)) == 0.0
+        db.query_custom_allreduce.assert_not_called()
+
+    def test_post_dispatch_prices_single_final_allreduce(self):
+        db = _make_mock_db(sm_version=90, backend="vllm")
+        post = _make_dispatch(moe_tp_size=1, moe_ep_size=8, attention_dp_size=1, pre_dispatch=False)
+
+        assert float(post.query(db, x=8)) == pytest.approx(1.5)
+        db.query_custom_allreduce.assert_called_once()
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/sdk/database/test_moe_dispatch.py
+++ b/tests/unit/sdk/database/test_moe_dispatch.py
@@ -41,6 +41,7 @@ def _make_dispatch(
     quant_mode=None,
     moe_backend=None,
     reduce_results=True,
+    attn_ar_modeled=False,
     hidden_size=7168,
     topk=8,
     num_experts=256,
@@ -59,6 +60,7 @@ def _make_dispatch(
         quant_mode=quant_mode,
         moe_backend=moe_backend,
         reduce_results=reduce_results,
+        attn_ar_modeled=attn_ar_modeled,
     )
 
 
@@ -611,15 +613,23 @@ class TestWideEpDeepEpLlNodeNumFallback:
 
 @pytest.mark.skipif(torch.xpu.is_available(), reason="skip for xpu")
 class TestVllmCommPath:
-    """With attention_dp == 1 vLLM's MoE block has no pre-dispatch collective
-    and exactly one final all-reduce, for pure TP and EP alike."""
+    """vLLM MoE block collectives: one final all-reduce. The pre-dispatch AR is
+    a proxy for the attention-output AR, skipped only when the model prices
+    that AR explicitly (attn_ar_modeled)."""
 
-    def test_pre_dispatch_is_free_when_attention_dp_is_1(self):
+    def test_pre_dispatch_is_free_when_model_prices_attention_ar(self):
         db = _make_mock_db(sm_version=90, backend="vllm")
-        pre = _make_dispatch(moe_tp_size=1, moe_ep_size=8, attention_dp_size=1, pre_dispatch=True)
+        pre = _make_dispatch(moe_tp_size=1, moe_ep_size=8, attention_dp_size=1, pre_dispatch=True, attn_ar_modeled=True)
 
         assert float(pre.query(db, x=8)) == 0.0
         db.query_custom_allreduce.assert_not_called()
+
+    def test_pre_dispatch_charges_proxy_ar_by_default(self):
+        db = _make_mock_db(sm_version=90, backend="vllm")
+        pre = _make_dispatch(moe_tp_size=1, moe_ep_size=8, attention_dp_size=1, pre_dispatch=True)
+
+        assert float(pre.query(db, x=8)) == pytest.approx(1.5)
+        db.query_custom_allreduce.assert_called_once()
 
     def test_post_dispatch_prices_single_final_allreduce(self):
         db = _make_mock_db(sm_version=90, backend="vllm")

--- a/tests/unit/sdk/models/test_qwen35.py
+++ b/tests/unit/sdk/models/test_qwen35.py
@@ -111,11 +111,7 @@ def test_qwen35_shared_expert_scalar_gate_uses_true_output_width():
     )
 
     for phase_ops in (model.context_ops, model.generation_ops):
-        scalar_gates = [
-            op
-            for op in phase_ops
-            if op._name.endswith("_shared_expert_gate_gemm")
-        ]
+        scalar_gates = [op for op in phase_ops if op._name.endswith("_shared_expert_gate_gemm")]
         assert len(scalar_gates) == 2
         assert {op._n for op in scalar_gates} == {1}
 
@@ -134,3 +130,29 @@ def test_qwen35_sglang_standard_dispatcher_omits_nonexistent_pre_dispatch():
             assert f"{prefix}_moe_pre_dispatch" not in op_names
             assert f"{prefix}_moe" in op_names
             assert f"{prefix}_moe_post_dispatch" in op_names
+
+
+def test_qwen35_sglang_default_moe_keeps_pre_dispatch_under_attention_dp():
+    """With DP attention the LayerCommunicator pre-MLP gather is real and priced."""
+    model = models.get_model(
+        "Qwen/Qwen3.5-35B-A3B",
+        _model_config(tp_size=4, moe_tp_size=1, moe_ep_size=8, attention_dp_size=2),
+        "sglang",
+    )
+
+    for phase_ops in (model.context_ops, model.generation_ops):
+        op_names = [op._name for op in phase_ops]
+        assert any(name.endswith("_moe_pre_dispatch") for name in op_names)
+
+
+def test_qwen35_memory_charges_kv_on_full_layers_and_constant_gdn_state():
+    """35B-A3B at tp4: 10 full layers hold per-token KV; 30 GDN layers hold a
+    constant per-request state (fp32 SSM + bf16 conv window), TP-sharded."""
+    model = models.get_model("Qwen/Qwen3.5-35B-A3B", _model_config(tp_size=4), "vllm")
+
+    assert model.get_kvcache_elements_per_token() == 10 * 2 * 1 * 256
+    expected_state = 30 * ((32 // 4) * 128 * 128 * 4 + (2 * 16 * 128 + 32 * 128) // 4 * 3 * 2)
+    assert model._gdn_state_bytes_per_request() == expected_state
+    per_token_bytes = 2 * model.get_kvcache_elements_per_token()
+    assert model.get_kvcache_bytes_per_sequence(4096) == 4096 * per_token_bytes + expected_state
+    assert model.get_kvcache_max_tokens(expected_state + 100 * per_token_bytes) == 100

--- a/tests/unit/sdk/models/test_qwen35.py
+++ b/tests/unit/sdk/models/test_qwen35.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Qwen3.5 hybrid GDN + full-attention LM modeling contracts."""
+
+import pytest
+
+from aiconfigurator.sdk import common, models
+from aiconfigurator.sdk import config as sdk_config
+from aiconfigurator.sdk.operations import CustomAllReduce
+
+pytestmark = pytest.mark.unit
+
+
+def _model_config(tp_size=2, *, moe_tp_size=None, moe_ep_size=1, attention_dp_size=1):
+    return sdk_config.ModelConfig(
+        tp_size=tp_size,
+        pp_size=1,
+        moe_tp_size=tp_size if moe_tp_size is None else moe_tp_size,
+        moe_ep_size=moe_ep_size,
+        attention_dp_size=attention_dp_size,
+        gemm_quant_mode=common.GEMMQuantMode.bfloat16,
+        kvcache_quant_mode=common.KVCacheQuantMode.bfloat16,
+    )
+
+
+@pytest.mark.parametrize(
+    (
+        "model_name",
+        "expected_k_heads",
+        "expected_v_heads",
+        "expected_in_proj_n",
+        "expected_ba_n",
+        "expected_out_proj_k",
+    ),
+    [
+        ("Qwen/Qwen3.5-27B", 4, 12, 4096, 24, 1536),
+        ("Qwen/Qwen3.5-35B-A3B", 4, 8, 3072, 16, 1024),
+    ],
+)
+def test_qwen35_tp4_gdn_uses_local_heads_without_resharding_projection_gemms(
+    model_name, expected_k_heads, expected_v_heads, expected_in_proj_n, expected_ba_n, expected_out_proj_k
+):
+    """GDN lookup heads are TP-local; qkvz and ba are separate per-rank GEMMs."""
+    model = models.get_model(model_name, _model_config(tp_size=4), "sglang")
+
+    context_ops = {op._name: op for op in model.context_ops}
+    generation_ops = {op._name: op for op in model.generation_ops}
+
+    for op_name in ("context_gdn_conv1d", "context_gdn_scan"):
+        assert context_ops[op_name]._num_k_heads == expected_k_heads
+        assert context_ops[op_name]._num_v_heads == expected_v_heads
+    for op_name in ("generation_gdn_conv1d", "generation_gdn_recurrence"):
+        assert generation_ops[op_name]._num_k_heads == expected_k_heads
+        assert generation_ops[op_name]._num_v_heads == expected_v_heads
+
+    assert context_ops["context_gdn_in_proj_gemm"]._n == expected_in_proj_n
+    assert context_ops["context_gdn_in_proj_ba_gemm"]._n == expected_ba_n
+    assert context_ops["context_gdn_out_proj_gemm"]._k == expected_out_proj_k
+    assert generation_ops["generation_gdn_in_proj_gemm"]._n == expected_in_proj_n
+    assert generation_ops["generation_gdn_in_proj_ba_gemm"]._n == expected_ba_n
+    assert generation_ops["generation_gdn_out_proj_gemm"]._k == expected_out_proj_k
+
+
+def test_qwen35_rejects_tensor_parallel_size_that_cannot_shard_gdn_heads():
+    with pytest.raises(ValueError, match="GDN head counts must both be divisible"):
+        models.get_model("Qwen/Qwen3.5-27B", _model_config(tp_size=3), "sglang")
+
+
+@pytest.mark.parametrize(
+    "model_config_kwargs",
+    [
+        {"tp_size": 8},  # pure TP (moe_tp follows tp)
+        {"tp_size": 8, "moe_tp_size": 1, "moe_ep_size": 8},  # attention TP + EP
+    ],
+)
+def test_qwen35_moe_prices_comm_through_dispatch_pair_for_all_topologies(model_config_kwargs):
+    """Every topology emits the same pre/MoE/post dispatch chain; layout-specific
+    collectives are resolved inside MoEDispatch, leaving one attention-side AR
+    per layer plus embedding."""
+    model = models.get_model("Qwen/Qwen3.5-35B-A3B", _model_config(**model_config_kwargs), "vllm")
+    for phase, phase_ops in (("context", model.context_ops), ("generation", model.generation_ops)):
+        op_names = [op._name for op in phase_ops]
+
+        assert not any(name.endswith("_moe_final_ar") for name in op_names)
+        for prefix in (f"{phase}_gdn", f"{phase}_full"):
+            expected_order = [
+                f"{prefix}_router_gemm",
+                f"{prefix}_moe_pre_dispatch",
+                f"{prefix}_moe",
+                f"{prefix}_moe_post_dispatch",
+                f"{prefix}_shared_expert_gate_gemm",
+                f"{prefix}_shared_gate_up_gemm",
+                f"{prefix}_shared_act_gate",
+                f"{prefix}_shared_down_gemm",
+            ]
+            indices = [op_names.index(name) for name in expected_order]
+            assert indices == sorted(indices)
+
+        # Explicit CustomAllReduce ops: 40 attention-side + 1 embedding.
+        allreduce_ops = [op for op in phase_ops if isinstance(op, CustomAllReduce)]
+        assert sum(op._scale_factor for op in allreduce_ops) == 41

--- a/tests/unit/sdk/models/test_qwen35.py
+++ b/tests/unit/sdk/models/test_qwen35.py
@@ -7,21 +7,31 @@ import pytest
 
 from aiconfigurator.sdk import common, models
 from aiconfigurator.sdk import config as sdk_config
-from aiconfigurator.sdk.operations import CustomAllReduce
+from aiconfigurator.sdk.operations import CustomAllReduce, OverlapOp
 
 pytestmark = pytest.mark.unit
 
 
-def _model_config(tp_size=2, *, moe_tp_size=None, moe_ep_size=1, attention_dp_size=1):
+def _model_config(tp_size=2, *, moe_tp_size=None, moe_ep_size=1, attention_dp_size=1, moe_backend=None):
     return sdk_config.ModelConfig(
         tp_size=tp_size,
         pp_size=1,
         moe_tp_size=tp_size if moe_tp_size is None else moe_tp_size,
         moe_ep_size=moe_ep_size,
         attention_dp_size=attention_dp_size,
+        moe_backend=moe_backend,
         gemm_quant_mode=common.GEMMQuantMode.bfloat16,
         kvcache_quant_mode=common.KVCacheQuantMode.bfloat16,
     )
+
+
+def _flatten_ops(phase_ops):
+    for op in phase_ops:
+        if isinstance(op, OverlapOp):
+            yield from op._group_a
+            yield from op._group_b
+        else:
+            yield op
 
 
 @pytest.mark.parametrize(
@@ -75,29 +85,50 @@ def test_qwen35_rejects_tensor_parallel_size_that_cannot_shard_gdn_heads():
     ],
 )
 def test_qwen35_moe_prices_comm_through_dispatch_pair_for_all_topologies(model_config_kwargs):
-    """Every topology emits the same pre/MoE/post dispatch chain; layout-specific
-    collectives are resolved inside MoEDispatch, leaving one attention-side AR
-    per layer plus embedding."""
+    """Every topology emits the same dispatch chain (serial in context, routed
+    and shared experts overlapped in generation); layout-specific collectives
+    are resolved inside MoEDispatch, leaving one attention-side AR per layer
+    plus embedding."""
     model = models.get_model("Qwen/Qwen3.5-35B-A3B", _model_config(**model_config_kwargs), "vllm")
-    for phase, phase_ops in (("context", model.context_ops), ("generation", model.generation_ops)):
-        op_names = [op._name for op in phase_ops]
 
-        assert not any(name.endswith("_moe_final_ar") for name in op_names)
-        for prefix in (f"{phase}_gdn", f"{phase}_full"):
-            expected_order = [
-                f"{prefix}_router_gemm",
-                f"{prefix}_moe_pre_dispatch",
-                f"{prefix}_moe",
-                f"{prefix}_moe_post_dispatch",
-                f"{prefix}_shared_expert_gate_gemm",
-                f"{prefix}_shared_gate_up_gemm",
-                f"{prefix}_shared_act_gate",
-                f"{prefix}_shared_down_gemm",
-            ]
-            indices = [op_names.index(name) for name in expected_order]
-            assert indices == sorted(indices)
+    context_names = [op._name for op in model.context_ops]
+    assert not any(name.endswith("_moe_final_ar") for name in context_names)
+    for prefix in ("context_gdn", "context_full"):
+        expected_order = [
+            f"{prefix}_router_gemm",
+            f"{prefix}_moe_pre_dispatch",
+            f"{prefix}_moe",
+            f"{prefix}_moe_post_dispatch",
+            f"{prefix}_shared_expert_gate_gemm",
+            f"{prefix}_shared_gate_up_gemm",
+            f"{prefix}_shared_act_gate",
+            f"{prefix}_shared_down_gemm",
+            f"{prefix}_shared_merge",
+        ]
+        indices = [context_names.index(name) for name in expected_order]
+        assert indices == sorted(indices)
 
-        # Explicit CustomAllReduce ops: 40 attention-side + 1 embedding.
+    # Generation runs routed and shared experts on parallel CUDA streams
+    # (OverlapOp), followed by the merge.
+    generation_ops = {op._name: op for op in model.generation_ops}
+    for prefix in ("generation_gdn", "generation_full"):
+        overlap = generation_ops[f"{prefix}_moe_overlap"]
+        assert [op._name for op in overlap._group_a] == [
+            f"{prefix}_router_gemm",
+            f"{prefix}_moe_pre_dispatch",
+            f"{prefix}_moe",
+            f"{prefix}_moe_post_dispatch",
+        ]
+        assert [op._name for op in overlap._group_b] == [
+            f"{prefix}_shared_expert_gate_gemm",
+            f"{prefix}_shared_gate_up_gemm",
+            f"{prefix}_shared_act_gate",
+            f"{prefix}_shared_down_gemm",
+        ]
+        assert f"{prefix}_shared_merge" in generation_ops
+
+    # Explicit CustomAllReduce ops: 40 attention-side + 1 embedding.
+    for phase_ops in (model.context_ops, model.generation_ops):
         allreduce_ops = [op for op in phase_ops if isinstance(op, CustomAllReduce)]
         assert sum(op._scale_factor for op in allreduce_ops) == 41
 
@@ -111,7 +142,7 @@ def test_qwen35_shared_expert_scalar_gate_uses_true_output_width():
     )
 
     for phase_ops in (model.context_ops, model.generation_ops):
-        scalar_gates = [op for op in phase_ops if op._name.endswith("_shared_expert_gate_gemm")]
+        scalar_gates = [op for op in _flatten_ops(phase_ops) if op._name.endswith("_shared_expert_gate_gemm")]
         assert len(scalar_gates) == 2
         assert {op._n for op in scalar_gates} == {1}
 
@@ -130,6 +161,26 @@ def test_qwen35_sglang_standard_dispatcher_omits_nonexistent_pre_dispatch():
             assert f"{prefix}_moe_pre_dispatch" not in op_names
             assert f"{prefix}_moe" in op_names
             assert f"{prefix}_moe_post_dispatch" in op_names
+
+
+def test_qwen35_sglang_deepep_prices_one_dispatch_and_replicates_shared_expert():
+    """DeepEP rows hold the full dispatch+combine round trip, so one dispatch
+    op prices it; sglang DeepEP replicates the shared expert (tp_size=1)
+    instead of TP-sharding it."""
+    model = models.get_model(
+        "Qwen/Qwen3.5-35B-A3B",
+        _model_config(tp_size=8, moe_tp_size=1, moe_ep_size=8, moe_backend="deepep_moe"),
+        "sglang",
+    )
+    cfg = model.extra_params
+
+    for phase, phase_ops in (("context", model.context_ops), ("generation", model.generation_ops)):
+        op_names = [op._name for op in phase_ops]
+        for prefix in (f"{phase}_gdn", f"{phase}_full"):
+            assert f"{prefix}_moe_pre_dispatch" in op_names
+            assert f"{prefix}_moe_post_dispatch" not in op_names
+        gate_up_widths = {op._n for op in phase_ops if op._name.endswith("_shared_gate_up_gemm")}
+        assert gate_up_widths == {2 * cfg.shared_expert_inter_size}
 
 
 def test_qwen35_sglang_default_moe_keeps_pre_dispatch_under_attention_dp():

--- a/tests/unit/sdk/models/test_qwen35.py
+++ b/tests/unit/sdk/models/test_qwen35.py
@@ -100,3 +100,37 @@ def test_qwen35_moe_prices_comm_through_dispatch_pair_for_all_topologies(model_c
         # Explicit CustomAllReduce ops: 40 attention-side + 1 embedding.
         allreduce_ops = [op for op in phase_ops if isinstance(op, CustomAllReduce)]
         assert sum(op._scale_factor for op in allreduce_ops) == 41
+
+
+def test_qwen35_shared_expert_scalar_gate_uses_true_output_width():
+    """The runtime ReplicatedLinear scalar gate is hidden_size -> 1."""
+    model = models.get_model(
+        "Qwen/Qwen3.5-397B-A17B",
+        _model_config(tp_size=8, moe_tp_size=1, moe_ep_size=8),
+        "vllm",
+    )
+
+    for phase_ops in (model.context_ops, model.generation_ops):
+        scalar_gates = [
+            op
+            for op in phase_ops
+            if op._name.endswith("_shared_expert_gate_gemm")
+        ]
+        assert len(scalar_gates) == 2
+        assert {op._n for op in scalar_gates} == {1}
+
+
+def test_qwen35_sglang_standard_dispatcher_omits_nonexistent_pre_dispatch():
+    """SGLang StandardDispatcher has no collective before routed experts."""
+    model = models.get_model(
+        "Qwen/Qwen3.5-397B-A17B",
+        _model_config(tp_size=8, moe_tp_size=1, moe_ep_size=8),
+        "sglang",
+    )
+
+    for phase, phase_ops in (("context", model.context_ops), ("generation", model.generation_ops)):
+        op_names = [op._name for op in phase_ops]
+        for prefix in (f"{phase}_gdn", f"{phase}_full"):
+            assert f"{prefix}_moe_pre_dispatch" not in op_names
+            assert f"{prefix}_moe" in op_names
+            assert f"{prefix}_moe_post_dispatch" in op_names


### PR DESCRIPTION
#### Overview:

  Correctness fixes for Qwen3.5 (hybrid GDN + full-attention, dense & MoE), from per-op timeline alignment (vLLM 0.24.0 / SGLang 0.5.14) and review. Modeling + collector only — no refreshed perf data (see data note).

  #### Details:

  **SDK modeling:**
  - Per-op composition vs serving: qkv GEMM missed the output gate (2x q slice, ~44% under); `in_proj_ba` is its own GEMM (`2*num_v_heads`); shared expert = gated-SiLU + scalar`hidden -> 1` gate; per-head q/k RMSNorm now priced (`use_qk_norm=True`).
  - Hybrid memory: token-linear KV only on full-attention layers (was all layers — 4x over on 35B-A3B); GDN layers charge a constant per-request FP32 state.
  - GDN lookup: TP-local head counts, **exact-or-SOL** in Python and the Rust twin (nearest-shape borrowing could serve one SKU from another's rows as silicon). SOL formulas: conv width `2K+V`, FP32 state.
  - MoE collectives: vLLM runs no pre-dispatch collective at `attention_dp == 1` — gated behind new `MoEDispatch(attn_ar_modeled=...)`, default False keeps every other model's behavior (vLLM branch only). SGLang default path omits pre-dispatch at dp == 1. SGLang DeepEP tables store the full dispatch+combine round trip, so composing pre+post double-charged every layer — now one dispatch op (`SGLangEPMOEModel` precedent), with the shared expert replicated (`tp_size=1`), not TP-sharded.
  - Generation: vLLM decode runs shared/routed experts on parallel streams — now an `OverlapOp` (deepseek precedent) plus a `shared_merge` element-wise op. `moe_backend/is_context/sms` forwarded; EPLB stays unmodeled; `cp_size > 1` rejected.
  - `ENGINE_SPEC_SCHEMA_VERSION` 6 -> 7 (`MoEDispatchOp` gained a positional bincode field).

  **Collector (GDN):**
  - Serving parity: conv metadata precomputed outside the timed span (was a D2H sync + numpy repack per call); FP32 recurrent state; SGLang `dt_bias` dtype; conv state in the serving SD layout + transposed view (the kernels take explicit strides).
  - Timing domain: graph replay everywhere (the eager prefill conv timed the launch envelope, ~4.9x high; replay matches production to -0.3%), `repeat_n=10` kernels per replay (decode conv ~2x high at repeat_n=1).
  - Cases: GDN expands TP-local geometries over declared `tensor_parallel_sizes` (TP16 on MoE SKUs); exact below-grid GEMM widths (scalar gate n=1, b/a widths per TP).

  **Data dependency (follow-up collection PR):** packaged `gdn_perf` tables predate the TP-local lookup — tp>1 queries fall back to SOL, and vLLM tables carry the old calibration even at tp=1. The new GEMM widths / TP16 geometries have no rows yet (SILICON reports missing data; HYBRID works). Re-collect with the target system's existing gdn parquet removed first.

  **Scope:** Qwen3.5 text tower only (vision encoder not modeled); TRT-LLM not validated — its dispatch branch keeps the legacy proxy AR and its GDN collector is untouched.

  #### Where should the reviewer start?

  - `aic-core/src/aiconfigurator_core/sdk/models/qwen35.py` — op composition, memory overrides
  - `aic-core/src/aiconfigurator_core/sdk/operations/moe.py` — `attn_ar_modeled`, the only cross-model surface (default preserves existing behavior)
  - `aic-core/src/aiconfigurator_core/sdk/operations/mamba.py` + `aic-core/rust/aiconfigurator-core/src/perf_database/state_space.rs` — exact-or-SOL parity
  - `collector/vllm/collect_gdn.py`, `collector/sglang/collect_gdn.py` — serving parity, timing domain
  - `collector/case_generator.py`, `collector/cases/models/Qwen3_5*_cases.yaml` — case expansion

  #### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

  - Relates to GitHub issue: #xxx