### PR TITLE
fix(logging): improve recommend mode error messages during escalation

### DIFF
--- a/src/aiconfigurator/cli/api.py
+++ b/src/aiconfigurator/cli/api.py
@@ -11,7 +11,7 @@ This module provides simple function interfaces to the CLI's "default", "exp",
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields, replace
 
 import pandas as pd
 
@@ -392,12 +392,10 @@ def _build_recommend_tasks(base_tasks: dict, total_gpus: int) -> dict:
     and topology-specific caps (e.g. deepep_moe intra-node EP limits,
     non-MoE pinned-to-1 dims) without any manual extension logic.
     """
-    import dataclasses
-
     rebuilt = {}
     for name, task in base_tasks.items():
-        reset = {f.name: None for f in dataclasses.fields(task) if f.name in TASK_REBUILD_FIELDS}
-        rebuilt[name] = dataclasses.replace(task, total_gpus=total_gpus, **reset)
+        reset = {f.name: None for f in fields(task) if f.name in TASK_REBUILD_FIELDS}
+        rebuilt[name] = replace(task, total_gpus=total_gpus, **reset)
     return rebuilt
 
 
@@ -577,6 +575,9 @@ def cli_recommend(
         escalation_budgets.append(budget)
         budget *= 2
 
+    # Initial attempt: interim (False) if escalation budgets exist, final (True) if none
+    is_final = len(escalation_budgets) == 0
+    base_tasks = {name: replace(task, recommend_done=is_final) for name, task in base_tasks.items()}
     result = _execute_and_wrap_result(
         base_tasks,
         mode="default",
@@ -591,6 +592,11 @@ def cli_recommend(
         for name, outcome in result.outcomes.items()
         if outcome.error is not None and is_gpu_retriable(outcome.error)
     ]
+    # If initial attempt has no retriable errors, mark tasks as final for correct diagnostics
+    if not retriable and not is_final:
+        for name in result.tasks:
+            result.tasks[name] = replace(result.tasks[name], recommend_done=True)
+
     for attempt, gpu_budget in enumerate(escalation_budgets):
         if not retriable:
             break
@@ -600,6 +606,9 @@ def cli_recommend(
             gpu_budget,
         )
         tasks = _build_recommend_tasks(base_tasks, gpu_budget)
+        # Mark as final if this is the last escalation budget
+        is_final_attempt = attempt == len(escalation_budgets) - 1
+        tasks = {name: replace(task, recommend_done=is_final_attempt) for name, task in tasks.items()}
         result = _execute_and_wrap_result(
             tasks,
             mode="default",
@@ -614,6 +623,10 @@ def cli_recommend(
             for name, outcome in result.outcomes.items()
             if outcome.error is not None and is_gpu_retriable(outcome.error)
         ]
+        # Early termination: if no more retriable, mark tasks as final
+        if not retriable and not is_final_attempt:
+            for name in result.tasks:
+                result.tasks[name] = replace(result.tasks[name], recommend_done=True)
 
     if not result.best_configs:
         raise NoFeasibleConfigError("No feasible GPU configuration found for the given load target.")

--- a/src/aiconfigurator/cli/main.py
+++ b/src/aiconfigurator/cli/main.py
@@ -2141,6 +2141,7 @@ def _execute_tasks(
     results: dict[str, dict[str, pd.DataFrame]] = {}
     outcomes: dict[str, ExperimentOutcome] = {}
     start_time = time.time()
+    recommend_mode = target_request_rate is not None or target_concurrency is not None
 
     def _run_one(exp_name: str, task) -> tuple[str, dict | None, ExperimentOutcome]:
         """Run a single experiment and return (name, result_or_None, outcome)."""
@@ -2161,7 +2162,7 @@ def _execute_tasks(
             # internally, so --total-gpus advice would point at an ignored flag.
             gpu_hint = (
                 "(2) the model does not fit — try a quantized model; "
-                if target_request_rate is not None or target_concurrency is not None
+                if recommend_mode
                 else "(2) the model does not fit — try a larger --total-gpus value or a quantized model; "
             )
             msg = (
@@ -2178,7 +2179,7 @@ def _execute_tasks(
             return exp_name, None, ExperimentOutcome(exp_name, error=exc)
         except Exception as exc:
             if is_expected_cli_error(exc):
-                logger.log(logging.ERROR, "Error running experiment %s: %s", exp_name, exc)
+                logger.log(logging.INFO, "Experiment %s: %s", exp_name, exc)
                 logger.debug("Traceback for experiment %s", exp_name, exc_info=True)
             else:
                 logger.exception("Error running experiment %s", exp_name)
@@ -2202,17 +2203,27 @@ def _execute_tasks(
     if len(results) < 1:
         first_config = next(iter(tasks.values()), None)
         db_mode = getattr(first_config, "database_mode", None) if first_config else None
-        if db_mode == common.DatabaseMode.SILICON.name:
-            logger.error(
-                "No successful experiment runs to compare. "
-                "If this is a frontier or newly-released model, retry with --database-mode HYBRID "
-                "to extend coverage beyond the silicon database."
-            )
-        else:
-            logger.error("No successful experiment runs to compare.")
+        is_recommend_done = recommend_mode and getattr(first_config, "recommend_done", None) is True
+
+        # Log errors at ERROR level for final attempts, DEBUG for interim escalation
+        if is_recommend_done or not recommend_mode:
+            if db_mode == common.DatabaseMode.SILICON.name:
+                logger.error(
+                    "No successful experiment runs to compare. "
+                    "If this is a frontier or newly-released model, retry with --database-mode HYBRID "
+                    "to extend coverage beyond the silicon database."
+                )
+            elif not recommend_mode:
+                logger.error("No successful experiment runs to compare.")
+
         for outcome in outcomes.values():
             if outcome.error is not None:
-                logger.error("  -> Experiment %s failed: %s", outcome.experiment, outcome.error)
+                logger.log(
+                    logging.INFO if recommend_mode else logging.ERROR,
+                    "  -> Experiment %s: %s",
+                    outcome.experiment,
+                    outcome.error,
+                )
         return "none", {}, {}, {}, {}, outcomes
 
     best_configs: dict[str, pd.DataFrame] = {}

--- a/src/aiconfigurator/sdk/sweep.py
+++ b/src/aiconfigurator/sdk/sweep.py
@@ -473,6 +473,7 @@ def sweep_agg(
     num_gpu_list: list[int] | None = None,
     predictor: Any = None,
     speculative_profile: SpeculativeDecodingProfile | None = None,
+    recommend_done: bool | None = None,
 ) -> pd.DataFrame:
     """Sweep parallel x batch x ctx_tokens for agg; return feasible-candidate DataFrame.
 
