### PR TITLE
fix(sdk): gpt-oss hybrid-SWA KV memory + decode-share MTP activation scaling (AIC-1743 wave 1)

### DIFF
--- a/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
+++ b/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
@@ -200,14 +200,18 @@ class BaseBackend:
     def _runtime_config_for_agg_candidate(runtime_config: RuntimeConfig, batch_size: int) -> RuntimeConfig:
         return dataclasses.replace(runtime_config, batch_size=batch_size)
 
-    def _memory_usage_kwargs_for_agg(self, num_tokens: int, agg_extra: dict) -> dict:
+    def _memory_usage_kwargs_for_agg(
+        self, num_tokens: int, agg_extra: dict, mtp_scaled_tokens: int | None = None
+    ) -> dict:
         """Kwargs for the ``_get_memory_usage`` call from ``run_agg``.
 
-        Default: pass the locally-computed ``num_tokens``. TRT-LLM passes
-        ``max_num_tokens`` (BuildConfig.max_num_tokens) for activation sizing
-        and forwards ``max_seq_len`` for KV cache sizing.
+        Default: pass the locally-computed ``num_tokens`` plus the decode-token
+        share for MTP activation scaling. TRT-LLM passes ``max_num_tokens``
+        (BuildConfig.max_num_tokens) for activation sizing and forwards
+        ``max_seq_len`` for KV cache sizing; that budget already includes draft
+        tokens, so it does not forward ``mtp_scaled_tokens``.
         """
-        return {"num_tokens": num_tokens}
+        return {"num_tokens": num_tokens, "mtp_scaled_tokens": mtp_scaled_tokens}
 
     def _oom_check_kwargs(self, agg_extra: dict) -> dict:
         """Extra kwargs for ``InferenceSummary.set_memory_and_check_oom``.
@@ -1771,8 +1775,13 @@ class BaseBackend:
             # will not be corrected by balance score when it's larger than 1.0
             # in order to indicate what's happening
             num_tokens = num_gen_requests + ctx_tokens
+            # Only the decode requests' tokens verify nextn+1 under speculative
+            # decoding; the context share is processed once (see the MTP
+            # correction in _get_memory_usage).
+            mtp_scaled_tokens = int(num_gen_requests)
         else:
             num_tokens = ctx_tokens
+            mtp_scaled_tokens = None
 
         memory = self._get_memory_usage(
             model,
@@ -1783,7 +1792,11 @@ class BaseBackend:
             osl,
             prefix=prefix,
             encoder_memory=encoder_memory,
-            **self._memory_usage_kwargs_for_agg(num_tokens=num_tokens, agg_extra=agg_extra),
+            **self._memory_usage_kwargs_for_agg(
+                num_tokens=num_tokens,
+                agg_extra=agg_extra,
+                mtp_scaled_tokens=mtp_scaled_tokens,
+            ),
         )
         tp = model.config.tp_size
         pp = model.config.pp_size
@@ -2038,6 +2051,7 @@ class BaseBackend:
         max_seq_len: int | None = None,
         encoder_memory: dict[str, float] | None = None,
         mtp_activation_scaling: bool = True,
+        mtp_scaled_tokens: int | None = None,
     ) -> dict[str, float]:
         """
         Get the memory usage of the backend.
@@ -2096,7 +2110,22 @@ class BaseBackend:
         # (draft tokens included) -- re-multiplying there double-counts and can drive the
         # prefill worker's KV budget negative.
         if mtp_activation_scaling and model.config.nextn > 0:
-            activations = activations * (model.config.nextn + 1)
+            if mtp_scaled_tokens is not None and num_tokens > 0:
+                # Mixed context+decode step (agg): only the decode-token share
+                # verifies nextn+1 tokens; context tokens are processed once.
+                # Scaling the whole footprint models (nextn+1)*(context+decode)
+                # instead of context+(nextn+1)*decode, which at long ISL
+                # inflates activations ~(nextn+1)x and over-prunes concurrency.
+                decode_share = min(max(mtp_scaled_tokens, 0), num_tokens)
+                activations = (
+                    activations
+                    * (num_tokens - decode_share + decode_share * (model.config.nextn + 1))
+                    / num_tokens
+                )
+            else:
+                # Decode-only steps (disagg decode worker): every token in the
+                # step is part of verification, so the full multiplier applies.
+                activations = activations * (model.config.nextn + 1)
 
         # Backend-level activation overhead (SGLang only by default).
         if self.ACTIVATION_OVERHEAD_FRAC > 0:

--- a/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
+++ b/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
@@ -795,6 +795,11 @@ class BaseBackend:
                 prefix=prefix,
             )
         else:
+            # "static": activations default to the context token count
+            # ((isl - prefix) * batch_size), i.e. the prefill peak -- the decode
+            # steps of a static batch only ever process
+            # batch_size * beam_width * (nextn + 1) tokens, far fewer. So this
+            # footprint has no decode share either (mtp_scaled_tokens=0).
             memory = self._get_memory_usage(
                 model,
                 database,
@@ -804,6 +809,7 @@ class BaseBackend:
                 osl,
                 prefix=prefix,
                 encoder_memory=encoder_memory,
+                mtp_scaled_tokens=0,
             )
 
         # Calculate total latencies and energies (simple sums - decoupled!)
@@ -1022,13 +1028,22 @@ class BaseBackend:
         AFD uses the same backend activation/KV/NCCL/other memory model as
         agg/disagg, then substitutes the weights that actually live on the
         A- or F-worker pool.
