### PR TITLE
feat: enable Kimi K3 image and video encoder modeling

### DIFF
--- a/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
+++ b/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
@@ -30,6 +30,16 @@ from aiconfigurator_core.sdk.step_estimate import MixedStepInput, StepEstimate
 logger = logging.getLogger(__name__)
 
 
+@dataclasses.dataclass(frozen=True)
+class _EncoderVisualWorkload:
+    """One homogeneous image/video sequence group entering a vision encoder."""
+
+    kind: str
+    count_per_request: int
+    post_merge_tokens: int
+    pre_merge_tokens: int
+
+
 class BaseBackend:
     """Base class for all inference backends.
 
@@ -210,10 +220,12 @@ class BaseBackend:
 
     @staticmethod
     def _visual_context_tokens_from_encoder_config(enc_cfg, runtime_config: RuntimeConfig) -> int:
-        if not isinstance(enc_cfg, common.VisionEncoderConfig) or runtime_config.num_images_per_request <= 0:
+        if not isinstance(enc_cfg, common.VisionEncoderConfig):
             return 0
-        post_merge, _ = BaseBackend._encoder_pre_merge_per_visual(runtime_config, enc_cfg)
-        return post_merge * runtime_config.num_images_per_request
+        return sum(
+            workload.post_merge_tokens * workload.count_per_request
+            for workload in BaseBackend._encoder_visual_workloads(runtime_config, enc_cfg)
+        )
 
     @staticmethod
     def _visual_context_tokens(model: BaseModel, runtime_config: RuntimeConfig) -> int:
@@ -252,6 +264,70 @@ class BaseBackend:
             return 0, 0
         return tokens_per_image, pre_merge_per_image
 
+    @staticmethod
+    def _encoder_video_tokens_per_visual(
+        runtime_config: RuntimeConfig,
+        enc_cfg: common.VisionEncoderConfig,
+    ) -> tuple[int, int]:
+        """Return post-/pre-merge tokens for one representative video.
+
+        Frames are first grouped by ``temporal_patch_size``. Kimi K3 uses a
+        Conv2d per frame (temporal_patch_size=1), attends jointly over the full
+        t*h*w sequence, then ``sd2_tpool`` collapses all temporal positions; its
+        LLM-visible token count therefore depends only on spatial resolution.
+        Other ViTs retain one output time step per temporal patch group.
+        """
+        if runtime_config.video_height <= 0 or runtime_config.video_width <= 0 or runtime_config.video_num_frames <= 0:
+            return 0, 0
+        temporal_patch = max(1, enc_cfg.temporal_patch_size)
+        temporal_tokens = -(-runtime_config.video_num_frames // temporal_patch)
+        if enc_cfg.max_temporal_patches > 0 and temporal_tokens > enc_cfg.max_temporal_patches:
+            raise ValueError(
+                f"{enc_cfg.encoder_type} supports at most {enc_cfg.max_temporal_patches} temporal patches; "
+                f"got {temporal_tokens} from video_num_frames={runtime_config.video_num_frames} "
+                f"and temporal_patch_size={temporal_patch}"
+            )
+        spatial_pre = (runtime_config.video_height // enc_cfg.patch_size) * (
+            runtime_config.video_width // enc_cfg.patch_size
+        )
+        spatial_stride = enc_cfg.patch_size * enc_cfg.spatial_merge_size
+        spatial_post = (runtime_config.video_height // spatial_stride) * (runtime_config.video_width // spatial_stride)
+        pre_merge = temporal_tokens * spatial_pre
+        post_merge = spatial_post if enc_cfg.temporal_pool_all else temporal_tokens * spatial_post
+        if pre_merge <= 0 or post_merge <= 0:
+            return 0, 0
+        return post_merge, pre_merge
+
+    @staticmethod
+    def _encoder_visual_workloads(
+        runtime_config: RuntimeConfig,
+        enc_cfg: common.VisionEncoderConfig,
+    ) -> list[_EncoderVisualWorkload]:
+        workloads = []
+        if runtime_config.num_images_per_request > 0:
+            post_merge, pre_merge = BaseBackend._encoder_pre_merge_per_visual(runtime_config, enc_cfg)
+            if pre_merge > 0:
+                workloads.append(
+                    _EncoderVisualWorkload(
+                        kind="image",
+                        count_per_request=runtime_config.num_images_per_request,
+                        post_merge_tokens=post_merge,
+                        pre_merge_tokens=pre_merge,
+                    )
+                )
+        if runtime_config.num_videos_per_request > 0:
+            post_merge, pre_merge = BaseBackend._encoder_video_tokens_per_visual(runtime_config, enc_cfg)
+            if pre_merge > 0:
+                workloads.append(
+                    _EncoderVisualWorkload(
+                        kind="video",
+                        count_per_request=runtime_config.num_videos_per_request,
+                        post_merge_tokens=post_merge,
+                        pre_merge_tokens=pre_merge,
+                    )
+                )
+        return workloads
+
     def _run_encoder_phase(
         self,
         model: BaseModel,
@@ -270,64 +346,68 @@ class BaseBackend:
             return encoder_latency_dict, encoder_energy_wms_dict, encoder_source_dict, 0
 
         enc_cfg = getattr(model, "encoder_config", None)
-        num_images = runtime_config.num_images_per_request
-        if num_images <= 0 or not isinstance(enc_cfg, common.VisionEncoderConfig):
+        if not isinstance(enc_cfg, common.VisionEncoderConfig):
             return encoder_latency_dict, encoder_energy_wms_dict, encoder_source_dict, 0
 
-        tokens_per_image, pre_merge_per_image = self._encoder_pre_merge_per_visual(runtime_config, enc_cfg)
-        if tokens_per_image == 0:
-            # No image dimensions specified; skip encoder modeling.
+        workloads = self._encoder_visual_workloads(runtime_config, enc_cfg)
+        if not workloads:
+            # No image/video dimensions specified; skip encoder modeling.
             return encoder_latency_dict, encoder_energy_wms_dict, encoder_source_dict, 0
 
-        n_img_post = tokens_per_image * num_images  # post-merge: injected into LLM context
+        visual_context_tokens = sum(w.post_merge_tokens * w.count_per_request for w in workloads)
 
-        # Encoder DP: whole images are sharded across the tp_size ranks and the
+        # Encoder DP: whole visuals are sharded across the tp_size ranks and the
         # busiest rank (ceil share) gates the phase.
         encoder_dp_size = model.config.tp_size if model.config.enable_encoder_dp else 1
-        images_local = -(-batch_size * num_images // encoder_dp_size)
 
-        # Per-op shape rules (the encoder orchestration — this token math —
-        # stays Python-side; only the per-op values may come from the
-        # compiled engine below). Projector ops and the DP exit AllGather run
-        # on post-merge tokens; ViT attention uses cu_seqlens (each image an
-        # independent varlen sequence of pre_merge_per_image patches).
-        def _encoder_eff_s(op) -> int:
-            use_post = "encoder_projector" in op._name or "all_gather" in op._name
-            use_varlen = "encoder_attention" in op._name
-            if use_varlen:
-                return pre_merge_per_image
-            return tokens_per_image if use_post else pre_merge_per_image
+        for workload in workloads:
+            visuals_local = -(-batch_size * workload.count_per_request // encoder_dp_size)
 
-        if should_use_rust_engine_step(runtime_config, database):
-            rust = self._run_encoder_phase_with_rust(
-                model,
-                database,
-                images_local,
-                _encoder_eff_s,
-                include_energy=include_energy,
-            )
-            if rust is not None:
-                encoder_latency_dict, encoder_energy_wms_dict, encoder_source_dict = rust
-                return encoder_latency_dict, encoder_energy_wms_dict, encoder_source_dict, n_img_post
+            # Per-op shape rules (the encoder orchestration — this token math
+            # — stays Python-side; only per-op values may come from the
+            # compiled engine). Projector ops and the DP exit AllGather run on
+            # post-merge tokens. Attention sees each image/video as an
+            # independent varlen sequence of pre-merge patches; for Kimi K3 a
+            # video's sequence length is frames*h*w before temporal pooling.
+            def _encoder_eff_s(op) -> int:
+                use_post = "encoder_projector" in op._name or "all_gather" in op._name
+                return workload.post_merge_tokens if use_post else workload.pre_merge_tokens
 
-        for op in model.encoder_ops:
-            eff_batch, eff_s = images_local, _encoder_eff_s(op)
-            x = eff_batch * eff_s
-            result = op.query(
-                database,
-                x=x,
-                batch_size=eff_batch,
-                beam_width=1,
-                s=eff_s,
-                prefix=0,
-                model_name=getattr(model, "model_name", ""),
-            )
-            encoder_latency_dict[op._name] += float(result)
-            if include_energy:
-                encoder_energy_wms_dict[op._name] += getattr(result, "energy", 0.0)
-            encoder_source_dict[op._name] = getattr(result, "source", "silicon")
+            if should_use_rust_engine_step(runtime_config, database):
+                rust = self._run_encoder_phase_with_rust(
+                    model,
+                    database,
+                    visuals_local,
+                    _encoder_eff_s,
+                    include_energy=include_energy,
+                )
+                if rust is not None:
+                    latency, energy, sources = rust
+                    for name, value in latency.items():
+                        encoder_latency_dict[name] += value
+                    for name, value in energy.items():
+                        encoder_energy_wms_dict[name] += value
+                    encoder_source_dict.update(sources)
+                    continue
 
-        return encoder_latency_dict, encoder_energy_wms_dict, encoder_source_dict, n_img_post
+            for op in model.encoder_ops:
+                eff_batch, eff_s = visuals_local, _encoder_eff_s(op)
+                x = eff_batch * eff_s
+                result = op.query(
+                    database,
+                    x=x,
+                    batch_size=eff_batch,
+                    beam_width=1,
+                    s=eff_s,
+                    prefix=0,
+                    model_name=getattr(model, "model_name", ""),
+                )
+                encoder_latency_dict[op._name] += float(result)
+                if include_energy:
+                    encoder_energy_wms_dict[op._name] += getattr(result, "energy", 0.0)
+                encoder_source_dict[op._name] = getattr(result, "source", "silicon")
+
+        return encoder_latency_dict, encoder_energy_wms_dict, encoder_source_dict, visual_context_tokens
 
     def _run_encoder_phase_with_rust(
         self,
@@ -1526,18 +1606,19 @@ class BaseBackend:
         enc_cfg = getattr(model, "encoder_config", None)
         if not model.encoder_ops or not isinstance(enc_cfg, common.VisionEncoderConfig):
             return {}
-        if runtime_config.num_images_per_request <= 0:
+        workloads = self._encoder_visual_workloads(runtime_config, enc_cfg)
+        if not workloads:
             return {}
-        tokens_per_image, pre_merge_per_image = self._encoder_pre_merge_per_visual(runtime_config, enc_cfg)
-        if pre_merge_per_image <= 0:
-            return {}
-        # ViT activations follow the busiest rank's image share; the embeddings
+        # ViT activations follow the busiest rank's visual share; embeddings
         # buffer covers the full batch on every rank.
-        total_images = batch_size * runtime_config.num_images_per_request
         encoder_dp_size = model.config.tp_size if model.config.enable_encoder_dp else 1
-        images_local = -(-total_images // encoder_dp_size)
-        num_tokens = images_local * pre_merge_per_image
-        embed_tokens = total_images * tokens_per_image
+        num_tokens = sum(
+            -(-batch_size * workload.count_per_request // encoder_dp_size) * workload.pre_merge_tokens
+            for workload in workloads
+        )
+        embed_tokens = batch_size * sum(
+            workload.count_per_request * workload.post_merge_tokens for workload in workloads
+        )
         return self._get_encoder_component_memory(model, num_tokens, embed_tokens)
 
     def run_agg(
@@ -1579,6 +1660,11 @@ class BaseBackend:
             runtime_config.image_height,
             runtime_config.image_width,
             runtime_config.num_images_per_request,
+            runtime_config.num_image_tokens,
+            runtime_config.video_height,
+            runtime_config.video_width,
+            runtime_config.video_num_frames,
+            runtime_config.num_videos_per_request,
         )
         cache_key = (
             self._make_agg_cache_key(isl, osl, b, ctx_tokens, engine_step_backend_key, agg_extra),

--- a/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
+++ b/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
@@ -360,6 +360,10 @@ class BaseBackend:
         # busiest rank (ceil share) gates the phase.
         encoder_dp_size = model.config.tp_size if model.config.enable_encoder_dp else 1
 
+        def _record_encoder_source(name: str, source: str) -> None:
+            existing = encoder_source_dict.get(name)
+            encoder_source_dict[name] = source if existing is None or existing == source else "mixed"
+
         for workload in workloads:
             visuals_local = -(-batch_size * workload.count_per_request // encoder_dp_size)
 
@@ -387,7 +391,8 @@ class BaseBackend:
                         encoder_latency_dict[name] += value
                     for name, value in energy.items():
                         encoder_energy_wms_dict[name] += value
-                    encoder_source_dict.update(sources)
+                    for name, source in sources.items():
+                        _record_encoder_source(name, source)
                     continue
 
             for op in model.encoder_ops:
@@ -405,7 +410,7 @@ class BaseBackend:
                 encoder_latency_dict[op._name] += float(result)
                 if include_energy:
                     encoder_energy_wms_dict[op._name] += getattr(result, "energy", 0.0)
-                encoder_source_dict[op._name] = getattr(result, "source", "silicon")
+                _record_encoder_source(op._name, getattr(result, "source", "silicon"))
 
         return encoder_latency_dict, encoder_energy_wms_dict, encoder_source_dict, visual_context_tokens
 

--- a/aic-core/src/aiconfigurator_core/sdk/common.py
+++ b/aic-core/src/aiconfigurator_core/sdk/common.py
@@ -183,6 +183,23 @@ class VisionEncoderConfig:
             rotated fraction — the 2-axis vision RoPE always rotates the full
             head_dim (vLLM ApplyRotaryEmb / SGLang cat([cos, cos])). Only gates
             the encoder_rope_apply op; 0.0 means no RoPE.
+        qkv_hidden_size (int): Absolute Q/K/V width before head splitting. Zero
+            means ``hidden_size``. Kimi K3 deliberately uses 1536-wide Q/K/V
+            projections around a 1024-wide residual stream.
+        temporal_pool_all (bool): Whether all temporal patches are pooled into
+            one output time step after attention. Kimi K3 ``sd2_tpool`` does;
+            Qwen3-VL retains one output step per temporal patch group.
+        max_temporal_patches (int): Maximum temporal grid length supported by
+            the checkpoint's positional embedding. Zero means unspecified.
+        model_patch_embed/model_pos_embed/model_final_norm (bool): Include the
+            corresponding vision-tower work in ``encoder_ops``. These remain
+            false for the historical Qwen3-VL model to preserve its calibrated
+            op graph, while Kimi K3 enables all three.
+        projector_post_norm (bool): Model the output norm after the projector.
+            Kimi K3 PatchMergerV2 applies RMSNorm after its second linear.
+        encoder_type (str): Architecture-specific semantic tag. Runtime token
+            accounting uses this only for diagnostics; behavior is represented
+            by the explicit fields above.
     """
 
     depth: int
