### PR TITLE
test(sdk): rebuild the comprehensive singleton after engine-cache eviction (AIC-1777)

### DIFF
--- a/tests/unit/sdk/database/conftest.py
+++ b/tests/unit/sdk/database/conftest.py
@@ -1,7 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import atexit
 import os
+import shutil
 import tempfile
 from collections import defaultdict
 from unittest.mock import patch
@@ -401,6 +403,12 @@ def _get_comprehensive_db_singleton() -> PerfDatabase:
     system_spec = cached["system_spec"]
 
     tmp_dir = tempfile.mkdtemp()
+    # Superseded singleton dirs must survive until process exit: deepcopied
+    # databases (mutable_comprehensive_perf_db) keep referencing the old
+    # systems path, and a post-eviction engine re-fetch through such a copy
+    # would turn "empty tables" into a missing-directory error if the dir
+    # were removed eagerly on rebuild. Clean them all up at exit instead.
+    atexit.register(shutil.rmtree, tmp_dir, ignore_errors=True)
     yaml_file = os.path.join(tmp_dir, "test_system.yaml")
     with open(yaml_file, "w") as f:
         yaml.dump(system_spec, f)

--- a/tests/unit/sdk/database/conftest.py
+++ b/tests/unit/sdk/database/conftest.py
@@ -369,11 +369,33 @@ def _build_comprehensive_test_data():
 _comprehensive_db_singleton: PerfDatabase | None = None
 
 
+def _singleton_survived_eviction(db: PerfDatabase) -> bool:
+    """Whether the singleton's engine-backed state is still the build-time one.
+
+    ``clear_all_op_caches()`` (and the other documented eviction levers)
+    advance ``engine._PROBE_CACHE_GENERATION`` and clear the engine-handle
+    LRU. The singleton's synthetic tables exist only in this conftest's
+    module-level router — its tmp data dir holds just the system yaml — so
+    any post-eviction re-fetch through the engine collapses the tables to
+    the near-empty on-disk state and poisons every later test on the worker
+    (order-dependent TestSupportedQuantModes / TestUpdateSupportMatrix
+    failures; see AIC-1777). The probe-spec memo stored on the database
+    carries the generation it was resolved under — a mismatch means a lever
+    fired since the build and the singleton must be rebuilt.
+    """
+    from aiconfigurator_core.sdk import engine as _engine
+
+    memo = db.__dict__.get("_table_view_probe_spec")
+    return memo is not None and memo[0] == _engine._PROBE_CACHE_GENERATION
+
+
 def _get_comprehensive_db_singleton() -> PerfDatabase:
-    """Build and cache a fully-initialized PerfDatabase singleton."""
+    """Build (or rebuild after engine-cache eviction) the shared singleton."""
     global _comprehensive_db_singleton
     if _comprehensive_db_singleton is not None:
-        return _comprehensive_db_singleton
+        if _singleton_survived_eviction(_comprehensive_db_singleton):
+            return _comprehensive_db_singleton
+        _comprehensive_db_singleton = None
 
     cached = _build_comprehensive_test_data()
     system_spec = cached["system_spec"]

--- a/tests/unit/sdk/database/conftest.py
+++ b/tests/unit/sdk/database/conftest.py
@@ -371,33 +371,37 @@ def _build_comprehensive_test_data():
 _comprehensive_db_singleton: PerfDatabase | None = None
 
 
-def _singleton_survived_eviction(db: PerfDatabase) -> bool:
-    """Whether the singleton's engine-backed state is still the build-time one.
-
-    ``clear_all_op_caches()`` (and the other documented eviction levers)
-    advance ``engine._PROBE_CACHE_GENERATION`` and clear the engine-handle
-    LRU. The singleton's synthetic tables exist only in this conftest's
-    module-level router — its tmp data dir holds just the system yaml — so
-    any post-eviction re-fetch through the engine collapses the tables to
-    the near-empty on-disk state and poisons every later test on the worker
-    (order-dependent TestSupportedQuantModes / TestUpdateSupportMatrix
-    failures; see AIC-1777). The probe-spec memo stored on the database
-    carries the generation it was resolved under — a mismatch means a lever
-    fired since the build and the singleton must be rebuilt.
-    """
-    from aiconfigurator_core.sdk import engine as _engine
-
-    memo = db.__dict__.get("_table_view_probe_spec")
-    return memo is not None and memo[0] == _engine._PROBE_CACHE_GENERATION
+# Generation of ``engine._PROBE_CACHE_GENERATION`` the singleton was built
+# under. Recorded explicitly at build time: this database never reaches the
+# real ``fetch_table_view`` (the module router answers its fetches from
+# ``_COMPREHENSIVE_OVERRIDES``), so the engine-side probe-spec memo a
+# database normally carries is never written for it and cannot be used as
+# the eviction signal.
+_comprehensive_db_generation: int | None = None
 
 
 def _get_comprehensive_db_singleton() -> PerfDatabase:
-    """Build (or rebuild after engine-cache eviction) the shared singleton."""
-    global _comprehensive_db_singleton
-    if _comprehensive_db_singleton is not None:
-        if _singleton_survived_eviction(_comprehensive_db_singleton):
-            return _comprehensive_db_singleton
-        _comprehensive_db_singleton = None
+    """Build (or rebuild after an eviction lever fired) the shared singleton.
+
+    ``clear_all_op_caches()`` and the other documented eviction levers wipe
+    the per-op class caches and advance ``engine._PROBE_CACHE_GENERATION``.
+    Tests that fire a lever while a scoped stub fetch is active (e.g. the
+    router-survival test in ``test_data_loaders.py``) leave the shared class
+    caches re-populated from the stub under this singleton's cache key, so
+    whichever test on the xdist worker touches the singleton next reads
+    stub-shaped tables and fails order-dependently (AIC-1777:
+    TestSupportedQuantModes / TestUpdateSupportMatrix). Rebuilding whenever
+    the generation moved since the build cures that: the rebuild happens at
+    the NEXT fixture request, which in those orders is outside the stub
+    window, and steady-state accesses (no lever fired) keep the documented
+    same-object singleton contract.
+    """
+    global _comprehensive_db_singleton, _comprehensive_db_generation
+    from aiconfigurator_core.sdk import engine as _engine
+
+    if _comprehensive_db_singleton is not None and _comprehensive_db_generation == _engine._PROBE_CACHE_GENERATION:
+        return _comprehensive_db_singleton
+    _comprehensive_db_singleton = None
 
     cached = _build_comprehensive_test_data()
     system_spec = cached["system_spec"]
@@ -447,6 +451,7 @@ def _get_comprehensive_db_singleton() -> PerfDatabase:
     try:
         _comprehensive_db_singleton = PerfDatabase("test_system", "trtllm", "v1", tmp_dir)
         _warm_lazy_op_caches(_comprehensive_db_singleton)
+        _comprehensive_db_generation = _engine._PROBE_CACHE_GENERATION
     finally:
         yaml_patch.stop()
 


### PR DESCRIPTION
Fixes a latent, order-dependent unit flake on main (AIC-1777) that any PR changing the collected test count can trip — it currently blocks #1540's CI and passes on main only by xdist chunk-seating luck.

**Minimal repro (fails on clean main, serial, two tests):** `test_comprehensive_router_survives_scoped_stub_patch` followed by `TestSupportedQuantModes::test_supported_quant_modes_structure`.

**Mechanism — corrected per tianhaox's review:** the singleton's fetches never reach the engine (the conftest router answers them), so the original "engine re-fetch over an empty dir" narrative below does not apply to this database. The actual pollution path: an eviction lever fired while a scoped stub fetch is active leaves the shared per-op class caches re-populated from the stub under the singleton's cache key; the next test on the worker that touches the singleton reads stub-shaped tables. The fix records `engine._PROBE_CACHE_GENERATION` explicitly at build (the memo-based predicate from the first revision never executed — this database has no probe-spec memo — and silently degenerated to rebuild-on-every-access; see the review thread for the measured 12-vs-4 build counts).

**Original mechanism notes (kept for the general engine-eviction context, not this singleton's path):** `clear_all_op_caches()` clears the compiled-engine handle LRU and advances `engine._PROBE_CACHE_GENERATION`. The shared `comprehensive_perf_db` singleton's synthetic tables live only in the conftest's module-level router — its tmp data dir holds just the system yaml — so the next engine-backed fetch re-creates a handle over an effectively empty data dir and every table collapses (`supported_quant_mode['gemm']` degrades to `['bfloat16']`, producing the observed `assert 'fp8' in ['bfloat16']` / `assert 0 > 0` failures in whichever tests share the worker afterwards). The conftest comment's claim that routing survives cache clears held for the python fetch path but not for the engine data plane introduced by #1552/#1555/#1566.

**Fix:** the singleton accessor checks the generation recorded in the database's probe-spec memo (the module's own eviction contract) and rebuilds the singleton when a lever has fired since build. No production code touched; polluter-local restores were tried and verified NOT to work (the scoped stub fetch is still active during the polluter's `finally`, so any reload there plants stub tables under the shared class-cache key).

**Verification:** the minimal repro pair passes; polluter + all three victims pass in worst-case (adjacent serial) order; full unit suite green both `-n 2` (3710 passed) and serial (3710 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database reliability by detecting when cached engine state is outdated.
  * Automatically rebuilds the database connection when stale state is detected, preventing inconsistent behavior.
  * Preserved temporary database paths for the lifetime of the process, ensuring copied database instances continue to work correctly.
  * Automatically cleans up superseded temporary database directories when the process exits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
