### PR TITLE
feat(models): model Llama 4 Scout and Maverick vision encoders

### DIFF
--- a/aic-core/src/aiconfigurator_core/model_configs/meta-llama--Llama-4-Maverick-17B-128E-Instruct_config.json
+++ b/aic-core/src/aiconfigurator_core/model_configs/meta-llama--Llama-4-Maverick-17B-128E-Instruct_config.json
@@ -4,6 +4,11 @@
   ],
   "boi_token_index": 200080,
   "eoi_token_index": 200081,
+  "image_processor_config": {
+    "add_global_tile": true,
+    "max_patches": 16,
+    "resize_to_max_canvas": false
+  },
   "image_token_index": 200092,
   "model_type": "llama4",
   "text_config": {

--- a/aic-core/src/aiconfigurator_core/model_configs/meta-llama--Llama-4-Maverick-17B-128E-Instruct_config.json
+++ b/aic-core/src/aiconfigurator_core/model_configs/meta-llama--Llama-4-Maverick-17B-128E-Instruct_config.json
@@ -2,6 +2,9 @@
   "architectures": [
     "Llama4ForConditionalGeneration"
   ],
+  "boi_token_index": 200080,
+  "eoi_token_index": 200081,
+  "image_token_index": 200092,
   "model_type": "llama4",
   "text_config": {
     "attention_bias": false,
@@ -31,5 +34,29 @@
     "vocab_size": 202048
   },
   "torch_dtype": "bfloat16",
-  "transformers_version": "4.51.0.dev0"
+  "transformers_version": "4.51.0.dev0",
+  "vision_config": {
+    "attention_dropout": 0.0,
+    "hidden_act": "gelu",
+    "hidden_size": 1408,
+    "image_size": 336,
+    "initializer_range": 0.02,
+    "intermediate_size": 5632,
+    "model_type": "llama4_vision_model",
+    "multi_modal_projector_bias": false,
+    "norm_eps": 0.00001,
+    "num_attention_heads": 16,
+    "num_channels": 3,
+    "num_hidden_layers": 34,
+    "patch_size": 14,
+    "pixel_shuffle_ratio": 0.5,
+    "projector_dropout": 0.0,
+    "projector_input_dim": 4096,
+    "projector_output_dim": 4096,
+    "rope_theta": 10000,
+    "torch_dtype": "bfloat16",
+    "vision_feature_layer": -1,
+    "vision_feature_select_strategy": "default",
+    "vision_output_dim": 4096
+  }
 }

--- a/aic-core/src/aiconfigurator_core/model_configs/meta-llama--Llama-4-Scout-17B-16E-Instruct_config.json
+++ b/aic-core/src/aiconfigurator_core/model_configs/meta-llama--Llama-4-Scout-17B-16E-Instruct_config.json
@@ -4,6 +4,11 @@
   ],
   "boi_token_index": 200080,
   "eoi_token_index": 200081,
+  "image_processor_config": {
+    "add_global_tile": true,
+    "max_patches": 16,
+    "resize_to_max_canvas": false
+  },
   "image_token_index": 200092,
   "model_type": "llama4",
   "text_config": {

--- a/aic-core/src/aiconfigurator_core/model_configs/meta-llama--Llama-4-Scout-17B-16E-Instruct_config.json
+++ b/aic-core/src/aiconfigurator_core/model_configs/meta-llama--Llama-4-Scout-17B-16E-Instruct_config.json
@@ -2,6 +2,9 @@
   "architectures": [
     "Llama4ForConditionalGeneration"
   ],
+  "boi_token_index": 200080,
+  "eoi_token_index": 200081,
+  "image_token_index": 200092,
   "model_type": "llama4",
   "text_config": {
     "attention_bias": false,
@@ -37,5 +40,29 @@
     "vocab_size": 202048
   },
   "torch_dtype": "bfloat16",
-  "transformers_version": "4.51.0.dev0"
+  "transformers_version": "4.51.0.dev0",
+  "vision_config": {
+    "attention_dropout": 0.0,
+    "hidden_act": "gelu",
+    "hidden_size": 1408,
+    "image_size": 336,
+    "initializer_range": 0.02,
+    "intermediate_size": 5632,
+    "model_type": "llama4_vision_model",
+    "multi_modal_projector_bias": false,
+    "norm_eps": 0.00001,
+    "num_attention_heads": 16,
+    "num_channels": 3,
+    "num_hidden_layers": 34,
+    "patch_size": 14,
+    "pixel_shuffle_ratio": 0.5,
+    "projector_dropout": 0.0,
+    "projector_input_dim": 4096,
+    "projector_output_dim": 4096,
+    "rope_theta": 10000,
+    "torch_dtype": "bfloat16",
+    "vision_feature_layer": -1,
+    "vision_feature_select_strategy": "default",
+    "vision_output_dim": 4096
+  }
 }

--- a/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
+++ b/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
@@ -30,6 +30,17 @@ from aiconfigurator_core.sdk.step_estimate import MixedStepInput, StepEstimate
 logger = logging.getLogger(__name__)
 
 
+@dataclasses.dataclass(frozen=True)
+class _EncoderVisualWorkload:
+    """Per-request-image token geometry after checkpoint preprocessing."""
+
+    output_tokens_per_image: int
+    output_tokens_per_sequence: int
+    transformer_tokens_per_sequence: int
+    patch_tokens_per_sequence: int
+    sequences_per_image: int
+
+
 class BaseBackend:
     """Base class for all inference backends.
 
@@ -212,8 +223,8 @@ class BaseBackend:
     def _visual_context_tokens_from_encoder_config(enc_cfg, runtime_config: RuntimeConfig) -> int:
         if not isinstance(enc_cfg, common.VisionEncoderConfig) or runtime_config.num_images_per_request <= 0:
             return 0
-        post_merge, _ = BaseBackend._encoder_pre_merge_per_visual(runtime_config, enc_cfg)
-        return post_merge * runtime_config.num_images_per_request
+        workload = BaseBackend._encoder_workload_per_visual(runtime_config, enc_cfg)
+        return workload.output_tokens_per_image * runtime_config.num_images_per_request
 
     @staticmethod
     def _visual_context_tokens(model: BaseModel, runtime_config: RuntimeConfig) -> int:
@@ -226,17 +237,94 @@ class BaseBackend:
         runtime_config: RuntimeConfig,
         enc_cfg,
     ) -> tuple[int, int]:
-        """Resolve the per-image pre-merge / post-merge token counts from
-        RuntimeConfig + VisionEncoderConfig.
+        """Compatibility wrapper for per-image output and ViT token counts.
 
         Resolution order:
             1. image_height + image_width (computed from patch/merge sizes)
             2. num_image_tokens (explicit per-image override)
 
-        Returns ``(tokens_post_merge_per_image, pre_merge_per_image)``.
+        Returns ``(output_tokens_per_image, transformer_tokens_per_image)``.
+        The second value includes per-sequence special tokens and all local or
+        global tile sequences for fixed tiled encoders.
         Returns ``(0, 0)`` when neither is set (text-only path).
         """
