### PR TITLE
feat(models): model Kimi K2.5 image and video encoder

### DIFF
--- a/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
+++ b/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
@@ -226,28 +226,41 @@ class BaseBackend:
         runtime_config: RuntimeConfig,
         enc_cfg,
     ) -> tuple[int, int]:
-        """Resolve the per-image pre-merge / post-merge token counts from
+        """Resolve per-visual pre-merge / post-merge token counts from
         RuntimeConfig + VisionEncoderConfig.
 
         Resolution order:
             1. image_height + image_width (computed from patch/merge sizes)
-            2. num_image_tokens (explicit per-image override)
+            2. num_image_tokens (explicit per-visual post-merge override)
+
+        ``num_frames_per_visual`` increases the temporal transformer sequence
+        after grouping frames by ``temporal_patch_size``. Architectures such as
+        Kimi K2.5 then pool time in their PatchMerger, so frames increase encoder
+        work but not the number of visual embeddings injected into the LLM.
 
         Returns ``(tokens_post_merge_per_image, pre_merge_per_image)``.
         Returns ``(0, 0)`` when neither is set (text-only path).
         """
+        if runtime_config.num_frames_per_visual <= 0:
+            raise ValueError(f"num_frames_per_visual must be positive, got {runtime_config.num_frames_per_visual}")
+        frames = runtime_config.num_frames_per_visual
+        temporal_tokens = math.ceil(frames / max(1, enc_cfg.temporal_patch_size))
         has_image_dims = runtime_config.image_height > 0 and runtime_config.image_width > 0
         if has_image_dims:
             img_stride = enc_cfg.patch_size * enc_cfg.spatial_merge_size
-            tokens_per_image = (runtime_config.image_height // img_stride) * (runtime_config.image_width // img_stride)
-            pre_merge_per_image = (runtime_config.image_height // enc_cfg.patch_size) * (
+            spatial_post_merge = (runtime_config.image_height // img_stride) * (
+                runtime_config.image_width // img_stride
+            )
+            spatial_pre_merge = (runtime_config.image_height // enc_cfg.patch_size) * (
                 runtime_config.image_width // enc_cfg.patch_size
             )
         elif runtime_config.num_image_tokens > 0:
-            tokens_per_image = runtime_config.num_image_tokens
-            pre_merge_per_image = tokens_per_image * (enc_cfg.spatial_merge_size**2)
+            spatial_post_merge = runtime_config.num_image_tokens
+            spatial_pre_merge = spatial_post_merge * (enc_cfg.spatial_merge_size**2)
         else:
             return 0, 0
+        pre_merge_per_image = spatial_pre_merge * temporal_tokens
+        tokens_per_image = spatial_post_merge * (1 if enc_cfg.pool_temporal else temporal_tokens)
         if tokens_per_image <= 0 or pre_merge_per_image <= 0:
             return 0, 0
         return tokens_per_image, pre_merge_per_image
@@ -1579,6 +1592,8 @@ class BaseBackend:
             runtime_config.image_height,
             runtime_config.image_width,
             runtime_config.num_images_per_request,
+            runtime_config.num_frames_per_visual,
+            runtime_config.num_image_tokens,
         )
         cache_key = (
             self._make_agg_cache_key(isl, osl, b, ctx_tokens, engine_step_backend_key, agg_extra),

--- a/aic-core/src/aiconfigurator_core/sdk/common.py
+++ b/aic-core/src/aiconfigurator_core/sdk/common.py
@@ -183,6 +183,19 @@ class VisionEncoderConfig:
             rotated fraction — the 2-axis vision RoPE always rotates the full
             head_dim (vLLM ApplyRotaryEmb / SGLang cat([cos, cos])). Only gates
             the encoder_rope_apply op; 0.0 means no RoPE.
+        gemm_quant_mode (str): Encoder GEMM precision, kept separate from the
+            language checkpoint's quantization mode.
+        fmha_quant_mode (str): Encoder-attention precision. EncoderAttention
+            currently supports bfloat16 only.
+        patch_embed_input_channels (int): Input channels for a Conv2d-equivalent
+            patch embedding GEMM. Zero means the patch embed is not modeled.
+        final_norm (bool): Whether the vision transformer has a final norm.
+        projector_pre_norm (bool): Whether PatchMerger normalizes patch features
+            before spatial/temporal merging.
+        pool_temporal (bool): Whether the merger pools the temporal dimension so
+            video frames increase encoder work but not LLM visual-token count.
+        video_attention_type (str): Declared video attention topology, retained
+            explicitly for architecture validation and reporting.
     """
 
     depth: int
@@ -197,6 +210,15 @@ class VisionEncoderConfig:
     projector_dims: tuple[tuple[int, int], ...] = ()
     projector_n_instances: int = 1
     partial_rotary_factor: float = 0.0
+    # New fields are appended, never inserted: this dataclass has a generated
+    # positional constructor and legacy callers may still use it positionally.
+    gemm_quant_mode: str = "bfloat16"
+    fmha_quant_mode: str = "bfloat16"
+    patch_embed_input_channels: int = 0
+    final_norm: bool = False
+    projector_pre_norm: bool = False
+    pool_temporal: bool = False
+    video_attention_type: str = ""
 
 
 @dataclass(frozen=True)

--- a/aic-core/src/aiconfigurator_core/sdk/config.py
+++ b/aic-core/src/aiconfigurator_core/sdk/config.py
@@ -160,6 +160,16 @@ class RuntimeConfig:
     # Frames in each visual input. 1 models an image; >1 models a video clip.
     num_frames_per_visual: int = 1
 
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.num_frames_per_visual, bool)
+            or not isinstance(self.num_frames_per_visual, int)
+            or self.num_frames_per_visual <= 0
+        ):
+            raise ValueError(
+                f"num_frames_per_visual must be a positive non-boolean integer, got {self.num_frames_per_visual!r}"
+            )
+
 
 @dataclass
 class AFDConfig:

--- a/aic-core/src/aiconfigurator_core/sdk/config.py
+++ b/aic-core/src/aiconfigurator_core/sdk/config.py
@@ -169,6 +169,8 @@ class RuntimeConfig:
             raise ValueError(
                 f"num_frames_per_visual must be a positive non-boolean integer, got {self.num_frames_per_visual!r}"
             )
+        if self.num_frames_per_visual > 1 and not (self.image_height > 0 and self.image_width > 0):
+            raise ValueError("num_frames_per_visual > 1 requires positive image_height and image_width")
 
 
 @dataclass

--- a/aic-core/src/aiconfigurator_core/sdk/config.py
+++ b/aic-core/src/aiconfigurator_core/sdk/config.py
@@ -156,9 +156,9 @@ class RuntimeConfig:
     image_height: int = 0
     image_width: int = 0
     num_images_per_request: int = 1
+    num_image_tokens: int = 0  # override: ViT output tokens per image; ignored when image_height/width are set
     # Frames in each visual input. 1 models an image; >1 models a video clip.
     num_frames_per_visual: int = 1
-    num_image_tokens: int = 0  # override: ViT output tokens per image; ignored when image_height/width are set
 
 
 @dataclass

--- a/aic-core/src/aiconfigurator_core/sdk/config.py
+++ b/aic-core/src/aiconfigurator_core/sdk/config.py
@@ -156,6 +156,8 @@ class RuntimeConfig:
     image_height: int = 0
     image_width: int = 0
     num_images_per_request: int = 1
+    # Frames in each visual input. 1 models an image; >1 models a video clip.
+    num_frames_per_visual: int = 1
     num_image_tokens: int = 0  # override: ViT output tokens per image; ignored when image_height/width are set
 
 

--- a/aic-core/src/aiconfigurator_core/sdk/models/deepseek.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/deepseek.py
@@ -9,6 +9,7 @@ import aiconfigurator_core.sdk.operations as ops
 from aiconfigurator_core.sdk import common
 from aiconfigurator_core.sdk.models.base import BaseModel, register_model
 from aiconfigurator_core.sdk.models.helpers import attention_projection_exclusions, mtp_scale_factor
+from aiconfigurator_core.sdk.models.vit_ops import build_encoder_ops
 
 logger = logging.getLogger(__name__)
 
@@ -71,6 +72,7 @@ class DeepSeekModel(BaseModel):
                 extra_params,
                 backend_name=backend_name,
                 attention_quant_exclusions=attn_exclusions,
+                encoder_config=model_info.get("encoder_config"),
             )
 
         # DEEPSEEK family — three-way dispatch on WideEP.
@@ -110,8 +112,14 @@ class DeepSeekModel(BaseModel):
         *args,
         backend_name: str = "",
         attention_quant_exclusions: frozenset = frozenset(),
+        encoder_config: common.VisionEncoderConfig | None = None,
     ) -> None:
         super().__init__(*args)
+        if encoder_config is not None:
+            self.encoder_config = encoder_config
+            self.encoder_ops.extend(
+                build_encoder_ops(encoder_config, self.config.tp_size, self.config.enable_encoder_dp)
+            )
         # Resolve vLLM attention head size. MLA models (e.g., KIMI K2.5) store v_head_dim=128
         # in extra_params; generic hidden_size // n_heads would give the wrong value (e.g., 112).
         self._vllm_head_size = (

--- a/aic-core/src/aiconfigurator_core/sdk/models/qwen3vl.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/qwen3vl.py
@@ -40,7 +40,7 @@ class Qwen3VLModel(LLAMAModel):
             model_info["context"],
             model_config,
             model_info["extra_params"],
-            encoder_config=model_info["extra_params"],
+            encoder_config=model_info.get("encoder_config") or model_info["extra_params"],
         )
 
     def __init__(self, *args, encoder_config: common.VisionEncoderConfig) -> None:
