### PR TITLE
feat(sdk): Nemotron-3-Ultra-550B H100 support via transfer ladder (alternative approach)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -71,7 +71,7 @@ jobs:
   build-and-test:
     name: Build and Test (${{ matrix.suite.name }})
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:

--- a/aic-core/rust/aiconfigurator-core/parity_tests/goldens/engine_step.json
+++ b/aic-core/rust/aiconfigurator-core/parity_tests/goldens/engine_step.json
@@ -1132,30 +1132,42 @@
     },
     "minimax-m25-nvfp4-h200-vllm-019-hybrid-balanced-miss": {
       "agg": {
-        "error": "MissingSystemFlopsError"
+        "error": "EmpiricalNotImplementedError"
       },
       "disagg": {
-        "error": "MissingSystemFlopsError"
+        "error": "EmpiricalNotImplementedError"
       },
       "mixed": {
         "error": "MissingSystemFlopsError"
       },
       "static": {
-        "error": "MissingSystemFlopsError"
+        "error": "EmpiricalNotImplementedError"
       }
     },
     "minimax-m25-nvfp4-h200-vllm-019-hybrid-xprofile": {
       "agg": {
-        "error": "MissingSystemFlopsError"
+        "values": {
+          "agg_request": 210.6834999458623,
+          "agg_tpot": 72.8863529156999,
+          "agg_ttft": 137.7971470301624
+        }
       },
       "disagg": {
-        "error": "MissingSystemFlopsError"
+        "values": {
+          "disagg_request": 152.294,
+          "disagg_tpot": 9.466,
+          "disagg_ttft": 142.828
+        }
       },
       "mixed": {
         "error": "MissingSystemFlopsError"
       },
       "static": {
-        "error": "MissingSystemFlopsError"
+        "values": {
+          "static_ctx": 72.135,
+          "static_gen": 6.818,
+          "static_total": 78.953
+        }
       }
     },
     "minimax-m27-b200-vllm-019-isl1024-osl2": {

--- a/aic-core/rust/aiconfigurator-core/src/common/enums.rs
+++ b/aic-core/rust/aiconfigurator-core/src/common/enums.rs
@@ -199,6 +199,7 @@ pub enum GemmQuantMode {
     Fp8Block,
     Fp8Ootb,
     Nvfp4,
+    Nvfp4Wo,
 }
 
 impl GemmQuantMode {
@@ -258,6 +259,12 @@ impl GemmQuantMode {
                 name: "nvfp4",
                 compute_dtype: Some(ComputeDtype::Fp4),
             },
+            Self::Nvfp4Wo => QuantMapping {
+                memory: 9.0 / 16.0,
+                compute: 1.0,
+                name: "nvfp4_wo",
+                compute_dtype: Some(ComputeDtype::Bfloat16),
+            },
         }
     }
 
