### PR TITLE
feat(adapter): support Dynamo nightly estimate reporting

### DIFF
--- a/.github/workflows/build-platform-wheels-copied-pr.yml
+++ b/.github/workflows/build-platform-wheels-copied-pr.yml
@@ -11,7 +11,7 @@ on:
     paths:
       - ".github/actions/build-platform-wheel/**"
       - ".github/workflows/build-platform-wheels-copied-pr.yml"
-      - ".github/workflows/build-platform-wheels.yml"
+      - ".github/workflows/validate-platform-wheels.yml"
       - "docker/Dockerfile"
       - "LICENSE"
       - "pyproject.toml"
@@ -29,5 +29,4 @@ permissions:
 jobs:
   build:
     name: Build copied-PR platform wheels
-    uses: ./.github/workflows/build-platform-wheels.yml
-    secrets: inherit
+    uses: ./.github/workflows/validate-platform-wheels.yml

--- a/.github/workflows/build-platform-wheels.yml
+++ b/.github/workflows/build-platform-wheels.yml
@@ -8,11 +8,10 @@ on:
     branches:
       - main
       - "release/*"
-  workflow_call:
 
 concurrency:
   group: platform-wheels-${{ github.ref }}
-  cancel-in-progress: ${{ startsWith(github.ref, 'refs/heads/pull-request/') }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -75,21 +74,6 @@ jobs:
           platform: ${{ matrix.platform }}
           wheel_base: ${{ matrix.wheel_base }}
 
-      - name: Report disabled copied-PR Artifactory staging
-        if: >-
-          matrix.upload_upper &&
-          startsWith(github.ref, 'refs/heads/pull-request/') &&
-          vars.PLATFORM_WHEEL_STAGING_ENABLED != 'true'
-        shell: bash
-        run: |
-          echo "::notice title=Copied-PR Artifactory staging disabled::Set PLATFORM_WHEEL_STAGING_ENABLED=true when staging is ready."
-          {
-            echo "### Copied pull-request Artifactory staging"
-            echo
-            echo '- Status: skipped because `PLATFORM_WHEEL_STAGING_ENABLED` is not `true`.'
-            echo '- Follow-up: [#1432](https://github.com/ai-dynamo/aiconfigurator/issues/1432).'
-          } >> "${GITHUB_STEP_SUMMARY}"
-
       - name: Report disabled post-merge Artifactory staging
         if: >-
           matrix.upload_upper &&
@@ -104,31 +88,6 @@ jobs:
             echo '- Status: skipped because `PLATFORM_WHEEL_STAGING_ENABLED` is not `true`.'
           } >> "${GITHUB_STEP_SUMMARY}"
 
-      - name: Resolve copied pull-request staging path
-        id: pr-staging
-        if: startsWith(github.ref, 'refs/heads/pull-request/')
-        shell: bash
-        run: |
-          pr_number="${GITHUB_REF_NAME#pull-request/}"
-          if [[ ! "${pr_number}" =~ ^[0-9]+$ ]]; then
-            echo "::error::Expected a copy-pr-bot branch named pull-request/<number>, got ${GITHUB_REF_NAME}"
-            exit 1
-          fi
-          echo "subpath=PR/${pr_number}/${GITHUB_SHA}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}" >> "${GITHUB_OUTPUT}"
-
-      - name: Stage copied pull-request wheels in Artifactory
-        if: >-
-          vars.PLATFORM_WHEEL_STAGING_ENABLED == 'true' &&
-          startsWith(github.ref, 'refs/heads/pull-request/')
-        env:
-          ARTIFACTORY_URL: ${{ secrets.ARTIFACTORY_URL }}
-          ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_PR_TOKEN }}
-          ARTIFACTORY_PYPI_REPO_NAME: ${{ secrets.ARTIFACTORY_PYPI_REPO_NAME }}
-          ARTIFACTORY_SUBPATH: ${{ steps.pr-staging.outputs.subpath }}
-          UPLOAD_UPPER: ${{ matrix.upload_upper }}
-        shell: bash
-        run: bash tools/stage_wheels_in_artifactory.sh
-
       - name: Stage post-merge wheels in Artifactory
         if: >-
           vars.PLATFORM_WHEEL_STAGING_ENABLED == 'true' &&
@@ -142,50 +101,6 @@ jobs:
         shell: bash
         run: bash tools/stage_wheels_in_artifactory.sh
 
