### PR TITLE
fix(tests): reuse real torch across collector test modules

### DIFF
--- a/tests/unit/collector/_real_torch.py
+++ b/tests/unit/collector/_real_torch.py
@@ -17,7 +17,11 @@ _real_torch: ModuleType | None = None
 
 @contextmanager
 def real_torch() -> Iterator[ModuleType]:
-    """Cache torch's native registrations and restore the caller's module entry."""
+    """Borrow torch, restoring any existing module entry on exit.
+
+    A first import remains registered when there was no previous entry. Removing
+    it would make a later ordinary import repeat torch's native registrations.
+    """
     global _real_torch
     previous = sys.modules.get("torch")
     try:

--- a/tests/unit/collector/_real_torch.py
+++ b/tests/unit/collector/_real_torch.py
@@ -13,17 +13,14 @@ from unittest.mock import MagicMock
 import pytest
 
 _real_torch: ModuleType | None = None
+_MISSING = object()
 
 
 @contextmanager
 def real_torch() -> Iterator[ModuleType]:
-    """Borrow torch, restoring any existing module entry on exit.
-
-    A first import remains registered when there was no previous entry. Removing
-    it would make a later ordinary import repeat torch's native registrations.
-    """
+    """Borrow torch, restoring the original module state on exit."""
     global _real_torch
-    previous = sys.modules.get("torch")
+    previous = sys.modules.get("torch", _MISSING)
     try:
         if _real_torch is None:
             if isinstance(previous, MagicMock):
@@ -35,5 +32,7 @@ def real_torch() -> Iterator[ModuleType]:
         sys.modules["torch"] = _real_torch
         yield _real_torch
     finally:
-        if previous is not None:
+        if previous is _MISSING:
+            sys.modules.pop("torch", None)
+        else:
             sys.modules["torch"] = previous

--- a/tests/unit/collector/_real_torch.py
+++ b/tests/unit/collector/_real_torch.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Borrow real torch without disturbing collector tests that require a mock."""
+
+import importlib
+import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import pytest
+
+_real_torch: ModuleType | None = None
+
+
+@contextmanager
+def real_torch() -> Iterator[ModuleType]:
+    """Cache torch's native registrations and restore the caller's module entry."""
+    global _real_torch
+    previous = sys.modules.get("torch")
+    try:
+        if _real_torch is None:
+            if isinstance(previous, MagicMock):
+                sys.modules.pop("torch")
+            try:
+                _real_torch = importlib.import_module("torch")
+            except ImportError:
+                pytest.skip("real torch required for tensor operations", allow_module_level=True)
+        sys.modules["torch"] = _real_torch
+        yield _real_torch
+    finally:
+        if previous is not None:
+            sys.modules["torch"] = previous

--- a/tests/unit/collector/test_dsv4_megamoe_workload.py
+++ b/tests/unit/collector/test_dsv4_megamoe_workload.py
@@ -1,36 +1,26 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import sys
 from argparse import Namespace
-from unittest.mock import MagicMock
 
 import pytest
 
-_saved_mock = sys.modules.get("torch")
-_restore_mock = isinstance(_saved_mock, MagicMock)
-if _restore_mock:
-    sys.modules.pop("torch")
+from tests.unit.collector._real_torch import real_torch
 
-try:
-    import torch as _real_torch
-except ImportError:
-    if _restore_mock:
-        sys.modules["torch"] = _saved_mock
-    pytest.skip("real torch required for tensor operations", allow_module_level=True)
-
-try:
+with real_torch() as torch:
     from collector.sglang.collect_dsv4_megamoe import build_cases
     from collector.sglang.dsv4_megamoe_workload import (
         _sampled_power_law_xmax,
         build_routing_plan,
         parse_distribution,
     )
-finally:
-    if _restore_mock:
-        sys.modules["torch"] = _saved_mock
 
-torch = _real_torch
+
+@pytest.fixture(autouse=True)
+def _use_real_torch():
+    # Routing helpers import torch lazily while the other collector tests need a mock.
+    with real_torch():
+        yield
 
 
 @pytest.mark.unit

--- a/tests/unit/collector/test_helper_moe_distribution.py
+++ b/tests/unit/collector/test_helper_moe_distribution.py
@@ -14,39 +14,16 @@ KV-cache stack. That is left for a follow-up if the function is ever refactored.
 """
 
 import sys
-from unittest.mock import MagicMock
 
 import pytest
 
