### PR TITLE
feat(deprecation): add AISimulate migration warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ configurations and runs anywhere via the CLI.
 
 Let's get started.
 
+> [!WARNING]
+> AIConfigurator 0.12.0 is the compatibility release for moving CLI and
+> Sweeper workflows to AISimulate. Legacy entry points are planned for removal
+> in AIConfigurator 0.13.0. Follow the
+> [AISimulate migration guide](docs/aisimulate_migration.md) for replacement
+> commands, API guidance, and the temporary compatibility behavior.
+
 ## Build and Install
 
 ### Install from PyPI

--- a/README.md
+++ b/README.md
@@ -26,11 +26,12 @@ configurations and runs anywhere via the CLI.
 Let's get started.
 
 > [!WARNING]
-> AIConfigurator 0.12.0 is the compatibility release for moving CLI and
-> Sweeper workflows to AISimulate. Legacy entry points are planned for removal
-> in AIConfigurator 0.13.0. Follow the
-> [AISimulate migration guide](docs/aisimulate_migration.md) for replacement
-> commands, API guidance, and the temporary compatibility behavior.
+> AIConfigurator 0.12.0 is the compatibility release for moving the
+> application distribution and Sweeper workflows to AISimulate. The
+> `aiconfigurator` CLI command remains supported from the `aisimulate` wheel;
+> users change the installed package, not the command name. Follow the
+> [AISimulate migration guide](docs/aisimulate_migration.md) for installation,
+> API guidance, and the temporary compatibility behavior.
 
 ## Build and Install
 

