### PR TITLE
docs: make AIC transition policy explicit

### DIFF
--- a/.github/AIC_MIGRATION_CHECKLIST.md
+++ b/.github/AIC_MIGRATION_CHECKLIST.md
@@ -1,0 +1,39 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# AIC repository cutover checklist
+
+This checklist covers transition actions that cannot be completed by changing
+tracked repository files. Complete each action only at its approved release
+milestone; do not imply that a replacement artifact is available before its
+published release has been verified.
+
+## Stable AISimulate launch
+
+- [ ] Verify the stable `aisimulate` Python wheel and `aisimulate-core` Rust
+      crate are published for every supported migration platform.
+- [ ] Run clean-environment install and representative smoke tests against the
+      exact published artifacts.
+- [ ] Lead the AIC 0.12 release notes with the maintenance-only policy, the
+      AISimulate successor link, and the migration guide; do not leave the
+      transition buried in generated changelog entries.
+- [ ] Update the AIC GitHub description to identify AISimulate as the active
+      successor and AIC as maintenance-only.
+- [ ] Pin transition DEP issue
+      [#1517](https://github.com/ai-dynamo/aiconfigurator/issues/1517).
+- [ ] Confirm the README installation gate matches actual PyPI and crates.io
+      availability before recommending migration.
+
+## AIC 0.13 compatibility closeout
+
+- [ ] Publish the approved removal version and date alongside the supported
+      compatibility matrix and rollback guidance.
+- [ ] Triage every open AIC issue and pull request as migrated, compatibility
+      work, or historical context.
+- [ ] Archive the AIC repository at the approved 0.13 cutover milestone; do not
+      delete repository history or yank historical artifacts solely because of
+      the migration.
+- [ ] Verify the archived README, security policy, documentation redirects,
+      issue history, releases, and package/crate provenance remain accessible.

--- a/.github/ISSUE_TEMPLATE/aic_maintenance_report.yml
+++ b/.github/ISSUE_TEMPLATE/aic_maintenance_report.yml
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: AIC Maintenance Report
+description: Report a regression in supported AIC behavior or a blocker to AISimulate migration
+title: "[AIC Maintenance] "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > [!IMPORTANT]
+        > AIConfigurator is maintenance-only. New features and active product
+        > development belong in [AISimulate](https://github.com/ai-dynamo/aisimulate/issues/new/choose).
+        > Do not disclose security vulnerabilities here; use the repository's
+        > [private security policy](https://github.com/ai-dynamo/aiconfigurator/security/policy).
+
+  - type: dropdown
+    id: maintenance_scope
+    attributes:
+      label: Maintenance scope
+      description: Select the supported reason this report remains in AIC.
+      options:
+        - Regression in previously supported AIC behavior
+        - Blocker to migration from AIC to AISimulate
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: AIC version or commit
+      placeholder: "For example: 0.11.0 or a full commit SHA"
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem and impact
+      description: Describe the observed behavior, expected behavior, and user impact.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: Include the smallest safe commands, configuration, and logs that reproduce the problem.
+    validations:
+      required: true
+
+  - type: textarea
+    id: migration_context
+    attributes:
+      label: Migration context
+      description: If this blocks migration, explain which AISimulate migration step is blocked.
+
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmation
+      options:
+        - label: I confirmed this is not a new feature or new coverage request for AISimulate.
+          required: true
+        - label: I removed secrets, credentials, and security-vulnerability details from this public report.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+blank_issues_enabled: true
+contact_links:
+  - name: AISimulate features and new coverage
+    url: https://github.com/ai-dynamo/aisimulate/issues/new/choose
+    about: Propose new features, models, hardware, frameworks, and active product work in AISimulate.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: AISimulate features and new coverage
     url: https://github.com/ai-dynamo/aisimulate/issues/new/choose
     about: Propose new features, models, hardware, frameworks, and active product work in AISimulate.
+  - name: Report a security vulnerability
+    url: https://github.com/ai-dynamo/aiconfigurator/security/policy
+    about: Follow the private NVIDIA PSIRT reporting paths; do not disclose vulnerabilities in a public issue.

--- a/.github/ISSUE_TEMPLATE/support_matrix_request.md
+++ b/.github/ISSUE_TEMPLATE/support_matrix_request.md
@@ -1,11 +1,18 @@
 ---
-name: Support Matrix Coverage Request
-about: Request support for a model, hardware, or framework combination
-title: "[Support Matrix] Request coverage for <model/hardware/framework>"
+name: AIC Compatibility Coverage Gap
+about: Report a regression or migration blocker for previously supported AIC coverage
+title: "[AIC Compatibility] Coverage gap for <model/hardware/framework>"
 labels: support-matrix
 ---
 
-## What coverage are you requesting?
+> [!IMPORTANT]
+> New model, hardware, and framework coverage belongs in
+> [AISimulate](https://github.com/ai-dynamo/aisimulate/issues). AIConfigurator
+> accepts only bug, security, and migration-blocking fixes during its
+> maintenance-only compatibility window. Continue here only if this combination
+> was already supported by AIC or the gap blocks migration to AISimulate.
+
+## What existing coverage regressed or blocks migration?
 
 **Model (HuggingFace ID):**
 <!-- e.g. meta-llama/Llama-4-Scout-17B-16E-Instruct -->
@@ -27,4 +34,4 @@ labels: support-matrix
 
 ## Additional context
 
-<!-- Any other details about your use case, urgency, or environment. -->
+<!-- Include the last working AIC version and evidence that the combination was supported, or explain exactly how the gap blocks AISimulate migration. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,18 @@
+> [!IMPORTANT]
+> AIConfigurator is in a maintenance-only transition to
+> [AISimulate](https://github.com/ai-dynamo/aisimulate). New features, model
+> coverage, and other active development belong there. AIC accepts only bug,
+> security, and migration-blocking fixes during its compatibility window.
+
+#### AIC transition scope:
+
+<!-- Select the single reason this change still belongs in the frozen AIC repository. -->
+
+- [ ] Bug fix to supported AIC behavior
+- [ ] Security fix (do not disclose vulnerabilities in a public PR)
+- [ ] Migration-blocking compatibility fix
+- [ ] Documentation or test correction with no new product behavior
+
 #### Overview:
 
 <!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
@@ -13,3 +28,4 @@
 #### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
 
 - closes GitHub issue: #xxx
+- relates to Linear issue: AIC-xxxx

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,10 +8,9 @@
 
 <!-- Select the single reason this change still belongs in the frozen AIC repository. -->
 
-- [ ] Bug fix to supported AIC behavior
+- [ ] Bug fix to supported AIC behavior, including corrective documentation or tests
 - [ ] Security fix (do not disclose vulnerabilities in a public PR)
-- [ ] Migration-blocking compatibility fix
-- [ ] Documentation or test correction with no new product behavior
+- [ ] Migration-blocking compatibility fix, including transition documentation or tests
 
 #### Overview:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,32 +5,39 @@ SPDX-License-Identifier: Apache-2.0
 
 # Contribution Guidelines
 
-Contributions that fix documentation errors or that make small changes
-to existing code can be contributed directly by following the rules
-below and submitting an appropriate PR.
+## AIConfigurator transition scope
 
-Contributions intended to add significant new functionality must
-follow a more collaborative path described in the following
-points. Before submitting a large PR that adds a major enhancement or
-extension, be sure to submit a GitHub issue that describes the
-proposed change so that the Dynamo team can provide feedback.
+AIConfigurator is in a maintenance-only transition to
+[AISimulate](https://github.com/ai-dynamo/aisimulate). New features, model or
+hardware coverage, and other active development must be proposed and
+implemented in AISimulate. The AIC repository accepts only bug, security, and
+migration-blocking fixes during its compatibility window.
 
-- As part of the GitHub issue discussion, a design for your change
+Documentation corrections and small fixes to existing AIC behavior can be
+contributed here by following the rules below. Report security vulnerabilities
+through [SECURITY.md](SECURITY.md), not through a public issue or pull request.
+
+Before submitting a significant AIC compatibility or migration fix, open an
+[AIC issue](https://github.com/ai-dynamo/aiconfigurator/issues) describing the
+problem so the Dynamo team can confirm that it belongs in this frozen
+repository rather than AISimulate.
+
+- As part of the GitHub issue discussion, the scope of your fix
   will be agreed upon. An up-front design discussion is required to
-  ensure that your enhancement is done in a manner that is consistent
-  with Dynamo's overall architecture.
+  ensure that it preserves the AIC compatibility contract and does not create
+  new active-product behavior in this repository.
 
-- The Dynamo project is spread across multiple GitHub Repositories.
-  The Dynamo team will provide guidance about how and where your enhancement
+- The Dynamo project is spread across multiple GitHub repositories.
+  The Dynamo team will provide guidance about how and where your change
   should be implemented.
 
 - Testing is a critical part of any Dynamo
-  enhancement. You should plan on spending significant time on
+  change. You should plan on spending significant time on
   creating tests for your change. The Dynamo team will help you to
   design your testing so that it is compatible with existing testing
   infrastructure.
 
-- If your enhancement provides a user visible feature then you need to
+- If your fix changes user-visible behavior then you need to
   provide documentation.
 
 

--- a/README.md
+++ b/README.md
@@ -65,8 +65,11 @@ installing the latest supported AIC release:
 python -m pip install aiconfigurator
 ```
 
-After the stable AISimulate 0.12 artifacts are published, migrate the installed
-distribution while retaining the established `aiconfigurator` command:
+After the stable AISimulate 0.12 artifacts are published on PyPI and the
+corresponding release is announced in
+[AISimulate releases](https://github.com/ai-dynamo/aisimulate/releases), migrate
+the installed distribution while retaining the established `aiconfigurator`
+command:
 
 ```bash
 python -m pip uninstall -y aiconfigurator aiconfigurator-core

--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@ SPDX-License-Identifier: Apache-2.0
 
 # aiconfigurator
 
+> [!WARNING]
+> **AIConfigurator is in a maintenance-only transition to
+> [AISimulate](https://github.com/ai-dynamo/aisimulate).** New features, model
+> coverage, and other active development belong in the AISimulate repository.
+> AIC accepts only bug, security, and migration-blocking fixes while its 0.12
+> compatibility window is completed. Existing releases and repository history
+> remain available; follow the
+> [AISimulate migration guide](docs/aisimulate_migration.md) after the stable
+> replacement artifacts are published.
+
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/ai-dynamo/aiconfigurator)
 [![Discord](https://dcbadge.limes.pink/api/server/mRJ2KNzwYE?style=flat)](https://discord.gg/mRJ2KNzwYE)
 
@@ -23,19 +33,13 @@ For a technical deep dive into the design and methodology of AIConfigurator, ple
 The tool models LLM inference using collected data for a target machine and framework. It evaluates thousands of
 configurations and runs anywhere via the CLI.
 
-Let's get started.
-
-> [!WARNING]
-> AIConfigurator 0.12.0 is the compatibility release for moving the
-> application distribution and Sweeper workflows to AISimulate. The
-> `aiconfigurator` CLI command remains supported from the `aisimulate` wheel;
-> users change the installed package, not the command name. Follow the
-> [AISimulate migration guide](docs/aisimulate_migration.md) for installation,
-> API guidance, and the temporary compatibility behavior.
-
 ## Build and Install
 
-### Install from PyPI
+### Compatibility install from PyPI
+
+New development and new integrations should target AISimulate. Until the
+stable AISimulate 0.12 artifacts are published, existing AIC users may continue
+installing the latest supported AIC release:
 
 > **Public PyPI support: Linux x86-64 only.** The required
 > `aiconfigurator-core` wheel bundles a native Rust/PyO3 extension and is
@@ -58,8 +62,20 @@ Let's get started.
 > Windows has no supported installation path.
 
 ```bash
-pip3 install aiconfigurator
+python -m pip install aiconfigurator
 ```
+
+After the stable AISimulate 0.12 artifacts are published, migrate the installed
+distribution while retaining the established `aiconfigurator` command:
+
+```bash
+python -m pip uninstall -y aiconfigurator aiconfigurator-core
+python -m pip install "aisimulate==0.12.0"
+```
+
+Do not substitute an AISimulate development build for the stable transition
+artifact. See the [migration guide](docs/aisimulate_migration.md) for the
+publication gate, supported platforms, CLI behavior, and API changes.
 
 The upper `aiconfigurator` wheel contains the CLI, generator, and versioned
 server-config adapter.
@@ -77,12 +93,14 @@ from aiconfigurator.sdk.task_v2 import Task
 The core wheel intentionally does not expose `task_v2`; the standalone core
 never depends back on the application package.
 
-#### Upgrading from 0.9
+#### Upgrading an existing AIC environment from 0.9
 
 Version 0.9 shipped core files inside `aiconfigurator`. Package installers cannot
 safely transfer those same paths to the new dependency during a normal in-place
 upgrade because dependencies are installed before dependents. Remove the old
-owner first when crossing this package boundary:
+owner first when crossing this package boundary. This compatibility path applies
+only after the matching AIC 0.12 artifact is published; it is not the starting
+point for new development or integrations:
 
 ```bash
 python3 -m pip uninstall -y aiconfigurator aiconfigurator-core

--- a/aic-core/pyproject.toml
+++ b/aic-core/pyproject.toml
@@ -7,8 +7,8 @@ version = "0.12.0"
 authors = [
     { name = "NVIDIA Inc.", email = "sw-dl-dynamo@nvidia.com" },
 ]
-description = "Standalone core modeling, data, and Rust estimators for AIConfigurator"
-readme = { text = "Standalone core modeling, data, and Rust estimators for AIConfigurator.", content-type = "text/markdown" }
+description = "AIConfigurator core compatibility distribution; active development has moved to AISimulate"
+readme = { text = "AIConfigurator core compatibility distribution. Active development has moved to [AISimulate](https://github.com/ai-dynamo/aisimulate); see the [migration guide](https://github.com/ai-dynamo/aiconfigurator/blob/main/docs/aisimulate_migration.md).", content-type = "text/markdown" }
 license = "Apache-2.0"
 requires-python = ">=3.11,<3.14"
 dependencies = [
@@ -19,6 +19,12 @@ dependencies = [
     "pyyaml>=6.0",
     "scipy>=1.13.1",
 ]
+
+[project.urls]
+GitHub = "https://github.com/ai-dynamo/aiconfigurator"
+Repository = "https://github.com/ai-dynamo/aiconfigurator.git"
+AISimulate = "https://github.com/ai-dynamo/aisimulate"
+Migration = "https://github.com/ai-dynamo/aiconfigurator/blob/main/docs/aisimulate_migration.md"
 
 [build-system]
 requires = ["maturin>=1.12,<2"]

--- a/aic-core/rust/aiconfigurator-core/Cargo.toml
+++ b/aic-core/rust/aiconfigurator-core/Cargo.toml
@@ -5,9 +5,10 @@
 name = "aiconfigurator-core"
 version = "0.12.0"
 edition = "2021"
-description = "Rust-native core latency estimator for AIConfigurator"
+description = "AIConfigurator compatibility core; active development has moved to AISimulate"
 license = "Apache-2.0"
 repository = "https://github.com/ai-dynamo/aiconfigurator"
+homepage = "https://github.com/ai-dynamo/aisimulate"
 documentation = "https://docs.rs/aiconfigurator-core"
 readme = "README.md"
 

--- a/aic-core/rust/aiconfigurator-core/README.md
+++ b/aic-core/rust/aiconfigurator-core/README.md
@@ -1,5 +1,11 @@
 # AIConfigurator Rust Core
 
+> **Maintenance-only transition:** active development has moved to
+> [AISimulate](https://github.com/ai-dynamo/aisimulate). This crate remains
+> available as an AIConfigurator compatibility surface while the documented
+> migration and removal gates are completed. See the
+> [migration guide](https://github.com/ai-dynamo/aiconfigurator/blob/main/docs/aisimulate_migration.md).
+
 Rust-native core that estimates prefill, decode, and forward-pass latency from
 AIC model metadata and perf files, without re-entering Python on the hot path.
 

--- a/docs/aisimulate_migration.md
+++ b/docs/aisimulate_migration.md
@@ -10,6 +10,14 @@ distribution and Sweeper workflows to AISimulate. The established
 `aiconfigurator` CLI command continues to work, while the legacy AIC
 distribution and direct Sweeper entry points emit targeted migration warnings.
 
+> [!IMPORTANT]
+> Run the replacement installation commands only after stable
+> `aisimulate==0.12.0` artifacts are published on PyPI and announced in the
+> [AISimulate releases](https://github.com/ai-dynamo/aisimulate/releases).
+> Until then, existing users should remain on the latest supported AIC release.
+> AISimulate development releases do not satisfy this publication gate and are
+> not the stable transition baseline.
+
 ## Install the replacement
 
 ```bash
@@ -64,3 +72,9 @@ Code installed from `aisimulate==0.12.0` may temporarily continue importing
 the migrated AIC namespace while it moves to the supported AISimulate APIs.
 Do not use that compatibility namespace for new integrations: it is retained
 only to make the one-release migration window non-breaking.
+
+## Maintainer repository cutover
+
+The code changes in this repository do not update GitHub settings or publish
+release artifacts. Before announcing the stable cutover, maintainers must
+complete the [AIC repository cutover checklist](../.github/AIC_MIGRATION_CHECKLIST.md).

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,6 +20,16 @@ tailwind.config = {
 </head>
 <body class="bg-white dark:bg-slate-900 text-slate-800 dark:text-slate-200 min-h-screen flex flex-col font-sans">
 
+<div role="alert" class="mx-6 mt-5 rounded-lg border border-amber-300 bg-amber-50 px-5 py-4 text-sm text-amber-950 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-100">
+  <strong>Maintenance-only transition:</strong>
+  new features, model coverage, and active development have moved to
+  <a class="font-semibold underline" href="https://github.com/ai-dynamo/aisimulate">AISimulate</a>.
+  AIConfigurator accepts only bug, security, and migration-blocking fixes while compatibility closes.
+  Existing users should follow the
+  <a class="font-semibold underline" href="https://github.com/ai-dynamo/aiconfigurator/blob/main/docs/aisimulate_migration.md">migration guide</a>
+  after stable replacement artifacts are published.
+</div>
+
 <div class="flex justify-end p-3 px-6">
   <button id="theme-toggle" title="Toggle dark/light mode"
     class="border border-slate-200 dark:border-slate-700 rounded-md px-2 py-1 cursor-pointer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ version = "0.12.0"
 authors = [
     { name = "NVIDIA Inc.", email = "sw-dl-dynamo@nvidia.com" },
 ]
-description = "aiconfigurator: automatic disaggregated serving offline configuration"
+description = "AIConfigurator compatibility distribution; active development has moved to AISimulate"
 
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -84,6 +84,8 @@ service = [
 [project.urls]
 GitHub = "https://github.com/ai-dynamo/aiconfigurator"
 Repository = "https://github.com/ai-dynamo/aiconfigurator.git"
+AISimulate = "https://github.com/ai-dynamo/aisimulate"
+Migration = "https://github.com/ai-dynamo/aiconfigurator/blob/main/docs/aisimulate_migration.md"
 
 [build-system]
 requires = ["setuptools>=69", "wheel"]

--- a/tests/unit/test_repository_transition_policy.py
+++ b/tests/unit/test_repository_transition_policy.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SUCCESSOR_URL = "https://github.com/ai-dynamo/aisimulate"
+MIGRATION_URL = "https://github.com/ai-dynamo/aiconfigurator/blob/main/docs/aisimulate_migration.md"
+FIX_SCOPE = "bug, security, and migration-blocking fixes"
+pytestmark = pytest.mark.unit
+
+
+def _read(path: str) -> str:
+    return (ROOT / path).read_text()
+
+
+def test_contributor_entry_points_enforce_the_transition_scope() -> None:
+    for path in (
+        "README.md",
+        "CONTRIBUTING.md",
+        ".github/pull_request_template.md",
+        ".github/ISSUE_TEMPLATE/support_matrix_request.md",
+        "docs/index.html",
+    ):
+        content = " ".join(line.removeprefix("> ").strip() for line in _read(path).splitlines())
+        assert SUCCESSOR_URL in content, path
+        assert FIX_SCOPE in content, path
+
+
+def test_migration_install_is_gated_on_stable_artifact_publication() -> None:
+    migration_guide = _read("docs/aisimulate_migration.md")
+    assert "only after stable" in migration_guide
+    assert "development releases do not satisfy this publication gate" in migration_guide
+    assert "https://github.com/ai-dynamo/aisimulate/releases" in migration_guide
+
+
+def test_python_package_metadata_names_the_successor() -> None:
+    for path in ("pyproject.toml", "aic-core/pyproject.toml"):
+        metadata = tomllib.loads(_read(path))["project"]
+        assert "active development has moved to AISimulate" in metadata["description"]
+        assert metadata["urls"]["AISimulate"] == SUCCESSOR_URL
+        assert metadata["urls"]["Migration"] == MIGRATION_URL
+
+
+def test_rust_crate_metadata_and_readme_name_the_successor() -> None:
+    crate_root = "aic-core/rust/aiconfigurator-core"
+    package = tomllib.loads(_read(f"{crate_root}/Cargo.toml"))["package"]
+    assert "active development has moved to AISimulate" in package["description"]
+    assert package["homepage"] == SUCCESSOR_URL
+    assert SUCCESSOR_URL in _read(f"{crate_root}/README.md")
+
+
+def test_cutover_checklist_covers_non_code_repository_actions() -> None:
+    checklist = _read(".github/AIC_MIGRATION_CHECKLIST.md")
+    for required_action in (
+        "Lead the AIC 0.12 release notes",
+        "Update the AIC GitHub description",
+        "Pin transition DEP issue",
+        "Archive the AIC repository",
+    ):
+        assert required_action in checklist

--- a/tests/unit/test_repository_transition_policy.py
+++ b/tests/unit/test_repository_transition_policy.py
@@ -33,8 +33,9 @@ def test_contributor_entry_points_enforce_the_transition_scope() -> None:
 
     issue_config = yaml.safe_load(_read(".github/ISSUE_TEMPLATE/config.yml"))
     assert issue_config["blank_issues_enabled"] is False
-    assert SUCCESSOR_URL in issue_config["contact_links"][0]["url"]
-    assert issue_config["contact_links"][1]["url"].endswith("/security/policy")
+    contact_links = {link["name"]: link["url"] for link in issue_config["contact_links"]}
+    assert SUCCESSOR_URL in contact_links["AISimulate features and new coverage"]
+    assert contact_links["Report a security vulnerability"].endswith("/security/policy")
 
     maintenance_form = yaml.safe_load(_read(".github/ISSUE_TEMPLATE/aic_maintenance_report.yml"))
     assert SUCCESSOR_URL in maintenance_form["body"][0]["attributes"]["value"]
@@ -51,9 +52,11 @@ def test_migration_install_is_gated_on_stable_artifact_publication() -> None:
     assert "development releases do not satisfy this publication gate" in migration_guide
     assert RELEASES_URL in migration_guide
 
-    readme = _read("README.md")
-    assert "published on PyPI" in readme
-    assert RELEASES_URL in readme
+    readme = " ".join(_read("README.md").splitlines())
+    assert (
+        "After the stable AISimulate 0.12 artifacts are published on PyPI and the corresponding release "
+        f"is announced in [AISimulate releases]({RELEASES_URL}), migrate the installed distribution"
+    ) in readme
 
 
 def test_python_package_metadata_names_the_successor() -> None:

--- a/tests/unit/test_repository_transition_policy.py
+++ b/tests/unit/test_repository_transition_policy.py
@@ -5,6 +5,7 @@ import tomllib
 from pathlib import Path
 
 import pytest
+import yaml
 
 ROOT = Path(__file__).resolve().parents[2]
 SUCCESSOR_URL = "https://github.com/ai-dynamo/aisimulate"
@@ -30,8 +31,18 @@ def test_contributor_entry_points_enforce_the_transition_scope() -> None:
         assert SUCCESSOR_URL in content, path
         assert FIX_SCOPE in content, path
 
-    issue_config = _read(".github/ISSUE_TEMPLATE/config.yml")
-    assert SUCCESSOR_URL in issue_config
+    issue_config = yaml.safe_load(_read(".github/ISSUE_TEMPLATE/config.yml"))
+    assert issue_config["blank_issues_enabled"] is False
+    assert SUCCESSOR_URL in issue_config["contact_links"][0]["url"]
+    assert issue_config["contact_links"][1]["url"].endswith("/security/policy")
+
+    maintenance_form = yaml.safe_load(_read(".github/ISSUE_TEMPLATE/aic_maintenance_report.yml"))
+    assert SUCCESSOR_URL in maintenance_form["body"][0]["attributes"]["value"]
+    scope = next(field for field in maintenance_form["body"] if field.get("id") == "maintenance_scope")
+    assert scope["attributes"]["options"] == [
+        "Regression in previously supported AIC behavior",
+        "Blocker to migration from AIC to AISimulate",
+    ]
 
 
 def test_migration_install_is_gated_on_stable_artifact_publication() -> None:

--- a/tests/unit/test_repository_transition_policy.py
+++ b/tests/unit/test_repository_transition_policy.py
@@ -8,6 +8,7 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
 SUCCESSOR_URL = "https://github.com/ai-dynamo/aisimulate"
+RELEASES_URL = f"{SUCCESSOR_URL}/releases"
 MIGRATION_URL = "https://github.com/ai-dynamo/aiconfigurator/blob/main/docs/aisimulate_migration.md"
 FIX_SCOPE = "bug, security, and migration-blocking fixes"
 pytestmark = pytest.mark.unit
@@ -29,12 +30,19 @@ def test_contributor_entry_points_enforce_the_transition_scope() -> None:
         assert SUCCESSOR_URL in content, path
         assert FIX_SCOPE in content, path
 
+    issue_config = _read(".github/ISSUE_TEMPLATE/config.yml")
+    assert SUCCESSOR_URL in issue_config
+
 
 def test_migration_install_is_gated_on_stable_artifact_publication() -> None:
     migration_guide = _read("docs/aisimulate_migration.md")
     assert "only after stable" in migration_guide
     assert "development releases do not satisfy this publication gate" in migration_guide
-    assert "https://github.com/ai-dynamo/aisimulate/releases" in migration_guide
+    assert RELEASES_URL in migration_guide
+
+    readme = _read("README.md")
+    assert "published on PyPI" in readme
+    assert RELEASES_URL in readme
 
 
 def test_python_package_metadata_names_the_successor() -> None:


### PR DESCRIPTION
#### AIC transition scope:

- [ ] Bug fix to supported AIC behavior, including corrective documentation or tests
- [ ] Security fix (do not disclose vulnerabilities in a public PR)
- [x] Migration-blocking compatibility fix, including transition documentation or tests

#### Overview:

Make the AIConfigurator maintenance-only policy and AISimulate successor visible at every repository entry point without directing users to unpublished replacement artifacts.

#### Details:

- Lead the README, contribution guide, PR template, issue intake, docs landing page, and Python/Rust package metadata with the AIC-to-AISimulate transition.
- Route new features and coverage to `ai-dynamo/aisimulate`; retain AIC only for bug, security, and migration-blocking fixes.
- Gate `aisimulate==0.12.0` migration commands on publication of the stable artifacts and distinguish development releases from the transition baseline.
- Add a maintainer checklist for release notes, repository description, DEP pinning, artifact verification, issue/PR triage, and eventual AIC archival.
- Add a unit policy test so these repository-level signals cannot silently drift or disappear.

#### Where should the reviewer start?

Start with `README.md` and `CONTRIBUTING.md`, then review `tests/unit/test_repository_transition_policy.py` together with `.github/AIC_MIGRATION_CHECKLIST.md`.

#### Validation:

- `ruff check tests/unit/test_repository_transition_policy.py`
- `ruff format --check tests/unit/test_repository_transition_policy.py`
- `uv run --python 3.12 --no-project --with pytest --with pyyaml pytest --confcutdir=tests/unit -p no:cacheprovider -p no:timeout -q tests/unit/test_repository_transition_policy.py` (5 passed)
- Parsed both Python `pyproject.toml` files and the Rust `Cargo.toml` with Python 3.12 `tomllib`
- Parsed all issue-template YAML with PyYAML
- `cargo metadata --manifest-path aic-core/rust/aiconfigurator-core/Cargo.toml --no-deps --format-version 1`
- `uv build --wheel` (wheel built successfully)
- `git diff --check`

#### Current CI context:

- The exact `main` base SHA, `77fd0773407b3683d8a671fe24a30a7110651b64`, already fails the same power-data invariant and compile-engine parity assertions exercised by this PR CI.

#### Related Issues:

- Relates to [AIC-1939](https://linear.app/nvidia/issue/AIC-1939/deprecation-close-aic-repository-transition-signaling-gaps)
- Follows up [AIC-1652](https://linear.app/nvidia/issue/AIC-1652/deprecation-add-aisimulate-migration-warnings-in-the-aic-repository)
- Relates to GitHub issue: #1517


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for transitioning from AIConfigurator to AISimulate, including migration steps, compatibility timelines, publication prerequisites, and supported installation platforms.
  * Added maintenance notices, migration links, and release-artifact verification guidance across project and package documentation.

* **Chores**
  * Updated contribution, issue, and pull request guidance for compatibility, migration, security, and maintenance work.
  * Added maintenance-report and security-reporting options, plus a stable-transition verification checklist.

* **Tests**
  * Added checks to ensure transition policies and migration documentation remain consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->