### PR TITLE
feat(sdk): Mistral-Medium-3.5 (Mistral3) multimodal model support

### DIFF
--- a/aic-core/src/aiconfigurator_core/model_configs/mistralai--Mistral-Medium-3.5-128B_config.json
+++ b/aic-core/src/aiconfigurator_core/model_configs/mistralai--Mistral-Medium-3.5-128B_config.json
@@ -1,0 +1,76 @@
+{
+  "architectures": [
+    "Mistral3ForConditionalGeneration"
+  ],
+  "dtype": "bfloat16",
+  "image_token_index": 10,
+  "model_type": "mistral3",
+  "multimodal_projector_bias": false,
+  "projector_hidden_act": "gelu",
+  "quantization_config": {
+    "activation_scheme": "static",
+    "dequantize": false,
+    "modules_to_not_convert": [
+      "model.vision_tower",
+      "model.multi_modal_projector",
+      "lm_head"
+    ],
+    "quant_method": "fp8",
+    "weight_block_size": null
+  },
+  "spatial_merge_size": 2,
+  "text_config": {
+    "attention_dropout": 0.0,
+    "bos_token_id": 1,
+    "eos_token_id": 2,
+    "head_dim": 128,
+    "hidden_act": "silu",
+    "hidden_size": 12288,
+    "initializer_range": 0.02,
+    "intermediate_size": 28672,
+    "max_position_embeddings": 262144,
+    "model_type": "ministral3",
+    "num_attention_heads": 96,
+    "num_hidden_layers": 88,
+    "num_key_value_heads": 8,
+    "pad_token_id": 11,
+    "rms_norm_eps": 1e-05,
+    "rope_parameters": {
+      "beta_fast": 4.0,
+      "beta_slow": 1.0,
+      "factor": 64.0,
+      "llama_4_scaling_beta": 0,
+      "mscale": 1.0,
+      "mscale_all_dim": 0.0,
+      "original_max_position_embeddings": 4096,
+      "rope_theta": 1000000.0,
+      "rope_type": "yarn",
+      "type": "yarn"
+    },
+    "sliding_window": null,
+    "tie_word_embeddings": false,
+    "use_cache": true,
+    "vocab_size": 131072
+  },
+  "tie_word_embeddings": false,
+  "transformers_version": "5.6.0.dev0",
+  "vision_config": {
+    "attention_dropout": 0.0,
+    "head_dim": 104,
+    "hidden_act": "silu",
+    "hidden_size": 1664,
+    "image_size": 1540,
+    "initializer_range": 0.02,
+    "intermediate_size": 8192,
+    "model_type": "pixtral",
+    "num_attention_heads": 16,
+    "num_channels": 3,
+    "num_hidden_layers": 48,
+    "patch_size": 14,
+    "rope_parameters": {
+      "rope_theta": 10000.0,
+      "rope_type": "default"
+    }
+  },
+  "vision_feature_layer": -1
+}

--- a/aic-core/src/aiconfigurator_core/sdk/common.py
+++ b/aic-core/src/aiconfigurator_core/sdk/common.py
@@ -183,6 +183,9 @@ class VisionEncoderConfig:
             rotated fraction — the 2-axis vision RoPE always rotates the full
             head_dim (vLLM ApplyRotaryEmb / SGLang cat([cos, cos])). Only gates
             the encoder_rope_apply op; 0.0 means no RoPE.
