### PR TITLE
fix(fpm): add directional correction bounds

### DIFF
--- a/aic-core/rust/aiconfigurator-core/src/fpm/correction.rs
+++ b/aic-core/rust/aiconfigurator-core/src/fpm/correction.rs
@@ -14,7 +14,8 @@ use super::samples::{median_ratio, AxisRange, BucketedSamples, StoreStats, WithO
 pub(crate) struct CorrectionBuckets {
     samples: BucketedSamples<CorrectionObservation>,
     min_observations: usize,
-    max_correction_factor: Option<f64>,
+    min_faster_correction_factor: Option<f64>,
+    max_slower_correction_factor: Option<f64>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -27,7 +28,8 @@ impl WithOptions for CorrectionBuckets {
         Self {
             samples: BucketedSamples::new_fixed(options, axis_ranges),
             min_observations: options.min_observations,
-            max_correction_factor: options.max_correction_factor,
+            min_faster_correction_factor: options.min_faster_correction_factor,
+            max_slower_correction_factor: options.max_slower_correction_factor,
         }
     }
 }
@@ -52,12 +54,18 @@ impl CorrectionBuckets {
         {
             // Corrections are absolute observed/native samples, not
             // incremental multipliers. Bound each sample before the median is
-            // computed so repeated outliers cannot exceed the ceiling.
+            // computed so repeated outliers cannot exceed either directional
+            // limit.
             let correction_factor = observed_ms / native_ms;
+            let lower_bounded_correction_factor = self
+                .min_faster_correction_factor
+                .map_or(correction_factor, |min_factor| {
+                    correction_factor.max(min_factor)
+                });
             let bounded_correction_factor = self
-                .max_correction_factor
-                .map_or(correction_factor, |max_factor| {
-                    correction_factor.min(max_factor)
+                .max_slower_correction_factor
+                .map_or(lower_bounded_correction_factor, |max_factor| {
+                    lower_bounded_correction_factor.min(max_factor)
                 });
             self.samples.add(
                 x,

--- a/aic-core/rust/aiconfigurator-core/src/fpm/correction.rs
+++ b/aic-core/rust/aiconfigurator-core/src/fpm/correction.rs
@@ -3,9 +3,9 @@
 
 //! Online native-correction grid for the forward-pass perf model.
 //!
-//! Buckets observed `(workload feature, observed_ms, native_ms)` samples into a
-//! fixed-bound grid and applies the local median `observed_ms / native_ms`
-//! ratio as a correction factor on top of the native AIC estimate.
+//! Buckets observed `(workload feature, observed_ms / native_ms)` correction
+//! samples into a fixed-bound grid and applies the local median ratio on top of
+//! the native AIC estimate.
 
 use super::options::ForwardPassPerfOptions;
 use super::samples::{median_ratio, AxisRange, BucketedSamples, StoreStats, WithOptions};
@@ -14,12 +14,12 @@ use super::samples::{median_ratio, AxisRange, BucketedSamples, StoreStats, WithO
 pub(crate) struct CorrectionBuckets {
     samples: BucketedSamples<CorrectionObservation>,
     min_observations: usize,
+    max_correction_factor: Option<f64>,
 }
 
 #[derive(Clone, Copy, Debug)]
 struct CorrectionObservation {
-    observed_ms: f64,
-    native_ms: f64,
+    correction_factor: f64,
 }
 
 impl WithOptions for CorrectionBuckets {
@@ -27,6 +27,7 @@ impl WithOptions for CorrectionBuckets {
         Self {
             samples: BucketedSamples::new_fixed(options, axis_ranges),
             min_observations: options.min_observations,
+            max_correction_factor: options.max_correction_factor,
         }
     }
 }
@@ -49,11 +50,19 @@ impl CorrectionBuckets {
     pub(crate) fn add_observation(&mut self, x: Vec<f64>, observed_ms: f64, native_ms: f64) {
         if native_ms.is_finite() && native_ms > 0.0 && observed_ms.is_finite() && observed_ms > 0.0
         {
+            // Corrections are absolute observed/native samples, not
+            // incremental multipliers. Bound each sample before the median is
+            // computed so repeated outliers cannot exceed the ceiling.
+            let correction_factor = observed_ms / native_ms;
+            let bounded_correction_factor = self
+                .max_correction_factor
+                .map_or(correction_factor, |max_factor| {
+                    correction_factor.min(max_factor)
+                });
             self.samples.add(
                 x,
                 CorrectionObservation {
-                    observed_ms,
-                    native_ms,
+                    correction_factor: bounded_correction_factor,
                 },
             );
         }
@@ -75,7 +84,7 @@ impl CorrectionBuckets {
         median_ratio(
             bucket
                 .iter()
-                .map(|(_, obs)| obs.observed_ms / obs.native_ms),
+                .map(|(_, observation)| observation.correction_factor),
         )
         .unwrap_or(1.0)
     }
@@ -99,7 +108,7 @@ impl CorrectionBuckets {
                 median_ratio(
                     bucket
                         .iter()
-                        .map(|(_, obs)| obs.observed_ms / obs.native_ms),
+                        .map(|(_, observation)| observation.correction_factor),
                 )
             })
             .collect()

--- a/aic-core/rust/aiconfigurator-core/src/fpm/model.rs
+++ b/aic-core/rust/aiconfigurator-core/src/fpm/model.rs
@@ -88,7 +88,9 @@ pub enum ForwardPassPerfReadiness {
 /// Native correction grids use fixed constructor-time ranges from
 /// `ForwardPassPerfOptions`: `max_num_tokens` bounds `sum_prefill_tokens`,
 /// `max_batch_size` bounds `num_decode_requests`, and `max_kv_tokens` bounds
-/// `sum_decode_kv_tokens`.
+/// `sum_decode_kv_tokens`. `max_correction_factor` optionally places an
+/// absolute upper bound on learned native correction factors while preserving
+/// downward corrections.
 ///
 /// Queued request fields are accepted for FPM schema parity but ignored by this
 /// forward-pass-level model. `estimate_forward_pass_time_ms` treats FPM as a
@@ -307,11 +309,13 @@ impl ForwardPassPerfModel {
     /// finite positive `wall_time` across ranks as the observed latency target
     /// in milliseconds. Iterations with no scheduled work or no positive
     /// `wall_time` are ignored. Native models update the matching region's
-    /// median `observed_ms / native_ms` correction factor. Regions are used only
-    /// after their inferred workload kind has `min_observations` total samples;
-    /// empty regions keep the default factor `1.0`. Observations outside the
-    /// configured correction bounds are ignored by native correction models.
-    /// Regression models learn a workload-specific linear fit.
+    /// median `observed_ms / native_ms` correction factor, with each ratio
+    /// bounded by `max_correction_factor` when configured. Regions are used
+    /// only after their inferred workload kind has `min_observations` total
+    /// samples; empty regions keep the default factor `1.0`. Observations
+    /// outside the configured correction bounds are ignored by native
+    /// correction models. Regression models learn a workload-specific linear
+    /// fit.
     ///
     /// Pure Rust over the `Engine` — no Python re-entry.
     pub fn tune_with_fpms(

--- a/aic-core/rust/aiconfigurator-core/src/fpm/model.rs
+++ b/aic-core/rust/aiconfigurator-core/src/fpm/model.rs
@@ -88,9 +88,9 @@ pub enum ForwardPassPerfReadiness {
 /// Native correction grids use fixed constructor-time ranges from
 /// `ForwardPassPerfOptions`: `max_num_tokens` bounds `sum_prefill_tokens`,
 /// `max_batch_size` bounds `num_decode_requests`, and `max_kv_tokens` bounds
-/// `sum_decode_kv_tokens`. `max_correction_factor` optionally places an
-/// absolute upper bound on learned native correction factors while preserving
-/// downward corrections.
+/// `sum_decode_kv_tokens`. `min_faster_correction_factor` and
+/// `max_slower_correction_factor` optionally place independent absolute bounds
+/// on learned native correction factors in each direction.
 ///
 /// Queued request fields are accepted for FPM schema parity but ignored by this
 /// forward-pass-level model. `estimate_forward_pass_time_ms` treats FPM as a
@@ -262,9 +262,10 @@ impl ForwardPassPerfModel {
     /// correction factor for the matching workload region. Correction factors
     /// default to `1.0` for inferred workload kinds with fewer than
     /// `min_observations` total samples, empty regions, and queries outside the
-    /// configured correction bounds in `ForwardPassPerfOptions`. Regression
-    /// models return `Ok(None)` until the matching inferred workload kind has
-    /// enough tuning samples. Empty scheduled work returns `Ok(Some(0.0))`.
+    /// configured correction-grid workload ranges in
+    /// `ForwardPassPerfOptions`. Regression models return `Ok(None)` until the
+    /// matching inferred workload kind has enough tuning samples. Empty
+    /// scheduled work returns `Ok(Some(0.0))`.
     ///
     /// Pure Rust over the `Engine` — no Python re-entry.
     pub fn estimate_forward_pass_time_ms(
@@ -310,10 +311,11 @@ impl ForwardPassPerfModel {
     /// in milliseconds. Iterations with no scheduled work or no positive
     /// `wall_time` are ignored. Native models update the matching region's
     /// median `observed_ms / native_ms` correction factor, with each ratio
-    /// bounded by `max_correction_factor` when configured. Regions are used
-    /// only after their inferred workload kind has `min_observations` total
-    /// samples; empty regions keep the default factor `1.0`. Observations
-    /// outside the configured correction bounds are ignored by native
+    /// bounded by `min_faster_correction_factor` and
+    /// `max_slower_correction_factor` when configured. Regions are used only
+    /// after their inferred workload kind has `min_observations` total samples;
+    /// empty regions keep the default factor `1.0`. Observations outside the
+    /// configured correction-grid workload ranges are ignored by native
     /// correction models. Regression models learn a workload-specific linear
     /// fit.
     ///

--- a/aic-core/rust/aiconfigurator-core/src/fpm/options.rs
+++ b/aic-core/rust/aiconfigurator-core/src/fpm/options.rs
@@ -30,13 +30,22 @@ pub struct ForwardPassPerfOptions {
     /// correction is used for an inferred workload kind.
     #[serde(default = "default_min_observations")]
     pub min_observations: usize,
-    /// Optional absolute upper bound on native correction factors.
+    /// Optional absolute lower bound on native correction factors for
+    /// observations faster than the native estimate.
     ///
-    /// Values must be finite and at least `1.0`. Downward corrections remain
-    /// unbounded. `None` preserves the default unbounded behavior. Regression
-    /// fallback does not use this option.
+    /// Values must be finite, greater than `0.0`, and at most `1.0`. Setting
+    /// this to `1.0` disables faster corrections. `None` preserves the default
+    /// unbounded behavior. Regression fallback does not use this option.
     #[serde(default)]
-    pub max_correction_factor: Option<f64>,
+    pub min_faster_correction_factor: Option<f64>,
+    /// Optional absolute upper bound on native correction factors for
+    /// observations slower than the native estimate.
+    ///
+    /// Values must be finite and at least `1.0`. Setting this to `1.0`
+    /// disables slower corrections. `None` preserves the default unbounded
+    /// behavior. Regression fallback does not use this option.
+    #[serde(default)]
+    pub max_slower_correction_factor: Option<f64>,
     /// Target bucket count for workload-specific sample retirement and correction lookup.
     #[serde(default = "default_bucket_count")]
     pub bucket_count: usize,
@@ -62,7 +71,8 @@ impl Default for ForwardPassPerfOptions {
         Self {
             max_observations: DEFAULT_MAX_OBSERVATIONS,
             min_observations: DEFAULT_MIN_OBSERVATIONS,
-            max_correction_factor: None,
+            min_faster_correction_factor: None,
+            max_slower_correction_factor: None,
             bucket_count: DEFAULT_BUCKET_COUNT,
             max_num_tokens: DEFAULT_MAX_NUM_TOKENS,
             max_batch_size: DEFAULT_MAX_BATCH_SIZE,
@@ -78,10 +88,20 @@ pub(crate) fn validate_options(options: &ForwardPassPerfOptions) -> Result<(), A
     if options.min_observations == 0 {
         return Err(invalid_perf_options("min_observations must be >= 1"));
     }
-    if let Some(max_correction_factor) = options.max_correction_factor {
-        if !max_correction_factor.is_finite() || max_correction_factor < 1.0 {
+    if let Some(min_faster_correction_factor) = options.min_faster_correction_factor {
+        if !min_faster_correction_factor.is_finite()
+            || min_faster_correction_factor <= 0.0
+            || min_faster_correction_factor > 1.0
+        {
             return Err(invalid_perf_options(
-                "max_correction_factor must be finite and >= 1.0",
+                "min_faster_correction_factor must be finite and in (0.0, 1.0]",
+            ));
+        }
+    }
+    if let Some(max_slower_correction_factor) = options.max_slower_correction_factor {
+        if !max_slower_correction_factor.is_finite() || max_slower_correction_factor < 1.0 {
+            return Err(invalid_perf_options(
+                "max_slower_correction_factor must be finite and >= 1.0",
             ));
         }
     }

--- a/aic-core/rust/aiconfigurator-core/src/fpm/options.rs
+++ b/aic-core/rust/aiconfigurator-core/src/fpm/options.rs
@@ -21,7 +21,7 @@ pub(crate) const DEFAULT_MAX_KV_TOKENS: u32 = 2_000_000;
 /// These defaults match the current planner regression behavior: retain a
 /// bounded sliding sample set, wait for enough observations before predicting
 /// from learned data, and bucket observations by workload kind.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ForwardPassPerfOptions {
     /// Maximum retained observations across all buckets for each inferred workload kind.
     #[serde(default = "default_max_observations")]
@@ -30,6 +30,13 @@ pub struct ForwardPassPerfOptions {
     /// correction is used for an inferred workload kind.
     #[serde(default = "default_min_observations")]
     pub min_observations: usize,
+    /// Optional absolute upper bound on native correction factors.
+    ///
+    /// Values must be finite and at least `1.0`. Downward corrections remain
+    /// unbounded. `None` preserves the default unbounded behavior. Regression
+    /// fallback does not use this option.
+    #[serde(default)]
+    pub max_correction_factor: Option<f64>,
     /// Target bucket count for workload-specific sample retirement and correction lookup.
     #[serde(default = "default_bucket_count")]
     pub bucket_count: usize,
@@ -55,6 +62,7 @@ impl Default for ForwardPassPerfOptions {
         Self {
             max_observations: DEFAULT_MAX_OBSERVATIONS,
             min_observations: DEFAULT_MIN_OBSERVATIONS,
+            max_correction_factor: None,
             bucket_count: DEFAULT_BUCKET_COUNT,
             max_num_tokens: DEFAULT_MAX_NUM_TOKENS,
             max_batch_size: DEFAULT_MAX_BATCH_SIZE,
@@ -69,6 +77,13 @@ pub(crate) fn validate_options(options: &ForwardPassPerfOptions) -> Result<(), A
     }
     if options.min_observations == 0 {
         return Err(invalid_perf_options("min_observations must be >= 1"));
+    }
+    if let Some(max_correction_factor) = options.max_correction_factor {
+        if !max_correction_factor.is_finite() || max_correction_factor < 1.0 {
+            return Err(invalid_perf_options(
+                "max_correction_factor must be finite and >= 1.0",
+            ));
+        }
     }
     if options.bucket_count == 0 {
         return Err(invalid_perf_options("bucket_count must be >= 1"));

--- a/aic-core/rust/aiconfigurator-core/src/fpm/samples.rs
+++ b/aic-core/rust/aiconfigurator-core/src/fpm/samples.rs
@@ -129,8 +129,8 @@ impl<T: Clone> BucketedSamples<T> {
             return None;
         }
 
-        // Estimation must not clamp outside configured correction bounds into
-        // edge regions.
+        // Estimation must not clamp outside configured correction-grid
+        // workload ranges into edge regions.
         let mut key = Vec::with_capacity(x.len());
         for (i, value) in x.iter().enumerate() {
             let lo = self.axis_min[i];
@@ -194,7 +194,8 @@ impl<T: Clone> BucketedSamples<T> {
 
     fn retire_from_fattest_bucket(&mut self) {
         // Eviction removes samples only. Dynamic regression bounds remain
-        // monotonic; fixed correction bounds are configured at model creation.
+        // monotonic; fixed correction-grid workload ranges are configured at
+        // model creation.
         let Some(key) = self
             .buckets
             .iter()

--- a/aic-core/rust/aiconfigurator-core/src/fpm/tests.rs
+++ b/aic-core/rust/aiconfigurator-core/src/fpm/tests.rs
@@ -327,17 +327,50 @@ fn options_reject_zero_bounds() {
 }
 
 #[test]
-fn options_validate_max_correction_factor() {
+fn options_validate_directional_correction_factors() {
+    assert_eq!(
+        ForwardPassPerfOptions::default().min_faster_correction_factor,
+        None
+    );
+    assert_eq!(
+        ForwardPassPerfOptions::default().max_slower_correction_factor,
+        None
+    );
+
     let model = ForwardPassPerfModel::from_regression(ForwardPassPerfOptions {
-        max_correction_factor: Some(1.0),
+        min_faster_correction_factor: Some(0.5),
+        max_slower_correction_factor: Some(2.0),
         ..Default::default()
     })
     .unwrap();
-    assert_eq!(model.options().max_correction_factor, Some(1.0));
+    assert_eq!(model.options().min_faster_correction_factor, Some(0.5));
+    assert_eq!(model.options().max_slower_correction_factor, Some(2.0));
+
+    for valid_factor in [f64::MIN_POSITIVE, 1.0] {
+        ForwardPassPerfModel::from_regression(ForwardPassPerfOptions {
+            min_faster_correction_factor: Some(valid_factor),
+            ..Default::default()
+        })
+        .unwrap();
+    }
+    ForwardPassPerfModel::from_regression(ForwardPassPerfOptions {
+        max_slower_correction_factor: Some(1.0),
+        ..Default::default()
+    })
+    .unwrap();
+
+    for invalid_factor in [f64::NEG_INFINITY, -1.0, 0.0, 1.001, f64::INFINITY, f64::NAN] {
+        let err = ForwardPassPerfModel::from_regression(ForwardPassPerfOptions {
+            min_faster_correction_factor: Some(invalid_factor),
+            ..Default::default()
+        })
+        .unwrap_err();
+        assert!(matches!(err, AicError::InvalidEngineConfig(_)));
+    }
 
     for invalid_factor in [f64::NEG_INFINITY, -1.0, 0.0, 0.999, f64::INFINITY, f64::NAN] {
         let err = ForwardPassPerfModel::from_regression(ForwardPassPerfOptions {
-            max_correction_factor: Some(invalid_factor),
+            max_slower_correction_factor: Some(invalid_factor),
             ..Default::default()
         })
         .unwrap_err();
@@ -621,7 +654,8 @@ fn tuning_ignores_idle_wall_time_and_queued_only_work() {
 #[test]
 fn fallback_regression_has_no_correction_factors() {
     let model = ForwardPassPerfModel::from_regression(ForwardPassPerfOptions {
-        max_correction_factor: Some(2.0),
+        min_faster_correction_factor: Some(0.5),
+        max_slower_correction_factor: Some(2.0),
         ..Default::default()
     })
     .unwrap();
@@ -677,10 +711,10 @@ fn native_correction_applies_after_bucket_is_ready() {
 /// The configured ceiling is absolute relative to the native estimate. It does
 /// not compound as matching outliers are added to an already-corrected bucket.
 #[test]
-fn native_correction_cap_is_absolute_across_repeated_outliers() {
+fn native_slower_correction_ceiling_is_absolute_across_repeated_outliers() {
     let mut model = native_model(ForwardPassPerfOptions {
         min_observations: 2,
-        max_correction_factor: Some(2.0),
+        max_slower_correction_factor: Some(2.0),
         ..Default::default()
     });
     let metrics = prefill_fpm(20, 0.0);
@@ -721,13 +755,53 @@ fn native_correction_cap_is_absolute_across_repeated_outliers() {
     assert_close(model.avg_correction_factor().unwrap(), 2.0);
 }
 
-/// Correction samples are capped before taking the median, retaining the
-/// contribution of observations below the ceiling.
+/// Saturating the slower ceiling does not make a correction monotonic. Lower
+/// observations move the retained-sample median down as capped samples age out.
 #[test]
-fn native_correction_cap_is_applied_at_observation_ingestion() {
+fn native_correction_recovers_from_saturated_slower_ceiling() {
     let mut model = native_model(ForwardPassPerfOptions {
         min_observations: 2,
-        max_correction_factor: Some(2.0),
+        max_observations: 4,
+        max_slower_correction_factor: Some(2.0),
+        ..Default::default()
+    });
+    let metrics = prefill_fpm(20, 0.0);
+    let native_ms = model
+        .estimate_forward_pass_time_ms(&[metrics])
+        .unwrap()
+        .unwrap();
+    let outlier = prefill_fpm(20, native_ms * 90.0 / 1000.0);
+    let recovered = prefill_fpm(20, native_ms / 1000.0);
+
+    model
+        .tune_with_fpms(&[
+            vec![outlier.clone()],
+            vec![outlier.clone()],
+            vec![outlier.clone()],
+            vec![outlier],
+        ])
+        .unwrap();
+    assert_close(model.max_correction_factor().unwrap(), 2.0);
+
+    model
+        .tune_with_fpms(&[vec![recovered.clone()], vec![recovered.clone()]])
+        .unwrap();
+    assert_close(model.max_correction_factor().unwrap(), 1.5);
+
+    model
+        .tune_with_fpms(&[vec![recovered.clone()], vec![recovered]])
+        .unwrap();
+    assert_close(model.max_correction_factor().unwrap(), 1.0);
+}
+
+/// Directional limits are applied to each correction sample before taking the
+/// median, retaining the contribution of observations inside either bound.
+#[test]
+fn native_directional_correction_bounds_are_applied_at_observation_ingestion() {
+    let mut model = native_model(ForwardPassPerfOptions {
+        min_observations: 2,
+        min_faster_correction_factor: Some(0.5),
+        max_slower_correction_factor: Some(2.0),
         ..Default::default()
     });
     let metrics = prefill_fpm(20, 0.0);
@@ -738,30 +812,32 @@ fn native_correction_cap_is_applied_at_observation_ingestion() {
 
     model
         .tune_with_fpms(&[
-            vec![prefill_fpm(20, native_ms / 1000.0)],
+            vec![prefill_fpm(20, native_ms * 0.1 / 1000.0)],
             vec![prefill_fpm(20, native_ms * 100.0 / 1000.0)],
         ])
         .unwrap();
 
-    // The stored samples are [1.0, 2.0], whose median is 1.5. Capping only
-    // after taking the raw [1.0, 100.0] median would incorrectly produce 2.0.
+    // The stored samples are [0.5, 2.0], whose median is 1.25. Applying bounds
+    // only after taking the raw [0.1, 100.0] median would produce 2.0.
     assert_close(
         model
             .estimate_forward_pass_time_ms(&[prefill_fpm(20, 0.0)])
             .unwrap()
             .unwrap(),
-        native_ms * 1.5,
+        native_ms * 1.25,
     );
-    assert_close(model.max_correction_factor().unwrap(), 1.5);
+    assert_close(model.min_correction_factor().unwrap(), 1.25);
+    assert_close(model.max_correction_factor().unwrap(), 1.25);
+    assert_close(model.avg_correction_factor().unwrap(), 1.25);
 }
 
 /// An upper ceiling does not clamp genuine observations below the native
 /// estimate.
 #[test]
-fn native_correction_cap_preserves_downward_corrections() {
+fn native_slower_correction_ceiling_preserves_faster_corrections() {
     let mut model = native_model(ForwardPassPerfOptions {
         min_observations: 2,
-        max_correction_factor: Some(2.0),
+        max_slower_correction_factor: Some(2.0),
         ..Default::default()
     });
     let metrics = prefill_fpm(20, 0.0);
@@ -783,6 +859,41 @@ fn native_correction_cap_preserves_downward_corrections() {
         native_ms * 0.5,
     );
     assert_close(model.max_correction_factor().unwrap(), 0.5);
+}
+
+/// A faster-correction floor bounds only ratios below one and leaves slower
+/// corrections unbounded when no slower ceiling is configured.
+#[test]
+fn native_faster_correction_floor_is_independent() {
+    let options = ForwardPassPerfOptions {
+        min_observations: 2,
+        min_faster_correction_factor: Some(0.5),
+        ..Default::default()
+    };
+
+    let mut faster_model = native_model(options.clone());
+    let faster_metrics = prefill_fpm(20, 0.0);
+    let faster_native_ms = faster_model
+        .estimate_forward_pass_time_ms(&[faster_metrics])
+        .unwrap()
+        .unwrap();
+    let faster = prefill_fpm(20, faster_native_ms * 0.1 / 1000.0);
+    faster_model
+        .tune_with_fpms(&[vec![faster.clone()], vec![faster]])
+        .unwrap();
+    assert_close(faster_model.min_correction_factor().unwrap(), 0.5);
+
+    let mut slower_model = native_model(options);
+    let slower_metrics = prefill_fpm(20, 0.0);
+    let slower_native_ms = slower_model
+        .estimate_forward_pass_time_ms(&[slower_metrics])
+        .unwrap()
+        .unwrap();
+    let slower = prefill_fpm(20, slower_native_ms * 8.0 / 1000.0);
+    slower_model
+        .tune_with_fpms(&[vec![slower.clone()], vec![slower]])
+        .unwrap();
+    assert_close(slower_model.max_correction_factor().unwrap(), 8.0);
 }
 
 /// min_observations is workload-kind-wide; empty in-range regions keep the
@@ -845,7 +956,7 @@ fn native_correction_min_observations_is_workload_kind_wide_and_empty_regions_de
     assert_eq!(model.diagnostics().correction_ready_buckets, 2);
 }
 
-/// Observations outside the configured correction bounds are ignored.
+/// Observations outside the configured correction-grid workload ranges are ignored.
 #[test]
 fn native_correction_uses_configured_bounds_and_ignores_out_of_range_observations() {
     let mut model = native_model(ForwardPassPerfOptions {

--- a/aic-core/rust/aiconfigurator-core/src/fpm/tests.rs
+++ b/aic-core/rust/aiconfigurator-core/src/fpm/tests.rs
@@ -326,6 +326,25 @@ fn options_reject_zero_bounds() {
     assert!(matches!(err, AicError::InvalidEngineConfig(_)));
 }
 
+#[test]
+fn options_validate_max_correction_factor() {
+    let model = ForwardPassPerfModel::from_regression(ForwardPassPerfOptions {
+        max_correction_factor: Some(1.0),
+        ..Default::default()
+    })
+    .unwrap();
+    assert_eq!(model.options().max_correction_factor, Some(1.0));
+
+    for invalid_factor in [f64::NEG_INFINITY, -1.0, 0.0, 0.999, f64::INFINITY, f64::NAN] {
+        let err = ForwardPassPerfModel::from_regression(ForwardPassPerfOptions {
+            max_correction_factor: Some(invalid_factor),
+            ..Default::default()
+        })
+        .unwrap_err();
+        assert!(matches!(err, AicError::InvalidEngineConfig(_)));
+    }
+}
+
 // ---- regression-only mode (engine-agnostic) ----
 
 #[test]
@@ -601,7 +620,11 @@ fn tuning_ignores_idle_wall_time_and_queued_only_work() {
 
 #[test]
 fn fallback_regression_has_no_correction_factors() {
-    let model = ForwardPassPerfModel::from_regression(ForwardPassPerfOptions::default()).unwrap();
+    let model = ForwardPassPerfModel::from_regression(ForwardPassPerfOptions {
+        max_correction_factor: Some(2.0),
+        ..Default::default()
+    })
+    .unwrap();
     assert_eq!(model.min_correction_factor(), None);
     assert_eq!(model.max_correction_factor(), None);
     assert_eq!(model.avg_correction_factor(), None);
@@ -649,6 +672,117 @@ fn native_correction_applies_after_bucket_is_ready() {
         model.diagnostics().source,
         ForwardPassPerfSource::AicWithCorrection
     );
+}
+
+/// The configured ceiling is absolute relative to the native estimate. It does
+/// not compound as matching outliers are added to an already-corrected bucket.
+#[test]
+fn native_correction_cap_is_absolute_across_repeated_outliers() {
+    let mut model = native_model(ForwardPassPerfOptions {
+        min_observations: 2,
+        max_correction_factor: Some(2.0),
+        ..Default::default()
+    });
+    let metrics = prefill_fpm(20, 0.0);
+    let native_ms = model
+        .estimate_forward_pass_time_ms(&[metrics])
+        .unwrap()
+        .unwrap();
+    let outlier = prefill_fpm(20, native_ms * 90.0 / 1000.0);
+
+    model
+        .tune_with_fpms(&[vec![outlier.clone()], vec![outlier.clone()]])
+        .unwrap();
+    assert_close(
+        model
+            .estimate_forward_pass_time_ms(&[prefill_fpm(20, 0.0)])
+            .unwrap()
+            .unwrap(),
+        native_ms * 2.0,
+    );
+
+    model
+        .tune_with_fpms(&[
+            vec![outlier.clone()],
+            vec![outlier.clone()],
+            vec![outlier.clone()],
+            vec![outlier],
+        ])
+        .unwrap();
+    assert_close(
+        model
+            .estimate_forward_pass_time_ms(&[prefill_fpm(20, 0.0)])
+            .unwrap()
+            .unwrap(),
+        native_ms * 2.0,
+    );
+    assert_close(model.min_correction_factor().unwrap(), 2.0);
+    assert_close(model.max_correction_factor().unwrap(), 2.0);
+    assert_close(model.avg_correction_factor().unwrap(), 2.0);
+}
+
+/// Correction samples are capped before taking the median, retaining the
+/// contribution of observations below the ceiling.
+#[test]
+fn native_correction_cap_is_applied_at_observation_ingestion() {
+    let mut model = native_model(ForwardPassPerfOptions {
+        min_observations: 2,
+        max_correction_factor: Some(2.0),
+        ..Default::default()
+    });
+    let metrics = prefill_fpm(20, 0.0);
+    let native_ms = model
+        .estimate_forward_pass_time_ms(&[metrics])
+        .unwrap()
+        .unwrap();
+
+    model
+        .tune_with_fpms(&[
+            vec![prefill_fpm(20, native_ms / 1000.0)],
+            vec![prefill_fpm(20, native_ms * 100.0 / 1000.0)],
+        ])
+        .unwrap();
+
+    // The stored samples are [1.0, 2.0], whose median is 1.5. Capping only
+    // after taking the raw [1.0, 100.0] median would incorrectly produce 2.0.
+    assert_close(
+        model
+            .estimate_forward_pass_time_ms(&[prefill_fpm(20, 0.0)])
+            .unwrap()
+            .unwrap(),
+        native_ms * 1.5,
+    );
+    assert_close(model.max_correction_factor().unwrap(), 1.5);
+}
+
+/// An upper ceiling does not clamp genuine observations below the native
+/// estimate.
+#[test]
+fn native_correction_cap_preserves_downward_corrections() {
+    let mut model = native_model(ForwardPassPerfOptions {
+        min_observations: 2,
+        max_correction_factor: Some(2.0),
+        ..Default::default()
+    });
+    let metrics = prefill_fpm(20, 0.0);
+    let native_ms = model
+        .estimate_forward_pass_time_ms(&[metrics])
+        .unwrap()
+        .unwrap();
+    let faster = prefill_fpm(20, native_ms * 0.5 / 1000.0);
+
+    model
+        .tune_with_fpms(&[vec![faster.clone()], vec![faster]])
+        .unwrap();
+
+    assert_close(
+        model
+            .estimate_forward_pass_time_ms(&[prefill_fpm(20, 0.0)])
+            .unwrap()
+            .unwrap(),
+        native_ms * 0.5,
+    );
+    assert_close(model.max_correction_factor().unwrap(), 0.5);
 }
 
 /// min_observations is workload-kind-wide; empty in-range regions keep the

--- a/aic-core/src/aiconfigurator_core/sdk/rust_engine_step.py
+++ b/aic-core/src/aiconfigurator_core/sdk/rust_engine_step.py
@@ -75,7 +75,10 @@ class RustForwardPassPerfModel:
     ``max_num_tokens`` bounds ``sum_prefill_tokens`` and defaults to ``8192``,
     ``max_batch_size`` bounds ``num_decode_requests`` and defaults to ``512``,
     and ``max_kv_tokens`` bounds ``sum_decode_kv_tokens`` and defaults to
-    ``2000000``.
+    ``2000000``. ``max_correction_factor`` optionally places an absolute upper
+    bound on learned native correction factors; it must be finite and at least
+    ``1.0``. Downward corrections remain unchanged, and omitting the option
+    preserves the default unbounded behavior.
     """
 
     def __init__(self, inner: Any) -> None:

--- a/aic-core/src/aiconfigurator_core/sdk/rust_engine_step.py
+++ b/aic-core/src/aiconfigurator_core/sdk/rust_engine_step.py
@@ -75,10 +75,13 @@ class RustForwardPassPerfModel:
     ``max_num_tokens`` bounds ``sum_prefill_tokens`` and defaults to ``8192``,
     ``max_batch_size`` bounds ``num_decode_requests`` and defaults to ``512``,
     and ``max_kv_tokens`` bounds ``sum_decode_kv_tokens`` and defaults to
-    ``2000000``. ``max_correction_factor`` optionally places an absolute upper
-    bound on learned native correction factors; it must be finite and at least
-    ``1.0``. Downward corrections remain unchanged, and omitting the option
-    preserves the default unbounded behavior.
+    ``2000000``. ``min_faster_correction_factor`` optionally places an absolute
+    lower bound on corrections below ``1.0`` and must be finite and in
+    ``(0.0, 1.0]``. ``max_slower_correction_factor`` independently places an
+    absolute upper bound on corrections above ``1.0`` and must be finite and at
+    least ``1.0``. For example, ``0.5`` limits learned speedups to ``2x``, while
+    ``2.0`` limits learned slowdowns to ``2x``. Omitting either option leaves
+    that direction unbounded. Regression fallback ignores both options.
     """
 
     def __init__(self, inner: Any) -> None:

--- a/tests/unit/sdk/test_rust_engine_step.py
+++ b/tests/unit/sdk/test_rust_engine_step.py
@@ -509,13 +509,13 @@ def test_forward_pass_perf_model_regression_marshalling(monkeypatch) -> None:
 
 
 @pytest.mark.integration
-def test_forward_pass_perf_model_native_correction_cap_end_to_end() -> None:
+def test_forward_pass_perf_model_native_directional_bounds_end_to_end() -> None:
     """End-to-end native forward-pass model over a real fixture.
 
     Builds a native model via ``compile_engine`` (crossing into the Rust core),
-    estimates a prefill iteration, then tunes with an 8x observation while a
-    2x absolute correction cap is configured. Requires the compiled
-    ``aiconfigurator_core`` extension.
+    estimates a prefill iteration, then drives one correction bucket through
+    its slower ceiling, faster floor, and recovery between them. Requires the
+    compiled ``aiconfigurator_core`` extension.
     """
     pytest.importorskip("aiconfigurator_core")
     from aiconfigurator.sdk.rust_engine_step import RustForwardPassPerfModel
@@ -541,7 +541,12 @@ def test_forward_pass_perf_model_native_correction_cap_end_to_end() -> None:
     }
     model = RustForwardPassPerfModel.from_native(
         config,
-        {"min_observations": 2, "max_correction_factor": 2.0},
+        {
+            "min_observations": 2,
+            "max_observations": 2,
+            "min_faster_correction_factor": 0.5,
+            "max_slower_correction_factor": 2.0,
+        },
     )
 
     prefill = [
@@ -578,6 +583,37 @@ def test_forward_pass_perf_model_native_correction_cap_end_to_end() -> None:
     assert model.get_min_correction_factor() == pytest.approx(2.0)
     assert model.get_max_correction_factor() == pytest.approx(2.0)
     assert model.diagnostics()["source"] == "aic_with_correction"
+
+    faster_obs = [
+        {
+            "version": 1,
+            "wall_time": native_ms * 0.1 / 1000.0,
+            "scheduled_requests": {
+                "num_prefill_requests": 2,
+                "sum_prefill_tokens": 2048,
+                "sum_prefill_kv_tokens": 0,
+            },
+        }
+    ]
+    model.tune_with_fpms([faster_obs])
+    assert model.estimate_forward_pass_time_ms(prefill) == pytest.approx(native_ms * 1.25)
+
+    model.tune_with_fpms([faster_obs])
+    assert model.estimate_forward_pass_time_ms(prefill) == pytest.approx(native_ms * 0.5)
+
+    recovery_obs = [
+        {
+            "version": 1,
+            "wall_time": native_ms * 1.25 / 1000.0,
+            "scheduled_requests": {
+                "num_prefill_requests": 2,
+                "sum_prefill_tokens": 2048,
+                "sum_prefill_kv_tokens": 0,
+            },
+        }
+    ]
+    model.tune_with_fpms([recovery_obs, recovery_obs])
+    assert model.estimate_forward_pass_time_ms(prefill) == pytest.approx(native_ms * 1.25)
 
 
 @pytest.mark.integration

--- a/tests/unit/sdk/test_rust_engine_step.py
+++ b/tests/unit/sdk/test_rust_engine_step.py
@@ -509,13 +509,13 @@ def test_forward_pass_perf_model_regression_marshalling(monkeypatch) -> None:
 
 
 @pytest.mark.integration
-def test_forward_pass_perf_model_native_end_to_end() -> None:
+def test_forward_pass_perf_model_native_correction_cap_end_to_end() -> None:
     """End-to-end native forward-pass model over a real fixture.
 
     Builds a native model via ``compile_engine`` (crossing into the Rust core),
-    estimates a prefill iteration, then tunes with an observation engineered to
-    drive the correction factor to exactly 2.0 off the model's own native
-    estimate. Requires the compiled ``aiconfigurator_core`` extension.
+    estimates a prefill iteration, then tunes with an 8x observation while a
+    2x absolute correction cap is configured. Requires the compiled
+    ``aiconfigurator_core`` extension.
     """
     pytest.importorskip("aiconfigurator_core")
     from aiconfigurator.sdk.rust_engine_step import RustForwardPassPerfModel
@@ -539,7 +539,10 @@ def test_forward_pass_perf_model_native_end_to_end() -> None:
         "nextn": None,
         "extra": {},
     }
-    model = RustForwardPassPerfModel.from_native(config, {"min_observations": 2})
+    model = RustForwardPassPerfModel.from_native(
+        config,
+        {"min_observations": 2, "max_correction_factor": 2.0},
+    )
 
     prefill = [
         {
@@ -560,7 +563,7 @@ def test_forward_pass_perf_model_native_end_to_end() -> None:
     obs = [
         {
             "version": 1,
-            "wall_time": native_ms * 2.0 / 1000.0,
+            "wall_time": native_ms * 8.0 / 1000.0,
             "scheduled_requests": {
                 "num_prefill_requests": 2,
                 "sum_prefill_tokens": 2048,
@@ -573,6 +576,7 @@ def test_forward_pass_perf_model_native_end_to_end() -> None:
     corrected = model.estimate_forward_pass_time_ms(prefill)
     assert corrected == pytest.approx(native_ms * 2.0)
     assert model.get_min_correction_factor() == pytest.approx(2.0)
+    assert model.get_max_correction_factor() == pytest.approx(2.0)
     assert model.diagnostics()["source"] == "aic_with_correction"
 
 


### PR DESCRIPTION
## What

- Add independent optional `min_faster_correction_factor` and `max_slower_correction_factor` bounds to `ForwardPassPerfOptions`.
- Validate the faster floor as finite and in `(0.0, 1.0]`, and the slower ceiling as finite and at least `1.0`.
- Clamp each absolute `observed_ms / native_ms` sample before it enters the native correction bucket median.
- Keep correction estimates and the min/max/average diagnostic getters consistent by deriving all of them from the bounded samples.
- Document and test the JSON/Python facade path, independent configuration, and recovery away from either saturated bound.

Both options default to `None`, preserving the existing unbounded behavior. Either direction can be configured independently, and regression fallback ignores both options.

For example, `min_faster_correction_factor = 0.5` prevents learned latency from falling below 50% of native (at most a 2x learned speedup), while `max_slower_correction_factor = 2.0` prevents it from exceeding 200% of native (at most a 2x learned slowdown).

## Why

Related to [ai-dynamo/dynamo#12430](https://github.com/ai-dynamo/dynamo/issues/12430).

Transient forward-pass outliers can otherwise teach native AIC a very large slower correction for a matching workload region and depress downstream Planner capacity estimates after the transient has passed. The slower ceiling directly mitigates that failure mode. The independently optional faster floor also protects against abnormally short samples producing over-optimistic capacity estimates.

AIC already computes the raw native latency while admitting each tuning observation. Applying the bounds here avoids a second model, another native estimate, or duplicated bucket tracking in Dynamo.

Correction observations are absolute ratios, not incremental multipliers. A sequence such as `1.3, 1.4, 1.5` contributes three samples whose median is `1.4`; it is not `1.3 × 1.4 × 1.5`. Bounds are applied to each sample at ingestion. As bounded samples age out, later observations can move the median back toward `1.0`, including after either limit has been reached.

## Validation

- `26 passed`: focused Rust FPM tests, including repeated 90x outliers, both directional limits, ingestion-before-median behavior, recovery from a saturated ceiling, invalid options, and regression isolation.
- `315 passed`: full `aiconfigurator-core` Rust unit suite.
- `23 passed`: full Python `test_rust_engine_step.py` facade suite, including native JSON → PyO3 → Rust propagation and recovery from both directions.
- Public Rust facade consumer passed `cargo check --release`.
- Ruff check/format and `git diff --check` passed.

## Runtime impact

Native tuning adds at most one lower-bound comparison and one upper-bound comparison when admitting an observation. It does not create another model or add an estimate call. The ratio is computed once at ingestion rather than being recomputed for every matching correction lookup.

## Compatibility

Missing JSON fields deserialize to `None`, so existing callers retain unbounded behavior. `ForwardPassPerfOptions` retains `PartialEq` but no longer derives `Eq`, because the validated bounds are `f64` values. The earlier single-bound name existed only on this draft branch and is replaced by the directional names in this revision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added independent optional limits for learned native correction factors.
  * Faster corrections can have a minimum floor, while slower corrections can have a maximum ceiling.
  * Limits are applied per observation before correction factors are aggregated.
  * Unbounded behavior remains available by default.

* **Bug Fixes**
  * Prevented repeated slower outliers from compounding beyond configured limits.
  * Preserved recovery as older observations are replaced.

* **Tests**
  * Added coverage for valid and invalid limits, fallback behavior, capping, and recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->