+        workload = BaseBackend._encoder_workload_per_visual(runtime_config, enc_cfg)
+        return (
+            workload.output_tokens_per_image,
+            workload.transformer_tokens_per_sequence * workload.sequences_per_image,
+        )
+
+    @staticmethod
+    def _tiled_encoder_sequence_count(height: int, width: int, enc_cfg: common.VisionEncoderConfig) -> int:
+        """Mirror Llama4ImageProcessor's best-fit canvas and global-tile rule."""
+        tile = enc_cfg.image_size
+        candidates: list[tuple[int, int]] = []
+        for chunk_count in range(enc_cfg.max_num_tiles, 0, -1):
+            for factor in range(1, int(chunk_count**0.5) + 1):
+                if chunk_count % factor == 0:
+                    candidates.append((factor * tile, (chunk_count // factor) * tile))
+                    if factor != chunk_count // factor:
+                        candidates.append(((chunk_count // factor) * tile, factor * tile))
+
+        scales = [min(target_h / height, target_w / width) for target_h, target_w in candidates]
+        upscaling = [scale for scale in scales if scale >= 1]
+        if upscaling:
+            selected_scale = max(upscaling) if enc_cfg.resize_to_max_canvas else min(upscaling)
+        else:
+            selected_scale = max(scales)
+        viable = [
+            candidate
+            for candidate, scale in zip(candidates, scales, strict=True)
+            if abs(scale - selected_scale) <= 1e-12
+        ]
+        target_h, target_w = min(viable, key=lambda size: size[0] * size[1])
+        local_tiles = (target_h // tile) * (target_w // tile)
+        return local_tiles + int(enc_cfg.add_global_tile and local_tiles > 1)
+
+    @staticmethod
+    def _encoder_workload_per_visual(
+        runtime_config: RuntimeConfig,
+        enc_cfg: common.VisionEncoderConfig,
+    ) -> _EncoderVisualWorkload:
+        """Resolve output, ViT, and raw-patch tokens for one request image.
+
+        Dynamic-resolution encoders retain the legacy one-sequence formula.
+        Fixed tiled encoders (Llama 4) use the published image-processor canvas
+        selection, run each local/global tile as an independent ViT sequence,
+        and account for the per-tile CLS token separately from patch embedding.
+        """
+        zero = _EncoderVisualWorkload(0, 0, 0, 0, 0)
         has_image_dims = runtime_config.image_height > 0 and runtime_config.image_width > 0
+
+        if enc_cfg.image_size > 0 and enc_cfg.max_num_tiles > 0:
+            post_per_sequence = (enc_cfg.image_size // (enc_cfg.patch_size * enc_cfg.spatial_merge_size)) ** 2
+            patch_per_sequence = (enc_cfg.image_size // enc_cfg.patch_size) ** 2
+            transformer_per_sequence = patch_per_sequence + int(enc_cfg.has_cls_token)
+            if has_image_dims:
+                sequences = BaseBackend._tiled_encoder_sequence_count(
+                    runtime_config.image_height,
+                    runtime_config.image_width,
+                    enc_cfg,
+                )
+                output_tokens = post_per_sequence * sequences
+            elif runtime_config.num_image_tokens > 0:
+                output_tokens = runtime_config.num_image_tokens
+                if output_tokens % post_per_sequence != 0:
+                    raise ValueError(
+                        "num_image_tokens must be a whole number of Llama 4 image chunks: "
+                        f"got {output_tokens}, chunk output is {post_per_sequence} tokens"
+                    )
+                sequences = output_tokens // post_per_sequence
+            else:
+                return zero
+            return _EncoderVisualWorkload(
+                output_tokens,
+                post_per_sequence,
+                transformer_per_sequence,
+                patch_per_sequence,
+                sequences,
+            )
+
         if has_image_dims:
             img_stride = enc_cfg.patch_size * enc_cfg.spatial_merge_size
             tokens_per_image = (runtime_config.image_height // img_stride) * (runtime_config.image_width // img_stride)
@@ -247,10 +335,16 @@ class BaseBackend:
             tokens_per_image = runtime_config.num_image_tokens
             pre_merge_per_image = tokens_per_image * (enc_cfg.spatial_merge_size**2)
         else:
-            return 0, 0
+            return zero
         if tokens_per_image <= 0 or pre_merge_per_image <= 0:
-            return 0, 0
-        return tokens_per_image, pre_merge_per_image
+            return zero
+        return _EncoderVisualWorkload(
+            tokens_per_image,
+            tokens_per_image,
+            pre_merge_per_image,
+            pre_merge_per_image,
+            1,
+        )
 
     def _run_encoder_phase(
         self,
@@ -274,35 +368,38 @@ class BaseBackend:
         if num_images <= 0 or not isinstance(enc_cfg, common.VisionEncoderConfig):
             return encoder_latency_dict, encoder_energy_wms_dict, encoder_source_dict, 0
 
-        tokens_per_image, pre_merge_per_image = self._encoder_pre_merge_per_visual(runtime_config, enc_cfg)
-        if tokens_per_image == 0:
+        workload = self._encoder_workload_per_visual(runtime_config, enc_cfg)
+        if workload.output_tokens_per_image == 0:
             # No image dimensions specified; skip encoder modeling.
             return encoder_latency_dict, encoder_energy_wms_dict, encoder_source_dict, 0
 
-        n_img_post = tokens_per_image * num_images  # post-merge: injected into LLM context
+        n_img_post = workload.output_tokens_per_image * num_images  # post-merge: injected into LLM context
 
         # Encoder DP: whole images are sharded across the tp_size ranks and the
         # busiest rank (ceil share) gates the phase.
         encoder_dp_size = model.config.tp_size if model.config.enable_encoder_dp else 1
         images_local = -(-batch_size * num_images // encoder_dp_size)
+        sequences_local = images_local * workload.sequences_per_image
 
         # Per-op shape rules (the encoder orchestration — this token math —
         # stays Python-side; only the per-op values may come from the
         # compiled engine below). Projector ops and the DP exit AllGather run
-        # on post-merge tokens; ViT attention uses cu_seqlens (each image an
-        # independent varlen sequence of pre_merge_per_image patches).
+        # on post-merge tokens; ViT attention uses cu_seqlens (each tile is an
+        # independent varlen sequence containing its raw patches plus CLS).
         def _encoder_eff_s(op) -> int:
-            use_post = "encoder_projector" in op._name or "all_gather" in op._name
+            if "encoder_patch_embedding" in op._name:
+                return workload.patch_tokens_per_sequence
+            use_post = "encoder_projector" in op._name or op._name == "encoder_dp_all_gather"
             use_varlen = "encoder_attention" in op._name
             if use_varlen:
-                return pre_merge_per_image
-            return tokens_per_image if use_post else pre_merge_per_image
+                return workload.transformer_tokens_per_sequence
+            return workload.output_tokens_per_sequence if use_post else workload.transformer_tokens_per_sequence
 
         if should_use_rust_engine_step(runtime_config, database):
             rust = self._run_encoder_phase_with_rust(
                 model,
                 database,
-                images_local,
+                sequences_local,
                 _encoder_eff_s,
                 include_energy=include_energy,
             )
@@ -311,7 +408,7 @@ class BaseBackend:
                 return encoder_latency_dict, encoder_energy_wms_dict, encoder_source_dict, n_img_post
 
         for op in model.encoder_ops:
-            eff_batch, eff_s = images_local, _encoder_eff_s(op)
+            eff_batch, eff_s = sequences_local, _encoder_eff_s(op)
             x = eff_batch * eff_s
             result = op.query(
                 database,
@@ -333,7 +430,7 @@ class BaseBackend:
         self,
         model: BaseModel,
         database: PerfDatabase,
-        images_local: int,
+        sequences_local: int,
         eff_s_of,
         *,
         include_energy: bool,
@@ -345,7 +442,7 @@ class BaseBackend:
         compile path threads no image configuration), so they travel through
         the ad-hoc op-list evaluation FFI: ops are grouped by their resolved
         ``eff_s`` (the shape math above), each group serialized to OpSpec
-        JSON and evaluated at ``batch=images_local, s=eff_s, x=batch*s``.
+        JSON and evaluated at ``batch=sequences_local, s=eff_s, x=batch*s``.
         Accumulation matches the Python loop for the shipped encoder op
         lists (unique names): latency/energy fold with ``+=``; sources are
         last-wins ACROSS shape groups, while duplicate names WITHIN one
@@ -372,10 +469,10 @@ class BaseBackend:
                     database,
                     ops_json=ops_json,
                     is_context=True,
-                    batch_size=images_local,
+                    batch_size=sequences_local,
                     s=eff_s,
                     prefix=0,
-                    x=images_local * eff_s,
+                    x=sequences_local * eff_s,
                 )
                 for name, latency_ms, energy_wms, source in entries:
                     latency_dict[name] += float(latency_ms)
@@ -1494,7 +1591,7 @@ class BaseBackend:
     def _get_encoder_component_memory(self, model: BaseModel, num_tokens: int, embed_tokens: int) -> dict[str, float]:
         """Encoder memory component colocated with the prefill/agg worker.
 
-        num_tokens: pre-merge patches run through the ViT on this rank.
+        num_tokens: transformer tokens run through the ViT on this rank.
         embed_tokens: post-merge tokens of the projected-embeddings buffer
         every rank holds at the encoder exit (the full batch in both modes).
         """
@@ -1528,16 +1625,16 @@ class BaseBackend:
             return {}
         if runtime_config.num_images_per_request <= 0:
             return {}
-        tokens_per_image, pre_merge_per_image = self._encoder_pre_merge_per_visual(runtime_config, enc_cfg)
-        if pre_merge_per_image <= 0:
+        workload = self._encoder_workload_per_visual(runtime_config, enc_cfg)
+        if workload.transformer_tokens_per_sequence <= 0:
             return {}
         # ViT activations follow the busiest rank's image share; the embeddings
         # buffer covers the full batch on every rank.
         total_images = batch_size * runtime_config.num_images_per_request
         encoder_dp_size = model.config.tp_size if model.config.enable_encoder_dp else 1
         images_local = -(-total_images // encoder_dp_size)
-        num_tokens = images_local * pre_merge_per_image
-        embed_tokens = total_images * tokens_per_image
+        num_tokens = images_local * workload.sequences_per_image * workload.transformer_tokens_per_sequence
+        embed_tokens = total_images * workload.output_tokens_per_image
         return self._get_encoder_component_memory(model, num_tokens, embed_tokens)
 
     def run_agg(

--- a/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
+++ b/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
@@ -35,6 +35,7 @@ class _EncoderVisualWorkload:
     """Per-request-image token geometry after checkpoint preprocessing."""
 
     output_tokens_per_image: int
+    context_tokens_per_image: int
     output_tokens_per_sequence: int
     transformer_tokens_per_sequence: int
     patch_tokens_per_sequence: int
@@ -224,7 +225,7 @@ class BaseBackend:
         if not isinstance(enc_cfg, common.VisionEncoderConfig) or runtime_config.num_images_per_request <= 0:
             return 0
         workload = BaseBackend._encoder_workload_per_visual(runtime_config, enc_cfg)
-        return workload.output_tokens_per_image * runtime_config.num_images_per_request
+        return workload.context_tokens_per_image * runtime_config.num_images_per_request
 
     @staticmethod
     def _visual_context_tokens(model: BaseModel, runtime_config: RuntimeConfig) -> int:
@@ -258,6 +259,11 @@ class BaseBackend:
     def _tiled_encoder_sequence_count(height: int, width: int, enc_cfg: common.VisionEncoderConfig) -> int:
         """Mirror Llama4ImageProcessor's best-fit canvas and global-tile rule."""
         tile = enc_cfg.image_size
+        if height <= 0 or width <= 0 or tile <= 0 or enc_cfg.max_num_tiles <= 0:
+            raise ValueError(
+                "tiled sequence count requires positive geometry: "
+                f"height={height}, width={width}, tile={tile}, max_num_tiles={enc_cfg.max_num_tiles}"
+            )
         candidates: list[tuple[int, int]] = []
         for chunk_count in range(enc_cfg.max_num_tiles, 0, -1):
             for factor in range(1, int(chunk_count**0.5) + 1):
@@ -293,7 +299,7 @@ class BaseBackend:
         selection, run each local/global tile as an independent ViT sequence,
         and account for the per-tile CLS token separately from patch embedding.
         """
-        zero = _EncoderVisualWorkload(0, 0, 0, 0, 0)
+        zero = _EncoderVisualWorkload(0, 0, 0, 0, 0, 0)
         has_image_dims = runtime_config.image_height > 0 and runtime_config.image_width > 0
 
         if enc_cfg.image_size > 0 and enc_cfg.max_num_tiles > 0:
@@ -310,15 +316,30 @@ class BaseBackend:
             elif runtime_config.num_image_tokens > 0:
                 output_tokens = runtime_config.num_image_tokens
                 if output_tokens % post_per_sequence != 0:
-                    raise ValueError(
-                        "num_image_tokens must be a whole number of Llama 4 image chunks: "
-                        f"got {output_tokens}, chunk output is {post_per_sequence} tokens"
+                    # ``num_image_tokens`` is a public workload-level override,
+                    # not a declaration of processor tile geometry. Preserve
+                    # its legacy arbitrary-token approximation as one synthetic
+                    # sequence when the count cannot describe whole Llama 4
+                    # chunks. Image dimensions still take the exact tiled path.
+                    patch_tokens = output_tokens * enc_cfg.spatial_merge_size**2
+                    return _EncoderVisualWorkload(
+                        output_tokens,
+                        output_tokens + enc_cfg.prompt_image_tokens,
+                        output_tokens,
+                        patch_tokens + int(enc_cfg.has_cls_token),
+                        patch_tokens,
+                        1,
                     )
                 sequences = output_tokens // post_per_sequence
             else:
                 return zero
+            local_tiles = sequences - int(enc_cfg.add_global_tile and sequences > 1)
+            context_tokens = output_tokens + enc_cfg.prompt_image_tokens
+            if local_tiles > 1:
+                context_tokens += local_tiles * enc_cfg.prompt_tokens_per_local_tile
             return _EncoderVisualWorkload(
                 output_tokens,
+                context_tokens,
                 post_per_sequence,
                 transformer_per_sequence,
                 patch_per_sequence,
@@ -339,6 +360,7 @@ class BaseBackend:
         if tokens_per_image <= 0 or pre_merge_per_image <= 0:
             return zero
         return _EncoderVisualWorkload(
+            tokens_per_image,
             tokens_per_image,
             tokens_per_image,
             pre_merge_per_image,
@@ -373,7 +395,7 @@ class BaseBackend:
             # No image dimensions specified; skip encoder modeling.
             return encoder_latency_dict, encoder_energy_wms_dict, encoder_source_dict, 0
 
-        n_img_post = workload.output_tokens_per_image * num_images  # post-merge: injected into LLM context
+        n_img_context = workload.context_tokens_per_image * num_images
 
         # Encoder DP: whole images are sharded across the tp_size ranks and the
         # busiest rank (ceil share) gates the phase.
@@ -387,13 +409,14 @@ class BaseBackend:
         # on post-merge tokens; ViT attention uses cu_seqlens (each tile is an
         # independent varlen sequence containing its raw patches plus CLS).
         def _encoder_eff_s(op) -> int:
-            if "encoder_patch_embedding" in op._name:
+            name = op._name
+            if "encoder_patch_embedding" in name:
                 return workload.patch_tokens_per_sequence
-            use_post = "encoder_projector" in op._name or op._name == "encoder_dp_all_gather"
-            use_varlen = "encoder_attention" in op._name
-            if use_varlen:
+            if "encoder_attention" in name:
                 return workload.transformer_tokens_per_sequence
-            return workload.output_tokens_per_sequence if use_post else workload.transformer_tokens_per_sequence
+            if "encoder_projector" in name or name == "encoder_dp_all_gather":
+                return workload.output_tokens_per_sequence
+            return workload.transformer_tokens_per_sequence
 
         if should_use_rust_engine_step(runtime_config, database):
             rust = self._run_encoder_phase_with_rust(
@@ -405,7 +428,7 @@ class BaseBackend:
             )
             if rust is not None:
                 encoder_latency_dict, encoder_energy_wms_dict, encoder_source_dict = rust
-                return encoder_latency_dict, encoder_energy_wms_dict, encoder_source_dict, n_img_post
+                return encoder_latency_dict, encoder_energy_wms_dict, encoder_source_dict, n_img_context
 
         for op in model.encoder_ops:
             eff_batch, eff_s = sequences_local, _encoder_eff_s(op)
@@ -424,7 +447,7 @@ class BaseBackend:
                 encoder_energy_wms_dict[op._name] += getattr(result, "energy", 0.0)
             encoder_source_dict[op._name] = getattr(result, "source", "silicon")
 
-        return encoder_latency_dict, encoder_energy_wms_dict, encoder_source_dict, n_img_post
+        return encoder_latency_dict, encoder_energy_wms_dict, encoder_source_dict, n_img_context
 
     def _run_encoder_phase_with_rust(
         self,

--- a/aic-core/src/aiconfigurator_core/sdk/common.py
+++ b/aic-core/src/aiconfigurator_core/sdk/common.py
@@ -153,6 +153,10 @@ class HybridMoEConfig:
     swa_num_heads: int = 0
     use_qk_norm: bool = False
     use_head_wise_attn_gate: bool = False
+    # Llama 4 is a multimodal wrapper around this hybrid text backbone.  Keep
+    # the exact vision-tower metadata beside the text layer plan instead of
+    # flattening it away when ``text_config`` is unwrapped.
+    vision_config: "VisionEncoderConfig | None" = None
 
 
 @dataclass(frozen=True)
@@ -183,6 +187,17 @@ class VisionEncoderConfig:
             rotated fraction — the 2-axis vision RoPE always rotates the full
             head_dim (vLLM ApplyRotaryEmb / SGLang cat([cos, cos])). Only gates
             the encoder_rope_apply op; 0.0 means no RoPE.
+        image_size (int): Fixed square image-tile size in pixels. Zero denotes
+            a dynamic-resolution encoder such as Qwen3-VL.
+        num_channels (int): Number of channels consumed by patch embedding.
+        has_cls_token (bool): Whether each tile appends a CLS token before the
+            transformer and removes it before pixel shuffle/projector work.
+        max_num_tiles (int): Maximum tile count selected by the checkpoint's
+            image processor. Zero means the input is not tiled.
+        resize_to_max_canvas (bool): Whether processor tiling chooses the
+            largest viable upscaling canvas instead of the smallest one.
+        add_global_tile (bool): Whether the image processor adds a global
+            thumbnail whenever the selected canvas contains multiple tiles.
     """
 
     depth: int
@@ -197,6 +212,12 @@ class VisionEncoderConfig:
     projector_dims: tuple[tuple[int, int], ...] = ()
     projector_n_instances: int = 1
     partial_rotary_factor: float = 0.0
+    image_size: int = 0
+    num_channels: int = 3
+    has_cls_token: bool = False
+    max_num_tiles: int = 0
+    resize_to_max_canvas: bool = False
+    add_global_tile: bool = False
 
 
 @dataclass(frozen=True)

--- a/aic-core/src/aiconfigurator_core/sdk/common.py
+++ b/aic-core/src/aiconfigurator_core/sdk/common.py
@@ -198,6 +198,11 @@ class VisionEncoderConfig:
             largest viable upscaling canvas instead of the smallest one.
         add_global_tile (bool): Whether the image processor adds a global
             thumbnail whenever the selected canvas contains multiple tiles.
+        prompt_image_tokens (int): Fixed non-embedding tokens emitted around
+            each image by the multimodal processor (for Llama 4: image start,
+            global-image marker, and image end).
+        prompt_tokens_per_local_tile (int): Structural separator tokens emitted
+            per local tile when a tiled prompt also contains a global tile.
     """
 
     depth: int
@@ -218,6 +223,8 @@ class VisionEncoderConfig:
     max_num_tiles: int = 0
     resize_to_max_canvas: bool = False
     add_global_tile: bool = False
+    prompt_image_tokens: int = 0
+    prompt_tokens_per_local_tile: int = 0
 
 
 @dataclass(frozen=True)

--- a/aic-core/src/aiconfigurator_core/sdk/models/hybrid_moe.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/hybrid_moe.py
@@ -7,6 +7,7 @@ import aiconfigurator_core.sdk.operations as ops
 from aiconfigurator_core.sdk import common
 from aiconfigurator_core.sdk.models.base import BaseModel, register_model
 from aiconfigurator_core.sdk.models.helpers import mtp_scale_factor
+from aiconfigurator_core.sdk.models.vit_ops import build_llama4_encoder_ops
 from aiconfigurator_core.sdk.utils import _load_model_config_from_model_path
 
 
@@ -49,7 +50,17 @@ class HybridMoEModel(BaseModel):
             model_info["context"],
             model_config,
         )
-        model.set_hybrid_config(model_info["extra_params"])
+        hybrid_config = model_info["extra_params"]
+        model.set_hybrid_config(hybrid_config)
+        if model_info["architecture"] == "Llama4ForConditionalGeneration" and hybrid_config.vision_config:
+            model.encoder_config = hybrid_config.vision_config
+            model.encoder_ops.extend(
+                build_llama4_encoder_ops(
+                    hybrid_config.vision_config,
+                    model.config.tp_size,
+                    model.config.enable_encoder_dp,
+                )
+            )
         return model
 
     def __init__(self, topk: int, num_experts: int, moe_inter_size: int, *args) -> None:

--- a/aic-core/src/aiconfigurator_core/sdk/models/vit_ops.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/vit_ops.py
@@ -221,3 +221,145 @@ def build_encoder_ops(enc_cfg: common.VisionEncoderConfig, tp_size: int, enable_
             )
         )
     return result
+
+
+def _llama4_projector_ops(enc_cfg: common.VisionEncoderConfig, tp_size: int) -> list:
+    """Build Llama 4's pixel-shuffle adaptor and multimodal connector.
+
+    The checkpoint contains two distinct modules and therefore two distinct
+    communication boundaries:
+
+    * ``vision_adapter.mlp`` is column-parallel then row-parallel.  Its second
+      GEMM reduces the 4096-wide output across TP ranks.
+    * ``multi_modal_projector.linear_1`` is column-parallel with gathered
+      output, projecting the 4096-wide vision embedding to the 5120-wide text
+      embedding consumed by the hybrid-MoE backbone.
+    """
+    dims = enc_cfg.projector_dims
+    if len(dims) != 3:
+        raise ValueError(f"Llama 4 expects exactly three projector dimensions, got {dims!r}")
+    (merge_in, adapter_hidden), (adapter_in, adapter_out), (connector_in, connector_out) = dims
+    if adapter_hidden != adapter_in or adapter_out != connector_in:
+        raise ValueError(f"Llama 4 projector dimensions are not composable: {dims!r}")
+    for dim_name, dim in (
+        ("adapter_hidden", adapter_hidden),
+        ("adapter_in", adapter_in),
+        ("connector_out", connector_out),
+    ):
+        if dim % tp_size != 0:
+            raise ValueError(f"Llama 4 {dim_name} ({dim}) must be divisible by tp_size ({tp_size})")
+
+    q = common.GEMMQuantMode.bfloat16
+    result = [
+        # pixel_shuffle turns four 1408-wide patch vectors into one 5632-wide
+        # vector before the MLP; it is a real memory-movement stage even though
+        # it has no trainable weights.
+        ops.ElementWise("encoder_projector_pixel_shuffle", 1, merge_in, merge_in, 0.8),
+        # vLLM ColumnParallelLinear: output features are sharded.
+        ops.GEMM("encoder_projector_adapter_fc0_gemm", 1, adapter_hidden // tp_size, merge_in, q),
+        ops.ElementWise(
+            "encoder_projector_adapter_fc0_act",
+            1,
+            adapter_hidden // tp_size,
+            adapter_hidden // tp_size,
+            0.8,
+        ),
+        # vLLM RowParallelLinear: input features are sharded; output is reduced.
+        ops.GEMM("encoder_projector_adapter_fc1_gemm", 1, adapter_out, adapter_in // tp_size, q),
+        ops.CustomAllReduce("encoder_projector_adapter_ar", 1, adapter_out, tp_size),
+        ops.ElementWise("encoder_projector_adapter_fc1_act", 1, adapter_out, adapter_out, 0.8),
+        # The final connector is ColumnParallelLinear(gather_output=True).
+        ops.GEMM("encoder_projector_mm_gemm", 1, connector_out // tp_size, connector_in, q),
+    ]
+    if tp_size > 1:
+        result.append(
+            ops.NCCL(
+                "encoder_projector_mm_all_gather",
+                1,
+                "all_gather",
+                num_elements_per_token=connector_out,
+                num_gpus=tp_size,
+                comm_quant_mode=common.CommQuantMode.half,
+            )
+        )
+    return result
+
+
+def build_llama4_encoder_ops(
+    enc_cfg: common.VisionEncoderConfig,
+    tp_size: int,
+    enable_encoder_dp: bool = True,
+) -> list:
+    """Build the checkpoint-faithful Llama 4 image-tower operation graph.
+
+    Unlike Qwen3-VL's shared ViT path, Llama 4 has a learned patch-embedding
+    linear, a per-tile CLS token, a pixel-shuffle adaptor, and a separate
+    vision-to-text connector.  The backend supplies their different sequence
+    lengths: raw patches for patch embedding, raw patches + CLS for the ViT,
+    and post-shuffle image tokens for adaptor/connector operations.
+    """
+    if enc_cfg.image_size <= 0:
+        raise ValueError("Llama 4 vision_config.image_size must be positive")
+    if not enc_cfg.has_cls_token:
+        raise ValueError("Llama 4 vision encoder requires a CLS token")
+    if enc_cfg.image_size % enc_cfg.patch_size != 0:
+        raise ValueError(
+            f"Llama 4 image_size ({enc_cfg.image_size}) must be divisible by patch_size ({enc_cfg.patch_size})"
+        )
+    merge_stride = enc_cfg.patch_size * enc_cfg.spatial_merge_size
+    if enc_cfg.image_size % merge_stride != 0:
+        raise ValueError(
+            f"Llama 4 image_size ({enc_cfg.image_size}) must be divisible by the merged-patch stride ({merge_stride})"
+        )
+
+    encoder_tp = 1 if enable_encoder_dp else tp_size
+    if enc_cfg.hidden_size % encoder_tp != 0:
+        raise ValueError(
+            f"Llama 4 vision hidden_size ({enc_cfg.hidden_size}) must be divisible by tp_size ({encoder_tp})"
+        )
+    patch_input = enc_cfg.num_channels * enc_cfg.patch_size**2
+    q = common.GEMMQuantMode.bfloat16
+    result = [
+        ops.GEMM("encoder_patch_embedding_gemm", 1, enc_cfg.hidden_size // encoder_tp, patch_input, q),
+    ]
+    if encoder_tp > 1:
+        # vLLM's patch-embedding ColumnParallelLinear uses gather_output=True,
+        # so every TP rank sees the full hidden vector before the ViT blocks.
+        result.append(
+            ops.NCCL(
+                "encoder_patch_embedding_all_gather",
+                1,
+                "all_gather",
+                num_elements_per_token=enc_cfg.hidden_size,
+                num_gpus=encoder_tp,
+                comm_quant_mode=common.CommQuantMode.half,
+            )
+        )
+    result.extend(
+        [
+            # Class/position additions plus the pre-transformer LayerNorm.
+            ops.ElementWise(
+                "encoder_class_position_norm",
+                1,
+                3 * enc_cfg.hidden_size,
+                3 * enc_cfg.hidden_size,
+                0.8,
+            ),
+            *_vit_transformer_ops(enc_cfg, encoder_tp),
+            ops.ElementWise("encoder_post_norm", 1, 2 * enc_cfg.hidden_size, 2 * enc_cfg.hidden_size, 0.8),
+            *_llama4_projector_ops(enc_cfg, encoder_tp),
+        ]
+    )
+
+    if enable_encoder_dp and tp_size > 1:
+        result.append(
+            ops.NCCL(
+                "encoder_dp_all_gather",
+                1,
+                "all_gather",
+                num_elements_per_token=enc_cfg.out_hidden_size * tp_size,
+                num_gpus=tp_size,
+                comm_quant_mode=common.CommQuantMode.half,
+            )
+        )
+    return result

--- a/aic-core/src/aiconfigurator_core/sdk/utils.py
+++ b/aic-core/src/aiconfigurator_core/sdk/utils.py
@@ -502,6 +502,84 @@ def _parse_nemotron_block_configs(block_configs: list[dict]) -> list[BlockConfig
     return grouped_configs if grouped_configs else None
 
 
+def _parse_llama4_vision_config(vision_cfg: dict, text_hidden_size: int) -> VisionEncoderConfig:
+    """Translate the published Llama 4 tower + connector shapes without defaults.
+
+    The Llama 4 engine pixel-shuffles ``1 / ratio`` patches along each spatial
+    axis, feeds the concatenated width to the two-layer vision adaptor, and
+    then applies a separate connector into the text hidden size.  Requiring
+    the checkpoint fields here prevents a partial curated config from silently
+    falling back to Transformers' generic Llama4VisionConfig defaults.
+    """
+    required = (
+        "hidden_size",
+        "num_hidden_layers",
+        "num_attention_heads",
+        "num_channels",
+        "intermediate_size",
+        "image_size",
+        "patch_size",
+        "pixel_shuffle_ratio",
+        "projector_input_dim",
+        "projector_output_dim",
+        "vision_output_dim",
+    )
+    missing = [key for key in required if key not in vision_cfg]
+    if missing:
+        raise ValueError(f"Llama 4 vision_config is missing required fields: {', '.join(missing)}")
+
+    ratio = vision_cfg["pixel_shuffle_ratio"]
+    if not isinstance(ratio, (int, float)) or ratio <= 0:
+        raise ValueError(f"Llama 4 pixel_shuffle_ratio must be positive, got {ratio!r}")
+    spatial_merge_size = round(1.0 / float(ratio))
+    if spatial_merge_size <= 0 or abs(float(ratio) * spatial_merge_size - 1.0) > 1e-9:
+        raise ValueError(f"Llama 4 pixel_shuffle_ratio must have an integral reciprocal, got {ratio!r}")
+
+    hidden = vision_cfg["hidden_size"]
+    merge_dim = hidden * spatial_merge_size**2
+    if merge_dim != vision_cfg["intermediate_size"]:
+        raise ValueError(
+            "Llama 4 pixel-shuffle width must equal vision intermediate_size: "
+            f"{hidden} * {spatial_merge_size}^2 = {merge_dim}, "
+            f"config has {vision_cfg['intermediate_size']}"
+        )
+    if vision_cfg["projector_output_dim"] != vision_cfg["vision_output_dim"]:
+        raise ValueError(
+            "Llama 4 vision adaptor output must match multimodal projector input: "
+            f"projector_output_dim={vision_cfg['projector_output_dim']} "
+            f"vision_output_dim={vision_cfg['vision_output_dim']}"
+        )
+
+    adapter_hidden = vision_cfg["projector_input_dim"]
+    adapter_out = vision_cfg["projector_output_dim"]
+    return VisionEncoderConfig(
+        depth=vision_cfg["num_hidden_layers"],
+        hidden_size=hidden,
+        num_heads=vision_cfg["num_attention_heads"],
+        intermediate_size=vision_cfg["intermediate_size"],
+        patch_size=vision_cfg["patch_size"],
+        temporal_patch_size=1,
+        spatial_merge_size=spatial_merge_size,
+        out_hidden_size=text_hidden_size,
+        projector_dims=(
+            (merge_dim, adapter_hidden),
+            (adapter_hidden, adapter_out),
+            (vision_cfg["vision_output_dim"], text_hidden_size),
+        ),
+        projector_n_instances=1,
+        # vLLM's mllama4 rotary implementation fixes this to 0.5; like the
+        # shared ViT path, AIC uses it as a RoPE-stage gate, not a dim shrink.
+        partial_rotary_factor=0.5,
+        image_size=vision_cfg["image_size"],
+        num_channels=vision_cfg["num_channels"],
+        has_cls_token=True,
+        # Published Llama4ImageProcessor metadata for Scout and Maverick.
+        max_num_tiles=16,
+        resize_to_max_canvas=False,
+        add_global_tile=True,
+    )
+
+
 def _parse_hf_config_json(config: dict) -> dict:
     """
     Convert a HuggingFace config.json dictionary into model configuration parameters.
@@ -650,18 +728,22 @@ def _parse_hf_config_json(config: dict) -> dict:
             raise ValueError(f"interleave_moe_layer_step must be a positive integer, got {step}")
         attn_pattern = tuple(i % 2 for i in range(layers))
         moe_freq = tuple(1 if (i + 1) % step == 0 else 0 for i in range(layers))
+        llama4_vision_config = _parse_llama4_vision_config(vision_cfg, hidden_size) if vision_cfg else None
         extra_params = HybridMoEConfig(
             attn_layer_pattern=attn_pattern,
             moe_layer_freq=moe_freq,
             # All attention dims are uniform (0 → fall back to model-level defaults).
             sliding_window_size=config.get("attention_chunk_size", 0),
             dense_inter_size=config.get("intermediate_size_mlp", 0),
+            use_qk_norm=bool(config.get("use_qk_norm", False)),
+            vision_config=llama4_vision_config,
         )
         logger.info(
             f"Llama4 hybrid config: interleave_moe_layer_step={step}, "
             f"global_attn_layers={sum(attn_pattern)}, local_attn_layers={attn_pattern.count(0)}, "
             f"moe_layers={sum(moe_freq)}, dense_layers={moe_freq.count(0)}, "
-            f"sliding_window_size={extra_params.sliding_window_size}"
+            f"sliding_window_size={extra_params.sliding_window_size}, "
+            f"vision_encoder={'enabled' if llama4_vision_config else 'absent'}"
         )
     elif architecture == "KimiK25ForConditionalGeneration":
         # KIMI K2.5 wraps a DeepSeek-V3-style MLA text model. Store v_head_dim so

--- a/aic-core/src/aiconfigurator_core/sdk/utils.py
+++ b/aic-core/src/aiconfigurator_core/sdk/utils.py
@@ -502,7 +502,11 @@ def _parse_nemotron_block_configs(block_configs: list[dict]) -> list[BlockConfig
     return grouped_configs if grouped_configs else None
 
 
-def _parse_llama4_vision_config(vision_cfg: dict, text_hidden_size: int) -> VisionEncoderConfig:
+def _parse_llama4_vision_config(
+    vision_cfg: dict,
+    image_processor_cfg: dict | None,
+    text_hidden_size: int,
+) -> VisionEncoderConfig:
     """Translate the published Llama 4 tower + connector shapes without defaults.
 
     The Llama 4 engine pixel-shuffles ``1 / ratio`` patches along each spatial
@@ -527,6 +531,19 @@ def _parse_llama4_vision_config(vision_cfg: dict, text_hidden_size: int) -> Visi
     missing = [key for key in required if key not in vision_cfg]
     if missing:
         raise ValueError(f"Llama 4 vision_config is missing required fields: {', '.join(missing)}")
+
+    processor_required = ("max_patches", "resize_to_max_canvas", "add_global_tile")
+    if not isinstance(image_processor_cfg, dict):
+        raise TypeError("Llama 4 config must preserve image_processor_config metadata")
+    processor_missing = [key for key in processor_required if key not in image_processor_cfg]
+    if processor_missing:
+        raise ValueError(f"Llama 4 image_processor_config is missing required fields: {', '.join(processor_missing)}")
+    max_patches = image_processor_cfg["max_patches"]
+    if not isinstance(max_patches, int) or isinstance(max_patches, bool) or max_patches <= 0:
+        raise ValueError(f"Llama 4 image_processor_config.max_patches must be a positive integer, got {max_patches!r}")
+    for key in ("resize_to_max_canvas", "add_global_tile"):
+        if not isinstance(image_processor_cfg[key], bool):
+            raise TypeError(f"Llama 4 image_processor_config.{key} must be boolean")
 
     ratio = vision_cfg["pixel_shuffle_ratio"]
     if not isinstance(ratio, (int, float)) or ratio <= 0:
@@ -573,10 +590,14 @@ def _parse_llama4_vision_config(vision_cfg: dict, text_hidden_size: int) -> Visi
         image_size=vision_cfg["image_size"],
         num_channels=vision_cfg["num_channels"],
         has_cls_token=True,
-        # Published Llama4ImageProcessor metadata for Scout and Maverick.
-        max_num_tiles=16,
-        resize_to_max_canvas=False,
-        add_global_tile=True,
+        max_num_tiles=max_patches,
+        resize_to_max_canvas=image_processor_cfg["resize_to_max_canvas"],
+        add_global_tile=image_processor_cfg["add_global_tile"],
+        # Llama4Processor._prompt_split_image emits image start, global-image,
+        # and image end tokens, plus one x/y separator per local tile whenever
+        # the prompt contains a local-tile grid and a global tile.
+        prompt_image_tokens=3,
+        prompt_tokens_per_local_tile=1,
     )
 
 
@@ -595,6 +616,7 @@ def _parse_hf_config_json(config: dict) -> dict:
     """
     architecture = config["architectures"][0]
     vision_cfg = config.get("vision_config")
+    image_processor_cfg = config.get("image_processor_config")
 
     # For multimodal models, unwrap the nested text config so that all LLM
     # parameters (layers, hidden_size, MoE fields, etc.) are read from the
@@ -728,7 +750,9 @@ def _parse_hf_config_json(config: dict) -> dict:
             raise ValueError(f"interleave_moe_layer_step must be a positive integer, got {step}")
         attn_pattern = tuple(i % 2 for i in range(layers))
         moe_freq = tuple(1 if (i + 1) % step == 0 else 0 for i in range(layers))
-        llama4_vision_config = _parse_llama4_vision_config(vision_cfg, hidden_size) if vision_cfg else None
+        llama4_vision_config = (
+            _parse_llama4_vision_config(vision_cfg, image_processor_cfg, hidden_size) if vision_cfg else None
+        )
         extra_params = HybridMoEConfig(
             attn_layer_pattern=attn_pattern,
             moe_layer_freq=moe_freq,

--- a/aic-core/src/aiconfigurator_core/sdk/utils.py
+++ b/aic-core/src/aiconfigurator_core/sdk/utils.py
@@ -759,7 +759,6 @@ def _parse_hf_config_json(config: dict) -> dict:
             # All attention dims are uniform (0 → fall back to model-level defaults).
             sliding_window_size=config.get("attention_chunk_size", 0),
             dense_inter_size=config.get("intermediate_size_mlp", 0),
-            use_qk_norm=bool(config.get("use_qk_norm", False)),
             vision_config=llama4_vision_config,
         )
         logger.info(

--- a/aic-core/src/aiconfigurator_core/sdk/utils.py
+++ b/aic-core/src/aiconfigurator_core/sdk/utils.py
@@ -750,9 +750,9 @@ def _parse_hf_config_json(config: dict) -> dict:
             raise ValueError(f"interleave_moe_layer_step must be a positive integer, got {step}")
         attn_pattern = tuple(i % 2 for i in range(layers))
         moe_freq = tuple(1 if (i + 1) % step == 0 else 0 for i in range(layers))
-        llama4_vision_config = (
-            _parse_llama4_vision_config(vision_cfg, image_processor_cfg, hidden_size) if vision_cfg else None
-        )
+        if not isinstance(vision_cfg, dict):
+            raise TypeError("Llama 4 config must preserve vision_config metadata")
+        llama4_vision_config = _parse_llama4_vision_config(vision_cfg, image_processor_cfg, hidden_size)
         extra_params = HybridMoEConfig(
             attn_layer_pattern=attn_pattern,
             moe_layer_freq=moe_freq,

--- a/tests/unit/sdk/models/test_llama4_vision.py
+++ b/tests/unit/sdk/models/test_llama4_vision.py
@@ -13,7 +13,7 @@ from aiconfigurator.sdk.backends.base_backend import BaseBackend
 from aiconfigurator.sdk.backends.trtllm_backend import TRTLLMBackend
 from aiconfigurator.sdk.config import RuntimeConfig
 from aiconfigurator.sdk.models import HybridMoEModel, get_model
-from aiconfigurator.sdk.utils import get_model_config_from_model_path
+from aiconfigurator.sdk.utils import _parse_hf_config_json, get_model_config_from_model_path
 
 pytestmark = pytest.mark.unit
 
@@ -21,6 +21,7 @@ LLAMA4_CHECKPOINTS = (
     ("meta-llama/Llama-4-Scout-17B-16E-Instruct", 16, 48, 0),
     ("meta-llama/Llama-4-Maverick-17B-128E-Instruct", 128, 24, 24),
 )
+LLAMA4_MODEL_IDS = tuple(checkpoint[0] for checkpoint in LLAMA4_CHECKPOINTS)
 
 
 def _model_config(**overrides):
@@ -64,10 +65,12 @@ def test_checkpoint_configs_preserve_text_and_exact_vision_shapes(model_id, num_
     assert vision.has_cls_token
     assert vision.max_num_tiles == 16
     assert vision.add_global_tile
+    assert vision.prompt_image_tokens == 3
+    assert vision.prompt_tokens_per_local_tile == 1
 
 
-@pytest.mark.parametrize("model_id,_,__,___", LLAMA4_CHECKPOINTS)
-def test_bundled_checkpoint_json_preserves_llama4_special_tokens_and_vision_metadata(model_id, _, __, ___):
+@pytest.mark.parametrize("model_id", LLAMA4_MODEL_IDS)
+def test_bundled_checkpoint_json_preserves_llama4_special_tokens_and_vision_metadata(model_id):
     config_path = (
         pkg_resources.files("aiconfigurator_core") / "model_configs" / (f"{model_id.replace('/', '--')}_config.json")
     )
@@ -76,6 +79,11 @@ def test_bundled_checkpoint_json_preserves_llama4_special_tokens_and_vision_meta
     assert checkpoint["boi_token_index"] == 200080
     assert checkpoint["eoi_token_index"] == 200081
     assert checkpoint["image_token_index"] == 200092
+    assert checkpoint["image_processor_config"] == {
+        "add_global_tile": True,
+        "max_patches": 16,
+        "resize_to_max_canvas": False,
+    }
     assert checkpoint["vision_config"] == {
         "attention_dropout": 0.0,
         "hidden_act": "gelu",
@@ -102,8 +110,8 @@ def test_bundled_checkpoint_json_preserves_llama4_special_tokens_and_vision_meta
     }
 
 
-@pytest.mark.parametrize("model_id,_,__,___", LLAMA4_CHECKPOINTS)
-def test_both_checkpoints_build_vision_and_hybrid_text_ops(model_id, _, __, ___):
+@pytest.mark.parametrize("model_id", LLAMA4_MODEL_IDS)
+def test_both_checkpoints_build_vision_and_hybrid_text_ops(model_id):
     model = get_model(model_id, _model_config(), "trtllm")
 
     assert isinstance(model, HybridMoEModel)
@@ -179,31 +187,62 @@ def test_llama4_encoder_dp_models_exit_all_gather_only():
 
 def test_single_tile_image_produces_nonzero_engine_and_text_tokens():
     enc_cfg = get_model_config_from_model_path(LLAMA4_CHECKPOINTS[0][0])["extra_params"].vision_config
-    workload = BaseBackend._encoder_workload_per_visual(
-        RuntimeConfig(image_height=336, image_width=336, num_images_per_request=1),
-        enc_cfg,
-    )
+    runtime_config = RuntimeConfig(image_height=336, image_width=336, num_images_per_request=1)
+    workload = BaseBackend._encoder_workload_per_visual(runtime_config, enc_cfg)
 
     assert workload.patch_tokens_per_sequence == 576
     assert workload.transformer_tokens_per_sequence == 577
     assert workload.output_tokens_per_sequence == 144
     assert workload.output_tokens_per_image == 144
+    assert workload.context_tokens_per_image == 147
     assert workload.sequences_per_image == 1
+    assert BaseBackend._visual_context_tokens_from_encoder_config(enc_cfg, runtime_config) == 147
 
 
 def test_four_local_tiles_add_engine_global_tile_and_720_text_tokens():
     enc_cfg = get_model_config_from_model_path(LLAMA4_CHECKPOINTS[0][0])["extra_params"].vision_config
-    workload = BaseBackend._encoder_workload_per_visual(
-        RuntimeConfig(image_height=672, image_width=672, num_images_per_request=1),
-        enc_cfg,
-    )
+    runtime_config = RuntimeConfig(image_height=672, image_width=672, num_images_per_request=1)
+    workload = BaseBackend._encoder_workload_per_visual(runtime_config, enc_cfg)
 
     assert workload.sequences_per_image == 5
     assert workload.output_tokens_per_image == 5 * 144
+    assert workload.context_tokens_per_image == 5 * 144 + 4 + 3
+    assert BaseBackend._visual_context_tokens_from_encoder_config(enc_cfg, runtime_config) == 727
 
 
-@pytest.mark.parametrize("model_id,_,__,___", LLAMA4_CHECKPOINTS)
-def test_nonzero_image_workload_reaches_encoder_and_text_context(model_id, _, __, ___):
+def test_token_only_override_preserves_non_chunk_aligned_sdk_workload():
+    enc_cfg = get_model_config_from_model_path(LLAMA4_CHECKPOINTS[0][0])["extra_params"].vision_config
+    runtime_config = RuntimeConfig(num_image_tokens=333, num_images_per_request=1)
+
+    workload = BaseBackend._encoder_workload_per_visual(runtime_config, enc_cfg)
+
+    assert workload.output_tokens_per_image == 333
+    assert workload.context_tokens_per_image == 336
+    assert workload.output_tokens_per_sequence == 333
+    assert workload.patch_tokens_per_sequence == 1332
+    assert workload.transformer_tokens_per_sequence == 1333
+    assert workload.sequences_per_image == 1
+
+
+@pytest.mark.parametrize("height,width", [(0, 336), (336, 0), (-1, 336)])
+def test_tiled_sequence_count_rejects_nonpositive_image_geometry(height, width):
+    enc_cfg = get_model_config_from_model_path(LLAMA4_CHECKPOINTS[0][0])["extra_params"].vision_config
+
+    with pytest.raises(ValueError, match="requires positive geometry"):
+        BaseBackend._tiled_encoder_sequence_count(height, width, enc_cfg)
+
+
+def test_llama4_parser_rejects_missing_processor_metadata():
+    model_id = LLAMA4_CHECKPOINTS[0][0]
+    raw_config = dict(get_model_config_from_model_path(model_id)["raw_config"])
+    raw_config.pop("image_processor_config")
+
+    with pytest.raises(TypeError, match="must preserve image_processor_config metadata"):
+        _parse_hf_config_json(raw_config)
+
+
+@pytest.mark.parametrize("model_id", LLAMA4_MODEL_IDS)
+def test_nonzero_image_workload_reaches_encoder_and_text_context(model_id):
     model = get_model(model_id, _model_config(), "trtllm")
     result = MagicMock(__float__=lambda self: 1.0, energy=2.0, source="silicon")
     for op in model.encoder_ops:
@@ -213,7 +252,7 @@ def test_nonzero_image_workload_reaches_encoder_and_text_context(model_id, _, __
 
     latency, energy, source, image_tokens = TRTLLMBackend()._run_encoder_phase(model, database, runtime, 1)
 
-    assert image_tokens == 144
+    assert image_tokens == 147
     assert sum(latency.values()) > 0
     assert sum(energy.values()) > 0
     assert source
@@ -253,3 +292,4 @@ def test_static_ttft_memory_and_energy_include_llama4_encoder():
     assert summary.get_encoder_power_avg() > 0
     assert row["encoder_memory"] > 0
     assert row["ttft"] == pytest.approx(row["encoder_latency"] + row["context_latency"])
+    assert model.context_ops[0].query.call_args.kwargs["s"] == runtime.isl + 147

--- a/tests/unit/sdk/models/test_llama4_vision.py
+++ b/tests/unit/sdk/models/test_llama4_vision.py
@@ -244,6 +244,34 @@ def test_llama4_parser_rejects_missing_processor_metadata():
         _parse_hf_config_json(raw_config)
 
 
+def test_llama4_parser_rejects_missing_vision_metadata_schema_drift():
+    model_id = LLAMA4_CHECKPOINTS[0][0]
+    raw_config = dict(get_model_config_from_model_path(model_id)["raw_config"])
+    raw_config.pop("vision_config")
+
+    with pytest.raises(TypeError, match="must preserve vision_config metadata"):
+        _parse_hf_config_json(raw_config)
+
+
+@pytest.mark.parametrize("invalid_value", [None, [], "", 0])
+def test_llama4_parser_rejects_nondict_vision_metadata(invalid_value):
+    model_id = LLAMA4_CHECKPOINTS[0][0]
+    raw_config = dict(get_model_config_from_model_path(model_id)["raw_config"])
+    raw_config["vision_config"] = invalid_value
+
+    with pytest.raises(TypeError, match="must preserve vision_config metadata"):
+        _parse_hf_config_json(raw_config)
+
+
+def test_llama4_parser_rejects_empty_vision_metadata():
+    model_id = LLAMA4_CHECKPOINTS[0][0]
+    raw_config = dict(get_model_config_from_model_path(model_id)["raw_config"])
+    raw_config["vision_config"] = {}
+
+    with pytest.raises(ValueError, match="vision_config is missing required fields"):
+        _parse_hf_config_json(raw_config)
+
+
 @pytest.mark.parametrize("model_id", LLAMA4_MODEL_IDS)
 def test_nonzero_image_workload_reaches_encoder_and_text_context(model_id):
     model = get_model(model_id, _model_config(), "trtllm")

--- a/tests/unit/sdk/models/test_llama4_vision.py
+++ b/tests/unit/sdk/models/test_llama4_vision.py
@@ -49,6 +49,9 @@ def test_checkpoint_configs_preserve_text_and_exact_vision_shapes(model_id, num_
     assert isinstance(hybrid, common.HybridMoEConfig)
     assert sum(hybrid.moe_layer_freq) == moe_layers
     assert hybrid.moe_layer_freq.count(0) == dense_layers
+    # AIC-1740 adds the vision phase without changing the established Llama 4
+    # hybrid-MoE text model (whose Rust parity goldens predate this feature).
+    assert not hybrid.use_qk_norm
 
     vision = hybrid.vision_config
     assert isinstance(vision, common.VisionEncoderConfig)

--- a/tests/unit/sdk/models/test_llama4_vision.py
+++ b/tests/unit/sdk/models/test_llama4_vision.py
@@ -1,0 +1,255 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.resources as pkg_resources
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from aiconfigurator.sdk import common, config
+from aiconfigurator.sdk.backends.base_backend import BaseBackend
+from aiconfigurator.sdk.backends.trtllm_backend import TRTLLMBackend
+from aiconfigurator.sdk.config import RuntimeConfig
+from aiconfigurator.sdk.models import HybridMoEModel, get_model
+from aiconfigurator.sdk.utils import get_model_config_from_model_path
+
+pytestmark = pytest.mark.unit
+
+LLAMA4_CHECKPOINTS = (
+    ("meta-llama/Llama-4-Scout-17B-16E-Instruct", 16, 48, 0),
+    ("meta-llama/Llama-4-Maverick-17B-128E-Instruct", 128, 24, 24),
+)
+
+
+def _model_config(**overrides):
+    values = {
+        "tp_size": 1,
+        "pp_size": 1,
+        "attention_dp_size": 1,
+        "moe_tp_size": 1,
+        "moe_ep_size": 1,
+    }
+    values.update(overrides)
+    return config.ModelConfig(**values)
+
+
+@pytest.mark.parametrize("model_id,num_experts,moe_layers,dense_layers", LLAMA4_CHECKPOINTS)
+def test_checkpoint_configs_preserve_text_and_exact_vision_shapes(model_id, num_experts, moe_layers, dense_layers):
+    info = get_model_config_from_model_path(model_id)
+
+    assert info["architecture"] == "Llama4ForConditionalGeneration"
+    assert info["layers"] == 48
+    assert info["hidden_size"] == 5120
+    assert info["num_experts"] == num_experts
+
+    hybrid = info["extra_params"]
+    assert isinstance(hybrid, common.HybridMoEConfig)
+    assert sum(hybrid.moe_layer_freq) == moe_layers
+    assert hybrid.moe_layer_freq.count(0) == dense_layers
+
+    vision = hybrid.vision_config
+    assert isinstance(vision, common.VisionEncoderConfig)
+    assert vision.depth == 34
+    assert vision.hidden_size == 1408
+    assert vision.num_heads == 16
+    assert vision.intermediate_size == 5632
+    assert vision.image_size == 336
+    assert vision.patch_size == 14
+    assert vision.spatial_merge_size == 2
+    assert vision.out_hidden_size == 5120
+    assert vision.projector_dims == ((5632, 4096), (4096, 4096), (4096, 5120))
+    assert vision.num_channels == 3
+    assert vision.has_cls_token
+    assert vision.max_num_tiles == 16
+    assert vision.add_global_tile
+
+
+@pytest.mark.parametrize("model_id,_,__,___", LLAMA4_CHECKPOINTS)
+def test_bundled_checkpoint_json_preserves_llama4_special_tokens_and_vision_metadata(model_id, _, __, ___):
+    config_path = (
+        pkg_resources.files("aiconfigurator_core") / "model_configs" / (f"{model_id.replace('/', '--')}_config.json")
+    )
+    checkpoint = json.loads(config_path.read_text())
+
+    assert checkpoint["boi_token_index"] == 200080
+    assert checkpoint["eoi_token_index"] == 200081
+    assert checkpoint["image_token_index"] == 200092
+    assert checkpoint["vision_config"] == {
+        "attention_dropout": 0.0,
+        "hidden_act": "gelu",
+        "hidden_size": 1408,
+        "image_size": 336,
+        "initializer_range": 0.02,
+        "intermediate_size": 5632,
+        "model_type": "llama4_vision_model",
+        "multi_modal_projector_bias": False,
+        "norm_eps": 1e-5,
+        "num_channels": 3,
+        "num_hidden_layers": 34,
+        "num_attention_heads": 16,
+        "patch_size": 14,
+        "pixel_shuffle_ratio": 0.5,
+        "projector_dropout": 0.0,
+        "projector_input_dim": 4096,
+        "projector_output_dim": 4096,
+        "rope_theta": 10000,
+        "torch_dtype": "bfloat16",
+        "vision_feature_layer": -1,
+        "vision_feature_select_strategy": "default",
+        "vision_output_dim": 4096,
+    }
+
+
+@pytest.mark.parametrize("model_id,_,__,___", LLAMA4_CHECKPOINTS)
+def test_both_checkpoints_build_vision_and_hybrid_text_ops(model_id, _, __, ___):
+    model = get_model(model_id, _model_config(), "trtllm")
+
+    assert isinstance(model, HybridMoEModel)
+    assert model.encoder_ops
+    assert model.context_ops
+    assert model.generation_ops
+    names = {op._name for op in model.encoder_ops}
+    assert {
+        "encoder_patch_embedding_gemm",
+        "encoder_qkv_gemm",
+        "encoder_attention",
+        "encoder_ffn1_gemm",
+        "encoder_ffn2_gemm",
+        "encoder_projector_pixel_shuffle",
+        "encoder_projector_adapter_fc0_gemm",
+        "encoder_projector_adapter_fc1_gemm",
+        "encoder_projector_adapter_ar",
+        "encoder_projector_mm_gemm",
+    } <= names
+
+
+def test_scout_encoder_operation_shapes_match_engine_modules():
+    model = get_model(LLAMA4_CHECKPOINTS[0][0], _model_config(), "trtllm")
+    by_name = {op._name: op for op in model.encoder_ops}
+
+    assert (by_name["encoder_patch_embedding_gemm"]._n, by_name["encoder_patch_embedding_gemm"]._k) == (
+        1408,
+        3 * 14 * 14,
+    )
+    assert (by_name["encoder_qkv_gemm"]._n, by_name["encoder_qkv_gemm"]._k) == (3 * 1408, 1408)
+    assert by_name["encoder_qkv_gemm"]._scale_factor == 34
+    assert by_name["encoder_attention"]._n == 16
+    assert by_name["encoder_attention"]._head_size == 88
+    assert by_name["encoder_attention"]._scale_factor == 34
+    assert (by_name["encoder_ffn1_gemm"]._n, by_name["encoder_ffn1_gemm"]._k) == (5632, 1408)
+    assert (by_name["encoder_projector_adapter_fc0_gemm"]._n, by_name["encoder_projector_adapter_fc0_gemm"]._k) == (
+        4096,
+        5632,
+    )
+    assert (by_name["encoder_projector_adapter_fc1_gemm"]._n, by_name["encoder_projector_adapter_fc1_gemm"]._k) == (
+        4096,
+        4096,
+    )
+    assert (by_name["encoder_projector_mm_gemm"]._n, by_name["encoder_projector_mm_gemm"]._k) == (5120, 4096)
+
+
+def test_llama4_encoder_tp_models_both_engine_communication_boundaries():
+    model = get_model(
+        LLAMA4_CHECKPOINTS[0][0],
+        _model_config(tp_size=8, moe_tp_size=1, moe_ep_size=8, enable_encoder_dp=False),
+        "trtllm",
+    )
+    by_name = {op._name: op for op in model.encoder_ops}
+
+    assert "encoder_patch_embedding_all_gather" in by_name
+    assert by_name["encoder_projector_adapter_ar"]._tp_size == 8
+    assert "encoder_projector_mm_all_gather" in by_name
+    assert "encoder_dp_all_gather" not in by_name
+
+
+def test_llama4_encoder_dp_models_exit_all_gather_only():
+    model = get_model(
+        LLAMA4_CHECKPOINTS[0][0],
+        _model_config(tp_size=8, moe_tp_size=1, moe_ep_size=8, enable_encoder_dp=True),
+        "trtllm",
+    )
+    names = {op._name for op in model.encoder_ops}
+
+    assert "encoder_dp_all_gather" in names
+    assert "encoder_patch_embedding_all_gather" not in names
+    assert "encoder_projector_mm_all_gather" not in names
+
+
+def test_single_tile_image_produces_nonzero_engine_and_text_tokens():
+    enc_cfg = get_model_config_from_model_path(LLAMA4_CHECKPOINTS[0][0])["extra_params"].vision_config
+    workload = BaseBackend._encoder_workload_per_visual(
+        RuntimeConfig(image_height=336, image_width=336, num_images_per_request=1),
+        enc_cfg,
+    )
+
+    assert workload.patch_tokens_per_sequence == 576
+    assert workload.transformer_tokens_per_sequence == 577
+    assert workload.output_tokens_per_sequence == 144
+    assert workload.output_tokens_per_image == 144
+    assert workload.sequences_per_image == 1
+
+
+def test_four_local_tiles_add_engine_global_tile_and_720_text_tokens():
+    enc_cfg = get_model_config_from_model_path(LLAMA4_CHECKPOINTS[0][0])["extra_params"].vision_config
+    workload = BaseBackend._encoder_workload_per_visual(
+        RuntimeConfig(image_height=672, image_width=672, num_images_per_request=1),
+        enc_cfg,
+    )
+
+    assert workload.sequences_per_image == 5
+    assert workload.output_tokens_per_image == 5 * 144
+
+
+@pytest.mark.parametrize("model_id,_,__,___", LLAMA4_CHECKPOINTS)
+def test_nonzero_image_workload_reaches_encoder_and_text_context(model_id, _, __, ___):
+    model = get_model(model_id, _model_config(), "trtllm")
+    result = MagicMock(__float__=lambda self: 1.0, energy=2.0, source="silicon")
+    for op in model.encoder_ops:
+        op.query = MagicMock(return_value=result)
+    database = SimpleNamespace(backend="trtllm", version="test", system="h200_sxm")
+    runtime = RuntimeConfig(batch_size=1, isl=256, osl=16, image_height=336, image_width=336)
+
+    latency, energy, source, image_tokens = TRTLLMBackend()._run_encoder_phase(model, database, runtime, 1)
+
+    assert image_tokens == 144
+    assert sum(latency.values()) > 0
+    assert sum(energy.values()) > 0
+    assert source
+    by_name = {op._name: op for op in model.encoder_ops}
+    assert by_name["encoder_patch_embedding_gemm"].query.call_args.kwargs["s"] == 576
+    assert by_name["encoder_attention"].query.call_args.kwargs["s"] == 577
+    assert by_name["encoder_projector_mm_gemm"].query.call_args.kwargs["s"] == 144
+
+
+def test_static_ttft_memory_and_energy_include_llama4_encoder():
+    model = get_model(LLAMA4_CHECKPOINTS[0][0], _model_config(), "trtllm")
+    result = MagicMock(__float__=lambda self: 1.0, energy=2.0, source="silicon")
+    for op in model.encoder_ops + model.context_ops + model.generation_ops:
+        op.query = MagicMock(return_value=result)
+    database = SimpleNamespace(
+        backend="trtllm",
+        version="test",
+        system="h200_sxm",
+        system_spec={
+            "gpu": {"mem_capacity": 16 * (1 << 40)},
+            "misc": {"nccl_mem": {1: 0}, "other_mem": 0},
+        },
+    )
+    runtime = RuntimeConfig(
+        batch_size=1,
+        isl=256,
+        osl=16,
+        image_height=336,
+        image_width=336,
+        engine_step_backend="python",
+    )
+
+    summary = TRTLLMBackend().run_static(model, database, runtime, mode="static")
+    row = summary.get_result_dict()
+
+    assert row["encoder_latency"] > 0
+    assert summary.get_encoder_power_avg() > 0
+    assert row["encoder_memory"] > 0
+    assert row["ttft"] == pytest.approx(row["encoder_latency"] + row["context_latency"])

--- a/tests/unit/sdk/test_utils.py
+++ b/tests/unit/sdk/test_utils.py
@@ -418,6 +418,24 @@ class TestParseHFConfig:
         config = {
             "architectures": ["Llama4ForConditionalGeneration"],
             "model_type": "llama4",
+            "image_processor_config": {
+                "add_global_tile": True,
+                "max_patches": 16,
+                "resize_to_max_canvas": False,
+            },
+            "vision_config": {
+                "hidden_size": 1408,
+                "num_hidden_layers": 34,
+                "num_attention_heads": 16,
+                "num_channels": 3,
+                "intermediate_size": 5632,
+                "image_size": 336,
+                "patch_size": 14,
+                "pixel_shuffle_ratio": 0.5,
+                "projector_input_dim": 4096,
+                "projector_output_dim": 4096,
+                "vision_output_dim": 4096,
+            },
             "text_config": {
                 "num_hidden_layers": 48,
                 "hidden_size": 5120,
@@ -444,6 +462,8 @@ class TestParseHFConfig:
         assert sum(cfg.moe_layer_freq) == 24  # 24 MoE layers
         assert cfg.moe_layer_freq.count(0) == 24  # 24 dense layers
         assert cfg.dense_inter_size == 16384
+        assert cfg.vision_config is not None
+        assert cfg.vision_config.image_size == 336
 
     def test_parse_mimov2flash_config(self):
         """Test MiMo-V2-Flash (explicit per-layer patterns, different SWA/global dims) → HybridMoEConfig."""

--- a/tests/unit/sdk/test_utils.py
+++ b/tests/unit/sdk/test_utils.py
@@ -358,6 +358,24 @@ class TestParseHFConfig:
         config = {
             "architectures": ["Llama4ForConditionalGeneration"],
             "model_type": "llama4",
+            "image_processor_config": {
+                "add_global_tile": True,
+                "max_patches": 16,
+                "resize_to_max_canvas": False,
+            },
+            "vision_config": {
+                "hidden_size": 1408,
+                "num_hidden_layers": 34,
+                "num_attention_heads": 16,
+                "num_channels": 3,
+                "intermediate_size": 5632,
+                "image_size": 336,
+                "patch_size": 14,
+                "pixel_shuffle_ratio": 0.5,
+                "projector_input_dim": 4096,
+                "projector_output_dim": 4096,
+                "vision_output_dim": 4096,
+            },
             "text_config": {
                 "num_hidden_layers": 48,
                 "hidden_size": 5120,
@@ -389,6 +407,8 @@ class TestParseHFConfig:
         assert cfg.attn_layer_pattern == tuple(i % 2 for i in range(48))
         assert cfg.sliding_window_size == 8192
         assert cfg.dense_inter_size == 16384
+        assert cfg.vision_config is not None
+        assert cfg.vision_config.image_size == 336
         # Llama 4 uses same dims for all layers → all four dim fields are 0
         assert cfg.swa_num_kv_heads == 0
         assert cfg.swa_head_dim == 0

--- a/tests/unit/support_matrix/test_multimodal_workload.py
+++ b/tests/unit/support_matrix/test_multimodal_workload.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pandas as pd
+import pytest
+
+from tools.support_matrix.support_matrix import (
+    SupportMatrix,
+    TestConstraints,
+    _get_support_matrix_image_size,
+    _require_nonzero_encoder_result,
+    _support_matrix_row_command,
+)
+
+pytestmark = pytest.mark.unit
+
+SCOUT = "meta-llama/Llama-4-Scout-17B-16E-Instruct"
+MAVERICK = "meta-llama/Llama-4-Maverick-17B-128E-Instruct"
+CONSTRAINTS = TestConstraints(total_gpus=32, isl=256, osl=256, prefix=128, ttft=2000.0, tpot=50.0)
+
+
+@pytest.mark.parametrize("model_id", [SCOUT, MAVERICK])
+def test_llama4_matrix_uses_checkpoint_image_size(model_id):
+    assert _get_support_matrix_image_size(model_id) == 336
+
+
+def test_llama4_matrix_guard_does_not_change_qwen3vl_workloads():
+    assert _get_support_matrix_image_size("Qwen/Qwen3-VL-32B-Instruct") == 0
+
+
+@pytest.mark.parametrize("mode", ["agg", "disagg"])
+@pytest.mark.parametrize("model_id", [SCOUT, MAVERICK])
+def test_llama4_matrix_tasks_enable_nonzero_image_work(mode, model_id):
+    task = SupportMatrix._create_task(
+        mode=mode,
+        model=model_id,
+        system="h200_sxm",
+        backend="trtllm",
+        version="1.3.0rc20",
+        constraints=CONSTRAINTS,
+        engine_step_backend=None,
+    )
+
+    assert task.image_height == 336
+    assert task.image_width == 336
+    assert task.num_images_per_request == 1
+
+
+def test_llama4_replay_command_cannot_skip_encoder():
+    command = _support_matrix_row_command(
+        model=SCOUT,
+        system="h200_sxm",
+        backend="trtllm",
+        version="1.3.0rc20",
+        mode="agg",
+        constraints=CONSTRAINTS,
+    )
+
+    assert "--image-height 336" in command
+    assert "--image-width 336" in command
+    assert "--num-images 1" in command
+
+
+@pytest.mark.parametrize("model_id", [SCOUT, MAVERICK])
+def test_matrix_rejects_skipped_llama4_encoder(model_id):
+    with pytest.raises(RuntimeError, match="produced no nonzero encoder work"):
+        _require_nonzero_encoder_result(model_id, pd.DataFrame({"encoder_latency": [0.0]}))
+
+
+@pytest.mark.parametrize("model_id", [SCOUT, MAVERICK])
+def test_matrix_accepts_nonzero_llama4_encoder(model_id):
+    _require_nonzero_encoder_result(model_id, pd.DataFrame({"encoder_latency": [1.0]}))

--- a/tests/unit/support_matrix/test_multimodal_workload.py
+++ b/tests/unit/support_matrix/test_multimodal_workload.py
@@ -4,6 +4,8 @@
 import pandas as pd
 import pytest
 
+from aiconfigurator.sdk.utils import HuggingFaceDownloadError
+from tools.support_matrix import support_matrix
 from tools.support_matrix.support_matrix import (
     SupportMatrix,
     TestConstraints,
@@ -70,3 +72,51 @@ def test_matrix_rejects_skipped_llama4_encoder(model_id):
 @pytest.mark.parametrize("model_id", [SCOUT, MAVERICK])
 def test_matrix_accepts_nonzero_llama4_encoder(model_id):
     _require_nonzero_encoder_result(model_id, pd.DataFrame({"encoder_latency": [1.0]}))
+
+
+@pytest.mark.parametrize("model_id", [SCOUT, MAVERICK])
+def test_matrix_rejects_missing_encoder_latency_column(model_id):
+    with pytest.raises(RuntimeError, match="produced no nonzero encoder work"):
+        _require_nonzero_encoder_result(model_id, pd.DataFrame({"ttft": [1.0]}))
+
+
+def test_live_matrix_paths_surface_metadata_failures_but_explicit_legacy_rendering_remains_tolerant(monkeypatch):
+    def _boom(_model_path):
+        raise HuggingFaceDownloadError("offline")
+
+    monkeypatch.setattr(support_matrix, "_get_model_info", _boom)
+
+    with pytest.raises(HuggingFaceDownloadError, match="offline"):
+        _require_nonzero_encoder_result(SCOUT, pd.DataFrame({"encoder_latency": [0.0]}))
+
+    with pytest.raises(HuggingFaceDownloadError, match="offline"):
+        SupportMatrix._create_task(
+            mode="agg",
+            model=SCOUT,
+            system="h200_sxm",
+            backend="trtllm",
+            version="1.3.0rc20",
+            constraints=CONSTRAINTS,
+            engine_step_backend=None,
+        )
+
+    with pytest.raises(HuggingFaceDownloadError, match="offline"):
+        _support_matrix_row_command(
+            model=SCOUT,
+            system="h200_sxm",
+            backend="trtllm",
+            version="1.3.0rc20",
+            mode="agg",
+            constraints=CONSTRAINTS,
+        )
+
+    command = _support_matrix_row_command(
+        model="arbitrary/legacy-model",
+        system="h200_sxm",
+        backend="trtllm",
+        version="1.3.0rc20",
+        mode="agg",
+        constraints=CONSTRAINTS,
+        image_size=0,
+    )
+    assert "--image-height" not in command

--- a/tools/support_matrix/support_matrix.py
+++ b/tools/support_matrix/support_matrix.py
@@ -33,7 +33,6 @@ from aiconfigurator.sdk.models import _get_model_info
 from aiconfigurator.sdk.models.helpers import _apply_model_quant_defaults
 from aiconfigurator.sdk.operations.util_empirical import PROVENANCE_ORDER, capture_provenance, worst_provenance
 from aiconfigurator.sdk.task_v2 import Task
-from aiconfigurator.sdk.utils import HuggingFaceDownloadError
 
 logger = logging.getLogger(__name__)
 
@@ -205,14 +204,8 @@ _DEFAULT_TIER = _LARGE  # > 100B params
 
 
 def _get_support_matrix_llama4_encoder_config(model_path: str) -> common.VisionEncoderConfig | None:
-    """Return the Llama 4 encoder config used by this issue's matrix guard."""
-    try:
-        model_info = _get_model_info(model_path)
-    except HuggingFaceDownloadError:
-        # Legacy result rows can name an arbitrary model and only need a replay
-        # command rendered. Preserve that offline behavior; real matrix runs
-        # resolve their model before reaching this helper.
-        return None
+    """Return the Llama 4 encoder config, propagating metadata failures."""
+    model_info = _get_model_info(model_path)
     if model_info.get("architecture") != "Llama4ForConditionalGeneration":
         return None
     extra_params = model_info.get("extra_params")
@@ -222,7 +215,7 @@ def _get_support_matrix_llama4_encoder_config(model_path: str) -> common.VisionE
 
 
 def _get_support_matrix_image_size(model_path: str) -> int:
-    """Pick the checkpoint-fixed Llama 4 image workload for automatic checks."""
+    """Pick the checkpoint-fixed Llama 4 image workload for live checks."""
     enc_cfg = _get_support_matrix_llama4_encoder_config(model_path)
     if enc_cfg is None:
         return 0

--- a/tools/support_matrix/support_matrix.py
+++ b/tools/support_matrix/support_matrix.py
@@ -33,6 +33,7 @@ from aiconfigurator.sdk.models import _get_model_info
 from aiconfigurator.sdk.models.helpers import _apply_model_quant_defaults
 from aiconfigurator.sdk.operations.util_empirical import PROVENANCE_ORDER, capture_provenance, worst_provenance
 from aiconfigurator.sdk.task_v2 import Task
+from aiconfigurator.sdk.utils import HuggingFaceDownloadError
 
 logger = logging.getLogger(__name__)
 
@@ -133,6 +134,7 @@ def _support_matrix_row_command(
     engine_step_comparison_atol: float = DEFAULT_ENGINE_STEP_COMPARISON_ATOL,
     engine_step_frontier_rtol: float = DEFAULT_ENGINE_STEP_FRONTIER_RTOL,
     engine_step_frontier_atol: float = DEFAULT_ENGINE_STEP_FRONTIER_ATOL,
+    image_size: int | None = None,
 ) -> str:
     """Return the repo-local CLI command that checks this model/system/backend path."""
     if constraints is None:
@@ -169,6 +171,10 @@ def _support_matrix_row_command(
         "1",
         "--no-color",
     ]
+    if image_size is None:
+        image_size = _get_support_matrix_image_size(model)
+    if image_size > 0:
+        parts.extend(["--image-height", str(image_size), "--image-width", str(image_size), "--num-images", "1"])
     if transfer_policy:
         parts.extend(["--transfer-policy", transfer_policy])
     if compare_engine_step_backends:
@@ -196,6 +202,41 @@ _SIZE_TIERS: list[tuple[float, TestConstraints]] = [
     (100e9, _MEDIUM),  # 10B - 100B params
 ]
 _DEFAULT_TIER = _LARGE  # > 100B params
+
+
+def _get_support_matrix_llama4_encoder_config(model_path: str) -> common.VisionEncoderConfig | None:
+    """Return the Llama 4 encoder config used by this issue's matrix guard."""
+    try:
+        model_info = _get_model_info(model_path)
+    except HuggingFaceDownloadError:
+        # Legacy result rows can name an arbitrary model and only need a replay
+        # command rendered. Preserve that offline behavior; real matrix runs
+        # resolve their model before reaching this helper.
+        return None
+    if model_info.get("architecture") != "Llama4ForConditionalGeneration":
+        return None
+    extra_params = model_info.get("extra_params")
+    if isinstance(extra_params, common.HybridMoEConfig):
+        return extra_params.vision_config
+    return None
+
+
+def _get_support_matrix_image_size(model_path: str) -> int:
+    """Pick the checkpoint-fixed Llama 4 image workload for automatic checks."""
+    enc_cfg = _get_support_matrix_llama4_encoder_config(model_path)
+    if enc_cfg is None:
+        return 0
+    return enc_cfg.image_size
+
+
+def _require_nonzero_encoder_result(model_path: str, pareto_df: pd.DataFrame) -> None:
+    """Reject a nominal matrix PASS that silently skipped a declared encoder."""
+    if _get_support_matrix_llama4_encoder_config(model_path) is None:
+        return
+    if "encoder_latency" not in pareto_df.columns or not (pareto_df["encoder_latency"] > 0).any():
+        raise RuntimeError(
+            f"{model_path} declares a vision encoder but the support-matrix run produced no nonzero encoder work"
+        )
 
 
 def _get_test_constraints(model_path: str) -> TestConstraints:
@@ -766,6 +807,13 @@ class SupportMatrix:
             # (e.g. AIC_SM_TRANSFERS="off" or "xshape,xquant"). None -> all kinds on.
             "transfer_policy": os.environ.get("AIC_SM_TRANSFERS") or None,
         }
+        image_size = _get_support_matrix_image_size(model)
+        if image_size > 0:
+            common_kwargs.update(
+                image_height=image_size,
+                image_width=image_size,
+                num_images_per_request=1,
+            )
         if mode == "disagg":
             # v2 disagg forbids shared top-level worker fields; fan out to both roles.
             return Task(
@@ -935,6 +983,7 @@ class SupportMatrix:
                 # pareto_frontier_df is non-empty iff pareto_df is, so we only check pareto_df.
                 if python_pareto_df is None or python_pareto_df.empty:
                     raise RuntimeError("Configuration returned no results, failed to catch traceback")
+                _require_nonzero_encoder_result(model, python_pareto_df)
 
                 if compare_engine_step_backends:
                     with _rust_core_autobuild_enabled():
@@ -950,6 +999,7 @@ class SupportMatrix:
                         )
                     if rust_pareto_df is None or rust_pareto_df.empty:
                         raise RuntimeError("Rust engine-step backend returned no results")
+                    _require_nonzero_encoder_result(model, rust_pareto_df)
                     mismatch = _compare_pareto_dfs(
                         python_pareto_df,
                         rust_pareto_df,
@@ -1373,6 +1423,9 @@ class SupportMatrix:
                     version=version,
                     mode=mode,
                     constraints=_DEFAULT_TIER,
+                    # Arbitrary legacy rows do not retain image workload
+                    # metadata and must remain renderable without model I/O.
+                    image_size=0,
                     compare_engine_step_backends=getattr(self, "compare_engine_step_backends", False),
                     engine_step_comparison_rtol=getattr(
                         self, "engine_step_comparison_rtol", DEFAULT_ENGINE_STEP_COMPARISON_RTOL


### PR DESCRIPTION
#### Overview:

Enable end-to-end vision-encoder modeling for:

- `meta-llama/Llama-4-Scout-17B-16E-Instruct`
- `meta-llama/Llama-4-Maverick-17B-128E-Instruct`

The bundled checkpoint configs previously retained only `text_config`. This restores checkpoint-specific Llama 4 vision and processor metadata and wires the multimodal path into the existing hybrid-MoE text backbone.

#### Details:

- preserve authoritative Scout/Maverick vision, image-processor, and multimodal token metadata
- model patch embedding, CLS token, ViT layers, pixel shuffle, adaptor/projector, and TP communication
- propagate projected image embeddings plus Llama 4 prompt-layout tokens into the text prefill path
- include vision latency, memory, and energy in TTFT estimates
- preserve arbitrary token-only SDK workload overrides while using exact tiling for image-dimension workloads
- fail closed when Llama 4 vision or processor metadata is absent or malformed
- fail closed when a live support-matrix run cannot resolve declared Llama 4 vision metadata
- use a nonzero image workload for both Llama 4 checkpoints in support-matrix generation
- add shared architecture tests plus checkpoint-specific shape/config assertions
- preserve the established text-only hybrid-MoE and Rust/Python parity behavior

This is architecture/formula validation only. No silicon-accuracy claim is made without measured Llama 4 vision profiling.

#### Where should the reviewer start?

- `aic-core/src/aiconfigurator_core/sdk/models/vit_ops.py`
- `aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py`
- `aic-core/src/aiconfigurator_core/sdk/utils.py`
- `tests/unit/sdk/models/test_llama4_vision.py`

#### Review closeout:

Codex and CodeRabbit submitted five actionable inline findings. All five were fixed with test-backed replies and all five review threads are resolved. Follow-up validation also caught and fixed an incidental Llama 4 text-parity change plus two stale text-only parser fixtures.

#### Validation:

- `.venv/bin/pytest -m unit -p no:timeout --ignore=tests/unit/sdk/database/test_moe_dispatch.py --ignore=tests/unit/cli/test_plain_output.py --maxfail=1 -q`
  - 3303 passed, 10 skipped, 749 deselected
- focused Llama 4, support-matrix, sweep, and encoder/backend regression suite
  - 161 passed
- affected Scout Rust/Python parity cases (static, mixed, disaggregated, and disaggregated tie-break)
  - 4 passed
- complete parser utility plus Llama 4 architecture tests
  - 114 passed
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
  - 543 files already formatted
- `git diff --check`

#### Related Issues:

- Relates to [AIC-1740](https://linear.app/nvidia/issue/AIC-1740/llama-4-enable-vision-encoder-modeling-for-scout-and-maverick)
