### PR TITLE
test: restore B200 power CI contract

### DIFF
--- a/aic-core/rust/aiconfigurator-core/parity_tests/goldens/per_op.json
+++ b/aic-core/rust/aiconfigurator-core/parity_tests/goldens/per_op.json
@@ -13,7 +13,7 @@
           "source": "empirical"
         },
         "context_attention": {
-          "energy_wms": 0.0,
+          "energy_wms": 443.84428875568517,
           "latency_ms": 0.9006829618708475,
           "source": "mixed"
         },
@@ -23,12 +23,12 @@
           "source": "empirical"
         },
         "context_embedding_ar": {
-          "energy_wms": 0.0,
+          "energy_wms": 12.87207756609958,
           "latency_ms": 0.04589320056140423,
           "source": "silicon"
         },
         "context_moe": {
-          "energy_wms": 0.0,
+          "energy_wms": 4650.878357851409,
           "latency_ms": 7.353446388244628,
           "source": "silicon"
         },
@@ -48,17 +48,17 @@
           "source": "silicon"
         },
         "context_proj_gemm": {
-          "energy_wms": 0.0,
+          "energy_wms": 93.16542583139285,
           "latency_ms": 0.11741446954220959,
           "source": "silicon"
         },
         "context_qkv_gemm": {
-          "energy_wms": 0.0,
+          "energy_wms": 113.38631237263097,
           "latency_ms": 0.14492136634260264,
           "source": "silicon"
         },
         "context_router_gemm": {
-          "energy_wms": 0.0,
+          "energy_wms": 47.88824307017971,
           "latency_ms": 0.11833338558861847,
           "source": "silicon"
         }
@@ -75,7 +75,7 @@
           "source": "empirical"
         },
         "generation_attention": {
-          "energy_wms": 0.0,
+          "energy_wms": 89.15719848399121,
           "latency_ms": 0.25956955552101135,
           "source": "silicon"
         },
@@ -85,17 +85,17 @@
           "source": "empirical"
         },
         "generation_embedding_ar": {
-          "energy_wms": 0.0,
+          "energy_wms": 1.3939920260887593,
           "latency_ms": 0.005722980014979839,
           "source": "silicon"
         },
         "generation_logits_gemm": {
-          "energy_wms": 0.0,
+          "energy_wms": 24.87529863166794,
           "latency_ms": 0.027535857502495716,
           "source": "silicon"
         },
         "generation_moe": {
-          "energy_wms": 0.0,
+          "energy_wms": 318.0664717176676,
           "latency_ms": 1.2002304553985597,
           "source": "silicon"
         },
@@ -115,17 +115,17 @@
           "source": "silicon"
         },
         "generation_proj_gemm": {
-          "energy_wms": 0.0,
+          "energy_wms": 50.82092526538146,
           "latency_ms": 0.07705356162073414,
           "source": "silicon"
         },
         "generation_qkv_gemm": {
-          "energy_wms": 0.0,
+          "energy_wms": 88.990814270938,
           "latency_ms": 0.12188329205904243,
           "source": "silicon"
         },
         "generation_router_gemm": {
-          "energy_wms": 0.0,
+          "energy_wms": 35.89557796639745,
           "latency_ms": 0.09948333535383398,
           "source": "silicon"
         }
@@ -895,17 +895,17 @@
           "source": "empirical"
         },
         "context_ar_1": {
-          "energy_wms": 0.0,
+          "energy_wms": 1241.060314309411,
           "latency_ms": 4.153224496841431,
           "source": "silicon"
         },
         "context_ar_2": {
-          "energy_wms": 0.0,
+          "energy_wms": 2026.220921321488,
           "latency_ms": 6.7807746887207045,
           "source": "silicon"
         },
         "context_attention": {
-          "energy_wms": 0.0,
+          "energy_wms": 1258.3229783233753,
           "latency_ms": 2.0995968487705867,
           "source": "mixed"
         },