-# test_collect_provenance_writer deliberately leaves a MagicMock cached as
-# sys.modules["torch"] (collect.py's fork-worker tests depend on it), so a
-# plain importorskip("torch") can "succeed" with the mock and every tensor
-# assertion below dies with `TypeError: '<' not supported between instances
-# of 'MagicMock' and 'int'` — whether that happens depends only on which
-# module pytest-xdist imports first on the worker (same pattern as
-# test_dsv4_megamoe_workload). Evict the mock, import the real torch (or
-# skip when it isn't installed), then put the mock back for the siblings
-# that rely on it. The restore lives in a `finally` so even an unexpected
-# import failure (e.g. an OSError loading torch's native libraries) cannot
-# leave the eviction in place; do NOT let collect.py see the real torch —
-# its fork-worker tests deadlock on macOS with a real torch cached.
-_saved_mock = sys.modules.get("torch")
-_restore_mock = isinstance(_saved_mock, MagicMock)
-if _restore_mock:
-    sys.modules.pop("torch")
-try:
-    import torch
-except ImportError:
-    # pytest.skip raises; the mock is restored by the finally during unwind.
-    pytest.skip("real torch required for tensor operations", allow_module_level=True)
-finally:
-    if _restore_mock:
-        sys.modules["torch"] = _saved_mock
+from tests.unit.collector._real_torch import real_torch
 
-from collector.helper import (
-    _generate_power_law_distribution,
-    _round_robin_adjust_per_rank,
-)
+with real_torch() as torch:
+    from collector.helper import (
+        _generate_power_law_distribution,
+        _round_robin_adjust_per_rank,
+    )
 
 pytestmark = pytest.mark.unit
 

--- a/tests/unit/collector/test_real_torch.py
+++ b/tests/unit/collector/test_real_torch.py
@@ -3,6 +3,7 @@
 
 """Exercise real tensor operations across repeated mock-preserving imports."""
 
+import importlib
 import sys
 from unittest.mock import MagicMock
 
@@ -25,6 +26,8 @@ def test_repeated_borrows_preserve_module_entry(monkeypatch, entry):
             assert sys.modules["torch"] is torch
             assert torch.arange(3).sum().item() == 3
         assert sys.modules["torch"] is (torch if entry is None else entry)
+        if entry is None:
+            assert importlib.import_module("torch") is torch
 
 
 def test_borrow_restores_mock_when_body_raises(monkeypatch):

--- a/tests/unit/collector/test_real_torch.py
+++ b/tests/unit/collector/test_real_torch.py
@@ -3,7 +3,6 @@
 
 """Exercise real tensor operations across repeated mock-preserving imports."""
 
-import importlib
 import sys
 from unittest.mock import MagicMock
 
@@ -25,9 +24,10 @@ def test_repeated_borrows_preserve_module_entry(monkeypatch, entry):
         with real_torch() as torch:
             assert sys.modules["torch"] is torch
             assert torch.arange(3).sum().item() == 3
-        assert sys.modules["torch"] is (torch if entry is None else entry)
         if entry is None:
-            assert importlib.import_module("torch") is torch
+            assert "torch" not in sys.modules
+        else:
+            assert sys.modules["torch"] is entry
 
 
 def test_borrow_restores_mock_when_body_raises(monkeypatch):

