### PR TITLE
fix(collector): normalize missing power metrics to zero

### DIFF
--- a/collector/helper.py
+++ b/collector/helper.py
@@ -850,6 +850,7 @@ def convert_perf_csv_to_parquet(
 
     try:
         import pyarrow as pa
+        import pyarrow.compute as pc_compute
         import pyarrow.csv as pc
         import pyarrow.parquet as pq
     except ImportError as exc:
@@ -870,6 +871,7 @@ def convert_perf_csv_to_parquet(
         table = pc.read_csv(csv_path)
         if merge_existing and parquet_path.exists():
             table = _merge_perf_rows(table, parquet_path, pa=pa, pq=pq)
+        table = _normalize_power_metrics(table, pa=pa, pc=pc_compute)
         pq.write_table(table, tmp_path, compression=compression)
         os.replace(tmp_path, parquet_path)
         if delete_source:
@@ -879,6 +881,35 @@ def convert_perf_csv_to_parquet(
             tmp_path.unlink()
         _release_merge_lock(merge_lock, lock_fd)
     return parquet_path
+
+
+def _normalize_power_metrics(table, *, pa, pc):
+    """Store unavailable power metrics as typed zero sentinels.
+
+    A running GPU workload cannot have a valid zero-watt measurement, and the
+    SDK already interprets zero energy as uncovered power data.  Committed
+    parquet files therefore use ``0.0`` rather than null for unavailable
+    ``power``/``power_limit`` cells.  Tables that omit these optional columns
+    remain unchanged.
+    """
+    for name in ("power", "power_limit"):
+        if name not in table.column_names:
+            continue
+
+        index = table.schema.get_field_index(name)
+        column = table.column(index)
+        try:
+            column = column.cast(pa.float64())
+        except (pa.ArrowInvalid, pa.ArrowNotImplementedError, pa.ArrowTypeError) as exc:
+            raise ValueError(f"{name} must be convertible to float64") from exc
+
+        column = pc.fill_null(column, 0.0)
+        for row_index, value in enumerate(column.to_pylist()):
+            if not math.isfinite(value) or value < 0.0:
+                raise ValueError(f"{name} must contain finite non-negative values; row {row_index} has {value!r}")
+
+        table = table.set_column(index, name, column)
+    return table
 
 
 def _acquire_merge_lock(lock_path: Path) -> int:
@@ -913,10 +944,11 @@ def _merge_perf_rows(new_table, parquet_path: Path, *, pa, pq):
     # with drifted types would otherwise round-trip through pandas and
     # silently rewrite the parquet under a different schema. Metric columns
     # are exempt from the type check — pyarrow.csv infers an all-empty
-    # optional metric column (e.g. power on a power-off run) as `null` while
-    # populated runs infer `double`, and treating that drift as a mismatch
-    # made the merge silently OVERWRITE the accumulated dataset. Metric
-    # values are cast to the existing metric type instead. Order-insensitive
+    # optional metric column as `null` while populated runs infer `double`,
+    # and treating that drift as a mismatch made the merge silently OVERWRITE
+    # the accumulated dataset. Metric types are reconciled for concatenation;
+    # the finalizer then casts power metrics to double and replaces nulls with
+    # the repository's 0.0 unavailable-measurement sentinel. Order-insensitive
     # (the merge realigns column order below); Arrow metadata is ignored
     # (pandas round-trips change it).
     def fields(schema):

--- a/tests/unit/collector/test_perf_output_finalization.py
+++ b/tests/unit/collector/test_perf_output_finalization.py
@@ -3,6 +3,7 @@
 
 from pathlib import Path
 
+import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 
@@ -173,7 +174,7 @@ def test_finalize_merge_tolerates_metric_column_type_drift(tmp_path):
     rows = {r["shape"]: r for r in pq.read_table(parquet).to_pylist()}
     assert sorted(rows) == ["s1", "s2", "s3"]  # accumulated, not overwritten
     assert rows["s1"]["power"] == 5.0
-    assert rows["s3"]["power"] is None
+    assert rows["s3"]["power"] == 0.0
     # metric column keeps the existing (double) type
     assert str(pq.read_table(parquet).schema.field("power").type) == "double"
 
@@ -210,13 +211,66 @@ def test_finalize_merge_tolerates_reverse_metric_type_drift(tmp_path):
     perf = tmp_path / "gemm_perf.txt"
     parquet = perf.with_suffix(".parquet")
 
-    perf.write_text("shape,latency,power\ns1,1.0,\n")  # power inferred as null
-    finalize_perf_files([perf])
+    pq.write_table(
+        pa.table(
+            {
+                "shape": ["s1"],
+                "latency": [1.0],
+                "power": pa.nulls(1),
+            }
+        ),
+        parquet,
+    )
     perf.write_text("shape,latency,power\ns2,2.0,7.5\n")
     finalize_perf_files([perf])
 
     rows = {r["shape"]: r for r in pq.read_table(parquet).to_pylist()}
     assert sorted(rows) == ["s1", "s2"]
-    assert rows["s1"]["power"] is None
+    assert rows["s1"]["power"] == 0.0
     assert rows["s2"]["power"] == 7.5
     assert str(pq.read_table(parquet).schema.field("power").type) == "double"
+
+
+def test_finalize_normalizes_all_empty_power_metrics_to_typed_zero(tmp_path):
+    perf = tmp_path / "gemm_perf.txt"
+    parquet = perf.with_suffix(".parquet")
+
+    perf.write_text("shape,latency,power,power_limit\ns1,1.0,,\ns2,2.0,,\n")
+    finalize_perf_files([perf])
+
+    table = pq.read_table(parquet)
+    assert table.select(["power", "power_limit"]).to_pylist() == [
+        {"power": 0.0, "power_limit": 0.0},
+        {"power": 0.0, "power_limit": 0.0},
+    ]
+    assert str(table.schema.field("power").type) == "double"
+    assert str(table.schema.field("power_limit").type) == "double"
+    assert table.column("power").null_count == 0
+    assert table.column("power_limit").null_count == 0
+
+
+@pytest.mark.parametrize("value", ["-1.0", "inf"])
+def test_finalize_rejects_invalid_power_measurements(tmp_path, value):
+    perf = tmp_path / "gemm_perf.txt"
+    perf.write_text(f"shape,latency,power,power_limit\ns1,1.0,{value},1000.0\n")
+
+    with pytest.raises(ValueError, match="power must contain finite non-negative values"):
+        finalize_perf_files([perf])
+
+
+def test_finalize_treats_csv_nan_power_as_unavailable(tmp_path):
+    perf = tmp_path / "gemm_perf.txt"
+    perf.write_text("shape,latency,power,power_limit\ns1,1.0,nan,1000.0\n")
+
+    [parquet] = finalize_perf_files([perf])
+
+    assert pq.read_table(parquet).column("power").to_pylist() == [0.0]
+
+
+def test_finalize_keeps_power_disabled_schema_column_free(tmp_path):
+    perf = tmp_path / "gemm_perf.txt"
+    perf.write_text("shape,latency\ns1,1.0\n")
+
+    [parquet] = finalize_perf_files([perf])
+
+    assert pq.read_table(parquet).column_names == ["shape", "latency"]

--- a/tests/unit/tools/test_parquet_diff.py
+++ b/tests/unit/tools/test_parquet_diff.py
@@ -161,6 +161,45 @@ def test_measurement_only_columns_use_full_row_delta(parquet_diff_module, tmp_pa
     assert row_diff.note == "unavailable keys; exact full-row add/remove diff used"
 
 
+def test_power_limit_is_a_measurement_not_an_identity_column(parquet_diff_module):
+    columns = ["framework", "shape", "latency", "power", "power_limit"]
+
+    assert parquet_diff_module._select_key_columns(columns, columns) == ["framework", "shape"]
+
+
+def test_power_metric_contract_rejects_null_non_double_and_invalid_values(parquet_diff_module):
+    table = pa.table(
+        {
+            "power": pa.array([100.0, None, -1.0, float("inf")], type=pa.float64()),
+            "power_limit": pa.array(["1000", "1000", "1000", "1000"]),
+        }
+    )
+
+    assert parquet_diff_module._power_metric_issues(table) == [
+        "power contains 1 null cells",
+        "power contains 2 non-finite or negative values",
+        "power_limit must be double, found string",
+    ]
+
+
+def test_strict_mode_fails_on_invalid_power_metrics(parquet_diff_module):
+    comparison = parquet_diff_module.Comparison(
+        path="gemm_perf.parquet",
+        base_path="gemm_perf.parquet",
+        status="M",
+        base_rows=1,
+        head_rows=1,
+        columns_match=True,
+        content_match=False,
+        base_hash="base",
+        head_hash="head",
+        row_diff=None,
+        power_issues=["power contains 1 null cells"],
+    )
+
+    assert parquet_diff_module.should_fail_strict([comparison], [])
+
+
 def test_full_row_delta_preserves_original_nested_values(parquet_diff_module):
     row = {"latency": float("nan"), "power": {"rails": ["gpu", "soc"]}}
 

--- a/tools/perf_database/parquet_diff.py
+++ b/tools/perf_database/parquet_diff.py
@@ -32,6 +32,7 @@ MEASUREMENT_COLUMNS = frozenset(
     {
         "latency",
         "power",
+        "power_limit",
         "energy",
         "avg_ms",
         "dispatch_avg_t_us",
@@ -108,6 +109,30 @@ class Comparison:
     base_hash: str | None
     head_hash: str | None
     row_diff: RowDiff | None
+    power_issues: list[str] = field(default_factory=list)
+
+
+def _power_metric_issues(table: pa.Table) -> list[str]:
+    """Return committed-data contract violations for optional power metrics."""
+    issues: list[str] = []
+    for name in ("power", "power_limit"):
+        if name not in table.column_names:
+            continue
+
+        field = table.schema.field(name)
+        column = table.column(name)
+        if not pa.types.is_float64(field.type):
+            issues.append(f"{name} must be double, found {field.type}")
+            continue
+        if column.null_count:
+            issues.append(f"{name} contains {column.null_count} null cells")
+
+        invalid = [
+            value for value in column.to_pylist() if value is not None and (not math.isfinite(value) or value < 0)
+        ]
+        if invalid:
+            issues.append(f"{name} contains {len(invalid)} non-finite or negative values")
+    return issues
 
 
 def _git(args: list[str], *, input_data: bytes | None = None, check: bool = True) -> subprocess.CompletedProcess:
@@ -788,6 +813,7 @@ def _compare(base_ref: str, head_ref: str, entry: DiffEntry, detail_dir: Path | 
         base_hash=base_snapshot.content_hash if base_snapshot else None,
         head_hash=head_snapshot.content_hash if head_snapshot else None,
         row_diff=row_diff,
+        power_issues=_power_metric_issues(head_snapshot.table) if head_snapshot else [],
     )
 
 
@@ -891,6 +917,7 @@ def render_report(
         f"- Deleted parquet files: {len(deleted)}",
         f"- Legacy `*_perf.txt` files added or modified: {len(legacy_perf_changes)}",
         f"- Row-level changes: +{added_rows} / -{removed_rows} / ~{modified_rows}",
+        f"- Invalid power-metric files: {sum(bool(c.power_issues) for c in comparisons)}",
     ]
     if full_diff_artifacts is not None:
         diff_artifact_label = "file" if len(full_diff_artifacts) == 1 else "files"
@@ -932,6 +959,15 @@ def render_report(
             lines.append(f"\n...and {len(legacy_perf_changes) - 50} more legacy text perf changes.")
         lines.append("")
 
+    invalid_power = [comparison for comparison in comparisons if comparison.power_issues]
+    if invalid_power:
+        lines.extend(["### Invalid Power Metrics", ""])
+        rows = [["File", "Issues"]]
+        for comparison in invalid_power:
+            rows.append([comparison.path, "; ".join(comparison.power_issues)])
+        lines.extend(_render_table(rows))
+        lines.append("")
+
     lines.extend(_render_inline_diff_previews(comparisons))
 
     has_row_detail_files = any(c.row_diff and c.row_diff.detail_files for c in comparisons)
@@ -964,7 +1000,7 @@ def should_fail_strict(comparisons: list[Comparison], legacy_perf_changes: list[
         for item in comparisons
         if item.base_path and item.base_path.endswith(".txt") and not (item.columns_match and item.content_match)
     ]
-    return bool(converted_bad or legacy_perf_changes)
+    return bool(converted_bad or legacy_perf_changes or any(item.power_issues for item in comparisons))
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary

- normalize optional `power` and `power_limit` columns to non-null `float64`
- encode unavailable measurements as the repository's `0.0` sentinel
- reject negative and non-finite power metrics during finalization
- keep power-disabled tables free of optional power columns
- make the parquet-diff strict gate reject nullable, non-double, negative, or non-finite power metrics
- treat `power_limit` as a measurement rather than an identity column

## Root cause

The power-enabled parquet overlays in #1535, #1536, and the original head of #1584 contain nullable double `power`/`power_limit` cells. The Rust parquet table view uses a strict double accessor, so a null produces `Cannot access Null as Double`. In the targeted support matrix, that loader error converted every one of the 142 rows to `FAIL`.

A running workload cannot have a valid zero-watt measurement, so `0.0` is the canonical invalid/unmeasured sentinel and does not erase a meaningful measured-zero state.

## Validation

- 28 focused unit tests passed
- Ruff and `git diff --check` passed
- normalized parquet integrity check proved that only prior null cells changed to `0.0`; all measured values and non-power cells stayed identical
- #1584 B200 TRT-LLM 1.3.0rc20 audit: 487,422 measured pairs across all 18 tables, including 139 exact-key MHC power measurements; 40,549 unmatched pairs use typed `0.0`; 3,319 backend-fact slices pass
- NVIDIA Compute Lab reproduction on B200/x86_64:
  - #1535 SGLang 0.5.14: 118 `PASS`, 2 `HYBRID_PASS`, 22 unrelated `FAIL`; zero null-access errors
  - #1536 vLLM 0.24.0: 122 `PASS`, 2 `HYBRID_PASS`, 18 unrelated `FAIL`; zero null-access errors

## Merge ordering

#1535, #1536, and #1584 are intentionally pure-data PRs and depend on this fix. Merge this PR first, then rebase/update all three data PRs onto the resulting `main` before merging them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized power metrics to consistent floating-point values, using `0.0` when unavailable.
  * Rejected negative, infinite, or otherwise invalid power measurements during finalization and comparison.
  * Preserved schemas without power columns when power collection is disabled.
  * Improved handling of metric type differences when merging performance data.

* **Validation**
  * Comparison reports now include power-metric issues and strict mode fails when invalid values are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->