### PR TITLE
fix(sdk): degrade DSA amortization to all-full when skip-indexer rows are absent

### DIFF
--- a/aic-core/rust/aiconfigurator-core/src/engine/runtime.rs
+++ b/aic-core/rust/aiconfigurator-core/src/engine/runtime.rs
@@ -1660,10 +1660,17 @@ mod tests {
     /// prefill], generation = [FpmForward decode], empty sol_ops (grid-exact
     /// queries never call SOL).
     fn build_fpm_engine(tmp: &std::path::Path, nextn: Option<u32>) -> Result<Engine, AicError> {
-        use crate::perf_database::fpm_forward::tests::{default_identity, default_rows, write_pair};
+        use crate::perf_database::fpm_forward::tests::{
+            default_identity, default_rows, write_pair,
+        };
         write_pair(tmp, &default_rows());
         let mut db = PerfDatabase::load(&systems_root(), "b200_sxm", "vllm", "0.19.0").unwrap();
-        db.set_fpm_forward_for_test(crate::perf_database::FpmForwardTable::new(tmp.to_path_buf(), "b200_sxm", "vllm", "0.25.1"));
+        db.set_fpm_forward_for_test(crate::perf_database::FpmForwardTable::new(
+            tmp.to_path_buf(),
+            "b200_sxm",
+            "vllm",
+            "0.25.1",
+        ));
         let fpm_op = |phase: FpmPhase| {
             Op::FpmForward(FpmForwardOp {
                 name: format!("fpm_forward_{}", phase.as_str()),
@@ -1721,7 +1728,9 @@ mod tests {
         // gen: batch 8; osl=0 clamps to 1 -> isl' = 2048, one step at
         // s = 2049 -> kv = 8*2049 = 16392: lerp between (8,4096)->7.0 and
         // (8,65536)->9.0, minus baseline (8, kv_floor=8) -> 6.0.
-        let ms = engine.mixed_step_latency(2048, 8, 2048, 0, 0, 1.0, 1.0).unwrap();
+        let ms = engine
+            .mixed_step_latency(2048, 8, 2048, 0, 0, 1.0, 1.0)
+            .unwrap();
         let pre = 20.0 + (40.0 - 20.0) * (2056.0 - 2048.0) / (4096.0 - 2048.0);
         let w = (16392.0 - 4096.0) / (65536.0 - 4096.0);
         let decode = 7.0 + (9.0 - 7.0) * w;
@@ -1738,7 +1747,12 @@ mod tests {
         use crate::perf_database::fpm_forward::tests::{default_identity, write_pair};
         write_pair(tmp, rows);
         let mut db = PerfDatabase::load(&systems_root(), "b200_sxm", "vllm", "0.19.0").unwrap();
-        db.set_fpm_forward_for_test(crate::perf_database::FpmForwardTable::new(tmp.to_path_buf(), "b200_sxm", "vllm", "0.25.1"));
+        db.set_fpm_forward_for_test(crate::perf_database::FpmForwardTable::new(
+            tmp.to_path_buf(),
+            "b200_sxm",
+            "vllm",
+            "0.25.1",
+        ));
         let fpm_op = |phase: FpmPhase| {
             Op::FpmForward(FpmForwardOp {
                 name: format!("fpm_forward_{}", phase.as_str()),
@@ -1789,11 +1803,23 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let engine = build_fpm_engine_with_rows(tmp.path(), &cliff_rows()).unwrap();
         // In-graph: pure prefill step, totals (1, 2048, 0) -> exact 47.0.
-        let graph = engine.mixed_step_breakdown(2048, 0, 2048, 0, 0, 1.0, 1.0).unwrap();
-        assert!((graph[1] - 47.0).abs() < 1e-9, "graph-side prefill {}", graph[1]);
+        let graph = engine
+            .mixed_step_breakdown(2048, 0, 2048, 0, 0, 1.0, 1.0)
+            .unwrap();
+        assert!(
+            (graph[1] - 47.0).abs() < 1e-9,
+            "graph-side prefill {}",
+            graph[1]
+        );
         // Crossing: 8 decode riders push the total to 2056 -> eager plateau.
-        let eager = engine.mixed_step_breakdown(2048, 8, 2048, 0, 0, 1.0, 1.0).unwrap();
-        assert!((eager[1] - 99.0).abs() < 1e-9, "eager-side prefill {}", eager[1]);
+        let eager = engine
+            .mixed_step_breakdown(2048, 8, 2048, 0, 0, 1.0, 1.0)
+            .unwrap();
+        assert!(
+            (eager[1] - 99.0).abs() < 1e-9,
+            "eager-side prefill {}",
+            eager[1]
+        );
         assert!(eager[1] > graph[1] * 2.0 - 1e-9);
     }
 
@@ -1805,7 +1831,9 @@ mod tests {
         let engine = build_fpm_engine_with_rows(tmp.path(), &cliff_rows()).unwrap();
         // ctx=1024 of isl=2048: chunk 1 -> (1, 1032, 0) = 10.0,
         // chunk 2 -> (1, 1032, 1024) = 14.0; average 12.0.
-        let parts = engine.mixed_step_breakdown(1024, 8, 2048, 0, 0, 1.0, 1.0).unwrap();
+        let parts = engine
+            .mixed_step_breakdown(1024, 8, 2048, 0, 0, 1.0, 1.0)
+            .unwrap();
         assert!((parts[1] - 12.0).abs() < 1e-9, "chunk average {}", parts[1]);
     }
 
@@ -1820,7 +1848,9 @@ mod tests {
         let ms = engine.decode_step_latency(8, 511, 0, 1.0).unwrap();
         assert!((ms - 7.0).abs() < 1e-12, "got {ms}");
         // mixed with ctx_tokens=0 must agree with the genonly convention
-        let mixed = engine.mixed_step_latency(0, 8, 511, 0, 0, 1.0, 1.0).unwrap();
+        let mixed = engine
+            .mixed_step_latency(0, 8, 511, 0, 0, 1.0, 1.0)
+            .unwrap();
         assert!((mixed - 7.0).abs() < 1e-12, "got {mixed}");
         assert_eq!(engine.decode_step_latency(0, 511, 0, 1.0).unwrap(), 0.0);
     }
@@ -1929,7 +1959,8 @@ mod tests {
         let spec = EngineSpec::new(fixture_engine_config(None), vec![hidden], generation_ops());
         let err = Engine::build(spec, Arc::new(db)).unwrap_err();
         assert!(
-            err.to_string().contains("exactly one FpmForward op per phase"),
+            err.to_string()
+                .contains("exactly one FpmForward op per phase"),
             "{err}"
         );
     }
@@ -2023,7 +2054,11 @@ mod tests {
         let math = 2.0 * m * n * k / tc_flops * 1000.0;
         let mem = quant.mapping().memory * (m * n + m * k + n * k) / spec.gpu.mem_bw * 1000.0;
         let gemm = &sol[1];
-        assert!((gemm.2 - math).abs() < 1e-12, "sol_math {} != {math}", gemm.2);
+        assert!(
+            (gemm.2 - math).abs() < 1e-12,
+            "sol_math {} != {math}",
+            gemm.2
+        );
         assert!((gemm.3 - mem).abs() < 1e-12, "sol_mem {} != {mem}", gemm.3);
     }
 
@@ -2058,8 +2093,7 @@ mod tests {
         assert_eq!(sol.len(), 1);
 
         let dims = dsa_dims(&op.architecture);
-        let flops =
-            dsa_context_sol_flops(spec, op.gemm_quant_mode, op.fmha_quant_mode).unwrap();
+        let flops = dsa_context_sol_flops(spec, op.gemm_quant_mode, op.fmha_quant_mode).unwrap();
         let leaf = |skip: bool| {
             dsa_context_sol(
                 spec,
@@ -2081,9 +2115,18 @@ mod tests {
         let expected_mem = w * full.mem_ms + (1.0 - w) * skip.mem_ms;
         let expected_time = w * full.time_ms() + (1.0 - w) * skip.time_ms();
         let (_, sol_time, sol_math, sol_mem) = &sol[0];
-        assert!((sol_time - expected_time).abs() < 1e-12, "{sol_time} vs {expected_time}");
-        assert!((sol_math - expected_math).abs() < 1e-12, "{sol_math} vs {expected_math}");
-        assert!((sol_mem - expected_mem).abs() < 1e-12, "{sol_mem} vs {expected_mem}");
+        assert!(
+            (sol_time - expected_time).abs() < 1e-12,
+            "{sol_time} vs {expected_time}"
+        );
+        assert!(
+            (sol_math - expected_math).abs() < 1e-12,
+            "{sol_math} vs {expected_math}"
+        );
+        assert!(
+            (sol_mem - expected_mem).abs() < 1e-12,
+            "{sol_mem} vs {expected_mem}"
+        );
         // The skip leaf must actually differ from the full leaf, or this
         // test would pass vacuously on a broken blend.
         assert!(skip.time_ms() < full.time_ms());

--- a/aic-core/rust/aiconfigurator-core/src/engine/spec.rs
+++ b/aic-core/rust/aiconfigurator-core/src/engine/spec.rs
@@ -994,17 +994,27 @@ mod tests {
     /// opaque "unexpected end of file".
     #[test]
     fn from_bincode_rejects_v11_dsa_producer_at_the_version_gate() {
-        let spec = EngineSpec::new(sample_engine_config(), vec![OpSpec::DsaContext(dsa_module())], vec![]);
+        let spec = EngineSpec::new(
+            sample_engine_config(),
+            vec![OpSpec::DsaContext(dsa_module())],
+            vec![],
+        );
         let mut bytes = spec.to_bincode().expect("to_bincode");
         bytes[..4].copy_from_slice(&11u32.to_le_bytes()); // a v11 producer's stamp
 
         match EngineSpec::from_bincode(&bytes) {
-            Err(AicError::UnsupportedSchemaVersion { kind, got, expected }) => {
+            Err(AicError::UnsupportedSchemaVersion {
+                kind,
+                got,
+                expected,
+            }) => {
                 assert_eq!(kind, "EngineSpec");
                 assert_eq!(got, 11);
                 assert_eq!(expected, ENGINE_SPEC_SCHEMA_VERSION);
             }
-            other => panic!("expected UnsupportedSchemaVersion for a v11 DSA payload, got {other:?}"),
+            other => {
+                panic!("expected UnsupportedSchemaVersion for a v11 DSA payload, got {other:?}")
+            }
         }
     }
 

--- a/aic-core/rust/aiconfigurator-core/src/operators/communication.rs
+++ b/aic-core/rust/aiconfigurator-core/src/operators/communication.rs
@@ -281,12 +281,12 @@ fn query_nccl_table(
         // (unknown collectives yield 0.0, not an error). The SOL_FULL
         // triple is `(sol_time, 0, sol_time)` — the bandwidth bound rides
         // in the mem slot.
-        DatabaseMode::Sol | DatabaseMode::SolFull => Ok(PerformanceResult::sol(
-            SolComponents::new(
+        DatabaseMode::Sol | DatabaseMode::SolFull => {
+            Ok(PerformanceResult::sol(SolComponents::new(
                 0.0,
                 nccl_sol_ms(&db.system_spec, dtype, num_gpus, operation, message_size),
-            ),
-        )),
+            )))
+        }
         DatabaseMode::Empirical => Ok(PerformanceResult::new(
             nccl_empirical(db, dtype, num_gpus, operation, message_size)?,
             Source::Empirical,

--- a/aic-core/rust/aiconfigurator-core/src/operators/dsa.rs
+++ b/aic-core/rust/aiconfigurator-core/src/operators/dsa.rs
@@ -121,12 +121,14 @@ impl DsaModuleOp {
         let v = dims.v_head_dim as f64;
         let idx = (dims.index_head_dim * dims.index_n_heads) as f64;
         let local_heads = f64::from(self.num_heads);
-        let quants = self.attn_projection_quant_modes.unwrap_or(DsaProjectionQuants {
-            q: self.gemm_quant_mode,
-            kv: self.gemm_quant_mode,
-            o: self.gemm_quant_mode,
-            indexer: self.gemm_quant_mode,
-        });
+        let quants = self
+            .attn_projection_quant_modes
+            .unwrap_or(DsaProjectionQuants {
+                q: self.gemm_quant_mode,
+                kv: self.gemm_quant_mode,
+                o: self.gemm_quant_mode,
+                indexer: self.gemm_quant_mode,
+            });
         let q_params = h * q_lora + q_lora * local_heads * qk;
         let kv_params = h * (kv_lora + dims.qk_rope_head_dim as f64)
             + kv_lora * local_heads * (dims.qk_nope_head_dim as f64 + v);
@@ -196,7 +198,7 @@ impl DsaModuleOp {
         {
             self.full_frac
         } else {
-            self.effective_full_frac(db.dsa.has_context_skip_rows())
+            self.effective_full_frac(db.dsa.has_context_skip_rows()?)
         };
         // CP (round-robin sequence split) prefill takes the sparse-delta
         // composition path (Python `ContextDSAModule.query` -> `_query_cp`
@@ -427,7 +429,7 @@ impl DsaModuleOp {
         {
             self.full_frac
         } else {
-            self.effective_full_frac(db.dsa.has_generation_skip_rows())
+            self.effective_full_frac(db.dsa.has_generation_skip_rows()?)
         };
         // `dsa_backend="trtllm"` mirrors Python's generation default
         // (`_query_generation_dsa_module_table(dsa_backend="trtllm")`).
@@ -1326,8 +1328,11 @@ mod tests {
     #[test]
     fn missing_skip_indexer_variant_degrades_amortization_to_all_full() {
         let db = sglang_db("h200_sxm", "0.5.10", DatabaseMode::Silicon);
-        assert!(!db.dsa.has_context_skip_rows(), "h200/0.5.10 ships full rows only");
-        assert!(!db.dsa.has_generation_skip_rows());
+        assert!(
+            !db.dsa.has_context_skip_rows().expect("probe"),
+            "h200/0.5.10 ships full rows only"
+        );
+        assert!(!db.dsa.has_generation_skip_rows().expect("probe"));
 
         let glm52 = glm52_op(KvCacheQuantMode::Bfloat16, GLM52_FULL_FRAC);
         let all_full = glm52_op(KvCacheQuantMode::Bfloat16, 1.0);
@@ -1366,8 +1371,11 @@ mod tests {
     #[test]
     fn present_skip_indexer_variant_keeps_mixed_amortization() {
         let db = sglang_db("gb200", "0.5.14", DatabaseMode::Silicon);
-        assert!(db.dsa.has_context_skip_rows(), "gb200 ships both variants");
-        assert!(db.dsa.has_generation_skip_rows());
+        assert!(
+            db.dsa.has_context_skip_rows().expect("probe"),
+            "gb200 ships both variants"
+        );
+        assert!(db.dsa.has_generation_skip_rows().expect("probe"));
 
         let glm52 = glm52_op(KvCacheQuantMode::Bfloat16, GLM52_FULL_FRAC);
         let all_full = glm52_op(KvCacheQuantMode::Bfloat16, 1.0);
@@ -1420,7 +1428,10 @@ mod tests {
     #[test]
     fn sol_mode_keeps_configured_amortization_on_full_only_table() {
         let db = sglang_db("h200_sxm", "0.5.10", DatabaseMode::Sol);
-        assert!(!db.dsa.has_context_skip_rows(), "anchor must be full-only");
+        assert!(
+            !db.dsa.has_context_skip_rows().expect("probe"),
+            "anchor must be full-only"
+        );
 
         let glm52 = glm52_op(KvCacheQuantMode::Bfloat16, GLM52_FULL_FRAC);
         let all_full = glm52_op(KvCacheQuantMode::Bfloat16, 1.0);

--- a/aic-core/rust/aiconfigurator-core/src/operators/dsa.rs
+++ b/aic-core/rust/aiconfigurator-core/src/operators/dsa.rs
@@ -139,6 +139,32 @@ impl DsaModuleOp {
         bytes * self.scale_factor
     }
 
+    /// Amortization weight after the missing-skip-table degradation. Verbatim
+    /// mirror of Python `operations/dsa.py::_effective_full_frac`: the
+    /// `*_skip_indexer` rows are produced only by the sglang collector and only
+    /// from 0.5.14 on, so a (system, backend, version) whose parquet omits them
+    /// degrades to all-full (`w = 1.0`) instead of failing the query — the same
+    /// policy `models/deepseek_v32.py` already applies to backends with no skip
+    /// producer ("we just cannot model their saving without data, so we count
+    /// them as full"). PESSIMISTIC: the indexer is charged on every layer.
+    ///
+    /// KNOWN GAP (accepted, AIC-1747 review): the degradation is SILENT.
+    /// The crate has no logging facility (the "Rust has no logging"
+    /// convention recorded at `operators/dsv4.rs`), and since the per-call
+    /// Python query stack was retired behind engine-routed shims (PR-5/PR-6)
+    /// there is no Python query path left to carry the one-time warning the
+    /// pre-migration design emitted. Surfacing fidelity degradation belongs
+    /// to an engine-side degradation/provenance surface — tracked as
+    /// AIC-1767 (AIC-1753 owns the adjacent support-matrix reporting
+    /// tier). Do not "fix" this by adding a log crate to the hot path.
+    fn effective_full_frac(&self, has_skip_rows: bool) -> f64 {
+        if self.full_frac >= 1.0 || has_skip_rows {
+            self.full_frac
+        } else {
+            1.0
+        }
+    }
+
     pub fn query_context(
         &self,
         db: &PerfDatabase,
@@ -158,7 +184,20 @@ impl DsaModuleOp {
                 self.cp_size
             )));
         }
-        let w = self.full_frac;
+        // full_frac >= 1.0 (DeepSeek-V3.2 / GLM-5) and the analytic SOL modes
+        // never consult the skip table — short-circuit BEFORE the probe so it
+        // is not even evaluated for them (the "skip path never taken"
+        // invariant documented on `full_frac`). SOL is skip-aware directly
+        // (the get_sol ports zero the indexer terms), so it keeps the
+        // configured blend — mirrors the retired Python
+        // `_effective_full_frac` mode gate.
+        let w = if self.full_frac >= 1.0
+            || matches!(db.database_mode, DatabaseMode::Sol | DatabaseMode::SolFull)
+        {
+            self.full_frac
+        } else {
+            self.effective_full_frac(db.dsa.has_context_skip_rows())
+        };
         // CP (round-robin sequence split) prefill takes the sparse-delta
         // composition path (Python `ContextDSAModule.query` -> `_query_cp`
         // when `_cp_size > 1`). GLM-5.2 amortizes full/skip on the CP path
@@ -381,7 +420,15 @@ impl DsaModuleOp {
         batch_size: u32,
         s: u32,
     ) -> Result<PerformanceResult, AicError> {
-        let w = self.full_frac;
+        // Same short-circuit as query_context: no probe for full_frac >= 1.0
+        // or the analytic SOL modes.
+        let w = if self.full_frac >= 1.0
+            || matches!(db.database_mode, DatabaseMode::Sol | DatabaseMode::SolFull)
+        {
+            self.full_frac
+        } else {
+            self.effective_full_frac(db.dsa.has_generation_skip_rows())
+        };
         // `dsa_backend="trtllm"` mirrors Python's generation default
         // (`_query_generation_dsa_module_table(dsa_backend="trtllm")`).
         let q = |skip_indexer: bool| {
@@ -1225,6 +1272,30 @@ mod tests {
         db
     }
 
+    /// Any shipped system at sglang 0.5.14 — the release that first split the
+    /// DSA tables into full + `*_skip_indexer` rows (and did not do so on
+    /// every system).
+    fn sglang_db(system: &str, version: &str, mode: DatabaseMode) -> PerfDatabase {
+        let systems_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .join("src/aiconfigurator_core/systems");
+        let mut db = PerfDatabase::load(&systems_root, system, "sglang", version)
+            .unwrap_or_else(|e| panic!("{system} db must load: {e}"));
+        db.database_mode = mode;
+        db
+    }
+
+    /// GLM-5.2: 21 indexer-computing layers out of 78 (`index_topk_freq=4`,
+    /// `index_skip_topk_offset=3`) — the weight Python's
+    /// `_dsa_full_layer_fraction` derives from the checkpoint config.
+    const GLM52_FULL_FRAC: f64 = 21.0 / 78.0;
+
+    fn glm52_op(kv: KvCacheQuantMode, full_frac: f64) -> DsaModuleOp {
+        let mut op = dsa_op(GLM, 64, kv);
+        op.full_frac = full_frac;
+        op
+    }
+
     fn dsa_op(architecture: &str, num_heads: u32, kv: KvCacheQuantMode) -> DsaModuleOp {
         DsaModuleOp::new(
             "dsa_module",
@@ -1242,6 +1313,153 @@ mod tests {
             ((got - want) / want).abs() < 1e-9,
             "rust {got} vs python {want}"
         );
+    }
+
+    /// AIC-1747: the sglang 0.5.9–0.5.12-era tables ship `dsa_context_module`
+    /// / `dsa_generation_module` rows ONLY — the collector's `*_skip_indexer`
+    /// split never ran there (0.5.14's gap closed with the AIC-1747 probe
+    /// collection, PR #1556). GLM-5.2 (`full_frac` = 21/78) used to take the
+    /// skip branch and die on the whole sweep. The amortization must degrade
+    /// to all-full, mirroring Python `operations/dsa.py::_effective_full_frac`.
+    /// Anchored to h200/0.5.10 — a table no in-flight data PR touches — so the
+    /// fixture holds in either merge order with #1556.
+    #[test]
+    fn missing_skip_indexer_variant_degrades_amortization_to_all_full() {
+        let db = sglang_db("h200_sxm", "0.5.10", DatabaseMode::Silicon);
+        assert!(!db.dsa.has_context_skip_rows(), "h200/0.5.10 ships full rows only");
+        assert!(!db.dsa.has_generation_skip_rows());
+
+        let glm52 = glm52_op(KvCacheQuantMode::Bfloat16, GLM52_FULL_FRAC);
+        let all_full = glm52_op(KvCacheQuantMode::Bfloat16, 1.0);
+
+        let degraded = glm52
+            .query_context(&db, 2, 4096, 512)
+            .expect("context query must not fail on a full-only table");
+        approx_rel_1e9(
+            degraded.latency_ms,
+            all_full
+                .query_context(&db, 2, 4096, 512)
+                .expect("all-full context")
+                .latency_ms,
+        );
+        approx_rel_1e9(degraded.latency_ms, 10.447453783383576);
+
+        let degraded_gen = glm52
+            .query_generation(&db, 2, 4096)
+            .expect("generation query must not fail on a full-only table");
+        approx_rel_1e9(
+            degraded_gen.latency_ms,
+            all_full
+                .query_generation(&db, 2, 4096)
+                .expect("all-full generation")
+                .latency_ms,
+        );
+        approx_rel_1e9(degraded_gen.latency_ms, 0.161296826171875);
+    }
+
+    /// The other half of AIC-1747: where the skip rows DO exist
+    /// (gb200/sglang/0.5.14 — anchored there because no in-flight data PR
+    /// touches that table, so the pins hold in either merge order with
+    /// #1556) the mixed amortization is untouched — the degradation must
+    /// never become the default. Pinned numerically so a silent collapse to
+    /// all-full fails here.
+    #[test]
+    fn present_skip_indexer_variant_keeps_mixed_amortization() {
+        let db = sglang_db("gb200", "0.5.14", DatabaseMode::Silicon);
+        assert!(db.dsa.has_context_skip_rows(), "gb200 ships both variants");
+        assert!(db.dsa.has_generation_skip_rows());
+
+        let glm52 = glm52_op(KvCacheQuantMode::Bfloat16, GLM52_FULL_FRAC);
+        let all_full = glm52_op(KvCacheQuantMode::Bfloat16, 1.0);
+
+        let mixed = glm52
+            .query_context(&db, 2, 4096, 512)
+            .expect("context query")
+            .latency_ms;
+        let full_only = all_full
+            .query_context(&db, 2, 4096, 512)
+            .expect("all-full context")
+            .latency_ms;
+        assert!(
+            mixed < full_only,
+            "skip layers must lower the amortized cost: {mixed} vs {full_only}"
+        );
+        // Exact blend identity: w*full + (1-w)*skip (full_frac = 0.0 is the
+        // pure-skip probe). Pinned too, so a data refresh that silently moves
+        // the amortization is caught either way.
+        let skip_only = glm52_op(KvCacheQuantMode::Bfloat16, 0.0)
+            .query_context(&db, 2, 4096, 512)
+            .expect("pure-skip context")
+            .latency_ms;
+        approx_rel_1e9(
+            mixed,
+            GLM52_FULL_FRAC * full_only + (1.0 - GLM52_FULL_FRAC) * skip_only,
+        );
+        approx_rel_1e9(mixed, 6.599784615384616);
+
+        let mixed_gen = glm52
+            .query_generation(&db, 2, 4096)
+            .expect("generation query")
+            .latency_ms;
+        let full_only_gen = all_full
+            .query_generation(&db, 2, 4096)
+            .expect("all-full generation")
+            .latency_ms;
+        assert!(mixed_gen < full_only_gen);
+        approx_rel_1e9(mixed_gen, 0.10149143817608174);
+    }
+
+    /// PR #1540 review follow-up: SOL is analytic and skip-aware directly
+    /// (the context get_sol port zeroes the indexer terms on skip layers), so
+    /// a full-only table must NOT degrade the configured blend there. Without
+    /// the mode gate the degraded op (w -> 1.0) collapses to the all-full SOL;
+    /// with it the blend keeps the cheaper skip layers and stays strictly
+    /// below. Generation SOL is not skip-aware (the indexer term is charged
+    /// unconditionally, matching Python), so its value is blend-neutral —
+    /// asserted only to not fail on the skip-less table.
+    #[test]
+    fn sol_mode_keeps_configured_amortization_on_full_only_table() {
+        let db = sglang_db("h200_sxm", "0.5.10", DatabaseMode::Sol);
+        assert!(!db.dsa.has_context_skip_rows(), "anchor must be full-only");
+
+        let glm52 = glm52_op(KvCacheQuantMode::Bfloat16, GLM52_FULL_FRAC);
+        let all_full = glm52_op(KvCacheQuantMode::Bfloat16, 1.0);
+
+        let mixed_sol = glm52
+            .query_context(&db, 2, 4096, 512)
+            .expect("SOL context query must not fail on a full-only table")
+            .latency_ms;
+        let full_sol = all_full
+            .query_context(&db, 2, 4096, 512)
+            .expect("all-full SOL context")
+            .latency_ms;
+        assert!(
+            mixed_sol < full_sol,
+            "SOL must keep the configured blend (degradation would collapse it to all-full): {mixed_sol} vs {full_sol}"
+        );
+        // Exact blend identity, same construction as the Silicon-mode mixed
+        // test: full_frac = 0.0 is the pure-skip SOL probe (the gate keeps
+        // configured fractions in SOL, so w stays 0.0 on the skip-less table).
+        let skip_sol = glm52_op(KvCacheQuantMode::Bfloat16, 0.0)
+            .query_context(&db, 2, 4096, 512)
+            .expect("pure-skip SOL context")
+            .latency_ms;
+        approx_rel_1e9(
+            mixed_sol,
+            GLM52_FULL_FRAC * full_sol + (1.0 - GLM52_FULL_FRAC) * skip_sol,
+        );
+
+        // Generation SOL is not skip-aware, so the blend is value-neutral:
+        // the mixed op must equal the all-full op exactly (and not fail).
+        let mixed_gen_sol = glm52
+            .query_generation(&db, 2, 4096)
+            .expect("SOL generation query must not fail on a full-only table")
+            .latency_ms;
+        let full_gen_sol = all_full
+            .query_generation(&db, 2, 4096)
+            .expect("all-full SOL generation")
+            .latency_ms;
+        approx_rel_1e9(mixed_gen_sol, full_gen_sol);
     }
 
     /// Context EMPIRICAL parity on b200_sxm/vllm/0.19.0. Fired variants

--- a/aic-core/rust/aiconfigurator-core/src/operators/dsv4.rs
+++ b/aic-core/rust/aiconfigurator-core/src/operators/dsv4.rs
@@ -211,7 +211,8 @@ impl Dsv4ModuleOp {
         let index_head_dim = dims.index_head_dim as f64;
         let cr = self.attn_kind.compress_ratio() as u32;
 
-        let mut gemm_elems = h * q_lora + q_lora * heads * head_dim + h * head_dim + o_groups * o_lora * h;
+        let mut gemm_elems =
+            h * q_lora + q_lora * heads * head_dim + h * head_dim + o_groups * o_lora * h;
         let mut bf16_elems = heads * head_dim * o_lora;
         let mut f32_elems = heads;
         if cr != 0 {
@@ -225,7 +226,8 @@ impl Dsv4ModuleOp {
             bf16_elems += h * index_n_heads;
             f32_elems += cr as f64 * 2.0 * index_head_dim;
         }
-        let bytes = gemm_elems * self.gemm_quant_mode.mapping().memory + bf16_elems * 2.0 + f32_elems * 4.0;
+        let bytes =
+            gemm_elems * self.gemm_quant_mode.mapping().memory + bf16_elems * 2.0 + f32_elems * 4.0;
         bytes * self.scale_factor
     }
 

--- a/aic-core/rust/aiconfigurator-core/src/operators/gemm.rs
+++ b/aic-core/rust/aiconfigurator-core/src/operators/gemm.rs
@@ -159,8 +159,7 @@ impl GemmOp {
             source = Source::Estimated;
         }
 
-        let mut result =
-            PerformanceResult::with_energy(latency.max(latency_floor), energy, source);
+        let mut result = PerformanceResult::with_energy(latency.max(latency_floor), energy, source);
         if let Some(components) = sol {
             result = result.with_sol(components);
         }
@@ -447,9 +446,12 @@ fn query_compute_scale_table(
         // Python `_query_compute_scale_table::get_sol`:
         // `sol_mem = 2 m k / bw * 1000` (read + write of the activation);
         // triple is `(sol_mem, 0, sol_mem)` — pure memory bound.
-        DatabaseMode::Sol | DatabaseMode::SolFull => Ok(PerformanceResult::sol(
-            SolComponents::new(0.0, 2.0 * m as f64 * k as f64 / db.system_spec.gpu.mem_bw * 1000.0),
-        )),
+        DatabaseMode::Sol | DatabaseMode::SolFull => {
+            Ok(PerformanceResult::sol(SolComponents::new(
+                0.0,
+                2.0 * m as f64 * k as f64 / db.system_spec.gpu.mem_bw * 1000.0,
+            )))
+        }
         DatabaseMode::Empirical => Ok(PerformanceResult::new(
             compute_scale_empirical(db, quant, m, k)?,
             Source::Empirical,
@@ -510,9 +512,12 @@ fn query_scale_matrix_table(
     match db.database_mode {
         // Python `_query_scale_matrix_table::get_sol`:
         // `sol_mem = 3 m k / bw * 1000`; triple `(sol_mem, 0, sol_mem)`.
-        DatabaseMode::Sol | DatabaseMode::SolFull => Ok(PerformanceResult::sol(
-            SolComponents::new(0.0, 3.0 * m as f64 * k as f64 / db.system_spec.gpu.mem_bw * 1000.0),
-        )),
+        DatabaseMode::Sol | DatabaseMode::SolFull => {
+            Ok(PerformanceResult::sol(SolComponents::new(
+                0.0,
+                3.0 * m as f64 * k as f64 / db.system_spec.gpu.mem_bw * 1000.0,
+            )))
+        }
         DatabaseMode::Empirical => Ok(PerformanceResult::new(
             scale_matrix_empirical(db, quant, m, k)?,
             Source::Empirical,

--- a/aic-core/rust/aiconfigurator-core/src/operators/mhc.rs
+++ b/aic-core/rust/aiconfigurator-core/src/operators/mhc.rs
@@ -65,7 +65,9 @@ impl MhcModuleOp {
         let hc_mult = f64::from(self.hc_mult);
         let mix_hc = (2.0 + hc_mult) * hc_mult;
         let hc_dim = hc_mult * f64::from(self.hidden_size);
-        2.0 * (mix_hc * hc_dim + mix_hc + 3.0) * self.quant_mode.mapping().memory * self.scale_factor
+        2.0 * (mix_hc * hc_dim + mix_hc + 3.0)
+            * self.quant_mode.mapping().memory
+            * self.scale_factor
     }
 
     pub fn new(

--- a/aic-core/rust/aiconfigurator-core/src/operators/moe.rs
+++ b/aic-core/rust/aiconfigurator-core/src/operators/moe.rs
@@ -1107,11 +1107,15 @@ mod tests {
     /// ```
     #[test]
     fn moe_nvfp4_wo_ladder_matches_python_oracle() {
-        let root =
-            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..").join("src/aiconfigurator_core/systems");
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .join("src/aiconfigurator_core/systems");
         let db = PerfDatabase::load(&root, "h200_sxm", "vllm", "0.19.0")
             .expect("h200/vllm/0.19.0 db loads")
-            .with_mode(crate::common::enums::DatabaseMode::Hybrid, TransferPolicy::ALL);
+            .with_mode(
+                crate::common::enums::DatabaseMode::Hybrid,
+                TransferPolicy::ALL,
+            );
 
         let op = MoeOp {
             name: "moe-nvfp4wo-ladder".into(),
@@ -1130,8 +1134,15 @@ mod tests {
             enable_eplb: false,
             is_context: false,
         };
-        let r = op.query(&db, 96).expect("nvfp4_wo resolves via XPROFILE ladder");
-        assert_oracle(&r, 8.439357376098632, Source::Empirical, "nvfp4_wo_ladder_t96");
+        let r = op
+            .query(&db, 96)
+            .expect("nvfp4_wo resolves via XPROFILE ladder");
+        assert_oracle(
+            &r,
+            8.439357376098632,
+            Source::Empirical,
+            "nvfp4_wo_ladder_t96",
+        );
     }
 
     #[test]

--- a/aic-core/rust/aiconfigurator-core/src/operators/op.rs
+++ b/aic-core/rust/aiconfigurator-core/src/operators/op.rs
@@ -565,7 +565,8 @@ mod tests {
     /// fp8 query (no fp8 table exists).
     fn one_row_gemm_db() -> (tempfile::TempDir, PerfDatabase) {
         let tmp = tempfile::tempdir().expect("tmpdir");
-        let data = crate::perf_database::energy_test_fixtures::write_energy_systems_root(tmp.path());
+        let data =
+            crate::perf_database::energy_test_fixtures::write_energy_systems_root(tmp.path());
         write_parquet(
             &data.join("gemm_perf.parquet"),
             &[
@@ -635,7 +636,11 @@ mod tests {
         ));
         let r = op.query(&db, &ctx()).expect("query");
         assert!((r.latency_ms - 1.0).abs() < 1e-12);
-        assert_eq!(r.source, Source::Silicon, "zero-valued nested composite must be source-neutral");
+        assert_eq!(
+            r.source,
+            Source::Silicon,
+            "zero-valued nested composite must be source-neutral"
+        );
     }
 
     #[test]
@@ -648,7 +653,11 @@ mod tests {
         ));
         let r = op.query(&db, &ctx()).expect("query");
         assert!((r.latency_ms - 1.0).abs() < 1e-12);
-        assert_eq!(r.source, Source::Silicon, "zero-valued opposite group must be source-neutral");
+        assert_eq!(
+            r.source,
+            Source::Silicon,
+            "zero-valued opposite group must be source-neutral"
+        );
     }
 
     #[test]
@@ -670,4 +679,3 @@ mod tests {
         assert_eq!(r.source, Source::Silicon);
     }
 }
-

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/attention.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/attention.rs
@@ -43,8 +43,8 @@ use super::{kernel_source_ok, SourceResolver};
 use crate::common::enums::{FmhaQuantMode, KvCacheQuantMode};
 use crate::common::error::AicError;
 use crate::common::system_spec::SystemSpec;
-use crate::operators::base::SolComponents;
 use crate::config::{PerfDbSources, PerfSource};
+use crate::operators::base::SolComponents;
 use crate::perf_database::parquet_loader::PerfReader;
 
 pub struct AttentionTable {
@@ -102,8 +102,12 @@ impl AttentionTable {
     /// perf file is sourced solely from `data_root/<basename>` with no
     /// `kernel_source` filter (pre-shared-layer behaviour).
     pub fn new(data_root: PathBuf, system_spec: SystemSpec) -> Self {
-        Self::with_sources(data_root, system_spec, &SourceResolver::fixed(PerfDbSources::default()))
-            .expect("fixed-map resolution is infallible")
+        Self::with_sources(
+            data_root,
+            system_spec,
+            &SourceResolver::fixed(PerfDbSources::default()),
+        )
+        .expect("fixed-map resolution is infallible")
     }
 
     /// Construct with shared-layer (sibling/cross-version) sources supplied by the
@@ -116,7 +120,8 @@ impl AttentionTable {
         resolver: &SourceResolver,
     ) -> Result<Self, AicError> {
         let context_sources = resolver.sources_for("context_attention_perf.parquet", &data_root)?;
-        let generation_sources = resolver.sources_for("generation_attention_perf.parquet", &data_root)?;
+        let generation_sources =
+            resolver.sources_for("generation_attention_perf.parquet", &data_root)?;
         let encoder_sources = resolver.sources_for("encoder_attention_perf.parquet", &data_root)?;
         Ok(Self {
             data_root,
@@ -783,7 +788,16 @@ pub(crate) fn context_attention_sol_with_prefix_ms(
     attn_flops: f64,
 ) -> f64 {
     context_attention_sol_with_prefix(
-        spec, b, s, prefix, n, n_kv, head_size, window_size, kv_quant, attn_flops,
+        spec,
+        b,
+        s,
+        prefix,
+        n,
+        n_kv,
+        head_size,
+        window_size,
+        kv_quant,
+        attn_flops,
     )
     .time_ms()
 }
@@ -1241,8 +1255,8 @@ mod tests {
     fn encoder_attention_query_matches_python_v2_engine() {
         let table = AttentionTable::new(b200_vllm_data_root(), b200_sxm_spec());
         let cases: &[(u32, u32, f64)] = &[
-            (1, 1024, 0.03258133431275686), // exact hit
-            (2, 1400, 0.0779337721462867),  // seq interp (sqrt blend)
+            (1, 1024, 0.03258133431275686),  // exact hit
+            (2, 1400, 0.0779337721462867),   // seq interp (sqrt blend)
             (64, 65536, 10944.346873534367), // batch beyond staircase (tapered util-hold)
         ];
         for &(b, s, expected) in cases {

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/communication.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/communication.rs
@@ -83,8 +83,13 @@ impl CommunicationTable {
         nccl_root: Option<PathBuf>,
         oneccl_root: Option<PathBuf>,
     ) -> Self {
-        Self::with_sources(data_root, nccl_root, oneccl_root, &SourceResolver::fixed(PerfDbSources::default()))
-            .expect("fixed-map resolution is infallible")
+        Self::with_sources(
+            data_root,
+            nccl_root,
+            oneccl_root,
+            &SourceResolver::fixed(PerfDbSources::default()),
+        )
+        .expect("fixed-map resolution is infallible")
     }
 
     /// Construct with shared-layer (sibling/cross-version) sources resolved from

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/dsa.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/dsa.rs
@@ -535,6 +535,28 @@ impl DsaTable {
             })
     }
 
+    /// Whether the GLM-5.2 skip-indexer (reuse-layer) rows are present in the
+    /// context file. `false` for a parquet that carries only
+    /// `dsa_context_module` rows (the sglang collector produces the skip split
+    /// from 0.5.14 on, and not on every system) — the loader returns its
+    /// no-rows error for that variant and the probe reports it as "absent"
+    /// WITHOUT surfacing the error, so `DsaModuleOp::query_context` can degrade
+    /// the shared-index amortization to all-full instead of failing. Mirrors
+    /// the Python slot test in `operations/dsa.py::_effective_full_frac`
+    /// (`database._context_dsa_module_skip_data` falsy).
+    pub fn has_context_skip_rows(&self) -> bool {
+        self.load_context_skip()
+            .map(|grids| !grids.by_keys.is_empty())
+            .unwrap_or(false)
+    }
+
+    /// Generation-side twin of [`Self::has_context_skip_rows`].
+    pub fn has_generation_skip_rows(&self) -> bool {
+        self.load_generation_skip()
+            .map(|grids| !grids.by_keys.is_empty())
+            .unwrap_or(false)
+    }
+
     fn load_context(&self) -> Result<&DsaGrids, AicError> {
         let cell = self
             .context

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/dsa.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/dsa.rs
@@ -43,8 +43,8 @@ use super::{kernel_source_ok, SourceResolver};
 use crate::common::enums::{FmhaQuantMode, GemmQuantMode, KvCacheQuantMode};
 use crate::common::error::AicError;
 use crate::common::system_spec::SystemSpec;
-use crate::operators::base::SolComponents;
 use crate::config::{PerfDbSources, PerfSource};
+use crate::operators::base::SolComponents;
 use crate::perf_database::parquet_loader::PerfReader;
 
 pub struct DsaTable {
@@ -191,7 +191,10 @@ const GLM_MOE_DSA_DIMS: DsaDims = DsaDims {
 /// query loader and the table view so a kernel rename lands once. BF16-KV
 /// rows back BOTH buckets (one real execution path per shape); FP8 rows
 /// bucket by the executed kernel, legacy names keep the substring rule.
-pub(crate) fn dsa_kernel_source_buckets(kernel_source: &str, kv_quant: &str) -> &'static [&'static str] {
+pub(crate) fn dsa_kernel_source_buckets(
+    kernel_source: &str,
+    kv_quant: &str,
+) -> &'static [&'static str] {
     if kv_quant == "bfloat16" {
         return &["trtllm", "flashmla_kv"];
     }
@@ -218,8 +221,11 @@ impl DsaTable {
     /// perf file is sourced solely from `data_root/<basename>` with no
     /// `kernel_source` filter (pre-shared-layer behaviour).
     pub fn new(data_root: PathBuf) -> Self {
-        Self::with_sources(data_root, &Arc::new(SourceResolver::fixed(PerfDbSources::default())))
-            .expect("fixed-map resolution is infallible")
+        Self::with_sources(
+            data_root,
+            &Arc::new(SourceResolver::fixed(PerfDbSources::default())),
+        )
+        .expect("fixed-map resolution is infallible")
     }
 
     /// Construct with shared-layer (sibling/cross-version) sources supplied by the
@@ -230,8 +236,10 @@ impl DsaTable {
         data_root: PathBuf,
         resolver: &Arc<SourceResolver>,
     ) -> Result<Self, AicError> {
-        let context_sources = resolver.sources_for("dsa_context_module_perf.parquet", &data_root)?;
-        let generation_sources = resolver.sources_for("dsa_generation_module_perf.parquet", &data_root)?;
+        let context_sources =
+            resolver.sources_for("dsa_context_module_perf.parquet", &data_root)?;
+        let generation_sources =
+            resolver.sources_for("dsa_generation_module_perf.parquet", &data_root)?;
         Ok(Self {
             data_root,
             context_sources,
@@ -274,8 +282,10 @@ impl DsaTable {
         let mut tables = DsaSparseTables::default();
         // mqa logits: every row goes to `mqa`.
         load_sparse_parquet(
-            &self.source_resolver
-                .sources_for(&format!("{file_prefix}_mqa_logits_module_perf.parquet"), &self.data_root)?,
+            &self.source_resolver.sources_for(
+                &format!("{file_prefix}_mqa_logits_module_perf.parquet"),
+                &self.data_root,
+            )?,
             num_heads,
             |_| SparseKind::Mqa,
             &mut tables,
@@ -283,8 +293,10 @@ impl DsaTable {
         // topk: split by `score_mode` — "flat" -> topk_flat, else topk_last
         // (Python: `"topk_flat" if str(r.get("score_mode","")) == "flat" else "topk_last"`).
         load_sparse_parquet(
-            &self.source_resolver
-                .sources_for(&format!("{file_prefix}_topk_module_perf.parquet"), &self.data_root)?,
+            &self.source_resolver.sources_for(
+                &format!("{file_prefix}_topk_module_perf.parquet"),
+                &self.data_root,
+            )?,
             num_heads,
             |score_mode| {
                 if score_mode == Some("flat") {
@@ -297,8 +309,10 @@ impl DsaTable {
         )?;
         // dsa_attn: optional, not used by the CP delta.
         load_sparse_parquet(
-            &self.source_resolver
-                .sources_for(&format!("{file_prefix}_dsa_attn_module_perf.parquet"), &self.data_root)?,
+            &self.source_resolver.sources_for(
+                &format!("{file_prefix}_dsa_attn_module_perf.parquet"),
+                &self.data_root,
+            )?,
             num_heads,
             |_| SparseKind::DsaAttn,
             &mut tables,
@@ -536,25 +550,28 @@ impl DsaTable {
     }
 
     /// Whether the GLM-5.2 skip-indexer (reuse-layer) rows are present in the
-    /// context file. `false` for a parquet that carries only
-    /// `dsa_context_module` rows (the sglang collector produces the skip split
-    /// from 0.5.14 on, and not on every system) — the loader returns its
-    /// no-rows error for that variant and the probe reports it as "absent"
-    /// WITHOUT surfacing the error, so `DsaModuleOp::query_context` can degrade
-    /// the shared-index amortization to all-full instead of failing. Mirrors
-    /// the Python slot test in `operations/dsa.py::_effective_full_frac`
-    /// (`database._context_dsa_module_skip_data` falsy).
-    pub fn has_context_skip_rows(&self) -> bool {
-        self.load_context_skip()
-            .map(|grids| !grids.by_keys.is_empty())
-            .unwrap_or(false)
+    /// context file. `Ok(false)` exactly for the loader's no-rows outcome
+    /// (a parquet that carries only `dsa_context_module` rows — the sglang
+    /// collector produces the skip split from 0.5.14 on, and not on every
+    /// system), so `DsaModuleOp::query_context` can degrade the shared-index
+    /// amortization to all-full instead of failing. Every OTHER load failure
+    /// (parquet/schema/row-conversion) propagates: a malformed skip row must
+    /// never silently select all-full while skip data exists.
+    pub fn has_context_skip_rows(&self) -> Result<bool, AicError> {
+        match self.load_context_skip() {
+            Ok(grids) => Ok(!grids.by_keys.is_empty()),
+            Err(AicError::PerfDatabase(msg)) if msg.contains(NO_DSA_ROWS_PREFIX) => Ok(false),
+            Err(err) => Err(err),
+        }
     }
 
     /// Generation-side twin of [`Self::has_context_skip_rows`].
-    pub fn has_generation_skip_rows(&self) -> bool {
-        self.load_generation_skip()
-            .map(|grids| !grids.by_keys.is_empty())
-            .unwrap_or(false)
+    pub fn has_generation_skip_rows(&self) -> Result<bool, AicError> {
+        match self.load_generation_skip() {
+            Ok(grids) => Ok(!grids.by_keys.is_empty()),
+            Err(AicError::PerfDatabase(msg)) if msg.contains(NO_DSA_ROWS_PREFIX) => Ok(false),
+            Err(err) => Err(err),
+        }
     }
 
     fn load_context(&self) -> Result<&DsaGrids, AicError> {
@@ -986,6 +1003,13 @@ pub(crate) fn dsa_generation_sol_ms(
 /// `step = 0, isl = s` in the shared `DsaHeadGrid` shape. Context keeps the
 /// raw `(step, isl)` coordinate (`load_context_dsa_module_data` keys on it
 /// exactly).
+/// Message prefix of the loader's "no rows" outcome. The probes below match
+/// on it to tell genuine absence (degrade the amortization) apart from real
+/// load failures (parquet/schema/row-conversion errors), which must stay
+/// loud: a malformed skip row must never silently select all-full while
+/// skip data exists.
+const NO_DSA_ROWS_PREFIX: &str = "no DSA module rows loaded";
+
 fn load_dsa_parquet(
     sources: &[PerfSource],
     collapse_isl_step_to_seq: bool,
@@ -1094,7 +1118,7 @@ fn load_dsa_parquet(
     }
     if !any_source || by_keys.is_empty() {
         return Err(AicError::PerfDatabase(format!(
-            "no DSA module rows loaded from {} source(s) (first: {})",
+            "{NO_DSA_ROWS_PREFIX} from {} source(s) (first: {})",
             sources.len(),
             sources
                 .first()
@@ -1852,6 +1876,84 @@ mod tests {
         // The skip row (9.0) still never blends in.
         assert_eq!(q("trtllm"), 5.0);
         assert_eq!(q("flashmla_kv"), 5.0);
+    }
+
+    /// PR #1540 review follow-up: the skip probe reports `Ok(false)` ONLY for
+    /// the loader's genuine no-rows outcome; every other load failure (here a
+    /// row-conversion error confined to a skip-tagged row) must propagate so
+    /// a malformed skip table can never silently select all-full amortization
+    /// while skip data exists. The full variant stays loadable either way
+    /// (its row filter skips the malformed skip row before parsing).
+    #[test]
+    fn skip_probe_reports_absence_but_propagates_load_errors() {
+        // Absence: full-only table -> Ok(false).
+        let absent = tempfile::tempdir().expect("tmpdir");
+        write_dsa_module_parquet(
+            &absent.path().join("dsa_context_module_perf.parquet"),
+            &[("dsa_context_module", "default", 1.0)],
+        );
+        let table = DsaTable::new(absent.path().to_path_buf());
+        assert!(!table
+            .has_context_skip_rows()
+            .expect("full-only is absence, not an error"));
+
+        // Presence: both variants -> Ok(true).
+        let present = tempfile::tempdir().expect("tmpdir");
+        write_dsa_module_parquet(
+            &present.path().join("dsa_context_module_perf.parquet"),
+            &[
+                ("dsa_context_module", "default", 1.0),
+                ("dsa_context_module_skip_indexer", "default", 0.5),
+            ],
+        );
+        let table = DsaTable::new(present.path().to_path_buf());
+        assert!(table
+            .has_context_skip_rows()
+            .expect("both variants present"));
+
+        // Corruption confined to a skip row (isl = -1 fails the u32
+        // conversion only in the skip load): the probe must ERROR, not
+        // report absence.
+        let corrupt = tempfile::tempdir().expect("tmpdir");
+        write_dsa_module_parquet_rows(
+            &corrupt.path().join("dsa_context_module_perf.parquet"),
+            &[
+                ("dsa_context_module", "default", "bfloat16", 1024, 1.0),
+                (
+                    "dsa_context_module_skip_indexer",
+                    "default",
+                    "bfloat16",
+                    -1,
+                    0.5,
+                ),
+            ],
+        );
+        let table = DsaTable::new(corrupt.path().to_path_buf());
+        let err = table
+            .has_context_skip_rows()
+            .expect_err("a malformed skip row must propagate, not read as absence");
+        assert!(
+            !err.to_string().contains(NO_DSA_ROWS_PREFIX),
+            "the propagated error must not be the absence outcome: {err}"
+        );
+        // The FULL variant of the same file still loads and answers.
+        let spec = b200_sxm_spec();
+        table
+            .query_context(
+                &spec,
+                1,
+                1024,
+                128,
+                KvCacheQuantMode::Bfloat16,
+                FmhaQuantMode::Bfloat16,
+                GemmQuantMode::Bfloat16,
+                "DeepseekV32ForCausalLM",
+                0,
+                INDEX_TOPK,
+                "trtllm",
+                false,
+            )
+            .expect("full-variant query must survive a malformed skip row");
     }
 
     /// FP8-KV rows bucket by executed-kernel name (the serving FP8-KV

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/dsv4.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/dsv4.rs
@@ -236,12 +236,18 @@ impl Dsv4Table {
     /// a fixed source map is the test-only path). Each DSV4 file falls back to its
     /// primary `data_root/<basename>` when the resolver names no override. No I/O.
     pub fn with_sources(data_root: PathBuf, resolver: &SourceResolver) -> Result<Self, AicError> {
-        let csa_context_sources = resolver.sources_for("dsv4_csa_context_module_perf.parquet", &data_root)?;
-        let hca_context_sources = resolver.sources_for("dsv4_hca_context_module_perf.parquet", &data_root)?;
-        let csa_generation_sources = resolver.sources_for("dsv4_csa_generation_module_perf.parquet", &data_root)?;
-        let hca_generation_sources = resolver.sources_for("dsv4_hca_generation_module_perf.parquet", &data_root)?;
-        let topk_calib_sources = resolver.sources_for("dsv4_csa_topk_calib_perf.parquet", &data_root)?;
-        let paged_mqa_sources = resolver.sources_for("dsv4_paged_mqa_logits_module_perf.parquet", &data_root)?;
+        let csa_context_sources =
+            resolver.sources_for("dsv4_csa_context_module_perf.parquet", &data_root)?;
+        let hca_context_sources =
+            resolver.sources_for("dsv4_hca_context_module_perf.parquet", &data_root)?;
+        let csa_generation_sources =
+            resolver.sources_for("dsv4_csa_generation_module_perf.parquet", &data_root)?;
+        let hca_generation_sources =
+            resolver.sources_for("dsv4_hca_generation_module_perf.parquet", &data_root)?;
+        let topk_calib_sources =
+            resolver.sources_for("dsv4_csa_topk_calib_perf.parquet", &data_root)?;
+        let paged_mqa_sources =
+            resolver.sources_for("dsv4_paged_mqa_logits_module_perf.parquet", &data_root)?;
         Ok(Self {
             csa_context_sources,
             hca_context_sources,

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/gemm.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/gemm.rs
@@ -28,9 +28,9 @@ use super::perf_interp::{
 use super::{kernel_source_ok, SourceResolver};
 use crate::common::enums::GemmQuantMode;
 use crate::common::error::AicError;
-use crate::operators::base::SolComponents;
 use crate::common::system_spec::SystemSpec;
 use crate::config::{PerfDbSources, PerfSource};
+use crate::operators::base::SolComponents;
 use crate::perf_database::parquet_loader::PerfReader;
 
 const GEMM_QUERY_CACHE_CAPACITY: usize = 32_768;
@@ -187,8 +187,12 @@ impl GemmTable {
     /// perf file is sourced solely from `data_root/<basename>` with no
     /// `kernel_source` filter (pre-shared-layer behaviour).
     pub fn new(data_root: PathBuf, system_spec: SystemSpec) -> Self {
-        Self::with_sources(data_root, system_spec, &SourceResolver::fixed(PerfDbSources::default()))
-            .expect("fixed-map resolution is infallible")
+        Self::with_sources(
+            data_root,
+            system_spec,
+            &SourceResolver::fixed(PerfDbSources::default()),
+        )
+        .expect("fixed-map resolution is infallible")
     }
 
     /// Construct with shared-layer (sibling/cross-version) sources supplied by the
@@ -203,8 +207,7 @@ impl GemmTable {
         let gemm_sources = resolver.sources_for("gemm_perf.parquet", &data_root)?;
         let compute_scale_sources =
             resolver.sources_for("computescale_perf.parquet", &data_root)?;
-        let scale_matrix_sources =
-            resolver.sources_for("scale_matrix_perf.parquet", &data_root)?;
+        let scale_matrix_sources = resolver.sources_for("scale_matrix_perf.parquet", &data_root)?;
         Ok(Self {
             data_root,
             system_spec,

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/mhc.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/mhc.rs
@@ -71,8 +71,7 @@ impl MhcTable {
     /// primary `data_root/mhc_module_perf.parquet` when the resolver names no override.
     /// No I/O.
     pub fn with_sources(data_root: PathBuf, resolver: &SourceResolver) -> Result<Self, AicError> {
-        let mhc_sources =
-            resolver.sources_for("mhc_module_perf.parquet", &data_root)?;
+        let mhc_sources = resolver.sources_for("mhc_module_perf.parquet", &data_root)?;
         Ok(Self {
             data_root,
             mhc_sources,

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/mla.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/mla.rs
@@ -39,8 +39,8 @@ use super::{kernel_source_ok, SourceResolver};
 use crate::common::enums::{FmhaQuantMode, GemmQuantMode, KvCacheQuantMode};
 use crate::common::error::AicError;
 use crate::common::system_spec::SystemSpec;
-use crate::operators::base::SolComponents;
 use crate::config::{PerfDbSources, PerfSource};
+use crate::operators::base::SolComponents;
 use crate::perf_database::parquet_loader::PerfReader;
 
 /// Axes for context-type MLA tables (op-level and module-level).
@@ -173,8 +173,12 @@ impl MlaTable {
     /// perf file is sourced solely from `data_root/<basename>` with no
     /// `kernel_source` filter (pre-shared-layer behaviour).
     pub fn new(data_root: PathBuf, system_spec: SystemSpec) -> Self {
-        Self::with_sources(data_root, system_spec, &SourceResolver::fixed(PerfDbSources::default()))
-            .expect("fixed-map resolution is infallible")
+        Self::with_sources(
+            data_root,
+            system_spec,
+            &SourceResolver::fixed(PerfDbSources::default()),
+        )
+        .expect("fixed-map resolution is infallible")
     }
 
     /// Construct with shared-layer (sibling/cross-version) sources supplied by the
@@ -186,14 +190,14 @@ impl MlaTable {
         system_spec: SystemSpec,
         resolver: &SourceResolver,
     ) -> Result<Self, AicError> {
-        let context_mla_sources =
-            resolver.sources_for("context_mla_perf.parquet", &data_root)?;
+        let context_mla_sources = resolver.sources_for("context_mla_perf.parquet", &data_root)?;
         let generation_mla_sources =
             resolver.sources_for("generation_mla_perf.parquet", &data_root)?;
-        let mla_bmm_sources =
-            resolver.sources_for("mla_bmm_perf.parquet", &data_root)?;
-        let mla_context_module_sources = resolver.sources_for("mla_context_module_perf.parquet", &data_root)?;
-        let mla_generation_module_sources = resolver.sources_for("mla_generation_module_perf.parquet", &data_root)?;
+        let mla_bmm_sources = resolver.sources_for("mla_bmm_perf.parquet", &data_root)?;
+        let mla_context_module_sources =
+            resolver.sources_for("mla_context_module_perf.parquet", &data_root)?;
+        let mla_generation_module_sources =
+            resolver.sources_for("mla_generation_module_perf.parquet", &data_root)?;
         Ok(Self {
             data_root,
             system_spec,
@@ -1554,8 +1558,8 @@ mod tests {
 
         // db.query_context_mla_module(b, s, prefix=0, num_heads=128, bf16^3)
         let ctx_mod_cases: &[(u32, u32, f64)] = &[
-            (2, 4096, 2.6503),             // exact hit
-            (2, 5000, 3.532393382077576),  // seq interior (sqrt blend)
+            (2, 4096, 2.6503),              // exact hit
+            (2, 5000, 3.532393382077576),   // seq interior (sqrt blend)
             (2, 100000, 705.5935422351143), // beyond seq range (tapered util-hold)
         ];
         for &(b, s, expected) in ctx_mod_cases {

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/mod.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/mod.rs
@@ -350,7 +350,14 @@ impl PerfDatabase {
         version: &str,
         perf_db_sources: &PerfDbSources,
     ) -> Result<Self, AicError> {
-        Self::load_with_sources_opts(systems_root, system, backend, version, perf_db_sources, false)
+        Self::load_with_sources_opts(
+            systems_root,
+            system,
+            backend,
+            version,
+            perf_db_sources,
+            false,
+        )
     }
 
     /// [`PerfDatabase::load_with_sources`] with an estimate-only escape hatch:
@@ -627,8 +634,7 @@ impl PerfDatabase {
         if let Some(tables) = memo.lock().unwrap().get(&key).and_then(Weak::upgrade) {
             return Ok(Self::from_tables(tables));
         }
-        let db =
-            Self::load_with_resolver(systems_root, system, backend, version, resolver, false)?;
+        let db = Self::load_with_resolver(systems_root, system, backend, version, resolver, false)?;
         let mut map = memo.lock().unwrap();
         map.retain(|_, weak| weak.strong_count() > 0);
         map.insert(key, Arc::downgrade(&db.tables));
@@ -998,7 +1004,12 @@ mod tests {
         // Table-backed lookups still miss lazily per family.
         assert!(tolerant
             .gemm
-            .query(crate::common::enums::GemmQuantMode::Bfloat16, 64, 4096, 4096)
+            .query(
+                crate::common::enums::GemmQuantMode::Bfloat16,
+                64,
+                4096,
+                4096
+            )
             .is_err());
     }
 

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/moe_a2a.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/moe_a2a.rs
@@ -114,9 +114,9 @@ impl MoeA2aTable {
     /// from `perf_db_sources` (Python-supplied). Each perf file falls back to
     /// its primary `data_root/<basename>` when absent from the map. No I/O.
     pub fn with_sources(data_root: PathBuf, resolver: &SourceResolver) -> Result<Self, AicError> {
-        let moe_a2a_sources =
-            resolver.sources_for("moe_a2a_perf.parquet", &data_root)?;
-        let legacy_normal_sources = resolver.sources_for("wideep_deepep_normal_perf.parquet", &data_root)?;
+        let moe_a2a_sources = resolver.sources_for("moe_a2a_perf.parquet", &data_root)?;
+        let legacy_normal_sources =
+            resolver.sources_for("wideep_deepep_normal_perf.parquet", &data_root)?;
         let legacy_ll_sources =
             resolver.sources_for("wideep_deepep_ll_perf.parquet", &data_root)?;
         let legacy_trtllm_alltoall_sources =
@@ -544,7 +544,9 @@ pub(crate) fn legacy_trtllm_backend(kernel_source: &str) -> Option<&'static str>
 /// low-precision combine kernel gets its own `"fp4"` dtype key (an nvfp4
 /// run's STANDARD combine still keys as `"nvfp4"`). An unmapped op_name skips
 /// the row. Shared with the table view.
-pub(crate) fn legacy_trtllm_phase_dtype(op_name: &str) -> Option<(&'static str, Option<&'static str>)> {
+pub(crate) fn legacy_trtllm_phase_dtype(
+    op_name: &str,
+) -> Option<(&'static str, Option<&'static str>)> {
     match op_name {
         "alltoall_prepare" => Some(("prepare", None)),
         "alltoall_dispatch" => Some(("dispatch", None)),

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/moe_expert_compute.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/moe_expert_compute.rs
@@ -207,8 +207,12 @@ impl MoeExpertComputeTable {
     /// perf file is sourced solely from `data_root/<basename>` with no
     /// `kernel_source` filter (pre-shared-layer behaviour).
     pub fn new(data_root: PathBuf, spec: SystemSpec) -> Self {
-        Self::with_sources(data_root, spec, &SourceResolver::fixed(PerfDbSources::default()))
-            .expect("fixed-map resolution is infallible")
+        Self::with_sources(
+            data_root,
+            spec,
+            &SourceResolver::fixed(PerfDbSources::default()),
+        )
+        .expect("fixed-map resolution is infallible")
     }
 
     /// Construct with shared-layer (sibling/cross-version) sources resolved
@@ -220,8 +224,10 @@ impl MoeExpertComputeTable {
         resolver: &SourceResolver,
     ) -> Result<Self, AicError> {
         let moe_ep_sources = resolver.sources_for("moe_expert_compute_perf.parquet", &data_root)?;
-        let legacy_context_sources = resolver.sources_for("wideep_context_moe_perf.parquet", &data_root)?;
-        let legacy_generation_sources = resolver.sources_for("wideep_generation_moe_perf.parquet", &data_root)?;
+        let legacy_context_sources =
+            resolver.sources_for("wideep_context_moe_perf.parquet", &data_root)?;
+        let legacy_generation_sources =
+            resolver.sources_for("wideep_generation_moe_perf.parquet", &data_root)?;
         let legacy_trtllm_wideep_sources =
             resolver.sources_for("wideep_moe_perf.parquet", &data_root)?;
         Ok(Self {

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/source_resolution.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/source_resolution.rs
@@ -282,7 +282,8 @@ fn check_strict_provenance_coverage(
             return Ok(());
         }
     };
-    let covered: BTreeSet<String> = match meta.get(serde_yaml::Value::String("tables".to_string())) {
+    let covered: BTreeSet<String> = match meta.get(serde_yaml::Value::String("tables".to_string()))
+    {
         Some(serde_yaml::Value::Mapping(tables)) => tables
             .keys()
             .filter_map(|key| match key {
@@ -369,9 +370,7 @@ fn parse_reuse_yaml(path: &Path) -> Result<Vec<ReuseEntry>, AicError> {
         let missing: Vec<&str> = REUSE_ENTRY_REQUIRED_KEYS
             .iter()
             .copied()
-            .filter(|key| {
-                !entry_map.contains_key(serde_yaml::Value::String((*key).to_string()))
-            })
+            .filter(|key| !entry_map.contains_key(serde_yaml::Value::String((*key).to_string())))
             .collect();
         if !missing.is_empty() {
             return Err(perf_err(format!(
@@ -511,7 +510,10 @@ pub(crate) fn resolve_op_data_path(
             }
         }
     }
-    system_data_root.join(backend).join(version).join(op_filename)
+    system_data_root
+        .join(backend)
+        .join(version)
+        .join(op_filename)
 }
 
 /// Yield `(version, version_path)` for a backend across BOTH tree layouts.
@@ -712,11 +714,11 @@ fn manifest_entries_for(
         if op_file != op_file_basename {
             continue;
         }
-        let kernel_source = match entry_map.get(serde_yaml::Value::String("kernel_source".to_string()))
-        {
-            Some(serde_yaml::Value::String(s)) if !s.is_empty() => Some(s.clone()),
-            _ => None, // falsy kernel_source is skipped at consumption
-        };
+        let kernel_source =
+            match entry_map.get(serde_yaml::Value::String("kernel_source".to_string())) {
+                Some(serde_yaml::Value::String(s)) if !s.is_empty() => Some(s.clone()),
+                _ => None, // falsy kernel_source is skipped at consumption
+            };
         let tier = match entry_map.get(serde_yaml::Value::String("tier".to_string())) {
             Some(serde_yaml::Value::String(s)) => Some(s.clone()),
             _ => None,
@@ -923,8 +925,16 @@ pub fn resolve_one(
         if !donor_path.is_file() {
             continue;
         }
-        let donor_dir = donor_path.parent().map(Path::to_path_buf).unwrap_or_default();
-        if version_dir_unusable_for_request(&donor_dir, &ctx.system_data_root, ctx.strict, &mut warnings)? {
+        let donor_dir = donor_path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_default();
+        if version_dir_unusable_for_request(
+            &donor_dir,
+            &ctx.system_data_root,
+            ctx.strict,
+            &mut warnings,
+        )? {
             continue;
         }
         if op_file_family_from_path(&donor_path, &ctx.system_data_root).is_some() {
@@ -986,8 +996,16 @@ pub fn resolve_one(
             if !sibling_path.is_file() {
                 continue;
             }
-            let sibling_dir = sibling_path.parent().map(Path::to_path_buf).unwrap_or_default();
-            if version_dir_unusable_for_request(&sibling_dir, &ctx.system_data_root, ctx.strict, &mut warnings)? {
+            let sibling_dir = sibling_path
+                .parent()
+                .map(Path::to_path_buf)
+                .unwrap_or_default();
+            if version_dir_unusable_for_request(
+                &sibling_dir,
+                &ctx.system_data_root,
+                ctx.strict,
+                &mut warnings,
+            )? {
                 continue;
             }
             records.push((sibling_version, sibling_path, "fallback", None));
@@ -998,8 +1016,11 @@ pub fn resolve_one(
     let mut per_framework_filter: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
     let mut per_framework_fallback: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
     for entry in manifest_entries_for(&ctx.systems_root, op_file_basename)? {
-        let frameworks_lower: BTreeSet<String> =
-            entry.frameworks.iter().map(|fw| fw.to_lowercase()).collect();
+        let frameworks_lower: BTreeSet<String> = entry
+            .frameworks
+            .iter()
+            .map(|fw| fw.to_lowercase())
+            .collect();
         if !frameworks_lower.contains(&backend_lower) {
             continue; // Active backend isn't listed as a consumer of this kernel_source.
         }
@@ -1062,8 +1083,16 @@ pub fn resolve_one(
             if !sibling_path.is_file() {
                 continue;
             }
-            let sibling_dir = sibling_path.parent().map(Path::to_path_buf).unwrap_or_default();
-            if version_dir_unusable_for_request(&sibling_dir, &ctx.system_data_root, ctx.strict, &mut warnings)? {
+            let sibling_dir = sibling_path
+                .parent()
+                .map(Path::to_path_buf)
+                .unwrap_or_default();
+            if version_dir_unusable_for_request(
+                &sibling_dir,
+                &ctx.system_data_root,
+                ctx.strict,
+                &mut warnings,
+            )? {
                 continue;
             }
             if !fallback_only.is_disjoint(&ks_filter) {
@@ -1131,7 +1160,11 @@ impl SourceResolver {
     /// legacy `<data>/<backend>/<version>` dir used for the Fixed-map
     /// default-primary fallback (identical to the retired
     /// `resolve_op_sources`).
-    pub fn sources_for(&self, basename: &str, data_root: &Path) -> Result<Vec<PerfSource>, AicError> {
+    pub fn sources_for(
+        &self,
+        basename: &str,
+        data_root: &Path,
+    ) -> Result<Vec<PerfSource>, AicError> {
         match &self.kind {
             ResolverKind::Fixed(map) => Ok(match map.get(basename) {
                 Some(sources) if !sources.is_empty() => sources.clone(),
@@ -1227,7 +1260,10 @@ mod tests {
         let root = tmp.path();
         let data = root.join("data");
         for v in ["1.0.0", "1.2.0", "0.9.0", "0.5.0"] {
-            write(&data.join(format!("gemm/trtllm/{v}/gemm_perf.parquet")), "stub");
+            write(
+                &data.join(format!("gemm/trtllm/{v}/gemm_perf.parquet")),
+                "stub",
+            );
         }
         write(&data.join("gemm/vllm/0.5.0/gemm_perf.parquet"), "stub");
         write(
@@ -1241,11 +1277,26 @@ mod tests {
         let report = resolve_one(&ctx(root, "trtllm", "1.0.0"), "gemm_perf.parquet", None).unwrap();
         assert_eq!(
             channels(&report),
-            ["primary", "declared_reuse", "fallback", "fallback", "cross_backend"]
+            [
+                "primary",
+                "declared_reuse",
+                "fallback",
+                "fallback",
+                "cross_backend"
+            ]
         );
-        assert_eq!(versions(&report), ["1.0.0", "1.2.0", "0.9.0", "0.5.0", "0.5.0"]);
+        assert_eq!(
+            versions(&report),
+            ["1.0.0", "1.2.0", "0.9.0", "0.5.0", "0.5.0"]
+        );
         let last = report.records.last().unwrap();
-        let ks: Vec<&str> = last.ks_filter.as_ref().unwrap().iter().map(String::as_str).collect();
+        let ks: Vec<&str> = last
+            .ks_filter
+            .as_ref()
+            .unwrap()
+            .iter()
+            .map(String::as_str)
+            .collect();
         assert_eq!(ks, ["shared_kernel"]);
         assert!(report.records[..4].iter().all(|r| r.ks_filter.is_none()));
         assert!(report.records.iter().all(|r| r.exists));
@@ -1261,7 +1312,10 @@ mod tests {
         let root = tmp.path();
         let data = root.join("data");
         write(&data.join("trtllm/1.0.0/gemm_perf.parquet"), "stub");
-        write(&data.join("trtllm/1.0.0/INCOMPLETE.txt"), "partial collection\n");
+        write(
+            &data.join("trtllm/1.0.0/INCOMPLETE.txt"),
+            "partial collection\n",
+        );
         write(&data.join("gemm/trtllm/0.9.0/gemm_perf.parquet"), "stub");
         let report = resolve_one(&ctx(root, "trtllm", "1.0.0"), "gemm_perf.parquet", None).unwrap();
         assert_eq!(channels(&report), ["fallback"]);
@@ -1301,13 +1355,19 @@ mod tests {
         let root = tmp.path();
         let data = root.join("data");
         for v in ["1.2.0rc5", "1.2.0", "nightly-build", "1.2.0rc4"] {
-            write(&data.join(format!("gemm/trtllm/{v}/gemm_perf.parquet")), "stub");
+            write(
+                &data.join(format!("gemm/trtllm/{v}/gemm_perf.parquet")),
+                "stub",
+            );
         }
         let report =
             resolve_one(&ctx(root, "trtllm", "1.2.0rc5"), "gemm_perf.parquet", None).unwrap();
         // 1.2.0 > 1.2.0rc5 (never implicit); nightly-build unparseable (warned).
         assert_eq!(versions(&report), ["1.2.0rc5", "1.2.0rc4"]);
-        assert!(report.warnings.iter().any(|w| w.kind == "unparseable_sibling"));
+        assert!(report
+            .warnings
+            .iter()
+            .any(|w| w.kind == "unparseable_sibling"));
     }
 
     #[test]
@@ -1328,7 +1388,8 @@ mod tests {
         c.strict = true;
         let err = resolve_one(&c, "gemm_perf.parquet", None).unwrap_err();
         assert!(
-            err.to_string().contains("missing required key(s): from_version, reason, approved_by"),
+            err.to_string()
+                .contains("missing required key(s): from_version, reason, approved_by"),
             "{err}"
         );
         // non-strict: warn and keep resolving with zero declared donors.
@@ -1345,7 +1406,10 @@ mod tests {
     fn strict_primary_missing_sidecar_fails_closed() {
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
-        write(&root.join("data/gemm/trtllm/1.0.0/gemm_perf.parquet"), "stub");
+        write(
+            &root.join("data/gemm/trtllm/1.0.0/gemm_perf.parquet"),
+            "stub",
+        );
         let mut c = ctx(root, "trtllm", "1.0.0");
         c.strict = true;
 
@@ -1387,7 +1451,10 @@ mod tests {
             "schema_version: 1\nreuse:\n  - table: wideep_moe_perf\n    from_version: '0.9.0'\n    reason: r\n    approved_by: a\n",
         );
         write(&donor.join("wideep_moe_perf.parquet"), "stub");
-        write(&donor.join("collection_meta.yaml"), "schema_version: 1\ntables: {}\n");
+        write(
+            &donor.join("collection_meta.yaml"),
+            "schema_version: 1\ntables: {}\n",
+        );
         let mut c = ctx(root, "trtllm", "1.0.0");
         c.strict = true;
 
@@ -1420,8 +1487,14 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
         let data = root.join("data");
-        write(&data.join("comm/trtllm/1.0.0/custom_allreduce_perf.parquet"), "stub");
-        write(&data.join("comm/trtllm/0.9.0/custom_allreduce_perf.parquet"), "stub");
+        write(
+            &data.join("comm/trtllm/1.0.0/custom_allreduce_perf.parquet"),
+            "stub",
+        );
+        write(
+            &data.join("comm/trtllm/0.9.0/custom_allreduce_perf.parquet"),
+            "stub",
+        );
         let report = resolve_one(
             &ctx(root, "trtllm", "1.0.0"),
             "custom_allreduce_perf.parquet",
@@ -1466,10 +1539,16 @@ mod tests {
         );
         let resolver = SourceResolver::fixed(map);
         // present-but-empty = deliberate veto
-        assert!(resolver.sources_for("vetoed.parquet", &data_root).unwrap().is_empty());
+        assert!(resolver
+            .sources_for("vetoed.parquet", &data_root)
+            .unwrap()
+            .is_empty());
         // explicit list passes through
         assert_eq!(
-            resolver.sources_for("explicit.parquet", &data_root).unwrap()[0].0,
+            resolver
+                .sources_for("explicit.parquet", &data_root)
+                .unwrap()[0]
+                .0,
             PathBuf::from("/x/explicit.parquet")
         );
         // absent = default primary (legacy path when no family dir has it)

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/state_space.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/state_space.rs
@@ -111,8 +111,13 @@ impl StateSpaceTable {
     /// perf file is sourced solely from `data_root/<basename>` with no
     /// `kernel_source` filter (pre-shared-layer behaviour).
     pub fn new(data_root: PathBuf, backend: &str, version: &str) -> Self {
-        Self::with_sources(data_root, backend, version, &SourceResolver::fixed(PerfDbSources::default()))
-            .expect("fixed-map resolution is infallible")
+        Self::with_sources(
+            data_root,
+            backend,
+            version,
+            &SourceResolver::fixed(PerfDbSources::default()),
+        )
+        .expect("fixed-map resolution is infallible")
     }
 
     /// Construct with shared-layer (sibling/cross-version) sources supplied by the

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/table_view.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/table_view.rs
@@ -415,7 +415,11 @@ pub fn view_generation_attention(sources: &[PerfSource]) -> Result<Option<ViewNo
             n.to_string(),
             b.to_string(),
         ];
-        root.insert_first_wins(&path, &full_seq.to_string(), classic_leaf(latency, ctx.power()?));
+        root.insert_first_wins(
+            &path,
+            &full_seq.to_string(),
+            classic_leaf(latency, ctx.power()?),
+        );
         Ok(())
     })?;
     Ok(found.map(|_| root))
@@ -446,7 +450,9 @@ pub fn view_encoder_attention(sources: &[PerfSource]) -> Result<Option<ViewNode>
 /// level a constant "AUTO", and `*_eager` rows (kernel_source OR backend
 /// suffix) are dropped — EXCEPT on b60, detected by "b60" in any source path.
 pub fn view_custom_allreduce(sources: &[PerfSource]) -> Result<Option<ViewNode>, AicError> {
-    let is_b60 = sources.iter().any(|s| s.0.to_string_lossy().contains("b60"));
+    let is_b60 = sources
+        .iter()
+        .any(|s| s.0.to_string_lossy().contains("b60"));
     let mut root = ViewNode::branch();
     let found = fold_sources(sources, |ctx| {
         let r = ctx.reader;
@@ -455,7 +461,11 @@ pub fn view_custom_allreduce(sources: &[PerfSource]) -> Result<Option<ViewNode>,
             .str_optional(r.col_optional("kernel_source"))?
             .unwrap_or("")
             .to_string();
-        let backend = ctx.row.str_optional(r.col_optional("backend"))?.unwrap_or("").to_string();
+        let backend = ctx
+            .row
+            .str_optional(r.col_optional("backend"))?
+            .unwrap_or("")
+            .to_string();
         if (kernel_source.ends_with("_eager") || backend.ends_with("_eager")) && !is_b60 {
             return Ok(());
         }
@@ -463,7 +473,11 @@ pub fn view_custom_allreduce(sources: &[PerfSource]) -> Result<Option<ViewNode>,
         let message_size = ctx.row.u64(r.col("message_size")?)?;
         let latency = ctx.row.f64(r.col("latency")?)?;
         let path = ["half".to_string(), tp_size.to_string(), "AUTO".to_string()];
-        root.insert_first_wins(&path, &message_size.to_string(), classic_leaf(latency, ctx.power()?));
+        root.insert_first_wins(
+            &path,
+            &message_size.to_string(),
+            classic_leaf(latency, ctx.power()?),
+        );
         Ok(())
     })?;
     Ok(found.map(|_| root))
@@ -481,7 +495,11 @@ pub fn view_nccl(sources: &[PerfSource]) -> Result<Option<ViewNode>, AicError> {
         let op_name = str_cell_or_empty(ctx, "op_name")?;
         let latency = ctx.row.f64(r.col("latency")?)?;
         let path = [dtype, op_name, num_gpus.to_string()];
-        root.insert_first_wins(&path, &message_size.to_string(), classic_leaf(latency, ctx.power()?));
+        root.insert_first_wins(
+            &path,
+            &message_size.to_string(),
+            classic_leaf(latency, ctx.power()?),
+        );
         Ok(())
     })?;
     Ok(found.map(|_| root))
@@ -520,7 +538,11 @@ pub fn view_generation_mla(sources: &[PerfSource]) -> Result<Option<ViewNode>, A
         let latency = ctx.row.f64(r.col("latency")?)?;
         let full_seq = s + step;
         let path = [kv_dtype, num_heads.to_string(), b.to_string()];
-        root.insert_first_wins(&path, &full_seq.to_string(), classic_leaf(latency, ctx.power()?));
+        root.insert_first_wins(
+            &path,
+            &full_seq.to_string(),
+            classic_leaf(latency, ctx.power()?),
+        );
         Ok(())
     })?;
     Ok(found.map(|_| root))
@@ -538,7 +560,11 @@ pub fn view_mla_bmm(sources: &[PerfSource]) -> Result<Option<ViewNode>, AicError
         let op_name = str_cell_or_empty(ctx, "op_name")?;
         let latency = ctx.row.f64(r.col("latency")?)?;
         let path = [quant, op_name, num_heads.to_string()];
-        root.insert_first_wins(&path, &num_tokens.to_string(), classic_leaf(latency, ctx.power()?));
+        root.insert_first_wins(
+            &path,
+            &num_tokens.to_string(),
+            classic_leaf(latency, ctx.power()?),
+        );
         Ok(())
     })?;
     Ok(found.map(|_| root))
@@ -558,7 +584,13 @@ pub fn view_wideep_context_mla(sources: &[PerfSource]) -> Result<Option<ViewNode
         let s = ctx.row.u32(r.col("isl")?)?;
         let num_heads = ctx.row.u32(r.col("num_heads")?)?;
         let latency = ctx.row.f64(r.col("latency")?)?;
-        let path = [kernel_source, quant, kv_dtype, num_heads.to_string(), s.to_string()];
+        let path = [
+            kernel_source,
+            quant,
+            kv_dtype,
+            num_heads.to_string(),
+            s.to_string(),
+        ];
         root.insert_first_wins(&path, &b.to_string(), classic_leaf(latency, ctx.power()?));
         Ok(())
     })?;
@@ -579,8 +611,17 @@ pub fn view_wideep_generation_mla(sources: &[PerfSource]) -> Result<Option<ViewN
         let num_heads = ctx.row.u32(r.col("num_heads")?)?;
         let latency = ctx.row.f64(r.col("latency")?)?;
         let full_seq = s + step;
-        let path = [kernel_source, kv_dtype, num_heads.to_string(), b.to_string()];
-        root.insert_first_wins(&path, &full_seq.to_string(), classic_leaf(latency, ctx.power()?));
+        let path = [
+            kernel_source,
+            kv_dtype,
+            num_heads.to_string(),
+            b.to_string(),
+        ];
+        root.insert_first_wins(
+            &path,
+            &full_seq.to_string(),
+            classic_leaf(latency, ctx.power()?),
+        );
         Ok(())
     })?;
     Ok(found.map(|_| root))
@@ -705,7 +746,13 @@ pub fn view_generation_mla_module(sources: &[PerfSource]) -> Result<Option<ViewN
         let power = first_power.power(ctx)?;
         let kv_dtype = ctx.row.str_owned(r.col("kv_cache_dtype")?)?;
         let gemm = ctx.row.str_owned(r.col("gemm_type")?)?;
-        let path = [kv_dtype, gemm, native.to_string(), num_heads.to_string(), b.to_string()];
+        let path = [
+            kv_dtype,
+            gemm,
+            native.to_string(),
+            num_heads.to_string(),
+            b.to_string(),
+        ];
         root.insert_first_wins(&path, &s.to_string(), classic_leaf(latency, power));
         Ok(())
     })?;
@@ -814,7 +861,14 @@ fn view_gdn_like(
 pub fn view_gdn(sources: &[PerfSource]) -> Result<Option<ViewNode>, AicError> {
     view_gdn_like(
         sources,
-        &["d_model", "num_k_heads", "head_k_dim", "num_v_heads", "head_v_dim", "d_conv"],
+        &[
+            "d_model",
+            "num_k_heads",
+            "head_k_dim",
+            "num_v_heads",
+            "head_v_dim",
+            "d_conv",
+        ],
         &["context"],
         true,
     )
@@ -825,7 +879,14 @@ pub fn view_gdn(sources: &[PerfSource]) -> Result<Option<ViewNode>, AicError> {
 pub fn view_kda(sources: &[PerfSource]) -> Result<Option<ViewNode>, AicError> {
     view_gdn_like(
         sources,
-        &["d_model", "num_k_heads", "head_k_dim", "num_v_heads", "head_v_dim", "d_conv"],
+        &[
+            "d_model",
+            "num_k_heads",
+            "head_k_dim",
+            "num_v_heads",
+            "head_v_dim",
+            "d_conv",
+        ],
         &["context", "verify"],
         false,
     )
@@ -870,7 +931,11 @@ pub fn view_moe(sources: &[PerfSource]) -> Result<Option<(ViewNode, ViewNode)>, 
             moe_tp.to_string(),
             moe_ep.to_string(),
         ];
-        target.insert_first_wins(&path, &num_tokens.to_string(), classic_leaf(latency, ctx.power()?));
+        target.insert_first_wins(
+            &path,
+            &num_tokens.to_string(),
+            classic_leaf(latency, ctx.power()?),
+        );
         Ok(())
     })?;
     Ok(found.map(|_| (default, low_latency)))
@@ -903,7 +968,11 @@ pub fn view_wideep_moe(sources: &[PerfSource]) -> Result<Option<ViewNode>, AicEr
             moe_tp.to_string(),
             moe_ep.to_string(),
         ];
-        root.insert_first_wins(&path, &num_tokens.to_string(), classic_leaf(latency, ctx.power()?));
+        root.insert_first_wins(
+            &path,
+            &num_tokens.to_string(),
+            classic_leaf(latency, ctx.power()?),
+        );
         Ok(())
     })?;
     Ok(found.map(|_| root))
@@ -922,14 +991,19 @@ pub fn view_wideep_deepep_ll(sources: &[PerfSource]) -> Result<Option<ViewNode>,
         let num_token = ctx.row.u32(r.col("num_token")?)?;
         let num_topk = ctx.row.u32(r.col("num_topk")?)?;
         let num_experts = ctx.row.u32(r.col("num_experts")?)?;
-        let lat = ctx.row.f64(r.col("combine_avg_t_us")?)? + ctx.row.f64(r.col("dispatch_avg_t_us")?)?;
+        let lat =
+            ctx.row.f64(r.col("combine_avg_t_us")?)? + ctx.row.f64(r.col("dispatch_avg_t_us")?)?;
         let path = [
             node_num.to_string(),
             hidden.to_string(),
             num_topk.to_string(),
             num_experts.to_string(),
         ];
-        root.insert_first_wins(&path, &num_token.to_string(), classic_leaf(lat, ctx.power()?));
+        root.insert_first_wins(
+            &path,
+            &num_token.to_string(),
+            classic_leaf(lat, ctx.power()?),
+        );
         Ok(())
     })?;
     Ok(found.map(|_| root))
@@ -959,7 +1033,11 @@ pub fn view_wideep_deepep_normal(sources: &[PerfSource]) -> Result<Option<ViewNo
             num_experts.to_string(),
             dispatch_sms.to_string(),
         ];
-        root.insert_first_wins(&path, &num_token.to_string(), classic_leaf(lat, ctx.power()?));
+        root.insert_first_wins(
+            &path,
+            &num_token.to_string(),
+            classic_leaf(lat, ctx.power()?),
+        );
         Ok(())
     })?;
     Ok(found.map(|_| root))
@@ -1000,7 +1078,11 @@ pub fn view_wideep_moe_compute(sources: &[PerfSource]) -> Result<Option<ViewNode
             moe_tp.to_string(),
             moe_ep.to_string(),
         ];
-        root.insert_first_wins(&path, &num_tokens.to_string(), classic_leaf(latency, ctx.power()?));
+        root.insert_first_wins(
+            &path,
+            &num_tokens.to_string(),
+            classic_leaf(latency, ctx.power()?),
+        );
         Ok(())
     })?;
     Ok(found.map(|_| root))
@@ -1046,7 +1128,11 @@ pub fn view_trtllm_alltoall(sources: &[PerfSource]) -> Result<Option<ViewNode>, 
             num_experts.to_string(),
             moe_ep.to_string(),
         ];
-        root.insert_first_wins(&path, &num_tokens.to_string(), classic_leaf(latency, ctx.power()?));
+        root.insert_first_wins(
+            &path,
+            &num_tokens.to_string(),
+            classic_leaf(latency, ctx.power()?),
+        );
         Ok(())
     })?;
     Ok(found.map(|_| root))
@@ -1137,13 +1223,12 @@ fn row_power_lenient(ctx: &RowCtx<'_>) -> Result<f64, AicError> {
 /// Storage-agnostic like Python's `float(raw)`: an INT64 latency cell is a
 /// value, not a "null latency" corruption report.
 fn require_latency(ctx: &RowCtx<'_>, table: &str) -> Result<f64, AicError> {
-    let lat = num_optional(ctx.row, ctx.reader.col_optional("latency"))?
-        .ok_or_else(|| {
-            AicError::PerfDatabase(format!(
-                "null latency cell in a {table} row: latency is schema-required and must be \
+    let lat = num_optional(ctx.row, ctx.reader.col_optional("latency"))?.ok_or_else(|| {
+        AicError::PerfDatabase(format!(
+            "null latency cell in a {table} row: latency is schema-required and must be \
                  finite; refusing to load corrupt perf data"
-            ))
-        })?;
+        ))
+    })?;
     if !lat.is_finite() {
         return Err(AicError::PerfDatabase(format!(
             "non-finite latency cell in a {table} row: latency is schema-required and must be \
@@ -1174,7 +1259,10 @@ pub fn view_moe_a2a(
             legacy_normal,
             "deepep_ht",
             &[
-                ("dispatch", &["dispatch_transmit_us", "dispatch_notify_us"][..]),
+                (
+                    "dispatch",
+                    &["dispatch_transmit_us", "dispatch_notify_us"][..],
+                ),
                 ("combine", &["combine_transmit_us", "combine_notify_us"][..]),
             ][..],
         ),
@@ -1232,14 +1320,16 @@ pub fn view_moe_a2a(
             "kernel_source",
             crate::perf_database::moe_a2a::LEGACY_TRTLLM_DEFAULT_KERNEL_SOURCE,
         )?;
-        let Some(comm_backend) = crate::perf_database::moe_a2a::legacy_trtllm_backend(&kernel_source)
+        let Some(comm_backend) =
+            crate::perf_database::moe_a2a::legacy_trtllm_backend(&kernel_source)
         else {
             return Ok(());
         };
         // Null op_name reads as "" (unmapped) and skips the row, like the
         // Python adapter's map .get('') miss.
         let op_name = str_cell_or_empty(ctx, "op_name")?;
-        let Some((phase, fixed_dtype)) = crate::perf_database::moe_a2a::legacy_trtllm_phase_dtype(&op_name)
+        let Some((phase, fixed_dtype)) =
+            crate::perf_database::moe_a2a::legacy_trtllm_phase_dtype(&op_name)
         else {
             return Ok(());
         };
@@ -1305,7 +1395,11 @@ pub fn view_moe_a2a(
         Ok(())
     })?;
 
-    Ok(if new_found.is_some() || legacy_loaded { Some(root) } else { None })
+    Ok(if new_found.is_some() || legacy_loaded {
+        Some(root)
+    } else {
+        None
+    })
 }
 
 /// `operations/moe_comm.py::load_moe_expert_compute_data` — the unified
@@ -1323,7 +1417,10 @@ pub fn view_moe_expert_compute(
     let mut root = ViewNode::branch();
     let mut legacy_loaded = false;
 
-    for (legacy_sources, inference_phase) in [(legacy_context, "context"), (legacy_generation, "generation")] {
+    for (legacy_sources, inference_phase) in [
+        (legacy_context, "context"),
+        (legacy_generation, "generation"),
+    ] {
         let found = fold_sources(legacy_sources, |ctx| {
             let r = ctx.reader;
             let latency = ctx.row.f64(r.col("latency")?)?;
@@ -1408,7 +1505,11 @@ pub fn view_moe_expert_compute(
         Ok(())
     })?;
 
-    Ok(if new_found.is_some() || legacy_loaded { Some(root) } else { None })
+    Ok(if new_found.is_some() || legacy_loaded {
+        Some(root)
+    } else {
+        None
+    })
 }
 
 /// Per-source accumulator reproducing the DSA loaders' two-rule merge:
@@ -1506,7 +1607,8 @@ fn view_dsa_module(
                 }
                 // int(step): negative values stayed negative prefix keys.
                 let prefix = step.map(|v| v as i64).unwrap_or(0);
-                for backend in crate::perf_database::dsa::dsa_kernel_source_buckets(&ks, &kv_dtype) {
+                for backend in crate::perf_database::dsa::dsa_kernel_source_buckets(&ks, &kv_dtype)
+                {
                     source_values.put(
                         vec![
                             fmha.clone(),
@@ -1524,7 +1626,8 @@ fn view_dsa_module(
                 }
             } else {
                 let s = row.u32(r.col("isl")?)? + row.u32(r.col("step")?)?;
-                for backend in crate::perf_database::dsa::dsa_kernel_source_buckets(&ks, &kv_dtype) {
+                for backend in crate::perf_database::dsa::dsa_kernel_source_buckets(&ks, &kv_dtype)
+                {
                     source_values.put(
                         vec![
                             kv_dtype.clone(),
@@ -1560,13 +1663,19 @@ fn view_dsa_module(
 
 /// `operations/dsa.py::load_context_dsa_module_data` —
 /// `[mla_dtype][kv_cache_dtype][gemm_type][architecture][dsa_backend][num_heads][prefix][s][b]`.
-pub fn view_context_dsa_module(sources: &[PerfSource], skip: bool) -> Result<Option<ViewNode>, AicError> {
+pub fn view_context_dsa_module(
+    sources: &[PerfSource],
+    skip: bool,
+) -> Result<Option<ViewNode>, AicError> {
     view_dsa_module(sources, true, skip)
 }
 
 /// `operations/dsa.py::load_generation_dsa_module_data` —
 /// `[kv_cache_dtype][gemm_type][architecture][dsa_backend][num_heads][b][isl+step]`.
-pub fn view_generation_dsa_module(sources: &[PerfSource], skip: bool) -> Result<Option<ViewNode>, AicError> {
+pub fn view_generation_dsa_module(
+    sources: &[PerfSource],
+    skip: bool,
+) -> Result<Option<ViewNode>, AicError> {
     view_dsa_module(sources, false, skip)
 }
 
@@ -1617,8 +1726,10 @@ fn validate_view_dsv4_head_semantics(
     // (dsv4.rs::validate_dsv4_local_head_semantics) — one home for the #1429
     // pattern; only the tp-presence preconditions above are view-specific
     // (they carry the path label Python's loader printed).
-    let mut observed: std::collections::BTreeMap<(String, String), std::collections::BTreeSet<(u32, u32)>> =
-        std::collections::BTreeMap::new();
+    let mut observed: std::collections::BTreeMap<
+        (String, String),
+        std::collections::BTreeSet<(u32, u32)>,
+    > = std::collections::BTreeMap::new();
     for (heads, tp, model, version) in rows {
         let tp = tp.map(|v| v.max(1)).unwrap_or(1);
         observed
@@ -1632,7 +1743,10 @@ fn validate_view_dsv4_head_semantics(
 /// Shared body of the two DSV4 attention-kind loaders. Malformed rows are
 /// SKIPPED (the Python loaders' try/except-continue), matching the appended
 /// duplicate-header tolerance.
-fn view_dsv4_kind_module(sources: &[PerfSource], context: bool) -> Result<Option<ViewNode>, AicError> {
+fn view_dsv4_kind_module(
+    sources: &[PerfSource],
+    context: bool,
+) -> Result<Option<ViewNode>, AicError> {
     // Two passes like Python: the semantics validator scans the full row set
     // first, then the fold runs. Collect the decoded fields once.
     struct Decoded {
@@ -1682,7 +1796,11 @@ fn view_dsv4_kind_module(sources: &[PerfSource], context: bool) -> Result<Option
             } else {
                 missing_tp_rows += 1;
             }
-            let model = ctx.row.str_optional(r.col_optional("model"))?.unwrap_or("").to_string();
+            let model = ctx
+                .row
+                .str_optional(r.col_optional("model"))?
+                .unwrap_or("")
+                .to_string();
             let version = ctx
                 .row
                 .str_optional(r.col_optional("version"))?
@@ -1723,7 +1841,9 @@ fn view_dsv4_kind_module(sources: &[PerfSource], context: bool) -> Result<Option
             (s_raw, prefix)
         } else {
             // int(row["isl"]) + int(row["step"]): missing/null/NaN step -> skip.
-            let Some(step) = py_cell("step")? else { return Ok(()) };
+            let Some(step) = py_cell("step")? else {
+                return Ok(());
+            };
             (s_raw.saturating_add(step), 0)
         };
         // max(1, int(row.get("tp_size", 1) or 1)) inside the try: an absent
@@ -1812,7 +1932,9 @@ pub fn view_context_dsv4_kind_module(sources: &[PerfSource]) -> Result<Option<Vi
 
 /// `operations/dsv4.py::load_generation_dsv4_kind_module_data` —
 /// `[kv][gemm][native][local][compress_ratio][b][isl+step]`.
-pub fn view_generation_dsv4_kind_module(sources: &[PerfSource]) -> Result<Option<ViewNode>, AicError> {
+pub fn view_generation_dsv4_kind_module(
+    sources: &[PerfSource],
+) -> Result<Option<ViewNode>, AicError> {
     view_dsv4_kind_module(sources, false)
 }
 
@@ -1899,12 +2021,14 @@ pub fn view_dsv4_megamoe_module(data_root: &std::path::Path) -> Result<Option<Vi
         let num_max = int_cell_or_falsy_default(ctx, "num_max_tokens_per_rank", 0)?;
         let effective_num_max =
             int_cell_or_falsy_default(ctx, "effective_num_max_tokens_per_rank", num_max)?;
-        let global_tokens = int_cell_or_falsy_default(
-            ctx,
-            "global_num_tokens",
-            num_tokens as i64 * moe_ep as i64,
-        )?;
-        let phase = ctx.row.str_optional(r.col_optional("phase"))?.unwrap_or("").trim().to_string();
+        let global_tokens =
+            int_cell_or_falsy_default(ctx, "global_num_tokens", num_tokens as i64 * moe_ep as i64)?;
+        let phase = ctx
+            .row
+            .str_optional(r.col_optional("phase"))?
+            .unwrap_or("")
+            .trim()
+            .to_string();
         if phase.is_empty() {
             return Err(AicError::PerfDatabase(format!(
                 "DSv4 MegaMoE unified perf file requires a phase column: {}",
@@ -1935,11 +2059,17 @@ pub fn view_dsv4_megamoe_module(data_root: &std::path::Path) -> Result<Option<Vi
             ),
             ("used_cuda_graph", ViewValue::Bool(true)),
             ("kernel_dtype", ViewValue::Str(kernel_dtype.clone())),
-            ("routed_scaling_factor", ViewValue::F64(routed_scaling_factor)),
+            (
+                "routed_scaling_factor",
+                ViewValue::F64(routed_scaling_factor),
+            ),
             ("includes_routed_scale", ViewValue::Bool(true)),
             ("includes_gate_topk", ViewValue::Bool(false)),
             ("buffer_policy", ViewValue::Str(buffer_policy)),
-            ("includes_buffer_init", ViewValue::Bool(includes_buffer_init)),
+            (
+                "includes_buffer_init",
+                ViewValue::Bool(includes_buffer_init),
+            ),
             ("phase", ViewValue::Str(phase.clone())),
         ]);
         let path = [
@@ -1986,7 +2116,9 @@ pub fn view_dsv4_sparse_kernel(sources: &[PerfSource]) -> Result<Option<ViewNode
             // negative key (a collector-bug sentinel like step=-1 dropped
             // only itself, filed under -1, never the whole family). This
             // subsumes the loader's duplicate-header/blank batch_size guard.
-            let Some(idx) = r.col_optional(col) else { return Ok(()) };
+            let Some(idx) = r.col_optional(col) else {
+                return Ok(());
+            };
             let Some(value) = py_int_optional(ctx.row, idx)? else {
                 return Ok(());
             };
@@ -2029,7 +2161,9 @@ pub fn view_dsv4_csa_topk_calib(sources: &[PerfSource]) -> Result<Option<ViewNod
             // `_coerce` = int(float(cell)); a null / NaN / non-numeric cell
             // is a bad key that skips the row (this subsumes the loader's
             // duplicate-header guard on the batch_size cell).
-            let Some(idx) = r.col_optional(col) else { return Ok(()) };
+            let Some(idx) = r.col_optional(col) else {
+                return Ok(());
+            };
             let Some(value) = py_int_optional(ctx.row, idx)? else {
                 return Ok(());
             };
@@ -2037,7 +2171,9 @@ pub fn view_dsv4_csa_topk_calib(sources: &[PerfSource]) -> Result<Option<ViewNod
         }
         // score_mode stays a string key; `_is_bad_key` skipped blank and
         // NaN/inf SENTINEL strings.
-        let Some(mode_col) = r.col_optional("score_mode") else { return Ok(()) };
+        let Some(mode_col) = r.col_optional("score_mode") else {
+            return Ok(());
+        };
         let Some(mode) = ctx.row.str_optional(Some(mode_col))? else {
             return Ok(());
         };
@@ -2123,21 +2259,51 @@ pub const TABLE_VIEW_ATTRIBUTES: &[(&str, &[&str])] = &[
     ("_gemm_data", &["gemm_perf.parquet"]),
     ("_compute_scale_data", &["computescale_perf.parquet"]),
     ("_scale_matrix_data", &["scale_matrix_perf.parquet"]),
-    ("_context_attention_data", &["context_attention_perf.parquet"]),
-    ("_generation_attention_data", &["generation_attention_perf.parquet"]),
-    ("_encoder_attention_data", &["encoder_attention_perf.parquet"]),
+    (
+        "_context_attention_data",
+        &["context_attention_perf.parquet"],
+    ),
+    (
+        "_generation_attention_data",
+        &["generation_attention_perf.parquet"],
+    ),
+    (
+        "_encoder_attention_data",
+        &["encoder_attention_perf.parquet"],
+    ),
     ("_context_mla_data", &["context_mla_perf.parquet"]),
     ("_generation_mla_data", &["generation_mla_perf.parquet"]),
     ("_mla_bmm_data", &["mla_bmm_perf.parquet"]),
-    ("_context_mla_module_data", &["mla_context_module_perf.parquet"]),
-    ("_generation_mla_module_data", &["mla_generation_module_perf.parquet"]),
-    ("_wideep_context_mla_data", &["wideep_context_mla_perf.parquet"]),
-    ("_wideep_generation_mla_data", &["wideep_generation_mla_perf.parquet"]),
+    (
+        "_context_mla_module_data",
+        &["mla_context_module_perf.parquet"],
+    ),
+    (
+        "_generation_mla_module_data",
+        &["mla_generation_module_perf.parquet"],
+    ),
+    (
+        "_wideep_context_mla_data",
+        &["wideep_context_mla_perf.parquet"],
+    ),
+    (
+        "_wideep_generation_mla_data",
+        &["wideep_generation_mla_perf.parquet"],
+    ),
     ("_moe_data", &["moe_perf.parquet"]),
     ("_moe_low_latency_data", &["moe_perf.parquet"]),
-    ("_wideep_context_moe_data", &["wideep_context_moe_perf.parquet"]),
-    ("_wideep_generation_moe_data", &["wideep_generation_moe_perf.parquet"]),
-    ("_wideep_deepep_normal_data", &["wideep_deepep_normal_perf.parquet"]),
+    (
+        "_wideep_context_moe_data",
+        &["wideep_context_moe_perf.parquet"],
+    ),
+    (
+        "_wideep_generation_moe_data",
+        &["wideep_generation_moe_perf.parquet"],
+    ),
+    (
+        "_wideep_deepep_normal_data",
+        &["wideep_deepep_normal_perf.parquet"],
+    ),
     ("_wideep_deepep_ll_data", &["wideep_deepep_ll_perf.parquet"]),
     ("_wideep_moe_compute_data", &["wideep_moe_perf.parquet"]),
     ("_trtllm_alltoall_data", &["trtllm_alltoall_perf.parquet"]),
@@ -2162,10 +2328,22 @@ pub const TABLE_VIEW_ATTRIBUTES: &[(&str, &[&str])] = &[
     ("_custom_allreduce_data", &["custom_allreduce_perf.parquet"]),
     ("_nccl_data", &["nccl_perf.parquet"]),
     ("_oneccl_data", &["oneccl_perf.parquet"]),
-    ("_context_dsa_module_data", &["dsa_context_module_perf.parquet"]),
-    ("_context_dsa_module_skip_data", &["dsa_context_module_perf.parquet"]),
-    ("_generation_dsa_module_data", &["dsa_generation_module_perf.parquet"]),
-    ("_generation_dsa_module_skip_data", &["dsa_generation_module_perf.parquet"]),
+    (
+        "_context_dsa_module_data",
+        &["dsa_context_module_perf.parquet"],
+    ),
+    (
+        "_context_dsa_module_skip_data",
+        &["dsa_context_module_perf.parquet"],
+    ),
+    (
+        "_generation_dsa_module_data",
+        &["dsa_generation_module_perf.parquet"],
+    ),
+    (
+        "_generation_dsa_module_skip_data",
+        &["dsa_generation_module_perf.parquet"],
+    ),
     ("_mhc_module_data", &["mhc_module_perf.parquet"]),
     (
         "_context_deepseek_v4_attention_module_data",
@@ -2185,10 +2363,22 @@ pub const TABLE_VIEW_ATTRIBUTES: &[(&str, &[&str])] = &[
         "_dsv4_sparse_kernel_data.paged_mqa_logits",
         &["dsv4_paged_mqa_logits_module_perf.parquet"],
     ),
-    ("_dsv4_sparse_kernel_data.hca_attn", &["dsv4_hca_attn_module_perf.parquet"]),
-    ("_dsv4_sparse_kernel_data.csa_attn", &["dsv4_csa_attn_module_perf.parquet"]),
-    ("_dsv4_csa_topk_calib_data", &["dsv4_csa_topk_calib_perf.parquet"]),
-    ("_dsv4_megamoe_module_data", &["dsv4_megamoe_module_perf.parquet"]),
+    (
+        "_dsv4_sparse_kernel_data.hca_attn",
+        &["dsv4_hca_attn_module_perf.parquet"],
+    ),
+    (
+        "_dsv4_sparse_kernel_data.csa_attn",
+        &["dsv4_csa_attn_module_perf.parquet"],
+    ),
+    (
+        "_dsv4_csa_topk_calib_data",
+        &["dsv4_csa_topk_calib_perf.parquet"],
+    ),
+    (
+        "_dsv4_megamoe_module_data",
+        &["dsv4_megamoe_module_perf.parquet"],
+    ),
     ("_mamba2_data", &["mamba2_perf.parquet"]),
     ("_gdn_data", &["gdn_perf.parquet"]),
     ("_kda_data", &["kda_perf.parquet"]),
@@ -2201,7 +2391,11 @@ pub const TABLE_VIEW_ATTRIBUTES: &[(&str, &[&str])] = &[
 /// sparse sub-tables are addressed as
 /// `"_dsv4_sparse_kernel_data.<paged_mqa_logits|hca_attn|csa_attn>"`.
 pub fn table_view_json(tables: &PerfTables, attribute: &str) -> Result<Option<String>, AicError> {
-    let src = |basename: &str| tables.source_resolver.sources_for(basename, &tables.data_root);
+    let src = |basename: &str| {
+        tables
+            .source_resolver
+            .sources_for(basename, &tables.data_root)
+    };
     let comm_src = |root: Option<&std::path::Path>, basename: &str| -> Vec<PerfSource> {
         match root {
             // _build_op_sources refused an EXISTING primary whose version dir
@@ -2218,25 +2412,45 @@ pub fn table_view_json(tables: &PerfTables, attribute: &str) -> Result<Option<St
         "_gemm_data" => view_gemm(&src("gemm_perf.parquet")?)?,
         "_compute_scale_data" => view_gemm_scale(&src("computescale_perf.parquet")?)?,
         "_scale_matrix_data" => view_gemm_scale(&src("scale_matrix_perf.parquet")?)?,
-        "_context_attention_data" => view_context_attention(&src("context_attention_perf.parquet")?)?,
-        "_generation_attention_data" => view_generation_attention(&src("generation_attention_perf.parquet")?)?,
-        "_encoder_attention_data" => view_encoder_attention(&src("encoder_attention_perf.parquet")?)?,
+        "_context_attention_data" => {
+            view_context_attention(&src("context_attention_perf.parquet")?)?
+        }
+        "_generation_attention_data" => {
+            view_generation_attention(&src("generation_attention_perf.parquet")?)?
+        }
+        "_encoder_attention_data" => {
+            view_encoder_attention(&src("encoder_attention_perf.parquet")?)?
+        }
         "_context_mla_data" => view_context_mla(&src("context_mla_perf.parquet")?)?,
         "_generation_mla_data" => view_generation_mla(&src("generation_mla_perf.parquet")?)?,
         "_mla_bmm_data" => view_mla_bmm(&src("mla_bmm_perf.parquet")?)?,
-        "_context_mla_module_data" => view_context_mla_module(&src("mla_context_module_perf.parquet")?)?,
-        "_generation_mla_module_data" => view_generation_mla_module(&src("mla_generation_module_perf.parquet")?)?,
-        "_wideep_context_mla_data" => view_wideep_context_mla(&src("wideep_context_mla_perf.parquet")?)?,
-        "_wideep_generation_mla_data" => view_wideep_generation_mla(&src("wideep_generation_mla_perf.parquet")?)?,
+        "_context_mla_module_data" => {
+            view_context_mla_module(&src("mla_context_module_perf.parquet")?)?
+        }
+        "_generation_mla_module_data" => {
+            view_generation_mla_module(&src("mla_generation_module_perf.parquet")?)?
+        }
+        "_wideep_context_mla_data" => {
+            view_wideep_context_mla(&src("wideep_context_mla_perf.parquet")?)?
+        }
+        "_wideep_generation_mla_data" => {
+            view_wideep_generation_mla(&src("wideep_generation_mla_perf.parquet")?)?
+        }
         // Each arm folds moe_perf.parquet (the largest shipped table) and
         // discards the twin — accepted: the fold runs once per (database,
         // attribute) behind MoE.load_data's class cache, not per query. If
         // this ever matters, cache the (default, low_latency) pair here.
         "_moe_data" => view_moe(&src("moe_perf.parquet")?)?.map(|(default, _)| default),
-        "_moe_low_latency_data" => view_moe(&src("moe_perf.parquet")?)?.map(|(_, low_latency)| low_latency),
+        "_moe_low_latency_data" => {
+            view_moe(&src("moe_perf.parquet")?)?.map(|(_, low_latency)| low_latency)
+        }
         "_wideep_context_moe_data" => view_wideep_moe(&src("wideep_context_moe_perf.parquet")?)?,
-        "_wideep_generation_moe_data" => view_wideep_moe(&src("wideep_generation_moe_perf.parquet")?)?,
-        "_wideep_deepep_normal_data" => view_wideep_deepep_normal(&src("wideep_deepep_normal_perf.parquet")?)?,
+        "_wideep_generation_moe_data" => {
+            view_wideep_moe(&src("wideep_generation_moe_perf.parquet")?)?
+        }
+        "_wideep_deepep_normal_data" => {
+            view_wideep_deepep_normal(&src("wideep_deepep_normal_perf.parquet")?)?
+        }
         "_wideep_deepep_ll_data" => view_wideep_deepep_ll(&src("wideep_deepep_ll_perf.parquet")?)?,
         "_wideep_moe_compute_data" => view_wideep_moe_compute(&src("wideep_moe_perf.parquet")?)?,
         "_trtllm_alltoall_data" => view_trtllm_alltoall(&src("trtllm_alltoall_perf.parquet")?)?,
@@ -2253,10 +2467,20 @@ pub fn table_view_json(tables: &PerfTables, attribute: &str) -> Result<Option<St
             &src("wideep_moe_perf.parquet")?,
         )?,
         "_custom_allreduce_data" => view_custom_allreduce(&src("custom_allreduce_perf.parquet")?)?,
-        "_nccl_data" => view_nccl(&comm_src(tables.communication.nccl_root(), "nccl_perf.parquet"))?,
-        "_oneccl_data" => view_nccl(&comm_src(tables.communication.oneccl_root(), "oneccl_perf.parquet"))?,
-        "_context_dsa_module_data" => view_context_dsa_module(&src("dsa_context_module_perf.parquet")?, false)?,
-        "_context_dsa_module_skip_data" => view_context_dsa_module(&src("dsa_context_module_perf.parquet")?, true)?,
+        "_nccl_data" => view_nccl(&comm_src(
+            tables.communication.nccl_root(),
+            "nccl_perf.parquet",
+        ))?,
+        "_oneccl_data" => view_nccl(&comm_src(
+            tables.communication.oneccl_root(),
+            "oneccl_perf.parquet",
+        ))?,
+        "_context_dsa_module_data" => {
+            view_context_dsa_module(&src("dsa_context_module_perf.parquet")?, false)?
+        }
+        "_context_dsa_module_skip_data" => {
+            view_context_dsa_module(&src("dsa_context_module_perf.parquet")?, true)?
+        }
         "_generation_dsa_module_data" => {
             view_generation_dsa_module(&src("dsa_generation_module_perf.parquet")?, false)?
         }
@@ -2275,9 +2499,15 @@ pub fn table_view_json(tables: &PerfTables, attribute: &str) -> Result<Option<St
         "_dsv4_sparse_kernel_data.paged_mqa_logits" => {
             view_dsv4_sparse_kernel(&src("dsv4_paged_mqa_logits_module_perf.parquet")?)?
         }
-        "_dsv4_sparse_kernel_data.hca_attn" => view_dsv4_sparse_kernel(&src("dsv4_hca_attn_module_perf.parquet")?)?,
-        "_dsv4_sparse_kernel_data.csa_attn" => view_dsv4_sparse_kernel(&src("dsv4_csa_attn_module_perf.parquet")?)?,
-        "_dsv4_csa_topk_calib_data" => view_dsv4_csa_topk_calib(&src("dsv4_csa_topk_calib_perf.parquet")?)?,
+        "_dsv4_sparse_kernel_data.hca_attn" => {
+            view_dsv4_sparse_kernel(&src("dsv4_hca_attn_module_perf.parquet")?)?
+        }
+        "_dsv4_sparse_kernel_data.csa_attn" => {
+            view_dsv4_sparse_kernel(&src("dsv4_csa_attn_module_perf.parquet")?)?
+        }
+        "_dsv4_csa_topk_calib_data" => {
+            view_dsv4_csa_topk_calib(&src("dsv4_csa_topk_calib_perf.parquet")?)?
+        }
         "_dsv4_megamoe_module_data" => view_dsv4_megamoe_module(&tables.data_root)?,
         "_mamba2_data" => view_mamba2(&src("mamba2_perf.parquet")?)?,
         "_gdn_data" => view_gdn(&src("gdn_perf.parquet")?)?,

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/trtllm_alltoall.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/trtllm_alltoall.rs
@@ -74,8 +74,7 @@ impl TrtllmAlltoallTable {
     /// a fixed source map is the test-only path). The perf file falls back to its
     /// primary `data_root/<basename>` when the resolver names no override. No I/O.
     pub fn with_sources(data_root: PathBuf, resolver: &SourceResolver) -> Result<Self, AicError> {
-        let alltoall_sources =
-            resolver.sources_for("trtllm_alltoall_perf.parquet", &data_root)?;
+        let alltoall_sources = resolver.sources_for("trtllm_alltoall_perf.parquet", &data_root)?;
         Ok(Self {
             data_root,
             alltoall_sources,

--- a/aic-core/rust/aiconfigurator-core/src/perf_database/wideep_mla.rs
+++ b/aic-core/rust/aiconfigurator-core/src/perf_database/wideep_mla.rs
@@ -104,8 +104,12 @@ impl WideEpMlaTable {
     /// perf file is sourced solely from `data_root/<basename>` with no
     /// `kernel_source` filter (pre-shared-layer behaviour).
     pub fn new(data_root: PathBuf, system_spec: SystemSpec) -> Self {
-        Self::with_sources(data_root, system_spec, &SourceResolver::fixed(PerfDbSources::default()))
-            .expect("fixed-map resolution is infallible")
+        Self::with_sources(
+            data_root,
+            system_spec,
+            &SourceResolver::fixed(PerfDbSources::default()),
+        )
+        .expect("fixed-map resolution is infallible")
     }
 
     /// Construct with shared-layer (sibling/cross-version) sources supplied by the
@@ -117,8 +121,10 @@ impl WideEpMlaTable {
         system_spec: SystemSpec,
         resolver: &SourceResolver,
     ) -> Result<Self, AicError> {
-        let context_sources = resolver.sources_for("wideep_context_mla_perf.parquet", &data_root)?;
-        let generation_sources = resolver.sources_for("wideep_generation_mla_perf.parquet", &data_root)?;
+        let context_sources =
+            resolver.sources_for("wideep_context_mla_perf.parquet", &data_root)?;
+        let generation_sources =
+            resolver.sources_for("wideep_generation_mla_perf.parquet", &data_root)?;
         Ok(Self {
             data_root,
             system_spec,

--- a/aic-core/rust/aiconfigurator-core/src/py_ops.rs
+++ b/aic-core/rust/aiconfigurator-core/src/py_ops.rs
@@ -176,7 +176,11 @@ pub(crate) fn wrap_op(py: Python<'_>, op: Op) -> PyResult<Py<PyAny>> {
 // ---------------------------------------------------------------------------
 
 /// Base class of every engine-backed op: owns the typed [`Op`] value.
-#[pyclass(subclass, name = "Operation", module = "aiconfigurator_core._aiconfigurator_core")]
+#[pyclass(
+    subclass,
+    name = "Operation",
+    module = "aiconfigurator_core._aiconfigurator_core"
+)]
 pub struct PyOperation {
     pub(crate) inner: Op,
 }
@@ -207,8 +211,20 @@ macro_rules! inner_accessor {
 }
 
 inner_accessor!(gemm, gemm_mut, Gemm, GemmOp, "GEMM");
-inner_accessor!(embedding, embedding_mut, Embedding, EmbeddingOp, "Embedding");
-inner_accessor!(elementwise, elementwise_mut, Elementwise, ElementwiseOp, "ElementWise");
+inner_accessor!(
+    embedding,
+    embedding_mut,
+    Embedding,
+    EmbeddingOp,
+    "Embedding"
+);
+inner_accessor!(
+    elementwise,
+    elementwise_mut,
+    Elementwise,
+    ElementwiseOp,
+    "ElementWise"
+);
 inner_accessor!(
     context_attention,
     context_attention_mut,
@@ -230,7 +246,13 @@ inner_accessor!(
     EncoderAttentionOp,
     "EncoderAttention"
 );
-inner_accessor!(context_mla, context_mla_mut, ContextMla, ContextMlaOp, "ContextMLA");
+inner_accessor!(
+    context_mla,
+    context_mla_mut,
+    ContextMla,
+    ContextMlaOp,
+    "ContextMLA"
+);
 inner_accessor!(
     generation_mla,
     generation_mla_mut,
@@ -295,8 +317,8 @@ impl PyOperation {
 
     #[getter(_scale_factor)]
     fn scale_factor(&self) -> PyResult<f64> {
-        let json = serde_json::to_value(&self.inner)
-            .map_err(|e| PyValueError::new_err(e.to_string()))?;
+        let json =
+            serde_json::to_value(&self.inner).map_err(|e| PyValueError::new_err(e.to_string()))?;
         json.as_object()
             .and_then(|m| m.values().next())
             .and_then(|fields| fields.get("scale_factor"))
@@ -375,7 +397,13 @@ impl PyGemm {
         py: Python<'py>,
     ) -> PyResult<(Bound<'py, PyTuple>, Bound<'py, PyDict>)> {
         let o = slf.as_super().gemm()?;
-        let args = (o.name.clone(), o.scale_factor, o.n, o.k, enum_token(&o.quant_mode))
+        let args = (
+            o.name.clone(),
+            o.scale_factor,
+            o.n,
+            o.k,
+            enum_token(&o.quant_mode),
+        )
             .into_pyobject(py)?;
         let kwargs = PyDict::new(py);
         kwargs.set_item("seq_split", o.seq_split)?;
@@ -397,7 +425,11 @@ impl PyGemm {
 
     #[getter(_quant_mode)]
     fn quant_mode<'py>(slf: PyRef<'py, Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        py_enum_member(py, "GEMMQuantMode", &enum_token(&slf.as_super().gemm()?.quant_mode))
+        py_enum_member(
+            py,
+            "GEMMQuantMode",
+            &enum_token(&slf.as_super().gemm()?.quant_mode),
+        )
     }
 
     #[getter(_scale_num_tokens)]
@@ -474,7 +506,8 @@ impl PyEmbedding {
         py: Python<'py>,
     ) -> PyResult<(Bound<'py, PyTuple>, Bound<'py, PyDict>)> {
         let o = slf.as_super().embedding()?;
-        let args = (o.name.clone(), o.scale_factor, o.vocab_size, o.hidden_size).into_pyobject(py)?;
+        let args =
+            (o.name.clone(), o.scale_factor, o.vocab_size, o.hidden_size).into_pyobject(py)?;
         let kwargs = PyDict::new(py);
         kwargs.set_item("seq_split", o.seq_split)?;
         Ok((args, kwargs))
@@ -541,7 +574,11 @@ impl PyElementWise {
             scale_factor,
             bytes_per_token: (dim_in * 2 + dim_out * 2) as f64,
             // Python: `op._scale_num_tokens if op._scale_num_tokens else 1`.
-            scale_num_tokens: if scale_num_tokens == 0 { 1 } else { scale_num_tokens },
+            scale_num_tokens: if scale_num_tokens == 0 {
+                1
+            } else {
+                scale_num_tokens
+            },
             seq_split,
         });
         Ok((PyElementWise, PyOperation { inner }))
@@ -726,7 +763,11 @@ impl PyNCCL {
 
     #[getter(_comm_quant_mode)]
     fn comm_quant_mode<'py>(slf: PyRef<'py, Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        py_enum_member(py, "CommQuantMode", &enum_token(&slf.as_super().nccl()?.dtype))
+        py_enum_member(
+            py,
+            "CommQuantMode",
+            &enum_token(&slf.as_super().nccl()?.dtype),
+        )
     }
 
     #[getter(_seq_split)]
@@ -903,7 +944,11 @@ impl PyDeepSeekV4MHCModule {
 
     #[getter(_quant_mode)]
     fn quant_mode<'py>(slf: PyRef<'py, Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        py_enum_member(py, "GEMMQuantMode", &enum_token(&slf.as_super().mhc()?.quant_mode))
+        py_enum_member(
+            py,
+            "GEMMQuantMode",
+            &enum_token(&slf.as_super().mhc()?.quant_mode),
+        )
     }
 
     #[getter(_architecture)]
@@ -1013,7 +1058,10 @@ impl PyContextAttention {
     }
 
     #[getter(_kvcache_quant_mode)]
-    fn kvcache_quant_mode<'py>(slf: PyRef<'py, Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+    fn kvcache_quant_mode<'py>(
+        slf: PyRef<'py, Self>,
+        py: Python<'py>,
+    ) -> PyResult<Bound<'py, PyAny>> {
         py_enum_member(
             py,
             "KVCacheQuantMode",
@@ -1291,7 +1339,10 @@ impl PyContextMLA {
     }
 
     #[getter(_kvcache_quant_mode)]
-    fn kvcache_quant_mode<'py>(slf: PyRef<'py, Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+    fn kvcache_quant_mode<'py>(
+        slf: PyRef<'py, Self>,
+        py: Python<'py>,
+    ) -> PyResult<Bound<'py, PyAny>> {
         py_enum_member(
             py,
             "KVCacheQuantMode",
@@ -1476,7 +1527,10 @@ impl PyMLAModule {
     }
 
     #[getter(_kvcache_quant_mode)]
-    fn kvcache_quant_mode<'py>(slf: PyRef<'py, Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+    fn kvcache_quant_mode<'py>(
+        slf: PyRef<'py, Self>,
+        py: Python<'py>,
+    ) -> PyResult<Bound<'py, PyAny>> {
         py_enum_member(
             py,
             "KVCacheQuantMode",
@@ -1559,7 +1613,11 @@ impl PyMLABmm {
 
     #[getter(_quant_mode)]
     fn quant_mode<'py>(slf: PyRef<'py, Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        py_enum_member(py, "GEMMQuantMode", &enum_token(&slf.as_super().mla_bmm()?.quant_mode))
+        py_enum_member(
+            py,
+            "GEMMQuantMode",
+            &enum_token(&slf.as_super().mla_bmm()?.quant_mode),
+        )
     }
 
     #[getter(_if_pre)]
@@ -1701,7 +1759,11 @@ impl PyMoE {
 
     #[getter(_quant_mode)]
     fn quant_mode<'py>(slf: PyRef<'py, Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        py_enum_member(py, "MoEQuantMode", &enum_token(&slf.as_super().moe()?.quant_mode))
+        py_enum_member(
+            py,
+            "MoEQuantMode",
+            &enum_token(&slf.as_super().moe()?.quant_mode),
+        )
     }
 
     #[getter(_workload_distribution)]
@@ -2226,7 +2288,11 @@ impl PyMoEExpertCompute {
 
     #[getter(_quant_mode)]
     fn quant_mode<'py>(slf: PyRef<'py, Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        py_enum_member(py, "MoEQuantMode", &enum_token(&slf.as_super().moe_ep()?.quant_mode))
+        py_enum_member(
+            py,
+            "MoEQuantMode",
+            &enum_token(&slf.as_super().moe_ep()?.quant_mode),
+        )
     }
 
     #[getter(_workload_distribution)]
@@ -2392,7 +2458,11 @@ impl PyDeepSeekV4MegaMoEModule {
 
     #[getter(_quant_mode)]
     fn quant_mode<'py>(slf: PyRef<'py, Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        py_enum_member(py, "MoEQuantMode", &enum_token(&slf.as_super().megamoe()?.quant_mode))
+        py_enum_member(
+            py,
+            "MoEQuantMode",
+            &enum_token(&slf.as_super().megamoe()?.quant_mode),
+        )
     }
 
     #[getter(_workload_distribution)]
@@ -2437,7 +2507,13 @@ inner_accessor!(moe, moe_mut, Moe, crate::operators::MoeOp, "MoE");
 // State-space family (Mamba2 / GDN / KDA kernels)
 // ---------------------------------------------------------------------------
 
-inner_accessor!(mamba2, mamba2_mut, Mamba2, crate::operators::Mamba2Op, "Mamba2Kernel");
+inner_accessor!(
+    mamba2,
+    mamba2_mut,
+    Mamba2,
+    crate::operators::Mamba2Op,
+    "Mamba2Kernel"
+);
 inner_accessor!(gdn, gdn_mut, Gdn, crate::operators::GdnOp, "GDNKernel");
 inner_accessor!(kda, kda_mut, Kda, crate::operators::KdaOp, "KDAKernel");
 
@@ -2892,7 +2968,10 @@ impl PyWideEPContextMLA {
     }
 
     #[getter(_kvcache_quant_mode)]
-    fn kvcache_quant_mode<'py>(slf: PyRef<'py, Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+    fn kvcache_quant_mode<'py>(
+        slf: PyRef<'py, Self>,
+        py: Python<'py>,
+    ) -> PyResult<Bound<'py, PyAny>> {
         py_enum_member(
             py,
             "KVCacheQuantMode",
@@ -2989,7 +3068,10 @@ impl PyWideEPGenerationMLA {
     }
 
     #[getter(_kvcache_quant_mode)]
-    fn kvcache_quant_mode<'py>(slf: PyRef<'py, Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+    fn kvcache_quant_mode<'py>(
+        slf: PyRef<'py, Self>,
+        py: Python<'py>,
+    ) -> PyResult<Bound<'py, PyAny>> {
         py_enum_member(
             py,
             "KVCacheQuantMode",
@@ -3204,7 +3286,12 @@ macro_rules! msa_class {
 }
 
 msa_class!(PyContextMSAModule, "ContextMSAModule", MsaContext, true);
-msa_class!(PyGenerationMSAModule, "GenerationMSAModule", MsaGeneration, false);
+msa_class!(
+    PyGenerationMSAModule,
+    "GenerationMSAModule",
+    MsaGeneration,
+    false
+);
 
 // ---------------------------------------------------------------------------
 // DSA modules
@@ -3276,9 +3363,18 @@ fn dsa_projection_dict<'py>(
     quants: &DsaProjectionQuants,
 ) -> PyResult<Bound<'py, PyDict>> {
     let map = PyDict::new(py);
-    map.set_item("q", py_enum_member(py, "GEMMQuantMode", &enum_token(&quants.q))?)?;
-    map.set_item("kv", py_enum_member(py, "GEMMQuantMode", &enum_token(&quants.kv))?)?;
-    map.set_item("o", py_enum_member(py, "GEMMQuantMode", &enum_token(&quants.o))?)?;
+    map.set_item(
+        "q",
+        py_enum_member(py, "GEMMQuantMode", &enum_token(&quants.q))?,
+    )?;
+    map.set_item(
+        "kv",
+        py_enum_member(py, "GEMMQuantMode", &enum_token(&quants.kv))?,
+    )?;
+    map.set_item(
+        "o",
+        py_enum_member(py, "GEMMQuantMode", &enum_token(&quants.o))?,
+    )?;
     map.set_item(
         "indexer",
         py_enum_member(py, "GEMMQuantMode", &enum_token(&quants.indexer))?,
@@ -3356,7 +3452,10 @@ impl PyContextDSAModule {
         let kwargs = PyDict::new(py);
         kwargs.set_item("dsa_full_layer_fraction", o.full_frac)?;
         if let Some(quants) = &o.attn_projection_quant_modes {
-            kwargs.set_item("attn_projection_quant_modes", dsa_projection_dict(py, quants)?)?;
+            kwargs.set_item(
+                "attn_projection_quant_modes",
+                dsa_projection_dict(py, quants)?,
+            )?;
         }
         Ok((args, kwargs))
     }
@@ -3378,17 +3477,32 @@ impl PyContextDSAModule {
 
     #[getter(_gemm_quant_mode)]
     fn gemm_quant_mode<'py>(slf: PyRef<'py, Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        py_enum_member(py, "GEMMQuantMode", &enum_token(&slf.as_super().dsa()?.gemm_quant_mode))
+        py_enum_member(
+            py,
+            "GEMMQuantMode",
+            &enum_token(&slf.as_super().dsa()?.gemm_quant_mode),
+        )
     }
 
     #[getter(_kvcache_quant_mode)]
-    fn kvcache_quant_mode<'py>(slf: PyRef<'py, Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        py_enum_member(py, "KVCacheQuantMode", &enum_token(&slf.as_super().dsa()?.kv_cache_dtype))
+    fn kvcache_quant_mode<'py>(
+        slf: PyRef<'py, Self>,
+        py: Python<'py>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        py_enum_member(
+            py,
+            "KVCacheQuantMode",
+            &enum_token(&slf.as_super().dsa()?.kv_cache_dtype),
+        )
     }
 
     #[getter(_fmha_quant_mode)]
     fn fmha_quant_mode<'py>(slf: PyRef<'py, Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        py_enum_member(py, "FMHAQuantMode", &enum_token(&slf.as_super().dsa()?.fmha_quant_mode))
+        py_enum_member(
+            py,
+            "FMHAQuantMode",
+            &enum_token(&slf.as_super().dsa()?.fmha_quant_mode),
+        )
     }
 
     #[getter(_attn_projection_quant_modes)]
@@ -3481,7 +3595,10 @@ impl PyGenerationDSAModule {
         let kwargs = PyDict::new(py);
         kwargs.set_item("dsa_full_layer_fraction", o.full_frac)?;
         if let Some(quants) = &o.attn_projection_quant_modes {
-            kwargs.set_item("attn_projection_quant_modes", dsa_projection_dict(py, quants)?)?;
+            kwargs.set_item(
+                "attn_projection_quant_modes",
+                dsa_projection_dict(py, quants)?,
+            )?;
         }
         Ok((args, kwargs))
     }
@@ -3503,12 +3620,20 @@ impl PyGenerationDSAModule {
 
     #[getter(_gemm_quant_mode)]
     fn gemm_quant_mode<'py>(slf: PyRef<'py, Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        py_enum_member(py, "GEMMQuantMode", &enum_token(&slf.as_super().dsa()?.gemm_quant_mode))
+        py_enum_member(
+            py,
+            "GEMMQuantMode",
+            &enum_token(&slf.as_super().dsa()?.gemm_quant_mode),
+        )
     }
 
     #[getter(_kv_cache_dtype)]
     fn kv_cache_dtype<'py>(slf: PyRef<'py, Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        py_enum_member(py, "KVCacheQuantMode", &enum_token(&slf.as_super().dsa()?.kv_cache_dtype))
+        py_enum_member(
+            py,
+            "KVCacheQuantMode",
+            &enum_token(&slf.as_super().dsa()?.kv_cache_dtype),
+        )
     }
 
     #[getter(_attn_projection_quant_modes)]
@@ -3989,7 +4114,6 @@ pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyFallbackOp>()?;
     Ok(())
 }
-
 
 /// Deserialize one externally-tagged opspec JSON document into an
 /// engine-backed op object (used by the FPMForwardOp spec adapter).

--- a/tests/unit/sdk/database/test_dsa_skip_indexer_fail_open.py
+++ b/tests/unit/sdk/database/test_dsa_skip_indexer_fail_open.py
@@ -9,102 +9,22 @@ skip-indexer rows. Those rows exist only in the sglang collector's 0.5.14 output
 (PR #1556 collected h200/h100/b200; 0.5.9-0.5.12 tables have none anywhere), so
 the skip query used to hard-fail every GLM-5.2 sweep point on skip-less tables.
 
-Policy (mirrors ``models/deepseek_v32.py``'s no-skip-producer gate): degrade the
-amortization to all-full instead of erroring, and stay byte-identical wherever
-the skip rows DO exist. Since the per-call Python query stack was retired behind
-engine-routed shims (PR-5/PR-6), the amortization and its degradation execute in
-the compiled engine — the behavioral regressions (degrade-to-all-full, mixed
-amortization preserved, SOL-mode blend retention, exact twin pins) live in the
-Rust operator tests (``operators/dsa.rs``). This file keeps the Python-side
-surfaces that still exist: the parquet loaders' full/skip split and the shipped
-table-view availability the degradation keys off.
+Policy (mirrors ``models/deepseek_v32.py``'s no-skip-producer gate): the engine
+operator degrades the amortization to all-full instead of erroring, and stays
+byte-identical wherever the skip rows exist. The per-call Python query stack and
+the legacy Python parquet loaders are gone (PR-5/PR-6/PR-7), so ALL behavioral
+regressions — degrade-to-all-full with exact pins, mixed amortization preserved
+with a blend identity, SOL-mode blend retention, the full/skip ``op_name``
+split — live in the Rust operator tests (``operators/dsa.rs``). This file keeps
+the one Python surface left: the shipped table-view availability the engine
+degradation keys off.
 """
 
-import pyarrow as pa
-import pyarrow.parquet as pq
 import pytest
 
-from aiconfigurator.sdk.operations.dsa import (
-    ContextDSAModule,
-    GenerationDSAModule,
-    load_context_dsa_module_data,
-    load_generation_dsa_module_data,
-)
+from aiconfigurator.sdk.operations.dsa import ContextDSAModule, GenerationDSAModule
 
 pytestmark = pytest.mark.unit
-
-GLM5_ARCHITECTURE = "GlmMoeDsaForCausalLM"
-
-FULL_LATENCY = 10.0
-
-
-def _write_dsa_parquet(path, op_names, latency=FULL_LATENCY):
-    """Minimal DSA module table in the shipped sglang schema.
-
-    ``op_names`` selects which variants are present; passing only
-    ``dsa_context_module`` reproduces a skip-less table (the pre-#1556 h200
-    state, still the live state for sglang 0.5.9-0.5.12).
-    """
-    rows = [{"op_name": name} for name in op_names]
-    table = pa.table(
-        {
-            "framework": ["sglang"] * len(rows),
-            "version": ["0.5.14"] * len(rows),
-            "device": ["h200_sxm"] * len(rows),
-            "op_name": [r["op_name"] for r in rows],
-            "kernel_source": ["sglang_dsa_indexer_trtllm"] * len(rows),
-            "model": ["zai-org/GLM-5.2-FP8"] * len(rows),
-            "architecture": [GLM5_ARCHITECTURE] * len(rows),
-            "mla_dtype": ["bfloat16"] * len(rows),
-            "kv_cache_dtype": ["fp8"] * len(rows),
-            "gemm_type": ["fp8_block"] * len(rows),
-            "num_heads": [64] * len(rows),
-            "batch_size": [1] * len(rows),
-            "isl": [4096] * len(rows),
-            "tp_size": [1] * len(rows),
-            "step": [0] * len(rows),
-            "latency": [latency] * len(rows),
-        }
-    )
-    pq.write_table(table, path)
-    return str(path)
-
-
-# ───────────────────────────────────────────────────────────────────────
-# Loader: the full-only table loads, and its skip variant is empty (no raise)
-# ───────────────────────────────────────────────────────────────────────
-
-
-@pytest.mark.parametrize(
-    ("loader", "op_name"),
-    [
-        (load_context_dsa_module_data, "dsa_context_module"),
-        (load_generation_dsa_module_data, "dsa_generation_module"),
-    ],
-)
-def test_full_only_table_loads_and_skip_variant_is_empty(tmp_path, loader, op_name):
-    src = _write_dsa_parquet(tmp_path / f"{op_name}_perf.parquet", [op_name])
-
-    full = loader(src, op_kind="full")
-    assert full, "full-indexer rows must load"
-
-    # The skip variant must not raise — it simply yields no rows.
-    skip = loader(src, op_kind="skip")
-    assert not skip
-
-
-def test_both_variants_still_split_by_op_name(tmp_path):
-    src = _write_dsa_parquet(
-        tmp_path / "dsa_context_module_perf.parquet",
-        ["dsa_context_module", "dsa_context_module_skip_indexer"],
-    )
-    assert load_context_dsa_module_data(src, op_kind="full")
-    assert load_context_dsa_module_data(src, op_kind="skip")
-
-
-# ───────────────────────────────────────────────────────────────────────
-# The shipped data the degradation exists for
-# ───────────────────────────────────────────────────────────────────────
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/sdk/database/test_dsa_skip_indexer_fail_open.py
+++ b/tests/unit/sdk/database/test_dsa_skip_indexer_fail_open.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""AIC-1747: a DSA perf table with no ``*_skip_indexer`` rows must not kill the model.
+
+GLM-5.2 shares one topk index across a layer group and amortizes
+``per_layer = w*full + (1-w)*skip`` (w = 21/78 = 0.2692) off directly-collected
+skip-indexer rows. Those rows exist only in the sglang collector's 0.5.14 output
+(PR #1556 collected h200/h100/b200; 0.5.9-0.5.12 tables have none anywhere), so
+the skip query used to hard-fail every GLM-5.2 sweep point on skip-less tables.
+
+Policy (mirrors ``models/deepseek_v32.py``'s no-skip-producer gate): degrade the
+amortization to all-full instead of erroring, and stay byte-identical wherever
+the skip rows DO exist. Since the per-call Python query stack was retired behind
+engine-routed shims (PR-5/PR-6), the amortization and its degradation execute in
+the compiled engine — the behavioral regressions (degrade-to-all-full, mixed
+amortization preserved, SOL-mode blend retention, exact twin pins) live in the
+Rust operator tests (``operators/dsa.rs``). This file keeps the Python-side
+surfaces that still exist: the parquet loaders' full/skip split and the shipped
+table-view availability the degradation keys off.
+"""
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from aiconfigurator.sdk.operations.dsa import (
+    ContextDSAModule,
+    GenerationDSAModule,
+    load_context_dsa_module_data,
+    load_generation_dsa_module_data,
+)
+
+pytestmark = pytest.mark.unit
+
+GLM5_ARCHITECTURE = "GlmMoeDsaForCausalLM"
+
+FULL_LATENCY = 10.0
+
+
+def _write_dsa_parquet(path, op_names, latency=FULL_LATENCY):
+    """Minimal DSA module table in the shipped sglang schema.
+
+    ``op_names`` selects which variants are present; passing only
+    ``dsa_context_module`` reproduces a skip-less table (the pre-#1556 h200
+    state, still the live state for sglang 0.5.9-0.5.12).
+    """
+    rows = [{"op_name": name} for name in op_names]
+    table = pa.table(
+        {
+            "framework": ["sglang"] * len(rows),
+            "version": ["0.5.14"] * len(rows),
+            "device": ["h200_sxm"] * len(rows),
+            "op_name": [r["op_name"] for r in rows],
+            "kernel_source": ["sglang_dsa_indexer_trtllm"] * len(rows),
+            "model": ["zai-org/GLM-5.2-FP8"] * len(rows),
+            "architecture": [GLM5_ARCHITECTURE] * len(rows),
+            "mla_dtype": ["bfloat16"] * len(rows),
+            "kv_cache_dtype": ["fp8"] * len(rows),
+            "gemm_type": ["fp8_block"] * len(rows),
+            "num_heads": [64] * len(rows),
+            "batch_size": [1] * len(rows),
+            "isl": [4096] * len(rows),
+            "tp_size": [1] * len(rows),
+            "step": [0] * len(rows),
+            "latency": [latency] * len(rows),
+        }
+    )
+    pq.write_table(table, path)
+    return str(path)
+
+
+# ───────────────────────────────────────────────────────────────────────
+# Loader: the full-only table loads, and its skip variant is empty (no raise)
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("loader", "op_name"),
+    [
+        (load_context_dsa_module_data, "dsa_context_module"),
+        (load_generation_dsa_module_data, "dsa_generation_module"),
+    ],
+)
+def test_full_only_table_loads_and_skip_variant_is_empty(tmp_path, loader, op_name):
+    src = _write_dsa_parquet(tmp_path / f"{op_name}_perf.parquet", [op_name])
+
+    full = loader(src, op_kind="full")
+    assert full, "full-indexer rows must load"
+
+    # The skip variant must not raise — it simply yields no rows.
+    skip = loader(src, op_kind="skip")
+    assert not skip
+
+
+def test_both_variants_still_split_by_op_name(tmp_path):
+    src = _write_dsa_parquet(
+        tmp_path / "dsa_context_module_perf.parquet",
+        ["dsa_context_module", "dsa_context_module_skip_indexer"],
+    )
+    assert load_context_dsa_module_data(src, op_kind="full")
+    assert load_context_dsa_module_data(src, op_kind="skip")
+
+
+# ───────────────────────────────────────────────────────────────────────
+# The shipped data the degradation exists for
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("system", "version", "expect_skip_rows"),
+    [
+        # 0.5.9-0.5.12-era tables have no skip rows anywhere (the AIC-1747
+        # probe collection covered 0.5.14 only) — this is the gap the
+        # degradation now exists for. Anchored to tables no in-flight data PR
+        # touches, matching the Rust twin's test anchors.
+        ("h200_sxm", "0.5.10", False),
+        ("b200_sxm", "0.5.14", True),
+        ("gb200", "0.5.14", True),
+    ],
+)
+def test_shipped_sglang_skip_row_availability(system, version, expect_skip_rows):
+    """Pins the shipped skip-row availability the engine degradation keys off."""
+    from aiconfigurator_core.sdk.perf_database import get_database
+
+    db = get_database(system, "sglang", version)
+    ContextDSAModule.load_data(db)
+    GenerationDSAModule.load_data(db)
+
+    assert bool(db._context_dsa_module_skip_data) is expect_skip_rows
+    assert bool(db._generation_dsa_module_skip_data) is expect_skip_rows
+    # Either way the FULL table loads — the model must never die at load.
+    assert db._context_dsa_module_data
+    assert db._generation_dsa_module_data


### PR DESCRIPTION
## What

A DSA perf table with no `*_skip_indexer` rows must not kill the model. GLM-5.2 shares one topk index across a layer group and amortizes per-layer DSA as `full_frac·full + (1−full_frac)·skip` (21/78), using directly-collected skip-indexer rows. On tables without those rows the unavoidable skip query hard-failed every GLM-5.2 sweep point (`PerfDataNotAvailableError` at model load — the AIC-1743 §5 finding). Policy, per the documented `models/deepseek_v32.py` precedent for backends with no skip producer: **degrade the amortization to all-full instead of erroring** — pessimistic (the indexer is charged on every layer), byte-identical wherever the skip rows exist. Linear: AIC-1747.

**Scope after #1556:** the 0.5.14 tables are now variant-complete, so this degradation serves the sglang **0.5.9–0.5.12** tables (no skip rows anywhere) and any future partially-populated table. It is the fail-open safety net, not the recipe-critical path it started as.

## Engine-era design (v2 — rebased over #1552/#1555)

This PR was originally implemented in the Python per-call query stack, which #1552/#1555 retired behind engine-routed shims (the shim rejects `skip_indexer=` outright, and the sweep hot path executes entirely in the compiled engine). The redesign sites everything where execution actually happens now:

- **`aic-core/rust/aiconfigurator-core/src/operators/dsa.rs`** — `effective_full_frac(has_skip_rows)`: keeps `full_frac` when ≥ 1.0 or when skip rows exist; degrades to 1.0 otherwise. Both call sites short-circuit **before** the table probe for `full_frac ≥ 1.0` architectures (DeepSeek-V3.2 / GLM-5: the "skip table is never touched" invariant stays literally true) and for `Sol`/`SolFull`: the analytic model is skip-aware directly (the context `get_sol` port zeroes the indexer terms on skip layers), so degrading there inflated the context SOL and served no data need — SOL keeps the configured blend and never probes the table (CodeRabbit's Major on the v1 diff, verified and carried over).
- **`aic-core/rust/aiconfigurator-core/src/perf_database/dsa.rs`** — `has_context_skip_rows()` / `has_generation_skip_rows()` table-presence probes (lazy, per-table).
- **Known gap, documented in-code:** the degradation is **silent**. The crate deliberately has no logging (the `operators/dsv4.rs` convention), and the per-call Python path that carried the v1 one-time warning no longer exists. Engine-side fidelity-degradation surfacing is tracked as **AIC-1767** (filed with this v2; AIC-1753 owns the adjacent support-matrix reporting tier); please don't ask for a log crate in the hot path.
- **Parity-rules note (`.claude/rules/rust-core/parity.md`):** goldens are untouched and the parity suite is green — the only behavior change is error→value on configs no golden pins (skip-less-table GLM-5.2). The newly-reachable config class is anchored by Rust oracle tests per Rule 1.2; no parity case was appended because the 0.5.9–0.5.12-era tables lack full-engine-step op coverage for GLM-5.2.

## Tests

- **Rust operator regressions carry all behavior** (they run on the only execution path): degrade-to-all-full with exact numeric pins; mixed amortization preserved with an exact blend identity `w·full + (1−w)·skip` plus pins; SOL-mode blend retention on a skip-less table (strictly below all-full — the discriminating assertion); fresh-DB probe semantics.
- **Anchors are merge-order-proof**: full-only fixtures anchor to `h200/sglang/0.5.10` (representative of the 0.5.9–0.5.12 era this now serves), mixed fixtures to `gb200/sglang/0.5.14` — tables no in-flight data PR touches. All pins verified on post-#1556 main.
- **Python file keeps the surfaces that still exist**: the parquet loaders' full/skip `op_name` split (a full-only table loads, its skip variant is empty, no raise) and the shipped table-view availability pins the degradation keys off (`h200/0.5.10` no-skip, `b200`/`gb200` 0.5.14 both-variants).
- Generation SOL is not skip-aware (the indexer term is unconditional in the analytic model), so the SOL gate is value-neutral there — covered by the context-side assertions.

## Verification

`cargo test` full suite green; `pytest tests/unit -n 2` full suite green; Rust/Python engine-step parity suite green; `ruff format --check` / `ruff check` clean (the outstanding review comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DSA amortization behavior when skip-indexer performance data is unavailable.
  * Preserved configured weighting for SOL and SOL_FULL modes.
  * Ensured full-only and mixed performance tables are handled correctly.
  * Improved resilience when performance data sources are missing or cannot be loaded.
  * Added safer handling for unavailable performance data during context and generation calculations.

* **Tests**
  * Added coverage for skip-indexer availability, fallback behavior, and shipped performance datasets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->