-  finalize-pr:
-    name: Finalize copied pull-request wheel set
-    needs: build
-    if: >-
-      success() &&
-      vars.PLATFORM_WHEEL_STAGING_ENABLED == 'true' &&
-      startsWith(github.ref, 'refs/heads/pull-request/')
-    runs-on: prod-aiconfigurator-default-amd64-v1
-    permissions:
-      contents: read
-    steps:
-      - name: Mark the validated matrix complete
-        env:
-          ARTIFACTORY_URL: ${{ secrets.ARTIFACTORY_URL }}
-          ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_PR_TOKEN }}
-          ARTIFACTORY_PYPI_REPO_NAME: ${{ secrets.ARTIFACTORY_PYPI_REPO_NAME }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          pr_number="${GITHUB_REF_NAME#pull-request/}"
-          if [[ ! "${pr_number}" =~ ^[0-9]+$ ]]; then
-            echo "::error::Expected a copy-pr-bot branch named pull-request/<number>, got ${GITHUB_REF_NAME}"
-            exit 1
-          fi
-          ARTIFACTORY_SUBPATH="PR/${pr_number}/${GITHUB_SHA}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}"
-          : "${ARTIFACTORY_URL:?ARTIFACTORY_URL is not configured}"
-          : "${ARTIFACTORY_TOKEN:?ARTIFACTORY_TOKEN is not configured}"
-          : "${ARTIFACTORY_PYPI_REPO_NAME:?ARTIFACTORY_PYPI_REPO_NAME is not configured}"
-          if [[ "${ARTIFACTORY_URL}" != https://* ]]; then
-            echo "::error::ARTIFACTORY_URL must use HTTPS"
-            exit 1
-          fi
-
-          target="${ARTIFACTORY_URL%/}/${ARTIFACTORY_PYPI_REPO_NAME}/${ARTIFACTORY_SUBPATH}/_COMPLETE.json"
-          payload="{\"status\":\"complete\",\"repository\":\"${GITHUB_REPOSITORY}\",\"run_id\":\"${GITHUB_RUN_ID}\",\"run_attempt\":\"${GITHUB_RUN_ATTEMPT}\"}"
-          curl --fail-with-body --show-error --silent \
-            --connect-timeout 30 --max-time 300 \
-            --retry 3 --retry-delay 5 --retry-all-errors \
-            --request PUT --header "Content-Type: application/json" \
-            --header "Authorization: Bearer ${ARTIFACTORY_TOKEN}" \
-            --data-binary "${payload}" \
-            "${target}"
-          echo "Completed ${ARTIFACTORY_SUBPATH}/"
-
   finalize-post-merge:
     name: Finalize post-merge wheel set
     needs: build
@@ -197,6 +112,14 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Checkout finalizer source
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          sparse-checkout: tools/finalize_wheels_in_artifactory.py
+          sparse-checkout-cone-mode: false
+
       - name: Mark the validated matrix complete
         env:
           ARTIFACTORY_URL: ${{ secrets.ARTIFACTORY_URL }}
@@ -204,23 +127,4 @@ jobs:
           ARTIFACTORY_PYPI_REPO_NAME: ${{ secrets.ARTIFACTORY_PYPI_REPO_NAME }}
           ARTIFACTORY_SUBPATH: post-merge/${{ github.sha }}/${{ github.run_id }}/${{ github.run_attempt }}
         shell: bash
-        run: |
-          set -euo pipefail
-          : "${ARTIFACTORY_URL:?ARTIFACTORY_URL is not configured}"
-          : "${ARTIFACTORY_TOKEN:?ARTIFACTORY_TOKEN is not configured}"
-          : "${ARTIFACTORY_PYPI_REPO_NAME:?ARTIFACTORY_PYPI_REPO_NAME is not configured}"
-          if [[ "${ARTIFACTORY_URL}" != https://* ]]; then
-            echo "::error::ARTIFACTORY_URL must use HTTPS"
-            exit 1
-          fi
-
-          target="${ARTIFACTORY_URL%/}/${ARTIFACTORY_PYPI_REPO_NAME}/${ARTIFACTORY_SUBPATH}/_COMPLETE.json"
-          payload="{\"status\":\"complete\",\"repository\":\"${GITHUB_REPOSITORY}\",\"run_id\":\"${GITHUB_RUN_ID}\",\"run_attempt\":\"${GITHUB_RUN_ATTEMPT}\"}"
-          curl --fail-with-body --show-error --silent \
-            --connect-timeout 30 --max-time 300 \
-            --retry 3 --retry-delay 5 --retry-all-errors \
-            --request PUT --header "Content-Type: application/json" \
-            --header "Authorization: Bearer ${ARTIFACTORY_TOKEN}" \
-            --data-binary "${payload}" \
-            "${target}"
-          echo "Completed ${ARTIFACTORY_SUBPATH}/"
+        run: python tools/finalize_wheels_in_artifactory.py

--- a/.github/workflows/validate-platform-wheels.yml
+++ b/.github/workflows/validate-platform-wheels.yml
@@ -4,6 +4,7 @@
 name: Validate platform wheels
 
 on:
+  workflow_call:
   pull_request:
     types:
       - opened
@@ -12,7 +13,6 @@ on:
     paths:
       - ".github/actions/build-platform-wheel/**"
       - ".github/workflows/build-platform-wheels-copied-pr.yml"
-      - ".github/workflows/build-platform-wheels.yml"
       - ".github/workflows/validate-platform-wheels.yml"
       - "docker/Dockerfile"
       - "LICENSE"

--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ Let's get started.
 > set to Artifactory when platform-wheel staging is enabled. These Artifactory
 > artifacts are separate from public PyPI: Linux aarch64 and macOS arm64 users
 > with access to the release artifacts can install the matching wheel set.
+> Each staged set publishes `_MANIFEST.json` with immutable wheel SHA-256 and
+> size metadata, then writes `_COMPLETE.json` last with the manifest checksum.
+> Consumers must verify both files before installing a wheel.
+> Copied pull-request workflows validate wheels only on isolated GitHub-hosted
+> runners. They do not use the persistent release runners, receive Artifactory
+> credentials, or publish wheel artifacts.
 > Windows has no supported installation path.
 
 ```bash

--- a/docs/config_adapter.md
+++ b/docs/config_adapter.md
@@ -108,10 +108,18 @@ current flat estimate API, so they require an explicit shared
 `free_gpu_memory_fraction` override.
 
 Worker sizing uses replicas, `multinode.nodeCount`, GPU limits, and literal engine
-parallelism flags. Literal environment substitutions are supported. A known
-numeric `CONCURRENCY_PER_GPU * DEPLOYMENT_GPU_COUNT` performance point is
-expanded without executing shell. Multiple explicit points create multiple
-outcomes.
+parallelism flags. Literal environment substitutions are supported. Shell
+comments are discarded while parsing worker commands, and no command is
+executed. A literal space-separated `CONCURRENCIES` environment value expands
+to ordered operating points. A known numeric
+`CONCURRENCY_PER_GPU * DEPLOYMENT_GPU_COUNT` performance point is expanded
+without executing shell. Multiple explicit points create multiple outcomes.
+
+TRT-LLM speculative settings are read from mounted engine ConfigMaps as well as
+worker flags. Active speculation requires an explicit `nextn_accepted`
+override; the adapter never guesses an acceptance rate. Uneven concurrency
+distribution and conflicting role-specific memory fractions remain rejected
+with stable diagnostics.
 
 For Helm-based benchmark infrastructure, render `recipe-values.yaml` into a
 DynamoGraphDeployment before adaptation. The matching unrendered

--- a/docs/config_adapter.md
+++ b/docs/config_adapter.md
@@ -115,11 +115,13 @@ to ordered operating points. A known numeric
 `CONCURRENCY_PER_GPU * DEPLOYMENT_GPU_COUNT` performance point is expanded
 without executing shell. Multiple explicit points create multiple outcomes.
 
-TRT-LLM speculative settings are read from mounted engine ConfigMaps as well as
-worker flags. Active speculation requires an explicit `nextn_accepted`
-override; the adapter never guesses an acceptance rate. Uneven concurrency
-distribution and conflicting role-specific memory fractions remain rejected
-with stable diagnostics.
+TRT-LLM speculative settings are read from worker flags and engine ConfigMaps
+whose volume mount resolves the exact `--extra-engine-args` path. Unmounted
+files, conflicting active depths across roles, and ambiguous mounts are
+rejected. A zero depth remains disabled. Active speculation requires an
+explicit `nextn_accepted` override; the adapter never guesses an acceptance
+rate. Uneven concurrency distribution and conflicting role-specific memory
+fractions remain rejected with stable diagnostics.
 
 For Helm-based benchmark infrastructure, render `recipe-values.yaml` into a
 DynamoGraphDeployment before adaptation. The matching unrendered

--- a/src/aiconfigurator/sdk/config_adapter/README.md
+++ b/src/aiconfigurator/sdk/config_adapter/README.md
@@ -49,9 +49,10 @@ itself never invokes it.
 The adapters support vLLM, SGLang, and TRT-LLM. Unsupported or ambiguous
 topologies are returned as rejected outcomes with structured diagnostics.
 For Dynamo performance Jobs, literal `CONCURRENCIES` values are expanded in
-order and shell comments are ignored during command parsing. Mounted TRT-LLM
-engine ConfigMaps are inspected for speculative decoding; an active setting is
-rejected unless the caller supplies `nextn_accepted`.
+order and shell comments are ignored during command parsing. TRT-LLM engine
+ConfigMaps are inspected only when their volume mount resolves the exact engine
+argument path. Conflicting active depths are rejected, zero depth stays
+disabled, and active speculation requires a caller-supplied `nextn_accepted`.
 
 ## Contract
 

--- a/src/aiconfigurator/sdk/config_adapter/README.md
+++ b/src/aiconfigurator/sdk/config_adapter/README.md
@@ -48,6 +48,10 @@ itself never invokes it.
 
 The adapters support vLLM, SGLang, and TRT-LLM. Unsupported or ambiguous
 topologies are returned as rejected outcomes with structured diagnostics.
+For Dynamo performance Jobs, literal `CONCURRENCIES` values are expanded in
+order and shell comments are ignored during command parsing. Mounted TRT-LLM
+engine ConfigMaps are inspected for speculative decoding; an active setting is
+rejected unless the caller supplies `nextn_accepted`.
 
 ## Contract
 

--- a/src/aiconfigurator/sdk/config_adapter/dynamo.py
+++ b/src/aiconfigurator/sdk/config_adapter/dynamo.py
@@ -9,7 +9,7 @@ import re
 import shlex
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 import yaml
@@ -202,16 +202,28 @@ def _mounted_config(service: Mapping[str, Any], config_maps: Mapping[str, Any]) 
     main = _container(service)
     extra = service.get("extraPodSpec", {})
     volumes = extra.get("volumes", []) if isinstance(extra, Mapping) else []
-    names: list[str] = []
+    config_volumes: dict[str, tuple[str, Mapping[str, str] | None]] = {}
     if isinstance(volumes, list):
         for volume in volumes:
             if not isinstance(volume, Mapping):
                 continue
             config_map = volume.get("configMap", {})
-            if isinstance(config_map, Mapping) and isinstance(config_map.get("name"), str):
-                names.append(config_map["name"])
-    if not names:
-        return {}
+            volume_name = volume.get("name")
+            config_map_name = config_map.get("name") if isinstance(config_map, Mapping) else None
+            if not isinstance(volume_name, str) or not isinstance(config_map_name, str):
+                continue
+            projected_paths: dict[str, str] = {}
+            items = config_map.get("items")
+            if isinstance(items, list):
+                for item in items:
+                    if not isinstance(item, Mapping):
+                        continue
+                    key = item.get("key")
+                    path = item.get("path")
+                    if isinstance(key, str) and isinstance(path, str):
+                        projected_paths[key] = path
+            config_volumes[volume_name] = (config_map_name, projected_paths or None)
+
     env = _env(main.get("env", []))
     engine_path: Any = env.get("ENGINE_ARGS", "")
     try:
@@ -221,12 +233,35 @@ def _mounted_config(service: Mapping[str, Any], config_maps: Mapping[str, Any]) 
     if flags.get("extra-engine-args") not in (None, True):
         engine_path = flags["extra-engine-args"]
     engine_path = str(engine_path)
-    engine_basename = Path(engine_path).name if engine_path else ""
     candidates: list[Mapping[str, Any]] = []
-    for name in names:
-        for filename, config in config_maps.get(name, {}).items():
-            if not engine_path or engine_basename == filename:
-                candidates.append(config)
+    mounts = main.get("volumeMounts", [])
+    if isinstance(mounts, list):
+        for mount in mounts:
+            if not isinstance(mount, Mapping):
+                continue
+            volume_name = mount.get("name")
+            mount_path = mount.get("mountPath")
+            if not isinstance(volume_name, str) or not isinstance(mount_path, str):
+                continue
+            volume_config = config_volumes.get(volume_name)
+            if volume_config is None:
+                continue
+            config_map_name, projected_paths = volume_config
+            sub_path = mount.get("subPath")
+            for filename, config in config_maps.get(config_map_name, {}).items():
+                if projected_paths is not None and filename not in projected_paths:
+                    continue
+                projected_path = projected_paths[filename] if projected_paths is not None else filename
+                if isinstance(sub_path, str):
+                    if sub_path != projected_path:
+                        continue
+                    resolved_path = PurePosixPath(mount_path)
+                else:
+                    resolved_path = PurePosixPath(mount_path) / projected_path
+                if not engine_path or resolved_path == PurePosixPath(engine_path):
+                    candidates.append(config)
+    if engine_path and not candidates:
+        raise ValueError(f"engine config path {engine_path!r} does not resolve to a mounted ConfigMap file")
     if len(candidates) > 1:
         raise ValueError("worker mounts multiple ambiguous engine ConfigMap files")
     return candidates[0] if candidates else {}
@@ -767,51 +802,65 @@ def _request_for_point(
         systems = SystemSettingsV1(prefill=system, decode=overrides.decode_system_name or system)
 
     speculative_flag_names = {"num-speculative-tokens", "speculative-num-steps", "speculative-token-num"}
-    speculative_values: list[Any] = []
-    speculative_configs: list[Mapping[str, Any]] = []
+    speculation_disabled = {"", "0", "false", "none", "disabled"}
+
+    def speculation_enabled(value: Any) -> bool:
+        return value is not None and value is not False and str(value).lower() not in speculation_disabled
+
+    speculative_values: list[tuple[str, Any]] = []
+    speculative_enable_values: list[Any] = []
     for service in services:
         config = service.engine_config.get("speculative_config")
         speculative_config = config if isinstance(config, Mapping) else {}
-        if speculative_config:
-            speculative_configs.append(speculative_config)
         speculative_values.append(
-            _coalesce(
-                "speculative depth",
-                (
+            (
+                service.name,
+                _coalesce(
+                    "speculative depth",
                     (
-                        f"{service.name} command",
-                        _flag(service, "num-speculative-tokens", "speculative-num-steps", "speculative-token-num"),
-                    ),
-                    (f"{service.name} engine ConfigMap", speculative_config.get("max_draft_len")),
-                    (
-                        f"{service.name} engine ConfigMap",
-                        speculative_config.get("num_nextn_predict_layers"),
+                        (
+                            f"{service.name} command",
+                            _flag(
+                                service,
+                                "num-speculative-tokens",
+                                "speculative-num-steps",
+                                "speculative-token-num",
+                            ),
+                        ),
+                        (f"{service.name} engine ConfigMap", speculative_config.get("max_draft_len")),
+                        (
+                            f"{service.name} engine ConfigMap",
+                            speculative_config.get("num_nextn_predict_layers"),
+                        ),
                     ),
                 ),
             )
         )
-    speculative_enable_values = [
+        speculative_enable_values.extend(
+            speculative_config.get(key) for key in ("decoding_type", "speculative_model_dir")
+        )
+    speculative_enable_values.extend(
         value
         for service in services
         for key, value in service.flags.items()
         if "specul" in key and key not in speculative_flag_names
-    ] + speculative_configs
-    speculation_disabled = {"", "0", "false", "none", "disabled"}
-
-    def speculation_enabled(value: Any) -> bool:
-        if isinstance(value, Mapping):
-            return bool(value)
-        return value is not None and value is not False and str(value).lower() not in speculation_disabled
-
-    active_speculation = any(speculation_enabled(value) for value in (*speculative_values, *speculative_enable_values))
+    )
+    active_depths = [
+        (service_name, _as_int(value, f"{service_name} speculative depth"))
+        for service_name, value in speculative_values
+        if speculation_enabled(value)
+    ]
+    depth_values = {value for _, value in active_depths}
+    if len(depth_values) > 1:
+        detail = ", ".join(f"{service_name}={value}" for service_name, value in active_depths)
+        raise ValueError(f"worker services use different speculative depths: {detail}")
+    source_nextn = next(iter(depth_values), None)
+    active_speculation = source_nextn is not None or any(
+        speculation_enabled(value) for value in speculative_enable_values
+    )
     if active_speculation and overrides.nextn_accepted is None:
         raise ValueError("speculative decoding requires an explicit nextn_accepted override")
-    source_nextn = next((value for value in speculative_values if speculation_enabled(value)), None)
-    nextn = (
-        overrides.nextn
-        if overrides.nextn is not None
-        else (_as_int(source_nextn, "speculative depth") if source_nextn else 0)
-    )
+    nextn = overrides.nextn if overrides.nextn is not None else (source_nextn if source_nextn is not None else 0)
 
     free_fraction = overrides.free_gpu_memory_fraction
     if free_fraction is None:

--- a/src/aiconfigurator/sdk/config_adapter/dynamo.py
+++ b/src/aiconfigurator/sdk/config_adapter/dynamo.py
@@ -855,8 +855,10 @@ def _request_for_point(
         detail = ", ".join(f"{service_name}={value}" for service_name, value in active_depths)
         raise ValueError(f"worker services use different speculative depths: {detail}")
     source_nextn = next(iter(depth_values), None)
-    active_speculation = source_nextn is not None or any(
-        speculation_enabled(value) for value in speculative_enable_values
+    active_speculation = (
+        speculation_enabled(overrides.nextn)
+        or source_nextn is not None
+        or any(speculation_enabled(value) for value in speculative_enable_values)
     )
     if active_speculation and overrides.nextn_accepted is None:
         raise ValueError("speculative decoding requires an explicit nextn_accepted override")

--- a/src/aiconfigurator/sdk/config_adapter/dynamo.py
+++ b/src/aiconfigurator/sdk/config_adapter/dynamo.py
@@ -150,7 +150,7 @@ def _flags(command: str) -> dict[str, str | bool]:
     if "$(" in command or "`" in command:
         raise ValueError("engine arguments contain a shell-derived value")
     try:
-        tokens = shlex.split(command)
+        tokens = shlex.split(command, comments=True)
     except ValueError as error:
         raise ValueError(f"cannot parse engine arguments: {error}") from error
     result: dict[str, str | bool] = {}
@@ -625,6 +625,42 @@ def _discover_points(documents: Sequence[Mapping[str, Any]], overrides: AdapterO
             for concurrency, isl, osl in calls:
                 explicit.append(_Point(f"point-{len(explicit)}", isl, osl, concurrency))
             continue
+        if "CONCURRENCIES" in env:
+            raw_concurrencies = env["CONCURRENCIES"]
+            if "$" in raw_concurrencies or "`" in raw_concurrencies:
+                explicit.append(
+                    _Point(
+                        "concurrency-sweep",
+                        env.get("ISL"),
+                        env.get("OSL"),
+                        None,
+                        error="CONCURRENCIES must contain literal integers",
+                    )
+                )
+                continue
+            concurrencies = raw_concurrencies.split()
+            if not concurrencies:
+                explicit.append(
+                    _Point(
+                        "concurrency-sweep",
+                        env.get("ISL"),
+                        env.get("OSL"),
+                        None,
+                        error="CONCURRENCIES must contain at least one integer",
+                    )
+                )
+                continue
+            explicit.extend(
+                _Point(
+                    f"concurrency-{concurrency}",
+                    env.get("ISL"),
+                    env.get("OSL"),
+                    concurrency,
+                    env.get("PREFIX", 0),
+                )
+                for concurrency in concurrencies
+            )
+            continue
         if not any(key in env for key in ("ISL", "OSL", "TOTAL_CONCURRENCY", "CONCURRENCY", "CONCURRENCY_PER_GPU")):
             continue
         concurrency: Any = env.get("TOTAL_CONCURRENCY", env.get("CONCURRENCY"))
@@ -731,19 +767,40 @@ def _request_for_point(
         systems = SystemSettingsV1(prefill=system, decode=overrides.decode_system_name or system)
 
     speculative_flag_names = {"num-speculative-tokens", "speculative-num-steps", "speculative-token-num"}
-    speculative_values = [
-        _flag(service, "num-speculative-tokens", "speculative-num-steps", "speculative-token-num")
-        for service in services
-    ]
+    speculative_values: list[Any] = []
+    speculative_configs: list[Mapping[str, Any]] = []
+    for service in services:
+        config = service.engine_config.get("speculative_config")
+        speculative_config = config if isinstance(config, Mapping) else {}
+        if speculative_config:
+            speculative_configs.append(speculative_config)
+        speculative_values.append(
+            _coalesce(
+                "speculative depth",
+                (
+                    (
+                        f"{service.name} command",
+                        _flag(service, "num-speculative-tokens", "speculative-num-steps", "speculative-token-num"),
+                    ),
+                    (f"{service.name} engine ConfigMap", speculative_config.get("max_draft_len")),
+                    (
+                        f"{service.name} engine ConfigMap",
+                        speculative_config.get("num_nextn_predict_layers"),
+                    ),
+                ),
+            )
+        )
     speculative_enable_values = [
         value
         for service in services
         for key, value in service.flags.items()
         if "specul" in key and key not in speculative_flag_names
-    ]
+    ] + speculative_configs
     speculation_disabled = {"", "0", "false", "none", "disabled"}
 
     def speculation_enabled(value: Any) -> bool:
+        if isinstance(value, Mapping):
+            return bool(value)
         return value is not None and value is not False and str(value).lower() not in speculation_disabled
 
     active_speculation = any(speculation_enabled(value) for value in (*speculative_values, *speculative_enable_values))

--- a/tests/fixtures/config_adapter/dynamo_nightly/dsv4/benchmark-job.yaml
+++ b/tests/fixtures/config_adapter/dynamo_nightly/dsv4/benchmark-job.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: dsv4-pro-disagg-bench
+spec:
+  template:
+    spec:
+      containers:
+        - name: bench
+          env:
+            - {name: ISL, value: "8192"}
+            - {name: OSL, value: "1024"}
+            - {name: CONCURRENCIES, value: "1 8 64 128 256 512 1024"}

--- a/tests/fixtures/config_adapter/dynamo_nightly/dsv4/deployment.yaml
+++ b/tests/fixtures/config_adapter/dynamo_nightly/dsv4/deployment.yaml
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Sanitized from the resolved Dynamo-CI RecipeDeployment nightly bundle.
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: dsv4
+spec:
+  backendFramework: vllm
+  services:
+    VllmPrefillWorker:
+      componentType: worker
+      subComponentType: prefill
+      replicas: 1
+      multinode: {nodeCount: 2}
+      resources: {limits: {gpu: "4"}}
+      extraPodSpec:
+        mainContainer:
+          env:
+            - {name: MODEL_PATH, value: deepseek-ai/DeepSeek-V4-Pro}
+          command: [/bin/sh, -c]
+          args:
+            - |
+              # Bind vLLM's DP coordinator so the operator's probe reaches the real server.
+              exec python3 -m dynamo.vllm \
+                --model "${MODEL_PATH}" \
+                --tensor-parallel-size 1 \
+                --pipeline-parallel-size 1 \
+                --data-parallel-size 8 \
+                --disaggregation-mode prefill \
+                --enable-expert-parallel \
+                --max-model-len 9280 \
+                --max-num-seqs 16 \
+                --gpu-memory-utilization 0.8
+    VllmDecodeWorker:
+      componentType: worker
+      subComponentType: decode
+      replicas: 1
+      multinode: {nodeCount: 2}
+      resources: {limits: {gpu: "4"}}
+      extraPodSpec:
+        mainContainer:
+          env:
+            - {name: MODEL_PATH, value: deepseek-ai/DeepSeek-V4-Pro}
+          command: [/bin/sh, -c]
+          args:
+            - |
+              # See the prefill worker's coordinator rationale.
+              exec python3 -m dynamo.vllm \
+                --model "${MODEL_PATH}" \
+                --tensor-parallel-size 1 \
+                --pipeline-parallel-size 1 \
+                --data-parallel-size 8 \
+                --disaggregation-mode decode \
+                --enable-expert-parallel \
+                --max-model-len 9280 \
+                --max-num-seqs 128 \
+                --gpu-memory-utilization 0.9

--- a/tests/fixtures/config_adapter/dynamo_nightly/kimi/benchmark-job.yaml
+++ b/tests/fixtures/config_adapter/dynamo_nightly/kimi/benchmark-job.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: aiperf-synthetic
+spec:
+  template:
+    spec:
+      containers:
+        - name: perf
+          env:
+            - {name: CONCURRENCIES, value: "1 2 4 8 16 32 64 128 256"}
+            - {name: ISL, value: "1000"}
+            - {name: OSL, value: "1500"}

--- a/tests/fixtures/config_adapter/dynamo_nightly/kimi/deployment.yaml
+++ b/tests/fixtures/config_adapter/dynamo_nightly/kimi/deployment.yaml
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Sanitized from the resolved Dynamo-CI RecipeDeployment nightly bundle.
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: kimi-k25-agg-kv-eagle
+spec:
+  backendFramework: trtllm
+  services:
+    agg:
+      componentType: worker
+      replicas: 3
+      multinode: {nodeCount: 2}
+      resources: {limits: {gpu: "4"}}
+      extraPodSpec:
+        volumes:
+          - name: trtllm-config
+            configMap: {name: kimi-k25-agg-kv-eagle-config}
+        mainContainer:
+          volumeMounts:
+            - name: trtllm-config
+              mountPath: /config
+          command: [python3, -m, dynamo.trtllm]
+          args:
+            - --model-path
+            - nvidia/Kimi-K2.5-NVFP4
+            - --extra-engine-args
+            - /config/agg.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kimi-k25-agg-kv-eagle-config
+data:
+  agg.yaml: |
+    tensor_parallel_size: 8
+    max_batch_size: 128
+    kv_cache_config:
+      dtype: fp8
+      free_gpu_memory_fraction: 0.75
+    speculative_config:
+      decoding_type: Eagle3
+      max_draft_len: 3
+      speculative_model_dir: nvidia/Kimi-K2.5-Thinking-Eagle3

--- a/tests/unit/sdk/config_adapter/test_dynamo.py
+++ b/tests/unit/sdk/config_adapter/test_dynamo.py
@@ -125,6 +125,16 @@ def test_agg_backends_support_string_and_list_arguments(backend, args_as_string)
     )
 
 
+def test_override_only_speculation_requires_explicit_acceptance():
+    outcome = adapt_config(
+        DynamoRecipeSource(_agg_yaml("trtllm")),
+        AdapterOverrides(isl=1024, osl=128, concurrency=16, nextn=1, nextn_accepted=None),
+    ).outcomes[0]
+
+    assert outcome.status == "rejected"
+    assert outcome.diagnostics[-1].message == "speculative decoding requires an explicit nextn_accepted override"
+
+
 def test_resolved_dsv4_shell_comments_do_not_change_engine_arguments():
     fixture = _NIGHTLY_FIXTURES / "dsv4"
 

--- a/tests/unit/sdk/config_adapter/test_dynamo.py
+++ b/tests/unit/sdk/config_adapter/test_dynamo.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+import yaml
 
 from aiconfigurator.sdk.config_adapter import (
     AdapterOverrides,
@@ -221,6 +222,25 @@ def test_resolved_kimi_engine_speculation_is_preserved_with_explicit_acceptance(
     assert outcome.request.model.nextn_accepted == 1.5
 
 
+def test_resolved_kimi_unmounted_engine_config_is_rejected():
+    fixture = _NIGHTLY_FIXTURES / "kimi"
+    documents = list(yaml.safe_load_all((fixture / "deployment.yaml").read_text()))
+    deployment = next(document for document in documents if document.get("kind") == "DynamoGraphDeployment")
+    del deployment["spec"]["services"]["agg"]["extraPodSpec"]["mainContainer"]["volumeMounts"]
+
+    outcome = adapt_config(
+        DynamoRecipeSource(documents, fixture / "benchmark-job.yaml"),
+        AdapterOverrides(
+            system_name="gb200",
+            nextn_accepted=1.5,
+            workload_points=(WorkloadPointOverride(point_id="concurrency-3", isl=1000, osl=1500, concurrency=3),),
+        ),
+    ).outcomes[0]
+
+    assert outcome.status == "rejected"
+    assert "does not resolve to a mounted ConfigMap file" in outcome.diagnostics[-1].message
+
+
 def test_disagg_env_substitution_and_role_sizing():
     deployment = """
 kind: DynamoGraphDeployment
@@ -285,6 +305,7 @@ spec:
         nodeSelector: {nvidia.com/gpu.product: NVIDIA-B200}
         volumes: [{name: engine, configMap: {name: engine}}]
         mainContainer:
+          volumeMounts: [{name: engine, mountPath: /configs}]
           env:
             - {name: MODEL_PATH, value: QWEN/QWEN3-32B}
             - {name: ENGINE_ARGS, value: /configs/config.yaml}
@@ -368,6 +389,7 @@ spec:
         nodeSelector: {nvidia.com/gpu.product: NVIDIA-H200}
         volumes: [{name: engine, configMap: {name: engine}}]
         mainContainer:
+          volumeMounts: [{name: engine, mountPath: /config}]
           args:
             - >-
               python -m dynamo.trtllm --model-path QWEN/QWEN3-32B
@@ -402,6 +424,7 @@ spec:
         nodeSelector: {nvidia.com/gpu.product: NVIDIA-H200}
         volumes: [{name: engine, configMap: {name: engine}}]
         mainContainer:
+          volumeMounts: [{name: engine, mountPath: /config}]
           args:
             - >-
               python -m dynamo.trtllm --model-path QWEN/QWEN3-32B
@@ -413,7 +436,7 @@ spec:
     ).outcomes[0]
 
     assert outcome.status == "rejected"
-    assert "does not declare tensor parallelism" in outcome.diagnostics[-1].message
+    assert "does not resolve to a mounted ConfigMap file" in outcome.diagnostics[-1].message
 
 
 def test_non_integral_gpu_count_is_rejected():
@@ -598,6 +621,7 @@ spec:
         nodeSelector: {nvidia.com/gpu.product: NVIDIA-H200}
         volumes: [{name: engine, configMap: {name: engine}}]
         mainContainer:
+          volumeMounts: [{name: engine, mountPath: /configs}]
           env:
             - {name: MODEL_PATH, value: QWEN/QWEN3-32B}
             - {name: ENGINE_ARGS, value: /configs/config.yaml}
@@ -690,6 +714,104 @@ def test_zero_speculative_depth_remains_disabled():
     assert outcome.request is not None
     assert outcome.request.model.nextn == 0
     assert outcome.request.model.nextn_accepted is None
+
+
+def test_zero_speculative_depth_in_engine_config_remains_disabled():
+    deployment = """
+kind: ConfigMap
+metadata: {name: engine}
+data:
+  config.yaml: |
+    tensor_parallel_size: 2
+    speculative_config:
+      num_nextn_predict_layers: 0
+---
+kind: DynamoGraphDeployment
+metadata: {name: zero-speculation}
+spec:
+  backendFramework: trtllm
+  services:
+    worker:
+      componentType: worker
+      resources: {limits: {gpu: "2"}}
+      extraPodSpec:
+        nodeSelector: {nvidia.com/gpu.product: NVIDIA-H200}
+        volumes: [{name: engine, configMap: {name: engine}}]
+        mainContainer:
+          volumeMounts: [{name: engine, mountPath: /config}]
+          args:
+            - >-
+              python -m dynamo.trtllm --model-path QWEN/QWEN3-32B
+              --extra-engine-args /config/config.yaml
+"""
+
+    outcome = adapt_config(
+        DynamoRecipeSource(deployment),
+        AdapterOverrides(isl=1024, osl=128, concurrency=8),
+    ).outcomes[0]
+
+    assert outcome.status == "adapted"
+    assert outcome.request is not None
+    assert outcome.request.model.nextn == 0
+    assert outcome.request.model.nextn_accepted is None
+
+
+def test_conflicting_engine_config_speculative_depths_are_rejected():
+    deployment = """
+kind: ConfigMap
+metadata: {name: prefill-engine}
+data:
+  config.yaml: |
+    tensor_parallel_size: 1
+    speculative_config: {num_nextn_predict_layers: 2}
+---
+kind: ConfigMap
+metadata: {name: decode-engine}
+data:
+  config.yaml: |
+    tensor_parallel_size: 1
+    speculative_config: {num_nextn_predict_layers: 3}
+---
+kind: DynamoGraphDeployment
+metadata: {name: conflicting-speculation}
+spec:
+  backendFramework: trtllm
+  services:
+    prefill:
+      componentType: worker
+      subComponentType: prefill
+      resources: {limits: {gpu: "1"}}
+      extraPodSpec:
+        nodeSelector: {nvidia.com/gpu.product: NVIDIA-H200}
+        volumes: [{name: engine, configMap: {name: prefill-engine}}]
+        mainContainer:
+          volumeMounts: [{name: engine, mountPath: /config}]
+          args:
+            - >-
+              python -m dynamo.trtllm --model-path QWEN/QWEN3-32B
+              --disaggregation-mode prefill --extra-engine-args /config/config.yaml
+    decode:
+      componentType: worker
+      subComponentType: decode
+      resources: {limits: {gpu: "1"}}
+      extraPodSpec:
+        nodeSelector: {nvidia.com/gpu.product: NVIDIA-H200}
+        volumes: [{name: engine, configMap: {name: decode-engine}}]
+        mainContainer:
+          volumeMounts: [{name: engine, mountPath: /config}]
+          args:
+            - >-
+              python -m dynamo.trtllm --model-path QWEN/QWEN3-32B
+              --disaggregation-mode decode --extra-engine-args /config/config.yaml
+"""
+
+    outcome = adapt_config(
+        DynamoRecipeSource(deployment),
+        AdapterOverrides(isl=1024, osl=128, concurrency=8, nextn_accepted=1.5),
+    ).outcomes[0]
+
+    assert outcome.status == "rejected"
+    assert "different speculative depths" in outcome.diagnostics[-1].message
 
 
 def test_speculative_model_flag_remains_active():

--- a/tests/unit/sdk/config_adapter/test_dynamo.py
+++ b/tests/unit/sdk/config_adapter/test_dynamo.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from aiconfigurator.sdk.config_adapter import (
@@ -14,6 +16,8 @@ from aiconfigurator.sdk.config_adapter import (
 )
 
 pytestmark = pytest.mark.unit
+
+_NIGHTLY_FIXTURES = Path(__file__).parents[3] / "fixtures" / "config_adapter" / "dynamo_nightly"
 
 
 def _dynamo_ci_recipe() -> dict:
@@ -118,6 +122,103 @@ def test_agg_backends_support_string_and_list_arguments(backend, args_as_string)
         "Aggregated worker replicas are omitted during cli_estimate lowering because "
         "cli_estimate has no aggregated worker-count parameter."
     )
+
+
+def test_resolved_dsv4_shell_comments_do_not_change_engine_arguments():
+    fixture = _NIGHTLY_FIXTURES / "dsv4"
+
+    outcome = adapt_config(
+        DynamoRecipeSource(fixture / "deployment.yaml", fixture / "benchmark-job.yaml"),
+        AdapterOverrides(
+            system_name="gb200",
+            free_gpu_memory_fraction=0.9,
+            workload_points=(WorkloadPointOverride(point_id="concurrency-8", isl=8192, osl=1024, concurrency=8),),
+        ),
+    ).outcomes[0]
+
+    assert outcome.status == "adapted"
+    assert outcome.request is not None
+    assert outcome.request.topology.kind == "disagg"
+
+
+def test_resolved_dsv4_sweep_preserves_all_points_and_fail_closed_diagnostics():
+    fixture = _NIGHTLY_FIXTURES / "dsv4"
+
+    report = adapt_config(
+        DynamoRecipeSource(fixture / "deployment.yaml", fixture / "benchmark-job.yaml"),
+        AdapterOverrides(system_name="gb200"),
+    )
+
+    assert [outcome.point_id for outcome in report.outcomes] == [
+        "concurrency-1",
+        "concurrency-8",
+        "concurrency-64",
+        "concurrency-128",
+        "concurrency-256",
+        "concurrency-512",
+        "concurrency-1024",
+    ]
+    assert all(outcome.status == "rejected" for outcome in report.outcomes)
+    assert "must be divisible" in report.outcomes[0].diagnostics[-1].message
+    assert all(
+        "conflicting free-gpu-memory-fraction" in outcome.diagnostics[-1].message for outcome in report.outcomes[1:]
+    )
+
+
+def test_resolved_kimi_engine_config_requires_speculative_acceptance():
+    fixture = _NIGHTLY_FIXTURES / "kimi"
+
+    outcome = adapt_config(
+        DynamoRecipeSource(fixture / "deployment.yaml", fixture / "benchmark-job.yaml"),
+        AdapterOverrides(
+            system_name="gb200",
+            workload_points=(WorkloadPointOverride(point_id="concurrency-3", isl=1000, osl=1500, concurrency=3),),
+        ),
+    ).outcomes[0]
+
+    assert outcome.status == "rejected"
+    assert "nextn_accepted" in outcome.diagnostics[-1].message
+
+
+def test_resolved_kimi_sweep_preserves_all_points_and_uneven_distribution_diagnostics():
+    fixture = _NIGHTLY_FIXTURES / "kimi"
+
+    report = adapt_config(
+        DynamoRecipeSource(fixture / "deployment.yaml", fixture / "benchmark-job.yaml"),
+        AdapterOverrides(system_name="gb200"),
+    )
+
+    assert [outcome.point_id for outcome in report.outcomes] == [
+        "concurrency-1",
+        "concurrency-2",
+        "concurrency-4",
+        "concurrency-8",
+        "concurrency-16",
+        "concurrency-32",
+        "concurrency-64",
+        "concurrency-128",
+        "concurrency-256",
+    ]
+    assert all(outcome.status == "rejected" for outcome in report.outcomes)
+    assert all("must be divisible" in outcome.diagnostics[-1].message for outcome in report.outcomes)
+
+
+def test_resolved_kimi_engine_speculation_is_preserved_with_explicit_acceptance():
+    fixture = _NIGHTLY_FIXTURES / "kimi"
+
+    outcome = adapt_config(
+        DynamoRecipeSource(fixture / "deployment.yaml", fixture / "benchmark-job.yaml"),
+        AdapterOverrides(
+            system_name="gb200",
+            nextn_accepted=1.5,
+            workload_points=(WorkloadPointOverride(point_id="concurrency-3", isl=1000, osl=1500, concurrency=3),),
+        ),
+    ).outcomes[0]
+
+    assert outcome.status == "adapted"
+    assert outcome.request is not None
+    assert outcome.request.model.nextn == 3
+    assert outcome.request.model.nextn_accepted == 1.5
 
 
 def test_disagg_env_substitution_and_role_sizing():

--- a/tests/unit/tools/test_finalize_wheels_in_artifactory.py
+++ b/tests/unit/tools/test_finalize_wheels_in_artifactory.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import hashlib
+import json
+
+import pytest
+
+from tools.finalize_wheels_in_artifactory import FinalizeError, build_manifest, finalize
+
+
+class FakeArtifacts:
+    def __init__(self) -> None:
+        self.files = {
+            "aiconfigurator-2.0.0-py3-none-any.whl": (b"upper", "a" * 64),
+            "aiconfigurator_core-2.0.0-cp311-abi3-manylinux_2_28_x86_64.whl": (b"core", "b" * 64),
+        }
+        self.uploads: list[tuple[str, bytes]] = []
+
+    def list_files(self, subpath: str) -> list[dict]:
+        return [
+            {"filename": name, "sha256": checksum, "size": len(payload)}
+            for name, (payload, checksum) in self.files.items()
+        ]
+
+    def upload(self, path: str, payload: bytes) -> None:
+        self.uploads.append((path, payload))
+
+
+def test_finalize_writes_manifest_before_completion_marker() -> None:
+    artifacts = FakeArtifacts()
+
+    manifest = finalize(
+        artifacts,
+        subpath="post-merge/sha/42/2",
+        repository="ai-dynamo/aiconfigurator",
+        commit_sha="sha",
+        run_id=42,
+        run_attempt=2,
+    )
+
+    assert [path for path, _ in artifacts.uploads] == [
+        "post-merge/sha/42/2/_MANIFEST.json",
+        "post-merge/sha/42/2/_COMPLETE.json",
+    ]
+    marker = json.loads(artifacts.uploads[1][1])
+    assert marker["manifest_sha256"] == hashlib.sha256(artifacts.uploads[0][1]).hexdigest()
+    assert marker["commit_sha"] == "sha"
+    assert manifest["wheels"][0]["filename"] == "aiconfigurator-2.0.0-py3-none-any.whl"
+
+
+def test_manifest_requires_upper_and_core_wheels() -> None:
+    with pytest.raises(FinalizeError, match="upper wheel"):
+        build_manifest(
+            [{"filename": "aiconfigurator_core-2.0.0-linux.whl", "sha256": "a" * 64, "size": 1}],
+            repository="ai-dynamo/aiconfigurator",
+            commit_sha="sha",
+            run_id=1,
+            run_attempt=1,
+        )
+
+    with pytest.raises(FinalizeError, match="core wheel"):
+        build_manifest(
+            [{"filename": "aiconfigurator-2.0.0-py3-none-any.whl", "sha256": "a" * 64, "size": 1}],
+            repository="ai-dynamo/aiconfigurator",
+            commit_sha="sha",
+            run_id=1,
+            run_attempt=1,
+        )

--- a/tools/finalize_wheels_in_artifactory.py
+++ b/tools/finalize_wheels_in_artifactory.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Publish a checksummed wheel manifest, then mark an Artifactory set complete."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Mapping, Sequence
+from typing import Any, Protocol
+
+MANIFEST_SCHEMA = "aic-wheel-manifest/1.0.0"
+UPPER_RE = re.compile(r"^aiconfigurator-[^-].*\.whl$")
+CORE_RE = re.compile(r"^aiconfigurator_core-.*\.whl$")
+
+
+class FinalizeError(RuntimeError):
+    pass
+
+
+class Artifacts(Protocol):
+    def list_files(self, subpath: str) -> list[dict[str, Any]]: ...
+
+    def upload(self, path: str, payload: bytes) -> None: ...
+
+
+def build_manifest(
+    files: Sequence[Mapping[str, Any]],
+    *,
+    repository: str,
+    commit_sha: str,
+    run_id: int,
+    run_attempt: int,
+) -> dict[str, Any]:
+    wheels: list[dict[str, Any]] = []
+    for item in files:
+        filename = item.get("filename")
+        checksum = item.get("sha256")
+        size = item.get("size")
+        if not isinstance(filename, str) or not filename.endswith(".whl"):
+            continue
+        if not isinstance(checksum, str) or not re.fullmatch(r"[0-9a-f]{64}", checksum):
+            raise FinalizeError(f"wheel {filename} has no valid SHA-256")
+        if isinstance(size, bool) or not isinstance(size, int) or size <= 0:
+            raise FinalizeError(f"wheel {filename} has no positive size")
+        wheels.append({"filename": filename, "sha256": checksum, "size": size})
+    wheels.sort(key=lambda item: item["filename"])
+    if len([item for item in wheels if UPPER_RE.fullmatch(item["filename"])]) != 1:
+        raise FinalizeError("completed platform build must contain exactly one upper wheel")
+    if not any(CORE_RE.fullmatch(item["filename"]) for item in wheels):
+        raise FinalizeError("completed platform build must contain at least one core wheel")
+    return {
+        "schemaVersion": MANIFEST_SCHEMA,
+        "repository": repository,
+        "commitSha": commit_sha,
+        "workflowRunId": run_id,
+        "workflowRunAttempt": run_attempt,
+        "wheels": wheels,
+    }
+
+
+def _json_bytes(value: Mapping[str, Any]) -> bytes:
+    return (json.dumps(value, indent=2, sort_keys=True) + "\n").encode()
+
+
+def finalize(
+    artifacts: Artifacts,
+    *,
+    subpath: str,
+    repository: str,
+    commit_sha: str,
+    run_id: int,
+    run_attempt: int,
+) -> dict[str, Any]:
+    manifest = build_manifest(
+        artifacts.list_files(subpath),
+        repository=repository,
+        commit_sha=commit_sha,
+        run_id=run_id,
+        run_attempt=run_attempt,
+    )
+    manifest_payload = _json_bytes(manifest)
+    artifacts.upload(f"{subpath}/_MANIFEST.json", manifest_payload)
+    marker = {
+        "status": "complete",
+        "repository": repository,
+        "commit_sha": commit_sha,
+        "run_id": str(run_id),
+        "run_attempt": str(run_attempt),
+        "manifest_sha256": hashlib.sha256(manifest_payload).hexdigest(),
+    }
+    artifacts.upload(f"{subpath}/_COMPLETE.json", _json_bytes(marker))
+    return manifest
+
+
+class ArtifactoryApi:
+    def __init__(self, base_url: str, token: str, repository: str) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+        self.repository = repository
+
+    def _request(self, url: str, *, payload: bytes | None = None) -> bytes:
+        headers = {"Authorization": f"Bearer {self.token}", "User-Agent": "aiconfigurator-wheel-finalizer"}
+        if payload is not None:
+            headers["Content-Type"] = "application/json"
+        for attempt in range(3):
+            request = urllib.request.Request(url, data=payload, headers=headers, method="PUT" if payload else "GET")
+            try:
+                with urllib.request.urlopen(request, timeout=300) as response:
+                    return response.read()
+            except urllib.error.HTTPError as exc:
+                if exc.code < 500 and exc.code != 429:
+                    raise FinalizeError(f"Artifactory request failed for {url}: {exc}") from exc
+                last_error: Exception = exc
+            except urllib.error.URLError as exc:
+                last_error = exc
+            if attempt < 2:
+                time.sleep(2**attempt)
+        raise FinalizeError(f"Artifactory request failed for {url}: {last_error}") from last_error
+
+    def _storage_url(self, path: str) -> str:
+        quoted = "/".join(urllib.parse.quote(part, safe="") for part in path.split("/"))
+        return f"{self.base_url}/api/storage/{self.repository}/{quoted}"
+
+    def _artifact_url(self, path: str) -> str:
+        quoted = "/".join(urllib.parse.quote(part, safe="") for part in path.split("/"))
+        return f"{self.base_url}/{self.repository}/{quoted}"
+
+    def _json(self, url: str) -> Mapping[str, Any]:
+        try:
+            value = json.loads(self._request(url))
+        except json.JSONDecodeError as exc:
+            raise FinalizeError(f"Artifactory returned invalid JSON for {url}") from exc
+        if not isinstance(value, Mapping):
+            raise FinalizeError(f"Artifactory returned a non-object for {url}")
+        return value
+
+    def list_files(self, subpath: str) -> list[dict[str, Any]]:
+        listing = self._json(f"{self._storage_url(subpath)}?list&deep=0&listFolders=0")
+        files = listing.get("files")
+        if not isinstance(files, list):
+            raise FinalizeError("Artifactory wheel listing has no files list")
+        result: list[dict[str, Any]] = []
+        for item in files:
+            uri = item.get("uri") if isinstance(item, Mapping) else None
+            if not isinstance(uri, str) or not uri.startswith("/") or "/" in uri[1:]:
+                continue
+            filename = uri[1:]
+            if not filename.endswith(".whl"):
+                continue
+            metadata = self._json(self._storage_url(f"{subpath}/{filename}"))
+            checksums = metadata.get("checksums")
+            sha256 = checksums.get("sha256") if isinstance(checksums, Mapping) else None
+            try:
+                size = int(metadata["size"])
+            except (KeyError, TypeError, ValueError) as exc:
+                raise FinalizeError(f"Artifactory metadata has no valid size for {filename}") from exc
+            result.append({"filename": filename, "sha256": sha256, "size": size})
+        return result
+
+    def upload(self, path: str, payload: bytes) -> None:
+        self._request(self._artifact_url(path), payload=payload)
+
+
+def _required_environment(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise FinalizeError(f"{name} is not configured")
+    return value
+
+
+def main() -> int:
+    try:
+        base_url = _required_environment("ARTIFACTORY_URL")
+        token = _required_environment("ARTIFACTORY_TOKEN")
+        artifact_repository = _required_environment("ARTIFACTORY_PYPI_REPO_NAME")
+        subpath = _required_environment("ARTIFACTORY_SUBPATH")
+        repository = _required_environment("GITHUB_REPOSITORY")
+        commit_sha = _required_environment("GITHUB_SHA")
+        run_id = int(_required_environment("GITHUB_RUN_ID"))
+        run_attempt = int(_required_environment("GITHUB_RUN_ATTEMPT"))
+        if not base_url.startswith("https://"):
+            raise FinalizeError("ARTIFACTORY_URL must use HTTPS")
+        if subpath.startswith("/") or ".." in subpath.split("/"):
+            raise FinalizeError("ARTIFACTORY_SUBPATH must be relative and contain no parent traversal")
+        finalize(
+            ArtifactoryApi(base_url, token, artifact_repository),
+            subpath=subpath,
+            repository=repository,
+            commit_sha=commit_sha,
+            run_id=run_id,
+            run_attempt=run_attempt,
+        )
+    except (FinalizeError, ValueError) as exc:
+        raise SystemExit(f"error: {exc}") from exc
+    print(f"Completed {subpath}/")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- harden the Dynamo adapter against resolved DSV4 and Kimi nightly bundles
- preserve ordered literal concurrency sweeps and shell-comment handling
- detect TRT-LLM speculative settings from engine configuration
- keep uneven concurrency, role-specific memory fractions, and missing acceptance rates fail-closed
- publish checksum-verified platform-wheel manifests and completion markers

## Why

Dynamo-CI needs reproducible AIC estimates after direct K8s nightlies. The adapter must emit estimates only when the resolved recipe maps faithfully and return stable diagnostics otherwise.

This adds the AIC-side contract required by the Dynamo-CI reporting MR. It improves continuous coverage for AIC-1743, but does not itself fix SWA KV accounting, MTP activation, prefix reuse, database coverage, or PASS semantics.

## Validation

- `uv run ruff check` on changed Python and tests
- `uv run pytest tests/unit/sdk/config_adapter tests/unit/tools/test_finalize_wheels_in_artifactory.py tests/integration/test_config_adapter_estimate.py -q`
- 73 tests passed
- workflow YAML and `git diff --check` passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Platform wheel releases now include immutable manifests with SHA-256 and size metadata, plus completion markers for verification before installation.
  - Dynamo performance configuration supports literal concurrency sweeps, improved comment handling, and speculative decoding detection from mounted engine configurations.
- **Bug Fixes**
  - Improved validation for unsupported concurrency, unresolved engine configurations, and conflicting settings.
  - Strengthened wheel publication checks to ensure complete, verifiable releases.
- **Documentation**
  - Clarified installation, wheel verification, concurrency expansion, and speculative decoding guidance.
  - Documented that copied pull-request workflows validate wheels without publishing artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->