--- a/tests/unit/collector/test_real_torch.py
+++ b/tests/unit/collector/test_real_torch.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Exercise real tensor operations across repeated mock-preserving imports."""
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.unit.collector._real_torch import real_torch
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize("entry", [None, MagicMock()])
+def test_repeated_borrows_preserve_module_entry(monkeypatch, entry):
+    if entry is None:
+        monkeypatch.delitem(sys.modules, "torch", raising=False)
+    else:
+        monkeypatch.setitem(sys.modules, "torch", entry)
+
+    for _ in range(3):
+        with real_torch() as torch:
+            assert sys.modules["torch"] is torch
+            assert torch.arange(3).sum().item() == 3
+        assert sys.modules["torch"] is (torch if entry is None else entry)
+
+
+def test_borrow_restores_mock_when_body_raises(monkeypatch):
+    mock_torch = MagicMock()
+    monkeypatch.setitem(sys.modules, "torch", mock_torch)
+
+    with pytest.raises(RuntimeError, match="consumer failed"), real_torch() as torch:
+        assert torch.ones(2).sum().item() == 2
+        raise RuntimeError("consumer failed")
+
+    assert sys.modules["torch"] is mock_torch
+
+
+def test_borrow_preserves_existing_real_torch(monkeypatch):
+    with real_torch() as torch:
+        pass
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    with real_torch() as borrowed:
+        assert borrowed is torch
+    assert sys.modules["torch"] is torch

--- a/tests/unit/collector/test_sglang_moe_ep_routing.py
+++ b/tests/unit/collector/test_sglang_moe_ep_routing.py
@@ -4,9 +4,10 @@
 import importlib.util
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
+
+from tests.unit.collector._real_torch import real_torch
 
 
 def _import_helper_module():
@@ -14,33 +15,13 @@ def _import_helper_module():
     helper_path = Path(__file__).resolve().parents[3] / "collector" / "helper.py"
     spec = importlib.util.spec_from_file_location(module_name, helper_path)
     module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
     spec.loader.exec_module(module)
     return module
 
 
-# test_parallel_run.py injects a MagicMock as "torch" into sys.modules so
-# collector code can be imported without CUDA.  This test needs real tensors
-# and a helper.py copy imported against real torch, but it must not permanently
-# replace the injected mock in sys.modules.
-_saved_mock = sys.modules.get("torch")
-_restore_mock = isinstance(_saved_mock, MagicMock)
-if _restore_mock:
-    sys.modules.pop("torch")
-
-try:
-    import torch as _real_torch
-except ImportError:
-    if _restore_mock:
-        sys.modules["torch"] = _saved_mock
-    pytest.skip("real torch required for tensor operations", allow_module_level=True)
-
-try:
+with real_torch() as torch:
     _HELPER_MODULE = _import_helper_module()
-finally:
-    if _restore_mock:
-        sys.modules["torch"] = _saved_mock
-
-torch = _real_torch
 
 
 @pytest.fixture(autouse=True)
@@ -48,7 +29,7 @@ def _use_real_torch(monkeypatch):
     # At test execution time sys.modules["torch"] is still test_parallel_run.py's
     # MagicMock. helper.py functions do lazy `import torch`, so they pick up the
     # mock rather than the real module. Swap in real torch for each test's duration.
-    monkeypatch.setitem(sys.modules, "torch", _real_torch)
+    monkeypatch.setitem(sys.modules, "torch", torch)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
#### Overview:

On machines with PyTorch installed, collecting the collector tests after the provenance tests imports PyTorch repeatedly while borrowing it from a mocked `sys.modules` entry. The second import fails with `Only a single TORCH_LIBRARY can be used to register the namespace triton`.

Cache the real module in one shared test helper and restore an existing caller module entry after each borrow. When PyTorch was not previously imported, retain the ordinary import behavior so subsequent plain imports reuse its native registrations.

#### Details:

- Share the borrow context across the three tensor-dependent collector test modules, including DSV4's lazy imports during test execution.
- Preserve the mock used by `collect.py` and its fork-worker tests.
- Register the routing test's dynamically loaded helper module before executing it. Once the PyTorch collection error is removed, its dataclass annotations need the module in `sys.modules` on Python 3.13.
- Exercise repeated tensor operations, mock restoration after exceptions, and an existing real module.

Validation on Linux, Python 3.13.13, PyTorch 2.13.0+cpu:

- Baseline: provenance followed by the three tensor test modules fails with two TORCH_LIBRARY collection errors.
- Fixed: the three modules, provenance writer, parallel-run fork-worker tests, and new helper tests pass together: **301 passed**.
- Fresh-process check confirms ordinary import after the first borrow works and three successive mock swaps reuse the real module.
- Applicable Ruff and Ruff-format pre-commit hooks pass. The all-hook launcher encountered an unrelated existing system Node/npm incompatibility while initializing ESLint; the changed files are Python only.
- Full collector collection remains blocked by eight missing `aiconfigurator_core._aiconfigurator_core` extension imports. The unmodified baseline has those same eight errors plus the two PyTorch errors fixed here. Tests were run with `--confcutdir=tests/unit/collector` and local source paths to avoid the root CLI fixture's dependency on that unbuilt extension.

This addresses the PyTorch import collision in #1422 and verifies the affected fork-worker combination on Linux. It does not change the independent GLM checkpoint expectations mentioned there; macOS deadlock behavior was not tested.

#### Review follow-up and CI baseline:

The first-import behavior is intentional: an originally absent `torch` entry remains registered, while an existing entry (including the collector mock) is restored. A fresh-process check with real PyTorch reproduces the native `TORCH_LIBRARY` error if the entry is removed before a subsequent ordinary import. The helper now documents this distinction explicitly, and the regression checks ordinary imports after borrowing. The related combination still passes all **301 tests**, and Ruff/format pass.

The initial PR's [Rust/Python parity job](https://github.com/ai-dynamo/aiconfigurator/actions/runs/34038559202/job/101501018917) has the same two golden-energy failures, including identical actual values, as the [unmodified main job at this PR's base](https://github.com/ai-dynamo/aiconfigurator/actions/runs/33604681100/job/100165870723): 2 failed, 62 passed. These tests execute separately from the modified collector tests. The initial PR's [unit job](https://github.com/ai-dynamo/aiconfigurator/actions/runs/34038559202/job/101501018953) likewise has the same single `test_power_columns_satisfy_energy_model_input_contract` failure as the [baseline unit job](https://github.com/ai-dynamo/aiconfigurator/actions/runs/33604681100/job/100165870879): both have 2750 passing tests (14 skips on the PR, 12 on the baseline). This PR does not modify those data or energy-model expectations.

#### Where should the reviewer start?

`tests/unit/collector/_real_torch.py`, then the three migrated consumers.

#### Related Issues:

- Relates to #1422 (part 1; Linux validation of part 2).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved test reliability for scenarios requiring the native Torch module.
  - Tests now preserve and restore the prior Torch environment, including when Torch was absent, mocked, or already loaded.
  - Expanded coverage to verify cleanup after repeated usage and ensure temporary test setup does not affect subsequent tests.
  - Simplified setup across collector and routing test suites while retaining appropriate handling for environments where Torch is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->