@@ -78,7 +78,7 @@ class Qwen3VLMoEModel(MOEModel):
             model_config,
             model_info["extra_params"],
         )
-        return cls(*moe_args, *base_args, encoder_config=model_info["extra_params"])
+        return cls(*moe_args, *base_args, encoder_config=model_info.get("encoder_config") or model_info["extra_params"])
 
     def __init__(
         self, topk: int, num_experts: int, moe_inter_size: int, *args, encoder_config: common.VisionEncoderConfig

--- a/aic-core/src/aiconfigurator_core/sdk/models/vit_ops.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/vit_ops.py
@@ -75,61 +75,80 @@ def _vit_transformer_ops(enc_cfg: common.VisionEncoderConfig, tp_size: int) -> l
         if inter_vit % tp_size != 0:
             raise ValueError(f"ViT intermediate_size ({inter_vit}) must be divisible by tp_size ({tp_size})")
 
-    # ViT always runs in bfloat16 regardless of LLM quantization settings
-    vit_gemm_mode = common.GEMMQuantMode.bfloat16
-    vit_fmha_mode = common.FMHAQuantMode.bfloat16
+    try:
+        vit_gemm_mode = common.GEMMQuantMode[enc_cfg.gemm_quant_mode]
+        vit_fmha_mode = common.FMHAQuantMode[enc_cfg.fmha_quant_mode]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported vision encoder precision: {exc.args[0]}") from exc
 
-    result = [
-        ops.ElementWise("encoder_add_norm_1", depth, 2 * h_vit, 2 * h_vit, 0.8),
-        ops.GEMM(
-            "encoder_qkv_gemm",
-            depth,
-            3 * n_vit * head_size_vit // tp_size,
-            h_vit,
-            vit_gemm_mode,
-        ),
-        ops.EncoderAttention(
-            "encoder_attention",
-            depth,
-            n_vit // tp_size,
-            head_size_vit,
-            fmha_quant_mode=vit_fmha_mode,
-            partial_rotary_factor=0.0,
-        ),
-        ops.GEMM(
-            "encoder_proj_gemm",
-            depth,
-            h_vit,
-            n_vit * head_size_vit // tp_size,
-            vit_gemm_mode,
-            low_precision_input=True,
-        ),
-        ops.CustomAllReduce("encoder_ar_1", depth, h_vit, tp_size),
-        ops.ElementWise("encoder_add_norm_2", depth, 2 * h_vit, 2 * h_vit, 0.8),
-        ops.GEMM(
-            "encoder_ffn1_gemm",
-            depth,
-            inter_vit // tp_size,
-            h_vit,
-            vit_gemm_mode,
-        ),
-        ops.ElementWise(
-            "encoder_act",
-            depth,
-            inter_vit // tp_size,
-            inter_vit // tp_size,
-            0.8,
-        ),
-        ops.GEMM(
-            "encoder_ffn2_gemm",
-            depth,
-            h_vit,
-            inter_vit // tp_size,
-            vit_gemm_mode,
-            low_precision_input=True,
-        ),
-        ops.CustomAllReduce("encoder_ar_2", depth, h_vit, tp_size),
-    ]
+    result = []
+    if enc_cfg.patch_embed_input_channels > 0:
+        result.extend(
+            [
+                ops.GEMM(
+                    "encoder_patch_embed_gemm",
+                    1,
+                    h_vit,
+                    enc_cfg.patch_embed_input_channels * enc_cfg.patch_size**2,
+                    vit_gemm_mode,
+                ),
+                ops.ElementWise("encoder_pos_embed", 1, h_vit, h_vit, 0.8),
+            ]
+        )
+
+    result.extend(
+        [
+            ops.ElementWise("encoder_add_norm_1", depth, 2 * h_vit, 2 * h_vit, 0.8),
+            ops.GEMM(
+                "encoder_qkv_gemm",
+                depth,
+                3 * n_vit * head_size_vit // tp_size,
+                h_vit,
+                vit_gemm_mode,
+            ),
+            ops.EncoderAttention(
+                "encoder_attention",
+                depth,
+                n_vit // tp_size,
+                head_size_vit,
+                fmha_quant_mode=vit_fmha_mode,
+                partial_rotary_factor=0.0,
+            ),
+            ops.GEMM(
+                "encoder_proj_gemm",
+                depth,
+                h_vit,
+                n_vit * head_size_vit // tp_size,
+                vit_gemm_mode,
+                low_precision_input=True,
+            ),
+            ops.CustomAllReduce("encoder_ar_1", depth, h_vit, tp_size),
+            ops.ElementWise("encoder_add_norm_2", depth, 2 * h_vit, 2 * h_vit, 0.8),
+            ops.GEMM(
+                "encoder_ffn1_gemm",
+                depth,
+                inter_vit // tp_size,
+                h_vit,
+                vit_gemm_mode,
+            ),
+            ops.ElementWise(
+                "encoder_act",
+                depth,
+                inter_vit // tp_size,
+                inter_vit // tp_size,
+                0.8,
+            ),
+            ops.GEMM(
+                "encoder_ffn2_gemm",
+                depth,
+                h_vit,
+                inter_vit // tp_size,
+                vit_gemm_mode,
+                low_precision_input=True,
+            ),
+            ops.CustomAllReduce("encoder_ar_2", depth, h_vit, tp_size),
+        ]
+    )
 
     if enc_cfg.partial_rotary_factor > 0:
         # the attention op's internal RoPE term is disabled in exchange (partial_rotary_factor=0.0).
@@ -137,6 +156,16 @@ def _vit_transformer_ops(enc_cfg: common.VisionEncoderConfig, tp_size: int) -> l
         # duplicates the half-dim cos/sin table to full head_dim and rotates all of Q/K.
         rope_dim = 6 * (n_vit // tp_size) * head_size_vit
         result.append(ops.ElementWise("encoder_rope_apply", depth, rope_dim, rope_dim, 0.8))
+
+    if enc_cfg.final_norm:
+        result.append(ops.ElementWise("encoder_final_norm", 1, h_vit, h_vit, 0.8))
+    if enc_cfg.projector_pre_norm:
+        result.append(ops.ElementWise("encoder_merger_pre_norm", 1, h_vit, h_vit, 0.8))
+    if enc_cfg.pool_temporal:
+        # Kimi's sd2_tpool merger performs temporal mean pooling and spatial
+        # 2x2 rearrangement before PatchMerger. This is a memory-bound layout
+        # operation; projector GEMMs below run on the resulting post-merge tokens.
+        result.append(ops.ElementWise("encoder_patch_merge_pool", 1, h_vit, h_vit, 0.8))
 
     return result
 
@@ -157,7 +186,10 @@ def _projector_ops(enc_cfg: common.VisionEncoderConfig, tp_size: int) -> list:
         return []
 
     n_inst = enc_cfg.projector_n_instances
-    vit_gemm_mode = common.GEMMQuantMode.bfloat16
+    try:
+        vit_gemm_mode = common.GEMMQuantMode[enc_cfg.gemm_quant_mode]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported vision encoder GEMM precision: {exc.args[0]}") from exc
     n_layers = len(dims)
 
     result = []

--- a/aic-core/src/aiconfigurator_core/sdk/utils.py
+++ b/aic-core/src/aiconfigurator_core/sdk/utils.py
@@ -517,6 +517,8 @@ def _parse_hf_config_json(config: dict) -> dict:
     """
     architecture = config["architectures"][0]
     vision_cfg = config.get("vision_config")
+    encoder_config = None
+    root_quant_cfg = config.get("quantization_config")
 
     # For multimodal models, unwrap the nested text config so that all LLM
     # parameters (layers, hidden_size, MoE fields, etc.) are read from the
@@ -673,6 +675,83 @@ def _parse_hf_config_json(config: dict) -> dict:
             "kv_lora_rank": config.get("kv_lora_rank", 0),
             "qk_rope_head_dim": config.get("qk_rope_head_dim", 0),
         }
+        if vision_cfg:
+            merge_kernel = vision_cfg.get("merge_kernel_size", [2, 2])
+            if not (isinstance(merge_kernel, list) and len(merge_kernel) == 2 and merge_kernel[0] == merge_kernel[1]):
+                raise ValueError(f"Kimi K2.5 requires a square merge_kernel_size, got {merge_kernel!r}")
+            if vision_cfg.get("mm_projector_type") != "patchmerger":
+                raise ValueError(
+                    "Kimi K2.5 vision modeling requires mm_projector_type='patchmerger', "
+                    f"got {vision_cfg.get('mm_projector_type')!r}"
+                )
+            if vision_cfg.get("merge_type") != "sd2_tpool":
+                raise ValueError(
+                    f"Kimi K2.5 vision modeling requires merge_type='sd2_tpool', got {vision_cfg.get('merge_type')!r}"
+                )
+            if vision_cfg.get("video_attn_type") != "spatial_temporal":
+                raise ValueError(
+                    "Kimi K2.5 vision modeling requires video_attn_type='spatial_temporal', "
+                    f"got {vision_cfg.get('video_attn_type')!r}"
+                )
+
+            # Quantization is scoped independently for the language and vision
+            # towers. The Moonshot checkpoint nests its compressed-tensors config
+            # under text_config; NVIDIA's model-level NVFP4 config explicitly
+            # excludes both vision_tower* and mm_projector*. In both target
+            # checkpoints the complete encoder therefore remains BF16.
+            nested_text_quant_cfg = (
+                text_cfg.get("quantization_config") if text_key and isinstance(text_cfg, dict) else None
+            )
+            quant_is_text_only = root_quant_cfg is not None and root_quant_cfg == nested_text_quant_cfg
+            if root_quant_cfg and not quant_is_text_only:
+                ignore = tuple(str(pattern).lower() for pattern in root_quant_cfg.get("ignore", []))
+                vision_ignored = any("vision_tower" in pattern for pattern in ignore)
+                projector_ignored = any("mm_projector" in pattern for pattern in ignore)
+                if not (vision_ignored and projector_ignored):
+                    raise ValueError(
+                        "Kimi K2.5 has model-level quantization but does not explicitly exclude both "
+                        "vision_tower and mm_projector; refusing to infer encoder precision from the language model"
+                    )
+
+            hidden_vit = vision_cfg["vt_hidden_size"]
+            spatial_merge_size = int(merge_kernel[0])
+            merger_dim = hidden_vit * spatial_merge_size**2
+            out_hidden_size = vision_cfg["text_hidden_size"]
+            if out_hidden_size != hidden_size:
+                raise ValueError(
+                    f"Kimi K2.5 vision text_hidden_size ({out_hidden_size}) does not match "
+                    f"text_config.hidden_size ({hidden_size})"
+                )
+            encoder_config = VisionEncoderConfig(
+                depth=vision_cfg["vt_num_hidden_layers"],
+                hidden_size=hidden_vit,
+                num_heads=vision_cfg["vt_num_attention_heads"],
+                intermediate_size=vision_cfg["vt_intermediate_size"],
+                patch_size=vision_cfg["patch_size"],
+                temporal_patch_size=1,
+                spatial_merge_size=spatial_merge_size,
+                out_hidden_size=out_hidden_size,
+                projector_dims=((merger_dim, merger_dim), (merger_dim, out_hidden_size)),
+                partial_rotary_factor=1.0,
+                gemm_quant_mode="bfloat16",
+                fmha_quant_mode="bfloat16",
+                patch_embed_input_channels=3,
+                final_norm=True,
+                projector_pre_norm=True,
+                pool_temporal=True,
+                video_attention_type=vision_cfg["video_attn_type"],
+            )
+            logger.info(
+                "Kimi K2.5 vision encoder config: depth=%d, hidden=%d, patch=%d, "
+                "merge=%d, video_attention=%s, gemm=%s, fmha=%s",
+                encoder_config.depth,
+                encoder_config.hidden_size,
+                encoder_config.patch_size,
+                encoder_config.spatial_merge_size,
+                encoder_config.video_attention_type,
+                encoder_config.gemm_quant_mode,
+                encoder_config.fmha_quant_mode,
+            )
     elif architecture == "KimiK3ForConditionalGeneration":
         # Kimi-K3: hybrid KDA linear attention + MLA full attention with LatentMoE.
         # linear_attn_config.kda_layers / full_attn_layers are 1-based layer ids.
@@ -924,6 +1003,7 @@ def _parse_hf_config_json(config: dict) -> dict:
                 projector_n_instances=1 + len(deepstack_visual_indexes),
                 partial_rotary_factor=0.5,
             )
+            encoder_config = extra_params
             logger.info(
                 "Qwen3VL vision encoder config: depth=%d, hidden=%d, patch=%d, spatial_merge=%d",
                 extra_params.depth,
@@ -945,6 +1025,7 @@ def _parse_hf_config_json(config: dict) -> dict:
         "num_experts": num_experts,
         "moe_inter_size": moe_inter_size,
         "extra_params": extra_params,
+        "encoder_config": encoder_config,
     }
 
 

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -1375,9 +1375,10 @@ def cli_estimate(
                 "or pick afd_phase in {'prefill','decode'}."
             )
         has_visual_workload = image_height > 0 and image_width > 0 and num_images > 0
-        if has_visual_workload and afd_phase in ("prefill", "both"):
+        if has_visual_workload and (afd_phase != "decode" or not afd_combined_with_pd):
             raise ValueError(
-                "Visual encoder modeling is not supported when AFD covers the prefill phase. "
+                "Visual encoder modeling is not supported when AFD covers the prefill phase "
+                "or when afd_combined_with_pd=False. "
                 "Use afd_phase='decode' with afd_combined_with_pd=True so the regular prefill "
                 "path accounts for encoder latency, memory, energy, and visual tokens."
             )

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -167,6 +167,7 @@ def cli_default(
     image_height: int = 0,
     image_width: int = 0,
     num_images: int = 1,
+    num_frames_per_visual: int = 1,
     enable_encoder_dp: bool = True,
     ttft: float = 2000.0,
     tpot: float = 30.0,
@@ -203,6 +204,10 @@ def cli_default(
             ('SILICON', 'HYBRID', 'EMPIRICAL', 'SOL'). Default is 'SILICON'.
         isl: Input sequence length. Default is 4000.
         osl: Output sequence length. Default is 1000.
+        image_height: Height of each visual input. Zero disables encoder modeling.
+        image_width: Width of each visual input. Zero disables encoder modeling.
+        num_images: Number of visual inputs per request.
+        num_frames_per_visual: Frames per visual input; 1 is an image and >1 is video.
         enable_encoder_dp: Model the vision encoder data-parallel (default True;
             vLLM mm_encoder_tp_mode="data" / SGLang --mm-enable-dp-encoder semantics).
             False models the legacy TP-sharded encoder.
@@ -293,6 +298,7 @@ def cli_default(
         image_height=image_height,
         image_width=image_width,
         num_images=num_images,
+        num_frames_per_visual=num_frames_per_visual,
         enable_encoder_dp=enable_encoder_dp,
         ttft=ttft,
         tpot=tpot,
@@ -327,6 +333,7 @@ def cli_default(
         mock_args.image_height = image_height
         mock_args.image_width = image_width
         mock_args.num_images = num_images
+        mock_args.num_frames_per_visual = num_frames_per_visual
         mock_args.ttft = ttft
         mock_args.tpot = tpot
         mock_args.request_latency = request_latency
@@ -388,6 +395,7 @@ def cli_recommend(
     image_height: int = 0,
     image_width: int = 0,
     num_images: int = 1,
+    num_frames_per_visual: int = 1,
     ttft: float = 2000.0,
     tpot: float = 30.0,
     request_latency: float | None = None,
@@ -436,6 +444,7 @@ def cli_recommend(
         image_height: Image height for vision-language models.
         image_width: Image width for vision-language models.
         num_images: Number of images per request.
+        num_frames_per_visual: Frames per visual input; 1 is an image and >1 is video.
         ttft: Time to first token SLA target in ms. Default is 2000.
         tpot: Time per output token SLA target in ms. Default is 30.
         request_latency: Optional end-to-end request latency target (ms).
@@ -506,6 +515,7 @@ def cli_recommend(
         image_height=image_height,
         image_width=image_width,
         num_images=num_images,
+        num_frames_per_visual=num_frames_per_visual,
         ttft=ttft,
         tpot=tpot,
         request_latency=request_latency,
@@ -573,6 +583,7 @@ def cli_recommend(
         mock_args.image_height = image_height
         mock_args.image_width = image_width
         mock_args.num_images = num_images
+        mock_args.num_frames_per_visual = num_frames_per_visual
         mock_args.ttft = ttft
         mock_args.tpot = tpot
         mock_args.request_latency = request_latency
@@ -933,6 +944,7 @@ def cli_estimate(
     image_height: int = 0,
     image_width: int = 0,
     num_images: int = 1,
+    num_frames_per_visual: int = 1,
     enable_encoder_dp: bool = True,
     batch_size: int = 128,
     ctx_tokens: int | None = None,
@@ -1011,6 +1023,7 @@ def cli_estimate(
         image_height: Image height in pixels for VL models. Default 0 disables encoder modeling.
         image_width: Image width in pixels for VL models. Default 0 disables encoder modeling.
         num_images: Number of images per request for VL models. Default 1.
+        num_frames_per_visual: Frames per visual input. Default 1 models images; >1 models video.
         enable_encoder_dp: Model the vision encoder data-parallel (default True;
             vLLM mm_encoder_tp_mode="data" / SGLang --mm-enable-dp-encoder semantics).
             False models the legacy TP-sharded encoder.
@@ -1190,6 +1203,7 @@ def cli_estimate(
             image_height=image_height,
             image_width=image_width,
             num_images=num_images,
+            num_frames_per_visual=num_frames_per_visual,
             enable_encoder_dp=enable_encoder_dp,
             batch_size=batch_size,
             prefix=prefix,
@@ -1225,6 +1239,7 @@ def cli_estimate(
             image_height=image_height,
             image_width=image_width,
             num_images=num_images,
+            num_frames_per_visual=num_frames_per_visual,
             enable_encoder_dp=enable_encoder_dp,
             batch_size=batch_size,
             ctx_tokens=ctx_tokens if ctx_tokens is not None else isl,
@@ -1280,6 +1295,7 @@ def cli_estimate(
             image_height=image_height,
             image_width=image_width,
             num_images=num_images,
+            num_frames_per_visual=num_frames_per_visual,
             enable_encoder_dp=enable_encoder_dp,
             # Prefill config (fall back to shared args)
             prefill_tp_size=prefill_tp_size if prefill_tp_size is not None else tp_size,
@@ -1398,6 +1414,7 @@ def cli_estimate(
             image_height=image_height,
             image_width=image_width,
             num_images=num_images,
+            num_frames_per_visual=num_frames_per_visual,
             enable_encoder_dp=enable_encoder_dp,
             batch_size=batch_size,
             prefix=prefix,
@@ -1447,6 +1464,7 @@ def _run_agg_estimate(
     image_height,
     image_width,
     num_images,
+    num_frames_per_visual,
     enable_encoder_dp,
     batch_size,
     ctx_tokens,
@@ -1508,6 +1526,7 @@ def _run_agg_estimate(
         image_height=image_height,
         image_width=image_width,
         num_images_per_request=num_images,
+        num_frames_per_visual=num_frames_per_visual,
         prefix=prefix,
         engine_step_backend=engine_step_backend,
     )
@@ -1583,6 +1602,7 @@ def _run_static_estimate(
     image_height,
     image_width,
     num_images,
+    num_frames_per_visual,
     enable_encoder_dp,
     batch_size,
     prefix,
@@ -1655,6 +1675,7 @@ def _run_static_estimate(
         image_height=image_height,
         image_width=image_width,
         num_images_per_request=num_images,
+        num_frames_per_visual=num_frames_per_visual,
         prefix=prefix,
         engine_step_backend=engine_step_backend,
     )
@@ -1724,6 +1745,7 @@ def _run_disagg_estimate(
     image_height,
     image_width,
     num_images,
+    num_frames_per_visual,
     enable_encoder_dp,
     prefill_tp_size,
     prefill_pp_size,
@@ -1826,6 +1848,7 @@ def _run_disagg_estimate(
         image_height=image_height,
         image_width=image_width,
         num_images_per_request=num_images,
+        num_frames_per_visual=num_frames_per_visual,
         prefix=prefix,
         engine_step_backend=engine_step_backend,
     )

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -1097,7 +1097,9 @@ def cli_estimate(
             ``'decode'`` (default), or ``'both'``. AFD is orthogonal to P/D
             disaggregation: ``'decode'`` models AFD on decode only, ``'prefill'``
             on the context phase (reports TTFT), and ``'both'`` reports TTFT+TPOT
-            with AFD on both phases.
+            with AFD on both phases. Visual workloads currently require
+            ``'decode'`` with ``afd_combined_with_pd=True`` so encoder work is
+            modeled by the regular prefill complement.
         afd_combined_with_pd: (afd-only) When True (default), combine the
             single-phase AFD estimate with a regular static estimate for the
             other phase (merging TTFT/TPOT, rate-matched throughput, and GPU
@@ -1357,6 +1359,13 @@ def cli_estimate(
                 "'both' means AFD covers prefill+decode internally; there is no "
                 "separate static pool to combine with. Pass --no-afd-combined-with-pd, "
                 "or pick afd_phase in {'prefill','decode'}."
+            )
+        has_visual_workload = image_height > 0 and image_width > 0 and num_images > 0
+        if has_visual_workload and afd_phase in ("prefill", "both"):
+            raise ValueError(
+                "Visual encoder modeling is not supported when AFD covers the prefill phase. "
+                "Use afd_phase='decode' with afd_combined_with_pd=True so the regular prefill "
+                "path accounts for encoder latency, memory, energy, and visual tokens."
             )
 
         resolved_version = _resolve_version_for(system_name)

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -44,6 +44,17 @@ DEFAULT_DECODE_LATENCY_CORRECTION_SCALE = 1.08
 POWER_DATA_COVERAGE_THRESHOLD = 0.9
 
 
+def _validate_visual_workload(image_height: int, image_width: int, num_frames_per_visual: int) -> None:
+    if (
+        isinstance(num_frames_per_visual, bool)
+        or not isinstance(num_frames_per_visual, int)
+        or num_frames_per_visual <= 0
+    ):
+        raise ValueError(f"num_frames_per_visual must be a positive non-boolean integer, got {num_frames_per_visual!r}")
+    if num_frames_per_visual > 1 and not (image_height > 0 and image_width > 0):
+        raise ValueError("num_frames_per_visual > 1 requires positive image_height and image_width")
+
+
 def cli_support(
     model_path: str,
     system: str,
@@ -277,6 +288,7 @@ def cli_default(
         >>> print(result.chosen_exp)  # e.g., 'agg_trtllm' or 'disagg_vllm'
         >>> print(result.best_throughputs)  # Shows all 6 backend/mode combinations
     """
+    _validate_visual_workload(image_height, image_width, num_frames_per_visual)
     # Fail fast on inconsistent MTP inputs (same early check as the CLI path).
     # nextn="auto" resolves the draft depth from the checkpoint first.
     if nextn == "auto":
@@ -480,6 +492,7 @@ def cli_recommend(
         ... )
         >>> print(result.best_configs)
     """
+    _validate_visual_workload(image_height, image_width, num_frames_per_visual)
     import math
 
     from aiconfigurator.sdk.perf_database import load_system_spec
@@ -1124,6 +1137,7 @@ def cli_estimate(
         ...     decode_batch_size=64, decode_num_workers=2,
         ... )
     """
+    _validate_visual_workload(image_height, image_width, num_frames_per_visual)
     from aiconfigurator.sdk.backends.factory import get_backend
     from aiconfigurator.sdk.models import get_model
     from aiconfigurator.sdk.perf_database import (

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -226,6 +226,17 @@ def _positive_float(value: str) -> float:
     return f
 
 
+def _positive_int(value: str) -> int:
+    """Argparse type for positive integers."""
+    try:
+        parsed = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"must be a positive integer, got {value!r}") from None
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError(f"must be a positive integer, got {value!r}")
+    return parsed
+
+
 def _validate_model_path(model_path: str) -> str:
     """
     Validate model_path which can be:
@@ -416,7 +427,7 @@ def _add_default_mode_arguments(parser):
     )
     parser.add_argument(
         "--num-frames-per-visual",
-        type=int,
+        type=_positive_int,
         default=1,
         help="Frames per visual input. Use 1 for images and >1 for video clips. Default: 1.",
     )
@@ -617,7 +628,7 @@ def _add_recommend_mode_arguments(parser):
     )
     parser.add_argument(
         "--num-frames-per-visual",
-        type=int,
+        type=_positive_int,
         default=1,
         help="Frames per visual input. Use 1 for images and >1 for video clips. Default: 1.",
     )
@@ -822,7 +833,7 @@ def _add_estimate_mode_arguments(parser):
     )
     parser.add_argument(
         "--num-frames-per-visual",
-        type=int,
+        type=_positive_int,
         default=1,
         help="Frames per visual input. Use 1 for images and >1 for video clips. Default: 1.",
     )
@@ -1505,7 +1516,6 @@ def build_default_tasks(
     image_height: int = 0,
     image_width: int = 0,
     num_images: int = 1,
-    num_frames_per_visual: int = 1,
     enable_encoder_dp: bool = True,
     ttft: float = 2000.0,
     tpot: float = 30.0,
@@ -1524,6 +1534,7 @@ def build_default_tasks(
     afd_max_a_batch_size: int = 1024,
     afd_max_candidates: int = 10_000,
     afd_candidate_overflow: str = "error",
+    num_frames_per_visual: int = 1,
 ) -> dict[str, Task]:
     """Build task configs for the selected default-mode serving modes.
 
@@ -1572,6 +1583,8 @@ def build_default_tasks(
         Task objects keyed by serving mode and, when requested, backend.
     """
     decode_system = decode_system or system
+    if num_frames_per_visual > 1 and not (image_height > 0 and image_width > 0):
+        raise ValueError("num_frames_per_visual > 1 requires positive image_height and image_width")
     if serving_mode not in ("auto", "all", "agg", "disagg", "afd"):
         raise ValueError(f"Invalid serving_mode: {serving_mode!r}. Use 'auto', 'all', 'agg', 'disagg', or 'afd'.")
     if serving_mode == "auto":

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -415,6 +415,12 @@ def _add_default_mode_arguments(parser):
         "--num-images", type=int, default=1, help="Number of images per request for vision-language models. Default: 1."
     )
     parser.add_argument(
+        "--num-frames-per-visual",
+        type=int,
+        default=1,
+        help="Frames per visual input. Use 1 for images and >1 for video clips. Default: 1.",
+    )
+    parser.add_argument(
         "--disable-encoder-dp",
         action="store_true",
         help="Model the vision encoder as TP-sharded instead of the default data-parallel "
@@ -608,6 +614,12 @@ def _add_recommend_mode_arguments(parser):
     )
     parser.add_argument(
         "--num-images", type=int, default=1, help="Number of images per request for vision-language models. Default: 1."
+    )
+    parser.add_argument(
+        "--num-frames-per-visual",
+        type=int,
+        default=1,
+        help="Frames per visual input. Use 1 for images and >1 for video clips. Default: 1.",
     )
     parser.add_argument(
         "--ttft",
@@ -807,6 +819,12 @@ def _add_estimate_mode_arguments(parser):
     )
     parser.add_argument(
         "--num-images", type=int, default=1, help="Number of images per request for vision-language models. Default: 1."
+    )
+    parser.add_argument(
+        "--num-frames-per-visual",
+        type=int,
+        default=1,
+        help="Frames per visual input. Use 1 for images and >1 for video clips. Default: 1.",
     )
     parser.add_argument(
         "--disable-encoder-dp",
@@ -1487,6 +1505,7 @@ def build_default_tasks(
     image_height: int = 0,
     image_width: int = 0,
     num_images: int = 1,
+    num_frames_per_visual: int = 1,
     enable_encoder_dp: bool = True,
     ttft: float = 2000.0,
     tpot: float = 30.0,
@@ -1519,6 +1538,10 @@ def build_default_tasks(
         database_mode: Database mode for performance estimation.
         isl: Input sequence length.
         osl: Output sequence length.
+        image_height: Height of each visual input. Zero disables encoder modeling.
+        image_width: Width of each visual input. Zero disables encoder modeling.
+        num_images: Number of visual inputs per request.
+        num_frames_per_visual: Frames per visual input; 1 is an image and >1 is video.
         ttft: Time to first token target in ms.
         tpot: Time per output token target in ms.
         request_latency: Optional end-to-end request latency target (ms).
@@ -1679,10 +1702,11 @@ def build_default_tasks(
         global_kwargs["nextn"] = nextn
         global_kwargs["nextn_accepted"] = nextn_accepted
 
-    if image_height or image_width or (num_images and num_images != 1):
+    if image_height or image_width or (num_images and num_images != 1) or num_frames_per_visual != 1:
         global_kwargs["image_height"] = image_height
         global_kwargs["image_width"] = image_width
         global_kwargs["num_images_per_request"] = num_images
+        global_kwargs["num_frames_per_visual"] = num_frames_per_visual
     if not enable_encoder_dp:
         global_kwargs["enable_encoder_dp"] = False
 
@@ -2462,6 +2486,7 @@ def _run_estimate_mode(args):
         image_height=args.image_height,
         image_width=args.image_width,
         num_images=args.num_images,
+        num_frames_per_visual=args.num_frames_per_visual,
         enable_encoder_dp=not args.disable_encoder_dp,
         batch_size=args.batch_size,
         ctx_tokens=args.ctx_tokens,
@@ -2542,7 +2567,9 @@ def _run_estimate_mode(args):
     print(f"  ISL:              {result.isl}")
     print(f"  OSL:              {result.osl}")
     if args.image_height > 0 and args.image_width > 0 and args.num_images > 0:
-        print(f"  Images:           {args.num_images} x {args.image_height}x{args.image_width}")
+        media = "Images" if args.num_frames_per_visual == 1 else "Video clips"
+        frames = "" if args.num_frames_per_visual == 1 else f" x {args.num_frames_per_visual} frames"
+        print(f"  {media + ':':<18}{args.num_images} x {args.image_height}x{args.image_width}{frames}")
         print(f"  Encoder parallel: {'TP (weight-sharded)' if args.disable_encoder_dp else 'DP (data-parallel)'}")
 
     # ``--prefix`` and ``--nextn`` are common parameters applied to every
@@ -2764,6 +2791,7 @@ def _run_recommend(args) -> None:
             image_height=args.image_height,
             image_width=args.image_width,
             num_images=args.num_images,
+            num_frames_per_visual=args.num_frames_per_visual,
             ttft=args.ttft,
             tpot=args.tpot,
             request_latency=args.request_latency,
@@ -2918,6 +2946,7 @@ def main(args):
             image_height=args.image_height,
             image_width=args.image_width,
             num_images=args.num_images,
+            num_frames_per_visual=args.num_frames_per_visual,
             enable_encoder_dp=not args.disable_encoder_dp,
             ttft=args.ttft,
             tpot=args.tpot,

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -757,6 +757,8 @@ class Task:
             raise ValueError(
                 f"num_frames_per_visual must be a positive non-boolean integer, got {self.num_frames_per_visual!r}"
             )
+        if self.num_frames_per_visual > 1 and not (self.image_height > 0 and self.image_width > 0):
+            raise ValueError("num_frames_per_visual > 1 requires positive image_height and image_width")
         # Validate the MTP pair BEFORE model-identity resolution: the latter is
         # skipped when no primary model path is set, and the check must not
         # depend on it (non-negative integer nextn; finite acceptance in range).

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -464,10 +464,12 @@ class Task:
     isl: int = 4000
     osl: int = 1000
     prefix: int = 0
-    # Multimodal image inputs (folded into the effective ISL by RuntimeConfig).
+    # Multimodal inputs (folded into the effective ISL by RuntimeConfig).
     image_height: int = 0
     image_width: int = 0
     num_images_per_request: int = 1
+    # 1 models an image; >1 models a video clip per visual input.
+    num_frames_per_visual: int = 1
     # Vision encoder data parallelism (ModelConfig default).
     enable_encoder_dp: bool = True
     ttft: float = 1000.0
@@ -1505,6 +1507,7 @@ class Task:
             image_height=self.image_height,
             image_width=self.image_width,
             num_images_per_request=self.num_images_per_request,
+            num_frames_per_visual=self.num_frames_per_visual,
             ttft=self.ttft,
             tpot=self.tpot,
             request_latency=self.request_latency,

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -468,8 +468,6 @@ class Task:
     image_height: int = 0
     image_width: int = 0
     num_images_per_request: int = 1
-    # 1 models an image; >1 models a video clip per visual input.
-    num_frames_per_visual: int = 1
     # Vision encoder data parallelism (ModelConfig default).
     enable_encoder_dp: bool = True
     ttft: float = 1000.0
@@ -635,6 +633,10 @@ class Task:
     afd_decode_degradation: float | None = None
     afd_ttft_correction_factor: float | None = None
     afd_decode_latency_correction: float = 1.0
+
+    # Keep new public fields at the end so existing positional construction is stable.
+    # 1 models an image; >1 models a video clip per visual input.
+    num_frames_per_visual: int = 1
 
     # ====== 11. Internal — resolved in __post_init__ ======
     _is_moe: bool = field(default=False, repr=False, init=False)

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -749,6 +749,14 @@ class Task:
 
     def __post_init__(self) -> None:
         self._check_prefix_discipline()
+        if (
+            isinstance(self.num_frames_per_visual, bool)
+            or not isinstance(self.num_frames_per_visual, int)
+            or self.num_frames_per_visual <= 0
+        ):
+            raise ValueError(
+                f"num_frames_per_visual must be a positive non-boolean integer, got {self.num_frames_per_visual!r}"
+            )
         # Validate the MTP pair BEFORE model-identity resolution: the latter is
         # skipped when no primary model path is set, and the check must not
         # depend on it (non-negative integer nextn; finite acceptance in range).

--- a/tests/unit/cli/test_afd_phase_completion.py
+++ b/tests/unit/cli/test_afd_phase_completion.py
@@ -984,7 +984,13 @@ def test_cli_estimate_afd_combined_with_pd_true_runs_static_combine(monkeypatch)
     monkeypatch.setattr(api, "_run_static_estimate", fake_run_static_estimate)
 
     result = api.cli_estimate(
-        **_afd_cli_estimate_kwargs(afd_combined_with_pd=True, enable_encoder_dp=False),
+        **_afd_cli_estimate_kwargs(
+            afd_combined_with_pd=True,
+            image_height=448,
+            image_width=448,
+            num_frames_per_visual=8,
+            enable_encoder_dp=False,
+        ),
     )
 
     # Merged result should reflect static_ctx TTFT and AFD TPOT, plus the
@@ -994,6 +1000,9 @@ def test_cli_estimate_afd_combined_with_pd_true_runs_static_combine(monkeypatch)
     # The encoder-parallelism choice must reach the static complement: a
     # non-default value proves forwarding rather than the callee default.
     assert captured["static_kwargs"]["enable_encoder_dp"] is False
+    assert captured["static_kwargs"]["image_height"] == 448
+    assert captured["static_kwargs"]["image_width"] == 448
+    assert captured["static_kwargs"]["num_frames_per_visual"] == 8
     assert result.ttft == 50.0
     assert result.tpot == 5.0
     assert result.num_total_gpus == 12
@@ -1012,6 +1021,25 @@ def test_cli_estimate_afd_phase_both_with_combined_with_pd_raises(monkeypatch):
     with pytest.raises(ValueError, match="afd_combined_with_pd=True is incompatible with afd_phase='both'"):
         api.cli_estimate(
             **_afd_cli_estimate_kwargs(afd_phase="both", afd_combined_with_pd=True),
+        )
+
+
+@pytest.mark.parametrize("afd_phase", ["prefill", "both"])
+def test_cli_estimate_rejects_visual_workload_when_afd_covers_prefill(monkeypatch, afd_phase):
+    """AFD prefill does not yet account for vision encoder work."""
+    _install_estimate_perf_db_stubs(monkeypatch)
+    monkeypatch.setattr(api, "_run_afd_estimate", lambda **_kwargs: _estimate_result(raw={}))
+
+    with pytest.raises(ValueError, match="Visual encoder modeling is not supported when AFD covers the prefill"):
+        api.cli_estimate(
+            **_afd_cli_estimate_kwargs(
+                afd_phase=afd_phase,
+                afd_combined_with_pd=False,
+                image_height=448,
+                image_width=448,
+                num_images=1,
+                num_frames_per_visual=8,
+            ),
         )
 
 

--- a/tests/unit/cli/test_afd_phase_completion.py
+++ b/tests/unit/cli/test_afd_phase_completion.py
@@ -1043,6 +1043,24 @@ def test_cli_estimate_rejects_visual_workload_when_afd_covers_prefill(monkeypatc
         )
 
 
+def test_cli_estimate_rejects_visual_afd_decode_without_prefill_complement(monkeypatch):
+    """Visual AFD decode alone would omit all prefill-side encoder work."""
+    _install_estimate_perf_db_stubs(monkeypatch)
+    monkeypatch.setattr(api, "_run_afd_estimate", lambda **_kwargs: _estimate_result(raw={}))
+
+    with pytest.raises(ValueError, match="afd_combined_with_pd=False"):
+        api.cli_estimate(
+            **_afd_cli_estimate_kwargs(
+                afd_phase="decode",
+                afd_combined_with_pd=False,
+                image_height=448,
+                image_width=448,
+                num_images=1,
+                num_frames_per_visual=8,
+            ),
+        )
+
+
 def test_cli_main_estimate_value_error_exits_without_traceback(monkeypatch):
     """Estimate-mode validation errors surface as a concise CLI error.
 

--- a/tests/unit/cli/test_argument_parsing.py
+++ b/tests/unit/cli/test_argument_parsing.py
@@ -437,6 +437,18 @@ class TestCLIArgumentParsing:
         args = cli_parser.parse_args(["estimate", *common_args, "--disable-encoder-dp"])
         assert args.disable_encoder_dp is True
 
+    @pytest.mark.parametrize("mode", ["default", "recommend", "estimate"])
+    def test_num_frames_per_visual_flag(self, cli_parser, mode):
+        args = [mode, "--model-path", "moonshotai/Kimi-K2.5", "--system", "b200_sxm"]
+        if mode == "default":
+            args.extend(["--total-gpus", "8"])
+        elif mode == "recommend":
+            args.extend(["--target-request-rate", "1"])
+        args.extend(["--image-height", "448", "--image-width", "448", "--num-frames-per-visual", "8"])
+
+        parsed = cli_parser.parse_args(args)
+        assert parsed.num_frames_per_visual == 8
+
     def test_recommend_mode_parses_request_rate(self, cli_parser):
         args = cli_parser.parse_args(
             [

--- a/tests/unit/cli/test_argument_parsing.py
+++ b/tests/unit/cli/test_argument_parsing.py
@@ -449,6 +449,29 @@ class TestCLIArgumentParsing:
         parsed = cli_parser.parse_args(args)
         assert parsed.num_frames_per_visual == 8
 
+    @pytest.mark.parametrize("mode", ["default", "recommend", "estimate"])
+    def test_num_frames_per_visual_defaults_to_one(self, cli_parser, mode):
+        args = [mode, "--model-path", "moonshotai/Kimi-K2.5", "--system", "b200_sxm"]
+        if mode == "default":
+            args.extend(["--total-gpus", "8"])
+        elif mode == "recommend":
+            args.extend(["--target-request-rate", "1"])
+
+        assert cli_parser.parse_args(args).num_frames_per_visual == 1
+
+    @pytest.mark.parametrize("mode", ["default", "recommend", "estimate"])
+    @pytest.mark.parametrize("value", ["0", "-1"])
+    def test_num_frames_per_visual_rejects_non_positive_values(self, cli_parser, mode, value):
+        args = [mode, "--model-path", "moonshotai/Kimi-K2.5", "--system", "b200_sxm"]
+        if mode == "default":
+            args.extend(["--total-gpus", "8"])
+        elif mode == "recommend":
+            args.extend(["--target-request-rate", "1"])
+        args.extend(["--num-frames-per-visual", value])
+
+        with pytest.raises(SystemExit):
+            cli_parser.parse_args(args)
+
     def test_recommend_mode_parses_request_rate(self, cli_parser):
         args = cli_parser.parse_args(
             [

--- a/tests/unit/cli/test_cli_api.py
+++ b/tests/unit/cli/test_cli_api.py
@@ -11,10 +11,22 @@ import pandas as pd
 import pytest
 
 from aiconfigurator.cli import CLIResult, cli_exp, cli_generate
+from aiconfigurator.cli.api import _validate_visual_workload
 from aiconfigurator.sdk import common
 from aiconfigurator.sdk.errors import NoFeasibleConfigError
 
 pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize("value", [0, -1, 1.5, True, False])
+def test_public_cli_apis_reject_invalid_frame_counts(value):
+    with pytest.raises(ValueError, match="positive non-boolean integer"):
+        _validate_visual_workload(448, 448, value)
+
+
+def test_public_cli_apis_reject_video_without_dimensions():
+    with pytest.raises(ValueError, match="requires positive image_height and image_width"):
+        _validate_visual_workload(0, 0, 8)
 
 
 class TestCLIEstimateUnit:

--- a/tests/unit/cli/test_cli_workflow.py
+++ b/tests/unit/cli/test_cli_workflow.py
@@ -9,6 +9,7 @@ while keeping heavy computation mocked out.
 """
 
 import argparse
+import inspect
 import logging
 from unittest.mock import MagicMock, patch
 
@@ -29,6 +30,16 @@ from aiconfigurator.cli.report_and_save import _apply_inclusive_tpot
 from aiconfigurator.sdk.errors import NoFeasibleConfigError
 
 pytestmark = pytest.mark.unit
+
+
+def test_build_default_tasks_appends_new_video_parameter():
+    parameters = list(inspect.signature(build_default_tasks).parameters)
+    assert parameters[-2:] == ["afd_candidate_overflow", "num_frames_per_visual"]
+
+
+def test_build_default_tasks_rejects_video_without_dimensions():
+    with pytest.raises(ValueError, match="requires positive image_height and image_width"):
+        build_default_tasks("moonshotai/Kimi-K2.5", 8, "b200_sxm", num_frames_per_visual=8)
 
 
 class TestCLILogLevelResolution:

--- a/tests/unit/sdk/backends/test_encoder.py
+++ b/tests/unit/sdk/backends/test_encoder.py
@@ -264,6 +264,11 @@ class TestRuntimeConfigImageFields:
         init_fields = [field.name for field in fields(RuntimeConfig) if field.init]
         assert init_fields[-2:] == ["num_image_tokens", "num_frames_per_visual"]
 
+    @pytest.mark.parametrize("value", [0, -1, 1.5, True, False])
+    def test_num_frames_per_visual_requires_positive_non_boolean_integer(self, value):
+        with pytest.raises(ValueError, match="positive non-boolean integer"):
+            RuntimeConfig(num_frames_per_visual=value)
+
     def test_default_num_image_tokens_is_zero(self):
         rc = RuntimeConfig(batch_size=1, isl=512, osl=128)
         assert rc.num_image_tokens == 0

--- a/tests/unit/sdk/backends/test_encoder.py
+++ b/tests/unit/sdk/backends/test_encoder.py
@@ -269,6 +269,10 @@ class TestRuntimeConfigImageFields:
         with pytest.raises(ValueError, match="positive non-boolean integer"):
             RuntimeConfig(num_frames_per_visual=value)
 
+    def test_video_frames_require_image_dimensions(self):
+        with pytest.raises(ValueError, match="requires positive image_height and image_width"):
+            RuntimeConfig(num_frames_per_visual=8)
+
     def test_default_num_image_tokens_is_zero(self):
         rc = RuntimeConfig(batch_size=1, isl=512, osl=128)
         assert rc.num_image_tokens == 0

--- a/tests/unit/sdk/backends/test_encoder.py
+++ b/tests/unit/sdk/backends/test_encoder.py
@@ -13,6 +13,8 @@ Covers:
 - InferenceSummary encoder latency/energy accessors
 """
 
+from dataclasses import fields
+
 import pytest
 
 from aiconfigurator.sdk import common, config
@@ -257,6 +259,10 @@ class TestEncoderRuntime:
 
 class TestRuntimeConfigImageFields:
     """Test image-related fields added to RuntimeConfig for VL support."""
+
+    def test_new_video_field_preserves_legacy_positional_order(self):
+        init_fields = [field.name for field in fields(RuntimeConfig) if field.init]
+        assert init_fields[-2:] == ["num_image_tokens", "num_frames_per_visual"]
 
     def test_default_num_image_tokens_is_zero(self):
         rc = RuntimeConfig(batch_size=1, isl=512, osl=128)

--- a/tests/unit/sdk/models/test_kimi_k25_vision.py
+++ b/tests/unit/sdk/models/test_kimi_k25_vision.py
@@ -146,7 +146,8 @@ def test_encoder_parallelism_models_required_communication():
 
 def test_video_frame_count_must_be_positive():
     enc = get_model_config_from_model_path("moonshotai/Kimi-K2.5")["encoder_config"]
-    runtime = config.RuntimeConfig(image_height=448, image_width=448, num_frames_per_visual=0)
+    runtime = config.RuntimeConfig(image_height=448, image_width=448)
+    runtime.num_frames_per_visual = 0
 
     with pytest.raises(ValueError, match="num_frames_per_visual must be positive"):
         BaseBackend._encoder_pre_merge_per_visual(runtime, enc)

--- a/tests/unit/sdk/models/test_kimi_k25_vision.py
+++ b/tests/unit/sdk/models/test_kimi_k25_vision.py
@@ -1,0 +1,217 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Kimi K2.5 image/video encoder parsing, construction, and runtime tests."""
+
+from copy import deepcopy
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from aiconfigurator.sdk import common, config
+from aiconfigurator.sdk.backends.base_backend import BaseBackend
+from aiconfigurator.sdk.backends.trtllm_backend import TRTLLMBackend
+from aiconfigurator.sdk.models import get_model
+from aiconfigurator.sdk.performance_result import PerformanceResult
+from aiconfigurator.sdk.utils import _parse_hf_config_json, get_model_config_from_model_path
+
+pytestmark = pytest.mark.unit
+
+_KIMI_MODELS = ("moonshotai/Kimi-K2.5", "nvidia/Kimi-K2.5-NVFP4")
+
+
+def _model_config(tp_size: int = 1, *, enable_encoder_dp: bool = True) -> config.ModelConfig:
+    return config.ModelConfig(
+        tp_size=tp_size,
+        attention_dp_size=1,
+        moe_tp_size=tp_size,
+        moe_ep_size=1,
+        enable_encoder_dp=enable_encoder_dp,
+    )
+
+
+@pytest.mark.parametrize("model_id", _KIMI_MODELS)
+def test_real_vision_config_is_preserved_alongside_language_config(model_id):
+    info = get_model_config_from_model_path(model_id)
+
+    assert "text_config" in info["raw_config"]
+    assert info["raw_config"]["vision_config"]["video_attn_type"] == "spatial_temporal"
+    assert info["extra_params"] == {
+        "v_head_dim": 128,
+        "kv_lora_rank": 512,
+        "qk_rope_head_dim": 64,
+    }
+    assert isinstance(info["encoder_config"], common.VisionEncoderConfig)
+
+
+@pytest.mark.parametrize("model_id", _KIMI_MODELS)
+def test_kimi_vision_geometry_matches_published_checkpoint(model_id):
+    enc = get_model_config_from_model_path(model_id)["encoder_config"]
+
+    assert (enc.depth, enc.hidden_size, enc.num_heads, enc.intermediate_size) == (27, 1152, 16, 4304)
+    assert (enc.patch_size, enc.temporal_patch_size, enc.spatial_merge_size) == (14, 1, 2)
+    assert enc.projector_dims == ((4608, 4608), (4608, 7168))
+    assert enc.out_hidden_size == 7168
+    assert enc.partial_rotary_factor == 1.0
+    assert enc.video_attention_type == "spatial_temporal"
+    assert enc.pool_temporal is True
+    assert enc.final_norm is True
+    assert enc.projector_pre_norm is True
+
+
+@pytest.mark.parametrize("model_id", _KIMI_MODELS)
+def test_kimi_builds_spatial_temporal_vit_patch_merger_and_projector(model_id):
+    model = get_model(model_id, _model_config(), "trtllm")
+    names = {op._name for op in model.encoder_ops}
+
+    assert {
+        "encoder_patch_embed_gemm",
+        "encoder_pos_embed",
+        "encoder_qkv_gemm",
+        "encoder_attention",
+        "encoder_rope_apply",
+        "encoder_final_norm",
+        "encoder_merger_pre_norm",
+        "encoder_patch_merge_pool",
+        "encoder_projector_fc0_gemm",
+        "encoder_projector_fc1_gemm",
+        "encoder_projector_ar",
+    } <= names
+
+
+@pytest.mark.parametrize(
+    "model_id,language_modes",
+    [
+        (
+            "moonshotai/Kimi-K2.5",
+            (
+                common.GEMMQuantMode.bfloat16,
+                common.MoEQuantMode.int4_wo,
+                common.FMHAQuantMode.bfloat16,
+                common.KVCacheQuantMode.bfloat16,
+            ),
+        ),
+        (
+            "nvidia/Kimi-K2.5-NVFP4",
+            (
+                common.GEMMQuantMode.nvfp4,
+                common.MoEQuantMode.nvfp4,
+                common.FMHAQuantMode.fp8,
+                common.KVCacheQuantMode.fp8,
+            ),
+        ),
+    ],
+)
+def test_language_checkpoint_modes_are_retained_while_encoder_stays_bf16(model_id, language_modes):
+    model_cfg = _model_config()
+    model = get_model(model_id, model_cfg, "trtllm")
+
+    assert (
+        model_cfg.gemm_quant_mode,
+        model_cfg.moe_quant_mode,
+        model_cfg.fmha_quant_mode,
+        model_cfg.kvcache_quant_mode,
+    ) == language_modes
+    assert model.encoder_config.gemm_quant_mode == "bfloat16"
+    assert model.encoder_config.fmha_quant_mode == "bfloat16"
+    assert {op._quant_mode for op in model.encoder_ops if hasattr(op, "_quant_mode")} == {common.GEMMQuantMode.bfloat16}
+    encoder_attention = next(op for op in model.encoder_ops if op._name == "encoder_attention")
+    assert encoder_attention._fmha_quant_mode == common.FMHAQuantMode.bfloat16
+
+
+def test_model_level_quantization_must_explicitly_exclude_kimi_vision_components():
+    raw = deepcopy(get_model_config_from_model_path("nvidia/Kimi-K2.5-NVFP4")["raw_config"])
+    raw["quantization_config"]["ignore"] = ["language_model.lm_head"]
+
+    with pytest.raises(ValueError, match="does not explicitly exclude both vision_tower and mm_projector"):
+        _parse_hf_config_json(raw)
+
+
+def test_encoder_parallelism_models_required_communication():
+    dp_model = get_model("moonshotai/Kimi-K2.5", _model_config(tp_size=2), "trtllm")
+    tp_model = get_model(
+        "moonshotai/Kimi-K2.5",
+        _model_config(tp_size=2, enable_encoder_dp=False),
+        "trtllm",
+    )
+
+    dp_names = {op._name for op in dp_model.encoder_ops}
+    tp_ops = {op._name: op for op in tp_model.encoder_ops}
+    assert "encoder_dp_all_gather" in dp_names
+    assert tp_ops["encoder_ar_1"]._tp_size == 2
+    assert tp_ops["encoder_ar_2"]._tp_size == 2
+    assert tp_ops["encoder_projector_ar"]._tp_size == 2
+
+
+def test_video_frame_count_must_be_positive():
+    enc = get_model_config_from_model_path("moonshotai/Kimi-K2.5")["encoder_config"]
+    runtime = config.RuntimeConfig(image_height=448, image_width=448, num_frames_per_visual=0)
+
+    with pytest.raises(ValueError, match="num_frames_per_visual must be positive"):
+        BaseBackend._encoder_pre_merge_per_visual(runtime, enc)
+
+
+@pytest.mark.parametrize("model_id", _KIMI_MODELS)
+def test_kimi_image_and_video_runtime_cover_latency_memory_energy_and_ttft(model_id):
+    model = get_model(model_id, _model_config(), "trtllm")
+    backend = TRTLLMBackend()
+    database = SimpleNamespace(
+        backend="trtllm",
+        version="structural-test",
+        system="b200_sxm",
+        system_spec={
+            "gpu": {"mem_capacity": 1024 * (1 << 30)},
+            "misc": {"nccl_mem": {1: 0}, "other_mem": 0},
+        },
+    )
+
+    def _shape_scaled_result(*_args, **kwargs):
+        x = kwargs["x"]
+        return PerformanceResult(x / 1_000_000.0, energy=x / 100_000.0, source="structural-test")
+
+    for op in model.context_ops + model.generation_ops + model.encoder_ops:
+        op.query = MagicMock(side_effect=_shape_scaled_result)
+
+    image_runtime = config.RuntimeConfig(
+        batch_size=1,
+        isl=128,
+        osl=1,
+        image_height=448,
+        image_width=448,
+        num_frames_per_visual=1,
+        engine_step_backend="python",
+    )
+    video_runtime = config.RuntimeConfig(
+        batch_size=1,
+        isl=128,
+        osl=1,
+        image_height=448,
+        image_width=448,
+        num_frames_per_visual=8,
+        engine_step_backend="python",
+    )
+
+    enc = model.encoder_config
+    assert BaseBackend._encoder_pre_merge_per_visual(image_runtime, enc) == (256, 1024)
+    assert BaseBackend._encoder_pre_merge_per_visual(video_runtime, enc) == (256, 8192)
+    assert BaseBackend._visual_context_tokens(model, image_runtime) == 256
+    assert BaseBackend._visual_context_tokens(model, video_runtime) == 256
+
+    image_summary = backend.run_static(model, database, image_runtime, mode="static_ctx")
+    image_attention_call = next(op for op in model.encoder_ops if op._name == "encoder_attention").query.call_args
+    video_summary = backend.run_static(model, database, video_runtime, mode="static_ctx")
+    video_attention_call = next(op for op in model.encoder_ops if op._name == "encoder_attention").query.call_args
+
+    assert image_attention_call.kwargs["s"] == 1024
+    assert video_attention_call.kwargs["s"] == 8192
+    assert sum(image_summary.get_encoder_latency_dict().values()) > 0
+    assert sum(image_summary.get_encoder_energy_wms_dict().values()) > 0
+    assert sum(video_summary.get_encoder_latency_dict().values()) > sum(
+        image_summary.get_encoder_latency_dict().values()
+    )
+    assert sum(video_summary.get_encoder_energy_wms_dict().values()) > sum(
+        image_summary.get_encoder_energy_wms_dict().values()
+    )
+    assert video_summary.get_encoder_memory()["activations"] > image_summary.get_encoder_memory()["activations"]
+    assert video_summary.get_result_dict()["ttft"] > image_summary.get_result_dict()["ttft"]

--- a/tests/unit/sdk/task_v2/test_task_config.py
+++ b/tests/unit/sdk/task_v2/test_task_config.py
@@ -44,6 +44,11 @@ def test_num_frames_per_visual_requires_positive_non_boolean_integer(value):
         Task(num_frames_per_visual=value)
 
 
+def test_video_frames_require_image_dimensions():
+    with pytest.raises(ValueError, match="requires positive image_height and image_width"):
+        Task(num_frames_per_visual=8)
+
+
 def test_agg_with_model_resolves_identity_and_backend():
     t = Task(
         serving_mode="agg",

--- a/tests/unit/sdk/task_v2/test_task_config.py
+++ b/tests/unit/sdk/task_v2/test_task_config.py
@@ -8,6 +8,8 @@ against the legacy CLI; these tests focus on construction, defaulting,
 prefix discipline, and the build_* helpers.
 """
 
+from dataclasses import fields
+
 import pytest
 
 from aiconfigurator.sdk import common
@@ -28,6 +30,12 @@ def test_default_task_config_is_agg_with_default_workload():
     assert t.osl == 1000
     assert t.ttft == 1000.0
     assert t.tpot == 50.0
+
+
+def test_new_video_field_preserves_legacy_positional_order():
+    init_fields = [field.name for field in fields(Task) if field.init]
+    assert init_fields[-2:] == ["afd_decode_latency_correction", "num_frames_per_visual"]
+    assert init_fields.index("enable_encoder_dp") == init_fields.index("num_images_per_request") + 1
 
 
 def test_agg_with_model_resolves_identity_and_backend():

--- a/tests/unit/sdk/task_v2/test_task_config.py
+++ b/tests/unit/sdk/task_v2/test_task_config.py
@@ -38,6 +38,12 @@ def test_new_video_field_preserves_legacy_positional_order():
     assert init_fields.index("enable_encoder_dp") == init_fields.index("num_images_per_request") + 1
 
 
+@pytest.mark.parametrize("value", [0, -1, 1.5, True, False])
+def test_num_frames_per_visual_requires_positive_non_boolean_integer(value):
+    with pytest.raises(ValueError, match="positive non-boolean integer"):
+        Task(num_frames_per_visual=value)
+
+
 def test_agg_with_model_resolves_identity_and_backend():
     t = Task(
         serving_mode="agg",

--- a/tests/unit/support_matrix/test_support_matrix_order.py
+++ b/tests/unit/support_matrix/test_support_matrix_order.py
@@ -142,3 +142,42 @@ def test_task_uses_silicon_database_mode(monkeypatch):
     )
 
     assert captured_kwargs["database_mode"] == common.DatabaseMode.SILICON.name
+
+
+@pytest.mark.parametrize("mode", ["agg", "disagg"])
+@pytest.mark.parametrize("model", ["moonshotai/Kimi-K2.5", "nvidia/Kimi-K2.5-NVFP4"])
+def test_kimi_matrix_tasks_exercise_representative_encoder_workload(monkeypatch, mode, model):
+    captured_kwargs = {}
+
+    class FakeTask:
+        def __init__(self, **kwargs):
+            captured_kwargs.update(kwargs)
+
+    monkeypatch.setattr(support_matrix_module, "Task", FakeTask)
+    SupportMatrix._create_task(
+        mode=mode,
+        model=model,
+        system="b200_sxm",
+        backend="trtllm",
+        version="1.2.0rc5",
+        constraints=TestConstraints(total_gpus=8, isl=256, osl=256, prefix=0, ttft=2000.0, tpot=50.0),
+        engine_step_backend=None,
+    )
+
+    assert captured_kwargs["image_height"] == 448
+    assert captured_kwargs["image_width"] == 448
+    assert captured_kwargs["num_images_per_request"] == 1
+    assert captured_kwargs["num_frames_per_visual"] == 1
+
+
+def test_kimi_matrix_reproduction_command_includes_visual_workload():
+    command = support_matrix_module._support_matrix_row_command(
+        model="nvidia/Kimi-K2.5-NVFP4",
+        system="b200_sxm",
+        backend="trtllm",
+        version="1.2.0rc5",
+        mode="agg",
+        constraints=TestConstraints(total_gpus=8, isl=256, osl=256, prefix=0, ttft=2000.0, tpot=50.0),
+    )
+
+    assert "--image-height 448 --image-width 448 --num-images 1" in command

--- a/tools/support_matrix/support_matrix.py
+++ b/tools/support_matrix/support_matrix.py
@@ -118,6 +118,26 @@ class HardwareIncompatibility:
     reason: str
 
 
+_KIMI_K25_VISION_MODELS = frozenset({"moonshotai/Kimi-K2.5", "nvidia/Kimi-K2.5-NVFP4"})
+
+
+def _representative_vision_workload(model: str) -> dict[str, int]:
+    """Return the visual workload required to exercise encoder support.
+
+    Support-matrix rows historically used text-only RuntimeConfig values even
+    for multimodal checkpoints. Kimi K2.5 rows use a representative 448x448
+    image so both agg and disagg checks query the newly modeled encoder path.
+    """
+    if model not in _KIMI_K25_VISION_MODELS:
+        return {}
+    return {
+        "image_height": 448,
+        "image_width": 448,
+        "num_images_per_request": 1,
+        "num_frames_per_visual": 1,
+    }
+
+
 def _support_matrix_row_command(
     *,
     model: str,
@@ -165,10 +185,20 @@ def _support_matrix_row_command(
         str(constraints.ttft),
         "--tpot",
         str(constraints.tpot),
-        "--top-n",
-        "1",
-        "--no-color",
     ]
+    workload = _representative_vision_workload(model)
+    if workload:
+        parts.extend(
+            [
+                "--image-height",
+                str(workload["image_height"]),
+                "--image-width",
+                str(workload["image_width"]),
+                "--num-images",
+                str(workload["num_images_per_request"]),
+            ]
+        )
+    parts.extend(["--top-n", "1", "--no-color"])
     if transfer_policy:
         parts.extend(["--transfer-policy", transfer_policy])
     if compare_engine_step_backends:
@@ -766,6 +796,7 @@ class SupportMatrix:
             # (e.g. AIC_SM_TRANSFERS="off" or "xshape,xquant"). None -> all kinds on.
             "transfer_policy": os.environ.get("AIC_SM_TRANSFERS") or None,
         }
+        common_kwargs.update(_representative_vision_workload(model))
         if mode == "disagg":
             # v2 disagg forbids shared top-level worker fields; fan out to both roles.
             return Task(


### PR DESCRIPTION
## Summary

Implements AIC-1737 for `moonshotai/Kimi-K2.5` and `nvidia/Kimi-K2.5-NVFP4`.

- preserves the real Kimi vision configuration alongside `text_config`
- models patch embedding, the 27-layer spatial-temporal ViT, full encoder attention/RoPE, temporal-spatial pooling, PatchMerger/projector, and encoder communication
- includes encoder latency, memory, energy, visual context tokens, and TTFT
- adds explicit image/video runtime input via `num_frames_per_visual` across RuntimeConfig, Task, and CLI
- keeps the vision tower and projector explicitly BF16 for both checkpoints while preserving each checkpoint's language quantization behavior
- makes Kimi support-matrix agg/disagg checks exercise a representative 448x448 visual workload

## Why

Kimi K2.5 previously unwrapped and modeled only its DeepSeek-compatible language `text_config`. The top-level vision configuration was discarded, no encoder operations were built, and support-matrix checks could pass through a text-only workload.

## Validation

- `90 passed`: focused Kimi image/video, support-matrix, and CLI argument tests
- `514 passed`: parser, model, encoder backend, Task, CLI, and support-matrix regressions
- Ruff lint and format checks passed
- `git diff --check` passed

The runtime tests validate graph shape and accounting behavior, not measured silicon accuracy. Encoder performance-data collection and silicon calibration remain follow-up work under AIC-1742.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for multi-frame visual inputs across CLI, API, task configuration, estimates, and recommendations.
  * Added vision encoder configuration for Kimi K2.5 and Qwen3-VL models.
  * Added configurable vision precision, patch embedding, normalization, temporal pooling, and video attention settings.
  * Estimates now distinguish images from video clips and display frame counts.

* **Bug Fixes**
  * Added validation for positive frame counts and unsupported vision quantization modes.
  * Improved visual token calculations for temporal inputs.

* **Tests**
  * Expanded coverage for video workloads, vision configuration, performance, CLI parsing, and support-matrix scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->