--- a/docs/aisimulate_migration.md
+++ b/docs/aisimulate_migration.md
@@ -1,0 +1,71 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Migrate from AIConfigurator to AISimulate
+
+AIConfigurator 0.12.0 is the compatibility release for moving CLI and Sweeper
+workflows to AISimulate. Legacy AIC CLI and Sweeper entry points continue to
+work during this window, emit targeted deprecation warnings, and are planned
+for removal in AIConfigurator 0.13.0.
+
+## Install the replacement
+
+```bash
+python -m pip uninstall -y aiconfigurator aiconfigurator-core
+python -m pip install "aisimulate==0.12.0"
+```
+
+The `aisimulate` wheel contains the complete application and installs the
+`aisimulate` command. During the 0.12 compatibility window it also retains the
+`aiconfigurator` command and import namespace; these compatibility names do not
+represent separately published AIC artifacts.
+
+## Migrate CLI commands
+
+Keep the arguments for your current mode and change the executable:
+
+```bash
+# Before
+aiconfigurator cli default --model-path Qwen/Qwen3-32B-FP8 --total-gpus 32 --system h200_sxm
+aiconfigurator cli recommend --model-path Qwen/Qwen3-32B-FP8 --system h200_sxm --target-request-rate 50
+
+# AISimulate 0.12 replacement
+aisimulate cli default --model-path Qwen/Qwen3-32B-FP8 --total-gpus 32 --system h200_sxm
+aisimulate cli recommend --model-path Qwen/Qwen3-32B-FP8 --system h200_sxm --target-request-rate 50
+```
+
+The same executable substitution applies to the `estimate`, `exp`, `generate`,
+and `support` modes. In 0.12, both executable names deliberately route to the
+same proven implementation. The future `predict` and redesigned `recommend`
+commands will not replace that implementation until their parity and product
+gates pass.
+
+## Migrate Sweeper code
+
+Replace direct calls to `aiconfigurator.sdk.sweep.sweep_agg`,
+`sweep_disagg`, or `sweep_afd` with the AISimulate Sweeper and an explicit
+runner:
+
+```python
+from aisimulate import EngineReplayRunnerFactory
+from aisimulate.sweeper import SmartSearchConfig, Sweeper
+
+config = SmartSearchConfig.from_yaml("smart_sweep.yaml")
+candidates = Sweeper(
+    runner_factory=EngineReplayRunnerFactory(),
+).run(config)
+```
+
+Use a Dynamo runner factory instead when the configuration selects Dynamo
+Router or Planner adapters. See the
+[AISimulate Sweeper documentation](https://github.com/ai-dynamo/aisimulate/tree/main/docs/sweeper)
+for configuration, runner, result, and adapter guidance.
+
+## Temporary compatibility
+
+Code installed from `aisimulate==0.12.0` may temporarily continue importing
+the migrated AIC namespace while it moves to the supported AISimulate APIs.
+Do not use that compatibility namespace for new integrations: it is retained
+only to make the one-release migration window non-breaking.

--- a/docs/aisimulate_migration.md
+++ b/docs/aisimulate_migration.md
@@ -5,10 +5,10 @@ SPDX-License-Identifier: Apache-2.0
 
 # Migrate from AIConfigurator to AISimulate
 
-AIConfigurator 0.12.0 is the compatibility release for moving CLI and Sweeper
-workflows to AISimulate. Legacy AIC CLI and Sweeper entry points continue to
-work during this window, emit targeted deprecation warnings, and are planned
-for removal in AIConfigurator 0.13.0.
+AIConfigurator 0.12.0 is the compatibility release for moving the application
+distribution and Sweeper workflows to AISimulate. The established
+`aiconfigurator` CLI command continues to work, while the legacy AIC
+distribution and direct Sweeper entry points emit targeted migration warnings.
 
 ## Install the replacement
 
@@ -18,29 +18,24 @@ python -m pip install "aisimulate==0.12.0"
 ```
 
 The `aisimulate` wheel contains the complete application and installs the
-`aisimulate` command. During the 0.12 compatibility window it also retains the
-`aiconfigurator` command and import namespace; these compatibility names do not
-represent separately published AIC artifacts.
+established `aiconfigurator` command. It does not install a second top-level
+application command named `aisimulate`. The command name is independent of the
+distribution name and does not represent a separately published AIC artifact.
 
-## Migrate CLI commands
+## Keep CLI commands unchanged
 
-Keep the arguments for your current mode and change the executable:
+Change the installed distribution, then keep the command and arguments for
+your current mode:
 
 ```bash
-# Before
+# Before and after installing AISimulate 0.12
 aiconfigurator cli default --model-path Qwen/Qwen3-32B-FP8 --total-gpus 32 --system h200_sxm
 aiconfigurator cli recommend --model-path Qwen/Qwen3-32B-FP8 --system h200_sxm --target-request-rate 50
-
-# AISimulate 0.12 replacement
-aisimulate cli default --model-path Qwen/Qwen3-32B-FP8 --total-gpus 32 --system h200_sxm
-aisimulate cli recommend --model-path Qwen/Qwen3-32B-FP8 --system h200_sxm --target-request-rate 50
 ```
 
-The same executable substitution applies to the `estimate`, `exp`, `generate`,
-and `support` modes. In 0.12, both executable names deliberately route to the
-same proven implementation. The future `predict` and redesigned `recommend`
-commands will not replace that implementation until their parity and product
-gates pass.
+The `default`, `estimate`, `recommend`, `exp`, `generate`, and `support` modes
+retain their current command paths. AISimulate becomes the package and source
+owner without renaming the user-facing CLI.
 
 ## Migrate Sweeper code
 

--- a/src/aiconfigurator/deprecation.py
+++ b/src/aiconfigurator/deprecation.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Targeted migration warnings for legacy AIConfigurator entry points."""
+
+from __future__ import annotations
+
+import functools
+import logging
+import warnings
+from collections.abc import Callable
+from typing import ParamSpec, TypeVar
+
+logger = logging.getLogger(__name__)
+
+_MIGRATION_GUIDE = "https://github.com/ai-dynamo/aiconfigurator/blob/main/docs/aisimulate_migration.md"
+_warned_entry_points: set[str] = set()
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+
+
+def warn_legacy_cli(mode: str | None) -> None:
+    """Warn once when a legacy AIC CLI mode is selected."""
+
+    command = "aiconfigurator cli" + (f" {mode}" if mode else "")
+    replacement = "aisimulate cli" + (f" {mode}" if mode else "")
+    key = f"cli:{mode or '<root>'}"
+    if key in _warned_entry_points:
+        return
+    _warned_entry_points.add(key)
+    message = (
+        f"`{command}` is deprecated and will be removed in AIConfigurator "
+        f"0.13.0. Install `aisimulate==0.12.0` and run `{replacement} ...`. "
+        "During the 0.12 compatibility window, both commands execute the "
+        f"same implementation. Migration guide: {_MIGRATION_GUIDE}"
+    )
+    warnings.warn(message, DeprecationWarning, stacklevel=4)
+    logger.warning("%s", message)
+
+
+def deprecated_sweeper_entry_point(
+    function: Callable[_P, _R],
+) -> Callable[_P, _R]:
+    """Mark one legacy sweep function with a warn-once migration message."""
+
+    entry_point = f"{function.__module__}.{function.__name__}"
+
+    @functools.wraps(function)
+    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+        if entry_point not in _warned_entry_points:
+            _warned_entry_points.add(entry_point)
+            warnings.warn(
+                f"`{entry_point}()` is deprecated and will be removed in "
+                "AIConfigurator 0.13.0. Migrate to "
+                "`aisimulate.sweeper.Sweeper(...).run(config)`. Installing "
+                "`aisimulate==0.12.0` temporarily retains the legacy "
+                f"`aiconfigurator` import namespace. Migration guide: {_MIGRATION_GUIDE}",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        return function(*args, **kwargs)
+
+    return wrapper

--- a/src/aiconfigurator/deprecation.py
+++ b/src/aiconfigurator/deprecation.py
@@ -21,19 +21,19 @@ _R = TypeVar("_R")
 
 
 def warn_legacy_cli(mode: str | None) -> None:
-    """Warn once when a legacy AIC CLI mode is selected."""
+    """Warn once when the CLI is run from the legacy AIC distribution."""
 
     command = "aiconfigurator cli" + (f" {mode}" if mode else "")
-    replacement = "aisimulate cli" + (f" {mode}" if mode else "")
     key = f"cli:{mode or '<root>'}"
     if key in _warned_entry_points:
         return
     _warned_entry_points.add(key)
     message = (
-        f"`{command}` is deprecated and will be removed in AIConfigurator "
-        f"0.13.0. Install `aisimulate==0.12.0` and run `{replacement} ...`. "
-        "During the 0.12 compatibility window, both commands execute the "
-        f"same implementation. Migration guide: {_MIGRATION_GUIDE}"
+        f"`{command}` is running from the deprecated AIConfigurator "
+        "distribution, which is planned for removal in AIConfigurator 0.13.0. "
+        f"Install `aisimulate==0.12.0` and keep running `{command} ...`; "
+        "AISimulate preserves the established command name and arguments. "
+        f"Migration guide: {_MIGRATION_GUIDE}"
     )
     warnings.warn(message, DeprecationWarning, stacklevel=4)
     logger.warning("%s", message)

--- a/src/aiconfigurator/main.py
+++ b/src/aiconfigurator/main.py
@@ -8,11 +8,14 @@ import sys
 from aiconfigurator import __version__
 from aiconfigurator.cli.main import configure_parser as configure_cli_parser
 from aiconfigurator.cli.main import main as cli_main
+from aiconfigurator.deprecation import warn_legacy_cli
 from aiconfigurator.generator.api import generator_cli_helper
 from aiconfigurator.logging_utils import setup_logging
 
 
 def _run_cli(extra_args: list[str]) -> None:
+    mode = extra_args[0] if extra_args and not extra_args[0].startswith("-") else None
+    warn_legacy_cli(mode)
     if generator_cli_helper(extra_args):
         return
     cli_parser = argparse.ArgumentParser(description="AIConfigurator for disaggregated serving deployment.")

--- a/src/aiconfigurator/sdk/sweep.py
+++ b/src/aiconfigurator/sdk/sweep.py
@@ -41,6 +41,7 @@ from typing import Any
 import numpy as np
 import pandas as pd
 
+from aiconfigurator.deprecation import deprecated_sweeper_entry_point
 from aiconfigurator.sdk import common, config
 from aiconfigurator.sdk.backends.base_backend import BaseBackend
 from aiconfigurator.sdk.backends.factory import get_backend
@@ -439,6 +440,7 @@ def _language_only_config(model_config):
     return dataclasses.replace(model_config, language_only=True)
 
 
+@deprecated_sweeper_entry_point
 def sweep_agg(
     *,
     model_path: str,
@@ -1267,6 +1269,7 @@ def _find_best_disagg_under_constraint(
     return df
 
 
+@deprecated_sweeper_entry_point
 def sweep_disagg(
     *,
     model_path: str,
@@ -1574,6 +1577,7 @@ def sweep_disagg(
 # ---------------------------------------------------------------------------
 
 
+@deprecated_sweeper_entry_point
 def sweep_afd(
     *,
     model_path: str,

--- a/tests/unit/test_aisimulate_deprecation.py
+++ b/tests/unit/test_aisimulate_deprecation.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Migration-warning contracts for legacy AIC CLI and Sweeper surfaces."""
+
+import warnings
+
+import pytest
+
+from aiconfigurator import deprecation
+from aiconfigurator import main as root_main
+from aiconfigurator.sdk import sweep
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _fresh_warning_state():
+    before = set(deprecation._warned_entry_points)
+    deprecation._warned_entry_points.clear()
+    try:
+        yield
+    finally:
+        deprecation._warned_entry_points.clear()
+        deprecation._warned_entry_points.update(before)
+
+
+def _stub_cli(monkeypatch) -> None:
+    monkeypatch.setattr(root_main, "generator_cli_helper", lambda _args: False)
+    monkeypatch.setattr(
+        root_main,
+        "configure_cli_parser",
+        lambda parser: parser.add_argument("mode"),
+    )
+    monkeypatch.setattr(root_main, "cli_main", lambda _args: None)
+
+
+@pytest.mark.parametrize(
+    "mode",
+    ["default", "estimate", "recommend", "exp", "generate", "support"],
+)
+def test_each_legacy_cli_mode_warns_with_replacement(monkeypatch, mode) -> None:
+    _stub_cli(monkeypatch)
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        root_main.main(["cli", mode])
+
+    assert len(captured) == 1
+    warning = captured[0]
+    assert warning.category is DeprecationWarning
+    assert f"`aiconfigurator cli {mode}`" in str(warning.message)
+    assert f"`aisimulate cli {mode} ...`" in str(warning.message)
+    assert "AIConfigurator 0.13.0" in str(warning.message)
+    assert "0.12 compatibility window" in str(warning.message)
+    assert warning.filename == __file__
+
+
+def test_cli_warning_fires_once_per_mode(monkeypatch) -> None:
+    _stub_cli(monkeypatch)
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        root_main.main(["cli", "default"])
+        root_main.main(["cli", "default"])
+
+    assert len(captured) == 1
+
+
+def test_version_command_remains_unaffected() -> None:
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        root_main.main(["version"])
+
+    assert captured == []
+
+
+@pytest.mark.parametrize("entry_point", [sweep.sweep_agg, sweep.sweep_disagg, sweep.sweep_afd])
+def test_each_legacy_sweeper_entry_point_warns_once_at_caller(entry_point) -> None:
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        with pytest.raises(TypeError):
+            entry_point()
+        with pytest.raises(TypeError):
+            entry_point()
+
+    assert len(captured) == 1
+    warning = captured[0]
+    assert warning.category is DeprecationWarning
+    assert entry_point.__name__ in str(warning.message)
+    assert "aisimulate.sweeper.Sweeper" in str(warning.message)
+    assert "AIConfigurator 0.13.0" in str(warning.message)
+    assert warning.filename == __file__

--- a/tests/unit/test_aisimulate_deprecation.py
+++ b/tests/unit/test_aisimulate_deprecation.py
@@ -39,7 +39,7 @@ def _stub_cli(monkeypatch) -> None:
     "mode",
     ["default", "estimate", "recommend", "exp", "generate", "support"],
 )
-def test_each_legacy_cli_mode_warns_with_replacement(monkeypatch, mode) -> None:
+def test_each_legacy_cli_mode_warns_without_renaming_the_command(monkeypatch, mode) -> None:
     _stub_cli(monkeypatch)
 
     with warnings.catch_warnings(record=True) as captured:
@@ -50,9 +50,11 @@ def test_each_legacy_cli_mode_warns_with_replacement(monkeypatch, mode) -> None:
     warning = captured[0]
     assert warning.category is DeprecationWarning
     assert f"`aiconfigurator cli {mode}`" in str(warning.message)
-    assert f"`aisimulate cli {mode} ...`" in str(warning.message)
+    assert f"`aiconfigurator cli {mode} ...`" in str(warning.message)
+    assert "`aisimulate cli" not in str(warning.message)
     assert "AIConfigurator 0.13.0" in str(warning.message)
-    assert "0.12 compatibility window" in str(warning.message)
+    assert "deprecated AIConfigurator distribution" in str(warning.message)
+    assert "preserves the established command name" in str(warning.message)
     assert warning.filename == __file__
 
 


### PR DESCRIPTION
#### Overview:

Add targeted migration warnings to AIConfigurator's legacy CLI and Sweeper surfaces for the AIC 0.12 compatibility window.

#### Details:

- Warn once per legacy CLI mode, point users to the `aisimulate` distribution, and preserve the existing `aiconfigurator cli <mode>` command.
- Warn once per direct `sweep_agg`, `sweep_disagg`, and `sweep_afd` call and point to `aisimulate.sweeper.Sweeper`.
- Attribute warnings to the caller, keep the version command unaffected, and log the CLI notice so users see it with default warning filters.
- Document copy-paste CLI and SDK migration steps, the temporary compatibility behavior, and the planned AIC 0.13.0 removal.

#### Where should the reviewer start?

Start with `src/aiconfigurator/deprecation.py`, then review `tests/unit/test_aisimulate_deprecation.py` and `docs/aisimulate_migration.md` together for the warning and migration contract.

#### Validation:

- `ruff check` and `ruff format --check` on all changed Python files
- `python -m pytest -p no:timeout -q tests/unit/test_aisimulate_deprecation.py tests/unit/cli/test_root_command.py tests/unit/cli/test_cli_workflow.py tests/unit/sdk/sweep/test_sweep.py` (124 passed)

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to GitHub issue: #1517
- Internal NVIDIA tracking: [AIC-1652](https://linear.app/nvidia/issue/AIC-1652)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated migration guidance for AISimulate 0.12.0, including installation, API compatibility, and the continued use of the `aiconfigurator` command.
  * Clarified the transition of application distribution and Sweeper workflows to AISimulate, including planned legacy entry-point removal.

* **Deprecation Notices**
  * Legacy CLI modes and Sweeper entry points now display clear, one-time migration warnings while remaining available during the compatibility period.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