+        gated_mlp (bool): ViT FFN is a gated (SwiGLU-style) MLP with separate
+            gate and up projections (e.g. Pixtral, hidden_act="silu"). False
+            (default) models a plain up/down MLP (e.g. Qwen3-VL, GELU).
     """
 
     depth: int
@@ -197,6 +200,7 @@ class VisionEncoderConfig:
     projector_dims: tuple[tuple[int, int], ...] = ()
     projector_n_instances: int = 1
     partial_rotary_factor: float = 0.0
+    gated_mlp: bool = False
 
 
 @dataclass(frozen=True)
@@ -638,6 +642,8 @@ DefaultHFModels = {
     "stepfun-ai/Step-3.7-Flash-FP8",
     "nvidia/Gemma-4-26B-A4B-NVFP4",
     "nvidia/Gemma-4-31B-IT-NVFP4",
+    # Mistral Medium 3.5 Models
+    "mistralai/Mistral-Medium-3.5-128B",
 }
 
 # Bundled model configs and the default support-matrix roster intentionally have
@@ -703,6 +709,7 @@ ModelFamily = {
     "GEMMA4MIX",
     "MINIMAXM3",
     "STEP3P7",
+    "MISTRAL3",
 }
 ARCHITECTURE_TO_MODEL_FAMILY = {
     "LlamaForCausalLM": "LLAMA",
@@ -741,6 +748,7 @@ ARCHITECTURE_TO_MODEL_FAMILY = {
     "Qwen3_5ForConditionalGeneration": "QWEN35",
     "Qwen3_5MoeForConditionalGeneration": "QWEN35",
     "Gemma4ForConditionalGeneration": "GEMMA4MIX",
+    "Mistral3ForConditionalGeneration": "MISTRAL3",
 }
 
 # Multimodal architectures whose LLM config lives under a nested key (e.g. "text_config").
@@ -760,6 +768,7 @@ MULTIMODAL_TEXT_CONFIG_KEY = {
     "Qwen3VLForConditionalGeneration": "text_config",
     "Qwen3VLMoeForConditionalGeneration": "text_config",
     "MiniMaxM3SparseForConditionalGeneration": "text_config",
+    "Mistral3ForConditionalGeneration": "text_config",
 }
 
 # Architectures whose speculative decoding is DSPARK-style: ``nextn`` is the

--- a/aic-core/src/aiconfigurator_core/sdk/models/__init__.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/__init__.py
@@ -184,6 +184,7 @@ from aiconfigurator_core.sdk.models.gemma4 import Gemma4MixModel
 from aiconfigurator_core.sdk.models.gpt import GPTModel
 from aiconfigurator_core.sdk.models.hybrid_moe import HybridMoEModel
 from aiconfigurator_core.sdk.models.llama import LLAMAModel
+from aiconfigurator_core.sdk.models.mistral3 import Mistral3Model
 from aiconfigurator_core.sdk.models.moe import MOEModel
 from aiconfigurator_core.sdk.models.nemotron_h import NemotronHModel
 from aiconfigurator_core.sdk.models.nemotron_nas import NemotronNas
@@ -200,6 +201,7 @@ __all__ = [
     "HybridMoEModel",
     "LLAMAModel",
     "MOEModel",
+    "Mistral3Model",
     "NemotronHModel",
     "NemotronNas",
     "Qwen3VLMoEModel",

--- a/aic-core/src/aiconfigurator_core/sdk/models/blocks/vit.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/blocks/vit.py
@@ -18,6 +18,7 @@ For a ViT with depth D and projector_dims with P (in, out) pairs::
     encoder_proj_gemm     GEMM  (low_precision_input=True)
     encoder_ar_1          CustomAllReduce
     encoder_add_norm_2    ElementWise
+    encoder_gate_gemm     GEMM  (only if gated_mlp; SwiGLU gate projection)
     encoder_ffn1_gemm     GEMM
     encoder_act           ElementWise
     encoder_ffn2_gemm     GEMM  (low_precision_input=True)
@@ -108,6 +109,14 @@ def _vit_transformer_ops(enc_cfg: common.VisionEncoderConfig, tp_size: int) -> l
         ),
         ops.CustomAllReduce("encoder_ar_1", depth, h_vit, tp_size),
         ops.ElementWise("encoder_add_norm_2", depth, 2 * h_vit, 2 * h_vit, 0.8),
+        # SwiGLU-style FFN (enc_cfg.gated_mlp) has a separate gate projection
+        # (hidden -> intermediate) alongside the up projection below; plain
+        # up/down FFNs omit it.
+        *(
+            [ops.GEMM("encoder_gate_gemm", depth, inter_vit // tp_size, h_vit, vit_gemm_mode)]
+            if enc_cfg.gated_mlp
+            else []
+        ),
         ops.GEMM(
             "encoder_ffn1_gemm",
             depth,

--- a/aic-core/src/aiconfigurator_core/sdk/models/mistral3.py
+++ b/aic-core/src/aiconfigurator_core/sdk/models/mistral3.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from aiconfigurator_core.sdk import common
+from aiconfigurator_core.sdk.models.base import BaseModel, register_model
+from aiconfigurator_core.sdk.models.llama import LLAMAModel
+
+from .blocks.vit import build_encoder_ops
+
+
+@register_model("MISTRAL3")
+class Mistral3Model(LLAMAModel):
+    """
+    Mistral-Medium-3.5 series. Extends LLAMAModel with a Pixtral vision encoder.
+
+    The LLM backbone (text_config) is a dense GQA decoder and reuses all
+    LLAMAModel context/generation ops. The Pixtral ViT (vision_config) runs
+    before the LLM prefill phase and is represented as encoder_ops.
+
+    ViT ops run in bfloat16 regardless of LLM quantization. The ViT FFN is
+    SwiGLU (gated_mlp), so build_encoder_ops emits a separate gate projection.
+    Encoder parallelism follows ModelConfig.enable_encoder_dp: DP replicas over
+    the tp_size ranks by default, legacy TP sharding otherwise.
+    """
+
+    @classmethod
+    def create(cls, model_info: dict, model_config, backend_name: str) -> BaseModel:
+        return cls(
+            model_info["model_path"],
+            model_info["model_family"],
+            model_info["architecture"],
+            model_info["layers"],
+            model_info["n"],
+            model_info["n_kv"],
+            model_info["d"],
+            model_info["hidden_size"],
+            model_info["inter_size"],
+            model_info["vocab"],
+            model_info["context"],
+            model_config,
+            model_info["extra_params"],
+            encoder_config=model_info["extra_params"],
+        )
+
+    def __init__(self, *args, encoder_config: common.VisionEncoderConfig) -> None:
+        super().__init__(*args)
+
+        if encoder_config is None:
+            return
+        self.encoder_config = encoder_config
+        # EPD language-only workers keep encoder_config (vision tokens still
+        # extend the LLM context) but never host the ViT ops.
+        if not self.config.language_only:
+            self.encoder_ops.extend(
+                build_encoder_ops(encoder_config, self.config.tp_size, self.config.enable_encoder_dp)
+            )

--- a/aic-core/src/aiconfigurator_core/sdk/utils.py
+++ b/aic-core/src/aiconfigurator_core/sdk/utils.py
@@ -522,6 +522,10 @@ def _parse_hf_config_json(config: dict) -> dict:
     """
     architecture = config["architectures"][0]
     vision_cfg = config.get("vision_config")
