### PR TITLE
fix(recommend): require explicit DSPARK acceptance

### DIFF
--- a/aic-core/src/aiconfigurator_core/sdk/config_builders.py
+++ b/aic-core/src/aiconfigurator_core/sdk/config_builders.py
@@ -9,6 +9,8 @@ Keeping them in ``sdk`` prevents lower-level code from importing CLI code.
 
 from __future__ import annotations
 
+import logging
+
 from aiconfigurator_core.sdk.common import (
     CommQuantMode,
     FMHAQuantMode,
@@ -17,6 +19,8 @@ from aiconfigurator_core.sdk.common import (
     MoEQuantMode,
 )
 from aiconfigurator_core.sdk.config import ModelConfig
+
+logger = logging.getLogger(__name__)
 
 
 def build_model_config(
@@ -92,39 +96,31 @@ def resolve_nextn_auto(model_path: str) -> int:
     return int(cfg.get("num_nextn_predict_layers") or 0)
 
 
-# Conservative nextn_accepted fraction for DSPARK recommend mode.
-# nextn_accepted has no backend equivalent — it is AIC's throughput planning
-# assumption (average accepted tokens per step as a fraction of the block size).
-# 0.8 is conservative for a well-aligned draft model.
-_DSPARK_DEFAULT_ACCEPTANCE = 0.8
-
-
-def resolve_dspark_nextn(model_path: str) -> tuple[int, float] | None:
-    """Resolve DSPARK speculative parameters for the recommend/sizing path.
+def resolve_dspark_nextn(model_path: str) -> int | None:
+    """Resolve the DSPARK draft depth for the recommend/sizing path.
 
     DSPARK architectures use a standalone trained draft model whose block size
     is a fixed architectural constant — not stored in the main checkpoint, so
     ``nextn='auto'`` always returns 0 for these models.
 
-    Returns ``(nextn, nextn_accepted)`` when the model is a DSPARK architecture,
-    where ``nextn`` is the architectural block size and ``nextn_accepted`` is a
-    conservative throughput planning assumption (no backend equivalent).
-    Returns ``None`` when the model is not DSPARK or the config cannot be fetched.
-    Raises ``ValueError`` when ``model_path`` is empty, matching ``resolve_nextn_auto``.
+    Returns the architectural block size when the model uses DSPARK. Accepted
+    draft-token progress remains an explicit workload input in the upper SDK
+    layer and is intentionally not inferred here. Returns ``None`` for other
+    architectures or when expected model-config access fails. Unexpected or
+    malformed metadata errors propagate. Raises ``ValueError`` when
+    ``model_path`` is empty, matching ``resolve_nextn_auto``.
     """
     from aiconfigurator_core.sdk.common import DSPARK_NEXTN
-    from aiconfigurator_core.sdk.utils import get_model_config_from_model_path
+    from aiconfigurator_core.sdk.utils import HuggingFaceDownloadError, get_model_config_from_model_path
 
     if not model_path:
         raise ValueError("resolve_dspark_nextn requires a model path.")
     try:
         info = get_model_config_from_model_path(model_path)
-        block_size = DSPARK_NEXTN.get(info.get("architecture", ""), 0)
-        if block_size:
-            return block_size, block_size * _DSPARK_DEFAULT_ACCEPTANCE
-    except Exception:
-        pass
-    return None
+    except (HuggingFaceDownloadError, OSError) as exc:
+        logger.warning("Could not resolve DSPARK draft depth for %r: %s", model_path, exc)
+        return None
+    return DSPARK_NEXTN.get(info["architecture"])
 
 
 def apply_nextn(

--- a/docs/cli_user_guide.md
+++ b/docs/cli_user_guide.md
@@ -394,8 +394,8 @@ aiconfigurator cli recommend --model-path Qwen/Qwen3-32B --system h200_sxm --bac
 - `--ttft`, `--tpot`: SLA targets in ms (default: 2000ms, 30ms)
 - `--request-latency`: End-to-end request latency target in ms
 - `--isl`, `--osl`: Input/output sequence lengths (default: 4000, 1000)
-- `--nextn`: MTP draft length, or `auto` to use the checkpoint's `num_nextn_predict_layers`
-- `--nextn-accepted`: Required when the resolved draft depth is greater than 0; it must be a measured average in the range `0 <= nextn_accepted <= nextn`
+- `--nextn`: MTP draft length, or `auto` to use the checkpoint's `num_nextn_predict_layers` and then DSPARK architecture metadata. Omitted or `0` keeps speculation disabled unless a DSPARK model is paired with an explicit `--nextn-accepted` measurement.
+- `--nextn-accepted`: Required when the resolved draft depth is greater than 0; it must be a measured average in the range `0 <= nextn_accepted <= nextn`. AIC never infers this workload-dependent value.
 - All other arguments match `default` mode (quantization, prefix caching, etc.)
 
 The output includes `total_gpus_needed` and `replicas_needed` columns, showing both agg and disagg configurations ranked by fewest GPUs first.
@@ -952,16 +952,18 @@ Hybrid mode is a quick solution to support new models without modeling the opera
 #### Speculative Decoding (`--nextn`, `--nextn-accepted`)
 
 These flags enable MTP (Multi-Token Prediction) speculative decoding in the
-configuration search. MTP is **never enabled implicitly** — omitting `--nextn`
-keeps it off even for models that ship MTP layers (the CLI logs a hint when
-the checkpoint declares them):
+configuration search. MTP is **never enabled implicitly** — omitting both flags
+keeps it off even for models that ship MTP layers. In recommend mode only, an
+explicit `--nextn-accepted` measurement can pair with an omitted depth to select
+a DSPARK architecture's fixed block size:
 
 - `--nextn N` — MTP draft length (compute cost side: extra MTP-layer forward
   plus the wider verify batch; no fixed upper bound). Default: 0 (disabled).
 - `--nextn auto` — take the draft depth from the checkpoint's
-  `num_nextn_predict_layers` (absent or 0 keeps MTP disabled). Only the depth
-  comes from the checkpoint — the acceptance value below is still required,
-  because it is a property of your workload, not of the model.
+  `num_nextn_predict_layers`. If that value is absent or 0 for a DSPARK model,
+  use its fixed architectural block size instead. Only the depth is resolved —
+  the acceptance value below is still required because it is a property of
+  your backend and workload, not of the model.
 - `--nextn-accepted A` — Average accepted draft tokens per decode step
   (`0 <= nextn_accepted <= nextn`); each step yields `1 + nextn_accepted` output tokens.
   Required whenever the draft depth is > 0 (explicit or via `auto`) — there is

--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -376,13 +376,6 @@ def cli_default(
 
 _MAX_GPUS_PER_WORKER = 64
 
-# Conservative nextn_accepted fraction used when recommend auto-enables DSPARK.
-# nextn_accepted has no backend equivalent — it is AIC's throughput modeling
-# assumption (accepted tokens per step as a fraction of the block size).
-# Users who have empirical acceptance data can override via cli_recommend's
-# nextn_accepted parameter. 0.8 is conservative for a well-aligned draft model.
-_DSPARK_DEFAULT_ACCEPTANCE = 0.8
-
 
 def _build_recommend_tasks(base_tasks: dict, total_gpus: int) -> dict:
     """Scale GPU candidates for recommend mode."""
@@ -425,7 +418,7 @@ def cli_recommend(
     tpot: float = 30.0,
     request_latency: float | None = None,
     prefix: int = 0,
-    nextn: int | str = 0,
+    nextn: int | str | None = None,
     nextn_accepted: float | None = None,
     strict_sla: bool = False,
     enable_chunked_prefill: bool = False,
@@ -473,8 +466,10 @@ def cli_recommend(
         tpot: Time per output token SLA target in ms. Default is 30.
         request_latency: Optional end-to-end request latency target (ms).
         prefix: Prefix cache length.
-        nextn: MTP draft length, or 'auto' to use the checkpoint's
-            num_nextn_predict_layers. Default is 0 (disabled).
+        nextn: MTP draft length, or 'auto' to resolve the depth from the
+            checkpoint, falling back to DSPARK architecture metadata. Omitted
+            or 0 keeps speculative decoding disabled unless a DSPARK model is
+            paired with an explicit ``nextn_accepted`` workload measurement.
         nextn_accepted: Average accepted draft tokens per decode step
             (0 <= nextn_accepted <= nextn). Required when the draft depth
             resolves to > 0.
@@ -521,19 +516,16 @@ def cli_recommend(
     gpus_per_node = spec["node"]["num_gpus_per_node"]
 
     # Fail fast on inconsistent MTP inputs (same early check as cli_default).
-    # nextn="auto" resolves the draft depth from the checkpoint first.
+    # Explicit "auto" resolves the checkpoint depth first and falls back to
+    # DSPARK's architectural block size. An omitted nextn may use that DSPARK
+    # depth only when the caller supplied an explicit workload acceptance
+    # measurement. Explicit nextn=0 always remains the opt-out.
     if nextn == "auto":
         nextn = _resolve_nextn_auto(model_path)
-
-    # DSPARK architectures (e.g. Kimi-K3) always run with a standalone draft
-    # model in production. Their block size is an architectural constant absent
-    # from the checkpoint, so nextn="auto" returns 0. Auto-enable here so that
-    # recommend produces accurate throughput estimates without requiring callers
-    # to know about DSPARK internals.
-    if nextn == 0 and (dspark := _resolve_dspark_nextn(model_path)):
-        nextn, dspark_accepted = dspark
-        if nextn_accepted is None:
-            nextn_accepted = dspark_accepted
+        if nextn == 0:
+            nextn = _resolve_dspark_nextn(model_path) or 0
+    elif nextn is None:
+        nextn = _resolve_dspark_nextn(model_path) if nextn_accepted is not None else 0
 
     nextn, nextn_accepted = _normalize_nextn(nextn, nextn_accepted)
 

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -691,11 +691,11 @@ def _add_recommend_mode_arguments(parser):
     parser.add_argument(
         "--nextn",
         type=_parse_nextn,
-        default=0,
+        default=None,
         help="MTP (Multi-Token Prediction) draft length, or 'auto' to use the checkpoint's "
-        "num_nextn_predict_layers (absent/0 keeps MTP disabled). When the depth is > 0, enables "
-        "speculative decoding in the configuration search and requires --nextn-accepted. "
-        "Default: 0 (disabled); MTP is never enabled implicitly when the flag is omitted.",
+        "num_nextn_predict_layers and then DSPARK architecture metadata. When the depth is > 0, "
+        "enables speculative decoding and requires a measured --nextn-accepted value. Omitted or "
+        "0 keeps speculation disabled unless a DSPARK model is paired with --nextn-accepted.",
     )
     parser.add_argument(
         "--nextn-accepted",
@@ -3093,8 +3093,15 @@ def main(args):
             raise SystemExit("recommend mode requires --model-path")
         if not getattr(args, "system", None):
             raise SystemExit("recommend mode requires --system")
-        _resolve_and_validate_nextn(args)
-        _run_recommend(args)
+        # Preserve omitted, explicit zero, and "auto" as distinct recommend API
+        # inputs. cli_recommend owns DSPARK fallback and acceptance validation.
+        try:
+            _run_recommend(args)
+        except Exception as exc:
+            if is_expected_cli_error(exc):
+                logger.debug("Traceback for recommend mode", exc_info=True)
+                raise SystemExit("Error: " + str(exc)) from exc
+            raise
         return
 
     if args.mode == "default":

--- a/tests/unit/cli/test_argument_parsing.py
+++ b/tests/unit/cli/test_argument_parsing.py
@@ -578,9 +578,7 @@ class TestCLIArgumentParsing:
         )
         assert not hasattr(args, "total_gpus")
 
-    def test_recommend_nextn_auto_resolves_and_validates(self, cli_parser, monkeypatch):
-        import aiconfigurator.cli.main as cli_main
-
+    def test_recommend_nextn_auto_is_preserved_for_api_resolution(self, cli_parser):
         args = cli_parser.parse_args(
             [
                 "recommend",
@@ -596,12 +594,23 @@ class TestCLIArgumentParsing:
                 "0.7",
             ]
         )
-        monkeypatch.setattr(cli_main, "resolve_nextn_auto", lambda _model_path: 2)
-
-        cli_main._resolve_and_validate_nextn(args)
-
-        assert args.nextn == 2
+        assert args.nextn == "auto"
         assert args.nextn_accepted == 0.7
+
+    def test_recommend_omitted_nextn_has_distinct_sentinel(self, cli_parser):
+        args = cli_parser.parse_args(
+            [
+                "recommend",
+                "--model-path",
+                "moonshotai/Kimi-K3",
+                "--system",
+                "h200_sxm",
+                "--target-request-rate",
+                "10",
+            ]
+        )
+
+        assert args.nextn is None
 
     def test_recommend_nextn_requires_explicit_acceptance(self, cli_parser):
         from aiconfigurator.cli.main import _resolve_and_validate_nextn

--- a/tests/unit/cli/test_cli_api.py
+++ b/tests/unit/cli/test_cli_api.py
@@ -540,14 +540,8 @@ class TestCLIRecommendUnit:
         assert captured_kwargs["enable_wideep"] is True
         assert captured_kwargs["moe_backend"] == "deepep_moe"
 
-    def test_dspark_nextn_auto_enabled(self, monkeypatch):
-        """cli_recommend auto-enables DSPARK via the nextn='auto' → 0 → DSPARK path.
-
-        Exercises the realistic production flow: nextn='auto' calls
-        _resolve_nextn_auto which returns 0 for DSPARK models (block size is not
-        in the checkpoint), then _resolve_dspark_nextn fills in the architectural
-        block size and planning acceptance.
-        """
+    def test_dspark_nextn_auto_uses_explicit_acceptance(self, monkeypatch):
+        """Explicit auto resolves DSPARK depth without inferring acceptance."""
         import aiconfigurator.cli.api as api
 
         captured = {}
@@ -562,20 +556,37 @@ class TestCLIRecommendUnit:
         monkeypatch.setattr(api, "build_default_tasks", fake_build_default_tasks)
         monkeypatch.setattr(api, "_execute_tasks_internal", fake_execute)
         monkeypatch.setattr(api, "_resolve_nextn_auto", lambda _: 0)
-        monkeypatch.setattr(api, "_resolve_dspark_nextn", lambda _: (7, 5.6))
+        monkeypatch.setattr(api, "_resolve_dspark_nextn", lambda _: 7)
 
         api.cli_recommend(
             model_path="moonshotai/Kimi-K3",
             system="h200_sxm",
             target_concurrency=16,
             nextn="auto",
+            nextn_accepted=3.0,
         )
 
         assert captured["nextn"] == 7
-        assert abs(captured["nextn_accepted"] - 5.6) < 1e-9
+        assert captured["nextn_accepted"] == 3.0
 
-    def test_dspark_explicit_nextn_accepted_not_overridden(self, monkeypatch):
-        """Explicit nextn_accepted is preserved when DSPARK is auto-detected."""
+    def test_dspark_auto_requires_explicit_acceptance(self, monkeypatch):
+        """DSPARK architectural depth never implies workload acceptance."""
+        import aiconfigurator.cli.api as api
+
+        monkeypatch.setattr(api, "_resolve_nextn_auto", lambda _: 0)
+        monkeypatch.setattr(api, "_resolve_dspark_nextn", lambda _: 7)
+
+        with pytest.raises(ValueError, match="requires 'nextn_accepted'"):
+            api.cli_recommend(
+                model_path="moonshotai/Kimi-K3",
+                system="h200_sxm",
+                target_concurrency=16,
+                nextn="auto",
+            )
+
+    @pytest.mark.parametrize("accepted", [3.0, 0.0])
+    def test_dspark_omitted_depth_uses_explicit_acceptance(self, monkeypatch, accepted):
+        """Measured acceptance opts an omitted DSPARK depth into architecture resolution."""
         import aiconfigurator.cli.api as api
 
         captured = {}
@@ -589,17 +600,78 @@ class TestCLIRecommendUnit:
 
         monkeypatch.setattr(api, "build_default_tasks", fake_build_default_tasks)
         monkeypatch.setattr(api, "_execute_tasks_internal", fake_execute)
-        monkeypatch.setattr(api, "_resolve_dspark_nextn", lambda _: (7, 5.6))
+        monkeypatch.setattr(api, "_resolve_dspark_nextn", lambda _: 7)
 
         api.cli_recommend(
             model_path="moonshotai/Kimi-K3",
             system="h200_sxm",
             target_concurrency=16,
-            nextn_accepted=3.0,
+            nextn_accepted=accepted,
         )
 
         assert captured["nextn"] == 7
-        assert captured["nextn_accepted"] == 3.0
+        assert captured["nextn_accepted"] == accepted
+
+    def test_dspark_explicit_zero_opts_out(self, monkeypatch):
+        """Explicit nextn=0 remains disabled and bypasses DSPARK resolution."""
+        import aiconfigurator.cli.api as api
+
+        captured = {}
+
+        def fake_build_default_tasks(**kwargs):
+            captured.update(kwargs)
+            return {}
+
+        def fake_execute(tasks, mode, **kwargs):
+            return ("agg", {"agg": pd.DataFrame({"x": [1]})}, {}, {}, {}, {})
+
+        monkeypatch.setattr(api, "build_default_tasks", fake_build_default_tasks)
+        monkeypatch.setattr(api, "_execute_tasks_internal", fake_execute)
+        monkeypatch.setattr(
+            api,
+            "_resolve_dspark_nextn",
+            lambda _: pytest.fail("explicit zero must not resolve DSPARK"),
+        )
+
+        api.cli_recommend(
+            model_path="moonshotai/Kimi-K3",
+            system="h200_sxm",
+            target_concurrency=16,
+            nextn=0,
+        )
+
+        assert captured["nextn"] == 0
+        assert captured["nextn_accepted"] is None
+
+    def test_omitted_speculation_remains_disabled(self, monkeypatch):
+        """Existing callers that omit both inputs keep speculative decoding off."""
+        import aiconfigurator.cli.api as api
+
+        captured = {}
+
+        def fake_build_default_tasks(**kwargs):
+            captured.update(kwargs)
+            return {}
+
+        def fake_execute(tasks, mode, **kwargs):
+            return ("agg", {"agg": pd.DataFrame({"x": [1]})}, {}, {}, {}, {})
+
+        monkeypatch.setattr(api, "build_default_tasks", fake_build_default_tasks)
+        monkeypatch.setattr(api, "_execute_tasks_internal", fake_execute)
+        monkeypatch.setattr(
+            api,
+            "_resolve_dspark_nextn",
+            lambda _: pytest.fail("omitted speculation must not fetch DSPARK metadata"),
+        )
+
+        api.cli_recommend(
+            model_path="moonshotai/Kimi-K3",
+            system="h200_sxm",
+            target_concurrency=16,
+        )
+
+        assert captured["nextn"] == 0
+        assert captured["nextn_accepted"] is None
 
     def test_non_dspark_model_unaffected(self, monkeypatch):
         """Non-DSPARK models are not touched by the DSPARK auto-detect path."""
@@ -616,12 +688,14 @@ class TestCLIRecommendUnit:
 
         monkeypatch.setattr(api, "build_default_tasks", fake_build_default_tasks)
         monkeypatch.setattr(api, "_execute_tasks_internal", fake_execute)
+        monkeypatch.setattr(api, "_resolve_nextn_auto", lambda _: 0)
         monkeypatch.setattr(api, "_resolve_dspark_nextn", lambda _: None)
 
         api.cli_recommend(
             model_path="Qwen/Qwen3-32B",
             system="h200_sxm",
             target_concurrency=16,
+            nextn="auto",
         )
 
         assert captured["nextn"] == 0

--- a/tests/unit/cli/test_cli_workflow.py
+++ b/tests/unit/cli/test_cli_workflow.py
@@ -98,8 +98,7 @@ class TestCLIIntegration:
     """Workflow tests for the CLI orchestration layer (builders/executor/save)."""
 
     @patch("aiconfigurator.cli.main._run_recommend")
-    def test_cli_recommend_resolves_nextn_before_dispatch(self, mock_run_recommend, cli_parser, monkeypatch):
-        monkeypatch.setattr("aiconfigurator.cli.main.resolve_nextn_auto", lambda _model_path: 2)
+    def test_cli_recommend_preserves_auto_until_api_dispatch(self, mock_run_recommend, cli_parser):
         args = cli_parser.parse_args(
             [
                 "recommend",
@@ -118,9 +117,28 @@ class TestCLIIntegration:
 
         cli_main(args)
 
-        assert args.nextn == 2
+        assert args.nextn == "auto"
         assert args.nextn_accepted == 0.7
         mock_run_recommend.assert_called_once_with(args)
+
+    @patch("aiconfigurator.cli.main._run_recommend", side_effect=ValueError("nextn=7 requires acceptance"))
+    def test_cli_recommend_reports_acceptance_error_without_traceback(self, _mock_run_recommend, cli_parser):
+        args = cli_parser.parse_args(
+            [
+                "recommend",
+                "--model-path",
+                "moonshotai/Kimi-K3",
+                "--system",
+                "h200_sxm",
+                "--target-request-rate",
+                "10",
+                "--nextn",
+                "auto",
+            ]
+        )
+
+        with pytest.raises(SystemExit, match="Error: nextn=7 requires acceptance"):
+            cli_main(args)
 
     @patch("aiconfigurator.cli.main._execute_tasks")
     @patch("aiconfigurator.cli.main.build_default_tasks")

--- a/tests/unit/sdk/test_speculative.py
+++ b/tests/unit/sdk/test_speculative.py
@@ -169,21 +169,14 @@ class TestResolveDsparkNextn:
         )
         assert resolve_dspark_nextn("meta-llama/Llama-3.1-8B-Instruct") is None
 
-    def test_kimi_k3_returns_block_size_and_acceptance(self, monkeypatch):
-        from aiconfigurator_core.sdk.config_builders import (
-            _DSPARK_DEFAULT_ACCEPTANCE,
-            resolve_dspark_nextn,
-        )
+    def test_kimi_k3_returns_block_size(self, monkeypatch):
+        from aiconfigurator_core.sdk.config_builders import resolve_dspark_nextn
 
         monkeypatch.setattr(
             "aiconfigurator_core.sdk.utils.get_model_config_from_model_path",
             lambda _: {"architecture": "KimiK3ForConditionalGeneration"},
         )
-        result = resolve_dspark_nextn("moonshotai/Kimi-K3")
-        assert result is not None
-        nextn, nextn_accepted = result
-        assert nextn == 7
-        assert abs(nextn_accepted - 7 * _DSPARK_DEFAULT_ACCEPTANCE) < 1e-9
+        assert resolve_dspark_nextn("moonshotai/Kimi-K3") == 7
 
     def test_empty_model_path_raises(self):
         from aiconfigurator_core.sdk.config_builders import resolve_dspark_nextn
@@ -191,11 +184,35 @@ class TestResolveDsparkNextn:
         with pytest.raises(ValueError, match="requires a model path"):
             resolve_dspark_nextn("")
 
-    def test_fetch_failure_returns_none(self, monkeypatch):
+    def test_expected_fetch_failure_warns_and_returns_none(self, monkeypatch, caplog):
+        from aiconfigurator_core.sdk.config_builders import resolve_dspark_nextn
+        from aiconfigurator_core.sdk.utils import HuggingFaceDownloadError
+
+        monkeypatch.setattr(
+            "aiconfigurator_core.sdk.utils.get_model_config_from_model_path",
+            lambda _: (_ for _ in ()).throw(HuggingFaceDownloadError("network error")),
+        )
+        with caplog.at_level("WARNING", logger="aiconfigurator_core.sdk.config_builders"):
+            assert resolve_dspark_nextn("some/model") is None
+        assert "some/model" in caplog.text
+        assert "network error" in caplog.text
+
+    def test_unexpected_failure_propagates(self, monkeypatch):
         from aiconfigurator_core.sdk.config_builders import resolve_dspark_nextn
 
         monkeypatch.setattr(
             "aiconfigurator_core.sdk.utils.get_model_config_from_model_path",
-            lambda _: (_ for _ in ()).throw(RuntimeError("network error")),
+            lambda _: (_ for _ in ()).throw(RuntimeError("programming error")),
         )
-        assert resolve_dspark_nextn("some/model") is None
+        with pytest.raises(RuntimeError, match="programming error"):
+            resolve_dspark_nextn("some/model")
+
+    def test_malformed_metadata_propagates(self, monkeypatch):
+        from aiconfigurator_core.sdk.config_builders import resolve_dspark_nextn
+
+        monkeypatch.setattr(
+            "aiconfigurator_core.sdk.utils.get_model_config_from_model_path",
+            lambda _: {},
+        )
+        with pytest.raises(KeyError, match="architecture"):
+            resolve_dspark_nextn("some/model")


### PR DESCRIPTION
## Summary

- keep DSPARK draft depth architecture-derived while requiring a measured acceptance input
- distinguish omitted, `auto`, and explicit-zero `nextn` so the opt-out is preserved
- warn on expected model-config access failures and propagate malformed or unexpected errors
- document the contract and add focused CLI/SDK regression coverage

## Context

Follow-up to #1506.

## Testing

- `ruff check` on all changed Python files
- `ruff format --check` on all changed Python files
- 174 focused CLI/SDK/cross-package tests passed
- broader unit audit: 4098 passed, 32 failed, 11 skipped; the failures are pre-existing worktree artifact mismatches (prepared Rust extension/API and checked-in performance data/native enums), outside these changed paths


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DSPARK-aware automatic speculative-decoding depth selection using checkpoint or architecture metadata.
  * Added support for explicitly providing acceptance measurements when depth is omitted.
  * Preserved explicit `--nextn 0` as an opt-out.

* **Bug Fixes**
  * Improved recommendation error messages with concise CLI output.
  * Unexpected or malformed metadata errors now surface clearly instead of being silently suppressed.

* **Documentation**
  * Updated speculative-decoding guidance for automatic and omitted `--nextn` values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->