### PR TITLE
fix(fpm): enable correction bounds by default

### DIFF
--- a/aic-core/API.md
+++ b/aic-core/API.md
@@ -63,6 +63,11 @@ models and missing or unreadable model, system, or performance data. Check
 `aic_with_correction`, or `fallback_regression`, and to inspect any fallback
 warning.
 
+Native online corrections default to an absolute factor range of `[0.5, 2.0]`.
+Pass `None` explicitly as `min_faster_correction_factor` or
+`max_slower_correction_factor` in the options dictionary to remove the bound
+in that direction. Regression fallback ignores both options.
+
 Use `from_native(...)` instead when native AIC support is required and an
 unsupported configuration or native data failure should surface rather than
 fall back.

--- a/aic-core/rust/aiconfigurator-core/src/fpm/model.rs
+++ b/aic-core/rust/aiconfigurator-core/src/fpm/model.rs
@@ -89,8 +89,9 @@ pub enum ForwardPassPerfReadiness {
 /// `ForwardPassPerfOptions`: `max_num_tokens` bounds `sum_prefill_tokens`,
 /// `max_batch_size` bounds `num_decode_requests`, and `max_kv_tokens` bounds
 /// `sum_decode_kv_tokens`. `min_faster_correction_factor` and
-/// `max_slower_correction_factor` optionally place independent absolute bounds
-/// on learned native correction factors in each direction.
+/// `max_slower_correction_factor` place independent absolute bounds on learned
+/// native correction factors in each direction, defaulting to `0.5` and `2.0`.
+/// Callers may explicitly disable either bound.
 ///
 /// Queued request fields are accepted for FPM schema parity but ignored by this
 /// forward-pass-level model. `estimate_forward_pass_time_ms` treats FPM as a

--- a/aic-core/rust/aiconfigurator-core/src/fpm/options.rs
+++ b/aic-core/rust/aiconfigurator-core/src/fpm/options.rs
@@ -11,6 +11,8 @@ use super::samples::integer_sqrt;
 
 pub(crate) const DEFAULT_MAX_OBSERVATIONS: usize = 64;
 pub(crate) const DEFAULT_MIN_OBSERVATIONS: usize = 5;
+pub(crate) const DEFAULT_MIN_FASTER_CORRECTION_FACTOR: f64 = 0.5;
+pub(crate) const DEFAULT_MAX_SLOWER_CORRECTION_FACTOR: f64 = 2.0;
 pub(crate) const DEFAULT_BUCKET_COUNT: usize = 16;
 pub(crate) const DEFAULT_MAX_NUM_TOKENS: u32 = 8192;
 pub(crate) const DEFAULT_MAX_BATCH_SIZE: u32 = 512;
@@ -18,9 +20,9 @@ pub(crate) const DEFAULT_MAX_KV_TOKENS: u32 = 2_000_000;
 
 /// In-memory tuning controls for `ForwardPassPerfModel`.
 ///
-/// These defaults match the current planner regression behavior: retain a
-/// bounded sliding sample set, wait for enough observations before predicting
-/// from learned data, and bucket observations by workload kind.
+/// The defaults retain a bounded sliding sample set, wait for enough
+/// observations before predicting from learned data, bucket observations by
+/// workload kind, and bound native correction factors to `[0.5, 2.0]`.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ForwardPassPerfOptions {
     /// Maximum retained observations across all buckets for each inferred workload kind.
@@ -33,18 +35,20 @@ pub struct ForwardPassPerfOptions {
     /// Optional absolute lower bound on native correction factors for
     /// observations faster than the native estimate.
     ///
-    /// Values must be finite, greater than `0.0`, and at most `1.0`. Setting
-    /// this to `1.0` disables faster corrections. `None` preserves the default
-    /// unbounded behavior. Regression fallback does not use this option.
-    #[serde(default)]
+    /// Values must be finite, greater than `0.0`, and at most `1.0`. Defaults
+    /// to `0.5`, limiting learned speedups to `2x`. Setting this to `1.0`
+    /// disables faster corrections; setting it to `None` removes the lower
+    /// bound. Regression fallback does not use this option.
+    #[serde(default = "default_min_faster_correction_factor")]
     pub min_faster_correction_factor: Option<f64>,
     /// Optional absolute upper bound on native correction factors for
     /// observations slower than the native estimate.
     ///
-    /// Values must be finite and at least `1.0`. Setting this to `1.0`
-    /// disables slower corrections. `None` preserves the default unbounded
-    /// behavior. Regression fallback does not use this option.
-    #[serde(default)]
+    /// Values must be finite and at least `1.0`. Defaults to `2.0`, limiting
+    /// learned slowdowns to `2x`. Setting this to `1.0` disables slower
+    /// corrections; setting it to `None` removes the upper bound. Regression
+    /// fallback does not use this option.
+    #[serde(default = "default_max_slower_correction_factor")]
     pub max_slower_correction_factor: Option<f64>,
     /// Target bucket count for workload-specific sample retirement and correction lookup.
     #[serde(default = "default_bucket_count")]
@@ -71,8 +75,8 @@ impl Default for ForwardPassPerfOptions {
         Self {
             max_observations: DEFAULT_MAX_OBSERVATIONS,
             min_observations: DEFAULT_MIN_OBSERVATIONS,
-            min_faster_correction_factor: None,
-            max_slower_correction_factor: None,
+            min_faster_correction_factor: default_min_faster_correction_factor(),
+            max_slower_correction_factor: default_max_slower_correction_factor(),
             bucket_count: DEFAULT_BUCKET_COUNT,
             max_num_tokens: DEFAULT_MAX_NUM_TOKENS,
             max_batch_size: DEFAULT_MAX_BATCH_SIZE,
@@ -141,6 +145,14 @@ fn default_max_observations() -> usize {
 
 fn default_min_observations() -> usize {
     DEFAULT_MIN_OBSERVATIONS
+}
+
+fn default_min_faster_correction_factor() -> Option<f64> {
+    Some(DEFAULT_MIN_FASTER_CORRECTION_FACTOR)
+}
+
+fn default_max_slower_correction_factor() -> Option<f64> {
+    Some(DEFAULT_MAX_SLOWER_CORRECTION_FACTOR)
 }
 
 fn default_bucket_count() -> usize {

--- a/aic-core/rust/aiconfigurator-core/src/fpm/tests.rs
+++ b/aic-core/rust/aiconfigurator-core/src/fpm/tests.rs
@@ -327,16 +327,44 @@ fn options_reject_zero_bounds() {
 }
 
 #[test]
-fn options_validate_directional_correction_factors() {
+fn options_default_directional_correction_factors() {
+    let defaults = ForwardPassPerfOptions::default();
     assert_eq!(
-        ForwardPassPerfOptions::default().min_faster_correction_factor,
-        None
+        defaults.min_faster_correction_factor,
+        Some(0.5)
     );
     assert_eq!(
-        ForwardPassPerfOptions::default().max_slower_correction_factor,
-        None
+        defaults.max_slower_correction_factor,
+        Some(2.0)
     );
 
+    let omitted: ForwardPassPerfOptions = serde_json::from_str("{}").unwrap();
+    assert_eq!(omitted.min_faster_correction_factor, Some(0.5));
+    assert_eq!(omitted.max_slower_correction_factor, Some(2.0));
+
+    let unbounded: ForwardPassPerfOptions = serde_json::from_str(
+        r#"{
+            "min_faster_correction_factor": null,
+            "max_slower_correction_factor": null
+        }"#,
+    )
+    .unwrap();
+    assert_eq!(unbounded.min_faster_correction_factor, None);
+    assert_eq!(unbounded.max_slower_correction_factor, None);
+
+    let no_floor: ForwardPassPerfOptions =
+        serde_json::from_str(r#"{"min_faster_correction_factor": null}"#).unwrap();
+    assert_eq!(no_floor.min_faster_correction_factor, None);
+    assert_eq!(no_floor.max_slower_correction_factor, Some(2.0));
+
+    let no_ceiling: ForwardPassPerfOptions =
+        serde_json::from_str(r#"{"max_slower_correction_factor": null}"#).unwrap();
+    assert_eq!(no_ceiling.min_faster_correction_factor, Some(0.5));
+    assert_eq!(no_ceiling.max_slower_correction_factor, None);
+}
+
+#[test]
+fn options_validate_directional_correction_factors() {
     let model = ForwardPassPerfModel::from_regression(ForwardPassPerfOptions {
         min_faster_correction_factor: Some(0.5),
         max_slower_correction_factor: Some(2.0),
@@ -794,14 +822,12 @@ fn native_correction_recovers_from_saturated_slower_ceiling() {
     assert_close(model.max_correction_factor().unwrap(), 1.0);
 }
 
-/// Directional limits are applied to each correction sample before taking the
-/// median, retaining the contribution of observations inside either bound.
+/// Default directional limits are applied to each correction sample before
+/// taking the median, retaining observations inside either bound.
 #[test]
-fn native_directional_correction_bounds_are_applied_at_observation_ingestion() {
+fn native_default_directional_correction_bounds_are_applied_at_observation_ingestion() {
     let mut model = native_model(ForwardPassPerfOptions {
         min_observations: 2,
-        min_faster_correction_factor: Some(0.5),
-        max_slower_correction_factor: Some(2.0),
         ..Default::default()
     });
     let metrics = prefill_fpm(20, 0.0);
@@ -837,6 +863,7 @@ fn native_directional_correction_bounds_are_applied_at_observation_ingestion() {
 fn native_slower_correction_ceiling_preserves_faster_corrections() {
     let mut model = native_model(ForwardPassPerfOptions {
         min_observations: 2,
+        min_faster_correction_factor: None,
         max_slower_correction_factor: Some(2.0),
         ..Default::default()
     });
@@ -868,6 +895,7 @@ fn native_faster_correction_floor_is_independent() {
     let options = ForwardPassPerfOptions {
         min_observations: 2,
         min_faster_correction_factor: Some(0.5),
+        max_slower_correction_factor: None,
         ..Default::default()
     };
 
@@ -904,6 +932,7 @@ fn native_correction_min_observations_is_workload_kind_wide_and_empty_regions_de
         min_observations: 2,
         bucket_count: 4,
         max_num_tokens: 100,
+        max_slower_correction_factor: None,
         ..Default::default()
     });
 

--- a/aic-core/src/aiconfigurator_core/sdk/rust_engine_step.py
+++ b/aic-core/src/aiconfigurator_core/sdk/rust_engine_step.py
@@ -75,13 +75,14 @@ class RustForwardPassPerfModel:
     ``max_num_tokens`` bounds ``sum_prefill_tokens`` and defaults to ``8192``,
     ``max_batch_size`` bounds ``num_decode_requests`` and defaults to ``512``,
     and ``max_kv_tokens`` bounds ``sum_decode_kv_tokens`` and defaults to
-    ``2000000``. ``min_faster_correction_factor`` optionally places an absolute
-    lower bound on corrections below ``1.0`` and must be finite and in
-    ``(0.0, 1.0]``. ``max_slower_correction_factor`` independently places an
-    absolute upper bound on corrections above ``1.0`` and must be finite and at
-    least ``1.0``. For example, ``0.5`` limits learned speedups to ``2x``, while
-    ``2.0`` limits learned slowdowns to ``2x``. Omitting either option leaves
-    that direction unbounded. Regression fallback ignores both options.
+    ``2000000``. ``min_faster_correction_factor`` places an absolute lower bound
+    on corrections below ``1.0`` and must be finite and in ``(0.0, 1.0]``.
+    It defaults to ``0.5``, limiting learned speedups to ``2x``.
+    ``max_slower_correction_factor`` independently places an absolute upper
+    bound on corrections above ``1.0`` and must be finite and at least ``1.0``.
+    It defaults to ``2.0``, limiting learned slowdowns to ``2x``. Passing
+    ``None`` for either option leaves that direction unbounded. Regression
+    fallback ignores both options.
     """
 
     def __init__(self, inner: Any) -> None:

--- a/tests/unit/sdk/test_rust_engine_step.py
+++ b/tests/unit/sdk/test_rust_engine_step.py
@@ -509,8 +509,8 @@ def test_forward_pass_perf_model_regression_marshalling(monkeypatch) -> None:
 
 
 @pytest.mark.integration
-def test_forward_pass_perf_model_native_directional_bounds_end_to_end() -> None:
-    """End-to-end native forward-pass model over a real fixture.
+def test_forward_pass_perf_model_native_default_directional_bounds_end_to_end() -> None:
+    """End-to-end native forward-pass model with default bounds over a real fixture.
 
     Builds a native model via ``compile_engine`` (crossing into the Rust core),
     estimates a prefill iteration, then drives one correction bucket through
@@ -544,8 +544,6 @@ def test_forward_pass_perf_model_native_directional_bounds_end_to_end() -> None:
         {
             "min_observations": 2,
             "max_observations": 2,
-            "min_faster_correction_factor": 0.5,
-            "max_slower_correction_factor": 2.0,
         },
     )
 


### PR DESCRIPTION
## What changed

- Default native forward-pass correction factors to `0.5`–`2.0`.
- Apply the same defaults when options JSON omits either field.
- Preserve explicit per-direction opt-out with JSON `null` / Python `None`.
- Document the new behavior and cover Rust, serde, and Python end-to-end paths.

## Why

The directional-bound implementation previously defaulted both options to `None`, so existing native AIC callers remained unbounded unless every integration explicitly supplied values. Real MiniMax disaggregated replay showed that repeated admission of an extreme FPM can otherwise skew subsequent estimates. This follow-up makes the validated `0.5` and `2.0` values the safe native defaults.

Regression fallback continues to ignore both options.

## Validation

- `cargo test --offline --release -p aiconfigurator-core --lib`: 321 passed
- `pytest tests/unit/sdk/test_rust_engine_step.py`: 23 passed
- `pytest -m unit`: 3,029 passed, 10 skipped
- Ruff lint and format checks passed
- `git diff --check` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that adaptive forward-pass modeling uses default correction-factor bounds of 0.5 for speedups and 2.0 for slowdowns.
  - Documented that either bound can be disabled with `None`.
  - Clarified that regression fallback does not use these settings.

- **Bug Fixes**
  - Updated native model defaults to apply bounded directional corrections instead of leaving them unrestricted.

- **Tests**
  - Updated coverage for default bounds, explicit `null` values, and native end-to-end behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->