### PR TITLE
fix(sdk): admit partial perf data before version fallback

### DIFF
--- a/aic-core/src/aiconfigurator_core/sdk/operations/base.py
+++ b/aic-core/src/aiconfigurator_core/sdk/operations/base.py
@@ -121,12 +121,30 @@ def _version_dir_is_partial(version_dir: str) -> bool:
     return os.path.isfile(os.path.join(version_dir, "INCOMPLETE.txt"))
 
 
+def _version_dir_is_unusable(version_dir: str) -> bool:
+    """Whether the whole directory must be excluded from data loading.
+
+    ``collection_meta.yaml`` with ``status: partial`` is structured coverage
+    metadata: successfully collected rows are valid and must remain primary,
+    while older versions fill missing coordinates. Only legacy
+    ``INCOMPLETE.txt`` lacks enough granularity to admit any of its rows.
+
+    A structured sidecar supersedes a stale legacy marker. Parse validation is
+    owned by perf_database's admission layer; this hot-path resolver only needs
+    to know that the structured sidecar exists.
+    """
+    if os.path.isfile(os.path.join(version_dir, "collection_meta.yaml")):
+        return False
+    return os.path.isfile(os.path.join(version_dir, "INCOMPLETE.txt"))
+
+
 def resolve_op_data_path(system_data_root: str, backend: str, version: str, op_filename: str) -> str:
     """Resolve one op table under the family-first layout, legacy fallback.
 
     Family dirs are discovered structurally (any first-level dir that is not
-    a known backend dir); dirs marked partial (yaml-first, txt fallback — see
-    ``_version_dir_is_partial``) are skipped. Candidates run through the
+    a known backend dir). Structured partial tables are loadable and use
+    older-version shape fill; only legacy whole-dir-incomplete directories
+    (see ``_version_dir_is_unusable``) are skipped. Candidates run through the
     .parquet->.txt fallback. When nothing exists, returns the legacy-shaped
     path so callers keep their missing-file semantics.
     """
