### PR TITLE
chore: move tqdm to development dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ dependencies = [
     "pydantic>=2.5",
     "pyarrow>=15.0.0",
     "pyyaml>=6.0",
-    "tqdm>=4.0.0",
     "bokeh",
     "nvidia-ml-py",
     "munch>=4.0.0",
@@ -73,6 +72,7 @@ dev = [
     "pytest-xdist==3.8.0",
     "prometheus-api-client==0.6.0",
     "import-ipynb==0.2",
+    "tqdm>=4.0.0",
 ]
 service = [
     "fastapi>=0.115.12",

--- a/uv.lock
+++ b/uv.lock
@@ -38,7 +38,6 @@ dependencies = [
     { name = "pyarrow" },
     { name = "pydantic" },
     { name = "pyyaml" },
-    { name = "tqdm" },
 ]
 
 [package.optional-dependencies]
@@ -55,6 +54,7 @@ dev = [
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "ruff" },
+    { name = "tqdm" },
     { name = "uv" },
 ]
 service = [
@@ -94,7 +94,7 @@ requires-dist = [
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = "==3.8.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.14.1" },
-    { name = "tqdm", specifier = ">=4.0.0" },
+    { name = "tqdm", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "uv", marker = "extra == 'dev'" },
     { name = "uvicorn", marker = "extra == 'service'", specifier = ">=0.34.2" },
 ]


### PR DESCRIPTION
## Summary

- move `tqdm` from the default installation requirements to the `dev` extra
- update `uv.lock` so `tqdm` is selected by `extra == 'dev'`

## Why

AIConfigurator's packaged CLI and SDK do not import `tqdm`. Its repository uses are limited to Collector and development tools, whose documented and CI environments already install the `dev` extra.

Regular `aiconfigurator` installations will no longer receive `tqdm`; development and test installations remain unchanged.

## Validation

- `uv lock --check`
- verified the base dependency export excludes `tqdm`
- verified the `dev` export includes `tqdm==4.67.3`
- built the wheel and verified its metadata contains `Requires-Dist: tqdm>=4.0.0; extra == "dev"`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Moved the progress display utility to development-only dependencies, reducing the packages installed for production use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->