@@ -677,10 +678,14 @@ def sweep_agg(
                 "model identity/quant modes). Check the collected cells against the resolved quant "
                 "configuration, or use forward_model='op_level'."
             )
-        raise InsufficientMemoryError(
-            "sweep_agg: no results — model does not fit in GPU memory for any parallel config. "
-            "Try increasing --total-gpus, using a quantized model, or a system with more VRAM per GPU."
-        )
+        msg = "sweep_agg: no results — model does not fit in GPU memory for any parallel config."
+        if recommend_done is False:  # Interim: more budgets to try
+            msg += " Trying with more GPUs and different parallelism combinations..."
+        elif recommend_done is True:  # Complete: no more budgets
+            msg += " No viable configuration found. Try a quantized model or a system with more VRAM per GPU."
+        else:  # None: default mode
+            msg += " Try increasing --total-gpus, using a quantized model, or a system with more VRAM per GPU."
+        raise InsufficientMemoryError(msg)
     if not saw_memory_fit:
         raise KVCacheCapacityError(
             "sweep_agg: no results — requested batch_size exceeds KV cache capacity for all configs. "
@@ -711,6 +716,7 @@ def _get_disagg_worker_candidates(
     predictor: Any = None,
     speculative_profile: SpeculativeDecodingProfile | None = None,
     free_gpu_memory_fraction: float | None = None,
+    recommend_done: bool | None = None,
 ) -> pd.DataFrame:
     """Enumerate (parallel, batch_size) worker candidates for a disagg role.
 
@@ -812,10 +818,14 @@ def _get_disagg_worker_candidates(
                     "matches the model identity/quant modes). Check the collected cells against the "
                     "resolved quant configuration, or use forward_model='op_level'."
                 )
-            raise InsufficientMemoryError(
-                f"sweep_disagg/{role}: no results — model does not fit in GPU memory for any parallel config. "
-                "Try increasing GPU budget, using a quantized model, or a system with more VRAM per GPU."
-            )
+            msg = f"sweep_disagg/{role}: no results — model does not fit in GPU memory for any parallel config."
+            if recommend_done is False:  # Interim: more budgets to try
+                msg += " Trying with more GPUs and different parallelism combinations..."
+            elif recommend_done is True:  # Complete: no more budgets
+                msg += " No viable configuration found. Try a quantized model or a system with more VRAM per GPU."
+            else:  # None: default mode
+                msg += " Try increasing GPU budget, using a quantized model, or a system with more VRAM per GPU."
+            raise InsufficientMemoryError(msg)
         raise NoFeasibleConfigError(
             f"sweep_disagg/{role}: no parallel configuration met TTFT/TPOT or request-latency constraints."
         )
@@ -1319,6 +1329,7 @@ def sweep_disagg(
     predictor: Any = None,
     speculative_profile: SpeculativeDecodingProfile | None = None,
     free_gpu_memory_fraction: float | None = None,
+    recommend_done: bool | None = None,
 ) -> pd.DataFrame:
     """Sweep prefill_parallel x decode_parallel x batches x workers with rate matching.
 
@@ -1432,6 +1443,7 @@ def sweep_disagg(
         predictor=predictor,
         speculative_profile=speculative_profile,
         free_gpu_memory_fraction=free_gpu_memory_fraction,
+        recommend_done=recommend_done,
     )
     decode_summary_df = _get_disagg_worker_candidates(
         model_path=model_path,
@@ -1446,6 +1458,7 @@ def sweep_disagg(
         predictor=predictor,
         speculative_profile=speculative_profile,
         free_gpu_memory_fraction=free_gpu_memory_fraction,
+        recommend_done=recommend_done,
     )
 
     if len(prefill_summary_df) == 0 or len(decode_summary_df) == 0:

--- a/src/aiconfigurator/sdk/task_v2.py
+++ b/src/aiconfigurator/sdk/task_v2.py
@@ -725,7 +725,7 @@ class Task:
     # not a primitive value).
     predictor: Any = field(default=None, repr=False)
 
-    # ====== 10. AFD config (serving_mode='afd') ======
+    # ====== 9. AFD config (serving_mode='afd') ======
     afd_total_gpus: int | None = None  # AFD GPU budget (defaults to total_gpus)
     afd_combined_with_pd: bool = True
     afd_comm_overhead_factor: float = 1.0
@@ -757,6 +757,10 @@ class Task:
     afd_decode_degradation: float | None = None
     afd_ttft_correction_factor: float | None = None
     afd_decode_latency_correction: float = 1.0
+
+    # ====== 10. Recommend escalation context ======
+    # None=default mode, False=recommend interim, True=recommend final
+    recommend_done: bool | None = None
 
     # ====== 11. Internal — resolved in __post_init__ ======
     _is_moe: bool = field(default=False, repr=False, init=False)
@@ -2719,6 +2723,7 @@ class Task:
             # Per-cell (per-replica) budget for the E+agg rate matching; a
             # plain agg row is a single worker and ignores it.
             "num_gpu_list": self._replica_num_gpu_list() if self.enable_epd else None,
+            "recommend_done": self.recommend_done,
         }
 
     def sweep_disagg_kwargs(self, *, prefill_database, decode_database, encoder_database=None) -> dict[str, Any]:
@@ -2769,6 +2774,7 @@ class Task:
             "max_encoder_workers": self.max_encoder_workers,
             "encoder_latency_correction": self.encoder_latency_correction,
             "encoder_database": encoder_database,
+            "recommend_done": self.recommend_done,
         }
 
     def sweep_afd_kwargs(self, *, database) -> dict[str, Any]:

--- a/tests/unit/cli/test_cli_api.py
+++ b/tests/unit/cli/test_cli_api.py
@@ -34,6 +34,7 @@ class _FakeRecommendTask:
     serving_mode: str = "agg"
     enable_wideep: bool = False
     moe_backend: str | None = None
+    recommend_done: bool | None = None
 
 
 class TestCLIEstimateUnit:
@@ -1048,6 +1049,7 @@ class TestCLIRecommendUnit:
         from aiconfigurator.sdk.errors import ExperimentOutcome, InsufficientMemoryError
 
         call_count = 0
+        captured_tasks = []
 
         def fake_build_default_tasks(**kwargs):
             return {"agg": _FakeRecommendTask()}
@@ -1055,6 +1057,7 @@ class TestCLIRecommendUnit:
         def fake_execute(tasks, mode, **kwargs):
             nonlocal call_count
             call_count += 1
+            captured_tasks.append(tasks)
             if call_count == 1:
                 oom = InsufficientMemoryError("model does not fit")
                 return ("none", {}, {}, {}, {}, {"agg": ExperimentOutcome("agg", error=oom)})
@@ -1070,6 +1073,10 @@ class TestCLIRecommendUnit:
         )
 
         assert call_count == 2
+        # Initial attempt: recommend_done=False (interim, escalation budgets available)
+        assert captured_tasks[0]["agg"].recommend_done is False
+        # Escalation attempt: recommend_done=True (final, this is the last budget)
+        assert captured_tasks[1]["agg"].recommend_done is True
 
     def test_escalation_ceiling(self, monkeypatch):
         import aiconfigurator.cli.api as api


### PR DESCRIPTION
## Overview

Improve error messaging in recommend mode escalation to reduce noise and provide context-appropriate diagnostics.

## Details

Changed transient expected "errors" during escalation from ERROR to INFO level, reducing visual noise of routine retries.  This is done through a new field in Task: recommend_done: bool | None to track escalation progress (only when in recommend mode).

Users running aiconfigurator cli recommend see clean progress during automated escalation, with actionable diagnostics only if all attempts fail. Avoids repeating suggestions during retries and never suggests --total-gpus in recommend mode where the tool controls that parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Recommendation searches now indicate whether escalation is still in progress or complete.
  - Out-of-memory guidance adapts to the current recommendation search status for aggregate and disaggregated workloads.

- **Bug Fixes**
  - Recommendation runs no longer suggest increasing total GPUs when results are unavailable.
  - Expected recommendation errors are logged less disruptively.
  - Interim failures and no-result messages are deferred until the final attempt.
  - Retried searches remain marked as in progress until escalation finishes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->