@@ -139,7 +157,7 @@ def resolve_op_data_path(system_data_root: str, backend: str, version: str, op_f
         if entry.startswith(".") or entry in _KNOWN_BACKEND_DIRS:
             continue
         version_dir = os.path.join(system_data_root, entry, backend, version)
-        if not os.path.isdir(version_dir) or _version_dir_is_partial(version_dir):
+        if not os.path.isdir(version_dir) or _version_dir_is_unusable(version_dir):
             continue
         candidate = _resolve_perf_data_path(os.path.join(version_dir, op_filename))
         if os.path.exists(candidate):

--- a/aic-core/src/aiconfigurator_core/sdk/perf_database.py
+++ b/aic-core/src/aiconfigurator_core/sdk/perf_database.py
@@ -405,11 +405,27 @@ def _load_collection_meta_yaml(path: str) -> dict:
     return raw
 
 
-def _collection_meta_has_partial_table(meta: dict) -> bool:
+def _collection_meta_partial_tables(meta: dict) -> frozenset[str]:
+    """Return tables whose collection coverage is incomplete.
+
+    ``status: partial`` is table/shape coverage metadata, not a statement that
+    the successfully collected rows are invalid.  Those rows remain eligible
+    as the primary source; older versions only fill coordinates they do not
+    contain (design §6.1/§6.2 first-wins semantics).
+    """
     tables = meta.get("tables")
     if not isinstance(tables, dict):
-        return False
-    return any(isinstance(table, dict) and table.get("status") == "partial" for table in tables.values())
+        return frozenset()
+    return frozenset(
+        name
+        for name, table in tables.items()
+        if isinstance(name, str) and isinstance(table, dict) and table.get("status") == "partial"
+    )
+
+
+def _collection_meta_has_partial_table(meta: dict) -> bool:
+    """Compatibility predicate for metadata/reporting callers."""
+    return bool(_collection_meta_partial_tables(meta))
 
 
 def _version_dir_state(version_path: str, *, data_dir: str | None = None) -> dict[str, object]:
@@ -418,9 +434,12 @@ def _version_dir_state(version_path: str, *, data_dir: str | None = None) -> dic
     - ``declared_reuse``: parsed ``reuse.yaml`` contents (design §6.3) when it has
       >=1 entry; the legacy marker-only sentinel when only ``SHARED_LAYER_REUSE.txt``
       is present; ``None`` when neither declares reuse.
-    - ``partial``: True when ``collection_meta.yaml`` has any table with
-      ``status: partial`` (whole-dir discovery parity with today; per-table nuance
-      is PR 4 scope), or (fallback) ``INCOMPLETE.txt`` is present.
+    - ``partial`` / ``partial_tables``: informational collection-coverage
+      state from ``collection_meta.yaml``. Partial tables still contribute all
+      successfully collected rows; older versions fill only missing shapes.
+    - ``unusable``: whole-directory exclusion. This is reserved for the legacy
+      ``INCOMPLETE.txt`` marker, which has no table/shape granularity. A present
+      ``collection_meta.yaml`` supersedes that legacy marker.
     - ``has_perf``: whether the dir holds real perf output files.
 
     ``data_dir`` scopes the one-time-per-tree legacy-marker deprecation warning
@@ -439,18 +458,24 @@ def _version_dir_state(version_path: str, *, data_dir: str | None = None) -> dic
         _warn_legacy_marker_once(warn_scope, SHARED_LAYER_REUSE_MARKER, REUSE_YAML_MARKER)
         declared_reuse = {"entries": [], "legacy": True}
 
-    partial = False
+    partial_tables: frozenset[str] = frozenset()
+    unusable = False
     meta_yaml_path = os.path.join(version_path, COLLECTION_META_MARKER)
     legacy_incomplete_path = os.path.join(version_path, INCOMPLETE_MARKER)
     if os.path.isfile(meta_yaml_path):
-        partial = _collection_meta_has_partial_table(_load_collection_meta_yaml(meta_yaml_path))
+        partial_tables = _collection_meta_partial_tables(_load_collection_meta_yaml(meta_yaml_path))
     elif os.path.isfile(legacy_incomplete_path):
         _warn_legacy_marker_once(warn_scope, INCOMPLETE_MARKER, COLLECTION_META_MARKER)
-        partial = True
+        # INCOMPLETE.txt predates per-table provenance, so there is no safe way
+        # to identify which rows/tables succeeded. Keep the legacy fail-closed
+        # whole-directory behavior only for this unstructured marker.
+        unusable = True
 
     return {
         "declared_reuse": declared_reuse,
-        "partial": partial,
+        "partial": bool(partial_tables) or unusable,
+        "partial_tables": partial_tables,
+        "unusable": unusable,
         "has_perf": _database_version_dir_has_perf_files(version_path),
     }
 
@@ -459,7 +484,7 @@ def _database_version_dir_is_declared(version_path: str, *, data_dir: str | None
     if not os.path.isdir(version_path):
         return False
     state = _version_dir_state(version_path, data_dir=data_dir)
-    if state["partial"]:
+    if state["unusable"]:
         return False
     return bool(state["has_perf"]) or state["declared_reuse"] is not None
 
@@ -532,7 +557,7 @@ def is_shared_layer_marker_only_version(
     saw_marker = False
     for version_path, data_dir in _iter_database_version_paths(system, backend, version, systems_paths=systems_paths):
         state = _version_dir_state(version_path, data_dir=data_dir)
-        if state["partial"]:
+        if state["unusable"]:
             continue
         if state["has_perf"]:
             return False
@@ -845,17 +870,19 @@ def _check_strict_provenance_for_request(paths: list[str], backend: str, data_di
             _check_strict_provenance_coverage(os.path.dirname(donor_path), strict=strict, only_table=entry["table"])
 
 
-def _version_dir_partial_for_request(version_path: str, data_dir: str, *, strict: bool) -> bool:
-    """``get_database()``'s request-scoped wrapper around
-    ``_version_dir_state``'s ``partial`` flag: a malformed sidecar under it
-    raises in strict mode (same ``ValueError``), and in non-strict mode is
-    logged and treated as "not partial" rather than aborting the whole
-    lookup. ``_version_dir_state``'s OTHER call sites (discovery/listing,
-    e.g. ``_declared_versions``) are out of this per-request hook's scope and
-    keep their pre-existing unconditional raise.
+def _version_dir_unusable_for_request(version_path: str, data_dir: str, *, strict: bool) -> bool:
+    """Return whether a request must reject the whole version directory.
+
+    Structured ``collection_meta.yaml`` partial status is intentionally *not*
+    grounds for rejection: valid primary rows are loaded and sibling versions
+    fill only missing shapes. Whole-directory rejection remains only for the
+    unstructured legacy ``INCOMPLETE.txt`` marker.
+
+    A malformed sidecar raises in strict mode; non-strict mode warns and lets
+    normal loading continue, matching the existing request-scoped behavior.
     """
     try:
-        return bool(_version_dir_state(version_path, data_dir=data_dir)["partial"])
+        return bool(_version_dir_state(version_path, data_dir=data_dir)["unusable"])
     except ValueError as e:
         if strict:
             raise
@@ -942,7 +969,7 @@ def get_database(
         data_dir_abs = os.path.join(systems_root, data_dir)
         paths = [p for v, p in _iter_backend_version_dirs(data_dir_abs, backend) if v == version]
         is_incomplete = bool(paths) and all(
-            _version_dir_partial_for_request(p, data_dir_abs, strict=effective_strict) for p in paths
+            _version_dir_unusable_for_request(p, data_dir_abs, strict=effective_strict) for p in paths
         )
         if paths and not is_incomplete:
             request_key = (tuple(sorted(paths)), backend)
@@ -1170,7 +1197,7 @@ def _iter_database_refs_for_system(systems_root: str, system: str, system_spec: 
 
         for version in sorted(version_paths):
             paths = version_paths[version]
-            if all(_version_dir_state(p, data_dir=data_dir)["partial"] for p in paths):
+            if all(_version_dir_state(p, data_dir=data_dir)["unusable"] for p in paths):
                 continue
             yield system, backend_name, version, systems_root
 
@@ -2242,10 +2269,10 @@ class PerfDatabase:
         `self.data_provenance[op_file_basename]` — see that attribute's
         docstring for the granularity contract.
 
-        An existing primary whose containing version dir is marked partial
-        (legacy-layout fallback only — the resolver already skips partial
-        family dirs) is refused entirely: no record, no source tuple, only a
-        warning; channels 2-4 still fill.
+        A structured ``status: partial`` primary is admitted normally: its
+        successful rows win and channels 2-4 fill missing shapes. Only a
+        legacy ``INCOMPLETE.txt`` directory is refused wholesale because that
+        marker carries no table/shape-level coverage information.
 
         Returns just the primary tuple (still recorded) when the shared layer
         is disabled, when the op file is framework-agnostic (nccl / oneccl),
@@ -2261,23 +2288,19 @@ class PerfDatabase:
         op_file_basename = op_filename_enum.value
         records: list[dict[str, object]] = []
         primary_version_dir = os.path.dirname(primary_path)
-        if os.path.isfile(primary_path) and _version_dir_partial_for_request(
+        if os.path.isfile(primary_path) and _version_dir_unusable_for_request(
             primary_version_dir, system_data_root, strict=self.strict_provenance
         ):
-            # Only the LEGACY-layout fallback can get here: resolve_op_data_path
-            # already skips partial FAMILY dirs, so a family-layout primary is
-            # never partial (pinned by test_reuse_ordering.py's
-            # test_partial_family_dir_is_skipped_by_resolver_not_the_admission_guard).
-            # Partial dirs are excluded from discovery and every reuse channel
-            # (design §5/§6) — refuse the primary too; channels 2-4 below still
-            # fill, and data_provenance keeps listing admitted sources only.
+            # Only the unstructured legacy marker is a whole-directory veto.
+            # Structured partial tables are admitted above fallback sources so
+            # their successful rows remain authoritative for covered shapes.
             logger.warning(
-                "Not admitting primary source %s for %s: version dir %s is marked partial "
-                "(collection_meta.yaml status: partial, or legacy INCOMPLETE.txt); partial "
-                "dirs are excluded from data loading (Collector V3 design §5/§6).",
+                "Not admitting primary source %s for %s: version dir %s carries legacy %s "
+                "without table/shape-level coverage metadata; sibling sources may still fill.",
                 primary_path,
                 op_file_basename,
                 primary_version_dir,
+                INCOMPLETE_MARKER,
             )
         else:
             records.append({"version": self.version, "path": primary_path, "channel": "primary", "ks_filter": None})

--- a/aic-core/src/aiconfigurator_core/sdk/perf_database.py
+++ b/aic-core/src/aiconfigurator_core/sdk/perf_database.py
@@ -2349,6 +2349,10 @@ class PerfDatabase:
             donor_path = resolve_op_data_path(system_data_root, backend_lower, from_version, op_file_basename)
             if not os.path.isfile(donor_path):
                 continue
+            if _version_dir_unusable_for_request(
+                os.path.dirname(donor_path), system_data_root, strict=self.strict_provenance
+            ):
+                continue
             records.append(
                 {
                     "version": from_version,
@@ -2385,6 +2389,10 @@ class PerfDatabase:
             for _, sibling_version in earlier_versions:
                 sibling_path = resolve_op_data_path(system_data_root, backend_lower, sibling_version, op_file_basename)
                 if not os.path.isfile(sibling_path):
+                    continue
+                if _version_dir_unusable_for_request(
+                    os.path.dirname(sibling_path), system_data_root, strict=self.strict_provenance
+                ):
                     continue
                 records.append(
                     {"version": sibling_version, "path": sibling_path, "channel": "fallback", "ks_filter": None}
@@ -2430,6 +2438,10 @@ class PerfDatabase:
             for sibling_version in fw_versions:
                 sibling_path = resolve_op_data_path(system_data_root, framework, sibling_version, op_file_basename)
                 if not os.path.isfile(sibling_path):
+                    continue
+                if _version_dir_unusable_for_request(
+                    os.path.dirname(sibling_path), system_data_root, strict=self.strict_provenance
+                ):
                     continue
                 records.append(
                     {

--- a/tests/unit/sdk/database/test_dual_layout_discovery.py
+++ b/tests/unit/sdk/database/test_dual_layout_discovery.py
@@ -118,8 +118,8 @@ def test_resolve_op_path_skips_incomplete_family_dir(systems_root):
     _write(systems_root, "data/h200_sxm/gemm/sglang/0.5.14/gemm_perf.parquet")
     _write(systems_root, "data/h200_sxm/gemm/sglang/0.5.14/INCOMPLETE.txt", b"x")
     _write(systems_root, "data/h200_sxm/sglang/0.5.14/gemm_perf.parquet")  # legacy fallback
-    assert resolve_op_data_path(root, "sglang", "0.5.14", "gemm_perf.parquet").endswith(
-        "sglang/0.5.14/gemm_perf.parquet"
+    assert resolve_op_data_path(root, "sglang", "0.5.14", "gemm_perf.parquet") == str(
+        systems_root / "data/h200_sxm/sglang/0.5.14/gemm_perf.parquet"
     )
 
 
@@ -182,10 +182,9 @@ def test_reuse_yaml_with_zero_entries_is_not_declared(systems_root):
     assert supported["h200_sxm"]["sglang"] == ["0.5.14"]
 
 
-def test_collection_meta_partial_table_excludes_that_family_path(systems_root):
-    # partial in ONE family dir hides that path; the version stays declared
-    # through the other family dir (per-path semantics preserved, mirrors the
-    # existing INCOMPLETE.txt behavior).
+def test_collection_meta_partial_table_keeps_family_path_declared(systems_root):
+    # Structured partial coverage keeps successful rows usable. The version
+    # remains declared and older sibling versions may fill missing shapes.
     _write(systems_root, "data/h200_sxm/gemm/sglang/0.5.14/gemm_perf.parquet")
     _write(systems_root, "data/h200_sxm/attention/sglang/0.5.14/context_attention_perf.parquet")
     _write_yaml(
@@ -197,7 +196,7 @@ def test_collection_meta_partial_table_excludes_that_family_path(systems_root):
     assert supported["h200_sxm"]["sglang"] == ["0.5.14"]
 
 
-def test_collection_meta_partial_in_all_paths_means_undeclared(systems_root):
+def test_collection_meta_partial_in_all_paths_remains_declared(systems_root):
     _write(systems_root, "data/h200_sxm/gemm/sglang/0.5.14/gemm_perf.parquet")
     _write_yaml(
         systems_root,
@@ -205,7 +204,7 @@ def test_collection_meta_partial_in_all_paths_means_undeclared(systems_root):
         {"tables": {"gemm_perf": {"status": "partial"}}},
     )
     supported = get_supported_databases(str(systems_root))
-    assert supported["h200_sxm"].get("sglang", []) == []
+    assert supported["h200_sxm"]["sglang"] == ["0.5.14"]
 
 
 def test_shared_layer_reuse_txt_fallback_warns_once_per_data_dir(systems_root, caplog):
@@ -275,7 +274,7 @@ def test_reuse_yaml_non_list_reuse_key_raises(systems_root):
         _declared_versions(data_dir, "sglang")
 
 
-def test_resolve_op_path_skips_partial_collection_meta_family_dir(systems_root):
+def test_resolve_op_path_uses_partial_collection_meta_family_dir(systems_root):
     root = str(systems_root / "data/h200_sxm")
     _write(systems_root, "data/h200_sxm/gemm/sglang/0.5.14/gemm_perf.parquet")
     _write_yaml(
@@ -285,6 +284,6 @@ def test_resolve_op_path_skips_partial_collection_meta_family_dir(systems_root):
     )
     _write(systems_root, "data/h200_sxm/sglang/0.5.14/gemm_perf.parquet")  # legacy fallback
 
-    assert resolve_op_data_path(root, "sglang", "0.5.14", "gemm_perf.parquet").endswith(
-        "sglang/0.5.14/gemm_perf.parquet"
+    assert resolve_op_data_path(root, "sglang", "0.5.14", "gemm_perf.parquet") == str(
+        systems_root / "data/h200_sxm/gemm/sglang/0.5.14/gemm_perf.parquet"
     )

--- a/tests/unit/sdk/database/test_reuse_ordering.py
+++ b/tests/unit/sdk/database/test_reuse_ordering.py
@@ -445,37 +445,17 @@ def test_nccl_op_name_early_exit_still_applies(systems_root: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Partial version dirs are never admitted as the primary source.
-# resolve_op_data_path skips partial FAMILY dirs, but its final legacy-layout
-# fallback returns an existing file with no partial check — the admission
-# chokepoint (_build_op_sources) must refuse that primary itself.
+# Partial collection semantics
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("marker", ["incomplete_txt", "meta_yaml_partial"])
-def test_partial_legacy_primary_not_admitted_donors_still_fill(
-    systems_root: Path, caplog: pytest.LogCaptureFixture, marker: str
+def test_legacy_incomplete_primary_not_admitted_donors_still_fill(
+    systems_root: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """A legacy-layout dir holding the requested version's table but marked
-    partial (INCOMPLETE.txt legacy marker, or collection_meta.yaml with any
-    ``status: partial`` table) must NOT be admitted as the primary source.
-    Channels 2-4 still fill, and data_provenance lists admitted sources
-    only — no primary record for the refused file."""
+    """The unstructured legacy INCOMPLETE marker remains a whole-dir veto."""
     backend, requested, earlier = "trtllm", "1.0.0", "0.9.0"
     _write(systems_root, f"data/h100_sxm/{backend}/{requested}/gemm_perf.parquet")
-    if marker == "incomplete_txt":
-        _write(systems_root, f"data/h100_sxm/{backend}/{requested}/INCOMPLETE.txt", b"partial collection\n")
-    else:
-        _write_yaml(
-            systems_root,
-            f"data/h100_sxm/{backend}/{requested}/collection_meta.yaml",
-            {
-                "schema_version": 1,
-                "runtime": {"framework": backend, "version": requested},
-                "tables": {"gemm_perf": {"status": "partial"}},
-            },
-        )
-    # A complete family-layout earlier sibling fills via channel 3 (fallback).
+    _write(systems_root, f"data/h100_sxm/{backend}/{requested}/INCOMPLETE.txt", b"partial collection\n")
     _write(systems_root, f"data/h100_sxm/gemm/{backend}/{earlier}/gemm_perf.parquet")
 
     db = _build_db(systems_root, backend=backend, version=requested)
@@ -487,17 +467,58 @@ def test_partial_legacy_primary_not_admitted_donors_still_fill(
     assert provenance[0]["version"] == earlier
     assert [path for path, _ in sources] == [e["path"] for e in provenance]
     assert not any(f"{backend}/{requested}/gemm_perf.parquet" in path for path, _ in sources)
-    assert any("partial" in r.getMessage() and requested in r.getMessage() for r in caplog.records)
+    assert any("INCOMPLETE.txt" in r.getMessage() and requested in r.getMessage() for r in caplog.records)
 
 
-def test_partial_family_dir_is_skipped_by_resolver_not_the_admission_guard(systems_root: Path) -> None:
-    """Scope guard: a family-layout primary can never be partial, because
-    resolve_op_data_path already skips partial family dirs — the admission
-    guard in _build_op_sources only ever fires for the legacy-layout
-    fallback path. Here the partial family dir is skipped upstream, so the
-    primary resolves to the (nonexistent) legacy-shaped path and keeps its
-    provenance record with exists=False, per the usual missing-primary
-    semantics."""
+def test_structured_partial_legacy_primary_is_admitted_before_fallback(systems_root: Path) -> None:
+    """Structured partial means missing coverage, not invalid successful rows."""
+    backend, requested, earlier = "trtllm", "1.0.0", "0.9.0"
+    _write(systems_root, f"data/h100_sxm/{backend}/{requested}/gemm_perf.parquet")
+    _write_yaml(
+        systems_root,
+        f"data/h100_sxm/{backend}/{requested}/collection_meta.yaml",
+        {
+            "schema_version": 1,
+            "runtime": {"framework": backend, "version": requested},
+            "tables": {"gemm_perf": {"status": "partial"}},
+        },
+    )
+    _write(systems_root, f"data/h100_sxm/gemm/{backend}/{earlier}/gemm_perf.parquet")
+
+    db = _build_db(systems_root, backend=backend, version=requested)
+    sources = _sources_for(db, systems_root, common.PerfDataFilename.gemm)
+
+    provenance = db.data_provenance["gemm_perf.parquet"]
+    assert [e["channel"] for e in provenance] == ["primary", "fallback"]
+    assert [e["version"] for e in provenance] == [requested, earlier]
+    assert provenance[0]["exists"] is True
+    assert [path for path, _ in sources] == [e["path"] for e in provenance]
+
+
+def test_structured_partial_family_primary_is_resolved_and_admitted(systems_root: Path) -> None:
+    """Family-layout partial data stays primary; older rows fill gaps only."""
+    backend, requested, earlier = "trtllm", "1.0.0", "0.9.0"
+    primary_rel = f"data/h100_sxm/gemm/{backend}/{requested}/gemm_perf.parquet"
+    _write(systems_root, primary_rel)
+    _write_yaml(
+        systems_root,
+        f"data/h100_sxm/gemm/{backend}/{requested}/collection_meta.yaml",
+        {"tables": {"gemm_perf": {"status": "partial"}}},
+    )
+    _write(systems_root, f"data/h100_sxm/gemm/{backend}/{earlier}/gemm_perf.parquet")
+
+    db = _build_db(systems_root, backend=backend, version=requested)
+    sources = _sources_for(db, systems_root, common.PerfDataFilename.gemm)
+
+    provenance = db.data_provenance["gemm_perf.parquet"]
+    assert [e["channel"] for e in provenance] == ["primary", "fallback"]
+    assert provenance[0]["path"] == str(systems_root / primary_rel)
+    assert provenance[0]["exists"] is True
+    assert [path for path, _ in sources] == [e["path"] for e in provenance]
+
+
+def test_legacy_incomplete_family_dir_is_skipped_by_resolver(systems_root: Path) -> None:
+    """Legacy INCOMPLETE still skips the family path because it has no coverage detail."""
     backend, requested, earlier = "trtllm", "1.0.0", "0.9.0"
     _write(systems_root, f"data/h100_sxm/gemm/{backend}/{requested}/gemm_perf.parquet")
     _write(systems_root, f"data/h100_sxm/gemm/{backend}/{requested}/INCOMPLETE.txt", b"partial collection\n")
@@ -508,7 +529,7 @@ def test_partial_family_dir_is_skipped_by_resolver_not_the_admission_guard(syste
 
     provenance = db.data_provenance["gemm_perf.parquet"]
     assert [e["channel"] for e in provenance] == ["primary", "fallback"]
-    assert provenance[0]["exists"] is False  # legacy-shaped path, not the partial family file
+    assert provenance[0]["exists"] is False
     assert f"gemm/{backend}/{requested}" not in provenance[0]["path"]
     assert provenance[1]["version"] == earlier
     assert [path for path, _ in sources] == [e["path"] for e in provenance]

--- a/tests/unit/sdk/database/test_reuse_ordering.py
+++ b/tests/unit/sdk/database/test_reuse_ordering.py
@@ -29,6 +29,7 @@ import yaml
 
 from aiconfigurator.sdk import common
 from aiconfigurator.sdk.operations.base import resolve_op_data_path
+from aiconfigurator.sdk.operations.gemm import load_gemm_data
 from aiconfigurator.sdk.perf_database import PerfDatabase, _load_op_kernel_source_manifest_entries
 
 pytestmark = pytest.mark.unit
@@ -148,6 +149,25 @@ def test_declared_reuse_channel_admits_newer_donor_in_isolation(systems_root: Pa
     assert _channels(db, "moe_perf.parquet") == ["primary", "declared_reuse"]
 
 
+def test_declared_reuse_rejects_legacy_incomplete_donor(systems_root: Path) -> None:
+    """A declared legacy-layout donor carrying INCOMPLETE.txt is unusable."""
+    backend, requested, donor = "sglang", "0.5.12", "0.5.14"
+    _write(systems_root, f"data/h100_sxm/gemm/{backend}/{requested}/gemm_perf.parquet")
+    _write_yaml(
+        systems_root,
+        f"data/h100_sxm/gemm/{backend}/{requested}/reuse.yaml",
+        {"reuse": [_reuse_entry("gemm_perf", donor)]},
+    )
+    _write(systems_root, f"data/h100_sxm/{backend}/{donor}/gemm_perf.parquet")
+    _write(systems_root, f"data/h100_sxm/{backend}/{donor}/INCOMPLETE.txt", b"partial collection\n")
+
+    db = _build_db(systems_root, backend=backend, version=requested)
+    sources = _sources_for(db, systems_root, common.PerfDataFilename.gemm)
+
+    assert _channels(db, "gemm_perf.parquet") == ["primary"]
+    assert all(donor not in path for path, _ in sources)
+
+
 def test_declared_reuse_works_with_no_primary_data_at_all(systems_root: Path) -> None:
     """Mirrors the real l40s/quantize/vllm/0.22.0 case: the requested version
     dir holds ONLY a reuse.yaml, no parquet of its own."""
@@ -189,6 +209,20 @@ def test_fallback_nearest_earlier_descending_no_manifest_needed(systems_root: Pa
 
     assert _versions(db, "gemm_perf.parquet") == ["1.0.0", "0.9.0", "0.8.0"]
     assert _channels(db, "gemm_perf.parquet") == ["primary", "fallback", "fallback"]
+
+
+def test_fallback_rejects_legacy_incomplete_donor(systems_root: Path) -> None:
+    """Implicit same-backend fallback must honor the legacy whole-dir veto."""
+    backend, requested, donor = "trtllm", "1.0.0", "0.9.0"
+    _write(systems_root, f"data/h100_sxm/gemm/{backend}/{requested}/gemm_perf.parquet")
+    _write(systems_root, f"data/h100_sxm/{backend}/{donor}/gemm_perf.parquet")
+    _write(systems_root, f"data/h100_sxm/{backend}/{donor}/INCOMPLETE.txt", b"partial collection\n")
+
+    db = _build_db(systems_root, backend=backend, version=requested)
+    sources = _sources_for(db, systems_root, common.PerfDataFilename.gemm)
+
+    assert _channels(db, "gemm_perf.parquet") == ["primary"]
+    assert all(donor not in path for path, _ in sources)
 
 
 def test_fallback_excludes_newer_than_requested(systems_root: Path) -> None:
@@ -353,6 +387,62 @@ def test_full_channel_order_declared_then_fallback_nearest_then_cross_backend(sy
 # ---------------------------------------------------------------------------
 # Self-overlap (the l40s case): primary already owns the table
 # ---------------------------------------------------------------------------
+
+
+def test_cross_backend_rejects_legacy_incomplete_donor(systems_root: Path) -> None:
+    """Cross-backend fill must not admit an INCOMPLETE legacy directory."""
+    backend, requested = "trtllm", "1.0.0"
+    donor_backend, donor_version = "sglang", "0.5.14"
+    _write(systems_root, f"data/h100_sxm/gemm/{backend}/{requested}/gemm_perf.parquet")
+    _write(systems_root, f"data/h100_sxm/{donor_backend}/{donor_version}/gemm_perf.parquet")
+    _write(
+        systems_root,
+        f"data/h100_sxm/{donor_backend}/{donor_version}/INCOMPLETE.txt",
+        b"partial collection\n",
+    )
+    _write_manifest(
+        systems_root,
+        [("gemm_perf.parquet", "shared_kernel", "shared", [backend, donor_backend])],
+    )
+
+    db = _build_db(systems_root, backend=backend, version=requested)
+    sources = _sources_for(db, systems_root, common.PerfDataFilename.gemm)
+
+    assert _channels(db, "gemm_perf.parquet") == ["primary"]
+    assert all(donor_backend not in path for path, _ in sources)
+
+
+def test_loaded_rows_keep_primary_and_fill_only_missing_shapes(systems_root: Path) -> None:
+    """Exercise the loader: overlap is first-wins; fallback fills only gaps."""
+    backend, requested, donor = "trtllm", "1.0.0", "0.9.0"
+    header = "framework,version,device,op_name,gemm_dtype,m,n,k,latency\n"
+    primary_rows = header + "trtllm,1.0.0,h100,gemm,bfloat16,128,256,512,1.25\n"
+    fallback_rows = header + (
+        "trtllm,0.9.0,h100,gemm,bfloat16,128,256,512,9.50\ntrtllm,0.9.0,h100,gemm,bfloat16,256,256,512,2.50\n"
+    )
+    _write(
+        systems_root,
+        f"data/h100_sxm/gemm/{backend}/{requested}/gemm_perf.txt",
+        primary_rows.encode(),
+    )
+    _write_yaml(
+        systems_root,
+        f"data/h100_sxm/gemm/{backend}/{requested}/collection_meta.yaml",
+        {"tables": {"gemm_perf": {"status": "partial"}}},
+    )
+    _write(
+        systems_root,
+        f"data/h100_sxm/gemm/{backend}/{donor}/gemm_perf.txt",
+        fallback_rows.encode(),
+    )
+
+    db = _build_db(systems_root, backend=backend, version=requested)
+    sources = _sources_for(db, systems_root, common.PerfDataFilename.gemm)
+    loaded = load_gemm_data(sources)
+
+    quant = common.GEMMQuantMode.bfloat16
+    assert loaded[quant][128][256][512]["latency"] == pytest.approx(1.25)
+    assert loaded[quant][256][256][512]["latency"] == pytest.approx(2.50)
 
 
 def test_self_overlap_declared_donor_admitted_after_primary(systems_root: Path) -> None:


### PR DESCRIPTION
#### Overview:

  Fix perf-data fallback semantics for partially collected tables. Successfully collected rows from the requested framework version now remain the primary source, while older versions fill only missing shapes.

  #### Details:

  - Treat collection_meta.yaml entries with status: partial as incomplete coverage rather than invalid data.
  - Admit successfully collected rows from partial tables as the primary source.
  - Preserve first-wins source ordering so older versions only fill missing shapes.
  - Continue rejecting directories marked with legacy INCOMPLETE.txt, since that marker lacks table- or shape-level coverage information.
  - Add regression tests covering family-first and legacy layouts, partial-table admission, and legacy incomplete-directory rejection.
  - Verified with Ruff and the relevant SDK database tests:
      - 87 passed
      - 2 skipped

  #### Where should the reviewer start?

  Please start with:

  - aic-core/src/aiconfigurator_core/sdk/perf_database.py
      - _version_dir_state
      - _version_dir_unusable_for_request
      - PerfDatabase._build_op_sources

  - aic-core/src/aiconfigurator_core/sdk/operations/base.py
      - _version_dir_is_unusable
      - resolve_op_data_path

  Regression coverage is in:

  - tests/unit/sdk/database/test_reuse_ordering.py
  - tests/unit/sdk/database/test_dual_layout_discovery.py


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading and fallback behavior for partially populated collections.
  * Structured partial collections remain available for valid data retrieval and reuse.
  * Legacy incomplete markers continue to exclude affected directories safely.
  * Improved discovery and validation across legacy and family-based layouts.
  * Ensured valid fallback sources can be used when primary data is incomplete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->