### PR TITLE
fix(sdk): use plotext.plotsize alias for cross-version compatibility

### DIFF
--- a/src/aiconfigurator/sdk/pareto_analysis.py
+++ b/src/aiconfigurator/sdk/pareto_analysis.py
@@ -1722,7 +1722,9 @@ def draw_pareto_to_string(
             keys "df", "label", "color", "marker" similar to ``series``.
     """
 
-    plotext.plot_size(80, 30)
+    # plotsize is the stable alias supported across plotext versions;
+    # plot_size was added later and is absent in older CI environments.
+    plotext.plotsize(80, 30)
     plotext.theme("clear")
 
     palette = [


### PR DESCRIPTION
## Overview

`draw_pareto_to_string` in `pareto_analysis.py` calls `plotext.plot_size(80, 30)`, which does not exist in the plotext version shipped in the CI pre-built venv, causing `test_cli_default_build_subset` to fail with:

```
AttributeError: module 'plotext' has no attribute 'plot_size'
```

`plotsize` is the stable alias present across all supported plotext versions. `plot_size` was added later and is absent in older environments. Both are available in the pinned version (5.3.2).

## Details

- Changed `plotext.plot_size(80, 30)` → `plotext.plotsize(80, 30)` in `src/aiconfigurator/sdk/pareto_analysis.py`
- No behaviour change — `plotsize` and `plot_size` are identical in 5.3.2

## Test plan

- [ ] `test_cli_default_build_subset` passes in CI
- [ ] `ruff check` and `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Pareto analysis chart sizing to improve compatibility and ensure plots render correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->