@@ -915,17 +915,17 @@
           "source": "empirical"
         },
         "context_ffn2_gemm": {
-          "energy_wms": 0.0,
+          "energy_wms": 2412.4856061005785,
           "latency_ms": 2.465787113521622,
           "source": "silicon"
         },
         "context_gate_ffn1_gemm": {
-          "energy_wms": 0.0,
+          "energy_wms": 5370.3208732571675,
           "latency_ms": 5.50227539102377,
           "source": "silicon"
         },
         "context_logits_gemm": {
-          "energy_wms": 0.0,
+          "energy_wms": 36.3816553055184,
           "latency_ms": 0.04490145929010149,
           "source": "silicon"
         },
@@ -935,12 +935,12 @@
           "source": "silicon"
         },
         "context_proj_gemm": {
-          "energy_wms": 0.0,
+          "energy_wms": 687.0389489479833,
           "latency_ms": 0.704659186800321,
           "source": "silicon"
         },
         "context_qkv_gemm": {
-          "energy_wms": 0.0,
+          "energy_wms": 900.8384159623752,
           "latency_ms": 0.9238646324744872,
           "source": "silicon"
         }
@@ -962,17 +962,17 @@
           "source": "empirical"
         },
         "generation_ar_1": {
-          "energy_wms": 0.0,
+          "energy_wms": 70.86046348975658,
           "latency_ms": 0.29070720851421356,
           "source": "silicon"
         },
         "generation_ar_2": {
-          "energy_wms": 0.0,
+          "energy_wms": 115.69055263633726,
           "latency_ms": 0.474624013900757,
           "source": "silicon"
         },
         "generation_attention": {
-          "energy_wms": 0.0,
+          "energy_wms": 413.1342389794529,
           "latency_ms": 0.5440381292355596,
           "source": "silicon"
         },
@@ -982,17 +982,17 @@
           "source": "empirical"
         },
         "generation_ffn2_gemm": {
-          "energy_wms": 0.0,
+          "energy_wms": 681.5905006091823,
           "latency_ms": 0.755631020623632,
           "source": "silicon"
         },
         "generation_gate_ffn1_gemm": {
-          "energy_wms": 0.0,
+          "energy_wms": 1339.3268222872184,
           "latency_ms": 1.5073875994774963,
           "source": "silicon"
         },
         "generation_logits_gemm": {
-          "energy_wms": 0.0,
+          "energy_wms": 36.3816553055184,
           "latency_ms": 0.04490145929010149,
           "source": "silicon"
         },
@@ -1002,12 +1002,12 @@
           "source": "silicon"
         },
         "generation_proj_gemm": {
-          "energy_wms": 0.0,
+          "energy_wms": 138.43094306704904,
           "latency_ms": 0.20666239162286126,
           "source": "silicon"
         },
         "generation_qkv_gemm": {
-          "energy_wms": 0.0,
+          "energy_wms": 291.73523112528625,
           "latency_ms": 0.40689951426000137,
           "source": "silicon"
         }