+
+        ``num_tokens=0`` (AFD's ``phase == "prefill"`` callers) makes
+        ``_get_memory_usage`` derive the count from ``(isl - prefix) * batch_size``
+        -- a prefill-only footprint, so it carries no decode share that verifies
+        nextn+1 draft tokens. Decode callers pass ``num_tokens > 0`` (one token
+        per request) and keep the full ``(nextn+1)`` multiplier.
         """
         kwargs = {
             "num_tokens": num_tokens,
             "prefix": prefix,
         }
-        if "max_seq_len" in inspect.signature(self._get_memory_usage).parameters:
+        memory_usage_params = inspect.signature(self._get_memory_usage).parameters
+        if "max_seq_len" in memory_usage_params:
             kwargs["max_seq_len"] = max_seq_len
+        if num_tokens == 0 and "mtp_scaled_tokens" in memory_usage_params:
+            kwargs["mtp_scaled_tokens"] = 0
 
         memory = self._get_memory_usage(
             model,

--- a/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
+++ b/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
@@ -768,6 +768,8 @@ class BaseBackend:
         )
 
         if mode == "static_ctx":
+            # Prefill-only step: no decode tokens, so no share of the activation
+            # footprint verifies nextn+1 draft tokens (mtp_scaled_tokens=0).
             memory = self._get_memory_usage(
                 model,
                 database,
@@ -777,6 +779,7 @@ class BaseBackend:
                 1,
                 prefix=prefix,
                 encoder_memory=encoder_memory,
+                mtp_scaled_tokens=0,
             )
         elif mode == "static_gen":
             memory = self._get_memory_usage(
@@ -1780,8 +1783,9 @@ class BaseBackend:
             # correction in _get_memory_usage).
             mtp_scaled_tokens = int(num_gen_requests)
         else:
+            # b == 1: context-only step, no decode share to scale.
             num_tokens = ctx_tokens
-            mtp_scaled_tokens = None
+            mtp_scaled_tokens = 0
 
         memory = self._get_memory_usage(
             model,

--- a/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
+++ b/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
@@ -2139,9 +2139,7 @@ class BaseBackend:
                 # inflates activations ~(nextn+1)x and over-prunes concurrency.
                 decode_share = min(max(mtp_scaled_tokens, 0), num_tokens)
                 activations = (
-                    activations
-                    * (num_tokens - decode_share + decode_share * (model.config.nextn + 1))
-                    / num_tokens
+                    activations * (num_tokens - decode_share + decode_share * (model.config.nextn + 1)) / num_tokens
                 )
             else:
                 # Decode-only steps (disagg decode worker): every token in the

--- a/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
+++ b/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
@@ -208,8 +208,10 @@ class BaseBackend:
         Default: pass the locally-computed ``num_tokens`` plus the decode-token
         share for MTP activation scaling. TRT-LLM passes ``max_num_tokens``
         (BuildConfig.max_num_tokens) for activation sizing and forwards
-        ``max_seq_len`` for KV cache sizing; that budget already includes draft
-        tokens, so it does not forward ``mtp_scaled_tokens``.
+        ``max_seq_len`` for KV cache sizing; it does not forward
+        ``mtp_scaled_tokens``, which RETAINS the legacy full ``(nextn+1)``
+        multiplier on that path pending its own analysis (see the comment in
+        ``TRTLLMBackend._memory_usage_kwargs_for_agg``).
         """
         return {"num_tokens": num_tokens, "mtp_scaled_tokens": mtp_scaled_tokens}
 

--- a/aic-core/src/aiconfigurator_core/sdk/backends/trtllm_backend.py
+++ b/aic-core/src/aiconfigurator_core/sdk/backends/trtllm_backend.py
@@ -124,9 +124,13 @@ class TRTLLMBackend(BaseBackend):
             agg_extra["free_gpu_memory_fraction"],
         )
 
-    def _memory_usage_kwargs_for_agg(self, num_tokens: int, agg_extra: dict) -> dict:
+    def _memory_usage_kwargs_for_agg(
+        self, num_tokens: int, agg_extra: dict, mtp_scaled_tokens: int | None = None
+    ) -> dict:
         # Activation memory tracks BuildConfig.max_num_tokens, not the agg-derived
