### PR TITLE
fix(sdk): guard draw_pareto_to_string against incompatible plotext versions

### DIFF
--- a/src/aiconfigurator/sdk/pareto_analysis.py
+++ b/src/aiconfigurator/sdk/pareto_analysis.py
@@ -1722,7 +1722,19 @@ def draw_pareto_to_string(
             keys "df", "label", "color", "marker" similar to ``series``.
     """
 
-    plotext.plot_size(80, 30)
+    # plotext 6.x is a full rewrite with an incompatible API (no theme/plot/build).
+    # Return early so callers get an empty string rather than an AttributeError.
+    if not hasattr(plotext, "theme") or not hasattr(plotext, "build"):
+        return ""
+
+    # The size-setting function was renamed/aliased across versions (plot_size in
+    # 3.x-5.x, absent in 6.x which is already excluded above).  Probe in
+    # preference order; skip gracefully if none match (default terminal size).
+    for _size_fn_name in ("plotsize", "plot_size", "limit_size", "limitsize"):
+        _size_fn = getattr(plotext, _size_fn_name, None)
+        if _size_fn is not None:
+            _size_fn(80, 30)
+            break
     plotext.theme("clear")
 
     palette = [


### PR DESCRIPTION
## Overview

\`draw_pareto_to_string\` calls \`plotext.plot_size()\` which does not exist in the plotext version installed in the CI environment, causing \`test_cli_default_build_subset\` to fail.

Changing it to \`plotsize\` (as in PR #1588) also fails — the CI has a version where neither name exists. From testing, both plotext 2.x and plotext 6.x lack both functions (3.x–5.x have both). The function naming is inconsistent across releases.

## Fix

- **Early-exit guard**: if \`theme()\` or \`build()\` are absent, return \`""\` immediately. The Pareto plot is cosmetic; callers already handle an empty return. This covers any plotext version that has undergone a full API rename.
- **Size-function probe**: try \`plotsize\` / \`plot_size\` / \`limit_size\` / \`limitsize\` in order using \`getattr\` with a default, skipping gracefully if none match.

## Test plan

- [ ] \`test_cli_default_build_subset\` passes in CI
- [ ] \`ruff check\` and \`ruff format --check\` clean
- [ ] Existing \`test_draw_pareto_to_string\` still passes (5.3.2 has \`theme\` and \`build\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)