### PR TITLE
fix(generator): support HF aliases in naive sizing (cherry-pick #1523)

### DIFF
--- a/aic-core/src/aiconfigurator_core/sdk/memory.py
+++ b/aic-core/src/aiconfigurator_core/sdk/memory.py
@@ -586,7 +586,29 @@ class NaiveKVCacheEstimator:
         return 2
 
     @staticmethod
-    def _swa_layout(hf_config: dict) -> tuple[int | None, int | None, int | None]:
+    def _raw_dimension(hf_config: dict, *keys: str) -> int | None:
+        """Return the first usable raw-config dimension among equivalent HF keys.
+
+        Hugging Face config families use several names for the same dimensions and
+        may serialize an unused preferred key as ``null``. Only positive integers
+        are dimensions; invalid preferred values are skipped in favor of an alias.
+        """
+        for key in keys:
+            value = hf_config.get(key)
+            if isinstance(value, bool):
+                continue
+            try:
+                parsed = int(value)
+            except (OverflowError, TypeError, ValueError):
+                continue
+            if isinstance(value, float) and not value.is_integer():
+                continue
+            if parsed > 0:
+                return parsed
+        return None
+
+    @classmethod
+    def _swa_layout(cls, hf_config: dict) -> tuple[int | None, int | None, int | None]:
         """Sliding-window size + (SWA, global) layer counts from an HF config.
 
         Returns ``(sliding_window, num_swa_layers, num_global_layers)`` for a hybrid
@@ -608,7 +630,7 @@ class NaiveKVCacheEstimator:
             num_swa = sum(1 for t in layer_types if "sliding" in str(t).lower())
             return sliding_window, num_swa, len(layer_types) - num_swa
 
-        num_layers = hf_config.get("num_hidden_layers")
+        num_layers = cls._raw_dimension(hf_config, "num_hidden_layers", "n_layer", "num_layers")
         pattern = hf_config.get("sliding_window_pattern")
         if sliding_window and num_layers and pattern and int(pattern) > 0:
             num_global = int(num_layers) // int(pattern)
@@ -657,23 +679,45 @@ class NaiveKVCacheEstimator:
                 "num_global_layers": None,
             }
 
-        hidden = hf_config.get("hidden_size")
-        heads = hf_config.get("num_attention_heads")
-        head_dim = hf_config.get("head_dim") or hf_config.get("attention_head_dim")
+        dimension = cls._raw_dimension
+        hidden = dimension(hf_config, "hidden_size", "n_embd", "n_embed")
+        layers = dimension(hf_config, "num_hidden_layers", "n_layer", "num_layers")
+        heads = dimension(hf_config, "num_attention_heads", "n_head", "num_heads")
+        head_dim = dimension(hf_config, "head_dim", "attention_head_dim")
         if head_dim is None and hidden and heads:
             head_dim = int(hidden) // int(heads)
+        num_experts = (
+            dimension(
+                hf_config,
+                "n_routed_experts",
+                "num_local_experts",
+                "num_experts",
+            )
+            or 0
+        )
+        inter = dimension(hf_config, "intermediate_size", "ffn_dim", "n_inner", "ffn_hidden_size")
+        if inter is None and hidden and not num_experts:
+            # Dense decoder families conventionally use a 4x hidden FFN when the
+            # config omits the intermediate dimension (or serializes it as null).
+            inter = 4 * int(hidden)
+        num_kv_heads = dimension(hf_config, "num_key_value_heads", "num_kv_heads", "n_head_kv", "n_kv_heads")
+        # Legacy Falcon configs retain num_kv_heads=num_attention_heads while
+        # multi_query selects one shared K/V head. New-decoder configs use the
+        # explicit KV-head count instead.
+        if hf_config.get("multi_query") and not hf_config.get("new_decoder_architecture"):
+            num_kv_heads = 1
         sliding_window, num_swa_layers, num_global_layers = cls._swa_layout(hf_config)
         return {
-            "layers": hf_config.get("num_hidden_layers"),
-            "num_kv_heads": hf_config.get("num_key_value_heads") or heads,
+            "layers": layers,
+            "num_kv_heads": num_kv_heads or heads,
             "head_dim": head_dim,
             "kv_lora_rank": hf_config.get("kv_lora_rank"),
             "qk_rope_head_dim": hf_config.get("qk_rope_head_dim"),
             "vocab": hf_config.get("vocab_size"),
             "hidden": hidden,
-            "inter": hf_config.get("intermediate_size"),
-            "num_experts": hf_config.get("n_routed_experts") or hf_config.get("num_local_experts") or 0,
-            "moe_inter": hf_config.get("moe_intermediate_size") or hf_config.get("intermediate_size") or 0,
+            "inter": inter,
+            "num_experts": num_experts,
+            "moe_inter": hf_config.get("moe_intermediate_size") or inter or 0,
             "sliding_window": sliding_window,
             "num_swa_layers": num_swa_layers,
             "num_global_layers": num_global_layers,
@@ -720,9 +764,10 @@ class NaiveKVCacheEstimator:
         Coarse param count (embeddings + per-layer attention + dense/MoE FFN), times
         dtype bytes, divided by TP*PP. NOT calibrated; for models AIC cannot fully
         model. Attention-DP replicates rather than shards, so it does NOT divide
-        here. ``hidden_size`` / ``num_hidden_layers`` / ``vocab_size`` /
-        ``intermediate_size`` are all required: returns ``None`` (the caller raises)
-        when any is missing, rather than fabricating a placeholder.
+        here. Hidden size and layer count accept their standard Hugging Face aliases;
+        dense models without an explicit intermediate size use the conventional
+        ``4 * hidden_size`` expansion. Returns ``None`` (the caller raises) when a
+        required dimension is still missing, rather than fabricating a placeholder.
         """
         geom = self.geometry
         hidden = geom.get("hidden")
@@ -805,13 +850,13 @@ class NaiveKVCacheEstimator:
         if kv_per_token is None or not (math.isfinite(kv_per_token) and kv_per_token > 0.0):
             raise ValueError(
                 "insufficient model metadata; missing: per-token KV geometry "
-                "(num_hidden_layers + num_key_value_heads/head_dim, or the MLA latent dims)"
+                "(layer count + KV attention heads/head dimension, or the MLA latent dims)"
             )
         weight_bytes = self.weight_bytes()
         if weight_bytes is None:
             raise ValueError(
                 "insufficient model metadata; missing: weight-estimate fields "
-                "(hidden_size, num_hidden_layers, vocab_size, intermediate_size)"
+                "(hidden size, layer count, vocab_size, FFN intermediate size)"
             )
         kv_per_token = float(kv_per_token)
         weight_bytes = float(weight_bytes)

--- a/src/aiconfigurator/generator/naive.py
+++ b/src/aiconfigurator/generator/naive.py
@@ -272,8 +272,8 @@ def _estimate_model_weight_bytes(model_path: str, *, model_metadata: dict[str, A
             weight_bytes = estimator.weight_bytes()
             if weight_bytes is None:
                 raise ValueError(
-                    "insufficient raw model metadata; expected hidden_size, "
-                    "num_hidden_layers, vocab_size, and intermediate_size"
+                    "insufficient raw model metadata; expected hidden/layer/vocab "
+                    "dimensions and FFN geometry (canonical or Hugging Face aliases)"
                 )
             logger.info(
                 "Estimated model weight size from raw config for %s: %.2f GiB",

--- a/tests/unit/sdk/test_memory_estimation.py
+++ b/tests/unit/sdk/test_memory_estimation.py
@@ -350,6 +350,168 @@ def test_naive_geometry_from_raw_unsupported_arch():
     assert _estimator({**geom, "inter": None}).weight_bytes() is None
 
 
+@pytest.mark.parametrize(
+    ("hf_config", "expected"),
+    [
+        pytest.param(
+            {
+                "n_embd": 768,
+                "n_layer": 12,
+                "n_head": 12,
+                "n_inner": None,
+                "vocab_size": 50_257,
+            },
+            (768, 12, 12, 64, 3_072, 50_257),
+            id="gpt2",
+        ),
+        pytest.param(
+            {
+                "hidden_size": 768,
+                "num_hidden_layers": 12,
+                "num_attention_heads": 12,
+                "intermediate_size": None,
+                "ffn_dim": 3_072,
+                "vocab_size": 50_272,
+            },
+            (768, 12, 12, 64, 3_072, 50_272),
+            id="opt",
+        ),
+        pytest.param(
+            {"hidden_size": 64, "n_layer": 2, "n_head": 8, "vocab_size": 250_880},
+            (64, 2, 8, 8, 256, 250_880),
+            id="bloom",
+        ),
+        pytest.param(
+            {
+                "n_embd": 4_096,
+                "n_layer": 28,
+                "n_head": 16,
+                "n_inner": None,
+                "vocab_size": 50_400,
+            },
+            (4_096, 28, 16, 256, 16_384, 50_400),
+            id="gpt-j",
+        ),
+        pytest.param(
+            {
+                "hidden_size": 2_048,
+                "num_layers": 24,
+                "num_heads": 16,
+                "intermediate_size": None,
+                "vocab_size": 50_257,
+            },
+            (2_048, 24, 16, 128, 8_192, 50_257),
+            id="gpt-neo",
+        ),
+        pytest.param(
+            {
+                "hidden_size": 4_544,
+                "num_hidden_layers": 32,
+                "num_attention_heads": 71,
+                "num_kv_heads": 71,
+                "ffn_hidden_size": 18_176,
+                "multi_query": True,
+                "new_decoder_architecture": False,
+                "vocab_size": 65_024,
+            },
+            (4_544, 32, 1, 64, 18_176, 65_024),
+            id="falcon",
+        ),
+        pytest.param(
+            {
+                "n_embd": 4_096,
+                "n_layer": 28,
+                "n_head": 16,
+                "n_inner": None,
+                "vocab_size": 50_400,
+            },
+            (4_096, 28, 16, 256, 16_384, 50_400),
+            id="codegen",
+        ),
+        pytest.param(
+            {"n_embed": 1_024, "n_layer": 20, "n_head": 16, "n_inner": 0, "vocab_size": 50_400},
+            (1_024, 20, 16, 64, 4_096, 50_400),
+            id="n-embed-alias",
+        ),
+    ],
+)
+def test_naive_geometry_supports_hf_alias_families(hf_config, expected):
+    geom = memory.NaiveKVCacheEstimator._geometry(hf_config, None)
+    hidden, layers, kv_heads, head_dim, inter, vocab = expected
+    assert geom == {
+        "layers": layers,
+        "num_kv_heads": kv_heads,
+        "head_dim": head_dim,
+        "kv_lora_rank": None,
+        "qk_rope_head_dim": None,
+        "vocab": vocab,
+        "hidden": hidden,
+        "inter": inter,
+        "num_experts": 0,
+        "moe_inter": inter,
+        "sliding_window": None,
+        "num_swa_layers": None,
+        "num_global_layers": None,
+    }
+
+    estimator = _estimator(geom)
+    expected_weight_params = 2 * vocab * hidden + layers * (4 * hidden**2 + 3 * hidden * inter)
+    assert estimator.weight_bytes() == expected_weight_params * 2
+    assert estimator.kv_bytes_per_token() == 2 * kv_heads * head_dim * layers * 2
+
+
+@pytest.mark.parametrize("invalid_preferred", [-1, 0, None, "not-an-int", 1.5, True])
+def test_naive_raw_dimension_skips_invalid_preferred_alias(invalid_preferred):
+    hf_config = {"hidden_size": invalid_preferred, "n_embd": 768}
+
+    assert memory.NaiveKVCacheEstimator._raw_dimension(hf_config, "hidden_size", "n_embd") == 768
+
+
+def test_naive_falcon_new_decoder_keeps_explicit_kv_head_count():
+    hf_config = {
+        "hidden_size": 8_192,
+        "num_hidden_layers": 60,
+        "num_attention_heads": 64,
+        "num_kv_heads": 8,
+        "ffn_hidden_size": 32_768,
+        "multi_query": True,
+        "new_decoder_architecture": True,
+        "vocab_size": 65_024,
+    }
+    geom = memory.NaiveKVCacheEstimator._geometry(hf_config, None)
+    assert geom["num_kv_heads"] == 8
+
+
+@pytest.mark.parametrize("missing_key", ["n_embd", "n_layer", "vocab_size"])
+def test_naive_raw_alias_geometry_keeps_required_dimensions_fail_closed(missing_key):
+    hf_config = {
+        "n_embd": 768,
+        "n_layer": 12,
+        "n_head": 12,
+        "head_dim": 64,
+        "vocab_size": 50_257,
+    }
+    hf_config.pop(missing_key)
+    geom = memory.NaiveKVCacheEstimator._geometry(hf_config, None)
+    assert _estimator(geom).weight_bytes() is None
+
+
+def test_naive_num_experts_alias_does_not_use_dense_ffn_fallback():
+    hf_config = {
+        "hidden_size": 1_024,
+        "num_hidden_layers": 12,
+        "num_attention_heads": 16,
+        "num_experts": 8,
+        "vocab_size": 32_000,
+    }
+
+    geom = memory.NaiveKVCacheEstimator._geometry(hf_config, None)
+
+    assert geom["num_experts"] == 8
+    assert geom["inter"] is None
+    assert _estimator(geom).weight_bytes() is None
+
+
 def test_naive_kv_per_token_empty_geometry_is_none():
     assert _estimator({}).kv_bytes_per_token() is None
     assert _estimator({}).weight_bytes() is None
@@ -408,6 +570,12 @@ def test_naive_swa_layout_from_layer_types():
 def test_naive_swa_layout_from_pattern():
     # sliding_window + sliding_window_pattern=6: one global layer every 6 layers.
     hf_config = {"sliding_window": 4096, "num_hidden_layers": 30, "sliding_window_pattern": 6}
+    assert memory.NaiveKVCacheEstimator._swa_layout(hf_config) == (4096, 25, 5)
+
+
+@pytest.mark.parametrize("layer_key", ["n_layer", "num_layers"])
+def test_naive_swa_layout_from_pattern_supports_layer_aliases(layer_key):
+    hf_config = {"sliding_window": 4096, layer_key: 30, "sliding_window_pattern": 6}
     assert memory.NaiveKVCacheEstimator._swa_layout(hf_config) == (4096, 25, 5)
 
 
@@ -515,6 +683,35 @@ def test_naive_fallback_unsupported_arch_uses_raw_read(monkeypatch):
     assert out["source"] == "naive_fallback"
     # Raw-read standard branch: layers=48, n_kv=8, head_dim=4096/32=128, bf16.
     assert out["kv_size_per_token_bytes"] == 2 * 8 * 128 * 48 * 2  # 196608
+
+
+def test_naive_fallback_unsupported_arch_uses_hf_aliases(monkeypatch):
+    raw_config = {
+        "architectures": ["FooBarForCausalLM"],
+        "n_embd": 768,
+        "n_layer": 12,
+        "n_head": 12,
+        "n_inner": None,
+        "vocab_size": 50_257,
+        "torch_dtype": "float16",
+    }
+    monkeypatch.setattr(
+        memory.NaiveKVCacheEstimator,
+        "_load_config",
+        lambda *a, **k: dict(raw_config),
+    )
+
+    out = _naive_estimate(
+        "foo/bar-aliased-unknown-arch",
+        tp_size=1,
+        pp_size=1,
+        gpu_memory_capacity_bytes_override=20 * _GIB,
+        naive_kv_reservation=memory._DEFAULT_NAIVE_KV_RESERVATION,
+        allow_hf_config_download=False,
+    )
+
+    assert out["source"] == "naive_fallback"
+    assert out["kv_size_per_token_bytes"] == 2 * 12 * 64 * 12 * 2
 
 
 def test_naive_fallback_raises_without_config():


### PR DESCRIPTION
## Summary

- Cherry-pick of #1523 to `release/0.11.0`.
- Resolve standard Hugging Face raw-config aliases for hidden size, layer count, attention/KV heads, and FFN size during naive sizing.
- Use the conventional dense `4 * hidden` FFN fallback when appropriate while keeping invalid and unsupported MoE configurations fail-closed.
- Cover GPT-2, OPT, BLOOM, GPT-J, GPT-Neo, Falcon, and CodeGen configuration families.

This fixes NVBug 6596690, where non-Llama Hugging Face config aliases cause `weight_bytes()` to return `None`, so the naive fallback raises instead of producing a deployment configuration.

## Original PR

- Main PR: #1523
- Main merge commit: `1a572a4b7a76e1d9130454055953ad6b2ab4420d`
- Cherry-pick commit: `607703ec79cdf0cfccd0eb76affb435511197d1a`

## Release adaptation

The merge commit cherry-picked cleanly with no manual conflict resolution. `git range-diff` confirms the backported patch is equivalent to main apart from the cherry-pick provenance trailer.

## Validation

- Built `aiconfigurator==0.11.0` and `aiconfigurator-core==0.11.0` from the release worktree with `uv sync --extra dev`.
- `97 passed`: release-branch memory estimator and naive generator unit tests.
- Ruff check and format checks passed on all changed Python files.
- `git diff --check origin/release/0.11.0...HEAD` passed.
- The source PR passed independent agentic review before merging to main.

## Related Issues

- NVBug: 6596690
- [x] Confirmed — no related GitHub issue
