### PR TITLE
fix(collector): reject non-divisible DSV4 head geometry

### DIFF
--- a/collector/sglang/collect_dsv4_attn.py
+++ b/collector/sglang/collect_dsv4_attn.py
@@ -1225,6 +1225,11 @@ def _resolve_local_heads(*, native_heads: int, module_heads: int | None, tp_size
     cross-checked, never persisted — a value matching neither is a geometry
     surprise worth failing the case over.
     """
+    if int(native_heads) % tp_size != 0:
+        raise RuntimeError(
+            f"DSV4 attention head geometry mismatch: native_heads={int(native_heads)} "
+            f"is not divisible by tp_size={tp_size}"
+        )
     local_heads = max(1, int(native_heads) // tp_size)
     if module_heads is not None and int(module_heads) not in (int(native_heads), local_heads):
         raise RuntimeError(

--- a/tests/unit/collector/sglang/test_collect_dsv4_attn_contract.py
+++ b/tests/unit/collector/sglang/test_collect_dsv4_attn_contract.py
@@ -59,6 +59,13 @@ def test_dsv4_persisted_num_heads_is_rank_local_with_geometry_guard():
     assert resolve(native_heads=64, module_heads=8, tp_size=8) == 8
     # Pro native=128 without a module attribute still derives from config.
     assert resolve(native_heads=128, module_heads=None, tp_size=4) == 32
+    # Exact division remains valid even when each rank has only one head.
+    assert resolve(native_heads=64, module_heads=1, tp_size=64) == 1
+    # Truncating a non-divisible geometry would persist the wrong native identity.
+    for native_heads, tp_size in [(64, 3), (65, 8), (4, 8)]:
+        for module_heads in (None, native_heads, max(1, native_heads // tp_size)):
+            with pytest.raises(RuntimeError, match=r"native_heads=.*not divisible.*tp_size="):
+                resolve(native_heads=native_heads, module_heads=module_heads, tp_size=tp_size)
     # Geometry surprises fail the case (observe, don't guess).
     with pytest.raises(RuntimeError, match=r"head geometry mismatch"):
         resolve(native_heads=64, module_heads=16, tp_size=8)


### PR DESCRIPTION
#### AIC transition scope:

- [x] Bug fix to supported AIC behavior, including corrective documentation or tests
- [ ] Security fix
- [ ] Migration-blocking compatibility fix

#### Overview:

Reject non-divisible DSV4 native-head/TP geometry before deriving the rank-local head count, as requested in #1466. For example, 64 native heads with TP=3 currently produces 21 local heads, which reconstructs as a different native identity (63).

This is a configuration-validation correction. Current standard 64/128-head models with the existing power-of-two TP sweep are unaffected; this PR does not claim those models have produced incorrect data.

#### Details:

Add the requested divisibility check and retain the existing module-head consistency validation. Extend the existing collector contract test with non-divisible and TP-larger-than-head-count cases, covering native, local, and absent module head attributes. Exact division, including one head per rank, remains valid.

Validation:
- The extended contract test fails on main (`DID NOT RAISE RuntimeError`) and passes after the fix.
- `python -m pytest --confcutdir=tests/unit/collector tests/unit/collector/sglang/test_collect_dsv4_attn_contract.py -q`: 6 passed. This follows the existing test's AST extraction of the actual helper and does not require importing SGLang or loading a model.
- Ruff lint and format checks passed; the repository's Ruff and Ruff-format pre-commit hooks passed.
- The full pre-commit invocation could not initialize its unrelated ESLint environment because the system Node selected by nodeenv lacks `node:path`; no JavaScript files are changed.


Remote CI baseline comparison: the Rust/Python engine-step parity job reports the same two golden-energy mismatches as the [unchanged direct main baseline f254959](https://github.com/ai-dynamo/aiconfigurator/actions/runs/34306677905/job/102324713375). Both runs report 2 failed / 62 passed, with identical actual values for GPT-OSS-20B and Nemotron-NAS. This collector-only change does not modify those TRTLLM parity paths.

The unit CI job also matches the [same main baseline](https://github.com/ai-dynamo/aiconfigurator/actions/runs/34306677905/job/102324713383): 1 failed / 2750 passed / 12 skipped. Its only failure is `test_power_columns_satisfy_energy_model_input_contract`, with identical invalid `power_limit` data in 15 B200/TRTLLM parquet files.

#### Where should the reviewer start?

`collector/sglang/collect_dsv4_attn.py::_resolve_local_heads`

#### Related Issues:

Fixes #1466


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of attention head configurations to reject incompatible tensor-parallel settings with a clear geometry-mismatch error.
  * Valid configurations with evenly divisible heads continue to be supported.

* **Tests**
  * Expanded coverage for valid single-head division and invalid non-divisible configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
