### PR TITLE
fix(cli): use the plotext plotsize API

### DIFF
--- a/src/aiconfigurator/sdk/pareto_analysis.py
+++ b/src/aiconfigurator/sdk/pareto_analysis.py
@@ -1722,7 +1722,7 @@ def draw_pareto_to_string(
             keys "df", "label", "color", "marker" similar to ``series``.
     """
 
-    plotext.plot_size(80, 30)
+    plotext.plotsize(80, 30)
     plotext.theme("clear")
 
     palette = [

--- a/tests/unit/cli/test_plain_output.py
+++ b/tests/unit/cli/test_plain_output.py
@@ -10,6 +10,7 @@ import sys
 from unittest.mock import MagicMock
 
 import pandas as pd
+import plotext
 import pytest
 
 from aiconfigurator.cli.report_and_save import (
@@ -76,7 +77,9 @@ def test_colored_formatter_force_no_color_disables_colors():
 
 
 @pytest.mark.parametrize("use_ansi", [True, False])
-def test_draw_pareto_to_string(use_ansi):
+def test_draw_pareto_to_string(monkeypatch, use_ansi):
+    plotsize = MagicMock(wraps=plotext.plotsize)
+    monkeypatch.setattr(plotext, "plotsize", plotsize)
     setup_logging(no_color=not use_ansi)
     df = pd.DataFrame({"tokens/s/user": [1.0, 2.0], "tokens/s/gpu_cluster": [10.0, 20.0]})
     out = draw_pareto_to_string(
@@ -84,6 +87,7 @@ def test_draw_pareto_to_string(use_ansi):
         [{"df": df, "label": "a"}],
         highlight={"df": df.head(1), "label": "best"},
     )
+    plotsize.assert_called_once_with(80, 30)
     assert (_ESC in out) == use_ansi
 
 


### PR DESCRIPTION
#### Overview:

Fix terminal Pareto rendering failures caused by calling a Plotext API alias that is not available in every installed environment.

#### Details:

- Use the canonical plotsize API when setting terminal plot dimensions.
- Extend the existing plain-output regression test to assert the expected 80 by 30 dimensions.

#### Where should the reviewer start?

- src/aiconfigurator/sdk/pareto_analysis.py
- tests/unit/cli/test_plain_output.py

#### Related Issues:

- Relates to ai-dynamo/dynamo#13079

#### Validation:

- git diff --check
- Plotext 5.3.2 API smoke check passed.
- Full test suite was not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ASCII Pareto chart rendering by updating plot sizing to use the supported plotting interface.
  * Ensured consistent 80×30 chart dimensions for both ANSI and plain-text output modes.

* **Tests**
  * Added coverage verifying Pareto output sizing across supported display formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->