### PR TITLE
feat(sdk): declared queryable-version list (query_versions.yaml)

### DIFF
--- a/aic-core/src/aiconfigurator_core/sdk/perf_database.py
+++ b/aic-core/src/aiconfigurator_core/sdk/perf_database.py
@@ -108,6 +108,85 @@ def get_systems_paths() -> list[str]:
     return list(_SYSTEMS_PATHS)
 
 
+_QUERY_VERSIONS_BASENAME = "query_versions.yaml"
+
+
+@functools.cache
+def _load_query_versions(systems_paths: tuple[str, ...]) -> dict | None:
+    """Load the declared queryable-version list, or None when absent.
+
+    The file lives next to the ``<system>.yaml`` specs; the first search root
+    that carries one wins. Absence disables version mapping entirely (the
+    module behaves exactly as before the list existed).
+    """
+    for systems_root in systems_paths:
+        path = os.path.join(systems_root, _QUERY_VERSIONS_BASENAME)
+        if os.path.isfile(path):
+            try:
+                with open(path, encoding="utf-8") as f:
+                    doc = yaml.safe_load(f) or {}
+            except Exception as e:
+                logger.warning(f"failed to parse {path}: {e}; query-version mapping disabled")
+                return None
+            return doc
+    return None
+
+
+def get_query_versions(
+    system: str, backend: str, systems_paths: str | list[str] | None = None
+) -> list[str] | None:
+    """Declared queryable versions for (system, backend); None when unlisted.
+
+    Per-platform ``overrides`` win over the framework ``defaults``. The first
+    entry is the platform's primary/default version.
+    """
+    if systems_paths is None:
+        systems_paths = get_systems_paths()
+    elif isinstance(systems_paths, str):
+        systems_paths = [systems_paths]
+    doc = _load_query_versions(tuple(systems_paths))
+    if not doc:
+        return None
+    versions = (doc.get("overrides") or {}).get(system, {}).get(backend)
+    if versions is None:
+        versions = (doc.get("defaults") or {}).get(backend)
+    return [str(v) for v in versions] if versions else None
+
+
+def resolve_query_version(
+    system: str, backend: str, version: str, systems_paths: str | list[str] | None = None
+) -> str:
+    """Map a requested version onto the declared queryable set.
+
+    - listed version: returned unchanged;
+    - unlisted version whose directory is still declared on disk: returned
+      unchanged with a deprecation warning (transitional grace for pinned
+      tests and fixture data);
+    - unlisted version with no directory: soft-mapped to the platform's
+      primary (first list entry) with a warning — the request would otherwise
+      fail outright.
+    """
+    versions = get_query_versions(system, backend, systems_paths=systems_paths)
+    if not versions or version in versions:
+        return version
+    for _version_path, _data_dir in _iter_database_version_paths(
+        system, backend, version, systems_paths=systems_paths
+    ):
+        logger.warning(
+            f"{backend}/{version} on {system} is not a declared queryable version "
+            f"(declared: {versions}); serving it from its remaining data directory. "
+            f"It may be retired without notice — prefer {versions[0]}."
+        )
+        return version
+    primary = versions[0]
+    logger.warning(
+        f"{backend}/{version} on {system} is not a declared queryable version and has "
+        f"no data directory; mapping to the platform primary {backend}/{primary} "
+        f"(declared: {versions})."
+    )
+    return primary
+
+
 @functools.cache
 def _load_system_spec_from_paths(systems_paths: tuple[str, ...], system_name: str) -> dict:
     for systems_root in systems_paths:
@@ -940,6 +1019,8 @@ def get_database(
     if not version:
         logger.error(f"No database version available for {system=}, {backend=}")
         return None
+
+    version = resolve_query_version(system, backend, version, systems_paths=systems_paths)
 
     shared_flag = _shared_layer_enabled(database_mode) if shared_layer is None else bool(shared_layer)
     # Only pass the override kwarg when explicitly set: PerfDatabase derives the

--- a/aic-core/src/aiconfigurator_core/sdk/perf_database.py
+++ b/aic-core/src/aiconfigurator_core/sdk/perf_database.py
@@ -132,9 +132,7 @@ def _load_query_versions(systems_paths: tuple[str, ...]) -> dict | None:
     return None
 
 
-def get_query_versions(
-    system: str, backend: str, systems_paths: str | list[str] | None = None
-) -> list[str] | None:
+def get_query_versions(system: str, backend: str, systems_paths: str | list[str] | None = None) -> list[str] | None:
     """Declared queryable versions for (system, backend); None when unlisted.
 
     Per-platform ``overrides`` win over the framework ``defaults``. The first
@@ -153,9 +151,7 @@ def get_query_versions(
     return [str(v) for v in versions] if versions else None
 
 
-def resolve_query_version(
-    system: str, backend: str, version: str, systems_paths: str | list[str] | None = None
-) -> str:
+def resolve_query_version(system: str, backend: str, version: str, systems_paths: str | list[str] | None = None) -> str:
     """Map a requested version onto the declared queryable set.
 
     - listed version: returned unchanged;
@@ -169,9 +165,7 @@ def resolve_query_version(
     versions = get_query_versions(system, backend, systems_paths=systems_paths)
     if not versions or version in versions:
         return version
-    for _version_path, _data_dir in _iter_database_version_paths(
-        system, backend, version, systems_paths=systems_paths
-    ):
+    for _version_path, _data_dir in _iter_database_version_paths(system, backend, version, systems_paths=systems_paths):
         logger.warning(
             f"{backend}/{version} on {system} is not a declared queryable version "
             f"(declared: {versions}); serving it from its remaining data directory. "

--- a/aic-core/src/aiconfigurator_core/systems/query_versions.yaml
+++ b/aic-core/src/aiconfigurator_core/systems/query_versions.yaml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Declared queryable versions per (platform, framework).
+#
+# This list — not the set of version directories on disk — defines which
+# backend versions the SDK considers queryable:
+#
+#   - a version IN the list resolves normally;
+#   - a version NOT in the list whose directory still exists resolves with a
+#     deprecation warning (transitional grace, so pinned tests/fixtures keep
+#     working while their data dirs remain);
+#   - a version NOT in the list with no directory is soft-mapped to the
+#     platform's PRIMARY (first entry) with a warning, instead of failing.
+#
+# Version directories on disk that are not listed here are DATA SOURCES, not
+# versions: they feed the resolver's fill channels (declared reuse, earlier
+# siblings, cross-backend) but carry no queryability promise of their own.
+# Retiring one is a plain directory deletion — no reuse.yaml marker needed.
+#
+# Maintenance: when a new framework version finishes collection, append it
+# here (it becomes an overlay of the previous primary until its table
+# coverage is complete, then it becomes the primary). The first entry of
+# each list is the platform's primary/default version.
+schema_version: 1
+defaults:
+  trtllm: ["1.3.0rc20", "1.3.0rc23"]
+  sglang: ["0.5.14", "0.5.16"]
+  vllm: ["0.24.0"]
+overrides:
+  a100_sxm:
+    trtllm: ["1.0.0"]
+    sglang: ["0.5.10"]
+    vllm: ["0.14.0"]
+  b60:
+    vllm: ["0.20.0"]

--- a/tests/unit/sdk/database/test_query_versions.py
+++ b/tests/unit/sdk/database/test_query_versions.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Declared queryable-version list (query_versions.yaml) resolution.
+
+The list — not the set of version directories — defines queryability:
+listed versions pass; unlisted versions with a surviving directory pass
+under a deprecation warning; unlisted versions with no directory soft-map
+to the platform primary instead of failing.
+"""
+
+import os
+
+import pytest
+import yaml
+
+from aiconfigurator_core.sdk import perf_database as pdb
+
+pytestmark = pytest.mark.unit
+
+_DOC = {
+    "schema_version": 1,
+    "defaults": {
+        "trtllm": ["1.3.0rc20", "1.3.0rc23"],
+        "sglang": ["0.5.14", "0.5.16"],
+        "vllm": ["0.24.0"],
+    },
+    "overrides": {
+        "a100_sxm": {"trtllm": ["1.0.0"], "sglang": ["0.5.10"], "vllm": ["0.14.0"]},
+        "b60": {"vllm": ["0.20.0"]},
+    },
+}
+
+
+@pytest.fixture
+def systems_root(tmp_path):
+    """A minimal systems root: one system spec, a data tree, and the list."""
+    root = tmp_path / "systems"
+    root.mkdir()
+    (root / "h200_sxm.yaml").write_text("data_dir: data/h200_sxm\n")
+    (root / "a100_sxm.yaml").write_text("data_dir: data/a100_sxm\n")
+    (root / "query_versions.yaml").write_text(yaml.dump(_DOC))
+    # a surviving unlisted version dir (grace case)
+    os.makedirs(root / "data" / "h200_sxm" / "moe" / "trtllm" / "1.3.0rc10")
+    pdb._load_query_versions.cache_clear()
+    yield str(root)
+    pdb._load_query_versions.cache_clear()
+
+
+def test_listed_version_passes_unchanged(systems_root):
+    assert pdb.resolve_query_version("h200_sxm", "trtllm", "1.3.0rc20", systems_root) == "1.3.0rc20"
+    assert pdb.resolve_query_version("h200_sxm", "trtllm", "1.3.0rc23", systems_root) == "1.3.0rc23"
+
+
+def test_override_beats_default(systems_root):
+    assert pdb.get_query_versions("a100_sxm", "trtllm", systems_root) == ["1.0.0"]
+    assert pdb.get_query_versions("h200_sxm", "trtllm", systems_root) == ["1.3.0rc20", "1.3.0rc23"]
+    # a100's own primary passes; the global primary is NOT in a100's list but
+    # has no dir either -> maps to a100's primary
+    assert pdb.resolve_query_version("a100_sxm", "trtllm", "1.0.0", systems_root) == "1.0.0"
+    assert pdb.resolve_query_version("a100_sxm", "trtllm", "1.2.0rc5", systems_root) == "1.0.0"
+
+
+def test_unlisted_with_surviving_dir_passes_with_warning(systems_root, caplog):
+    with caplog.at_level("WARNING"):
+        got = pdb.resolve_query_version("h200_sxm", "trtllm", "1.3.0rc10", systems_root)
+    assert got == "1.3.0rc10"
+    assert any("not a declared queryable version" in r.message for r in caplog.records)
+
+
+def test_unlisted_without_dir_maps_to_primary(systems_root, caplog):
+    with caplog.at_level("WARNING"):
+        got = pdb.resolve_query_version("h200_sxm", "trtllm", "0.0.0rc999", systems_root)
+    assert got == "1.3.0rc20"
+    assert any("mapping to the platform primary" in r.message for r in caplog.records)
+
+
+def test_absent_list_disables_mapping(tmp_path):
+    root = tmp_path / "bare"
+    root.mkdir()
+    (root / "h200_sxm.yaml").write_text("data_dir: data/h200_sxm\n")
+    pdb._load_query_versions.cache_clear()
+    try:
+        assert pdb.get_query_versions("h200_sxm", "trtllm", str(root)) is None
+        assert pdb.resolve_query_version("h200_sxm", "trtllm", "anything", str(root)) == "anything"
+    finally:
+        pdb._load_query_versions.cache_clear()
+
+
+def test_shipped_list_matches_shipped_primaries():
+    """The checked-in list's primaries must hold data in the shipped tree."""
+    versions = pdb.get_query_versions("h200_sxm", "trtllm")
+    assert versions and versions[0] == "1.3.0rc20"
+    db = pdb.get_database("h200_sxm", "trtllm", versions[0])
+    assert db is not None


### PR DESCRIPTION
## What

Queryability is currently defined by which version directories exist on disk. That makes every historical version a permanent liability: retiring one requires a per-directory `reuse.yaml` marker, and #1581 needed 300+ markers, 83 donor retargets and four fixture-restore rounds just to delete files.

This PR separates **queryable versions** (a declared list) from **data directories** (resolver fill sources):

- `systems/query_versions.yaml` — per (platform, framework) list, `defaults` + per-platform `overrides`, first entry = platform primary. Initial values: trtllm `{1.3.0rc20, 1.3.0rc23}`, sglang `{0.5.14, 0.5.16}`, vllm `{0.24.0}`; a100/b60 declare their real baselines (`1.0.0`/`0.5.10`/`0.14.0`, `0.20.0`) instead of pretending to be current.
- `get_database` resolves the requested version through the list: **listed** → unchanged; **unlisted, directory survives** → unchanged + deprecation warning (grace for pinned tests / fixture data); **unlisted, no directory** → soft-mapped to the platform primary with a warning instead of failing.
- Unlisted version directories become *data sources, not versions*: they still feed the fill channels, but retiring one is now a plain directory deletion — no marker needed.

Non-breaking: absent list file disables mapping entirely; all current dirs exist so today only warnings change. 380 database unit tests pass (374 + 6 new).

## Follow-ups enabled

1. Delete the ~300 transitional `reuse.yaml` markers created by #1581 (their mapping role moves here).
2. Rust-side twin for `Engine::from_spec_bytes` version resolution.
3. Test-fixture discipline: fixtures pin listed versions or checked-in synthetic trees only.

Draft until the initial list values are confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added query-version metadata for supported inference backends and platforms.
  * Added platform-specific version overrides and primary-version fallbacks.
  * Preserved access to undeclared versions when corresponding data is available.
  * Added graceful fallback behavior when query-version metadata is missing or invalid.

* **Tests**
  * Added coverage for version resolution, platform overrides, fallback behavior, and missing configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->