@@ -1162,7 +1162,7 @@
   "post_freeze_pins": {
     "gpt-oss-20b-b200-trtllm-isl1024-osl2": {
       "engine": "rust",
-      "git_head": "760b6c92edc00389ff79938b62b028c01bcfefdd"
+      "git_head": "77fd0773407b3683d8a671fe24a30a7110651b64"
     },
     "kimi-k25-b200-sglang-isl1024-osl2": {
       "engine": "rust",
@@ -1190,7 +1190,7 @@
     },
     "nemotron-nas-b200-trtllm-isl1024-osl2": {
       "engine": "rust",
-      "git_head": "760b6c92edc00389ff79938b62b028c01bcfefdd"
+      "git_head": "77fd0773407b3683d8a671fe24a30a7110651b64"
     },
     "qwen3-30b-a3b-b200-vllm-isl1024-osl2": {
       "engine": "rust",

--- a/aic-core/rust/aiconfigurator-core/parity_tests/test_compile_engine_parity.py
+++ b/aic-core/rust/aiconfigurator-core/parity_tests/test_compile_engine_parity.py
@@ -80,9 +80,10 @@ pytestmark = pytest.mark.integration
 #            Fallback-MLA path and the sglang perf tables.
 #   trtllm : gpt-oss-20b (MoE -> exercises the `TrtllmAlltoall` flavor +
 #            trtllm comm quant + trtllm MoE) and Nemotron-Super-49B (dense,
-#            CustomAllReduce-heavy), both b200_sxm/trtllm/1.3.0rc10. The MoE
-#            case is the load-bearing one: it is the only subset member that
-#            hits the trtllm dispatch-flavor branch.
+#            CustomAllReduce-heavy), both on the b200_sxm/trtllm current slot
+#            (1.3.0rc20). Both now exercise energy after #1584; the MoE case is
+#            also the only subset member that hits the trtllm dispatch-flavor
+#            branch.
 _SUBSET_IDS_BY_BACKEND = {
     "vllm": [
         "minimax-m25-b200-vllm-isl1024-osl2",
@@ -103,10 +104,12 @@ _SUBSET_IDS_BY_BACKEND = {
 
 # Subset members on power-carrying database identities: their per-op goldens
 # must carry nonzero energy_wms, so the energy comparison branch is proven to
-# execute (anti-vacuous guard in TestCompileEnginePerOpParity). EMPTY since
-# the 2026-08 prune removed the last engine-step-complete power identity —
-# repopulate when a current-slot power collection lands.
-_POWER_SUBSET_IDS: set[str] = set()
+# execute (anti-vacuous guard in TestCompileEnginePerOpParity). The B200
+# TRT-LLM current slot gained matched power data in #1584.
+_POWER_SUBSET_IDS = {
+    "gpt-oss-20b-b200-trtllm-isl1024-osl2",
+    "nemotron-nas-b200-trtllm-isl1024-osl2",
+}
 
 # Preserve the per-backend ordering (vllm, then sglang, then trtllm) so the
 # parametrize ids group readably and the determinism sweep covers vllm first.

--- a/tests/unit/sdk/database/test_power_data_invariants.py
+++ b/tests/unit/sdk/database/test_power_data_invariants.py
@@ -6,16 +6,19 @@
 Policy (2026-08): power/energy tests pin no values and bind to no specific
 backend version. They assert query-surface invariants over WHATEVER power
 data is currently shipped: every parquet that carries power columns must
-satisfy the energy model's input contract (finite, non-negative power;
-positive power limit). The energy MATH is anchored by the rust synthetic
-oracles on power-carrying fixtures (``energy_test_fixtures`` tests in
-``operators/{gemm,attention}.rs``); this test guards the shipped data plane
-those models consume. If no power-carrying parquet is shipped at all, the
-suite records that state explicitly instead of passing vacuously.
+store either a finite positive ``power`` / ``power_limit`` measurement pair
+or the exact ``0.0`` / ``0.0`` unavailable-measurement sentinel. The energy
+MATH is anchored by the rust synthetic oracles on power-carrying fixtures
+(``energy_test_fixtures`` tests in ``operators/{gemm,attention}.rs``); this
+test guards the shipped data plane those models consume. If no power-carrying
+parquet is shipped at all, the suite records that state explicitly instead
+of passing vacuously.
 """
 
 from pathlib import Path
 
+import numpy as np
+import pandas as pd
 import pyarrow.parquet as pq
 import pytest
 
@@ -36,6 +39,15 @@ def _power_carrying_files() -> list[Path]:
     return files
 
 
+def _invalid_power_pairs(frame: pd.DataFrame) -> pd.Series:
+    power = frame["power"]
+    power_limit = frame["power_limit"]
+    finite = np.isfinite(power) & np.isfinite(power_limit)
+    measured = (power > 0.0) & (power_limit > 0.0)
+    unmeasured = (power == 0.0) & (power_limit == 0.0)
+    return ~(finite & (measured | unmeasured))
+
+
 def test_power_columns_satisfy_energy_model_input_contract():
     files = _power_carrying_files()
     if not files:
@@ -43,14 +55,28 @@ def test_power_columns_satisfy_energy_model_input_contract():
     problems = []
     for path in files:
         rel = path.relative_to(_DATA_ROOT)
-        table = pq.read_table(path, columns=[c for c in _POWER_COLUMNS if c in pq.read_schema(path).names])
+        schema = pq.read_schema(path)
+        missing = [column for column in _POWER_COLUMNS if column not in schema.names]
+        if missing:
+            problems.append(f"{rel}: missing paired columns {missing}")
+            continue
+        table = pq.read_table(path, columns=list(_POWER_COLUMNS))
         frame = table.to_pandas()
-        if "power" in frame:
-            bad = frame["power"].isna() | (frame["power"] < 0)
-            if bad.any():
-                problems.append(f"{rel}: {int(bad.sum())} rows with NaN/negative power")
-        if "power_limit" in frame:
-            bad = frame["power_limit"].isna() | (frame["power_limit"] <= 0)
-            if bad.any():
-                problems.append(f"{rel}: {int(bad.sum())} rows with NaN/non-positive power_limit")
+        bad = _invalid_power_pairs(frame)
+        if bad.any():
+            problems.append(
+                f"{rel}: {int(bad.sum())} invalid power pairs "
+                "(expected positive/positive measurement or 0.0/0.0 sentinel)"
+            )
     assert not problems, "power data violates the energy-model input contract:\n" + "\n".join(problems)
+
+
+def test_power_pair_contract_accepts_only_measurements_or_paired_zero_sentinel():
+    frame = pd.DataFrame(
+        {
+            "power": [100.0, 0.0, 0.0, 100.0, -1.0, np.nan, 100.0],
+            "power_limit": [1000.0, 0.0, 1000.0, 0.0, 1000.0, 1000.0, np.inf],
+        }
+    )
+
+    assert _invalid_power_pairs(frame).tolist() == [False, False, True, True, True, True, True]


### PR DESCRIPTION
## Summary

- restore the shipped B200 power-data invariant: rows must be either a finite positive `power` / `power_limit` measurement pair or the exact `0.0` / `0.0` unavailable-measurement sentinel
- refresh the two affected TRT-LLM current-slot per-op goldens with the repository pinning tool and activate their anti-vacuous energy coverage
- keep this maintenance-only under the AIC code freeze; no parquet data or runtime behavior changes

Linear: [AIC-1940](https://linear.app/nvidia/issue/AIC-1940/cidata-restore-aic-b200-power-data-invariant-and-engine-parity)

Related: #1584, #1590, [AIC-1934](https://linear.app/nvidia/issue/AIC-1934/power27data-close-collector-dataset-and-power-support-coverage-gaps)

## Why

PR #1584 added matched B200 TRT-LLM `1.3.0rc20` power data with 487,422 measured rows and 40,549 intentional `0.0` / `0.0` sentinels for unmatched rows. A later invariant test rejected every non-positive `power_limit`, while the compile-engine goldens still pinned the pre-power current slot. That merge-order drift made `main` fail despite the shipped data satisfying its documented paired-value contract.

## Validation

- `pytest tests/unit/sdk/database/test_power_data_invariants.py`: 2 passed
- compile-engine parity: 64 passed
- full engine-step parity: 276 passed
- Rust crate and public API tests: 539 passed, 2 ignored
- broader Python unit/build suite: 4,857 passed, 11 skipped
- `ruff check .`: passed
- `ruff format --check .`: 678 files already formatted
- golden audit: 29 intended `energy_wms` updates, two provenance SHA updates, zero other case-field changes, zero parquet changes

The broad local Python lane excludes `tests/unit/sdk/database/test_moe_dispatch.py` because the repository's macOS development environment does not install Torch; hosted container CI remains authoritative for that test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded energy-measurement validation to require complete, valid power data and support explicit zero-value cases.
  - Added focused coverage for accepted and rejected power measurements.
  - Extended performance parity checks to cover energy reporting across additional model operations and routing scenarios.

- **Chores**
  - Refreshed benchmark reference data and compatibility baselines to reflect current energy measurements and runtime versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->