### PR TITLE
ci: install prebuilt cargo-deny instead of compiling from source

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -27,14 +27,21 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
-      - name: Install and run cargo-deny
+      - name: Install cargo-deny
+        # Use a prebuilt binary instead of `cargo install cargo-deny@0.19.0`,
+        # which compiles cargo-deny and its dependency tree from source and
+        # currently fails building the transitive `tinyvec` crate under the
+        # runner's Rust toolchain (its `use alloc::vec::{self, Vec}` shadows the
+        # `vec!` macro, now a hard error). Same pinned version, no compile.
+        uses: taiki-e/install-action@e67fa11c4b9316fa714ddf0abed07a0c3143b95b # v2.87.4
+        with:
+          tool: cargo-deny@0.19.0
+      - name: Run cargo-deny
         working-directory: aic-core/rust/aiconfigurator-core
         # Default log level (warn) surfaces "license inferred from file" notes
         # so any crate that may need a [[licenses.clarify]] entry is named.
         # --show-stats prints a per-license usage summary at the end.
-        run: |
-          cargo-deny --version || cargo install cargo-deny@0.19.0
-          cargo-deny --all-features check --show-stats licenses bans
+        run: cargo-deny --all-features check --show-stats licenses bans
 
   core-public-api-contract:
     name: aic-core public API contract


### PR DESCRIPTION
## Problem

The **Cargo Deny** job is failing on every open PR (the failure is in building the linter, so it's independent of PR content; `main` shows a stale green from its last run). It runs:

```
cargo-deny --version || cargo install cargo-deny@0.19.0
```

`cargo install` compiles cargo-deny and its whole dependency tree from source, and that build now fails on the transitive crate `tinyvec`:

```
error: cannot find macro `vec` in this scope        (tinyvec/…/lib.rs:710)
note: `vec` is imported here, but it is a module, not a macro
      use alloc::vec::{self, Vec};
error: could not compile `tinyvec` (lib) due to 1 previous error
error: failed to compile `cargo-deny v0.19.0`
```

`tinyvec`'s `use alloc::vec::{self, Vec}` shadows the `vec!` macro, which is a hard error under the runner's current Rust toolchain — so cargo-deny never builds and the check can't run.

## Fix

Install the **pinned prebuilt** cargo-deny 0.19.0 binary via `taiki-e/install-action` instead of compiling from source. Same version, same `cargo-deny … check` command — it just skips the source build, so the `tinyvec` breakage no longer applies. The action is SHA-pinned per repo convention.

## Notes
- No change to the deny ruleset, version, or checks performed.
- Unblocks Cargo Deny for all open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the dependency license and bans validation workflow to use a pinned tool version.
  * Improved consistency and reliability of automated checks across builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->