### PR TITLE
fix(cli): default --free-gpu-memory-fraction to the framework default

### DIFF
--- a/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
+++ b/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
@@ -159,16 +159,24 @@ class BaseBackend:
         """
         return step_throughput
 
-    def _resolve_agg_kwargs(self, kwargs: dict, isl: int, osl: int) -> dict:
+    def _resolve_agg_kwargs(self, kwargs: dict, isl: int, osl: int, backend_version: str | None = None) -> dict:
         """Resolve backend-specific run_agg kwargs to defaults.
 
-        Default: returns an empty dict. TRT-LLM resolves ``max_seq_len`` /
-        ``max_num_tokens`` / ``free_gpu_memory_fraction`` here so both
-        ``run_agg`` and ``find_best_agg_result_under_constraints`` see the
-        same values when forwarding. Idempotent — calling with already-resolved
-        kwargs returns the same values.
+        Default: resolves ``free_gpu_memory_fraction`` — an explicit kwarg
+        wins, else the backend default (possibly version-dependent, see
+        ``get_default_free_gpu_memory_fraction``). Backends without a default
+        return an empty dict. TRT-LLM overrides to also resolve
+        ``max_seq_len`` / ``max_num_tokens``, so both ``run_agg`` and
+        ``find_best_agg_result_under_constraints`` see the same values when
+        forwarding. Idempotent — calling with already-resolved kwargs returns
+        the same values.
         """
-        return {}
+        fraction = kwargs.get("free_gpu_memory_fraction")
+        if fraction is None:
+            fraction = self.get_default_free_gpu_memory_fraction(backend_version)
+        if fraction is None:
+            return {}
+        return {"free_gpu_memory_fraction": fraction}
 
     def _make_agg_cache_key(
         self,
@@ -179,8 +187,12 @@ class BaseBackend:
         engine_step_backend_key: str,
         agg_extra: dict,
     ) -> tuple:
-        """Build the cache key for ``run_agg`` results."""
-        return (isl, osl, b, ctx_tokens, engine_step_backend_key)
+        """Build the cache key for ``run_agg`` results.
+
+        The resolved fraction is part of the key: the cached summary embeds
+        the KV-budget OOM verdict, which depends on it.
+        """
+        return (isl, osl, b, ctx_tokens, engine_step_backend_key, agg_extra.get("free_gpu_memory_fraction"))
 
     @staticmethod
     def _runtime_config_for_agg_candidate(runtime_config: RuntimeConfig, batch_size: int) -> RuntimeConfig:
@@ -1402,8 +1414,8 @@ class BaseBackend:
         balance_score = isl * b / ctx_tokens / decode_iterations
 
         # Backend-specific kwargs (TRT-LLM: max_seq_len / max_num_tokens /
-        # free_gpu_memory_fraction; others: {}).
-        agg_extra = self._resolve_agg_kwargs(kwargs, isl=isl, osl=osl)
+        # free_gpu_memory_fraction; vLLM / SGLang: free_gpu_memory_fraction).
+        agg_extra = self._resolve_agg_kwargs(kwargs, isl=isl, osl=osl, backend_version=database.version)
 
         visual_cache_key = (
             runtime_config.image_height,
@@ -1733,7 +1745,7 @@ class BaseBackend:
 
         # Resolve backend-specific kwargs once; forward into run_agg so each
         # (b, ctx_tokens) point sees the same backend params.
-        sweep_extra = self._resolve_agg_kwargs(kwargs, isl=isl_eff, osl=osl)
+        sweep_extra = self._resolve_agg_kwargs(kwargs, isl=isl_eff, osl=osl, backend_version=database.version)
 
         # when b is larger than 1024, the result is not good as the data collection is not enough
         # to cover this.

--- a/aic-core/src/aiconfigurator_core/sdk/backends/trtllm_backend.py
+++ b/aic-core/src/aiconfigurator_core/sdk/backends/trtllm_backend.py
@@ -77,7 +77,9 @@ class TRTLLMBackend(BaseBackend):
     def get_kv_cache_memory_check_params(self) -> tuple[float, float]:
         return KV_CACHE_MEMORY_RESERVED_FRACTION, KV_CACHE_MEMORY_TOLERANCE
 
-    def _resolve_agg_kwargs(self, kwargs: dict, isl: int, osl: int) -> dict:
+    def _resolve_agg_kwargs(self, kwargs: dict, isl: int, osl: int, backend_version: str | None = None) -> dict:
+        # backend_version is unused: TRT-LLM's fraction default is not
+        # version-dependent.
         # Use ``if x is None`` (rather than kwargs.get default) so that an
         # explicit None from the Python API still falls back to the constant.
         max_seq_len = kwargs.get("max_seq_len")

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -480,8 +480,12 @@ def _add_default_mode_arguments(parser):
     parser.add_argument(
         "--free-gpu-memory-fraction",
         type=float,
-        default=1.0,
-        help="Fraction of free GPU memory TRT-LLM allocates for KV cache (default: 1.0). "
+        default=None,
+        help="Fraction of GPU memory the framework allocates for KV cache "
+        "(default: the framework's own default for the selected backend -- vLLM's "
+        "gpu_memory_utilization, resolved by backend version; TRT-LLM's "
+        "free_gpu_memory_fraction; SGLang's mem_fraction_static, derived from device "
+        "capacity where known and 0.88 otherwise). "
         "Used to filter batch sizes that would exceed KV cache capacity.",
     )
     parser.add_argument(
@@ -653,8 +657,12 @@ def _add_recommend_mode_arguments(parser):
     parser.add_argument(
         "--free-gpu-memory-fraction",
         type=float,
-        default=1.0,
-        help="Fraction of free GPU memory allocated for KV cache (default: 1.0).",
+        default=None,
+        help="Fraction of GPU memory the framework allocates for KV cache "
+        "(default: the framework's own default for the selected backend -- vLLM's "
+        "gpu_memory_utilization, resolved by backend version; TRT-LLM's "
+        "free_gpu_memory_fraction; SGLang's mem_fraction_static, derived from device "
+        "capacity where known and 0.88 otherwise).",
     )
     parser.add_argument(
         "--max-seq-len",
@@ -1159,8 +1167,12 @@ def _add_estimate_mode_arguments(parser):
     parser.add_argument(
         "--free-gpu-memory-fraction",
         type=float,
-        default=0.9,
-        help="Fraction of free GPU memory available for KV cache (default: 0.9). "
+        default=None,
+        help="Fraction of GPU memory the framework allocates for KV cache "
+        "(default: the framework's own default for the selected backend -- vLLM's "
+        "gpu_memory_utilization, resolved by backend version; TRT-LLM's "
+        "free_gpu_memory_fraction; SGLang's mem_fraction_static, derived from device "
+        "capacity where known and 0.88 otherwise). "
         "Used to estimate max concurrent sequences and warn when batch_size "
         "exceeds KV cache capacity.",
     )

--- a/tests/unit/cli/test_argument_parsing.py
+++ b/tests/unit/cli/test_argument_parsing.py
@@ -51,6 +51,22 @@ class TestCLIArgumentParsing:
         action = next(action for action in cli_parser._actions if action.dest == "mode")
         assert set(action.choices.keys()) == {"default", "exp", "generate", "support", "estimate", "recommend"}
 
+    @pytest.mark.parametrize("mode", ["default", "recommend", "estimate"])
+    def test_free_gpu_memory_fraction_defaults_to_backend_default(self, cli_parser, mode):
+        """``--free-gpu-memory-fraction`` must default to None, not a hardcoded number.
+
+        The backend resolves None to the framework's own default, version-aware for
+        vLLM (``gpu_memory_utilization`` 0.92 on 0.22+). A concrete argparse default
+        is never None and therefore bypasses that resolution entirely: the sweep then
+        packs KV to the hardcoded fraction and recommends decode batch sizes the
+        engine cannot admit (ai-dynamo/aiconfigurator#1396).
+        """
+        subparser_action = next(action for action in cli_parser._actions if action.dest == "mode")
+        mode_parser = subparser_action.choices[mode]
+
+        action = next(a for a in mode_parser._actions if a.dest == "free_gpu_memory_fraction")
+        assert action.default is None
+
     def test_generate_mode_required_args(self, cli_parser):
         """Test that generate mode requires the correct arguments."""
         subparsers = [action for action in cli_parser._actions if action.dest == "mode"]

--- a/tests/unit/sdk/test_kv_cache_budget_semantics.py
+++ b/tests/unit/sdk/test_kv_cache_budget_semantics.py
@@ -127,3 +127,67 @@ def test_explicit_fraction_overrides_backend_default():
     assert kwargs["free_gpu_memory_fraction"] == 0.8
     kwargs = backend._static_oom_check_kwargs(180 * (1 << 30), backend_version="0.19.0")
     assert kwargs["free_gpu_memory_fraction"] == pytest.approx(0.90)
+
+
+def test_vllm_agg_resolver_carries_version_aware_fraction():
+    """The agg resolver must not drop the fraction: run_agg budgets through
+    ``_oom_check_kwargs(agg_extra)``, and before this resolver existed the
+    base class returned {} — every aggregated vLLM run was budgeted at the
+    0.92 constant regardless of database version or explicit override."""
+    backend = VLLMBackend()
+    assert backend._resolve_agg_kwargs({}, isl=1024, osl=1024, backend_version="0.19.0") == {
+        "free_gpu_memory_fraction": pytest.approx(0.90)
+    }
+    assert backend._resolve_agg_kwargs({}, isl=1024, osl=1024, backend_version="0.22.0") == {
+        "free_gpu_memory_fraction": pytest.approx(0.92)
+    }
+    # explicit override wins over the version default
+    resolved = backend._resolve_agg_kwargs(
+        {"free_gpu_memory_fraction": 0.75}, isl=1024, osl=1024, backend_version="0.22.0"
+    )
+    assert resolved == {"free_gpu_memory_fraction": 0.75}
+    # idempotent: re-resolving forwarded kwargs returns the same values
+    assert backend._resolve_agg_kwargs(resolved, isl=1024, osl=1024, backend_version="0.22.0") == resolved
+    # and the resolved value is what the agg OOM check budgets with
+    oom_kwargs = backend._oom_check_kwargs(
+        backend._resolve_agg_kwargs({}, isl=1024, osl=1024, backend_version="0.19.0")
+    )
+    assert oom_kwargs["free_gpu_memory_fraction"] == pytest.approx(0.90)
+    assert oom_kwargs["fraction_of_free"] is False
+
+
+def test_sglang_agg_resolver_honors_explicit_fraction():
+    """SGLang agg keeps its 0.88 fallback when unset but must honor an
+    explicit user fraction (it was previously discarded the same way)."""
+    from aiconfigurator.sdk.backends.sglang_backend import (
+        SGLANG_FALLBACK_MEM_FRACTION_STATIC,
+        SGLANGBackend,
+    )
+
+    backend = SGLANGBackend()
+    resolved = backend._resolve_agg_kwargs({}, isl=1024, osl=1024)
+    assert backend._oom_check_kwargs(resolved)["free_gpu_memory_fraction"] == SGLANG_FALLBACK_MEM_FRACTION_STATIC
+    resolved = backend._resolve_agg_kwargs({"free_gpu_memory_fraction": 0.8}, isl=1024, osl=1024)
+    assert backend._oom_check_kwargs(resolved)["free_gpu_memory_fraction"] == 0.8
+
+
+def test_agg_cache_key_distinguishes_fraction():
+    """The cached run_agg summary embeds the KV-budget OOM verdict, so
+    summaries resolved under different fractions must not share an entry."""
+    backend = VLLMBackend()
+    key_090 = backend._make_agg_cache_key(
+        1024, 1024, 8, 512, "python", backend._resolve_agg_kwargs({}, isl=1024, osl=1024, backend_version="0.19.0")
+    )
+    key_092 = backend._make_agg_cache_key(
+        1024, 1024, 8, 512, "python", backend._resolve_agg_kwargs({}, isl=1024, osl=1024, backend_version="0.22.0")
+    )
+    assert key_090 != key_092
+
+
+def test_base_backend_agg_resolver_defaults_off():
+    """Backends without a default fraction resolve to {} (no budget check)."""
+
+    class _NoDefault(BaseBackend):
+        pass
+
+    assert _NoDefault()._resolve_agg_kwargs({}, isl=1024, osl=1024) == {}


### PR DESCRIPTION
## Problem

`#1423` taught the backend layer the framework's real KV-cache fraction — version-aware for vLLM (`VLLM_GPU_MEMORY_UTILIZATION_BY_VERSION`: 0.90 on 0.14/0.19, 0.92 on 0.22+), 0.9 for TRT-LLM, 0.88 for SGLang. `BaseBackend._fraction_budget_kwargs` applies it through the `free_gpu_memory_fraction is None` branch.

**That branch is unreachable from the CLI.** argparse fills a concrete default — `1.0` for `default`/`recommend` (`main.py:483`, `:657`) and `0.9` for `estimate` (`:1165`) — and `args.free_gpu_memory_fraction` is passed through verbatim (`main.py:2459`, `:2755`), so the value is never `None`. Only the yaml/`exp` path, which leaves the key unset, ever receives the version-derived default.

## Effect

Kimi-K2.5-NVFP4, 8×B200, disagg, vLLM 0.22.0 — same sweep, only the fraction differs:

| fraction | top1 concurrency | decode bs/rank | `(d)memory` per rank |
|---|---|---|---|
| **1.0** (today's `default`/`recommend`) | **384** | **96** | **179.7 GiB of 180 — 99.8% of the device** |
| 0.92 (version default) | 72 | 18 | 161.7 GiB |

The engine admits 28.98 seq/rank in that deployment, so the fraction-1.0 recommendation is exactly the symptom #1423 set out to eliminate — *"predicted decode bs=96/rank vs 29/rank actually admitted on B200 for Kimi-K2.5-NVFP4"*, quoted in the `vllm_backend.py` comment — and it is still reachable through `recommend`/`default`.

The leverage is large because KV is a small difference of two large numbers. Solving the two rows above for a common non-KV footprint gives ≈157.5 GiB of the 180:

```
fraction 0.92 -> budget 162.3 GiB -> KV = 162.3 - 157.5 ≈  4.8 GiB -> bs 18
fraction 1.0  -> budget 176.4 GiB -> KV = 176.4 - 157.5 ≈ 18.9 GiB -> bs 96
```

8 points of fraction = 14.4 GiB landing on a ~5 GiB base, so the admissible batch moves 5×.

`estimate` fails the other way: 0.9 is *stricter* than the 0.92 vLLM actually uses, so it reports KV-capacity OOM for configurations the sweep itself recommends as top1.

## Change

`default=None` in all three parsers, so the backend resolves the framework default. Help text now names the resolved values. Passing `--free-gpu-memory-fraction` explicitly is unchanged.

Added a parametrized regression test over the three modes asserting the default is `None` — a hardcoded value silently bypasses the resolution, which is what made this survive #1423.

## Validation

Sweep re-run both ways on the numbers above (`aiconfigurator cli exp`, yaml with and without an explicit `free_gpu_memory_fraction: 1.0`). Post-fix top1 (conc 72 / bs 18, 310.5 tok/s/GPU predicted) was also measured end-to-end on 8×B200 with dynamo + vLLM 0.22.0: **362.4 tok/s/GPU**, i.e. the prediction is ~14% conservative, and decode bs 18 sits at 62% of the pool's 29.1-sequence capacity — comfortably inside the deployable range.

I could not execute the test suite in this environment (no built `aiconfigurator_core` Rust extension available here), so CI is the first run of the new test.

Refs #1396.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * GPU memory allocation now uses framework-, backend-, and version-specific defaults when no fraction is provided.
  * The `--free-gpu-memory-fraction` help text explains this behavior and includes example values.
  * Behavior is consistent across default, recommend, and estimate CLI modes.
  * KV-cache budget calculations now correctly account for the resolved memory fraction, improving results across different configurations.

* **Tests**
  * Added coverage for framework-specific defaults, explicit overrides, and cache-budget handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->