@@ -197,6 +214,14 @@ class VisionEncoderConfig:
     projector_dims: tuple[tuple[int, int], ...] = ()
     projector_n_instances: int = 1
     partial_rotary_factor: float = 0.0
+    qkv_hidden_size: int = 0
+    temporal_pool_all: bool = False
+    max_temporal_patches: int = 0
+    model_patch_embed: bool = False
+    model_pos_embed: bool = False
+    model_final_norm: bool = False
+    projector_post_norm: bool = False
+    encoder_type: str = "generic_vit"
 
 
 @dataclass(frozen=True)
@@ -281,6 +306,7 @@ class KimiK3Config:
     first_k_dense_replace: int = 0
     dense_inter_size: int = 0
     attn_res_block_size: int = 0
+    vision_config: VisionEncoderConfig | None = None
 
 
 @dataclass(frozen=True)

--- a/aic-core/src/aiconfigurator_core/sdk/config.py
+++ b/aic-core/src/aiconfigurator_core/sdk/config.py
@@ -157,6 +157,10 @@ class RuntimeConfig:
     image_width: int = 0
     num_images_per_request: int = 1
     num_image_tokens: int = 0  # override: ViT output tokens per image; ignored when image_height/width are set
+    video_height: int = 0
+    video_width: int = 0
+    video_num_frames: int = 0
+    num_videos_per_request: int = 0
 
 
 @dataclass

