### PR TITLE
fix(sdk): decode-share MTP scaling for static/AFD paths + reversion guards (follow-up to #1537)

### DIFF
--- a/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
+++ b/aic-core/src/aiconfigurator_core/sdk/backends/base_backend.py
@@ -664,6 +664,12 @@ class BaseBackend:
                 **memory_extra,
             )
         else:
+            # "static": activations default to the context token count
+            # ((isl - prefix) * batch_size), i.e. the prefill peak — the decode
+            # steps of a static batch only ever process
+            # batch_size * beam_width * (nextn + 1) tokens, far fewer. So this
+            # footprint has no decode share either (mtp_scaled_tokens=0), the
+            # same rule the static_ctx branch above already applies.
             memory = self._get_memory_usage(
                 model,
                 database,
@@ -673,6 +679,7 @@ class BaseBackend:
                 osl,
                 prefix=prefix,
                 encoder_memory=encoder_memory,
+                mtp_scaled_tokens=0,
                 **memory_extra,
             )
 
@@ -897,8 +904,16 @@ class BaseBackend:
             "num_tokens": num_tokens,
             "prefix": prefix,
         }
-        if "max_seq_len" in inspect.signature(self._get_memory_usage).parameters:
+        memory_usage_params = inspect.signature(self._get_memory_usage).parameters
+        if "max_seq_len" in memory_usage_params:
             kwargs["max_seq_len"] = max_seq_len
