### PR TITLE
feat(sdk): self-contained result rows + closed-loop latency refinement (report + opt-in SLA)

### DIFF
--- a/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
+++ b/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
@@ -1641,6 +1641,15 @@ class BaseBackend:
             "version": database.version,
             "system": database.system,
             "power_w": agg_power_avg_w,
+            # operating-point step timings: already computed above (through
+            # the compiled engine step when routed there — these are the
+            # FFI-returned scalars, identical under either engine), recorded
+            # so post-processing can refine without re-querying timing
+            "mix_step_ms": mix_step_latency_ms,
+            "genonly_step_ms": genonly_step_latency_ms,
+            "prefill_step_ms": _prefill_step_ms,
+            "num_mix_steps": num_mix_steps,
+            "num_genonly_steps": num_genonly_steps,
         }
         summary = InferenceSummary(RuntimeConfig(isl=isl, osl=osl))
         summary.set_memory_and_check_oom(

--- a/aic-core/src/aiconfigurator_core/sdk/common.py
+++ b/aic-core/src/aiconfigurator_core/sdk/common.py
@@ -780,7 +780,8 @@ ColumnsAgg = [
     "backend",
     "version",
     "system",
-    "power_w",  # NEW: E2E weighted average power in watts    # operating-point step timings, recorded so result rows are
+    "power_w",  # NEW: E2E weighted average power in watts
+    # operating-point step timings, recorded so result rows are
     # self-contained for post-processing refinement (sdk/closed_loop_ttft)
     "mix_step_ms",
     "genonly_step_ms",

--- a/aic-core/src/aiconfigurator_core/sdk/common.py
+++ b/aic-core/src/aiconfigurator_core/sdk/common.py
@@ -780,7 +780,13 @@ ColumnsAgg = [
     "backend",
     "version",
     "system",
-    "power_w",  # NEW: E2E weighted average power in watts
+    "power_w",  # NEW: E2E weighted average power in watts    # operating-point step timings, recorded so result rows are
+    # self-contained for post-processing refinement (sdk/closed_loop_ttft)
+    "mix_step_ms",
+    "genonly_step_ms",
+    "prefill_step_ms",
+    "num_mix_steps",
+    "num_genonly_steps",
 ]
 
 """
@@ -809,6 +815,10 @@ ColumnsDisagg = [
     "tokens/s/gpu",
     "tokens/s/user",
     "(p)seq/s/worker",
+    # raw solo context latency of one prefill worker (pre-correction),
+    # recorded so disagg rows are self-contained for post-processing
+    # refinement (sdk/closed_loop_ttft)
+    "(p)prefill_step_ms",
     "(d)seq/s/worker",
     "num_total_gpus",
     "(p)tp",

--- a/docs/design/closed_loop_refinement.md
+++ b/docs/design/closed_loop_refinement.md
@@ -58,26 +58,14 @@ H20, isl4096/osl256):
   and batched prefill, shallow to deep queueing): bit-identical TTFT and
   throughput at all nine validation points.
 
-Against the dynamo mocker (independent discrete-event serving simulation,
-wall clock, same perf-DB timing; 31 closed-loop operating points: 9 agg tp4
-+ 22 disagg across 1P1D/2P1D/1P2D, isl 1024-8192, osl 128-2048, C 4-48; the
-16 extended-disagg predictions were generated before their measurements):
-
-- throughput: within 1.3% on agg and the extended disagg grid (3.8% on the
-  first disagg matrix);
-- TTFT mean: within ~11% on 25 of 31 points; TPOT within ~10% everywhere;
-- structural cross-checks confirmed by the DES: prefill-saturated regime
-  shift (TTFT recedes past the knee while TPOT grows), and the closed-loop
-  conservation result that adding decode capacity to a prefill-bound tandem
-  leaves throughput unchanged while nearly doubling steady TTFT.
-
 Against real serving (trtllm-serve 1.3.0rc20, H20 tp4, chunked prefill,
-same 9 agg closed-loop points, predictions unchanged): throughput within
-5.3% on 7 of 9 points and TTFT p99 within a few percent at low/moderate
-concurrency; the residual splits cleanly into the structure component
-(bounded by the DES comparison above) and a perf-DB timing component that
-dominates only in deep-churn small-prompt corners (real mixed passes up to
-2x the DB pricing) — a timing-data issue, not an estimator issue.
+9 agg closed-loop points, isl 1024-8192, osl 128-256, C 4-48, predictions
+generated before the measurements): throughput within 5.3% on 7 of 9
+points and TTFT p99 within a few percent at low/moderate concurrency; the
+residual concentrates in deep-churn small-prompt corners where real mixed
+passes cost up to 2x the perf-DB pricing — a timing-data gap, not an
+estimator-structure one (refined TTFT errs on the conservative side
+there).
 
 Known error modes (measured, understood, not corrected for):
 

--- a/docs/design/closed_loop_refinement.md
+++ b/docs/design/closed_loop_refinement.md
@@ -89,13 +89,15 @@ estimator does not model. Open-loop arrivals, shape distributions,
 prefix-cache dynamics and latency *distributions* (p50/p99 structure,
 transients) belong to the full queueing-model evaluator work.
 
-## Relation to SLA filtering (non-goal here)
+## Relation to SLA filtering
 
-The refined columns are report-only: sweep, SLA-target filtering, pareto
-and picking all still read the legacy `ttft`/`tpot` columns, so results
-are unchanged by this PR. If refined values should ever drive SLA
-filtering, the wiring is: refine before the filter and compare
-`ttft_refined`/`tpot_refined` against the targets, behind an opt-in flag
-(default off) — the refined steady closed-loop TTFT at the row's
-operating point is the quantity an SLA on served latency actually
-constrains. Left to a follow-up change.
+The pipeline is untouched: sweep, SLA-target filtering, pareto and picking
+all still read the legacy `ttft`/`tpot` columns, so default results are
+unchanged by this PR. For consumers who want the SLA verdict on the
+values a fixed-concurrency benchmark would actually measure,
+`filter_closed_loop_sla(df, ttft_ms=..., tpot_ms=...)` is an approximate
+post-filter: it refines the rows and drops those whose refined values
+exceed the targets (rows it cannot price are kept — it only ever tightens
+the legacy verdict where it has evidence). Moving this comparison into
+the pipeline filter itself (replacing the legacy columns) is a product
+decision left to a follow-up.

--- a/docs/design/closed_loop_refinement.md
+++ b/docs/design/closed_loop_refinement.md
@@ -104,10 +104,23 @@ post-filtering a picked table can return empty even when a
 lower-concurrency point of the same deployment complies;
 `pick_under_closed_loop_sla(df, ...)` closes that gap — feed it the full
 per-operating-point summary (sweep with a loose TTFT target) and it
-re-picks each deployment's best surviving row, which is equivalent to
-enforcing the SLA at the original filter. Moving this comparison into
-the pipeline filter itself (replacing the legacy columns) is a product
-decision left to a follow-up. AFD frames pass through unpriced (refined
-NaN, legacy verdict kept): their closed-loop mapping — the mini tandem
-over `prefill_t_step`/`decode_t_step` — needs its own validation pass
-first.
+re-picks each deployment's best surviving row.
+
+For full in-pipeline enforcement, `Task(refined_sla=True)` (default off)
+makes the sweep itself compare the targets against the refined values:
+agg candidate points gate on the solo chunked-prefill lower bound (the
+static TTFT is NOT a bound — deep saturation moves cycle time into TPOT,
+so gating on it would discard compliant points) and are then priced;
+disagg drops the 1.8 prefill gate to the solo bound and keeps, per
+decode-parallel category, the best rate-matched combination whose
+refined values comply. Pricing is memoized on the operating-point
+inputs. Two effects observed on an 8-GPU Qwen3-32B sweep
+(isl4096/osl256, ttft 2000ms): points the fixed factor wrongly killed
+come back (disagg: a 3-worker tp2 prefill pool, solo x1.8 = 2070ms >
+target but refined 1145ms, +57% tokens/s/gpu over the legacy pick; agg:
+deep-saturation rows with static TTFT above target but refined below,
++6% on the top pick), and rate-matched combinations whose refined TTFT
+explodes under queueing are dropped. AFD frames pass through unpriced
+(refined NaN, legacy verdict kept): their closed-loop mapping — the mini
+tandem over `prefill_t_step`/`decode_t_step` — needs its own validation
+pass first.

--- a/docs/design/closed_loop_refinement.md
+++ b/docs/design/closed_loop_refinement.md
@@ -47,6 +47,14 @@ effects emerge from iterating the budget arithmetic.
 
 ## Validation
 
+The figures below are one-off measurements (August 2026, Qwen3-32B,
+H20 trtllm perf data, isl4096/osl256), recorded with their configuration
+rather than reproduced in CI; the evaluator comparisons ran against the
+gated evaluator on the queueing-model branch. The in-repo unit tests
+(`tests/unit/sdk/test_closed_loop_ttft.py`) lock the estimator semantics
+these results rely on (closed-loop identity, P/D imbalance signatures,
+admission rules, DataFrame refinement).
+
 Against the full queueing-model evaluator on identical timing (Qwen3-32B,
 H20, isl4096/osl256):
 

--- a/docs/design/closed_loop_refinement.md
+++ b/docs/design/closed_loop_refinement.md
@@ -1,0 +1,63 @@
+# Closed-loop latency refinement (post-processing)
+
+Sweep result rows carry `ttft`/`tpot` computed with per-operating-point
+heuristics (agg: a clamped queuing factor; disagg: a constant prefill
+pre-correction). This feature makes result rows **self-contained** and adds
+a post-processing step that replays the scheduler's own arithmetic to
+produce quantitatively refined latencies — without touching the prediction
+pipeline.
+
+## Recorded columns (additive)
+
+Agg rows (`ColumnsAgg`): `mix_step_ms`, `genonly_step_ms`,
+`prefill_step_ms`, `num_mix_steps`, `num_genonly_steps` — the
+operating-point step timings `run_agg` already computes (through the
+compiled engine step when routed there; the values are the FFI-returned
+scalars, identical under either engine, so no Rust-side change is needed
+and no parity-governed path is touched).
+
+Disagg rows (`ColumnsDisagg`): `(p)prefill_step_ms` — the raw solo context
+latency of one prefill worker, captured *before* the autoscale TTFT
+pre-correction is applied.
+
+## The estimators (`sdk/closed_loop_ttft.py`)
+
+`estimate_closed_loop_latency` replays the fused continuous-batching pass
+calendar (budget arithmetic per pass, admission-ordered chunking, closed
+loop with visibility delay) — a deterministic recursion, no RNG, no fitted
+constants, milliseconds per operating point. `estimate_disagg_closed_loop_latency`
+replays the P/D tandem (whole-prompt prefill batches behind a round-robin
+router, decode-attach handoff, per-iteration decode). Timing enters as the
+recorded row scalars.
+
+`refine_closed_loop_latency(df)` dispatches per row shape and returns a
+copy with additive `ttft_refined` / `tpot_refined` / `throughput_refined`
+columns. The three are one consistent timeline — they satisfy the
+closed-loop identity `C/X = TTFT + (osl-1) * TPOT` — so consume them as a
+set; mixing a refined column with a legacy one breaks that conservation.
+Rows that cannot be priced keep NaN.
+
+## Why a recursion instead of a formula
+
+Closed-loop TTFT under continuous batching is not monotone in concurrency
+(replacement prefill chunks stretch everyone's passes; past the knee,
+larger decode batches eat the cycle and TTFT recedes), and any closed-form
+multiplier misses that shape. The recursion reproduces it because both
+effects emerge from iterating the budget arithmetic.
+
+## Validation
+
+Against the full queueing-model evaluator on identical timing (Qwen3-32B,
+H20, isl4096/osl256):
+
+- agg estimator, exact timing callables: TTFT/TPOT/throughput within 0.2%
+  over C=2..64 (bit-identical up to C=8);
+- agg estimator fed only the recorded row scalars: within ~3% over the
+  same sweep (the linear-in-tokens chunk reconstruction);
+- disagg tandem estimator vs the disagg evaluator (1P1D/2P1D/2P2D, serial
+  and batched prefill, shallow to deep queueing): bit-identical TTFT and
+  throughput at all nine validation points.
+
+Scope: fixed-shape closed loop. Open-loop arrivals, shape distributions,
+prefix-cache dynamics and latency *distributions* (p50/p99 structure,
+transients) belong to the full queueing-model evaluator work.

--- a/docs/design/closed_loop_refinement.md
+++ b/docs/design/closed_loop_refinement.md
@@ -58,6 +58,56 @@ H20, isl4096/osl256):
   and batched prefill, shallow to deep queueing): bit-identical TTFT and
   throughput at all nine validation points.
 
-Scope: fixed-shape closed loop. Open-loop arrivals, shape distributions,
+Against the dynamo mocker (independent discrete-event serving simulation,
+wall clock, same perf-DB timing; 31 closed-loop operating points: 9 agg tp4
++ 22 disagg across 1P1D/2P1D/1P2D, isl 1024-8192, osl 128-2048, C 4-48; the
+16 extended-disagg predictions were generated before their measurements):
+
+- throughput: within 1.3% on agg and the extended disagg grid (3.8% on the
+  first disagg matrix);
+- TTFT mean: within ~11% on 25 of 31 points; TPOT within ~10% everywhere;
+- structural cross-checks confirmed by the DES: prefill-saturated regime
+  shift (TTFT recedes past the knee while TPOT grows), and the closed-loop
+  conservation result that adding decode capacity to a prefill-bound tandem
+  leaves throughput unchanged while nearly doubling steady TTFT.
+
+Against real serving (trtllm-serve 1.3.0rc20, H20 tp4, chunked prefill,
+same 9 agg closed-loop points, predictions unchanged): throughput within
+5.3% on 7 of 9 points and TTFT p99 within a few percent at low/moderate
+concurrency; the residual splits cleanly into the structure component
+(bounded by the DES comparison above) and a perf-DB timing component that
+dominates only in deep-churn small-prompt corners (real mixed passes up to
+2x the DB pricing) — a timing-data issue, not an estimator issue.
+
+Known error modes (measured, understood, not corrected for):
+
+- saturation-knee amplification: within a few percent of the knee, a
+  5-10% decode-step pricing error is leveraged into a 20-40% TTFT queue
+  error (the same sensitivity that makes any rho->1 queueing formula
+  fragile); away from the knee the same pricing error costs 1-3%. Read
+  near-knee refined TTFT as a lower-bound estimate.
+- sub-saturated tails: the deterministic recursion settles into a
+  collision-free phase, so its p50/p99 understate the occasional
+  prefill collisions a jittered system shows (means unaffected);
+- deep-concurrency small-prompt agg: admission order (immediate vs
+  bunched prefill waves) can shift TTFT conservatively upward while ITL
+  and throughput still match.
+
+Scope: fixed-shape closed loop with TRT-LLM scheduling semantics (fused
+chunked passes; disagg decode-attach not budget-gated). Engines that
+account a disagg KV attach against the decode prefill budget (vLLM-style)
+serialize the tandem when isl reaches that budget — a real behavior this
+estimator does not model. Open-loop arrivals, shape distributions,
 prefix-cache dynamics and latency *distributions* (p50/p99 structure,
 transients) belong to the full queueing-model evaluator work.
+
+## Relation to SLA filtering (non-goal here)
+
+The refined columns are report-only: sweep, SLA-target filtering, pareto
+and picking all still read the legacy `ttft`/`tpot` columns, so results
+are unchanged by this PR. If refined values should ever drive SLA
+filtering, the wiring is: refine before the filter and compare
+`ttft_refined`/`tpot_refined` against the targets, behind an opt-in flag
+(default off) — the refined steady closed-loop TTFT at the row's
+operating point is the quantity an SLA on served latency actually
+constrains. Left to a follow-up change.

--- a/docs/design/closed_loop_refinement.md
+++ b/docs/design/closed_loop_refinement.md
@@ -98,6 +98,16 @@ values a fixed-concurrency benchmark would actually measure,
 `filter_closed_loop_sla(df, ttft_ms=..., tpot_ms=...)` is an approximate
 post-filter: it refines the rows and drops those whose refined values
 exceed the targets (rows it cannot price are kept — it only ever tightens
-the legacy verdict where it has evidence). Moving this comparison into
+the legacy verdict where it has evidence). Because the pipeline picks
+each deployment's operating point before any post-processing runs,
+post-filtering a picked table can return empty even when a
+lower-concurrency point of the same deployment complies;
+`pick_under_closed_loop_sla(df, ...)` closes that gap — feed it the full
+per-operating-point summary (sweep with a loose TTFT target) and it
+re-picks each deployment's best surviving row, which is equivalent to
+enforcing the SLA at the original filter. Moving this comparison into
 the pipeline filter itself (replacing the legacy columns) is a product
-decision left to a follow-up.
+decision left to a follow-up. AFD frames pass through unpriced (refined
+NaN, legacy verdict kept): their closed-loop mapping — the mini tandem
+over `prefill_t_step`/`decode_t_step` — needs its own validation pass
+first.

--- a/docs/design/closed_loop_refinement.md
+++ b/docs/design/closed_loop_refinement.md
@@ -115,7 +115,10 @@ per-operating-point summary (sweep with a loose TTFT target) and it
 re-picks each deployment's best surviving row.
 
 For full in-pipeline enforcement, `Task(refined_sla=True)` (default off)
-makes the sweep itself compare the targets against the refined values:
+makes the sweep itself compare the targets against the refined values,
+and the single-point estimates (`run_single_agg`/`run_single_disagg`)
+report the closed-loop repriced headline instead of the static/legacy
+value:
 agg candidate points gate on the solo chunked-prefill lower bound (the
 static TTFT is NOT a bound — deep saturation moves cycle time into TPOT,
 so gating on it would discard compliant points) and are then priced;

--- a/src/aiconfigurator/sdk/closed_loop_ttft.py
+++ b/src/aiconfigurator/sdk/closed_loop_ttft.py
@@ -427,6 +427,35 @@ def _price_closed_loop_row_uncached(row):
         return float("nan"), float("nan"), float("nan")
 
 
+def reprice_closed_loop_row(row):
+    """Copy of a summary row with headline latency/throughput repriced from
+    the closed-loop estimate at the row's own operating point.
+
+    Overwrites ``ttft``/``tpot``/``request_latency`` and the throughput
+    family so the row reads as one consistent closed-loop timeline (the raw
+    recorded columns stay). Rows that cannot be priced return unchanged.
+    """
+    t, p, x = price_closed_loop_row(row)
+    out = dict(row)
+    if t != t:  # NaN — unpriceable, keep the legacy verdict
+        return out
+    osl = int(row["osl"])
+    gpus = float(row.get("num_total_gpus") or 0.0)
+    out["ttft"] = t
+    out["tpot"] = p
+    out["request_latency"] = t + p * max(osl - 1, 0)
+    out["seq/s"] = x
+    out["tokens/s"] = x * osl
+    if gpus:
+        out["seq/s/gpu"] = x / gpus
+        out["tokens/s/gpu"] = x * osl / gpus
+    if "tokens/s/user" in out and p > 0:
+        out["tokens/s/user"] = 1000.0 / p
+    if "request_rate" in out:
+        out["request_rate"] = x
+    return out
+
+
 def filter_closed_loop_sla(df, ttft_ms=None, tpot_ms=None):
     """Approximate SLA post-filter on the refined closed-loop values.
 

--- a/src/aiconfigurator/sdk/closed_loop_ttft.py
+++ b/src/aiconfigurator/sdk/closed_loop_ttft.py
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Minimal closed-loop TTFT estimator: the pass-calendar recursion as one
+pure function, for POST-PROCESSING existing sweep results.
+
+This is the smallest faithful core of the quantitative queueing evaluator:
+a deterministic replay of the continuous-batching scheduler's own budget
+arithmetic at pass granularity (no RNG, no fitted constants, no event
+heap). It exists so result DataFrames can be refined non-invasively — the
+prediction pipeline itself is untouched; timing enters through two injected
+callables (the same quantities the pipeline already computes).
+
+Semantics modeled (vLLM-v1-style fused pass, which TRT-LLM's in-flight
+batching also follows): running decodes spend one budget token each and
+emit; queued prefills consume the remaining budget as chunks in admission
+order; a prefill completer emits its first token in the same pass off the
+final chunk's logits; closed loop replaces a completed request immediately,
+visible to the scheduler after ``turnaround_ms``. Not modeled here (use the
+full queueing evaluator): mixed-pass fused timing hooks, KV-pressure
+admission, variable shapes, open-loop arrivals, SGLang's alternating mode.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+
+def estimate_closed_loop_latency(
+    concurrency: int,
+    isl: int,
+    osl: int,
+    prefill_ms: Callable[[int, int, int], float],
+    decode_ms: Callable[[int, int], float],
+    max_num_batched_tokens: int = 8192,
+    prefix: int = 0,
+    turnaround_ms: float = 0.0,
+    enable_chunked_prefill: bool = True,
+    warmup_generations: int = 4,
+    window_generations: int = 4,
+) -> dict:
+    """Steady-state closed-loop latency at one operating point.
+
+    ``prefill_ms(batch, mean_isl, mean_prefix)`` and
+    ``decode_ms(batch, context_len)`` price one prefill batch / one decode
+    iteration — the caller wires them to whatever timing source it already
+    has. Returns a dict with ``ttft_steady_mean/p50/p99``,
+    ``ttft_transient_max``, ``tpot_mean``, ``itl_p50/p99`` and
+    ``throughput_rps`` (all ms / req-per-s).
+    """
+    if concurrency < 1 or isl < 1 or osl < 1:
+        raise ValueError("concurrency, isl and osl must be >= 1")
+    if not 0 <= prefix < isl:
+        raise ValueError("prefix must be in [0, isl)")
+    eff_isl = max(1, isl - prefix)
+
+    # slot = [remaining_prefill, generated, arrival_ms, first_token_ms,
+    #         last_token_ms, gap_sum, gap_count, gaps_list_or_None]
+    def new_slot(arrival: float) -> list:
+        return [eff_isl, 0, arrival, -1.0, -1.0, []]
+
+    slots = [new_slot(0.0) for _ in range(concurrency)]
+    pending: list = []  # (visible_ms, slot) replacements not yet admitted
+    now = 0.0
+    completions = 0
+    warmup = warmup_generations * concurrency
+    target = (warmup_generations + window_generations) * concurrency
+    steady_start = None
+    ttfts: list = []
+    transient_max = 0.0
+    gaps: list = []
+    tpots: list = []
+    steady_completions = 0
+
+    max_passes = 200 * (warmup_generations + window_generations) * osl
+    for _ in range(max_passes):
+        if completions >= target:
+            break
+        if pending:  # sync scheduler: arrivals visible by pass start join it
+            admitted = [s for t, s in pending if t <= now]
+            if admitted:
+                slots.extend(admitted)
+                pending = [(t, s) for t, s in pending if t > now]
+
+        # --- one fused pass: budget arithmetic in admission order ---
+        budget = max_num_batched_tokens
+        n_prefill = 0
+        prefill_tokens = 0
+        prefill_prefix = 0
+        completers = []
+        decoders = []
+        for s in slots:
+            if s[0] > 0:
+                if budget <= 0:
+                    continue
+                if not enable_chunked_prefill and s[0] > budget:
+                    break  # whole prompts only: admission stops here
+                chunk = s[0] if s[0] <= budget else budget
+                done_before = prefix + (eff_isl - s[0])
+                s[0] -= chunk
+                budget -= chunk
+                n_prefill += 1
+                prefill_tokens += done_before + chunk
+                prefill_prefix += done_before
+                if s[0] == 0:
+                    completers.append(s)
+            elif s[1] < osl and budget > 0:
+                budget -= 1
+                decoders.append(s)
+
+        duration = 0.0
+        if n_prefill:
+            duration += prefill_ms(n_prefill, prefill_tokens // n_prefill, prefill_prefix // n_prefill)
+        if decoders:
+            ctx = sum(isl + s[1] for s in decoders) // len(decoders)
+            duration += decode_ms(len(decoders), ctx)
+        if duration <= 0.0 and not completers and not decoders:
+            if not pending:
+                raise RuntimeError("stalled: no schedulable work (budget too small?)")
+            now = max(now, min(t for t, _ in pending))
+            continue
+        now += duration
+
+        # --- emissions & accounting ---
+        for s in completers + decoders:
+            s[1] += 1
+            if s[3] < 0:
+                s[3] = now
+                t = now - s[2]
+                if completions >= warmup:
+                    ttfts.append(t)
+                transient_max = max(transient_max, t)
+            else:
+                s[5].append(now - s[4])
+            s[4] = now
+        finished = [s for s in completers + decoders if s[1] >= osl]
+        for s in finished:
+            completions += 1
+            if completions == warmup:
+                steady_start = now
+            if completions > warmup:
+                steady_completions += 1
+                gaps.extend(s[5])
+                if s[5]:
+                    tpots.append(sum(s[5]) / len(s[5]))
+            slots.remove(s)
+            pending.append((now + turnaround_ms, new_slot(now)))
+    else:
+        raise RuntimeError("did not converge within max_passes")
+
+    window = now - (steady_start or 0.0)
+    q = lambda v, x: sorted(v)[min(len(v) - 1, max(0, round(x * len(v)) - 1))] if v else float("nan")
+    return {
+        "ttft_steady_mean": sum(ttfts) / len(ttfts) if ttfts else float("nan"),
+        "ttft_steady_p50": q(ttfts, 0.5),
+        "ttft_steady_p99": q(ttfts, 0.99),
+        "ttft_transient_max": transient_max,
+        "tpot_mean": sum(tpots) / len(tpots) if tpots else float("nan"),
+        "itl_p50": q(gaps, 0.5),
+        "itl_p99": q(gaps, 0.99),
+        "throughput_rps": steady_completions / (window / 1000.0) if window > 0 else 0.0,
+    }
+
+
+def refine_closed_loop_ttft(
+    df,
+    prefill_ms: Callable[[int, int, int], float],
+    decode_ms: Callable[[int, int], float],
+    turnaround_ms: float = 0.0,
+    enable_chunked_prefill: bool = True,
+):
+    """Post-process an agg result DataFrame (``ColumnsAgg`` schema): run the
+    pass-calendar estimate per row and RETURN A COPY with additive columns
+    ``ttft_refined`` / ``tpot_refined`` / ``throughput_refined`` — existing
+    columns (including the legacy ``ttft``) are untouched, so downstream
+    consumers opt in per column. Rows it cannot price (missing/invalid
+    inputs) keep NaN in the new columns.
+    """
+    out = df.copy()
+    ttfts, tpots, xs = [], [], []
+    for _, row in out.iterrows():
+        try:
+            r = estimate_closed_loop_latency(
+                concurrency=int(row["bs"]),
+                isl=int(row["isl"]),
+                osl=int(row["osl"]),
+                prefill_ms=prefill_ms,
+                decode_ms=decode_ms,
+                max_num_batched_tokens=int(row["ctx_tokens"]),
+                prefix=int(row.get("prefix", 0) or 0),
+                turnaround_ms=turnaround_ms,
+                enable_chunked_prefill=enable_chunked_prefill,
+            )
+            ttfts.append(r["ttft_steady_mean"])
+            tpots.append(r["tpot_mean"])
+            xs.append(r["throughput_rps"])
+        except (KeyError, ValueError, RuntimeError):
+            ttfts.append(float("nan"))
+            tpots.append(float("nan"))
+            xs.append(float("nan"))
+    out["ttft_refined"] = ttfts
+    out["tpot_refined"] = tpots
+    out["throughput_refined"] = xs
+    return out

--- a/src/aiconfigurator/sdk/closed_loop_ttft.py
+++ b/src/aiconfigurator/sdk/closed_loop_ttft.py
@@ -356,3 +356,22 @@ def refine_closed_loop_latency(df):
     out["tpot_refined"] = tpots
     out["throughput_refined"] = xs
     return out
+
+
+def filter_closed_loop_sla(df, ttft_ms=None, tpot_ms=None):
+    """Approximate SLA post-filter on the refined closed-loop values.
+
+    Refines ``df`` (see :func:`refine_closed_loop_latency`) and drops rows
+    whose ``ttft_refined`` / ``tpot_refined`` exceed the given targets — the
+    steady closed-loop values a fixed-concurrency benchmark at the row's
+    operating point would measure. Rows that cannot be priced (refined NaN)
+    are KEPT: they already passed the pipeline's legacy SLA filter and this
+    post-filter only ever tightens that verdict where it has evidence.
+    Returns the refined copy, filtered.
+    """
+    out = refine_closed_loop_latency(df)
+    if ttft_ms is not None:
+        out = out[~(out["ttft_refined"] > float(ttft_ms))]
+    if tpot_ms is not None:
+        out = out[~(out["tpot_refined"] > float(tpot_ms))]
+    return out

--- a/src/aiconfigurator/sdk/closed_loop_ttft.py
+++ b/src/aiconfigurator/sdk/closed_loop_ttft.py
@@ -161,39 +161,194 @@ def estimate_closed_loop_latency(
     }
 
 
-def refine_closed_loop_ttft(
-    df,
-    prefill_ms: Callable[[int, int, int], float],
-    decode_ms: Callable[[int, int], float],
+def estimate_disagg_closed_loop_latency(
+    concurrency: int,
+    isl: int,
+    osl: int,
+    prefill_workers: int,
+    decode_workers: int,
+    prefill_step_ms: float,
+    decode_step_ms: float,
+    prefill_batch: int = 1,
+    decode_max_seqs: int = 256,
     turnaround_ms: float = 0.0,
-    enable_chunked_prefill: bool = True,
-):
-    """Post-process an agg result DataFrame (``ColumnsAgg`` schema): run the
-    pass-calendar estimate per row and RETURN A COPY with additive columns
+    handoff_ms: float = 0.0,
+    warmup_generations: int = 4,
+    window_generations: int = 4,
+) -> dict:
+    """Closed-loop latency for a P/D-disaggregated deployment (mini tandem).
+
+    Serving flow: each prefill worker runs one batch of up to
+    ``prefill_batch`` whole prompts per pass at ``prefill_step_ms`` (the raw
+    solo context latency the disagg row records as ``(p)prefill_step_ms`` —
+    TRT-LLM native disagg deploys ctx workers without chunked prefill); a
+    static round-robin router assigns arrivals; the first token becomes
+    user-visible after the KV handoff (decode-attach flow, ``handoff_ms``
+    per request — ~0 on NVLink at ms scale); decode workers emit one token
+    per ``decode_step_ms`` iteration (the row's ``tpot`` — disagg decode has
+    no prefill interference) for up to ``decode_max_seqs`` running
+    sequences. Closed loop: a completed request's replacement dispatches
+    immediately and becomes visible after ``turnaround_ms``.
+    """
+    if min(concurrency, isl, osl, prefill_workers, decode_workers, prefill_batch) < 1:
+        raise ValueError("concurrency/isl/osl/workers/prefill_batch must be >= 1")
+
+    # request = [visible_ms, arrival_ms, generated, first_ms, last_ms, gaps]
+    p_free = [0.0] * prefill_workers
+    p_queues: list[list] = [[] for _ in range(prefill_workers)]
+    d_free = [0.0] * decode_workers
+    d_running: list[list] = [[] for _ in range(decode_workers)]
+    state = {"rr_p": 0, "rr_d": 0, "completions": 0, "steady_start": None, "steady_completions": 0}
+    warmup = warmup_generations * concurrency
+    target = (warmup_generations + window_generations) * concurrency
+    ttfts: list = []
+    gaps: list = []
+    tpots: list = []
+
+    def dispatch(arrival_ms: float, visible_ms: float) -> None:
+        r = [visible_ms, arrival_ms, 0, -1.0, -1.0, []]
+        p_queues[state["rr_p"] % prefill_workers].append(r)
+        state["rr_p"] += 1
+
+    def complete(r: list, end_ms: float) -> None:
+        state["completions"] += 1
+        if state["completions"] == warmup:
+            state["steady_start"] = end_ms
+        if state["completions"] > warmup:
+            state["steady_completions"] += 1
+            gaps.extend(r[5])
+            if r[5]:
+                tpots.append(sum(r[5]) / len(r[5]))
+        dispatch(end_ms, end_ms + turnaround_ms)
+
+    for _ in range(concurrency):
+        dispatch(0.0, 0.0)
+
+    now = 0.0
+    max_iters = 400 * (target + 1) * osl
+    for _ in range(max_iters):
+        if state["completions"] >= target:
+            break
+        t_p = min(
+            (max(p_free[i], min(r[0] for r in q)) for i, q in enumerate(p_queues) if q),
+            default=float("inf"),
+        )
+        t_d = min(
+            (max(d_free[i], min(r[0] for r in run)) for i, run in enumerate(d_running) if run),
+            default=float("inf"),
+        )
+        now = min(t_p, t_d)
+        if now == float("inf"):
+            raise RuntimeError("tandem stalled — invalid configuration")
+
+        for i, q in enumerate(p_queues):  # whole-prompt prefill batches
+            if not q or p_free[i] > now:
+                continue
+            batch = [r for r in q if r[0] <= now][:prefill_batch]
+            if not batch:
+                continue
+            end = now + prefill_step_ms
+            p_free[i] = end
+            for r in batch:
+                q.remove(r)
+                first = end + handoff_ms  # decode-attach: TTFT includes handoff
+                r[2] = 1
+                r[3] = first
+                r[4] = first
+                if state["completions"] >= warmup:
+                    ttfts.append(first - r[1])
+                if r[2] >= osl:
+                    complete(r, first)
+                else:
+                    r[0] = first  # joins its decode worker when the KV lands
+                    d_running[state["rr_d"] % decode_workers].append(r)
+                    state["rr_d"] += 1
+
+        for i, run in enumerate(d_running):  # one token per iteration
+            if not run or d_free[i] > now:
+                continue
+            batch = [r for r in run if r[0] <= now][:decode_max_seqs]
+            if not batch:
+                continue
+            end = now + decode_step_ms
+            d_free[i] = end
+            for r in batch:
+                r[2] += 1
+                r[5].append(end - r[4])
+                r[4] = end
+                if r[2] >= osl:
+                    run.remove(r)
+                    complete(r, end)
+    else:
+        raise RuntimeError("tandem did not converge within max_iters")
+
+    window = now - (state["steady_start"] or 0.0)
+
+    def q(v: list, x: float) -> float:
+        return sorted(v)[min(len(v) - 1, max(0, round(x * len(v)) - 1))] if v else float("nan")
+
+    return {
+        "ttft_steady_mean": sum(ttfts) / len(ttfts) if ttfts else float("nan"),
+        "ttft_steady_p50": q(ttfts, 0.5),
+        "ttft_steady_p99": q(ttfts, 0.99),
+        "tpot_mean": sum(tpots) / len(tpots) if tpots else float("nan"),
+        "itl_p50": q(gaps, 0.5),
+        "itl_p99": q(gaps, 0.99),
+        "throughput_rps": state["steady_completions"] / (window / 1000.0) if window > 0 else 0.0,
+    }
+
+
+def refine_closed_loop_latency(df):
+    """Post-process a result DataFrame using only its own columns.
+
+    Agg rows (``ColumnsAgg`` + the recorded step timings) replay the fused
+    pass calendar; disagg rows (``ColumnsDisagg`` with ``(p)prefill_step_ms``)
+    replay the mini tandem. Returns a COPY with additive columns
     ``ttft_refined`` / ``tpot_refined`` / ``throughput_refined`` — existing
-    columns (including the legacy ``ttft``) are untouched, so downstream
-    consumers opt in per column. Rows it cannot price (missing/invalid
-    inputs) keep NaN in the new columns.
+    columns (including the legacy ``ttft``) are untouched, and the three
+    refined columns are jointly consistent (they satisfy the closed-loop
+    identity C/X = TTFT + (osl-1)*TPOT), so consume them as a set. Rows that
+    cannot be priced keep NaN.
     """
     out = df.copy()
     ttfts, tpots, xs = [], [], []
+    disagg = "(p)workers" in out.columns
     for _, row in out.iterrows():
         try:
-            r = estimate_closed_loop_latency(
-                concurrency=int(row["bs"]),
-                isl=int(row["isl"]),
-                osl=int(row["osl"]),
-                prefill_ms=prefill_ms,
-                decode_ms=decode_ms,
-                max_num_batched_tokens=int(row["ctx_tokens"]),
-                prefix=int(row.get("prefix", 0) or 0),
-                turnaround_ms=turnaround_ms,
-                enable_chunked_prefill=enable_chunked_prefill,
-            )
+            if disagg:
+                r = estimate_disagg_closed_loop_latency(
+                    concurrency=int(row["concurrency"]),
+                    isl=int(row["isl"]),
+                    osl=int(row["osl"]),
+                    prefill_workers=int(row["(p)workers"]),
+                    decode_workers=int(row["(d)workers"]),
+                    prefill_step_ms=float(row["(p)prefill_step_ms"]),
+                    decode_step_ms=float(row["tpot"]),
+                    prefill_batch=int(row["(p)bs"]),
+                    decode_max_seqs=int(row["(d)bs"]),
+                )
+            else:
+                chunk_ref = max(1, min(int(row["ctx_tokens"]), int(row["isl"]) - int(row.get("prefix", 0) or 0)))
+                step = float(row["prefill_step_ms"])
+                t_gen = float(row["genonly_step_ms"])
+                r = estimate_closed_loop_latency(
+                    concurrency=int(row["bs"]),
+                    isl=int(row["isl"]),
+                    osl=int(row["osl"]),
+                    # linear-in-tokens reconstruction of the recorded
+                    # per-chunk prefill cost; decode priced at the recorded
+                    # operating-point iteration time
+                    prefill_ms=lambda b, i, p, _s=step, _c=chunk_ref: _s * (b * max(1, i - p)) / _c,
+                    decode_ms=lambda b, c, _g=t_gen: _g,
+                    max_num_batched_tokens=int(row["ctx_tokens"]),
+                    prefix=int(row.get("prefix", 0) or 0),
+                )
+            if not (r["ttft_steady_mean"] == r["ttft_steady_mean"]):  # NaN guard
+                raise ValueError("estimate returned NaN")
             ttfts.append(r["ttft_steady_mean"])
             tpots.append(r["tpot_mean"])
             xs.append(r["throughput_rps"])
-        except (KeyError, ValueError, RuntimeError):
+        except (KeyError, ValueError, TypeError, RuntimeError):
             ttfts.append(float("nan"))
             tpots.append(float("nan"))
             xs.append(float("nan"))

--- a/src/aiconfigurator/sdk/closed_loop_ttft.py
+++ b/src/aiconfigurator/sdk/closed_loop_ttft.py
@@ -54,7 +54,7 @@ def estimate_closed_loop_latency(
     eff_isl = max(1, isl - prefix)
 
     # slot = [remaining_prefill, generated, arrival_ms, first_token_ms,
-    #         last_token_ms, gap_sum, gap_count, gaps_list_or_None]
+    #         last_token_ms, gaps]
     def new_slot(arrival: float) -> list:
         return [eff_isl, 0, arrival, -1.0, -1.0, []]
 

--- a/src/aiconfigurator/sdk/closed_loop_ttft.py
+++ b/src/aiconfigurator/sdk/closed_loop_ttft.py
@@ -311,51 +311,90 @@ def refine_closed_loop_latency(df):
     cannot be priced keep NaN.
     """
     out = df.copy()
-    ttfts, tpots, xs = [], [], []
-    disagg = "(p)workers" in out.columns
-    for _, row in out.iterrows():
-        try:
-            if disagg:
-                r = estimate_disagg_closed_loop_latency(
-                    concurrency=int(row["concurrency"]),
-                    isl=int(row["isl"]),
-                    osl=int(row["osl"]),
-                    prefill_workers=int(row["(p)workers"]),
-                    decode_workers=int(row["(d)workers"]),
-                    prefill_step_ms=float(row["(p)prefill_step_ms"]),
-                    decode_step_ms=float(row["tpot"]),
-                    prefill_batch=int(row["(p)bs"]),
-                    decode_max_seqs=int(row["(d)bs"]),
-                )
-            else:
-                chunk_ref = max(1, min(int(row["ctx_tokens"]), int(row["isl"]) - int(row.get("prefix", 0) or 0)))
-                step = float(row["prefill_step_ms"])
-                t_gen = float(row["genonly_step_ms"])
-                r = estimate_closed_loop_latency(
-                    concurrency=int(row["bs"]),
-                    isl=int(row["isl"]),
-                    osl=int(row["osl"]),
-                    # linear-in-tokens reconstruction of the recorded
-                    # per-chunk prefill cost; decode priced at the recorded
-                    # operating-point iteration time
-                    prefill_ms=lambda b, i, p, _s=step, _c=chunk_ref: _s * (b * max(1, i - p)) / _c,
-                    decode_ms=lambda b, c, _g=t_gen: _g,
-                    max_num_batched_tokens=int(row["ctx_tokens"]),
-                    prefix=int(row.get("prefix", 0) or 0),
-                )
-            if not (r["ttft_steady_mean"] == r["ttft_steady_mean"]):  # NaN guard
-                raise ValueError("estimate returned NaN")
-            ttfts.append(r["ttft_steady_mean"])
-            tpots.append(r["tpot_mean"])
-            xs.append(r["throughput_rps"])
-        except (KeyError, ValueError, TypeError, RuntimeError):
-            ttfts.append(float("nan"))
-            tpots.append(float("nan"))
-            xs.append(float("nan"))
-    out["ttft_refined"] = ttfts
-    out["tpot_refined"] = tpots
-    out["throughput_refined"] = xs
+    priced = [price_closed_loop_row(row) for _, row in out.iterrows()]
+    out["ttft_refined"] = [p[0] for p in priced]
+    out["tpot_refined"] = [p[1] for p in priced]
+    out["throughput_refined"] = [p[2] for p in priced]
     return out
+
+
+def price_closed_loop_row(row):
+    """Price one result row -> ``(ttft_ms, tpot_ms, rps)``.
+
+    ``row`` is any mapping (a summary ``dict`` or a DataFrame row); disagg
+    rows are recognized by the ``(p)workers`` key. Returns a NaN triple when
+    the row cannot be priced. Results are memoized on the pricing inputs —
+    sweeps re-encounter the same operating point once per latency-target
+    pair, and its refined values do not depend on the target.
+    """
+    try:
+        if "(p)workers" in row:
+            key = tuple(
+                row[k]
+                for k in (
+                    "concurrency",
+                    "isl",
+                    "osl",
+                    "(p)workers",
+                    "(d)workers",
+                    "(p)prefill_step_ms",
+                    "tpot",
+                    "(p)bs",
+                    "(d)bs",
+                )
+            )
+        else:
+            key = tuple(row[k] for k in ("bs", "isl", "osl", "ctx_tokens", "prefill_step_ms", "genonly_step_ms")) + (
+                row.get("prefix", 0) or 0,
+            )
+    except (KeyError, TypeError):
+        return float("nan"), float("nan"), float("nan")
+    cached = _PRICE_CACHE.get(key)
+    if cached is None:
+        cached = _price_closed_loop_row_uncached(row)
+        if len(_PRICE_CACHE) < 65536:
+            _PRICE_CACHE[key] = cached
+    return cached
+
+
+_PRICE_CACHE: dict = {}
+
+
+def _price_closed_loop_row_uncached(row):
+    try:
+        if "(p)workers" in row:
+            r = estimate_disagg_closed_loop_latency(
+                concurrency=int(row["concurrency"]),
+                isl=int(row["isl"]),
+                osl=int(row["osl"]),
+                prefill_workers=int(row["(p)workers"]),
+                decode_workers=int(row["(d)workers"]),
+                prefill_step_ms=float(row["(p)prefill_step_ms"]),
+                decode_step_ms=float(row["tpot"]),
+                prefill_batch=int(row["(p)bs"]),
+                decode_max_seqs=int(row["(d)bs"]),
+            )
+        else:
+            chunk_ref = max(1, min(int(row["ctx_tokens"]), int(row["isl"]) - int(row.get("prefix", 0) or 0)))
+            step = float(row["prefill_step_ms"])
+            t_gen = float(row["genonly_step_ms"])
+            r = estimate_closed_loop_latency(
+                concurrency=int(row["bs"]),
+                isl=int(row["isl"]),
+                osl=int(row["osl"]),
+                # linear-in-tokens reconstruction of the recorded
+                # per-chunk prefill cost; decode priced at the recorded
+                # operating-point iteration time
+                prefill_ms=lambda b, i, p, _s=step, _c=chunk_ref: _s * (b * max(1, i - p)) / _c,
+                decode_ms=lambda b, c, _g=t_gen: _g,
+                max_num_batched_tokens=int(row["ctx_tokens"]),
+                prefix=int(row.get("prefix", 0) or 0),
+            )
+        if not (r["ttft_steady_mean"] == r["ttft_steady_mean"]):  # NaN guard
+            raise ValueError("estimate returned NaN")
+        return r["ttft_steady_mean"], r["tpot_mean"], r["throughput_rps"]
+    except (KeyError, ValueError, TypeError, RuntimeError):
+        return float("nan"), float("nan"), float("nan")
 
 
 def filter_closed_loop_sla(df, ttft_ms=None, tpot_ms=None):

--- a/src/aiconfigurator/sdk/closed_loop_ttft.py
+++ b/src/aiconfigurator/sdk/closed_loop_ttft.py
@@ -375,3 +375,43 @@ def filter_closed_loop_sla(df, ttft_ms=None, tpot_ms=None):
     if tpot_ms is not None:
         out = out[~(out["tpot_refined"] > float(tpot_ms))]
     return out
+
+
+# deployment identity: the columns that stay fixed while the concurrency
+# ladder sweeps the operating point
+_AGG_CONFIG_KEYS = ["model", "parallel"]
+_DISAGG_CONFIG_KEYS = [
+    "model",
+    "(p)parallel",
+    "(p)bs",
+    "(p)workers",
+    "(d)parallel",
+    "(d)bs",
+    "(d)workers",
+]
+
+
+def pick_under_closed_loop_sla(df, ttft_ms=None, tpot_ms=None):
+    """Re-pick each deployment's operating point under the refined SLA.
+
+    The pipeline picks operating points before this module runs, so
+    post-filtering an already-picked table can drop a deployment whose
+    lower-concurrency rows were still compliant. Feed this the FULL
+    per-operating-point summary frame instead (sweep with a loose TTFT
+    target so those rows survive): it applies
+    :func:`filter_closed_loop_sla` and keeps each deployment's best
+    surviving row — equivalent to enforcing the SLA at the original
+    filter. Priced rows rank by ``throughput_refined``; rows the refiner
+    cannot price keep their legacy verdict and rank by recorded
+    ``tokens/s``.
+    """
+    out = filter_closed_loop_sla(df, ttft_ms=ttft_ms, tpot_ms=tpot_ms)
+    if out.empty:
+        return out
+    keys = _DISAGG_CONFIG_KEYS if "(p)workers" in out.columns else _AGG_CONFIG_KEYS
+    keys = [k for k in keys if k in out.columns]
+    sort_cols = [c for c in ("throughput_refined", "tokens/s") if c in out.columns]
+    ranked = out.sort_values(sort_cols, ascending=False, na_position="last")
+    if not keys:
+        return ranked
+    return ranked.groupby(keys, dropna=False, sort=False).head(1)

--- a/src/aiconfigurator/sdk/closed_loop_ttft.py
+++ b/src/aiconfigurator/sdk/closed_loop_ttft.py
@@ -224,19 +224,31 @@ def estimate_disagg_closed_loop_latency(
     for _ in range(concurrency):
         dispatch(0.0, 0.0)
 
+    # For osl >= 2 every dispatch comes from a decode completion and events
+    # are processed in non-decreasing time, so each queue is FIFO in visible
+    # time: the earliest entry is [0] and the eligible set is a leading run.
+    # That turns the per-iteration O(C) min-scans (the profile's 78%) into
+    # O(1) lookups with bit-identical results. osl == 1 interleaves prefill
+    # and decode completions inside one event and keeps the full scans.
+    fifo = osl >= 2
+
     now = 0.0
     max_iters = 400 * (target + 1) * osl
     for _ in range(max_iters):
         if state["completions"] >= target:
             break
-        t_p = min(
-            (max(p_free[i], min(r[0] for r in q)) for i, q in enumerate(p_queues) if q),
-            default=float("inf"),
-        )
-        t_d = min(
-            (max(d_free[i], min(r[0] for r in run)) for i, run in enumerate(d_running) if run),
-            default=float("inf"),
-        )
+        if fifo:
+            t_p = min((max(p_free[i], q[0][0]) for i, q in enumerate(p_queues) if q), default=float("inf"))
+            t_d = min((max(d_free[i], run[0][0]) for i, run in enumerate(d_running) if run), default=float("inf"))
+        else:
+            t_p = min(
+                (max(p_free[i], min(r[0] for r in q)) for i, q in enumerate(p_queues) if q),
+                default=float("inf"),
+            )
+            t_d = min(
+                (max(d_free[i], min(r[0] for r in run)) for i, run in enumerate(d_running) if run),
+                default=float("inf"),
+            )
         now = min(t_p, t_d)
         if now == float("inf"):
             raise RuntimeError("tandem stalled — invalid configuration")
@@ -244,13 +256,23 @@ def estimate_disagg_closed_loop_latency(
         for i, q in enumerate(p_queues):  # whole-prompt prefill batches
             if not q or p_free[i] > now:
                 continue
-            batch = [r for r in q if r[0] <= now][:prefill_batch]
+            if fifo:
+                k = 0
+                for r in q:
+                    if r[0] > now or k >= prefill_batch:
+                        break
+                    k += 1
+                batch = q[:k]
+                del q[:k]
+            else:
+                batch = [r for r in q if r[0] <= now][:prefill_batch]
             if not batch:
                 continue
             end = now + prefill_step_ms
             p_free[i] = end
             for r in batch:
-                q.remove(r)
+                if not fifo:
+                    q.remove(r)
                 first = end + handoff_ms  # decode-attach: TTFT includes handoff
                 r[2] = 1
                 r[3] = first
@@ -267,7 +289,15 @@ def estimate_disagg_closed_loop_latency(
         for i, run in enumerate(d_running):  # one token per iteration
             if not run or d_free[i] > now:
                 continue
-            batch = [r for r in run if r[0] <= now][:decode_max_seqs]
+            if fifo:
+                k = 0
+                for r in run:
+                    if r[0] > now or k >= decode_max_seqs:
+                        break
+                    k += 1
+                batch = run[:k]
+            else:
+                batch = [r for r in run if r[0] <= now][:decode_max_seqs]
             if not batch:
                 continue
             end = now + decode_step_ms

--- a/src/aiconfigurator/sdk/inference_session.py
+++ b/src/aiconfigurator/sdk/inference_session.py
@@ -270,6 +270,7 @@ class DisaggInferenceSession:
         Get the disagg summary df based on prefill and decode summary df
         """
         prefill_dict = prefill_summary_df.iloc[0].to_dict()
+        prefill_dict["prefill_step_ms"] = prefill_dict["ttft"]  # raw solo, pre-correction
         prefill_dict["ttft"] = prefill_dict["ttft"] * _AUTOSCALE_TTFT_CORRECTION_FACTOR
         decode_dict = decode_summary_df.iloc[0].to_dict()
 
@@ -729,7 +730,10 @@ class DisaggInferenceSession:
             # correction factor. as we need to get the lc after rate matching, we cannot get the
             # exact value now. Let's make it simple to do pre-correction instead of post-correction.
             correction_factor = _AUTOSCALE_TTFT_CORRECTION_FACTOR
-            prefill_candidates = prefill_summary_df.assign(ttft=prefill_summary_df["ttft"] * correction_factor)
+            prefill_candidates = prefill_summary_df.assign(
+                prefill_step_ms=prefill_summary_df["ttft"],  # raw solo, pre-correction
+                ttft=prefill_summary_df["ttft"] * correction_factor,
+            )
 
             prefill_candidates = prefill_candidates[prefill_candidates["ttft"] < ttft]
             if len(prefill_candidates) == 0:

--- a/src/aiconfigurator/sdk/inference_session.py
+++ b/src/aiconfigurator/sdk/inference_session.py
@@ -270,7 +270,9 @@ class DisaggInferenceSession:
         Get the disagg summary df based on prefill and decode summary df
         """
         prefill_dict = prefill_summary_df.iloc[0].to_dict()
-        prefill_dict["prefill_step_ms"] = prefill_dict["ttft"]  # raw solo, pre-correction
+        prefill_dict["prefill_step_ms"] = prefill_dict["ttft"] - prefill_dict.get(
+            "encoder_latency", 0.0
+        )  # raw solo context, pre-correction
         prefill_dict["ttft"] = prefill_dict["ttft"] * _AUTOSCALE_TTFT_CORRECTION_FACTOR
         decode_dict = decode_summary_df.iloc[0].to_dict()
 
@@ -731,7 +733,8 @@ class DisaggInferenceSession:
             # exact value now. Let's make it simple to do pre-correction instead of post-correction.
             correction_factor = _AUTOSCALE_TTFT_CORRECTION_FACTOR
             prefill_candidates = prefill_summary_df.assign(
-                prefill_step_ms=prefill_summary_df["ttft"],  # raw solo, pre-correction
+                prefill_step_ms=prefill_summary_df["ttft"]
+                - prefill_summary_df.get("encoder_latency", 0.0),  # raw solo context
                 ttft=prefill_summary_df["ttft"] * correction_factor,
             )
 

--- a/src/aiconfigurator/sdk/picking.py
+++ b/src/aiconfigurator/sdk/picking.py
@@ -119,6 +119,7 @@ def _build_disagg_summary_dict(
         "tokens/s/gpu": tokens_s_gpu,
         "tokens/s/user": decode_summary_dict["tokens/s/user"],
         "(p)seq/s/worker": prefill_summary_dict["seq/s"],
+        "(p)prefill_step_ms": prefill_summary_dict.get("prefill_step_ms"),
         "(d)seq/s/worker": decode_summary_dict["seq/s"],
         "num_total_gpus": num_total_gpus,
         "(p)tp": prefill_summary_dict["tp"],
@@ -441,6 +442,7 @@ def pick_autoscale(
 
     # -- Filter prefill candidates by TTFT --
     prefill_candidates = prefill_df.copy()
+    prefill_candidates["prefill_step_ms"] = prefill_candidates["ttft"]  # raw solo, pre-correction
     prefill_candidates["ttft_corrected"] = prefill_candidates["ttft"] * correction_factor
     prefill_meets_sla = prefill_candidates[prefill_candidates["ttft_corrected"] < target_ttft]
 

--- a/src/aiconfigurator/sdk/picking.py
+++ b/src/aiconfigurator/sdk/picking.py
@@ -119,7 +119,14 @@ def _build_disagg_summary_dict(
         "tokens/s/gpu": tokens_s_gpu,
         "tokens/s/user": decode_summary_dict["tokens/s/user"],
         "(p)seq/s/worker": prefill_summary_dict["seq/s"],
-        "(p)prefill_step_ms": prefill_summary_dict.get("prefill_step_ms"),
+        # float when present (keeps the column numeric); None sentinel when
+        # absent — the rate-match parity test compares by equality, which a
+        # NaN default would break. Mirrored in sweep._rate_match_dict.
+        "(p)prefill_step_ms": (
+            float(prefill_summary_dict["prefill_step_ms"])
+            if prefill_summary_dict.get("prefill_step_ms") is not None
+            else None
+        ),
         "(d)seq/s/worker": decode_summary_dict["seq/s"],
         "num_total_gpus": num_total_gpus,
         "(p)tp": prefill_summary_dict["tp"],
@@ -442,7 +449,9 @@ def pick_autoscale(
 
     # -- Filter prefill candidates by TTFT --
     prefill_candidates = prefill_df.copy()
-    prefill_candidates["prefill_step_ms"] = prefill_candidates["ttft"]  # raw solo, pre-correction
+    prefill_candidates["prefill_step_ms"] = prefill_candidates["ttft"] - prefill_candidates.get(
+        "encoder_latency", 0.0
+    )  # raw solo context, pre-correction
     prefill_candidates["ttft_corrected"] = prefill_candidates["ttft"] * correction_factor
     prefill_meets_sla = prefill_candidates[prefill_candidates["ttft_corrected"] < target_ttft]
 

--- a/src/aiconfigurator/sdk/sweep.py
+++ b/src/aiconfigurator/sdk/sweep.py
@@ -41,6 +41,7 @@ import pandas as pd
 from aiconfigurator.sdk import common, config
 from aiconfigurator.sdk.backends.base_backend import BaseBackend
 from aiconfigurator.sdk.backends.factory import get_backend
+from aiconfigurator.sdk.closed_loop_ttft import price_closed_loop_row
 from aiconfigurator.sdk.errors import (
     InsufficientMemoryError,
     KVCacheCapacityError,
@@ -268,6 +269,7 @@ def _sweep_one_parallel_agg(
     max_seq_len: int | None,
     predictor: Any = None,
     speculative_profile: SpeculativeDecodingProfile | None = None,
+    refined_sla: bool = False,
 ) -> tuple[pd.DataFrame, bool, bool]:
     """Sweep batch_size x ctx_tokens for one fixed parallel choice.
 
@@ -351,7 +353,27 @@ def _sweep_one_parallel_agg(
             if model_oom or kv_cache_oom:
                 break  # ctx_tokens monotonic → larger will also OOM
             result_dict = summary.get_result_dict()
-            if result_dict and result_dict["tpot"] <= tpot_target and result_dict["ttft"] <= ttft_target:
+            keep = bool(result_dict) and result_dict["tpot"] <= tpot_target
+            if keep and refined_sla:
+                # the static ttft is NOT a bound on the refined value (deep
+                # saturation moves cycle time from TTFT into TPOT), so gate
+                # on the true lower bound — the solo chunked prefill time —
+                # then enforce the SLA on the refined values. Unpriceable
+                # points (NaN) fall back to the legacy verdict.
+                eff = max(1, isl - int(result_dict.get("prefix", 0) or 0))
+                chunk = max(1, min(int(result_dict["ctx_tokens"]), eff))
+                solo_ms = float(result_dict["prefill_step_ms"]) * -(-eff // chunk)
+                if solo_ms > ttft_target:
+                    keep = False
+                else:
+                    ttft_r, tpot_r, _ = price_closed_loop_row(result_dict)
+                    if ttft_r == ttft_r:  # priced
+                        keep = ttft_r <= ttft_target and tpot_r <= tpot_target
+                    else:
+                        keep = result_dict["ttft"] <= ttft_target
+            elif keep:
+                keep = result_dict["ttft"] <= ttft_target
+            if keep:
                 results_dict_list.append(result_dict)
                 results_per_ops_source.append(summary.get_per_ops_source())
 
@@ -382,6 +404,7 @@ def sweep_agg(
     max_seq_len: int | None = None,
     predictor: Any = None,
     speculative_profile: SpeculativeDecodingProfile | None = None,
+    refined_sla: bool = False,
 ) -> pd.DataFrame:
     """Sweep parallel x batch x ctx_tokens for agg; return feasible-candidate DataFrame.
 
@@ -496,6 +519,7 @@ def sweep_agg(
                     max_seq_len=max_seq_len,
                     predictor=predictor,
                     speculative_profile=speculative_profile,
+                    refined_sla=refined_sla,
                 )
                 saw_model_fit |= point_saw_model_fit
                 saw_memory_fit |= point_saw_memory_fit
@@ -671,6 +695,7 @@ def _find_best_disagg_under_constraint(
     decode_degradation: float,
     match_workers: Any,
     autoscale_ttft_correction_factor: float = _AUTOSCALE_TTFT_CORRECTION_FACTOR,
+    refined_sla: bool = False,
 ) -> pd.DataFrame | None:
     """For one (ttft, tpot) pair, filter + rate-match + pick best per decode parallel.
 
@@ -683,9 +708,15 @@ def _find_best_disagg_under_constraint(
     matches.
     """
 
+    # refined mode gates on the raw solo TTFT only (a necessary condition:
+    # the refined closed-loop TTFT is never below solo), then enforces the
+    # SLA on the refined value of each rate-matched combination below —
+    # applying the fixed factor here would pre-kill combinations the
+    # refined check accepts.
+    gate_factor = 1.0 if refined_sla else autoscale_ttft_correction_factor
     p_corrected = prefill_summary_df.assign(
         prefill_step_ms=prefill_summary_df["ttft"],  # raw solo, pre-correction
-        ttft=prefill_summary_df["ttft"] * autoscale_ttft_correction_factor,
+        ttft=prefill_summary_df["ttft"] * gate_factor,
     )
     p_candidates = p_corrected[p_corrected["ttft"] < ttft_target]
     if len(p_candidates) == 0:
@@ -743,7 +774,21 @@ def _find_best_disagg_under_constraint(
                     decode_degradation=decode_degradation,
                 )
                 category_results.append(disagg_dict)
-        if category_results:
+        if refined_sla and category_results:
+            # walk the category best-first and keep the first combination
+            # whose refined closed-loop values meet the SLA — prices only as
+            # many combos as needed. NaN (unpriceable) keeps legacy verdict.
+            best = None
+            for cand in sorted(category_results, key=lambda x: (x["tokens/s/gpu"], -x["num_total_gpus"]), reverse=True):
+                ttft_r, tpot_r, _ = price_closed_loop_row(cand)
+                if not (ttft_r > ttft_target or tpot_r > tpot_target):
+                    best = cand
+                    break
+            if best is not None:
+                all_category_results.append(best)
+            else:
+                logger.debug("sweep_disagg: no refined-SLA result for decode parallel %s", parallel_value)
+        elif category_results:
             best = max(category_results, key=lambda x: (x["tokens/s/gpu"], -x["num_total_gpus"]))
             all_category_results.append(best)
         else:
@@ -785,6 +830,7 @@ def sweep_disagg(
     rate_matching_prefill_degradation: float | None = None,
     rate_matching_decode_degradation: float | None = None,
     autoscale_ttft_correction_factor: float | None = None,
+    refined_sla: bool = False,
     predictor: Any = None,
     speculative_profile: SpeculativeDecodingProfile | None = None,
     free_gpu_memory_fraction: float | None = None,
@@ -975,6 +1021,7 @@ def sweep_disagg(
             decode_degradation=d_deg,
             match_workers=_match_workers,
             autoscale_ttft_correction_factor=ttft_corr,
+            refined_sla=refined_sla,
         )
         if partial is not None:
             disagg_df = pd.concat([disagg_df, partial], axis=0, ignore_index=True)

--- a/src/aiconfigurator/sdk/sweep.py
+++ b/src/aiconfigurator/sdk/sweep.py
@@ -160,6 +160,7 @@ def _rate_match_dict(
         "tokens/s/gpu": tokens_s_gpu,
         "tokens/s/user": d["tokens/s/user"],
         "(p)seq/s/worker": p["seq/s"],
+        "(p)prefill_step_ms": p.get("prefill_step_ms"),
         "(d)seq/s/worker": d["seq/s"],
         "num_total_gpus": num_total_gpus,
         "(p)tp": p["tp"],
@@ -682,7 +683,10 @@ def _find_best_disagg_under_constraint(
     matches.
     """
 
-    p_corrected = prefill_summary_df.assign(ttft=prefill_summary_df["ttft"] * autoscale_ttft_correction_factor)
+    p_corrected = prefill_summary_df.assign(
+        prefill_step_ms=prefill_summary_df["ttft"],  # raw solo, pre-correction
+        ttft=prefill_summary_df["ttft"] * autoscale_ttft_correction_factor,
+    )
     p_candidates = p_corrected[p_corrected["ttft"] < ttft_target]
     if len(p_candidates) == 0:
         logger.debug("sweep_disagg: no prefill candidates meet ttft<%sms", ttft_target)

--- a/src/aiconfigurator/sdk/sweep.py
+++ b/src/aiconfigurator/sdk/sweep.py
@@ -166,7 +166,8 @@ def _rate_match_dict(
         "tokens/s/gpu": tokens_s_gpu,
         "tokens/s/user": d["tokens/s/user"],
         "(p)seq/s/worker": p["seq/s"],
-        "(p)prefill_step_ms": p.get("prefill_step_ms"),
+        # float-or-None mirrors picking._build_disagg_summary_dict (parity)
+        "(p)prefill_step_ms": (float(p["prefill_step_ms"]) if p.get("prefill_step_ms") is not None else None),
         "(d)seq/s/worker": d["seq/s"],
         "num_total_gpus": num_total_gpus,
         "(p)tp": p["tp"],
@@ -817,7 +818,7 @@ def _find_best_disagg_under_constraint(
     # refined check accepts.
     gate_factor = 1.0 if refined_sla else autoscale_ttft_correction_factor
     p_corrected = prefill_summary_df.assign(
-        prefill_step_ms=prefill_summary_df["ttft"],  # raw solo, pre-correction
+        prefill_step_ms=prefill_summary_df["ttft"] - prefill_summary_df.get("encoder_latency", 0.0),  # raw solo context
         ttft=prefill_summary_df["ttft"] * gate_factor,
     )
     p_candidates = p_corrected[p_corrected["ttft"] < ttft_target]

--- a/src/aiconfigurator/sdk/sweep.py
+++ b/src/aiconfigurator/sdk/sweep.py
@@ -71,6 +71,10 @@ _DECODE_FILTER_RATIO_MAX = 1.0
 _MAX_DECODE_WORKERS_PER_CATEGORY = 16
 _MAX_PREFILL_WORKERS = 32
 
+# refined-SLA mode: how many top combos per decode-parallel category get the
+# concurrency knee search (each search is ~10 tandem pricings).
+_REFINED_KNEE_TOP_K = 3
+
 # Default decode batch-size schedule for disagg worker enumeration.
 _DEFAULT_DECODE_BATCH_SCHEDULE: list[int] = (
     list(range(1, 16, 1)) + list(range(16, 32, 2)) + list(range(32, 128, 4)) + list(range(128, 512, 8)) + [512]
@@ -678,6 +682,67 @@ def _get_disagg_worker_candidates(
     return pd.concat(result_rows, axis=0, ignore_index=True)
 
 
+def _refined_tune_combo(cand: dict, ttft_target: float, tpot_target: float) -> dict | None:
+    """Knee-tune one rate-matched combo under the refined closed-loop SLA.
+
+    Searches the largest concurrency <= the inherited one whose refined
+    TTFT/TPOT meet the targets, then reprices the row's latency/throughput
+    columns from the tandem estimate at that point. The inherited
+    concurrency is the decode ladder's memory-validated operating point, so
+    the search never exceeds it (decode steps are priced at that point's
+    batch — conservative below it); pushing beyond it is represented by the
+    ladder's next rung, which is its own combo. Returns ``None`` when no
+    concurrency complies and the combo unchanged when it cannot be priced
+    (legacy verdict, fail-open).
+    """
+    c_inh = int(cand["concurrency"])
+
+    def priced(c: int):
+        t, p, x = price_closed_loop_row(dict(cand, concurrency=c))
+        return (t, p, x) if t == t else None
+
+    def ok(tpx) -> bool:
+        return tpx is not None and tpx[0] <= ttft_target and tpx[1] <= tpot_target
+
+    at_inh = priced(c_inh)
+    if at_inh is None:
+        return dict(cand)  # unpriceable — keep the legacy verdict
+    if ok(at_inh):
+        best_c, best = c_inh, at_inh
+    else:
+        best_c, best = None, None
+        lo, hi = 1, c_inh  # hi is known non-compliant
+        while lo < hi:
+            mid = (lo + hi) // 2
+            tpx = priced(mid)
+            if ok(tpx):
+                best_c, best = mid, tpx
+                lo = mid + 1
+            else:
+                hi = mid
+        if best_c is None:
+            return None
+    ttft_r, tpot_r, x_r = best
+    gpus = cand.get("num_total_gpus") or 0
+    osl = cand["osl"]
+    out = dict(cand)
+    out.update(
+        {
+            "concurrency": best_c,
+            "ttft": ttft_r,
+            "tpot": tpot_r,
+            "request_latency": ttft_r + tpot_r * max(osl - 1, 0),
+            "request_rate": x_r,
+            "seq/s": x_r,
+            "seq/s/gpu": x_r / gpus if gpus else 0.0,
+            "tokens/s": x_r * osl,
+            "tokens/s/gpu": x_r * osl / gpus if gpus else 0.0,
+            "tokens/s/user": 1000.0 / tpot_r if tpot_r > 0 else 0.0,
+        }
+    )
+    return out
+
+
 def _find_best_disagg_under_constraint(
     *,
     ttft_target: float,
@@ -775,15 +840,22 @@ def _find_best_disagg_under_constraint(
                 )
                 category_results.append(disagg_dict)
         if refined_sla and category_results:
-            # walk the category best-first and keep the first combination
-            # whose refined closed-loop values meet the SLA — prices only as
-            # many combos as needed. NaN (unpriceable) keeps legacy verdict.
-            best = None
-            for cand in sorted(category_results, key=lambda x: (x["tokens/s/gpu"], -x["num_total_gpus"]), reverse=True):
-                ttft_r, tpot_r, _ = price_closed_loop_row(cand)
-                if not (ttft_r > ttft_target or tpot_r > tpot_target):
-                    best = cand
-                    break
+            # knee-tune the top combos of the category (max compliant
+            # concurrency + tandem repricing), keep the best; fall back to a
+            # best-first accept/reject walk over the rest if none complies.
+            ranked = sorted(category_results, key=lambda x: (x["tokens/s/gpu"], -x["num_total_gpus"]), reverse=True)
+            tuned = []
+            for cand in ranked[:_REFINED_KNEE_TOP_K]:
+                t = _refined_tune_combo(cand, ttft_target, tpot_target)
+                if t is not None:
+                    tuned.append(t)
+            best = max(tuned, key=lambda x: (x["tokens/s/gpu"], -x["num_total_gpus"])) if tuned else None
+            if best is None:
+                for cand in ranked[_REFINED_KNEE_TOP_K:]:
+                    ttft_r, tpot_r, _ = price_closed_loop_row(cand)
+                    if not (ttft_r > ttft_target or tpot_r > tpot_target):
+                        best = cand
+                        break
             if best is not None:
                 all_category_results.append(best)
             else:

--- a/src/aiconfigurator/sdk/sweep.py
+++ b/src/aiconfigurator/sdk/sweep.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import dataclasses
 import functools
+import itertools
 import logging
 from typing import Any
 
@@ -682,7 +683,25 @@ def _get_disagg_worker_candidates(
     return pd.concat(result_rows, axis=0, ignore_index=True)
 
 
-def _refined_tune_combo(cand: dict, ttft_target: float, tpot_target: float) -> dict | None:
+def _decode_step_from_ladder(ladder: list[tuple[float, float]], n_d: float, default: float) -> float:
+    """Interpolate the decode step (ms) at per-worker occupancy ``n_d`` from
+    the decode ladder's (concurrency, tpot) rungs; clamped at the ends."""
+    if not ladder:
+        return default
+    if n_d <= ladder[0][0]:
+        return ladder[0][1]
+    for (b0, t0), (b1, t1) in itertools.pairwise(ladder):
+        if n_d <= b1:
+            return t0 + (t1 - t0) * (n_d - b0) / (b1 - b0) if b1 > b0 else t1
+    return ladder[-1][1]
+
+
+def _refined_tune_combo(
+    cand: dict,
+    ttft_target: float,
+    tpot_target: float,
+    ladder: list[tuple[float, float]] | None = None,
+) -> dict | None:
     """Knee-tune one rate-matched combo under the refined closed-loop SLA.
 
     Searches the largest concurrency <= the inherited one whose refined
@@ -696,10 +715,28 @@ def _refined_tune_combo(cand: dict, ttft_target: float, tpot_target: float) -> d
     (legacy verdict, fail-open).
     """
     c_inh = int(cand["concurrency"])
+    osl = cand["osl"]
+    d_workers = max(1, int(cand.get("(d)workers", 1) or 1))
 
     def priced(c: int):
-        t, p, x = price_closed_loop_row(dict(cand, concurrency=c))
-        return (t, p, x) if t == t else None
+        # occupancy-consistent decode step: the row's tpot is priced at its
+        # ladder point's batch, but the tandem's actual decode occupancy at
+        # concurrency c can sit well below it (Little: n_d = X*osl*step) —
+        # iterate step lookup on the decode ladder to the fixed point.
+        # Real-metal arbitration measured the scalar variant off by ~29% on
+        # TPOT at the knee, with cycle conservation pushing it into TTFT.
+        step = float(cand["tpot"])
+        t = p = x = float("nan")
+        for _ in range(3):
+            t, p, x = price_closed_loop_row(dict(cand, concurrency=c, tpot=step))
+            if t != t:
+                return None
+            n_d = x * osl * step / 1000.0 / d_workers
+            new_step = _decode_step_from_ladder(ladder, n_d, step) if ladder else step
+            if abs(new_step - step) < 0.3:
+                break
+            step = new_step
+        return (t, p, x)
 
     def ok(tpx) -> bool:
         return tpx is not None and tpx[0] <= ttft_target and tpx[1] <= tpot_target
@@ -811,6 +848,11 @@ def _find_best_disagg_under_constraint(
             .head(_MAX_DECODE_WORKERS_PER_CATEGORY)
         )
         decode_records = group_sorted.to_dict("records")
+        # per-worker (concurrency, tpot) rungs for occupancy-consistent
+        # decode-step lookup in the refined knee search
+        ladder = sorted(
+            zip(parallel_group["concurrency"].astype(float), parallel_group["tpot"].astype(float), strict=True)
+        )
         category_results: list[dict] = []
         for d_worker in decode_records:
             d_throughput = float(d_worker["seq/s"])
@@ -846,7 +888,7 @@ def _find_best_disagg_under_constraint(
             ranked = sorted(category_results, key=lambda x: (x["tokens/s/gpu"], -x["num_total_gpus"]), reverse=True)
             tuned = []
             for cand in ranked[:_REFINED_KNEE_TOP_K]:
-                t = _refined_tune_combo(cand, ttft_target, tpot_target)
+                t = _refined_tune_combo(cand, ttft_target, tpot_target, ladder=ladder)
                 if t is not None:
                     tuned.append(t)
             best = max(tuned, key=lambda x: (x["tokens/s/gpu"], -x["num_total_gpus"])) if tuned else None

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -2236,6 +2236,10 @@ class Task:
         result = summary.get_result_dict()
         if result is None:
             raise RuntimeError("run_single_agg produced no result; configuration may be invalid.")
+        if self.refined_sla:
+            from aiconfigurator.sdk.closed_loop_ttft import reprice_closed_loop_row
+
+            result = reprice_closed_loop_row(result)
         return result
 
     def run_single_disagg(
@@ -2347,7 +2351,15 @@ class Task:
         # --- Rate-match the pair ---
         p_dict = p_summary.get_summary_df().iloc[0].to_dict()
         d_dict = d_summary.get_summary_df().iloc[0].to_dict()
-        return _rate_match_dict(p_dict, prefill_num_workers, d_dict, decode_num_workers)
+        # raw solo context latency, so the row is self-contained for the
+        # closed-loop refinement tier (mirrors the sweep-side stash sites)
+        p_dict["prefill_step_ms"] = p_dict["ttft"] - p_dict.get("encoder_latency", 0.0)
+        row = _rate_match_dict(p_dict, prefill_num_workers, d_dict, decode_num_workers)
+        if self.refined_sla:
+            from aiconfigurator.sdk.closed_loop_ttft import reprice_closed_loop_row
+
+            row = reprice_closed_loop_row(row)
+        return row
 
     def _run_afd_single_point(self, database):
         """Run a single pinned-topology AFD estimate via AFDInferenceSession."""

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -587,6 +587,12 @@ class Task:
     # ``picking.pick_autoscale``; default 1.8 locked by parity test.
     autoscale_ttft_correction_factor: float = 1.8
 
+    # Enforce the TTFT/TPOT targets on the refined steady closed-loop values
+    # (sdk/closed_loop_ttft) instead of the fixed-factor-corrected ones:
+    # candidate operating points are re-priced by the pass-calendar
+    # estimators during the sweep. Default off (legacy behavior unchanged).
+    refined_sla: bool = False
+
     # ====== 8.5 Predictor strategy ======
     # Optional Predictor that decides how each single config point is
     # predicted.  None (default) uses sdk.predictor.AnalyticPredictor --
@@ -1955,6 +1961,7 @@ class Task:
             "enable_chunked_prefill": self.enable_chunked_prefill,
             "free_gpu_memory_fraction": self.free_gpu_memory_fraction,
             "max_seq_len": self.max_seq_len,
+            "refined_sla": self.refined_sla,
         }
 
     def sweep_disagg_kwargs(self, *, prefill_database, decode_database) -> dict[str, Any]:
@@ -2008,6 +2015,7 @@ class Task:
             "rate_matching_decode_degradation": self.rate_match_decode_degradation,
             "autoscale_ttft_correction_factor": self.autoscale_ttft_correction_factor,
             "require_same_tp": require_same_tp,
+            "refined_sla": self.refined_sla,
         }
 
     def sweep_afd_kwargs(self, *, database) -> dict[str, Any]:

--- a/tests/unit/sdk/test_closed_loop_ttft.py
+++ b/tests/unit/sdk/test_closed_loop_ttft.py
@@ -9,6 +9,7 @@ from aiconfigurator.sdk.closed_loop_ttft import (
     estimate_closed_loop_latency,
     estimate_disagg_closed_loop_latency,
     filter_closed_loop_sla,
+    pick_under_closed_loop_sla,
     refine_closed_loop_latency,
 )
 
@@ -154,6 +155,41 @@ class TestRefineDataFrame:
         assert loose["ttft"].tolist() == [123.0, 456.0]
         assert "ttft_refined" in loose.columns  # returns the refined copy
         assert "ttft_refined" not in df.columns  # input untouched
+
+    def test_repick_recovers_lower_concurrency_point(self):
+        step = prefill_ms(1, 2048, 0)
+        ladder = []
+        for bs in (2, 16):  # same deployment, two operating points
+            ladder.append(
+                {
+                    "model": "m",
+                    "parallel": "tp4",
+                    "bs": bs,
+                    "isl": 2048,
+                    "osl": 32,
+                    "ctx_tokens": 8192,
+                    "prefix": 0,
+                    "ttft": 100.0,
+                    "tokens/s": 100.0 * bs,
+                    "prefill_step_ms": step,
+                    "genonly_step_ms": 5.0,
+                    "mix_step_ms": step + 5.0,
+                    "num_mix_steps": 1,
+                    "num_genonly_steps": 31,
+                }
+            )
+        df = pd.DataFrame(ladder)
+        refined = refine_closed_loop_latency(df)["ttft_refined"]
+        assert refined.iloc[1] > refined.iloc[0]  # deeper point queues more
+        target = (refined.iloc[0] + refined.iloc[1]) / 2.0
+
+        # naive post-filter of the PICKED row (the bs=16 one) yields nothing
+        picked = df.iloc[[1]]
+        assert filter_closed_loop_sla(picked, ttft_ms=target).empty
+        # re-pick over the full ladder recovers the compliant bs=2 row
+        best = pick_under_closed_loop_sla(df, ttft_ms=target)
+        assert best["bs"].tolist() == [2]
+        assert best["ttft_refined"].iloc[0] <= target
 
     def test_disagg_rows_use_tandem(self):
         df = pd.DataFrame(

--- a/tests/unit/sdk/test_closed_loop_ttft.py
+++ b/tests/unit/sdk/test_closed_loop_ttft.py
@@ -11,6 +11,7 @@ from aiconfigurator.sdk.closed_loop_ttft import (
     filter_closed_loop_sla,
     pick_under_closed_loop_sla,
     refine_closed_loop_latency,
+    reprice_closed_loop_row,
 )
 
 pytestmark = pytest.mark.unit
@@ -190,6 +191,37 @@ class TestRefineDataFrame:
         best = pick_under_closed_loop_sla(df, ttft_ms=target)
         assert best["bs"].tolist() == [2]
         assert best["ttft_refined"].iloc[0] <= target
+
+    def test_reprice_row_overwrites_headline_consistently(self):
+        row = {
+            "concurrency": 8,
+            "isl": 4096,
+            "osl": 64,
+            "(p)workers": 1,
+            "(d)workers": 1,
+            "(p)bs": 1,
+            "(d)bs": 64,
+            "(p)prefill_step_ms": 2000.0,
+            "tpot": 21.0,
+            "ttft": 3600.0,  # legacy 1.8-style value
+            "request_latency": 0.0,
+            "num_total_gpus": 2,
+            "seq/s": 0.4,
+            "tokens/s": 25.6,
+            "tokens/s/gpu": 12.8,
+            "tokens/s/user": 47.6,
+            "request_rate": 0.4,
+        }
+        out = reprice_closed_loop_row(row)
+        assert out["ttft"] != 3600.0 and out["ttft"] > 2000.0  # tandem value
+        assert out["request_latency"] == pytest.approx(out["ttft"] + 63 * out["tpot"])
+        assert out["tokens/s"] == pytest.approx(out["seq/s"] * 64)
+        assert out["tokens/s/gpu"] == pytest.approx(out["tokens/s"] / 2)
+        assert row["ttft"] == 3600.0  # input untouched
+        # unpriceable rows pass through unchanged
+        broken = dict(row)
+        broken.pop("(p)prefill_step_ms")
+        assert reprice_closed_loop_row(broken)["ttft"] == 3600.0
 
     def test_knee_search_finds_max_compliant_concurrency(self):
         from aiconfigurator.sdk.sweep import _refined_tune_combo

--- a/tests/unit/sdk/test_closed_loop_ttft.py
+++ b/tests/unit/sdk/test_closed_loop_ttft.py
@@ -191,6 +191,43 @@ class TestRefineDataFrame:
         assert best["bs"].tolist() == [2]
         assert best["ttft_refined"].iloc[0] <= target
 
+    def test_knee_search_finds_max_compliant_concurrency(self):
+        from aiconfigurator.sdk.sweep import _refined_tune_combo
+
+        cand = {
+            "concurrency": 64,
+            "isl": 4096,
+            "osl": 64,
+            "(p)workers": 1,
+            "(d)workers": 1,
+            "(p)bs": 1,
+            "(d)bs": 64,
+            "(p)prefill_step_ms": 2000.0,
+            "tpot": 21.0,
+            "ttft": 2000.0,
+            "num_total_gpus": 2,
+            "request_rate": 0.0,
+            "seq/s": 0.4,
+            "seq/s/gpu": 0.2,
+            "tokens/s": 25.6,
+            "tokens/s/gpu": 12.8,
+            "tokens/s/user": 47.6,
+            "request_latency": 0.0,
+        }
+        # deep queue at the inherited point: TTFT far above target
+        target = 6000.0
+        assert refine_closed_loop_latency(pd.DataFrame([cand]))["ttft_refined"].iloc[0] > target
+        tuned = _refined_tune_combo(cand, ttft_target=target, tpot_target=30.0)
+        assert tuned is not None and tuned["concurrency"] < 64
+        assert tuned["ttft"] <= target  # knee point complies...
+        again = dict(tuned, concurrency=tuned["concurrency"] + 1)
+        assert refine_closed_loop_latency(pd.DataFrame([again]))["ttft_refined"].iloc[0] > target  # ...maximally
+        # throughput columns repriced consistently from the tandem
+        assert tuned["tokens/s"] == pytest.approx(tuned["seq/s"] * 64, rel=1e-6)
+        assert tuned["tokens/s/gpu"] == pytest.approx(tuned["tokens/s"] / 2, rel=1e-6)
+        # an impossible target yields None
+        assert _refined_tune_combo(cand, ttft_target=1.0, tpot_target=30.0) is None
+
     def test_disagg_rows_use_tandem(self):
         df = pd.DataFrame(
             [

--- a/tests/unit/sdk/test_closed_loop_ttft.py
+++ b/tests/unit/sdk/test_closed_loop_ttft.py
@@ -1,11 +1,15 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Minimal closed-loop pass-calendar estimator (post-processing tier)."""
+"""Minimal closed-loop pass-calendar estimators (post-processing tier)."""
 
 import pandas as pd
 import pytest
 
-from aiconfigurator.sdk.closed_loop_ttft import estimate_closed_loop_latency, refine_closed_loop_ttft
+from aiconfigurator.sdk.closed_loop_ttft import (
+    estimate_closed_loop_latency,
+    estimate_disagg_closed_loop_latency,
+    refine_closed_loop_latency,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -18,15 +22,14 @@ def decode_ms(b, ctx):
     return max(1.0, 2.0 + 0.05 * b + 0.001 * ctx)
 
 
-class TestEstimateClosedLoopLatency:
+class TestAggEstimator:
     def test_c1_ttft_is_one_own_prefill(self):
         r = estimate_closed_loop_latency(1, 2048, 16, prefill_ms, decode_ms)
         assert r["ttft_steady_mean"] == pytest.approx(prefill_ms(1, 2048, 0))
 
     def test_littles_law_identity_holds(self):
-        # C/X == TTFT + (osl-1)*TPOT: the recursion satisfies the
-        # closed-loop accounting identity by construction (the turnaround
-        # wait is part of TTFT — measured from the dispatch instant)
+        # C/X == TTFT + (osl-1)*TPOT: outputs are one consistent timeline
+        # (the turnaround wait is part of TTFT, measured from dispatch)
         r = estimate_closed_loop_latency(8, 2048, 64, prefill_ms, decode_ms, turnaround_ms=15.0)
         cycle = 8 / r["throughput_rps"] * 1000.0
         assert cycle == pytest.approx(r["ttft_steady_mean"] + 63 * r["tpot_mean"], rel=0.02)
@@ -54,16 +57,94 @@ class TestEstimateClosedLoopLatency:
             estimate_closed_loop_latency(1, 128, 8, prefill_ms, decode_ms, prefix=128)
 
 
+class TestDisaggTandemEstimator:
+    def test_c1_ttft_is_prefill_plus_handoff(self):
+        r = estimate_disagg_closed_loop_latency(1, 4096, 8, 1, 1, 2000.0, 21.0, handoff_ms=5.0)
+        assert r["ttft_steady_mean"] == pytest.approx(2005.0)
+
+    def test_prefill_bound_imbalance_lands_in_ttft_not_tpot(self):
+        # D-surplus regime: deeper closed loop piles prefill queueing into
+        # TTFT while decode-side TPOT stays put (the disagg signature)
+        shallow = estimate_disagg_closed_loop_latency(2, 4096, 256, 1, 1, 2000.0, 21.0, decode_max_seqs=64)
+        deep = estimate_disagg_closed_loop_latency(16, 4096, 256, 1, 1, 2000.0, 21.0, decode_max_seqs=64)
+        assert deep["ttft_steady_mean"] > shallow["ttft_steady_mean"] * 4
+        assert deep["tpot_mean"] == pytest.approx(shallow["tpot_mean"], rel=0.05)
+
+    def test_decode_bound_imbalance_lands_in_tpot_not_ttft(self):
+        # P-surplus regime: decode slots saturate; TPOT inflates, TTFT holds
+        ok = estimate_disagg_closed_loop_latency(4, 1024, 256, 2, 1, 500.0, 21.0, decode_max_seqs=4)
+        sat = estimate_disagg_closed_loop_latency(12, 1024, 256, 2, 1, 500.0, 21.0, decode_max_seqs=4)
+        assert sat["tpot_mean"] > ok["tpot_mean"] * 2
+        assert sat["ttft_steady_mean"] < ok["ttft_steady_mean"] * 3
+
+    def test_adding_prefill_worker_relieves_ttft(self):
+        one = estimate_disagg_closed_loop_latency(8, 4096, 256, 1, 1, 2000.0, 21.0)
+        two = estimate_disagg_closed_loop_latency(8, 4096, 256, 2, 1, 2000.0, 21.0)
+        assert two["ttft_steady_mean"] < one["ttft_steady_mean"]
+
+    def test_rejects_invalid(self):
+        with pytest.raises(ValueError):
+            estimate_disagg_closed_loop_latency(1, 128, 8, 0, 1, 100.0, 10.0)
+
+
 class TestRefineDataFrame:
-    def test_additive_columns_and_bad_rows_nan(self):
+    def test_agg_rows_additive_columns_and_bad_rows_nan(self):
+        step = prefill_ms(1, 2048, 0)
         df = pd.DataFrame(
             [
-                {"bs": 4, "isl": 2048, "osl": 32, "ctx_tokens": 8192, "prefix": 0, "ttft": 123.0},
-                {"bs": 0, "isl": 2048, "osl": 32, "ctx_tokens": 8192, "prefix": 0, "ttft": 456.0},
+                {
+                    "bs": 4,
+                    "isl": 2048,
+                    "osl": 32,
+                    "ctx_tokens": 8192,
+                    "prefix": 0,
+                    "ttft": 123.0,
+                    "prefill_step_ms": step,
+                    "genonly_step_ms": 5.0,
+                    "mix_step_ms": step + 5.0,
+                    "num_mix_steps": 1,
+                    "num_genonly_steps": 31,
+                },
+                {
+                    "bs": 0,
+                    "isl": 2048,
+                    "osl": 32,
+                    "ctx_tokens": 8192,
+                    "prefix": 0,
+                    "ttft": 456.0,
+                    "prefill_step_ms": step,
+                    "genonly_step_ms": 5.0,
+                    "mix_step_ms": step + 5.0,
+                    "num_mix_steps": 1,
+                    "num_genonly_steps": 31,
+                },
             ]
         )
-        out = refine_closed_loop_ttft(df, prefill_ms, decode_ms)
-        assert list(df.columns) == ["bs", "isl", "osl", "ctx_tokens", "prefix", "ttft"]  # input untouched
-        assert out["ttft"].tolist() == [123.0, 456.0]  # legacy column preserved
+        out = refine_closed_loop_latency(df)
+        assert out["ttft"].tolist() == [123.0, 456.0]  # legacy untouched
         assert out["ttft_refined"].iloc[0] > 0
-        assert pd.isna(out["ttft_refined"].iloc[1])  # invalid row -> NaN, no raise
+        assert pd.isna(out["ttft_refined"].iloc[1])  # invalid row -> NaN
+        # refined triple is jointly consistent (closed-loop identity)
+        cycle = 4 / out["throughput_refined"].iloc[0] * 1000.0
+        assert cycle == pytest.approx(out["ttft_refined"].iloc[0] + 31 * out["tpot_refined"].iloc[0], rel=0.02)
+
+    def test_disagg_rows_use_tandem(self):
+        df = pd.DataFrame(
+            [
+                {
+                    "concurrency": 8,
+                    "isl": 4096,
+                    "osl": 64,
+                    "(p)workers": 1,
+                    "(d)workers": 1,
+                    "(p)bs": 1,
+                    "(d)bs": 64,
+                    "(p)prefill_step_ms": 2000.0,
+                    "tpot": 21.0,
+                    "ttft": 3600.0,
+                }
+            ]
+        )
+        out = refine_closed_loop_latency(df)
+        assert out["ttft_refined"].iloc[0] > 2000.0  # queueing beyond solo
+        assert out["tpot_refined"].iloc[0] == pytest.approx(21.0, rel=0.05)

--- a/tests/unit/sdk/test_closed_loop_ttft.py
+++ b/tests/unit/sdk/test_closed_loop_ttft.py
@@ -8,6 +8,7 @@ import pytest
 from aiconfigurator.sdk.closed_loop_ttft import (
     estimate_closed_loop_latency,
     estimate_disagg_closed_loop_latency,
+    filter_closed_loop_sla,
     refine_closed_loop_latency,
 )
 
@@ -127,6 +128,32 @@ class TestRefineDataFrame:
         # refined triple is jointly consistent (closed-loop identity)
         cycle = 4 / out["throughput_refined"].iloc[0] * 1000.0
         assert cycle == pytest.approx(out["ttft_refined"].iloc[0] + 31 * out["tpot_refined"].iloc[0], rel=0.02)
+
+    def test_sla_post_filter_drops_on_refined_keeps_nan(self):
+        step = prefill_ms(1, 2048, 0)
+        row = {
+            "bs": 4,
+            "isl": 2048,
+            "osl": 32,
+            "ctx_tokens": 8192,
+            "prefix": 0,
+            "ttft": 123.0,
+            "prefill_step_ms": step,
+            "genonly_step_ms": 5.0,
+            "mix_step_ms": step + 5.0,
+            "num_mix_steps": 1,
+            "num_genonly_steps": 31,
+        }
+        bad = dict(row, bs=0, ttft=456.0)  # unpriceable -> refined NaN
+        df = pd.DataFrame([row, bad])
+        refined = refine_closed_loop_latency(df)["ttft_refined"].iloc[0]
+
+        tight = filter_closed_loop_sla(df, ttft_ms=refined - 1.0)
+        assert tight["ttft"].tolist() == [456.0]  # violator dropped, NaN row kept
+        loose = filter_closed_loop_sla(df, ttft_ms=refined + 1.0, tpot_ms=1e9)
+        assert loose["ttft"].tolist() == [123.0, 456.0]
+        assert "ttft_refined" in loose.columns  # returns the refined copy
+        assert "ttft_refined" not in df.columns  # input untouched
 
     def test_disagg_rows_use_tandem(self):
         df = pd.DataFrame(

--- a/tests/unit/sdk/test_closed_loop_ttft.py
+++ b/tests/unit/sdk/test_closed_loop_ttft.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Minimal closed-loop pass-calendar estimator (post-processing tier)."""
+
+import pandas as pd
+import pytest
+
+from aiconfigurator.sdk.closed_loop_ttft import estimate_closed_loop_latency, refine_closed_loop_ttft
+
+pytestmark = pytest.mark.unit
+
+
+def prefill_ms(b, mean_isl, mean_prefix):
+    return 10.0 + 0.02 * b * max(0, mean_isl - mean_prefix)
+
+
+def decode_ms(b, ctx):
+    return max(1.0, 2.0 + 0.05 * b + 0.001 * ctx)
+
+
+class TestEstimateClosedLoopLatency:
+    def test_c1_ttft_is_one_own_prefill(self):
+        r = estimate_closed_loop_latency(1, 2048, 16, prefill_ms, decode_ms)
+        assert r["ttft_steady_mean"] == pytest.approx(prefill_ms(1, 2048, 0))
+
+    def test_littles_law_identity_holds(self):
+        # C/X == TTFT + (osl-1)*TPOT: the recursion satisfies the
+        # closed-loop accounting identity by construction (the turnaround
+        # wait is part of TTFT — measured from the dispatch instant)
+        r = estimate_closed_loop_latency(8, 2048, 64, prefill_ms, decode_ms, turnaround_ms=15.0)
+        cycle = 8 / r["throughput_rps"] * 1000.0
+        assert cycle == pytest.approx(r["ttft_steady_mean"] + 63 * r["tpot_mean"], rel=0.02)
+
+    def test_queueing_grows_with_concurrency(self):
+        t = [estimate_closed_loop_latency(c, 4096, 64, prefill_ms, decode_ms)["ttft_steady_mean"] for c in (1, 4, 16)]
+        assert t[0] < t[1] < t[2]
+
+    def test_prefix_reduces_ttft(self):
+        cold = estimate_closed_loop_latency(4, 4096, 32, prefill_ms, decode_ms)
+        warm = estimate_closed_loop_latency(4, 4096, 32, prefill_ms, decode_ms, prefix=3072)
+        assert warm["ttft_steady_mean"] < cold["ttft_steady_mean"]
+
+    def test_chunked_off_admits_whole_prompts_only(self):
+        on = estimate_closed_loop_latency(8, 6000, 16, prefill_ms, decode_ms, max_num_batched_tokens=8192)
+        off = estimate_closed_loop_latency(
+            8, 6000, 16, prefill_ms, decode_ms, max_num_batched_tokens=8192, enable_chunked_prefill=False
+        )
+        assert on["ttft_steady_mean"] != off["ttft_steady_mean"]
+
+    def test_rejects_invalid(self):
+        with pytest.raises(ValueError):
+            estimate_closed_loop_latency(0, 128, 8, prefill_ms, decode_ms)
+        with pytest.raises(ValueError):
+            estimate_closed_loop_latency(1, 128, 8, prefill_ms, decode_ms, prefix=128)
+
+
+class TestRefineDataFrame:
+    def test_additive_columns_and_bad_rows_nan(self):
+        df = pd.DataFrame(
+            [
+                {"bs": 4, "isl": 2048, "osl": 32, "ctx_tokens": 8192, "prefix": 0, "ttft": 123.0},
+                {"bs": 0, "isl": 2048, "osl": 32, "ctx_tokens": 8192, "prefix": 0, "ttft": 456.0},
+            ]
+        )
+        out = refine_closed_loop_ttft(df, prefill_ms, decode_ms)
+        assert list(df.columns) == ["bs", "isl", "osl", "ctx_tokens", "prefix", "ttft"]  # input untouched
+        assert out["ttft"].tolist() == [123.0, 456.0]  # legacy column preserved
+        assert out["ttft_refined"].iloc[0] > 0
+        assert pd.isna(out["ttft_refined"].iloc[1])  # invalid row -> NaN, no raise


### PR DESCRIPTION
## What

Three pieces; default results unchanged (the third is opt-in):

**1. Result rows become self-contained.** `run_agg` records the operating-point step timings it already computes into the summary row (`ColumnsAgg`: `mix_step_ms`, `genonly_step_ms`, `prefill_step_ms`, `num_mix_steps`, `num_genonly_steps`). Disagg rows record `(p)prefill_step_ms` — the raw solo context latency of one prefill worker, captured *before* the autoscale TTFT pre-correction.

**2. A post-processing refinement tier** (`sdk/closed_loop_ttft.py`):

```python
out = refine_closed_loop_latency(df)   # df in, df out — consumes only the row's own columns
# adds ttft_refined / tpot_refined / throughput_refined; legacy columns untouched
```

Under the hood: a deterministic replay of the scheduler's own budget arithmetic at pass granularity — the fused continuous-batching calendar for agg rows, the P/D tandem (round-robin router, whole-prompt prefill batches, decode-attach handoff) for disagg rows. No RNG, no fitted constants, ~ms per row. The three refined columns are one consistent timeline (they satisfy the closed-loop identity `C/X = TTFT + (osl−1)·TPOT`), so consume them as a set.

**3. Opt-in refined-SLA enforcement in the sweep** (`Task(refined_sla=True)`, default off): `sweep_agg`/`sweep_disagg` compare the TTFT/TPOT targets against the refined steady closed-loop values instead of the fixed-factor-corrected ones. Agg candidate points gate on the solo chunked-prefill lower bound and are then priced; disagg drops the 1.8 prefill gate to the solo bound (a true necessary condition) and knee-tunes the top rate-matched combinations per decode-parallel category — a binary search for the largest compliant concurrency (never above the decode ladder's memory-validated point), with the decode step iterated to its occupancy-consistent value on the decode ladder (Little's law fixed point). Priced rows are repriced from the tandem, retiring the flat rate-match derate for refined rows. Post-processing helpers `filter_closed_loop_sla` / `pick_under_closed_loop_sla` cover the same semantics outside the pipeline. Pricing is memoized; overhead on an 8-GPU Qwen3-32B sweep: agg +~2s, disagg ~2min.

## Usage & cost

**Default: everything off.** Without touching anything, the only change is bookkeeping — result rows carry the extra step-timing columns; sweep results, SLA filtering, picking and runtimes are byte-identical to main (locked by the parity/unit suites).

**Tier 1 — post-processing (call it when you want it):**

```python
out  = refine_closed_loop_latency(df)                    # adds *_refined columns
ok   = filter_closed_loop_sla(df, ttft_ms=500)           # post-filter on refined values
best = pick_under_closed_loop_sla(df, ttft_ms=500)       # re-pick per deployment
```

Cost: ~ms per row (pure-Python deterministic replay; no DB or engine calls).

**Tier 2 — in-sweep enforcement:** `Task(refined_sla=True)` — or `refined_sla: true` in an experiment YAML (maps through `Task.from_yaml`). Deliberately NOT applied to `pick_autoscale` (the dynamo-planner profiling flow: its 1.8 is autoscaling headroom, a different semantic) or AFD frames (pass through unpriced pending their own validation). Measured on an 8-GPU Qwen3-32B sweep (isl4096/osl256, ttft 2000ms / tpot 30ms, H20 perf data, warm DB):

All warm-process numbers (cold adds a one-time ~3-6s perf-DB load either way); pricing is memoized process-wide, so repeated sweeps over the same operating points pay it once:

| sweep | default | refined_sla=True |
|---|---|---|
| agg, single SLA point | ~0.5s | +<1s |
| agg, pareto tpot sweep | ~1s | +~3.6s first run, +0.2s cached |
| disagg, single SLA point | ~0.4s | ~3.2s |
| disagg, pareto tpot sweep | ~2.9s | ~58s |
| single-point estimate (`run_single_agg`/`run_single_disagg`) | ms | +ms (headline repriced to the closed-loop values; `run_single_disagg`'s default output previously reported the raw solo TTFT with no correction at all) |

The disagg pareto cost is the concurrency knee search: each latency-target pair prices its own rate-matched candidates through the tandem (~1.8k pricings at 4–235ms each; operating-point results are memoized). Single-SLA-point tasks — the common "give me a deployment for this target" call — stay at seconds.

## Why

The heuristic TTFT corrections on result rows are clamped/fitted and miss the real shape of closed-loop queueing — which is not even monotone in concurrency (replacement prefill chunks stretch passes; past the knee, larger decode batches eat the cycle and TTFT recedes). A recursion reproduces this because both effects emerge from iterating the budget arithmetic; a multiplier cannot. Derivation and scope notes: `docs/design/closed_loop_refinement.md`.

## Validation (vs the full queueing-model evaluator, identical timing; Qwen3-32B, H20, isl4096/osl256)

| arm | result |
|---|---|
| agg estimator, exact timing callables, C=2..64 | TTFT/TPOT/throughput within **0.2%** (bit-identical ≤C=8) |
| agg estimator fed only recorded row scalars | within **~3%** over the same sweep |
| disagg tandem vs disagg evaluator (1P1D/2P1D/2P2D, serial & batched prefill, shallow→deep queueing) | **bit-identical** TTFT & throughput at all nine points |

## Validation against real serving

Same estimators, nine closed-loop operating points against `trtllm-serve` 1.3.0rc20 (Qwen3-32B tp4, H20, chunked prefill ON, isl 1024/4096/8192 x C 4/16/48; predictions computed from the perf DB before the measurements ran):

| isl/osl | C | throughput est vs real (d%) | TTFT p99 d% | TPOT d% |
|---|---|---|---|---|
| 1024/128 | 4 | 2.68 vs 2.57 (+4.4%) | +2.4% | -13.5% |
| 1024/128 | 16 | 5.07 vs 4.81 (+5.3%) | +8.3% | -10.8% |
| 1024/128 | 48 | 6.16 vs 3.97 (+55%) | +3.8% | -49% |
| 4096/256 | 4 | 0.95 vs 0.91 (+4.5%) | -0.3% | -2.6% |
| 4096/256 | 16 | 1.39 vs 1.39 (+0.1%) | +29.5% | -4.5% |
| 4096/256 | 48 | 1.61 vs 1.29 (+24.3%) | -0.3% | -18.5% |
| 8192/128 | 4 | 0.69 vs 0.70 (-0.6%) | +2.4% | +2.7% |
| 8192/128 | 16 | 0.78 vs 0.81 (-4.2%) | +22.6% | +5.7% |
| 8192/128 | 48 | 0.81 vs 0.82 (-0.5%) | +30.6% | +7.5% |

Reading: throughput within 5.3% on 7/9 points; the two misses (1024 C48, 4096/256 C48) trace to perf-DB timing in deep-churn regimes (real mixed passes cost up to ~2x the DB pricing; the same gap appears if you price those steps standalone), not to the recursion — refined TTFT errs on the conservative side there. The measured closed-loop TTFT correction factor (steady TTFT / solo no-queue TTFT) spans **2.8-14.4x** across this small grid and is non-monotone in concurrency — which is why the refinement computes it from the operating point instead of applying any fixed multiplier.

## 8xH20 A/B arbitration: legacy pick vs refined pick

For the same task (8 GPUs, isl4096/osl256, TTFT<=2000ms, TPOT<=30ms) the legacy sweep picks 1P(tp4)+1D(tp4)@C5; `refined_sla=True` picks 3P(tp2)+1D(tp2)@C16. Both were deployed on 8xH20 (TRT-LLM native disagg, ctx unchunked bs1, gen bs64; predictions frozen before measuring; steady-state protocol: 20 generations/slot, first 5 and last 1 discarded — the synchronized first round costs 1.5-5x the steady TTFT and multi-worker round-robin needs ~5 generations to relax).

Arm A — the legacy pick's topology at three concurrencies the legacy model prices identically (solo x1.8 = 1077.5ms):

| C | real TTFT | refined pred | legacy pred |
|---|---|---|---|
| 5 | 629 | 737 (+17%) | 1077.5 (+71%) |
| 9 | 2828 | 3132 (+11%) | 1077.5 (-62%) |
| 13 | 5065 | 5526 (+9%) | 1077.5 (-79%) |

Arm B — the refined pick's topology:

| C | real TTFT | refined pred | real TPOT (pred) | real X (pred) |
|---|---|---|---|---|
| 16 (pick) | **1201 <= SLA** | 1596 (+33%, conservative) | 17.17 (17.62) | 2.867 (2.713) |
| 19 | 2239 — violates, as predicted | 2731 (+22%) | 17.21 | 2.863 |

Real-vs-real: the refined pick serves **91.8 vs 57.1 tok/s/gpu (+61%) under the same TTFT SLA** — the legacy 1.8x gate had pre-killed the tp2-prefill family (solo x1.8 = 2070 > 2000) whose true closed-loop TTFT at the knee is 1201ms. X(C16)=X(C19) confirms the knee plateau: concurrency past the knee buys zero throughput and doubles TTFT.

## Rust/Python parity

No parity-governed path is touched (`operations/**`, `perf_database.py`, `perf_interp/**`, `engine.py`, `rust_engine_step.py` all unchanged). The recorded scalars are the FFI-returned values — identical whichever engine step computed them — and the estimators live in the Python orchestration layer, which stays Python by the dedup plan. `test_rate_match_parity` extended coverage passes.

## Tests

1004 sdk unit tests green (13 new: estimator semantics incl. the closed-loop identity, P/D imbalance signatures, chunked-off admission, DataFrame refine with NaN tolerance, rate-match parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added closed-loop latency estimation for aggregate and disaggregated serving configurations.
  - Added refined TTFT, TPOT, and throughput metrics based on recorded operating-point measurements.
  - Added modeling for batching, queueing, prefix caching, chunked prefill, worker scaling, and handoff delays.
  - Results now include detailed prefill, generation, mixed-step timing metrics, and step counts.

- **Bug Fixes**
  - Preserved raw prefill-step latency alongside corrected TTFT values.

- **Documentation**
  - Added guidance on closed-loop refinement, validation, and supported scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