--- a/aic-core/src/aiconfigurator_core/sdk/models/kimi_k3.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/kimi_k3.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import aiconfigurator_core.sdk.operations as ops
 from aiconfigurator_core.sdk import common
 from aiconfigurator_core.sdk.models.base import BaseModel, register_model
+from aiconfigurator_core.sdk.models.vit_ops import build_kimi_k3_encoder_ops
 
 
 @register_model("KIMIK3")
@@ -121,6 +122,15 @@ class KimiK3Model(BaseModel):
 
         self._build_context_ops()
         self._build_generation_ops()
+        if cfg.vision_config is not None:
+            self.encoder_config = cfg.vision_config
+            self.encoder_ops.extend(
+                build_kimi_k3_encoder_ops(
+                    cfg.vision_config,
+                    self.config.tp_size,
+                    self.config.enable_encoder_dp,
+                )
+            )
 
     # ------------------------------------------------------------------
     # Layer bookkeeping

--- a/aic-core/src/aiconfigurator_core/sdk/models/vit_ops.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/vit_ops.py
@@ -67,7 +67,10 @@ def _vit_transformer_ops(enc_cfg: common.VisionEncoderConfig, tp_size: int) -> l
     h_vit = enc_cfg.hidden_size
     n_vit = enc_cfg.num_heads
     inter_vit = enc_cfg.intermediate_size
-    head_size_vit = h_vit // n_vit
+    qkv_hidden = enc_cfg.qkv_hidden_size or h_vit
+    if qkv_hidden % n_vit != 0:
+        raise ValueError(f"ViT qkv_hidden_size ({qkv_hidden}) must be divisible by num_heads ({n_vit})")
+    head_size_vit = qkv_hidden // n_vit
 
     if tp_size > 1:
         if n_vit % tp_size != 0:
@@ -79,64 +82,92 @@ def _vit_transformer_ops(enc_cfg: common.VisionEncoderConfig, tp_size: int) -> l
     vit_gemm_mode = common.GEMMQuantMode.bfloat16
     vit_fmha_mode = common.FMHAQuantMode.bfloat16
 
-    result = [
-        ops.ElementWise("encoder_add_norm_1", depth, 2 * h_vit, 2 * h_vit, 0.8),
-        ops.GEMM(
-            "encoder_qkv_gemm",
-            depth,
-            3 * n_vit * head_size_vit // tp_size,
-            h_vit,
-            vit_gemm_mode,
-        ),
-        ops.EncoderAttention(
-            "encoder_attention",
-            depth,
-            n_vit // tp_size,
-            head_size_vit,
-            fmha_quant_mode=vit_fmha_mode,
-            partial_rotary_factor=0.0,
-        ),
-        ops.GEMM(
-            "encoder_proj_gemm",
-            depth,
-            h_vit,
-            n_vit * head_size_vit // tp_size,
-            vit_gemm_mode,
-            low_precision_input=True,
-        ),
-        ops.CustomAllReduce("encoder_ar_1", depth, h_vit, tp_size),
-        ops.ElementWise("encoder_add_norm_2", depth, 2 * h_vit, 2 * h_vit, 0.8),
-        ops.GEMM(
-            "encoder_ffn1_gemm",
-            depth,
-            inter_vit // tp_size,
-            h_vit,
-            vit_gemm_mode,
-        ),
-        ops.ElementWise(
-            "encoder_act",
-            depth,
-            inter_vit // tp_size,
-            inter_vit // tp_size,
-            0.8,
-        ),
-        ops.GEMM(
-            "encoder_ffn2_gemm",
-            depth,
-            h_vit,
-            inter_vit // tp_size,
-            vit_gemm_mode,
-            low_precision_input=True,
-        ),
-        ops.CustomAllReduce("encoder_ar_2", depth, h_vit, tp_size),
-    ]
+    result = []
+    if enc_cfg.model_patch_embed:
+        # Conv2d(kernel=stride=patch_size) is one matrix multiply per output
+        # patch, with K = RGB channels * patch area and N = vision hidden.
+        result.append(
+            ops.GEMM(
+                "encoder_patch_embed_gemm",
+                1,
+                h_vit,
+                3 * enc_cfg.patch_size * enc_cfg.patch_size,
+                vit_gemm_mode,
+            )
+        )
+    if enc_cfg.model_pos_embed:
+        # Learned spatial embedding plus fixed temporal embedding, added once
+        # per pre-merge patch before the transformer stack.
+        result.append(ops.ElementWise("encoder_pos_embed", 1, 2 * h_vit, h_vit, 0.8))
+
+    result.extend(
+        [
+            ops.ElementWise("encoder_add_norm_1", depth, 2 * h_vit, 2 * h_vit, 0.8),
+            ops.GEMM(
+                "encoder_qkv_gemm",
+                depth,
+                3 * qkv_hidden // tp_size,
+                h_vit,
+                vit_gemm_mode,
+            ),
+            ops.EncoderAttention(
+                "encoder_attention",
+                depth,
+                n_vit // tp_size,
+                head_size_vit,
+                fmha_quant_mode=vit_fmha_mode,
+                partial_rotary_factor=0.0,
+            ),
+            ops.GEMM(
+                "encoder_proj_gemm",
+                depth,
+                h_vit,
+                qkv_hidden // tp_size,
+                vit_gemm_mode,
+                low_precision_input=True,
+            ),
+            ops.CustomAllReduce("encoder_ar_1", depth, h_vit, tp_size),
+            ops.ElementWise("encoder_add_norm_2", depth, 2 * h_vit, 2 * h_vit, 0.8),
+            ops.GEMM(
+                "encoder_ffn1_gemm",
+                depth,
+                inter_vit // tp_size,
+                h_vit,
+                vit_gemm_mode,
+            ),
+            ops.ElementWise(
+                "encoder_act",
+                depth,
+                inter_vit // tp_size,
+                inter_vit // tp_size,
+                0.8,
+            ),
+            ops.GEMM(
+                "encoder_ffn2_gemm",
+                depth,
+                h_vit,
+                inter_vit // tp_size,
+                vit_gemm_mode,
+                low_precision_input=True,
+            ),
+            ops.CustomAllReduce("encoder_ar_2", depth, h_vit, tp_size),
+        ]
+    )
 
     if enc_cfg.partial_rotary_factor > 0:
         # the attention op's internal RoPE term is disabled in exchange (partial_rotary_factor=0.0).
         # partial_rotary_factor gates the op but does not shrink it: the eager kernel
         # duplicates the half-dim cos/sin table to full head_dim and rotates all of Q/K.