@@ -276,6 +283,7 @@ pub enum MoeQuantMode {
     Fp8Block,
     W4afp8,
     Nvfp4,
+    Nvfp4Wo,
     W4a16Mxfp4,
     W4a8Mxfp4Mxfp8,
     /// Blackwell trtllm-gen MXFP4xMXFP8 kernel rows
@@ -327,6 +335,12 @@ impl MoeQuantMode {
                 compute: 4.0,
                 name: "nvfp4",
                 compute_dtype: Some(ComputeDtype::Fp4),
+            },
+            Self::Nvfp4Wo => QuantMapping {
+                memory: 9.0 / 16.0,
+                compute: 1.0,
+                name: "nvfp4_wo",
+                compute_dtype: Some(ComputeDtype::Bfloat16),
             },
             Self::W4a16Mxfp4 => QuantMapping {
                 memory: 0.5,

--- a/aic-core/rust/aiconfigurator-core/src/operators/gemm.rs
+++ b/aic-core/rust/aiconfigurator-core/src/operators/gemm.rs
@@ -229,6 +229,7 @@ fn query_gemm_table(
 const GEMM_QUANT_UTIL_LEVEL: &[(f64, f64, f64)] = &[
     (2.0, 1.0, 0.70),    // w16a16 / bfloat16              [data 0.55-0.79]
     (1.0, 1.0, 0.55),    // w8a16 / int8_wo                [inferred]
+    (0.5625, 1.0, 0.45), // w4a16+scales / nvfp4_wo (Marlin FP4) [copies inferred (0.5,1)]
     (0.5, 1.0, 0.45),    // w4a16 / int4_wo                [inferred]
     (1.0, 2.0, 0.45),    // w8a8 / fp8(_block/_ootb), sq   [data 0.28-0.55]
     (0.5, 2.0, 0.35),    // w4a8                           [inferred]

--- a/aic-core/rust/aiconfigurator-core/src/operators/moe.rs
+++ b/aic-core/rust/aiconfigurator-core/src/operators/moe.rs
@@ -55,6 +55,7 @@ use std::sync::Arc;
 const MOE_QUANT_UTIL_LEVEL: &[(f64, f64, f64)] = &[
     (2.0, 1.0, 0.53),    // w16a16 / bfloat16              [data]
     (1.0, 1.0, 0.45),    // w8a16                          [inferred]
+    (0.5625, 1.0, 0.07), // w4a16+scales / nvfp4_wo (Marlin FP4) [copies measured (0.5,1)]
     (0.5, 1.0, 0.07),    // w4a16 (int4_wo, mxfp4)         [data]
     (1.0, 2.0, 0.40),    // w8a8 / fp8(_block)             [data]
     (0.5, 2.0, 0.15),    // w4a8 (w4afp8, mxfp4_mxfp8)     [data]
@@ -85,6 +86,7 @@ const ALL_MOE_QUANTS: &[MoeQuantMode] = &[
     MoeQuantMode::Fp8Block,
     MoeQuantMode::W4afp8,
     MoeQuantMode::Nvfp4,
+    MoeQuantMode::Nvfp4Wo,
     MoeQuantMode::W4a16Mxfp4,
     MoeQuantMode::W4a8Mxfp4Mxfp8,
     MoeQuantMode::W4a8Mxfp4Mxfp8Trtllm,
@@ -1041,6 +1043,50 @@ mod tests {
     ///     quant_mode=common.MoEQuantMode.nvfp4, workload_distribution="balanced",
     ///     database_mode=common.DatabaseMode.EMPIRICAL))
     /// ```
+    /// nvfp4_wo ladder-approach parity: no collected data exists, so the query
+    /// walks the transfer ladder (XPROFILE to bfloat16, rescaled by the
+    /// util-level ratio e(nvfp4_wo)/e(bfloat16)). Python oracle (shared_layer=False,
+    /// HYBRID, h200/vllm/0.19.0, same shape as the GEMM oracle):
+    ///
+    /// ```python
+    /// db = perf_database.get_database_view("h200_sxm", "vllm", "0.19.0",
+    ///     allow_missing_data=True, database_mode=DatabaseMode.HYBRID,
+    ///     transfer_policy=None, shared_layer=False)
+    /// float(MoE._query_moe_table(db, num_tokens=96, hidden_size=7168,
+    ///     inter_size=2048, topk=8, num_experts=256, moe_tp_size=1, moe_ep_size=1,
+    ///     quant_mode=MoEQuantMode.nvfp4_wo, workload_distribution="power_law_1.2",
+    ///     database_mode=DatabaseMode.HYBRID))
+    /// # → 8.439357376098632  (XPROFILE borrow from bfloat16, rescaled by 0.07/0.53)
+    /// ```
+    #[test]
+    fn moe_nvfp4_wo_ladder_matches_python_oracle() {
+        let root =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..").join("src/aiconfigurator_core/systems");
+        let db = PerfDatabase::load(&root, "h200_sxm", "vllm", "0.19.0")
+            .expect("h200/vllm/0.19.0 db loads")
+            .with_mode(crate::common::enums::DatabaseMode::Hybrid, TransferPolicy::ALL);
+
+        let op = MoeOp {
+            name: "moe-nvfp4wo-ladder".into(),
+            scale_factor: 1.0,
+            hidden_size: 7168,
+            inter_size: 2048,
+            topk: 8,
+            num_experts: 256,
+            moe_tp_size: 1,
+            moe_ep_size: 1,
+            quant_mode: MoeQuantMode::Nvfp4Wo,
+            workload_distribution: "power_law_1.2".into(),
+            attention_dp_size: 1,
+            is_gated: true,
+            moe_backend: None,
+            enable_eplb: false,
+            is_context: false,
+        };
+        let r = op.query(&db, 96).expect("nvfp4_wo resolves via XPROFILE ladder");
+        assert_oracle(&r, 8.439357376098632, Source::Empirical, "nvfp4_wo_ladder_t96");
+    }
+
     #[test]
     fn moe_empirical_low_latency_table_selection_matches_python_oracles() {
         let db = b200_trtllm_db().with_mode(

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/gemm.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/gemm.rs
@@ -546,6 +546,7 @@ pub(crate) fn gemm_quant_by_name(name: &str) -> Option<GemmQuantMode> {
         "fp8_block" => Fp8Block,
         "fp8_ootb" => Fp8Ootb,
         "nvfp4" => Nvfp4,
+        "nvfp4_wo" => Nvfp4Wo,
         _ => return None,
     })
 }

--- a/aic-core/src/aiconfigurator_core/sdk/common.py
+++ b/aic-core/src/aiconfigurator_core/sdk/common.py
@@ -1198,6 +1198,7 @@ class GEMMQuantMode(Enum):
         1, 2, "fp8_ootb", "fp8"
     )  # in future, should deprecate this mode as it's specific for trtllm trt backend
     nvfp4 = QuantMapping(9 / 16, 4, "nvfp4", "fp4")  # nvfp4 on blackwell. 1 fp8 scale per 16 nvfp4 weights.
+    nvfp4_wo = QuantMapping(9 / 16, 1, "nvfp4_wo", "bfloat16")  # nvfp4 sw dequant to bf16 (non-Blackwell)
 
 
 class MoEQuantMode(Enum):
@@ -1211,6 +1212,7 @@ class MoEQuantMode(Enum):
     fp8_block = QuantMapping(1, 2, "fp8_block", "fp8")  # specific for trtllm torch ds fp8
     w4afp8 = QuantMapping(0.5, 2, "w4afp8", "fp8")  # specific for trtllm torch ds w4a8
     nvfp4 = QuantMapping(9 / 16, 4, "nvfp4", "fp4")  # nvfp4 on blackwell. 1 fp8 scale per 16 nvfp4 weights.
+    nvfp4_wo = QuantMapping(9 / 16, 1, "nvfp4_wo", "bfloat16")  # nvfp4 sw dequant to bf16 (non-Blackwell)
     w4a16_mxfp4 = QuantMapping(0.5, 1, "w4a16_mxfp4", "bfloat16")  # native data format for gpt oss
     w4a8_mxfp4_mxfp8 = QuantMapping(0.5, 2, "w4a8_mxfp4_mxfp8", "fp8")
     # mxfp4 weights, mxfp8 activations (recommended for Blackwell)

--- a/aic-core/src/aiconfigurator_core/sdk/models/__init__.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/__init__.py
@@ -42,6 +42,7 @@ from aiconfigurator_core.sdk.models.helpers import (
     resolve_dsv4_moe_arch,
     resolve_dsv4_moe_arch_mode,
     resolve_kimi_k3_moe_arch_mode,
+    resolve_nvfp4_for_system,
 )
 
 # Auto-import every other module in this package so ``@register_model``
@@ -209,4 +210,5 @@ __all__ = [
     "resolve_dsv4_moe_arch",
     "resolve_dsv4_moe_arch_mode",
     "resolve_kimi_k3_moe_arch_mode",
+    "resolve_nvfp4_for_system",
 ]

--- a/aic-core/src/aiconfigurator_core/sdk/models/helpers.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/helpers.py
@@ -775,6 +775,46 @@ def resolve_dsv4_moe_arch(
         model_config.moe_quant_mode = mode
 
 
+def resolve_nvfp4_for_system(
+    model_config: config.ModelConfig,
+    system_name: str | None,
+    model_path: str | None = None,
+) -> None:
+    """Remap native nvfp4 to weight-only nvfp4_wo on non-Blackwell systems.
+
+    Non-Blackwell hardware has no native FP4 tensor cores, so all runtimes
+    dequantize weights to BF16 before the MMA. nvfp4_wo captures this:
+    memory=9/16 (FP4 weight traffic) and compute=1 (BF16 speed). The
+    transfer ladder then models the Marlin-class memory savings via the
+    (0.5625, 1) util-level entry — no direct bfloat16 table aliasing needed.
+
+    Deployability (whether a runtime can load the checkpoint at a given
+    version) is a separate question handled by the support matrix.
+    """
+    from aiconfigurator_core.sdk.perf_database import is_blackwell_system
+
+    if is_blackwell_system(system_name):
+        return  # native FP4 TC — nvfp4 stays as-is
+
+    gemm_q = model_config.gemm_quant_mode
+    moe_q = model_config.moe_quant_mode
+    if (gemm_q is None or moe_q is None) and model_path:
+        info = _get_model_info(model_path)
+        inferred = _infer_quant_modes_from_raw_config(
+            info.get("raw_config", {}),
+            info.get("architecture", ""),
+        )
+        if gemm_q is None:
+            gemm_q = inferred.get("gemm_quant_mode")
+        if moe_q is None:
+            moe_q = inferred.get("moe_quant_mode")
+
+    if gemm_q == common.GEMMQuantMode.nvfp4:
+        model_config.gemm_quant_mode = common.GEMMQuantMode.nvfp4_wo
+    if moe_q == common.MoEQuantMode.nvfp4:
+        model_config.moe_quant_mode = common.MoEQuantMode.nvfp4_wo
+
+
 def resolve_context_fmha_by_data(
     model_config: config.ModelConfig,
     model_path: str,

--- a/aic-core/src/aiconfigurator_core/sdk/models/nemotron_h.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/nemotron_h.py
@@ -127,7 +127,7 @@ class NemotronHModel(BaseModel):
             count = layer_counts["M"]
             nheads_per_gpu = cfg.mamba_num_heads // tp_size
             d_inner_per_gpu = nheads_per_gpu * cfg.mamba_head_dim
-            n_groups_per_gpu = cfg.n_groups // tp_size
+            n_groups_per_gpu = max(cfg.n_groups // tp_size, 1)
             in_proj_out_per_gpu = 2 * d_inner_per_gpu + 2 * n_groups_per_gpu * cfg.ssm_state_size + nheads_per_gpu
             self.context_ops.extend(
                 [
@@ -418,7 +418,7 @@ class NemotronHModel(BaseModel):
             count = layer_counts["M"] * mtp
             nheads_per_gpu = cfg.mamba_num_heads // tp_size
             d_inner_per_gpu = nheads_per_gpu * cfg.mamba_head_dim
-            n_groups_per_gpu = cfg.n_groups // tp_size
+            n_groups_per_gpu = max(cfg.n_groups // tp_size, 1)
             in_proj_out_per_gpu = 2 * d_inner_per_gpu + 2 * n_groups_per_gpu * cfg.ssm_state_size + nheads_per_gpu
             self.generation_ops.extend(
                 [

--- a/aic-core/src/aiconfigurator_core/sdk/operations/gemm.py
+++ b/aic-core/src/aiconfigurator_core/sdk/operations/gemm.py
@@ -62,6 +62,7 @@ logger = logging.getLogger(__name__)
 _GEMM_QUANT_UTIL_LEVEL: dict[tuple[float, float], float] = {
     (2, 1): 0.70,  # w16a16 / bfloat16               [data 0.55-0.79]
     (1, 1): 0.55,  # w8a16 / int8_wo                 [inferred]
+    (0.5625, 1): 0.45,  # w4a16+scales / nvfp4_wo (Marlin FP4, BF16 compute) [copies inferred (0.5,1)]
     (0.5, 1): 0.45,  # w4a16 / int4_wo (fused-dequant weight-only runs below
     #                  the bf16 compute roofline it shares; Marlin-class) [inferred]
     (1, 2): 0.45,  # w8a8 / fp8(_block/_ootb), sq    [data 0.28-0.55]

--- a/aic-core/src/aiconfigurator_core/sdk/operations/moe.py
+++ b/aic-core/src/aiconfigurator_core/sdk/operations/moe.py
@@ -87,6 +87,7 @@ def _cache_key(database: PerfDatabase) -> tuple:
 _MOE_QUANT_UTIL_LEVEL: dict[tuple[float, float], float] = {
     (2, 1): 0.53,  # w16a16 / bfloat16              [data]
     (1, 1): 0.45,  # w8a16                          [inferred]
+    (0.5625, 1): 0.07,  # w4a16+scales / nvfp4_wo (Marlin FP4, weight-only BF16) [copies measured (0.5,1)]
     (0.5, 1): 0.07,  # w4a16 (int4_wo, mxfp4)       [data]
     (1, 2): 0.40,  # w8a8 / fp8(_block)             [data]
     (0.5, 2): 0.15,  # w4a8 (w4afp8, mxfp4_mxfp8)   [data]

--- a/docs/design/how_to_add_a_gemm_quant_mode.md
+++ b/docs/design/how_to_add_a_gemm_quant_mode.md
@@ -1,14 +1,19 @@
-# How to add a GEMM quant mode (without collected data)
+# How to add a GEMM or MoE quant mode (without collected data)
 
 The handoff recipe for PR #1392's `nvfp4_wo` and any successor. Mechanism
 rationale lives in `gemm_quant_transfer_design.md`; this page is only the
 steps.
 
-## The two lines
+As of PR #1392, **MoE follows the same two-line recipe as GEMM**: add the
+enum variant and one util-level row; the transfer ladder handles the rest.
+No normalization functions, no validation aliases, no query-layer changes in
+either operation family.
 
-1. **Enum line** — `GEMMQuantMode` in
+## The two lines (applies to both GEMM and MoE)
+
+1. **Enum line** — `GEMMQuantMode` *and* `MoEQuantMode` in
    `aic-core/src/aiconfigurator_core/sdk/common.py`, with
-   `QuantMapping(memory, compute, name)`:
+   `QuantMapping(memory, compute, name, compute_dtype)`:
    - `memory` = weight bytes per element **including scales**
      (nvfp4-style 4-bit + 1 fp8 scale per 16 = `9/16`).
    - `compute` = the precision the MMA actually runs in (1 = bf16, 2 = fp8,
@@ -16,44 +21,64 @@ steps.
      this field decides which data is borrowed (compute-first ordering ⇒
      weight-only borrows bfloat16), so get it right.
 
-   Rust mirror, same PR: the `GemmQuantMode` variant in
-   `rust/aiconfigurator-core/src/common/enums.rs` and the name-parse arm in
-   `gemm_quant_by_name` (`src/perf_database/gemm.rs`).
+   Rust mirrors, same PR:
+   - `GemmQuantMode` / `MoeQuantMode` variants in
+     `aic-core/rust/aiconfigurator-core/src/common/enums.rs`
+   - Name-parse arm in `gemm_quant_by_name`
+     (`aic-core/rust/aiconfigurator-core/src/perf_database/gemm.rs`)
+     (MoE uses `#[serde(rename_all = "snake_case")]` so no explicit parser needed)
+   - Add the variant to `ALL_MOE_QUANTS` in
+     `aic-core/rust/aiconfigurator-core/src/operators/moe.rs`
 
-2. **Util-level line** — only if the `(memory, compute)` profile is not yet
-   listed: one row in `_GEMM_QUANT_UTIL_LEVEL`
-   (`operations/gemm.py`; derivation method on the table) and its Rust
-   mirror `GEMM_QUANT_UTIL_LEVEL` (`operators/gemm.rs`). If unsure, match
-   the structurally nearest `[inferred]` row — only ratios are consumed.
-   **The validate gate requires the profile to be listed**, so this line is
-   not optional for a new profile.
+2. **Util-level line** — one row in each table if the `(memory, compute)`
+   profile is not yet listed:
+   - GEMM: `_GEMM_QUANT_UTIL_LEVEL`
+     (`aic-core/src/aiconfigurator_core/sdk/operations/gemm.py`) + Rust mirror
+     `GEMM_QUANT_UTIL_LEVEL`
+     (`aic-core/rust/aiconfigurator-core/src/operators/gemm.rs`)
+   - MoE: `_MOE_QUANT_UTIL_LEVEL`
+     (`aic-core/src/aiconfigurator_core/sdk/operations/moe.py`) + Rust mirror
+     `MOE_QUANT_UTIL_LEVEL`
+     (`aic-core/rust/aiconfigurator-core/src/operators/moe.rs`)
+
+   If unsure of the level, match the structurally nearest `[inferred]` row —
+   only ratios are consumed. **The validate gate requires the profile to be
+   listed in both tables**, so these lines are not optional for a new profile.
 
 No table normalization, no `validation_aliases`, no query-layer changes.
 HYBRID/EMPIRICAL then estimates via the transfer ladder (SOL stays your
-quant's own — the w4 memory-side benefit is preserved); SILICON still
-rejects until real data exists.
+quant's own — the memory-side benefit is preserved); SILICON still rejects
+until real data exists.
 
 ## Verify
 
-- Template test:
+- GEMM template test:
   `tests/unit/sdk/database/test_gemm_quant_transfer.py::test_xprofile_weight_only_borrows_bf16_not_fp8`
   (`int4_wo` is the data-less stand-in; clone for your quant).
   `test_level_table_covers_every_gemm_quant_profile` will fail loudly if
-  the level line is missing.
-- Rust parity: extend `gemm_quant_transfer_ladder_matches_python_oracles`
-  (`operators/gemm.rs`) with a Python-probed oracle (generation snippet in
-  its doc comment).
+  the GEMM level line is missing.
+- MoE validate test: add a `test_validate_<quant>_ladder_admitted_in_hybrid`
+  (see `test_validate_nvfp4_wo_ladder_admitted_in_hybrid` in
+  `tests/unit/sdk/task_v2/test_task_config.py` as a template).
+- Rust parity:
+  - GEMM: extend `gemm_quant_transfer_ladder_matches_python_oracles`
+    (`aic-core/rust/aiconfigurator-core/src/operators/gemm.rs`) with a
+    Python-probed oracle.
+  - MoE: add a `moe_<quant>_ladder_matches_python_oracle` test in
+    `aic-core/rust/aiconfigurator-core/src/operators/moe.rs`
+    (see `moe_nvfp4_wo_ladder_matches_python_oracle`).
 - Before pushing: `cargo test --workspace --all-features` +
   `parity_tests/test_engine_step_parity.py`.
 
 ## Graduating to collected data
 
-The ladder only fires behind an own-data miss: once `gemm_perf.parquet`
-carries rows for your quant they win automatically — no code change, delete
-nothing. Provenance moves `xprofile → silicon` by itself.
+The ladder only fires behind an own-data miss: once `gemm_perf.parquet` or
+`moe_perf.parquet` carries rows for your quant they win automatically — no
+code change, delete nothing. Provenance moves `xprofile → silicon` by itself.
 
 ## Out of the mechanism's scope
 
-Checkpoint-name → quant resolution (`cli/api.py` `resolve_*`) and the
-support-matrix FP4 gate are separate decisions with their own owners; this
-recipe only makes the quant *estimable*.
+Checkpoint-name → quant resolution (`cli/api.py` `resolve_*`), the
+non-Blackwell remap (`resolve_nvfp4_for_system`), and the support-matrix
+hardware gate are separate decisions with their own owners; this recipe only
+makes the quant *estimable*.

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -28,7 +28,12 @@ from aiconfigurator.sdk.config_builders import apply_nextn as _apply_nextn
 from aiconfigurator.sdk.config_builders import build_model_config as _build_model_config
 from aiconfigurator.sdk.config_builders import resolve_nextn_auto as _resolve_nextn_auto
 from aiconfigurator.sdk.errors import ExperimentOutcome, NoFeasibleConfigError, is_gpu_retriable
-from aiconfigurator.sdk.models import check_is_moe, resolve_context_fmha_by_data, resolve_dsv4_moe_arch
+from aiconfigurator.sdk.models import (
+    check_is_moe,
+    resolve_context_fmha_by_data,
+    resolve_dsv4_moe_arch,
+    resolve_nvfp4_for_system,
+)
 from aiconfigurator.sdk.speculative import (
     SpeculativeDecodingProfile,
 )
@@ -1501,6 +1506,7 @@ def _run_agg_estimate(
         model_config, model_path, load_database(system_name), backend_name, is_context_role=True
     )
     resolve_dsv4_moe_arch(model_config, model_path, system_name=system_name, backend_name=backend_name)
+    resolve_nvfp4_for_system(model_config, system_name, model_path)
     runtime_config = RuntimeConfig(
         isl=isl,
         osl=osl,
@@ -1647,6 +1653,7 @@ def _run_static_estimate(
         is_context_role=static_mode != "static_gen",
     )
     resolve_dsv4_moe_arch(model_config, model_path, system_name=system_name, backend_name=backend_name)
+    resolve_nvfp4_for_system(model_config, system_name, model_path)
 
     runtime_config = RuntimeConfig(
         batch_size=batch_size,
@@ -1813,12 +1820,14 @@ def _run_disagg_estimate(
         prefill_model_config, model_path, load_database(system_name), backend_name, is_context_role=True
     )
     resolve_dsv4_moe_arch(prefill_model_config, model_path, system_name=system_name, backend_name=backend_name)
+    resolve_nvfp4_for_system(prefill_model_config, system_name, model_path)
     resolve_dsv4_moe_arch(
         decode_model_config,
         model_path,
         system_name=decode_system_name or system_name,
         backend_name=backend_name,
     )
+    resolve_nvfp4_for_system(decode_model_config, decode_system_name or system_name, model_path)
 
     runtime_config = RuntimeConfig(
         isl=isl,
@@ -2123,7 +2132,9 @@ def _run_afd_estimate(
         a_model_config, model_path, database, backend_name, is_context_role=afd_phase in ("prefill", "both")
     )
     resolve_dsv4_moe_arch(a_model_config, model_path, system_name=system_name, backend_name=backend_name)
+    resolve_nvfp4_for_system(a_model_config, system_name, model_path)
     resolve_dsv4_moe_arch(f_model_config, model_path, system_name=system_name, backend_name=backend_name)
+    resolve_nvfp4_for_system(f_model_config, system_name, model_path)
 
     afd_config = AFDConfig(
         n_a_nodes=n_a_nodes,

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -1074,6 +1074,17 @@ class Task:
         roles = ["agg"] if self.serving_mode in ("agg", "afd") else ["prefill", "decode"]
         fmha_explicit = self._fmha_explicit
 
+        # nvfp4 → nvfp4_wo on non-Blackwell: no native FP4 tensor cores, so all
+        # runtimes dequantize to BF16 before the MMA. The transfer ladder models
+        # the Marlin-class memory savings via the (0.5625, 1) util-level entry.
+        for role in roles:
+            system = self._role_attr(role, "system_name")
+            if not is_blackwell_system(system):
+                if self._role_attr(role, "gemm_quant_mode") == common.GEMMQuantMode.nvfp4:
+                    self._set_role_attr(role, "gemm_quant_mode", common.GEMMQuantMode.nvfp4_wo)
+                if self._role_attr(role, "moe_quant_mode") == common.MoEQuantMode.nvfp4:
+                    self._set_role_attr(role, "moe_quant_mode", common.MoEQuantMode.nvfp4_wo)
+
         # Data-driven FMHA resolution: if an inferred fp8 has no fp8 slice in
         # the role's fmha-keyed context-attention table, fall back to bfloat16
         # with a warning instead of failing validate later.  bf16-as-fp8 is

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -1592,18 +1592,19 @@ class Task:
 
         # Fused defaults: what a task without large-EP data explores today.
         if self.backend_name == "sglang":
+            x = [1, 2, 4, 8, 16] if self._is_moe else [1, 2, 4, 8]
             fused = {
-                "num_gpu": [1, 2, 4, 8],
-                "tp": [1, 2, 4, 8],
+                "num_gpu": x,
+                "tp": x,
                 "pp": [1],
-                "dp": [1, 2, 4, 8],
+                "dp": x,
                 # Intra-node DeepEP (ep 1-8, NVLink) is EP-only; standard comm
                 # (fused_moe + allgather/RS) also explores MoE TP.
-                "moe_tp": [1] if self.moe_backend == "deepep_moe" else [1, 2, 4, 8],
-                "moe_ep": [1, 2, 4, 8],
+                "moe_tp": [1] if self.moe_backend == "deepep_moe" else x,
+                "moe_ep": x,
             }
         else:
-            x = [1, 2, 4, 8]
+            x = [1, 2, 4, 8, 16] if self._is_moe else [1, 2, 4, 8]
             fused = {"num_gpu": x, "tp": x, "pp": [1], "dp": x, "moe_tp": x, "moe_ep": x}
 
         # Large-EP ladder, offered when the perf data covers this model shape on

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -211,21 +211,22 @@ def build_disagg_parallel_lists(
     Kept here so the new sdk.task_v2 module does not depend on V1 (sdk.task).
     Algorithm identical; locked by integration parity test.
     """
+    base = [1, 2, 4, 8, 16] if is_moe else [1, 2, 4, 8]
     prefill_cfg: dict[str, list[int]] = {
-        "num_gpu_per_worker": [1, 2, 4, 8],
-        "tp_list": [1, 2, 4, 8],
+        "num_gpu_per_worker": base,
+        "tp_list": base,
         "pp_list": [1, 2, 4, 8] if should_enable_pp else [1],
         "dp_list": [1],
         "moe_tp_list": [1],
-        "moe_ep_list": [1, 2, 4, 8] if is_moe else [1],
+        "moe_ep_list": base if is_moe else [1],
     }
     decode_cfg: dict[str, list[int]] = {
-        "num_gpu_per_worker": [1, 2, 4, 8],
-        "tp_list": [1, 2, 4, 8],
+        "num_gpu_per_worker": base,
+        "tp_list": base,
         "pp_list": [1, 2, 4, 8] if should_enable_pp else [1],
-        "dp_list": [1, 2, 4, 8] if is_moe else [1],
+        "dp_list": base if is_moe else [1],
         "moe_tp_list": [1],
-        "moe_ep_list": [1, 2, 4, 8] if is_moe else [1],
+        "moe_ep_list": base if is_moe else [1],
     }
     if not is_moe:
         if prefill_system in ("gb200", "gb300"):
@@ -249,7 +250,7 @@ def build_disagg_parallel_lists(
                 "moe_ep_list": [4, 8, 16, 32],
             }
         else:
-            x = [1, 2, 4, 8]
+            x = [1, 2, 4, 8, 16]
             prefill_cfg = {
                 "num_gpu_per_worker": x,
                 "tp_list": x,
@@ -268,7 +269,7 @@ def build_disagg_parallel_lists(
                 "moe_ep_list": [4, 8, 16, 32, 64],
             }
         else:
-            x = [1, 2, 4, 8]
+            x = [1, 2, 4, 8, 16]
             decode_cfg = {
                 "num_gpu_per_worker": x,
                 "tp_list": x,
@@ -299,23 +300,23 @@ def build_disagg_parallel_lists(
             prefill_cfg = _sglang_megamoe_parallel_lists(prefill_system, should_enable_pp)
             decode_cfg = _sglang_megamoe_parallel_lists(decode_system, should_enable_pp)
         elif moe_backend == "deepep_moe":
-            x = [1, 2, 4, 8]
+            x = [1, 2, 4, 8, 16]
             for cfg in (prefill_cfg, decode_cfg):
                 cfg["num_gpu_per_worker"] = x
                 cfg["tp_list"] = x
                 cfg["pp_list"] = x if should_enable_pp else [1]
                 cfg["dp_list"] = x
                 cfg["moe_tp_list"] = [1]
-                cfg["moe_ep_list"] = [1, 2, 4, 8]
+                cfg["moe_ep_list"] = [1, 2, 4, 8, 16]
         else:
-            x = [1, 2, 4, 8]
+            x = [1, 2, 4, 8, 16]
             prefill_cfg = {
                 "num_gpu_per_worker": x,
                 "tp_list": x,
                 "pp_list": x if should_enable_pp else [1],
                 "dp_list": x,
                 "moe_tp_list": x,
-                "moe_ep_list": [1, 2, 4, 8],
+                "moe_ep_list": [1, 2, 4, 8, 16],
             }
             decode_cfg = {
                 "num_gpu_per_worker": x,
@@ -323,10 +324,10 @@ def build_disagg_parallel_lists(
                 "pp_list": x if should_enable_pp else [1],
                 "dp_list": x,
                 "moe_tp_list": x,
-                "moe_ep_list": [1, 2, 4, 8],
+                "moe_ep_list": [1, 2, 4, 8, 16],
             }
     elif backend_name == "vllm":
-        x = [1, 2, 4, 8]
+        x = [1, 2, 4, 8, 16]
         prefill_cfg = {
             "num_gpu_per_worker": x,
             "tp_list": x,

--- a/tests/unit/cli/test_afd_phase_completion.py
+++ b/tests/unit/cli/test_afd_phase_completion.py
@@ -261,6 +261,9 @@ def test_run_afd_estimate_passes_prefix_and_nextn(monkeypatch):
             return summary
 
     monkeypatch.setattr("aiconfigurator.sdk.inference_session.AFDInferenceSession", FakeSession)
+    # Stub out the nvfp4 remap: this test uses a fake model_path that has no
+    # HF config, so the remap's _get_model_info would fail trying to download it.
+    monkeypatch.setattr("aiconfigurator.cli.api.resolve_nvfp4_for_system", lambda *a, **k: None)
 
     api._run_afd_estimate(
         model_path="test-model",

--- a/tests/unit/sdk/models/test_nvfp4_fallback.py
+++ b/tests/unit/sdk/models/test_nvfp4_fallback.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from aiconfigurator_core.sdk import common
+from aiconfigurator_core.sdk.config import ModelConfig
+from aiconfigurator_core.sdk.models.helpers import resolve_nvfp4_for_system
+
+pytestmark = pytest.mark.unit
+
+
+def _model_config(**overrides) -> ModelConfig:
+    defaults = dict(tp_size=8, moe_tp_size=1, moe_ep_size=8)
+    defaults.update(overrides)
+    return ModelConfig(**defaults)
+
+
+def test_nvfp4_remapped_to_nvfp4_wo_on_hopper():
+    """nvfp4 → nvfp4_wo unconditionally on non-Blackwell (hardware fact)."""
+    mc = _model_config(
+        gemm_quant_mode=common.GEMMQuantMode.nvfp4,
+        moe_quant_mode=common.MoEQuantMode.nvfp4,
+    )
+    resolve_nvfp4_for_system(mc, "h100_sxm")
+    assert mc.gemm_quant_mode == common.GEMMQuantMode.nvfp4_wo
+    assert mc.moe_quant_mode == common.MoEQuantMode.nvfp4_wo
+
+
+def test_nvfp4_unchanged_on_blackwell():
+    """Blackwell has native FP4 TC — nvfp4 stays as-is."""
+    mc = _model_config(
+        gemm_quant_mode=common.GEMMQuantMode.nvfp4,
+        moe_quant_mode=common.MoEQuantMode.nvfp4,
+    )
+    resolve_nvfp4_for_system(mc, "b200_sxm")
+    assert mc.gemm_quant_mode == common.GEMMQuantMode.nvfp4
+    assert mc.moe_quant_mode == common.MoEQuantMode.nvfp4
+
+
+def test_bfloat16_unchanged_on_hopper():
+    mc = _model_config(
+        gemm_quant_mode=common.GEMMQuantMode.bfloat16,
+        moe_quant_mode=common.MoEQuantMode.bfloat16,
+    )
+    resolve_nvfp4_for_system(mc, "h100_sxm")
+    assert mc.gemm_quant_mode == common.GEMMQuantMode.bfloat16
+    assert mc.moe_quant_mode == common.MoEQuantMode.bfloat16
+
+
+def test_nvfp4_wo_memory_matches_nvfp4():
+    assert common.GEMMQuantMode.nvfp4_wo.value.memory == common.GEMMQuantMode.nvfp4.value.memory
+    assert common.MoEQuantMode.nvfp4_wo.value.memory == common.MoEQuantMode.nvfp4.value.memory
+
+
+def test_nvfp4_wo_compute_matches_bfloat16():
+    assert common.GEMMQuantMode.nvfp4_wo.value.compute == common.GEMMQuantMode.bfloat16.value.compute
+    assert common.MoEQuantMode.nvfp4_wo.value.compute == common.MoEQuantMode.bfloat16.value.compute
+
+
+def test_static_estimate_calls_resolve_nvfp4(monkeypatch):
+    """The static estimate path must call resolve_nvfp4_for_system.
+
+    Without the remap, nvfp4 on non-Blackwell hits MissingSystemFlopsError
+    on fp4_tc_flops. This verifies _run_static_estimate has the call.
+    """
+    import inspect
+
+    import aiconfigurator.cli.api as api
+
+    source = inspect.getsource(api._run_static_estimate)
+    assert "resolve_nvfp4_for_system" in source, "_run_static_estimate must call resolve_nvfp4_for_system"

--- a/tests/unit/sdk/task_v2/test_coverage_candidates.py
+++ b/tests/unit/sdk/task_v2/test_coverage_candidates.py
@@ -216,10 +216,10 @@ def test_covered_model_gets_union_of_wideep_and_fused_ladders(synth_systems):
     explores both regimes."""
     t = _synth_task()
     assert t.agg_num_gpu_candidates == [1, 2, 4, 8, 16, 32, 64]
-    assert t.agg_tp_candidates == [1, 2, 4, 8]
+    assert t.agg_tp_candidates == [1, 2, 4, 8, 16]
     assert t.agg_pp_candidates == [1]
     assert t.agg_dp_candidates == [1, 2, 4, 8, 16, 32, 64]
-    assert t.agg_moe_tp_candidates == [1, 2, 4, 8]
+    assert t.agg_moe_tp_candidates == [1, 2, 4, 8, 16]
     assert t.agg_moe_ep_candidates == [1, 2, 4, 8, 16, 32, 64]
 
 
@@ -254,7 +254,7 @@ def test_compute_coverage_is_quant_specific(synth_systems):
     by the run's MoE quant mode, so another quant gets no large-EP tuples."""
     t = _synth_task(moe_quant_mode=common.MoEQuantMode.fp8_block)
     assert t._resolve_moe_comm_backend("agg", _tuple(dp=8, moe_ep=8)) is None
-    assert t.agg_moe_ep_candidates == [1, 2, 4, 8]  # fused defaults
+    assert t.agg_moe_ep_candidates == [1, 2, 4, 8, 16]  # fused defaults
 
 
 def test_unready_family_never_resolves_a_backend(synth_systems, monkeypatch):
@@ -348,7 +348,7 @@ def test_generation_only_coverage_keeps_decode_fused_and_warns(synth_systems_gen
     assert len(warnings) == 1, warnings
     assert "context phase is not" in warnings[0]
     # ...and the whole task falls back to the fused ladders/tuples.
-    assert t.decode_moe_ep_candidates == [1, 2, 4, 8]
+    assert t.decode_moe_ep_candidates == [1, 2, 4, 8, 16]
     assert all(t._resolve_moe_comm_backend("decode", tup) is None for tup in t.iter_parallel("decode"))
 
 
@@ -391,8 +391,8 @@ def test_uncovered_model_keeps_fused_defaults_and_logs_once(caplog):
             total_gpus=8,
         )
         t._large_ep_coverage("agg")  # a second probe must not re-log
-    assert t.agg_moe_ep_candidates == [1, 2, 4, 8]
-    assert t.agg_num_gpu_candidates == [1, 2, 4, 8]
+    assert t.agg_moe_ep_candidates == [1, 2, 4, 8, 16]
+    assert t.agg_num_gpu_candidates == [1, 2, 4, 8]  # capped to total_gpus=8
     assert all(t._resolve_moe_comm_backend("agg", tup) is None for tup in t.iter_parallel("agg"))
     hits = [r for r in caplog.records if "large-EP" in r.message and "collector" in r.message]
     assert len(hits) == 1, [r.message for r in caplog.records]

--- a/tests/unit/sdk/task_v2/test_g4_auto_participation.py
+++ b/tests/unit/sdk/task_v2/test_g4_auto_participation.py
@@ -113,8 +113,8 @@ def test_qwen3_no_coverage_control_stays_fully_fused():
 
     assert t._large_ep_coverage("agg") == {}
     # Fused defaults, not the unioned multi-node ladders.
-    assert t.agg_moe_ep_candidates == [1, 2, 4, 8]
-    assert t.agg_num_gpu_candidates == [1, 2, 4, 8]
+    assert t.agg_moe_ep_candidates == [1, 2, 4, 8, 16]
+    assert t.agg_num_gpu_candidates == [1, 2, 4, 8, 16]
 
     tuples = list(t.iter_parallel("agg"))
     assert tuples

--- a/tests/unit/sdk/task_v2/test_task_config.py
+++ b/tests/unit/sdk/task_v2/test_task_config.py
@@ -1834,6 +1834,42 @@ def test_validate_gemm_quant_transfer_reachable_in_hybrid():
             make(mode, policy, quant=common.GEMMQuantMode.nvfp4).validate()
 
 
+def test_validate_nvfp4_wo_ladder_admitted_in_hybrid():
+    """nvfp4_wo has no collected MoE data on any system, but its util-level
+    entry is present so it is XPROFILE-reachable in HYBRID. SILICON rejects
+    (no data, no transfer). GEMM nvfp4_wo also goes through the XPROFILE
+    ladder to bfloat16.
+
+    This pins the ladder approach: validate admits without any alias, purely
+    through profile reachability — consistent with GEMM's treatment.
+    """
+
+    def make(mode, policy=None):
+        # vLLM 0.24.0 on H100: nvfp4 → nvfp4_wo (non-Blackwell remap)
+        return Task(
+            serving_mode="agg",
+            model_path="nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4",
+            system_name="h100_sxm",
+            backend_name="vllm",
+            backend_version="0.24.0",
+            database_mode=mode,
+            transfer_policy=policy,
+        )
+
+    # HYBRID: util-level entry present → XPROFILE-reachable for both GEMM and MoE
+    make("HYBRID").validate()
+    make("HYBRID", "xprofile").validate()
+
+    # SILICON: no data, no transfer → both quant modes are rejected
+    with pytest.raises(ValueError, match="nvfp4_wo"):
+        make("SILICON").validate()
+
+    # With XPROFILE disabled: ladder cannot reach nvfp4_wo → rejected
+    for disabled in ("off", "conservative", "xquant"):
+        with pytest.raises(ValueError, match="nvfp4_wo"):
+            make("HYBRID", disabled).validate()
+
+
 def test_validate_fp8_static_not_transfer_admitted_in_hybrid():
     """fp8_static is a composite mode (fp8 base minus compute_scale/scale_matrix);
     the overhead tables have no transfer ladder, so HYBRID must NOT admit it via
@@ -2022,3 +2058,27 @@ def test_trtllm_dp1_tep_tuples_stay_fused():
     for tup in t.iter_parallel("agg"):
         if t._resolve_moe_comm_backend("agg", tup) is not None:
             assert tup[2] > 1, f"dp=1 large-EP tuple leaked: {tup}"
+
+
+def test_nvfp4_remapped_to_nvfp4_wo_on_hopper():
+    """nvfp4 models on non-Blackwell get remapped to nvfp4_wo unconditionally."""
+    t = Task(
+        serving_mode="agg",
+        model_path="nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4",
+        system_name="h100_sxm",
+        backend_name="trtllm",
+    )
+    assert t.gemm_quant_mode == common.GEMMQuantMode.nvfp4_wo
+    assert t.moe_quant_mode == common.MoEQuantMode.nvfp4_wo
+
+
+def test_nvfp4_preserved_on_blackwell():
+    """Blackwell keeps native nvfp4 quant modes."""
+    t = Task(
+        serving_mode="agg",
+        model_path="nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4",
+        system_name="b200_sxm",
+        backend_name="trtllm",
+    )
+    assert t.gemm_quant_mode == common.GEMMQuantMode.nvfp4
+    assert t.moe_quant_mode == common.MoEQuantMode.nvfp4

--- a/tests/unit/sdk/task_v2/test_task_config.py
+++ b/tests/unit/sdk/task_v2/test_task_config.py
@@ -1012,8 +1012,8 @@ def test_sglang_agg_default_moe_ep_search():
     the union with the multi-node ladder instead (test_coverage_candidates)."""
     qwen = "Qwen/Qwen3-235B-A22B"
     t = Task(serving_mode="agg", model_path=qwen, system_name="h200_sxm", backend_name="sglang")
-    assert t.agg_moe_tp_candidates == [1, 2, 4, 8]
-    assert t.agg_moe_ep_candidates == [1, 2, 4, 8]
+    assert t.agg_moe_tp_candidates == [1, 2, 4, 8, 16]
+    assert t.agg_moe_ep_candidates == [1, 2, 4, 8, 16]
     t2 = Task(
         serving_mode="agg",
         model_path=qwen,

--- a/tests/unit/sdk/task_v2/test_task_config.py
+++ b/tests/unit/sdk/task_v2/test_task_config.py
@@ -42,7 +42,7 @@ def test_agg_with_model_resolves_identity_and_backend():
     assert t.nextn is not None
     assert t.backend_version is not None  # resolved to latest
     # Search space defaults populated
-    assert t.agg_tp_candidates == [1, 2, 4, 8]
+    assert t.agg_tp_candidates == [1, 2, 4, 8, 16]
     assert t.agg_pp_candidates == [1]
 
 
@@ -1022,7 +1022,7 @@ def test_sglang_agg_default_moe_ep_search():
         moe_backend="deepep_moe",
     )
     assert t2.agg_moe_tp_candidates == [1]
-    assert t2.agg_moe_ep_candidates == [1, 2, 4, 8]
+    assert t2.agg_moe_ep_candidates == [1, 2, 4, 8, 16]
 
 
 def test_run_validates_by_default():
@@ -1981,7 +1981,7 @@ def test_to_dict_emits_resolved_state_with_enum_names():
     # Backend version resolved automatically
     assert d["backend_version"] is not None
     # Search candidates populated
-    assert d["agg_tp_candidates"] == [1, 2, 4, 8]
+    assert d["agg_tp_candidates"] == [1, 2, 4, 8, 16]
 
 
 def test_to_dict_excludes_internal_fields():


### PR DESCRIPTION
## Overview

Alternative implementation of H100 NVFP4 support (see #1392) using Tianhaox's ladder design. Presented for direct comparison — the two approaches have identical user-visible behavior but differ in how nvfp4_wo is estimated.

## Design

nvfp4_wo is a weight-only profile: `memory=9/16` (FP4 weight traffic including scales), `compute=1` (BF16 MMA). On non-Blackwell hardware there are no native FP4 tensor cores; all runtimes dequantize weights to BF16 before the MMA.

**This PR** adds one enum entry and one util-level line per operation family, then lets the existing transfer ladder do the work — identical to how GEMM already handles data-less quants (#1455). No normalization functions, no validation aliases.

**#1392** aliases nvfp4_wo directly to bfloat16 rows at the query layer.

The ladder approach is more accurate for MoE: with `memory=9/16` in the SOL formula, the roofline correctly models Marlin FP4's reduced weight traffic; borrowing bfloat16 rows directly assumes full 2-byte weight traffic (wrong in both directions).

## Details

**Commit 1 — ladder approach (net deletions vs #1392):**

1. **MoE through the ladder** — add `(0.5625, 1): 0.07` to `_MOE_QUANT_UTIL_LEVEL` (and Rust mirror), copying the measured `(0.5, 1)` w4a16 row. No normalize functions, no op-scoped alias. Validate admits nvfp4_wo in HYBRID via existing XPROFILE profile-reachability.

2. **Unconditional remap on non-Blackwell** — `resolve_nvfp4_for_system()` and `task_v2._resolve_quant_modes` check only `is_blackwell_system()`. No version constants in the modeling layer — deployability is the support matrix's concern.

3. **NemotronH n_groups_per_gpu clamp** — `max(n_groups // tp_size, 1)` for the GEMM projection weight sizing to prevent zero at TP > n_groups.

Also updates `docs/design/how_to_add_a_gemm_quant_mode.md` to cover MoE, which now follows the same two-line recipe.

**Commit 2 — 16-GPU MoE search space expansion:**

Expand default MoE parallelism candidates from `[1,2,4,8]` to `[1,2,4,8,16]` across all backends for both agg and disagg modes, so Nemotron-3-Ultra-550B fits on 16xH100.

**Decode throughput prior.** Under the `0.07` MoE util level (matching the measured weight-only `(0.5, 1)` family), Hopper NVFP4 MoE decode is modeled ~2x slower than BF16 (8.44 ms vs 4.14 ms oracle). This reflects that Marlin FP4 kernels are memory-bound and the MoE transfer ratio `0.07/0.53` is low. NVFP4 checkpoints are recommended on Hopper only when the memory savings outweigh the throughput cost. Collecting real Marlin FP4 MoE data graduates this estimate automatically — the ladder only fires behind an own-data miss. The GEMM table uses a higher ratio (`0.45/0.70`) because dense Marlin has benchmark backing at higher utilization; grouped/MoE measured w4a16 does not.

## Test plan

- [x] `cargo test` — 364 passed (includes `moe_nvfp4_wo_ladder_matches_python_oracle` parity oracle: 8.439357 ms via XPROFILE)
- [x] `test_validate_nvfp4_wo_ladder_admitted_in_hybrid` — HYBRID passes, SILICON + non-XPROFILE policies reject
- [x] `test_static_estimate_calls_resolve_nvfp4` — static path has the remap call
- [x] `test_nvfp4_remapped_to_nvfp4_wo_on_hopper` / `test_nvfp4_preserved_on_blackwell` (Task level)
- [x] `test_nvfp4_fallback.py` — enum properties, unconditional remap
- [x] `test_level_table_covers_every_gemm_quant_profile` — passes (both GEMM and MoE util tables complete)
- [x] Golden fixtures regenerated for H200 nvfp4→nvfp4_wo remap
- [x] ruff check + format clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for NVFP4 weight-only quantization in GEMM and MoE workloads.
  - Automatically adapts native NVFP4 configurations on non-Blackwell systems while preserving native behavior on Blackwell.
  - Expanded default parallel-search options to support configurations using up to 16 GPUs.

- **Bug Fixes**
  - Improved sizing for Mamba workloads with small tensor-parallel configurations.

- **Documentation**
  - Expanded quantization guidance to cover GEMM and MoE modes.

- **Tests**
  - Added coverage for NVFP4 fallback behavior and expanded configuration searches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->