-        # num_tokens. KV cache tracks max_seq_len per slot.
+        # num_tokens. KV cache tracks max_seq_len per slot. max_num_tokens is the
+        # engine's per-iteration budget (draft tokens included), so the decode-share
+        # MTP scaling does not apply; mtp_scaled_tokens is intentionally dropped.
         return {
             "num_tokens": agg_extra["max_num_tokens"],
             "max_seq_len": agg_extra["max_seq_len"],

--- a/aic-core/src/aiconfigurator_core/sdk/backends/trtllm_backend.py
+++ b/aic-core/src/aiconfigurator_core/sdk/backends/trtllm_backend.py
@@ -134,6 +134,7 @@ class TRTLLMBackend(BaseBackend):
         # whether the decode-share correction applies to a budget-based footprint
         # needs its own analysis (compare the AIC-1110 suppression on the
         # KV-capacity path, which treats the budget as already draft-inclusive).
+        # Tracked in AIC-1755.
         return {
             "num_tokens": agg_extra["max_num_tokens"],
             "max_seq_len": agg_extra["max_seq_len"],

--- a/aic-core/src/aiconfigurator_core/sdk/backends/trtllm_backend.py
+++ b/aic-core/src/aiconfigurator_core/sdk/backends/trtllm_backend.py
@@ -128,9 +128,12 @@ class TRTLLMBackend(BaseBackend):
         self, num_tokens: int, agg_extra: dict, mtp_scaled_tokens: int | None = None
     ) -> dict:
         # Activation memory tracks BuildConfig.max_num_tokens, not the agg-derived
-        # num_tokens. KV cache tracks max_seq_len per slot. max_num_tokens is the
-        # engine's per-iteration budget (draft tokens included), so the decode-share
-        # MTP scaling does not apply; mtp_scaled_tokens is intentionally dropped.
+        # num_tokens. KV cache tracks max_seq_len per slot. mtp_scaled_tokens is
+        # intentionally dropped (None), which RETAINS the legacy full (nextn+1)
+        # multiplier on this path: max_num_tokens is a per-iteration budget, and
+        # whether the decode-share correction applies to a budget-based footprint
+        # needs its own analysis (compare the AIC-1110 suppression on the
+        # KV-capacity path, which treats the budget as already draft-inclusive).
         return {
             "num_tokens": agg_extra["max_num_tokens"],
             "max_seq_len": agg_extra["max_seq_len"],

--- a/aic-core/src/aiconfigurator_core/sdk/models/moe.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/moe.py
@@ -58,6 +58,39 @@ class MOEModel(BaseModel):
             return SGLangEPMOEModel(*moe_args, *base_args, extra_params)
         return cls(*moe_args, *base_args, extra_params)
 
+    # gpt-oss alternates banded (window 128) and global attention, half the
+    # layers each. The timing path already models this (see the
+    # GptOssForCausalLM branch below: attn_scale_factor = 2, window_size = 128);
+    # these constants keep the memory path consistent with it.
+    _GPTOSS_WINDOW_SIZE = 128
+    _GPTOSS_ATTN_SCALE_FACTOR = 2
+
+    def get_kvcache_bytes_per_sequence(self, seq_len: int) -> float:
+        """KV cache bytes for one sequence on one GPU.
+
+        gpt-oss SWA layers cap at the 128-token window while global layers grow
+        with ``seq_len`` — mirroring the hybrid split the timing ops already
+        use. Without this, gpt-oss is billed full context on every layer
+        (~2x at long ISL), which false-OOMs configs that fit on real GPUs.
+        Non-gpt-oss MoE models keep the linear base behavior.
+        """
+        if self.architecture != "GptOssForCausalLM":
+            return super().get_kvcache_bytes_per_sequence(seq_len)
+        seq_len = max(0, seq_len)
+        bytes_per_elem = self.config.kvcache_quant_mode.value.memory
+        num_kv_heads_per_gpu = (self._num_kv_heads + self.config.tp_size - 1) // self.config.tp_size
+        per_layer_per_token = num_kv_heads_per_gpu * self._head_size * 2 * bytes_per_elem
+        num_swa = self._num_layers // self._GPTOSS_ATTN_SCALE_FACTOR
+        num_global = self._num_layers - num_swa
+        swa_seq = min(seq_len, self._GPTOSS_WINDOW_SIZE)
+        return float(per_layer_per_token * (num_swa * swa_seq + num_global * seq_len))
+
+    def get_kvcache_max_tokens(self, kv_budget_bytes: float) -> int:
+        """Capacity inverse over the window-capped KV curve (non-linear past the window)."""
+        if self.architecture != "GptOssForCausalLM":
+            return super().get_kvcache_max_tokens(kv_budget_bytes)
+        return self._binary_search_kvcache_max_tokens(kv_budget_bytes)
+
     def __init__(self, topk: int, num_experts: int, moe_inter_size: int, *args) -> None:
         super().__init__(*args)
 

--- a/aic-core/src/aiconfigurator_core/sdk/models/moe.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/moe.py
@@ -14,6 +14,31 @@ from aiconfigurator_core.sdk.utils import _load_model_config_from_model_path
 logger = logging.getLogger(__name__)
 
 
+# gpt-oss alternates banded (window 128) and global attention, half the layers
+# each. The timing paths already model this (see the GptOssForCausalLM branches
+# in MOEModel and SGLangEPMOEModel: attn_scale_factor = 2, window_size = 128);
+# these constants and helpers keep the memory path consistent with them.
+_GPTOSS_WINDOW_SIZE = 128
+_GPTOSS_ATTN_SCALE_FACTOR = 2
+
+
+def _gptoss_hybrid_kv_bytes_per_sequence(model: BaseModel, seq_len: int) -> float:
+    """Hybrid SWA/global KV bytes for one gpt-oss sequence on one GPU.
+
+    SWA layers cap at the 128-token window while global layers grow with
+    ``seq_len``. Without this, gpt-oss is billed full context on every layer
+    (~2x at long ISL), which false-OOMs configs that fit on real GPUs.
+    """
+    seq_len = max(0, seq_len)
+    bytes_per_elem = model.config.kvcache_quant_mode.value.memory
+    num_kv_heads_per_gpu = (model._num_kv_heads + model.config.tp_size - 1) // model.config.tp_size
+    per_layer_per_token = num_kv_heads_per_gpu * model._head_size * 2 * bytes_per_elem
+    num_swa = model._num_layers // _GPTOSS_ATTN_SCALE_FACTOR
+    num_global = model._num_layers - num_swa
+    swa_seq = min(seq_len, _GPTOSS_WINDOW_SIZE)
+    return float(per_layer_per_token * (num_swa * swa_seq + num_global * seq_len))
+
+
 @register_model("MOE")
 class MOEModel(BaseModel):
     """
@@ -58,32 +83,11 @@ class MOEModel(BaseModel):
             return SGLangEPMOEModel(*moe_args, *base_args, extra_params)
         return cls(*moe_args, *base_args, extra_params)
 
-    # gpt-oss alternates banded (window 128) and global attention, half the
-    # layers each. The timing path already models this (see the
-    # GptOssForCausalLM branch below: attn_scale_factor = 2, window_size = 128);
-    # these constants keep the memory path consistent with it.
-    _GPTOSS_WINDOW_SIZE = 128
-    _GPTOSS_ATTN_SCALE_FACTOR = 2
-
     def get_kvcache_bytes_per_sequence(self, seq_len: int) -> float:
-        """KV cache bytes for one sequence on one GPU.
-
-        gpt-oss SWA layers cap at the 128-token window while global layers grow
-        with ``seq_len`` — mirroring the hybrid split the timing ops already
-        use. Without this, gpt-oss is billed full context on every layer
-        (~2x at long ISL), which false-OOMs configs that fit on real GPUs.
-        Non-gpt-oss MoE models keep the linear base behavior.
-        """
+        """KV cache bytes for one sequence on one GPU (gpt-oss: hybrid SWA layout)."""
         if self.architecture != "GptOssForCausalLM":
             return super().get_kvcache_bytes_per_sequence(seq_len)
-        seq_len = max(0, seq_len)
-        bytes_per_elem = self.config.kvcache_quant_mode.value.memory
-        num_kv_heads_per_gpu = (self._num_kv_heads + self.config.tp_size - 1) // self.config.tp_size
-        per_layer_per_token = num_kv_heads_per_gpu * self._head_size * 2 * bytes_per_elem
-        num_swa = self._num_layers // self._GPTOSS_ATTN_SCALE_FACTOR
-        num_global = self._num_layers - num_swa
-        swa_seq = min(seq_len, self._GPTOSS_WINDOW_SIZE)
-        return float(per_layer_per_token * (num_swa * swa_seq + num_global * seq_len))
+        return _gptoss_hybrid_kv_bytes_per_sequence(self, seq_len)
 
     def get_kvcache_max_tokens(self, kv_budget_bytes: float) -> int:
         """Capacity inverse over the window-capped KV curve (non-linear past the window)."""
@@ -418,6 +422,23 @@ class SGLangEPMOEModel(BaseModel):
     Models fused all-to-all dispatch+compute with no post-dispatch ops.
     Uses wideep/deepep perf tables for MoE kernel latency.
     """
+
+    def get_kvcache_bytes_per_sequence(self, seq_len: int) -> float:
+        """KV cache bytes for one sequence on one GPU (gpt-oss: hybrid SWA layout).
+
+        SGLangEPMOEModel subclasses BaseModel directly, so it does not inherit
+        MOEModel's override; without this, gpt-oss served through the DeepEP
+        path keeps the ~2x linear KV overcharge its own timing branch avoids.
+        """
+        if self.architecture != "GptOssForCausalLM":
+            return super().get_kvcache_bytes_per_sequence(seq_len)
+        return _gptoss_hybrid_kv_bytes_per_sequence(self, seq_len)
+
+    def get_kvcache_max_tokens(self, kv_budget_bytes: float) -> int:
+        """Capacity inverse over the window-capped KV curve (non-linear past the window)."""
+        if self.architecture != "GptOssForCausalLM":
+            return super().get_kvcache_max_tokens(kv_budget_bytes)
+        return self._binary_search_kvcache_max_tokens(kv_budget_bytes)
 
     @classmethod
     def supports_cp(cls, backend_name: str) -> bool:

--- a/tests/unit/models/test_gptoss_swa_kv_memory.py
+++ b/tests/unit/models/test_gptoss_swa_kv_memory.py
@@ -68,3 +68,17 @@ def test_gptoss_kv_max_tokens_inverts_the_piecewise_curve():
     budget = model.get_kvcache_bytes_per_sequence(seq_len)
     max_tokens = model.get_kvcache_max_tokens(budget)
     assert abs(max_tokens - seq_len) <= 1
+
+
+def test_gptoss_deepep_path_also_gets_hybrid_layout():
+    """SGLangEPMOEModel subclasses BaseModel directly and must not regress to linear KV."""
+    model_config = sdk_config.ModelConfig(tp_size=1, moe_tp_size=1, moe_ep_size=1)
+    model_config.kvcache_quant_mode = sdk_config.common.KVCacheQuantMode.fp8
+    model_config.moe_backend = "deepep_moe"
+    model = get_model(GPTOSS, model_config, "sglang")
+    assert type(model).__name__ == "SGLangEPMOEModel"
+    seq_len = 65_936
+    got = model.get_kvcache_bytes_per_sequence(seq_len)
+    assert got == pytest.approx(_expected_bytes(seq_len), rel=1e-9)
+    budget = model.get_kvcache_bytes_per_sequence(50_000)
+    assert abs(model.get_kvcache_max_tokens(budget) - 50_000) <= 1

--- a/tests/unit/models/test_gptoss_swa_kv_memory.py
+++ b/tests/unit/models/test_gptoss_swa_kv_memory.py
@@ -9,11 +9,13 @@ the two cannot drift apart again (the drift produced a ~2x KV overcharge and
 false OOMs at long ISL).
 """
 
+from types import SimpleNamespace
+
 import pytest
 
 from aiconfigurator_core.sdk import config as sdk_config
+from aiconfigurator_core.sdk.backends.factory import get_backend
 from aiconfigurator_core.sdk.models import get_model
-
 
 GPTOSS = "openai/gpt-oss-120b"
 
@@ -26,10 +28,11 @@ NUM_SWA = LAYERS // 2
 NUM_GLOBAL = LAYERS - NUM_SWA
 
 
-def _model(tp_size: int = 1, kvcache_bytes_per_elem: int = 1):
+def _model(tp_size: int = 1, kvcache_bytes_per_elem: int = 1, nextn: int = 0):
     model_config = sdk_config.ModelConfig(tp_size=tp_size, moe_tp_size=1, moe_ep_size=1)
     if kvcache_bytes_per_elem == 1:
         model_config.kvcache_quant_mode = sdk_config.common.KVCacheQuantMode.fp8
+    model_config.nextn = nextn
     model = get_model(GPTOSS, model_config, "vllm")
     return model
 
@@ -68,6 +71,57 @@ def test_gptoss_kv_max_tokens_inverts_the_piecewise_curve():
     budget = model.get_kvcache_bytes_per_sequence(seq_len)
     max_tokens = model.get_kvcache_max_tokens(budget)
     assert abs(max_tokens - seq_len) <= 1
+
+
+@pytest.mark.parametrize("nextn", [0, 1, 3], ids=("spec-off", "nextn1", "nextn3"))
+def test_gptoss_kv_bytes_is_nextn_independent(nextn):
+    """Speculative decoding must not re-linearize the window-capped KV curve.
+
+    Draft tokens are a per-step compute cost, not extra resident KV, so the
+    hybrid-SWA byte count is identical with spec decode on and off.
+    """
+    model = _model(nextn=nextn)
+    seq_len = 65_936  # 65536 ISL + 400 OSL, the 64k agentic recipe shape
+    assert model.get_kvcache_bytes_per_sequence(seq_len) == pytest.approx(_expected_bytes(seq_len), rel=1e-9)
+
+
+def test_gptoss_backend_memory_kv_stays_window_aware_under_spec_decode():
+    """The breakdown's ``kvcache`` (base_backend._get_memory_usage, the sole KV
+    sizing site) must follow the window-capped curve with ``nextn > 0``.
+
+    Pins the recipe operating point: batch 48 at ISL 65536 / OSL 400, fp8 KV,
+    TP1 -> 54.4 GiB, not the ~2x all-layers-full-context value that false-OOMs
+    the shipped 8xB200 agg recipe.
+    """
+    batch_size, isl, osl = 48, 65_536, 400
+    seq_len = isl + osl
+    model = _model(nextn=3)
+    database = SimpleNamespace(system_spec={"misc": {"nccl_mem": {1: 0}, "other_mem": 0}})
+
+    memory = get_backend("vllm")._get_memory_usage(
+        model, database, batch_size=batch_size, beam_width=1, isl=isl, osl=osl
+    )
+
+    expected_gib = batch_size * _expected_bytes(seq_len) / (1 << 30)
+    assert memory["kvcache"] == pytest.approx(expected_gib, rel=1e-9)
+    assert memory["kvcache"] == pytest.approx(54.4, abs=0.1)
+    linear_gib = batch_size * seq_len * LAYERS * 2 * KV_HEADS * HEAD_SIZE / (1 << 30)
+    assert memory["kvcache"] < 0.52 * linear_gib
+
+
+def test_gptoss_kv_bytes_scale_linearly_with_kvcache_dtype():
+    """Guard against misreading a dtype difference as a layout regression.
+
+    The window-aware bf16 figure (2.268 GiB/seq at 65,936) is within 0.2% of the
+    *linear* fp8 figure (2.264 GiB/seq) that the hybrid override removed, so the
+    two are easy to confuse when reading a CLI breakdown. Pin that the only
+    difference between the two dtypes is the element size.
+    """
+    seq_len = 65_936
+    fp8 = _model(kvcache_bytes_per_elem=1).get_kvcache_bytes_per_sequence(seq_len)
+    bf16 = _model(kvcache_bytes_per_elem=2).get_kvcache_bytes_per_sequence(seq_len)
+    assert bf16 == pytest.approx(2 * fp8, rel=1e-9)
+    assert bf16 == pytest.approx(_expected_bytes(seq_len, bytes_per_elem=2), rel=1e-9)
 
 
 def test_gptoss_deepep_path_also_gets_hybrid_layout():

--- a/tests/unit/models/test_gptoss_swa_kv_memory.py
+++ b/tests/unit/models/test_gptoss_swa_kv_memory.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""gpt-oss KV-cache memory must honor the hybrid SWA layout.
+
+gpt-oss-120b: 36 layers, half banded at window 128 and half global, 8 KV heads,
+head_size 64. The timing path (MOEModel's GptOssForCausalLM branch) already
+splits layers this way; these tests pin the memory path to the same layout so
+the two cannot drift apart again (the drift produced a ~2x KV overcharge and
+false OOMs at long ISL).
+"""
+
+import pytest
+
+from aiconfigurator_core.sdk import config as sdk_config
+from aiconfigurator_core.sdk.models import get_model
+
+
+GPTOSS = "openai/gpt-oss-120b"
+
+# Model geometry (from the HF config, mirrored in AIC's model info).
+LAYERS = 36
+KV_HEADS = 8
+HEAD_SIZE = 64
+WINDOW = 128
+NUM_SWA = LAYERS // 2
+NUM_GLOBAL = LAYERS - NUM_SWA
+
+
+def _model(tp_size: int = 1, kvcache_bytes_per_elem: int = 1):
+    model_config = sdk_config.ModelConfig(tp_size=tp_size, moe_tp_size=1, moe_ep_size=1)
+    if kvcache_bytes_per_elem == 1:
+        model_config.kvcache_quant_mode = sdk_config.common.KVCacheQuantMode.fp8
+    model = get_model(GPTOSS, model_config, "vllm")
+    return model
+
+
+def _expected_bytes(seq_len: int, bytes_per_elem: int = 1, tp: int = 1) -> float:
+    kv_per_gpu = (KV_HEADS + tp - 1) // tp
+    per_layer_token = kv_per_gpu * HEAD_SIZE * 2 * bytes_per_elem
+    return per_layer_token * (NUM_SWA * min(seq_len, WINDOW) + NUM_GLOBAL * seq_len)
+
+
+def test_gptoss_kv_bytes_long_sequence_pins_hybrid_layout():
+    """At ISL+OSL = 65,936 (the 64k agentic recipe shape), fp8 KV, TP1."""
+    model = _model()
+    seq_len = 65_936
+    got = model.get_kvcache_bytes_per_sequence(seq_len)
+    expected = _expected_bytes(seq_len)
+    assert got == pytest.approx(expected, rel=1e-9)
+    # Regression guard: the linear (all-layers-full-context) value is ~2x.
+    linear = seq_len * LAYERS * 2 * KV_HEADS * HEAD_SIZE
+    assert got < 0.52 * linear
+
+
+def test_gptoss_kv_bytes_below_window_matches_linear():
+    """Below the 128-token window the hybrid and linear formulas agree."""
+    model = _model()
+    seq_len = 100
+    got = model.get_kvcache_bytes_per_sequence(seq_len)
+    linear = seq_len * LAYERS * 2 * KV_HEADS * HEAD_SIZE
+    assert got == pytest.approx(linear, rel=1e-9)
+
+
+def test_gptoss_kv_max_tokens_inverts_the_piecewise_curve():
+    """Capacity inverse must follow the window-capped curve, not the seq_len=1 slope."""
+    model = _model()
+    seq_len = 50_000
+    budget = model.get_kvcache_bytes_per_sequence(seq_len)
+    max_tokens = model.get_kvcache_max_tokens(budget)
+    assert abs(max_tokens - seq_len) <= 1

--- a/tests/unit/sdk/backends/test_base_backend.py
+++ b/tests/unit/sdk/backends/test_base_backend.py
@@ -69,6 +69,7 @@ class _TestBackend(BaseBackend):
         num_tokens=0,
         prefix=0,
         encoder_memory=None,
+        mtp_scaled_tokens=None,
     ) -> dict[str, float]:
         return {"total": 1.0}
 

