### PR TITLE
chore: bump version to 0.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,13 @@ owner first when crossing this package boundary:
 
 ```bash
 python3 -m pip uninstall -y aiconfigurator aiconfigurator-core
-python3 -m pip install 'aiconfigurator==0.11.0'
+python3 -m pip install 'aiconfigurator==0.12.0'
 ```
 
 If a normal upgrade was already attempted, repair the core payload with:
 
 ```bash
-python3 -m pip install --force-reinstall --no-deps 'aiconfigurator-core==0.11.0'
+python3 -m pip install --force-reinstall --no-deps 'aiconfigurator-core==0.12.0'
 ```
 
 ### Build and Install from Source

--- a/aic-core/pyproject.toml
+++ b/aic-core/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "aiconfigurator-core"
-version = "0.11.0"
+version = "0.12.0"
 authors = [
     { name = "NVIDIA Inc.", email = "sw-dl-dynamo@nvidia.com" },
 ]

--- a/aic-core/rust/aiconfigurator-core/Cargo.lock
+++ b/aic-core/rust/aiconfigurator-core/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "aiconfigurator-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "csv",
  "serde",

--- a/aic-core/rust/aiconfigurator-core/Cargo.toml
+++ b/aic-core/rust/aiconfigurator-core/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "aiconfigurator-core"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "Rust-native core latency estimator for AIConfigurator"
 license = "Apache-2.0"

--- a/aic-core/rust/aiconfigurator-core/README.md
+++ b/aic-core/rust/aiconfigurator-core/README.md
@@ -43,7 +43,7 @@ crate's `embed-python` feature, which enables PyO3's `auto-initialize` support:
 
 ```toml
 [dependencies]
-aiconfigurator-core = { version = "0.11.0", features = ["embed-python"] }
+aiconfigurator-core = { version = "0.12.0", features = ["embed-python"] }
 ```
 
 Applications that embed Python in an existing host may initialize the

--- a/aic-core/uv.lock
+++ b/aic-core/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [[package]]
 name = "aiconfigurator-core"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "aiconfigurator"
-version = "0.11.0"
+version = "0.12.0"
 authors = [
     { name = "NVIDIA Inc.", email = "sw-dl-dynamo@nvidia.com" },
 ]
@@ -40,7 +40,7 @@ license-files = ["LICENSE"]
 requires-python = ">=3.11,<3.14"
 
 dependencies = [
-    "aiconfigurator-core==0.11.0",
+    "aiconfigurator-core==0.12.0",
     "jinja2>=3.1.0",
     "packaging>=20.0",
     "matplotlib>=3.9.4",

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [[package]]
 name = "aiconfigurator"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiconfigurator-core" },
@@ -97,7 +97,7 @@ provides-extras = ["dev", "service"]
 
 [[package]]
 name = "aiconfigurator-core"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "aic-core" }
 dependencies = [
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
#### Overview:

Bump the AIConfigurator Python packages and Rust crate from 0.11.0 to 0.12.0.

#### Details:

- update the aiconfigurator and aiconfigurator-core Python project versions
- keep the upper package's exact aiconfigurator-core dependency pin synchronized
- update both uv lockfiles
- update the aiconfigurator-core Rust crate version and tracked crate lock entry
- align current Python install and Rust dependency examples with 0.12.0

Validation:

- root uv lock check passed offline
- aic-core uv lock check passed offline
- Python, Rust, dependency-pin, and lockfile version contract checks passed
- standalone aiconfigurator-core cargo check passed offline
- git diff --check passed

#### Where should the reviewer start?

Review pyproject.toml, aic-core/pyproject.toml, and aic-core/rust/aiconfigurator-core/Cargo.toml for the synchronized package versions.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated upgrade instructions and standalone usage examples for version 0.12.0.

- **Chores**
  - Released the application and core packages as version 0.12.0.
  - Updated the core dependency to version 0.12.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->