-        rope_dim = 6 * (n_vit // tp_size) * head_size_vit
+        rope_dim = 6 * qkv_hidden // tp_size
         result.append(ops.ElementWise("encoder_rope_apply", depth, rope_dim, rope_dim, 0.8))
+
+    if enc_cfg.model_final_norm:
+        result.append(ops.ElementWise("encoder_final_norm", 1, 2 * h_vit, h_vit, 0.8))
+    if enc_cfg.temporal_pool_all:
+        # Kimi K3's sd2_tpool reads every t*h*w patch once, averages the
+        # temporal axis, and groups each spatial_merge_size² block for the
+        # projector. Runtime dispatch keeps this op on pre-merge tokens.
+        result.append(ops.ElementWise("encoder_spatial_temporal_merge", 1, h_vit, h_vit, 0.8))
 
     return result
 
@@ -184,6 +215,16 @@ def _projector_ops(enc_cfg: common.VisionEncoderConfig, tp_size: int) -> list:
             )
 
     result.append(ops.CustomAllReduce("encoder_projector_ar", n_inst, dims[-1][1], tp_size))
+    if enc_cfg.projector_post_norm:
+        result.append(
+            ops.ElementWise(
+                "encoder_projector_post_norm",
+                n_inst,
+                2 * dims[-1][1],
+                dims[-1][1],
+                0.8,
+            )
+        )
     return result
 
 
@@ -221,3 +262,24 @@ def build_encoder_ops(enc_cfg: common.VisionEncoderConfig, tp_size: int, enable_
             )
         )
     return result
+
+
+def build_kimi_k3_encoder_ops(
+    enc_cfg: common.VisionEncoderConfig,
+    tp_size: int,
+    enable_encoder_dp: bool = True,
+) -> list:
+    """Build MoonViT3D + PatchMergerV2 ops for Kimi K3.
+
+    Keep this explicit entry point so Kimi K3 cannot silently inherit Kimi
+    K2.5/PatchMerger-v1 or Qwen3-VL token semantics if the generic builder
+    evolves. The shape-bearing details live on ``VisionEncoderConfig`` and
+    are validated here before delegating to the shared operation factories.
+    """
+    if enc_cfg.encoder_type != "kimi_k3_moonvit3d_patchmergerv2":
+        raise ValueError(f"Expected Kimi K3 encoder config, got {enc_cfg.encoder_type!r}")
+    if not enc_cfg.temporal_pool_all or not enc_cfg.projector_post_norm:
+        raise ValueError("Kimi K3 requires sd2_tpool and PatchMergerV2 post-norm semantics")
+    if enc_cfg.qkv_hidden_size <= 0:
+        raise ValueError("Kimi K3 requires an explicit architecture-specific qkv_hidden_size")
+    return build_encoder_ops(enc_cfg, tp_size, enable_encoder_dp)