--- a/tests/unit/sdk/backends/test_base_backend.py
+++ b/tests/unit/sdk/backends/test_base_backend.py
@@ -252,6 +252,57 @@ def test_run_static_declares_mtp_decode_share_per_mode(
     assert captured.get("mtp_scaled_tokens") == expected_share
 
 
+@pytest.mark.parametrize(
+    ("batch_size", "ctx_tokens", "expected_share"),
+    [
+        # b > 1: mixed step; only the num_gen_requests decode requests verify
+        # nextn+1 draft tokens (the context share is processed once).
+        (4, 8, 3),
+        # b == 1: context-only step, no decode share to scale.
+        (1, 8, 0),
+    ],
+)
+def test_run_agg_declares_mtp_decode_share_at_call_site(
+    backend: BaseBackend,
+    model,
+    database,
+    monkeypatch,
+    batch_size: int,
+    ctx_tokens: int,
+    expected_share: int,
+) -> None:
+    """run_agg must pass the decode-request share of num_tokens as
+    mtp_scaled_tokens to _get_memory_usage (the run_agg counterpart of
+    test_run_static_declares_mtp_decode_share_per_mode above: pins the CALL
+    SITE, not just the _get_memory_usage formula covered elsewhere)."""
+    captured: dict = {}
+
+    def _record(*args, **kwargs):
+        captured.update(kwargs)
+        return {"total": 1.0}
+
+    monkeypatch.setattr(backend, "_get_memory_usage", _record)
+    monkeypatch.setattr(
+        backend,
+        "run_mixed",
+        lambda *args, **kwargs: StepEstimate(latency_ms=1.0, energy_wms=1.0),
+    )
+    monkeypatch.setattr(
+        backend,
+        "_get_genonly_step_latency",
+        lambda *args, **kwargs: (1.0, 1.0, {}, {}),
+    )
+
+    backend.run_agg(
+        model,
+        database,
+        RuntimeConfig(batch_size=batch_size, beam_width=1, isl=8, osl=5, prefix=2),
+        ctx_tokens=ctx_tokens,
+    )
+
+    assert captured.get("mtp_scaled_tokens") == expected_share
+
+
 def test_run_agg_with_osl_one_does_not_divide_by_zero(
     backend: BaseBackend,
     model,

--- a/tests/unit/sdk/backends/test_base_backend.py
+++ b/tests/unit/sdk/backends/test_base_backend.py
@@ -216,6 +216,42 @@ def test_run_static_can_route_to_rust_engine_step_backend(
     assert summary.get_generation_source_dict() == {"generation_qkv_gemm": "silicon", "generation_attention": "mixed"}
 
 
+@pytest.mark.parametrize(
+    ("mode", "expected_share"),
+    [
+        # "static" and "static_ctx" both size activations from the DERIVED
+        # context token count ((isl - prefix) * batch_size), so no share of that
+        # footprint verifies nextn+1 draft tokens.
+        ("static", 0),
+        ("static_ctx", 0),
+        # Decode-only step (num_tokens = batch_size * beam_width): every token is
+        # verified, so the full (nextn+1) multiplier stays (no decode-share cap).
+        ("static_gen", None),
+    ],
+)
+def test_run_static_declares_mtp_decode_share_per_mode(
+    backend: BaseBackend,
+    model,
+    database,
+    runtime_config: RuntimeConfig,
+    monkeypatch,
+    mode: str,
+    expected_share: int | None,
+) -> None:
+    """Each static mode must declare its decode-token share to ``_get_memory_usage``."""
+    captured: dict = {}
+
+    def _record(*args, **kwargs):
+        captured.update(kwargs)
+        return {"total": 1.0}
+
+    monkeypatch.setattr(backend, "_get_memory_usage", _record)
+
+    backend.run_static(model, database, runtime_config, mode=mode, stride=2)
+
+    assert captured.get("mtp_scaled_tokens") == expected_share
+
+
 def test_run_agg_with_osl_one_does_not_divide_by_zero(
     backend: BaseBackend,
     model,

--- a/tests/unit/sdk/backends/test_mtp_activation_decode_share.py
+++ b/tests/unit/sdk/backends/test_mtp_activation_decode_share.py
@@ -91,3 +91,60 @@ def test_prefill_only_step_does_not_scale(setup):
     base = _memory(backend, model, database, nextn=0, num_tokens=65_536, mtp_scaled_tokens=0)
     spec = _memory(backend, model, database, nextn=3, num_tokens=65_536, mtp_scaled_tokens=0)
     assert spec == pytest.approx(base, rel=1e-9)
+
+
+def _partition_activations(backend, model, database, *, nextn, num_tokens):
+    """Activation GiB through the AFD path (``get_partition_memory_usage``)."""
+    model.config.nextn = nextn
+    return backend.get_partition_memory_usage(
+        model,
+        database,
+        partition_ops=[],
+        batch_size=4,
+        beam_width=1,
+        isl=65_536,
+        osl=400,
+        num_tokens=num_tokens,
+        max_seq_len=65_536,
+    )["activations"]
+
+
+def test_afd_prefill_partition_does_not_scale(setup):
+    """AFD prefill workers (``num_tokens=0``) size activations from the context tokens.
+
+    ``InferenceSession._estimate_{a,f}_memory_dict`` passes ``num_tokens=0`` for
+    ``phase == "prefill"``, which ``_get_memory_usage`` expands to
+    ``(isl - prefix) * batch_size`` -- a prefill-only footprint that never
+    verifies nextn+1 draft tokens.
+    """
+    backend, model, database = setup
+    base = _partition_activations(backend, model, database, nextn=0, num_tokens=0)
+    spec = _partition_activations(backend, model, database, nextn=3, num_tokens=0)
+    assert spec == pytest.approx(base, rel=1e-9)
+
+
+def test_afd_decode_partition_keeps_full_multiplier(setup):
+    """AFD decode workers pass ``num_tokens=batch_size``: every token is verified."""
+    backend, model, database = setup
+    base = _partition_activations(backend, model, database, nextn=0, num_tokens=4)
+    spec = _partition_activations(backend, model, database, nextn=3, num_tokens=4)
+    assert spec / base == pytest.approx(4.0, rel=1e-6)
+
+
+def test_trtllm_budget_path_ignores_the_decode_share():
+    """TRT-LLM's agg override intentionally drops ``mtp_scaled_tokens`` (AIC-1746).
+
+    Its ``num_tokens`` is ``BuildConfig.max_num_tokens`` (a per-iteration budget),
+    not the agg-derived mixed-step count, so the decode-share correction is not
+    forwarded and the legacy full ``(nextn+1)`` multiplier is retained on that
+    path pending its own analysis.
+    """
+    from aiconfigurator_core.sdk.backends.factory import get_backend
+
+    agg_extra = {"max_num_tokens": 8192, "max_seq_len": 4096, "free_gpu_memory_fraction": 0.9}
+    kwargs = get_backend("trtllm")._memory_usage_kwargs_for_agg(
+        num_tokens=65_539,
+        agg_extra=agg_extra,
+        mtp_scaled_tokens=3,
+    )
+    assert kwargs == {"num_tokens": 8192, "max_seq_len": 4096}

--- a/tests/unit/sdk/backends/test_mtp_activation_decode_share.py
+++ b/tests/unit/sdk/backends/test_mtp_activation_decode_share.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""MTP activation scaling must apply to the decode-token share only on mixed steps.
+
+Aggregated serving processes context and decode tokens in one step
+(``num_tokens = ctx_tokens + num_gen_requests``). Speculative decoding verifies
+``nextn + 1`` tokens per *decode* request; context tokens are processed once.
+Multiplying the whole activation footprint by ``(nextn + 1)`` models
+``(nextn+1) x (context + decode)`` instead of ``context + (nextn+1) x decode``,
+which at long ISL inflates activations ~(nextn+1)x and over-prunes concurrency
+(observed: GLM-5.2 agg recommendation pinned at concurrency 8 vs 64 measured).
+
+Decode-only steps (disagg decode workers, ``mtp_scaled_tokens=None``) keep the
+full multiplier: every token in those steps is part of verification.
+"""
+
+import pytest
+
+from aiconfigurator_core.sdk import config as sdk_config
+from aiconfigurator_core.sdk.models import get_model
+
+
+GPTOSS = "openai/gpt-oss-120b"  # any registered model works; we only need activations
+
+
+def _memory(backend, model, database, *, nextn, num_tokens, mtp_scaled_tokens):
+    model.config.nextn = nextn
+    return backend._get_memory_usage(
+        model,
+        database,
+        batch_size=4,
+        beam_width=1,
+        isl=65_536,
+        osl=400,
+        num_tokens=num_tokens,
+        mtp_scaled_tokens=mtp_scaled_tokens,
+    )["activations"]
+
+
+@pytest.fixture
+def setup():
+    from types import SimpleNamespace
+
+    from aiconfigurator_core.sdk.backends.factory import get_backend
+
+    model_config = sdk_config.ModelConfig(tp_size=1, moe_tp_size=1, moe_ep_size=1)
+    model = get_model(GPTOSS, model_config, "vllm")
+    backend = get_backend("vllm")
+    database = SimpleNamespace(
+        backend="vllm",
+        version="test-version",
+        system="b200_sxm",
+        system_spec={
+            "gpu": {"mem_capacity": 180 * (1 << 30)},
+            "misc": {"nccl_mem": {1: 0, 2: 0, 4: 0, 8: 0}, "other_mem": 0},
+        },
+    )
+    return backend, model, database
+
+
+def test_context_dominated_step_barely_scales(setup):
+    """65,536 ctx + 3 decode tokens: (nextn+1) on the whole step is ~4x too big."""
+    backend, model, database = setup
+    num_tokens = 65_536 + 3
+    base = _memory(backend, model, database, nextn=0, num_tokens=num_tokens, mtp_scaled_tokens=3)
+    spec = _memory(backend, model, database, nextn=3, num_tokens=num_tokens, mtp_scaled_tokens=3)
+    # Correct scaling: (65536 + 3*4) / 65539 ~= 1.00014, nowhere near 4x.
+    assert spec / base == pytest.approx((65_536 + 3 * 4) / num_tokens, rel=1e-6)
+    assert spec / base < 1.01
+
+
+def test_decode_only_step_keeps_full_multiplier(setup):
+    """mtp_scaled_tokens=None (disagg decode worker): full (nextn+1) applies."""
+    backend, model, database = setup
+    base = _memory(backend, model, database, nextn=0, num_tokens=512, mtp_scaled_tokens=None)
+    spec = _memory(backend, model, database, nextn=3, num_tokens=512, mtp_scaled_tokens=None)
+    assert spec / base == pytest.approx(4.0, rel=1e-6)
+
+
+def test_all_decode_share_equals_full_multiplier(setup):
+    """mtp_scaled_tokens == num_tokens degenerates to the old behavior."""
+    backend, model, database = setup
+    base = _memory(backend, model, database, nextn=0, num_tokens=512, mtp_scaled_tokens=512)
+    spec = _memory(backend, model, database, nextn=3, num_tokens=512, mtp_scaled_tokens=512)
+    assert spec / base == pytest.approx(4.0, rel=1e-6)

--- a/tests/unit/sdk/backends/test_mtp_activation_decode_share.py
+++ b/tests/unit/sdk/backends/test_mtp_activation_decode_share.py
@@ -19,7 +19,6 @@ import pytest
 from aiconfigurator_core.sdk import config as sdk_config
 from aiconfigurator_core.sdk.models import get_model
 
-
 GPTOSS = "openai/gpt-oss-120b"  # any registered model works; we only need activations
 
 

--- a/tests/unit/sdk/backends/test_mtp_activation_decode_share.py
+++ b/tests/unit/sdk/backends/test_mtp_activation_decode_share.py
@@ -136,7 +136,7 @@ def test_trtllm_budget_path_ignores_the_decode_share():
     Its ``num_tokens`` is ``BuildConfig.max_num_tokens`` (a per-iteration budget),
     not the agg-derived mixed-step count, so the decode-share correction is not
     forwarded and the legacy full ``(nextn+1)`` multiplier is retained on that
-    path pending its own analysis.
+    path pending its own analysis (tracked in AIC-1755).
     """
     from aiconfigurator_core.sdk.backends.factory import get_backend
 

--- a/tests/unit/sdk/backends/test_mtp_activation_decode_share.py
+++ b/tests/unit/sdk/backends/test_mtp_activation_decode_share.py
@@ -83,3 +83,11 @@ def test_all_decode_share_equals_full_multiplier(setup):
     base = _memory(backend, model, database, nextn=0, num_tokens=512, mtp_scaled_tokens=512)
     spec = _memory(backend, model, database, nextn=3, num_tokens=512, mtp_scaled_tokens=512)
     assert spec / base == pytest.approx(4.0, rel=1e-6)
+
+
+def test_prefill_only_step_does_not_scale(setup):
+    """mtp_scaled_tokens=0 (static_ctx / disagg prefill worker): no draft share."""
+    backend, model, database = setup
+    base = _memory(backend, model, database, nextn=0, num_tokens=65_536, mtp_scaled_tokens=0)
+    spec = _memory(backend, model, database, nextn=3, num_tokens=65_536, mtp_scaled_tokens=0)
+    assert spec == pytest.approx(base, rel=1e-9)


### PR DESCRIPTION
## What

Fixes two accounting defects that made AIConfigurator unable to evaluate (or grossly under-recommend) the Dynamo recipes' agentic-workload configurations, per the AIC-1743 census: (1) gpt-oss KV-cache memory ignored the hybrid sliding-window layout — a 1.996× per-sequence overcharge that false-OOM'd the shipped recipe operating points; (2) speculative decoding multiplied the **entire** mixed-batch activation footprint by `(nextn+1)` instead of only the decode-token share — over-pruning agg concurrency ~4× at 64k ISL.

## Origin & authorship

The first four commits are the patch series attached to Linear AIC-1743 by Ben Hamm (three-way replicated there), applied verbatim via `git am --signoff` — authorship preserved, patch-ids verified identical to the attached files. On top: a tests-only commit pinning nextn-independence, a path-level 54.4 GiB regression and the bf16=2×fp8 KV relationship; decode-share coverage for the two remaining call sites (plain `static` mode and AFD partitions — AFD prefill activations drop 176.0→44.0 GiB at gpt-oss/64k/bs4/nextn3); a separate ruff style commit (kept apart so the upstream commits stay byte-identical); and a call-site reversion guard test for `run_agg`'s `mtp_scaled_tokens` threading.

## Validation

- gpt-oss bs=64 recipe operating point: OOM → fits (KV exactly **72.580 GiB**, total 143.4/180 GiB).
- GLM-5.2-NVFP4 agg B200 sweep (16 GPUs, EAGLE 3/1.69, 64k/400/90% reuse, SILICON): **0.33× → 1.88×** of the recipe's measured 176.42 tok/s/GPU.
- Pinned exact-replay census (41 Dynamo recipe configs): 3 → 7 valid, of which +3 are gpt-oss rows unlocked by this PR (with `--kv-cache-dtype=fp8` pinned as the recipes serve it).
- Suites: 3510 unit tests passed / 50 skipped; ruff clean; rust twin audited (no activation/KV model duplicated there — memory verdicts are Python-owned on every path).
- The TRT-LLM `max_num_tokens` budget path deliberately retains the legacy multiplier pending its own analysis — now pinned by a regression test and tracked in AIC-1755.

Linear: AIC-1746 (part of the AIC-1743 / Gap: Dynamo Recipe Alignment project).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved memory estimates for speculative decoding by distinguishing context and decode token usage.
  * Enhanced GPT-OSS support with hybrid sliding-window KV-cache accounting.
  * Improved maximum token capacity calculations for models using hybrid attention.
  * Preserved existing behavior for prefill-only workloads and supported execution paths.

* **Tests**
  * Added coverage for KV-cache sizing, data types, speculative decoding, and hybrid attention across supported backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->