### PR TITLE
perf(core): specialize communication curves

### DIFF
--- a/aic-core/rust/aiconfigurator-core/src/perf_database/axis_curve.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/axis_curve.rs
@@ -7,25 +7,72 @@ use std::collections::BTreeMap;
 
 use crate::common::error::AicError;
 
-#[derive(Clone, Debug, Default)]
-pub(crate) struct AxisCurve {
-    points: Box<[(u32, f64)]>,
+pub(crate) trait AxisCoordinate: Copy + Ord {
+    fn as_f64(self) -> f64;
+
+    fn exact(value: f64) -> Option<Self>;
 }
 
-impl AxisCurve {
-    pub(crate) fn from_map(points: BTreeMap<u32, f64>) -> Self {
+impl AxisCoordinate for u32 {
+    fn as_f64(self) -> f64 {
+        f64::from(self)
+    }
+
+    fn exact(value: f64) -> Option<Self> {
+        if value >= 0.0 && value <= f64::from(u32::MAX) && value.fract() == 0.0 {
+            Some(value as u32)
+        } else {
+            None
+        }
+    }
+}
+
+impl AxisCoordinate for u64 {
+    fn as_f64(self) -> f64 {
+        self as f64
+    }
+
+    fn exact(value: f64) -> Option<Self> {
+        // `u64::MAX as f64` rounds to 2^64, so keep the upper bound exclusive.
+        if (0.0..18_446_744_073_709_551_616.0).contains(&value) && value.fract() == 0.0 {
+            Some(value as u64)
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct AxisCurve<K = u32> {
+    axis_label: &'static str,
+    points: Box<[(K, f64)]>,
+}
+
+impl Default for AxisCurve<u32> {
+    fn default() -> Self {
+        Self::from_map("num_tokens", BTreeMap::new())
+    }
+}
+
+impl<K: AxisCoordinate> AxisCurve<K> {
+    pub(crate) fn from_map(axis_label: &'static str, points: BTreeMap<K, f64>) -> Self {
         Self {
+            axis_label,
             points: points.into_iter().collect(),
         }
     }
 
-    pub(crate) fn from_sorted_iter(points: impl IntoIterator<Item = (u32, f64)>) -> Self {
+    pub(crate) fn from_sorted_iter(
+        axis_label: &'static str,
+        points: impl IntoIterator<Item = (K, f64)>,
+    ) -> Self {
         let points: Vec<_> = points.into_iter().collect();
         assert!(
             points.windows(2).all(|pair| pair[0].0 < pair[1].0),
             "AxisCurve points must be strictly ascending and unique"
         );
         Self {
+            axis_label,
             points: points.into_boxed_slice(),
         }
     }
@@ -34,18 +81,18 @@ impl AxisCurve {
         self.points.is_empty()
     }
 
-    pub(crate) fn get(&self, coordinate: u32) -> Option<f64> {
+    pub(crate) fn get(&self, coordinate: K) -> Option<f64> {
         self.points
             .binary_search_by_key(&coordinate, |&(coordinate, _)| coordinate)
             .ok()
             .map(|index| self.points[index].1)
     }
 
-    pub(crate) fn iter(&self) -> impl DoubleEndedIterator<Item = (u32, f64)> + '_ {
+    pub(crate) fn iter(&self) -> impl DoubleEndedIterator<Item = (K, f64)> + '_ {
         self.points.iter().copied()
     }
 
-    pub(crate) fn singleton_underflow(&self, coordinate: u32) -> Option<u32> {
+    pub(crate) fn singleton_underflow(&self, coordinate: K) -> Option<K> {
         if self.points.len() == 1 && coordinate < self.points[0].0 {
             Some(self.points[0].0)
         } else {
@@ -55,18 +102,15 @@ impl AxisCurve {
 
     /// Resolve with the one-axis `perf_interp` Grid contract: exact hits,
     /// raw interpolation within the measured range, and a boundary-util hold
-    /// outside it with `k_tail=1`.
-    pub(crate) fn query(
-        &self,
-        coordinate: f64,
-        axis_label: &str,
-        sol: &dyn Fn(f64) -> f64,
-    ) -> Result<f64, AicError> {
+    /// outside it with `k_tail=1`. Keep this in sync with
+    /// `perf_interp::grid_hold`; the differential tests below guard the shared
+    /// behavior for `u32` curves.
+    pub(crate) fn query(&self, coordinate: f64, sol: &dyn Fn(f64) -> f64) -> Result<f64, AicError> {
         if self.points.is_empty() {
-            return Err(miss(axis_label, coordinate, "empty table"));
+            return Err(self.miss(coordinate, "empty table"));
         }
 
-        if let Some(axis_value) = exact_coordinate(coordinate) {
+        if let Some(axis_value) = K::exact(coordinate) {
             if let Some(latency) = self.get(axis_value) {
                 return Ok(latency);
             }
@@ -74,47 +118,36 @@ impl AxisCurve {
 
         let upper = self
             .points
-            .partition_point(|&(axis_value, _)| f64::from(axis_value) < coordinate);
+            .partition_point(|&(axis_value, _)| axis_value.as_f64() < coordinate);
         if upper == 0 || upper == self.points.len() {
             let anchor = if upper == 0 {
                 self.points[0]
             } else {
                 self.points[self.points.len() - 1]
             };
-            let anchor_sol = sol(f64::from(anchor.0));
+            let anchor_sol = sol(anchor.0.as_f64());
             if anchor.1.is_nan() || anchor.1 <= 0.0 || anchor_sol.is_nan() || anchor_sol <= 0.0 {
-                return Err(miss(
-                    axis_label,
-                    coordinate,
-                    "no positive-util boundary anchor",
-                ));
+                return Err(self.miss(coordinate, "no positive-util boundary anchor"));
             }
             let query_sol = sol(coordinate);
             if query_sol.is_nan() || query_sol <= 0.0 {
-                return Err(miss(axis_label, coordinate, "non-positive SOL at query"));
+                return Err(self.miss(coordinate, "non-positive SOL at query"));
             }
             return Ok(query_sol / (anchor_sol / anchor.1));
         }
 
         let lower = self.points[upper - 1];
         let upper = self.points[upper];
-        let weight = (coordinate - f64::from(lower.0)) / f64::from(upper.0 - lower.0);
+        let weight = (coordinate - lower.0.as_f64()) / (upper.0.as_f64() - lower.0.as_f64());
         Ok(lower.1 + (upper.1 - lower.1) * weight)
     }
-}
 
-fn exact_coordinate(value: f64) -> Option<u32> {
-    if value >= 0.0 && value <= f64::from(u32::MAX) && value.fract() == 0.0 {
-        Some(value as u32)
-    } else {
-        None
+    fn miss(&self, coordinate: f64, reason: &str) -> AicError {
+        AicError::PerfDatabase(format!(
+            "perf_interp: no data to anchor query {{{}={coordinate}}} ({reason})",
+            self.axis_label
+        ))
     }
-}
-
-fn miss(axis_label: &str, coordinate: f64, reason: &str) -> AicError {
-    AicError::PerfDatabase(format!(
-        "perf_interp: no data to anchor query {{{axis_label}={coordinate}}} ({reason})"
-    ))
 }
 
 #[cfg(test)]
@@ -124,55 +157,42 @@ mod tests {
 
     #[test]
     fn axis_curve_resolves_exact_interpolated_and_held_values() {
-        let curve = AxisCurve::from_map(BTreeMap::from([(10, 1.0), (20, 3.0)]));
-        assert_eq!(
-            curve.query(10.0, "num_tokens", &|tokens| tokens).unwrap(),
-            1.0
-        );
-        assert_eq!(
-            curve.query(15.0, "num_tokens", &|tokens| tokens).unwrap(),
-            2.0
-        );
-        assert_eq!(
-            curve.query(40.0, "num_tokens", &|tokens| tokens).unwrap(),
-            6.0
-        );
-        assert_eq!(
-            curve.query(5.0, "num_tokens", &|tokens| tokens).unwrap(),
-            0.5
-        );
+        let curve = AxisCurve::from_map("num_tokens", BTreeMap::from([(10_u32, 1.0), (20, 3.0)]));
+        assert_eq!(curve.query(10.0, &|tokens| tokens).unwrap(), 1.0);
+        assert_eq!(curve.query(15.0, &|tokens| tokens).unwrap(), 2.0);
+        assert_eq!(curve.query(40.0, &|tokens| tokens).unwrap(), 6.0);
+        assert_eq!(curve.query(5.0, &|tokens| tokens).unwrap(), 0.5);
     }
 
     #[test]
     fn axis_curve_preserves_singleton_and_invalid_hold_semantics() {
-        let singleton = AxisCurve::from_map(BTreeMap::from([(10, 0.0)]));
+        let singleton = AxisCurve::from_map("num_tokens", BTreeMap::from([(10_u32, 0.0)]));
         assert_eq!(singleton.singleton_underflow(9), Some(10));
-        assert!(singleton
-            .query(20.0, "num_tokens", &|tokens| tokens)
-            .is_err());
+        assert!(singleton.query(20.0, &|tokens| tokens).is_err());
     }
 
     #[test]
     fn axis_curve_is_bit_exact_with_the_generic_grid() {
-        let points = BTreeMap::from([(10, 1.25), (20, 2.75), (40, 5.5)]);
-        let curve = AxisCurve::from_map(points.clone());
-        let mut node = Node::branch();
-        for (&token, &latency) in &points {
-            node.insert(&[token], latency);
-        }
         let sol = |tokens: f64| tokens * tokens + 1.0;
-        let generic_sol = |coords: &[f64]| sol(coords[0]);
-        let config = OpInterpConfig::grid(&["num_tokens"], &generic_sol);
-
-        for tokens in [5.0, 10.0, 15.5, 20.0, 31.0, 40.0, 80.0] {
-            let expected = perf_interp::query(&config, &node, &[tokens]).unwrap();
-            let actual = curve.query(tokens, "num_tokens", &sol).unwrap();
-            assert_eq!(actual.to_bits(), expected.to_bits(), "tokens={tokens}");
+        for stride in [1_u32, 3, 17, 257] {
+            let points =
+                BTreeMap::from([(10 * stride, 1.25), (20 * stride, 2.75), (40 * stride, 5.5)]);
+            for tokens in [
+                5.0 * f64::from(stride),
+                10.0 * f64::from(stride),
+                15.5 * f64::from(stride),
+                20.0 * f64::from(stride),
+                31.0 * f64::from(stride),
+                40.0 * f64::from(stride),
+                80.0 * f64::from(stride),
+            ] {
+                assert_query_parity(points.clone(), tokens, &sol);
+            }
         }
     }
 
     fn assert_query_parity(points: BTreeMap<u32, f64>, num_tokens: f64, sol: &dyn Fn(f64) -> f64) {
-        let curve = AxisCurve::from_map(points.clone());
+        let curve = AxisCurve::from_map("num_tokens", points.clone());
         let mut node = Node::branch();
         for (&token, &latency) in &points {
             node.insert(&[token], latency);
@@ -180,7 +200,7 @@ mod tests {
         let generic_sol = |coords: &[f64]| sol(coords[0]);
         let config = OpInterpConfig::grid(&["num_tokens"], &generic_sol);
         let expected = perf_interp::query(&config, &node, &[num_tokens]);
-        let actual = curve.query(num_tokens, "num_tokens", sol);
+        let actual = curve.query(num_tokens, sol);
         match (actual, expected) {
             (Ok(actual), Ok(expected)) => assert_eq!(actual.to_bits(), expected.to_bits()),
             (Err(actual), Err(expected)) => assert_eq!(actual.to_string(), expected.to_string()),
@@ -209,27 +229,25 @@ mod tests {
     }
 
     #[test]
-    fn axis_curve_uses_the_supplied_axis_label() {
-        let curve = AxisCurve::default();
-        let err = curve
-            .query(1024.5, "message_bytes", &|bytes| bytes)
-            .unwrap_err();
+    fn axis_curve_uses_its_axis_label_for_reachable_misses() {
+        let curve = AxisCurve::from_map("message_bytes", BTreeMap::from([(1024_u64, 0.0)]));
+        let err = curve.query(2048.0, &|bytes| bytes).unwrap_err();
         assert_eq!(
             err.to_string(),
             "perf database error: perf_interp: no data to anchor query \
-             {message_bytes=1024.5} (empty table)"
+             {message_bytes=2048} (no positive-util boundary anchor)"
         );
     }
 
     #[test]
     #[should_panic(expected = "AxisCurve points must be strictly ascending and unique")]
     fn axis_curve_rejects_unsorted_points() {
-        AxisCurve::from_sorted_iter([(2, 2.0), (1, 1.0)]);
+        AxisCurve::from_sorted_iter("num_tokens", [(2_u32, 2.0), (1, 1.0)]);
     }
 
     #[test]
     #[should_panic(expected = "AxisCurve points must be strictly ascending and unique")]
     fn axis_curve_rejects_duplicate_points() {
-        AxisCurve::from_sorted_iter([(1, 1.0), (1, 2.0)]);
+        AxisCurve::from_sorted_iter("num_tokens", [(1_u32, 1.0), (1, 2.0)]);
     }
 }

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/axis_curve.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/axis_curve.rs
@@ -1,18 +1,18 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Immutable one-axis token curves used by MoE-family perf tables.
+//! Immutable one-axis curves used by performance tables.
 
 use std::collections::BTreeMap;
 
 use crate::common::error::AicError;
 
 #[derive(Clone, Debug, Default)]
-pub(crate) struct TokenCurve {
+pub(crate) struct AxisCurve {
     points: Box<[(u32, f64)]>,
 }
 
-impl TokenCurve {
+impl AxisCurve {
     pub(crate) fn from_map(points: BTreeMap<u32, f64>) -> Self {
         Self {
             points: points.into_iter().collect(),
@@ -23,7 +23,7 @@ impl TokenCurve {
         let points: Vec<_> = points.into_iter().collect();
         assert!(
             points.windows(2).all(|pair| pair[0].0 < pair[1].0),
-            "TokenCurve points must be strictly ascending and unique"
+            "AxisCurve points must be strictly ascending and unique"
         );
         Self {
             points: points.into_boxed_slice(),
@@ -34,9 +34,9 @@ impl TokenCurve {
         self.points.is_empty()
     }
 
-    pub(crate) fn get(&self, token: u32) -> Option<f64> {
+    pub(crate) fn get(&self, coordinate: u32) -> Option<f64> {
         self.points
-            .binary_search_by_key(&token, |&(token, _)| token)
+            .binary_search_by_key(&coordinate, |&(coordinate, _)| coordinate)
             .ok()
             .map(|index| self.points[index].1)
     }
@@ -45,8 +45,8 @@ impl TokenCurve {
         self.points.iter().copied()
     }
 
-    pub(crate) fn singleton_underflow(&self, num_tokens: u32) -> Option<u32> {
-        if self.points.len() == 1 && num_tokens < self.points[0].0 {
+    pub(crate) fn singleton_underflow(&self, coordinate: u32) -> Option<u32> {
+        if self.points.len() == 1 && coordinate < self.points[0].0 {
             Some(self.points[0].0)
         } else {
             None
@@ -56,20 +56,25 @@ impl TokenCurve {
     /// Resolve with the one-axis `perf_interp` Grid contract: exact hits,
     /// raw interpolation within the measured range, and a boundary-util hold
     /// outside it with `k_tail=1`.
-    pub(crate) fn query(&self, num_tokens: f64, sol: &dyn Fn(f64) -> f64) -> Result<f64, AicError> {
+    pub(crate) fn query(
+        &self,
+        coordinate: f64,
+        axis_label: &str,
+        sol: &dyn Fn(f64) -> f64,
+    ) -> Result<f64, AicError> {
         if self.points.is_empty() {
-            return Err(miss(num_tokens, "empty table"));
+            return Err(miss(axis_label, coordinate, "empty table"));
         }
 
-        if let Some(token) = exact_token(num_tokens) {
-            if let Some(latency) = self.get(token) {
+        if let Some(axis_value) = exact_coordinate(coordinate) {
+            if let Some(latency) = self.get(axis_value) {
                 return Ok(latency);
             }
         }
 
         let upper = self
             .points
-            .partition_point(|&(token, _)| f64::from(token) < num_tokens);
+            .partition_point(|&(axis_value, _)| f64::from(axis_value) < coordinate);
         if upper == 0 || upper == self.points.len() {
             let anchor = if upper == 0 {
                 self.points[0]
@@ -78,23 +83,27 @@ impl TokenCurve {
             };
             let anchor_sol = sol(f64::from(anchor.0));
             if anchor.1.is_nan() || anchor.1 <= 0.0 || anchor_sol.is_nan() || anchor_sol <= 0.0 {
-                return Err(miss(num_tokens, "no positive-util boundary anchor"));
+                return Err(miss(
+                    axis_label,
+                    coordinate,
+                    "no positive-util boundary anchor",
+                ));
             }
-            let query_sol = sol(num_tokens);
+            let query_sol = sol(coordinate);
             if query_sol.is_nan() || query_sol <= 0.0 {
-                return Err(miss(num_tokens, "non-positive SOL at query"));
+                return Err(miss(axis_label, coordinate, "non-positive SOL at query"));
             }
             return Ok(query_sol / (anchor_sol / anchor.1));
         }
 
         let lower = self.points[upper - 1];
         let upper = self.points[upper];
-        let weight = (num_tokens - f64::from(lower.0)) / f64::from(upper.0 - lower.0);
+        let weight = (coordinate - f64::from(lower.0)) / f64::from(upper.0 - lower.0);
         Ok(lower.1 + (upper.1 - lower.1) * weight)
     }
 }
 
-fn exact_token(value: f64) -> Option<u32> {
+fn exact_coordinate(value: f64) -> Option<u32> {
     if value >= 0.0 && value <= f64::from(u32::MAX) && value.fract() == 0.0 {
         Some(value as u32)
     } else {
@@ -102,9 +111,9 @@ fn exact_token(value: f64) -> Option<u32> {
     }
 }
 
-fn miss(num_tokens: f64, reason: &str) -> AicError {
+fn miss(axis_label: &str, coordinate: f64, reason: &str) -> AicError {
     AicError::PerfDatabase(format!(
-        "perf_interp: no data to anchor query {{num_tokens={num_tokens}}} ({reason})"
+        "perf_interp: no data to anchor query {{{axis_label}={coordinate}}} ({reason})"
     ))
 }
 
@@ -114,25 +123,39 @@ mod tests {
     use crate::perf_database::perf_interp::{self, Node, OpInterpConfig};
 
     #[test]
-    fn token_curve_resolves_exact_interpolated_and_held_values() {
-        let curve = TokenCurve::from_map(BTreeMap::from([(10, 1.0), (20, 3.0)]));
-        assert_eq!(curve.query(10.0, &|tokens| tokens).unwrap(), 1.0);
-        assert_eq!(curve.query(15.0, &|tokens| tokens).unwrap(), 2.0);
-        assert_eq!(curve.query(40.0, &|tokens| tokens).unwrap(), 6.0);
-        assert_eq!(curve.query(5.0, &|tokens| tokens).unwrap(), 0.5);
+    fn axis_curve_resolves_exact_interpolated_and_held_values() {
+        let curve = AxisCurve::from_map(BTreeMap::from([(10, 1.0), (20, 3.0)]));
+        assert_eq!(
+            curve.query(10.0, "num_tokens", &|tokens| tokens).unwrap(),
+            1.0
+        );
+        assert_eq!(
+            curve.query(15.0, "num_tokens", &|tokens| tokens).unwrap(),
+            2.0
+        );
+        assert_eq!(
+            curve.query(40.0, "num_tokens", &|tokens| tokens).unwrap(),
+            6.0
+        );
+        assert_eq!(
+            curve.query(5.0, "num_tokens", &|tokens| tokens).unwrap(),
+            0.5
+        );
     }
 
     #[test]
-    fn token_curve_preserves_singleton_and_invalid_hold_semantics() {
-        let singleton = TokenCurve::from_map(BTreeMap::from([(10, 0.0)]));
+    fn axis_curve_preserves_singleton_and_invalid_hold_semantics() {
+        let singleton = AxisCurve::from_map(BTreeMap::from([(10, 0.0)]));
         assert_eq!(singleton.singleton_underflow(9), Some(10));
-        assert!(singleton.query(20.0, &|tokens| tokens).is_err());
+        assert!(singleton
+            .query(20.0, "num_tokens", &|tokens| tokens)
+            .is_err());
     }
 
     #[test]
-    fn token_curve_is_bit_exact_with_the_generic_grid() {
+    fn axis_curve_is_bit_exact_with_the_generic_grid() {
         let points = BTreeMap::from([(10, 1.25), (20, 2.75), (40, 5.5)]);
-        let curve = TokenCurve::from_map(points.clone());
+        let curve = AxisCurve::from_map(points.clone());
         let mut node = Node::branch();
         for (&token, &latency) in &points {
             node.insert(&[token], latency);
@@ -143,13 +166,13 @@ mod tests {
 
         for tokens in [5.0, 10.0, 15.5, 20.0, 31.0, 40.0, 80.0] {
             let expected = perf_interp::query(&config, &node, &[tokens]).unwrap();
-            let actual = curve.query(tokens, &sol).unwrap();
+            let actual = curve.query(tokens, "num_tokens", &sol).unwrap();
             assert_eq!(actual.to_bits(), expected.to_bits(), "tokens={tokens}");
         }
     }
 
     fn assert_query_parity(points: BTreeMap<u32, f64>, num_tokens: f64, sol: &dyn Fn(f64) -> f64) {
-        let curve = TokenCurve::from_map(points.clone());
+        let curve = AxisCurve::from_map(points.clone());
         let mut node = Node::branch();
         for (&token, &latency) in &points {
             node.insert(&[token], latency);
@@ -157,7 +180,7 @@ mod tests {
         let generic_sol = |coords: &[f64]| sol(coords[0]);
         let config = OpInterpConfig::grid(&["num_tokens"], &generic_sol);
         let expected = perf_interp::query(&config, &node, &[num_tokens]);
-        let actual = curve.query(num_tokens, sol);
+        let actual = curve.query(num_tokens, "num_tokens", sol);
         match (actual, expected) {
             (Ok(actual), Ok(expected)) => assert_eq!(actual.to_bits(), expected.to_bits()),
             (Err(actual), Err(expected)) => assert_eq!(actual.to_string(), expected.to_string()),
@@ -166,7 +189,7 @@ mod tests {
     }
 
     #[test]
-    fn token_curve_errors_match_the_generic_grid() {
+    fn axis_curve_errors_match_the_generic_grid() {
         assert_query_parity(BTreeMap::new(), 10.0, &|tokens| tokens);
         assert_query_parity(BTreeMap::from([(10, 0.0)]), 20.0, &|tokens| tokens);
         assert_query_parity(BTreeMap::from([(10, 1.0)]), 20.0, &|tokens| {
@@ -186,14 +209,27 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "TokenCurve points must be strictly ascending and unique")]
-    fn token_curve_rejects_unsorted_points() {
-        TokenCurve::from_sorted_iter([(2, 2.0), (1, 1.0)]);
+    fn axis_curve_uses_the_supplied_axis_label() {
+        let curve = AxisCurve::default();
+        let err = curve
+            .query(1024.5, "message_bytes", &|bytes| bytes)
+            .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "perf database error: perf_interp: no data to anchor query \
+             {message_bytes=1024.5} (empty table)"
+        );
     }
 
     #[test]
-    #[should_panic(expected = "TokenCurve points must be strictly ascending and unique")]
-    fn token_curve_rejects_duplicate_points() {
-        TokenCurve::from_sorted_iter([(1, 1.0), (1, 2.0)]);
+    #[should_panic(expected = "AxisCurve points must be strictly ascending and unique")]
+    fn axis_curve_rejects_unsorted_points() {
+        AxisCurve::from_sorted_iter([(2, 2.0), (1, 1.0)]);
+    }
+
+    #[test]
+    #[should_panic(expected = "AxisCurve points must be strictly ascending and unique")]
+    fn axis_curve_rejects_duplicate_points() {
+        AxisCurve::from_sorted_iter([(1, 1.0), (1, 2.0)]);
     }
 }

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/communication.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/communication.rs
@@ -26,12 +26,12 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
+use super::axis_curve::AxisCurve;
+use super::{kernel_source_ok, resolve_op_sources};
 use crate::common::enums::CommQuantMode;
 use crate::common::error::AicError;
 use crate::common::system_spec::SystemSpec;
 use crate::config::{PerfDbSources, PerfSource};
-use super::{kernel_source_ok, resolve_op_sources};
-use super::perf_interp::{self, Node, OpInterpConfig};
 use crate::perf_database::parquet_loader::PerfReader;
 
 pub struct CommunicationTable {
@@ -61,12 +61,12 @@ pub struct CommunicationTable {
 
 struct CustomAllReduceGrids {
     /// (quant_name, tp_size) -> {message_size -> latency_ms}
-    by_keys: BTreeMap<(String, u32), BTreeMap<u64, f64>>,
+    by_keys: BTreeMap<(String, u32), AxisCurve>,
 }
 
 struct NcclGrids {
     /// (dtype_name, operation, num_gpus) -> {message_size -> latency_ms}
-    by_keys: BTreeMap<(String, String, u32), BTreeMap<u64, f64>>,
+    by_keys: BTreeMap<(String, String, u32), AxisCurve>,
 }
 
 impl CommunicationTable {
@@ -127,13 +127,13 @@ impl CommunicationTable {
         }
         let grids = self.load_custom_allreduce()?;
         let key = (quant.name().to_string(), tp_size_effective);
-        let by_size = grids.by_keys.get(&key).ok_or_else(|| {
+        let curve = grids.by_keys.get(&key).ok_or_else(|| {
             AicError::PerfDatabase(format!(
                 "custom_allreduce data missing for {key:?} at {}",
                 self.data_root.display()
             ))
         })?;
-        interp_message_size(by_size, message_size)
+        interp_message_size(curve, message_size)
     }
 
     /// Custom-allreduce latency at a RAW tp_size, mirroring the full Python
@@ -222,19 +222,19 @@ impl CommunicationTable {
         let key = (dtype.name().to_string(), operation.to_string(), num_gpus_effective);
 
         if let Ok(grids) = self.load_nccl() {
-            if let Some(by_size) = grids.by_keys.get(&key) {
-                return interp_message_size(by_size, message_size);
+            if let Some(curve) = grids.by_keys.get(&key) {
+                return interp_message_size(curve, message_size);
             }
         }
         // Fall back to OneCCL.
         let grids = self.load_oneccl()?;
-        let by_size = grids.by_keys.get(&key).ok_or_else(|| {
+        let curve = grids.by_keys.get(&key).ok_or_else(|| {
             AicError::PerfDatabase(format!(
                 "neither NCCL nor OneCCL has data for {key:?} at {}",
                 self.data_root.display()
             ))
         })?;
-        interp_message_size(by_size, message_size)
+        interp_message_size(curve, message_size)
     }
 
     /// Collected `(message_size,) -> latency_ms` points of the
@@ -249,19 +249,22 @@ impl CommunicationTable {
     ) -> Result<Vec<(Vec<f64>, f64)>, AicError> {
         let grids = self.load_custom_allreduce()?;
         let key = (quant.name().to_string(), tp_size);
-        let by_size = grids.by_keys.get(&key).ok_or_else(|| {
+        let curve = grids.by_keys.get(&key).ok_or_else(|| {
             AicError::PerfDatabase(format!(
                 "custom_allreduce data missing for {key:?} at {}",
                 self.data_root.display()
             ))
         })?;
-        if by_size.is_empty() {
+        if curve.is_empty() {
             return Err(AicError::PerfDatabase(format!(
                 "custom_allreduce data empty for {key:?} at {}",
                 self.data_root.display()
             )));
         }
-        Ok(by_size.iter().map(|(&size, &lat)| (vec![size as f64], lat)).collect())
+        Ok(curve
+            .iter()
+            .map(|(size, latency)| (vec![f64::from(size)], latency))
+            .collect())
     }
 
     /// The single NCCL source the empirical path calibrates from, with
@@ -312,19 +315,22 @@ impl CommunicationTable {
     ) -> Result<Vec<(Vec<f64>, f64)>, AicError> {
         let grids = self.nccl_empirical_source()?;
         let key = (dtype.name().to_string(), operation.to_string(), num_gpus);
-        let by_size = grids.by_keys.get(&key).ok_or_else(|| {
+        let curve = grids.by_keys.get(&key).ok_or_else(|| {
             AicError::PerfDatabase(format!(
                 "NCCL data missing for {key:?} at {}",
                 self.data_root.display()
             ))
         })?;
-        if by_size.is_empty() {
+        if curve.is_empty() {
             return Err(AicError::PerfDatabase(format!(
                 "NCCL data empty for {key:?} at {}",
                 self.data_root.display()
             )));
         }
-        Ok(by_size.iter().map(|(&size, &lat)| (vec![size as f64], lat)).collect())
+        Ok(curve
+            .iter()
+            .map(|(size, latency)| (vec![f64::from(size)], latency))
+            .collect())
     }
 
     /// Maximum recorded `num_gpus` for an NCCL (dtype, operation) tuple.
@@ -403,19 +409,38 @@ impl CommunicationTable {
 /// Python keeps float element counts (e.g. the gemma4 CP KV all-gather sizes
 /// `kvcache_bytes_per_token / comm_bytes`), and the engine query coordinate
 /// is float anyway. Truncating to integer first shifted the lerp point.
-fn interp_message_size(by_size: &BTreeMap<u64, f64>, message_size: f64) -> Result<f64, AicError> {
+fn interp_message_size(by_size: &AxisCurve, message_size: f64) -> Result<f64, AicError> {
     if by_size.is_empty() {
         return Err(AicError::PerfDatabase(
             "comm data has no message_size points".to_string(),
         ));
     }
-    let mut node = Node::branch();
-    for (&size, &latency) in by_size {
-        node.insert(&[size.min(u32::MAX as u64) as u32], latency);
+    by_size.query(message_size, "message_bytes", &|size| size)
+}
+
+/// Freeze a loaded message-size bucket after row/source precedence has been
+/// resolved in the original `u64` key space. Insertion order is ascending, so
+/// if distinct oversized coordinates clamp to `u32::MAX`, the last point wins
+/// exactly as it did when the generic interpolation node was built per query.
+fn message_size_curve(points: BTreeMap<u64, f64>) -> AxisCurve {
+    let mut clamped = BTreeMap::new();
+    for (size, latency) in points {
+        clamped.insert(size.min(u64::from(u32::MAX)) as u32, latency);
     }
-    let sol = |c: &[f64]| c[0];
-    let cfg = OpInterpConfig::grid(&["message_bytes"], &sol);
-    perf_interp::query(&cfg, &node, &[message_size])
+    AxisCurve::from_map(clamped)
+}
+
+fn insert_first_message_point<K: Ord>(
+    by_keys: &mut BTreeMap<K, BTreeMap<u64, f64>>,
+    key: K,
+    message_size: u64,
+    latency: f64,
+) {
+    by_keys
+        .entry(key)
+        .or_default()
+        .entry(message_size)
+        .or_insert(latency);
 }
 
 fn load_custom_allreduce_parquet(sources: &[PerfSource]) -> Result<CustomAllReduceGrids, AicError> {
@@ -459,11 +484,12 @@ fn load_custom_allreduce_parquet(sources: &[PerfSource]) -> Result<CustomAllRedu
             // behavior is stable in production).
             // First-wins parity with Python `load_custom_allreduce_data`,
             // extended across shared-layer sources (earlier source wins).
-            by_keys
-                .entry(("half".to_string(), row.u32(num_gpus_col)?))
-                .or_default()
-                .entry(row.u64(message_size_col)?)
-                .or_insert(row.f64(latency_col)?);
+            insert_first_message_point(
+                &mut by_keys,
+                ("half".to_string(), row.u32(num_gpus_col)?),
+                row.u64(message_size_col)?,
+                row.f64(latency_col)?,
+            );
         }
     }
     if !any_source || by_keys.is_empty() {
@@ -473,7 +499,12 @@ fn load_custom_allreduce_parquet(sources: &[PerfSource]) -> Result<CustomAllRedu
             sources.first().map(|s| s.path().display().to_string()).unwrap_or_default()
         )));
     }
-    Ok(CustomAllReduceGrids { by_keys })
+    Ok(CustomAllReduceGrids {
+        by_keys: by_keys
+            .into_iter()
+            .map(|(key, points)| (key, message_size_curve(points)))
+            .collect(),
+    })
 }
 
 fn load_nccl_parquet(path: &Path) -> Result<NcclGrids, AicError> {
@@ -488,15 +519,16 @@ fn load_nccl_parquet(path: &Path) -> Result<NcclGrids, AicError> {
     for row in reader.rows()? {
         let row = row?;
         // First-wins parity with Python `load_nccl_data`.
-        by_keys
-            .entry((
+        insert_first_message_point(
+            &mut by_keys,
+            (
                 row.str_owned(nccl_dtype_col)?,
                 row.str_owned(op_name_col)?,
                 row.u32(num_gpus_col)?,
-            ))
-            .or_default()
-            .entry(row.u64(message_size_col)?)
-            .or_insert(row.f64(latency_col)?);
+            ),
+            row.u64(message_size_col)?,
+            row.f64(latency_col)?,
+        );
     }
     if by_keys.is_empty() {
         return Err(AicError::PerfDatabase(format!(
@@ -504,7 +536,12 @@ fn load_nccl_parquet(path: &Path) -> Result<NcclGrids, AicError> {
             path.display()
         )));
     }
-    Ok(NcclGrids { by_keys })
+    Ok(NcclGrids {
+        by_keys: by_keys
+            .into_iter()
+            .map(|(key, points)| (key, message_size_curve(points)))
+            .collect(),
+    })
 }
 
 fn clone_err(err: &AicError) -> AicError {
@@ -514,6 +551,7 @@ fn clone_err(err: &AicError) -> AicError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::perf_database::perf_interp::{self, Node, OpInterpConfig};
 
     const REPO_ROOT_HINT: &str = env!("CARGO_MANIFEST_DIR");
 
@@ -535,6 +573,143 @@ mod tests {
     /// system-spec-aware NCCL root for b200_sxm.
     fn b200_nccl_root() -> Option<PathBuf> {
         Some(systems_root().join("data/b200_sxm/comm/nccl/2.27.3"))
+    }
+
+    fn generic_message_size_query(
+        points: &BTreeMap<u64, f64>,
+        message_size: f64,
+    ) -> Result<f64, AicError> {
+        if points.is_empty() {
+            return Err(AicError::PerfDatabase(
+                "comm data has no message_size points".to_string(),
+            ));
+        }
+        let mut node = Node::branch();
+        for (&size, &latency) in points {
+            node.insert(&[size.min(u64::from(u32::MAX)) as u32], latency);
+        }
+        let sol = |coordinates: &[f64]| coordinates[0];
+        let config = OpInterpConfig::grid(&["message_bytes"], &sol);
+        perf_interp::query(&config, &node, &[message_size])
+    }
+
+    #[test]
+    fn message_size_curve_matches_generic_grid() {
+        let points = BTreeMap::from([(256, 1.25), (1024, 2.75), (4096, 5.5)]);
+        let curve = message_size_curve(points.clone());
+
+        for message_size in [64.0, 256.0, 640.5, 1024.0, 2048.25, 4096.0, 8192.0] {
+            let expected = generic_message_size_query(&points, message_size).unwrap();
+            let actual = interp_message_size(&curve, message_size).unwrap();
+            assert_eq!(
+                actual.to_bits(),
+                expected.to_bits(),
+                "message_size={message_size}"
+            );
+        }
+
+        let singleton = BTreeMap::from([(1024, 3.0)]);
+        let curve = message_size_curve(singleton.clone());
+        for message_size in [512.0, 1024.0, 2048.0] {
+            let expected = generic_message_size_query(&singleton, message_size).unwrap();
+            let actual = interp_message_size(&curve, message_size).unwrap();
+            assert_eq!(actual.to_bits(), expected.to_bits());
+        }
+    }
+
+    #[test]
+    fn message_size_curve_preserves_errors_and_clamped_duplicate_precedence() {
+        let empty = BTreeMap::new();
+        let empty_curve = message_size_curve(empty.clone());
+        assert_eq!(
+            interp_message_size(&empty_curve, 1024.0)
+                .unwrap_err()
+                .to_string(),
+            generic_message_size_query(&empty, 1024.0)
+                .unwrap_err()
+                .to_string()
+        );
+
+        let invalid = BTreeMap::from([(1024, 0.0)]);
+        let invalid_curve = message_size_curve(invalid.clone());
+        assert_eq!(
+            interp_message_size(&invalid_curve, 2048.0)
+                .unwrap_err()
+                .to_string(),
+            generic_message_size_query(&invalid, 2048.0)
+                .unwrap_err()
+                .to_string()
+        );
+
+        let oversized = BTreeMap::from([
+            (u64::from(u32::MAX) + 1, 1.0),
+            (u64::from(u32::MAX) + 2, 2.0),
+        ]);
+        let curve = message_size_curve(oversized.clone());
+        assert_eq!(curve.iter().collect::<Vec<_>>(), vec![(u32::MAX, 2.0)]);
+        let expected = generic_message_size_query(&oversized, f64::from(u32::MAX)).unwrap();
+        let actual = interp_message_size(&curve, f64::from(u32::MAX)).unwrap();
+        assert_eq!(actual.to_bits(), expected.to_bits());
+    }
+
+    #[test]
+    fn custom_allreduce_preserves_first_source_and_first_row_precedence() {
+        let key = ("half".to_string(), 4);
+        let mut by_keys = BTreeMap::new();
+        insert_first_message_point(&mut by_keys, key.clone(), 1024, 1.0);
+        insert_first_message_point(&mut by_keys, key.clone(), 1024, 2.0);
+        insert_first_message_point(&mut by_keys, key.clone(), 1024, 3.0);
+        insert_first_message_point(&mut by_keys, key.clone(), 2048, 4.0);
+        let curve = message_size_curve(by_keys.remove(&key).unwrap());
+        assert_eq!(interp_message_size(&curve, 1024.0).unwrap(), 1.0);
+        assert_eq!(interp_message_size(&curve, 2048.0).unwrap(), 4.0);
+    }
+
+    fn table_with_loaded_collectives(
+        nccl: BTreeMap<(String, String, u32), AxisCurve>,
+        oneccl: BTreeMap<(String, String, u32), AxisCurve>,
+    ) -> CommunicationTable {
+        let nccl_cell = OnceLock::new();
+        assert!(nccl_cell.set(Ok(NcclGrids { by_keys: nccl })).is_ok());
+        let oneccl_cell = OnceLock::new();
+        assert!(oneccl_cell.set(Ok(NcclGrids { by_keys: oneccl })).is_ok());
+        CommunicationTable {
+            data_root: PathBuf::from("synthetic"),
+            nccl_root: None,
+            oneccl_root: None,
+            custom_allreduce_sources: Vec::new(),
+            custom_allreduce: OnceLock::new(),
+            nccl: nccl_cell,
+            oneccl: oneccl_cell,
+        }
+    }
+
+    #[test]
+    fn nccl_primary_and_oneccl_fallback_use_frozen_curves() {
+        let key = ("half".to_string(), "all_reduce".to_string(), 4);
+        let primary = BTreeMap::from([(
+            key.clone(),
+            message_size_curve(BTreeMap::from([(1024, 1.0)])),
+        )]);
+        let fallback = BTreeMap::from([(
+            key.clone(),
+            message_size_curve(BTreeMap::from([(1024, 2.0)])),
+        )]);
+        let table = table_with_loaded_collectives(primary, fallback.clone());
+        assert_eq!(
+            table
+                .query_nccl(CommQuantMode::Half, "all_reduce", 4, 1024.0)
+                .unwrap(),
+            1.0
+        );
+
+        let table = table_with_loaded_collectives(BTreeMap::new(), fallback);
+        assert_eq!(
+            table
+                .query_nccl(CommQuantMode::Half, "all_reduce", 4, 1024.0)
+                .unwrap(),
+            2.0
+        );
     }
 
     #[test]

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/communication.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/communication.rs
@@ -60,13 +60,13 @@ pub struct CommunicationTable {
 }
 
 struct CustomAllReduceGrids {
-    /// (quant_name, tp_size) -> {message_size -> latency_ms}
-    by_keys: BTreeMap<(String, u32), AxisCurve>,
+    /// `(quant_name, tp_size)` -> immutable `u64` message-size curve.
+    by_keys: BTreeMap<(String, u32), AxisCurve<u64>>,
 }
 
 struct NcclGrids {
-    /// (dtype_name, operation, num_gpus) -> {message_size -> latency_ms}
-    by_keys: BTreeMap<(String, String, u32), AxisCurve>,
+    /// `(dtype_name, operation, num_gpus)` -> immutable `u64` message-size curve.
+    by_keys: BTreeMap<(String, String, u32), AxisCurve<u64>>,
 }
 
 impl CommunicationTable {
@@ -263,7 +263,7 @@ impl CommunicationTable {
         }
         Ok(curve
             .iter()
-            .map(|(size, latency)| (vec![f64::from(size)], latency))
+            .map(|(size, latency)| (vec![size as f64], latency))
             .collect())
     }
 
@@ -329,7 +329,7 @@ impl CommunicationTable {
         }
         Ok(curve
             .iter()
-            .map(|(size, latency)| (vec![f64::from(size)], latency))
+            .map(|(size, latency)| (vec![size as f64], latency))
             .collect())
     }
 
@@ -403,34 +403,17 @@ impl CommunicationTable {
 /// proxy is exactly ratio-equivalent.
 ///
 /// The query coordinate is passed as `f64` without truncation (Python does
-/// none). Table keys clamp to `u32` only as a defensive bound; every shipped
-/// comm table tops out at 512 MiB message sizes, well under `u32::MAX`.
-/// Interpolate the 1-D size curve at a possibly FRACTIONAL message size —
-/// Python keeps float element counts (e.g. the gemma4 CP KV all-gather sizes
-/// `kvcache_bytes_per_token / comm_bytes`), and the engine query coordinate
-/// is float anyway. Truncating to integer first shifted the lerp point.
-fn interp_message_size(by_size: &AxisCurve, message_size: f64) -> Result<f64, AicError> {
-    if by_size.is_empty() {
-        return Err(AicError::PerfDatabase(
-            "comm data has no message_size points".to_string(),
-        ));
-    }
-    by_size.query(message_size, "message_bytes", &|size| size)
+/// none), while collected message-size keys retain their original `u64`
+/// values. Interpolate the 1-D size curve at a possibly FRACTIONAL message
+/// size — Python keeps float element counts (e.g. the gemma4 CP KV all-gather
+/// sizes `kvcache_bytes_per_token / comm_bytes`), and the engine query
+/// coordinate is float anyway. Truncating to integer first shifted the lerp
+/// point.
+fn interp_message_size(curve: &AxisCurve<u64>, message_size: f64) -> Result<f64, AicError> {
+    curve.query(message_size, &|size| size)
 }
 
-/// Freeze a loaded message-size bucket after row/source precedence has been
-/// resolved in the original `u64` key space. Insertion order is ascending, so
-/// if distinct oversized coordinates clamp to `u32::MAX`, the last point wins
-/// exactly as it did when the generic interpolation node was built per query.
-fn message_size_curve(points: BTreeMap<u64, f64>) -> AxisCurve {
-    let mut clamped = BTreeMap::new();
-    for (size, latency) in points {
-        clamped.insert(size.min(u64::from(u32::MAX)) as u32, latency);
-    }
-    AxisCurve::from_map(clamped)
-}
-
-fn insert_first_message_point<K: Ord>(
+fn insert_first_wins_message_point<K: Ord>(
     by_keys: &mut BTreeMap<K, BTreeMap<u64, f64>>,
     key: K,
     message_size: u64,
@@ -458,7 +441,6 @@ fn load_custom_allreduce_parquet(sources: &[PerfSource]) -> Result<CustomAllRedu
         let latency_col = reader.col("latency")?;
         let kernel_source_col = reader.col_optional("kernel_source");
         let backend_col = reader.col_optional("backend");
-        let ks_col = reader.col_optional("kernel_source");
 
         // Mirror Python/legacy: skip "_eager" kernel sources on systems other
         // than b60. We can't see the system name from here, so apply the filter
@@ -468,7 +450,7 @@ fn load_custom_allreduce_parquet(sources: &[PerfSource]) -> Result<CustomAllRedu
 
         for row in reader.rows()? {
             let row = row?;
-            if !kernel_source_ok(source.kernel_sources(), ks_col, &row)? {
+            if !kernel_source_ok(source.kernel_sources(), kernel_source_col, &row)? {
                 continue;
             }
             if !is_b60 {
@@ -484,7 +466,7 @@ fn load_custom_allreduce_parquet(sources: &[PerfSource]) -> Result<CustomAllRedu
             // behavior is stable in production).
             // First-wins parity with Python `load_custom_allreduce_data`,
             // extended across shared-layer sources (earlier source wins).
-            insert_first_message_point(
+            insert_first_wins_message_point(
                 &mut by_keys,
                 ("half".to_string(), row.u32(num_gpus_col)?),
                 row.u64(message_size_col)?,
@@ -502,7 +484,7 @@ fn load_custom_allreduce_parquet(sources: &[PerfSource]) -> Result<CustomAllRedu
     Ok(CustomAllReduceGrids {
         by_keys: by_keys
             .into_iter()
-            .map(|(key, points)| (key, message_size_curve(points)))
+            .map(|(key, points)| (key, AxisCurve::from_map("message_bytes", points)))
             .collect(),
     })
 }
@@ -519,7 +501,7 @@ fn load_nccl_parquet(path: &Path) -> Result<NcclGrids, AicError> {
     for row in reader.rows()? {
         let row = row?;
         // First-wins parity with Python `load_nccl_data`.
-        insert_first_message_point(
+        insert_first_wins_message_point(
             &mut by_keys,
             (
                 row.str_owned(nccl_dtype_col)?,
@@ -539,7 +521,7 @@ fn load_nccl_parquet(path: &Path) -> Result<NcclGrids, AicError> {
     Ok(NcclGrids {
         by_keys: by_keys
             .into_iter()
-            .map(|(key, points)| (key, message_size_curve(points)))
+            .map(|(key, points)| (key, AxisCurve::from_map("message_bytes", points)))
             .collect(),
     })
 }
@@ -551,7 +533,6 @@ fn clone_err(err: &AicError) -> AicError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::perf_database::perf_interp::{self, Node, OpInterpConfig};
 
     const REPO_ROOT_HINT: &str = env!("CARGO_MANIFEST_DIR");
 
@@ -575,31 +556,20 @@ mod tests {
         Some(systems_root().join("data/b200_sxm/comm/nccl/2.27.3"))
     }
 
-    fn generic_message_size_query(
-        points: &BTreeMap<u64, f64>,
-        message_size: f64,
-    ) -> Result<f64, AicError> {
-        if points.is_empty() {
-            return Err(AicError::PerfDatabase(
-                "comm data has no message_size points".to_string(),
-            ));
-        }
-        let mut node = Node::branch();
-        for (&size, &latency) in points {
-            node.insert(&[size.min(u64::from(u32::MAX)) as u32], latency);
-        }
-        let sol = |coordinates: &[f64]| coordinates[0];
-        let config = OpInterpConfig::grid(&["message_bytes"], &sol);
-        perf_interp::query(&config, &node, &[message_size])
-    }
-
     #[test]
-    fn message_size_curve_matches_generic_grid() {
+    fn message_size_curve_matches_python_grid() {
         let points = BTreeMap::from([(256, 1.25), (1024, 2.75), (4096, 5.5)]);
-        let curve = message_size_curve(points.clone());
+        let curve = AxisCurve::from_map("message_bytes", points);
 
-        for message_size in [64.0, 256.0, 640.5, 1024.0, 2048.25, 4096.0, 8192.0] {
-            let expected = generic_message_size_query(&points, message_size).unwrap();
+        for (message_size, expected) in [
+            (64.0_f64, 0.3125_f64),
+            (256.0, 1.25),
+            (640.5, 2.0009765625),
+            (1024.0, 2.75),
+            (2048.25, 3.6668904622395835),
+            (4096.0, 5.5),
+            (8192.0, 11.0),
+        ] {
             let actual = interp_message_size(&curve, message_size).unwrap();
             assert_eq!(
                 actual.to_bits(),
@@ -608,67 +578,115 @@ mod tests {
             );
         }
 
-        let singleton = BTreeMap::from([(1024, 3.0)]);
-        let curve = message_size_curve(singleton.clone());
-        for message_size in [512.0, 1024.0, 2048.0] {
-            let expected = generic_message_size_query(&singleton, message_size).unwrap();
+        let curve = AxisCurve::from_map("message_bytes", BTreeMap::from([(1024, 3.0)]));
+        for (message_size, expected) in [(512.0_f64, 1.5_f64), (1024.0, 3.0), (2048.0, 6.0)] {
             let actual = interp_message_size(&curve, message_size).unwrap();
             assert_eq!(actual.to_bits(), expected.to_bits());
         }
     }
 
     #[test]
-    fn message_size_curve_preserves_errors_and_clamped_duplicate_precedence() {
-        let empty = BTreeMap::new();
-        let empty_curve = message_size_curve(empty.clone());
+    fn message_size_curve_preserves_errors_and_u64_coordinates() {
+        let empty_curve = AxisCurve::from_map("message_bytes", BTreeMap::<u64, f64>::new());
         assert_eq!(
             interp_message_size(&empty_curve, 1024.0)
                 .unwrap_err()
                 .to_string(),
-            generic_message_size_query(&empty, 1024.0)
-                .unwrap_err()
-                .to_string()
+            "perf database error: perf_interp: no data to anchor query \
+             {message_bytes=1024} (empty table)"
         );
 
-        let invalid = BTreeMap::from([(1024, 0.0)]);
-        let invalid_curve = message_size_curve(invalid.clone());
+        let invalid_curve = AxisCurve::from_map("message_bytes", BTreeMap::from([(1024_u64, 0.0)]));
         assert_eq!(
             interp_message_size(&invalid_curve, 2048.0)
                 .unwrap_err()
                 .to_string(),
-            generic_message_size_query(&invalid, 2048.0)
-                .unwrap_err()
-                .to_string()
+            "perf database error: perf_interp: no data to anchor query \
+             {message_bytes=2048} (no positive-util boundary anchor)"
         );
 
-        let oversized = BTreeMap::from([
-            (u64::from(u32::MAX) + 1, 1.0),
-            (u64::from(u32::MAX) + 2, 2.0),
-        ]);
-        let curve = message_size_curve(oversized.clone());
-        assert_eq!(curve.iter().collect::<Vec<_>>(), vec![(u32::MAX, 2.0)]);
-        let expected = generic_message_size_query(&oversized, f64::from(u32::MAX)).unwrap();
-        let actual = interp_message_size(&curve, f64::from(u32::MAX)).unwrap();
-        assert_eq!(actual.to_bits(), expected.to_bits());
+        let first_oversized = u64::from(u32::MAX) + 1;
+        let second_oversized = first_oversized + 1;
+        let curve = AxisCurve::from_map(
+            "message_bytes",
+            BTreeMap::from([(1024, 1.0), (first_oversized, 2.0), (second_oversized, 3.0)]),
+        );
+        assert_eq!(
+            curve.iter().collect::<Vec<_>>(),
+            vec![(1024, 1.0), (first_oversized, 2.0), (second_oversized, 3.0)]
+        );
+
+        // Oracle values from Python perf_interp Grid with the same integer
+        // coordinates and linear message-size SOL.
+        for (message_size, expected) in [
+            (first_oversized as f64, 2.0_f64),
+            (first_oversized as f64 + 0.5, 2.5),
+            (second_oversized as f64, 3.0),
+            ((second_oversized * 2) as f64, 6.0),
+        ] {
+            let actual = interp_message_size(&curve, message_size).unwrap();
+            assert_eq!(actual.to_bits(), expected.to_bits());
+        }
+    }
+
+    #[test]
+    fn empirical_points_preserve_distinct_u64_coordinates() {
+        let first_oversized = u64::from(u32::MAX) + 1;
+        let second_oversized = first_oversized + 1;
+        let points = BTreeMap::from([(1024, 1.0), (first_oversized, 2.0), (second_oversized, 3.0)]);
+        let custom_key = ("half".to_string(), 4);
+        let nccl_key = ("half".to_string(), "all_reduce".to_string(), 4);
+        let table = table_with_loaded_collectives(
+            BTreeMap::from([(
+                custom_key,
+                AxisCurve::from_map("message_bytes", points.clone()),
+            )]),
+            BTreeMap::from([(nccl_key, AxisCurve::from_map("message_bytes", points))]),
+            BTreeMap::new(),
+        );
+        let expected = vec![
+            (vec![1024.0], 1.0),
+            (vec![first_oversized as f64], 2.0),
+            (vec![second_oversized as f64], 3.0),
+        ];
+        assert_eq!(
+            table
+                .custom_allreduce_points(CommQuantMode::Half, 4)
+                .unwrap(),
+            expected
+        );
+        assert_eq!(
+            table
+                .nccl_empirical_points(CommQuantMode::Half, "all_reduce", 4)
+                .unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn custom_allreduce_preserves_first_source_and_first_row_precedence() {
         let key = ("half".to_string(), 4);
         let mut by_keys = BTreeMap::new();
-        insert_first_message_point(&mut by_keys, key.clone(), 1024, 1.0);
-        insert_first_message_point(&mut by_keys, key.clone(), 1024, 2.0);
-        insert_first_message_point(&mut by_keys, key.clone(), 1024, 3.0);
-        insert_first_message_point(&mut by_keys, key.clone(), 2048, 4.0);
-        let curve = message_size_curve(by_keys.remove(&key).unwrap());
+        insert_first_wins_message_point(&mut by_keys, key.clone(), 1024, 1.0);
+        insert_first_wins_message_point(&mut by_keys, key.clone(), 1024, 2.0);
+        insert_first_wins_message_point(&mut by_keys, key.clone(), 1024, 3.0);
+        insert_first_wins_message_point(&mut by_keys, key.clone(), 2048, 4.0);
+        let curve = AxisCurve::from_map("message_bytes", by_keys.remove(&key).unwrap());
         assert_eq!(interp_message_size(&curve, 1024.0).unwrap(), 1.0);
         assert_eq!(interp_message_size(&curve, 2048.0).unwrap(), 4.0);
     }
 
     fn table_with_loaded_collectives(
-        nccl: BTreeMap<(String, String, u32), AxisCurve>,
-        oneccl: BTreeMap<(String, String, u32), AxisCurve>,
+        custom_allreduce: BTreeMap<(String, u32), AxisCurve<u64>>,
+        nccl: BTreeMap<(String, String, u32), AxisCurve<u64>>,
+        oneccl: BTreeMap<(String, String, u32), AxisCurve<u64>>,
     ) -> CommunicationTable {
+        let custom_allreduce_cell = OnceLock::new();
+        assert!(custom_allreduce_cell
+            .set(Ok(CustomAllReduceGrids {
+                by_keys: custom_allreduce
+            }))
+            .is_ok());
         let nccl_cell = OnceLock::new();
         assert!(nccl_cell.set(Ok(NcclGrids { by_keys: nccl })).is_ok());
         let oneccl_cell = OnceLock::new();
@@ -678,7 +696,7 @@ mod tests {
             nccl_root: None,
             oneccl_root: None,
             custom_allreduce_sources: Vec::new(),
-            custom_allreduce: OnceLock::new(),
+            custom_allreduce: custom_allreduce_cell,
             nccl: nccl_cell,
             oneccl: oneccl_cell,
         }
@@ -689,13 +707,13 @@ mod tests {
         let key = ("half".to_string(), "all_reduce".to_string(), 4);
         let primary = BTreeMap::from([(
             key.clone(),
-            message_size_curve(BTreeMap::from([(1024, 1.0)])),
+            AxisCurve::from_map("message_bytes", BTreeMap::from([(1024, 1.0)])),
         )]);
         let fallback = BTreeMap::from([(
             key.clone(),
-            message_size_curve(BTreeMap::from([(1024, 2.0)])),
+            AxisCurve::from_map("message_bytes", BTreeMap::from([(1024, 2.0)])),
         )]);
-        let table = table_with_loaded_collectives(primary, fallback.clone());
+        let table = table_with_loaded_collectives(BTreeMap::new(), primary, fallback.clone());
         assert_eq!(
             table
                 .query_nccl(CommQuantMode::Half, "all_reduce", 4, 1024.0)
@@ -703,7 +721,7 @@ mod tests {
             1.0
         );
 
-        let table = table_with_loaded_collectives(BTreeMap::new(), fallback);
+        let table = table_with_loaded_collectives(BTreeMap::new(), BTreeMap::new(), fallback);
         assert_eq!(
             table
                 .query_nccl(CommQuantMode::Half, "all_reduce", 4, 1024.0)

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/dsv4_megamoe.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/dsv4_megamoe.rs
@@ -153,7 +153,7 @@ impl Dsv4MegaMoeTable {
         // Python: OpInterpConfig(axes=("num_tokens",), resolver=Grid(),
         // sol_fn=lambda t: float(t)) — in-range RAW lerp, boundary util-hold
         // beyond the collected range with the linear token proxy.
-        curve.query(f64::from(num_tokens), "num_tokens", &|t| t)
+        curve.query(f64::from(num_tokens), &|t| t)
     }
 
     fn load_module(&self) -> Result<&Dsv4MegaMoeGrids, AicError> {
@@ -293,7 +293,7 @@ fn load_module_parquet(path: &PathBuf) -> Result<Dsv4MegaMoeGrids, AicError> {
     Ok(Dsv4MegaMoeGrids {
         by_keys: by_keys
             .into_iter()
-            .map(|(key, curve)| (key, AxisCurve::from_map(curve)))
+            .map(|(key, curve)| (key, AxisCurve::from_map("num_tokens", curve)))
             .collect(),
     })
 }

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/dsv4_megamoe.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/dsv4_megamoe.rs
@@ -43,7 +43,7 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
-use super::token_curve::TokenCurve;
+use super::axis_curve::AxisCurve;
 use crate::common::enums::MoeQuantMode;
 use crate::common::error::AicError;
 use crate::perf_database::parquet_loader::PerfReader;
@@ -56,7 +56,7 @@ pub struct Dsv4MegaMoeTable {
 }
 
 struct Dsv4MegaMoeGrids {
-    by_keys: BTreeMap<Dsv4MegaMoeKey, TokenCurve>,
+    by_keys: BTreeMap<Dsv4MegaMoeKey, AxisCurve>,
 }
 
 /// Full table key (every level of the Python nested dict except the trailing
@@ -153,7 +153,7 @@ impl Dsv4MegaMoeTable {
         // Python: OpInterpConfig(axes=("num_tokens",), resolver=Grid(),
         // sol_fn=lambda t: float(t)) — in-range RAW lerp, boundary util-hold
         // beyond the collected range with the linear token proxy.
-        curve.query(f64::from(num_tokens), &|t| t)
+        curve.query(f64::from(num_tokens), "num_tokens", &|t| t)
     }
 
     fn load_module(&self) -> Result<&Dsv4MegaMoeGrids, AicError> {
@@ -293,7 +293,7 @@ fn load_module_parquet(path: &PathBuf) -> Result<Dsv4MegaMoeGrids, AicError> {
     Ok(Dsv4MegaMoeGrids {
         by_keys: by_keys
             .into_iter()
-            .map(|(key, curve)| (key, TokenCurve::from_map(curve)))
+            .map(|(key, curve)| (key, AxisCurve::from_map(curve)))
             .collect(),
     })
 }

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/mhc.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/mhc.rs
@@ -26,7 +26,7 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
-use super::token_curve::TokenCurve;
+use super::axis_curve::AxisCurve;
 use super::{kernel_source_ok, resolve_op_sources};
 use crate::common::error::AicError;
 use crate::config::{PerfDbSources, PerfSource};
@@ -42,7 +42,7 @@ pub struct MhcTable {
 }
 
 struct MhcGrids {
-    by_keys: BTreeMap<MhcKey, TokenCurve>,
+    by_keys: BTreeMap<MhcKey, AxisCurve>,
 }
 
 /// Python `load_mhc_module_data` keys `data[op][hc_mult][hidden_size]` — NO
@@ -128,7 +128,7 @@ impl MhcTable {
         // Engine 1-axis token curve; the caller-threaded per-op roofline
         // anchors beyond-range holds (Python `sol_fn=lambda t: get_sol(t,
         // op_name)[0]`).
-        by_tokens.query(num_tokens as f64, &|t| sol(op, t))
+        by_tokens.query(num_tokens as f64, "num_tokens", &|t| sol(op, t))
     }
 
     /// Collected `(num_tokens,) -> latency` points for one RESOLVED op half
@@ -236,7 +236,7 @@ fn load_mhc_parquet(sources: &[PerfSource]) -> Result<MhcGrids, AicError> {
     Ok(MhcGrids {
         by_keys: by_keys
             .into_iter()
-            .map(|(key, curve)| (key, TokenCurve::from_map(curve)))
+            .map(|(key, curve)| (key, AxisCurve::from_map(curve)))
             .collect(),
     })
 }

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/mhc.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/mhc.rs
@@ -128,7 +128,7 @@ impl MhcTable {
         // Engine 1-axis token curve; the caller-threaded per-op roofline
         // anchors beyond-range holds (Python `sol_fn=lambda t: get_sol(t,
         // op_name)[0]`).
-        by_tokens.query(num_tokens as f64, "num_tokens", &|t| sol(op, t))
+        by_tokens.query(num_tokens as f64, &|t| sol(op, t))
     }
 
     /// Collected `(num_tokens,) -> latency` points for one RESOLVED op half
@@ -236,7 +236,7 @@ fn load_mhc_parquet(sources: &[PerfSource]) -> Result<MhcGrids, AicError> {
     Ok(MhcGrids {
         by_keys: by_keys
             .into_iter()
-            .map(|(key, curve)| (key, AxisCurve::from_map(curve)))
+            .map(|(key, curve)| (key, AxisCurve::from_map("num_tokens", curve)))
             .collect(),
     })
 }

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/mod.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/mod.rs
@@ -152,6 +152,7 @@ pub(crate) fn kernel_source_ok(
 }
 
 pub mod attention;
+mod axis_curve;
 pub mod communication;
 pub mod dsa;
 pub mod dsv4;
@@ -165,7 +166,6 @@ mod moe_index;
 pub mod parquet_loader;
 pub mod perf_interp;
 pub mod state_space;
-mod token_curve;
 pub mod wideep;
 pub mod wideep_mla;
 pub mod wideep_moe;

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/moe.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/moe.rs
@@ -31,8 +31,8 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
+use super::axis_curve::AxisCurve;
 use super::moe_index::{MoeIndex, MoeShapeKey};
-use super::token_curve::TokenCurve;
 use super::{kernel_source_ok, resolve_op_sources};
 use crate::common::enums::MoeQuantMode;
 use crate::common::error::AicError;
@@ -83,7 +83,7 @@ struct LoadedMoeGrids {
 }
 
 struct MoeGrids {
-    index: MoeIndex<MoeShapeKey, TokenCurve>,
+    index: MoeIndex<MoeShapeKey, AxisCurve>,
     /// Distinct quant names in first-seen (file row) order. Python's
     /// transfer ladder iterates the table dict in INSERTION order
     /// (`for q in moe_table`), which breaks profile-distance ties by file
@@ -201,7 +201,7 @@ impl MoeTable {
                  measured_token={only}, key={key:?}"
             )));
         }
-        by_tokens.query(num_tokens as f64, sol)
+        by_tokens.query(num_tokens as f64, "num_tokens", sol)
     }
 
     /// Probe the TRT-LLM low-latency NVFP4 MoE kernel table.
@@ -264,7 +264,9 @@ impl MoeTable {
                  measured_token={only}, key={key:?}"
             )));
         }
-        by_tokens.query(num_tokens as f64, sol).map(Some)
+        by_tokens
+            .query(num_tokens as f64, "num_tokens", sol)
+            .map(Some)
     }
 
     /// `true` iff the loaded low-latency grid has any rows.
@@ -487,11 +489,11 @@ fn load_moe_parquet(sources: &[PerfSource]) -> Result<LoadedMoeGrids, AicError> 
     }
     Ok(LoadedMoeGrids {
         default: MoeGrids {
-            index: default_index.map_values(TokenCurve::from_map),
+            index: default_index.map_values(AxisCurve::from_map),
             quants_in_load_order: default_quants,
         },
         low_latency: MoeGrids {
-            index: low_latency_index.map_values(TokenCurve::from_map),
+            index: low_latency_index.map_values(AxisCurve::from_map),
             quants_in_load_order: low_latency_quants,
         },
     })
@@ -537,9 +539,9 @@ mod tests {
         };
         let mut index = MoeIndex::default();
         *index.entry("fp8".into(), "power_law".into(), shape) =
-            TokenCurve::from_map(BTreeMap::from([(1, 1.0)]));
+            AxisCurve::from_map(BTreeMap::from([(1, 1.0)]));
         *index.entry("fp8".into(), "uniform".into(), shape) =
-            TokenCurve::from_map(BTreeMap::from([(1, 2.0)]));
+            AxisCurve::from_map(BTreeMap::from([(1, 2.0)]));
         let grids = MoeGrids {
             index,
             quants_in_load_order: vec!["fp8".to_string()],

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/moe.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/moe.rs
@@ -201,7 +201,7 @@ impl MoeTable {
                  measured_token={only}, key={key:?}"
             )));
         }
-        by_tokens.query(num_tokens as f64, "num_tokens", sol)
+        by_tokens.query(num_tokens as f64, sol)
     }
 
     /// Probe the TRT-LLM low-latency NVFP4 MoE kernel table.
@@ -264,9 +264,7 @@ impl MoeTable {
                  measured_token={only}, key={key:?}"
             )));
         }
-        by_tokens
-            .query(num_tokens as f64, "num_tokens", sol)
-            .map(Some)
+        by_tokens.query(num_tokens as f64, sol).map(Some)
     }
 
     /// `true` iff the loaded low-latency grid has any rows.
@@ -489,11 +487,11 @@ fn load_moe_parquet(sources: &[PerfSource]) -> Result<LoadedMoeGrids, AicError> 
     }
     Ok(LoadedMoeGrids {
         default: MoeGrids {
-            index: default_index.map_values(AxisCurve::from_map),
+            index: default_index.map_values(|curve| AxisCurve::from_map("num_tokens", curve)),
             quants_in_load_order: default_quants,
         },
         low_latency: MoeGrids {
-            index: low_latency_index.map_values(AxisCurve::from_map),
+            index: low_latency_index.map_values(|curve| AxisCurve::from_map("num_tokens", curve)),
             quants_in_load_order: low_latency_quants,
         },
     })
@@ -539,9 +537,9 @@ mod tests {
         };
         let mut index = MoeIndex::default();
         *index.entry("fp8".into(), "power_law".into(), shape) =
-            AxisCurve::from_map(BTreeMap::from([(1, 1.0)]));
+            AxisCurve::from_map("num_tokens", BTreeMap::from([(1, 1.0)]));
         *index.entry("fp8".into(), "uniform".into(), shape) =
-            AxisCurve::from_map(BTreeMap::from([(1, 2.0)]));
+            AxisCurve::from_map("num_tokens", BTreeMap::from([(1, 2.0)]));
         let grids = MoeGrids {
             index,
             quants_in_load_order: vec!["fp8".to_string()],

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/perf_interp.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/perf_interp.rs
@@ -29,6 +29,11 @@
 //!   config rejects it for Grid too).
 //! - The GEMM site index is built once per table by the owner (tables are
 //!   immutable after load) instead of Python's id-keyed LRU cache.
+//!
+//! One-axis token and communication tables use the immutable `AxisCurve`
+//! fast path instead of constructing a `Node` per query. Its query contract
+//! must remain bit-identical to a RAW `Grid { k_tail: 1 }`; the differential
+//! tests in `axis_curve.rs` enforce that relationship.
 
 use std::collections::BTreeMap;
 

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/wideep.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/wideep.rs
@@ -221,6 +221,7 @@ fn dispatch_fields(points: &BTreeMap<u32, DispatchPoint>) -> [AxisCurve; Dispatc
     std::array::from_fn(|index| {
         let field = DispatchField::ALL[index];
         AxisCurve::from_sorted_iter(
+            "num_tokens",
             points
                 .iter()
                 .map(|(&token, &point)| (token, field.value(point))),
@@ -625,7 +626,7 @@ impl WideEpTable {
                 self.data_root.display()
             ))
         })?;
-        by_tokens.query(num_tokens as f64, "num_tokens", &|t| t)
+        by_tokens.query(num_tokens as f64, &|t| t)
     }
 
     /// Collected `(num_tokens, latency)` points of one resolved alltoall
@@ -919,7 +920,7 @@ fn query_moe(
             )));
         }
     }
-    by_tokens.query(num_tokens as f64, "num_tokens", sol)
+    by_tokens.query(num_tokens as f64, sol)
 }
 
 /// Resolve one `DispatchPoint` field's token curve on the engine, with the
@@ -946,7 +947,7 @@ fn dispatch_field(
             return Ok(0.0);
         }
     }
-    fields[field.index()].query(num_tokens as f64, "num_tokens", &|t| t)
+    fields[field.index()].query(num_tokens as f64, &|t| t)
 }
 
 /// Resolve one `DispatchPoint` field on the DeepEP-normal 2-axis
@@ -1180,7 +1181,7 @@ fn load_moe_parquet(sources: &[PerfSource]) -> Result<MoeGrids, AicError> {
         )));
     }
     Ok(MoeGrids {
-        index: index.map_values(AxisCurve::from_map),
+        index: index.map_values(|curve| AxisCurve::from_map("num_tokens", curve)),
         quants_in_load_order,
     })
 }
@@ -1307,7 +1308,7 @@ fn load_alltoall_parquet(sources: &[PerfSource]) -> Result<AlltoallGrids, AicErr
     Ok(AlltoallGrids {
         by_keys: by_keys
             .into_iter()
-            .map(|(key, curve)| (key, AxisCurve::from_map(curve)))
+            .map(|(key, curve)| (key, AxisCurve::from_map("num_tokens", curve)))
             .collect(),
     })
 }

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/wideep.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/wideep.rs
@@ -48,10 +48,10 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
+use super::axis_curve::AxisCurve;
 use super::moe::MoeSiblingSlice;
 use super::moe_index::{MoeIndex, MoeShapeKey};
 use super::perf_interp::{self, Node, OpInterpConfig};
-use super::token_curve::TokenCurve;
 use super::{kernel_source_ok, resolve_op_sources};
 use crate::common::enums::MoeQuantMode;
 use crate::common::error::AicError;
@@ -79,7 +79,7 @@ pub struct WideEpTable {
 }
 
 struct MoeGrids {
-    index: MoeIndex<MoeShapeKey, TokenCurve>,
+    index: MoeIndex<MoeShapeKey, AxisCurve>,
     /// Distinct quant names in first-seen (file row) order — Python's dict
     /// insertion order, consumed by the operator-layer transfer ladder
     /// (same contract as `moe.rs::MoeTable::available_quants`).
@@ -92,7 +92,7 @@ struct MoeGrids {
 /// `distribution` axis (the parquet column is ignored, as in Python) and NO
 /// `inter_size`/`moe_tp_size`.
 struct AlltoallGrids {
-    by_keys: BTreeMap<AlltoallKey, TokenCurve>,
+    by_keys: BTreeMap<AlltoallKey, AxisCurve>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -120,13 +120,13 @@ struct NormalDispatchGrids {
 
 struct NormalDispatchSlice {
     by_sms: BTreeMap<u32, DispatchPoints>,
-    direct_fields: Option<[TokenCurve; DispatchField::COUNT]>,
+    direct_fields: Option<[AxisCurve; DispatchField::COUNT]>,
     fields: [Node; DispatchField::COUNT],
 }
 
 struct DispatchCurve {
     points: DispatchPoints,
-    fields: [TokenCurve; DispatchField::COUNT],
+    fields: [AxisCurve; DispatchField::COUNT],
 }
 
 struct DispatchPoints {
@@ -217,10 +217,10 @@ impl DispatchPoints {
     }
 }
 
-fn dispatch_fields(points: &BTreeMap<u32, DispatchPoint>) -> [TokenCurve; DispatchField::COUNT] {
+fn dispatch_fields(points: &BTreeMap<u32, DispatchPoint>) -> [AxisCurve; DispatchField::COUNT] {
     std::array::from_fn(|index| {
         let field = DispatchField::ALL[index];
-        TokenCurve::from_sorted_iter(
+        AxisCurve::from_sorted_iter(
             points
                 .iter()
                 .map(|(&token, &point)| (token, field.value(point))),
@@ -625,7 +625,7 @@ impl WideEpTable {
                 self.data_root.display()
             ))
         })?;
-        by_tokens.query(num_tokens as f64, &|t| t)
+        by_tokens.query(num_tokens as f64, "num_tokens", &|t| t)
     }
 
     /// Collected `(num_tokens, latency)` points of one resolved alltoall
@@ -919,7 +919,7 @@ fn query_moe(
             )));
         }
     }
-    by_tokens.query(num_tokens as f64, sol)
+    by_tokens.query(num_tokens as f64, "num_tokens", sol)
 }
 
 /// Resolve one `DispatchPoint` field's token curve on the engine, with the
@@ -930,7 +930,7 @@ fn query_moe(
 /// Python's util-hold on the SUMMED curve (`q/b * 0 = 0`).
 fn dispatch_field(
     by_tokens: &DispatchPoints,
-    fields: &[TokenCurve; DispatchField::COUNT],
+    fields: &[AxisCurve; DispatchField::COUNT],
     field: DispatchField,
     num_tokens: u32,
 ) -> Result<f64, AicError> {
@@ -946,7 +946,7 @@ fn dispatch_field(
             return Ok(0.0);
         }
     }
-    fields[field.index()].query(num_tokens as f64, &|t| t)
+    fields[field.index()].query(num_tokens as f64, "num_tokens", &|t| t)
 }
 
 /// Resolve one `DispatchPoint` field on the DeepEP-normal 2-axis
@@ -1180,7 +1180,7 @@ fn load_moe_parquet(sources: &[PerfSource]) -> Result<MoeGrids, AicError> {
         )));
     }
     Ok(MoeGrids {
-        index: index.map_values(TokenCurve::from_map),
+        index: index.map_values(AxisCurve::from_map),
         quants_in_load_order,
     })
 }
@@ -1307,7 +1307,7 @@ fn load_alltoall_parquet(sources: &[PerfSource]) -> Result<AlltoallGrids, AicErr
     Ok(AlltoallGrids {
         by_keys: by_keys
             .into_iter()
-            .map(|(key, curve)| (key, TokenCurve::from_map(curve)))
+            .map(|(key, curve)| (key, AxisCurve::from_map(curve)))
             .collect(),
     })
 }

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/wideep_moe.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/wideep_moe.rs
@@ -144,7 +144,7 @@ impl WideEpMoeTable {
             moe_tp_size,
             moe_ep_size,
         )?;
-        by_tokens.query(num_tokens as f64, "num_tokens", sol)
+        by_tokens.query(num_tokens as f64, sol)
     }
 
     /// Own-slice `num_tokens -> latency_ms` points, after the level-wise
@@ -350,7 +350,12 @@ fn load_compute_parquet(sources: &[PerfSource]) -> Result<WideEpMoeGrids, AicErr
     Ok(WideEpMoeGrids {
         index: index
             .into_iter()
-            .map(|(kernel, index)| (kernel, index.map_values(AxisCurve::from_map)))
+            .map(|(kernel, index)| {
+                (
+                    kernel,
+                    index.map_values(|curve| AxisCurve::from_map("num_tokens", curve)),
+                )
+            })
             .collect(),
     })
 }

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/wideep_moe.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/wideep_moe.rs
@@ -30,8 +30,8 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
+use super::axis_curve::AxisCurve;
 use super::moe_index::MoeIndex;
-use super::token_curve::TokenCurve;
 use super::{kernel_source_ok, resolve_op_sources};
 use crate::common::enums::MoeQuantMode;
 use crate::common::error::AicError;
@@ -48,7 +48,7 @@ pub struct WideEpMoeTable {
 }
 
 struct WideEpMoeGrids {
-    index: BTreeMap<String, MoeIndex<WideEpMoeShapeKey, TokenCurve>>,
+    index: BTreeMap<String, MoeIndex<WideEpMoeShapeKey, AxisCurve>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -144,7 +144,7 @@ impl WideEpMoeTable {
             moe_tp_size,
             moe_ep_size,
         )?;
-        by_tokens.query(num_tokens as f64, sol)
+        by_tokens.query(num_tokens as f64, "num_tokens", sol)
     }
 
     /// Own-slice `num_tokens -> latency_ms` points, after the level-wise
@@ -222,7 +222,7 @@ impl WideEpMoeTable {
         num_slots: u32,
         moe_tp_size: u32,
         moe_ep_size: u32,
-    ) -> Result<&TokenCurve, AicError> {
+    ) -> Result<&AxisCurve, AicError> {
         let grids = self.load_compute()?;
         let Some(by_quant) = grids.index.get(kernel_source) else {
             return Err(AicError::PerfDatabase(format!(
@@ -350,7 +350,7 @@ fn load_compute_parquet(sources: &[PerfSource]) -> Result<WideEpMoeGrids, AicErr
     Ok(WideEpMoeGrids {
         index: index
             .into_iter()
-            .map(|(kernel, index)| (kernel, index.map_values(TokenCurve::from_map)))
+            .map(|(kernel, index)| (kernel, index.map_values(AxisCurve::from_map)))
             .collect(),
     })
 }


### PR DESCRIPTION
## Summary

- Generalize the immutable one-dimensional MoE `TokenCurve` into an internal `AxisCurve<K>` with the axis label bound to the curve. Token curves retain `u32` keys; communication curves use true `u64` keys.
- Freeze custom-allreduce, NCCL, and OneCCL message-size points into immutable curves at table load time instead of rebuilding generic interpolation trees for every query.
- Preserve source/row precedence, every raw communication coordinate exposed through empirical-point APIs, topology scaling, NCCL-to-OneCCL fallback, provenance, predictions, and public APIs. Oversized communication queries now match the Python implementation instead of being clamped to `u32::MAX`.

PR #1495 merged while this change was under development. These commits are therefore based directly on `main` at `4603654`; its tree is identical to the original #1495 head `ead965e` used for validation.

## Validation

### Correctness

- `cargo check -p aiconfigurator-core`
- `cargo test -p aiconfigurator-core` — 320 passed
- `cargo test -p aiconfigurator-core --features embed-python` — 327 unit and 3 integration tests passed
- Python database, compile-engine, Rust engine-step, and support-matrix tests — 616 passed
- Full Rust/Python compile-engine and engine-step parity matrix — 376 passed
- `git diff --check`
- Differential tests cover the generic one-axis interpolation contract; focused communication tests cover exact, fractional, singleton, boundary, invalid-anchor, source/row precedence, fallback, distinct coordinates above `u32::MAX`, empirical-point exposure, and Python-oracle parity.
- Existing fixtures and both final-head performance corpora produced bit-identical predictions.
- The pre-review-head release and profiling DynoSim reports were byte-identical after removing only `wall_time_ms`, `processed_tokens_per_s`, and `processed_output_tokens_per_s` (normalized SHA-256 `687aab3a1de410d4f3d920ce74c22166cbf52421e73b1f0bac1961a2ef58d8a9`).

The repository-wide `cargo clippy ... -D warnings` and `cargo fmt --all -- --check` gates fail on the exact baseline as well (70 pre-existing Clippy findings and existing rustfmt drift). The candidate reports 64 of the same pre-existing Clippy classes. The optional PyTorch-dependent `test_moe_dispatch.py` was excluded because the standard development environment does not install PyTorch.

### Performance

Point comparisons only; no warm-ups or statistical-significance claim. Release builds used `RUSTFLAGS="-C target-cpu=x86-64-v3"`.

| Corpus | Baseline | Candidate | Improvement |
| --- | ---: | ---: | ---: |
| Repeated communication queries | 484.291 ns/query | 50.803 ns/query | **9.53x** |
| DeepSeek-V4-Flash HYBRID engine step | 20.807 us / 12 workloads | 10.582 us | **49.1%** |
| DeepSeek-V4-Flash SILICON engine step | 20.931 us / 12 workloads | 10.297 us | **50.8%** |

The engine-step corpus uses B200, vLLM 0.24.0, TP4, attention-DP1, and MoE TP1/EP4. All 24 reported predictions are bit-identical between revisions.

Pre-review-head matched DynoSim Astra replay (not rerun for review-fix commit `0fa09bb`):

| Metric | #1495 baseline | Candidate | Change |
| --- | ---: | ---: | ---: |
| Processed tokens/s | 39,146,431 | 42,745,735 | **+9.19%** |
| Wall time | 65.928 s | 60.376 s | **-8.42%** |

- Dynamo `80ad0e77`, 12 aggregated vLLM workers, B200 TP4/attention-DP1 and MoE TP1/EP4, CPU 0.
- Deterministic 2x Astra trace SHA-256 `806487947000d49d4e8a817112e479a8b7282ffb3f388259cb921cf13bc3ff1b`.
- Both runs completed 187,906 requests, 2,401,594,588 input tokens, 179,237,676 output tokens, and 2,580,832,264 processed tokens with prefix-cache reuse ratio `0.4195790934`.
- CPU 0 averaged 97.0% idle before the baseline and 99.7% idle before the candidate.
- Frozen extension SHA-256: baseline `43edbf558e309eb5b7d40a242badfd93a7d4466c751ec6574cac6cf76e7249cb`; candidate `1d87ea0bf312d2dad46a176f267ddc6c6271d98d71715bf4bf608b173c9f7172`.

The pre-review-head candidate steady-state profile removes `perf_interp::Node` construction and B-tree insertion from the custom-allreduce query chain. Its inclusive interpolation share falls from 7.80% in the existing comparable vLLM profile to 0.40% (**94.9% lower**). The requested attachment captured 59.27 seconds, from request 2,144 through 187,890, because the candidate completed just before the 60-second timer; the completed profiling report still matches the ordinary-release report exactly after normalization.

Those DynoSim/profile measurements used pre-review tree `e7c62260da331097e9b1ca4ef47c170403b33657` (`4a5b68c` before rebasing, identical to `3eee383`). Final-head performance validation was intentionally limited to the two basic corpora above.