+        # ``num_tokens == 0`` (AFD's ``phase == "prefill"`` callers) makes
+        # ``_get_memory_usage`` derive the count from ``(isl - prefix) * batch_size``
+        # — a prefill-only footprint, so it carries no decode share that
+        # verifies nextn+1 draft tokens. Decode callers pass ``num_tokens > 0``
+        # (one token per request) and keep the full ``(nextn+1)`` multiplier.
+        if num_tokens == 0 and "mtp_scaled_tokens" in memory_usage_params:
+            kwargs["mtp_scaled_tokens"] = 0
 
         memory = self._get_memory_usage(
             model,

--- a/aic-core/src/aiconfigurator_core/sdk/backends/trtllm_backend.py
+++ b/aic-core/src/aiconfigurator_core/sdk/backends/trtllm_backend.py
@@ -132,6 +132,7 @@ class TRTLLMBackend(BaseBackend):
         # whether the decode-share correction applies to a budget-based footprint
         # needs its own analysis (compare the AIC-1110 suppression on the
         # KV-capacity path, which treats the budget as already draft-inclusive).
+        # Tracked in AIC-1755.
         return {
             "num_tokens": agg_extra["max_num_tokens"],
             "max_seq_len": agg_extra["max_seq_len"],

--- a/tests/unit/sdk/backends/test_base_backend.py
+++ b/tests/unit/sdk/backends/test_base_backend.py
@@ -161,6 +161,72 @@ class TestMTPActivationMemoryScaling:
         assert spec == pytest.approx(base, rel=1e-9)
 
 
+class TestAFDPartitionActivationScaling:
+    """``get_partition_memory_usage`` must honor the AFD ``num_tokens`` contract.
+
+    ``InferenceSession._estimate_{a,f}_memory_dict`` passes ``num_tokens=0`` for
+    ``phase == "prefill"`` -- the sentinel that makes ``_get_memory_usage`` derive
+    the count from ``(isl - prefix) * batch_size``, a prefill-only footprint --
+    and ``num_tokens=batch_size`` (one token per request) for decode.
+    """
+
+    MODEL = "openai/gpt-oss-120b"
+
+    @classmethod
+    def _model(cls, *, nextn: int):
+        from aiconfigurator.sdk.models import get_model
+
+        model = get_model(cls.MODEL, ModelConfig(tp_size=1, moe_tp_size=1, moe_ep_size=1), "vllm")
+        model.config.nextn = nextn
+        return model
+
+    @staticmethod
+    def _database():
+        return SimpleNamespace(
+            backend="vllm",
+            version="test-version",
+            system="b200_sxm",
+            system_spec={
+                "gpu": {"mem_capacity": 180 * (1 << 30)},
+                "misc": {"nccl_mem": {1: 0, 2: 0, 4: 0, 8: 0}, "other_mem": 0},
+            },
+        )
+
+    def _partition_activations(self, *, nextn: int, num_tokens: int) -> float:
+        from aiconfigurator.sdk.backends.factory import get_backend
+
+        return get_backend("vllm").get_partition_memory_usage(
+            self._model(nextn=nextn),
+            self._database(),
+            partition_ops=[],
+            batch_size=4,
+            beam_width=1,
+            isl=65_536,
+            osl=400,
+            num_tokens=num_tokens,
+            max_seq_len=65_536,
+        )["activations"]
+
+    def test_prefill_partition_does_not_scale(self):
+        """AFD prefill workers size activations from the derived context tokens.
+
+        Pins the measured shape (gpt-oss-120b, ISL 65,536, batch 4, TP1): the
+        context footprint is 44.0 GiB, which the full ``(nextn+1)`` multiplier
+        turned into 176.0 GiB -- a 4x over-count that shrinks the A/F worker KV
+        budget and over-prunes AFD batch sizes.
+        """
+        base = self._partition_activations(nextn=0, num_tokens=0)
+        spec = self._partition_activations(nextn=3, num_tokens=0)
+        assert base == pytest.approx(44.0, abs=0.1)
+        assert spec == pytest.approx(base, rel=1e-9)
+
+    def test_decode_partition_keeps_full_multiplier(self):
+        """AFD decode workers pass ``num_tokens=batch_size``: every token is verified."""
+        base = self._partition_activations(nextn=0, num_tokens=4)
+        spec = self._partition_activations(nextn=3, num_tokens=4)
+        assert spec / base == pytest.approx(4.0, rel=1e-6)
+
+
 @pytest.mark.parametrize("mode", ["static", "static_ctx", "static_gen"])
 @pytest.mark.parametrize("latency_correction_scale", [1.0, 1.25])
 def test_run_static_latency_only_matches_run_static_latency(
@@ -268,6 +334,132 @@ def test_run_static_can_route_to_rust_engine_step_backend(
     assert summary.get_generation_energy_wms_dict() == {"generation_qkv_gemm": 12.0, "generation_attention": 5.0}
     assert summary.get_context_source_dict() == {"context_qkv_gemm": "silicon", "context_attention": "empirical"}
     assert summary.get_generation_source_dict() == {"generation_qkv_gemm": "silicon", "generation_attention": "mixed"}
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected_share"),
+    [
+        # "static" and "static_ctx" both size activations from the DERIVED
+        # context token count ((isl - prefix) * batch_size), so no share of that
+        # footprint verifies nextn+1 draft tokens.
+        ("static", 0),
+        ("static_ctx", 0),
+        # Decode-only step (num_tokens = batch_size * beam_width): every token is
+        # verified, so the full (nextn+1) multiplier stays (no decode-share cap).
+        ("static_gen", None),
+    ],
+)
+def test_run_static_declares_mtp_decode_share_per_mode(
+    backend: BaseBackend,
+    model,
+    database,
+    monkeypatch,
+    mode: str,
+    expected_share: int | None,
+) -> None:
+    """Each static mode must declare its decode-token share to ``_get_memory_usage``.
+
+    The latency side is stubbed at the engine bridge (the compiled engine is the
+    only static engine-step executor); memory sizing stays a Python
+    ``_get_memory_usage`` call, which is the surface under test here.
+    """
+    from aiconfigurator.sdk.backends import base_backend as base_backend_module
+
+    def _fake_rust_breakdown(model_arg, database_arg, runtime_config_arg, mode_arg, stride_arg, scale_arg):
+        ctx = {"context_attention": 1.0}
+        gen = {"generation_attention": 1.0}
+        if mode_arg == "static_ctx":
+            gen = {}
+        elif mode_arg == "static_gen":
+            ctx = {}
+        return (ctx, gen, dict(ctx), dict(gen), dict.fromkeys(ctx, "silicon"), dict.fromkeys(gen, "silicon"))
+
+    monkeypatch.setattr(
+        base_backend_module,
+        "estimate_static_latency_breakdown_with_rust",
+        _fake_rust_breakdown,
+    )
+
+    captured: dict = {}
+
+    def _record(*args, **kwargs):
+        captured.update(kwargs)
+        return {"total": 1.0}
+
+    monkeypatch.setattr(backend, "_get_memory_usage", _record)
+
+    backend.run_static(
+        model,
+        database,
+        RuntimeConfig(batch_size=2, beam_width=1, isl=8, osl=5, prefix=2, engine_step_backend="rust"),
+        mode=mode,
+        stride=2,
+    )
+
+    assert captured.get("mtp_scaled_tokens") == expected_share
+
+
+def test_run_agg_declares_mtp_decode_share_at_call_site(
+    backend: BaseBackend,
+    model,
+    database,
+    monkeypatch,
+) -> None:
+    """run_agg must pass the decode-request share of ``num_tokens`` as
+    ``mtp_scaled_tokens`` to ``_get_memory_usage``.
+
+    The run_agg counterpart of test_run_static_declares_mtp_decode_share_per_mode
+    above: pins the CALL SITE for a mixed step (b > 1: only the num_gen_requests
+    decode requests verify nextn+1 draft tokens; the context share is processed
+    once). The b == 1 context-only step and its separate decode peak are pinned
+    by test_run_agg_b1_uses_scheduled_activation_peak below.
+    """
+    memory_calls: list[dict] = []
+
+    def _record(*args, **kwargs):
+        memory_calls.append(kwargs)
+        return {"total": 1.0}
+
+    monkeypatch.setattr(backend, "_get_memory_usage", _record)
+    monkeypatch.setattr(
+        backend,
+        "run_mixed",
+        lambda *args, **kwargs: StepEstimate(latency_ms=1.0, energy_wms=1.0),
+    )
+    monkeypatch.setattr(
+        backend,
+        "_get_genonly_step_latency",
+        lambda *args, **kwargs: (1.0, 1.0, {}, {}),
+    )
+
+    backend.run_agg(
+        model,
+        database,
+        RuntimeConfig(batch_size=4, beam_width=1, isl=8, osl=5, prefix=2, engine_step_backend="rust"),
+        ctx_tokens=8,
+    )
+
+    assert len(memory_calls) == 1
+    assert memory_calls[0].get("mtp_scaled_tokens") == 3
+
+
+def test_trtllm_budget_path_ignores_the_decode_share() -> None:
+    """TRT-LLM's agg override intentionally drops ``mtp_scaled_tokens``.
+
+    Its ``num_tokens`` is ``BuildConfig.max_num_tokens`` (a per-iteration budget),
+    not the agg-derived mixed-step count, so the decode-share correction is not
+    forwarded and the legacy full ``(nextn+1)`` multiplier is retained on that
+    path pending its own analysis (tracked in AIC-1755).
+    """
+    from aiconfigurator.sdk.backends.factory import get_backend
+
+    agg_extra = {"max_num_tokens": 8192, "max_seq_len": 4096, "free_gpu_memory_fraction": 0.9}
+    kwargs = get_backend("trtllm")._memory_usage_kwargs_for_agg(
+        num_tokens=65_539,
+        agg_extra=agg_extra,
+        mtp_scaled_tokens=3,
+    )
+    assert kwargs == {"num_tokens": 8192, "max_seq_len": 4096}
 
 
 def test_run_agg_with_osl_one_does_not_divide_by_zero(

--- a/tests/unit/sdk/models/test_model_config.py
+++ b/tests/unit/sdk/models/test_model_config.py
@@ -848,9 +848,11 @@ class TestGptOssHybridKVCache:
         *,
         tp_size: int = 1,
         kvcache_quant_mode: common.KVCacheQuantMode = common.KVCacheQuantMode.fp8,
+        nextn: int = 0,
     ):
         model_config = config.ModelConfig(tp_size=tp_size, moe_tp_size=tp_size, moe_ep_size=1)
         model_config.kvcache_quant_mode = kvcache_quant_mode
+        model_config.nextn = nextn
         return get_model(cls.MODEL, model_config, backend_name="vllm")
 
     def test_long_sequence_uses_hybrid_layout(self):
@@ -907,6 +909,58 @@ class TestGptOssHybridKVCache:
         max_tokens = model.get_kvcache_max_tokens(budget)
         assert model.get_kvcache_bytes_per_sequence(max_tokens) <= budget
         assert model.get_kvcache_bytes_per_sequence(max_tokens + 1) > budget
+
+    @pytest.mark.parametrize("nextn", [0, 1, 3], ids=("spec-off", "nextn1", "nextn3"))
+    def test_kv_bytes_is_nextn_independent(self, nextn: int):
+        """Speculative decoding must not re-linearize the window-capped KV curve.
+
+        Draft tokens are a per-step compute cost, not extra resident KV, so the
+        hybrid-SWA byte count is identical with spec decode on and off.
+        """
+        model = self._model(nextn=nextn)
+        seq_len = 65_936  # 65536 ISL + 400 OSL, the 64k agentic recipe shape
+        assert model.get_kvcache_bytes_per_sequence(seq_len) == pytest.approx(self._expected_bytes(seq_len), rel=1e-9)
+
+    def test_backend_memory_kv_stays_window_aware_under_spec_decode(self):
+        """The breakdown's ``kvcache`` (``base_backend._get_memory_usage``, the sole
+        KV sizing site) must follow the window-capped curve with ``nextn > 0``.
+
+        Pins the recipe operating point: batch 48 at ISL 65536 / OSL 400, fp8 KV,
+        TP1 -> 54.4 GiB, not the ~2x all-layers-full-context value that false-OOMs
+        the shipped 8xB200 agg recipe.
+        """
+        from types import SimpleNamespace
+
+        from aiconfigurator.sdk.backends.factory import get_backend
+
+        batch_size, isl, osl = 48, 65_536, 400
+        seq_len = isl + osl
+        model = self._model(nextn=3)
+        database = SimpleNamespace(system_spec={"misc": {"nccl_mem": {1: 0}, "other_mem": 0}})
+
+        memory = get_backend("vllm")._get_memory_usage(
+            model, database, batch_size=batch_size, beam_width=1, isl=isl, osl=osl
+        )
+
+        expected_gib = batch_size * self._expected_bytes(seq_len) / (1 << 30)
+        assert memory["kvcache"] == pytest.approx(expected_gib, rel=1e-9)
+        assert memory["kvcache"] == pytest.approx(54.4, abs=0.1)
+        linear_gib = batch_size * seq_len * self.LAYERS * 2 * self.KV_HEADS * self.HEAD_SIZE / (1 << 30)
+        assert memory["kvcache"] < 0.52 * linear_gib
+
+    def test_kv_bytes_scale_linearly_with_kvcache_dtype(self):
+        """Guard against misreading a dtype difference as a layout regression.
+
+        The window-aware bf16 figure (2.268 GiB/seq at 65,936) is within 0.2% of
+        the *linear* fp8 figure (2.264 GiB/seq) that the hybrid override removed,
+        so the two are easy to confuse when reading a CLI breakdown. Pin that the
+        only difference between the two dtypes is the element size.
+        """
+        seq_len = 65_936
+        fp8 = self._model().get_kvcache_bytes_per_sequence(seq_len)
+        bf16 = self._model(kvcache_quant_mode=common.KVCacheQuantMode.bfloat16).get_kvcache_bytes_per_sequence(seq_len)
+        assert bf16 == pytest.approx(2 * fp8, rel=1e-9)
+        assert bf16 == pytest.approx(self._expected_bytes(seq_len, bytes_per_elem=2), rel=1e-9)
 
 
 class TestGetKvcacheMaxTokens:


### PR DESCRIPTION
## What

Drops the MTP `(nextn+1)` draft multiplier from the two remaining prefill-sized activation footprints, and pins the whole decode-share contract with call-site guard tests. Linear: AIC-1746.

**This is a rework of the original branch onto current main.** The engine migration (PR-5/PR-6/PR-7) landed while this PR was in flight and absorbed most of the original production change; the branch was rebuilt from scratch on main so the diff now carries only what main still lacks. The prior approval predates the rework and should be considered stale.

## Production change (2 sites, both declare `mtp_scaled_tokens=0`)

1. **`run_static`'s plain `"static"` mode** (`base_backend.py`): the `static_ctx` branch already declares `mtp_scaled_tokens=0` on main, but the `"static"` else-branch — which sizes activations from the same derived context token count `((isl - prefix) * batch_size)` — did not, so with `nextn > 0` it still applied the full `(nextn+1)` multiplier to a footprint that contains no draft tokens.
2. **`get_partition_memory_usage` with `num_tokens=0`** — the AFD prefill-phase sentinel (`InferenceSession._estimate_{a,f}_memory_dict` passes `num_tokens=0` for `phase == "prefill"`, `num_tokens=batch_size` for decode). On the measured shape (gpt-oss-120b, ISL 65,536, batch 4, TP1, nextn 3) the multiplier turned a 44.0 GiB context footprint into 176.0 GiB — a 4x over-count that shrinks the A/F worker KV budget and over-prunes AFD batch sizes.

Decode-shaped callers are untouched and keep the full multiplier (every token they process is verified): `static_gen`, AFD decode (`num_tokens=batch_size`), and `run_agg`'s decode share (already on main). TRT-LLM's agg budget path also intentionally keeps the legacy multiplier (`max_num_tokens` is a per-iteration budget; whether the correction applies there needs its own analysis — tracked in AIC-1755; the only non-test edit outside `base_backend.py` is that comment line).

## Tests (re-sited onto the engine-era surfaces)

The compiled engine is now the only static/agg engine-step executor, so the guards stub the latency side exactly the way the neighboring tests do (`estimate_static_latency_breakdown_with_rust` bridge / `run_mixed`), while memory sizing — the surface under test — remains a Python `_get_memory_usage` call:

- `test_run_static_declares_mtp_decode_share_per_mode`: `static`/`static_ctx` → `mtp_scaled_tokens=0`, `static_gen` → full multiplier retained.
- `test_run_agg_declares_mtp_decode_share_at_call_site`: the `b > 1` mixed step passes the `num_gen_requests` decode share (`b == 1` is already pinned on main by `test_run_agg_b1_uses_scheduled_activation_peak`).
- `test_trtllm_budget_path_ignores_the_decode_share`: pins the intentional drop on the TRT-LLM budget path.
- `TestAFDPartitionActivationScaling`: the AFD `num_tokens` contract end-to-end through `get_partition_memory_usage` (prefill 44.0 GiB pin + nextn-invariance; decode keeps the 4x).
- `TestGptOssHybridKVCache` additions: the window-capped KV curve is nextn-independent, stays window-aware through `_get_memory_usage` at the recipe operating point (batch 48, ISL 65,536 → 54.4 GiB, not the ~2x linear value that false-OOMs the shipped 8xB200 agg recipe), and scales linearly with KV-cache dtype.

Red/green verified: on unpatched main, `test_prefill_partition_does_not_scale` fails with exactly the 176.0-vs-44.0 over-count and `test_run_static_declares_mtp_decode_share_per_mode[static-0]` fails with `None != 0`; with the fix, both pass.

## What the original PR carried that is now on main (dropped from this diff)

The `static_ctx` branch fix, `run_agg`'s decode-share call site and `_memory_usage_kwargs_for_agg` helper, the TRT-LLM override, `TestMTPActivationMemoryScaling`, and `test_run_agg_b1_uses_scheduled_activation_peak`.

## Verification

- Full unit suite: 3722 passed, 10 skipped (`-n 2`).
- `tests/cross_package` + Rust parity suite: green (memory sizing is outside the engine-step latency goldens; no re-pin needed).
- `ruff check` / `ruff format --check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved memory estimates for workloads using speculative decoding.
  - Prefill calculations now avoid applying decode-only token scaling.
  - Decode calculations continue to account for speculative tokens correctly.
  - Corrected window-aware KV-cache sizing, including BF16 and FP8 precision differences.
  - Improved multimodal token calculations by aligning image dimensions with processing strides.
  - Improved aggregate result validation and cache consistency.

- **Tests**
  - Added coverage for activation scaling, aggregation memory paths, speculative decoding, and KV-cache limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->