### PR TITLE
ci: invoke the wheel finalizer with python3

### DIFF
--- a/.github/workflows/build-platform-wheels.yml
+++ b/.github/workflows/build-platform-wheels.yml
@@ -127,4 +127,7 @@ jobs:
           ARTIFACTORY_PYPI_REPO_NAME: ${{ secrets.ARTIFACTORY_PYPI_REPO_NAME }}
           ARTIFACTORY_SUBPATH: post-merge/${{ github.sha }}/${{ github.run_id }}/${{ github.run_attempt }}
         shell: bash
-        run: python tools/finalize_wheels_in_artifactory.py
+        # The self-hosted runner has no `python` alias and this job adds no
+        # interpreter setup (sparse checkout only); the script is pure stdlib,
+        # so the distro python3 is sufficient.
+        run: python3 tools/finalize_wheels_in_artifactory.py


### PR DESCRIPTION
Third and last piece of the wheel-workflow repairs. `Finalize post-merge wheel set` has **never been green**: it was `skipped` until `PLATFORM_WHEEL_STAGING_ENABLED` was turned on, and has failed with `python: command not found` (exit 127) on every run since — the job runs on the self-hosted amd64 runner with a sparse checkout of just the finalizer script and no interpreter setup step, and that runner has no `python` alias.

The finalizer is pure stdlib (`urllib`/`hashlib`/`json`), so invoking it with the distro `python3` is the complete fix — no setup-python needed. Contingency stated in the commit message if the runner image ever lacks `python3` as well.

With this, the whole post-merge wheel workflow should go green end-to-end: per-platform builds are already fixed (#1565 for the macOS sudo issue; the manylinux failure on a9e012ac was a transient PyPI 502, green on re-run). As with #1565, the workflow is push-only, so the definitive green lands on this PR's merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the wheel finalization workflow to use the available Python 3 interpreter.
  * Clarified that no additional interpreter setup is required on the build runner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->