### PR TITLE
fix(test): remove duplicate WideEP version override

### DIFF
--- a/tests/unit/sdk/database/test_wideep_mla_backend_validation.py
+++ b/tests/unit/sdk/database/test_wideep_mla_backend_validation.py
@@ -24,7 +24,6 @@ def blackwell_empirical_database():
         allow_unlisted_version=True,
         database_mode=common.DatabaseMode.EMPIRICAL,
         shared_layer=False,
-        allow_unlisted_version=True,
     )
     assert database is not None
     return database


### PR DESCRIPTION
## Summary
- remove the duplicated allow_unlisted_version keyword introduced when #1558 and #1562 merged concurrently
- retain the intended explicit historical-version opt-in while restoring Python parseability

## Validation
- python -m py_compile tests/unit/sdk/database/test_wideep_mla_backend_validation.py
- pytest -q tests/unit/sdk/database/test_wideep_mla_backend_validation.py (6 passed)
- ruff check and ruff format --check
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated WideEP MLA backend validation tests to use the standard database version validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->