+    # Captured before the text_config flatten below drops top-level keys.
+    # Mistral3/Pixtral keeps spatial_merge_size at the top level (Qwen3-VL
+    # nests it inside vision_config).
+    top_level_spatial_merge_size = config.get("spatial_merge_size") if vision_cfg else None
 
     # For multimodal models, unwrap the nested text config so that all LLM
     # parameters (layers, hidden_size, MoE fields, etc.) are read from the
@@ -931,6 +935,54 @@ def _parse_hf_config_json(config: dict) -> dict:
             )
             logger.info(
                 "Qwen3VL vision encoder config: depth=%d, hidden=%d, patch=%d, spatial_merge=%d",
+                extra_params.depth,
+                extra_params.hidden_size,
+                extra_params.patch_size,
+                extra_params.spatial_merge_size,
+            )
+    elif architecture == "Mistral3ForConditionalGeneration":
+        if vision_cfg:
+            # spatial_merge_size sizes both the patch merger and the image-token
+            # counts; a silent default would mispredict, so require a positive
+            # integer (reject missing/None, bool, non-int, and <= 0).
+            merge = top_level_spatial_merge_size
+            if not isinstance(merge, int) or isinstance(merge, bool) or merge <= 0:
+                raise ValueError(
+                    "Mistral3 config needs a positive integer top-level 'spatial_merge_size' to size "
+                    f"the Pixtral patch merger and per-image token counts; got {merge!r}."
+                )
+            vit_hidden = vision_cfg["hidden_size"]
+            # After the text_config flatten, hidden_size is the LLM hidden dim,
+            # which is the projector's output dimension.
+            text_hidden = hidden_size
+            # PatchMerger fuses spatial_merge_size² patches per token, so the
+            # projector's first GEMM takes vit_hidden * spatial_merge_size² in:
+            #   patch_merger:  merger_dim -> vit_hidden
+            #   linear_1:      vit_hidden -> text_hidden
+            #   linear_2:      text_hidden -> text_hidden
+            merger_dim = vit_hidden * merge**2
+            # ViT FFN is SwiGLU (hidden_act="silu"); gated_mlp=True adds the
+            # separate gate projection the plain up/down builder omits. The
+            # generic projector builder adds an activation after every non-final
+            # GEMM (a spurious post-merger act vs Mistral3, which activates only
+            # after linear_1) and omits the pre-merger RMSNorm; both are tiny
+            # ElementWise terms and do not affect the projector GEMM cost.
+            extra_params = VisionEncoderConfig(
+                depth=vision_cfg["num_hidden_layers"],
+                hidden_size=vit_hidden,
+                num_heads=vision_cfg["num_attention_heads"],
+                intermediate_size=vision_cfg["intermediate_size"],
+                patch_size=vision_cfg["patch_size"],
+                temporal_patch_size=1,
+                spatial_merge_size=merge,
+                out_hidden_size=text_hidden,
+                projector_dims=((merger_dim, vit_hidden), (vit_hidden, text_hidden), (text_hidden, text_hidden)),
+                projector_n_instances=1,
+                partial_rotary_factor=0.5,
+                gated_mlp=True,
+            )
+            logger.info(
+                "Mistral3 (Pixtral) vision encoder config: depth=%d, hidden=%d, patch=%d, spatial_merge=%d",
                 extra_params.depth,
                 extra_params.hidden_size,
                 extra_params.patch_size,

--- a/src/aiconfigurator/sdk/models/mistral3.py
+++ b/src/aiconfigurator/sdk/models/mistral3.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compatibility alias for aiconfigurator_core.sdk.models.mistral3."""
+
+from aiconfigurator.sdk._compat import alias_module as _alias_module
+
+_alias_module(__name__, "aiconfigurator_core.sdk.models.mistral3")

--- a/tests/cross_package/test_import_contract.py
+++ b/tests/cross_package/test_import_contract.py
@@ -43,6 +43,7 @@ CORE_SDK_LEAF_MODULES = [
     "models.kimi_k3",
     "models.llama",
     "models.minimax_m3",
+    "models.mistral3",
     "models.moe",
     "models.nemotron_h",
     "models.nemotron_nas",

--- a/tests/unit/sdk/models/test_mistral3.py
+++ b/tests/unit/sdk/models/test_mistral3.py
@@ -1,0 +1,162 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Mistral-Medium-3.5 multimodal support.
+
+The ``Mistral3ForConditionalGeneration`` architecture is a dense GQA text
+decoder mapped to the LLAMA op graph plus a Pixtral (gated/SwiGLU) vision
+encoder. Covers architecture routing, the Pixtral vision-config parsing
+(including the top-level spatial_merge_size that the text_config flatten would
+otherwise drop), the gated ViT FFN gate projection, and the assembled model
+graph.
+"""
+
+import pytest
+
+from aiconfigurator.sdk import common
+from aiconfigurator.sdk import config as sdk_config
+from aiconfigurator.sdk.models import get_model, get_model_family
+from aiconfigurator.sdk.models.blocks.vit import build_encoder_ops
+from aiconfigurator.sdk.utils import _parse_hf_config_json
+
+pytestmark = pytest.mark.unit
+
+_MODEL_PATH = "mistralai/Mistral-Medium-3.5-128B"
+
+
+def _raw_config():
+    """Minimal Mistral3 config with the fields the parser reads. spatial_merge_size
+    sits at the TOP level (Pixtral), not inside vision_config."""
+    return {
+        "architectures": ["Mistral3ForConditionalGeneration"],
+        "model_type": "mistral3",
+        "spatial_merge_size": 2,
+        "vision_feature_layer": -1,
+        "text_config": {
+            "head_dim": 128,
+            "hidden_size": 12288,
+            "intermediate_size": 28672,
+            "max_position_embeddings": 262144,
+            "num_attention_heads": 96,
+            "num_hidden_layers": 88,
+            "num_key_value_heads": 8,
+            "vocab_size": 131072,
+        },
+        "vision_config": {
+            "head_dim": 104,
+            "hidden_size": 1664,
+            "intermediate_size": 8192,
+            "num_attention_heads": 16,
+            "num_hidden_layers": 48,
+            "patch_size": 14,
+        },
+    }
+
+
+class TestMistral3ConfigParsing:
+    def test_architecture_maps_to_mistral3_family(self):
+        assert common.ARCHITECTURE_TO_MODEL_FAMILY["Mistral3ForConditionalGeneration"] == "MISTRAL3"
+        assert "MISTRAL3" in common.ModelFamily
+
+    def test_text_decoder_fields_from_text_config(self):
+        result = _parse_hf_config_json(_raw_config())
+        assert result["architecture"] == "Mistral3ForConditionalGeneration"
+        assert result["layers"] == 88
+        assert result["n"] == 96
+        assert result["n_kv"] == 8
+        assert result["d"] == 128
+        assert result["hidden_size"] == 12288
+        assert result["inter_size"] == 28672
+        assert result["vocab"] == 131072
+
+    def test_vision_encoder_config(self):
+        ep = _parse_hf_config_json(_raw_config())["extra_params"]
+        assert isinstance(ep, common.VisionEncoderConfig)
+        assert ep.depth == 48
+        assert ep.hidden_size == 1664
+        assert ep.num_heads == 16
+        # head_size derives from hidden/heads and must match the HF head_dim (104).
+        assert ep.hidden_size // ep.num_heads == 104
+        assert ep.intermediate_size == 8192
+        assert ep.patch_size == 14
+        assert ep.temporal_patch_size == 1
+        # Pulled from the TOP-LEVEL spatial_merge_size, not vision_config.
+        assert ep.spatial_merge_size == 2
+        assert ep.out_hidden_size == 12288
+        assert ep.gated_mlp is True
+        assert ep.partial_rotary_factor > 0
+
+    def test_projector_dims_are_three_pixtral_gemms(self):
+        ep = _parse_hf_config_json(_raw_config())["extra_params"]
+        # patch_merger (merger_dim -> vit_hidden), linear_1 (vit_hidden -> text),
+        # linear_2 (text -> text). merger_dim = vit_hidden * spatial_merge_size**2.
+        assert ep.projector_dims == ((1664 * 4, 1664), (1664, 12288), (12288, 12288))
+
+    @pytest.mark.parametrize("bad", [None, 0, -2, 2.5, True])
+    def test_invalid_top_level_spatial_merge_raises(self, bad):
+        # spatial_merge_size sizes the patch merger and image-token counts; a
+        # silent default (or a truthy-but-invalid value: negative, non-int,
+        # bool) would mispredict, so require a positive integer and fail loud.
+        cfg = _raw_config()
+        cfg["spatial_merge_size"] = bad
+        with pytest.raises(ValueError, match="spatial_merge_size"):
+            _parse_hf_config_json(cfg)
+
+    def test_missing_top_level_spatial_merge_raises(self):
+        cfg = _raw_config()
+        del cfg["spatial_merge_size"]
+        with pytest.raises(ValueError, match="spatial_merge_size"):
+            _parse_hf_config_json(cfg)
+
+
+class TestGatedViTBuilder:
+    def _cfg(self, gated):
+        return common.VisionEncoderConfig(
+            depth=2,
+            hidden_size=1664,
+            num_heads=16,
+            intermediate_size=8192,
+            patch_size=14,
+            temporal_patch_size=1,
+            spatial_merge_size=2,
+            out_hidden_size=12288,
+            projector_dims=((6656, 1664), (1664, 12288), (12288, 12288)),
+            gated_mlp=gated,
+        )
+
+    def test_gated_mlp_emits_gate_gemm(self):
+        names = [op._name for op in build_encoder_ops(self._cfg(gated=True), tp_size=1)]
+        assert "encoder_gate_gemm" in names
+        # gate sits before the up projection.
+        assert names.index("encoder_gate_gemm") < names.index("encoder_ffn1_gemm")
+
+    def test_plain_mlp_has_no_gate_gemm(self):
+        names = [op._name for op in build_encoder_ops(self._cfg(gated=False), tp_size=1)]
+        assert "encoder_gate_gemm" not in names
+        assert "encoder_ffn1_gemm" in names
+
+
+class TestMistral3ModelGraph:
+    def test_builds_as_mistral3_model_with_encoder(self):
+        assert get_model_family(_MODEL_PATH) == "MISTRAL3"
+        model_config = sdk_config.ModelConfig(tp_size=1, attention_dp_size=1)
+        model = get_model(_MODEL_PATH, model_config, backend_name="trtllm")
+
+        assert model.model_family == "MISTRAL3"
+        assert type(model).__name__ == "Mistral3Model"
+        # Dense Mistral GQA has no per-layer q/k norm.
+        assert model._use_qk_norm is False
+
+        ctx = {op._name for op in model.context_ops}
+        assert "context_attention" in ctx and "context_qkv_gemm" in ctx
+
+        enc = [op._name for op in model.encoder_ops]
+        assert "encoder_attention" in enc
+        assert "encoder_gate_gemm" in enc
+        assert "encoder_projector_fc0_gemm" in enc
+        assert "encoder_projector_fc2_gemm" in enc
+
+    def test_fp8_static_text_gemm_from_checkpoint(self):
+        model_config = sdk_config.ModelConfig(tp_size=1, attention_dp_size=1)
+        get_model(_MODEL_PATH, model_config, backend_name="trtllm")
+        assert model_config.gemm_quant_mode == common.GEMMQuantMode.fp8_static


### PR DESCRIPTION
## Summary

Adds full multimodal modeling for **Mistral-Medium-3.5-128B** (`Mistral3ForConditionalGeneration`): a dense GQA text decoder mapped onto the LLAMA op graph, plus the **Pixtral** vision encoder (ViT + SwiGLU FFN + 3-GEMM multimodal projector).

Data half is #1603 (Pixtral head_dim=104 encoder-attention cases + h200 rows). This PR works standalone for **text-only** serving on every backend; **image** evaluation lights up on vLLM/SGLang once #1603's data is on main.

## Changes (`aic-core` SDK)
- **`common.py`**: new `MISTRAL3` family + arch mapping; `text_config` flatten entry; `gated_mlp` flag on `VisionEncoderConfig`; model added to `DefaultHFModels` (and thus the default support matrix — text serving is viable on all backends).
- **`utils.py`**: parse the Pixtral `vision_config` into a `VisionEncoderConfig`, capturing the **top-level** `spatial_merge_size` before the `text_config` flatten drops it (raises if absent), and modeling the 3-GEMM projector (patch-merger → linear_1 → linear_2).
- **`blocks/vit.py`**: emit the SwiGLU gate projection (`encoder_gate_gemm`) when `gated_mlp` is set; unchanged for plain (Qwen3-VL) ViT FFNs.
- **`models/mistral3.py`**: `Mistral3Model(LLAMAModel)` attaching the encoder ops (+ legacy compat shim).
- Bundled the HF config for offline loading; unit tests; import-contract entry.

## Notes
- **TensorRT-LLM vision is unsupported**: no FMHA kernel for head_dim=104 (verified on H200). Text serving on trtllm is fine; the trtllm image path is classified unsupported via the absence of head_dim=104 data. The default support-matrix workload is text-only, so matrix membership is safe.
- FP8-static text GEMMs inferred from the checkpoint; ViT runs bf16 (matching `modules_to_not_convert`).

## Validation
- 774 SDK unit tests + import-contract + roster tests pass; ruff clean.
- Text-only eval works on all backends (h200: ttft≈146ms, tpot≈7.4ms).
- With #1603: image eval on h200 → vLLM `encoder_latency≈40ms` / SGLang `≈44ms` folded into TTFT; trtllm correctly raises the unsupported vision path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the Mistral Medium 3.5 128B multimodal model.
  - Added Pixtral vision processing, image-token handling, projector settings, and FP8 quantization support.
  - Added support for gated vision encoder layers and language-only operation.

- **Bug Fixes**
  - Improved multimodal configuration parsing and validation, including spatial merge settings.

- **Tests**
  - Added coverage for model routing, vision configuration, model assembly, gated layers, and quantization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->