--- a/aic-core/src/aiconfigurator_core/sdk/models/vit_ops.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/vit_ops.py
@@ -278,8 +278,14 @@ def build_kimi_k3_encoder_ops(
     """
     if enc_cfg.encoder_type != "kimi_k3_moonvit3d_patchmergerv2":
         raise ValueError(f"Expected Kimi K3 encoder config, got {enc_cfg.encoder_type!r}")
-    if not enc_cfg.temporal_pool_all or not enc_cfg.projector_post_norm:
-        raise ValueError("Kimi K3 requires sd2_tpool and PatchMergerV2 post-norm semantics")
+    if not (
+        enc_cfg.model_patch_embed
+        and enc_cfg.model_pos_embed
+        and enc_cfg.model_final_norm
+        and enc_cfg.temporal_pool_all
+        and enc_cfg.projector_post_norm
+    ):
+        raise ValueError("Kimi K3 requires complete MoonViT3D and PatchMergerV2 operation semantics")
     if enc_cfg.qkv_hidden_size <= 0:
         raise ValueError("Kimi K3 requires an explicit architecture-specific qkv_hidden_size")
     return build_encoder_ops(enc_cfg, tp_size, enable_encoder_dp)

--- a/aic-core/src/aiconfigurator_core/sdk/utils.py
+++ b/aic-core/src/aiconfigurator_core/sdk/utils.py
@@ -688,6 +688,62 @@ def _parse_hf_config_json(config: dict) -> dict:
                 "silently dropped and produce a wrong hybrid layer plan."
             )
         layer_types = tuple("linear_attention" if (i + 1) in kda_layer_ids else "full_attention" for i in range(layers))
+        kimi_vision_config = None
+        if vision_cfg:
+            merge_kernel = tuple(vision_cfg.get("merge_kernel_size") or ())
+            if len(merge_kernel) != 2 or any(not isinstance(v, int) or v <= 0 for v in merge_kernel):
+                raise ValueError("Kimi-K3 vision_config.merge_kernel_size must contain two positive integers")
+            if merge_kernel[0] != merge_kernel[1]:
+                raise ValueError(
+                    f"Kimi-K3 vision modeling currently requires a square merge_kernel_size; got {merge_kernel}"
+                )
+            if vision_cfg.get("merge_type") != "sd2_tpool":
+                raise ValueError(
+                    f"Kimi-K3 vision modeling requires merge_type='sd2_tpool'; got {vision_cfg.get('merge_type')!r}"
+                )
+            if vision_cfg.get("mm_projector_type") != "patchmergerv2":
+                raise ValueError(
+                    "Kimi-K3 vision modeling requires mm_projector_type='patchmergerv2'; "
+                    f"got {vision_cfg.get('mm_projector_type')!r}"
+                )
+
+            vision_hidden = vision_cfg["vt_hidden_size"]
+            vision_heads = vision_cfg["vt_num_attention_heads"]
+            qkv_hidden = vision_cfg.get("qkv_hidden_size") or vision_hidden
+            if qkv_hidden % vision_heads != 0:
+                raise ValueError(
+                    f"Kimi-K3 qkv_hidden_size ({qkv_hidden}) must be divisible by "
+                    f"vt_num_attention_heads ({vision_heads})"
+                )
+            merger_dim = vision_cfg["mm_hidden_size"] * merge_kernel[0] * merge_kernel[1]
+            out_hidden = vision_cfg["text_hidden_size"]
+            if out_hidden != hidden_size:
+                raise ValueError(
+                    f"Kimi-K3 vision text_hidden_size ({out_hidden}) must match "
+                    f"the language hidden_size ({hidden_size})"
+                )
+            kimi_vision_config = VisionEncoderConfig(
+                depth=vision_cfg["vt_num_hidden_layers"],
+                hidden_size=vision_hidden,
+                num_heads=vision_heads,
+                intermediate_size=vision_cfg["vt_intermediate_size"],
+                patch_size=vision_cfg["patch_size"],
+                # MoonVision3dPatchEmbed is a Conv2d applied independently to
+                # each frame; temporal pooling happens only after all ViT layers.
+                temporal_patch_size=1,
+                spatial_merge_size=merge_kernel[0],
+                out_hidden_size=out_hidden,
+                projector_dims=((merger_dim, merger_dim), (merger_dim, out_hidden)),
+                partial_rotary_factor=1.0,
+                qkv_hidden_size=qkv_hidden,
+                temporal_pool_all=True,
+                max_temporal_patches=vision_cfg.get("init_pos_emb_time", 0) or 0,
+                model_patch_embed=True,
+                model_pos_embed=True,
+                model_final_norm=True,
+                projector_post_norm=True,
+                encoder_type="kimi_k3_moonvit3d_patchmergerv2",
+            )
         extra_params = KimiK3Config(
             layer_types=layer_types,
             kda_num_heads=linear_attn_cfg["num_heads"],
@@ -707,11 +763,13 @@ def _parse_hf_config_json(config: dict) -> dict:
             first_k_dense_replace=config.get("first_k_dense_replace", 0),
             dense_inter_size=config.get("intermediate_size", 0),
             attn_res_block_size=config.get("attn_res_block_size", 0) or 0,
+            vision_config=kimi_vision_config,
         )
         logger.info(
             f"Kimi-K3 hybrid config: kda_layers={layer_types.count('linear_attention')}, "
             f"mla_layers={layer_types.count('full_attention')}, num_experts={num_experts}, "
-            f"latent={extra_params.routed_expert_hidden_size}, shared={extra_params.num_shared_experts}"
+            f"latent={extra_params.routed_expert_hidden_size}, shared={extra_params.num_shared_experts}, "
+            f"vision={'enabled' if kimi_vision_config is not None else 'absent'}"
         )
     elif architecture in {"DeepSeekForCausalLM", "DeepseekV3ForCausalLM"}:
         # DeepSeek V3 / R1 / Kimi K2: MLA latent geometry from config so the KV

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -464,10 +464,14 @@ class Task:
     isl: int = 4000
     osl: int = 1000
     prefix: int = 0
-    # Multimodal image inputs (folded into the effective ISL by RuntimeConfig).
+    # Multimodal inputs (post-merge tokens are folded into effective ISL).
     image_height: int = 0
     image_width: int = 0
     num_images_per_request: int = 1
+    video_height: int = 0
+    video_width: int = 0
+    video_num_frames: int = 0
+    num_videos_per_request: int = 0
     # Vision encoder data parallelism (ModelConfig default).
     enable_encoder_dp: bool = True
     ttft: float = 1000.0
@@ -1505,6 +1509,10 @@ class Task:
             image_height=self.image_height,
             image_width=self.image_width,
             num_images_per_request=self.num_images_per_request,
+            video_height=self.video_height,
+            video_width=self.video_width,
+            video_num_frames=self.video_num_frames,
+            num_videos_per_request=self.num_videos_per_request,
             ttft=self.ttft,
             tpot=self.tpot,
             request_latency=self.request_latency,

--- a/tests/unit/sdk/models/test_kimi_k3_vision.py
+++ b/tests/unit/sdk/models/test_kimi_k3_vision.py
@@ -1,0 +1,243 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from aiconfigurator.sdk import common, config
+from aiconfigurator.sdk.backends.base_backend import BaseBackend
+from aiconfigurator.sdk.models import _get_model_info, get_model
+from aiconfigurator.sdk.models.kimi_k3 import KimiK3Model
+
+pytestmark = pytest.mark.unit
+
+
+def _model_config(**kwargs) -> config.ModelConfig:
+    kwargs.setdefault("moe_tp_size", 1)
+    kwargs.setdefault("moe_ep_size", 1)
+    return config.ModelConfig(**kwargs)
+
+
+@pytest.fixture
+def kimi_k3_model() -> KimiK3Model:
+    return get_model("moonshotai/Kimi-K3", _model_config(), "sglang")
+
+
+class TestKimiK3VisionConfig:
+    def test_checkpoint_preserves_language_and_vision_configs_together(self):
+        extra = _get_model_info("moonshotai/Kimi-K3")["extra_params"]
+
+        assert isinstance(extra, common.KimiK3Config)
+        assert extra.layer_types.count("linear_attention") == 69
+        assert extra.layer_types.count("full_attention") == 24
+        assert isinstance(extra.vision_config, common.VisionEncoderConfig)
+
+    def test_architecture_specific_vision_geometry(self):
+        vision = _get_model_info("moonshotai/Kimi-K3")["extra_params"].vision_config
+
+        assert vision.depth == 27
+        assert vision.hidden_size == 1024
+        assert vision.num_heads == 12
+        assert vision.qkv_hidden_size == 1536
+        assert vision.qkv_hidden_size // vision.num_heads == 128
+        assert vision.patch_size == 14
+        assert vision.temporal_patch_size == 1
+        assert vision.spatial_merge_size == 2
+        assert vision.temporal_pool_all
+        assert vision.max_temporal_patches == 4
+        assert vision.projector_dims == ((4096, 4096), (4096, 7168))
+        assert vision.projector_post_norm
+
+    def test_kimi_k25_does_not_inherit_k3_patchmergerv2_semantics(self):
+        k25_info = _get_model_info("moonshotai/Kimi-K2.5")
+        k25_model = get_model("moonshotai/Kimi-K2.5", _model_config(), "sglang")
+
+        assert isinstance(k25_info["extra_params"], dict)
+        assert not hasattr(k25_info["extra_params"], "vision_config")
+        assert k25_model.encoder_ops == []
+
+
+class TestKimiK3VisionModel:
+    def test_model_keeps_language_and_dspark_paths(self, kimi_k3_model):
+        context_names = {op._name for op in kimi_k3_model.context_ops}
+        generation_names = {op._name for op in kimi_k3_model.generation_ops}
+
+        assert "context_kda_scan" in context_names
+        assert "context_mla_downscale_gemm" in context_names
+        assert "generation_kda_recurrent" in generation_names
+
+        dspark = get_model(
+            "moonshotai/Kimi-K3",
+            _model_config(nextn=7),
+            "sglang",
+        )
+        assert "draft_attention" in {op._name for op in dspark.generation_ops}
+        assert [op._name for op in dspark.encoder_ops] == [op._name for op in kimi_k3_model.encoder_ops]
+
+    def test_encoder_ops_cover_moonvit3d_patchmergerv2_and_communication(self, kimi_k3_model):
+        ops = {op._name: op for op in kimi_k3_model.encoder_ops}
+
+        assert ops["encoder_patch_embed_gemm"]._n == 1024
+        assert ops["encoder_patch_embed_gemm"]._k == 3 * 14 * 14
+        assert ops["encoder_qkv_gemm"]._n == 3 * 1536
+        assert ops["encoder_qkv_gemm"]._k == 1024
+        assert ops["encoder_attention"]._n == 12
+        assert ops["encoder_attention"]._head_size == 128
+        assert ops["encoder_proj_gemm"]._n == 1024
+        assert ops["encoder_proj_gemm"]._k == 1536
+        assert ops["encoder_projector_fc0_gemm"]._n == 4096
+        assert ops["encoder_projector_fc0_gemm"]._k == 4096
+        assert ops["encoder_projector_fc1_gemm"]._n == 7168
+        assert ops["encoder_projector_fc1_gemm"]._k == 4096
+        assert "encoder_spatial_temporal_merge" in ops
+        assert "encoder_projector_post_norm" in ops
+        assert "encoder_ar_1" in ops
+        assert "encoder_ar_2" in ops
+        assert "encoder_projector_ar" in ops
+
+    def test_encoder_dp_adds_embedding_all_gather(self):
+        model = get_model(
+            "moonshotai/Kimi-K3",
+            _model_config(tp_size=2, moe_tp_size=2),
+            "sglang",
+        )
+
+        assert "encoder_dp_all_gather" in {op._name for op in model.encoder_ops}
+
+
+class _LatencyResult:
+    def __init__(self, latency: float = 1.0, energy: float = 2.0):
+        self.latency = latency
+        self.energy = energy
+        self.source = "test"
+
+    def __float__(self) -> float:
+        return self.latency
+
+
+class _TestBackend(BaseBackend):
+    def find_best_agg_result_under_constraints(self, model, database, runtime_config, **kwargs):
+        raise NotImplementedError
+
+    def _get_memory_usage(self, *args, **kwargs):
+        return {"total": 1.0}
+
+
+@pytest.fixture
+def synthetic_database():
+    return SimpleNamespace(
+        backend="sglang",
+        version="test",
+        system="test",
+        system_spec={"gpu": {"mem_capacity": 80 * (1 << 30)}},
+    )
+
+
+def _stub_op_queries(model):
+    for op in model.encoder_ops + model.context_ops + model.generation_ops:
+        op.query = MagicMock(return_value=_LatencyResult())
+
+
+class TestKimiK3VisionRuntime:
+    def test_image_workload_executes_nonzero_encoder_work(self, kimi_k3_model, synthetic_database):
+        _stub_op_queries(kimi_k3_model)
+        backend = _TestBackend()
+        runtime = config.RuntimeConfig(
+            batch_size=1,
+            isl=64,
+            osl=2,
+            image_height=448,
+            image_width=448,
+            num_images_per_request=1,
+            engine_step_backend="python",
+        )
+
+        latency, energy, _, visual_tokens = backend._run_encoder_phase(
+            kimi_k3_model, synthetic_database, runtime, batch_size=1
+        )
+
+        assert sum(latency.values()) > 0
+        assert sum(energy.values()) > 0
+        assert visual_tokens == 16 * 16
+        attention = next(op for op in kimi_k3_model.encoder_ops if op._name == "encoder_attention")
+        attention.query.assert_called_once_with(
+            synthetic_database,
+            x=32 * 32,
+            batch_size=1,
+            beam_width=1,
+            s=32 * 32,
+            prefix=0,
+            model_name="",
+        )
+
+    def test_video_attention_scales_with_frames_but_tpool_output_does_not(self, kimi_k3_model, synthetic_database):
+        _stub_op_queries(kimi_k3_model)
+        backend = _TestBackend()
+        runtime = config.RuntimeConfig(
+            batch_size=1,
+            isl=64,
+            osl=2,
+            num_images_per_request=0,
+            video_height=448,
+            video_width=448,
+            video_num_frames=4,
+            num_videos_per_request=1,
+            engine_step_backend="python",
+        )
+
+        latency, _, _, visual_tokens = backend._run_encoder_phase(
+            kimi_k3_model, synthetic_database, runtime, batch_size=1
+        )
+
+        assert sum(latency.values()) > 0
+        assert visual_tokens == 16 * 16
+        attention = next(op for op in kimi_k3_model.encoder_ops if op._name == "encoder_attention")
+        projector = next(op for op in kimi_k3_model.encoder_ops if op._name == "encoder_projector_fc0_gemm")
+        assert attention.query.call_args.kwargs["s"] == 4 * 32 * 32
+        assert projector.query.call_args.kwargs["s"] == 16 * 16
+
+    def test_video_rejects_more_frames_than_k3_temporal_embedding(self, kimi_k3_model, synthetic_database):
+        runtime = config.RuntimeConfig(
+            batch_size=1,
+            isl=64,
+            osl=2,
+            num_images_per_request=0,
+            video_height=448,
+            video_width=448,
+            video_num_frames=5,
+            num_videos_per_request=1,
+            engine_step_backend="python",
+        )
+
+        with pytest.raises(ValueError, match="supports at most 4 temporal patches"):
+            _TestBackend()._run_encoder_phase(kimi_k3_model, synthetic_database, runtime, batch_size=1)
+
+    def test_encoder_latency_memory_energy_and_ttft_reach_summary(self, kimi_k3_model, synthetic_database):
+        _stub_op_queries(kimi_k3_model)
+        summary = _TestBackend().run_static(
+            kimi_k3_model,
+            synthetic_database,
+            config.RuntimeConfig(
+                batch_size=1,
+                isl=64,
+                osl=2,
+                num_images_per_request=0,
+                video_height=448,
+                video_width=448,
+                video_num_frames=4,
+                num_videos_per_request=1,
+                engine_step_backend="python",
+            ),
+            mode="static",
+            stride=1,
+        )
+
+        encoder_latency = sum(summary.get_encoder_latency_dict().values())
+        context_latency = sum(summary.get_context_latency_dict().values())
+        assert encoder_latency > 0
+        assert sum(summary.get_encoder_energy_wms_dict().values()) > 0
+        assert summary.get_encoder_memory()["weights"] > 0
+        assert summary.get_encoder_memory()["activations"] > 0
+        assert summary.get_summary_df().iloc[0]["ttft"] == pytest.approx(encoder_latency + context_latency)

--- a/tests/unit/sdk/models/test_kimi_k3_vision.py
+++ b/tests/unit/sdk/models/test_kimi_k3_vision.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import dataclasses
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -10,6 +11,7 @@ from aiconfigurator.sdk import common, config
 from aiconfigurator.sdk.backends.base_backend import BaseBackend
 from aiconfigurator.sdk.models import _get_model_info, get_model
 from aiconfigurator.sdk.models.kimi_k3 import KimiK3Model
+from aiconfigurator.sdk.models.vit_ops import build_kimi_k3_encoder_ops
 
 pytestmark = pytest.mark.unit
 
@@ -106,12 +108,29 @@ class TestKimiK3VisionModel:
 
         assert "encoder_dp_all_gather" in {op._name for op in model.encoder_ops}
 
+    @pytest.mark.parametrize(
+        "disabled_flag",
+        [
+            "model_patch_embed",
+            "model_pos_embed",
+            "model_final_norm",
+            "temporal_pool_all",
+            "projector_post_norm",
+        ],
+    )
+    def test_kimi_k3_builder_rejects_incomplete_encoder_semantics(self, disabled_flag):
+        vision = _get_model_info("moonshotai/Kimi-K3")["extra_params"].vision_config
+        incomplete = dataclasses.replace(vision, **{disabled_flag: False})
+
+        with pytest.raises(ValueError, match="complete MoonViT3D"):
+            build_kimi_k3_encoder_ops(incomplete, tp_size=1)
+
 
 class _LatencyResult:
-    def __init__(self, latency: float = 1.0, energy: float = 2.0):
+    def __init__(self, latency: float = 1.0, energy: float = 2.0, source: str = "test"):
         self.latency = latency
         self.energy = energy
-        self.source = "test"
+        self.source = source
 
     def __float__(self) -> float:
         return self.latency
@@ -197,6 +216,32 @@ class TestKimiK3VisionRuntime:
         projector = next(op for op in kimi_k3_model.encoder_ops if op._name == "encoder_projector_fc0_gemm")
         assert attention.query.call_args.kwargs["s"] == 4 * 32 * 32
         assert projector.query.call_args.kwargs["s"] == 16 * 16
+
+    def test_mixed_image_video_workloads_preserve_mixed_source(self, kimi_k3_model, synthetic_database):
+        for op in kimi_k3_model.encoder_ops:
+            op.query = MagicMock(
+                side_effect=lambda *args, **kwargs: _LatencyResult(
+                    source="silicon" if kwargs["s"] == 32 * 32 else "sol"
+                )
+            )
+        runtime = config.RuntimeConfig(
+            batch_size=1,
+            isl=64,
+            osl=2,
+            image_height=448,
+            image_width=448,
+            num_images_per_request=1,
+            video_height=448,
+            video_width=448,
+            video_num_frames=4,
+            num_videos_per_request=1,
+            engine_step_backend="python",
+        )
+
+        _, _, sources, _ = _TestBackend()._run_encoder_phase(kimi_k3_model, synthetic_database, runtime, batch_size=1)
+
+        assert sources["encoder_attention"] == "mixed"
+        assert sources["encoder_projector_fc0_gemm"] == "sol"
 
     def test_video_rejects_more_frames_than_k3_temporal_embedding(self, kimi_k3_model, synthetic_database):
         runtime = config.RuntimeConfig(

--- a/tests/unit/sdk/task_v2/test_task_config.py
+++ b/tests/unit/sdk/task_v2/test_task_config.py
@@ -304,13 +304,26 @@ def test_from_yaml_disagg_rejects_legacy_shared_model_path():
 
 
 def test_build_runtime_config_carries_workload():
-    t = Task(isl=2048, osl=512, ttft=300.0, tpot=20.0)
+    t = Task(
+        isl=2048,
+        osl=512,
+        ttft=300.0,
+        tpot=20.0,
+        video_height=448,
+        video_width=448,
+        video_num_frames=4,
+        num_videos_per_request=2,
+    )
     rt = t.build_runtime_config(batch_size=64)
     assert rt.isl == 2048
     assert rt.osl == 512
     assert rt.ttft == 300.0
     assert rt.tpot == 20.0
     assert rt.batch_size == 64
+    assert rt.video_height == 448
+    assert rt.video_width == 448
+    assert rt.video_num_frames == 4
+    assert rt.num_videos_per_request == 2
 
 
 def test_build_model_config_agg_uses_resolved_quant():

--- a/tests/unit/support_matrix/test_support_matrix_order.py
+++ b/tests/unit/support_matrix/test_support_matrix_order.py
@@ -142,3 +142,46 @@ def test_task_uses_silicon_database_mode(monkeypatch):
     )
 
     assert captured_kwargs["database_mode"] == common.DatabaseMode.SILICON.name
+
+
+@pytest.mark.parametrize(
+    ("model", "expected_visual"),
+    [
+        (
+            "moonshotai/Kimi-K3",
+            {"image_height": 448, "image_width": 448, "num_images_per_request": 1},
+        ),
+        ("moonshotai/Kimi-K2.5", {}),
+    ],
+)
+@pytest.mark.parametrize("mode", ["agg", "disagg"])
+def test_support_matrix_runs_real_kimi_k3_encoder_but_not_k25_semantics(monkeypatch, model, expected_visual, mode):
+    captured_kwargs = {}
+
+    class FakeTask:
+        def __init__(self, **kwargs):
+            captured_kwargs.update(kwargs)
+
+    monkeypatch.setattr(support_matrix_module, "Task", FakeTask)
+    SupportMatrix._create_task(
+        mode=mode,
+        model=model,
+        system="b200_sxm",
+        backend="sglang",
+        version="0.5.16",
+        constraints=TestConstraints(
+            total_gpus=128,
+            isl=256,
+            osl=256,
+            prefix=128,
+            ttft=2_000_000.0,
+            tpot=50_000.0,
+        ),
+        engine_step_backend=None,
+    )
+
+    for key in ("image_height", "image_width", "num_images_per_request"):
+        if key in expected_visual:
+            assert captured_kwargs[key] == expected_visual[key]
+        else:
+            assert key not in captured_kwargs

--- a/tests/unit/support_matrix/test_support_matrix_order.py
+++ b/tests/unit/support_matrix/test_support_matrix_order.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -185,3 +186,15 @@ def test_support_matrix_runs_real_kimi_k3_encoder_but_not_k25_semantics(monkeypa
             assert captured_kwargs[key] == expected_visual[key]
         else:
             assert key not in captured_kwargs
+
+
+def test_representative_visual_workload_fails_fast_for_curated_model_load_error(monkeypatch):
+    monkeypatch.setattr(support_matrix_module.common, "DefaultHFModels", {"test/curated-model"})
+    monkeypatch.setattr(
+        support_matrix_module,
+        "_get_model_info",
+        MagicMock(side_effect=RuntimeError("model metadata unavailable")),
+    )
+
+    with pytest.raises(RuntimeError, match="model metadata unavailable"):
+        support_matrix_module._representative_visual_workload("test/curated-model")

--- a/tools/support_matrix/support_matrix.py
+++ b/tools/support_matrix/support_matrix.py
@@ -118,6 +118,43 @@ class HardwareIncompatibility:
     reason: str
 
 
+def _representative_visual_workload(model: str) -> dict[str, int]:
+    """Return a small real encoder workload for multimodal matrix checks.
+
+    A text-only support-matrix request can construct encoder ops yet execute
+    none of them, yielding a false PASS for multimodal support. Use a square
+    input with 16 post-merge patches per side for any model whose parsed
+    config actually exposes a VisionEncoderConfig. Kimi K2.5 intentionally
+    remains absent until its distinct PatchMerger-v1 path is modeled.
+    """
+    # The generated matrix is built from the curated model catalog. Avoid a
+    # network lookup while upgrading arbitrary legacy/test rows.
+    if model not in common.DefaultHFModels:
+        return {}
+    try:
+        extra = _get_model_info(model).get("extra_params")
+    except Exception:
+        # Command rendering also upgrades legacy/test rows whose model ID may
+        # not be resolvable. The actual support check resolves the model before
+        # execution, so visual-workload enrichment stays best-effort here.
+        logger.debug("Could not resolve encoder config for %s", model, exc_info=True)
+        return {}
+    if isinstance(extra, common.VisionEncoderConfig):
+        encoder_config = extra
+    elif isinstance(extra, common.KimiK3Config):
+        encoder_config = extra.vision_config
+    else:
+        encoder_config = None
+    if not isinstance(encoder_config, common.VisionEncoderConfig):
+        return {}
+    side = encoder_config.patch_size * encoder_config.spatial_merge_size * 16
+    return {
+        "image_height": side,
+        "image_width": side,
+        "num_images_per_request": 1,
+    }
+
+
 def _support_matrix_row_command(
     *,
     model: str,
@@ -171,6 +208,18 @@ def _support_matrix_row_command(
     ]
     if transfer_policy:
         parts.extend(["--transfer-policy", transfer_policy])
+    visual_workload = _representative_visual_workload(model)
+    if visual_workload:
+        parts.extend(
+            [
+                "--image-height",
+                str(visual_workload["image_height"]),
+                "--image-width",
+                str(visual_workload["image_width"]),
+                "--num-images",
+                str(visual_workload["num_images_per_request"]),
+            ]
+        )
     if compare_engine_step_backends:
         # ``cli default`` does not expose the support-matrix Python/Rust
         # comparator; use the default Python engine-step path for the public
@@ -766,6 +815,7 @@ class SupportMatrix:
             # (e.g. AIC_SM_TRANSFERS="off" or "xshape,xquant"). None -> all kinds on.
             "transfer_policy": os.environ.get("AIC_SM_TRANSFERS") or None,
         }
+        common_kwargs.update(_representative_visual_workload(model))
         if mode == "disagg":
             # v2 disagg forbids shared top-level worker fields; fan out to both roles.
             return Task(

--- a/tools/support_matrix/support_matrix.py
+++ b/tools/support_matrix/support_matrix.py
@@ -131,14 +131,7 @@ def _representative_visual_workload(model: str) -> dict[str, int]:
     # network lookup while upgrading arbitrary legacy/test rows.
     if model not in common.DefaultHFModels:
         return {}
-    try:
-        extra = _get_model_info(model).get("extra_params")
-    except Exception:
-        # Command rendering also upgrades legacy/test rows whose model ID may
-        # not be resolvable. The actual support check resolves the model before
-        # execution, so visual-workload enrichment stays best-effort here.
-        logger.debug("Could not resolve encoder config for %s", model, exc_info=True)
-        return {}
+    extra = _get_model_info(model).get("extra_params")
     if isinstance(extra, common.VisionEncoderConfig):
         encoder_config = extra
     elif isinstance(extra, common.KimiK3Config):


### PR DESCRIPTION
#### Overview:

Enable image and video encoder modeling for `moonshotai/Kimi-K3` while preserving the existing Kimi K3 language and DSPARK paths.

This models the public checkpoint architecture and exposes encoder latency, memory, energy, visual-token accounting, and TTFT through aggregate and disaggregate estimation. The implementation is structurally validated but is not a claim of silicon accuracy; Kimi K3 encoder calibration remains follow-up work.

#### Details:

- preserve and validate the checkpoint `vision_config` alongside `KimiK3Config`
- model per-frame patch embedding, spatial-temporal ViT attention, architecture-specific 1536-wide QKV projections, MLPs, normalization, `sd2_tpool`, PatchMergerV2, projector, and TP/DP communication
- distinguish pre-merge attention tokens from post-merge visual context tokens for images and videos
- add explicit video geometry/count runtime fields and enforce the checkpoint's four-temporal-patch limit
- include encoder work in latency, memory, energy, TTFT, and backend cache accounting
- provide a representative visual workload for Kimi K3 support-matrix aggregate/disaggregate runs
- retain Kimi K2.5's existing language-only behavior

Validation on the final rebased head:

- `488 passed, 2 warnings` across Kimi K3 vision, support-matrix, encoder/backend, parser/model, and Task/runtime tests
- full unit suite on the updated exact head: `3298 passed, 10 skipped, 749 deselected, 8 warnings`
- `ruff check .`
- `ruff format --check .` (`542 files already formatted`)
- `git diff origin/main...HEAD --check`

Analytical SOL smoke results are nonzero for representative workloads:

- 448x448 image: 1024 encoder-attention tokens, 256 output visual tokens
- four-frame 448x448 video: 4096 encoder-attention tokens, 256 temporally pooled output visual tokens

No Kimi K3 encoder silicon latency/energy data was collected in this change. SOL latency is functional modeling evidence, not measured performance; energy calibration and engine/silicon correlation remain open.

#### Where should the reviewer start?

- `aic-core/src/aiconfigurator_core/sdk/utils.py` for checkpoint parsing
- `aic-core/src/aiconfigurator_core/sdk/models/vit_ops.py` for encoder graph construction
- `aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py` for image/video runtime accounting
- `tests/unit/sdk/models/test_kimi_k3_vision.py` for architecture and runtime coverage

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to Linear issue [AIC-1736](https://linear.app/nvidia/issue/AIC-1736/kimi-k3-enable-image-and-video-encoder-modeling)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for mixed image and video workloads, including video dimensions, frame counts, and multiple videos per request.
  * Added configurable vision-encoder options for temporal processing, attention sizing, embeddings, normalization, and architecture selection.
  * Added Kimi-K3 vision configuration and encoder modeling.
  * Support-matrix workflows now recognize compatible multimodal models and representative visual workloads.

* **Bug Fixes**
  * Added validation for unsupported encoder settings and videos exceeding temporal limits.

* **Tests**
  * Expanded coverage for vision configuration, runtime metrics, distributed execution, and video workload handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->